### PR TITLE
MCP Tasks: shared lifecycle engine, per-task poll scheduling, tri-state host policy

### DIFF
--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -57,6 +57,7 @@ import { TaskInlineProgress } from "./tasks/TaskInlineProgress";
 import {
   STATUS_CONFIG,
   expiredPlaceholderTask,
+  restoredPlaceholderTask,
   formatRelativeTime,
   isTerminalStatus,
   normalizeTask,
@@ -114,6 +115,9 @@ export function TasksTab({
   // render and restart the poll timer each tick.
   const tasksRef = useRef<NormalizedTask[]>([]);
   tasksRef.current = tasks;
+  // Last `tasks/list` snapshot (legacy wire only), so a tick that is not due
+  // can carry it forward instead of re-issuing the call or blanking the list.
+  const listedTasksRef = useRef<NormalizedTask[]>([]);
   const [selectedTaskId, setSelectedTaskId] = useState<string>("");
   const [taskResult, setTaskResult] = useState<unknown>(null);
   const [pendingRequest, setPendingRequest] = useState<unknown>(null);
@@ -236,7 +240,10 @@ export function TasksTab({
   // The server is setting the pace whenever its floor is the binding term.
   const usingServerInterval =
     serverSuggestedPollInterval !== null &&
-    serverSuggestedPollInterval >= userPreferredMinimum;
+    // Against the TICK floor, not the user's preference: on the hosted surface
+    // a 1500ms suggestion under a 1000ms user minimum would otherwise light the
+    // badge while the 2000ms hosted floor is what actually sets the pace.
+    serverSuggestedPollInterval >= tickFloorMs;
 
   // Subscribe to task-related elicitations via SSE
   // Per MCP Tasks spec (2025-11-25): when a task is in input_required status,
@@ -342,7 +349,7 @@ export function TasksTab({
     setSelectedTaskId("");
     setTaskResult(null);
     setPendingRequest(null);
-  }, [serverName, tasks]);
+  }, [serverName, tasks, scheduler]);
 
   const fetchTasks = useCallback(async () => {
     if (!serverName) return;
@@ -367,10 +374,31 @@ export function TasksTab({
       let serverTaskIds = new Set<string>();
 
       // The extension has no tasks/list: the tracker is the list.
+      //
+      // On the legacy wire the call returns EVERY task at once, so "is this
+      // due" is a question about the list as a whole: issue it when we have
+      // never listed, or when at least one previously-listed active task has
+      // reached its own floor. Calling it on every tick would read a 30s task
+      // at the tab's pace just because a 1s task shares the connection — the
+      // same floor breach the per-task scheduler exists to prevent, one level
+      // up.
+      let listedCarriedForward: NormalizedTask[] = [];
       if (taskCapabilities?.list) {
-        // Server supports tasks/list - fetch from server
-        serverResult = await listTasks(serverName);
-        serverTaskIds = new Set(serverResult.tasks.map((t) => t.taskId));
+        const knownListed = listedTasksRef.current;
+        const listDue =
+          knownListed.length === 0 ||
+          scheduler.dueTaskIds(knownListed.map((task) => task.taskId)).length >
+            0;
+
+        if (listDue) {
+          serverResult = await listTasks(serverName);
+          serverTaskIds = new Set(serverResult.tasks.map((t) => t.taskId));
+        } else {
+          // Not due: keep the last snapshot on screen rather than blanking the
+          // list, and do not re-issue the call.
+          listedCarriedForward = knownListed;
+          serverTaskIds = new Set(knownListed.map((task) => task.taskId));
+        }
       }
 
       // Get locally tracked tasks and fetch their current status
@@ -462,8 +490,15 @@ export function TasksTab({
       // rescheduled by its OWN advertised floor. A due handle that came back
       // empty is a failed read: it backs off rather than being retried at the
       // tab's pace.
+      // Expired PLACEHOLDERS are excluded. `expiredPlaceholderTask` returns a
+      // real `NormalizedTask`, so without this filter it would flow into
+      // `recordObservations` and re-register the very handle `onUnknownTask`
+      // just told the scheduler to forget — and it carries a display-only
+      // status that is not a lifecycle status, so the resurrected record would
+      // never read as terminal, stay permanently due, and pin
+      // `msUntilNextDue()` at zero for the rest of the session.
       const observed = trackedTaskStatuses.filter(
-        (task): task is NormalizedTask => task !== null
+        (task): task is NormalizedTask => task !== null && !task.expired
       );
       scheduler.recordObservations(
         observed.map((task) => ({
@@ -474,17 +509,32 @@ export function TasksTab({
           lastUpdatedAt: task.lastUpdatedAt,
         }))
       );
-      const observedIds = new Set(observed.map((task) => task.taskId));
-      scheduler.recordErrors(pendingIds.filter((id) => !observedIds.has(id)));
+      const settledIds = new Set(
+        trackedTaskStatuses
+          .filter((task): task is NormalizedTask => task !== null)
+          .map((task) => task.taskId)
+      );
+      // Only ids that produced NOTHING are failed reads. A confirmed-expired
+      // handle answered — it is retired, not unreachable — and backing it off
+      // would be recording an error against a handle nobody will poll again.
+      scheduler.recordErrors(pendingIds.filter((id) => !settledIds.has(id)));
 
       // A handle that was not due this tick keeps its last-known state rather
       // than disappearing from the list until its next read.
+      //
+      // The fallback is load-bearing, not defensive. On the FIRST tick after a
+      // reload `tasksRef.current` is empty while every restored handle is
+      // not-yet-due, so without it the list renders empty — which makes
+      // `hasActiveTasks` false, so auto-refresh never starts, so the handle is
+      // never polled when its floor finally elapses. The task would stay
+      // invisible until a manual refresh, and could expire server-side first.
       const previousById = new Map(
         tasksRef.current.map((task) => [task.taskId, task])
       );
-      const carriedForward = notDue
-        .map((tracked) => previousById.get(tracked.taskId))
-        .filter((task): task is NormalizedTask => task !== undefined);
+      const carriedForward = notDue.map(
+        (tracked) =>
+          previousById.get(tracked.taskId) ?? restoredPlaceholderTask(tracked)
+      );
 
       trackedTaskStatuses = [
         ...trackedTaskStatuses,
@@ -494,13 +544,34 @@ export function TasksTab({
 
       // Merge server tasks with tracked tasks (tracked tasks first for recency)
       // Filter out dismissed tasks from server results
+      const listed =
+        listedCarriedForward.length > 0
+          ? listedCarriedForward.filter((t) => !dismissedIds.has(t.taskId))
+          : serverResult.tasks
+              .filter((t) => !dismissedIds.has(t.taskId))
+              .map((t) =>
+                normalizeTask("legacy", t as unknown as Record<string, unknown>)
+              );
+      listedTasksRef.current = listed;
+      // Learn each listed task's own floor, so the NEXT decision about whether
+      // to call `tasks/list` is made per task rather than at the tab's pace.
+      if (listedCarriedForward.length === 0 && listed.length > 0) {
+        scheduler.recordObservations(
+          listed
+            .filter((task) => !isTerminalStatus(task.status))
+            .map((task) => ({
+              taskId: task.taskId,
+              status: task.status,
+              pollIntervalMs: task.pollInterval,
+              ttlMs: task.ttl ?? null,
+              lastUpdatedAt: task.lastUpdatedAt,
+            }))
+        );
+      }
+
       const allTasks: NormalizedTask[] = [
         ...trackedTaskStatuses.filter((t): t is NormalizedTask => t !== null),
-        ...serverResult.tasks
-          .filter((t) => !dismissedIds.has(t.taskId))
-          .map((t) =>
-            normalizeTask("legacy", t as unknown as Record<string, unknown>)
-          ),
+        ...listed,
       ];
 
       // Sort by createdAt descending (most recent first)

--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -5,7 +5,10 @@ import {
   HOSTED_TASK_POLL_FLOOR_MS,
   hostedPollIntervalMs,
 } from "@/shared/hosted-tasks";
-import { useTaskScheduler } from "@/hooks/use-task-scheduler";
+import {
+  MAX_RECOVERY_READ_ATTEMPTS,
+  useTaskScheduler,
+} from "@/hooks/use-task-scheduler";
 import { Button } from "@mcpjam/design-system/button";
 import { Badge } from "@mcpjam/design-system/badge";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
@@ -203,10 +206,28 @@ export function TasksTab({
   const pendingRequestDisplay = extractDisplayFromToolResult(pendingRequest);
   const taskResultDisplay = extractDisplayFromToolResult(taskResult);
 
+  // Restored handles that still owe the one `tasks/get` carrying their inline
+  // result. Read from the scheduler rather than from the rows, because the rows
+  // cannot show it: such a handle renders as `completed` and reads as finished
+  // while its result has never actually been fetched.
+  const recoveryReads = useMemo(
+    () => scheduler.recoveryReadState(tasks.map((t) => t.taskId)),
+    [tasks, scheduler]
+  );
+
   // Check if any task is in a non-terminal state (working, input_required, pending)
   const hasActiveTasks = useMemo(() => {
-    return tasks.some((t) => !isTerminalStatus(t.status));
-  }, [tasks]);
+    return (
+      tasks.some((t) => !isTerminalStatus(t.status)) ||
+      // ...or a restored terminal still owes its recovery read. Without this
+      // term the loop stops on the DISPLAYED status and the read never
+      // happens: not when it was scheduled for later (a stored `nextPollAt`
+      // in the future is not due on the first tick, so the timer never arms
+      // at all), and not after it failed (the backoff is recorded, then
+      // nothing is left running to honor it).
+      recoveryReads.pendingTaskIds.length > 0
+    );
+  }, [tasks, recoveryReads]);
 
   // Auto-enable polling when there are active tasks, unless user explicitly disabled
   useEffect(() => {
@@ -676,6 +697,20 @@ export function TasksTab({
     }
   }, [serverName, taskCapabilities, hosted, wire, scheduler]);
 
+  // The Refresh button, as distinct from a tick.
+  //
+  // A recovery read the tab has given up on is sitting on a backoff that can
+  // be a minute long, so plain `fetchTasks` would find it not due and the
+  // button would look broken on the one handle the message just told the user
+  // to retry. A person clicking Refresh is a better signal than our own guess
+  // about a failing transport, so their click drops that guess — and only that
+  // one: the server's advertised floor and any `Retry-After` still hold, and
+  // the automatic loop keeps backing off exactly as before.
+  const handleManualRefresh = useCallback(() => {
+    scheduler.retryRecoveryReads(recoveryReads.exhaustedTaskIds);
+    void fetchTasks();
+  }, [scheduler, recoveryReads, fetchTasks]);
+
   // Handle elicitation response from the dialog
   const handleElicitationResponse = useCallback(
     async (
@@ -1115,7 +1150,7 @@ export function TasksTab({
           {/* Secondary actions */}
           <div className="flex items-center gap-0.5 text-muted-foreground/80">
             <Button
-              onClick={fetchTasks}
+              onClick={handleManualRefresh}
               variant="ghost"
               size="sm"
               disabled={fetchingTasks}
@@ -1147,6 +1182,24 @@ export function TasksTab({
             </Button>
           </div>
         </div>
+
+        {/* Giving up on a recovery read has to SAY so. Going quietly idle is
+            the failure this whole path exists to prevent: the row still reads
+            "completed" while its result was never fetched, so silence would
+            look like success. */}
+        {recoveryReads.exhaustedTaskIds.length > 0 && (
+          <div className="px-2 pb-1.5 flex items-start gap-1.5">
+            <AlertCircle className="h-3 w-3 text-warning mt-[3px] flex-shrink-0" />
+            <p className="text-[10px] text-muted-foreground leading-snug">
+              Could not read back{" "}
+              {recoveryReads.exhaustedTaskIds.length === 1
+                ? "1 restored task's result"
+                : `${recoveryReads.exhaustedTaskIds.length} restored tasks' results`}{" "}
+              after {MAX_RECOVERY_READ_ATTEMPTS} attempts. Stopped retrying
+              automatically — use Refresh to try again.
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Tasks List */}

--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -379,11 +379,27 @@ export function TasksTab({
       // up.
       let listedCarriedForward: NormalizedTask[] = [];
       if (taskCapabilities?.list) {
+        // `tasks/list` is an INSEPARABLE batch: one request returns every task,
+        // so issuing it reads — and reschedules — the slowest member along with
+        // the fastest. Gating on "any member is due" therefore lets a task
+        // advertising 1s drag a task advertising 60s down to 1s polling: the
+        // exact floor breach the per-task scheduler exists to prevent, one
+        // level up. A batch's floor is its SLOWEST member's, so every active
+        // member has to be due before the call goes out.
+        //
+        // Terminal rows are excluded rather than counted. They never become due
+        // again, so including even one would freeze the list forever. When
+        // nothing active is left there is no floor to breach at all, and
+        // listing is how a task created elsewhere gets discovered — so that
+        // case falls back to the tab's own tick.
         const knownListed = listedTasksRef.current;
+        const activeListed = knownListed.filter(
+          (task) => !isTerminalStatus(task.status)
+        );
         const listDue =
-          knownListed.length === 0 ||
-          scheduler.dueTaskIds(knownListed.map((task) => task.taskId)).length >
-            0;
+          activeListed.length === 0 ||
+          scheduler.dueTaskIds(activeListed.map((task) => task.taskId))
+            .length === activeListed.length;
 
         if (listDue) {
           serverResult = await listTasks(serverName);
@@ -512,7 +528,8 @@ export function TasksTab({
       // Only ids that produced NOTHING are failed reads. A confirmed-expired
       // handle answered — it is retired, not unreachable — and backing it off
       // would be recording an error against a handle nobody will poll again.
-      scheduler.recordErrors(pendingIds.filter((id) => !settledIds.has(id)));
+      const failedIds = pendingIds.filter((id) => !settledIds.has(id));
+      scheduler.recordErrors(failedIds);
 
       // A handle that was not due this tick keeps its last-known state rather
       // than disappearing from the list until its next read.
@@ -531,9 +548,27 @@ export function TasksTab({
           previousById.get(tracked.taskId) ?? restoredPlaceholderTask(tracked)
       );
 
+      // A due read that FAILED keeps its row for exactly the same reason. The
+      // failure is transient by construction — a confirmed `-32602` produced an
+      // expired placeholder instead, and never lands here — so dropping the row
+      // would be self-defeating: with the last active task gone from the list,
+      // `hasActiveTasks` goes false, auto-refresh stops, and the backoff
+      // `recordErrors` just persisted is never actually retried. The handle
+      // strands until the user does something, which is the opposite of what a
+      // backoff is for.
+      const failedCarriedForward = failedIds
+        .map((taskId) => {
+          const previous = previousById.get(taskId);
+          if (previous) return previous;
+          const tracked = byId.get(taskId);
+          return tracked ? restoredPlaceholderTask(tracked) : null;
+        })
+        .filter((task): task is NormalizedTask => task !== null);
+
       trackedTaskStatuses = [
         ...trackedTaskStatuses,
         ...carriedForward,
+        ...failedCarriedForward,
         ...expiredEntries,
       ];
 

--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -2,8 +2,10 @@ import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import { isHostedMode } from "@/lib/apis/mode-client";
 import {
   HOSTED_TASK_BATCH_LIMIT,
+  HOSTED_TASK_POLL_FLOOR_MS,
   hostedPollIntervalMs,
 } from "@/shared/hosted-tasks";
+import { useTaskScheduler } from "@/hooks/use-task-scheduler";
 import { Button } from "@mcpjam/design-system/button";
 import { Badge } from "@mcpjam/design-system/badge";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
@@ -101,6 +103,11 @@ export function TasksTab({
   isActive = true,
 }: TasksTabProps) {
   const [tasks, setTasks] = useState<NormalizedTask[]>([]);
+  // Read inside `fetchTasks` to carry not-yet-due handles forward without
+  // making the callback depend on `tasks` — that would rebuild it on every
+  // render and restart the poll timer each tick.
+  const tasksRef = useRef<NormalizedTask[]>([]);
+  tasksRef.current = tasks;
   const [selectedTaskId, setSelectedTaskId] = useState<string>("");
   const [taskResult, setTaskResult] = useState<unknown>(null);
   const [pendingRequest, setPendingRequest] = useState<unknown>(null);
@@ -175,16 +182,19 @@ export function TasksTab({
     }
   }, [hasActiveTasks]);
 
-  // Per MCP Tasks spec: "Requestors SHOULD respect the pollInterval provided in responses"
-  // Calculate server-suggested poll interval from non-terminal tasks
-  // Use the minimum pollInterval from active tasks to not miss updates
+  // The slowest floor among the active tasks — NOT the fastest.
+  //
+  // A tick reads every due task, so honoring the fastest task's floor would
+  // breach every slower task's. This value is what the shared tick must
+  // respect and what the UI reports; the per-task decision of *which* tasks
+  // are actually due is the scheduler's, not this number's.
   const serverSuggestedPollInterval = useMemo(() => {
-    const activeTasksWithPollInterval = tasks
+    const activeFloors = tasks
       .filter((t) => !isTerminalStatus(t.status) && t.pollInterval)
       .map((t) => t.pollInterval!);
 
-    if (activeTasksWithPollInterval.length === 0) return null;
-    return Math.min(...activeTasksWithPollInterval);
+    if (activeFloors.length === 0) return null;
+    return Math.max(...activeFloors);
   }, [tasks]);
 
   // Subscribe to task-related elicitations via SSE
@@ -251,19 +261,32 @@ export function TasksTab({
         }
       : null;
 
-  // Priority: user override > server suggestion > user default
-  // Per MCP Tasks spec: "Requestors SHOULD respect the pollInterval provided in responses"
-  // But we allow user to explicitly override if they want
-  const requestedPollInterval =
-    userOverride ?? serverSuggestedPollInterval ?? userPollInterval;
-  const pollInterval = hosted
-    ? hostedPollIntervalMs(
-        requestedPollInterval,
-        serverSuggestedPollInterval ?? undefined,
-      )
-    : requestedPollInterval;
+  // Every term is a MAX. The user's setting is a preferred *minimum*, never
+  // permission to poll faster than a server asked to be polled — the old
+  // `userOverride ?? serverSuggested ?? userDefault` chain let a user typing
+  // 500 into the box replace a 30s server floor outright.
+  const userPreferredMinimum = userOverride ?? userPollInterval;
+  const pollInterval = Math.max(
+    userPreferredMinimum,
+    serverSuggestedPollInterval ?? 0,
+    // Each hosted tick is a full authorize → connect → request → disconnect
+    // round trip, so the hosted surface carries its own connection-cost floor.
+    hosted ? hostedPollIntervalMs(userPreferredMinimum) : 0,
+  );
+  // The server is setting the pace whenever its floor is the binding term.
   const usingServerInterval =
-    serverSuggestedPollInterval !== null && userOverride === null;
+    serverSuggestedPollInterval !== null &&
+    serverSuggestedPollInterval >= userPreferredMinimum;
+
+  // Per-task due-time scheduling. The shared tick below fires at the pace
+  // above; the scheduler decides which handles that tick is actually allowed
+  // to read, so a 30s task is not read every time a 1s task is.
+  const scheduler = useTaskScheduler({
+    serverId: serverName,
+    wire,
+    userMinimumIntervalMs: userPreferredMinimum,
+    surfaceFloorMs: hosted ? HOSTED_TASK_POLL_FLOOR_MS : 0,
+  });
 
   const handlePollIntervalChange = useCallback(
     (value: string) => {
@@ -340,7 +363,19 @@ export function TasksTab({
       const expiredEntries = pending
         .filter((t) => t.expired)
         .map((t) => expiredPlaceholderTask(t));
-      const livePending = pending.filter((t) => !t.expired);
+      // Only the handles whose own floor has elapsed. A tick that read every
+      // pending handle would poll a 30s task at the tab's 1s pace.
+      const dueIds = new Set(
+        scheduler.dueTaskIds(
+          pending.filter((t) => !t.expired).map((t) => t.taskId),
+        ),
+      );
+      const livePending = pending.filter(
+        (t) => !t.expired && dueIds.has(t.taskId),
+      );
+      // Handles that exist but are not due keep their last-known state on
+      // screen rather than blinking out until their next read.
+      const notDue = pending.filter((t) => !t.expired && !dueIds.has(t.taskId));
       const byId = new Map(livePending.map((t) => [t.taskId, t]));
       const pendingIds = livePending.map((t) => t.taskId);
 
@@ -398,7 +433,39 @@ export function TasksTab({
           }),
         );
       }
-      trackedTaskStatuses = [...trackedTaskStatuses, ...expiredEntries];
+      // Feed the scheduler what we actually observed, so each handle is
+      // rescheduled by its OWN advertised floor. A due handle that came back
+      // empty is a failed read: it backs off rather than being retried at the
+      // tab's pace.
+      const observed = trackedTaskStatuses.filter(
+        (task): task is NormalizedTask => task !== null,
+      );
+      scheduler.recordObservations(
+        observed.map((task) => ({
+          taskId: task.taskId,
+          status: task.status,
+          pollIntervalMs: task.pollInterval,
+          ttlMs: task.ttl ?? null,
+          lastUpdatedAt: task.lastUpdatedAt,
+        })),
+      );
+      const observedIds = new Set(observed.map((task) => task.taskId));
+      scheduler.recordErrors(pendingIds.filter((id) => !observedIds.has(id)));
+
+      // A handle that was not due this tick keeps its last-known state rather
+      // than disappearing from the list until its next read.
+      const previousById = new Map(
+        tasksRef.current.map((task) => [task.taskId, task]),
+      );
+      const carriedForward = notDue
+        .map((tracked) => previousById.get(tracked.taskId))
+        .filter((task): task is NormalizedTask => task !== undefined);
+
+      trackedTaskStatuses = [
+        ...trackedTaskStatuses,
+        ...carriedForward,
+        ...expiredEntries,
+      ];
 
       // Merge server tasks with tracked tasks (tracked tasks first for recency)
       // Filter out dismissed tasks from server results
@@ -424,7 +491,7 @@ export function TasksTab({
     } finally {
       setFetchingTasks(false);
     }
-  }, [serverName, taskCapabilities, hosted, wire]);
+  }, [serverName, taskCapabilities, hosted, wire, scheduler]);
 
   // Handle elicitation response from the dialog
   const handleElicitationResponse = useCallback(
@@ -598,17 +665,34 @@ export function TasksTab({
     }
   }, [serverConfig, serverName, fetchTasks, isActive, taskCapabilities]);
 
-  // Auto-refresh logic - uses user-configured pollInterval (persisted in localStorage)
-  // Only poll when tab is active
+  // Auto-refresh: a self-rearming timeout rather than a fixed interval.
+  //
+  // The delay is whatever the scheduler says the SOONEST task is waiting for,
+  // clamped to the tab's own pace. A fixed `setInterval(pollInterval)` would
+  // wake up at the fastest task's rate and then find nothing due — burning a
+  // render and, on the hosted path, tempting a connection per tick. Only poll
+  // when the tab is active.
   useEffect(() => {
     if (!autoRefresh || !serverName || !isActive) return;
 
-    const interval = setInterval(() => {
-      fetchTasks();
-    }, pollInterval);
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
 
-    return () => clearInterval(interval);
-  }, [autoRefresh, serverName, fetchTasks, pollInterval, isActive]);
+    const arm = (delayMs: number) => {
+      timer = setTimeout(async () => {
+        if (cancelled) return;
+        await fetchTasks();
+        if (cancelled) return;
+        arm(Math.max(scheduler.msUntilNextDue(), pollInterval));
+      }, delayMs);
+    };
+    arm(pollInterval);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [autoRefresh, serverName, fetchTasks, pollInterval, isActive, scheduler]);
 
   // Fetch result when selecting a completed or failed task, or pending request for input_required
   // Per MCP Tasks spec: when task is input_required, tasks/result returns the pending request

--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -47,7 +47,11 @@ import {
 } from "@/lib/task-tracker";
 import { Switch } from "@mcpjam/design-system/switch";
 import { Input } from "@mcpjam/design-system/input";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@mcpjam/design-system/tooltip";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@mcpjam/design-system/tooltip";
 import { Progress } from "@mcpjam/design-system/progress";
 import { TaskInlineProgress } from "./tasks/TaskInlineProgress";
 import {
@@ -84,7 +88,9 @@ function TaskStatusIcon({ status }: { status: TaskDisplayStatus }) {
   const Icon = config.icon;
   return (
     <Icon
-      className={`h-4 w-4 ${config.color} ${config.animate ? "animate-spin" : ""}`}
+      className={`h-4 w-4 ${config.color} ${
+        config.animate ? "animate-spin" : ""
+      }`}
     />
   );
 }
@@ -160,6 +166,33 @@ export function TasksTab({
   // never poll faster than the floor, because each tick is a full connect.
   const hosted = isHostedMode();
 
+  // Two DIFFERENT numbers, and conflating them starves fast tasks.
+  //
+  // `tickFloorMs` is how often the shared timer may wake at all. It carries
+  // only the GLOBAL floors — the user's preferred minimum, plus the hosted
+  // connection-cost floor — and deliberately NOT the per-server task floors:
+  // those are enforced per task by the scheduler, which decides which handles
+  // a given tick is allowed to read. Folding the slowest task's floor in here
+  // would make a 60s task delay a 2s task by 58 seconds, potentially past its
+  // TTL.
+  const userPreferredMinimum = userOverride ?? userPollInterval;
+  const tickFloorMs = Math.max(
+    userPreferredMinimum,
+    // Each hosted tick is a full authorize → connect → request → disconnect
+    // round trip, so the hosted surface carries its own connection-cost floor.
+    hosted ? hostedPollIntervalMs(userPreferredMinimum) : 0
+  );
+
+  // Per-task due-time scheduling. The shared tick fires at `tickFloorMs`; the
+  // scheduler decides which handles that tick is actually allowed to read, so
+  // a 30s task is not read every time a 1s task is.
+  const scheduler = useTaskScheduler({
+    serverId: serverName,
+    wire,
+    userMinimumIntervalMs: userPreferredMinimum,
+    surfaceFloorMs: hosted ? HOSTED_TASK_POLL_FLOOR_MS : 0,
+  });
+
   const selectedTask = useMemo(() => {
     return tasks.find((t) => t.taskId === selectedTaskId) ?? null;
   }, [tasks, selectedTaskId]);
@@ -197,6 +230,14 @@ export function TasksTab({
     return Math.max(...activeFloors);
   }, [tasks]);
 
+  // The number the UI reports and the poll-interval box edits: the pace a
+  // caller would observe, including the slowest active task's floor.
+  const pollInterval = Math.max(tickFloorMs, serverSuggestedPollInterval ?? 0);
+  // The server is setting the pace whenever its floor is the binding term.
+  const usingServerInterval =
+    serverSuggestedPollInterval !== null &&
+    serverSuggestedPollInterval >= userPreferredMinimum;
+
   // Subscribe to task-related elicitations via SSE
   // Per MCP Tasks spec (2025-11-25): when a task is in input_required status,
   // the server sends elicitations with relatedTaskId in the metadata
@@ -223,10 +264,16 @@ export function TasksTab({
     if (!isExtensionWire || selectedTask?.status !== "input_required") {
       return null;
     }
-    const answered = answeredInputKeys.get(selectedTask.taskId);
+    // Union of this session's answers and the keys persisted from earlier
+    // sessions — a reload must not re-prompt for something the server already
+    // acknowledged.
+    const answered = new Set([
+      ...(answeredInputKeys.get(selectedTask.taskId) ?? []),
+      ...scheduler.respondedInputKeys(selectedTask.taskId),
+    ]);
     const entries = Object.entries(selectedTask.inputRequests ?? {});
     for (const [key, value] of entries) {
-      if (answered?.has(key)) continue;
+      if (answered.has(key)) continue;
       const request = value as {
         method?: string;
         params?: { message?: string; requestedSchema?: unknown };
@@ -236,14 +283,13 @@ export function TasksTab({
       }
     }
     return null;
-  }, [isExtensionWire, selectedTask, answeredInputKeys]);
+  }, [isExtensionWire, selectedTask, answeredInputKeys, scheduler]);
 
   /** Keys in the current snapshot this UI cannot answer (sampling/roots). */
   const unanswerableInputCount = useMemo(() => {
     if (!isExtensionWire || selectedTask?.status !== "input_required") return 0;
     return Object.values(selectedTask.inputRequests ?? {}).filter(
-      (value) =>
-        (value as { method?: string })?.method !== "elicitation/create",
+      (value) => (value as { method?: string })?.method !== "elicitation/create"
     ).length;
   }, [isExtensionWire, selectedTask]);
 
@@ -261,33 +307,6 @@ export function TasksTab({
         }
       : null;
 
-  // Every term is a MAX. The user's setting is a preferred *minimum*, never
-  // permission to poll faster than a server asked to be polled — the old
-  // `userOverride ?? serverSuggested ?? userDefault` chain let a user typing
-  // 500 into the box replace a 30s server floor outright.
-  const userPreferredMinimum = userOverride ?? userPollInterval;
-  const pollInterval = Math.max(
-    userPreferredMinimum,
-    serverSuggestedPollInterval ?? 0,
-    // Each hosted tick is a full authorize → connect → request → disconnect
-    // round trip, so the hosted surface carries its own connection-cost floor.
-    hosted ? hostedPollIntervalMs(userPreferredMinimum) : 0,
-  );
-  // The server is setting the pace whenever its floor is the binding term.
-  const usingServerInterval =
-    serverSuggestedPollInterval !== null &&
-    serverSuggestedPollInterval >= userPreferredMinimum;
-
-  // Per-task due-time scheduling. The shared tick below fires at the pace
-  // above; the scheduler decides which handles that tick is actually allowed
-  // to read, so a 30s task is not read every time a 1s task is.
-  const scheduler = useTaskScheduler({
-    serverId: serverName,
-    wire,
-    userMinimumIntervalMs: userPreferredMinimum,
-    surfaceFloorMs: hosted ? HOSTED_TASK_POLL_FLOOR_MS : 0,
-  });
-
   const handlePollIntervalChange = useCallback(
     (value: string) => {
       const parsed = parseInt(value, 10);
@@ -301,7 +320,7 @@ export function TasksTab({
         localStorage.setItem(POLL_INTERVAL_STORAGE_KEY, String(parsed));
       }
     },
-    [serverSuggestedPollInterval],
+    [serverSuggestedPollInterval]
   );
 
   // Clear override when server suggestion goes away (tasks complete)
@@ -318,6 +337,7 @@ export function TasksTab({
     const taskIds = tasks.map((t) => t.taskId);
     dismissTasksForServer(serverName, taskIds);
     clearTrackedTasksForServer(serverName);
+    scheduler.forget(taskIds);
     setTasks([]);
     setSelectedTaskId("");
     setTaskResult(null);
@@ -367,11 +387,11 @@ export function TasksTab({
       // pending handle would poll a 30s task at the tab's 1s pace.
       const dueIds = new Set(
         scheduler.dueTaskIds(
-          pending.filter((t) => !t.expired).map((t) => t.taskId),
-        ),
+          pending.filter((t) => !t.expired).map((t) => t.taskId)
+        )
       );
       const livePending = pending.filter(
-        (t) => !t.expired && dueIds.has(t.taskId),
+        (t) => !t.expired && dueIds.has(t.taskId)
       );
       // Handles that exist but are not due keep their last-known state on
       // screen rather than blinking out until their next read.
@@ -380,6 +400,11 @@ export function TasksTab({
       const pendingIds = livePending.map((t) => t.taskId);
 
       const onUnknownTask = (taskId: string) => {
+        // Stop scheduling it too. Without this the engine's map grows for the
+        // life of the session, and a record that stays due-but-never-polled
+        // pins `msUntilNextDue()` at zero, collapsing every re-arm to the
+        // floor.
+        scheduler.forget([taskId]);
         // Unknown/expired is not an error: flag it and keep the handle so the
         // user sees what happened instead of a silent removal. Any other
         // failure (transient connect, structureless 404 from an older hosted
@@ -402,7 +427,7 @@ export function TasksTab({
               } catch {
                 return [];
               }
-            }),
+            })
           )
         ).flat();
         trackedTaskStatuses = entries.map((entry) => {
@@ -430,7 +455,7 @@ export function TasksTab({
               // wire there is no `tasks/list` to recover them from.
               return null;
             }
-          }),
+          })
         );
       }
       // Feed the scheduler what we actually observed, so each handle is
@@ -438,7 +463,7 @@ export function TasksTab({
       // empty is a failed read: it backs off rather than being retried at the
       // tab's pace.
       const observed = trackedTaskStatuses.filter(
-        (task): task is NormalizedTask => task !== null,
+        (task): task is NormalizedTask => task !== null
       );
       scheduler.recordObservations(
         observed.map((task) => ({
@@ -447,7 +472,7 @@ export function TasksTab({
           pollIntervalMs: task.pollInterval,
           ttlMs: task.ttl ?? null,
           lastUpdatedAt: task.lastUpdatedAt,
-        })),
+        }))
       );
       const observedIds = new Set(observed.map((task) => task.taskId));
       scheduler.recordErrors(pendingIds.filter((id) => !observedIds.has(id)));
@@ -455,7 +480,7 @@ export function TasksTab({
       // A handle that was not due this tick keeps its last-known state rather
       // than disappearing from the list until its next read.
       const previousById = new Map(
-        tasksRef.current.map((task) => [task.taskId, task]),
+        tasksRef.current.map((task) => [task.taskId, task])
       );
       const carriedForward = notDue
         .map((tracked) => previousById.get(tracked.taskId))
@@ -474,7 +499,7 @@ export function TasksTab({
         ...serverResult.tasks
           .filter((t) => !dismissedIds.has(t.taskId))
           .map((t) =>
-            normalizeTask("legacy", t as unknown as Record<string, unknown>),
+            normalizeTask("legacy", t as unknown as Record<string, unknown>)
           ),
       ];
 
@@ -497,7 +522,7 @@ export function TasksTab({
   const handleElicitationResponse = useCallback(
     async (
       action: "accept" | "decline" | "cancel",
-      parameters?: Record<string, unknown>,
+      parameters?: Record<string, unknown>
     ) => {
       try {
         await respondToElicitation(action, parameters);
@@ -507,11 +532,11 @@ export function TasksTab({
         setError(
           err instanceof Error
             ? err.message
-            : "Failed to respond to elicitation",
+            : "Failed to respond to elicitation"
         );
       }
     },
-    [respondToElicitation, fetchTasks],
+    [respondToElicitation, fetchTasks]
   );
 
   const fetchTaskResult = useCallback(
@@ -526,13 +551,13 @@ export function TasksTab({
         setTaskResult(result);
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "Failed to fetch task result",
+          err instanceof Error ? err.message : "Failed to fetch task result"
         );
       } finally {
         setLoading(false);
       }
     },
-    [serverName],
+    [serverName]
   );
 
   const handleCancelTask = useCallback(async () => {
@@ -547,9 +572,7 @@ export function TasksTab({
         // Cooperative cancel: the ack is empty, so record the request and
         // stop polling by default rather than waiting for a `cancelled` that
         // may never arrive.
-        setCancellationRequested((prev) =>
-          new Set(prev).add(selectedTaskId),
-        );
+        setCancellationRequested((prev) => new Set(prev).add(selectedTaskId));
         setAutoRefresh(false);
         userDisabledAutoRefresh.current = true;
       }
@@ -565,28 +588,30 @@ export function TasksTab({
   // Extension input_required: submit responses to the keyed inputRequests
   // snapshot via tasks/update. Partial responses are allowed.
   const handleSubmitInputResponses = useCallback(
-    async (inputResponses: Record<string, unknown>) => {
-      if (!serverName || !selectedTaskId) return;
+    async (inputResponses: Record<string, unknown>): Promise<boolean> => {
+      if (!serverName || !selectedTaskId) return false;
       setSubmittingInput(true);
       setError("");
       try {
         await updateTask(serverName, selectedTaskId, inputResponses);
         await fetchTasks();
+        return true;
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "Failed to submit task input",
+          err instanceof Error ? err.message : "Failed to submit task input"
         );
+        return false;
       } finally {
         setSubmittingInput(false);
       }
     },
-    [serverName, selectedTaskId, fetchTasks],
+    [serverName, selectedTaskId, fetchTasks]
   );
 
   const handleExtensionInputResponse = useCallback(
     async (
       action: "accept" | "decline" | "cancel",
-      parameters?: Record<string, unknown>,
+      parameters?: Record<string, unknown>
     ) => {
       if (!extensionInputRequest) return;
       // Partial responses are allowed: answer the key the user just handled.
@@ -594,6 +619,17 @@ export function TasksTab({
       // `{method, result}` envelope, which a conforming server would ignore
       // (leaving the task stuck in `input_required`).
       const key = extensionInputRequest.key;
+      const acknowledged = await handleSubmitInputResponses({
+        [key]: {
+          action,
+          ...(action === "accept" && parameters ? { content: parameters } : {}),
+        },
+      });
+      // ONLY after the acknowledgement. Marking the key optimistically would
+      // silently discard the user's answer whenever the update failed: the
+      // re-sent snapshot would still carry the key, we would skip it as
+      // "answered", and the task would sit in `input_required` forever.
+      if (!acknowledged) return;
       setAnsweredInputKeys((prev) => {
         const next = new Map(prev);
         const keys = new Set(next.get(selectedTaskId) ?? []);
@@ -601,14 +637,16 @@ export function TasksTab({
         next.set(selectedTaskId, keys);
         return next;
       });
-      await handleSubmitInputResponses({
-        [key]: {
-          action,
-          ...(action === "accept" && parameters ? { content: parameters } : {}),
-        },
-      });
+      // Durable, so a reload does not re-prompt. Keys only — never the prompt
+      // or the response.
+      scheduler.markInputResponded(selectedTaskId, [key]);
     },
-    [extensionInputRequest, handleSubmitInputResponses, selectedTaskId],
+    [
+      extensionInputRequest,
+      handleSubmitInputResponses,
+      selectedTaskId,
+      scheduler,
+    ]
   );
 
   // The "cancellation requested" banner is transient: once the task reaches a
@@ -681,18 +719,26 @@ export function TasksTab({
     const arm = (delayMs: number) => {
       timer = setTimeout(async () => {
         if (cancelled) return;
-        await fetchTasks();
-        if (cancelled) return;
-        arm(Math.max(scheduler.msUntilNextDue(), pollInterval));
+        // `finally`, so a throw escaping `fetchTasks` cannot break the chain
+        // permanently and silently — the switch would still read "Auto" while
+        // nothing ticked again until a dependency changed.
+        try {
+          await fetchTasks();
+        } finally {
+          if (!cancelled) {
+            // The EARLIEST due handle, floored only by the global terms.
+            arm(Math.max(scheduler.msUntilNextDue(), tickFloorMs));
+          }
+        }
       }, delayMs);
     };
-    arm(pollInterval);
+    arm(tickFloorMs);
 
     return () => {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, [autoRefresh, serverName, fetchTasks, pollInterval, isActive, scheduler]);
+  }, [autoRefresh, serverName, fetchTasks, tickFloorMs, isActive, scheduler]);
 
   // Fetch result when selecting a completed or failed task, or pending request for input_required
   // Per MCP Tasks spec: when task is input_required, tasks/result returns the pending request
@@ -1036,7 +1082,9 @@ export function TasksTab({
                 <TaskStatusIcon status={selectedTask.status} />
                 <Badge
                   variant="outline"
-                  className={`text-xs ${statusConfigFor(selectedTask.status).bgColor} ${statusConfigFor(selectedTask.status).color} border-0`}
+                  className={`text-xs ${
+                    statusConfigFor(selectedTask.status).bgColor
+                  } ${statusConfigFor(selectedTask.status).color} border-0`}
                 >
                   {selectedTask.status}
                 </Badge>
@@ -1286,7 +1334,9 @@ export function TasksTab({
       {/* Per MCP Tasks spec (2025-11-25): when a task needs input, server sends */}
       {/* elicitation requests with relatedTaskId in the metadata */}
       <ElicitationDialog
-        elicitationRequest={extensionDialogElicitation ?? legacyDialogElicitation}
+        elicitationRequest={
+          extensionDialogElicitation ?? legacyDialogElicitation
+        }
         onResponse={
           extensionDialogElicitation
             ? handleExtensionInputResponse

--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -47,7 +47,11 @@ import {
 } from "@/lib/task-tracker";
 import { Switch } from "@mcpjam/design-system/switch";
 import { Input } from "@mcpjam/design-system/input";
-import { Tooltip, TooltipTrigger, TooltipContent } from "@mcpjam/design-system/tooltip";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@mcpjam/design-system/tooltip";
 import { Progress } from "@mcpjam/design-system/progress";
 import { TaskInlineProgress } from "./tasks/TaskInlineProgress";
 import {
@@ -85,7 +89,9 @@ function TaskStatusIcon({ status }: { status: TaskDisplayStatus }) {
   const Icon = config.icon;
   return (
     <Icon
-      className={`h-4 w-4 ${config.color} ${config.animate ? "animate-spin" : ""}`}
+      className={`h-4 w-4 ${config.color} ${
+        config.animate ? "animate-spin" : ""
+      }`}
     />
   );
 }
@@ -290,8 +296,7 @@ export function TasksTab({
   const unanswerableInputCount = useMemo(() => {
     if (!isExtensionWire || selectedTask?.status !== "input_required") return 0;
     return Object.values(selectedTask.inputRequests ?? {}).filter(
-      (value) =>
-        (value as { method?: string })?.method !== "elicitation/create",
+      (value) => (value as { method?: string })?.method !== "elicitation/create"
     ).length;
   }, [isExtensionWire, selectedTask]);
 
@@ -322,7 +327,7 @@ export function TasksTab({
         localStorage.setItem(POLL_INTERVAL_STORAGE_KEY, String(parsed));
       }
     },
-    [serverSuggestedPollInterval],
+    [serverSuggestedPollInterval]
   );
 
   // Clear override when server suggestion goes away (tasks complete)
@@ -377,6 +382,19 @@ export function TasksTab({
       // at the tab's pace just because a 1s task shares the connection — the
       // same floor breach the per-task scheduler exists to prevent, one level
       // up.
+      const onUnknownTask = (taskId: string) => {
+        // Stop scheduling it too. Without this the engine's map grows for the
+        // life of the session, and a record that stays due-but-never-polled
+        // pins `msUntilNextDue()` at zero, collapsing every re-arm to the
+        // floor.
+        scheduler.forget([taskId]);
+        // Unknown/expired is not an error: flag it and keep the handle so the
+        // user sees what happened instead of a silent removal. Any other
+        // failure (transient connect, structureless 404 from an older hosted
+        // replica) keeps the handle untouched and retries on the next tick.
+        markTaskExpired(taskId, serverName);
+      };
+
       let listedCarriedForward: NormalizedTask[] = [];
       if (taskCapabilities?.list) {
         // `tasks/list` is an INSEPARABLE batch: one request returns every task,
@@ -396,19 +414,71 @@ export function TasksTab({
         const activeListed = knownListed.filter(
           (task) => !isTerminalStatus(task.status)
         );
+        const dueListed = scheduler.dueTaskIds(
+          activeListed.map((task) => task.taskId)
+        );
         const listDue =
-          activeListed.length === 0 ||
-          scheduler.dueTaskIds(activeListed.map((task) => task.taskId))
-            .length === activeListed.length;
+          activeListed.length === 0 || dueListed.length === activeListed.length;
 
         if (listDue) {
-          serverResult = await listTasks(serverName);
-          serverTaskIds = new Set(serverResult.tasks.map((t) => t.taskId));
+          try {
+            serverResult = await listTasks(serverName);
+            serverTaskIds = new Set(serverResult.tasks.map((t) => t.taskId));
+          } finally {
+            // Claims taken by the due check above. The fold-back below releases
+            // what it covers; this releases the rest (terminal members, and any
+            // id the list no longer returns) so a claim cannot outlive its tick.
+            scheduler.release(dueListed);
+          }
         } else {
-          // Not due: keep the last snapshot on screen rather than blanking the
-          // list, and do not re-issue the call.
+          // Not due as a batch: keep the last snapshot on screen rather than
+          // blanking the list, and do not re-issue the call.
           listedCarriedForward = knownListed;
           serverTaskIds = new Set(knownListed.map((task) => task.taskId));
+
+          // ...but the batch's floor must not STARVE its fastest member. A
+          // listed id is excluded from the per-handle path below (it is in
+          // `serverTaskIds`), so with a 1s task and a 60s task sharing the
+          // list, waiting for the batch would leave the 1s task unread for a
+          // minute — long enough to finish, and on a short TTL to be forgotten,
+          // before anything observed it. Each individually-due member gets its
+          // own `tasks/get` instead: discovery keeps the slowest member's
+          // floor, status does not.
+          const refreshed = await Promise.all(
+            dueListed.map(async (taskId) => {
+              try {
+                const envelope = await getTask(serverName, taskId);
+                return normalizeTask(envelope.wire, envelope.task);
+              } catch (err) {
+                if (err instanceof TaskUnknownOrExpiredError) {
+                  onUnknownTask(taskId);
+                }
+                // Anything else is transient; the handle backs off below.
+                return null;
+              }
+            })
+          );
+          const byRefreshedId = new Map(
+            refreshed
+              .filter((task): task is NormalizedTask => task !== null)
+              .map((task) => [task.taskId, task])
+          );
+          scheduler.recordObservations(
+            [...byRefreshedId.values()].map((task) => ({
+              taskId: task.taskId,
+              status: task.status,
+              pollIntervalMs: task.pollInterval,
+              ttlMs: task.ttl ?? null,
+              lastUpdatedAt: task.lastUpdatedAt,
+            }))
+          );
+          // Reads that produced nothing back off; both calls release the claim.
+          scheduler.recordErrors(
+            dueListed.filter((taskId) => !byRefreshedId.has(taskId))
+          );
+          listedCarriedForward = knownListed.map(
+            (task) => byRefreshedId.get(task.taskId) ?? task
+          );
         }
       }
 
@@ -438,19 +508,6 @@ export function TasksTab({
       const byId = new Map(livePending.map((t) => [t.taskId, t]));
       const pendingIds = livePending.map((t) => t.taskId);
 
-      const onUnknownTask = (taskId: string) => {
-        // Stop scheduling it too. Without this the engine's map grows for the
-        // life of the session, and a record that stays due-but-never-polled
-        // pins `msUntilNextDue()` at zero, collapsing every re-arm to the
-        // floor.
-        scheduler.forget([taskId]);
-        // Unknown/expired is not an error: flag it and keep the handle so the
-        // user sees what happened instead of a silent removal. Any other
-        // failure (transient connect, structureless 404 from an older hosted
-        // replica) keeps the handle untouched and retries on the next tick.
-        markTaskExpired(taskId, serverName);
-      };
-
       let trackedTaskStatuses: (NormalizedTask | null)[];
       if (hosted && pendingIds.length > 0) {
         // One ephemeral connection per server per tick instead of one per task.
@@ -466,7 +523,7 @@ export function TasksTab({
               } catch {
                 return [];
               }
-            }),
+            })
           )
         ).flat();
         trackedTaskStatuses = entries.map((entry) => {
@@ -494,7 +551,7 @@ export function TasksTab({
               // wire there is no `tasks/list` to recover them from.
               return null;
             }
-          }),
+          })
         );
       }
       // Feed the scheduler what we actually observed, so each handle is
@@ -623,7 +680,7 @@ export function TasksTab({
   const handleElicitationResponse = useCallback(
     async (
       action: "accept" | "decline" | "cancel",
-      parameters?: Record<string, unknown>,
+      parameters?: Record<string, unknown>
     ) => {
       try {
         await respondToElicitation(action, parameters);
@@ -633,11 +690,11 @@ export function TasksTab({
         setError(
           err instanceof Error
             ? err.message
-            : "Failed to respond to elicitation",
+            : "Failed to respond to elicitation"
         );
       }
     },
-    [respondToElicitation, fetchTasks],
+    [respondToElicitation, fetchTasks]
   );
 
   const fetchTaskResult = useCallback(
@@ -652,13 +709,13 @@ export function TasksTab({
         setTaskResult(result);
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "Failed to fetch task result",
+          err instanceof Error ? err.message : "Failed to fetch task result"
         );
       } finally {
         setLoading(false);
       }
     },
-    [serverName],
+    [serverName]
   );
 
   const handleCancelTask = useCallback(async () => {
@@ -673,9 +730,7 @@ export function TasksTab({
         // Cooperative cancel: the ack is empty, so record the request and
         // stop polling by default rather than waiting for a `cancelled` that
         // may never arrive.
-        setCancellationRequested((prev) =>
-          new Set(prev).add(selectedTaskId),
-        );
+        setCancellationRequested((prev) => new Set(prev).add(selectedTaskId));
         setAutoRefresh(false);
         userDisabledAutoRefresh.current = true;
       }
@@ -701,20 +756,20 @@ export function TasksTab({
         return true;
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "Failed to submit task input",
+          err instanceof Error ? err.message : "Failed to submit task input"
         );
         return false;
       } finally {
         setSubmittingInput(false);
       }
     },
-    [serverName, selectedTaskId, fetchTasks],
+    [serverName, selectedTaskId, fetchTasks]
   );
 
   const handleExtensionInputResponse = useCallback(
     async (
       action: "accept" | "decline" | "cancel",
-      parameters?: Record<string, unknown>,
+      parameters?: Record<string, unknown>
     ) => {
       if (!extensionInputRequest) return;
       // Partial responses are allowed: answer the key the user just handled.
@@ -1185,7 +1240,9 @@ export function TasksTab({
                 <TaskStatusIcon status={selectedTask.status} />
                 <Badge
                   variant="outline"
-                  className={`text-xs ${statusConfigFor(selectedTask.status).bgColor} ${statusConfigFor(selectedTask.status).color} border-0`}
+                  className={`text-xs ${
+                    statusConfigFor(selectedTask.status).bgColor
+                  } ${statusConfigFor(selectedTask.status).color} border-0`}
                 >
                   {selectedTask.status}
                 </Badge>
@@ -1435,7 +1492,9 @@ export function TasksTab({
       {/* Per MCP Tasks spec (2025-11-25): when a task needs input, server sends */}
       {/* elicitation requests with relatedTaskId in the metadata */}
       <ElicitationDialog
-        elicitationRequest={extensionDialogElicitation ?? legacyDialogElicitation}
+        elicitationRequest={
+          extensionDialogElicitation ?? legacyDialogElicitation
+        }
         onResponse={
           extensionDialogElicitation
             ? handleExtensionInputResponse

--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -47,11 +47,7 @@ import {
 } from "@/lib/task-tracker";
 import { Switch } from "@mcpjam/design-system/switch";
 import { Input } from "@mcpjam/design-system/input";
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from "@mcpjam/design-system/tooltip";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@mcpjam/design-system/tooltip";
 import { Progress } from "@mcpjam/design-system/progress";
 import { TaskInlineProgress } from "./tasks/TaskInlineProgress";
 import {
@@ -89,9 +85,7 @@ function TaskStatusIcon({ status }: { status: TaskDisplayStatus }) {
   const Icon = config.icon;
   return (
     <Icon
-      className={`h-4 w-4 ${config.color} ${
-        config.animate ? "animate-spin" : ""
-      }`}
+      className={`h-4 w-4 ${config.color} ${config.animate ? "animate-spin" : ""}`}
     />
   );
 }
@@ -296,7 +290,8 @@ export function TasksTab({
   const unanswerableInputCount = useMemo(() => {
     if (!isExtensionWire || selectedTask?.status !== "input_required") return 0;
     return Object.values(selectedTask.inputRequests ?? {}).filter(
-      (value) => (value as { method?: string })?.method !== "elicitation/create"
+      (value) =>
+        (value as { method?: string })?.method !== "elicitation/create",
     ).length;
   }, [isExtensionWire, selectedTask]);
 
@@ -327,7 +322,7 @@ export function TasksTab({
         localStorage.setItem(POLL_INTERVAL_STORAGE_KEY, String(parsed));
       }
     },
-    [serverSuggestedPollInterval]
+    [serverSuggestedPollInterval],
   );
 
   // Clear override when server suggestion goes away (tasks complete)
@@ -455,7 +450,7 @@ export function TasksTab({
               } catch {
                 return [];
               }
-            })
+            }),
           )
         ).flat();
         trackedTaskStatuses = entries.map((entry) => {
@@ -483,7 +478,7 @@ export function TasksTab({
               // wire there is no `tasks/list` to recover them from.
               return null;
             }
-          })
+          }),
         );
       }
       // Feed the scheduler what we actually observed, so each handle is
@@ -593,7 +588,7 @@ export function TasksTab({
   const handleElicitationResponse = useCallback(
     async (
       action: "accept" | "decline" | "cancel",
-      parameters?: Record<string, unknown>
+      parameters?: Record<string, unknown>,
     ) => {
       try {
         await respondToElicitation(action, parameters);
@@ -603,11 +598,11 @@ export function TasksTab({
         setError(
           err instanceof Error
             ? err.message
-            : "Failed to respond to elicitation"
+            : "Failed to respond to elicitation",
         );
       }
     },
-    [respondToElicitation, fetchTasks]
+    [respondToElicitation, fetchTasks],
   );
 
   const fetchTaskResult = useCallback(
@@ -622,13 +617,13 @@ export function TasksTab({
         setTaskResult(result);
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "Failed to fetch task result"
+          err instanceof Error ? err.message : "Failed to fetch task result",
         );
       } finally {
         setLoading(false);
       }
     },
-    [serverName]
+    [serverName],
   );
 
   const handleCancelTask = useCallback(async () => {
@@ -643,7 +638,9 @@ export function TasksTab({
         // Cooperative cancel: the ack is empty, so record the request and
         // stop polling by default rather than waiting for a `cancelled` that
         // may never arrive.
-        setCancellationRequested((prev) => new Set(prev).add(selectedTaskId));
+        setCancellationRequested((prev) =>
+          new Set(prev).add(selectedTaskId),
+        );
         setAutoRefresh(false);
         userDisabledAutoRefresh.current = true;
       }
@@ -669,20 +666,20 @@ export function TasksTab({
         return true;
       } catch (err) {
         setError(
-          err instanceof Error ? err.message : "Failed to submit task input"
+          err instanceof Error ? err.message : "Failed to submit task input",
         );
         return false;
       } finally {
         setSubmittingInput(false);
       }
     },
-    [serverName, selectedTaskId, fetchTasks]
+    [serverName, selectedTaskId, fetchTasks],
   );
 
   const handleExtensionInputResponse = useCallback(
     async (
       action: "accept" | "decline" | "cancel",
-      parameters?: Record<string, unknown>
+      parameters?: Record<string, unknown>,
     ) => {
       if (!extensionInputRequest) return;
       // Partial responses are allowed: answer the key the user just handled.
@@ -1153,9 +1150,7 @@ export function TasksTab({
                 <TaskStatusIcon status={selectedTask.status} />
                 <Badge
                   variant="outline"
-                  className={`text-xs ${
-                    statusConfigFor(selectedTask.status).bgColor
-                  } ${statusConfigFor(selectedTask.status).color} border-0`}
+                  className={`text-xs ${statusConfigFor(selectedTask.status).bgColor} ${statusConfigFor(selectedTask.status).color} border-0`}
                 >
                   {selectedTask.status}
                 </Badge>
@@ -1405,9 +1400,7 @@ export function TasksTab({
       {/* Per MCP Tasks spec (2025-11-25): when a task needs input, server sends */}
       {/* elicitation requests with relatedTaskId in the metadata */}
       <ElicitationDialog
-        elicitationRequest={
-          extensionDialogElicitation ?? legacyDialogElicitation
-        }
+        elicitationRequest={extensionDialogElicitation ?? legacyDialogElicitation}
         onResponse={
           extensionDialogElicitation
             ? handleExtensionInputResponse

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.hosted.test.tsx
@@ -45,6 +45,15 @@ vi.mock("@/lib/task-tracker", () => ({
   recordTaskObservation: vi.fn(),
   recordTaskObservations: vi.fn(),
   getTrackedTaskSchedule: vi.fn().mockReturnValue(undefined),
+  // Batched restore: one store read per tick for every handle the scheduler
+  // has not seen yet, instead of two per handle.
+  getTrackedTaskRestoreStates: vi.fn().mockReturnValue(new Map()),
+  taskIdentity: (t: {
+    serverId: string;
+    wire: string;
+    taskId: string;
+    scope?: string;
+  }) => `${t.scope ?? ""}\u0000${t.serverId}\u0000${t.wire}\u0000${t.taskId}`,
   recordRespondedInputKeys: vi.fn(),
   getRespondedInputKeys: vi.fn().mockReturnValue([]),
 }));

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.hosted.test.tsx
@@ -39,6 +39,11 @@ vi.mock("@/lib/task-tracker", () => ({
   clearTrackedTasksForServer: vi.fn(),
   getDismissedTaskIds: vi.fn().mockReturnValue(new Set()),
   dismissTasksForServer: vi.fn(),
+  // v3 durable scheduling state, written by `useTaskScheduler` after every
+  // observation so a reload resumes where the poller left off.
+  recordTaskObservation: vi.fn(),
+  recordRespondedInputKeys: vi.fn(),
+  getRespondedInputKeys: vi.fn().mockReturnValue([]),
 }));
 
 vi.mock("@/hooks/use-task-elicitation", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.hosted.test.tsx
@@ -39,9 +39,12 @@ vi.mock("@/lib/task-tracker", () => ({
   clearTrackedTasksForServer: vi.fn(),
   getDismissedTaskIds: vi.fn().mockReturnValue(new Set()),
   dismissTasksForServer: vi.fn(),
-  // v3 durable scheduling state, written by `useTaskScheduler` after every
-  // observation so a reload resumes where the poller left off.
+  // v3 durable scheduling state. `useTaskScheduler` reads the persisted
+  // schedule when it first sees a handle (so a reload resumes rather than
+  // re-polling immediately) and writes the whole tick back in one batch.
   recordTaskObservation: vi.fn(),
+  recordTaskObservations: vi.fn(),
+  getTrackedTaskSchedule: vi.fn().mockReturnValue(undefined),
   recordRespondedInputKeys: vi.fn(),
   getRespondedInputKeys: vi.fn().mockReturnValue([]),
 }));

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.restored-recovery.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.restored-recovery.test.tsx
@@ -1,0 +1,290 @@
+/**
+ * Restored terminal handles and their ONE recovery read.
+ *
+ * On the extension wire a task's result rides INLINE on `tasks/get` — there is
+ * no `tasks/result` to fetch it from later — while durable storage keeps only
+ * the handle's status. So a handle restored as `completed` is a status with
+ * nothing behind it, and the engine keeps owing it one read.
+ *
+ * The failure these tests pin is that the read is owed but nothing is left
+ * running to perform it: the tab decides whether to keep its poll loop armed
+ * from the DISPLAYED rows, and the row says `completed`. Two ways in, and the
+ * second needs no failure at all — a stored `nextPollAt` in the future is
+ * simply not due on the first tick.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { MCPServerConfig } from "@mcpjam/sdk/browser";
+
+const { MockTaskUnknownOrExpiredError } = vi.hoisted(() => ({
+  MockTaskUnknownOrExpiredError: class extends Error {
+    readonly code = "task-unknown-or-expired";
+  },
+}));
+
+const mockGetTask = vi.fn();
+const mockListTasks = vi.fn();
+const mockGetTaskCapabilities = vi.fn();
+const mockGetLatestProgress = vi.fn();
+const mockGetTrackedTasksForServer = vi.fn();
+const mockGetTrackedTaskRestoreStates = vi.fn();
+
+vi.mock("@/lib/apis/mcp-tasks-api", () => ({
+  listTasks: (...args: unknown[]) => mockListTasks(...args),
+  getTask: (...args: unknown[]) => mockGetTask(...args),
+  getTasksBatch: vi.fn(),
+  getTaskResult: vi.fn(),
+  cancelTask: vi.fn(),
+  updateTask: vi.fn(),
+  getLatestProgress: (...args: unknown[]) => mockGetLatestProgress(...args),
+  getTaskCapabilities: (...args: unknown[]) => mockGetTaskCapabilities(...args),
+  TaskUnknownOrExpiredError: MockTaskUnknownOrExpiredError,
+}));
+
+vi.mock("@/lib/task-tracker", () => ({
+  getTrackedTasksForServer: (...args: unknown[]) =>
+    mockGetTrackedTasksForServer(...args),
+  getTrackedTaskById: vi.fn().mockReturnValue(null),
+  untrackTask: vi.fn(),
+  markTaskExpired: vi.fn(),
+  clearTrackedTasksForServer: vi.fn(),
+  getDismissedTaskIds: vi.fn().mockReturnValue(new Set()),
+  dismissTasksForServer: vi.fn(),
+  recordTaskObservation: vi.fn(),
+  recordTaskObservations: vi.fn(),
+  getTrackedTaskSchedule: vi.fn().mockReturnValue(undefined),
+  // The durable schedule the scheduler seeds each newly-seen handle from —
+  // this is what makes a restored handle due later rather than immediately.
+  getTrackedTaskRestoreStates: (...args: unknown[]) =>
+    mockGetTrackedTaskRestoreStates(...args),
+  taskIdentity: (t: {
+    serverId: string;
+    wire: string;
+    taskId: string;
+    scope?: string;
+  }) => `${t.scope ?? ""}\u0000${t.serverId}\u0000${t.wire}\u0000${t.taskId}`,
+  recordRespondedInputKeys: vi.fn(),
+  getRespondedInputKeys: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("@/hooks/use-task-elicitation", () => ({
+  useTaskElicitation: () => ({
+    elicitation: null,
+    isResponding: false,
+    respond: vi.fn(),
+  }),
+}));
+
+vi.mock("../ElicitationDialog", () => ({ ElicitationDialog: () => null }));
+
+vi.mock("../ui/three-panel-layout", () => ({
+  ThreePanelLayout: ({
+    sidebar,
+    content,
+  }: {
+    sidebar: React.ReactNode;
+    content: React.ReactNode;
+  }) => (
+    <div>
+      <div data-testid="tasks-sidebar">{sidebar}</div>
+      <div data-testid="tasks-content">{content}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/json-editor", () => ({
+  JsonEditor: (props: any) => (
+    <div data-testid="json-editor">{JSON.stringify(props.value)}</div>
+  ),
+}));
+
+import { TasksTab } from "../TasksTab";
+import { MAX_RECOVERY_READ_ATTEMPTS } from "@/hooks/use-task-scheduler";
+
+const SERVER = "test-server";
+const TASK_ID = "ext-1";
+const CREATED_AT = "2026-07-27T00:00:00.000Z";
+
+const serverConfig = () =>
+  ({
+    transportType: "stdio",
+    command: "node",
+    args: ["server.js"],
+  }) as MCPServerConfig;
+
+/** Matches the mocked `taskIdentity` above, for a scope-less identity. */
+const restoreKey = (taskId: string) =>
+  `\u0000${SERVER}\u0000extension\u0000${taskId}`;
+
+/** The handle as the tracker remembers it after a reload: terminal, no result. */
+const trackedTerminal = () => [
+  {
+    taskId: TASK_ID,
+    serverId: SERVER,
+    wire: "extension",
+    createdAt: CREATED_AT,
+    status: "completed",
+  },
+];
+
+const restoreState = (nextPollAt: number) =>
+  new Map([
+    [
+      restoreKey(TASK_ID),
+      {
+        nextPollAt,
+        lastObservedAt: nextPollAt - 1_000,
+        pollIntervalMs: 1_000,
+        ttlMs: null,
+        status: "completed",
+        respondedInputKeys: [],
+      },
+    ],
+  ]);
+
+const completedWithResult = {
+  taskId: TASK_ID,
+  status: "completed",
+  createdAt: CREATED_AT,
+  lastUpdatedAt: "2026-07-27T00:01:00.000Z",
+  ttlMs: 60_000,
+  pollIntervalMs: 1_000,
+  result: { content: [{ type: "text", text: "inline done" }] },
+};
+
+const autoRefreshOn = () =>
+  screen.getByRole("switch").getAttribute("aria-checked") === "true";
+
+/** Runs the fake clock forward, flushing the promises each tick starts. */
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("TasksTab restored-terminal recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockGetTaskCapabilities.mockResolvedValue({
+      wire: "extension",
+      toolCalls: true,
+      list: false,
+      cancel: true,
+      update: true,
+      inlineResult: true,
+    });
+    mockGetTrackedTasksForServer.mockReturnValue(trackedTerminal());
+    mockGetTrackedTaskRestoreStates.mockReturnValue(new Map());
+    mockGetLatestProgress.mockResolvedValue(null);
+    mockGetTask.mockResolvedValue({
+      wire: "extension",
+      task: completedWithResult,
+    });
+  });
+
+  it("keeps auto-refresh armed for a recovery read that is not due until later", async () => {
+    // No failure anywhere: the stored floor simply has not elapsed. The row
+    // renders terminal on the first tick, so a decision made from the rows
+    // alone stops the loop before the read it is waiting for can happen.
+    mockGetTrackedTaskRestoreStates.mockReturnValue(
+      restoreState(Date.now() + 30_000)
+    );
+
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(TASK_ID)).toBeInTheDocument();
+    });
+    // Not due, so nothing was read — which is exactly the state the old
+    // decision mistook for "finished".
+    expect(mockGetTask).not.toHaveBeenCalled();
+    await waitFor(() => expect(autoRefreshOn()).toBe(true));
+  });
+
+  it("stays armed after a failed recovery read and retries on a later tick", async () => {
+    vi.useFakeTimers();
+    mockGetTrackedTaskRestoreStates.mockReturnValue(
+      restoreState(Date.now() - 1)
+    );
+    mockGetTask.mockRejectedValueOnce(new Error("connect ECONNREFUSED"));
+
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+
+    await advance(0);
+    expect(mockGetTask).toHaveBeenCalledTimes(1);
+    // The read failed and the handle backed off — the loop has to survive the
+    // failure or the backoff it just recorded is never honored.
+    expect(autoRefreshOn()).toBe(true);
+    expect(screen.queryByText("inline done")).not.toBeInTheDocument();
+
+    // The loop the failure did not stop performs the retry on a later tick.
+    for (let i = 0; i < 8 && mockGetTask.mock.calls.length < 2; i += 1) {
+      await advance(1_000);
+    }
+    await advance(1_000);
+    expect(mockGetTask).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByText(TASK_ID));
+    await advance(0);
+    expect(screen.getByText("inline done")).toBeInTheDocument();
+    // ...and with nothing left owed, the loop settles.
+    expect(autoRefreshOn()).toBe(false);
+  });
+
+  it("stops after the attempt bound, says so, and still retries on demand", async () => {
+    vi.useFakeTimers();
+    mockGetTrackedTaskRestoreStates.mockReturnValue(
+      restoreState(Date.now() - 1)
+    );
+    mockGetTask.mockRejectedValue(new Error("connect ECONNREFUSED"));
+
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+    await advance(0);
+
+    // Run well past the bound: the loop must stop itself, not be stopped by
+    // the test running out of ticks.
+    for (let i = 0; i < 40; i += 1) await advance(2_000);
+
+    expect(mockGetTask).toHaveBeenCalledTimes(MAX_RECOVERY_READ_ATTEMPTS);
+    expect(autoRefreshOn()).toBe(false);
+    expect(
+      screen.getByText(/Stopped retrying automatically/)
+    ).toBeInTheDocument();
+
+    // Going idle is only acceptable because the user can still get it back.
+    mockGetTask.mockResolvedValue({
+      wire: "extension",
+      task: completedWithResult,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTitle("Refresh tasks"));
+    });
+    await advance(0);
+
+    expect(mockGetTask).toHaveBeenCalledTimes(MAX_RECOVERY_READ_ATTEMPTS + 1);
+    fireEvent.click(screen.getByText(TASK_ID));
+    await advance(0);
+    expect(screen.getByText("inline done")).toBeInTheDocument();
+  });
+
+  it("does not keep auto-refresh on once the result has been recovered", async () => {
+    mockGetTrackedTaskRestoreStates.mockReturnValue(
+      restoreState(Date.now() - 1)
+    );
+
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+
+    await waitFor(() => expect(mockGetTask).toHaveBeenCalledTimes(1));
+    fireEvent.click(await screen.findByText(TASK_ID));
+    await screen.findByText("inline done");
+
+    // The read is spent: a genuinely finished handle owes nothing, so it must
+    // not hold the timer open.
+    await waitFor(() => expect(autoRefreshOn()).toBe(false));
+    expect(
+      screen.queryByText(/Could not read back/)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.test.tsx
@@ -45,6 +45,15 @@ vi.mock("@/lib/task-tracker", () => ({
   recordTaskObservation: vi.fn(),
   recordTaskObservations: vi.fn(),
   getTrackedTaskSchedule: vi.fn().mockReturnValue(undefined),
+  // Batched restore: one store read per tick for every handle the scheduler
+  // has not seen yet, instead of two per handle.
+  getTrackedTaskRestoreStates: vi.fn().mockReturnValue(new Map()),
+  taskIdentity: (t: {
+    serverId: string;
+    wire: string;
+    taskId: string;
+    scope?: string;
+  }) => `${t.scope ?? ""}\u0000${t.serverId}\u0000${t.wire}\u0000${t.taskId}`,
   recordRespondedInputKeys: vi.fn(),
   getRespondedInputKeys: vi.fn().mockReturnValue([]),
 }));

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.test.tsx
@@ -39,6 +39,11 @@ vi.mock("@/lib/task-tracker", () => ({
   clearTrackedTasksForServer: vi.fn(),
   getDismissedTaskIds: vi.fn().mockReturnValue(new Set()),
   dismissTasksForServer: vi.fn(),
+  // v3 durable scheduling state, written by `useTaskScheduler` after every
+  // observation so a reload resumes where the poller left off.
+  recordTaskObservation: vi.fn(),
+  recordRespondedInputKeys: vi.fn(),
+  getRespondedInputKeys: vi.fn().mockReturnValue([]),
 }));
 
 vi.mock("@/hooks/use-task-elicitation", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.test.tsx
@@ -39,9 +39,12 @@ vi.mock("@/lib/task-tracker", () => ({
   clearTrackedTasksForServer: vi.fn(),
   getDismissedTaskIds: vi.fn().mockReturnValue(new Set()),
   dismissTasksForServer: vi.fn(),
-  // v3 durable scheduling state, written by `useTaskScheduler` after every
-  // observation so a reload resumes where the poller left off.
+  // v3 durable scheduling state. `useTaskScheduler` reads the persisted
+  // schedule when it first sees a handle (so a reload resumes rather than
+  // re-polling immediately) and writes the whole tick back in one batch.
   recordTaskObservation: vi.fn(),
+  recordTaskObservations: vi.fn(),
+  getTrackedTaskSchedule: vi.fn().mockReturnValue(undefined),
   recordRespondedInputKeys: vi.fn(),
   getRespondedInputKeys: vi.fn().mockReturnValue([]),
 }));

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
@@ -10,7 +10,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useTaskScheduler } from "../use-task-scheduler";
-import { getTrackedTasks, setTrackedTaskScope, trackTask } from "@/lib/task-tracker";
+import {
+  getTrackedTasks,
+  recordTaskObservation,
+  setTrackedTaskScope,
+  trackTask,
+} from "@/lib/task-tracker";
 
 const NOW = new Date().toISOString();
 
@@ -97,7 +102,10 @@ describe("useTaskScheduler", () => {
     act(() => {
       result.current.recordObservations([{ taskId: "t1", status: "working" }]);
     });
-    expect(result.current.msUntilNextDue()).toBeGreaterThan(100);
+    // Asserted against the SURFACE floor specifically: a weaker
+    // `toBeGreaterThan(100)` would pass on the engine's 250ms absolute floor
+    // alone and prove nothing about the 5s hosted floor.
+    expect(result.current.msUntilNextDue()).toBeGreaterThanOrEqual(5_000);
   });
 
   it("stops scheduling a terminal task", () => {
@@ -124,14 +132,29 @@ describe("useTaskScheduler", () => {
   });
 
   it("backs off a failed read without changing the task's status", () => {
-    const { result } = scheduler(100);
-    result.current.dueTaskIds(["t1"]);
-    act(() => {
-      result.current.recordErrors(["t1"]);
-      result.current.recordErrors(["t1"]);
-    });
-    // Two consecutive errors ⇒ the backoff exceeds the user's 100ms preference.
-    expect(result.current.msUntilNextDue()).toBeGreaterThan(100);
+    vi.useFakeTimers();
+    try {
+      const { result } = scheduler(100);
+      result.current.dueTaskIds(["t1"]);
+      act(() => {
+        result.current.recordObservations([
+          { taskId: "t1", status: "working" },
+        ]);
+        result.current.recordErrors(["t1"]);
+        result.current.recordErrors(["t1"]);
+      });
+
+      // Two consecutive errors ⇒ the backoff exceeds the user's 100ms floor.
+      expect(result.current.msUntilNextDue()).toBeGreaterThanOrEqual(2_000);
+
+      // ...and the handle is still SCHEDULED once the backoff expires. A
+      // transport failure says nothing about the task, so it must not have
+      // been marked terminal.
+      vi.advanceTimersByTime(10_000);
+      expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("mirrors scheduling state into the tracker so a reload resumes", () => {
@@ -194,5 +217,76 @@ describe("useTaskScheduler", () => {
 
     // Same task id, different server: a separate handle, still due.
     expect(second.result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+  });
+
+  // ---- Resume after a reload ------------------------------------------------
+
+  it("does NOT treat a restored handle as due when its stored floor has not elapsed", () => {
+    trackTask({
+      taskId: "t1",
+      serverId: "s1",
+      wire: "extension",
+      createdAt: NOW,
+    });
+    recordTaskObservation(
+      { taskId: "t1", serverId: "s1", wire: "extension" },
+      {
+        status: "working",
+        pollIntervalMs: 60_000,
+        nextPollAt: Date.now() + 60_000,
+        lastObservedAt: Date.now(),
+      },
+    );
+
+    // A FRESH hook — the engine is empty, exactly as after a page reload.
+    const { result } = scheduler();
+    expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+  });
+
+  it("treats a restored handle as due once its stored floor has passed", () => {
+    trackTask({
+      taskId: "t1",
+      serverId: "s1",
+      wire: "extension",
+      createdAt: NOW,
+    });
+    recordTaskObservation(
+      { taskId: "t1", serverId: "s1", wire: "extension" },
+      { status: "working", nextPollAt: Date.now() - 1_000 },
+    );
+
+    const { result } = scheduler();
+    expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+  });
+
+  it("treats a handle with no persisted schedule as due — nothing to resume", () => {
+    trackTask({
+      taskId: "fresh",
+      serverId: "s1",
+      wire: "extension",
+      createdAt: NOW,
+    });
+    const { result } = scheduler();
+    expect(result.current.dueTaskIds(["fresh"])).toEqual(["fresh"]);
+  });
+
+  it("persists responded input keys and restores them across a reload", () => {
+    trackTask({
+      taskId: "t1",
+      serverId: "s1",
+      wire: "extension",
+      createdAt: NOW,
+    });
+    const first = scheduler();
+    act(() => {
+      first.result.current.markInputResponded("t1", ["ask-city"]);
+    });
+
+    // A fresh hook must not re-prompt for a key the server already
+    // acknowledged.
+    const second = scheduler();
+    expect(second.result.current.respondedInputKeys("t1")).toEqual([
+      "ask-city",
+    ]);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
@@ -149,15 +149,26 @@ describe("useTaskScheduler", () => {
   });
 
   it("applies a surface floor even when the server advertises none", () => {
-    const { result } = scheduler(100, 5_000);
-    result.current.dueTaskIds(["t1"]);
-    act(() => {
-      result.current.recordObservations([{ taskId: "t1", status: "working" }]);
-    });
-    // Asserted against the SURFACE floor specifically: a weaker
-    // `toBeGreaterThan(100)` would pass on the engine's 250ms absolute floor
-    // alone and prove nothing about the 5s hosted floor.
-    expect(result.current.msUntilNextDue()).toBeGreaterThanOrEqual(5_000);
+    // Fake timers because this assertion has ZERO slack: `msUntilNextDue()` is
+    // `nextPollAt - now`, the floor puts `nextPollAt` at exactly `now + 5000`,
+    // and a single millisecond of real wall-clock between the two lines makes
+    // it 4999. It flaked in CI for exactly that reason.
+    vi.useFakeTimers();
+    try {
+      const { result } = scheduler(100, 5_000);
+      result.current.dueTaskIds(["t1"]);
+      act(() => {
+        result.current.recordObservations([
+          { taskId: "t1", status: "working" },
+        ]);
+      });
+      // Asserted against the SURFACE floor specifically: a weaker
+      // `toBeGreaterThan(100)` would pass on the engine's 250ms absolute floor
+      // alone and prove nothing about the 5s hosted floor.
+      expect(result.current.msUntilNextDue()).toBe(5_000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("stops scheduling a terminal task", () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
@@ -289,4 +289,81 @@ describe("useTaskScheduler", () => {
       "ask-city",
     ]);
   });
+
+  it("keeps a restored TERMINAL handle unscheduled instead of re-polling it", () => {
+    trackTask({
+      taskId: "t1",
+      serverId: "s1",
+      wire: "extension",
+      createdAt: NOW,
+    });
+    recordTaskObservation(
+      { taskId: "t1", serverId: "s1", wire: "extension" },
+      { status: "completed" },
+    );
+
+    // Restoring it as `unknown` would read as non-terminal and get it polled
+    // again — re-reading a task whose result we already have.
+    const { result } = scheduler();
+    expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+  });
+
+  it("persists the backoff, so a reload cannot walk through it", () => {
+    trackTask({
+      taskId: "t1",
+      serverId: "s1",
+      wire: "extension",
+      createdAt: NOW,
+    });
+    const first = scheduler(100);
+    first.result.current.dueTaskIds(["t1"]);
+    act(() => {
+      first.result.current.recordObservations([
+        { taskId: "t1", status: "working" },
+      ]);
+      first.result.current.recordErrors(["t1"]);
+      first.result.current.recordErrors(["t1"]);
+      first.result.current.recordErrors(["t1"]);
+    });
+
+    // A fresh hook — as after a reload during the backoff. Persisting only
+    // successful observations left the tracker holding the elapsed
+    // `nextPollAt` from the last good read, so the handle came back due at
+    // once and repeated reloads bypassed the backoff entirely.
+    const second = scheduler(100);
+    expect(second.result.current.dueTaskIds(["t1"])).toEqual([]);
+  });
+
+  it("drops records for the previous server when the selection changes", () => {
+    vi.useFakeTimers();
+    try {
+      const { result, rerender } = renderHook(
+        ({ serverId }: { serverId: string }) =>
+          useTaskScheduler({
+            serverId,
+            wire: "extension",
+            userMinimumIntervalMs: 1_000,
+          }),
+        { initialProps: { serverId: "s1" } },
+      );
+
+      result.current.dueTaskIds(["t1"]);
+      act(() => {
+        result.current.recordObservations([
+          { taskId: "t1", status: "working", pollIntervalMs: 1_000 },
+        ]);
+      });
+
+      rerender({ serverId: "s2" });
+      vi.advanceTimersByTime(5_000);
+
+      // The old server's record would otherwise still answer `due()` — nothing
+      // on the new connection ever observes or forgets it, so
+      // `msUntilNextDue()` would sit at zero for the rest of the session and
+      // every re-arm would collapse to the floor.
+      expect(result.current.msUntilNextDue()).toBeGreaterThanOrEqual(1_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
@@ -71,6 +71,12 @@ describe("useTaskScheduler", () => {
       // shared-`Math.min` scheduler polled both here.
       vi.advanceTimersByTime(2_000);
       expect(result.current.dueTaskIds(["fast", "slow"])).toEqual(["fast"]);
+      // `dueTaskIds` CLAIMS what it hands back, so a caller that never folds
+      // the read back has to say so — otherwise the handle stays claimed and
+      // the next tick correctly refuses to re-issue it.
+      act(() => {
+        result.current.release(["fast"]);
+      });
 
       // The slow task comes due only at its own floor.
       vi.advanceTimersByTime(58_000);
@@ -78,6 +84,52 @@ describe("useTaskScheduler", () => {
         "fast",
         "slow",
       ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("claims what it hands back, so overlapping refreshes cannot duplicate a read", () => {
+    const { result } = scheduler();
+    // The tab's auto-refresh can interleave with one triggered by an input
+    // submission, a cancellation, or a rapid manual click. Without a claim both
+    // select the same due handle and issue duplicate `tasks/get` calls inside
+    // one advertised floor — where an out-of-order reply overwrites newer state
+    // with older.
+    expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+    expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+
+    // Folding the read back releases it — the handle is then withheld by its
+    // FLOOR rather than by a claim, so it returns once the floor elapses.
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        result.current.recordObservations([
+          { taskId: "t1", status: "working" },
+        ]);
+      });
+      expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+      vi.advanceTimersByTime(1_000);
+      expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+
+      // A failed read releases it too, so the backoff is eventually retried
+      // rather than stranded behind a claim nobody holds any more.
+      act(() => {
+        result.current.recordErrors(["t1"]);
+      });
+      vi.advanceTimersByTime(60_000);
+      expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+
+      // And a read that reached neither is released explicitly. Claiming
+      // reserves as well, so the handle is still withheld by its floor
+      // afterwards — which is what stops an abandoned read from becoming a hot
+      // retry loop — but it is no longer withheld forever.
+      act(() => {
+        result.current.release(["t1"]);
+      });
+      expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+      vi.advanceTimersByTime(1_000);
+      expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
     } finally {
       vi.useRealTimers();
     }

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
@@ -1,0 +1,198 @@
+/**
+ * `useTaskScheduler` — the Tasks tab's per-task poll scheduling.
+ *
+ * The regression these lock down: the tab used to poll every active task at
+ * `Math.min(...)` of their advertised intervals, with a user override that
+ * *replaced* the server's floor via a `??` chain. Both let MCPJam poll a
+ * server far faster than it asked to be polled.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTaskScheduler } from "../use-task-scheduler";
+import { getTrackedTasks, setTrackedTaskScope, trackTask } from "@/lib/task-tracker";
+
+const NOW = new Date().toISOString();
+
+function scheduler(userMinimumIntervalMs = 1_000, surfaceFloorMs = 0) {
+  return renderHook(() =>
+    useTaskScheduler({
+      serverId: "s1",
+      wire: "extension",
+      userMinimumIntervalMs,
+      surfaceFloorMs,
+    }),
+  );
+}
+
+describe("useTaskScheduler", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setTrackedTaskScope(undefined);
+  });
+
+  it("treats a never-observed handle as due immediately", () => {
+    const { result } = scheduler();
+    expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+  });
+
+  it("does not re-poll a handle before its own floor elapses", () => {
+    const { result } = scheduler();
+    result.current.dueTaskIds(["t1"]);
+    act(() => {
+      result.current.recordObservations([
+        { taskId: "t1", status: "working", pollIntervalMs: 60_000 },
+      ]);
+    });
+    expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+  });
+
+  it("does not drag a slow task down to a fast task's floor", () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = scheduler();
+      result.current.dueTaskIds(["fast", "slow"]);
+      act(() => {
+        result.current.recordObservations([
+          { taskId: "fast", status: "working", pollIntervalMs: 2_000 },
+          { taskId: "slow", status: "working", pollIntervalMs: 60_000 },
+        ]);
+      });
+
+      // Immediately after a read, neither is due.
+      expect(result.current.dueTaskIds(["fast", "slow"])).toEqual([]);
+
+      // Past the fast task's floor, only the fast task may be read. The old
+      // shared-`Math.min` scheduler polled both here.
+      vi.advanceTimersByTime(2_000);
+      expect(result.current.dueTaskIds(["fast", "slow"])).toEqual(["fast"]);
+
+      // The slow task comes due only at its own floor.
+      vi.advanceTimersByTime(58_000);
+      expect(result.current.dueTaskIds(["fast", "slow"]).sort()).toEqual([
+        "fast",
+        "slow",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never lets the user's preference undercut the server floor", () => {
+    // The user asked for 500ms; the server asked for 60s. The server wins.
+    const { result } = scheduler(500);
+    result.current.dueTaskIds(["t1"]);
+    act(() => {
+      result.current.recordObservations([
+        { taskId: "t1", status: "working", pollIntervalMs: 60_000 },
+      ]);
+    });
+    expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+    expect(result.current.msUntilNextDue()).toBeGreaterThan(500);
+  });
+
+  it("applies a surface floor even when the server advertises none", () => {
+    const { result } = scheduler(100, 5_000);
+    result.current.dueTaskIds(["t1"]);
+    act(() => {
+      result.current.recordObservations([{ taskId: "t1", status: "working" }]);
+    });
+    expect(result.current.msUntilNextDue()).toBeGreaterThan(100);
+  });
+
+  it("stops scheduling a terminal task", () => {
+    const { result } = scheduler();
+    result.current.dueTaskIds(["t1"]);
+    act(() => {
+      result.current.recordObservations([
+        { taskId: "t1", status: "completed" },
+      ]);
+    });
+    expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+  });
+
+  it("gives a batch the SLOWEST member's floor", () => {
+    const { result } = scheduler();
+    result.current.dueTaskIds(["a", "b"]);
+    act(() => {
+      result.current.recordObservations([
+        { taskId: "a", status: "working", pollIntervalMs: 1_000 },
+        { taskId: "b", status: "working", pollIntervalMs: 9_000 },
+      ]);
+    });
+    expect(result.current.batchIntervalMs(["a", "b"])).toBe(9_000);
+  });
+
+  it("backs off a failed read without changing the task's status", () => {
+    const { result } = scheduler(100);
+    result.current.dueTaskIds(["t1"]);
+    act(() => {
+      result.current.recordErrors(["t1"]);
+      result.current.recordErrors(["t1"]);
+    });
+    // Two consecutive errors ⇒ the backoff exceeds the user's 100ms preference.
+    expect(result.current.msUntilNextDue()).toBeGreaterThan(100);
+  });
+
+  it("mirrors scheduling state into the tracker so a reload resumes", () => {
+    trackTask({
+      taskId: "t1",
+      serverId: "s1",
+      wire: "extension",
+      createdAt: NOW,
+    });
+    const { result } = scheduler();
+    result.current.dueTaskIds(["t1"]);
+    act(() => {
+      result.current.recordObservations([
+        {
+          taskId: "t1",
+          status: "working",
+          pollIntervalMs: 5_000,
+          ttlMs: 60_000,
+          lastUpdatedAt: "2026-07-28T00:05:00Z",
+        },
+      ]);
+    });
+
+    expect(getTrackedTasks()[0]).toMatchObject({
+      status: "working",
+      pollIntervalMs: 5_000,
+      ttlMs: 60_000,
+      lastUpdatedAt: "2026-07-28T00:05:00Z",
+    });
+    expect(getTrackedTasks()[0].nextPollAt).toBeGreaterThan(0);
+  });
+
+  it("schedules nothing when the connection has no tasks wire", () => {
+    const { result } = renderHook(() =>
+      useTaskScheduler({
+        serverId: "s1",
+        wire: "none",
+        userMinimumIntervalMs: 1_000,
+      }),
+    );
+    expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+  });
+
+  it("keeps handles apart per server", () => {
+    const first = scheduler();
+    const second = renderHook(() =>
+      useTaskScheduler({
+        serverId: "s2",
+        wire: "extension",
+        userMinimumIntervalMs: 1_000,
+      }),
+    );
+
+    first.result.current.dueTaskIds(["t1"]);
+    act(() => {
+      first.result.current.recordObservations([
+        { taskId: "t1", status: "working", pollIntervalMs: 60_000 },
+      ]);
+    });
+
+    // Same task id, different server: a separate handle, still due.
+    expect(second.result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-task-scheduler.test.ts
@@ -26,7 +26,7 @@ function scheduler(userMinimumIntervalMs = 1_000, surfaceFloorMs = 0) {
       wire: "extension",
       userMinimumIntervalMs,
       surfaceFloorMs,
-    }),
+    })
   );
 }
 
@@ -193,7 +193,7 @@ describe("useTaskScheduler", () => {
         serverId: "s1",
         wire: "none",
         userMinimumIntervalMs: 1_000,
-      }),
+      })
     );
     expect(result.current.dueTaskIds(["t1"])).toEqual([]);
   });
@@ -205,7 +205,7 @@ describe("useTaskScheduler", () => {
         serverId: "s2",
         wire: "extension",
         userMinimumIntervalMs: 1_000,
-      }),
+      })
     );
 
     first.result.current.dueTaskIds(["t1"]);
@@ -235,7 +235,7 @@ describe("useTaskScheduler", () => {
         pollIntervalMs: 60_000,
         nextPollAt: Date.now() + 60_000,
         lastObservedAt: Date.now(),
-      },
+      }
     );
 
     // A FRESH hook — the engine is empty, exactly as after a page reload.
@@ -252,7 +252,7 @@ describe("useTaskScheduler", () => {
     });
     recordTaskObservation(
       { taskId: "t1", serverId: "s1", wire: "extension" },
-      { status: "working", nextPollAt: Date.now() - 1_000 },
+      { status: "working", nextPollAt: Date.now() - 1_000 }
     );
 
     const { result } = scheduler();
@@ -290,7 +290,7 @@ describe("useTaskScheduler", () => {
     ]);
   });
 
-  it("keeps a restored TERMINAL handle unscheduled instead of re-polling it", () => {
+  it("reads a restored TERMINAL extension handle exactly once, then stops", () => {
     trackTask({
       taskId: "t1",
       serverId: "s1",
@@ -299,13 +299,85 @@ describe("useTaskScheduler", () => {
     });
     recordTaskObservation(
       { taskId: "t1", serverId: "s1", wire: "extension" },
-      { status: "completed" },
+      { status: "completed" }
     );
 
-    // Restoring it as `unknown` would read as non-terminal and get it polled
-    // again — re-reading a task whose result we already have.
     const { result } = scheduler();
+
+    // ONE recovery read. The tracker persists a task's status but never its
+    // payload, and on the extension wire the result rides inline on
+    // `tasks/get` — there is no `tasks/result` to fetch it from later. So a
+    // handle restored as `completed` has a status with nothing behind it, and
+    // never polling it would leave the row showing "completed" with no result
+    // and no way to ever get one.
+    expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+
+    // ...and the read settles the debt. From here the ordinary terminal
+    // exclusion applies: the payload is in hand, so re-reading it is pure
+    // waste against a server that already answered.
+    act(() => {
+      result.current.recordObservations([
+        { taskId: "t1", status: "completed" },
+      ]);
+    });
     expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+  });
+
+  it("does not re-read a restored terminal LEGACY handle", () => {
+    trackTask({
+      taskId: "t1",
+      serverId: "s1",
+      wire: "legacy",
+      createdAt: NOW,
+    });
+    recordTaskObservation(
+      { taskId: "t1", serverId: "s1", wire: "legacy" },
+      { status: "completed" }
+    );
+
+    // Legacy does not have the extension's problem: its result comes from a
+    // separate `tasks/result` call the tab makes on demand, so the recovery
+    // read would buy nothing and cost a request.
+    const { result } = renderHook(() =>
+      useTaskScheduler({
+        serverId: "s1",
+        wire: "legacy",
+        userMinimumIntervalMs: 1_000,
+      })
+    );
+    expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+  });
+
+  it("backs a failed terminal-recovery read off instead of retrying every tick", () => {
+    vi.useFakeTimers();
+    try {
+      trackTask({
+        taskId: "t1",
+        serverId: "s1",
+        wire: "extension",
+        createdAt: NOW,
+      });
+      recordTaskObservation(
+        { taskId: "t1", serverId: "s1", wire: "extension" },
+        { status: "completed" }
+      );
+
+      const { result } = scheduler();
+      expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+
+      // The recovery read failed. It still owes a read, but the backoff has to
+      // govern it — otherwise an unreachable server is hammered once per tick
+      // by a handle that will never come back.
+      act(() => {
+        result.current.recordErrors(["t1"]);
+      });
+      expect(result.current.dueTaskIds(["t1"])).toEqual([]);
+
+      vi.advanceTimersByTime(60_000);
+      expect(result.current.dueTaskIds(["t1"])).toEqual(["t1"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("persists the backoff, so a reload cannot walk through it", () => {
@@ -344,7 +416,7 @@ describe("useTaskScheduler", () => {
             wire: "extension",
             userMinimumIntervalMs: 1_000,
           }),
-        { initialProps: { serverId: "s1" } },
+        { initialProps: { serverId: "s1" } }
       );
 
       result.current.dueTaskIds(["t1"]);

--- a/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
+++ b/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
@@ -37,11 +37,17 @@
 import { useCallback, useMemo, useRef } from "react";
 import {
   TaskLifecycleEngine,
+  taskLifecycleKey,
   type TaskLifecycleIdentity,
   type TaskLifecycleObservation,
   type LiveTasksWire,
 } from "@mcpjam/sdk/browser";
-import { recordTaskObservation } from "@/lib/task-tracker";
+import {
+  getRespondedInputKeys,
+  getTrackedTaskSchedule,
+  recordRespondedInputKeys,
+  recordTaskObservations,
+} from "@/lib/task-tracker";
 
 export interface SchedulerTaskState {
   taskId: string;
@@ -80,6 +86,14 @@ export interface TaskScheduler {
   /** Stops scheduling a handle (dismissed, cleared, or confirmed expired). */
   forget(taskIds: readonly string[]): void;
   /**
+   * Marks input keys answered, AFTER their `tasks/update` was acknowledged.
+   * Persists the keys — never the prompt or the response — so a reload does
+   * not re-prompt for something the user already answered.
+   */
+  markInputResponded(taskId: string, keys: readonly string[]): void;
+  /** Input keys already acknowledged for this handle, across reloads. */
+  respondedInputKeys(taskId: string): string[];
+  /**
    * Milliseconds until the next task is due, for arming one timer. Falls back
    * to the user's minimum when nothing is scheduled yet, so the first tick
    * after a page load still happens.
@@ -117,29 +131,58 @@ export function useTaskScheduler({
       if (!serverId || wire === "none") return undefined;
       return { serverId, wire, taskId, ...(scope ? { scope } : {}) };
     },
-    [serverId, wire, scope],
+    [serverId, wire, scope]
   );
 
   return useMemo<TaskScheduler>(
     () => ({
       dueTaskIds(candidateTaskIds) {
-        const due = new Set(
-          engine.due().map((record) => record.identity.taskId),
-        );
+        // Keyed on the COMPOSITE identity, not the bare task id: the engine
+        // may hold the same id under a different server, wire or scope, and
+        // matching on the id alone would let one of them satisfy another's
+        // due check.
+        const due = new Set(engine.due().map((record) => record.key));
+        const now = Date.now();
         return candidateTaskIds.filter((taskId) => {
           const identity = identityFor(taskId);
           if (!identity) return false;
-          // Never observed ⇒ due now. The floor is a statement about how often
-          // to RE-read, not a delay before the first read.
           if (!engine.get(identity)) {
-            engine.register(identity, { restored: true });
+            // First sighting this session — which, after a reload, means EVERY
+            // tracked handle. Seed the engine from the persisted schedule
+            // instead of registering fresh: registering fresh makes every
+            // restored handle due immediately, so a series of reloads would
+            // poll a server far faster than it asked to be polled, and the
+            // durable `nextPollAt` would never do anything.
+            const persisted = getTrackedTaskSchedule(identity);
+            engine.register(identity, {
+              restored: true,
+              pollIntervalMs: persisted?.pollIntervalMs,
+              ttlMs: persisted?.ttlMs,
+              // Restored so a reload does not re-prompt for an input the user
+              // already answered and the server already acknowledged.
+              respondedInputKeys: getRespondedInputKeys(identity),
+            });
+            if (persisted?.nextPollAt !== undefined) {
+              const record = engine.get(identity);
+              if (record) {
+                record.nextPollAt = persisted.nextPollAt;
+                record.lastObservedAt = persisted.lastObservedAt;
+              }
+              // A handle whose stored floor has not elapsed is NOT due, even
+              // though we have never read it in this session.
+              return persisted.nextPollAt <= now;
+            }
+            // No persisted schedule ⇒ genuinely new. The floor governs how
+            // often to RE-read, not a delay before the first read.
             return true;
           }
-          return due.has(taskId);
+          return due.has(taskLifecycleKey(identity));
         });
       },
 
       recordObservations(states) {
+        const persist: Parameters<typeof recordTaskObservations>[0][number][] =
+          [];
         for (const state of states) {
           const identity = identityFor(state.taskId);
           if (!identity) continue;
@@ -150,19 +193,24 @@ export function useTaskScheduler({
             lastUpdatedAt: state.lastUpdatedAt,
           } satisfies TaskLifecycleObservation;
           const record = engine.observe(identity, observation);
-          // Mirror the scheduling state into durable storage so a reload
-          // resumes at the right time rather than restarting every task.
-          recordTaskObservation(identity, {
-            status: record.status,
-            lastUpdatedAt: record.lastUpdatedAt,
-            ttlMs: record.ttlMs,
-            pollIntervalMs: record.pollIntervalMs,
-            nextPollAt: Number.isFinite(record.nextPollAt)
-              ? record.nextPollAt
-              : undefined,
-            lastObservedAt: record.lastObservedAt,
+          persist.push({
+            identity,
+            observation: {
+              status: record.status,
+              lastUpdatedAt: record.lastUpdatedAt,
+              ttlMs: record.ttlMs,
+              pollIntervalMs: record.pollIntervalMs,
+              nextPollAt: Number.isFinite(record.nextPollAt)
+                ? record.nextPollAt
+                : undefined,
+              lastObservedAt: record.lastObservedAt,
+            },
           });
         }
+        // ONE load + save for the whole tick. Mirroring the scheduling state
+        // into durable storage is what lets a reload resume at the right time
+        // rather than restarting every task at its floor.
+        recordTaskObservations(persist);
       },
 
       recordErrors(taskIds) {
@@ -170,6 +218,24 @@ export function useTaskScheduler({
           const identity = identityFor(taskId);
           if (identity) engine.observeError(identity);
         }
+      },
+
+      markInputResponded(taskId, keys) {
+        const identity = identityFor(taskId);
+        if (!identity || keys.length === 0) return;
+        engine.markInputKeysResponded(identity, keys);
+        recordRespondedInputKeys(identity, keys);
+      },
+
+      respondedInputKeys(taskId) {
+        const identity = identityFor(taskId);
+        if (!identity) return [];
+        // Union of this session's engine state and what survived a reload.
+        const persisted = getRespondedInputKeys(identity);
+        const record = engine.get(identity);
+        return [
+          ...new Set([...persisted, ...(record?.respondedInputKeys ?? [])]),
+        ];
       },
 
       forget(taskIds) {
@@ -192,6 +258,6 @@ export function useTaskScheduler({
         return engine.batchIntervalMs(records);
       },
     }),
-    [engine, identityFor, effectiveMinimum],
+    [engine, identityFor, effectiveMinimum]
   );
 }

--- a/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
+++ b/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
@@ -34,7 +34,7 @@
  * is already legal.
  */
 
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   TaskLifecycleEngine,
   isTerminalLifecycleStatus,
@@ -45,9 +45,10 @@ import {
 } from "@mcpjam/sdk/browser";
 import {
   getRespondedInputKeys,
-  getTrackedTaskSchedule,
+  getTrackedTaskRestoreStates,
   recordRespondedInputKeys,
   recordTaskObservations,
+  taskIdentity,
 } from "@/lib/task-tracker";
 
 /**
@@ -145,10 +146,18 @@ export function useTaskScheduler({
   // A change to either term must take effect on the ALREADY-SCHEDULED tasks,
   // not only on the next ones — otherwise raising the interval leaves every
   // in-flight task polling at the old rate until it happens to complete.
+  //
+  // In an effect, not during render: the engine is a ref-held mutable object,
+  // and writing to it while rendering is a side effect in the render phase.
+  // The write is idempotent, so this is a purity fix rather than a bug fix —
+  // but the rule holds regardless, and an effect is where a commit-time
+  // reconciliation of external state belongs.
   const effectiveMinimum = Math.max(userMinimumIntervalMs, surfaceFloorMs);
-  if (engine.getUserMinimumIntervalMs() !== effectiveMinimum) {
-    engine.setUserMinimumIntervalMs(effectiveMinimum);
-  }
+  useEffect(() => {
+    if (engine.getUserMinimumIntervalMs() !== effectiveMinimum) {
+      engine.setUserMinimumIntervalMs(effectiveMinimum);
+    }
+  }, [engine, effectiveMinimum]);
 
   const identityFor = useCallback(
     (taskId: string): TaskLifecycleIdentity | undefined => {
@@ -167,6 +176,19 @@ export function useTaskScheduler({
         // due check.
         const due = new Set(engine.due().map((record) => record.key));
         const now = Date.now();
+        // ONE store read for every handle this tick has never seen, rather
+        // than two per handle. After a reload EVERY tracked handle is unseen,
+        // so the per-handle form ran 2N full parses of the whole store in a
+        // single tick on the main thread — the cost the batched write path
+        // already avoids on the other side.
+        const unseen = candidateTaskIds
+          .map((taskId) => identityFor(taskId))
+          .filter(
+            (identity): identity is TaskLifecycleIdentity =>
+              !!identity && !engine.get(identity)
+          );
+        const restoreStates = getTrackedTaskRestoreStates(unseen);
+
         return candidateTaskIds.filter((taskId) => {
           const identity = identityFor(taskId);
           if (!identity) return false;
@@ -177,7 +199,7 @@ export function useTaskScheduler({
             // restored handle due immediately, so a series of reloads would
             // poll a server far faster than it asked to be polled, and the
             // durable `nextPollAt` would never do anything.
-            const persisted = getTrackedTaskSchedule(identity);
+            const persisted = restoreStates.get(taskIdentity(identity));
             engine.register(identity, {
               restored: true,
               pollIntervalMs: persisted?.pollIntervalMs,
@@ -190,7 +212,7 @@ export function useTaskScheduler({
               lastObservedAt: persisted?.lastObservedAt,
               // Restored so a reload does not re-prompt for an input the user
               // already answered and the server already acknowledged.
-              respondedInputKeys: getRespondedInputKeys(identity),
+              respondedInputKeys: persisted?.respondedInputKeys,
             });
             const restored = engine.get(identity);
             if (restored && isTerminalLifecycleStatus(restored.status)) {

--- a/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
+++ b/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
@@ -90,11 +90,25 @@ export interface UseTaskSchedulerArgs {
 
 export interface TaskScheduler {
   /**
-   * Narrows `candidateTaskIds` to the ones actually due now. An unknown handle
-   * is treated as due, so a newly created task is polled immediately and the
-   * floor applies only from its first observation onward.
+   * Narrows `candidateTaskIds` to the ones actually due now, CLAIMING each one
+   * it returns. An unknown handle is treated as due, so a newly created task is
+   * polled immediately and the floor applies only from its first observation
+   * onward.
+   *
+   * Claiming is what makes overlapping refreshes safe. The tab's auto-refresh
+   * can interleave with one triggered by an input submission, a cancellation,
+   * or a rapid manual click, and without a claim both invocations select the
+   * same due set and issue duplicate `tasks/get` calls inside one advertised
+   * floor — where an out-of-order reply can overwrite newer state with older.
+   *
+   * The caller MUST {@link TaskScheduler.release} what it receives, on every
+   * completion path including failure. `recordObservations` and `recordErrors`
+   * release automatically, so an ordinary tick needs nothing extra; `release`
+   * is for the ids that never reached either.
    */
   dueTaskIds(candidateTaskIds: readonly string[]): string[];
+  /** Releases claims for ids that produced neither an observation nor an error. */
+  release(taskIds: readonly string[]): void;
   /** Folds a poll's results back in, rescheduling each task by its own floor. */
   recordObservations(states: readonly SchedulerTaskState[]): void;
   /** Records a failed read for these ids: backoff, no status change. */
@@ -188,39 +202,15 @@ export function useTaskScheduler({
           );
         const restoreStates = getTrackedTaskRestoreStates(unseen);
 
-        /**
-         * A restored terminal handle that still owes exactly one read.
-         *
-         * The tracker persists a task's status but never its payload, and on
-         * the extension wire the result and error ride INLINE on `tasks/get` —
-         * there is no `tasks/result` to fetch them from later. So a handle
-         * restored as `completed` after a reload is a status with nothing
-         * behind it, and excluding it from polling (which is otherwise exactly
-         * right for a terminal handle) strands it: the row shows "completed"
-         * with no result and no way to ever get one, including manual refresh.
-         *
-         * Bounded to one read: `engine.observe` clears `restored`, after which
-         * the ordinary terminal exclusion takes over. `nextPollAt` is still
-         * honored, so a recovery read that fails backs off with everything
-         * else instead of retrying every tick.
-         *
-         * Legacy is excluded because it does not have the problem — its result
-         * comes from a separate `tasks/result` call the tab makes on demand.
-         */
-        const needsTerminalRecovery = (
-          record: NonNullable<ReturnType<typeof engine.get>>
-        ): boolean =>
-          wire === "extension" &&
-          record.restored &&
-          isTerminalLifecycleStatus(record.status) &&
-          record.nextPollAt <= now;
-
         return candidateTaskIds.filter((taskId) => {
           const identity = identityFor(taskId);
           if (!identity) return false;
           const known = engine.get(identity);
           if (known) {
-            return needsTerminalRecovery(known) || due.has(known.key);
+            if (!due.has(known.key)) return false;
+            // Refused when another refresh already holds it, so overlapping
+            // ticks split the work rather than duplicating it.
+            return engine.acquirePoll(identity);
           }
 
           // First sighting this session — which, after a reload, means EVERY
@@ -245,17 +235,24 @@ export function useTaskScheduler({
             respondedInputKeys: persisted?.respondedInputKeys,
           });
           const restored = engine.get(identity);
+          // `owesRead` inside the engine decides whether a restored terminal
+          // still needs its one recovery read, so asking `due()` is enough —
+          // and it is the only way `msUntilNextDue()` agrees, which is what
+          // actually arms the timer that brings us back here.
           if (restored && isTerminalLifecycleStatus(restored.status)) {
-            return needsTerminalRecovery(restored);
+            return (
+              engine.due().some((record) => record.key === restored.key) &&
+              engine.acquirePoll(identity)
+            );
           }
           if (persisted?.nextPollAt !== undefined) {
             // A handle whose stored floor has not elapsed is NOT due, even
             // though we have never read it in this session.
-            return persisted.nextPollAt <= now;
+            return persisted.nextPollAt <= now && engine.acquirePoll(identity);
           }
           // No persisted schedule ⇒ genuinely new. The floor governs how
           // often to RE-read, not a delay before the first read.
-          return true;
+          return engine.acquirePoll(identity);
         });
       },
 
@@ -272,6 +269,8 @@ export function useTaskScheduler({
             lastUpdatedAt: state.lastUpdatedAt,
           } satisfies TaskLifecycleObservation;
           const record = engine.observe(identity, observation);
+          // The read that held this claim has landed.
+          engine.releasePoll(identity);
           persist.push({
             identity,
             observation: {
@@ -299,6 +298,7 @@ export function useTaskScheduler({
           const identity = identityFor(taskId);
           if (!identity) continue;
           const record = engine.observeError(identity);
+          engine.releasePoll(identity);
           // The backoff has to be DURABLE. Persisting only successful
           // observations left the tracker holding the already-elapsed
           // `nextPollAt` from the last good read, so a reload during backoff
@@ -332,6 +332,13 @@ export function useTaskScheduler({
         return [
           ...new Set([...persisted, ...(record?.respondedInputKeys ?? [])]),
         ];
+      },
+
+      release(taskIds) {
+        for (const taskId of taskIds) {
+          const identity = identityFor(taskId);
+          if (identity) engine.releasePoll(identity);
+        }
       },
 
       forget(taskIds) {

--- a/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
+++ b/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
@@ -38,7 +38,6 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   TaskLifecycleEngine,
   isTerminalLifecycleStatus,
-  taskLifecycleKey,
   type TaskLifecycleIdentity,
   type TaskLifecycleObservation,
   type LiveTasksWire,
@@ -189,45 +188,74 @@ export function useTaskScheduler({
           );
         const restoreStates = getTrackedTaskRestoreStates(unseen);
 
+        /**
+         * A restored terminal handle that still owes exactly one read.
+         *
+         * The tracker persists a task's status but never its payload, and on
+         * the extension wire the result and error ride INLINE on `tasks/get` —
+         * there is no `tasks/result` to fetch them from later. So a handle
+         * restored as `completed` after a reload is a status with nothing
+         * behind it, and excluding it from polling (which is otherwise exactly
+         * right for a terminal handle) strands it: the row shows "completed"
+         * with no result and no way to ever get one, including manual refresh.
+         *
+         * Bounded to one read: `engine.observe` clears `restored`, after which
+         * the ordinary terminal exclusion takes over. `nextPollAt` is still
+         * honored, so a recovery read that fails backs off with everything
+         * else instead of retrying every tick.
+         *
+         * Legacy is excluded because it does not have the problem — its result
+         * comes from a separate `tasks/result` call the tab makes on demand.
+         */
+        const needsTerminalRecovery = (
+          record: NonNullable<ReturnType<typeof engine.get>>
+        ): boolean =>
+          wire === "extension" &&
+          record.restored &&
+          isTerminalLifecycleStatus(record.status) &&
+          record.nextPollAt <= now;
+
         return candidateTaskIds.filter((taskId) => {
           const identity = identityFor(taskId);
           if (!identity) return false;
-          if (!engine.get(identity)) {
-            // First sighting this session — which, after a reload, means EVERY
-            // tracked handle. Seed the engine from the persisted schedule
-            // instead of registering fresh: registering fresh makes every
-            // restored handle due immediately, so a series of reloads would
-            // poll a server far faster than it asked to be polled, and the
-            // durable `nextPollAt` would never do anything.
-            const persisted = restoreStates.get(taskIdentity(identity));
-            engine.register(identity, {
-              restored: true,
-              pollIntervalMs: persisted?.pollIntervalMs,
-              ttlMs: persisted?.ttlMs,
-              // A handle we last saw finished must come back finished. Without
-              // this it restores as `unknown`, reads as non-terminal, and gets
-              // polled again — re-reading a task whose result we already have.
-              status: restoredTerminalStatus(persisted?.status),
-              nextPollAt: persisted?.nextPollAt,
-              lastObservedAt: persisted?.lastObservedAt,
-              // Restored so a reload does not re-prompt for an input the user
-              // already answered and the server already acknowledged.
-              respondedInputKeys: persisted?.respondedInputKeys,
-            });
-            const restored = engine.get(identity);
-            if (restored && isTerminalLifecycleStatus(restored.status)) {
-              return false;
-            }
-            if (persisted?.nextPollAt !== undefined) {
-              // A handle whose stored floor has not elapsed is NOT due, even
-              // though we have never read it in this session.
-              return persisted.nextPollAt <= now;
-            }
-            // No persisted schedule ⇒ genuinely new. The floor governs how
-            // often to RE-read, not a delay before the first read.
-            return true;
+          const known = engine.get(identity);
+          if (known) {
+            return needsTerminalRecovery(known) || due.has(known.key);
           }
-          return due.has(taskLifecycleKey(identity));
+
+          // First sighting this session — which, after a reload, means EVERY
+          // tracked handle. Seed the engine from the persisted schedule
+          // instead of registering fresh: registering fresh makes every
+          // restored handle due immediately, so a series of reloads would
+          // poll a server far faster than it asked to be polled, and the
+          // durable `nextPollAt` would never do anything.
+          const persisted = restoreStates.get(taskIdentity(identity));
+          engine.register(identity, {
+            restored: true,
+            pollIntervalMs: persisted?.pollIntervalMs,
+            ttlMs: persisted?.ttlMs,
+            // A handle we last saw finished must come back finished. Without
+            // this it restores as `unknown`, reads as non-terminal, and is
+            // polled on the ordinary schedule forever rather than at most once.
+            status: restoredTerminalStatus(persisted?.status),
+            nextPollAt: persisted?.nextPollAt,
+            lastObservedAt: persisted?.lastObservedAt,
+            // Restored so a reload does not re-prompt for an input the user
+            // already answered and the server already acknowledged.
+            respondedInputKeys: persisted?.respondedInputKeys,
+          });
+          const restored = engine.get(identity);
+          if (restored && isTerminalLifecycleStatus(restored.status)) {
+            return needsTerminalRecovery(restored);
+          }
+          if (persisted?.nextPollAt !== undefined) {
+            // A handle whose stored floor has not elapsed is NOT due, even
+            // though we have never read it in this session.
+            return persisted.nextPollAt <= now;
+          }
+          // No persisted schedule ⇒ genuinely new. The floor governs how
+          // often to RE-read, not a delay before the first read.
+          return true;
         });
       },
 

--- a/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
+++ b/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
@@ -37,6 +37,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import {
   TaskLifecycleEngine,
+  isTerminalLifecycleStatus,
   taskLifecycleKey,
   type TaskLifecycleIdentity,
   type TaskLifecycleObservation,
@@ -48,6 +49,21 @@ import {
   recordRespondedInputKeys,
   recordTaskObservations,
 } from "@/lib/task-tracker";
+
+/**
+ * Narrows a persisted status string to a terminal lifecycle status.
+ *
+ * Only the three PROTOCOL terminal states are restored. MCPJam's own `expired`
+ * tombstone is deliberately excluded: it means the server forgot the handle,
+ * and a fresh session should be free to confirm that rather than inherit it.
+ */
+function restoredTerminalStatus(
+  status: string | undefined
+): "completed" | "failed" | "cancelled" | undefined {
+  return status === "completed" || status === "failed" || status === "cancelled"
+    ? status
+    : undefined;
+}
 
 export interface SchedulerTaskState {
   taskId: string;
@@ -110,11 +126,19 @@ export function useTaskScheduler({
   userMinimumIntervalMs,
   surfaceFloorMs = 0,
 }: UseTaskSchedulerArgs): TaskScheduler {
+  // The engine is keyed to the connection it holds records for. The hook
+  // instance survives a server or wire switch, and stale records from the
+  // previous connection would keep answering `due()` — pinning
+  // `msUntilNextDue()` at zero forever, because nothing on the NEW connection
+  // ever observes or forgets them, so every re-arm would collapse to the floor.
+  const identityKey = `${scope ?? ""}\u0000${serverId ?? ""}\u0000${wire}`;
   const engineRef = useRef<TaskLifecycleEngine | undefined>(undefined);
-  if (!engineRef.current) {
+  const engineKeyRef = useRef<string | undefined>(undefined);
+  if (!engineRef.current || engineKeyRef.current !== identityKey) {
     engineRef.current = new TaskLifecycleEngine({
       userMinimumIntervalMs: Math.max(userMinimumIntervalMs, surfaceFloorMs),
     });
+    engineKeyRef.current = identityKey;
   }
   const engine = engineRef.current;
 
@@ -158,16 +182,21 @@ export function useTaskScheduler({
               restored: true,
               pollIntervalMs: persisted?.pollIntervalMs,
               ttlMs: persisted?.ttlMs,
+              // A handle we last saw finished must come back finished. Without
+              // this it restores as `unknown`, reads as non-terminal, and gets
+              // polled again — re-reading a task whose result we already have.
+              status: restoredTerminalStatus(persisted?.status),
+              nextPollAt: persisted?.nextPollAt,
+              lastObservedAt: persisted?.lastObservedAt,
               // Restored so a reload does not re-prompt for an input the user
               // already answered and the server already acknowledged.
               respondedInputKeys: getRespondedInputKeys(identity),
             });
+            const restored = engine.get(identity);
+            if (restored && isTerminalLifecycleStatus(restored.status)) {
+              return false;
+            }
             if (persisted?.nextPollAt !== undefined) {
-              const record = engine.get(identity);
-              if (record) {
-                record.nextPollAt = persisted.nextPollAt;
-                record.lastObservedAt = persisted.lastObservedAt;
-              }
               // A handle whose stored floor has not elapsed is NOT due, even
               // though we have never read it in this session.
               return persisted.nextPollAt <= now;
@@ -214,10 +243,27 @@ export function useTaskScheduler({
       },
 
       recordErrors(taskIds) {
+        const persist: Parameters<typeof recordTaskObservations>[0][number][] =
+          [];
         for (const taskId of taskIds) {
           const identity = identityFor(taskId);
-          if (identity) engine.observeError(identity);
+          if (!identity) continue;
+          const record = engine.observeError(identity);
+          // The backoff has to be DURABLE. Persisting only successful
+          // observations left the tracker holding the already-elapsed
+          // `nextPollAt` from the last good read, so a reload during backoff
+          // restored the handle as immediately due and retried at once —
+          // repeated reloads would walk straight through the backoff.
+          persist.push({
+            identity,
+            observation: {
+              nextPollAt: Number.isFinite(record.nextPollAt)
+                ? record.nextPollAt
+                : undefined,
+            },
+          });
         }
+        recordTaskObservations(persist);
       },
 
       markInputResponded(taskId, keys) {

--- a/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
+++ b/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
@@ -65,6 +65,30 @@ function restoredTerminalStatus(
     : undefined;
 }
 
+/**
+ * How many times the tab will re-attempt a restored handle's ONE recovery read
+ * on its own before it stops and says so.
+ *
+ * The read is bounded because it is unbounded by construction otherwise: a
+ * restored terminal keeps owing its read until a read actually lands, so a
+ * handle whose server is permanently gone would keep the auto-refresh loop
+ * armed for the life of the tab. Five attempts spans the engine's 1s/2s/4s/8s
+ * backoff — long enough to ride out a restart, short enough that a dead server
+ * stops costing requests.
+ */
+export const MAX_RECOVERY_READ_ATTEMPTS = 5;
+
+/**
+ * Which restored handles still owe the one recovery read that fetches their
+ * result, split by whether the tab will still attempt it automatically.
+ */
+export interface RecoveryReadState {
+  /** Still owed and still within the attempt bound: keep the loop armed. */
+  pendingTaskIds: string[];
+  /** Still owed, but the tab has stopped retrying on its own. */
+  exhaustedTaskIds: string[];
+}
+
 export interface SchedulerTaskState {
   taskId: string;
   status: string;
@@ -131,6 +155,28 @@ export interface TaskScheduler {
   msUntilNextDue(): number;
   /** The floor a batch of these ids must respect: the SLOWEST member's. */
   batchIntervalMs(taskIds: readonly string[]): number;
+  /**
+   * Which of these handles still owe their restored-terminal recovery read.
+   *
+   * A PURE read of engine state — no claim, no registration, no scheduling —
+   * so it is safe to call during render, which is where the caller needs it:
+   * the decision it feeds is "keep the poll loop armed", and a surface that
+   * only asked after a tick would never arm the timer that produces the tick.
+   *
+   * It exists because the answer is invisible from the rendered rows. A
+   * restored `completed` handle renders as terminal and reads as finished,
+   * while the engine still owes it the `tasks/get` that carries the inline
+   * result. That is true whether the read is due now, due LATER (a stored
+   * `nextPollAt` in the future — no failure involved at all), or has failed
+   * and backed off; all three keep the handle here.
+   */
+  recoveryReadState(candidateTaskIds: readonly string[]): RecoveryReadState;
+  /**
+   * Re-arms recovery reads the tab has given up on, for an explicitly
+   * user-initiated refresh. Clears only the local error backoff — the server's
+   * advertised floor and any `Retry-After` still apply.
+   */
+  retryRecoveryReads(taskIds: readonly string[]): void;
 }
 
 export function useTaskScheduler({
@@ -345,6 +391,45 @@ export function useTaskScheduler({
         for (const taskId of taskIds) {
           const identity = identityFor(taskId);
           if (identity) engine.forget(identity);
+        }
+      },
+
+      recoveryReadState(candidateTaskIds) {
+        // `active()` is the engine's own answer to "does this handle still owe
+        // a read", so the extension-wire condition and the one-read bound stay
+        // in the one place that every scheduling method already agrees with.
+        // Restricting it to TERMINAL records is what makes this specifically
+        // the recovery read: a non-terminal handle owes an ordinary poll, and
+        // the tab already keeps the loop armed for those from its rendered
+        // rows.
+        const owing = new Map(
+          engine
+            .active()
+            .filter((record) => isTerminalLifecycleStatus(record.status))
+            .map((record) => [record.key, record])
+        );
+        const pendingTaskIds: string[] = [];
+        const exhaustedTaskIds: string[] = [];
+        for (const taskId of candidateTaskIds) {
+          const identity = identityFor(taskId);
+          if (!identity) continue;
+          const record = engine.get(identity);
+          if (!record) continue;
+          const owed = owing.get(record.key);
+          if (!owed) continue;
+          if (owed.consecutiveErrors >= MAX_RECOVERY_READ_ATTEMPTS) {
+            exhaustedTaskIds.push(taskId);
+          } else {
+            pendingTaskIds.push(taskId);
+          }
+        }
+        return { pendingTaskIds, exhaustedTaskIds };
+      },
+
+      retryRecoveryReads(taskIds) {
+        for (const taskId of taskIds) {
+          const identity = identityFor(taskId);
+          if (identity) engine.clearErrorBackoff(identity);
         }
       },
 

--- a/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
+++ b/mcpjam-inspector/client/src/hooks/use-task-scheduler.ts
@@ -1,0 +1,197 @@
+/**
+ * Per-task poll scheduling for the Tasks tab, backed by the SDK's shared
+ * lifecycle engine.
+ *
+ * ## What this replaces
+ *
+ * The tab used to collapse every active task into one interval:
+ *
+ * ```ts
+ * Math.min(...activeTasks.map(t => t.pollInterval))          // the fastest wins
+ * userOverride ?? serverSuggestedPollInterval ?? userDefault // a ?? chain
+ * ```
+ *
+ * Both are wrong, in the same direction. The `Math.min` applied the fastest
+ * task's floor to every other task, so one task advertising 500ms dragged a
+ * task asking for 30s down with it. The `??` chain let a user override
+ * *replace* the server's floor rather than be clamped by it, so a user typing
+ * 500 into the box polled a 30s-floor server sixty times per interval.
+ *
+ * The engine's rule is that every term is a `max`, applied **per task**:
+ *
+ * ```text
+ * max(server pollIntervalMs, user minimum, retry backoff, Retry-After)
+ * ```
+ *
+ * The user's setting is a *preferred minimum*, not permission to go faster.
+ *
+ * ## Batching
+ *
+ * The hosted path polls in batches, one ephemeral connection per server per
+ * tick. A batch polls every member, so it takes the **slowest** member's floor
+ * — taking the fastest would breach every other member's. {@link dueTaskIds}
+ * only ever returns tasks that are individually due, so a batch built from it
+ * is already legal.
+ */
+
+import { useCallback, useMemo, useRef } from "react";
+import {
+  TaskLifecycleEngine,
+  type TaskLifecycleIdentity,
+  type TaskLifecycleObservation,
+  type LiveTasksWire,
+} from "@mcpjam/sdk/browser";
+import { recordTaskObservation } from "@/lib/task-tracker";
+
+export interface SchedulerTaskState {
+  taskId: string;
+  status: string;
+  /** Server-advertised floor, already normalized to milliseconds by the route. */
+  pollIntervalMs?: number;
+  ttlMs?: number | null;
+  lastUpdatedAt?: string;
+}
+
+export interface UseTaskSchedulerArgs {
+  serverId: string | undefined;
+  wire: LiveTasksWire | "none";
+  scope?: string;
+  /** The user's preferred minimum, from the tab's poll-interval box. */
+  userMinimumIntervalMs: number;
+  /**
+   * Extra floor applied to every task on this surface. The hosted path passes
+   * its connection-cost floor here, because each hosted tick is a full
+   * authorize → connect → request → disconnect round trip.
+   */
+  surfaceFloorMs?: number;
+}
+
+export interface TaskScheduler {
+  /**
+   * Narrows `candidateTaskIds` to the ones actually due now. An unknown handle
+   * is treated as due, so a newly created task is polled immediately and the
+   * floor applies only from its first observation onward.
+   */
+  dueTaskIds(candidateTaskIds: readonly string[]): string[];
+  /** Folds a poll's results back in, rescheduling each task by its own floor. */
+  recordObservations(states: readonly SchedulerTaskState[]): void;
+  /** Records a failed read for these ids: backoff, no status change. */
+  recordErrors(taskIds: readonly string[]): void;
+  /** Stops scheduling a handle (dismissed, cleared, or confirmed expired). */
+  forget(taskIds: readonly string[]): void;
+  /**
+   * Milliseconds until the next task is due, for arming one timer. Falls back
+   * to the user's minimum when nothing is scheduled yet, so the first tick
+   * after a page load still happens.
+   */
+  msUntilNextDue(): number;
+  /** The floor a batch of these ids must respect: the SLOWEST member's. */
+  batchIntervalMs(taskIds: readonly string[]): number;
+}
+
+export function useTaskScheduler({
+  serverId,
+  wire,
+  scope,
+  userMinimumIntervalMs,
+  surfaceFloorMs = 0,
+}: UseTaskSchedulerArgs): TaskScheduler {
+  const engineRef = useRef<TaskLifecycleEngine | undefined>(undefined);
+  if (!engineRef.current) {
+    engineRef.current = new TaskLifecycleEngine({
+      userMinimumIntervalMs: Math.max(userMinimumIntervalMs, surfaceFloorMs),
+    });
+  }
+  const engine = engineRef.current;
+
+  // A change to either term must take effect on the ALREADY-SCHEDULED tasks,
+  // not only on the next ones — otherwise raising the interval leaves every
+  // in-flight task polling at the old rate until it happens to complete.
+  const effectiveMinimum = Math.max(userMinimumIntervalMs, surfaceFloorMs);
+  if (engine.getUserMinimumIntervalMs() !== effectiveMinimum) {
+    engine.setUserMinimumIntervalMs(effectiveMinimum);
+  }
+
+  const identityFor = useCallback(
+    (taskId: string): TaskLifecycleIdentity | undefined => {
+      if (!serverId || wire === "none") return undefined;
+      return { serverId, wire, taskId, ...(scope ? { scope } : {}) };
+    },
+    [serverId, wire, scope],
+  );
+
+  return useMemo<TaskScheduler>(
+    () => ({
+      dueTaskIds(candidateTaskIds) {
+        const due = new Set(
+          engine.due().map((record) => record.identity.taskId),
+        );
+        return candidateTaskIds.filter((taskId) => {
+          const identity = identityFor(taskId);
+          if (!identity) return false;
+          // Never observed ⇒ due now. The floor is a statement about how often
+          // to RE-read, not a delay before the first read.
+          if (!engine.get(identity)) {
+            engine.register(identity, { restored: true });
+            return true;
+          }
+          return due.has(taskId);
+        });
+      },
+
+      recordObservations(states) {
+        for (const state of states) {
+          const identity = identityFor(state.taskId);
+          if (!identity) continue;
+          const observation = {
+            status: state.status as TaskLifecycleObservation["status"],
+            pollIntervalMs: state.pollIntervalMs,
+            ttlMs: state.ttlMs,
+            lastUpdatedAt: state.lastUpdatedAt,
+          } satisfies TaskLifecycleObservation;
+          const record = engine.observe(identity, observation);
+          // Mirror the scheduling state into durable storage so a reload
+          // resumes at the right time rather than restarting every task.
+          recordTaskObservation(identity, {
+            status: record.status,
+            lastUpdatedAt: record.lastUpdatedAt,
+            ttlMs: record.ttlMs,
+            pollIntervalMs: record.pollIntervalMs,
+            nextPollAt: Number.isFinite(record.nextPollAt)
+              ? record.nextPollAt
+              : undefined,
+            lastObservedAt: record.lastObservedAt,
+          });
+        }
+      },
+
+      recordErrors(taskIds) {
+        for (const taskId of taskIds) {
+          const identity = identityFor(taskId);
+          if (identity) engine.observeError(identity);
+        }
+      },
+
+      forget(taskIds) {
+        for (const taskId of taskIds) {
+          const identity = identityFor(taskId);
+          if (identity) engine.forget(identity);
+        }
+      },
+
+      msUntilNextDue() {
+        return engine.msUntilNextDue() ?? effectiveMinimum;
+      },
+
+      batchIntervalMs(taskIds) {
+        const records = taskIds
+          .map((taskId) => identityFor(taskId))
+          .filter((identity): identity is TaskLifecycleIdentity => !!identity)
+          .map((identity) => engine.get(identity))
+          .filter((record): record is NonNullable<typeof record> => !!record);
+        return engine.batchIntervalMs(records);
+      },
+    }),
+    [engine, identityFor, effectiveMinimum],
+  );
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/task-tracker.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/task-tracker.test.ts
@@ -269,7 +269,7 @@ describe("task-tracker", () => {
     expect(getTrackedTasks()[0].wire).toBe("legacy");
   });
 
-  it("caps oversized strings from a hostile server", () => {
+  it("caps oversized DISPLAY strings from a hostile server", () => {
     const huge = "x".repeat(10_000);
     localStorage.setItem(
       STORAGE_KEY,
@@ -277,18 +277,57 @@ describe("task-tracker", () => {
         version: 3,
         tasks: [
           {
-            taskId: huge,
+            taskId: "t1",
             serverId: "s1",
             wire: "extension",
             createdAt: NOW,
             toolName: huge,
+            primitiveName: huge,
           },
         ],
       }),
     );
     const [task] = getTrackedTasks();
-    expect(task.taskId.length).toBe(1024);
     expect(task.toolName?.length).toBe(1024);
+    expect(task.primitiveName?.length).toBe(1024);
+  });
+
+  // Truncating an IDENTITY field does not shorten a value, it produces a
+  // DIFFERENT handle — and collapses any two values sharing a 1024-character
+  // prefix into one identity that shares `respondedInputKeys`/`nextPollAt`.
+  // For `scope`, the auth/org segment, that collapse crosses accounts.
+  it.each(["taskId", "serverId", "scope"])(
+    "drops a record whose %s is over-length rather than truncating it",
+    (field) => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          version: 3,
+          tasks: [
+            {
+              taskId: "t1",
+              serverId: "s1",
+              wire: "extension",
+              createdAt: NOW,
+              [field]: "x".repeat(10_000),
+            },
+          ],
+        }),
+      );
+      expect(getTrackedTasks()).toEqual([]);
+    },
+  );
+
+  it("refuses to write an over-length identity in the first place", () => {
+    // Rejected at the door rather than on the next load, so the handle does
+    // not appear to work and then vanish at the next reload.
+    trackTask({
+      taskId: "x".repeat(10_000),
+      serverId: "s1",
+      wire: "extension",
+      createdAt: NOW,
+    });
+    expect(getTrackedTasks()).toEqual([]);
   });
 
   it("caps the number of responded input keys it will retain", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/task-tracker.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/task-tracker.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearTrackedTasksForScope,
+  getRespondedInputKeys,
+  recordRespondedInputKeys,
+  recordTaskObservation,
   getTrackedTasks,
   getTrackedTasksForServer,
   markTaskExpired,
@@ -58,7 +61,7 @@ describe("task-tracker", () => {
     });
 
     const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) as string);
-    expect(stored.version).toBe(2);
+    expect(stored.version).toBe(3);
     expect(stored.tasks).toHaveLength(1);
   });
 
@@ -136,5 +139,174 @@ describe("task-tracker", () => {
 
     untrackTask("t1", "s1");
     expect(getTrackedTasks().map((t) => t.serverId)).toEqual(["s2"]);
+  });
+// ---- v3: resumable scheduling state + responded input keys --------------
+
+  it("resumes a handle's scheduling state across a reload", () => {
+    const id = { taskId: "t1", serverId: "s1", wire: "extension" as const };
+    trackTask({ ...id, createdAt: NOW });
+
+    recordTaskObservation(id, {
+      status: "working",
+      lastUpdatedAt: "2026-07-28T00:05:00Z",
+      ttlMs: 60_000,
+      pollIntervalMs: 5_000,
+      nextPollAt: 1_700_000_000_000,
+      lastObservedAt: 1_699_999_995_000,
+    });
+
+    const [task] = getTrackedTasks();
+    expect(task).toMatchObject({
+      status: "working",
+      lastUpdatedAt: "2026-07-28T00:05:00Z",
+      ttlMs: 60_000,
+      pollIntervalMs: 5_000,
+      nextPollAt: 1_700_000_000_000,
+      lastObservedAt: 1_699_999_995_000,
+    });
+  });
+
+  it("lets a null ttlMs overwrite a number — null means 'no expiry', not 'unset'", () => {
+    const id = { taskId: "t1", serverId: "s1", wire: "extension" as const };
+    trackTask({ ...id, createdAt: NOW });
+
+    recordTaskObservation(id, { ttlMs: 60_000 });
+    expect(getTrackedTasks()[0].ttlMs).toBe(60_000);
+    recordTaskObservation(id, { ttlMs: null });
+    expect(getTrackedTasks()[0].ttlMs).toBeNull();
+  });
+
+  it("does not resurrect an untracked handle", () => {
+    recordTaskObservation(
+      { taskId: "ghost", serverId: "s1", wire: "extension" },
+      { status: "working" },
+    );
+    expect(getTrackedTasks()).toHaveLength(0);
+  });
+
+  it("persists responded input KEYS and never a payload", () => {
+    const id = { taskId: "t1", serverId: "s1", wire: "extension" as const };
+    trackTask({ ...id, createdAt: NOW });
+
+    recordRespondedInputKeys(id, ["ask-name"]);
+    recordRespondedInputKeys(id, ["ask-name", "ask-email"]);
+
+    expect(getRespondedInputKeys(id).sort()).toEqual(["ask-email", "ask-name"]);
+    // The whole serialized store must contain no prompt or response content.
+    const raw = localStorage.getItem(STORAGE_KEY) as string;
+    expect(raw).not.toContain("elicitation");
+    expect(raw).not.toContain("content");
+  });
+
+  it("keeps responded keys scoped to their own handle", () => {
+    const a = { taskId: "t1", serverId: "s1", wire: "extension" as const };
+    const b = { taskId: "t2", serverId: "s1", wire: "extension" as const };
+    trackTask({ ...a, createdAt: NOW });
+    trackTask({ ...b, createdAt: NOW });
+
+    recordRespondedInputKeys(a, ["k"]);
+    expect(getRespondedInputKeys(b)).toEqual([]);
+  });
+
+  it("does not carry responded keys across wires for the same task id", () => {
+    const legacy = { taskId: "t1", serverId: "s1", wire: "legacy" as const };
+    const extension = { taskId: "t1", serverId: "s1", wire: "extension" as const };
+    trackTask({ ...legacy, createdAt: NOW });
+    trackTask({ ...extension, createdAt: NOW });
+
+    recordRespondedInputKeys(legacy, ["k"]);
+    expect(getRespondedInputKeys(extension)).toEqual([]);
+  });
+
+  // ---- Robustness against corrupt / hostile / future records --------------
+
+  it("ignores a record written by a NEWER schema version outright", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 99,
+        tasks: [
+          { taskId: "t1", serverId: "s1", wire: "extension", createdAt: NOW },
+        ],
+      }),
+    );
+    // Best-effort parsing a future record risks misreading fields whose meaning
+    // changed; re-deriving from the server is strictly safer.
+    expect(getTrackedTasks()).toHaveLength(0);
+  });
+
+  it("drops malformed entries but keeps the good ones beside them", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 3,
+        tasks: [
+          null,
+          "nope",
+          { serverId: "s1", wire: "extension", createdAt: NOW },
+          { taskId: "good", serverId: "s1", wire: "extension", createdAt: NOW },
+        ],
+      }),
+    );
+    expect(getTrackedTasks().map((t) => t.taskId)).toEqual(["good"]);
+  });
+
+  it("survives corrupt JSON instead of throwing on every page load", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(getTrackedTasks()).toEqual([]);
+  });
+
+  it("normalizes an unrecognized wire tag to legacy rather than trusting it", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 3,
+        tasks: [
+          { taskId: "t1", serverId: "s1", wire: "made-up", createdAt: NOW },
+        ],
+      }),
+    );
+    expect(getTrackedTasks()[0].wire).toBe("legacy");
+  });
+
+  it("caps oversized strings from a hostile server", () => {
+    const huge = "x".repeat(10_000);
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 3,
+        tasks: [
+          {
+            taskId: huge,
+            serverId: "s1",
+            wire: "extension",
+            createdAt: NOW,
+            toolName: huge,
+          },
+        ],
+      }),
+    );
+    const [task] = getTrackedTasks();
+    expect(task.taskId.length).toBe(1024);
+    expect(task.toolName?.length).toBe(1024);
+  });
+
+  it("caps the number of responded input keys it will retain", () => {
+    const id = { taskId: "t1", serverId: "s1", wire: "extension" as const };
+    trackTask({ ...id, createdAt: NOW });
+    recordRespondedInputKeys(
+      id,
+      Array.from({ length: 500 }, (_, i) => `k${i}`),
+    );
+    expect(getRespondedInputKeys(id)).toHaveLength(100);
+  });
+
+  it("never drops a handle because its ttlMs elapsed", () => {
+    const id = { taskId: "t1", serverId: "s1", wire: "extension" as const };
+    trackTask({ ...id, createdAt: NOW });
+    // A one-millisecond TTL, long since past. Discarding the task is the
+    // SERVER's call (tasks.md:136-140); we keep the handle and keep polling.
+    recordTaskObservation(id, { ttlMs: 1, lastObservedAt: Date.now() - 60_000 });
+    expect(getTrackedTasks().map((t) => t.taskId)).toEqual(["t1"]);
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/task-tracker.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/task-tracker.test.ts
@@ -25,9 +25,7 @@ describe("task-tracker", () => {
   it("migrates v1 bare-array entries to legacy-tagged records", () => {
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify([
-        { taskId: "old-1", serverId: "s1", createdAt: NOW },
-      ]),
+      JSON.stringify([{ taskId: "old-1", serverId: "s1", createdAt: NOW }])
     );
 
     expect(getTrackedTasks()).toEqual([
@@ -90,7 +88,7 @@ describe("task-tracker", () => {
           { taskId: "old", serverId: "s1", wire: "legacy", createdAt: stale },
           { taskId: "new", serverId: "s1", wire: "legacy", createdAt: NOW },
         ],
-      }),
+      })
     );
 
     expect(getTrackedTasks().map((t) => t.taskId)).toEqual(["new"]);
@@ -140,7 +138,7 @@ describe("task-tracker", () => {
     untrackTask("t1", "s1");
     expect(getTrackedTasks().map((t) => t.serverId)).toEqual(["s2"]);
   });
-// ---- v3: resumable scheduling state + responded input keys --------------
+  // ---- v3: resumable scheduling state + responded input keys --------------
 
   it("resumes a handle's scheduling state across a reload", () => {
     const id = { taskId: "t1", serverId: "s1", wire: "extension" as const };
@@ -179,7 +177,7 @@ describe("task-tracker", () => {
   it("does not resurrect an untracked handle", () => {
     recordTaskObservation(
       { taskId: "ghost", serverId: "s1", wire: "extension" },
-      { status: "working" },
+      { status: "working" }
     );
     expect(getTrackedTasks()).toHaveLength(0);
   });
@@ -210,7 +208,11 @@ describe("task-tracker", () => {
 
   it("does not carry responded keys across wires for the same task id", () => {
     const legacy = { taskId: "t1", serverId: "s1", wire: "legacy" as const };
-    const extension = { taskId: "t1", serverId: "s1", wire: "extension" as const };
+    const extension = {
+      taskId: "t1",
+      serverId: "s1",
+      wire: "extension" as const,
+    };
     trackTask({ ...legacy, createdAt: NOW });
     trackTask({ ...extension, createdAt: NOW });
 
@@ -228,7 +230,7 @@ describe("task-tracker", () => {
         tasks: [
           { taskId: "t1", serverId: "s1", wire: "extension", createdAt: NOW },
         ],
-      }),
+      })
     );
     // Best-effort parsing a future record risks misreading fields whose meaning
     // changed; re-deriving from the server is strictly safer.
@@ -246,7 +248,7 @@ describe("task-tracker", () => {
           { serverId: "s1", wire: "extension", createdAt: NOW },
           { taskId: "good", serverId: "s1", wire: "extension", createdAt: NOW },
         ],
-      }),
+      })
     );
     expect(getTrackedTasks().map((t) => t.taskId)).toEqual(["good"]);
   });
@@ -264,7 +266,7 @@ describe("task-tracker", () => {
         tasks: [
           { taskId: "t1", serverId: "s1", wire: "made-up", createdAt: NOW },
         ],
-      }),
+      })
     );
     expect(getTrackedTasks()[0].wire).toBe("legacy");
   });
@@ -285,7 +287,7 @@ describe("task-tracker", () => {
             primitiveName: huge,
           },
         ],
-      }),
+      })
     );
     const [task] = getTrackedTasks();
     expect(task.toolName?.length).toBe(1024);
@@ -312,10 +314,10 @@ describe("task-tracker", () => {
               [field]: "x".repeat(10_000),
             },
           ],
-        }),
+        })
       );
       expect(getTrackedTasks()).toEqual([]);
-    },
+    }
   );
 
   it("refuses to write an over-length identity in the first place", () => {
@@ -335,7 +337,7 @@ describe("task-tracker", () => {
     trackTask({ ...id, createdAt: NOW });
     recordRespondedInputKeys(
       id,
-      Array.from({ length: 500 }, (_, i) => `k${i}`),
+      Array.from({ length: 500 }, (_, i) => `k${i}`)
     );
     expect(getRespondedInputKeys(id)).toHaveLength(100);
   });
@@ -345,7 +347,45 @@ describe("task-tracker", () => {
     trackTask({ ...id, createdAt: NOW });
     // A one-millisecond TTL, long since past. Discarding the task is the
     // SERVER's call (tasks.md:136-140); we keep the handle and keep polling.
-    recordTaskObservation(id, { ttlMs: 1, lastObservedAt: Date.now() - 60_000 });
+    recordTaskObservation(id, {
+      ttlMs: 1,
+      lastObservedAt: Date.now() - 60_000,
+    });
     expect(getTrackedTasks().map((t) => t.taskId)).toEqual(["t1"]);
+  });
+
+  it("sheds other scopes' handles before its own when the store is full", () => {
+    // Seeded directly rather than through `trackTask`, because the trim halves
+    // the payload and so leaves ~half the ceiling free afterwards — the public
+    // API cannot easily park the store just under the limit. A browser gets
+    // there over time; the test gets there in one write.
+    const pad = "x".repeat(1000);
+    const seeded = Array.from({ length: 260 }, (_, i) => ({
+      taskId: `other-${i}-${pad}`.slice(0, 1000),
+      serverId: `srv-${pad}`.slice(0, 1000),
+      wire: "extension" as const,
+      createdAt: new Date().toISOString(),
+      dismissed: false,
+      scope: "other-org",
+    }));
+    localStorage.setItem(
+      "mcp-tracked-tasks",
+      JSON.stringify({ version: 3, tasks: seeded })
+    );
+
+    setTrackedTaskScope("my-org");
+    trackTask({
+      taskId: "fresh",
+      serverId: "srv",
+      wire: "extension",
+      createdAt: new Date().toISOString(),
+    });
+
+    // Adding this one task crosses the ceiling, so the trim runs. Out-of-scope
+    // entries used to be concatenated FIRST and the trim sheds from the tail,
+    // so the task created a moment ago was dropped while stale handles from a
+    // scope nobody has open survived. Losing the handle the user is waiting on
+    // is the worst outcome this store has.
+    expect(getTrackedTasks().map((t) => t.taskId)).toEqual(["fresh"]);
   });
 });

--- a/mcpjam-inspector/client/src/lib/task-tracker.ts
+++ b/mcpjam-inspector/client/src/lib/task-tracker.ts
@@ -1,16 +1,34 @@
 /**
- * Lightweight task tracker for MCP Tasks.
+ * Durable task tracker for MCP Tasks.
  *
  * Tasks are tracked locally because servers are not required to remember them:
  * legacy servers may forget them across sessions, and the extension wire has
- * no `tasks/list` at all — there the tracker IS the list.
+ * no `tasks/list` at all — there the tracker IS the list. For anonymous and
+ * local use it is the only copy; for authenticated users it is still the
+ * immediate write path, with the hosted registry as a best-effort recovery
+ * index behind it rather than a replacement.
  *
  * Identity is the composite `(scope, serverId, wire, taskId)`: task IDs are
  * only unique within a server, the same ID can exist on both wires while a
  * developer flips protocol versions, and hosted task IDs are bearer-ish
  * handles that must not leak between accounts or organizations sharing a
- * browser — hence the auth/org `scope` segment. Entries are stored under a
- * versioned schema key so old, origin-wide entries can be migrated on load.
+ * browser — hence the auth/org `scope` segment.
+ *
+ * ## What is stored, and what is deliberately not
+ *
+ * Enough to RESUME a task, and nothing more: the handle, its identity, its
+ * latest scheduling hints, and which input keys have been answered. Never the
+ * elicitation prompts, the sampling content, the roots, the responses, or the
+ * task's result. A tracker entry is a bookmark, not a transcript.
+ *
+ * ## Why an entry is dropped
+ *
+ * Only ever for storage bounds — count, age, string length, serialized size —
+ * and never from a TTL. `ttlMs` is the SERVER's licence to discard a task, not
+ * ours (`tasks.md:136-140`), it may change over the task's lifetime
+ * (`tasks.md:340`), and `null` means unlimited. So an elapsed TTL raises a
+ * handle's poll priority and does nothing else. The age bound is measured and
+ * documented as a localStorage cap, not as an expiry.
  */
 
 import { TRACKED_TASK_MAX_AGE_MS } from "@/shared/hosted-tasks";
@@ -34,6 +52,26 @@ export interface TrackedTask {
    * Undefined for purely local entries, which have no cross-account risk.
    */
   scope?: string;
+
+  // ---- v3: resumable scheduling state -------------------------------------
+  /** Last `lastUpdatedAt` observed from the server. Never inferred locally. */
+  lastUpdatedAt?: string;
+  /** Latest observed status, so a reload can render before the first poll. */
+  status?: string;
+  /** Latest `ttlMs`. `null` means the server said "no expiry". */
+  ttlMs?: number | null;
+  /** Latest server-advertised poll floor. MAY change in either direction. */
+  pollIntervalMs?: number;
+  /** Epoch ms this handle may next be polled; survives a reload. */
+  nextPollAt?: number;
+  /** Epoch ms a live read last answered for this handle, any status. */
+  lastObservedAt?: number;
+  /**
+   * Input keys whose `tasks/update` was acknowledged. KEYS ONLY — never the
+   * request, the prompt, or the response. This is what stops a reload from
+   * re-prompting for something the user already answered.
+   */
+  respondedInputKeys?: string[];
 }
 
 /**
@@ -56,8 +94,18 @@ function inScope(task: TrackedTask): boolean {
 }
 
 const STORAGE_KEY = "mcp-tracked-tasks";
-const SCHEMA_VERSION = 2;
+/**
+ * v1: bare array, no wire tag. v2: `{version, tasks}` with `wire`.
+ * v3: adds resumable scheduling state and responded input keys.
+ */
+const SCHEMA_VERSION = 3;
 const MAX_TRACKED_TASKS = 50;
+
+/** Bounds on untrusted, server-influenced strings before they are persisted. */
+const MAX_STRING_LENGTH = 1024;
+const MAX_RESPONDED_KEYS = 100;
+/** Whole-payload ceiling; entries are shed oldest-first until it is met. */
+const MAX_SERIALIZED_BYTES = 512 * 1024;
 
 interface StoredShape {
   version: number;
@@ -81,19 +129,111 @@ function isFresh(task: TrackedTask, now: number): boolean {
   return now - createdAt < TRACKED_TASK_MAX_AGE_MS;
 }
 
+function clampString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.length > MAX_STRING_LENGTH
+    ? value.slice(0, MAX_STRING_LENGTH)
+    : value;
+}
+
+function clampNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Normalizes one stored record. Anything unrecognized is dropped rather than
+ * trusted: this data is attacker-influenceable (a server picks the task id and
+ * the input keys) and it is read on every page load.
+ */
+function sanitize(raw: unknown): TrackedTask | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+  const record = raw as Record<string, unknown>;
+  const taskId = clampString(record.taskId);
+  const serverId = clampString(record.serverId);
+  if (!taskId || !serverId) return undefined;
+
+  // A stored entry without a wire tag predates the extension; defaulting keeps
+  // `wire` non-optional at runtime (identity depends on it).
+  const wire: TasksWire =
+    record.wire === "extension" || record.wire === "legacy"
+      ? record.wire
+      : "legacy";
+
+  const ttlMs =
+    record.ttlMs === null ? null : clampNumber(record.ttlMs);
+  const respondedInputKeys = Array.isArray(record.respondedInputKeys)
+    ? record.respondedInputKeys
+        .filter((key): key is string => typeof key === "string")
+        .slice(0, MAX_RESPONDED_KEYS)
+        .map((key) => key.slice(0, MAX_STRING_LENGTH))
+    : undefined;
+
+  const task: TrackedTask = {
+    taskId,
+    serverId,
+    wire,
+    createdAt: clampString(record.createdAt) ?? "",
+    ...(clampString(record.toolName) ? { toolName: clampString(record.toolName) } : {}),
+    ...(record.primitiveType === "tool" ||
+    record.primitiveType === "prompt" ||
+    record.primitiveType === "resource"
+      ? { primitiveType: record.primitiveType }
+      : {}),
+    ...(clampString(record.primitiveName)
+      ? { primitiveName: clampString(record.primitiveName) }
+      : {}),
+    ...(record.dismissed === true ? { dismissed: true } : {}),
+    ...(record.expired === true ? { expired: true } : {}),
+    ...(clampString(record.scope) !== undefined
+      ? { scope: clampString(record.scope) }
+      : {}),
+    ...(clampString(record.lastUpdatedAt)
+      ? { lastUpdatedAt: clampString(record.lastUpdatedAt) }
+      : {}),
+    ...(clampString(record.status) ? { status: clampString(record.status) } : {}),
+    ...(ttlMs !== undefined ? { ttlMs } : {}),
+    ...(clampNumber(record.pollIntervalMs) !== undefined
+      ? { pollIntervalMs: clampNumber(record.pollIntervalMs) }
+      : {}),
+    ...(clampNumber(record.nextPollAt) !== undefined
+      ? { nextPollAt: clampNumber(record.nextPollAt) }
+      : {}),
+    ...(clampNumber(record.lastObservedAt) !== undefined
+      ? { lastObservedAt: clampNumber(record.lastObservedAt) }
+      : {}),
+    ...(respondedInputKeys?.length ? { respondedInputKeys } : {}),
+  };
+  return task;
+}
+
+/**
+ * v1 → v3 and v2 → v3 are both pure widenings: every added field is optional,
+ * so an older record is already a valid v3 record once its `wire` is defaulted.
+ *
+ * A FUTURE version is ignored entirely rather than best-effort parsed. A newer
+ * tab may have written fields whose meaning we would get wrong, and a wrong
+ * `nextPollAt` or a wrongly-inherited `respondedInputKeys` is worse than
+ * re-deriving both from the server.
+ */
 function migrate(parsed: unknown): TrackedTask[] {
   // v1 stored a bare array with no wire tag; those entries predate the
   // extension, so they are legacy by construction.
   if (Array.isArray(parsed)) {
-    return parsed.map((task: TrackedTask) => ({ ...task, wire: "legacy" }));
+    return parsed
+      .map(sanitize)
+      .filter((task): task is TrackedTask => task !== undefined);
   }
-  const stored = parsed as StoredShape | null;
-  if (!stored || !Array.isArray(stored.tasks)) return [];
+  if (typeof parsed !== "object" || parsed === null) return [];
+  const stored = parsed as Partial<StoredShape>;
+  if (typeof stored.version === "number" && stored.version > SCHEMA_VERSION) {
+    return [];
+  }
+  if (!Array.isArray(stored.tasks)) return [];
   return stored.tasks
-    .filter((task) => task && task.taskId && task.serverId)
-    // A stored entry without a wire tag predates the extension; defaulting
-    // keeps `wire` non-optional at runtime (identity depends on it).
-    .map((task) => (task.wire ? task : { ...task, wire: "legacy" as const }));
+    .map(sanitize)
+    .filter((task): task is TrackedTask => task !== undefined);
 }
 
 /** Every entry on disk, regardless of scope — writes must not drop other actors' handles. */
@@ -104,6 +244,8 @@ function loadAllTasks(): TrackedTask[] {
     const now = Date.now();
     return migrate(JSON.parse(data)).filter((task) => isFresh(task, now));
   } catch {
+    // Corrupt JSON is indistinguishable from a hostile write; start clean
+    // rather than throwing on every page load.
     return [];
   }
 }
@@ -119,8 +261,22 @@ function saveInScope(next: TrackedTask[]): void {
 
 function saveTasks(tasks: TrackedTask[]): void {
   try {
-    const payload: StoredShape = { version: SCHEMA_VERSION, tasks };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    let payload = tasks;
+    let serialized = JSON.stringify({
+      version: SCHEMA_VERSION,
+      tasks: payload,
+    } satisfies StoredShape);
+    // Shed from the tail — the least recently tracked — until the payload fits.
+    // A quota rejection would otherwise lose the whole store, including the
+    // handle the user is actively waiting on.
+    while (serialized.length > MAX_SERIALIZED_BYTES && payload.length > 1) {
+      payload = payload.slice(0, Math.floor(payload.length / 2));
+      serialized = JSON.stringify({
+        version: SCHEMA_VERSION,
+        tasks: payload,
+      } satisfies StoredShape);
+    }
+    localStorage.setItem(STORAGE_KEY, serialized);
   } catch {
     // localStorage might be full or unavailable
   }
@@ -160,6 +316,84 @@ export function trackTask(task: Omit<TrackedTask, "dismissed">): void {
 
   tasks.unshift({ ...scoped, dismissed: false });
   saveInScope(tasks.slice(0, MAX_TRACKED_TASKS));
+}
+
+/**
+ * Folds an observation into a tracked handle so a reload resumes where the
+ * poller left off rather than restarting every task at its floor.
+ *
+ * A no-op for an untracked handle: this must never resurrect an entry the user
+ * cleared or that belongs to another actor.
+ */
+export function recordTaskObservation(
+  identity: { taskId: string; serverId: string; wire: TasksWire; scope?: string },
+  observation: {
+    status?: string;
+    lastUpdatedAt?: string;
+    ttlMs?: number | null;
+    pollIntervalMs?: number;
+    nextPollAt?: number;
+    lastObservedAt?: number;
+  },
+): void {
+  const scoped = { ...identity, scope: identity.scope ?? activeScope };
+  const key = taskIdentity(scoped);
+  const tasks = loadTasks();
+  const entry = tasks.find((t) => taskIdentity(t) === key);
+  if (!entry) return;
+
+  if (observation.status !== undefined) entry.status = observation.status;
+  if (observation.lastUpdatedAt !== undefined) {
+    entry.lastUpdatedAt = observation.lastUpdatedAt;
+  }
+  // `null` is meaningful (no expiry) and must overwrite a previous number, so
+  // this checks for `undefined` rather than truthiness.
+  if (observation.ttlMs !== undefined) entry.ttlMs = observation.ttlMs;
+  if (observation.pollIntervalMs !== undefined) {
+    entry.pollIntervalMs = observation.pollIntervalMs;
+  }
+  if (observation.nextPollAt !== undefined) {
+    entry.nextPollAt = observation.nextPollAt;
+  }
+  if (observation.lastObservedAt !== undefined) {
+    entry.lastObservedAt = observation.lastObservedAt;
+  }
+  saveInScope(tasks);
+}
+
+/**
+ * Marks input keys answered, after the `tasks/update` acknowledgement
+ * succeeded. Keys only — the request and the response are never persisted.
+ */
+export function recordRespondedInputKeys(
+  identity: { taskId: string; serverId: string; wire: TasksWire; scope?: string },
+  keys: readonly string[],
+): void {
+  if (keys.length === 0) return;
+  const scoped = { ...identity, scope: identity.scope ?? activeScope };
+  const key = taskIdentity(scoped);
+  const tasks = loadTasks();
+  const entry = tasks.find((t) => taskIdentity(t) === key);
+  if (!entry) return;
+
+  const merged = new Set([...(entry.respondedInputKeys ?? []), ...keys]);
+  entry.respondedInputKeys = [...merged]
+    .slice(0, MAX_RESPONDED_KEYS)
+    .map((k) => k.slice(0, MAX_STRING_LENGTH));
+  saveInScope(tasks);
+}
+
+export function getRespondedInputKeys(identity: {
+  taskId: string;
+  serverId: string;
+  wire: TasksWire;
+  scope?: string;
+}): string[] {
+  const scoped = { ...identity, scope: identity.scope ?? activeScope };
+  const key = taskIdentity(scoped);
+  return (
+    loadTasks().find((t) => taskIdentity(t) === key)?.respondedInputKeys ?? []
+  );
 }
 
 export function untrackTask(taskId: string, serverId?: string): void {

--- a/mcpjam-inspector/client/src/lib/task-tracker.ts
+++ b/mcpjam-inspector/client/src/lib/task-tracker.ts
@@ -154,7 +154,16 @@ function clampString(value: unknown): string | undefined {
  */
 function identityString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
-  return value.length > MAX_STRING_LENGTH ? undefined : value;
+  // NUL is REJECTED, not stripped or escaped. It is the delimiter the composite
+  // identity key is joined with, so a component containing one re-parses as a
+  // different split: `serverId: "a\u0000b"` with `taskId: "c"` produces the same
+  // key as `serverId: "a"` with `taskId: "b\u0000c"`. Two distinct handles would
+  // then share one record — inheriting each other's `nextPollAt` and, worse,
+  // each other's answered-input keys, so a prompt one of them never answered
+  // would be silently skipped.
+  return value.length > MAX_STRING_LENGTH || value.includes("\u0000")
+    ? undefined
+    : value;
 }
 
 function clampNumber(value: unknown): number | undefined {

--- a/mcpjam-inspector/client/src/lib/task-tracker.ts
+++ b/mcpjam-inspector/client/src/lib/task-tracker.ts
@@ -118,7 +118,9 @@ export function taskIdentity(task: {
   taskId: string;
   scope?: string;
 }): string {
-  return [task.scope ?? "", task.serverId, task.wire, task.taskId].join("\u0000");
+  return [task.scope ?? "", task.serverId, task.wire, task.taskId].join(
+    "\u0000"
+  );
 }
 
 function isFresh(task: TrackedTask, now: number): boolean {
@@ -137,7 +139,9 @@ function clampString(value: unknown): string | undefined {
 }
 
 function clampNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
 }
 
 /**
@@ -152,7 +156,15 @@ function sanitize(raw: unknown): TrackedTask | undefined {
   const record = raw as Record<string, unknown>;
   const taskId = clampString(record.taskId);
   const serverId = clampString(record.serverId);
+  const createdAt = clampString(record.createdAt);
   if (!taskId || !serverId) return undefined;
+  // Reject rather than default to `""`. Every other unrecognized field here is
+  // dropped; defaulting this one would produce a string no date parser
+  // accepts, and `isFresh` and the Tasks tab's sort comparator both call
+  // `new Date(createdAt).getTime()` — so the record would contribute `NaN` to
+  // an age check and to a comparator, giving an arbitrary ordering rather than
+  // an error.
+  if (!createdAt || Number.isNaN(Date.parse(createdAt))) return undefined;
 
   // A stored entry without a wire tag predates the extension; defaulting keeps
   // `wire` non-optional at runtime (identity depends on it).
@@ -161,8 +173,7 @@ function sanitize(raw: unknown): TrackedTask | undefined {
       ? record.wire
       : "legacy";
 
-  const ttlMs =
-    record.ttlMs === null ? null : clampNumber(record.ttlMs);
+  const ttlMs = record.ttlMs === null ? null : clampNumber(record.ttlMs);
   const respondedInputKeys = Array.isArray(record.respondedInputKeys)
     ? record.respondedInputKeys
         .filter((key): key is string => typeof key === "string")
@@ -174,8 +185,10 @@ function sanitize(raw: unknown): TrackedTask | undefined {
     taskId,
     serverId,
     wire,
-    createdAt: clampString(record.createdAt) ?? "",
-    ...(clampString(record.toolName) ? { toolName: clampString(record.toolName) } : {}),
+    createdAt,
+    ...(clampString(record.toolName)
+      ? { toolName: clampString(record.toolName) }
+      : {}),
     ...(record.primitiveType === "tool" ||
     record.primitiveType === "prompt" ||
     record.primitiveType === "resource"
@@ -192,7 +205,9 @@ function sanitize(raw: unknown): TrackedTask | undefined {
     ...(clampString(record.lastUpdatedAt)
       ? { lastUpdatedAt: clampString(record.lastUpdatedAt) }
       : {}),
-    ...(clampString(record.status) ? { status: clampString(record.status) } : {}),
+    ...(clampString(record.status)
+      ? { status: clampString(record.status) }
+      : {}),
     ...(ttlMs !== undefined ? { ttlMs } : {}),
     ...(clampNumber(record.pollIntervalMs) !== undefined
       ? { pollIntervalMs: clampNumber(record.pollIntervalMs) }
@@ -288,23 +303,23 @@ export function getTrackedTasks(): TrackedTask[] {
 
 export function getTrackedTasksForServer(
   serverId: string,
-  wire?: TasksWire,
+  wire?: TasksWire
 ): TrackedTask[] {
   return loadTasks().filter(
     (t) =>
       t.serverId === serverId &&
       !t.dismissed &&
-      (wire === undefined || t.wire === wire),
+      (wire === undefined || t.wire === wire)
   );
 }
 
 export function getTrackedTaskById(
   taskId: string,
-  serverId?: string,
+  serverId?: string
 ): TrackedTask | undefined {
   return loadTasks().find(
     (t) =>
-      t.taskId === taskId && (serverId === undefined || t.serverId === serverId),
+      t.taskId === taskId && (serverId === undefined || t.serverId === serverId)
   );
 }
 
@@ -325,8 +340,118 @@ export function trackTask(task: Omit<TrackedTask, "dismissed">): void {
  * A no-op for an untracked handle: this must never resurrect an entry the user
  * cleared or that belongs to another actor.
  */
+/**
+ * Applies one observation to a loaded entry. Shared by the single and batch
+ * write paths so their field semantics — notably `null` `ttlMs` meaning "no
+ * expiry" and therefore overwriting a number — cannot drift apart.
+ */
+function applyObservation(
+  entry: TrackedTask,
+  observation: TaskObservationPatch
+): void {
+  if (observation.status !== undefined) entry.status = observation.status;
+  if (observation.lastUpdatedAt !== undefined) {
+    entry.lastUpdatedAt = observation.lastUpdatedAt;
+  }
+  // `null` is meaningful (no expiry) and must overwrite a previous number, so
+  // this checks for `undefined` rather than truthiness.
+  if (observation.ttlMs !== undefined) entry.ttlMs = observation.ttlMs;
+  if (observation.pollIntervalMs !== undefined) {
+    entry.pollIntervalMs = observation.pollIntervalMs;
+  }
+  if (observation.nextPollAt !== undefined) {
+    entry.nextPollAt = observation.nextPollAt;
+  }
+  if (observation.lastObservedAt !== undefined) {
+    entry.lastObservedAt = observation.lastObservedAt;
+  }
+}
+
+export interface TaskObservationPatch {
+  status?: string;
+  lastUpdatedAt?: string;
+  ttlMs?: number | null;
+  pollIntervalMs?: number;
+  nextPollAt?: number;
+  lastObservedAt?: number;
+}
+
+export interface TaskIdentityRef {
+  taskId: string;
+  serverId: string;
+  wire: TasksWire;
+  scope?: string;
+}
+
+/**
+ * Batch form of {@link recordTaskObservation}.
+ *
+ * A poll tick observes every due handle, and the single-entry function parses
+ * and re-serializes the whole store per call — so N due handles cost 2N full
+ * parses and N serializations on the main thread, every interval. This makes
+ * the cost per TICK instead of per task, which also narrows the window in
+ * which two tabs polling the same server clobber each other's hints.
+ */
+export function recordTaskObservations(
+  entries: readonly {
+    identity: TaskIdentityRef;
+    observation: TaskObservationPatch;
+  }[]
+): void {
+  if (entries.length === 0) return;
+  const tasks = loadTasks();
+  const byKey = new Map(tasks.map((task) => [taskIdentity(task), task]));
+  let changed = false;
+  for (const { identity, observation } of entries) {
+    const entry = byKey.get(
+      taskIdentity({ ...identity, scope: identity.scope ?? activeScope })
+    );
+    // Never resurrects an untracked handle: this must not recreate an entry
+    // the user cleared or that belongs to another actor.
+    if (!entry) continue;
+    applyObservation(entry, observation);
+    changed = true;
+  }
+  if (changed) saveInScope(tasks);
+}
+
+/**
+ * The persisted scheduling state for a handle, for seeding the lifecycle
+ * engine after a reload. `undefined` when the handle is not tracked.
+ */
+export function getTrackedTaskSchedule(
+  identity: TaskIdentityRef
+):
+  | {
+      nextPollAt?: number;
+      lastObservedAt?: number;
+      pollIntervalMs?: number;
+      ttlMs?: number | null;
+      status?: string;
+    }
+  | undefined {
+  const key = taskIdentity({
+    ...identity,
+    scope: identity.scope ?? activeScope,
+  });
+  const entry = loadTasks().find((task) => taskIdentity(task) === key);
+  if (!entry) return undefined;
+  return {
+    nextPollAt: entry.nextPollAt,
+    lastObservedAt: entry.lastObservedAt,
+    pollIntervalMs: entry.pollIntervalMs,
+    ttlMs: entry.ttlMs,
+    status: entry.status,
+  };
+}
+
 export function recordTaskObservation(
-  identity: { taskId: string; serverId: string; wire: TasksWire; scope?: string },
+  identity: {
+    taskId: string;
+    serverId: string;
+    wire: TasksWire;
+    scope?: string;
+  },
   observation: {
     status?: string;
     lastUpdatedAt?: string;
@@ -334,7 +459,7 @@ export function recordTaskObservation(
     pollIntervalMs?: number;
     nextPollAt?: number;
     lastObservedAt?: number;
-  },
+  }
 ): void {
   const scoped = { ...identity, scope: identity.scope ?? activeScope };
   const key = taskIdentity(scoped);
@@ -366,8 +491,13 @@ export function recordTaskObservation(
  * succeeded. Keys only — the request and the response are never persisted.
  */
 export function recordRespondedInputKeys(
-  identity: { taskId: string; serverId: string; wire: TasksWire; scope?: string },
-  keys: readonly string[],
+  identity: {
+    taskId: string;
+    serverId: string;
+    wire: TasksWire;
+    scope?: string;
+  },
+  keys: readonly string[]
 ): void {
   if (keys.length === 0) return;
   const scoped = { ...identity, scope: identity.scope ?? activeScope };
@@ -403,8 +533,8 @@ export function untrackTask(taskId: string, serverId?: string): void {
         !(
           t.taskId === taskId &&
           (serverId === undefined || t.serverId === serverId)
-        ),
-    ),
+        )
+    )
   );
 }
 
@@ -436,7 +566,7 @@ export function dismissTask(taskId: string, serverId?: string): void {
 
 export function dismissTasksForServer(
   serverId: string,
-  taskIds: string[],
+  taskIds: string[]
 ): void {
   const idsToDissmiss = new Set(taskIds);
   const tasks = loadTasks();
@@ -452,7 +582,7 @@ export function getDismissedTaskIds(serverId: string): Set<string> {
   return new Set(
     loadTasks()
       .filter((t) => t.serverId === serverId && t.dismissed)
-      .map((t) => t.taskId),
+      .map((t) => t.taskId)
   );
 }
 
@@ -466,7 +596,7 @@ export function clearTrackedTasksForServer(serverId: string): void {
  * shared browser.
  */
 export function clearTrackedTasksForScope(
-  scope: string | null | undefined,
+  scope: string | null | undefined
 ): void {
   const target = scope ?? undefined;
   saveTasks(loadAllTasks().filter((t) => (t.scope ?? undefined) !== target));

--- a/mcpjam-inspector/client/src/lib/task-tracker.ts
+++ b/mcpjam-inspector/client/src/lib/task-tracker.ts
@@ -301,9 +301,21 @@ function loadTasks(): TrackedTask[] {
   return loadAllTasks().filter(inScope);
 }
 
-/** Persists the in-scope entries while preserving other actors' entries. */
+/**
+ * Persists the in-scope entries while preserving other actors' entries.
+ *
+ * Current scope FIRST, and the order is load-bearing rather than cosmetic.
+ * `saveTasks` sheds from the tail to fit the size ceiling, and `trackTask`
+ * unshifts, so the prefix is "newest, mine" and the tail is "oldest, someone
+ * else's". Concatenating the other way — which is what this did — put every
+ * preserved handle from a previous account or organization scope ahead of the
+ * current one, so a task created seconds ago was among the first records
+ * dropped while stale handles belonging to a scope nobody is looking at
+ * survived. Losing the handle the user is actively waiting on is the worst
+ * outcome this store has.
+ */
 function saveInScope(next: TrackedTask[]): void {
-  saveTasks([...loadAllTasks().filter((t) => !inScope(t)), ...next]);
+  saveTasks([...next, ...loadAllTasks().filter((t) => !inScope(t))]);
 }
 
 function saveTasks(tasks: TrackedTask[]): void {
@@ -313,9 +325,11 @@ function saveTasks(tasks: TrackedTask[]): void {
       version: SCHEMA_VERSION,
       tasks: payload,
     } satisfies StoredShape);
-    // Shed from the tail — the least recently tracked — until the payload fits.
-    // A quota rejection would otherwise lose the whole store, including the
-    // handle the user is actively waiting on.
+    // Shed from the tail until the payload fits. `saveInScope` orders the
+    // payload so the tail is the most expendable thing in the store — other
+    // scopes' entries, then this scope's oldest — and a quota rejection would
+    // otherwise lose the WHOLE store, including the handle the user is
+    // actively waiting on.
     while (serialized.length > MAX_SERIALIZED_BYTES && payload.length > 1) {
       payload = payload.slice(0, Math.floor(payload.length / 2));
       serialized = JSON.stringify({

--- a/mcpjam-inspector/client/src/lib/task-tracker.ts
+++ b/mcpjam-inspector/client/src/lib/task-tracker.ts
@@ -138,6 +138,25 @@ function clampString(value: unknown): string | undefined {
     : value;
 }
 
+/**
+ * An IDENTITY string: over-length is rejected, never truncated.
+ *
+ * `taskId`, `serverId` and `scope` are the three components of
+ * {@link taskIdentity}, so truncating one does not shorten a value — it
+ * silently produces a DIFFERENT handle than the one that was written, and any
+ * two values sharing a 1024-character prefix collapse into a single identity
+ * that shares `respondedInputKeys` and `nextPollAt`. For `scope` — the
+ * auth/org segment that keeps one account's handles out of another's — that
+ * collapse is a cross-account leak rather than a display glitch.
+ *
+ * Dropping the record instead costs a handle the user can re-create; the
+ * bounds still hold, because a rejected record is not persisted at all.
+ */
+function identityString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  return value.length > MAX_STRING_LENGTH ? undefined : value;
+}
+
 function clampNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value)
     ? value
@@ -154,10 +173,16 @@ function sanitize(raw: unknown): TrackedTask | undefined {
     return undefined;
   }
   const record = raw as Record<string, unknown>;
-  const taskId = clampString(record.taskId);
-  const serverId = clampString(record.serverId);
+  const taskId = identityString(record.taskId);
+  const serverId = identityString(record.serverId);
   const createdAt = clampString(record.createdAt);
   if (!taskId || !serverId) return undefined;
+  // Present but over-length. `identityString` cannot distinguish that from
+  // absent, and the two are not the same: an absent scope is the default
+  // scope, while an over-length one is a scope we cannot represent — reading
+  // it as "default" would file another account's handle under this one.
+  const scope = identityString(record.scope);
+  if (record.scope !== undefined && scope === undefined) return undefined;
   // Reject rather than default to `""`. Every other unrecognized field here is
   // dropped; defaulting this one would produce a string no date parser
   // accepts, and `isFresh` and the Tasks tab's sort comparator both call
@@ -199,9 +224,7 @@ function sanitize(raw: unknown): TrackedTask | undefined {
       : {}),
     ...(record.dismissed === true ? { dismissed: true } : {}),
     ...(record.expired === true ? { expired: true } : {}),
-    ...(clampString(record.scope) !== undefined
-      ? { scope: clampString(record.scope) }
-      : {}),
+    ...(scope !== undefined ? { scope } : {}),
     ...(clampString(record.lastUpdatedAt)
       ? { lastUpdatedAt: clampString(record.lastUpdatedAt) }
       : {}),
@@ -325,6 +348,17 @@ export function getTrackedTaskById(
 
 export function trackTask(task: Omit<TrackedTask, "dismissed">): void {
   const scoped = { ...task, scope: task.scope ?? activeScope };
+  // Same identity bound as the read path, applied HERE so an over-length
+  // server-chosen id is refused at the door. Writing it and rejecting it on
+  // the next `loadTasks` would make the handle vanish at the next reload with
+  // nothing to explain why.
+  if (
+    identityString(scoped.taskId) === undefined ||
+    identityString(scoped.serverId) === undefined ||
+    (scoped.scope !== undefined && identityString(scoped.scope) === undefined)
+  ) {
+    return;
+  }
   const tasks = loadTasks();
   const identity = taskIdentity(scoped);
   if (tasks.some((t) => taskIdentity(t) === identity)) return;
@@ -413,6 +447,57 @@ export function recordTaskObservations(
     changed = true;
   }
   if (changed) saveInScope(tasks);
+}
+
+/** Everything the lifecycle engine needs to restore one handle after a reload. */
+export interface TrackedTaskRestoreState {
+  nextPollAt?: number;
+  lastObservedAt?: number;
+  pollIntervalMs?: number;
+  ttlMs?: number | null;
+  status?: string;
+  respondedInputKeys: string[];
+}
+
+/**
+ * Batch form of {@link getTrackedTaskSchedule} + {@link getRespondedInputKeys}.
+ *
+ * Seeding the engine used to cost TWO full `loadTasks()` parses per newly-seen
+ * handle — so the first tick after a reload, when every tracked handle is
+ * newly seen, ran 2N parse-and-migrate passes over the whole store on the main
+ * thread. That is the same per-task cost {@link recordTaskObservations} exists
+ * to avoid on the write side; this is the read side of it. One parse per tick.
+ *
+ * Keyed by `taskIdentity(identity)` of the identity AS PASSED — not by the
+ * scope-defaulted key used to match rows — so a caller that omitted `scope`
+ * (meaning "the active scope") can look its own result up without having to
+ * know what the active scope is.
+ */
+export function getTrackedTaskRestoreStates(
+  identities: readonly TaskIdentityRef[]
+): Map<string, TrackedTaskRestoreState> {
+  const result = new Map<string, TrackedTaskRestoreState>();
+  if (identities.length === 0) return result;
+  const callerKeyByStoredKey = new Map<string, string>();
+  for (const identity of identities) {
+    callerKeyByStoredKey.set(
+      taskIdentity({ ...identity, scope: identity.scope ?? activeScope }),
+      taskIdentity(identity)
+    );
+  }
+  for (const entry of loadTasks()) {
+    const callerKey = callerKeyByStoredKey.get(taskIdentity(entry));
+    if (callerKey === undefined) continue;
+    result.set(callerKey, {
+      nextPollAt: entry.nextPollAt,
+      lastObservedAt: entry.lastObservedAt,
+      pollIntervalMs: entry.pollIntervalMs,
+      ttlMs: entry.ttlMs,
+      status: entry.status,
+      respondedInputKeys: entry.respondedInputKeys ?? [],
+    });
+  }
+  return result;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/task-tracker.ts
+++ b/mcpjam-inspector/client/src/lib/task-tracker.ts
@@ -419,9 +419,7 @@ export function recordTaskObservations(
  * The persisted scheduling state for a handle, for seeding the lifecycle
  * engine after a reload. `undefined` when the handle is not tracked.
  */
-export function getTrackedTaskSchedule(
-  identity: TaskIdentityRef
-):
+export function getTrackedTaskSchedule(identity: TaskIdentityRef):
   | {
       nextPollAt?: number;
       lastObservedAt?: number;
@@ -467,22 +465,7 @@ export function recordTaskObservation(
   const entry = tasks.find((t) => taskIdentity(t) === key);
   if (!entry) return;
 
-  if (observation.status !== undefined) entry.status = observation.status;
-  if (observation.lastUpdatedAt !== undefined) {
-    entry.lastUpdatedAt = observation.lastUpdatedAt;
-  }
-  // `null` is meaningful (no expiry) and must overwrite a previous number, so
-  // this checks for `undefined` rather than truthiness.
-  if (observation.ttlMs !== undefined) entry.ttlMs = observation.ttlMs;
-  if (observation.pollIntervalMs !== undefined) {
-    entry.pollIntervalMs = observation.pollIntervalMs;
-  }
-  if (observation.nextPollAt !== undefined) {
-    entry.nextPollAt = observation.nextPollAt;
-  }
-  if (observation.lastObservedAt !== undefined) {
-    entry.lastObservedAt = observation.lastObservedAt;
-  }
+  applyObservation(entry, observation);
   saveInScope(tasks);
 }
 

--- a/mcpjam-inspector/client/src/lib/task-utils.ts
+++ b/mcpjam-inspector/client/src/lib/task-utils.ts
@@ -51,7 +51,7 @@ function optionalNumber(value: unknown): number | undefined {
 
 export function normalizeTask(
   wire: TasksWire,
-  raw: Record<string, unknown>
+  raw: Record<string, unknown>,
 ): NormalizedTask {
   const ttl = wire === "extension" ? raw.ttlMs : raw.ttl;
   const pollInterval =

--- a/mcpjam-inspector/client/src/lib/task-utils.ts
+++ b/mcpjam-inspector/client/src/lib/task-utils.ts
@@ -51,7 +51,7 @@ function optionalNumber(value: unknown): number | undefined {
 
 export function normalizeTask(
   wire: TasksWire,
-  raw: Record<string, unknown>,
+  raw: Record<string, unknown>
 ): NormalizedTask {
   const ttl = wire === "extension" ? raw.ttlMs : raw.ttl;
   const pollInterval =

--- a/mcpjam-inspector/client/src/lib/task-utils.ts
+++ b/mcpjam-inspector/client/src/lib/task-utils.ts
@@ -146,7 +146,22 @@ export function restoredPlaceholderTask(tracked: {
   ttlMs?: number | null;
   pollIntervalMs?: number;
 }): NormalizedTask {
-  const status = (tracked.status ?? "working") as NormalizedTask["status"];
+  // Validated, not cast. The tracker is localStorage — hand-editable, and
+  // written by every version of this app the browser has ever run — so an
+  // unrecognized string reaching `status` unchecked would render as an unknown
+  // badge at best. The dangerous direction is a bogus value that reads as
+  // TERMINAL: the row would stop being polled and a live task would sit there
+  // frozen. `unavailable` is excluded for the same reason from the other side —
+  // it is this app's own tombstone for "the server forgot it", a conclusion
+  // only `expiredPlaceholderTask` is entitled to draw, never restored state.
+  const status: NormalizedTask["status"] =
+    tracked.status === "working" ||
+    tracked.status === "input_required" ||
+    tracked.status === "completed" ||
+    tracked.status === "failed" ||
+    tracked.status === "cancelled"
+      ? tracked.status
+      : "working";
   return {
     wire: tracked.wire,
     taskId: tracked.taskId,

--- a/mcpjam-inspector/client/src/lib/task-utils.ts
+++ b/mcpjam-inspector/client/src/lib/task-utils.ts
@@ -51,7 +51,7 @@ function optionalNumber(value: unknown): number | undefined {
 
 export function normalizeTask(
   wire: TasksWire,
-  raw: Record<string, unknown>,
+  raw: Record<string, unknown>
 ): NormalizedTask {
   const ttl = wire === "extension" ? raw.ttlMs : raw.ttl;
   const pollInterval =
@@ -125,6 +125,42 @@ export const STATUS_CONFIG: Record<TaskDisplayStatus, StatusConfig> = {
  * Renders a tracked handle the server has forgotten straight from tracker
  * state — no network read, since re-polling it can only fail again.
  */
+/**
+ * A row for a tracked handle we have not read yet in this session.
+ *
+ * Rendered on the first tick after a reload, when a restored handle's stored
+ * poll floor has not yet elapsed. It carries the last status the tracker
+ * persisted so the list is not empty — an empty list would make the tab think
+ * there are no active tasks, never start auto-refresh, and leave the handle
+ * unpolled and invisible until a manual refresh.
+ *
+ * Deliberately NOT marked `expired`: the server has said nothing about this
+ * handle. It is simply not due yet.
+ */
+export function restoredPlaceholderTask(tracked: {
+  taskId: string;
+  wire: TasksWire;
+  createdAt: string;
+  status?: string;
+  lastUpdatedAt?: string;
+  ttlMs?: number | null;
+  pollIntervalMs?: number;
+}): NormalizedTask {
+  const status = (tracked.status ?? "working") as NormalizedTask["status"];
+  return {
+    wire: tracked.wire,
+    taskId: tracked.taskId,
+    status,
+    createdAt: tracked.createdAt,
+    lastUpdatedAt: tracked.lastUpdatedAt ?? tracked.createdAt,
+    ttl: tracked.ttlMs ?? null,
+    ...(tracked.pollIntervalMs !== undefined
+      ? { pollInterval: tracked.pollIntervalMs }
+      : {}),
+    raw: { taskId: tracked.taskId },
+  };
+}
+
 export function expiredPlaceholderTask(tracked: {
   taskId: string;
   wire: TasksWire;

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -400,6 +400,7 @@ export {
   TaskLifecycleEngine,
   taskLifecycleKey,
   isTerminalLifecycleStatus,
+  toSnapshot as toTaskLifecycleSnapshot,
   TERMINAL_LIFECYCLE_STATUSES,
 } from "./mcp-client-manager/task-lifecycle.js";
 export type {

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -423,3 +423,20 @@ export {
   UNKNOWN_TASK_ERROR_CODE,
   TASKS_DECLARATION_REQUIRED_ERROR_CODE,
 } from "./mcp-client-manager/task-lifecycle-adapters.js";
+
+// Tasks product policy — pure predicates over the stored host config, so the
+// editor and every browser-side surface read the same tri-state.
+export {
+  MCPJAM_TASKS_POLICY_EXTENSION_ID,
+  readTasksPolicy,
+  describeInvalidTasksPolicy,
+  setTasksPolicy,
+  clearTasksPolicy,
+  taskModeForSurface,
+  surfaceMayDeclareTasks,
+} from "./host-config/tasks-policy.js";
+export type {
+  TasksPolicy,
+  TaskMode,
+  TaskSurface,
+} from "./host-config/tasks-policy.js";

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -391,3 +391,35 @@ export type {
   OpenAiAppsCapabilities,
   McpAppsCapabilities,
 } from "./host-config/index.js";
+
+// Shared task lifecycle engine. Browser-safe by construction: it performs no
+// I/O at all — it decides *when* a task may next be polled and remembers what
+// was last seen, while the caller owns the transport. That is exactly what
+// lets the Tasks tab, a Hono route and the CLI share one scheduler.
+export {
+  TaskLifecycleEngine,
+  taskLifecycleKey,
+  isTerminalLifecycleStatus,
+  TERMINAL_LIFECYCLE_STATUSES,
+} from "./mcp-client-manager/task-lifecycle.js";
+export type {
+  LiveTasksWire,
+  TaskLifecycleCallbacks,
+  TaskLifecycleEngineOptions,
+  TaskLifecycleError,
+  TaskLifecycleIdentity,
+  TaskLifecycleObservation,
+  TaskLifecycleRecord,
+  TaskLifecycleSnapshot,
+  TaskLifecycleStatus,
+  TaskObservationSource,
+} from "./mcp-client-manager/task-lifecycle.js";
+export {
+  extensionTaskToObservation,
+  legacyTaskToObservation,
+  isUnknownTaskError,
+  isTasksDeclarationRequiredError,
+  parseRetryAfterMs,
+  UNKNOWN_TASK_ERROR_CODE,
+  TASKS_DECLARATION_REQUIRED_ERROR_CODE,
+} from "./mcp-client-manager/task-lifecycle-adapters.js";

--- a/sdk/src/host-config/index.ts
+++ b/sdk/src/host-config/index.ts
@@ -50,3 +50,22 @@ export type {
   OpenAiAppsCapabilities,
   McpAppsCapabilities,
 } from "./public-types.js";
+
+// Tasks PRODUCT policy (`com.mcpjam/tasks`). Kept apart from the wire
+// extension on purpose: nothing here produces a capability value, and
+// `com.mcpjam/tasks` is never advertised to a server. The wire declaration is
+// always `io.modelcontextprotocol/tasks: {}`, and it lives in `tasks-ext.ts`.
+export {
+  MCPJAM_TASKS_POLICY_EXTENSION_ID,
+  readTasksPolicy,
+  describeInvalidTasksPolicy,
+  setTasksPolicy,
+  clearTasksPolicy,
+  taskModeForSurface,
+  surfaceMayDeclareTasks,
+} from "./tasks-policy.js";
+export type {
+  TasksPolicy,
+  TaskMode,
+  TaskSurface,
+} from "./tasks-policy.js";

--- a/sdk/src/host-config/tasks-policy.ts
+++ b/sdk/src/host-config/tasks-policy.ts
@@ -111,6 +111,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 export function readTasksPolicy(
   host: TasksPolicyHost | undefined
 ): TasksPolicy {
+  const mcpProfile = host?.mcpProfile as unknown;
+  // Same fail-closed rule as `extensions`, one level up. `host.mcpProfile` is
+  // typed but the value comes from JSON, so `mcpProfile: "on"` is reachable —
+  // and optional chaining would read `"on".extensions` as `undefined` and
+  // report `unset`, i.e. PRESERVE task controls on a config nobody can read.
+  if (mcpProfile !== undefined && !isRecord(mcpProfile)) return "invalid";
   const extensions = host?.mcpProfile?.extensions;
   if (extensions === undefined) return "unset";
   // Present but not a plain object: a config we cannot read must fail closed,
@@ -145,6 +151,9 @@ export function describeInvalidTasksPolicy(
   host: TasksPolicyHost | undefined
 ): string | undefined {
   if (readTasksPolicy(host) !== "invalid") return undefined;
+  if (host?.mcpProfile !== undefined && !isRecord(host.mcpProfile)) {
+    return `"mcpProfile" must be a plain JSON object.`;
+  }
   const entry =
     host?.mcpProfile?.extensions?.[MCPJAM_TASKS_POLICY_EXTENSION_ID];
   if (!isRecord(host?.mcpProfile?.extensions)) {
@@ -185,21 +194,57 @@ export function setTasksPolicy<T extends TasksPolicyHost>(
  * Distinct from `setTasksPolicy(host, false)`: this restores default behavior
  * (Tools keeps its explicit controls), whereas `false` actively disables Tasks
  * everywhere including those controls.
+ *
+ * ## No residue
+ *
+ * `hostConfigs` are content-addressed: the stored id IS the hash of the
+ * serialized host, so an empty container left behind by a set→clear round trip
+ * is not cosmetic — it mints a new hostConfig row for a host that is, in every
+ * observable way, the one that existed before the feature shipped. So the
+ * emptied containers are removed rather than kept: `extensions` goes away when
+ * nothing else lives in it, and `mcpProfile` goes away when `extensions` was
+ * all it held.
+ *
+ * The one thing this does NOT round-trip is a host that stored an *explicitly
+ * empty* `mcpProfile: {}` or `extensions: {}` before any policy was set — that
+ * is normalized to absent. Deliberate: absent and empty already mean exactly
+ * the same thing to every reader in this module, and preserving the difference
+ * would mean keeping the residue in the far more common case.
  */
 export function clearTasksPolicy<T extends TasksPolicyHost>(
   host: T | undefined
 ): T {
   const base = (host ?? {}) as T;
   const extensions = base.mcpProfile?.extensions;
+  // Nothing stored (or an unreadable container): clearing is a no-op, and
+  // rebuilding the host here would churn the hash for no change.
   if (!isRecord(extensions)) return base;
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      extensions,
+      MCPJAM_TASKS_POLICY_EXTENSION_ID
+    )
+  ) {
+    return base;
+  }
   const { [MCPJAM_TASKS_POLICY_EXTENSION_ID]: _removed, ...rest } = extensions;
-  return {
-    ...base,
-    mcpProfile: {
-      ...(base.mcpProfile ?? {}),
-      extensions: rest,
-    },
-  };
+  const { extensions: _dropped, ...profileRest } = (base.mcpProfile ??
+    {}) as Record<string, unknown>;
+
+  if (Object.keys(rest).length > 0) {
+    return {
+      ...base,
+      mcpProfile: { ...profileRest, extensions: rest },
+    };
+  }
+  if (Object.keys(profileRest).length > 0) {
+    return { ...base, mcpProfile: profileRest } as unknown as T;
+  }
+  const { mcpProfile: _removedProfile, ...hostRest } = base as Record<
+    string,
+    unknown
+  >;
+  return hostRest as unknown as T;
 }
 
 /**

--- a/sdk/src/host-config/tasks-policy.ts
+++ b/sdk/src/host-config/tasks-policy.ts
@@ -126,6 +126,12 @@ export function readTasksPolicy(
   }
   const entry = extensions[MCPJAM_TASKS_POLICY_EXTENSION_ID];
   if (!isRecord(entry)) return "invalid";
+  // OWN property only. `entry.enabled` would otherwise read through the
+  // prototype chain, so a polluted `Object.prototype.enabled` could make an
+  // entry that says nothing read as an explicit on or off — turning Tasks on
+  // across every surface without anything in the config saying so. This module
+  // fails closed; that has to include the lookup itself.
+  if (!Object.prototype.hasOwnProperty.call(entry, "enabled")) return "invalid";
   const enabled = entry.enabled;
   if (enabled === true) return "on";
   if (enabled === false) return "off";

--- a/sdk/src/host-config/tasks-policy.ts
+++ b/sdk/src/host-config/tasks-policy.ts
@@ -83,8 +83,22 @@ interface TasksPolicyHost {
   };
 }
 
+/**
+ * A PLAIN JSON object — not merely "an object".
+ *
+ * Host config is JSON, so anything with an exotic prototype (`new Map()`, a
+ * class instance) did not come from a config file and cannot be read as one.
+ * A looser `typeof === "object"` check would let `new Map()` through as an
+ * empty extensions container and report `unset`, which PRESERVES task controls
+ * on a config we cannot actually understand. Failing closed to `invalid` is
+ * the only safe reading, and it surfaces the repair warning.
+ */
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 /**
@@ -94,9 +108,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * than being coerced. Coercion here is how a typo becomes silently-enabled
  * Tasks on every surface.
  */
-export function readTasksPolicy(host: TasksPolicyHost | undefined): TasksPolicy {
+export function readTasksPolicy(
+  host: TasksPolicyHost | undefined
+): TasksPolicy {
   const extensions = host?.mcpProfile?.extensions;
-  if (!isRecord(extensions)) return "unset";
+  if (extensions === undefined) return "unset";
+  // Present but not a plain object: a config we cannot read must fail closed,
+  // not be treated as "nothing was configured".
+  if (!isRecord(extensions)) return "invalid";
   if (
     !Object.prototype.hasOwnProperty.call(
       extensions,
@@ -120,9 +139,11 @@ export function describeInvalidTasksPolicy(
   host: TasksPolicyHost | undefined
 ): string | undefined {
   if (readTasksPolicy(host) !== "invalid") return undefined;
-  const entry = host?.mcpProfile?.extensions?.[
-    MCPJAM_TASKS_POLICY_EXTENSION_ID
-  ];
+  const entry =
+    host?.mcpProfile?.extensions?.[MCPJAM_TASKS_POLICY_EXTENSION_ID];
+  if (!isRecord(host?.mcpProfile?.extensions)) {
+    return `"mcpProfile.extensions" must be a plain JSON object.`;
+  }
   if (!isRecord(entry)) {
     return `"${MCPJAM_TASKS_POLICY_EXTENSION_ID}" must be an object of the form { "enabled": true | false }.`;
   }
@@ -165,10 +186,7 @@ export function clearTasksPolicy<T extends TasksPolicyHost>(
   const base = (host ?? {}) as T;
   const extensions = base.mcpProfile?.extensions;
   if (!isRecord(extensions)) return base;
-  const {
-    [MCPJAM_TASKS_POLICY_EXTENSION_ID]: _removed,
-    ...rest
-  } = extensions;
+  const { [MCPJAM_TASKS_POLICY_EXTENSION_ID]: _removed, ...rest } = extensions;
   return {
     ...base,
     mcpProfile: {

--- a/sdk/src/host-config/tasks-policy.ts
+++ b/sdk/src/host-config/tasks-policy.ts
@@ -1,0 +1,244 @@
+/**
+ * MCPJam's Tasks **product policy** — distinct from, and never confused with,
+ * the wire extension.
+ *
+ * ```text
+ * hostConfig.mcpProfile.extensions["com.mcpjam/tasks"] = { enabled: boolean }
+ * ```
+ *
+ * `com.mcpjam/tasks` is MCPJam configuration. It MUST NOT be advertised to an
+ * MCP server, ever. The only thing that goes on the wire is
+ * `io.modelcontextprotocol/tasks: {}` in a request's client capabilities. The
+ * two are kept in separate modules for exactly this reason: nothing here
+ * produces a capability value, and nothing in `tasks-ext.ts` reads a host
+ * config.
+ *
+ * ## Why tri-state, not a boolean
+ *
+ * Three states are genuinely distinct and a two-state switch cannot express
+ * them:
+ *
+ *  - **unset** — the host has said nothing. The Tools tab keeps its existing
+ *    explicit per-call task controls, and every newly-added surface stays off.
+ *    This is what makes adding a Tasks-capable surface a non-event for hosts
+ *    that never opted in.
+ *  - **on** — enable Tasks on the *supported interactive surfaces* listed in
+ *    the matrix. Not "all surfaces": replay surfaces never create work, and
+ *    the API/CLI keep their own explicit opt-in.
+ *  - **off** — remove every task affordance and every declaration.
+ *
+ * A binary switch would collapse unset into one of the other two, silently
+ * changing behavior for hosts that never expressed an opinion. So the editor
+ * must offer On, Off, and "Use default" — the third is a real choice, not a
+ * reset button.
+ *
+ * `invalid` is a fourth *observed* state, never a stored one: a malformed
+ * value fails closed to the same behavior as `off`, and is reported so the
+ * editor can show a repair warning instead of silently ignoring what the user
+ * wrote.
+ */
+
+/** MCPJam's own extension id. Never sent to a server. */
+export const MCPJAM_TASKS_POLICY_EXTENSION_ID = "com.mcpjam/tasks" as const;
+
+/** What the stored config says. */
+export type TasksPolicy = "unset" | "on" | "off" | "invalid";
+
+/**
+ * What a given surface should actually do.
+ *
+ *  - `off` — no task affordances, no declaration on any request.
+ *  - `expose` — declare eligibility, surface the handle, and let the user (or
+ *    a later turn) follow it. The call itself returns promptly.
+ *  - `await` — declare eligibility and drive the task to a bounded terminal
+ *    result before returning. For automation, where nobody is watching a tab.
+ */
+export type TaskMode = "off" | "expose" | "await";
+
+/**
+ * The surfaces the policy distinguishes. Adding one here is deliberate: it
+ * forces a decision about its `unset` and `on` behavior in
+ * {@link taskModeForSurface} rather than letting it inherit something by
+ * accident.
+ */
+export type TaskSurface =
+  /** Local or hosted Tools tab. Has its own explicit per-call controls. */
+  | "tools"
+  /** Local, hosted-emulated, or BYOK chat and playground. */
+  | "chat"
+  /** The MCPJam agent. */
+  | "agent"
+  /** Eval / simulation execution — automation, so `await` rather than `expose`. */
+  | "eval"
+  /** Protocol + conformance harness. The test owns the exact wire. */
+  | "conformance"
+  /** Saved-result and pinned replay. Must NEVER create new work. */
+  | "replay"
+  /** Public API and CLI. Their own explicit request flag is the boundary. */
+  | "api";
+
+interface TasksPolicyHost {
+  mcpProfile?: {
+    extensions?: Record<string, unknown>;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reads the stored policy.
+ *
+ * Anything that is not a `{ enabled: boolean }` object is `invalid` rather
+ * than being coerced. Coercion here is how a typo becomes silently-enabled
+ * Tasks on every surface.
+ */
+export function readTasksPolicy(host: TasksPolicyHost | undefined): TasksPolicy {
+  const extensions = host?.mcpProfile?.extensions;
+  if (!isRecord(extensions)) return "unset";
+  if (
+    !Object.prototype.hasOwnProperty.call(
+      extensions,
+      MCPJAM_TASKS_POLICY_EXTENSION_ID
+    )
+  ) {
+    return "unset";
+  }
+  const entry = extensions[MCPJAM_TASKS_POLICY_EXTENSION_ID];
+  if (!isRecord(entry)) return "invalid";
+  const enabled = entry.enabled;
+  if (enabled === true) return "on";
+  if (enabled === false) return "off";
+  // Present but not a boolean — including absent `enabled`, which is a
+  // half-written config rather than a default.
+  return "invalid";
+}
+
+/** Human-readable reason for an `invalid` policy, for the editor's warning. */
+export function describeInvalidTasksPolicy(
+  host: TasksPolicyHost | undefined
+): string | undefined {
+  if (readTasksPolicy(host) !== "invalid") return undefined;
+  const entry = host?.mcpProfile?.extensions?.[
+    MCPJAM_TASKS_POLICY_EXTENSION_ID
+  ];
+  if (!isRecord(entry)) {
+    return `"${MCPJAM_TASKS_POLICY_EXTENSION_ID}" must be an object of the form { "enabled": true | false }.`;
+  }
+  return `"${MCPJAM_TASKS_POLICY_EXTENSION_ID}.enabled" must be true or false.`;
+}
+
+/**
+ * Returns a host with the policy set. Pure: the input is not mutated, so a
+ * caller can diff before and after.
+ */
+export function setTasksPolicy<T extends TasksPolicyHost>(
+  host: T | undefined,
+  enabled: boolean
+): T {
+  const base = (host ?? {}) as T;
+  return {
+    ...base,
+    mcpProfile: {
+      ...(base.mcpProfile ?? {}),
+      extensions: {
+        ...(isRecord(base.mcpProfile?.extensions)
+          ? base.mcpProfile.extensions
+          : {}),
+        [MCPJAM_TASKS_POLICY_EXTENSION_ID]: { enabled },
+      },
+    },
+  };
+}
+
+/**
+ * Returns a host with the policy removed — back to `unset`.
+ *
+ * Distinct from `setTasksPolicy(host, false)`: this restores default behavior
+ * (Tools keeps its explicit controls), whereas `false` actively disables Tasks
+ * everywhere including those controls.
+ */
+export function clearTasksPolicy<T extends TasksPolicyHost>(
+  host: T | undefined
+): T {
+  const base = (host ?? {}) as T;
+  const extensions = base.mcpProfile?.extensions;
+  if (!isRecord(extensions)) return base;
+  const {
+    [MCPJAM_TASKS_POLICY_EXTENSION_ID]: _removed,
+    ...rest
+  } = extensions;
+  return {
+    ...base,
+    mcpProfile: {
+      ...(base.mcpProfile ?? {}),
+      extensions: rest,
+    },
+  };
+}
+
+/**
+ * The published surface matrix.
+ *
+ * | Surface     | unset             | on            |
+ * | ----------- | ----------------- | ------------- |
+ * | tools       | explicit controls | expose        |
+ * | chat        | off               | expose        |
+ * | agent       | off               | expose        |
+ * | eval        | off               | await         |
+ * | conformance | explicit test     | explicit test |
+ * | replay      | off               | off           |
+ * | api         | explicit request  | explicit request |
+ *
+ * Two rows never move, whatever the policy says:
+ *
+ *  - **replay** is `off` in every state. A replay surface renders a recorded
+ *    result; creating new server-side work from one would be a side effect the
+ *    user never asked for and cannot see.
+ *  - **conformance** and **api** are caller-driven. The conformance harness
+ *    owns the exact wire it is testing — a host policy that silently added a
+ *    declaration would corrupt the very thing under test — and the public API's
+ *    per-request opt-in IS its policy boundary.
+ *
+ * `off` and `invalid` force `off` everywhere, including the Tools tab's
+ * explicit controls: an explicit Off is a statement, and failing closed on a
+ * malformed value is the only safe reading of one.
+ */
+export function taskModeForSurface(
+  policy: TasksPolicy,
+  surface: TaskSurface
+): TaskMode {
+  // Never creates work, whatever anyone configured.
+  if (surface === "replay") return "off";
+
+  // Caller-owned: the request itself decides, so the host policy only ever
+  // acts as a kill switch.
+  if (surface === "conformance" || surface === "api") {
+    return policy === "off" || policy === "invalid" ? "off" : "expose";
+  }
+
+  if (policy === "off" || policy === "invalid") return "off";
+
+  if (policy === "unset") {
+    // Preserve today's behavior exactly: Tools keeps its explicit per-call
+    // controls; nothing that was not already on turns on.
+    return surface === "tools" ? "expose" : "off";
+  }
+
+  // policy === "on"
+  return surface === "eval" ? "await" : "expose";
+}
+
+/**
+ * Whether this surface may put `io.modelcontextprotocol/tasks` on a request.
+ *
+ * The one predicate a route should call. It reads as the question the route
+ * actually has, rather than making every route re-derive it from a mode.
+ */
+export function surfaceMayDeclareTasks(
+  policy: TasksPolicy,
+  surface: TaskSurface
+): boolean {
+  return taskModeForSurface(policy, surface) !== "off";
+}

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -183,6 +183,7 @@ export {
   getTaskExt,
   updateTaskExt,
   cancelTaskExt,
+  openTaskDeclaredListen,
 } from "./tasks-ext.js";
 export type {
   TaskExt,
@@ -211,7 +212,64 @@ export {
   assertDetailedTaskExt,
   assertTaskExtAck,
   parseTaskExtNotificationParams,
+  assertTaskExtNotificationParams,
 } from "./tasks-ext-guards.js";
+
+// Shared task lifecycle engine — per-task due-time scheduling, dynamic
+// TTL/poll interval, backoff, durable input-key state. Every Tasks surface
+// drives this instead of writing its own polling loop.
+export {
+  TaskLifecycleEngine,
+  taskLifecycleKey,
+  isTerminalLifecycleStatus,
+  toSnapshot as toTaskLifecycleSnapshot,
+  TERMINAL_LIFECYCLE_STATUSES,
+} from "./task-lifecycle.js";
+export type {
+  LiveTasksWire,
+  TaskLifecycleCallbacks,
+  TaskLifecycleEngineOptions,
+  TaskLifecycleError,
+  TaskLifecycleIdentity,
+  TaskLifecycleObservation,
+  TaskLifecycleRecord,
+  TaskLifecycleSnapshot,
+  TaskLifecycleStatus,
+  TaskObservationSource,
+} from "./task-lifecycle.js";
+export {
+  extensionTaskToObservation,
+  legacyTaskToObservation,
+  isUnknownTaskError,
+  isTasksDeclarationRequiredError,
+  parseRetryAfterMs,
+  UNKNOWN_TASK_ERROR_CODE,
+  TASKS_DECLARATION_REQUIRED_ERROR_CODE,
+} from "./task-lifecycle-adapters.js";
+
+// `input_required` driver — routes a task's embedded elicitation / roots /
+// sampling requests through the SAME trust rules as the standalone path.
+export {
+  TASK_INPUT_METHODS,
+  isTaskInputMethod,
+  TaskInputRejectedError,
+  collectTaskInputResponses,
+  canDeclareTasksExtension,
+  readDeclaredInputCapabilities,
+  DEFAULT_TASK_INPUT_LIMITS,
+} from "./task-input-driver.js";
+export type {
+  CollectTaskInputResult,
+  DeclaredInputCapabilities,
+  TaskInputHandlerContext,
+  TaskInputHandlers,
+  TaskInputKeyOutcome,
+  TaskInputLimits,
+  TaskInputMethod,
+  TaskInputDriverOptions,
+  TaskInputRejection,
+  TaskInputRejectionReason,
+} from "./task-input-driver.js";
 export {
   TASK_EXT_INPUT_REQUEST_METHODS,
   isRecognizedInputRequestMethod,
@@ -280,6 +338,7 @@ export {
   SUBSCRIPTION_ID_META_KEY,
   SubscriptionsAcknowledgedNotificationMethod,
   ToolListChangedNotificationMethod,
+  TasksNotificationMethod,
   diffAcknowledgement,
   resolveRequestedFilter,
 } from "./subscription-coordinator.js";

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -258,6 +258,24 @@ export {
   readDeclaredInputCapabilities,
   DEFAULT_TASK_INPUT_LIMITS,
 } from "./task-input-driver.js";
+
+// The single task-creation fan-out point (durable tracking, hosted stream,
+// best-effort registry, analytics) and the bounded `await`-mode driver used
+// by automation surfaces.
+export { TaskCreatedSink } from "./task-created-event.js";
+export type {
+  TaskCreatedConsumer,
+  TaskCreatedConsumerFailure,
+  TaskCreatedDispatchResult,
+  TaskCreatedEvent,
+  TaskCreationSurface,
+} from "./task-created-event.js";
+export { driveTaskToTerminal } from "./task-await-driver.js";
+export type {
+  DriveTaskToTerminalArgs,
+  TaskAwaitOutcome,
+  TaskAwaitResult,
+} from "./task-await-driver.js";
 export type {
   CollectTaskInputResult,
   DeclaredInputCapabilities,

--- a/sdk/src/mcp-client-manager/subscription-coordinator.ts
+++ b/sdk/src/mcp-client-manager/subscription-coordinator.ts
@@ -103,9 +103,7 @@ export type SubscriptionNotificationKind =
   | "resource-updated"
   | "tasks";
 
-const METHOD_TO_KIND: Readonly<
-  Record<string, SubscriptionNotificationKind>
-> = {
+const METHOD_TO_KIND: Readonly<Record<string, SubscriptionNotificationKind>> = {
   [ToolListChangedNotificationMethod]: "tools-list-changed",
   [PromptListChangedNotificationMethod]: "prompts-list-changed",
   [ResourceListChangedNotificationMethod]: "resources-list-changed",
@@ -608,6 +606,13 @@ export class SubscriptionCoordinator {
       ...(this.desired.resourceUris
         ? { resourceUris: [...this.desired.resourceUris] }
         : {}),
+      // Copied for the same reason as `resourceUris`, and more urgently: the
+      // docs tell callers to drop terminal ids from this list, so a caller
+      // mutating the array it got back would silently change the desired
+      // filter with no reconcile — and `filtersEqual` would then compare the
+      // mutated array against itself and report "unchanged", leaving the live
+      // stream watching the wrong set.
+      ...(this.desired.taskIds ? { taskIds: [...this.desired.taskIds] } : {}),
     };
   }
 
@@ -642,7 +647,10 @@ export class SubscriptionCoordinator {
   ): Promise<void> {
     this.desired = {
       ...desired,
-      ...(desired.resourceUris ? { resourceUris: [...desired.resourceUris] } : {}),
+      ...(desired.resourceUris
+        ? { resourceUris: [...desired.resourceUris] }
+        : {}),
+      ...(desired.taskIds ? { taskIds: [...desired.taskIds] } : {}),
     };
     await this.enqueue(() => this.reconcile());
   }
@@ -692,8 +700,8 @@ export class SubscriptionCoordinator {
     return typeof raw === "string"
       ? raw
       : typeof raw === "number"
-        ? String(raw)
-        : undefined;
+      ? String(raw)
+      : undefined;
   }
 
   /**
@@ -745,8 +753,9 @@ export class SubscriptionCoordinator {
       return;
     }
     const acknowledged =
-      ((notification.params?.notifications as SubscriptionFilterShape) ??
-        undefined) ?? {};
+      (notification.params?.notifications as SubscriptionFilterShape) ??
+      undefined ??
+      {};
     this.markAcknowledged(stream, acknowledged);
   }
 
@@ -891,13 +900,26 @@ export class SubscriptionCoordinator {
     const wantedTaskIds = requested.taskIds ?? [];
     if (wantedTaskIds.length === 0) return { requested, rejected };
 
-    const canDeclare =
+    if (
       this.era === "modern" &&
-      typeof this.client.listenWithTasksDeclaration === "function";
-    if (canDeclare) return { requested, rejected };
+      typeof this.client.listenWithTasksDeclaration === "function"
+    ) {
+      return { requested, rejected };
+    }
 
     // Drop rather than downgrade: an undeclared task-filtered listen is a
     // guaranteed -32003, and the polling fallback loses nothing but latency.
+    //
+    // The REASON depends on why. `resolveRequestedFilter` reads the extension
+    // capability alone, so a 2025-11-25 server that advertises
+    // `io.modelcontextprotocol/tasks` reaches here — but on that era the
+    // extension MUST be treated as absent, so the honest report is
+    // "capability not advertised", not "we could not declare". Only a modern
+    // connection whose client lacks the declaration seam gets the latter.
+    const reason: SubscriptionInterestRejection["reason"] =
+      this.era === "modern"
+        ? "tasks-declaration-unavailable"
+        : "capability-not-advertised";
     const { taskIds: _dropped, ...withoutTasks } = requested;
     return {
       requested: withoutTasks,
@@ -907,7 +929,7 @@ export class SubscriptionCoordinator {
           (taskId): SubscriptionInterestRejection => ({
             interest: "tasks",
             taskId,
-            reason: "tasks-declaration-unavailable",
+            reason,
           })
         ),
       ],
@@ -930,7 +952,10 @@ export class SubscriptionCoordinator {
         await this.safeUnsubscribe(uri);
       }
       this.legacySubscribedUris.clear();
-      if (current && (current.status === "active" || current.status === "opening")) {
+      if (
+        current &&
+        (current.status === "active" || current.status === "opening")
+      ) {
         current.status = "cancelled";
         current.closeReason = "local-abort";
         current.closedAt = this.now();
@@ -1023,14 +1048,20 @@ export class SubscriptionCoordinator {
       ? this.streams.get(this.currentLocalId)
       : undefined;
     const live =
-      current &&
-      (current.status === "opening" || current.status === "active")
+      current && (current.status === "opening" || current.status === "active")
         ? current
         : undefined;
 
     if (this.disposed || isEmptyFilter(requested)) {
       if (live) await this.closeStream(live, "local-abort", "cancelled");
       this.currentLocalId = undefined;
+      // A filter that is empty ONLY because task ids were dropped is not the
+      // same as wanting nothing. Without a record here, the reason we fell
+      // back to polling would vanish and the caller would have no way to
+      // explain why notifications never arrived.
+      if (!this.disposed && rejected.length > 0) {
+        this.recordUnopenedStream(rejected);
+      }
       return;
     }
 
@@ -1040,6 +1071,33 @@ export class SubscriptionCoordinator {
     // A listen filter is immutable: change of desire ⇒ controlled close+reopen.
     if (live) await this.closeStream(live, "local-abort", "cancelled");
     await this.openModernStream(requested, rejected, 0);
+  }
+
+  /**
+   * Records a stream that was never opened, purely so its rejected interests
+   * remain visible through `getStreams()`. Terminal on arrival — there is no
+   * transport behind it.
+   */
+  private recordUnopenedStream(
+    rejected: SubscriptionInterestRejection[]
+  ): void {
+    const at = this.now();
+    const stream: SubscriptionStreamRecord = {
+      localId: `${this.instanceId}-unopened-${++this.streamSeq}`,
+      era: "modern",
+      requestedFilter: {},
+      rejectedInterests: [...rejected],
+      status: "error",
+      closeReason: "error",
+      error:
+        "No subscription was opened: every requested interest was rejected. " +
+        "Task state is polled instead.",
+      openedAt: at,
+      closedAt: at,
+      reconnectAttempt: 0,
+    };
+    this.streams.set(stream.localId, stream);
+    this.emitStream(stream);
   }
 
   private async openModernStream(

--- a/sdk/src/mcp-client-manager/subscription-coordinator.ts
+++ b/sdk/src/mcp-client-manager/subscription-coordinator.ts
@@ -577,6 +577,8 @@ export class SubscriptionCoordinator {
   private readonly rejections: RejectedSubscriptionNotification[] = [];
   /** Legacy adapter bookkeeping: URIs currently `resources/subscribe`d. */
   private legacySubscribedUris = new Set<string>();
+  /** Signature of the last all-rejected interest set recorded, for dedupe. */
+  private lastUnopenedSignature?: string;
 
   constructor(options: SubscriptionCoordinatorOptions) {
     this.options = options;
@@ -1060,6 +1062,7 @@ export class SubscriptionCoordinator {
       if (!this.disposed && rejected.length > 0) {
         this.recordUnopenedStream(rejected);
       }
+
       return;
     }
 
@@ -1079,6 +1082,20 @@ export class SubscriptionCoordinator {
   private recordUnopenedStream(
     rejected: SubscriptionInterestRejection[]
   ): void {
+    // Deduplicated. A caller that periodically reasserts an interest set which
+    // is entirely unavailable would otherwise accumulate one synthetic failure
+    // record — and one `onStreamChange` — per reassertion, turning a single
+    // steady condition into an ever-growing list of distinct "failures".
+    const signature = JSON.stringify(
+      [...rejected]
+        .map(
+          (r) => `${r.interest}|${r.uri ?? ""}|${r.taskId ?? ""}|${r.reason}`
+        )
+        .sort()
+    );
+    if (this.lastUnopenedSignature === signature) return;
+    this.lastUnopenedSignature = signature;
+
     const at = this.now();
     const stream: SubscriptionStreamRecord = {
       localId: `${this.instanceId}-unopened-${++this.streamSeq}`,
@@ -1088,8 +1105,7 @@ export class SubscriptionCoordinator {
       status: "error",
       closeReason: "error",
       error:
-        "No subscription was opened: every requested interest was rejected. " +
-        "Task state is polled instead.",
+        "No subscription was opened: every requested interest was rejected.",
       openedAt: at,
       closedAt: at,
       reconnectAttempt: 0,
@@ -1121,6 +1137,9 @@ export class SubscriptionCoordinator {
     };
     this.streams.set(stream.localId, stream);
     this.currentLocalId = stream.localId;
+    // A real open clears the memo, so if the interest set later becomes
+    // entirely unavailable again that IS recorded rather than suppressed.
+    this.lastUnopenedSignature = undefined;
     this.emitStream(stream);
 
     if (!listen) {

--- a/sdk/src/mcp-client-manager/subscription-coordinator.ts
+++ b/sdk/src/mcp-client-manager/subscription-coordinator.ts
@@ -103,9 +103,7 @@ export type SubscriptionNotificationKind =
   | "resource-updated"
   | "tasks";
 
-const METHOD_TO_KIND: Readonly<
-  Record<string, SubscriptionNotificationKind>
-> = {
+const METHOD_TO_KIND: Readonly<Record<string, SubscriptionNotificationKind>> = {
   [ToolListChangedNotificationMethod]: "tools-list-changed",
   [PromptListChangedNotificationMethod]: "prompts-list-changed",
   [ResourceListChangedNotificationMethod]: "resources-list-changed",
@@ -377,32 +375,59 @@ function isEmptyFilter(filter: SubscriptionFilterShape): boolean {
   );
 }
 
+/**
+ * Whether a notification is one this stream may deliver.
+ *
+ * Takes BOTH filters, and for the identifier-bearing kinds requires membership
+ * in each. The acknowledged filter alone is not enough: `markAcknowledged`
+ * stores whatever the server honored, and `diffAcknowledgement` only records
+ * what the server *dropped* — an id the server ADDED survives into
+ * `acknowledgedFilter` unchallenged. Checking that filter by itself therefore
+ * let a server deliver a task or resource we never asked about simply by
+ * claiming it had honored it, which is the exact inverse of the isolation this
+ * predicate exists to enforce.
+ *
+ * Requested-only would be wrong too: the server must not send a type it never
+ * agreed to honor. The safe set is the intersection, so an id has to have been
+ * both asked for and agreed to.
+ *
+ * The boolean list-changed kinds stay on the acknowledged filter. They carry no
+ * identifier, so there is no cross-surface state to leak — the worst case is a
+ * redundant list refetch.
+ */
 function filterAllows(
-  filter: SubscriptionFilterShape,
+  acknowledged: SubscriptionFilterShape,
+  requested: SubscriptionFilterShape,
   kind: SubscriptionNotificationKind,
   uri?: string,
   taskId?: string
 ): boolean {
   switch (kind) {
     case "tools-list-changed":
-      return Boolean(filter.toolsListChanged);
+      return Boolean(acknowledged.toolsListChanged);
     case "prompts-list-changed":
-      return Boolean(filter.promptsListChanged);
+      return Boolean(acknowledged.promptsListChanged);
     case "resources-list-changed":
-      return Boolean(filter.resourcesListChanged);
+      return Boolean(acknowledged.resourcesListChanged);
     case "resource-updated": {
-      const uris = filter.resourceSubscriptions ?? [];
       // A server may legitimately stamp an update for a URI whose exact form
       // differs only by template expansion; MCPJam does not guess — the URI
-      // must be one we asked for.
-      return uri !== undefined && uris.includes(uri);
+      // must be one we asked for AND one the server agreed to.
+      return (
+        uri !== undefined &&
+        (acknowledged.resourceSubscriptions ?? []).includes(uri) &&
+        (requested.resourceSubscriptions ?? []).includes(uri)
+      );
     }
     case "tasks": {
-      // Same rule as resources. A task notification for a handle we never
-      // asked about is unsolicited whatever it carries, and accepting it would
-      // let a server push state for a task belonging to another surface.
-      const ids = filter.taskIds ?? [];
-      return taskId !== undefined && ids.includes(taskId);
+      // Same rule as resources, and it matters more here: task ids are
+      // bearer-like handles, so accepting an unrequested one lets a server push
+      // state for a task belonging to another surface.
+      return (
+        taskId !== undefined &&
+        (acknowledged.taskIds ?? []).includes(taskId) &&
+        (requested.taskIds ?? []).includes(taskId)
+      );
     }
   }
 }
@@ -678,7 +703,9 @@ export class SubscriptionCoordinator {
   ): Promise<void> {
     this.desired = {
       ...desired,
-      ...(desired.resourceUris ? { resourceUris: [...desired.resourceUris] } : {}),
+      ...(desired.resourceUris
+        ? { resourceUris: [...desired.resourceUris] }
+        : {}),
       ...(desired.taskIds ? { taskIds: [...desired.taskIds] } : {}),
     };
     await this.enqueue(() => this.reconcile());
@@ -729,8 +756,8 @@ export class SubscriptionCoordinator {
     return typeof raw === "string"
       ? raw
       : typeof raw === "number"
-        ? String(raw)
-        : undefined;
+      ? String(raw)
+      : undefined;
   }
 
   /**
@@ -852,10 +879,13 @@ export class SubscriptionCoordinator {
       typeof notification.params?.taskId === "string"
         ? (notification.params.taskId as string)
         : undefined;
-    // Enforce against the ACKNOWLEDGED filter: the server must not send a type
-    // it did not agree to honor.
-    const effective = stream.acknowledgedFilter ?? stream.requestedFilter;
-    if (!filterAllows(effective, kind, uri, taskId)) {
+    // Enforce against BOTH: the server must not send a type it did not agree to
+    // honor, and must not deliver an identifier we never asked about even if it
+    // claims to have honored one.
+    const acknowledged = stream.acknowledgedFilter ?? stream.requestedFilter;
+    if (
+      !filterAllows(acknowledged, stream.requestedFilter, kind, uri, taskId)
+    ) {
       this.recordRejection({
         method: notification.method,
         subscriptionId,
@@ -973,7 +1003,10 @@ export class SubscriptionCoordinator {
         await this.safeUnsubscribe(uri);
       }
       this.legacySubscribedUris.clear();
-      if (current && (current.status === "active" || current.status === "opening")) {
+      if (
+        current &&
+        (current.status === "active" || current.status === "opening")
+      ) {
         current.status = "cancelled";
         current.closeReason = "local-abort";
         current.closedAt = this.now();
@@ -1095,8 +1128,7 @@ export class SubscriptionCoordinator {
       ? this.streams.get(this.currentLocalId)
       : undefined;
     const live =
-      current &&
-      (current.status === "opening" || current.status === "active")
+      current && (current.status === "opening" || current.status === "active")
         ? current
         : undefined;
 

--- a/sdk/src/mcp-client-manager/subscription-coordinator.ts
+++ b/sdk/src/mcp-client-manager/subscription-coordinator.ts
@@ -61,6 +61,10 @@
  */
 
 import type { ServerCapabilities } from "@modelcontextprotocol/client";
+// The ONE module allowed to read the tasks extension capability. Importing the
+// predicate rather than re-deriving it here is what keeps the "treat the
+// extension as absent on 2025-11-25" rule in a single place.
+import { serverDeclaresTasksExtension } from "./tasks-dispatch.js";
 
 /**
  * `_meta` key carrying the JSON-RPC id of the `subscriptions/listen` request a
@@ -82,13 +86,22 @@ export const ResourceListChangedNotificationMethod =
   "notifications/resources/list_changed" as const;
 export const ResourceUpdatedNotificationMethod =
   "notifications/resources/updated" as const;
+/**
+ * Optional `io.modelcontextprotocol/tasks` (SEP-2663) task notification.
+ *
+ * OPTIONAL is load-bearing: the extension never requires a server to send
+ * these, so this channel may only ever *reduce* polling. Correctness always
+ * rests on `tasks/get`, and every path below falls back to it.
+ */
+export const TasksNotificationMethod = "notifications/tasks" as const;
 
 /** The notification kinds this coordinator owns. */
 export type SubscriptionNotificationKind =
   | "tools-list-changed"
   | "prompts-list-changed"
   | "resources-list-changed"
-  | "resource-updated";
+  | "resource-updated"
+  | "tasks";
 
 const METHOD_TO_KIND: Readonly<
   Record<string, SubscriptionNotificationKind>
@@ -97,6 +110,7 @@ const METHOD_TO_KIND: Readonly<
   [PromptListChangedNotificationMethod]: "prompts-list-changed",
   [ResourceListChangedNotificationMethod]: "resources-list-changed",
   [ResourceUpdatedNotificationMethod]: "resource-updated",
+  [TasksNotificationMethod]: "tasks",
 };
 
 /** Product-level, era-neutral statement of what the user wants to observe. */
@@ -106,14 +120,30 @@ export interface DesiredSubscriptionInterests {
   resourcesListChanged?: boolean;
   /** Resource URIs to watch for `notifications/resources/updated`. */
   resourceUris?: readonly string[];
+  /**
+   * Task IDs to watch for `notifications/tasks`. Extension wire only. The
+   * caller is expected to drop terminal and dismissed IDs, which changes the
+   * filter and therefore closes and re-opens the stream — a listen filter is
+   * immutable for the life of a subscription.
+   */
+  taskIds?: readonly string[];
 }
 
-/** Wire-shaped filter (structurally the SDK's `SubscriptionFilter`). */
+/**
+ * Wire-shaped filter (structurally the SDK's `SubscriptionFilter`, plus the
+ * extension's `taskIds`).
+ *
+ * `taskIds` is not in upstream's `SubscriptionFilter` type, and does not need
+ * to be: `Client.listen` puts the filter on the wire verbatim
+ * (`notifications: filter`, client `dist/index.mjs:3711`) with no outbound
+ * schema strip, so the extension member survives the round trip.
+ */
 export interface SubscriptionFilterShape {
   toolsListChanged?: boolean;
   promptsListChanged?: boolean;
   resourcesListChanged?: boolean;
   resourceSubscriptions?: string[];
+  taskIds?: string[];
 }
 
 export type SubscriptionStreamStatus =
@@ -144,7 +174,18 @@ export interface SubscriptionInterestRejection {
   interest: SubscriptionNotificationKind;
   /** Present for `resource-updated` rejections. */
   uri?: string;
-  reason: "capability-not-advertised" | "not-acknowledged-by-server";
+  /** Present for `tasks` rejections. */
+  taskId?: string;
+  reason:
+    | "capability-not-advertised"
+    | "not-acknowledged-by-server"
+    /**
+     * A task-filtered listen was wanted but this connection cannot put the
+     * extension's per-request eligibility declaration on the listen request,
+     * so sending it would earn `-32003`. Polling continues; the handle is not
+     * lost. See `tasks-ext-listen-meta.ts`.
+     */
+    | "tasks-declaration-unavailable";
 }
 
 /** A notification the coordinator refused to deliver, kept for the debugger. */
@@ -195,6 +236,8 @@ export interface DeliveredSubscriptionNotification {
   params?: Record<string, unknown>;
   /** Resource URI for `resource-updated`. */
   uri?: string;
+  /** Task id for `tasks`. The params themselves are the full `DetailedTask`. */
+  taskId?: string;
   subscriptionId?: string;
   localSubscriptionId: string;
   at: number;
@@ -231,6 +274,19 @@ export interface SubscriptionClientPort {
   subscribeResource(params: { uri: string }): Promise<unknown>;
   unsubscribeResource(params: { uri: string }): Promise<unknown>;
   listen?(filter: SubscriptionFilterShape): Promise<McpSubscriptionHandle>;
+  /**
+   * Opens a listen stream carrying the `io.modelcontextprotocol/tasks`
+   * per-request eligibility declaration.
+   *
+   * Separate from {@link listen} on purpose. A task-filtered listen without
+   * the declaration MUST be answered `-32003` (`tasks.md:797-799`), so a
+   * connection that cannot declare must not send one at all — it drops the
+   * `taskIds` selection, records it as `tasks-declaration-unavailable`, and
+   * keeps polling. Absent method ⇒ exactly that.
+   */
+  listenWithTasksDeclaration?(
+    filter: SubscriptionFilterShape
+  ): Promise<McpSubscriptionHandle>;
 }
 
 /** Bounded re-listen policy. Re-listen, never resume: no replay exists. */
@@ -283,7 +339,17 @@ function cloneFilter(filter: SubscriptionFilterShape): SubscriptionFilterShape {
     ...(filter.resourceSubscriptions
       ? { resourceSubscriptions: [...filter.resourceSubscriptions] }
       : {}),
+    ...(filter.taskIds ? { taskIds: [...filter.taskIds] } : {}),
   };
+}
+
+/**
+ * Order-insensitive comparison key for the extension's `taskIds` member.
+ * `JSON.stringify` rather than a joined string: task IDs are opaque handles
+ * that may contain any character, so no separator is safe to assume.
+ */
+function taskIds(filter: SubscriptionFilterShape): string {
+  return JSON.stringify([...(filter.taskIds ?? [])].sort());
 }
 
 function filtersEqual(
@@ -296,7 +362,8 @@ function filtersEqual(
     Boolean(a.toolsListChanged) === Boolean(b.toolsListChanged) &&
     Boolean(a.promptsListChanged) === Boolean(b.promptsListChanged) &&
     Boolean(a.resourcesListChanged) === Boolean(b.resourcesListChanged) &&
-    uris(a) === uris(b)
+    uris(a) === uris(b) &&
+    taskIds(a) === taskIds(b)
   );
 }
 
@@ -305,14 +372,16 @@ function isEmptyFilter(filter: SubscriptionFilterShape): boolean {
     !filter.toolsListChanged &&
     !filter.promptsListChanged &&
     !filter.resourcesListChanged &&
-    (filter.resourceSubscriptions?.length ?? 0) === 0
+    (filter.resourceSubscriptions?.length ?? 0) === 0 &&
+    (filter.taskIds?.length ?? 0) === 0
   );
 }
 
 function filterAllows(
   filter: SubscriptionFilterShape,
   kind: SubscriptionNotificationKind,
-  uri?: string
+  uri?: string,
+  taskId?: string
 ): boolean {
   switch (kind) {
     case "tools-list-changed":
@@ -327,6 +396,13 @@ function filterAllows(
       // differs only by template expansion; MCPJam does not guess — the URI
       // must be one we asked for.
       return uri !== undefined && uris.includes(uri);
+    }
+    case "tasks": {
+      // Same rule as resources. A task notification for a handle we never
+      // asked about is unsolicited whatever it carries, and accepting it would
+      // let a server push state for a task belonging to another surface.
+      const ids = filter.taskIds ?? [];
+      return taskId !== undefined && ids.includes(taskId);
     }
   }
 }
@@ -398,6 +474,27 @@ export function resolveRequestedFilter(
     }
   }
 
+  const wantedTaskIds = [...new Set(desired.taskIds ?? [])];
+  if (wantedTaskIds.length > 0) {
+    // Gated on the tasks EXTENSION capability, not on any `notifications`
+    // sub-flag: SEP-2663 has no per-operation capability flags, so declaring
+    // the extension declares the whole method set — including this channel.
+    // `serverDeclaresTasksExtension` is also the one place allowed to read that
+    // capability, which is what keeps the "treat as absent on 2025-11-25" rule
+    // honest: on the legacy wire this correctly rejects rather than requesting.
+    if (serverDeclaresTasksExtension(capabilities)) {
+      requested.taskIds = wantedTaskIds;
+    } else {
+      for (const taskId of wantedTaskIds) {
+        rejected.push({
+          interest: "tasks",
+          taskId,
+          reason: "capability-not-advertised",
+        });
+      }
+    }
+  }
+
   return { requested, rejected };
 }
 
@@ -429,6 +526,20 @@ export function diffAcknowledgement(
       rejected.push({
         interest: "resource-updated",
         uri,
+        reason: "not-acknowledged-by-server",
+      });
+    }
+  }
+  // An unacknowledged task ID is precisely the case the polling fallback
+  // exists for: the handle is still ours and still pollable, we just will not
+  // be told about it. Recording it keeps that visible instead of leaving the
+  // caller to assume a stream it never got.
+  const ackedTasks = new Set(acknowledged.taskIds ?? []);
+  for (const taskId of requested.taskIds ?? []) {
+    if (!ackedTasks.has(taskId)) {
+      rejected.push({
+        interest: "tasks",
+        taskId,
         reason: "not-acknowledged-by-server",
       });
     }
@@ -699,10 +810,16 @@ export class SubscriptionCoordinator {
       typeof notification.params?.uri === "string"
         ? (notification.params.uri as string)
         : undefined;
+    // `notifications/tasks` carries a full `DetailedTask`, so the task id is a
+    // top-level member of the params rather than a nested envelope field.
+    const taskId =
+      typeof notification.params?.taskId === "string"
+        ? (notification.params.taskId as string)
+        : undefined;
     // Enforce against the ACKNOWLEDGED filter: the server must not send a type
     // it did not agree to honor.
     const effective = stream.acknowledgedFilter ?? stream.requestedFilter;
-    if (!filterAllows(effective, kind, uri)) {
+    if (!filterAllows(effective, kind, uri, taskId)) {
       this.recordRejection({
         method: notification.method,
         subscriptionId,
@@ -718,6 +835,7 @@ export class SubscriptionCoordinator {
       kind,
       params: notification.params,
       ...(uri ? { uri } : {}),
+      ...(taskId ? { taskId } : {}),
       ...(subscriptionId ? { subscriptionId } : {}),
       localSubscriptionId: stream.localId,
       at,
@@ -747,15 +865,53 @@ export class SubscriptionCoordinator {
   // ---- Reconciliation ----
 
   private async reconcile(): Promise<void> {
+    const resolved = this.resolveFilter();
+    if (this.era === "legacy") {
+      await this.reconcileLegacy(resolved.requested, resolved.rejected);
+      return;
+    }
+    await this.reconcileModern(resolved.requested, resolved.rejected);
+  }
+
+  /**
+   * `resolveRequestedFilter` plus the tasks-declaration gate.
+   *
+   * Kept together so every caller — reconcile and re-listen alike — sees the
+   * same filter. A re-listen that skipped the gate would resurrect a `taskIds`
+   * selection this connection cannot declare and earn a `-32003` on reconnect.
+   */
+  private resolveFilter(): {
+    requested: SubscriptionFilterShape;
+    rejected: SubscriptionInterestRejection[];
+  } {
     const { requested, rejected } = resolveRequestedFilter(
       this.desired,
       this.client.getServerCapabilities()
     );
-    if (this.era === "legacy") {
-      await this.reconcileLegacy(requested, rejected);
-      return;
-    }
-    await this.reconcileModern(requested, rejected);
+    const wantedTaskIds = requested.taskIds ?? [];
+    if (wantedTaskIds.length === 0) return { requested, rejected };
+
+    const canDeclare =
+      this.era === "modern" &&
+      typeof this.client.listenWithTasksDeclaration === "function";
+    if (canDeclare) return { requested, rejected };
+
+    // Drop rather than downgrade: an undeclared task-filtered listen is a
+    // guaranteed -32003, and the polling fallback loses nothing but latency.
+    const { taskIds: _dropped, ...withoutTasks } = requested;
+    return {
+      requested: withoutTasks,
+      rejected: [
+        ...rejected,
+        ...wantedTaskIds.map(
+          (taskId): SubscriptionInterestRejection => ({
+            interest: "tasks",
+            taskId,
+            reason: "tasks-declaration-unavailable",
+          })
+        ),
+      ],
+    };
   }
 
   // ---- Legacy adapter: list-changed handlers + per-URI subscribe RPCs ----
@@ -891,7 +1047,13 @@ export class SubscriptionCoordinator {
     rejected: SubscriptionInterestRejection[],
     reconnectAttempt: number
   ): Promise<void> {
-    const listen = this.client.listen?.bind(this.client);
+    // A filter carrying `taskIds` MUST go out declared. `resolveFilter` has
+    // already dropped `taskIds` when no declared opener exists, so reaching
+    // here with them means the opener is present.
+    const listen =
+      (requested.taskIds?.length ?? 0) > 0
+        ? this.client.listenWithTasksDeclaration?.bind(this.client)
+        : this.client.listen?.bind(this.client);
     const stream: SubscriptionStreamRecord = {
       localId: `${this.instanceId}-listen-${++this.streamSeq}`,
       era: "modern",
@@ -909,7 +1071,10 @@ export class SubscriptionCoordinator {
       stream.status = "error";
       stream.closeReason = "error";
       stream.error =
-        "The connected client does not implement subscriptions/listen.";
+        (requested.taskIds?.length ?? 0) > 0
+          ? "The connected client cannot open a task-filtered subscriptions/listen " +
+            "with the io.modelcontextprotocol/tasks declaration; task state will be polled."
+          : "The connected client does not implement subscriptions/listen.";
       stream.closedAt = this.now();
       this.emitStream(stream);
       return;
@@ -1002,10 +1167,7 @@ export class SubscriptionCoordinator {
   ): Promise<void> {
     if (this.disposed) return;
     if (this.currentLocalId !== closed.localId) return;
-    const { requested, rejected } = resolveRequestedFilter(
-      this.desired,
-      this.client.getServerCapabilities()
-    );
+    const { requested, rejected } = this.resolveFilter();
     if (isEmptyFilter(requested)) return;
     const attempt = closed.reconnectAttempt + 1;
     if (attempt > this.reconnectPolicy.maxAttempts) return;

--- a/sdk/src/mcp-client-manager/subscription-coordinator.ts
+++ b/sdk/src/mcp-client-manager/subscription-coordinator.ts
@@ -753,9 +753,7 @@ export class SubscriptionCoordinator {
       return;
     }
     const acknowledged =
-      (notification.params?.notifications as SubscriptionFilterShape) ??
-      undefined ??
-      {};
+      (notification.params?.notifications as SubscriptionFilterShape) ?? {};
     this.markAcknowledged(stream, acknowledged);
   }
 

--- a/sdk/src/mcp-client-manager/subscription-coordinator.ts
+++ b/sdk/src/mcp-client-manager/subscription-coordinator.ts
@@ -103,7 +103,9 @@ export type SubscriptionNotificationKind =
   | "resource-updated"
   | "tasks";
 
-const METHOD_TO_KIND: Readonly<Record<string, SubscriptionNotificationKind>> = {
+const METHOD_TO_KIND: Readonly<
+  Record<string, SubscriptionNotificationKind>
+> = {
   [ToolListChangedNotificationMethod]: "tools-list-changed",
   [PromptListChangedNotificationMethod]: "prompts-list-changed",
   [ResourceListChangedNotificationMethod]: "resources-list-changed",
@@ -408,10 +410,20 @@ function filterAllows(
 /**
  * Splits desired interests into the filter we will actually request and the
  * selections the server does not advertise (shown as rejected, not dropped).
+ *
+ * `era` is required for `taskIds` and for nothing else. The extension
+ * capability is a plain capability read with no era in it, so on 2025-11-25 a
+ * server that advertises `io.modelcontextprotocol/tasks` still reads as
+ * declaring it — while SEP-2663 says that on that revision the extension MUST
+ * be treated as absent. Omitting `era` therefore means "not a modern
+ * connection" and drops `taskIds`: the legacy wire must never carry an
+ * extension-only filter member, and defaulting the other way would put one
+ * there for every caller that has not been updated.
  */
 export function resolveRequestedFilter(
   desired: DesiredSubscriptionInterests,
-  capabilities: ServerCapabilities | undefined
+  capabilities: ServerCapabilities | undefined,
+  era?: "legacy" | "modern"
 ): {
   requested: SubscriptionFilterShape;
   rejected: SubscriptionInterestRejection[];
@@ -477,10 +489,11 @@ export function resolveRequestedFilter(
     // Gated on the tasks EXTENSION capability, not on any `notifications`
     // sub-flag: SEP-2663 has no per-operation capability flags, so declaring
     // the extension declares the whole method set — including this channel.
-    // `serverDeclaresTasksExtension` is also the one place allowed to read that
-    // capability, which is what keeps the "treat as absent on 2025-11-25" rule
-    // honest: on the legacy wire this correctly rejects rather than requesting.
-    if (serverDeclaresTasksExtension(capabilities)) {
+    // `serverDeclaresTasksExtension` is the one place allowed to READ that
+    // capability, but it is a pure capability read: the "treat the extension as
+    // absent on 2025-11-25" rule is the `era` term next to it, not something
+    // the predicate knows.
+    if (era === "modern" && serverDeclaresTasksExtension(capabilities)) {
       requested.taskIds = wantedTaskIds;
     } else {
       for (const taskId of wantedTaskIds) {
@@ -545,6 +558,19 @@ export function diffAcknowledgement(
   return rejected;
 }
 
+/**
+ * How many stream records a coordinator keeps.
+ *
+ * The history exists for the debugger, so it has to be long enough to show a
+ * reconnect sequence and the failures around it — but it cannot be unbounded.
+ * Task interest is revised as handles are created and reach terminal states,
+ * and every revision either opens a stream or records an unopened one, so on a
+ * long-lived connection this map grows with the SESSION rather than with
+ * anything the user can see. The oldest terminal records are the ones nobody
+ * is reading.
+ */
+const MAX_RETAINED_STREAMS = 50;
+
 let coordinatorSeq = 0;
 
 /**
@@ -564,7 +590,10 @@ export class SubscriptionCoordinator {
   private handlersRegistered = false;
   private disposed = false;
   private streamSeq = 0;
-  /** Local id → record. Insertion-ordered; closed records are retained. */
+  /**
+   * Local id → record. Insertion-ordered; closed records are retained up to
+   * {@link MAX_RETAINED_STREAMS}.
+   */
   private readonly streams = new Map<string, SubscriptionStreamRecord>();
   /** Local id → live handle (modern only). */
   private readonly handles = new Map<string, McpSubscriptionHandle>();
@@ -649,9 +678,7 @@ export class SubscriptionCoordinator {
   ): Promise<void> {
     this.desired = {
       ...desired,
-      ...(desired.resourceUris
-        ? { resourceUris: [...desired.resourceUris] }
-        : {}),
+      ...(desired.resourceUris ? { resourceUris: [...desired.resourceUris] } : {}),
       ...(desired.taskIds ? { taskIds: [...desired.taskIds] } : {}),
     };
     await this.enqueue(() => this.reconcile());
@@ -702,8 +729,8 @@ export class SubscriptionCoordinator {
     return typeof raw === "string"
       ? raw
       : typeof raw === "number"
-      ? String(raw)
-      : undefined;
+        ? String(raw)
+        : undefined;
   }
 
   /**
@@ -895,31 +922,25 @@ export class SubscriptionCoordinator {
   } {
     const { requested, rejected } = resolveRequestedFilter(
       this.desired,
-      this.client.getServerCapabilities()
+      this.client.getServerCapabilities(),
+      this.era
     );
     const wantedTaskIds = requested.taskIds ?? [];
     if (wantedTaskIds.length === 0) return { requested, rejected };
 
-    if (
-      this.era === "modern" &&
-      typeof this.client.listenWithTasksDeclaration === "function"
-    ) {
+    if (typeof this.client.listenWithTasksDeclaration === "function") {
       return { requested, rejected };
     }
 
     // Drop rather than downgrade: an undeclared task-filtered listen is a
     // guaranteed -32003, and the polling fallback loses nothing but latency.
     //
-    // The REASON depends on why. `resolveRequestedFilter` reads the extension
-    // capability alone, so a 2025-11-25 server that advertises
-    // `io.modelcontextprotocol/tasks` reaches here — but on that era the
-    // extension MUST be treated as absent, so the honest report is
-    // "capability not advertised", not "we could not declare". Only a modern
-    // connection whose client lacks the declaration seam gets the latter.
-    const reason: SubscriptionInterestRejection["reason"] =
-      this.era === "modern"
-        ? "tasks-declaration-unavailable"
-        : "capability-not-advertised";
+    // Only ONE reason is reachable here. `resolveRequestedFilter` was given the
+    // era, so a legacy connection already had its `taskIds` rejected as
+    // `capability-not-advertised` — whatever the server advertised, because on
+    // 2025-11-25 the extension MUST be treated as absent. So a non-empty
+    // `taskIds` at this point means a modern connection, and the only thing
+    // still missing is the declaration seam.
     const { taskIds: _dropped, ...withoutTasks } = requested;
     return {
       requested: withoutTasks,
@@ -929,7 +950,7 @@ export class SubscriptionCoordinator {
           (taskId): SubscriptionInterestRejection => ({
             interest: "tasks",
             taskId,
-            reason,
+            reason: "tasks-declaration-unavailable",
           })
         ),
       ],
@@ -952,10 +973,7 @@ export class SubscriptionCoordinator {
         await this.safeUnsubscribe(uri);
       }
       this.legacySubscribedUris.clear();
-      if (
-        current &&
-        (current.status === "active" || current.status === "opening")
-      ) {
+      if (current && (current.status === "active" || current.status === "opening")) {
         current.status = "cancelled";
         current.closeReason = "local-abort";
         current.closedAt = this.now();
@@ -1025,8 +1043,37 @@ export class SubscriptionCoordinator {
       reconnectAttempt: 0,
     };
     this.streams.set(stream.localId, stream);
+    this.pruneStreams();
     this.currentLocalId = stream.localId;
     this.emitStream(stream);
+  }
+
+  /**
+   * Trims the retained stream history to {@link MAX_RETAINED_STREAMS}, oldest
+   * first.
+   *
+   * Only records nothing else still points at are eligible: the intended
+   * stream, anything holding a live handle, and anything not yet closed stay
+   * regardless of age, because dropping one of those would strand the handle
+   * and break `resolveStream`'s id binding. In practice the eviction set is
+   * exactly the old terminal records — closed streams and the synthetic
+   * never-opened ones — which is what actually accumulates.
+   */
+  private pruneStreams(): void {
+    if (this.streams.size <= MAX_RETAINED_STREAMS) return;
+    for (const [localId, stream] of this.streams) {
+      if (this.streams.size <= MAX_RETAINED_STREAMS) return;
+      if (localId === this.currentLocalId) continue;
+      if (this.handles.has(localId)) continue;
+      if (stream.status === "opening" || stream.status === "active") continue;
+      this.streams.delete(localId);
+      // The id index outlives nothing: a subscription id that maps to a record
+      // we no longer hold would make `resolveStream` return `undefined` for a
+      // KNOWN id instead of falling through to the unbound-stream adoption.
+      if (stream.mcpSubscriptionId !== undefined) {
+        this.idIndex.delete(stream.mcpSubscriptionId);
+      }
+    }
   }
 
   private async safeUnsubscribe(uri: string): Promise<void> {
@@ -1048,7 +1095,8 @@ export class SubscriptionCoordinator {
       ? this.streams.get(this.currentLocalId)
       : undefined;
     const live =
-      current && (current.status === "opening" || current.status === "active")
+      current &&
+      (current.status === "opening" || current.status === "active")
         ? current
         : undefined;
 
@@ -1111,6 +1159,7 @@ export class SubscriptionCoordinator {
       reconnectAttempt: 0,
     };
     this.streams.set(stream.localId, stream);
+    this.pruneStreams();
     this.emitStream(stream);
   }
 
@@ -1136,6 +1185,7 @@ export class SubscriptionCoordinator {
       reconnectAttempt,
     };
     this.streams.set(stream.localId, stream);
+    this.pruneStreams();
     this.currentLocalId = stream.localId;
     // A real open clears the memo, so if the interest set later becomes
     // entirely unavailable again that IS recorded rather than suppressed.

--- a/sdk/src/mcp-client-manager/task-await-driver.ts
+++ b/sdk/src/mcp-client-manager/task-await-driver.ts
@@ -61,7 +61,12 @@ export interface TaskAwaitResult {
   task?: TaskLifecycleSnapshot;
   /** Input keys this surface could not answer, with reasons. */
   unansweredInput?: TaskInputRejection[];
-  /** The read error that ended an `unreachable` drive. */
+  /**
+   * The read error that ended an `unreachable` drive — or, on a `completed`
+   * legacy task, the reason its result could not be fetched. The outcome stays
+   * `completed` in that case because the task genuinely finished; this is how
+   * the caller learns the payload is missing rather than empty.
+   */
   lastError?: unknown;
 }
 
@@ -71,6 +76,21 @@ export interface DriveTaskToTerminalArgs {
   getTask: (
     identity: TaskLifecycleIdentity
   ) => Promise<TaskLifecycleObservation>;
+  /**
+   * Fetches a LEGACY task's result. Required on the 2025-11-25 wire, ignored on
+   * the extension.
+   *
+   * The two wires differ here and the difference is not cosmetic: the extension
+   * carries `result` inline on `tasks/get`, while 2025-11-25 returns only
+   * status from `tasks/get` and keeps the payload behind a separate
+   * `tasks/result` call. Without this seam a legacy drive reported `completed`
+   * with `task.result === undefined` for every successful task — which for an
+   * eval or a CLI consumer is the same as having failed, since the tool output
+   * is the entire point of waiting.
+   */
+  getResult?: (
+    identity: TaskLifecycleIdentity
+  ) => Promise<Record<string, unknown> | null>;
   /** Submits input responses. Resolving means the server acknowledged them. */
   updateTask?: (
     identity: TaskLifecycleIdentity,
@@ -177,10 +197,19 @@ export async function driveTaskToTerminal(
     // is sleeping, so a check that ran only once would let the second
     // iteration duplicate that read and breach the floor it just set.
     const existing = engine.get(identity);
-    if (existing && isTerminalLifecycleStatus(existing.status)) {
-      // Already finished, per whoever read it last. No read needed at all.
+    if (
+      existing &&
+      isTerminalLifecycleStatus(existing.status) &&
+      !engine.owesRead(existing)
+    ) {
+      // Already finished AND already read. `owesRead` is the load-bearing half:
+      // a shared engine can hold a handle RESTORED from durable storage as
+      // `completed`, and storage keeps a task's status but never its payload.
+      // Short-circuiting on the status alone would report success with no
+      // result — the same reload bug the UI path has, reached through a
+      // different door.
       const settled = engine.snapshot(identity)!;
-      return { outcome: terminalOutcome(settled.status), task: settled };
+      return await settleTerminal(settled);
     }
     if (existing && existing.nextPollAt > now()) {
       if (!(await waitUntilDue())) {
@@ -260,7 +289,7 @@ export async function driveTaskToTerminal(
     args.onState?.(snapshot);
 
     if (isTerminalLifecycleStatus(snapshot.status)) {
-      return { outcome: terminalOutcome(snapshot.status), task: snapshot };
+      return await settleTerminal(snapshot);
     }
 
     if (snapshot.status === "input_required") {
@@ -401,6 +430,61 @@ export async function driveTaskToTerminal(
     } finally {
       cancelTimer();
       if (onAbort) args.signal?.removeEventListener("abort", onAbort);
+    }
+  }
+
+  /**
+   * Turns a terminal snapshot into the drive's result, fetching the legacy
+   * payload when there is one to fetch.
+   *
+   * Both terminal exits go through here so the wire difference is handled once.
+   * A failure to fetch does NOT change the outcome: the task completed whether
+   * or not we could read what it produced, and reporting `failed` would be a
+   * lie about the server. It surfaces as `lastError` instead.
+   */
+  async function settleTerminal(
+    snapshot: TaskLifecycleSnapshot
+  ): Promise<TaskAwaitResult> {
+    const outcome = terminalOutcome(snapshot.status);
+    const base: TaskAwaitResult = {
+      outcome,
+      task: snapshot,
+      ...(lastError === undefined ? {} : { lastError }),
+    };
+    if (
+      outcome !== "completed" ||
+      identity.wire !== "legacy" ||
+      snapshot.result !== undefined
+    ) {
+      return base;
+    }
+    if (!args.getResult) {
+      return {
+        ...base,
+        lastError: new Error(
+          "Legacy task completed but no `getResult` was supplied: on the " +
+            "2025-11-25 wire the payload lives behind `tasks/result`, so the " +
+            "result cannot be recovered from `tasks/get` alone."
+        ),
+      };
+    }
+    try {
+      const fetched = await raceDeadline(args.getResult(identity));
+      if (fetched === TIMED_OUT || fetched === ABORTED) {
+        return {
+          ...base,
+          lastError: new Error(
+            `Legacy task completed but its result fetch was ${
+              fetched === TIMED_OUT ? "not answered in time" : "aborted"
+            }.`
+          ),
+        };
+      }
+      return fetched === null
+        ? base
+        : { ...base, task: { ...snapshot, result: fetched } };
+    } catch (error) {
+      return { ...base, lastError: error };
     }
   }
 

--- a/sdk/src/mcp-client-manager/task-await-driver.ts
+++ b/sdk/src/mcp-client-manager/task-await-driver.ts
@@ -68,7 +68,9 @@ export interface TaskAwaitResult {
 export interface DriveTaskToTerminalArgs {
   identity: TaskLifecycleIdentity;
   /** Reads current state. Rejects with a `-32602` for an unknown handle. */
-  getTask: (identity: TaskLifecycleIdentity) => Promise<TaskLifecycleObservation>;
+  getTask: (
+    identity: TaskLifecycleIdentity
+  ) => Promise<TaskLifecycleObservation>;
   /** Submits input responses. Resolving means the server acknowledged them. */
   updateTask?: (
     identity: TaskLifecycleIdentity,
@@ -87,6 +89,14 @@ export interface DriveTaskToTerminalArgs {
   maxInputRounds?: number;
   signal?: AbortSignal;
   /**
+   * Timer used to bound a single I/O call. Deliberately SEPARATE from
+   * {@link sleep}: `sleep` is the poll-pacing clock a test drives by hand,
+   * whereas this is a wall-clock watchdog that must not fire just because a
+   * test advanced its own clock. Injected only so the watchdog itself is
+   * testable.
+   */
+  setTimer?: (ms: number, fire: () => void) => () => void;
+  /**
    * Injected engine. Pass the surface's own so an `await` drive shares the
    * schedule with whatever else is polling that server; omit for a private one.
    */
@@ -95,6 +105,29 @@ export interface DriveTaskToTerminalArgs {
   sleep?: (ms: number) => Promise<void>;
   /** Observability hook. Never receives payloads — status transitions only. */
   onState?: (snapshot: TaskLifecycleSnapshot) => void;
+}
+
+/** Sentinels for {@link DriveTaskToTerminalArgs.setTimer}'s race outcomes. */
+const TIMED_OUT = Symbol("task-await-timeout");
+const ABORTED = Symbol("task-await-abort");
+
+function defaultSetTimer(ms: number, fire: () => void): () => void {
+  const handle = setTimeout(fire, ms);
+  return () => clearTimeout(handle);
+}
+
+/** Terminal lifecycle status → drive outcome. One mapping, two exits. */
+function terminalOutcome(status: string): TaskAwaitOutcome {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+    default:
+      return "expired";
+  }
 }
 
 const DEFAULT_TIMEOUT_MS = 5 * 60_000;
@@ -116,6 +149,7 @@ export async function driveTaskToTerminal(
   const sleep =
     args.sleep ??
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const setTimer = args.setTimer ?? defaultSetTimer;
   const engine = args.engine ?? new TaskLifecycleEngine({ now });
   const deadline = now() + (args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const maxErrors = args.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS;
@@ -123,6 +157,11 @@ export async function driveTaskToTerminal(
   const { identity } = args;
 
   engine.register(identity, { restored: true });
+  // Attaching to a SHARED engine must not jump the queue. If an interactive
+  // poller already read this handle a moment ago, its floor has not elapsed
+  // and reading again now would both breach that floor and duplicate the read.
+  // A private engine has `nextPollAt = now`, so this is a no-op there.
+  let firstRead = true;
   let inputRounds = 0;
   let lastError: unknown;
   let unansweredInput: TaskInputRejection[] | undefined;
@@ -135,18 +174,55 @@ export async function driveTaskToTerminal(
       return { outcome: "timeout", task: engine.snapshot(identity), lastError };
     }
 
+    if (firstRead) {
+      firstRead = false;
+      const existing = engine.get(identity);
+      if (existing && isTerminalLifecycleStatus(existing.status)) {
+        // Already finished, per whoever polled it last. No read needed.
+        const snapshot = engine.snapshot(identity)!;
+        return { outcome: terminalOutcome(snapshot.status), task: snapshot };
+      }
+      if (existing && existing.nextPollAt > now()) {
+        if (!(await waitUntilDue())) {
+          return {
+            outcome: "timeout",
+            task: engine.snapshot(identity),
+            lastError,
+          };
+        }
+        continue;
+      }
+    }
+
     let observation: TaskLifecycleObservation;
     try {
-      observation = await args.getTask(identity);
+      // BOUNDED, not a bare await. If the transport never settles — the exact
+      // unreachable-server case this driver exists to handle — a bare await
+      // would never return to the deadline or abort checks above, and a drive
+      // configured with `timeoutMs` would hang forever. The bound is a real
+      // timer rather than the injected `sleep`, so a test driving a controlled
+      // clock is unaffected while production stays bounded.
+      const bounded = await raceDeadline(args.getTask(identity));
+      if (bounded === TIMED_OUT) {
+        return {
+          outcome: "timeout",
+          task: engine.snapshot(identity),
+          lastError,
+        };
+      }
+      if (bounded === ABORTED) {
+        return { outcome: "aborted", task: engine.snapshot(identity) };
+      }
+      observation = bounded;
     } catch (error) {
       lastError = error;
       // Only a `tasks/get` `-32602` retires a handle — that is the one method
       // carrying the MUST (`tasks.md:793-795`), and this IS a `tasks/get`.
       if (isUnknownTaskError(error)) {
-        const record = engine.markExpired(identity);
-        args.onState?.(engine.snapshot(identity)!);
-        void record;
-        return { outcome: "expired", task: engine.snapshot(identity) };
+        engine.markExpired(identity);
+        const expired = engine.snapshot(identity);
+        if (expired) args.onState?.(expired);
+        return { outcome: "expired", task: expired };
       }
       const record = engine.observeError(identity);
       if (record.consecutiveErrors >= maxErrors) {
@@ -158,7 +234,11 @@ export async function driveTaskToTerminal(
       }
       const waited = await waitUntilDue();
       if (!waited) {
-        return { outcome: "timeout", task: engine.snapshot(identity), lastError };
+        return {
+          outcome: "timeout",
+          task: engine.snapshot(identity),
+          lastError,
+        };
       }
       continue;
     }
@@ -169,17 +249,7 @@ export async function driveTaskToTerminal(
     args.onState?.(snapshot);
 
     if (isTerminalLifecycleStatus(snapshot.status)) {
-      return {
-        outcome:
-          snapshot.status === "completed"
-            ? "completed"
-            : snapshot.status === "failed"
-              ? "failed"
-              : snapshot.status === "cancelled"
-                ? "cancelled"
-                : "expired",
-        task: snapshot,
-      };
+      return { outcome: terminalOutcome(snapshot.status), task: snapshot };
     }
 
     if (snapshot.status === "input_required") {
@@ -192,19 +262,37 @@ export async function driveTaskToTerminal(
           unansweredInput,
         };
       }
-      if (++inputRounds > maxInputRounds) {
-        return { outcome: "input-required", task: snapshot, unansweredInput };
-      }
-
       const pending = engine.pendingInputKeys(identity);
       if (pending.length === 0) {
-        // Everything in this snapshot is already answered; `tasks/update` is
-        // eventually consistent, so wait for the next one rather than
+        const keyedSnapshot = snapshot.inputRequests
+          ? Object.keys(snapshot.inputRequests).length
+          : 0;
+        if (keyedSnapshot === 0) {
+          // `input_required` with NO keyed requests at all. The 2025-11-25
+          // wire is like this by construction: its `Task` carries no
+          // `inputRequests`, and the request arrives out of band as an
+          // elicitation stamped with `relatedTaskId`. There is nothing this
+          // driver can ever answer, so report it rather than re-polling an
+          // unchanging state until the deadline.
+          return { outcome: "input-required", task: snapshot, unansweredInput };
+        }
+        // Every key in this snapshot is already answered. `tasks/update` is
+        // eventually consistent, so wait for the next snapshot rather than
         // re-submitting.
         if (!(await waitUntilDue())) {
           return { outcome: "timeout", task: snapshot, lastError };
         }
         continue;
+      }
+
+      // Counted HERE, once we know there is genuinely something unanswered.
+      // Counting on entry instead would spend the budget on already-answered
+      // repeats: `tasks/update` is eventually consistent, so the same keyed
+      // snapshot legitimately comes back several times while the server
+      // catches up, and a slowly-converging task would report
+      // `input-required` even though nothing was blocking it.
+      if (++inputRounds > maxInputRounds) {
+        return { outcome: "input-required", task: snapshot, unansweredInput };
       }
 
       const collected = await collectTaskInputResponses({
@@ -230,10 +318,18 @@ export async function driveTaskToTerminal(
       }
 
       try {
-        await args.updateTask(
-          identity,
-          collected.responses as Record<string, unknown>
+        const ack = await raceDeadline(
+          args.updateTask(
+            identity,
+            collected.responses as Record<string, unknown>
+          )
         );
+        if (ack === TIMED_OUT) {
+          return { outcome: "timeout", task: snapshot, lastError };
+        }
+        if (ack === ABORTED) {
+          return { outcome: "aborted", task: snapshot };
+        }
         // Marked responded ONLY after the acknowledgement. An optimistic mark
         // would silently discard the answers if the update failed.
         engine.markInputKeysResponded(identity, collected.answeredKeys);
@@ -252,6 +348,52 @@ export async function driveTaskToTerminal(
   }
 
   /**
+   * Resolves `work`, or one of the two sentinels if the deadline elapses or
+   * the caller aborts first.
+   *
+   * The abandoned promise is deliberately left with a no-op rejection handler
+   * rather than dropped: the underlying request may still fail later, and an
+   * unhandled rejection from a call we stopped waiting on is noise, not a
+   * signal.
+   */
+  /**
+   * Resolves `work`, or one of the two sentinels if the deadline elapses or
+   * the caller aborts first. This is what makes the drive bounded even when
+   * the transport itself never settles.
+   */
+  async function raceDeadline<T>(
+    work: Promise<T>
+  ): Promise<T | typeof TIMED_OUT | typeof ABORTED> {
+    // If the bound wins, nobody is left awaiting `work`. Attach a no-op
+    // handler now so a later rejection from the call we stopped waiting on
+    // does not surface as an unhandled rejection — it is noise, not a signal.
+    work.catch(() => undefined);
+
+    const remaining = deadline - now();
+    if (remaining <= 0) return TIMED_OUT;
+    if (args.signal?.aborted) return ABORTED;
+
+    let cancelTimer: () => void = () => undefined;
+    let onAbort: (() => void) | undefined;
+    const bound = new Promise<typeof TIMED_OUT | typeof ABORTED>((resolve) => {
+      cancelTimer = setTimer(remaining, () => resolve(TIMED_OUT));
+      if (args.signal) {
+        onAbort = () => resolve(ABORTED);
+        args.signal.addEventListener("abort", onAbort, { once: true });
+      }
+    });
+
+    try {
+      // `Promise.race` lets a genuine rejection from `work` propagate into the
+      // caller's try/catch, so the backoff and `-32602` paths still see it.
+      return await Promise.race([work, bound]);
+    } finally {
+      cancelTimer();
+      if (onAbort) args.signal?.removeEventListener("abort", onAbort);
+    }
+  }
+
+  /**
    * Sleeps until this task is next due. Returns `false` when the deadline
    * would elapse first — checked BEFORE sleeping so a long advertised floor
    * cannot push the drive past its own budget.
@@ -261,7 +403,11 @@ export async function driveTaskToTerminal(
     if (!record) return true;
     const delay = Math.max(0, record.nextPollAt - now());
     if (now() + delay >= deadline) return false;
-    if (delay > 0) await sleep(delay);
+    // Always yield, even at zero delay: an engine that keeps a task
+    // perpetually due would otherwise spin this loop synchronously until the
+    // deadline, starving the event loop — and under an injected clock that
+    // only advances on `sleep`, never terminating at all.
+    await sleep(delay);
     return true;
   }
 }

--- a/sdk/src/mcp-client-manager/task-await-driver.ts
+++ b/sdk/src/mcp-client-manager/task-await-driver.ts
@@ -192,19 +192,28 @@ export async function driveTaskToTerminal(
       }
       continue;
     }
-    // Reserve before dispatching, so a concurrent poller on the same engine
-    // sees this handle as taken rather than issuing its own read.
-    if (existing) engine.reserve([existing]);
+    // Lease the handle for the WHOLE request. Pushing the due time forward
+    // (what `reserve` does, and what this used to do alone) only covers a read
+    // that settles inside one interval; a `tasks/get` slower than the floor
+    // leaves the handle due again while this request is still open, so a
+    // concurrent poller dispatches on top of it and the later reply wins even
+    // when it saw the older state. `leasedRead` releases on every exit.
+    if (existing && !engine.acquirePoll(identity)) {
+      // Somebody else is mid-read on this exact handle. Wait for their result
+      // rather than issuing a duplicate of it.
+      if (!(await waitUntilDue())) {
+        return {
+          outcome: "timeout",
+          task: engine.snapshot(identity),
+          lastError,
+        };
+      }
+      continue;
+    }
 
     let observation: TaskLifecycleObservation;
     try {
-      // BOUNDED, not a bare await. If the transport never settles — the exact
-      // unreachable-server case this driver exists to handle — a bare await
-      // would never return to the deadline or abort checks above, and a drive
-      // configured with `timeoutMs` would hang forever. The bound is a real
-      // timer rather than the injected `sleep`, so a test driving a controlled
-      // clock is unaffected while production stays bounded.
-      const bounded = await raceDeadline(args.getTask(identity));
+      const bounded = await leasedRead(existing !== undefined);
       if (bounded === TIMED_OUT) {
         return {
           outcome: "timeout",
@@ -396,6 +405,70 @@ export async function driveTaskToTerminal(
   }
 
   /**
+   * Issues one `tasks/get` while holding the engine's in-flight lease.
+   *
+   * BOUNDED, not a bare await. If the transport never settles — the exact
+   * unreachable-server case this driver exists to handle — a bare await would
+   * never return to the deadline or abort checks in the loop, and a drive
+   * configured with `timeoutMs` would hang forever. The bound is a real timer
+   * rather than the injected `sleep`, so a test driving a controlled clock is
+   * unaffected while production stays bounded.
+   *
+   * The release is in a `finally` and therefore runs BEFORE the caller's
+   * `catch`, so the error path's backoff sleep does not sit on the lease and
+   * block an interactive poller for the whole backoff.
+   */
+  async function leasedRead(
+    leased: boolean
+  ): Promise<TaskLifecycleObservation | typeof TIMED_OUT | typeof ABORTED> {
+    try {
+      return await raceDeadline(args.getTask(identity));
+    } finally {
+      // On a timeout the underlying read may still be in flight, but we
+      // abandon its result rather than folding it in, so releasing cannot
+      // resurrect stale state — and holding the lease after giving up would
+      // park the handle on a shared engine forever.
+      if (leased) engine.releasePoll(identity);
+    }
+  }
+
+  /**
+   * Resolves as soon as `signal` aborts, without waiting for `work`.
+   *
+   * The pacing clock is injected and has no cancellation, so this races it
+   * rather than replacing it. Without the race, a caller aborting during the
+   * wait is not observed until the whole advertised floor elapses — on a task
+   * asking for 60s, an ostensibly cancelled automation drive stays pending for
+   * a full minute. Racing only ends the *wait*; the loop's own
+   * `signal.aborted` check is still what reports the `aborted` outcome.
+   */
+  function raceAbort(work: Promise<void>): Promise<void> {
+    const signal = args.signal;
+    if (!signal) return work;
+    if (signal.aborted) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const onAbort = () => {
+        cleanup();
+        resolve();
+      };
+      const cleanup = () => signal.removeEventListener("abort", onAbort);
+      signal.addEventListener("abort", onAbort, { once: true });
+      // Settle either way — a rejecting pacing clock is a caller bug, not a
+      // reason to strand the drive, and an unhandled rejection would be worse.
+      work.then(
+        () => {
+          cleanup();
+          resolve();
+        },
+        () => {
+          cleanup();
+          resolve();
+        }
+      );
+    });
+  }
+
+  /**
    * Sleeps until this task is next due. Returns `false` when the deadline
    * would elapse first — checked BEFORE sleeping so a long advertised floor
    * cannot push the drive past its own budget.
@@ -409,7 +482,7 @@ export async function driveTaskToTerminal(
     // perpetually due would otherwise spin this loop synchronously until the
     // deadline, starving the event loop — and under an injected clock that
     // only advances on `sleep`, never terminating at all.
-    await sleep(delay);
+    await raceAbort(sleep(delay));
     return true;
   }
 }

--- a/sdk/src/mcp-client-manager/task-await-driver.ts
+++ b/sdk/src/mcp-client-manager/task-await-driver.ts
@@ -157,11 +157,9 @@ export async function driveTaskToTerminal(
   const { identity } = args;
 
   engine.register(identity, { restored: true });
-  // Attaching to a SHARED engine must not jump the queue. If an interactive
-  // poller already read this handle a moment ago, its floor has not elapsed
-  // and reading again now would both breach that floor and duplicate the read.
-  // A private engine has `nextPollAt = now`, so this is a no-op there.
-  let firstRead = true;
+  // Attaching to a SHARED engine must not jump the queue: if an interactive
+  // poller read this handle a moment ago, its floor has not elapsed. A private
+  // engine has `nextPollAt = now`, so the check below is a no-op there.
   let inputRounds = 0;
   let lastError: unknown;
   let unansweredInput: TaskInputRejection[] | undefined;
@@ -174,25 +172,29 @@ export async function driveTaskToTerminal(
       return { outcome: "timeout", task: engine.snapshot(identity), lastError };
     }
 
-    if (firstRead) {
-      firstRead = false;
-      const existing = engine.get(identity);
-      if (existing && isTerminalLifecycleStatus(existing.status)) {
-        // Already finished, per whoever polled it last. No read needed.
-        const snapshot = engine.snapshot(identity)!;
-        return { outcome: terminalOutcome(snapshot.status), task: snapshot };
-      }
-      if (existing && existing.nextPollAt > now()) {
-        if (!(await waitUntilDue())) {
-          return {
-            outcome: "timeout",
-            task: engine.snapshot(identity),
-            lastError,
-          };
-        }
-        continue;
-      }
+    // Checked before EVERY dispatch, not just the first. On a shared engine an
+    // interactive poller can reserve or re-read this handle while this drive
+    // is sleeping, so a check that ran only once would let the second
+    // iteration duplicate that read and breach the floor it just set.
+    const existing = engine.get(identity);
+    if (existing && isTerminalLifecycleStatus(existing.status)) {
+      // Already finished, per whoever read it last. No read needed at all.
+      const settled = engine.snapshot(identity)!;
+      return { outcome: terminalOutcome(settled.status), task: settled };
     }
+    if (existing && existing.nextPollAt > now()) {
+      if (!(await waitUntilDue())) {
+        return {
+          outcome: "timeout",
+          task: engine.snapshot(identity),
+          lastError,
+        };
+      }
+      continue;
+    }
+    // Reserve before dispatching, so a concurrent poller on the same engine
+    // sees this handle as taken rather than issuing its own read.
+    if (existing) engine.reserve([existing]);
 
     let observation: TaskLifecycleObservation;
     try {

--- a/sdk/src/mcp-client-manager/task-await-driver.ts
+++ b/sdk/src/mcp-client-manager/task-await-driver.ts
@@ -1,0 +1,267 @@
+/**
+ * `await` mode: drive a created task to a bounded terminal result.
+ *
+ * Used by automation surfaces — eval execution, the CLI's `tasks watch`, the
+ * public API when a caller asks to block — where nobody is watching a tab, so
+ * returning a handle for someone to follow later is the same as returning
+ * nothing.
+ *
+ * Three properties, in the order they matter:
+ *
+ *  1. **It terminates.** Every exit is one of a small closed set, and the
+ *     deadline is checked before every wait. A task that needs human input
+ *     nobody can supply returns a deterministic `input-required` outcome
+ *     rather than hanging until the evaluation times out — the plan's
+ *     `TASK_INPUT_REQUIRED`.
+ *  2. **It never polls faster than allowed.** Waiting is delegated to the
+ *     lifecycle engine, so `pollIntervalMs`, the user minimum, error backoff
+ *     and `Retry-After` all apply exactly as they do interactively. An
+ *     automation surface has no licence the interactive one lacks.
+ *  3. **It performs no I/O of its own.** The caller supplies `getTask` and
+ *     `updateTask`, so this same driver runs over a local client, a hosted
+ *     reconnect-per-poll route, or an HTTP API client.
+ */
+
+import {
+  TaskLifecycleEngine,
+  isTerminalLifecycleStatus,
+  type TaskLifecycleIdentity,
+  type TaskLifecycleObservation,
+  type TaskLifecycleSnapshot,
+} from "./task-lifecycle.js";
+import { isUnknownTaskError } from "./task-lifecycle-adapters.js";
+import {
+  collectTaskInputResponses,
+  type TaskInputDriverOptions,
+  type TaskInputRejection,
+} from "./task-input-driver.js";
+
+/** How the drive ended. Every one is deterministic and reportable. */
+export type TaskAwaitOutcome =
+  /** Reached `completed`. `task` carries the inline result. */
+  | "completed"
+  /** Reached `failed` — a JSON-RPC fault, NOT a tool result with `isError`. */
+  | "failed"
+  /** Reached `cancelled`. */
+  | "cancelled"
+  /** A confirmed `tasks/get` `-32602`: the server no longer knows the handle. */
+  | "expired"
+  /** Needs input this surface cannot supply. The plan's `TASK_INPUT_REQUIRED`. */
+  | "input-required"
+  /** The deadline elapsed while the task was still working. */
+  | "timeout"
+  /** The caller's signal aborted. */
+  | "aborted"
+  /** Reads kept failing past the retry budget. */
+  | "unreachable";
+
+export interface TaskAwaitResult {
+  outcome: TaskAwaitOutcome;
+  /** Last validated state, when there was one. */
+  task?: TaskLifecycleSnapshot;
+  /** Input keys this surface could not answer, with reasons. */
+  unansweredInput?: TaskInputRejection[];
+  /** The read error that ended an `unreachable` drive. */
+  lastError?: unknown;
+}
+
+export interface DriveTaskToTerminalArgs {
+  identity: TaskLifecycleIdentity;
+  /** Reads current state. Rejects with a `-32602` for an unknown handle. */
+  getTask: (identity: TaskLifecycleIdentity) => Promise<TaskLifecycleObservation>;
+  /** Submits input responses. Resolving means the server acknowledged them. */
+  updateTask?: (
+    identity: TaskLifecycleIdentity,
+    inputResponses: Record<string, unknown>
+  ) => Promise<void>;
+  /** Answers `input_required` rounds. Absent ⇒ any input ends the drive. */
+  input?: TaskInputDriverOptions;
+  /** Total wall-clock budget. The whole drive, not a single read. */
+  timeoutMs?: number;
+  /** Consecutive failed reads tolerated before giving up. */
+  maxConsecutiveErrors?: number;
+  /**
+   * Cap on `input_required` rounds. A server that keeps asking for the same
+   * thing must not turn a bounded drive into an unbounded one.
+   */
+  maxInputRounds?: number;
+  signal?: AbortSignal;
+  /**
+   * Injected engine. Pass the surface's own so an `await` drive shares the
+   * schedule with whatever else is polling that server; omit for a private one.
+   */
+  engine?: TaskLifecycleEngine;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  /** Observability hook. Never receives payloads — status transitions only. */
+  onState?: (snapshot: TaskLifecycleSnapshot) => void;
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_MAX_CONSECUTIVE_ERRORS = 5;
+const DEFAULT_MAX_INPUT_ROUNDS = 10;
+
+/**
+ * Polls `identity` until it reaches a terminal state or a bounded exit.
+ *
+ * The loop deliberately re-checks the deadline *before* sleeping rather than
+ * after: a task whose advertised floor exceeds the remaining budget should
+ * report `timeout` immediately instead of sleeping past its own deadline and
+ * reporting it late.
+ */
+export async function driveTaskToTerminal(
+  args: DriveTaskToTerminalArgs
+): Promise<TaskAwaitResult> {
+  const now = args.now ?? (() => Date.now());
+  const sleep =
+    args.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const engine = args.engine ?? new TaskLifecycleEngine({ now });
+  const deadline = now() + (args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const maxErrors = args.maxConsecutiveErrors ?? DEFAULT_MAX_CONSECUTIVE_ERRORS;
+  const maxInputRounds = args.maxInputRounds ?? DEFAULT_MAX_INPUT_ROUNDS;
+  const { identity } = args;
+
+  engine.register(identity, { restored: true });
+  let inputRounds = 0;
+  let lastError: unknown;
+  let unansweredInput: TaskInputRejection[] | undefined;
+
+  for (;;) {
+    if (args.signal?.aborted) {
+      return { outcome: "aborted", task: engine.snapshot(identity) };
+    }
+    if (now() >= deadline) {
+      return { outcome: "timeout", task: engine.snapshot(identity), lastError };
+    }
+
+    let observation: TaskLifecycleObservation;
+    try {
+      observation = await args.getTask(identity);
+    } catch (error) {
+      lastError = error;
+      // Only a `tasks/get` `-32602` retires a handle — that is the one method
+      // carrying the MUST (`tasks.md:793-795`), and this IS a `tasks/get`.
+      if (isUnknownTaskError(error)) {
+        const record = engine.markExpired(identity);
+        args.onState?.(engine.snapshot(identity)!);
+        void record;
+        return { outcome: "expired", task: engine.snapshot(identity) };
+      }
+      const record = engine.observeError(identity);
+      if (record.consecutiveErrors >= maxErrors) {
+        return {
+          outcome: "unreachable",
+          task: engine.snapshot(identity),
+          lastError,
+        };
+      }
+      const waited = await waitUntilDue();
+      if (!waited) {
+        return { outcome: "timeout", task: engine.snapshot(identity), lastError };
+      }
+      continue;
+    }
+
+    lastError = undefined;
+    engine.observe(identity, observation);
+    const snapshot = engine.snapshot(identity)!;
+    args.onState?.(snapshot);
+
+    if (isTerminalLifecycleStatus(snapshot.status)) {
+      return {
+        outcome:
+          snapshot.status === "completed"
+            ? "completed"
+            : snapshot.status === "failed"
+              ? "failed"
+              : snapshot.status === "cancelled"
+                ? "cancelled"
+                : "expired",
+        task: snapshot,
+      };
+    }
+
+    if (snapshot.status === "input_required") {
+      // No handlers, or no way to submit ⇒ this is exactly the deterministic
+      // outcome the plan asks for, rather than a hang.
+      if (!args.input || !args.updateTask) {
+        return {
+          outcome: "input-required",
+          task: snapshot,
+          unansweredInput,
+        };
+      }
+      if (++inputRounds > maxInputRounds) {
+        return { outcome: "input-required", task: snapshot, unansweredInput };
+      }
+
+      const pending = engine.pendingInputKeys(identity);
+      if (pending.length === 0) {
+        // Everything in this snapshot is already answered; `tasks/update` is
+        // eventually consistent, so wait for the next one rather than
+        // re-submitting.
+        if (!(await waitUntilDue())) {
+          return { outcome: "timeout", task: snapshot, lastError };
+        }
+        continue;
+      }
+
+      const collected = await collectTaskInputResponses({
+        options: args.input,
+        taskId: identity.taskId,
+        serverId: identity.serverId,
+        inputRequests: (snapshot.inputRequests ?? {}) as never,
+        respondedKeys: new Set(snapshot.respondedInputKeys),
+        signal: args.signal,
+      });
+      unansweredInput = collected.rejections.length
+        ? collected.rejections
+        : undefined;
+
+      if (collected.answeredKeys.length === 0) {
+        // Nothing answerable and nothing left pending elsewhere: stop, and say
+        // which keys blocked it.
+        return {
+          outcome: "input-required",
+          task: snapshot,
+          unansweredInput: collected.rejections,
+        };
+      }
+
+      try {
+        await args.updateTask(
+          identity,
+          collected.responses as Record<string, unknown>
+        );
+        // Marked responded ONLY after the acknowledgement. An optimistic mark
+        // would silently discard the answers if the update failed.
+        engine.markInputKeysResponded(identity, collected.answeredKeys);
+      } catch (error) {
+        lastError = error;
+        const record = engine.observeError(identity);
+        if (record.consecutiveErrors >= maxErrors) {
+          return { outcome: "unreachable", task: snapshot, lastError };
+        }
+      }
+    }
+
+    if (!(await waitUntilDue())) {
+      return { outcome: "timeout", task: engine.snapshot(identity), lastError };
+    }
+  }
+
+  /**
+   * Sleeps until this task is next due. Returns `false` when the deadline
+   * would elapse first — checked BEFORE sleeping so a long advertised floor
+   * cannot push the drive past its own budget.
+   */
+  async function waitUntilDue(): Promise<boolean> {
+    const record = engine.get(identity);
+    if (!record) return true;
+    const delay = Math.max(0, record.nextPollAt - now());
+    if (now() + delay >= deadline) return false;
+    if (delay > 0) await sleep(delay);
+    return true;
+  }
+}

--- a/sdk/src/mcp-client-manager/task-created-event.ts
+++ b/sdk/src/mcp-client-manager/task-created-event.ts
@@ -120,6 +120,13 @@ export class TaskCreatedSink {
    */
   async dispatch(event: TaskCreatedEvent): Promise<TaskCreatedDispatchResult> {
     const degraded: TaskCreatedConsumerFailure[] = [];
+    // Functional failures are collected rather than thrown from inside the
+    // loop. Throwing on the first one skipped every consumer after it, so a
+    // tracker write that failed took the stream part and the registry record
+    // down with it — silently, and in registration order, which is not a
+    // meaningful priority. Delivery is attempted to EVERY consumer; the throw
+    // happens once, below, after they have all had their turn.
+    const fatal: TaskCreatedConsumerFailure[] = [];
     // Iterate a COPY: a consumer that unregisters itself (or a sibling) while
     // we are awaiting it would shift the indices under a live iterator and the
     // next consumer would be silently skipped.
@@ -143,12 +150,28 @@ export class TaskCreatedSink {
         }
         await consumer.handle(event);
       } catch (error) {
-        if (!consumer.bestEffort) throw error;
+        if (!consumer.bestEffort) {
+          fatal.push({ name: consumer.name, error });
+          continue;
+        }
         // The task is running on the server regardless of whether we recorded
         // a recovery row for it. Reporting this is right; failing the call is
         // not.
         degraded.push({ name: consumer.name, error });
       }
+    }
+    if (fatal.length === 1) {
+      // Rethrown unchanged: a lone functional failure should surface exactly
+      // as the consumer threw it, stack and type intact.
+      throw fatal[0].error;
+    }
+    if (fatal.length > 1) {
+      throw new AggregateError(
+        fatal.map((failure) => failure.error),
+        `${fatal.length} task-created consumers failed: ${fatal
+          .map((failure) => failure.name)
+          .join(", ")}`
+      );
     }
     return { degraded };
   }

--- a/sdk/src/mcp-client-manager/task-created-event.ts
+++ b/sdk/src/mcp-client-manager/task-created-event.ts
@@ -1,0 +1,123 @@
+/**
+ * The single task-creation fan-out point, and the `await`-mode driver.
+ *
+ * ## Why one event
+ *
+ * A created task has to reach four places at once: the durable browser
+ * tracker, the hosted chat stream, the best-effort hosted registry, and
+ * analytics. Before this, each execution surface wired its own subset, which
+ * is how a task created from chat could end up untracked while the same task
+ * created from the Tools tab was tracked. {@link TaskCreatedSink} makes the
+ * fan-out the thing surfaces share, so adding a consumer is one registration
+ * rather than an edit in every route.
+ *
+ * Two rules the sink enforces, from the plan:
+ *
+ *  1. **A registry failure must never convert a successful tool call into a
+ *     failure.** The task exists on the server whether or not we managed to
+ *     write a recovery row. Throwing here would tell the user their call
+ *     failed while the work runs on regardless.
+ *  2. **Tracking and client delivery are functional paths, not fire-and-forget.**
+ *     They are awaited, and a failure in one is reported rather than swallowed
+ *     inside an unobserved promise. "Best effort" describes the *registry*, not
+ *     the local tracker the user's next page load depends on.
+ */
+
+import type { LiveTasksWire, TaskLifecycleIdentity } from "./task-lifecycle.js";
+
+/** Where a task was created from. Mirrors the host-policy surface matrix. */
+export type TaskCreationSurface =
+  | "tools"
+  | "chat"
+  | "agent"
+  | "eval"
+  | "conformance"
+  | "api"
+  | "cli";
+
+/**
+ * A task handle, the moment it comes into existence.
+ *
+ * Deliberately carries no result, no input requests, and no tool arguments:
+ * consumers of this event persist and route, they do not render. Anything
+ * richer is read back from `tasks/get` by whoever actually needs it.
+ */
+export interface TaskCreatedEvent {
+  identity: TaskLifecycleIdentity;
+  wire: LiveTasksWire;
+  surface: TaskCreationSurface;
+  /** ISO timestamp reported by the server, not a local clock reading. */
+  createdAt?: string;
+  ttlMs?: number | null;
+  pollIntervalMs?: number;
+  /** The tool whose call produced this task, when the surface knows it. */
+  toolName?: string;
+  status?: string;
+}
+
+/** One registered consumer. */
+export interface TaskCreatedConsumer {
+  name: string;
+  /**
+   * `false` (the default) means a throw from this consumer propagates: it is a
+   * functional path — durable tracking, client event delivery — and a silent
+   * failure there loses the handle.
+   *
+   * `true` means a throw is captured and reported instead: for the hosted
+   * registry, which is a recovery index rather than the source of truth.
+   */
+  bestEffort?: boolean;
+  handle: (event: TaskCreatedEvent) => void | Promise<void>;
+}
+
+/** A consumer that failed. Reported, never silently dropped. */
+export interface TaskCreatedConsumerFailure {
+  name: string;
+  error: unknown;
+}
+
+export interface TaskCreatedDispatchResult {
+  /** Failures from `bestEffort` consumers. Non-empty is not an error. */
+  degraded: TaskCreatedConsumerFailure[];
+}
+
+/**
+ * Fan-out for {@link TaskCreatedEvent}.
+ *
+ * Consumers run in registration order and are awaited. Order matters for one
+ * reason: durable local tracking should land before anything that might be
+ * slow or remote, so a hung registry write cannot cost the user their handle.
+ */
+export class TaskCreatedSink {
+  private readonly consumers: TaskCreatedConsumer[] = [];
+
+  register(consumer: TaskCreatedConsumer): () => void {
+    this.consumers.push(consumer);
+    return () => {
+      const index = this.consumers.indexOf(consumer);
+      if (index >= 0) this.consumers.splice(index, 1);
+    };
+  }
+
+  /**
+   * Delivers to every consumer.
+   *
+   * @throws whatever a non-`bestEffort` consumer throws — those are the paths
+   * whose failure genuinely means the handle was lost.
+   */
+  async dispatch(event: TaskCreatedEvent): Promise<TaskCreatedDispatchResult> {
+    const degraded: TaskCreatedConsumerFailure[] = [];
+    for (const consumer of this.consumers) {
+      try {
+        await consumer.handle(event);
+      } catch (error) {
+        if (!consumer.bestEffort) throw error;
+        // The task is running on the server regardless of whether we recorded
+        // a recovery row for it. Reporting this is right; failing the call is
+        // not.
+        degraded.push({ name: consumer.name, error });
+      }
+    }
+    return { degraded };
+  }
+}

--- a/sdk/src/mcp-client-manager/task-created-event.ts
+++ b/sdk/src/mcp-client-manager/task-created-event.ts
@@ -82,6 +82,15 @@ export interface TaskCreatedDispatchResult {
 }
 
 /**
+ * How long a `bestEffort` consumer may take before the fan-out stops waiting
+ * for it. "Best effort" has to mean bounded effort: a registry write that
+ * hangs rather than failing would otherwise leave `dispatch()` pending
+ * forever, and a caller awaiting it would never return a tool call that
+ * already succeeded on the server.
+ */
+export const DEFAULT_BEST_EFFORT_TIMEOUT_MS = 5_000;
+
+/**
  * Fan-out for {@link TaskCreatedEvent}.
  *
  * Consumers run in registration order and are awaited. Order matters for one
@@ -90,6 +99,10 @@ export interface TaskCreatedDispatchResult {
  */
 export class TaskCreatedSink {
   private readonly consumers: TaskCreatedConsumer[] = [];
+
+  constructor(
+    private readonly bestEffortTimeoutMs = DEFAULT_BEST_EFFORT_TIMEOUT_MS
+  ) {}
 
   register(consumer: TaskCreatedConsumer): () => void {
     this.consumers.push(consumer);
@@ -107,8 +120,27 @@ export class TaskCreatedSink {
    */
   async dispatch(event: TaskCreatedEvent): Promise<TaskCreatedDispatchResult> {
     const degraded: TaskCreatedConsumerFailure[] = [];
-    for (const consumer of this.consumers) {
+    // Iterate a COPY: a consumer that unregisters itself (or a sibling) while
+    // we are awaiting it would shift the indices under a live iterator and the
+    // next consumer would be silently skipped.
+    for (const consumer of [...this.consumers]) {
       try {
+        if (consumer.bestEffort) {
+          // Bounded: a hang is degradation, exactly like a throw.
+          const timedOut = await withTimeout(
+            Promise.resolve(consumer.handle(event)),
+            this.bestEffortTimeoutMs
+          );
+          if (timedOut) {
+            degraded.push({
+              name: consumer.name,
+              error: new Error(
+                `${consumer.name} did not settle within ${this.bestEffortTimeoutMs}ms`
+              ),
+            });
+          }
+          continue;
+        }
         await consumer.handle(event);
       } catch (error) {
         if (!consumer.bestEffort) throw error;
@@ -119,5 +151,34 @@ export class TaskCreatedSink {
       }
     }
     return { degraded };
+  }
+}
+
+/**
+ * Resolves `false` when `work` settled in time, `true` when it did not.
+ *
+ * A rejection propagates so the caller's own `catch` still classifies it. The
+ * abandoned promise keeps a no-op handler for the timeout case, since a late
+ * failure from a call nobody is waiting on is noise.
+ */
+async function withTimeout(
+  work: Promise<unknown>,
+  ms: number
+): Promise<boolean> {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    await work;
+    return false;
+  }
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<true>((resolve) => {
+    timer = setTimeout(() => resolve(true), ms);
+  });
+  try {
+    return (
+      (await Promise.race([work.then(() => false as const), timeout])) === true
+    );
+  } finally {
+    clearTimeout(timer!);
+    work.catch(() => undefined);
   }
 }

--- a/sdk/src/mcp-client-manager/task-input-driver.ts
+++ b/sdk/src/mcp-client-manager/task-input-driver.ts
@@ -1,0 +1,503 @@
+/**
+ * `input_required` driver for the tasks extension.
+ *
+ * A task's input channel is **not** more trusted than a direct server→client
+ * request. `inputRequests` can carry `elicitation/create`, `roots/list`, and
+ * `sampling/createMessage` — the same three methods a server could have asked
+ * for out of band — so each one is routed through the same policy, consent,
+ * schema validation, and handler as its standalone counterpart. This module is
+ * the seam that enforces that, so no surface can accidentally grant a task
+ * channel privileges the standalone path would have refused.
+ *
+ * Two rules shape everything here:
+ *
+ * 1. **Declare only what you can fulfil.** A surface may declare the tasks
+ *    extension only when it has a complete handler path for each standalone
+ *    capability it declares. A request for a method the client did not declare
+ *    is rejected with a typed error and surfaced as actionable — never hung on,
+ *    and never quietly marked handled.
+ * 2. **Answered means acknowledged.** A key is marked responded only after the
+ *    `tasks/update` carrying it succeeds. Marking optimistically would silently
+ *    discard a user's answer whenever the update failed.
+ *
+ * The keyed `inputRequests` map is a **snapshot re-sent on every poll**, and it
+ * may grow between polls. Partial responses are legal: a caller answers what it
+ * can, updates, and observes the next snapshot.
+ */
+
+import type { InputRequests, InputResponses } from "./tasks-ext-types.js";
+import type { ClientCapabilityOptions } from "./types.js";
+import type { ElicitationContentValidator } from "./mrtr-driver.js";
+import {
+  SUPPORTED_ELICITATION_MODES,
+  type ElicitationMode,
+} from "./mrtr-driver.js";
+
+/** The three request methods an `input_required` task may embed. */
+export const TASK_INPUT_METHODS = [
+  "elicitation/create",
+  "roots/list",
+  "sampling/createMessage",
+] as const;
+
+export type TaskInputMethod = (typeof TASK_INPUT_METHODS)[number];
+
+export function isTaskInputMethod(method: unknown): method is TaskInputMethod {
+  return (
+    typeof method === "string" &&
+    (TASK_INPUT_METHODS as readonly string[]).includes(method)
+  );
+}
+
+/**
+ * Why a key could not be answered. Every one of these is *displayable state*,
+ * not a silent drop: an unanswerable key stays visible and stays unanswered.
+ */
+export type TaskInputRejectionReason =
+  /** The client never declared the capability this request needs. */
+  | "undeclared-capability"
+  /** The method is not one of the extension's three. */
+  | "unsupported-method"
+  /** `elicitation/create` asked for a mode this client cannot render. */
+  | "unsupported-elicitation-mode"
+  /** No handler was wired for a capability the client did declare. */
+  | "no-handler"
+  /** A size/count limit rejected the request before it was rendered. */
+  | "limit-exceeded"
+  /** The handler threw. */
+  | "handler-failed"
+  /** The request's own shape was invalid. */
+  | "malformed-request";
+
+export class TaskInputRejectedError extends Error {
+  readonly code = "TASK_INPUT_REJECTED";
+  constructor(
+    readonly reason: TaskInputRejectionReason,
+    readonly inputKey: string,
+    readonly method: string,
+    message: string
+  ) {
+    super(message);
+    this.name = "TaskInputRejectedError";
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** A key this driver could not answer, with the reason to show the user. */
+export interface TaskInputRejection {
+  inputKey: string;
+  method: string;
+  reason: TaskInputRejectionReason;
+  message: string;
+}
+
+export interface TaskInputHandlerContext {
+  readonly taskId: string;
+  readonly serverId: string;
+  readonly inputKey: string;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Handlers for the three methods. Each must be the *same* handler the
+ * standalone request path uses, so trust rules cannot diverge between the two
+ * channels. An absent handler is a `no-handler` rejection, never a silent skip.
+ */
+export interface TaskInputHandlers {
+  elicitation?: (
+    params: Record<string, unknown>,
+    ctx: TaskInputHandlerContext
+  ) => Promise<Record<string, unknown>>;
+  roots?: (
+    params: Record<string, unknown>,
+    ctx: TaskInputHandlerContext
+  ) => Promise<Record<string, unknown>>;
+  sampling?: (
+    params: Record<string, unknown>,
+    ctx: TaskInputHandlerContext
+  ) => Promise<Record<string, unknown>>;
+}
+
+/**
+ * Bounds applied *before* a request is rendered or forwarded. `inputRequests`
+ * is attacker-influenced: it comes from the server verbatim.
+ */
+export interface TaskInputLimits {
+  maxRequests?: number;
+  maxKeyLength?: number;
+  maxSerializedRequestBytes?: number;
+  maxResponsesPerUpdate?: number;
+}
+
+export const DEFAULT_TASK_INPUT_LIMITS: Required<TaskInputLimits> = {
+  maxRequests: 50,
+  maxKeyLength: 512,
+  maxSerializedRequestBytes: 256 * 1024,
+  maxResponsesPerUpdate: 50,
+};
+
+export interface TaskInputDriverOptions {
+  /** What this connection actually advertised. Governs which methods are legal. */
+  declaredCapabilities: ClientCapabilityOptions | undefined;
+  handlers: TaskInputHandlers;
+  /**
+   * Strict, dialect-aware validator for accepted elicitation content, matching
+   * the standalone elicitation path. Absent means content is not self-validated
+   * — acceptable only where the standalone path also does not validate.
+   */
+  validateElicitationContent?: ElicitationContentValidator;
+  supportedElicitationModes?: readonly ElicitationMode[];
+  limits?: TaskInputLimits;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Capabilities a connection declared, as booleans. Read from the exact object
+ * handed to `new Client(...)` so this can never disagree with the wire.
+ */
+export interface DeclaredInputCapabilities {
+  elicitation: boolean;
+  roots: boolean;
+  sampling: boolean;
+}
+
+export function readDeclaredInputCapabilities(
+  capabilities: ClientCapabilityOptions | undefined
+): DeclaredInputCapabilities {
+  const caps = (capabilities ?? {}) as Record<string, unknown>;
+  return {
+    elicitation: isRecord(caps.elicitation),
+    roots: isRecord(caps.roots),
+    sampling: isRecord(caps.sampling),
+  };
+}
+
+/**
+ * Whether a surface may declare the tasks extension at all.
+ *
+ * The rule from the plan: a surface may declare the extension only when it has
+ * a complete handler path for the standalone capabilities it declares. A
+ * connection that advertises `sampling` but wires no sampling handler would
+ * strand any task that asks for it, so declaring tasks there is a bug we can
+ * detect statically.
+ */
+export function canDeclareTasksExtension(
+  declaredCapabilities: ClientCapabilityOptions | undefined,
+  handlers: TaskInputHandlers
+): { ok: true } | { ok: false; missing: TaskInputMethod[] } {
+  const declared = readDeclaredInputCapabilities(declaredCapabilities);
+  const missing: TaskInputMethod[] = [];
+  if (declared.elicitation && !handlers.elicitation) {
+    missing.push("elicitation/create");
+  }
+  if (declared.roots && !handlers.roots) missing.push("roots/list");
+  if (declared.sampling && !handlers.sampling) {
+    missing.push("sampling/createMessage");
+  }
+  return missing.length === 0 ? { ok: true } : { ok: false, missing };
+}
+
+/** One key's outcome. */
+export type TaskInputKeyOutcome =
+  | { inputKey: string; status: "answered"; response: Record<string, unknown> }
+  | { inputKey: string; status: "rejected"; rejection: TaskInputRejection };
+
+export interface CollectTaskInputResult {
+  /** Responses ready to send in ONE `tasks/update`. May be partial. */
+  responses: InputResponses;
+  /** Keys answered this round, in the order they were collected. */
+  answeredKeys: string[];
+  /** Keys that could not be answered, each with a displayable reason. */
+  rejections: TaskInputRejection[];
+  /** Keys skipped because they were already answered in an earlier round. */
+  alreadyAnsweredKeys: string[];
+}
+
+function utf8Length(value: string): number {
+  // `TextEncoder` is available in every runtime this SDK targets (browser,
+  // worker, node18+), and byte length is what a limit should measure.
+  return new TextEncoder().encode(value).length;
+}
+
+function safeSerializedSize(value: unknown): number {
+  try {
+    return utf8Length(JSON.stringify(value) ?? "");
+  } catch {
+    // A cyclic or non-serializable request cannot be forwarded anyway; treat it
+    // as over-limit rather than crashing the collector.
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+/**
+ * Own-property keys of the snapshot, in insertion order.
+ *
+ * `Object.keys` already skips the prototype chain, but the explicit
+ * `hasOwnProperty` filter documents the intent and survives a future switch to
+ * a different enumeration. A server key of `constructor` or `__proto__` is
+ * data, not behavior.
+ */
+function ownKeys(inputRequests: InputRequests): string[] {
+  return Object.keys(inputRequests).filter((key) =>
+    Object.prototype.hasOwnProperty.call(inputRequests, key)
+  );
+}
+
+/**
+ * Routes one snapshot of `inputRequests` through the declared handlers.
+ *
+ * Answering is best-effort **per key**: one rejected key never blocks the
+ * others, because a partial `tasks/update` is legal and making progress on the
+ * answerable keys is strictly better than stalling the task. Every rejection is
+ * returned rather than thrown, so the caller can render "3 answered, 1 needs
+ * attention" instead of a dead end.
+ */
+export async function collectTaskInputResponses(args: {
+  options: TaskInputDriverOptions;
+  taskId: string;
+  serverId: string;
+  inputRequests: InputRequests;
+  /** Keys already acknowledged by a previous `tasks/update` — never re-prompted. */
+  respondedKeys?: ReadonlySet<string>;
+  signal?: AbortSignal;
+}): Promise<CollectTaskInputResult> {
+  const { options, taskId, serverId, inputRequests, signal } = args;
+  const respondedKeys = args.respondedKeys ?? new Set<string>();
+  const limits = { ...DEFAULT_TASK_INPUT_LIMITS, ...(options.limits ?? {}) };
+  const declared = readDeclaredInputCapabilities(options.declaredCapabilities);
+  const modes = options.supportedElicitationModes ?? SUPPORTED_ELICITATION_MODES;
+
+  const responses: Record<string, unknown> = {};
+  const answeredKeys: string[] = [];
+  const rejections: TaskInputRejection[] = [];
+  const alreadyAnsweredKeys: string[] = [];
+
+  const keys = ownKeys(inputRequests);
+  const overflow = keys.slice(limits.maxRequests);
+  for (const key of overflow) {
+    rejections.push({
+      inputKey: key.slice(0, limits.maxKeyLength),
+      method: "unknown",
+      reason: "limit-exceeded",
+      message:
+        `Task ${taskId} sent more than ${limits.maxRequests} input requests; ` +
+        `this key was not processed.`,
+    });
+  }
+
+  for (const key of keys.slice(0, limits.maxRequests)) {
+    if (respondedKeys.has(key)) {
+      alreadyAnsweredKeys.push(key);
+      continue;
+    }
+    if (key.length > limits.maxKeyLength) {
+      rejections.push({
+        inputKey: `${key.slice(0, 64)}…`,
+        method: "unknown",
+        reason: "limit-exceeded",
+        message: `Input key exceeds ${limits.maxKeyLength} characters.`,
+      });
+      continue;
+    }
+
+    const request = inputRequests[key] as unknown;
+    if (!isRecord(request)) {
+      rejections.push({
+        inputKey: key,
+        method: "unknown",
+        reason: "malformed-request",
+        message: `Input request "${key}" is not an object.`,
+      });
+      continue;
+    }
+    if (safeSerializedSize(request) > limits.maxSerializedRequestBytes) {
+      rejections.push({
+        inputKey: key,
+        method: String(request.method ?? "unknown"),
+        reason: "limit-exceeded",
+        message: `Input request "${key}" exceeds ${limits.maxSerializedRequestBytes} bytes.`,
+      });
+      continue;
+    }
+
+    const method = request.method;
+    const params = isRecord(request.params) ? request.params : {};
+
+    if (!isTaskInputMethod(method)) {
+      rejections.push({
+        inputKey: key,
+        method: String(method ?? "unknown"),
+        reason: "unsupported-method",
+        message:
+          `Task ${taskId} requested "${String(method)}" for key "${key}", ` +
+          `which is not one of the extension's input methods.`,
+      });
+      continue;
+    }
+
+    const gate = resolveHandler(method, declared, options.handlers);
+    if (!gate.ok) {
+      rejections.push({
+        inputKey: key,
+        method,
+        reason: gate.reason,
+        message: gate.message,
+      });
+      continue;
+    }
+
+    if (method === "elicitation/create") {
+      const mode = (params.mode as string | undefined) ?? "form";
+      if (!modes.includes(mode as ElicitationMode)) {
+        rejections.push({
+          inputKey: key,
+          method,
+          reason: "unsupported-elicitation-mode",
+          message:
+            `Elicitation for key "${key}" requested mode "${mode}" ` +
+            `(supported: ${modes.join(", ")}).`,
+        });
+        continue;
+      }
+    }
+
+    let response: Record<string, unknown>;
+    try {
+      response = await gate.handler(params, {
+        taskId,
+        serverId,
+        inputKey: key,
+        signal,
+      });
+    } catch (error) {
+      rejections.push({
+        inputKey: key,
+        method,
+        reason: "handler-failed",
+        message: error instanceof Error ? error.message : String(error),
+      });
+      continue;
+    }
+
+    if (method === "elicitation/create") {
+      const problem = validateElicitationResponse(
+        key,
+        params,
+        response,
+        options.validateElicitationContent
+      );
+      if (problem) {
+        rejections.push(problem);
+        continue;
+      }
+    }
+
+    responses[key] = response;
+    answeredKeys.push(key);
+    if (answeredKeys.length >= limits.maxResponsesPerUpdate) {
+      // Remaining keys stay pending and are answered on a later round — the
+      // snapshot is re-sent, so nothing is lost by stopping here.
+      break;
+    }
+  }
+
+  return {
+    responses: responses as InputResponses,
+    answeredKeys,
+    rejections,
+    alreadyAnsweredKeys,
+  };
+}
+
+type HandlerGate =
+  | {
+      ok: true;
+      handler: NonNullable<TaskInputHandlers["elicitation"]>;
+    }
+  | { ok: false; reason: TaskInputRejectionReason; message: string };
+
+/**
+ * Two distinct failures, deliberately kept apart:
+ *
+ *  - `undeclared-capability` — the server asked for something we never
+ *    advertised. That is a *server* protocol violation, and saying so is what
+ *    makes the message actionable.
+ *  - `no-handler` — we advertised it and then failed to wire it. That is our
+ *    bug, and it should read like one.
+ */
+function resolveHandler(
+  method: TaskInputMethod,
+  declared: DeclaredInputCapabilities,
+  handlers: TaskInputHandlers
+): HandlerGate {
+  const table: Record<
+    TaskInputMethod,
+    { declared: boolean; handler?: TaskInputHandlers["elicitation"]; capability: string }
+  > = {
+    "elicitation/create": {
+      declared: declared.elicitation,
+      handler: handlers.elicitation,
+      capability: "elicitation",
+    },
+    "roots/list": {
+      declared: declared.roots,
+      handler: handlers.roots,
+      capability: "roots",
+    },
+    "sampling/createMessage": {
+      declared: declared.sampling,
+      handler: handlers.sampling,
+      capability: "sampling",
+    },
+  };
+  const entry = table[method];
+  if (!entry.declared) {
+    return {
+      ok: false,
+      reason: "undeclared-capability",
+      message:
+        `Server requested "${method}" but this connection never declared the ` +
+        `"${entry.capability}" capability, so it cannot be fulfilled.`,
+    };
+  }
+  if (!entry.handler) {
+    return {
+      ok: false,
+      reason: "no-handler",
+      message:
+        `This surface declared "${entry.capability}" but wired no handler for ` +
+        `"${method}".`,
+    };
+  }
+  return { ok: true, handler: entry.handler };
+}
+
+/**
+ * Self-validates an accepted elicitation response against its own
+ * `requestedSchema`, exactly as the standalone elicitation path does. Decline
+ * and cancel carry no content and are responses, not errors.
+ */
+function validateElicitationResponse(
+  key: string,
+  params: Record<string, unknown>,
+  response: Record<string, unknown>,
+  validateContent?: ElicitationContentValidator
+): TaskInputRejection | undefined {
+  const action = response.action;
+  if (action !== "accept") return undefined;
+  const requestedSchema = params.requestedSchema;
+  if (requestedSchema === undefined || !validateContent) return undefined;
+  const result = validateContent(requestedSchema, response.content ?? {});
+  if (result.valid) return undefined;
+  return {
+    inputKey: key,
+    method: "elicitation/create",
+    reason: "malformed-request",
+    message:
+      `Accepted elicitation content for "${key}" failed schema validation: ` +
+      `${result.error ?? "invalid"}`,
+  };
+}

--- a/sdk/src/mcp-client-manager/task-input-driver.ts
+++ b/sdk/src/mcp-client-manager/task-input-driver.ts
@@ -268,9 +268,18 @@ export async function collectTaskInputResponses(args: {
   const respondedKeys = args.respondedKeys ?? new Set<string>();
   const limits = { ...DEFAULT_TASK_INPUT_LIMITS, ...(options.limits ?? {}) };
   const declared = readDeclaredInputCapabilities(options.declaredCapabilities);
-  const modes = options.supportedElicitationModes ?? SUPPORTED_ELICITATION_MODES;
+  const modes =
+    options.supportedElicitationModes ?? SUPPORTED_ELICITATION_MODES;
 
-  const responses: Record<string, unknown> = {};
+  // NULL-PROTOTYPE, and this is load-bearing rather than defensive styling.
+  // On a plain object literal, `responses["__proto__"] = value` invokes the
+  // inherited `__proto__` setter: it reassigns the object's prototype instead
+  // of creating an own property. The key would still land in `answeredKeys`,
+  // so the caller would mark it responded and never re-prompt, while the
+  // `tasks/update` carried nothing for it — the user's answer silently lost.
+  // A null prototype makes a hostile key ordinary data, which is what the
+  // module comment claims.
+  const responses: Record<string, unknown> = Object.create(null);
   const answeredKeys: string[] = [];
   const rejections: TaskInputRejection[] = [];
   const alreadyAnsweredKeys: string[] = [];
@@ -435,7 +444,11 @@ function resolveHandler(
 ): HandlerGate {
   const table: Record<
     TaskInputMethod,
-    { declared: boolean; handler?: TaskInputHandlers["elicitation"]; capability: string }
+    {
+      declared: boolean;
+      handler?: TaskInputHandlers["elicitation"];
+      capability: string;
+    }
   > = {
     "elicitation/create": {
       declared: declared.elicitation,

--- a/sdk/src/mcp-client-manager/task-lifecycle-adapters.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle-adapters.ts
@@ -76,6 +76,16 @@ const LEGACY_STATUSES = new Set([
  * An unrecognized status normalizes to `working` rather than being dropped: a
  * handle we cannot classify is still a handle we must keep polling, and
  * inventing a terminal state would strand it.
+ *
+ * There is deliberately no `inputRequests` here, and none is missing: the
+ * 2025-11-25 `Task` shape carries no keyed request map at all
+ * (`taskId`, `status`, `ttl`, `createdAt`, `lastUpdatedAt`, `pollInterval`,
+ * `statusMessage` — nothing else). On that wire an `input_required` task's
+ * request arrives out of band, as an elicitation stamped with `relatedTaskId`,
+ * and is answered through the elicitation channel rather than `tasks/update` —
+ * which the legacy wire does not have. `driveTaskToTerminal` recognizes the
+ * resulting "input_required with an empty keyed snapshot" and reports
+ * `input-required` rather than re-polling an unchanging state.
  */
 export function legacyTaskToObservation(
   task: MCPTask & Record<string, unknown>

--- a/sdk/src/mcp-client-manager/task-lifecycle-adapters.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle-adapters.ts
@@ -1,0 +1,156 @@
+/**
+ * Wire → lifecycle normalizers.
+ *
+ * The lifecycle engine is deliberately wire-blind: it schedules and remembers,
+ * and it must not grow a per-wire branch. These adapters are the only place
+ * that knows the difference between a 2025-11-25 in-core task and a SEP-2663
+ * extension task, and each keeps its own validator — the two wires are not
+ * compatible and must never share one.
+ *
+ * What is preserved and what is not:
+ *
+ *  - the raw payload is carried through verbatim, because a debugger has to be
+ *    able to show what the server actually sent;
+ *  - `ttlMs` distinguishes absent (leave the previous value) from `null` (the
+ *    server says: no expiry);
+ *  - a tool result with `isError: true` is a **completed** task. Only a
+ *    JSON-RPC error makes a task `failed` (`tasks.md:837`, `:891-892`). Getting
+ *    this backwards would report a tool's own error as a protocol fault.
+ */
+
+import type {
+  DetailedTaskExt,
+  GetTaskExtResult,
+  TaskExtNotificationParams,
+} from "./tasks-ext-types.js";
+import type { TaskLifecycleObservation } from "./task-lifecycle.js";
+import type { MCPTask } from "./types.js";
+
+/**
+ * Extension `tasks/get` result or `notifications/tasks` params → observation.
+ *
+ * Both carry the same `DetailedTask`, so they normalize identically; the caller
+ * decides which validator produced the input and tags the observation source.
+ */
+export function extensionTaskToObservation(
+  task: DetailedTaskExt | GetTaskExtResult | TaskExtNotificationParams
+): TaskLifecycleObservation {
+  const detailed = task as DetailedTaskExt;
+  return {
+    status: detailed.status,
+    statusMessage: detailed.statusMessage,
+    createdAt: detailed.createdAt,
+    lastUpdatedAt: detailed.lastUpdatedAt,
+    // `ttlMs` is required on the wire and may be `null`; passing it through
+    // unconditionally is what lets `null` overwrite an earlier number.
+    ttlMs: detailed.ttlMs,
+    pollIntervalMs: detailed.pollIntervalMs,
+    inputRequests:
+      detailed.status === "input_required" ? detailed.inputRequests : undefined,
+    result: detailed.status === "completed" ? detailed.result : undefined,
+    error: detailed.status === "failed" ? detailed.error : undefined,
+    raw: task,
+  };
+}
+
+/**
+ * Legacy 2025-11-25 statuses. The in-core utility used the same five names, so
+ * the normalized status needs no remapping — only the surrounding fields do.
+ */
+const LEGACY_STATUSES = new Set([
+  "working",
+  "input_required",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+/**
+ * Legacy `tasks/get` result → observation.
+ *
+ * The legacy wire names its timing fields `ttl` / `pollInterval` (not `ttlMs` /
+ * `pollIntervalMs`) and has no inline result — the result lives behind a
+ * separate `tasks/result` call. Both differences are absorbed here so no
+ * surface has to branch on the wire.
+ *
+ * An unrecognized status normalizes to `working` rather than being dropped: a
+ * handle we cannot classify is still a handle we must keep polling, and
+ * inventing a terminal state would strand it.
+ */
+export function legacyTaskToObservation(
+  task: MCPTask & Record<string, unknown>
+): TaskLifecycleObservation {
+  const rawStatus = String(task.status ?? "");
+  const status = LEGACY_STATUSES.has(rawStatus)
+    ? (rawStatus as TaskLifecycleObservation["status"])
+    : "working";
+  const ttl = task.ttl;
+  const pollInterval = task.pollInterval;
+  return {
+    status,
+    statusMessage:
+      typeof task.statusMessage === "string" ? task.statusMessage : undefined,
+    createdAt: typeof task.createdAt === "string" ? task.createdAt : undefined,
+    lastUpdatedAt:
+      typeof task.lastUpdatedAt === "string" ? task.lastUpdatedAt : undefined,
+    ttlMs: typeof ttl === "number" ? ttl : ttl === null ? null : undefined,
+    pollIntervalMs: typeof pollInterval === "number" ? pollInterval : undefined,
+    raw: task,
+  };
+}
+
+/**
+ * `-32602` is how a server reports a task id it does not know
+ * (`tasks.md:793-795`).
+ *
+ * The requirement level differs by method and the difference is load-bearing:
+ * `MUST` for `tasks/get`, `SHOULD` for `tasks/update` and `tasks/cancel`. So
+ * only a `tasks/get` `-32602` is proof; from update or cancel it is a hint that
+ * has to be confirmed by a `tasks/get` before a handle is retired. Callers get
+ * the raw predicate here and apply that rule themselves — see
+ * `TaskLifecycleEngine.markExpired`.
+ */
+export const UNKNOWN_TASK_ERROR_CODE = -32602;
+
+/** The extension's "this operation requires the tasks declaration" code. */
+export const TASKS_DECLARATION_REQUIRED_ERROR_CODE = -32003;
+
+function errorCodeOf(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const direct = (error as { code?: unknown }).code;
+  if (typeof direct === "number") return direct;
+  const nested = (error as { error?: { code?: unknown } }).error?.code;
+  return typeof nested === "number" ? nested : undefined;
+}
+
+export function isUnknownTaskError(error: unknown): boolean {
+  return errorCodeOf(error) === UNKNOWN_TASK_ERROR_CODE;
+}
+
+export function isTasksDeclarationRequiredError(error: unknown): boolean {
+  return errorCodeOf(error) === TASKS_DECLARATION_REQUIRED_ERROR_CODE;
+}
+
+/**
+ * Milliseconds from a `Retry-After` header value, which is either a delta in
+ * seconds or an HTTP date. `undefined` for anything else — a malformed hint
+ * must not become a zero-length backoff.
+ */
+export function parseRetryAfterMs(
+  value: string | number | null | undefined,
+  now: number = Date.now()
+): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value * 1000 : undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    return Number.isFinite(seconds) ? seconds * 1000 : undefined;
+  }
+  const at = Date.parse(trimmed);
+  if (Number.isNaN(at)) return undefined;
+  return Math.max(0, at - now);
+}

--- a/sdk/src/mcp-client-manager/task-lifecycle.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle.ts
@@ -1,0 +1,584 @@
+/**
+ * The shared task lifecycle engine.
+ *
+ * Before this module, every Tasks surface (the Tasks tab, chat, the hosted
+ * routes, the public API, the CLI) grew its own polling loop and its own idea
+ * of when a task is finished. That is how the poll floor got violated: the
+ * Tasks tab collapsed every active task to a single `Math.min(...)` across
+ * their advertised intervals and then let a user override *replace* the
+ * server's floor rather than be clamped by it.
+ *
+ * The engine owns exactly one thing per task: **when it is next allowed to be
+ * polled, and what we last saw**. It performs no I/O. Callers ask it what is
+ * due, do the transport work themselves, and hand the outcome back through
+ * {@link TaskLifecycleEngine.observe} / {@link TaskLifecycleEngine.observeError}.
+ * That keeps it usable from a browser tab, a Hono route, a Convex action, and
+ * the CLI without any of them sharing a transport.
+ *
+ * ## The poll-interval rule
+ *
+ * ```text
+ * effective interval = max(
+ *   server pollIntervalMs,   // the floor the server asked for
+ *   user minimum,            // a *preference*, never a licence to go faster
+ *   retry backoff,           // exponential, after consecutive errors
+ *   Retry-After              // a 429/503 hint, absolute
+ * )
+ * ```
+ *
+ * `pollIntervalMs` MAY change over a task's lifetime (`tasks.md:308`), in
+ * either direction. A shrinking value is normal and must never be reported as
+ * an anomaly. Both wires feed the same formula; only the validators differ.
+ */
+
+import type { InputRequests } from "./tasks-ext-types.js";
+import type { TasksWire } from "./tasks-dispatch.js";
+
+/** The two wires that can actually carry a task. `"none"` never reaches here. */
+export type LiveTasksWire = Exclude<TasksWire, "none">;
+
+/**
+ * Stable identity for a task handle.
+ *
+ * `wire` is part of the identity, not a decoration: the same task ID can exist
+ * on both wires while a developer flips protocol versions, and a stored handle
+ * must never silently change behavior because a server was reconfigured.
+ * `scope` is the auth/org context (hosted `projectId`), which keeps bearer-ish
+ * task IDs from leaking between accounts sharing a browser.
+ */
+export interface TaskLifecycleIdentity {
+  scope?: string;
+  serverId: string;
+  wire: LiveTasksWire;
+  taskId: string;
+}
+
+/** Composite key for {@link TaskLifecycleIdentity}. NUL-joined: no field may contain it. */
+export function taskLifecycleKey(identity: TaskLifecycleIdentity): string {
+  return [
+    identity.scope ?? "",
+    identity.serverId,
+    identity.wire,
+    identity.taskId,
+  ].join("\u0000");
+}
+
+/**
+ * Normalized status across both wires.
+ *
+ * `expired` is MCPJam's own tombstone for a handle the server no longer knows
+ * (a confirmed `-32602` on `tasks/get`), not a protocol status. `unknown` is
+ * the pre-first-observation state of a freshly registered handle.
+ */
+export type TaskLifecycleStatus =
+  | "unknown"
+  | "working"
+  | "input_required"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "expired";
+
+/** Statuses that will never change again. `expired` is terminal for MCPJam. */
+export const TERMINAL_LIFECYCLE_STATUSES: readonly TaskLifecycleStatus[] = [
+  "completed",
+  "failed",
+  "cancelled",
+  "expired",
+];
+
+export function isTerminalLifecycleStatus(
+  status: TaskLifecycleStatus
+): boolean {
+  return TERMINAL_LIFECYCLE_STATUSES.includes(status);
+}
+
+/** JSON-RPC error carried by a `failed` task. */
+export interface TaskLifecycleError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+/**
+ * A wire-neutral observation of a task.
+ *
+ * Both wires normalize into this before reaching the engine, so the scheduler
+ * has no per-wire branches. `raw` preserves what the server actually sent, for
+ * the debugger; the engine never interprets it.
+ */
+export interface TaskLifecycleObservation {
+  status: Exclude<TaskLifecycleStatus, "unknown" | "expired">;
+  statusMessage?: string;
+  createdAt?: string;
+  lastUpdatedAt?: string;
+  /** `null` means "no expiry" and is distinct from an absent field. */
+  ttlMs?: number | null;
+  pollIntervalMs?: number;
+  inputRequests?: InputRequests;
+  result?: Record<string, unknown>;
+  error?: TaskLifecycleError;
+  raw?: unknown;
+}
+
+/** Where an observation came from. Notifications do not reset error backoff blame. */
+export type TaskObservationSource = "poll" | "notification" | "create";
+
+/** Everything the engine knows about one handle. */
+export interface TaskLifecycleRecord {
+  readonly key: string;
+  readonly identity: TaskLifecycleIdentity;
+  status: TaskLifecycleStatus;
+  statusMessage?: string;
+  createdAt?: string;
+  lastUpdatedAt?: string;
+  ttlMs: number | null;
+  /** Latest server-advertised floor. MAY move in either direction. */
+  pollIntervalMs?: number;
+  inputRequests?: InputRequests;
+  result?: Record<string, unknown>;
+  error?: TaskLifecycleError;
+  raw?: unknown;
+  /** Epoch ms this task may next be polled. */
+  nextPollAt: number;
+  /** Consecutive transport/protocol errors; drives exponential backoff. */
+  consecutiveErrors: number;
+  /** Absolute epoch ms from a `Retry-After`, if one is in force. */
+  retryAfterUntil?: number;
+  /** Last time ANY live read answered for this handle, including a `-32602`. */
+  lastObservedAt?: number;
+  /** A `tasks/cancel` has been sent; the task may still complete normally. */
+  cancellationRequested: boolean;
+  /** Input keys whose `tasks/update` acknowledgement succeeded. */
+  respondedInputKeys: Set<string>;
+  /** Provenance, for the surfaces that show it. */
+  toolName?: string;
+  surface?: string;
+}
+
+/** Snapshot form of a record — safe to serialize and hand to a UI. */
+export interface TaskLifecycleSnapshot
+  extends Omit<TaskLifecycleRecord, "respondedInputKeys"> {
+  respondedInputKeys: string[];
+  terminal: boolean;
+}
+
+export interface TaskLifecycleCallbacks {
+  onTaskCreated?: (record: TaskLifecycleSnapshot) => void;
+  onState?: (record: TaskLifecycleSnapshot, previous: TaskLifecycleStatus) => void;
+  onInputRequired?: (record: TaskLifecycleSnapshot) => void;
+  onTerminal?: (record: TaskLifecycleSnapshot) => void;
+}
+
+export interface TaskLifecycleEngineOptions {
+  /**
+   * The user's *preferred minimum* interval. A preference, never permission to
+   * poll faster than the server's floor — it enters the formula as one more
+   * `max` term.
+   */
+  userMinimumIntervalMs?: number;
+  /** Hard floor applied to every task, whatever anyone asked for. */
+  absoluteFloorMs?: number;
+  /** Cap on any single computed interval, so a hostile `pollIntervalMs` cannot park a task forever. */
+  maximumIntervalMs?: number;
+  /** First backoff step after one error; doubles per consecutive error. */
+  errorBackoffBaseMs?: number;
+  errorBackoffMaxMs?: number;
+  now?: () => number;
+  callbacks?: TaskLifecycleCallbacks;
+}
+
+const DEFAULT_ABSOLUTE_FLOOR_MS = 250;
+const DEFAULT_MAXIMUM_INTERVAL_MS = 5 * 60_000;
+const DEFAULT_ERROR_BACKOFF_BASE_MS = 1_000;
+const DEFAULT_ERROR_BACKOFF_MAX_MS = 60_000;
+
+/** Guards against `NaN`/`Infinity`/negative values arriving from a server. */
+function finitePositive(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+export function toSnapshot(record: TaskLifecycleRecord): TaskLifecycleSnapshot {
+  return {
+    ...record,
+    respondedInputKeys: [...record.respondedInputKeys],
+    terminal: isTerminalLifecycleStatus(record.status),
+  };
+}
+
+/**
+ * Per-task due-time scheduler and state store for MCP Tasks.
+ *
+ * Deliberately I/O-free: it decides *when* and remembers *what*, and the
+ * caller owns the transport. See the module comment for why.
+ */
+export class TaskLifecycleEngine {
+  private readonly records = new Map<string, TaskLifecycleRecord>();
+  private readonly now: () => number;
+  private readonly absoluteFloorMs: number;
+  private readonly maximumIntervalMs: number;
+  private readonly backoffBaseMs: number;
+  private readonly backoffMaxMs: number;
+  private userMinimumIntervalMs: number;
+  private callbacks: TaskLifecycleCallbacks;
+
+  constructor(options: TaskLifecycleEngineOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.absoluteFloorMs = options.absoluteFloorMs ?? DEFAULT_ABSOLUTE_FLOOR_MS;
+    this.maximumIntervalMs =
+      options.maximumIntervalMs ?? DEFAULT_MAXIMUM_INTERVAL_MS;
+    this.backoffBaseMs =
+      options.errorBackoffBaseMs ?? DEFAULT_ERROR_BACKOFF_BASE_MS;
+    this.backoffMaxMs =
+      options.errorBackoffMaxMs ?? DEFAULT_ERROR_BACKOFF_MAX_MS;
+    this.userMinimumIntervalMs = Math.max(
+      0,
+      options.userMinimumIntervalMs ?? 0
+    );
+    this.callbacks = options.callbacks ?? {};
+  }
+
+  setCallbacks(callbacks: TaskLifecycleCallbacks): void {
+    this.callbacks = callbacks;
+  }
+
+  /**
+   * Updates the user's preferred minimum. Existing due times are recomputed so
+   * a *slower* preference takes effect immediately rather than after one more
+   * fast tick; a *faster* preference can still never breach a server floor.
+   */
+  setUserMinimumIntervalMs(intervalMs: number): void {
+    this.userMinimumIntervalMs = Math.max(0, intervalMs);
+    for (const record of this.records.values()) {
+      if (isTerminalLifecycleStatus(record.status)) continue;
+      const base = record.lastObservedAt ?? this.now();
+      record.nextPollAt = base + this.effectiveIntervalMs(record);
+    }
+  }
+
+  getUserMinimumIntervalMs(): number {
+    return this.userMinimumIntervalMs;
+  }
+
+  /**
+   * The interval this task must not be polled faster than, right now.
+   *
+   * Every term is a `max`. `Retry-After` participates as a *remaining
+   * duration* so it behaves the same as the other relative terms.
+   */
+  effectiveIntervalMs(record: TaskLifecycleRecord, at?: number): number {
+    const now = at ?? this.now();
+    const serverFloor = finitePositive(record.pollIntervalMs) ?? 0;
+    const backoff =
+      record.consecutiveErrors > 0
+        ? Math.min(
+            this.backoffBaseMs * 2 ** (record.consecutiveErrors - 1),
+            this.backoffMaxMs
+          )
+        : 0;
+    const retryAfter = record.retryAfterUntil
+      ? Math.max(0, record.retryAfterUntil - now)
+      : 0;
+    const raw = Math.max(
+      this.absoluteFloorMs,
+      serverFloor,
+      this.userMinimumIntervalMs,
+      backoff,
+      retryAfter
+    );
+    return Math.min(raw, Math.max(this.maximumIntervalMs, this.absoluteFloorMs));
+  }
+
+  get(identity: TaskLifecycleIdentity): TaskLifecycleRecord | undefined {
+    return this.records.get(taskLifecycleKey(identity));
+  }
+
+  getByKey(key: string): TaskLifecycleRecord | undefined {
+    return this.records.get(key);
+  }
+
+  snapshot(identity: TaskLifecycleIdentity): TaskLifecycleSnapshot | undefined {
+    const record = this.get(identity);
+    return record ? toSnapshot(record) : undefined;
+  }
+
+  all(): TaskLifecycleSnapshot[] {
+    return [...this.records.values()].map(toSnapshot);
+  }
+
+  /**
+   * Registers a handle. Idempotent: re-registering an existing task returns the
+   * live record rather than resetting its schedule, so a reconnect or a second
+   * surface adopting the same handle cannot restart its backoff.
+   */
+  register(
+    identity: TaskLifecycleIdentity,
+    init: {
+      createdAt?: string;
+      ttlMs?: number | null;
+      pollIntervalMs?: number;
+      status?: TaskLifecycleStatus;
+      toolName?: string;
+      surface?: string;
+      /** Adopted from durable storage; not re-notified as a creation. */
+      restored?: boolean;
+      respondedInputKeys?: readonly string[];
+    } = {}
+  ): TaskLifecycleRecord {
+    const key = taskLifecycleKey(identity);
+    const existing = this.records.get(key);
+    if (existing) return existing;
+
+    const now = this.now();
+    const record: TaskLifecycleRecord = {
+      key,
+      identity: { ...identity },
+      status: init.status ?? "unknown",
+      createdAt: init.createdAt,
+      ttlMs: init.ttlMs ?? null,
+      pollIntervalMs: finitePositive(init.pollIntervalMs),
+      nextPollAt: now,
+      consecutiveErrors: 0,
+      cancellationRequested: false,
+      respondedInputKeys: new Set(init.respondedInputKeys ?? []),
+      toolName: init.toolName,
+      surface: init.surface,
+    };
+    // A fresh handle is due immediately; the floor applies from the first
+    // observation onward, so the first read is never artificially delayed.
+    this.records.set(key, record);
+    if (!init.restored) {
+      this.callbacks.onTaskCreated?.(toSnapshot(record));
+    }
+    return record;
+  }
+
+  /** Drops a handle from scheduling. Does not touch durable storage. */
+  forget(identity: TaskLifecycleIdentity): void {
+    this.records.delete(taskLifecycleKey(identity));
+  }
+
+  clear(): void {
+    this.records.clear();
+  }
+
+  /**
+   * Folds a validated observation into the record and reschedules.
+   *
+   * Notifications and polls are reconciled identically — the extension makes
+   * notifications an optimization, never a separate source of truth — except
+   * that a notification does not by itself prove the *poll* path is healthy,
+   * so it clears the error count only when it actually carried state.
+   */
+  observe(
+    identity: TaskLifecycleIdentity,
+    observation: TaskLifecycleObservation,
+    source: TaskObservationSource = "poll"
+  ): TaskLifecycleRecord {
+    const record = this.register(identity, { restored: true });
+    const previous = record.status;
+    const now = this.now();
+
+    record.status = observation.status;
+    if (observation.statusMessage !== undefined) {
+      record.statusMessage = observation.statusMessage;
+    }
+    if (observation.createdAt !== undefined) {
+      record.createdAt = observation.createdAt;
+    }
+    if (observation.lastUpdatedAt !== undefined) {
+      record.lastUpdatedAt = observation.lastUpdatedAt;
+    }
+    if (observation.ttlMs !== undefined) {
+      // `null` is meaningful (no expiry) and must overwrite a previous number.
+      record.ttlMs = observation.ttlMs;
+    }
+    if (observation.pollIntervalMs !== undefined) {
+      // MAY move in either direction (`tasks.md:308`). A shrinking floor is
+      // normal; never flag it.
+      record.pollIntervalMs = finitePositive(observation.pollIntervalMs);
+    }
+    record.inputRequests = observation.inputRequests;
+    record.result = observation.result;
+    record.error = observation.error;
+    record.raw = observation.raw;
+    record.lastObservedAt = now;
+    record.consecutiveErrors = 0;
+    record.retryAfterUntil = undefined;
+
+    const terminal = isTerminalLifecycleStatus(record.status);
+    record.nextPollAt = terminal
+      ? Number.POSITIVE_INFINITY
+      : now + this.effectiveIntervalMs(record, now);
+
+    const snapshot = toSnapshot(record);
+    if (previous !== record.status) {
+      this.callbacks.onState?.(snapshot, previous);
+      if (record.status === "input_required") {
+        this.callbacks.onInputRequired?.(snapshot);
+      }
+      if (terminal) {
+        this.callbacks.onTerminal?.(snapshot);
+      }
+    } else if (record.status === "input_required" && source !== "create") {
+      // The keyed snapshot is re-sent on every poll and MAY grow. Re-announce
+      // so a newly-added key is surfaced even though the status did not change.
+      this.callbacks.onInputRequired?.(snapshot);
+    }
+    return record;
+  }
+
+  /**
+   * Records a failed read. Increments backoff and reschedules; never changes
+   * the task's status, because a transport failure says nothing about the task.
+   */
+  observeError(
+    identity: TaskLifecycleIdentity,
+    options: { retryAfterMs?: number } = {}
+  ): TaskLifecycleRecord {
+    const record = this.register(identity, { restored: true });
+    const now = this.now();
+    record.consecutiveErrors += 1;
+    const retryAfter = finitePositive(options.retryAfterMs);
+    if (retryAfter !== undefined) {
+      record.retryAfterUntil = now + retryAfter;
+    }
+    record.nextPollAt = now + this.effectiveIntervalMs(record, now);
+    return record;
+  }
+
+  /**
+   * Applies a `Retry-After` without counting an error — for a 429 that is rate
+   * limiting rather than failure.
+   */
+  applyRetryAfter(identity: TaskLifecycleIdentity, retryAfterMs: number): void {
+    const record = this.register(identity, { restored: true });
+    const now = this.now();
+    const ms = finitePositive(retryAfterMs);
+    if (ms === undefined) return;
+    record.retryAfterUntil = now + ms;
+    record.nextPollAt = Math.max(record.nextPollAt, now + ms);
+  }
+
+  /**
+   * Marks the handle unknown to the server. Only ever called from a **confirmed
+   * `tasks/get` `-32602`** — that is the one method carrying the MUST
+   * (`tasks.md:793-795`); update/cancel carry a SHOULD, so a `-32602` from
+   * either is a hint that must be confirmed with a `tasks/get` first.
+   */
+  markExpired(identity: TaskLifecycleIdentity): TaskLifecycleRecord {
+    const record = this.register(identity, { restored: true });
+    const previous = record.status;
+    record.status = "expired";
+    record.lastObservedAt = this.now();
+    record.nextPollAt = Number.POSITIVE_INFINITY;
+    record.consecutiveErrors = 0;
+    const snapshot = toSnapshot(record);
+    if (previous !== "expired") {
+      this.callbacks.onState?.(snapshot, previous);
+      this.callbacks.onTerminal?.(snapshot);
+    }
+    return record;
+  }
+
+  /**
+   * Notes that a `tasks/cancel` was accepted. Cancellation is cooperative: the
+   * ack says nothing about the task's fate, so the status is left alone and
+   * polling continues until a real terminal state is observed.
+   */
+  markCancellationRequested(identity: TaskLifecycleIdentity): void {
+    const record = this.register(identity, { restored: true });
+    record.cancellationRequested = true;
+  }
+
+  /**
+   * Marks an input key answered. Called only *after* the `tasks/update`
+   * acknowledgement succeeds — an optimistic mark would silently drop the
+   * user's answer if the update failed.
+   */
+  markInputKeysResponded(
+    identity: TaskLifecycleIdentity,
+    keys: readonly string[]
+  ): void {
+    const record = this.register(identity, { restored: true });
+    for (const key of keys) record.respondedInputKeys.add(key);
+  }
+
+  /**
+   * Input keys in the current snapshot that have not been answered yet.
+   * Own-property checked: a hostile key such as `constructor` must not be
+   * inherited from the prototype chain.
+   */
+  pendingInputKeys(identity: TaskLifecycleIdentity): string[] {
+    const record = this.get(identity);
+    if (!record?.inputRequests) return [];
+    return Object.keys(record.inputRequests).filter(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(record.inputRequests, key) &&
+        !record.respondedInputKeys.has(key)
+    );
+  }
+
+  /**
+   * Handles due for a poll now, soonest first. Terminal handles are never due.
+   */
+  due(at?: number): TaskLifecycleRecord[] {
+    const now = at ?? this.now();
+    return [...this.records.values()]
+      .filter(
+        (record) =>
+          !isTerminalLifecycleStatus(record.status) && record.nextPollAt <= now
+      )
+      .sort((a, b) => a.nextPollAt - b.nextPollAt);
+  }
+
+  /** Non-terminal handles, whether or not they are due. */
+  active(): TaskLifecycleRecord[] {
+    return [...this.records.values()].filter(
+      (record) => !isTerminalLifecycleStatus(record.status)
+    );
+  }
+
+  /**
+   * Milliseconds until the next handle becomes due, for a caller that wants to
+   * arm one timer instead of ticking. `undefined` when nothing is pending.
+   */
+  msUntilNextDue(at?: number): number | undefined {
+    const now = at ?? this.now();
+    let soonest = Number.POSITIVE_INFINITY;
+    for (const record of this.records.values()) {
+      if (isTerminalLifecycleStatus(record.status)) continue;
+      soonest = Math.min(soonest, record.nextPollAt);
+    }
+    if (!Number.isFinite(soonest)) return undefined;
+    return Math.max(0, soonest - now);
+  }
+
+  /**
+   * Reserves the given handles: pushes each one's due time forward by its own
+   * effective interval. Call this when a batch is dispatched so an in-flight
+   * request is not re-issued by the next tick.
+   */
+  reserve(records: readonly TaskLifecycleRecord[], at?: number): void {
+    const now = at ?? this.now();
+    for (const record of records) {
+      record.nextPollAt = now + this.effectiveIntervalMs(record, now);
+    }
+  }
+
+  /**
+   * The interval a *batch* must respect: the **maximum** floor among its
+   * members, not the minimum. A batch polls every member, so honoring the
+   * fastest member's floor would breach every slower member's.
+   */
+  batchIntervalMs(records: readonly TaskLifecycleRecord[], at?: number): number {
+    const now = at ?? this.now();
+    let interval = Math.max(this.absoluteFloorMs, this.userMinimumIntervalMs);
+    for (const record of records) {
+      interval = Math.max(interval, this.effectiveIntervalMs(record, now));
+    }
+    return interval;
+  }
+}

--- a/sdk/src/mcp-client-manager/task-lifecycle.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle.ts
@@ -685,8 +685,13 @@ export class TaskLifecycleEngine {
    * and the special case would never fire.
    *
    * Bounded to one read: `observe` clears `restored`.
+   *
+   * Public because it is not only the scheduler's business: any caller that
+   * short-circuits on "this handle is terminal, no read needed" has to ask the
+   * same question, and asking it with a bare `isTerminalLifecycleStatus` is how
+   * a restored terminal gets reported without the payload it never had.
    */
-  private owesRead(record: TaskLifecycleRecord): boolean {
+  owesRead(record: TaskLifecycleRecord): boolean {
     if (!isTerminalLifecycleStatus(record.status)) return true;
     return record.restored && record.identity.wire === "extension";
   }

--- a/sdk/src/mcp-client-manager/task-lifecycle.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle.ts
@@ -165,7 +165,10 @@ export interface TaskLifecycleSnapshot
 
 export interface TaskLifecycleCallbacks {
   onTaskCreated?: (record: TaskLifecycleSnapshot) => void;
-  onState?: (record: TaskLifecycleSnapshot, previous: TaskLifecycleStatus) => void;
+  onState?: (
+    record: TaskLifecycleSnapshot,
+    previous: TaskLifecycleStatus
+  ) => void;
   onInputRequired?: (record: TaskLifecycleSnapshot) => void;
   onTerminal?: (record: TaskLifecycleSnapshot) => void;
 }
@@ -192,6 +195,19 @@ const DEFAULT_ABSOLUTE_FLOOR_MS = 250;
 const DEFAULT_MAXIMUM_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_ERROR_BACKOFF_BASE_MS = 1_000;
 const DEFAULT_ERROR_BACKOFF_MAX_MS = 60_000;
+
+/**
+ * Coerces a caller-supplied interval to a usable non-negative number.
+ *
+ * `Math.max(0, NaN)` is `NaN`, and a `NaN` interval propagates into
+ * `nextPollAt`, where every comparison is false — so a single malformed
+ * preference would silently stop ALL polling rather than failing loudly.
+ */
+function normalizeInterval(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : 0;
+}
 
 /** Guards against `NaN`/`Infinity`/negative values arriving from a server. */
 function finitePositive(value: unknown): number | undefined {
@@ -233,9 +249,8 @@ export class TaskLifecycleEngine {
       options.errorBackoffBaseMs ?? DEFAULT_ERROR_BACKOFF_BASE_MS;
     this.backoffMaxMs =
       options.errorBackoffMaxMs ?? DEFAULT_ERROR_BACKOFF_MAX_MS;
-    this.userMinimumIntervalMs = Math.max(
-      0,
-      options.userMinimumIntervalMs ?? 0
+    this.userMinimumIntervalMs = normalizeInterval(
+      options.userMinimumIntervalMs
     );
     this.callbacks = options.callbacks ?? {};
   }
@@ -250,11 +265,19 @@ export class TaskLifecycleEngine {
    * fast tick; a *faster* preference can still never breach a server floor.
    */
   setUserMinimumIntervalMs(intervalMs: number): void {
-    this.userMinimumIntervalMs = Math.max(0, intervalMs);
+    this.userMinimumIntervalMs = normalizeInterval(intervalMs);
     for (const record of this.records.values()) {
       if (isTerminalLifecycleStatus(record.status)) continue;
       const base = record.lastObservedAt ?? this.now();
-      record.nextPollAt = base + this.effectiveIntervalMs(record);
+      // NEVER earlier, only later. Recomputing from `lastObservedAt` can land
+      // in the past while an error backoff or a `Retry-After` is in force —
+      // which would let a preference change punch straight through a wait the
+      // server asked for. A slower preference still extends the wait, which is
+      // the whole point of applying it to already-scheduled tasks.
+      record.nextPollAt = Math.max(
+        record.nextPollAt,
+        base + this.effectiveIntervalMs(record)
+      );
     }
   }
 
@@ -281,14 +304,22 @@ export class TaskLifecycleEngine {
     const retryAfter = record.retryAfterUntil
       ? Math.max(0, record.retryAfterUntil - now)
       : 0;
-    const raw = Math.max(
-      this.absoluteFloorMs,
-      serverFloor,
-      this.userMinimumIntervalMs,
-      backoff,
-      retryAfter
+    // The cap exists to stop a hostile or nonsensical `pollIntervalMs` from
+    // parking a task forever, so it applies to the terms we do not trust.
+    // `Retry-After` is NOT one of them: it is an explicit instruction from the
+    // server about its own rate limiting, and truncating "back off for ten
+    // minutes" to five would mean deliberately ignoring it. So clamp first,
+    // then let `Retry-After` raise the result back above the cap.
+    const capped = Math.min(
+      Math.max(this.absoluteFloorMs, this.userMinimumIntervalMs, backoff),
+      Math.max(this.maximumIntervalMs, this.absoluteFloorMs)
     );
-    return Math.min(raw, Math.max(this.maximumIntervalMs, this.absoluteFloorMs));
+    // Both protocol-imposed terms survive the cap. A server that asks to be
+    // polled every ten minutes, or that answers `Retry-After: 600`, has said
+    // something we are obliged to respect; clamping either to a local five
+    // minutes would mean deliberately polling twice as often as we were told
+    // to. The cap therefore governs only the terms MCPJam itself invented.
+    return Math.max(capped, serverFloor, retryAfter);
   }
 
   get(identity: TaskLifecycleIdentity): TaskLifecycleRecord | undefined {
@@ -381,10 +412,22 @@ export class TaskLifecycleEngine {
     const previous = record.status;
     const now = this.now();
 
-    record.status = observation.status;
-    if (observation.statusMessage !== undefined) {
-      record.statusMessage = observation.statusMessage;
+    // Terminal is FINAL. A poll issued before a terminal notification arrived
+    // can land after it, and applying it would revert a completed task's UI
+    // and scheduling to `working` — resurrecting a handle we already retired.
+    // The observation is still evidence the handle exists, so the observation
+    // clock advances; nothing else does.
+    if (isTerminalLifecycleStatus(record.status)) {
+      record.lastObservedAt = now;
+      return record;
     }
+
+    record.status = observation.status;
+    // Assigned unconditionally: an observation is a FULL snapshot, so a server
+    // omitting `statusMessage` is clearing it. Keeping the previous value
+    // would leave a stale message on screen after the condition it described
+    // was resolved.
+    record.statusMessage = observation.statusMessage;
     if (observation.createdAt !== undefined) {
       record.createdAt = observation.createdAt;
     }
@@ -405,8 +448,14 @@ export class TaskLifecycleEngine {
     record.error = observation.error;
     record.raw = observation.raw;
     record.lastObservedAt = now;
-    record.consecutiveErrors = 0;
-    record.retryAfterUntil = undefined;
+    if (source !== "notification") {
+      // Only a successful READ proves the poll path recovered. A notification
+      // arrives on a different channel entirely, so clearing the backoff on one
+      // would drop us straight back to the normal floor against a server whose
+      // `tasks/get` is still failing.
+      record.consecutiveErrors = 0;
+      record.retryAfterUntil = undefined;
+    }
 
     const terminal = isTerminalLifecycleStatus(record.status);
     record.nextPollAt = terminal
@@ -573,7 +622,10 @@ export class TaskLifecycleEngine {
    * members, not the minimum. A batch polls every member, so honoring the
    * fastest member's floor would breach every slower member's.
    */
-  batchIntervalMs(records: readonly TaskLifecycleRecord[], at?: number): number {
+  batchIntervalMs(
+    records: readonly TaskLifecycleRecord[],
+    at?: number
+  ): number {
     const now = at ?? this.now();
     let interval = Math.max(this.absoluteFloorMs, this.userMinimumIntervalMs);
     for (const record of records) {

--- a/sdk/src/mcp-client-manager/task-lifecycle.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle.ts
@@ -284,23 +284,42 @@ export class TaskLifecycleEngine {
   }
 
   /**
-   * Updates the user's preferred minimum. Existing due times are recomputed so
-   * a *slower* preference takes effect immediately rather than after one more
-   * fast tick; a *faster* preference can still never breach a server floor.
+   * Updates the user's preferred minimum.
+   *
+   * Existing due times are recomputed in both directions, so the setting takes
+   * effect on in-flight tasks rather than only on the next ones: a *slower*
+   * preference extends their wait immediately, and a *faster* one shortens the
+   * part of the wait that only the old preference caused.
+   *
+   * A faster preference still cannot breach a server floor — it is one `max`
+   * term among several, and the absolute waits (`Retry-After`, error backoff)
+   * are re-applied as floors afterwards.
    */
   setUserMinimumIntervalMs(intervalMs: number): void {
     this.userMinimumIntervalMs = normalizeInterval(intervalMs);
     for (const record of this.records.values()) {
       if (isTerminalLifecycleStatus(record.status)) continue;
       const base = record.lastObservedAt ?? this.now();
-      // NEVER earlier, only later. Recomputing from `lastObservedAt` can land
-      // in the past while an error backoff or a `Retry-After` is in force —
-      // which would let a preference change punch straight through a wait the
-      // server asked for. A slower preference still extends the wait, which is
-      // the whole point of applying it to already-scheduled tasks.
+      // Recomputed in BOTH directions. A blanket "never earlier" kept the
+      // superseded preference as if it were a server wait: dropping the box
+      // from 60s to 1s against a 2s server floor left every in-flight task
+      // parked for the rest of its old 60s, so the new setting did nothing
+      // until each task happened to come due.
+      const recomputed = base + this.effectiveIntervalMs(record);
+      // What a preference change must never do is punch through a wait the
+      // SERVER imposed, and those two are absolute rather than relative to
+      // `base` — a `base` in the past would otherwise land before them. So
+      // they are re-applied as floors on top of the recompute.
+      //
+      // The backoff is expressed as the CURRENT due time rather than
+      // recomputed, because its elapsed portion is not recoverable from
+      // `lastObservedAt`: an error advances `nextPollAt` without advancing the
+      // observation clock.
+      const backoffFloor = record.consecutiveErrors > 0 ? record.nextPollAt : 0;
       record.nextPollAt = Math.max(
-        record.nextPollAt,
-        base + this.effectiveIntervalMs(record)
+        recomputed,
+        record.retryAfterUntil ?? 0,
+        backoffFloor
       );
     }
   }
@@ -650,26 +669,48 @@ export class TaskLifecycleEngine {
   }
 
   /**
-   * Handles due for a poll now, soonest first. Terminal handles are never due,
-   * and neither is a handle with a read already in flight.
+   * Whether this handle still has a read owed to it.
+   *
+   * Normally that means "not terminal". The exception is a RESTORED terminal on
+   * the extension wire, and it is a protocol fact rather than a UI preference:
+   * durable storage keeps a task's status but never its payload, and on the
+   * extension the result and error ride INLINE on `tasks/get` — there is no
+   * `tasks/result` to fetch them from later. So a handle restored as
+   * `completed` is a status with nothing behind it, and excluding it from
+   * scheduling strands the result permanently.
+   *
+   * It lives HERE rather than in each caller because every scheduling method
+   * has to agree. A caller that special-cased `due()` alone would still find
+   * `msUntilNextDue()` ignoring the handle, so no timer would ever arm for it
+   * and the special case would never fire.
+   *
+   * Bounded to one read: `observe` clears `restored`.
+   */
+  private owesRead(record: TaskLifecycleRecord): boolean {
+    if (!isTerminalLifecycleStatus(record.status)) return true;
+    return record.restored && record.identity.wire === "extension";
+  }
+
+  /**
+   * Handles due for a poll now, soonest first. Terminal handles are never due —
+   * except a restored one that still owes its recovery read — and neither is a
+   * handle with a read already in flight.
    */
   due(at?: number): TaskLifecycleRecord[] {
     const now = at ?? this.now();
     return [...this.records.values()]
       .filter(
         (record) =>
-          !isTerminalLifecycleStatus(record.status) &&
+          this.owesRead(record) &&
           !record.pollInFlight &&
           record.nextPollAt <= now
       )
       .sort((a, b) => a.nextPollAt - b.nextPollAt);
   }
 
-  /** Non-terminal handles, whether or not they are due. */
+  /** Handles that still owe a read, whether or not they are due. */
   active(): TaskLifecycleRecord[] {
-    return [...this.records.values()].filter(
-      (record) => !isTerminalLifecycleStatus(record.status)
-    );
+    return [...this.records.values()].filter((record) => this.owesRead(record));
   }
 
   /**
@@ -680,7 +721,7 @@ export class TaskLifecycleEngine {
     const now = at ?? this.now();
     let soonest = Number.POSITIVE_INFINITY;
     for (const record of this.records.values()) {
-      if (isTerminalLifecycleStatus(record.status)) continue;
+      if (!this.owesRead(record)) continue;
       soonest = Math.min(soonest, record.nextPollAt);
     }
     if (!Number.isFinite(soonest)) return undefined;

--- a/sdk/src/mcp-client-manager/task-lifecycle.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle.ts
@@ -610,6 +610,35 @@ export class TaskLifecycleEngine {
   }
 
   /**
+   * Drops the ERROR BACKOFF for a handle, for a read a **person** asked for.
+   *
+   * The backoff is this client's own guess about a transport that keeps
+   * failing, and a user clicking Refresh is better evidence than that guess —
+   * without this, a handle that has backed off to a minute is unreachable for
+   * a minute no matter what the user does, which reads as a dead button.
+   *
+   * What it does NOT clear is anything the SERVER imposed. The advertised
+   * `pollIntervalMs` still applies from the last observation, and an explicit
+   * `Retry-After` still floors the result, so a user cannot click their way
+   * past a rate limit or an advertised floor. No-ops for an unknown handle:
+   * this only ever relaxes an existing schedule, never registers one.
+   */
+  clearErrorBackoff(identity: TaskLifecycleIdentity): void {
+    const record = this.records.get(taskLifecycleKey(identity));
+    if (!record) return;
+    const now = this.now();
+    record.consecutiveErrors = 0;
+    const serverFloor = finitePositive(record.pollIntervalMs) ?? 0;
+    record.nextPollAt = Math.max(
+      now,
+      record.lastObservedAt !== undefined
+        ? record.lastObservedAt + serverFloor
+        : 0,
+      record.retryAfterUntil ?? 0
+    );
+  }
+
+  /**
    * Marks the handle unknown to the server. Only ever called from a **confirmed
    * `tasks/get` `-32602`** — that is the one method carrying the MUST
    * (`tasks.md:793-795`); update/cancel carry a SHOULD, so a `-32602` from

--- a/sdk/src/mcp-client-manager/task-lifecycle.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle.ts
@@ -356,6 +356,15 @@ export class TaskLifecycleEngine {
       /** Adopted from durable storage; not re-notified as a creation. */
       restored?: boolean;
       respondedInputKeys?: readonly string[];
+      /**
+       * Due time carried over from durable storage. Without it a restored
+       * handle is due immediately, so a reload would re-read every task before
+       * its advertised floor elapsed — and repeated reloads would out-poll the
+       * server. Ignored for a handle that is already terminal.
+       */
+      nextPollAt?: number;
+      /** Last observation time carried over from durable storage. */
+      lastObservedAt?: number;
     } = {}
   ): TaskLifecycleRecord {
     const key = taskLifecycleKey(identity);
@@ -370,7 +379,18 @@ export class TaskLifecycleEngine {
       createdAt: init.createdAt,
       ttlMs: init.ttlMs ?? null,
       pollIntervalMs: finitePositive(init.pollIntervalMs),
-      nextPollAt: now,
+      // A restored due time wins over "now", but never moves a handle EARLIER
+      // than it would otherwise be: a stored value from the past just means the
+      // floor already elapsed, which `now` already expresses.
+      nextPollAt:
+        typeof init.nextPollAt === "number" && Number.isFinite(init.nextPollAt)
+          ? Math.max(now, init.nextPollAt)
+          : now,
+      lastObservedAt:
+        typeof init.lastObservedAt === "number" &&
+        Number.isFinite(init.lastObservedAt)
+          ? init.lastObservedAt
+          : undefined,
       consecutiveErrors: 0,
       cancellationRequested: false,
       respondedInputKeys: new Set(init.respondedInputKeys ?? []),
@@ -458,9 +478,20 @@ export class TaskLifecycleEngine {
     }
 
     const terminal = isTerminalLifecycleStatus(record.status);
-    record.nextPollAt = terminal
-      ? Number.POSITIVE_INFINITY
-      : now + this.effectiveIntervalMs(record, now);
+    if (terminal) {
+      record.nextPollAt = Number.POSITIVE_INFINITY;
+    } else if (source === "notification" && record.consecutiveErrors > 0) {
+      // A notification while the POLL path is failing must not push the
+      // recovery read further out. A steady notification stream would
+      // otherwise defer it indefinitely, so a broken `tasks/get` would stay
+      // broken and invisible for as long as the other channel kept talking.
+      record.nextPollAt = Math.min(
+        record.nextPollAt,
+        now + this.effectiveIntervalMs(record, now)
+      );
+    } else {
+      record.nextPollAt = now + this.effectiveIntervalMs(record, now);
+    }
 
     const snapshot = toSnapshot(record);
     if (previous !== record.status) {

--- a/sdk/src/mcp-client-manager/task-lifecycle.ts
+++ b/sdk/src/mcp-client-manager/task-lifecycle.ts
@@ -149,6 +149,30 @@ export interface TaskLifecycleRecord {
   lastObservedAt?: number;
   /** A `tasks/cancel` has been sent; the task may still complete normally. */
   cancellationRequested: boolean;
+  /**
+   * Adopted from durable storage and not yet confirmed by a live read.
+   *
+   * Cleared by the first {@link TaskLifecycleEngine.observe}. It matters
+   * because durable storage holds a task's *status* but never its payload: on
+   * the extension wire the result and error ride inline on `tasks/get`, so a
+   * handle restored as `completed` has a status and no result. A surface that
+   * wants to show the payload has to read it once more, and this flag is how it
+   * tells "finished, and we have the result" from "finished, and all we kept
+   * was the word".
+   */
+  restored: boolean;
+  /**
+   * A read is in flight for this handle right now.
+   *
+   * Distinct from {@link TaskLifecycleRecord.nextPollAt}, which is a *time*
+   * reservation. Pushing the due time forward only prevents a duplicate while
+   * the read finishes inside one interval; a read slower than the floor lets
+   * the next poller find the handle due again and dispatch concurrently. Two
+   * `tasks/get` in flight means the later reply wins even when it observed the
+   * older state, so the lease covers the whole request rather than a guess at
+   * how long it will take.
+   */
+  pollInFlight: boolean;
   /** Input keys whose `tasks/update` acknowledgement succeeded. */
   respondedInputKeys: Set<string>;
   /** Provenance, for the surfaces that show it. */
@@ -360,7 +384,16 @@ export class TaskLifecycleEngine {
        * Due time carried over from durable storage. Without it a restored
        * handle is due immediately, so a reload would re-read every task before
        * its advertised floor elapsed — and repeated reloads would out-poll the
-       * server. Ignored for a handle that is already terminal.
+       * server.
+       *
+       * Applied to terminal handles too, deliberately. A restored terminal is
+       * not the same as a terminal we watched arrive: `observe` sets
+       * `nextPollAt` to `Infinity` because it already holds the payload,
+       * whereas storage kept only the status. Parking a restored terminal at
+       * `Infinity` here would make the extension wire's inline result
+       * permanently unreachable across a reload, so the floor is honored
+       * instead and {@link TaskLifecycleRecord.restored} marks it as still
+       * owing one read.
        */
       nextPollAt?: number;
       /** Last observation time carried over from durable storage. */
@@ -393,6 +426,8 @@ export class TaskLifecycleEngine {
           : undefined,
       consecutiveErrors: 0,
       cancellationRequested: false,
+      restored: init.restored === true,
+      pollInFlight: false,
       respondedInputKeys: new Set(init.respondedInputKeys ?? []),
       toolName: init.toolName,
       surface: init.surface,
@@ -432,15 +467,28 @@ export class TaskLifecycleEngine {
     const previous = record.status;
     const now = this.now();
 
-    // Terminal is FINAL. A poll issued before a terminal notification arrived
-    // can land after it, and applying it would revert a completed task's UI
-    // and scheduling to `working` — resurrecting a handle we already retired.
-    // The observation is still evidence the handle exists, so the observation
-    // clock advances; nothing else does.
-    if (isTerminalLifecycleStatus(record.status)) {
+    // Terminal is FINAL — for a terminal we actually watched arrive. A poll
+    // issued before a terminal notification arrived can land after it, and
+    // applying it would revert a completed task's UI and scheduling to
+    // `working`, resurrecting a handle we already retired. The observation is
+    // still evidence the handle exists, so the observation clock advances;
+    // nothing else does.
+    //
+    // A RESTORED terminal is the exception, and it is not a loophole in that
+    // rule — it is the case the rule was never about. Durable storage keeps a
+    // task's status and not its payload, so a handle restored as `completed`
+    // is a status with no result behind it, and on the extension wire (where
+    // the result rides inline on `tasks/get`) that payload exists nowhere else.
+    // There is also no in-session ordering to protect: nothing observed this
+    // record, so there is no newer state for a late reply to trample. The
+    // server is authoritative and this first read is what makes it so.
+    if (isTerminalLifecycleStatus(record.status) && !record.restored) {
       record.lastObservedAt = now;
       return record;
     }
+    // A live read supersedes whatever storage remembered, so the handle stops
+    // owing one.
+    record.restored = false;
 
     record.status = observation.status;
     // Assigned unconditionally: an observation is a FULL snapshot, so a server
@@ -602,14 +650,17 @@ export class TaskLifecycleEngine {
   }
 
   /**
-   * Handles due for a poll now, soonest first. Terminal handles are never due.
+   * Handles due for a poll now, soonest first. Terminal handles are never due,
+   * and neither is a handle with a read already in flight.
    */
   due(at?: number): TaskLifecycleRecord[] {
     const now = at ?? this.now();
     return [...this.records.values()]
       .filter(
         (record) =>
-          !isTerminalLifecycleStatus(record.status) && record.nextPollAt <= now
+          !isTerminalLifecycleStatus(record.status) &&
+          !record.pollInFlight &&
+          record.nextPollAt <= now
       )
       .sort((a, b) => a.nextPollAt - b.nextPollAt);
   }
@@ -646,6 +697,40 @@ export class TaskLifecycleEngine {
     for (const record of records) {
       record.nextPollAt = now + this.effectiveIntervalMs(record, now);
     }
+  }
+
+  /**
+   * Claims a handle for a read that is about to be dispatched, returning
+   * whether the claim succeeded.
+   *
+   * `reserve` alone is not enough on a shared engine. It moves the due time
+   * forward by one interval, which only covers a read that settles inside that
+   * interval; a `tasks/get` slower than the floor leaves the handle due again
+   * while the first request is still open, and a second poller dispatches on
+   * top of it. Beyond the wasted request, the replies can land out of order and
+   * an older snapshot overwrites a newer one.
+   *
+   * So the lease is held for the life of the request, not for a guessed
+   * duration, and {@link due} skips a leased handle. It also still reserves, so
+   * the floor is respected the moment the lease is released.
+   *
+   * Callers MUST release in a `finally` — every exit, including a throw. The
+   * lease is not self-expiring on purpose: a timeout is exactly the case where
+   * a stale reply may still arrive, and quietly re-admitting a second reader
+   * would reintroduce the race this prevents.
+   */
+  acquirePoll(identity: TaskLifecycleIdentity, at?: number): boolean {
+    const record = this.records.get(taskLifecycleKey(identity));
+    if (!record || record.pollInFlight) return false;
+    record.pollInFlight = true;
+    this.reserve([record], at);
+    return true;
+  }
+
+  /** Releases a lease taken by {@link acquirePoll}. Idempotent. */
+  releasePoll(identity: TaskLifecycleIdentity): void {
+    const record = this.records.get(taskLifecycleKey(identity));
+    if (record) record.pollInFlight = false;
   }
 
   /**

--- a/sdk/src/mcp-client-manager/tasks-ext-guards.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-guards.ts
@@ -185,3 +185,26 @@ export function parseTaskExtNotificationParams(
     ? (parsed.data as TaskExtNotificationParams)
     : undefined;
 }
+
+/**
+ * Strict form of {@link parseTaskExtNotificationParams}.
+ *
+ * A `notifications/tasks` payload carries a full `DetailedTask` and is
+ * validated **identically to `tasks/get`** — the delivery channel changes
+ * nothing about how much a payload is trusted. Use this wherever a rejected
+ * notification should be diagnosable; use the lenient parser only where the
+ * caller genuinely wants to drop unparseable traffic and keep polling.
+ */
+export function assertTaskExtNotificationParams(
+  value: unknown,
+  context = "notifications/tasks params",
+  method = "notifications/tasks"
+): TaskExtNotificationParams {
+  const parsed = taskExtNotificationParamsSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new InvalidTaskExtPayloadError(context, issuesOf(parsed.error), {
+      method,
+    });
+  }
+  return parsed.data as TaskExtNotificationParams;
+}

--- a/sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts
@@ -103,11 +103,20 @@ type EnvelopeFn = () => Record<string, unknown> | undefined;
  * `call` MUST read the envelope synchronously (see the module comment); a call
  * that does not is a seam change and throws rather than silently sending an
  * undeclared request.
+ *
+ * `disposeUnobserved` is how that throw stays leak-free. The seam check can
+ * only run once `call` has SETTLED — for `listen()` that is after the server's
+ * acknowledgement, so by the time we decide the declaration never reached the
+ * wire the subscription is already live on the server. The caller receives a
+ * rejection and therefore never gets the handle, so nothing else can ever tear
+ * it down; without this hook every attempt would leak one server-side
+ * subscription. Give it whatever closes `T`.
  */
 export function withTasksExtensionEnvelope<T>(
   client: Client,
   declaredCapabilities: ClientCapabilityOptions | undefined,
-  call: () => Promise<T>
+  call: () => Promise<T>,
+  disposeUnobserved?: (value: T) => void | Promise<void>
 ): Promise<T> {
   const target = client as unknown as Record<string, unknown>;
   const original = target[ENVELOPE_MEMBER];
@@ -168,10 +177,24 @@ export function withTasksExtensionEnvelope<T>(
   // it. Two reasons: a call that also rejected must surface ITS error (the
   // server's `-32003` is more useful than our diagnosis of it), and abandoning
   // `pending` here would leave an unhandled rejection behind.
-  return pending.then((value) => {
+  return pending.then(async (value) => {
     if (!observed) {
       // Either the prologue became asynchronous or upstream stopped consulting
       // the envelope for listen. Both mean the request went out undeclared.
+      //
+      // Whatever `call` produced is about to be thrown away, so it has to be
+      // torn down HERE: the caller only ever sees the rejection, so a live
+      // subscription handle we do not close is a subscription nobody will ever
+      // close. Disposal failures are swallowed — the seam error is the fact
+      // worth reporting, and a failed close is at worst the leak we were
+      // already trying to avoid.
+      if (disposeUnobserved) {
+        try {
+          await disposeUnobserved(value);
+        } catch {
+          // Swallowed, including a synchronous throw.
+        }
+      }
       throw new TasksExtListenMetaSeamError(
         "the request was built without reading the outbound capabilities envelope, " +
           "so the eligibility declaration did not reach the wire"

--- a/sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts
@@ -1,0 +1,207 @@
+/**
+ * Per-call shadow that puts the `io.modelcontextprotocol/tasks` eligibility
+ * declaration onto exactly ONE `subscriptions/listen` request.
+ *
+ * ## Why a seam is needed at all
+ *
+ * SEP-2663 delivers optional `notifications/tasks` over a task-filtered
+ * `subscriptions/listen`, and — like every other extension operation — that
+ * listen request MUST carry the per-request eligibility declaration in
+ * `params._meta["io.modelcontextprotocol/clientCapabilities"]`. A non-declaring
+ * client gets `-32003`.
+ *
+ * `Client.listen(filter, options)` has no `_meta` parameter. It builds its own
+ * request body (`client dist/index.mjs:3706-3713`):
+ *
+ * ```js
+ * params: { _meta: { ...this._outboundMetaEnvelope() }, notifications: filter }
+ * ```
+ *
+ * `RequestOptions` carries `signal` / `timeout` / progress and nothing that
+ * reaches `params._meta`. So there is no public way to declare on a listen.
+ *
+ * ## Why the filter itself is fine
+ *
+ * Note what that same line does with the filter: `notifications: filter`,
+ * verbatim. Upstream validates `SubscriptionFilterSchema` nowhere on the send
+ * path, so the extension's `taskIds` member reaches the wire unmodified even
+ * though upstream's own type does not know about it. Only `_meta` needs help.
+ *
+ * ## The shape of the fix
+ *
+ * The same discipline as `tasks-ext-era-gate.ts`: a narrowly scoped,
+ * per-instance override of one private upstream member, installed for the
+ * shortest possible window and removed immediately.
+ *
+ * The window can be made exact because `listen()`'s prologue is **fully
+ * synchronous** up to and including the line above — transport check, era
+ * check, promise wiring, `_listenState.set`, the ack timer, the abort listener,
+ * then the request literal. The first `await` is the `transport.send` that
+ * follows. So:
+ *
+ * ```ts
+ * install();
+ * const pending = client.listen(filter, options); // envelope read, synchronously
+ * restore();                                       // nothing else can observe it
+ * return await pending;
+ * ```
+ *
+ * `restore()` runs in the same synchronous turn as the read, so no other
+ * request — on this client or any other — can pick up the widened envelope.
+ * That is what keeps the declaration per-request rather than connection-wide;
+ * `registerCapabilities()` would have been the easy path and is exactly the
+ * thing SEP-2663's per-request opt-in forbids.
+ *
+ * ## Maintenance
+ *
+ * REVISIT ON EVERY `@modelcontextprotocol/client` BUMP. Two things could break
+ * it, and both fail loudly rather than silently dropping the declaration:
+ *
+ *  - the private member is renamed or removed ⇒
+ *    {@link TasksExtListenMetaSeamError} on the attempted listen;
+ *  - the prologue stops being synchronous (an `await` moves above the request
+ *    literal) ⇒ the post-call verification below sees the override was never
+ *    invoked and throws.
+ *
+ * Delete this module once the client package accepts caller `_meta` on
+ * `listen()`.
+ */
+
+import { Client } from "@modelcontextprotocol/client";
+import { CLIENT_CAPABILITIES_META_KEY } from "@modelcontextprotocol/client";
+import { mergeClientCapabilities } from "./capabilities.js";
+import { MCP_TASKS_EXTENSION_ID } from "./tasks-dispatch.js";
+import type { ClientCapabilityOptions } from "./types.js";
+
+/** The private upstream member being shadowed. Named once. */
+const ENVELOPE_MEMBER = "_outboundMetaEnvelope" as const;
+
+/** Client package version this shadow was verified against. */
+const VERIFIED_CLIENT_VERSION = "2.0.0-beta.4 / 2.0.0-beta.5";
+
+/** Thrown when the seam this shadow depends on is no longer where it was. */
+export class TasksExtListenMetaSeamError extends Error {
+  constructor(reason: string) {
+    super(
+      `Cannot declare io.modelcontextprotocol/tasks on subscriptions/listen: ${reason}. ` +
+        `\`Protocol.${ENVELOPE_MEMBER}\` is a private member of @modelcontextprotocol/client ` +
+        `(verified against ${VERIFIED_CLIENT_VERSION}); without it the listen request would go ` +
+        `out undeclared and a conforming server would answer -32003. Re-verify ` +
+        `sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts against the new client build, or ` +
+        `disable task notifications and fall back to polling.`
+    );
+    this.name = "TasksExtListenMetaSeamError";
+  }
+}
+
+type EnvelopeFn = () => Record<string, unknown> | undefined;
+
+/**
+ * Runs `call` with the tasks extension merged into the client's outbound
+ * capabilities envelope, for the synchronous prologue of that one call only.
+ *
+ * `call` MUST read the envelope synchronously (see the module comment); a call
+ * that does not is a seam change and throws rather than silently sending an
+ * undeclared request.
+ */
+export function withTasksExtensionEnvelope<T>(
+  client: Client,
+  declaredCapabilities: ClientCapabilityOptions | undefined,
+  call: () => Promise<T>
+): Promise<T> {
+  const target = client as unknown as Record<string, unknown>;
+  const original = target[ENVELOPE_MEMBER];
+  if (original === undefined) {
+    throw new TasksExtListenMetaSeamError("the member is absent");
+  }
+  if (typeof original !== "function") {
+    throw new TasksExtListenMetaSeamError(
+      `the member is a ${typeof original}, not a function`
+    );
+  }
+  const inherited = original as EnvelopeFn;
+  const merged = mergeClientCapabilities(declaredCapabilities, {
+    extensions: { [MCP_TASKS_EXTENSION_ID]: {} },
+  } as ClientCapabilityOptions);
+
+  let observed = false;
+  const hadOwn = Object.prototype.hasOwnProperty.call(target, ENVELOPE_MEMBER);
+  const ownDescriptor = hadOwn
+    ? Object.getOwnPropertyDescriptor(target, ENVELOPE_MEMBER)
+    : undefined;
+
+  Object.defineProperty(target, ENVELOPE_MEMBER, {
+    value: function shadowedOutboundMetaEnvelope(
+      this: unknown
+    ): Record<string, unknown> | undefined {
+      observed = true;
+      const base = inherited.call(this) ?? {};
+      // Replace only the capabilities key. The protocol-version and client-info
+      // keys upstream generated stay exactly as they were.
+      return { ...base, [CLIENT_CAPABILITIES_META_KEY]: merged };
+    },
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
+
+  const restore = () => {
+    if (ownDescriptor) {
+      Object.defineProperty(target, ENVELOPE_MEMBER, ownDescriptor);
+    } else {
+      delete target[ENVELOPE_MEMBER];
+    }
+  };
+
+  let pending: Promise<T>;
+  try {
+    pending = call();
+  } catch (error) {
+    restore();
+    throw error;
+  }
+  // The synchronous prologue has run by now; anything later must not see the
+  // widened envelope.
+  restore();
+
+  // The seam check rides ON the pending promise rather than short-circuiting
+  // it. Two reasons: a call that also rejected must surface ITS error (the
+  // server's `-32003` is more useful than our diagnosis of it), and abandoning
+  // `pending` here would leave an unhandled rejection behind.
+  return pending.then((value) => {
+    if (!observed) {
+      // Either the prologue became asynchronous or upstream stopped consulting
+      // the envelope for listen. Both mean the request went out undeclared.
+      throw new TasksExtListenMetaSeamError(
+        "the request was built without reading the outbound capabilities envelope, " +
+          "so the eligibility declaration did not reach the wire"
+      );
+    }
+    return value;
+  });
+}
+
+/** Depth cap on the `inner` delegation walk; also the cycle guard. */
+const MAX_DELEGATION_DEPTH = 16;
+
+function isUpstreamClient(value: object): value is Client {
+  return (
+    value instanceof Client ||
+    typeof (value as Record<string, unknown>)[ENVELOPE_MEMBER] === "function"
+  );
+}
+
+/**
+ * The upstream `Client` behind a `ManagedMcpClient`-shaped object, found by
+ * walking the public `inner` delegation chain. `undefined` means nothing in the
+ * chain is an upstream client — a test double, which has no envelope to widen.
+ */
+export function resolveListenMetaTarget(managed: object): Client | undefined {
+  let current: unknown = managed;
+  for (let depth = 0; depth < MAX_DELEGATION_DEPTH; depth += 1) {
+    if (typeof current !== "object" || current === null) return undefined;
+    if (isUpstreamClient(current)) return current;
+    current = (current as { inner?: unknown }).inner;
+  }
+  return undefined;
+}

--- a/sdk/src/mcp-client-manager/tasks-ext.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext.ts
@@ -54,6 +54,10 @@ import { CLIENT_CAPABILITIES_META_KEY } from "@modelcontextprotocol/client";
 import { z } from "zod";
 import { mergeClientCapabilities } from "./capabilities.js";
 import { ensureTasksExtensionEraGateShadow } from "./tasks-ext-era-gate.js";
+import {
+  resolveListenMetaTarget,
+  withTasksExtensionEnvelope,
+} from "./tasks-ext-listen-meta.js";
 import type { ManagedMcpClient } from "./managed-mcp-client.js";
 import type { ClientCapabilityOptions, ClientRequestOptions } from "./types.js";
 import {
@@ -192,6 +196,41 @@ async function sendTasksExtRequest(
     },
     TASKS_EXT_WIRE_RESULT_SCHEMA,
     ctx.options
+  );
+}
+
+/**
+ * Opens a task-filtered `subscriptions/listen` carrying the extension's
+ * eligibility declaration.
+ *
+ * The declaration is mandatory on this request too — a non-declaring client
+ * MUST get `-32003` (`tasks.md:797-799`) — but `Client.listen` builds its own
+ * `params._meta` and takes no caller `_meta`. `tasks-ext-listen-meta.ts`
+ * explains the seam and why it is scoped to this one call.
+ *
+ * Returns `undefined` when this connection cannot listen at all, or cannot
+ * declare on the listen. Both are the same outcome for the caller: **do not
+ * send a task-filtered listen**, keep polling. Task notifications are OPTIONAL
+ * in the extension, so nothing is lost but latency.
+ *
+ * @throws {TasksExtListenMetaSeamError} when the upstream seam has moved. Loud
+ * on purpose: a silent fallback would hide a client bump that broke the
+ * declaration, and the caller can catch it to degrade to polling deliberately.
+ */
+export async function openTaskDeclaredListen(
+  ctx: Omit<TasksExtCallContext, "options">,
+  filter: Record<string, unknown>
+): Promise<unknown | undefined> {
+  const listen = (
+    ctx.client as {
+      listen?: (filter: unknown, options?: unknown) => Promise<unknown>;
+    }
+  ).listen;
+  if (typeof listen !== "function") return undefined;
+  const target = resolveListenMetaTarget(ctx.client as unknown as object);
+  if (target === undefined) return undefined;
+  return withTasksExtensionEnvelope(target, ctx.declaredCapabilities, () =>
+    listen.call(ctx.client, filter)
   );
 }
 

--- a/sdk/src/mcp-client-manager/tasks-ext.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext.ts
@@ -229,8 +229,21 @@ export async function openTaskDeclaredListen(
   if (typeof listen !== "function") return undefined;
   const target = resolveListenMetaTarget(ctx.client as unknown as object);
   if (target === undefined) return undefined;
-  return withTasksExtensionEnvelope(target, ctx.declaredCapabilities, () =>
-    listen.call(ctx.client, filter)
+  return withTasksExtensionEnvelope(
+    target,
+    ctx.declaredCapabilities,
+    () => listen.call(ctx.client, filter),
+    // `listen()` resolves only once the server has ACKNOWLEDGED, so a seam
+    // failure is detected with the subscription already live. The caller gets a
+    // rejection and never sees this handle, so if we do not close it here the
+    // server keeps the subscription — and never receives the
+    // `notifications/cancelled` that `close()` sends — for the life of the
+    // connection, once per attempt.
+    async (handle) => {
+      const close = (handle as { close?: () => Promise<void> } | undefined)
+        ?.close;
+      if (typeof close === "function") await close.call(handle);
+    }
   );
 }
 

--- a/sdk/tests/subscription-coordinator.tasks.test.ts
+++ b/sdk/tests/subscription-coordinator.tasks.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Task notifications over `subscriptions/listen`
+ * (`io.modelcontextprotocol/tasks`, SEP-2663).
+ *
+ * Two rules drive every case here:
+ *
+ *  1. Task notifications are OPTIONAL in the extension. They may reduce
+ *     polling; they may never be required for correctness. So every path that
+ *     cannot establish the stream must degrade to polling *visibly* — the
+ *     handle is never lost and the reason is always recorded.
+ *  2. A task-filtered listen MUST carry the per-request eligibility
+ *     declaration, or the server answers `-32003` (`tasks.md:797-799`). A
+ *     connection that cannot declare must therefore not send one at all.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { ServerCapabilities } from "@modelcontextprotocol/client";
+import {
+  SubscriptionCoordinator,
+  SUBSCRIPTION_ID_META_KEY,
+  SubscriptionsAcknowledgedNotificationMethod,
+  TasksNotificationMethod,
+  resolveRequestedFilter,
+  type DeliveredSubscriptionNotification,
+  type McpSubscriptionHandle,
+  type RejectedSubscriptionNotification,
+  type SubscriptionClientPort,
+  type SubscriptionFilterShape,
+  type SubscriptionStreamRecord,
+} from "../src/mcp-client-manager/subscription-coordinator.js";
+
+const TASKS_EXT = "io.modelcontextprotocol/tasks";
+
+const EXTENSION_CAPS = {
+  tools: { listChanged: true },
+  extensions: { [TASKS_EXT]: {} },
+} as unknown as ServerCapabilities;
+
+/** A 2026-07-28 server that does NOT advertise the tasks extension. */
+const NO_TASKS_CAPS = {
+  tools: { listChanged: true },
+} as ServerCapabilities;
+
+interface FixtureListen {
+  filter: SubscriptionFilterShape;
+  declared: boolean;
+  /** Re-emit the ack as a notification (the coordinator treats it idempotently). */
+  acknowledge: (honored?: SubscriptionFilterShape) => void;
+  dropRemotely: () => void;
+  closeLocally: () => void;
+}
+
+class TaskFixtureClient implements SubscriptionClientPort {
+  readonly listens: FixtureListen[] = [];
+  private handlers = new Map<
+    string,
+    Array<(n: { method: string; params?: Record<string, unknown> }) => void>
+  >();
+  private nextId = 0;
+
+  constructor(
+    private readonly caps: ServerCapabilities | undefined,
+    /** When false the client cannot declare on a listen (no seam). */
+    private readonly canDeclare = true
+  ) {
+    if (!canDeclare) {
+      (this as { listenWithTasksDeclaration?: unknown }).listenWithTasksDeclaration =
+        undefined;
+    }
+  }
+
+  getServerCapabilities(): ServerCapabilities | undefined {
+    return this.caps;
+  }
+  getProtocolEra(): "legacy" | "modern" {
+    return "modern";
+  }
+  setNotificationHandler(
+    method: string,
+    handler: (n: { method: string; params?: Record<string, unknown> }) => void
+  ): void {
+    const existing = this.handlers.get(method) ?? [];
+    existing.push(handler);
+    this.handlers.set(method, existing);
+  }
+  async subscribeResource(): Promise<unknown> {
+    return {};
+  }
+  async unsubscribeResource(): Promise<unknown> {
+    return {};
+  }
+
+  listen = (filter: SubscriptionFilterShape) => this.open(filter, false);
+
+  listenWithTasksDeclaration = (filter: SubscriptionFilterShape) =>
+    this.open(filter, true);
+
+  /**
+   * What the NEXT open resolves its `honoredFilter` with. Mirrors upstream,
+   * where `listen()` resolves on the acknowledgement and `honoredFilter` IS
+   * the acknowledged filter — so a server honoring only a subset is expressed
+   * here, before the open, not by a later notification.
+   */
+  nextHonoredFilter?: SubscriptionFilterShape;
+
+  private async open(
+    filter: SubscriptionFilterShape,
+    declared: boolean
+  ): Promise<McpSubscriptionHandle> {
+    const id = `listen:${++this.nextId}`;
+    let settle: (r: "local" | "graceful" | "remote") => void = () => {};
+    const closed = new Promise<"local" | "graceful" | "remote">((resolve) => {
+      settle = resolve;
+    });
+    let honored: SubscriptionFilterShape = this.nextHonoredFilter ?? filter;
+    this.nextHonoredFilter = undefined;
+    this.listens.push({
+      filter,
+      declared,
+      closeLocally: () => settle("local"),
+      acknowledge: (h?: SubscriptionFilterShape) => {
+        honored = h ?? filter;
+        this.emit(SubscriptionsAcknowledgedNotificationMethod, {
+          notifications: honored,
+          _meta: { [SUBSCRIPTION_ID_META_KEY]: id },
+        });
+      },
+      dropRemotely: () => settle("remote"),
+    });
+    return {
+      get honoredFilter() {
+        return honored;
+      },
+      subscriptionId: id,
+      close: async () => settle("local"),
+      closed,
+    };
+  }
+
+  emit(method: string, params?: Record<string, unknown>): void {
+    for (const handler of this.handlers.get(method) ?? []) {
+      handler({ method, params });
+    }
+  }
+
+  /** Deliver a full `DetailedTask` on the stream, as SEP-2663 specifies. */
+  emitTask(
+    listenIndex: number,
+    task: Record<string, unknown>
+  ): void {
+    this.emit(TasksNotificationMethod, {
+      ...task,
+      _meta: { [SUBSCRIPTION_ID_META_KEY]: `listen:${listenIndex + 1}` },
+    });
+  }
+}
+
+function harness(
+  caps: ServerCapabilities | undefined = EXTENSION_CAPS,
+  canDeclare = true
+) {
+  const client = new TaskFixtureClient(caps, canDeclare);
+  const delivered: DeliveredSubscriptionNotification[] = [];
+  const rejected: RejectedSubscriptionNotification[] = [];
+  const streams: SubscriptionStreamRecord[] = [];
+  let clock = 1_000;
+  const coordinator = new SubscriptionCoordinator({
+    client,
+    era: "modern",
+    now: () => ++clock,
+    sleep: async () => {},
+    reconnect: { maxAttempts: 1, initialDelayMs: 1, factor: 2, maxDelayMs: 10 },
+    onNotification: (e) => delivered.push(e),
+    onRejectedNotification: (e) => rejected.push(e),
+    onStreamChange: (s) => streams.push(s),
+  });
+  return { client, coordinator, delivered, rejected, streams };
+}
+
+const workingTask = (taskId: string) => ({
+  taskId,
+  status: "working",
+  createdAt: "2026-07-28T00:00:00Z",
+  lastUpdatedAt: "2026-07-28T00:00:01Z",
+  ttlMs: null,
+});
+
+describe("filter resolution", () => {
+  it("requests taskIds when the server advertises the tasks extension", () => {
+    const { requested, rejected } = resolveRequestedFilter(
+      { taskIds: ["t1", "t2"] },
+      EXTENSION_CAPS
+    );
+    expect(requested.taskIds).toEqual(["t1", "t2"]);
+    expect(rejected).toEqual([]);
+  });
+
+  it("rejects taskIds when the server does not advertise the extension", () => {
+    const { requested, rejected } = resolveRequestedFilter(
+      { taskIds: ["t1"] },
+      NO_TASKS_CAPS
+    );
+    expect(requested.taskIds).toBeUndefined();
+    expect(rejected).toEqual([
+      { interest: "tasks", taskId: "t1", reason: "capability-not-advertised" },
+    ]);
+  });
+
+  it("treats the extension as absent when the capability value is not an object", () => {
+    for (const bad of [true, "yes", [], null]) {
+      const { requested } = resolveRequestedFilter({ taskIds: ["t1"] }, {
+        extensions: { [TASKS_EXT]: bad },
+      } as unknown as ServerCapabilities);
+      expect(requested.taskIds).toBeUndefined();
+    }
+  });
+
+  it("dedupes task ids", () => {
+    const { requested } = resolveRequestedFilter(
+      { taskIds: ["t1", "t1", "t2"] },
+      EXTENSION_CAPS
+    );
+    expect(requested.taskIds).toEqual(["t1", "t2"]);
+  });
+});
+
+describe("opening the stream", () => {
+  it("opens through the DECLARED opener when the filter carries task ids", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+
+    expect(h.client.listens).toHaveLength(1);
+    expect(h.client.listens[0].declared).toBe(true);
+    expect(h.client.listens[0].filter.taskIds).toEqual(["t1"]);
+  });
+
+  it("uses the plain opener when no task ids are wanted", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ toolsListChanged: true });
+    expect(h.client.listens[0].declared).toBe(false);
+  });
+
+  it("drops task ids — and says why — when the connection cannot declare", async () => {
+    const h = harness(EXTENSION_CAPS, /* canDeclare */ false);
+    await h.coordinator.setDesiredInterests({
+      toolsListChanged: true,
+      taskIds: ["t1"],
+    });
+
+    // The listen still goes out for the other interests, WITHOUT taskIds: an
+    // undeclared task-filtered listen would be a guaranteed -32003.
+    expect(h.client.listens).toHaveLength(1);
+    expect(h.client.listens[0].filter.taskIds).toBeUndefined();
+
+    const stream = h.coordinator.getStreams().at(-1)!;
+    expect(stream.rejectedInterests).toContainEqual({
+      interest: "tasks",
+      taskId: "t1",
+      reason: "tasks-declaration-unavailable",
+    });
+  });
+
+  it("records an unacknowledged task id as rejected, so the caller knows to keep polling", async () => {
+    const h = harness();
+    h.client.nextHonoredFilter = { taskIds: ["t1"] };
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1", "t2"] });
+
+    const stream = h.coordinator.getStreams().at(-1)!;
+    expect(stream.rejectedInterests).toContainEqual({
+      interest: "tasks",
+      taskId: "t2",
+      reason: "not-acknowledged-by-server",
+    });
+  });
+});
+
+describe("delivery", () => {
+  it("delivers a full DetailedTask for an acknowledged task id", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+    h.client.listens[0].acknowledge();
+    h.client.emitTask(0, { ...workingTask("t1"), pollIntervalMs: 2_000 });
+
+    expect(h.delivered).toHaveLength(1);
+    expect(h.delivered[0]).toMatchObject({
+      kind: "tasks",
+      method: TasksNotificationMethod,
+      taskId: "t1",
+    });
+    // The whole task rides in the params — this is not a bare "something
+    // changed" ping, so a consumer can reconcile without a follow-up read.
+    expect(h.delivered[0].params).toMatchObject({
+      status: "working",
+      pollIntervalMs: 2_000,
+    });
+  });
+
+  it("refuses a task notification for an id we never asked about", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+    h.client.listens[0].acknowledge();
+    h.client.emitTask(0, workingTask("someone-elses-task"));
+
+    expect(h.delivered).toEqual([]);
+    expect(h.rejected.at(-1)).toMatchObject({ reason: "unrequested-type" });
+  });
+
+  it("refuses a task notification for an id the server did not acknowledge", async () => {
+    const h = harness();
+    // The server honors only `t1`, so pushing `t2` is unsolicited even though
+    // we asked for it — the ACKNOWLEDGED filter is what gates delivery.
+    h.client.nextHonoredFilter = { taskIds: ["t1"] };
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1", "t2"] });
+    h.client.emitTask(0, workingTask("t2"));
+
+    expect(h.delivered).toEqual([]);
+    expect(h.rejected.at(-1)).toMatchObject({ reason: "unrequested-type" });
+
+    // ...and `t1` on the same stream still flows.
+    h.client.emitTask(0, workingTask("t1"));
+    expect(h.delivered).toHaveLength(1);
+  });
+
+  it("refuses a task notification carrying no task id at all", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+    h.client.listens[0].acknowledge();
+    h.client.emitTask(0, { status: "working" });
+
+    expect(h.delivered).toEqual([]);
+    expect(h.rejected.at(-1)).toMatchObject({ reason: "unrequested-type" });
+  });
+
+  it("refuses anything delivered after the stream closed", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+    await h.coordinator.cancel();
+    h.client.emitTask(0, workingTask("t1"));
+
+    expect(h.delivered).toEqual([]);
+    expect(h.rejected.at(-1)).toMatchObject({ reason: "stream-not-active" });
+  });
+});
+
+describe("filter churn", () => {
+  it("closes and re-opens when the watched task set changes", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1", "t2"] });
+
+    // A listen filter is immutable, so a changed set is a new stream.
+    expect(h.client.listens).toHaveLength(2);
+    expect(h.client.listens[1].filter.taskIds).toEqual(["t1", "t2"]);
+  });
+
+  it("is idempotent when the set is unchanged, even in a different order", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1", "t2"] });
+    await h.coordinator.setDesiredInterests({ taskIds: ["t2", "t1"] });
+    expect(h.client.listens).toHaveLength(1);
+  });
+
+  it("tears the stream down when the last task goes terminal and is dropped", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+    await h.coordinator.setDesiredInterests({ taskIds: [] });
+
+    const stream = h.coordinator.getStreams().at(-1)!;
+    expect(stream.status).toBe("cancelled");
+  });
+
+  it("re-listens with the declaration after a remote loss", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+    h.client.listens[0].acknowledge();
+    h.client.listens[0].dropRemotely();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(h.client.listens).toHaveLength(2);
+    // The re-listen must go back out DECLARED, or it earns -32003 on reconnect.
+    expect(h.client.listens[1].declared).toBe(true);
+    expect(h.client.listens[1].filter.taskIds).toEqual(["t1"]);
+  });
+});
+
+describe("wire isolation", () => {
+  it("never requests task ids on a legacy connection", () => {
+    // On 2025-11-25 the extension capability MUST be treated as absent, and
+    // `resolveRequestedFilter` reads it through the one predicate that knows
+    // that rule.
+    const { requested, rejected } = resolveRequestedFilter(
+      { taskIds: ["t1"] },
+      { tools: { listChanged: true } } as ServerCapabilities
+    );
+    expect(requested.taskIds).toBeUndefined();
+    expect(rejected[0]).toMatchObject({ reason: "capability-not-advertised" });
+  });
+
+  it("does not put taskIds on a filter that never asked for them", async () => {
+    const h = harness();
+    await h.coordinator.setDesiredInterests({ toolsListChanged: true });
+    expect(h.client.listens[0].filter).not.toHaveProperty("taskIds");
+  });
+});

--- a/sdk/tests/subscription-coordinator.tasks.test.ts
+++ b/sdk/tests/subscription-coordinator.tasks.test.ts
@@ -64,8 +64,9 @@ class TaskFixtureClient implements SubscriptionClientPort {
     private readonly canDeclare = true
   ) {
     if (!canDeclare) {
-      (this as { listenWithTasksDeclaration?: unknown }).listenWithTasksDeclaration =
-        undefined;
+      (
+        this as { listenWithTasksDeclaration?: unknown }
+      ).listenWithTasksDeclaration = undefined;
     }
   }
 
@@ -144,10 +145,7 @@ class TaskFixtureClient implements SubscriptionClientPort {
   }
 
   /** Deliver a full `DetailedTask` on the stream, as SEP-2663 specifies. */
-  emitTask(
-    listenIndex: number,
-    task: Record<string, unknown>
-  ): void {
+  emitTask(listenIndex: number, task: Record<string, unknown>): void {
     this.emit(TasksNotificationMethod, {
       ...task,
       _meta: { [SUBSCRIPTION_ID_META_KEY]: `listen:${listenIndex + 1}` },
@@ -233,7 +231,11 @@ describe("filter resolution", () => {
       );
       expect(requested.taskIds).toBeUndefined();
       expect(rejected).toEqual([
-        { interest: "tasks", taskId: "t1", reason: "capability-not-advertised" },
+        {
+          interest: "tasks",
+          taskId: "t1",
+          reason: "capability-not-advertised",
+        },
       ]);
     }
   });
@@ -317,6 +319,26 @@ describe("delivery", () => {
       status: "working",
       pollIntervalMs: 2_000,
     });
+  });
+
+  it("refuses a task id the server acknowledged but we never requested", async () => {
+    const h = harness();
+    // The server echoes back MORE than it was asked for. `diffAcknowledgement`
+    // only records what a server DROPPED, so an id it ADDED survives into
+    // `acknowledgedFilter` unchallenged — and enforcing against that filter
+    // alone let it through. Task ids are bearer-like handles, so this is a
+    // server pushing state for another surface's task.
+    await h.coordinator.setDesiredInterests({ taskIds: ["t1"] });
+    h.client.listens[0].acknowledge({ taskIds: ["t1", "someone-elses"] });
+
+    h.client.emitTask(0, workingTask("someone-elses"));
+    expect(h.delivered).toEqual([]);
+    expect(h.rejected.at(-1)).toMatchObject({ reason: "unrequested-type" });
+
+    // ...and the id we actually asked for still arrives.
+    h.client.emitTask(0, workingTask("t1"));
+    expect(h.delivered).toHaveLength(1);
+    expect(h.delivered[0]).toMatchObject({ taskId: "t1" });
   });
 
   it("refuses a task notification for an id we never asked about", async () => {

--- a/sdk/tests/subscription-coordinator.tasks.test.ts
+++ b/sdk/tests/subscription-coordinator.tasks.test.ts
@@ -189,7 +189,8 @@ describe("filter resolution", () => {
   it("requests taskIds when the server advertises the tasks extension", () => {
     const { requested, rejected } = resolveRequestedFilter(
       { taskIds: ["t1", "t2"] },
-      EXTENSION_CAPS
+      EXTENSION_CAPS,
+      "modern"
     );
     expect(requested.taskIds).toEqual(["t1", "t2"]);
     expect(rejected).toEqual([]);
@@ -198,7 +199,8 @@ describe("filter resolution", () => {
   it("rejects taskIds when the server does not advertise the extension", () => {
     const { requested, rejected } = resolveRequestedFilter(
       { taskIds: ["t1"] },
-      NO_TASKS_CAPS
+      NO_TASKS_CAPS,
+      "modern"
     );
     expect(requested.taskIds).toBeUndefined();
     expect(rejected).toEqual([
@@ -208,17 +210,39 @@ describe("filter resolution", () => {
 
   it("treats the extension as absent when the capability value is not an object", () => {
     for (const bad of [true, "yes", [], null]) {
-      const { requested } = resolveRequestedFilter({ taskIds: ["t1"] }, {
-        extensions: { [TASKS_EXT]: bad },
-      } as unknown as ServerCapabilities);
+      const { requested } = resolveRequestedFilter(
+        { taskIds: ["t1"] },
+        { extensions: { [TASKS_EXT]: bad } } as unknown as ServerCapabilities,
+        "modern"
+      );
       expect(requested.taskIds).toBeUndefined();
+    }
+  });
+
+  // The extension capability is a plain capability read with no era in it, so
+  // the era rule has to live at the call site. This is the exported entry
+  // point — any consumer outside the coordinator gets its filter from here,
+  // and a legacy filter carrying an extension-only member is exactly the
+  // legacy/extension mixing this plan forbids.
+  it("drops taskIds on a legacy connection EVEN IF the server advertises the extension", () => {
+    for (const era of ["legacy", undefined] as const) {
+      const { requested, rejected } = resolveRequestedFilter(
+        { taskIds: ["t1"] },
+        EXTENSION_CAPS,
+        era
+      );
+      expect(requested.taskIds).toBeUndefined();
+      expect(rejected).toEqual([
+        { interest: "tasks", taskId: "t1", reason: "capability-not-advertised" },
+      ]);
     }
   });
 
   it("dedupes task ids", () => {
     const { requested } = resolveRequestedFilter(
       { taskIds: ["t1", "t1", "t2"] },
-      EXTENSION_CAPS
+      EXTENSION_CAPS,
+      "modern"
     );
     expect(requested.taskIds).toEqual(["t1", "t2"]);
   });
@@ -385,9 +409,7 @@ describe("filter churn", () => {
 
 describe("wire isolation", () => {
   it("never requests task ids on a legacy connection", () => {
-    // On 2025-11-25 the extension capability MUST be treated as absent, and
-    // `resolveRequestedFilter` reads it through the one predicate that knows
-    // that rule.
+    // No era and no extension capability: doubly ineligible.
     const { requested, rejected } = resolveRequestedFilter(
       { taskIds: ["t1"] },
       { tools: { listChanged: true } } as ServerCapabilities
@@ -400,5 +422,36 @@ describe("wire isolation", () => {
     const h = harness();
     await h.coordinator.setDesiredInterests({ toolsListChanged: true });
     expect(h.client.listens[0].filter).not.toHaveProperty("taskIds");
+  });
+});
+
+describe("retained stream history", () => {
+  it("is bounded, so a tab revising its watched set cannot grow it forever", async () => {
+    // Nothing implements `listenWithTasksDeclaration` here, so EVERY revision
+    // is a fully-rejected interest set and records a synthetic never-opened
+    // stream. A Tasks tab revising its watched set as handles are created and
+    // retire does exactly this, once per tick, for the life of the connection.
+    const h = harness(EXTENSION_CAPS, false);
+    for (let i = 0; i < 200; i += 1) {
+      await h.coordinator.setDesiredInterests({ taskIds: [`t${i}`] });
+    }
+    const streams = h.coordinator.getStreams();
+    expect(streams.length).toBeLessThanOrEqual(50);
+    // The newest records — the ones a debugger is actually reading — survive.
+    expect(streams.at(-1)!.rejectedInterests[0]).toMatchObject({
+      taskId: "t199",
+    });
+  });
+
+  it("never evicts the live stream, however much history piles up", async () => {
+    const h = harness();
+    for (let i = 0; i < 200; i += 1) {
+      await h.coordinator.setDesiredInterests({ taskIds: [`t${i}`] });
+      h.client.listens.at(-1)!.acknowledge();
+    }
+    const active = h.coordinator.getActiveStream();
+    expect(active).toBeDefined();
+    expect(active!.requestedFilter.taskIds).toEqual(["t199"]);
+    expect(h.coordinator.getStreams().length).toBeLessThanOrEqual(50);
   });
 });

--- a/sdk/tests/task-await-driver.test.ts
+++ b/sdk/tests/task-await-driver.test.ts
@@ -61,7 +61,7 @@ const working: TaskLifecycleObservation = {
 
 async function drive(
   overrides: Partial<Parameters<typeof driveTaskToTerminal>[0]> = {},
-  clock = controlledClock(),
+  clock = controlledClock()
 ): Promise<TaskAwaitResult> {
   return driveTaskToTerminal({
     identity,
@@ -166,17 +166,19 @@ describe("bounded exits", () => {
     const clock = controlledClock();
     const result = await drive(
       { getTask: async () => working, timeoutMs: 10_000 },
-      clock,
+      clock
     );
     expect(result.outcome).toBe("timeout");
   });
 
   it("reports timeout immediately when the next poll would overshoot the deadline", async () => {
     const clock = controlledClock();
-    const reads = scriptedReads([{ status: "working", pollIntervalMs: 60_000 }]);
+    const reads = scriptedReads([
+      { status: "working", pollIntervalMs: 60_000 },
+    ]);
     const result = await drive(
       { getTask: reads.getTask, timeoutMs: 5_000 },
-      clock,
+      clock
     );
     expect(result.outcome).toBe("timeout");
     // One read, then the deadline check — never a 60s sleep past the budget.
@@ -204,7 +206,7 @@ describe("bounded exits", () => {
         maxConsecutiveErrors: 3,
         timeoutMs: 10 * 60_000,
       },
-      clock,
+      clock
     );
     expect(result.outcome).toBe("unreachable");
     expect(result.lastError).toBe(error);
@@ -222,7 +224,7 @@ describe("bounded exits", () => {
         },
         timeoutMs: 60_000,
       },
-      clock,
+      clock
     );
     expect(result.outcome).toBe("completed");
   });
@@ -265,7 +267,7 @@ describe("input rounds", () => {
         },
         timeoutMs: 60_000,
       },
-      clock,
+      clock
     );
 
     expect(result.outcome).toBe("completed");
@@ -299,7 +301,7 @@ describe("input rounds", () => {
         },
         timeoutMs: 60_000,
       },
-      clock,
+      clock
     );
     expect(elicit).toHaveBeenCalledTimes(1);
   });
@@ -333,7 +335,7 @@ describe("input rounds", () => {
         },
         timeoutMs: 60_000,
       },
-      clock,
+      clock
     );
     // The answer was NOT silently discarded: it is re-collected and retried.
     expect(updateCalls).toBe(2);
@@ -361,7 +363,7 @@ describe("input rounds", () => {
         maxInputRounds: 3,
         timeoutMs: 10 * 60_000,
       },
-      clock,
+      clock
     );
     expect(result.outcome).toBe("input-required");
   });
@@ -411,5 +413,93 @@ describe("poll discipline", () => {
     });
     // A shrinking floor is normal and is followed, not flagged.
     expect(slept).toEqual([20_000, 2_000]);
+  });
+
+  it("holds an in-flight lease for the whole read, not just one interval", async () => {
+    const clock = controlledClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    let release!: (value: TaskLifecycleObservation) => void;
+    const inFlight = new Promise<TaskLifecycleObservation>((resolve) => {
+      release = resolve;
+    });
+
+    const drive = driveTaskToTerminal({
+      identity,
+      // The read is SLOWER than the advertised floor, which is the case a
+      // time-only reservation cannot cover: `reserve` pushes the due time by
+      // one interval, and once that elapses the handle reads as due again
+      // while this request is still open.
+      getTask: () => inFlight,
+      now: clock.now,
+      sleep: async (ms) => clock.advance(ms),
+      engine,
+      timeoutMs: 10 * 60_000,
+    });
+    await Promise.resolve();
+
+    // Well past any floor the engine could have set.
+    clock.advance(10 * 60_000);
+    expect(engine.due()).toEqual([]);
+    // ...and the interactive scheduler agrees, because it asks the same
+    // question. Two `tasks/get` in flight is not merely a wasted request: the
+    // later reply wins even when it observed the older state.
+    expect(engine.get(identity)?.pollInFlight).toBe(true);
+
+    release({ status: "completed", result: {} });
+    const result = await drive;
+    expect(result.outcome).toBe("completed");
+    // Released on the way out, so the handle is not parked forever on an
+    // engine that outlives this drive.
+    expect(engine.get(identity)?.pollInFlight).toBe(false);
+  });
+
+  it("releases the lease before backing off, not after", async () => {
+    const clock = controlledClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    let seenDuringBackoff: boolean | undefined;
+
+    let attempt = 0;
+    await driveTaskToTerminal({
+      identity,
+      getTask: async () => {
+        attempt += 1;
+        if (attempt === 1) throw new Error("connect failed");
+        return { status: "completed", result: {} };
+      },
+      now: clock.now,
+      sleep: async (ms) => {
+        // The backoff sleep must not sit on the lease: an interactive poller
+        // would be blocked for the entire backoff by a read that already
+        // finished.
+        seenDuringBackoff ??= engine.get(identity)?.pollInFlight;
+        clock.advance(ms);
+      },
+      engine,
+      timeoutMs: 10 * 60_000,
+    });
+
+    expect(seenDuringBackoff).toBe(false);
+  });
+
+  it("stops waiting the moment the caller aborts", async () => {
+    const clock = controlledClock();
+    const controller = new AbortController();
+    // A pacing clock that NEVER resolves, standing in for a long advertised
+    // floor. Without racing the signal, an aborted drive stays pending for the
+    // whole interval — on a task asking for 60s, a full minute after the
+    // caller gave up.
+    const drive = driveTaskToTerminal({
+      identity,
+      getTask: async () => ({ status: "working", pollIntervalMs: 60_000 }),
+      now: clock.now,
+      sleep: () => new Promise<void>(() => {}),
+      engine: new TaskLifecycleEngine({ now: clock.now }),
+      timeoutMs: 10 * 60_000,
+      signal: controller.signal,
+    });
+
+    await Promise.resolve();
+    controller.abort();
+    await expect(drive).resolves.toMatchObject({ outcome: "aborted" });
   });
 });

--- a/sdk/tests/task-await-driver.test.ts
+++ b/sdk/tests/task-await-driver.test.ts
@@ -502,4 +502,112 @@ describe("poll discipline", () => {
     controller.abort();
     await expect(drivePromise).resolves.toMatchObject({ outcome: "aborted" });
   });
+
+  it("fetches the legacy result rather than reporting a payload-less success", async () => {
+    const clock = controlledClock();
+    const legacy = { serverId: "srv", wire: "legacy", taskId: "t1" } as const;
+    // 2025-11-25 returns only STATUS from `tasks/get`; the payload lives behind
+    // a separate `tasks/result`. Without the seam every successful legacy drive
+    // handed automation `result === undefined`, which for an eval is the same
+    // as having failed.
+    const result = await driveTaskToTerminal({
+      identity: legacy,
+      getTask: async () => ({ status: "completed" }),
+      getResult: async () => ({ content: [{ type: "text", text: "done" }] }),
+      now: clock.now,
+      sleep: async (ms) => clock.advance(ms),
+      engine: new TaskLifecycleEngine({ now: clock.now }),
+      timeoutMs: 10 * 60_000,
+    });
+    expect(result.outcome).toBe("completed");
+    expect(result.task?.result).toEqual({
+      content: [{ type: "text", text: "done" }],
+    });
+  });
+
+  it("still reports a legacy task completed when its result cannot be fetched", async () => {
+    const clock = controlledClock();
+    const legacy = { serverId: "srv", wire: "legacy", taskId: "t1" } as const;
+    const result = await driveTaskToTerminal({
+      identity: legacy,
+      getTask: async () => ({ status: "completed" }),
+      getResult: async () => {
+        throw new Error("tasks/result failed");
+      },
+      now: clock.now,
+      sleep: async (ms) => clock.advance(ms),
+      engine: new TaskLifecycleEngine({ now: clock.now }),
+      timeoutMs: 10 * 60_000,
+    });
+    // The task finished whether or not we could read what it produced —
+    // reporting `failed` would be a lie about the server. The caller learns the
+    // payload is missing rather than empty.
+    expect(result.outcome).toBe("completed");
+    expect(result.task?.result).toBeUndefined();
+    expect((result.lastError as Error).message).toMatch(/tasks\/result failed/);
+  });
+
+  it("names the wiring gap when a legacy drive has no result seam", async () => {
+    const clock = controlledClock();
+    const legacy = { serverId: "srv", wire: "legacy", taskId: "t1" } as const;
+    const result = await driveTaskToTerminal({
+      identity: legacy,
+      getTask: async () => ({ status: "completed" }),
+      now: clock.now,
+      sleep: async (ms) => clock.advance(ms),
+      engine: new TaskLifecycleEngine({ now: clock.now }),
+      timeoutMs: 10 * 60_000,
+    });
+    expect(result.outcome).toBe("completed");
+    expect((result.lastError as Error).message).toMatch(/tasks\/result/);
+  });
+
+  it("does not short-circuit a RESTORED terminal in a shared engine", async () => {
+    const clock = controlledClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    // Storage keeps a task's status, never its payload. A drive attaching to a
+    // shared engine that holds a restored `completed` must still read once, or
+    // it reports success with no result — the reload bug reached through the
+    // automation door instead of the UI one.
+    engine.register(identity, { restored: true, status: "completed" });
+
+    let reads = 0;
+    const result = await driveTaskToTerminal({
+      identity,
+      getTask: async () => {
+        reads += 1;
+        return { status: "completed", result: { ok: true } };
+      },
+      now: clock.now,
+      sleep: async (ms) => clock.advance(ms),
+      engine,
+      timeoutMs: 10 * 60_000,
+    });
+    expect(reads).toBe(1);
+    expect(result.outcome).toBe("completed");
+    expect(result.task?.result).toEqual({ ok: true });
+  });
+
+  it("short-circuits a terminal that was actually observed", async () => {
+    const clock = controlledClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    engine.observe(identity, { status: "completed", result: { ok: true } });
+
+    let reads = 0;
+    const result = await driveTaskToTerminal({
+      identity,
+      getTask: async () => {
+        reads += 1;
+        return { status: "completed" };
+      },
+      now: clock.now,
+      sleep: async (ms) => clock.advance(ms),
+      engine,
+      timeoutMs: 10 * 60_000,
+    });
+    // Nothing is owed here: the payload is already in hand, so re-reading it
+    // would be a request against a server that already answered.
+    expect(reads).toBe(0);
+    expect(result.task?.result).toEqual({ ok: true });
+  });
 });

--- a/sdk/tests/task-await-driver.test.ts
+++ b/sdk/tests/task-await-driver.test.ts
@@ -423,7 +423,7 @@ describe("poll discipline", () => {
       release = resolve;
     });
 
-    const drive = driveTaskToTerminal({
+    const drivePromise = driveTaskToTerminal({
       identity,
       // The read is SLOWER than the advertised floor, which is the case a
       // time-only reservation cannot cover: `reserve` pushes the due time by
@@ -446,7 +446,7 @@ describe("poll discipline", () => {
     expect(engine.get(identity)?.pollInFlight).toBe(true);
 
     release({ status: "completed", result: {} });
-    const result = await drive;
+    const result = await drivePromise;
     expect(result.outcome).toBe("completed");
     // Released on the way out, so the handle is not parked forever on an
     // engine that outlives this drive.
@@ -488,7 +488,7 @@ describe("poll discipline", () => {
     // floor. Without racing the signal, an aborted drive stays pending for the
     // whole interval — on a task asking for 60s, a full minute after the
     // caller gave up.
-    const drive = driveTaskToTerminal({
+    const drivePromise = driveTaskToTerminal({
       identity,
       getTask: async () => ({ status: "working", pollIntervalMs: 60_000 }),
       now: clock.now,
@@ -500,6 +500,6 @@ describe("poll discipline", () => {
 
     await Promise.resolve();
     controller.abort();
-    await expect(drive).resolves.toMatchObject({ outcome: "aborted" });
+    await expect(drivePromise).resolves.toMatchObject({ outcome: "aborted" });
   });
 });

--- a/sdk/tests/task-await-driver.test.ts
+++ b/sdk/tests/task-await-driver.test.ts
@@ -1,0 +1,415 @@
+/**
+ * `await` mode (`src/mcp-client-manager/task-await-driver.ts`).
+ *
+ * The point of these is that the drive **always terminates**, and that it does
+ * so through a named outcome rather than by running out of evaluation budget.
+ * The one the plan calls out specifically: a task needing human input nobody
+ * can supply must return `input-required`, not hang.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  driveTaskToTerminal,
+  type TaskAwaitResult,
+} from "../src/mcp-client-manager/task-await-driver.js";
+import {
+  TaskLifecycleEngine,
+  type TaskLifecycleIdentity,
+  type TaskLifecycleObservation,
+} from "../src/mcp-client-manager/task-lifecycle.js";
+import type { ClientCapabilityOptions } from "../src/mcp-client-manager/types.js";
+
+const identity: TaskLifecycleIdentity = {
+  serverId: "srv",
+  wire: "extension",
+  taskId: "t1",
+};
+
+/** A clock the driver's injected `sleep` advances, so nothing waits for real. */
+function controlledClock(start = 1_000_000) {
+  let current = start;
+  return {
+    now: () => current,
+    sleep: async (ms: number) => {
+      current += ms;
+    },
+    advance: (ms: number) => {
+      current += ms;
+    },
+  };
+}
+
+/** Answers `getTask` from a scripted sequence, repeating the last entry. */
+function scriptedReads(sequence: TaskLifecycleObservation[]) {
+  let index = 0;
+  const calls: number[] = [];
+  return {
+    calls,
+    getTask: async () => {
+      calls.push(index);
+      const value = sequence[Math.min(index, sequence.length - 1)];
+      index += 1;
+      return value;
+    },
+  };
+}
+
+const working: TaskLifecycleObservation = {
+  status: "working",
+  pollIntervalMs: 1_000,
+};
+
+async function drive(
+  overrides: Partial<Parameters<typeof driveTaskToTerminal>[0]> = {},
+  clock = controlledClock(),
+): Promise<TaskAwaitResult> {
+  return driveTaskToTerminal({
+    identity,
+    getTask: async () => working,
+    now: clock.now,
+    sleep: clock.sleep,
+    engine: new TaskLifecycleEngine({ now: clock.now }),
+    ...overrides,
+  });
+}
+
+describe("terminal outcomes", () => {
+  it("returns completed with the inline result", async () => {
+    const result = await drive({
+      getTask: async () => ({
+        status: "completed",
+        result: { content: [{ type: "text", text: "done" }] },
+      }),
+    });
+    expect(result.outcome).toBe("completed");
+    expect(result.task?.result).toEqual({
+      content: [{ type: "text", text: "done" }],
+    });
+  });
+
+  it("treats a tool result with isError as COMPLETED, not failed", async () => {
+    // `failed` is only for JSON-RPC faults (tasks.md:837). Reporting a tool's
+    // own error as a protocol failure would misattribute it.
+    const result = await drive({
+      getTask: async () => ({
+        status: "completed",
+        result: { content: [], isError: true },
+      }),
+    });
+    expect(result.outcome).toBe("completed");
+  });
+
+  it("returns failed for a JSON-RPC fault", async () => {
+    const result = await drive({
+      getTask: async () => ({
+        status: "failed",
+        error: { code: -32000, message: "boom" },
+      }),
+    });
+    expect(result.outcome).toBe("failed");
+    expect(result.task?.error).toEqual({ code: -32000, message: "boom" });
+  });
+
+  it("returns cancelled", async () => {
+    const result = await drive({
+      getTask: async () => ({ status: "cancelled" }),
+    });
+    expect(result.outcome).toBe("cancelled");
+  });
+
+  it("polls until the task finishes", async () => {
+    const clock = controlledClock();
+    const reads = scriptedReads([
+      working,
+      working,
+      { status: "completed", result: {} },
+    ]);
+    const result = await drive({ getTask: reads.getTask }, clock);
+    expect(result.outcome).toBe("completed");
+    expect(reads.calls).toHaveLength(3);
+  });
+});
+
+describe("bounded exits", () => {
+  it("returns input-required rather than hanging when nothing can answer", async () => {
+    const result = await drive({
+      getTask: async () => ({
+        status: "input_required",
+        inputRequests: { k: { method: "elicitation/create" } } as never,
+      }),
+    });
+    // The plan's TASK_INPUT_REQUIRED: deterministic, not a timeout.
+    expect(result.outcome).toBe("input-required");
+  });
+
+  it("returns input-required naming the keys it could not answer", async () => {
+    const result = await drive({
+      getTask: async () => ({
+        status: "input_required",
+        inputRequests: { k: { method: "sampling/createMessage" } } as never,
+      }),
+      updateTask: async () => {},
+      input: {
+        // Sampling was never declared, so this key is unanswerable.
+        declaredCapabilities: { elicitation: {} } as ClientCapabilityOptions,
+        handlers: { elicitation: async () => ({ action: "cancel" }) },
+      },
+    });
+    expect(result.outcome).toBe("input-required");
+    expect(result.unansweredInput?.[0]).toMatchObject({
+      inputKey: "k",
+      reason: "undeclared-capability",
+    });
+  });
+
+  it("times out on a task that never finishes", async () => {
+    const clock = controlledClock();
+    const result = await drive(
+      { getTask: async () => working, timeoutMs: 10_000 },
+      clock,
+    );
+    expect(result.outcome).toBe("timeout");
+  });
+
+  it("reports timeout immediately when the next poll would overshoot the deadline", async () => {
+    const clock = controlledClock();
+    const reads = scriptedReads([{ status: "working", pollIntervalMs: 60_000 }]);
+    const result = await drive(
+      { getTask: reads.getTask, timeoutMs: 5_000 },
+      clock,
+    );
+    expect(result.outcome).toBe("timeout");
+    // One read, then the deadline check — never a 60s sleep past the budget.
+    expect(reads.calls).toHaveLength(1);
+  });
+
+  it("retires the handle on a tasks/get -32602", async () => {
+    const result = await drive({
+      getTask: async () => {
+        throw { code: -32602, message: "unknown task" };
+      },
+    });
+    expect(result.outcome).toBe("expired");
+    expect(result.task?.status).toBe("expired");
+  });
+
+  it("gives up after the consecutive-error budget, carrying the last error", async () => {
+    const clock = controlledClock();
+    const error = new Error("connect refused");
+    const result = await drive(
+      {
+        getTask: async () => {
+          throw error;
+        },
+        maxConsecutiveErrors: 3,
+        timeoutMs: 10 * 60_000,
+      },
+      clock,
+    );
+    expect(result.outcome).toBe("unreachable");
+    expect(result.lastError).toBe(error);
+  });
+
+  it("recovers when a transient read failure is followed by a good one", async () => {
+    const clock = controlledClock();
+    let call = 0;
+    const result = await drive(
+      {
+        getTask: async () => {
+          call += 1;
+          if (call === 1) throw new Error("transient");
+          return { status: "completed", result: {} };
+        },
+        timeoutMs: 60_000,
+      },
+      clock,
+    );
+    expect(result.outcome).toBe("completed");
+  });
+
+  it("stops on an aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const result = await drive({ signal: controller.signal });
+    expect(result.outcome).toBe("aborted");
+  });
+});
+
+describe("input rounds", () => {
+  it("answers, updates, and continues to a terminal state", async () => {
+    const clock = controlledClock();
+    const updates: Array<Record<string, unknown>> = [];
+    let call = 0;
+    const result = await drive(
+      {
+        getTask: async () => {
+          call += 1;
+          if (call === 1) {
+            return {
+              status: "input_required",
+              inputRequests: {
+                k: { method: "elicitation/create", params: {} },
+              } as never,
+            };
+          }
+          return { status: "completed", result: { ok: true } };
+        },
+        updateTask: async (_id, responses) => {
+          updates.push(responses);
+        },
+        input: {
+          declaredCapabilities: { elicitation: {} } as ClientCapabilityOptions,
+          handlers: {
+            elicitation: async () => ({ action: "accept", content: {} }),
+          },
+        },
+        timeoutMs: 60_000,
+      },
+      clock,
+    );
+
+    expect(result.outcome).toBe("completed");
+    expect(updates).toEqual([{ k: { action: "accept", content: {} } }]);
+  });
+
+  it("does not re-answer a key once its update was acknowledged", async () => {
+    const clock = controlledClock();
+    const elicit = vi.fn(async () => ({ action: "accept", content: {} }));
+    let call = 0;
+    // The keyed snapshot is re-sent on every poll and `tasks/update` is
+    // eventually consistent, so the SAME key comes back on the next read.
+    await drive(
+      {
+        getTask: async () => {
+          call += 1;
+          if (call <= 2) {
+            return {
+              status: "input_required",
+              inputRequests: {
+                k: { method: "elicitation/create", params: {} },
+              } as never,
+            };
+          }
+          return { status: "completed", result: {} };
+        },
+        updateTask: async () => {},
+        input: {
+          declaredCapabilities: { elicitation: {} } as ClientCapabilityOptions,
+          handlers: { elicitation: elicit },
+        },
+        timeoutMs: 60_000,
+      },
+      clock,
+    );
+    expect(elicit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT mark a key answered when the update fails", async () => {
+    const clock = controlledClock();
+    const elicit = vi.fn(async () => ({ action: "accept", content: {} }));
+    let updateCalls = 0;
+    let call = 0;
+    await drive(
+      {
+        getTask: async () => {
+          call += 1;
+          if (call <= 2) {
+            return {
+              status: "input_required",
+              inputRequests: {
+                k: { method: "elicitation/create", params: {} },
+              } as never,
+            };
+          }
+          return { status: "completed", result: {} };
+        },
+        updateTask: async () => {
+          updateCalls += 1;
+          throw new Error("update rejected");
+        },
+        input: {
+          declaredCapabilities: { elicitation: {} } as ClientCapabilityOptions,
+          handlers: { elicitation: elicit },
+        },
+        timeoutMs: 60_000,
+      },
+      clock,
+    );
+    // The answer was NOT silently discarded: it is re-collected and retried.
+    expect(updateCalls).toBe(2);
+    expect(elicit).toHaveBeenCalledTimes(2);
+  });
+
+  it("caps input rounds so a server that keeps asking cannot run forever", async () => {
+    const clock = controlledClock();
+    const result = await drive(
+      {
+        getTask: async () => ({
+          status: "input_required",
+          // A fresh key every round, so dedupe never converges.
+          inputRequests: {
+            [`k${Math.random()}`]: { method: "elicitation/create", params: {} },
+          } as never,
+        }),
+        updateTask: async () => {},
+        input: {
+          declaredCapabilities: { elicitation: {} } as ClientCapabilityOptions,
+          handlers: {
+            elicitation: async () => ({ action: "accept", content: {} }),
+          },
+        },
+        maxInputRounds: 3,
+        timeoutMs: 10 * 60_000,
+      },
+      clock,
+    );
+    expect(result.outcome).toBe("input-required");
+  });
+});
+
+describe("poll discipline", () => {
+  it("honors the advertised floor between reads — automation gets no licence", async () => {
+    const clock = controlledClock();
+    const slept: number[] = [];
+    const reads = scriptedReads([
+      { status: "working", pollIntervalMs: 30_000 },
+      { status: "working", pollIntervalMs: 30_000 },
+      { status: "completed", result: {} },
+    ]);
+    await driveTaskToTerminal({
+      identity,
+      getTask: reads.getTask,
+      now: clock.now,
+      sleep: async (ms) => {
+        slept.push(ms);
+        clock.advance(ms);
+      },
+      engine: new TaskLifecycleEngine({ now: clock.now }),
+      timeoutMs: 10 * 60_000,
+    });
+    expect(slept.every((ms) => ms >= 30_000)).toBe(true);
+  });
+
+  it("follows a poll interval that changes mid-task", async () => {
+    const clock = controlledClock();
+    const slept: number[] = [];
+    const reads = scriptedReads([
+      { status: "working", pollIntervalMs: 20_000 },
+      { status: "working", pollIntervalMs: 2_000 },
+      { status: "completed", result: {} },
+    ]);
+    await driveTaskToTerminal({
+      identity,
+      getTask: reads.getTask,
+      now: clock.now,
+      sleep: async (ms) => {
+        slept.push(ms);
+        clock.advance(ms);
+      },
+      engine: new TaskLifecycleEngine({ now: clock.now }),
+      timeoutMs: 10 * 60_000,
+    });
+    // A shrinking floor is normal and is followed, not flagged.
+    expect(slept).toEqual([20_000, 2_000]);
+  });
+});

--- a/sdk/tests/task-created-event.test.ts
+++ b/sdk/tests/task-created-event.test.ts
@@ -132,4 +132,58 @@ describe("failure handling", () => {
     await sink.dispatch(event);
     expect(after).toHaveBeenCalled();
   });
+
+  it("keeps running the remaining consumers past a FUNCTIONAL failure", async () => {
+    // The best-effort case above passed while this one did not: dispatch threw
+    // from inside the loop, so a tracker write that failed took the stream part
+    // and the registry record down with it, in registration order.
+    const stream = vi.fn();
+    const registry = vi.fn();
+    const sink = new TaskCreatedSink();
+    sink.register({
+      name: "tracker",
+      handle: () => {
+        throw new Error("localStorage unavailable");
+      },
+    });
+    sink.register({ name: "stream", handle: stream });
+    sink.register({ name: "registry", bestEffort: true, handle: registry });
+
+    await expect(sink.dispatch(event)).rejects.toThrow(
+      "localStorage unavailable"
+    );
+    expect(stream).toHaveBeenCalled();
+    expect(registry).toHaveBeenCalled();
+  });
+
+  it("reports every functional failure when more than one fails", async () => {
+    const sink = new TaskCreatedSink();
+    sink.register({
+      name: "tracker",
+      handle: () => {
+        throw new Error("tracker down");
+      },
+    });
+    sink.register({
+      name: "stream",
+      handle: () => {
+        throw new Error("stream closed");
+      },
+    });
+    sink.register({
+      name: "registry",
+      bestEffort: true,
+      handle: () => {
+        throw new Error("registry down");
+      },
+    });
+
+    const failure = await sink.dispatch(event).catch((error) => error);
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect(failure.message).toContain("tracker, stream");
+    expect((failure as AggregateError).errors.map((e: Error) => e.message)).toEqual([
+      "tracker down",
+      "stream closed",
+    ]);
+  });
 });

--- a/sdk/tests/task-created-event.test.ts
+++ b/sdk/tests/task-created-event.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The task-creation fan-out (`src/mcp-client-manager/task-created-event.ts`).
+ *
+ * The rule under test is the asymmetry: durable tracking and client delivery
+ * are FUNCTIONAL paths whose failure must surface, while the hosted registry
+ * is a recovery index whose failure must never turn a successful tool call
+ * into a failed one.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  TaskCreatedSink,
+  type TaskCreatedEvent,
+} from "../src/mcp-client-manager/task-created-event.js";
+
+const event: TaskCreatedEvent = {
+  identity: { serverId: "srv", wire: "extension", taskId: "t1" },
+  wire: "extension",
+  surface: "chat",
+  createdAt: "2026-07-28T00:00:00Z",
+  ttlMs: null,
+  toolName: "long_running",
+};
+
+describe("fan-out", () => {
+  it("delivers to every consumer, in registration order", async () => {
+    const order: string[] = [];
+    const sink = new TaskCreatedSink();
+    sink.register({ name: "tracker", handle: () => void order.push("tracker") });
+    sink.register({ name: "stream", handle: () => void order.push("stream") });
+    sink.register({
+      name: "registry",
+      bestEffort: true,
+      handle: () => void order.push("registry"),
+    });
+
+    await sink.dispatch(event);
+    // Durable local tracking lands before anything remote, so a hung registry
+    // write cannot cost the user their handle.
+    expect(order).toEqual(["tracker", "stream", "registry"]);
+  });
+
+  it("awaits async consumers rather than firing and forgetting", async () => {
+    let done = false;
+    const sink = new TaskCreatedSink();
+    sink.register({
+      name: "tracker",
+      handle: async () => {
+        await Promise.resolve();
+        done = true;
+      },
+    });
+    await sink.dispatch(event);
+    expect(done).toBe(true);
+  });
+
+  it("passes the handle through unchanged", async () => {
+    const spy = vi.fn();
+    const sink = new TaskCreatedSink();
+    sink.register({ name: "analytics", handle: spy });
+    await sink.dispatch(event);
+    expect(spy).toHaveBeenCalledWith(event);
+  });
+
+  it("unregisters", async () => {
+    const spy = vi.fn();
+    const sink = new TaskCreatedSink();
+    const off = sink.register({ name: "x", handle: spy });
+    off();
+    await sink.dispatch(event);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe("failure handling", () => {
+  it("degrades on a best-effort failure instead of failing the call", async () => {
+    const sink = new TaskCreatedSink();
+    const failure = new Error("registry unreachable");
+    sink.register({
+      name: "registry",
+      bestEffort: true,
+      handle: () => {
+        throw failure;
+      },
+    });
+
+    // The task is running on the server whether or not we recorded a recovery
+    // row for it. Throwing here would tell the user their call failed.
+    const result = await sink.dispatch(event);
+    expect(result.degraded).toEqual([{ name: "registry", error: failure }]);
+  });
+
+  it("reports a best-effort failure rather than swallowing it", async () => {
+    const sink = new TaskCreatedSink();
+    sink.register({
+      name: "registry",
+      bestEffort: true,
+      handle: async () => {
+        throw new Error("timeout");
+      },
+    });
+    const { degraded } = await sink.dispatch(event);
+    expect(degraded).toHaveLength(1);
+    expect(degraded[0].name).toBe("registry");
+  });
+
+  it("propagates a functional-path failure — a lost handle is not degradation", async () => {
+    const sink = new TaskCreatedSink();
+    sink.register({
+      name: "tracker",
+      handle: () => {
+        throw new Error("localStorage unavailable");
+      },
+    });
+    await expect(sink.dispatch(event)).rejects.toThrow(
+      "localStorage unavailable",
+    );
+  });
+
+  it("keeps running the remaining consumers past a best-effort failure", async () => {
+    const after = vi.fn();
+    const sink = new TaskCreatedSink();
+    sink.register({
+      name: "registry",
+      bestEffort: true,
+      handle: () => {
+        throw new Error("nope");
+      },
+    });
+    sink.register({ name: "analytics", bestEffort: true, handle: after });
+
+    await sink.dispatch(event);
+    expect(after).toHaveBeenCalled();
+  });
+});

--- a/sdk/tests/task-input-driver.test.ts
+++ b/sdk/tests/task-input-driver.test.ts
@@ -1,0 +1,314 @@
+/**
+ * The `input_required` driver (`src/mcp-client-manager/task-input-driver.ts`).
+ *
+ * The property under test throughout: a task's input channel is not more
+ * trusted than a direct server→client request. Everything the standalone path
+ * would refuse — an undeclared capability, an unrenderable elicitation mode,
+ * content that fails its own `requestedSchema` — is refused here too, and
+ * refused *visibly* rather than being silently marked handled.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  canDeclareTasksExtension,
+  collectTaskInputResponses,
+  readDeclaredInputCapabilities,
+  type TaskInputHandlers,
+} from "../src/mcp-client-manager/task-input-driver.js";
+import type { ClientCapabilityOptions } from "../src/mcp-client-manager/types.js";
+
+const ALL_CAPS = {
+  elicitation: {},
+  roots: {},
+  sampling: {},
+} as ClientCapabilityOptions;
+
+function handlers(overrides: Partial<TaskInputHandlers> = {}): TaskInputHandlers {
+  return {
+    elicitation: async () => ({ action: "accept", content: {} }),
+    roots: async () => ({ roots: [] }),
+    sampling: async () => ({
+      role: "assistant",
+      content: { type: "text", text: "ok" },
+      model: "test",
+    }),
+    ...overrides,
+  };
+}
+
+const collect = (args: {
+  inputRequests: Record<string, unknown>;
+  declaredCapabilities?: ClientCapabilityOptions;
+  handlers?: TaskInputHandlers;
+  respondedKeys?: Set<string>;
+  validateElicitationContent?: (
+    schema: unknown,
+    content: unknown
+  ) => { valid: boolean; error?: string };
+  limits?: { maxRequests?: number; maxResponsesPerUpdate?: number };
+}) =>
+  collectTaskInputResponses({
+    options: {
+      declaredCapabilities: args.declaredCapabilities ?? ALL_CAPS,
+      handlers: args.handlers ?? handlers(),
+      validateElicitationContent: args.validateElicitationContent,
+      limits: args.limits,
+    },
+    taskId: "task-1",
+    serverId: "srv",
+    inputRequests: args.inputRequests as never,
+    respondedKeys: args.respondedKeys,
+  });
+
+describe("all three extension input methods", () => {
+  it("routes elicitation, roots, and sampling through their declared handlers", async () => {
+    const seen: string[] = [];
+    const result = await collect({
+      inputRequests: {
+        e: { method: "elicitation/create", params: { message: "hi" } },
+        r: { method: "roots/list" },
+        s: { method: "sampling/createMessage", params: { messages: [] } },
+      },
+      handlers: handlers({
+        elicitation: async () => {
+          seen.push("elicitation");
+          return { action: "accept", content: {} };
+        },
+        roots: async () => {
+          seen.push("roots");
+          return { roots: [] };
+        },
+        sampling: async () => {
+          seen.push("sampling");
+          return { role: "assistant", content: { type: "text", text: "" }, model: "m" };
+        },
+      }),
+    });
+
+    expect(seen.sort()).toEqual(["elicitation", "roots", "sampling"]);
+    expect(result.answeredKeys.sort()).toEqual(["e", "r", "s"]);
+    expect(result.rejections).toEqual([]);
+  });
+
+  it("passes the task and key context to the handler, so a handler can attribute the prompt", async () => {
+    const spy = vi.fn(async () => ({ action: "accept", content: {} }));
+    await collect({
+      inputRequests: { k: { method: "elicitation/create", params: {} } },
+      handlers: handlers({ elicitation: spy }),
+    });
+    expect(spy).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ taskId: "task-1", serverId: "srv", inputKey: "k" })
+    );
+  });
+});
+
+describe("trust rules match the standalone path", () => {
+  it("refuses a method the client never declared, and says so", async () => {
+    const result = await collect({
+      inputRequests: { s: { method: "sampling/createMessage" } },
+      declaredCapabilities: { elicitation: {} } as ClientCapabilityOptions,
+    });
+
+    expect(result.answeredKeys).toEqual([]);
+    expect(result.rejections).toEqual([
+      expect.objectContaining({
+        inputKey: "s",
+        method: "sampling/createMessage",
+        reason: "undeclared-capability",
+      }),
+    ]);
+  });
+
+  it("distinguishes 'we never declared it' from 'we declared it and forgot the handler'", async () => {
+    const result = await collect({
+      inputRequests: { r: { method: "roots/list" } },
+      declaredCapabilities: ALL_CAPS,
+      handlers: handlers({ roots: undefined }),
+    });
+    expect(result.rejections[0]).toMatchObject({ reason: "no-handler" });
+  });
+
+  it("refuses an elicitation mode this client cannot render", async () => {
+    const result = await collect({
+      inputRequests: {
+        k: { method: "elicitation/create", params: { mode: "telepathy" } },
+      },
+    });
+    expect(result.rejections[0]).toMatchObject({
+      reason: "unsupported-elicitation-mode",
+    });
+  });
+
+  it("validates accepted elicitation content against its own requestedSchema", async () => {
+    const result = await collect({
+      inputRequests: {
+        k: {
+          method: "elicitation/create",
+          params: { requestedSchema: { type: "object" } },
+        },
+      },
+      handlers: handlers({
+        elicitation: async () => ({ action: "accept", content: { bad: 1 } }),
+      }),
+      validateElicitationContent: () => ({ valid: false, error: "nope" }),
+    });
+    expect(result.answeredKeys).toEqual([]);
+    expect(result.rejections[0]).toMatchObject({ reason: "malformed-request" });
+  });
+
+  it("does not schema-check a decline — a decline is a response, not content", async () => {
+    const validate = vi.fn(() => ({ valid: false, error: "unreachable" }));
+    const result = await collect({
+      inputRequests: {
+        k: {
+          method: "elicitation/create",
+          params: { requestedSchema: { type: "object" } },
+        },
+      },
+      handlers: handlers({ elicitation: async () => ({ action: "decline" }) }),
+      validateElicitationContent: validate,
+    });
+    expect(validate).not.toHaveBeenCalled();
+    expect(result.answeredKeys).toEqual(["k"]);
+  });
+
+  it("rejects an unrecognized method rather than forwarding it", async () => {
+    const result = await collect({
+      inputRequests: { k: { method: "tools/call" } },
+    });
+    expect(result.rejections[0]).toMatchObject({
+      reason: "unsupported-method",
+      method: "tools/call",
+    });
+  });
+});
+
+describe("partial answering", () => {
+  it("answers what it can and keeps the rest visible — one bad key never stalls the task", async () => {
+    const result = await collect({
+      inputRequests: {
+        ok: { method: "elicitation/create", params: {} },
+        bad: { method: "sampling/createMessage" },
+      },
+      declaredCapabilities: { elicitation: {} } as ClientCapabilityOptions,
+    });
+
+    expect(result.answeredKeys).toEqual(["ok"]);
+    expect(Object.keys(result.responses)).toEqual(["ok"]);
+    expect(result.rejections).toHaveLength(1);
+  });
+
+  it("never re-prompts a key an earlier update already acknowledged", async () => {
+    const spy = vi.fn(async () => ({ action: "accept", content: {} }));
+    const result = await collect({
+      inputRequests: {
+        done: { method: "elicitation/create", params: {} },
+        fresh: { method: "elicitation/create", params: {} },
+      },
+      handlers: handlers({ elicitation: spy }),
+      respondedKeys: new Set(["done"]),
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result.answeredKeys).toEqual(["fresh"]);
+    expect(result.alreadyAnsweredKeys).toEqual(["done"]);
+  });
+
+  it("surfaces a throwing handler as a rejection instead of failing the whole round", async () => {
+    const result = await collect({
+      inputRequests: {
+        boom: { method: "elicitation/create", params: {} },
+        fine: { method: "roots/list" },
+      },
+      handlers: handlers({
+        elicitation: async () => {
+          throw new Error("user closed the dialog");
+        },
+      }),
+    });
+    expect(result.answeredKeys).toEqual(["fine"]);
+    expect(result.rejections[0]).toMatchObject({
+      reason: "handler-failed",
+      message: "user closed the dialog",
+    });
+  });
+});
+
+describe("hostile input", () => {
+  it("treats a prototype-polluting key as an ordinary key", async () => {
+    const result = await collect({
+      inputRequests: JSON.parse(
+        '{"__proto__":{"method":"elicitation/create"},"constructor":{"method":"roots/list"}}'
+      ),
+    });
+    // Both are answered as data. Nothing on Object.prototype was touched.
+    expect(result.answeredKeys.sort()).toEqual(["__proto__", "constructor"]);
+    expect(({} as Record<string, unknown>).method).toBeUndefined();
+  });
+
+  it("caps the number of requests it will process and reports the overflow", async () => {
+    const inputRequests: Record<string, unknown> = {};
+    for (let i = 0; i < 10; i += 1) {
+      inputRequests[`k${i}`] = { method: "elicitation/create", params: {} };
+    }
+    const result = await collect({ inputRequests, limits: { maxRequests: 3 } });
+
+    expect(result.answeredKeys).toHaveLength(3);
+    // The dropped keys are REPORTED, never silently discarded.
+    expect(result.rejections).toHaveLength(7);
+    expect(result.rejections.every((r) => r.reason === "limit-exceeded")).toBe(true);
+  });
+
+  it("stops at the per-update response cap and leaves the remainder for a later round", async () => {
+    const inputRequests: Record<string, unknown> = {};
+    for (let i = 0; i < 5; i += 1) {
+      inputRequests[`k${i}`] = { method: "elicitation/create", params: {} };
+    }
+    const result = await collect({
+      inputRequests,
+      limits: { maxResponsesPerUpdate: 2 },
+    });
+    expect(result.answeredKeys).toHaveLength(2);
+    expect(result.rejections).toEqual([]);
+  });
+
+  it("rejects a non-object request entry", async () => {
+    const result = await collect({ inputRequests: { k: "not-an-object" } });
+    expect(result.rejections[0]).toMatchObject({ reason: "malformed-request" });
+  });
+});
+
+describe("declaration eligibility", () => {
+  it("reads declared capabilities off the exact object handed to the client", () => {
+    expect(readDeclaredInputCapabilities(ALL_CAPS)).toEqual({
+      elicitation: true,
+      roots: true,
+      sampling: true,
+    });
+    expect(readDeclaredInputCapabilities(undefined)).toEqual({
+      elicitation: false,
+      roots: false,
+      sampling: false,
+    });
+    // A non-object capability value is not a declaration.
+    expect(
+      readDeclaredInputCapabilities({ elicitation: true } as never).elicitation
+    ).toBe(false);
+  });
+
+  it("refuses to let a surface declare tasks when a declared capability has no handler", () => {
+    expect(canDeclareTasksExtension(ALL_CAPS, handlers())).toEqual({ ok: true });
+    expect(
+      canDeclareTasksExtension(ALL_CAPS, handlers({ sampling: undefined }))
+    ).toEqual({ ok: false, missing: ["sampling/createMessage"] });
+  });
+
+  it("allows declaring tasks when a capability is absent AND unhandled — nothing to strand", () => {
+    expect(
+      canDeclareTasksExtension({ elicitation: {} } as ClientCapabilityOptions, {
+        elicitation: async () => ({ action: "cancel" }),
+      })
+    ).toEqual({ ok: true });
+  });
+});

--- a/sdk/tests/task-lifecycle.test.ts
+++ b/sdk/tests/task-lifecycle.test.ts
@@ -165,15 +165,83 @@ describe("poll interval resolution", () => {
     }
   });
 
-  it("clamps a hostile pollIntervalMs to the maximum so a task cannot be parked forever", () => {
+  it("does NOT clamp a long server floor — the cap governs only local terms", () => {
     const clock = fakeClock();
     const engine = new TaskLifecycleEngine({
       now: clock.now,
       maximumIntervalMs: 60_000,
     });
     const id = identity("t1");
-    engine.observe(id, { status: "working", pollIntervalMs: 999_999_999 });
-    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(60_000);
+    // A server asking to be polled every ten minutes has said something we are
+    // obliged to respect. Clamping to a local 60s would mean polling ten times
+    // more often than instructed — a deliberate SHOULD violation. The tradeoff
+    // is accepted: a task parked by an absurd floor is still refreshable by
+    // hand, and its handle is still tracked.
+    engine.observe(id, { status: "working", pollIntervalMs: 600_000 });
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(600_000);
+  });
+
+  it("does NOT clamp a Retry-After longer than the maximum interval", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      maximumIntervalMs: 60_000,
+    });
+    const id = identity("t1");
+    engine.observe(id, { status: "working" });
+    engine.applyRetryAfter(id, 600_000);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(600_000);
+
+    // And it still decays with real time rather than staying pinned: 50s of
+    // the hint remain, which is below the cap but above every local term.
+    clock.advance(550_000);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(50_000);
+  });
+
+  it("still clamps the LOCAL terms — a runaway backoff cannot park a task", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      maximumIntervalMs: 5_000,
+      errorBackoffBaseMs: 1_000,
+      errorBackoffMaxMs: 10 * 60_000,
+    });
+    const id = identity("t1");
+    for (let i = 0; i < 20; i += 1) engine.observeError(id);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(5_000);
+  });
+
+  it("treats a non-finite user minimum as zero rather than poisoning the schedule", () => {
+    const clock = fakeClock();
+    // `Math.max(0, NaN)` is NaN, and a NaN interval makes every `nextPollAt`
+    // comparison false — one malformed preference would silently stop ALL
+    // polling instead of failing loudly.
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      userMinimumIntervalMs: Number.NaN,
+      absoluteFloorMs: 250,
+    });
+    const id = identity("t1");
+    engine.observe(id, { status: "working" });
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(250);
+    expect(Number.isFinite(engine.get(id)!.nextPollAt)).toBe(true);
+
+    engine.setUserMinimumIntervalMs(Number.NaN);
+    expect(Number.isFinite(engine.get(id)!.nextPollAt)).toBe(true);
+  });
+
+  it("a slower preference never shortens a wait the server asked for", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "working" });
+    engine.applyRetryAfter(id, 120_000);
+    const reserved = engine.get(id)!.nextPollAt;
+
+    // Recomputing from `lastObservedAt` would land in the past here, punching
+    // straight through the Retry-After.
+    engine.setUserMinimumIntervalMs(1_000);
+    expect(engine.get(id)!.nextPollAt).toBeGreaterThanOrEqual(reserved);
   });
 });
 
@@ -353,6 +421,73 @@ describe("state transitions", () => {
     clock.advance(1_000_000);
     expect(engine.due()).toEqual([]);
     expect(terminal).toEqual(["expired"]);
+  });
+});
+
+describe("terminal finality", () => {
+  it("ignores a late poll that would reanimate a terminal task", () => {
+    const engine = new TaskLifecycleEngine();
+    const id = identity("t1");
+    // A notification lands first; the poll that was already in flight lands
+    // after it. Applying the stale poll would revert completed UI to working.
+    engine.observe(
+      id,
+      { status: "completed", result: { ok: true } },
+      "notification",
+    );
+    engine.observe(id, { status: "working" }, "poll");
+
+    expect(engine.get(id)!.status).toBe("completed");
+    expect(engine.get(id)!.result).toEqual({ ok: true });
+  });
+
+  it("still advances the observation clock for a late poll", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "completed", result: {} });
+    const first = engine.get(id)!.lastObservedAt;
+
+    clock.advance(5_000);
+    engine.observe(id, { status: "working" });
+    // The handle demonstrably still exists, which is what the retention clock
+    // cares about — even though its state is final.
+    expect(engine.get(id)!.lastObservedAt).toBeGreaterThan(first!);
+  });
+});
+
+describe("observation bookkeeping", () => {
+  it("lets a server clear a status message by omitting it", () => {
+    const engine = new TaskLifecycleEngine();
+    const id = identity("t1");
+    engine.observe(id, { status: "working", statusMessage: "step 1 of 3" });
+    expect(engine.get(id)!.statusMessage).toBe("step 1 of 3");
+
+    // An observation is a FULL snapshot: omitting the field clears it, rather
+    // than leaving a stale message describing a resolved condition.
+    engine.observe(id, { status: "working" });
+    expect(engine.get(id)!.statusMessage).toBeUndefined();
+  });
+
+  it("a notification does not clear the POLL path's backoff", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      errorBackoffBaseMs: 1_000,
+    });
+    const id = identity("t1");
+    engine.observeError(id);
+    engine.observeError(id);
+    expect(engine.get(id)!.consecutiveErrors).toBe(2);
+
+    // Notifications arrive on a different channel; one says nothing about
+    // whether `tasks/get` recovered.
+    engine.observe(id, { status: "working" }, "notification");
+    expect(engine.get(id)!.consecutiveErrors).toBe(2);
+
+    // A successful READ is what proves it.
+    engine.observe(id, { status: "working" }, "poll");
+    expect(engine.get(id)!.consecutiveErrors).toBe(0);
   });
 });
 

--- a/sdk/tests/task-lifecycle.test.ts
+++ b/sdk/tests/task-lifecycle.test.ts
@@ -65,6 +65,71 @@ describe("identity", () => {
 });
 
 describe("poll interval resolution", () => {
+  it("lets a LOWERED user minimum shorten a wait it caused", () => {
+    const clock = { at: 1_000 };
+    const engine = new TaskLifecycleEngine({
+      now: () => clock.at,
+      userMinimumIntervalMs: 60_000,
+    });
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
+    expect(engine.get(identity)!.nextPollAt).toBe(clock.at + 60_000);
+
+    // A blanket "never earlier" kept the superseded preference as if it were a
+    // server wait: the task stayed parked for the rest of its old 60s, so the
+    // new setting did nothing until it happened to come due.
+    engine.setUserMinimumIntervalMs(1_000);
+    // Back down to the SERVER's floor, not to the user's 1s — the preference
+    // is one `max` term, never permission to poll faster than asked.
+    expect(engine.get(identity)!.nextPollAt).toBe(clock.at + 2_000);
+  });
+
+  it("does not let a lowered minimum punch through a Retry-After", () => {
+    const clock = { at: 1_000 };
+    const engine = new TaskLifecycleEngine({
+      now: () => clock.at,
+      userMinimumIntervalMs: 60_000,
+    });
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
+    engine.applyRetryAfter(identity, 120_000);
+    const deadline = engine.get(identity)!.nextPollAt;
+
+    // A wait the SERVER imposed is absolute and survives the recompute; only
+    // the part the old preference caused is recoverable.
+    engine.setUserMinimumIntervalMs(1_000);
+    expect(engine.get(identity)!.nextPollAt).toBe(deadline);
+  });
+
+  it("does not let a lowered minimum walk through an error backoff", () => {
+    const clock = { at: 1_000 };
+    const engine = new TaskLifecycleEngine({
+      now: () => clock.at,
+      userMinimumIntervalMs: 60_000,
+    });
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
+    clock.at += 60_000;
+    engine.observeError(identity);
+    const backedOffTo = engine.get(identity)!.nextPollAt;
+    expect(backedOffTo).toBeGreaterThan(clock.at);
+
+    engine.setUserMinimumIntervalMs(1_000);
+    expect(engine.get(identity)!.nextPollAt).toBe(backedOffTo);
+  });
+
   it("takes the MAXIMUM of the server floor and the user minimum, never the user's alone", () => {
     const clock = fakeClock();
     const engine = new TaskLifecycleEngine({
@@ -249,6 +314,35 @@ describe("poll interval resolution", () => {
 });
 
 describe("per-task scheduling", () => {
+  it("excludes a leased handle from `due` for the whole read", () => {
+    const clock = { at: 1_000 };
+    const engine = new TaskLifecycleEngine({ now: () => clock.at });
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "working", pollIntervalMs: 1_000 });
+
+    clock.at += 5_000;
+    expect(engine.due().map((r) => r.identity.taskId)).toEqual(["t1"]);
+
+    expect(engine.acquirePoll(identity)).toBe(true);
+    // A second acquirer is refused rather than dispatching on top of the
+    // first: two `tasks/get` in flight means the later reply wins even when it
+    // observed the older state.
+    expect(engine.acquirePoll(identity)).toBe(false);
+
+    // Time alone does NOT re-admit it. That is the whole difference between a
+    // lease and `reserve`: a read slower than its own floor would otherwise
+    // read as due again while still open.
+    clock.at += 10 * 60_000;
+    expect(engine.due()).toEqual([]);
+
+    engine.releasePoll(identity);
+    expect(engine.due().map((r) => r.identity.taskId)).toEqual(["t1"]);
+  });
+
   it("does not let a fast task drag a slow task below its own floor", () => {
     const clock = fakeClock();
     const engine = new TaskLifecycleEngine({ now: clock.now });
@@ -430,6 +524,42 @@ describe("state transitions", () => {
 });
 
 describe("terminal finality", () => {
+  it("applies the first observation to a RESTORED terminal handle", () => {
+    const engine = new TaskLifecycleEngine();
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    // Storage kept the status and nothing else — it never holds the payload,
+    // and on the extension wire the result rides inline on `tasks/get`, so
+    // this read is the only way the result is ever obtained.
+    engine.register(identity, { restored: true, status: "completed" });
+    engine.observe(identity, {
+      status: "completed",
+      result: { content: [{ type: "text", text: "done" }] },
+    });
+    expect(engine.get(identity)?.result).toEqual({
+      content: [{ type: "text", text: "done" }],
+    });
+    expect(engine.get(identity)?.restored).toBe(false);
+  });
+
+  it("still treats an OBSERVED terminal as final", () => {
+    const engine = new TaskLifecycleEngine();
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "completed", result: { a: 1 } });
+    // A poll issued before the terminal landed can answer after it. Applying
+    // it would revert a finished task's UI and scheduling to `working`.
+    engine.observe(identity, { status: "working" });
+    expect(engine.get(identity)?.status).toBe("completed");
+    expect(engine.get(identity)?.result).toEqual({ a: 1 });
+  });
+
   it("ignores a late poll that would reanimate a terminal task", () => {
     const engine = new TaskLifecycleEngine();
     const id = identity("t1");
@@ -595,136 +725,6 @@ describe("wire adapters", () => {
     expect(isUnknownTaskError({ error: { code: -32602 } })).toBe(true);
     expect(isUnknownTaskError({ code: -32003 })).toBe(false);
     expect(isUnknownTaskError(null)).toBe(false);
-  });
-
-  it("lets a LOWERED user minimum shorten a wait it caused", () => {
-    const clock = { at: 1_000 };
-    const engine = new TaskLifecycleEngine({
-      now: () => clock.at,
-      userMinimumIntervalMs: 60_000,
-    });
-    const identity = {
-      serverId: "s",
-      wire: "extension",
-      taskId: "t1",
-    } as const;
-    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
-    expect(engine.get(identity)!.nextPollAt).toBe(clock.at + 60_000);
-
-    // A blanket "never earlier" kept the superseded preference as if it were a
-    // server wait: the task stayed parked for the rest of its old 60s, so the
-    // new setting did nothing until it happened to come due.
-    engine.setUserMinimumIntervalMs(1_000);
-    // Back down to the SERVER's floor, not to the user's 1s — the preference
-    // is one `max` term, never permission to poll faster than asked.
-    expect(engine.get(identity)!.nextPollAt).toBe(clock.at + 2_000);
-  });
-
-  it("does not let a lowered minimum punch through a Retry-After", () => {
-    const clock = { at: 1_000 };
-    const engine = new TaskLifecycleEngine({
-      now: () => clock.at,
-      userMinimumIntervalMs: 60_000,
-    });
-    const identity = {
-      serverId: "s",
-      wire: "extension",
-      taskId: "t1",
-    } as const;
-    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
-    engine.applyRetryAfter(identity, 120_000);
-    const deadline = engine.get(identity)!.nextPollAt;
-
-    // A wait the SERVER imposed is absolute and survives the recompute; only
-    // the part the old preference caused is recoverable.
-    engine.setUserMinimumIntervalMs(1_000);
-    expect(engine.get(identity)!.nextPollAt).toBe(deadline);
-  });
-
-  it("does not let a lowered minimum walk through an error backoff", () => {
-    const clock = { at: 1_000 };
-    const engine = new TaskLifecycleEngine({
-      now: () => clock.at,
-      userMinimumIntervalMs: 60_000,
-    });
-    const identity = {
-      serverId: "s",
-      wire: "extension",
-      taskId: "t1",
-    } as const;
-    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
-    clock.at += 60_000;
-    engine.observeError(identity);
-    const backedOffTo = engine.get(identity)!.nextPollAt;
-    expect(backedOffTo).toBeGreaterThan(clock.at);
-
-    engine.setUserMinimumIntervalMs(1_000);
-    expect(engine.get(identity)!.nextPollAt).toBe(backedOffTo);
-  });
-
-  it("excludes a leased handle from `due` for the whole read", () => {
-    const clock = { at: 1_000 };
-    const engine = new TaskLifecycleEngine({ now: () => clock.at });
-    const identity = {
-      serverId: "s",
-      wire: "extension",
-      taskId: "t1",
-    } as const;
-    engine.observe(identity, { status: "working", pollIntervalMs: 1_000 });
-
-    clock.at += 5_000;
-    expect(engine.due().map((r) => r.identity.taskId)).toEqual(["t1"]);
-
-    expect(engine.acquirePoll(identity)).toBe(true);
-    // A second acquirer is refused rather than dispatching on top of the
-    // first: two `tasks/get` in flight means the later reply wins even when it
-    // observed the older state.
-    expect(engine.acquirePoll(identity)).toBe(false);
-
-    // Time alone does NOT re-admit it. That is the whole difference between a
-    // lease and `reserve`: a read slower than its own floor would otherwise
-    // read as due again while still open.
-    clock.at += 10 * 60_000;
-    expect(engine.due()).toEqual([]);
-
-    engine.releasePoll(identity);
-    expect(engine.due().map((r) => r.identity.taskId)).toEqual(["t1"]);
-  });
-
-  it("applies the first observation to a RESTORED terminal handle", () => {
-    const engine = new TaskLifecycleEngine();
-    const identity = {
-      serverId: "s",
-      wire: "extension",
-      taskId: "t1",
-    } as const;
-    // Storage kept the status and nothing else — it never holds the payload,
-    // and on the extension wire the result rides inline on `tasks/get`, so
-    // this read is the only way the result is ever obtained.
-    engine.register(identity, { restored: true, status: "completed" });
-    engine.observe(identity, {
-      status: "completed",
-      result: { content: [{ type: "text", text: "done" }] },
-    });
-    expect(engine.get(identity)?.result).toEqual({
-      content: [{ type: "text", text: "done" }],
-    });
-    expect(engine.get(identity)?.restored).toBe(false);
-  });
-
-  it("still treats an OBSERVED terminal as final", () => {
-    const engine = new TaskLifecycleEngine();
-    const identity = {
-      serverId: "s",
-      wire: "extension",
-      taskId: "t1",
-    } as const;
-    engine.observe(identity, { status: "completed", result: { a: 1 } });
-    // A poll issued before the terminal landed can answer after it. Applying
-    // it would revert a finished task's UI and scheduling to `working`.
-    engine.observe(identity, { status: "working" });
-    expect(engine.get(identity)?.status).toBe("completed");
-    expect(engine.get(identity)?.result).toEqual({ a: 1 });
   });
 
   it("parses Retry-After as both a delta and an HTTP date, and rejects garbage", () => {

--- a/sdk/tests/task-lifecycle.test.ts
+++ b/sdk/tests/task-lifecycle.test.ts
@@ -24,7 +24,10 @@ import {
   parseRetryAfterMs,
 } from "../src/mcp-client-manager/task-lifecycle-adapters.js";
 
-const identity = (taskId: string, overrides: Partial<TaskLifecycleIdentity> = {}): TaskLifecycleIdentity => ({
+const identity = (
+  taskId: string,
+  overrides: Partial<TaskLifecycleIdentity> = {}
+): TaskLifecycleIdentity => ({
   serverId: "srv",
   wire: "extension",
   taskId,
@@ -266,10 +269,12 @@ describe("per-task scheduling", () => {
     expect(engine.due().map((r) => r.identity.taskId)).toEqual(["fast"]);
 
     clock.advance(7_000);
-    expect(engine.due().map((r) => r.identity.taskId).sort()).toEqual([
-      "fast",
-      "slow",
-    ]);
+    expect(
+      engine
+        .due()
+        .map((r) => r.identity.taskId)
+        .sort()
+    ).toEqual(["fast", "slow"]);
   });
 
   it("gives a batch the SLOWEST member's floor, not the fastest", () => {
@@ -433,7 +438,7 @@ describe("terminal finality", () => {
     engine.observe(
       id,
       { status: "completed", result: { ok: true } },
-      "notification",
+      "notification"
     );
     engine.observe(id, { status: "working" }, "poll");
 
@@ -590,6 +595,71 @@ describe("wire adapters", () => {
     expect(isUnknownTaskError({ error: { code: -32602 } })).toBe(true);
     expect(isUnknownTaskError({ code: -32003 })).toBe(false);
     expect(isUnknownTaskError(null)).toBe(false);
+  });
+
+  it("excludes a leased handle from `due` for the whole read", () => {
+    const clock = { at: 1_000 };
+    const engine = new TaskLifecycleEngine({ now: () => clock.at });
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "working", pollIntervalMs: 1_000 });
+
+    clock.at += 5_000;
+    expect(engine.due().map((r) => r.identity.taskId)).toEqual(["t1"]);
+
+    expect(engine.acquirePoll(identity)).toBe(true);
+    // A second acquirer is refused rather than dispatching on top of the
+    // first: two `tasks/get` in flight means the later reply wins even when it
+    // observed the older state.
+    expect(engine.acquirePoll(identity)).toBe(false);
+
+    // Time alone does NOT re-admit it. That is the whole difference between a
+    // lease and `reserve`: a read slower than its own floor would otherwise
+    // read as due again while still open.
+    clock.at += 10 * 60_000;
+    expect(engine.due()).toEqual([]);
+
+    engine.releasePoll(identity);
+    expect(engine.due().map((r) => r.identity.taskId)).toEqual(["t1"]);
+  });
+
+  it("applies the first observation to a RESTORED terminal handle", () => {
+    const engine = new TaskLifecycleEngine();
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    // Storage kept the status and nothing else — it never holds the payload,
+    // and on the extension wire the result rides inline on `tasks/get`, so
+    // this read is the only way the result is ever obtained.
+    engine.register(identity, { restored: true, status: "completed" });
+    engine.observe(identity, {
+      status: "completed",
+      result: { content: [{ type: "text", text: "done" }] },
+    });
+    expect(engine.get(identity)?.result).toEqual({
+      content: [{ type: "text", text: "done" }],
+    });
+    expect(engine.get(identity)?.restored).toBe(false);
+  });
+
+  it("still treats an OBSERVED terminal as final", () => {
+    const engine = new TaskLifecycleEngine();
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "completed", result: { a: 1 } });
+    // A poll issued before the terminal landed can answer after it. Applying
+    // it would revert a finished task's UI and scheduling to `working`.
+    engine.observe(identity, { status: "working" });
+    expect(engine.get(identity)?.status).toBe("completed");
+    expect(engine.get(identity)?.result).toEqual({ a: 1 });
   });
 
   it("parses Retry-After as both a delta and an HTTP date, and rejects garbage", () => {

--- a/sdk/tests/task-lifecycle.test.ts
+++ b/sdk/tests/task-lifecycle.test.ts
@@ -406,6 +406,39 @@ describe("per-task scheduling", () => {
     expect(engine.due()).toEqual([]);
   });
 
+  it("clears the error backoff for a user-initiated read, keeping the server's floor", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 1_000 });
+    engine.observeError(id);
+    engine.observeError(id);
+    engine.observeError(id);
+    // Backed off well past the server's own floor: without this, a person
+    // clicking Refresh watches nothing happen.
+    expect(engine.msUntilNextDue()).toBeGreaterThan(1_000);
+
+    clock.advance(500);
+    engine.clearErrorBackoff(id);
+    expect(engine.get(id)?.consecutiveErrors).toBe(0);
+    // The SERVER's floor survives — 1s from the last observation, of which
+    // 500ms has elapsed — so a click cannot out-poll what the server asked for.
+    expect(engine.msUntilNextDue()).toBe(500);
+  });
+
+  it("never lets a cleared backoff punch through a Retry-After", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "working" });
+    engine.applyRetryAfter(id, 30_000);
+    engine.observeError(id);
+
+    engine.clearErrorBackoff(id);
+    // Rate limiting is the server's explicit instruction, not our guess.
+    expect(engine.msUntilNextDue()).toBe(30_000);
+  });
+
   it("applies a slower user minimum to already-scheduled tasks immediately", () => {
     const clock = fakeClock();
     const engine = new TaskLifecycleEngine({ now: clock.now });

--- a/sdk/tests/task-lifecycle.test.ts
+++ b/sdk/tests/task-lifecycle.test.ts
@@ -1,0 +1,468 @@
+/**
+ * The shared task lifecycle engine (`src/mcp-client-manager/task-lifecycle.ts`).
+ *
+ * The load-bearing property here is the poll-interval rule. Before the engine,
+ * the Tasks tab collapsed every active task to `Math.min(...)` of their
+ * advertised intervals and resolved a user override with `??` — so one fast
+ * task set the floor for all of them, and a user preference *replaced* the
+ * server's floor instead of being clamped by it. These tests pin the opposite:
+ * every term is a `max`, and a batch takes the slowest member's floor.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  TaskLifecycleEngine,
+  isTerminalLifecycleStatus,
+  taskLifecycleKey,
+  type TaskLifecycleIdentity,
+  type TaskLifecycleSnapshot,
+} from "../src/mcp-client-manager/task-lifecycle.js";
+import {
+  extensionTaskToObservation,
+  legacyTaskToObservation,
+  isUnknownTaskError,
+  parseRetryAfterMs,
+} from "../src/mcp-client-manager/task-lifecycle-adapters.js";
+
+const identity = (taskId: string, overrides: Partial<TaskLifecycleIdentity> = {}): TaskLifecycleIdentity => ({
+  serverId: "srv",
+  wire: "extension",
+  taskId,
+  ...overrides,
+});
+
+/** A clock the tests advance by hand, so nothing depends on wall time. */
+function fakeClock(start = 1_000_000) {
+  let current = start;
+  return {
+    now: () => current,
+    advance: (ms: number) => {
+      current += ms;
+      return current;
+    },
+    set: (ms: number) => {
+      current = ms;
+      return current;
+    },
+  };
+}
+
+describe("identity", () => {
+  it("keeps the wire in the key, so the same id on two wires is two handles", () => {
+    const legacy = taskLifecycleKey(identity("t1", { wire: "legacy" }));
+    const extension = taskLifecycleKey(identity("t1", { wire: "extension" }));
+    expect(legacy).not.toBe(extension);
+  });
+
+  it("keeps the auth scope in the key", () => {
+    expect(taskLifecycleKey(identity("t1", { scope: "projA" }))).not.toBe(
+      taskLifecycleKey(identity("t1", { scope: "projB" }))
+    );
+  });
+});
+
+describe("poll interval resolution", () => {
+  it("takes the MAXIMUM of the server floor and the user minimum, never the user's alone", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      userMinimumIntervalMs: 500,
+    });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 5_000 });
+
+    const record = engine.get(id)!;
+    // The old `userOverride ?? serverSuggested ?? userDefault` chain would have
+    // produced 500 here and hammered the server ten times per advertised tick.
+    expect(engine.effectiveIntervalMs(record)).toBe(5_000);
+  });
+
+  it("honors a user minimum that is SLOWER than the server floor", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      userMinimumIntervalMs: 30_000,
+    });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 1_000 });
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(30_000);
+  });
+
+  it("accepts a poll interval that SHRINKS mid-task without flagging it", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+
+    engine.observe(id, { status: "working", pollIntervalMs: 10_000 });
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(10_000);
+
+    clock.advance(10_000);
+    // `pollIntervalMs` MAY change in either direction (tasks.md:308).
+    engine.observe(id, { status: "working", pollIntervalMs: 2_000 });
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(2_000);
+  });
+
+  it("backs off exponentially on consecutive errors and resets on a good read", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      errorBackoffBaseMs: 1_000,
+      absoluteFloorMs: 100,
+    });
+    const id = identity("t1");
+    engine.register(id);
+
+    engine.observeError(id);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(1_000);
+    engine.observeError(id);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(2_000);
+    engine.observeError(id);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(4_000);
+
+    engine.observe(id, { status: "working" });
+    expect(engine.get(id)!.consecutiveErrors).toBe(0);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(100);
+  });
+
+  it("caps the backoff", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      errorBackoffBaseMs: 1_000,
+      errorBackoffMaxMs: 5_000,
+    });
+    const id = identity("t1");
+    for (let i = 0; i < 20; i += 1) engine.observeError(id);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(5_000);
+  });
+
+  it("lets Retry-After win over every other term while it is in force", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 1_000 });
+
+    engine.applyRetryAfter(id, 45_000);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(45_000);
+
+    // It decays as real time passes rather than staying pinned.
+    clock.advance(40_000);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(5_000);
+    clock.advance(10_000);
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(1_000);
+  });
+
+  it("ignores a NaN / negative / infinite pollIntervalMs from a server", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      absoluteFloorMs: 250,
+    });
+    const id = identity("t1");
+    for (const bad of [Number.NaN, -1, Number.POSITIVE_INFINITY]) {
+      engine.observe(id, { status: "working", pollIntervalMs: bad });
+      expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(250);
+    }
+  });
+
+  it("clamps a hostile pollIntervalMs to the maximum so a task cannot be parked forever", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      maximumIntervalMs: 60_000,
+    });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 999_999_999 });
+    expect(engine.effectiveIntervalMs(engine.get(id)!)).toBe(60_000);
+  });
+});
+
+describe("per-task scheduling", () => {
+  it("does not let a fast task drag a slow task below its own floor", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const fast = identity("fast");
+    const slow = identity("slow");
+
+    engine.observe(fast, { status: "working", pollIntervalMs: 1_000 });
+    engine.observe(slow, { status: "working", pollIntervalMs: 10_000 });
+
+    clock.advance(1_000);
+    expect(engine.due().map((r) => r.identity.taskId)).toEqual(["fast"]);
+
+    clock.advance(1_000);
+    engine.observe(fast, { status: "working", pollIntervalMs: 1_000 });
+    clock.advance(1_000);
+    // The slow task is still not due, 3s in, even though the fast one has been
+    // polled twice. The old shared-`Math.min` scheduler polled both every 1s.
+    expect(engine.due().map((r) => r.identity.taskId)).toEqual(["fast"]);
+
+    clock.advance(7_000);
+    expect(engine.due().map((r) => r.identity.taskId).sort()).toEqual([
+      "fast",
+      "slow",
+    ]);
+  });
+
+  it("gives a batch the SLOWEST member's floor, not the fastest", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const a = identity("a");
+    const b = identity("b");
+    engine.observe(a, { status: "working", pollIntervalMs: 1_000 });
+    engine.observe(b, { status: "working", pollIntervalMs: 9_000 });
+
+    const batch = [engine.get(a)!, engine.get(b)!];
+    expect(engine.batchIntervalMs(batch)).toBe(9_000);
+  });
+
+  it("never reports a terminal task as due", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "completed", result: { ok: true } });
+    clock.advance(1_000_000);
+    expect(engine.due()).toEqual([]);
+    expect(engine.msUntilNextDue()).toBeUndefined();
+  });
+
+  it("reserve() pushes a dispatched task forward so a tick cannot double-issue it", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 5_000 });
+    clock.advance(5_000);
+
+    const due = engine.due();
+    expect(due).toHaveLength(1);
+    engine.reserve(due);
+    expect(engine.due()).toEqual([]);
+  });
+
+  it("applies a slower user minimum to already-scheduled tasks immediately", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 1_000 });
+    expect(engine.msUntilNextDue()).toBe(1_000);
+
+    engine.setUserMinimumIntervalMs(20_000);
+    expect(engine.msUntilNextDue()).toBe(20_000);
+  });
+});
+
+describe("state transitions", () => {
+  it("announces creation once and does not re-announce a restored handle", () => {
+    const created: string[] = [];
+    const engine = new TaskLifecycleEngine({
+      callbacks: { onTaskCreated: (r) => created.push(r.identity.taskId) },
+    });
+    engine.register(identity("t1"));
+    engine.register(identity("t1"));
+    engine.register(identity("t2"), { restored: true });
+    expect(created).toEqual(["t1"]);
+  });
+
+  it("does not reset an existing handle's schedule on re-registration", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 10_000 });
+    const scheduled = engine.get(id)!.nextPollAt;
+
+    clock.advance(1_000);
+    engine.register(id);
+    expect(engine.get(id)!.nextPollAt).toBe(scheduled);
+  });
+
+  it("fires terminal exactly once per handle", () => {
+    const terminal: string[] = [];
+    const engine = new TaskLifecycleEngine({
+      callbacks: { onTerminal: (r) => terminal.push(r.status) },
+    });
+    const id = identity("t1");
+    engine.observe(id, { status: "working" });
+    engine.observe(id, { status: "completed", result: {} });
+    engine.observe(id, { status: "completed", result: {} });
+    expect(terminal).toEqual(["completed"]);
+  });
+
+  it("re-announces input_required when the keyed snapshot changes, not only on entry", () => {
+    const seen: TaskLifecycleSnapshot[] = [];
+    const engine = new TaskLifecycleEngine({
+      callbacks: { onInputRequired: (r) => seen.push(r) },
+    });
+    const id = identity("t1");
+    engine.observe(id, {
+      status: "input_required",
+      inputRequests: { a: { method: "elicitation/create" } } as never,
+    });
+    engine.observe(id, {
+      status: "input_required",
+      inputRequests: {
+        a: { method: "elicitation/create" },
+        b: { method: "elicitation/create" },
+      } as never,
+    });
+    expect(seen).toHaveLength(2);
+  });
+
+  it("treats a null ttlMs as meaningful and lets it overwrite a number", () => {
+    const engine = new TaskLifecycleEngine();
+    const id = identity("t1");
+    engine.observe(id, { status: "working", ttlMs: 60_000 });
+    expect(engine.get(id)!.ttlMs).toBe(60_000);
+    engine.observe(id, { status: "working", ttlMs: null });
+    expect(engine.get(id)!.ttlMs).toBeNull();
+  });
+
+  it("leaves the status alone when a read fails — a transport error is not a task state", () => {
+    const engine = new TaskLifecycleEngine();
+    const id = identity("t1");
+    engine.observe(id, { status: "working" });
+    engine.observeError(id);
+    expect(engine.get(id)!.status).toBe("working");
+  });
+
+  it("keeps polling after a cancel is requested — the ack says nothing about the task's fate", () => {
+    const clock = fakeClock();
+    const engine = new TaskLifecycleEngine({ now: clock.now });
+    const id = identity("t1");
+    engine.observe(id, { status: "working", pollIntervalMs: 1_000 });
+    engine.markCancellationRequested(id);
+
+    expect(engine.get(id)!.cancellationRequested).toBe(true);
+    expect(engine.get(id)!.status).toBe("working");
+    clock.advance(1_000);
+    expect(engine.due()).toHaveLength(1);
+  });
+
+  it("expiry is terminal and stops the schedule", () => {
+    const clock = fakeClock();
+    const terminal: string[] = [];
+    const engine = new TaskLifecycleEngine({
+      now: clock.now,
+      callbacks: { onTerminal: (r) => terminal.push(r.status) },
+    });
+    const id = identity("t1");
+    engine.observe(id, { status: "working" });
+    engine.markExpired(id);
+
+    expect(engine.get(id)!.status).toBe("expired");
+    expect(isTerminalLifecycleStatus("expired")).toBe(true);
+    clock.advance(1_000_000);
+    expect(engine.due()).toEqual([]);
+    expect(terminal).toEqual(["expired"]);
+  });
+});
+
+describe("input keys", () => {
+  it("only marks a key responded when told to — after the update was acknowledged", () => {
+    const engine = new TaskLifecycleEngine();
+    const id = identity("t1");
+    engine.observe(id, {
+      status: "input_required",
+      inputRequests: {
+        a: { method: "elicitation/create" },
+        b: { method: "elicitation/create" },
+      } as never,
+    });
+    expect(engine.pendingInputKeys(id).sort()).toEqual(["a", "b"]);
+
+    engine.markInputKeysResponded(id, ["a"]);
+    expect(engine.pendingInputKeys(id)).toEqual(["b"]);
+  });
+
+  it("keeps responded keys across a re-sent snapshot so a reload does not re-prompt", () => {
+    const engine = new TaskLifecycleEngine();
+    const id = identity("t1");
+    const snapshot = {
+      status: "input_required" as const,
+      inputRequests: { a: { method: "elicitation/create" } } as never,
+    };
+    engine.observe(id, snapshot);
+    engine.markInputKeysResponded(id, ["a"]);
+    engine.observe(id, snapshot);
+    expect(engine.pendingInputKeys(id)).toEqual([]);
+  });
+
+  it("restores responded keys from durable storage", () => {
+    const engine = new TaskLifecycleEngine();
+    const id = identity("t1");
+    engine.register(id, { restored: true, respondedInputKeys: ["a"] });
+    engine.observe(id, {
+      status: "input_required",
+      inputRequests: {
+        a: { method: "elicitation/create" },
+        b: { method: "elicitation/create" },
+      } as never,
+    });
+    expect(engine.pendingInputKeys(id)).toEqual(["b"]);
+  });
+
+  it("treats a prototype-chain key as data, not behavior", () => {
+    const engine = new TaskLifecycleEngine();
+    const id = identity("t1");
+    engine.observe(id, {
+      status: "input_required",
+      inputRequests: JSON.parse(
+        '{"constructor":{"method":"elicitation/create"}}'
+      ) as never,
+    });
+    expect(engine.pendingInputKeys(id)).toEqual(["constructor"]);
+  });
+});
+
+describe("wire adapters", () => {
+  it("normalizes an extension completed task, keeping the raw payload", () => {
+    const task = {
+      taskId: "t1",
+      status: "completed" as const,
+      createdAt: "2026-07-28T00:00:00Z",
+      lastUpdatedAt: "2026-07-28T00:01:00Z",
+      ttlMs: null,
+      result: { content: [], isError: true },
+    };
+    const observation = extensionTaskToObservation(task);
+    // `isError: true` is a COMPLETED task, not a failed one.
+    expect(observation.status).toBe("completed");
+    expect(observation.result).toEqual({ content: [], isError: true });
+    expect(observation.error).toBeUndefined();
+    expect(observation.raw).toBe(task);
+  });
+
+  it("normalizes the legacy wire's ttl / pollInterval field names", () => {
+    const observation = legacyTaskToObservation({
+      taskId: "t1",
+      status: "working",
+      ttl: 30_000,
+      pollInterval: 2_000,
+    } as never);
+    expect(observation.ttlMs).toBe(30_000);
+    expect(observation.pollIntervalMs).toBe(2_000);
+  });
+
+  it("keeps an unrecognized legacy status pollable rather than inventing a terminal state", () => {
+    const observation = legacyTaskToObservation({
+      taskId: "t1",
+      status: "who-knows",
+    } as never);
+    expect(observation.status).toBe("working");
+  });
+
+  it("recognizes the unknown-task error in both nested and flat shapes", () => {
+    expect(isUnknownTaskError({ code: -32602 })).toBe(true);
+    expect(isUnknownTaskError({ error: { code: -32602 } })).toBe(true);
+    expect(isUnknownTaskError({ code: -32003 })).toBe(false);
+    expect(isUnknownTaskError(null)).toBe(false);
+  });
+
+  it("parses Retry-After as both a delta and an HTTP date, and rejects garbage", () => {
+    const now = Date.parse("2026-07-28T00:00:00Z");
+    expect(parseRetryAfterMs("30", now)).toBe(30_000);
+    expect(parseRetryAfterMs("2026-07-28T00:00:45Z", now)).toBe(45_000);
+    // A malformed hint must not become a zero-length backoff.
+    expect(parseRetryAfterMs("soon", now)).toBeUndefined();
+    expect(parseRetryAfterMs(undefined, now)).toBeUndefined();
+  });
+});

--- a/sdk/tests/task-lifecycle.test.ts
+++ b/sdk/tests/task-lifecycle.test.ts
@@ -597,6 +597,71 @@ describe("wire adapters", () => {
     expect(isUnknownTaskError(null)).toBe(false);
   });
 
+  it("lets a LOWERED user minimum shorten a wait it caused", () => {
+    const clock = { at: 1_000 };
+    const engine = new TaskLifecycleEngine({
+      now: () => clock.at,
+      userMinimumIntervalMs: 60_000,
+    });
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
+    expect(engine.get(identity)!.nextPollAt).toBe(clock.at + 60_000);
+
+    // A blanket "never earlier" kept the superseded preference as if it were a
+    // server wait: the task stayed parked for the rest of its old 60s, so the
+    // new setting did nothing until it happened to come due.
+    engine.setUserMinimumIntervalMs(1_000);
+    // Back down to the SERVER's floor, not to the user's 1s — the preference
+    // is one `max` term, never permission to poll faster than asked.
+    expect(engine.get(identity)!.nextPollAt).toBe(clock.at + 2_000);
+  });
+
+  it("does not let a lowered minimum punch through a Retry-After", () => {
+    const clock = { at: 1_000 };
+    const engine = new TaskLifecycleEngine({
+      now: () => clock.at,
+      userMinimumIntervalMs: 60_000,
+    });
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
+    engine.applyRetryAfter(identity, 120_000);
+    const deadline = engine.get(identity)!.nextPollAt;
+
+    // A wait the SERVER imposed is absolute and survives the recompute; only
+    // the part the old preference caused is recoverable.
+    engine.setUserMinimumIntervalMs(1_000);
+    expect(engine.get(identity)!.nextPollAt).toBe(deadline);
+  });
+
+  it("does not let a lowered minimum walk through an error backoff", () => {
+    const clock = { at: 1_000 };
+    const engine = new TaskLifecycleEngine({
+      now: () => clock.at,
+      userMinimumIntervalMs: 60_000,
+    });
+    const identity = {
+      serverId: "s",
+      wire: "extension",
+      taskId: "t1",
+    } as const;
+    engine.observe(identity, { status: "working", pollIntervalMs: 2_000 });
+    clock.at += 60_000;
+    engine.observeError(identity);
+    const backedOffTo = engine.get(identity)!.nextPollAt;
+    expect(backedOffTo).toBeGreaterThan(clock.at);
+
+    engine.setUserMinimumIntervalMs(1_000);
+    expect(engine.get(identity)!.nextPollAt).toBe(backedOffTo);
+  });
+
   it("excludes a leased handle from `due` for the whole read", () => {
     const clock = { at: 1_000 };
     const engine = new TaskLifecycleEngine({ now: () => clock.at });

--- a/sdk/tests/tasks-ext-listen-meta.test.ts
+++ b/sdk/tests/tasks-ext-listen-meta.test.ts
@@ -162,6 +162,194 @@ describe("fail loud", () => {
     ).rejects.toThrow(TasksExtListenMetaSeamError);
     expect(call).toHaveBeenCalled();
   });
+
+  it("disposes what the unread call produced, so a seam failure cannot leak a subscription", async () => {
+    const client = realClient();
+    // `listen()` resolves only after the server's ack, so by the time the seam
+    // check runs the subscription is LIVE. The caller only ever sees the
+    // rejection, so nothing else can close it.
+    const handle = { close: vi.fn(async () => {}) };
+    await expect(
+      withTasksExtensionEnvelope(
+        client,
+        {},
+        async () => handle,
+        (value) => value.close()
+      )
+    ).rejects.toThrow(TasksExtListenMetaSeamError);
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports the seam failure when disposal itself fails", async () => {
+    const client = realClient();
+    await expect(
+      withTasksExtensionEnvelope(
+        client,
+        {},
+        async () => "handle",
+        () => {
+          throw new Error("close failed");
+        }
+      )
+    ).rejects.toThrow(TasksExtListenMetaSeamError);
+  });
+
+  it("does not dispose the value when the declaration DID reach the call", async () => {
+    const client = realClient();
+    const dispose = vi.fn();
+    await expect(
+      withTasksExtensionEnvelope(
+        client,
+        {},
+        async () => {
+          readEnvelope(client);
+          return "handle";
+        },
+        dispose
+      )
+    ).resolves.toBe("handle");
+    expect(dispose).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The claim the whole module rests on: `listen()`'s prologue reads the outbound
+ * envelope SYNCHRONOUSLY, before its first `await`, so a shadow installed and
+ * removed around the call reaches that one request and nothing else.
+ *
+ * Every other test here reads the envelope through the private member by hand.
+ * That verifies the shadow, not the claim — a client bump that moved the
+ * request literal below an `await` would leave all of them green and break
+ * only production. So this one drives a REAL `client.listen()` over a transport
+ * that captures the frame, and asserts on what actually went out.
+ */
+describe("the declaration on a real subscriptions/listen frame", () => {
+  const MODERN_PROTOCOL_VERSION = "2026-07-28";
+  const SUBSCRIPTION_ID_META_KEY = "io.modelcontextprotocol/subscriptionId";
+
+  type Frame = Record<string, any>;
+
+  /** Captures every outgoing frame and acknowledges any listen. */
+  class CapturingTransport {
+    onmessage?: (message: Frame) => void;
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    readonly sent: Frame[] = [];
+
+    async start(): Promise<void> {}
+
+    async send(message: Frame): Promise<void> {
+      this.sent.push(message);
+      if (message.method === "subscriptions/listen") {
+        queueMicrotask(() =>
+          this.onmessage?.({
+            jsonrpc: "2.0",
+            method: "notifications/subscriptions/acknowledged",
+            params: {
+              _meta: { [SUBSCRIPTION_ID_META_KEY]: message.id },
+              notifications: message.params?.notifications ?? {},
+            },
+          })
+        );
+      }
+    }
+
+    async close(): Promise<void> {
+      this.onclose?.();
+    }
+
+    setProtocolVersion(_version: string): void {}
+  }
+
+  async function connected(): Promise<{
+    client: Client;
+    transport: CapturingTransport;
+  }> {
+    const client = realClient();
+    const transport = new CapturingTransport();
+    // `connect({ prior })` is the public zero-round-trip modern connect: it
+    // establishes the 2026-07-28 era from a supplied `DiscoverResult` with no
+    // handshake, which is all `listen()`'s era gate needs. Nothing private is
+    // touched to get here.
+    await client.connect(transport as never, {
+      prior: {
+        supportedVersions: [MODERN_PROTOCOL_VERSION],
+        capabilities: {},
+        serverInfo: { name: "fake", version: "0.0.0" },
+      } as never,
+    });
+    return { client, transport };
+  }
+
+  function listenFrame(transport: CapturingTransport): Frame | undefined {
+    return transport.sent.find((m) => m.method === "subscriptions/listen");
+  }
+
+  it("puts BOTH the eligibility declaration and the extension's taskIds on the wire", async () => {
+    const { client, transport } = await connected();
+
+    const handle = await withTasksExtensionEnvelope(
+      client,
+      { elicitation: {}, roots: {} },
+      () =>
+        (
+          client as unknown as {
+            listen(filter: unknown): Promise<{ close(): Promise<void> }>;
+          }
+        ).listen({ taskIds: ["task-1", "task-2"], toolsListChanged: true })
+    );
+
+    const frame = listenFrame(transport);
+    expect(frame).toBeDefined();
+
+    // 1. The per-request eligibility declaration. Without it a conforming
+    //    server MUST answer -32003.
+    const capabilities = frame?.params?._meta?.[CLIENT_CAPABILITIES_META_KEY];
+    expect(capabilities?.extensions?.[TASKS_EXT]).toEqual({});
+    // The client's own declared capabilities survive the merge.
+    expect(capabilities?.elicitation).toEqual({});
+
+    // 2. The extension-only filter member. `taskIds` is not in upstream's
+    //    `SubscriptionFilter` type; this pins that upstream still forwards the
+    //    filter verbatim rather than stripping unknown members.
+    expect(frame?.params?.notifications?.taskIds).toEqual(["task-1", "task-2"]);
+    expect(frame?.params?.notifications?.toolsListChanged).toBe(true);
+
+    await handle.close();
+    await client.close();
+  });
+
+  it("leaves the NEXT request on the same connection undeclared", async () => {
+    const { client, transport } = await connected();
+
+    const handle = await withTasksExtensionEnvelope(client, {}, () =>
+      (
+        client as unknown as {
+          listen(filter: unknown): Promise<{ close(): Promise<void> }>;
+        }
+      ).listen({ taskIds: ["task-1"] })
+    );
+    await handle.close();
+
+    const second = await (
+      client as unknown as {
+        listen(filter: unknown): Promise<{ close(): Promise<void> }>;
+      }
+    ).listen({ toolsListChanged: true });
+
+    const frames = transport.sent.filter(
+      (m) => m.method === "subscriptions/listen"
+    );
+    expect(frames).toHaveLength(2);
+    expect(
+      frames[1].params?._meta?.[CLIENT_CAPABILITIES_META_KEY]?.extensions?.[
+        TASKS_EXT
+      ]
+    ).toBeUndefined();
+
+    await second.close();
+    await client.close();
+  });
 });
 
 describe("target resolution", () => {

--- a/sdk/tests/tasks-ext-listen-meta.test.ts
+++ b/sdk/tests/tasks-ext-listen-meta.test.ts
@@ -1,0 +1,183 @@
+/**
+ * The `subscriptions/listen` declaration seam
+ * (`src/mcp-client-manager/tasks-ext-listen-meta.ts`).
+ *
+ * These run against a REAL upstream `Client`, not a stand-in, because the whole
+ * point is the interaction with upstream's private envelope member. If a client
+ * bump moves or renames it, or makes `listen()`'s prologue asynchronous, these
+ * fail — which is the alarm the module exists to raise.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { Client, CLIENT_CAPABILITIES_META_KEY } from "@modelcontextprotocol/client";
+import {
+  TasksExtListenMetaSeamError,
+  resolveListenMetaTarget,
+  withTasksExtensionEnvelope,
+} from "../src/mcp-client-manager/tasks-ext-listen-meta.js";
+
+const TASKS_EXT = "io.modelcontextprotocol/tasks";
+const ENVELOPE_MEMBER = "_outboundMetaEnvelope";
+
+function realClient(): Client {
+  return new Client(
+    { name: "test", version: "0.0.0" },
+    { capabilities: { elicitation: {}, roots: {} } }
+  );
+}
+
+/** Reads the envelope the way `listen()` does: synchronously, via the member. */
+function readEnvelope(client: Client): Record<string, unknown> | undefined {
+  return (
+    client as unknown as {
+      _outboundMetaEnvelope(): Record<string, unknown> | undefined;
+    }
+  )._outboundMetaEnvelope();
+}
+
+describe("seam presence", () => {
+  it("the private member upstream builds its listen params from is still there", () => {
+    const client = realClient();
+    expect(
+      typeof (client as unknown as Record<string, unknown>)[ENVELOPE_MEMBER]
+    ).toBe("function");
+  });
+});
+
+describe("declaration injection", () => {
+  it("merges the tasks extension into the capabilities the call reads", async () => {
+    const client = realClient();
+    let seen: Record<string, unknown> | undefined;
+
+    await withTasksExtensionEnvelope(
+      client,
+      { elicitation: {}, roots: {} },
+      async () => {
+        seen = readEnvelope(client);
+      }
+    );
+
+    const capabilities = seen?.[CLIENT_CAPABILITIES_META_KEY] as
+      | { extensions?: Record<string, unknown>; elicitation?: unknown; roots?: unknown }
+      | undefined;
+    expect(capabilities?.extensions?.[TASKS_EXT]).toEqual({});
+    // Unrelated declared capabilities survive: this widens the envelope, it
+    // does not replace it.
+    expect(capabilities?.elicitation).toBeDefined();
+    expect(capabilities?.roots).toBeDefined();
+  });
+
+  it("preserves an unrelated extension the caller already declared", async () => {
+    const client = realClient();
+    let seen: Record<string, unknown> | undefined;
+
+    await withTasksExtensionEnvelope(
+      client,
+      { extensions: { "com.example/other": { a: 1 } } } as never,
+      async () => {
+        seen = readEnvelope(client);
+      }
+    );
+
+    const extensions = (
+      seen?.[CLIENT_CAPABILITIES_META_KEY] as { extensions?: Record<string, unknown> }
+    )?.extensions;
+    expect(extensions?.["com.example/other"]).toEqual({ a: 1 });
+    expect(extensions?.[TASKS_EXT]).toEqual({});
+  });
+
+  it("restores the envelope before anything else can observe it", async () => {
+    const client = realClient();
+    let inside: Record<string, unknown> | undefined;
+
+    await withTasksExtensionEnvelope(client, {}, async () => {
+      inside = readEnvelope(client);
+    });
+
+    const after = readEnvelope(client);
+    const capsInside = inside?.[CLIENT_CAPABILITIES_META_KEY] as
+      | { extensions?: Record<string, unknown> }
+      | undefined;
+    const capsAfter = after?.[CLIENT_CAPABILITIES_META_KEY] as
+      | { extensions?: Record<string, unknown> }
+      | undefined;
+
+    expect(capsInside?.extensions?.[TASKS_EXT]).toEqual({});
+    // The next request on this client is NOT declared. This is what keeps the
+    // opt-in per-request rather than connection-wide.
+    expect(capsAfter?.extensions?.[TASKS_EXT]).toBeUndefined();
+    expect(
+      Object.prototype.hasOwnProperty.call(client, ENVELOPE_MEMBER)
+    ).toBe(false);
+  });
+
+  it("restores the envelope when the call throws synchronously", () => {
+    const client = realClient();
+    expect(() =>
+      withTasksExtensionEnvelope(client, {}, () => {
+        throw new Error("boom");
+      })
+    ).toThrow("boom");
+    expect(
+      Object.prototype.hasOwnProperty.call(client, ENVELOPE_MEMBER)
+    ).toBe(false);
+  });
+
+  it("restores the envelope when the call rejects", async () => {
+    const client = realClient();
+    await expect(
+      withTasksExtensionEnvelope(client, {}, async () => {
+        throw new Error("late boom");
+      })
+    ).rejects.toThrow("late boom");
+    expect(
+      Object.prototype.hasOwnProperty.call(client, ENVELOPE_MEMBER)
+    ).toBe(false);
+  });
+});
+
+describe("fail loud", () => {
+  it("throws rather than silently sending undeclared when the member is gone", () => {
+    const fake = {} as unknown as Client;
+    expect(() => withTasksExtensionEnvelope(fake, {}, async () => 1)).toThrow(
+      TasksExtListenMetaSeamError
+    );
+  });
+
+  it("throws when the member is no longer a function", () => {
+    const fake = { [ENVELOPE_MEMBER]: "moved" } as unknown as Client;
+    expect(() => withTasksExtensionEnvelope(fake, {}, async () => 1)).toThrow(
+      /not a function/
+    );
+  });
+
+  it("rejects when the call never read the envelope — an undeclared request on the wire", async () => {
+    const client = realClient();
+    const call = vi.fn(async () => "sent");
+    // Simulates upstream moving the request literal below an `await`, or
+    // dropping the envelope from listen entirely. Either way the declaration
+    // did not reach the wire, and a conforming server would answer -32003.
+    await expect(
+      withTasksExtensionEnvelope(client, {}, call)
+    ).rejects.toThrow(TasksExtListenMetaSeamError);
+    expect(call).toHaveBeenCalled();
+  });
+});
+
+describe("target resolution", () => {
+  it("finds the upstream client through a delegation chain", () => {
+    const client = realClient();
+    const chained = { inner: { inner: client } };
+    expect(resolveListenMetaTarget(chained)).toBe(client);
+  });
+
+  it("returns undefined for a test double with no client in the chain", () => {
+    expect(resolveListenMetaTarget({ inner: { inner: {} } })).toBeUndefined();
+  });
+
+  it("terminates on a self-referential chain instead of hanging", () => {
+    const loop: { inner?: unknown } = {};
+    loop.inner = loop;
+    expect(resolveListenMetaTarget(loop)).toBeUndefined();
+  });
+});

--- a/sdk/tests/tasks-policy.test.ts
+++ b/sdk/tests/tasks-policy.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tasks product policy (`src/host-config/tasks-policy.ts`).
+ *
+ * The invariant that matters most here is the separation: `com.mcpjam/tasks`
+ * is MCPJam configuration and must never reach a server, while the wire
+ * declaration is always `io.modelcontextprotocol/tasks`. The rest is the
+ * tri-state and the published surface matrix.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MCPJAM_TASKS_POLICY_EXTENSION_ID,
+  clearTasksPolicy,
+  describeInvalidTasksPolicy,
+  readTasksPolicy,
+  setTasksPolicy,
+  surfaceMayDeclareTasks,
+  taskModeForSurface,
+  type TaskSurface,
+  type TasksPolicy,
+} from "../src/host-config/tasks-policy.js";
+import { MCP_TASKS_EXTENSION_ID } from "../src/mcp-client-manager/tasks-dispatch.js";
+
+const hostWith = (value: unknown) => ({
+  mcpProfile: { extensions: { [MCPJAM_TASKS_POLICY_EXTENSION_ID]: value } },
+});
+
+describe("the two ids are not the same thing", () => {
+  it("keeps the MCPJam policy id distinct from the wire extension id", () => {
+    expect(MCPJAM_TASKS_POLICY_EXTENSION_ID).toBe("com.mcpjam/tasks");
+    expect(MCP_TASKS_EXTENSION_ID).toBe("io.modelcontextprotocol/tasks");
+    expect(MCPJAM_TASKS_POLICY_EXTENSION_ID).not.toBe(MCP_TASKS_EXTENSION_ID);
+  });
+
+  it("stores the policy under the MCPJam id only — never under the wire id", () => {
+    const host = setTasksPolicy(undefined, true);
+    const extensions = host.mcpProfile?.extensions ?? {};
+    expect(extensions[MCPJAM_TASKS_POLICY_EXTENSION_ID]).toEqual({
+      enabled: true,
+    });
+    // A host config that carried the wire id would risk it being advertised.
+    expect(extensions[MCP_TASKS_EXTENSION_ID]).toBeUndefined();
+  });
+});
+
+describe("tri-state read", () => {
+  it("reports unset when nothing was written", () => {
+    expect(readTasksPolicy(undefined)).toBe("unset");
+    expect(readTasksPolicy({})).toBe("unset");
+    expect(readTasksPolicy({ mcpProfile: {} })).toBe("unset");
+    expect(readTasksPolicy({ mcpProfile: { extensions: {} } })).toBe("unset");
+  });
+
+  it("reads on and off", () => {
+    expect(readTasksPolicy(hostWith({ enabled: true }))).toBe("on");
+    expect(readTasksPolicy(hostWith({ enabled: false }))).toBe("off");
+  });
+
+  it("reports invalid rather than coercing a malformed value", () => {
+    // Coercion is how a typo becomes silently-enabled Tasks everywhere.
+    for (const bad of [true, "yes", 1, [], null, {}, { enabled: "true" }]) {
+      expect(readTasksPolicy(hostWith(bad))).toBe("invalid");
+    }
+  });
+
+  it("explains what is wrong so the editor can offer a repair", () => {
+    expect(describeInvalidTasksPolicy(hostWith("yes"))).toMatch(/must be an object/);
+    expect(describeInvalidTasksPolicy(hostWith({ enabled: 1 }))).toMatch(
+      /must be true or false/,
+    );
+    expect(describeInvalidTasksPolicy(hostWith({ enabled: true }))).toBeUndefined();
+  });
+});
+
+describe("write and clear", () => {
+  it("round-trips on and off", () => {
+    expect(readTasksPolicy(setTasksPolicy(undefined, true))).toBe("on");
+    expect(readTasksPolicy(setTasksPolicy(undefined, false))).toBe("off");
+  });
+
+  it("clear returns to unset, which is NOT the same as off", () => {
+    const off = setTasksPolicy(undefined, false);
+    expect(readTasksPolicy(off)).toBe("off");
+    expect(readTasksPolicy(clearTasksPolicy(off))).toBe("unset");
+    // The difference is observable: unset preserves the Tools tab's explicit
+    // controls, off removes them.
+    expect(taskModeForSurface("unset", "tools")).toBe("expose");
+    expect(taskModeForSurface("off", "tools")).toBe("off");
+  });
+
+  it("does not mutate the input host", () => {
+    const original = { mcpProfile: { extensions: { "com.other/x": {} } } };
+    const snapshot = JSON.stringify(original);
+    setTasksPolicy(original, true);
+    clearTasksPolicy(setTasksPolicy(original, true));
+    expect(JSON.stringify(original)).toBe(snapshot);
+  });
+
+  it("preserves unrelated extensions through set and clear", () => {
+    const host = { mcpProfile: { extensions: { "com.other/x": { a: 1 } } } };
+    const enabled = setTasksPolicy(host, true);
+    expect(enabled.mcpProfile.extensions["com.other/x"]).toEqual({ a: 1 });
+    const cleared = clearTasksPolicy(enabled);
+    expect(cleared.mcpProfile.extensions["com.other/x"]).toEqual({ a: 1 });
+    expect(
+      cleared.mcpProfile.extensions[MCPJAM_TASKS_POLICY_EXTENSION_ID],
+    ).toBeUndefined();
+  });
+
+  it("preserves other mcpProfile fields", () => {
+    const host = { mcpProfile: { profileVersion: 1 as const } };
+    expect(setTasksPolicy(host, true).mcpProfile.profileVersion).toBe(1);
+  });
+});
+
+describe("the published surface matrix", () => {
+  const matrix: Array<[TaskSurface, Record<TasksPolicy, string>]> = [
+    ["tools", { unset: "expose", on: "expose", off: "off", invalid: "off" }],
+    ["chat", { unset: "off", on: "expose", off: "off", invalid: "off" }],
+    ["agent", { unset: "off", on: "expose", off: "off", invalid: "off" }],
+    ["eval", { unset: "off", on: "await", off: "off", invalid: "off" }],
+    [
+      "conformance",
+      { unset: "expose", on: "expose", off: "off", invalid: "off" },
+    ],
+    ["replay", { unset: "off", on: "off", off: "off", invalid: "off" }],
+    ["api", { unset: "expose", on: "expose", off: "off", invalid: "off" }],
+  ];
+
+  for (const [surface, expected] of matrix) {
+    for (const policy of Object.keys(expected) as TasksPolicy[]) {
+      it(`${surface} under ${policy} → ${expected[policy]}`, () => {
+        expect(taskModeForSurface(policy, surface)).toBe(expected[policy]);
+      });
+    }
+  }
+
+  it("never creates work on a replay surface, whatever the policy says", () => {
+    for (const policy of ["unset", "on", "off", "invalid"] as TasksPolicy[]) {
+      expect(taskModeForSurface(policy, "replay")).toBe("off");
+      expect(surfaceMayDeclareTasks(policy, "replay")).toBe(false);
+    }
+  });
+
+  it("turns everything off on an explicit Off, including the Tools controls", () => {
+    const surfaces: TaskSurface[] = [
+      "tools",
+      "chat",
+      "agent",
+      "eval",
+      "conformance",
+      "replay",
+      "api",
+    ];
+    for (const surface of surfaces) {
+      expect(surfaceMayDeclareTasks("off", surface)).toBe(false);
+    }
+  });
+
+  it("fails closed on an invalid policy — identically to off", () => {
+    const surfaces: TaskSurface[] = ["tools", "chat", "agent", "eval", "api"];
+    for (const surface of surfaces) {
+      expect(taskModeForSurface("invalid", surface)).toBe(
+        taskModeForSurface("off", surface),
+      );
+    }
+  });
+
+  it("leaves newly-supported surfaces off when the host never opted in", () => {
+    // The point of `unset`: adding a Tasks-capable surface is a non-event for
+    // a host that never expressed an opinion.
+    for (const surface of ["chat", "agent", "eval"] as TaskSurface[]) {
+      expect(taskModeForSurface("unset", surface)).toBe("off");
+    }
+  });
+
+  it("drives automation to a terminal result rather than exposing a handle", () => {
+    // Nobody is watching a tab during an eval, so a handle nobody follows is
+    // the same as a hang.
+    expect(taskModeForSurface("on", "eval")).toBe("await");
+    expect(taskModeForSurface("on", "chat")).toBe("expose");
+  });
+});

--- a/sdk/tests/tasks-policy.test.ts
+++ b/sdk/tests/tasks-policy.test.ts
@@ -63,6 +63,19 @@ describe("tri-state read", () => {
     }
   });
 
+  it("fails closed on a malformed mcpProfile, not just a malformed extensions", () => {
+    // `host.mcpProfile` is typed, but the value comes from JSON. Optional
+    // chaining reads `"on".extensions` as undefined, which would report
+    // `unset` — i.e. PRESERVE the Tools tab's controls on a config nobody can
+    // read. The module's invariant is fail-closed at every level.
+    for (const bad of ["on", 1, true, [], null]) {
+      expect(readTasksPolicy({ mcpProfile: bad } as never)).toBe("invalid");
+    }
+    expect(describeInvalidTasksPolicy({ mcpProfile: "on" } as never)).toMatch(
+      /"mcpProfile" must be a plain JSON object/,
+    );
+  });
+
   it("explains what is wrong so the editor can offer a repair", () => {
     expect(describeInvalidTasksPolicy(hostWith("yes"))).toMatch(/must be an object/);
     expect(describeInvalidTasksPolicy(hostWith({ enabled: 1 }))).toMatch(
@@ -110,6 +123,52 @@ describe("write and clear", () => {
   it("preserves other mcpProfile fields", () => {
     const host = { mcpProfile: { profileVersion: 1 as const } };
     expect(setTasksPolicy(host, true).mcpProfile.profileVersion).toBe(1);
+  });
+
+  // `hostConfigs` are content-addressed — the stored id IS the hash of the
+  // serialized host — so "reads back as unset" is not enough. An emptied
+  // `extensions: {}` left behind by a set→clear round trip mints a NEW
+  // hostConfig row for a host that is, observably, the pre-feature one. The
+  // plan's requirement is zero hash churn, which only byte-identity proves.
+  describe("set → clear leaves no residue in the serialized host", () => {
+    const fixtures: Array<[string, Record<string, unknown>]> = [
+      ["a host with no mcpProfile at all", { name: "h", version: "1" }],
+      [
+        "a host whose mcpProfile has other fields",
+        { name: "h", mcpProfile: { profileVersion: 1 } },
+      ],
+      [
+        "a host with other extensions",
+        { name: "h", mcpProfile: { extensions: { "com.other/x": { a: 1 } } } },
+      ],
+      [
+        "a host with other extensions and other profile fields",
+        {
+          name: "h",
+          mcpProfile: {
+            profileVersion: 1,
+            extensions: { "com.other/x": { a: 1 } },
+          },
+        },
+      ],
+    ];
+
+    for (const [label, host] of fixtures) {
+      it(label, () => {
+        const before = JSON.stringify(host);
+        for (const enabled of [true, false]) {
+          const cleared = clearTasksPolicy(setTasksPolicy(host, enabled));
+          expect(readTasksPolicy(cleared)).toBe("unset");
+          expect(JSON.stringify(cleared)).toBe(before);
+        }
+      });
+    }
+
+    it("clearing a host that never had a policy is a no-op", () => {
+      for (const [, host] of fixtures) {
+        expect(clearTasksPolicy(host)).toBe(host);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
Continues the MCP Tasks full-support plan. Workstream A landed in #3511 / #3515; this is **Workstream B** (one lifecycle engine) and **Workstream C** (host policy + execution seams).

## Workstream B — one lifecycle engine

Every Tasks surface was growing its own polling loop and its own idea of when a task is finished. `sdk/src/mcp-client-manager/task-lifecycle.ts` is now the single owner of *when a task may next be polled and what we last saw*. It performs no I/O — callers ask what is due, do the transport work, and hand the outcome back — so the same scheduler drives a browser tab, a Hono route, a Convex action and the CLI.

### The poll floor

Two real bugs, both in the same direction:

- `TasksTab.tsx` collapsed every active task to a single `Math.min(...)` across their advertised intervals, so one task asking for 500 ms dragged a task asking for 30 s down with it.
- The interval resolved as `userOverride ?? serverSuggestedPollInterval ?? userPollInterval` — a `??` chain, not a `max`. A user typing 500 into the box **replaced** a 30 s server floor outright.

The rule is now `max(server pollIntervalMs, user minimum, retry backoff, Retry-After)`, applied **per task**. The user's setting is a preferred minimum, never permission to go faster. A batch takes the **slowest** member's floor, not the fastest. `pollIntervalMs` may move in either direction mid-task, and a shrinking value is normal — never surfaced as an anomaly.

The tab's timer became a self-rearming timeout sized from the soonest due handle. A handle that is not due keeps its last-known state on screen instead of blinking out; a due handle that came back empty is a failed read (backoff), not a retry at the tab's pace.

### `input_required`, completely

`task-input-driver.ts` handles all three extension methods — `elicitation/create`, `roots/list`, `sampling/createMessage` — each routed through the *same* policy, consent and schema validation as its standalone counterpart. A task channel is not more trusted than a direct server→client request. "Undeclared capability", "declared but no handler wired" and "unrenderable elicitation mode" are distinct, displayable rejections, never a silent "handled". Answering is partial per key, and a key is marked responded only **after** its `tasks/update` is acknowledged.

### Notifications, with polling underneath

The subscription coordinator gains a `tasks` kind and a `taskIds` filter, gated on the server's extension capability through the one predicate that knows the "treat as absent on 2025-11-25" rule. Delivery is enforced against the *acknowledged* filter, so an unrequested or unacknowledged task id is refused. Notifications are optional in the extension, so every failure path degrades to polling **visibly**: an unacknowledged id and a connection that cannot declare are both recorded as rejected interests rather than silently dropped.

`tasks-ext-listen-meta.ts` solves a real blocker: a task-filtered `subscriptions/listen` MUST carry the per-request eligibility declaration or earn `-32003`, but `Client.listen` builds its own `params._meta` and accepts none from the caller. Same discipline as the A0 era-gate shadow — a per-instance override of one private upstream member, installed only across `listen()`'s synchronous prologue and removed in the same turn, so the declaration stays per-request rather than connection-wide. It fails loud if the member moves or the prologue stops being synchronous. (The filter itself needs no seam: upstream sends it verbatim, so `taskIds` reaches the wire unmodified.)

### Durable tracker

Schema v3 persists `lastUpdatedAt`, the latest `ttlMs` and `pollIntervalMs`, the next due time, and which input keys were answered — **keys only**, never a prompt, response or result. Records are sanitized on read: unknown wires normalize to legacy, oversized strings are clamped, malformed entries are dropped beside good ones, corrupt JSON starts clean, and a record from a *newer* schema version is ignored outright rather than best-effort parsed.

Entries are still dropped only for storage bounds — count, age, string length, serialized size — and never from a TTL. Discarding a task once its TTL elapses is the server's call, `ttlMs` may change over a task's lifetime, and `null` means unlimited.

## Workstream C — host policy and execution seams

`host-config/tasks-policy.ts` keeps MCPJam's product policy in a different module from the wire extension. `com.mcpjam/tasks` is configuration and is never advertised to a server; the only thing that goes on the wire is `io.modelcontextprotocol/tasks: {}`.

It is **tri-state** because three states are genuinely distinct and a boolean cannot express them. `unset` keeps the Tools tab's existing explicit per-call controls and leaves every newly-added surface off — so adding a Tasks-capable surface is a non-event for a host that never opted in. `on` enables the supported interactive surfaces, not "all surfaces". `off` removes every affordance and declaration, including the Tools controls. A malformed value reads as `invalid` rather than being coerced (coercion is how a typo becomes silently-enabled Tasks everywhere) and fails closed with a repair message for the editor.

Two rows of the surface matrix never move: **replay** is off in every state, since creating server-side work from a recorded result is a side effect the user never asked for and cannot see; **conformance** and the **public API** are caller-driven, so the policy is only ever a kill switch there — a host policy that silently added a declaration would corrupt the very thing under test.

`task-created-event.ts` is one fan-out point for a created handle, so durable tracking, hosted stream delivery, the registry and analytics stop being wired per-surface. A best-effort consumer (the registry) that throws is reported as degraded; a functional-path consumer (the tracker) that throws propagates. A registry failure must never convert a successful tool call into a failure — but a lost handle is not degradation.

`task-await-driver.ts` gives automation surfaces a bounded drive to a terminal result. Every exit is a named outcome, and a task needing input nobody can supply returns `input-required` naming the blocking keys rather than hanging until the eval budget runs out. The deadline is checked *before* each wait, so a long advertised floor cannot push the drive past its own budget. Waiting is delegated to the lifecycle engine — automation gets no poll licence the interactive path lacks.

## Testing

144 new tests, all passing:

| Suite | Tests |
| --- | --- |
| `task-lifecycle.test.ts` | 32 |
| `task-await-driver.test.ts` | 19 |
| `task-input-driver.test.ts` | 18 |
| `subscription-coordinator.tasks.test.ts` | 19 |
| `tasks-ext-listen-meta.test.ts` | 12 |
| `tasks-policy.test.ts` | 44 |
| `task-created-event.test.ts` | 9 |
| `use-task-scheduler.test.ts` (client) | 11 |
| `task-tracker.test.ts` (client, +13) | 21 |

The listen-meta tests run against a **real** upstream `Client`, not a stand-in, because the whole point is the interaction with upstream's private envelope member — a client bump that moves it fails these rather than silently dropping the declaration.

Full client suite passes (6608 tests). Full SDK suite passes apart from one pre-existing unrelated failure in `browser-entry-guard.test.ts` (`src/xaa/constants.ts`), verified present on `main` before these changes; the new browser-entry exports were separately confirmed to pull in zero `node_modules` and no forbidden packages.

## Not in this PR

Workstreams E (public API `v1/tasks`), F (CLI cloud commands), and G (docs/fixtures/metrics) are still open, as is the Inspector-side registry integration (D5). The backend half of Workstream D is in the companion `mcpjam-backend` PR and must deploy before its Inspector callers are enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQjGLarf5FKESJqY9C8Nsh

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQjGLarf5FKESJqY9C8Nsh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral change to task polling, persistence, and subscription handling across reloads and hosted connections; mistakes could cause missed updates, excess server load, or stuck/restored tasks, but changes are heavily tested and fail closed on policy/declaration gaps.
> 
> **Overview**
> **Tasks tab polling** no longer uses one `setInterval` and `Math.min` of poll intervals (or a user override that could undercut the server floor). It wires in `useTaskScheduler` around the SDK `TaskLifecycleEngine`: each handle is read only when due, claims prevent duplicate `tasks/get` on overlapping refreshes, and auto-refresh is a self-rearming timeout from `msUntilNextDue()`. Legacy `tasks/list` is gated so the batch respects the **slowest** active task’s floor; when the list isn’t due as a whole, individually due listed tasks still get per-id `tasks/get`. Rows that aren’t due yet (or failed transient reads) stay visible via `restoredPlaceholderTask` / carry-forward so reload doesn’t empty the list and kill auto-refresh. Restored extension **completed** handles owe one inline recovery read—auto-refresh stays on until that finishes or hits `MAX_RECOVERY_READ_ATTEMPTS`, with UI + manual Refresh clearing backoff for exhausted cases. Extension input keys are marked answered only after `tasks/update` succeeds and are persisted for reload.
> 
> **Local tracker** bumps to schema **v3**: resumable `nextPollAt`, status, poll/TTL hints, and answered-input **keys only**; batched read/write APIs, stricter sanitize/identity rules, and save ordering that prefers the current scope when trimming storage.
> 
> **SDK** exports the shared lifecycle engine and adapters, tri-state **`com.mcpjam/tasks`** host policy (never on the wire), task-input and await drivers, and task-created fan-out. The subscription coordinator adds optional **`notifications/tasks`** with `taskIds` filtering (modern era + extension capability), intersection of requested/acknowledged filters for delivery, declared `listenWithTasksDeclaration` when needed, and visible rejection when declaration isn’t available—polling remains the correctness path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53baf529738a22ff6df0bcf269c5536108293b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a shared task lifecycle engine with per‑task due‑time scheduling and a tri‑state Tasks host policy, plus task notifications and a complete input driver. Improves reliability across reloads, polling, and automation, and keeps the Tasks tab live while restored terminals finish their one recovery read.

- **New Features**
  - Shared `TaskLifecycleEngine` with per‑task scheduling: max(server `pollIntervalMs`, user minimum, backoff, Retry‑After); adapters for legacy and `io.modelcontextprotocol/tasks`; `await` driver for named terminal outcomes; `TaskCreatedSink` fan‑out.
  - Tasks tab uses `use-task-scheduler`; tracker schema v3 persists schedule hints and answered input keys (keys only) to resume after reload.
  - `input_required` driver (`elicitation/create`, `roots/list`, `sampling/createMessage`) with the same policy/consent/schema checks as standalone; optional task notifications via `subscriptions/listen` with `taskIds` and a per‑request declaration seam; always falls back to polling.
  - Tri‑state host policy `com.mcpjam/tasks` (`unset`/`on`/`off`), never advertised on the wire.

- **Bug Fixes**
  - Scheduling and leases: engine claims due reads and releases on settle; `tasks/list` waits for the slowest active member while individually‑due tasks get per‑id `tasks/get`; user preference changes can pull earlier due times when allowed, with `Retry‑After` and error backoff as floors; timers arm correctly; restored terminals owe one recovery read.
  - UI liveness: the Tasks tab keeps auto‑refresh active while a restored terminal (extension wire) still owes its recovery read; attempts are capped at 5; manual Refresh clears local backoff first.
  - Notifications and streams: delivery is enforced against the intersection of requested and acknowledged filters for identifier‑bearing kinds (tasks/resources) to prevent unsolicited updates; notifications don’t clear poll‑path backoff; the `subscriptions/listen` seam closes leaked streams on failure; unopened stream records are bounded.
  - Persistence and identity: reject NULs and over‑long `scope`/`serverId`/`taskId`; strict status restore (protocol terminals only), durable backoff/next‑due; null‑prototype maps; malformed `createdAt` rejected; abort/deadline races fixed; trim preserves the current scope so newest local tasks are kept ahead of old scopes.
  - Creation and results: fan‑out delivers to every consumer before throwing and aggregates functional failures; legacy results fetched via `tasks/result` through a `getResult` seam; terminal fast path respects `owesRead`; terminal settle unified.

<sup>Written for commit a53baf529738a22ff6df0bcf269c5536108293b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

