### PR TITLE
feat: environment-backed chatboxes — publish UI + live-follow chat-v2 (Phase 5)

### DIFF
--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
@@ -21,6 +21,7 @@ import {
   type ProjectEnvironmentView,
 } from "@/hooks/useProjectEnvironments";
 import { ProjectEnvironmentEditor } from "./ProjectEnvironmentEditor";
+import { EnvironmentChatboxSection } from "./environment-chatbox-section";
 import { useProjectEnvironmentConsumers } from "./use-project-environment-consumers";
 
 /**
@@ -288,10 +289,11 @@ function EnvironmentDetail({
   const restoreEnvironment = useRestoreProjectEnvironment();
   const [confirmingArchive, setConfirmingArchive] = useState(false);
   const [busy, setBusy] = useState(false);
-  const { suiteCount, journeyCount } = useProjectEnvironmentConsumers(
-    projectId,
-    confirmingArchive ? environment.environmentId : null
-  );
+  const { suiteCount, journeyCount, chatboxCount } =
+    useProjectEnvironmentConsumers(
+      projectId,
+      confirmingArchive ? environment.environmentId : null
+    );
 
   const isArchived = !!environment.archivedAt;
 
@@ -300,16 +302,23 @@ function EnvironmentDetail({
   // stays hedged ("may be incomplete"). Wait for BOTH to settle before
   // reporting, so a half-loaded state can't flash a misleading zero.
   const referenceSummary =
-    suiteCount === null || journeyCount === null
+    suiteCount === null || journeyCount === null || chatboxCount === null
       ? "Checking references…"
       : (() => {
           const suitePart = `${suiteCount} suite${suiteCount === 1 ? "" : "s"}`;
           const journeyPart = `${journeyCount} journey${
             journeyCount === 1 ? "" : "s"
           }`;
+          // The published chatbox is called out separately: unlike suites and
+          // journeys (which fail at their next launch), a chatbox share link
+          // is live for outsiders and starts failing the moment this archives.
+          const chatboxPart =
+            chatboxCount > 0
+              ? " Its published chatbox link stops working immediately."
+              : "";
           return suiteCount + journeyCount > 0
-            ? `${suitePart} and ${journeyPart} reference it (count may be incomplete).`
-            : "No referencing suites or journeys found (count may be incomplete).";
+            ? `${suitePart} and ${journeyPart} reference it (count may be incomplete).${chatboxPart}`
+            : `No referencing suites or journeys found (count may be incomplete).${chatboxPart}`;
         })();
 
   const onArchive = async () => {
@@ -383,6 +392,18 @@ function EnvironmentDetail({
         environment={environment}
         canManage={canManage && !isArchived}
       />
+
+      {/* Publish-as-chatbox (Phase 5). Hidden for archived environments: the
+          backend rejects publish on archived, and an existing published link
+          already fails loudly with the archived error. */}
+      {!isArchived ? (
+        <EnvironmentChatboxSection
+          projectId={projectId}
+          environmentId={environment.environmentId}
+          environmentName={environment.name}
+          canManage={canManage}
+        />
+      ) : null}
 
       {canManage && !isArchived ? (
         <div className="flex items-center justify-between border-t pt-4">

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/archive-consumer-counts.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/archive-consumer-counts.test.tsx
@@ -12,9 +12,10 @@ const { mockFlagValue, mockListEnvironments, mockConsumers } = vi.hoisted(
     mockFlagValue: { value: true as boolean | undefined },
     mockListEnvironments: vi.fn(() => [] as unknown[]),
     mockConsumers: {
-      value: { suiteCount: 0, journeyCount: 0 } as {
+      value: { suiteCount: 0, journeyCount: 0, chatboxCount: 0 } as {
         suiteCount: number | null;
         journeyCount: number | null;
+        chatboxCount: number | null;
       },
     },
   })
@@ -34,6 +35,10 @@ vi.mock("../ProjectEnvironmentEditor", () => ({
 }));
 vi.mock("../use-project-environment-consumers", () => ({
   useProjectEnvironmentConsumers: () => mockConsumers.value,
+}));
+// The publish panel has its own Convex reads/mutations; out of scope here.
+vi.mock("../environment-chatbox-section", () => ({
+  EnvironmentChatboxSection: () => null,
 }));
 
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";
@@ -72,7 +77,7 @@ beforeEach(() => {
 
 describe("archive-confirm consumer counts", () => {
   it("names both the suite and the journey counts", () => {
-    mockConsumers.value = { suiteCount: 2, journeyCount: 3 };
+    mockConsumers.value = { suiteCount: 2, journeyCount: 3, chatboxCount: 0 };
     renderAndOpenArchiveConfirm();
 
     const summary = screen.getByText(/reference it/i);
@@ -81,7 +86,7 @@ describe("archive-confirm consumer counts", () => {
   });
 
   it("reports zero of each (not 'journeys aren't scanned') when nothing references it", () => {
-    mockConsumers.value = { suiteCount: 0, journeyCount: 0 };
+    mockConsumers.value = { suiteCount: 0, journeyCount: 0, chatboxCount: 0 };
     renderAndOpenArchiveConfirm();
 
     expect(
@@ -91,7 +96,7 @@ describe("archive-confirm consumer counts", () => {
   });
 
   it("singularizes a single journey reference", () => {
-    mockConsumers.value = { suiteCount: 0, journeyCount: 1 };
+    mockConsumers.value = { suiteCount: 0, journeyCount: 1, chatboxCount: 0 };
     renderAndOpenArchiveConfirm();
 
     const summary = screen.getByText(/reference it/i);
@@ -99,9 +104,25 @@ describe("archive-confirm consumer counts", () => {
   });
 
   it("shows a checking state until both scans settle", () => {
-    mockConsumers.value = { suiteCount: 2, journeyCount: null };
+    mockConsumers.value = { suiteCount: 2, journeyCount: null, chatboxCount: 0 };
     renderAndOpenArchiveConfirm();
 
     expect(screen.getByText(/checking references/i)).toBeInTheDocument();
+  });
+
+  it("holds the checking state until the chatbox scan settles too (Phase 5)", () => {
+    mockConsumers.value = { suiteCount: 2, journeyCount: 3, chatboxCount: null };
+    renderAndOpenArchiveConfirm();
+
+    expect(screen.getByText(/checking references/i)).toBeInTheDocument();
+  });
+
+  it("warns that a published chatbox link stops working immediately (Phase 5)", () => {
+    mockConsumers.value = { suiteCount: 0, journeyCount: 0, chatboxCount: 1 };
+    renderAndOpenArchiveConfirm();
+
+    expect(
+      screen.getByText(/chatbox link stops working immediately/i)
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * The publish-as-chatbox panel on the Environments route (Phase 5,
+ * live-follow). Mutations are mocked with a NAME-KEYED dispatcher (the
+ * ChatboxesTab.journeys pattern) — a single-mutation mock breaks the moment a
+ * component holds more than one `useMutation`.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockQuery, mutationMocks } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mutationMocks: {
+    publish: vi.fn(),
+    unpublish: vi.fn(),
+    setMode: vi.fn(),
+  },
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => mockQuery(name, args),
+  useConvexAuth: () => ({ isAuthenticated: true }),
+  useMutation: (name: string) => {
+    switch (name) {
+      case "chatboxes:publishEnvironmentChatbox":
+        return mutationMocks.publish;
+      case "chatboxes:unpublishEnvironmentChatbox":
+        return mutationMocks.unpublish;
+      case "chatboxes:setChatboxMode":
+        return mutationMocks.setMode;
+      default:
+        return vi.fn();
+    }
+  },
+}));
+vi.mock("@/contexts/db-user-ready-context", () => ({
+  useDbUserReady: () => true,
+}));
+vi.mock("@/hooks/useProjects", () => ({
+  shouldQueryProjectId: (projectId: string | null | undefined) => !!projectId,
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { EnvironmentChatboxSection } from "../environment-chatbox-section";
+
+const ENV_CHATBOX_ROW = {
+  chatboxId: "cbx-env",
+  environmentId: "env-1",
+  name: "Staging",
+  mode: "anyone_with_link",
+  allowGuestAccess: true,
+  link: {
+    token: "tok",
+    path: "/c/tok",
+    url: "https://mcpjam.com/c/tok",
+  },
+};
+
+function stubChatboxList(rows: unknown[] | undefined) {
+  mockQuery.mockImplementation((name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    if (name === "chatboxes:listChatboxes") return rows;
+    return undefined;
+  });
+}
+
+function renderSection(props?: Partial<{ canManage: boolean }>) {
+  return render(
+    <EnvironmentChatboxSection
+      projectId="proj-1"
+      environmentId="env-1"
+      environmentName="Staging"
+      canManage={props?.canManage ?? true}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mutationMocks.publish.mockResolvedValue({
+    chatboxId: "cbx-env",
+    environmentId: "env-1",
+    created: true,
+  });
+  mutationMocks.unpublish.mockResolvedValue({ deleted: true });
+  mutationMocks.setMode.mockResolvedValue({});
+});
+
+describe("EnvironmentChatboxSection", () => {
+  it("offers publish when the environment has no chatbox", async () => {
+    stubChatboxList([]);
+    renderSection();
+
+    fireEvent.click(screen.getByTestId("environment-chatbox-publish"));
+    await waitFor(() =>
+      expect(mutationMocks.publish).toHaveBeenCalledWith({
+        environmentId: "env-1",
+      })
+    );
+  });
+
+  it("renders nothing while the list is loading (no publish flash)", () => {
+    stubChatboxList(undefined);
+    const { container } = renderSection();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the share link and unpublishes behind a confirm", async () => {
+    stubChatboxList([ENV_CHATBOX_ROW]);
+    renderSection();
+
+    expect(
+      screen.getByTestId("environment-chatbox-link").textContent
+    ).toContain("https://mcpjam.com/c/tok");
+
+    // First click arms the confirm; the mutation must NOT fire yet.
+    fireEvent.click(screen.getByTestId("environment-chatbox-unpublish"));
+    expect(mutationMocks.unpublish).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("environment-chatbox-unpublish-confirm"));
+    await waitFor(() =>
+      expect(mutationMocks.unpublish).toHaveBeenCalledWith({
+        environmentId: "env-1",
+      })
+    );
+  });
+
+  it("ignores another environment's chatbox row", () => {
+    stubChatboxList([{ ...ENV_CHATBOX_ROW, environmentId: "env-other" }]);
+    renderSection();
+    // Reads as unpublished → publish affordance, no link.
+    expect(
+      screen.getByTestId("environment-chatbox-publish")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("environment-chatbox-link")
+    ).not.toBeInTheDocument();
+  });
+
+  it("read-only members see the link but no publish/unpublish/access controls", () => {
+    stubChatboxList([ENV_CHATBOX_ROW]);
+    renderSection({ canManage: false });
+
+    expect(
+      screen.getByTestId("environment-chatbox-link")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("environment-chatbox-unpublish")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("environment-chatbox-access")
+    ).not.toBeInTheDocument();
+  });
+
+  it("read-only members with an UNPUBLISHED environment see nothing", () => {
+    stubChatboxList([]);
+    const { container } = renderSection({ canManage: false });
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
@@ -118,7 +118,9 @@ describe("EnvironmentChatboxSection", () => {
     fireEvent.click(screen.getByTestId("environment-chatbox-unpublish"));
     expect(mutationMocks.unpublish).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByTestId("environment-chatbox-unpublish-confirm"));
+    fireEvent.click(
+      screen.getByTestId("environment-chatbox-unpublish-confirm")
+    );
     await waitFor(() =>
       expect(mutationMocks.unpublish).toHaveBeenCalledWith({
         environmentId: "env-1",
@@ -142,9 +144,7 @@ describe("EnvironmentChatboxSection", () => {
     stubChatboxList([ENV_CHATBOX_ROW]);
     renderSection({ canManage: false });
 
-    expect(
-      screen.getByTestId("environment-chatbox-link")
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("environment-chatbox-link")).toBeInTheDocument();
     expect(
       screen.queryByTestId("environment-chatbox-unpublish")
     ).not.toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/use-project-environment-consumers.test.ts
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/use-project-environment-consumers.test.ts
@@ -25,13 +25,19 @@ import { useProjectEnvironmentConsumers } from "../use-project-environment-consu
 
 const SUITE_QUERY = "testSuites:getTestSuitesOverview";
 const JOURNEY_QUERY = "journeys:listJourneysByProject";
+const CHATBOX_QUERY = "chatboxes:listChatboxes";
 
 /** Route each Convex query name to a canned result (or `undefined` = loading). */
-function stubQueries(results: { suites?: unknown; journeys?: unknown }) {
+function stubQueries(results: {
+  suites?: unknown;
+  journeys?: unknown;
+  chatboxes?: unknown;
+}) {
   mockQuery.mockImplementation((name: string, args: unknown) => {
     if (args === "skip") return undefined;
     if (name === SUITE_QUERY) return results.suites;
     if (name === JOURNEY_QUERY) return results.journeys;
+    if (name === CHATBOX_QUERY) return results.chatboxes;
     return undefined;
   });
 }
@@ -78,7 +84,7 @@ describe("useProjectEnvironmentConsumers", () => {
   });
 
   it("reports null per-source while that source is still loading", () => {
-    stubQueries({ suites: [], journeys: undefined });
+    stubQueries({ suites: [], journeys: undefined, chatboxes: undefined });
 
     const { result } = renderHook(() =>
       useProjectEnvironmentConsumers("proj-1", "env-1")
@@ -86,6 +92,29 @@ describe("useProjectEnvironmentConsumers", () => {
 
     expect(result.current.suiteCount).toBe(0);
     expect(result.current.journeyCount).toBeNull();
+    expect(result.current.chatboxCount).toBeNull();
+  });
+
+  it("counts the published chatbox backed by the environment (Phase 5)", () => {
+    stubQueries({
+      suites: [],
+      journeys: [],
+      chatboxes: [
+        // Host-backed rows: field absent (old backend) or explicit null.
+        { chatboxId: "cbx-host-a" },
+        { chatboxId: "cbx-host-b", environmentId: null },
+        // The env-backed row.
+        { chatboxId: "cbx-env", environmentId: "env-1" },
+        // Another environment's chatbox must not count.
+        { chatboxId: "cbx-other", environmentId: "env-2" },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useProjectEnvironmentConsumers("proj-1", "env-1")
+    );
+
+    expect(result.current.chatboxCount).toBe(1);
   });
 
   it("skips both queries and reports null when no environment is targeted", () => {

--- a/mcpjam-inspector/client/src/components/project-environments/environment-chatbox-section.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/environment-chatbox-section.tsx
@@ -1,0 +1,281 @@
+import { useState } from "react";
+import { ChevronDown, Copy, ExternalLink, Globe, Loader2 } from "lucide-react";
+import { toast } from "@/lib/toast";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import { convexErrMessage } from "@/lib/convex-error";
+import { useChatboxMutations } from "@/hooks/useChatboxes";
+import {
+  chatboxAccessPresetFromSettings,
+  settingsFromChatboxAccessPreset,
+  type ChatboxAccessPreset,
+} from "@/lib/chatbox-access-presets";
+import {
+  useEnvironmentChatbox,
+  usePublishEnvironmentChatbox,
+  useUnpublishEnvironmentChatbox,
+} from "@/hooks/useProjectEnvironments";
+
+const ACCESS_PRESET_LABELS: Record<ChatboxAccessPreset, string> = {
+  project: "Project members",
+  invited_only: "Invited only",
+  link_guests: "Anyone with the link",
+};
+
+/**
+ * Publish-as-chatbox panel for one environment (Phase 5, live-follow).
+ *
+ * The published chatbox is a POINTER to the environment: edits reflect
+ * immediately on the share link, so unlike ChatboxesTab there is no
+ * republish/snapshot affordance here — just publish, access mode, copy link,
+ * and unpublish. Invited-member management stays on the chatbox surfaces;
+ * this panel deliberately does not fork ChatboxShareSection (which needs the
+ * full members-carrying `ChatboxSettings`).
+ */
+export function EnvironmentChatboxSection({
+  projectId,
+  environmentId,
+  environmentName,
+  canManage,
+}: {
+  projectId: string;
+  environmentId: string;
+  environmentName: string;
+  canManage: boolean;
+}) {
+  const chatbox = useEnvironmentChatbox(projectId, environmentId);
+  const publishChatbox = usePublishEnvironmentChatbox();
+  const unpublishChatbox = useUnpublishEnvironmentChatbox();
+  const { setChatboxMode } = useChatboxMutations();
+  const [busy, setBusy] = useState(false);
+  const [confirmingUnpublish, setConfirmingUnpublish] = useState(false);
+
+  if (chatbox === undefined) {
+    return null;
+  }
+
+  const onPublish = async () => {
+    setBusy(true);
+    try {
+      await publishChatbox({ environmentId });
+      toast.success(`Published “${environmentName}” as a chatbox.`);
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Could not publish the chatbox."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onUnpublish = async () => {
+    setBusy(true);
+    try {
+      await unpublishChatbox({ environmentId });
+      toast.success("Chatbox unpublished. The share link no longer works.");
+      setConfirmingUnpublish(false);
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Could not unpublish the chatbox."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onAccessPresetChange = async (preset: ChatboxAccessPreset) => {
+    if (!chatbox) return;
+    const current = chatboxAccessPresetFromSettings(
+      chatbox.mode,
+      chatbox.allowGuestAccess
+    );
+    if (preset === current) return;
+    const target = settingsFromChatboxAccessPreset(preset);
+    setBusy(true);
+    try {
+      await setChatboxMode({ chatboxId: chatbox.chatboxId, mode: target.mode });
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Could not update chatbox access."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCopyLink = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success("Link copied.");
+    } catch {
+      toast.error("Could not copy the link.");
+    }
+  };
+
+  if (!chatbox) {
+    if (!canManage) return null;
+    return (
+      <div className="flex items-center justify-between gap-3 rounded-md border p-3">
+        <div>
+          <p className="text-sm font-medium text-foreground">Chatbox</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Publish this environment as a shareable chat. The link always runs
+            the environment as currently configured — edits apply immediately.
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="shrink-0"
+          disabled={busy}
+          onClick={() => void onPublish()}
+          data-testid="environment-chatbox-publish"
+        >
+          {busy ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : null}
+          Publish as chatbox
+        </Button>
+      </div>
+    );
+  }
+
+  const accessPreset = chatboxAccessPresetFromSettings(
+    chatbox.mode,
+    chatbox.allowGuestAccess
+  );
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Globe className="size-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">
+              Published as chatbox
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Live-follow: the link runs the environment as currently
+              configured. Archiving the environment makes the link fail.
+            </p>
+          </div>
+        </div>
+        {canManage ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 shrink-0 text-xs"
+                disabled={busy}
+                data-testid="environment-chatbox-access"
+              >
+                {ACCESS_PRESET_LABELS[accessPreset]}
+                <ChevronDown className="ml-1 size-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuRadioGroup
+                value={accessPreset}
+                onValueChange={(value) =>
+                  void onAccessPresetChange(value as ChatboxAccessPreset)
+                }
+              >
+                {(
+                  Object.keys(ACCESS_PRESET_LABELS) as ChatboxAccessPreset[]
+                ).map((preset) => (
+                  <DropdownMenuRadioItem key={preset} value={preset}>
+                    {ACCESS_PRESET_LABELS[preset]}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+      </div>
+
+      {chatbox.link ? (
+        <div className="flex items-center gap-2">
+          <code
+            className="min-w-0 flex-1 truncate rounded bg-muted/50 px-2 py-1.5 font-mono text-[11px] text-muted-foreground"
+            data-testid="environment-chatbox-link"
+          >
+            {chatbox.link.url}
+          </code>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 shrink-0 px-2 text-xs"
+            onClick={() => void onCopyLink(chatbox.link!.url)}
+          >
+            <Copy className="mr-1 size-3" /> Copy
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-7 shrink-0 px-2 text-xs"
+            asChild
+          >
+            <a
+              href={chatbox.link.url}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              <ExternalLink className="mr-1 size-3" /> Open
+            </a>
+          </Button>
+        </div>
+      ) : null}
+
+      {canManage ? (
+        <div className="flex items-center justify-end gap-2 text-xs">
+          {confirmingUnpublish ? (
+            <>
+              <span className="text-muted-foreground">
+                Unpublish? The share link stops working; the environment is
+                untouched.
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="destructive"
+                className="h-7 text-xs"
+                disabled={busy}
+                onClick={() => void onUnpublish()}
+                data-testid="environment-chatbox-unpublish-confirm"
+              >
+                {busy ? (
+                  <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                ) : null}
+                Unpublish
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs"
+                disabled={busy}
+                onClick={() => setConfirmingUnpublish(false)}
+              >
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs text-destructive hover:text-destructive"
+              onClick={() => setConfirmingUnpublish(true)}
+              data-testid="environment-chatbox-unpublish"
+            >
+              Unpublish
+            </Button>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/project-environments/use-project-environment-consumers.ts
+++ b/mcpjam-inspector/client/src/components/project-environments/use-project-environment-consumers.ts
@@ -15,7 +15,16 @@ import { shouldQueryProjectId } from "@/hooks/useProjects";
 export function useProjectEnvironmentConsumers(
   projectId: string | null,
   environmentId: string | null
-): { suiteCount: number | null; journeyCount: number | null } {
+): {
+  suiteCount: number | null;
+  journeyCount: number | null;
+  /**
+   * Published chatboxes backed by this environment (0 or 1 — backend-enforced
+   * one-per-environment). Unlike the advisory suite/journey scans this one is
+   * exact when settled: the chatbox list carries `environmentId` per row.
+   */
+  chatboxCount: number | null;
+} {
   const { isAuthenticated } = useConvexAuth();
   const isUserReady = useDbUserReady();
   const enableQuery =
@@ -34,9 +43,14 @@ export function useProjectEnvironmentConsumers(
     enableQuery ? ({ projectId } as any) : "skip"
   ) as Array<{ environmentIds?: string[] | null }> | undefined;
 
+  const chatboxes = useQuery(
+    "chatboxes:listChatboxes" as any,
+    enableQuery ? ({ projectId } as any) : "skip"
+  ) as Array<{ environmentId?: string | null }> | undefined;
+
   return useMemo(() => {
     if (!environmentId) {
-      return { suiteCount: null, journeyCount: null };
+      return { suiteCount: null, journeyCount: null, chatboxCount: null };
     }
     const suiteCount =
       overview === undefined
@@ -50,6 +64,12 @@ export function useProjectEnvironmentConsumers(
         : journeys.filter((journey) =>
             (journey.environmentIds ?? []).includes(environmentId)
           ).length;
-    return { suiteCount, journeyCount };
-  }, [overview, journeys, environmentId]);
+    const chatboxCount =
+      chatboxes === undefined
+        ? null
+        : chatboxes.filter(
+            (chatbox) => chatbox.environmentId === environmentId
+          ).length;
+    return { suiteCount, journeyCount, chatboxCount };
+  }, [overview, journeys, chatboxes, environmentId]);
 }

--- a/mcpjam-inspector/client/src/components/project-environments/use-project-environment-consumers.ts
+++ b/mcpjam-inspector/client/src/components/project-environments/use-project-environment-consumers.ts
@@ -67,9 +67,8 @@ export function useProjectEnvironmentConsumers(
     const chatboxCount =
       chatboxes === undefined
         ? null
-        : chatboxes.filter(
-            (chatbox) => chatbox.environmentId === environmentId
-          ).length;
+        : chatboxes.filter((chatbox) => chatbox.environmentId === environmentId)
+            .length;
     return { suiteCount, journeyCount, chatboxCount };
   }, [overview, journeys, chatboxes, environmentId]);
 }

--- a/mcpjam-inspector/client/src/hooks/useChatboxes.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxes.ts
@@ -110,6 +110,13 @@ export interface ChatboxListItem {
   /** The named host this chatbox resolves through. */
   namedHostId: string;
   namedHostName: string;
+  /**
+   * Phase 5: non-null iff this chatbox is environment-backed (live-follow,
+   * mcpjam-backend #805) — for those rows `namedHostId`/`namedHostName` are
+   * display-only. Optional so a backend predating the field reads as
+   * host-backed.
+   */
+  environmentId?: string | null;
   createdAt: number;
   updatedAt: number;
 }

--- a/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
@@ -178,6 +178,99 @@ export function useRestoreProjectEnvironment(): (args: {
   return useMutation("projectEnvironments:restoreEnvironment" as any) as never;
 }
 
+// ── Environment-backed chatbox (Phase 5, live-follow) ───────────────────────
+
+/**
+ * Projection returned by `chatboxes:publishEnvironmentChatbox` /
+ * carried per-row by `chatboxes:listChatboxes` for env-backed rows. The
+ * chatbox is a POINTER to the environment (no host-config pin): editing the
+ * environment updates the published chatbox immediately, so there is no
+ * revision captured here on purpose.
+ */
+export interface EnvironmentChatboxSummary {
+  chatboxId: string;
+  environmentId: string;
+  name: string;
+  mode: "anyone_with_link" | "invited_only" | "project_members";
+  allowGuestAccess: boolean;
+  link: { token: string; path: string; url: string } | null;
+}
+
+/**
+ * The published chatbox for one environment, or `null` when unpublished.
+ * Reads the project chatbox list (which carries `environmentId` per row since
+ * mcpjam-backend #805) rather than a dedicated query — one-per-environment is
+ * backend-enforced, so `find` is exact. `undefined` while loading; a backend
+ * predating #805 never marks a row, which correctly reads as unpublished.
+ */
+export function useEnvironmentChatbox(
+  projectId: string | null,
+  environmentId: string | null
+): EnvironmentChatboxSummary | null | undefined {
+  const { isAuthenticated } = useConvexAuth();
+  const isUserReady = useDbUserReady();
+  const normalizedProjectId = projectId?.trim() || null;
+  const enableQuery =
+    isAuthenticated &&
+    isUserReady &&
+    shouldQueryProjectId(normalizedProjectId) &&
+    Boolean(environmentId?.trim());
+  const chatboxes = useQuery(
+    "chatboxes:listChatboxes" as any,
+    enableQuery ? ({ projectId: normalizedProjectId } as any) : "skip"
+  ) as
+    | Array<{
+        chatboxId: string;
+        environmentId?: string | null;
+        name: string;
+        mode: EnvironmentChatboxSummary["mode"];
+        allowGuestAccess: boolean;
+        link?: { token: string; path: string; url: string } | null;
+      }>
+    | undefined;
+  if (!enableQuery || chatboxes === undefined) return undefined;
+  const row = chatboxes.find(
+    (chatbox) => chatbox.environmentId === environmentId?.trim()
+  );
+  if (!row) return null;
+  return {
+    chatboxId: row.chatboxId,
+    environmentId: environmentId!.trim(),
+    name: row.name,
+    mode: row.mode,
+    allowGuestAccess: row.allowGuestAccess,
+    link: row.link ?? null,
+  };
+}
+
+/**
+ * Publish an environment as a chatbox (project-admin gated, idempotent:
+ * a second publish returns the existing row with `created: false`).
+ */
+export function usePublishEnvironmentChatbox(): (args: {
+  environmentId: string;
+}) => Promise<{
+  chatboxId: string;
+  environmentId: string;
+  name: string;
+  mode: EnvironmentChatboxSummary["mode"];
+  accessVersion: number;
+  link: { token: string; path: string; url: string } | null;
+  created: boolean;
+}> {
+  return useMutation("chatboxes:publishEnvironmentChatbox" as any) as never;
+}
+
+/**
+ * Unpublish: deletes the chatbox row + its cascade ONLY — the host and the
+ * environment both survive (backend-guarded).
+ */
+export function useUnpublishEnvironmentChatbox(): (args: {
+  environmentId: string;
+}) => Promise<{ deleted: boolean; chatboxId?: string }> {
+  return useMutation("chatboxes:unpublishEnvironmentChatbox" as any) as never;
+}
+
 /**
  * True when a mutation rejection is the backend's stale-`expectedRevision`
  * conflict. Wire-tolerant: matches the structured ConvexError code first and

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.chatbox-environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.chatbox-environment.test.ts
@@ -86,7 +86,10 @@ vi.mock("../../../utils/chatbox-runtime-config.js", async () => {
   >("../../../utils/chatbox-runtime-config.js");
   // The route's parsing (`readChatboxEnvironment`) stays REAL — that is the
   // seam under test; only the network fetch is mocked.
-  return { ...actual, fetchChatboxRuntimeConfig: fetchChatboxRuntimeConfigMock };
+  return {
+    ...actual,
+    fetchChatboxRuntimeConfig: fetchChatboxRuntimeConfigMock,
+  };
 });
 
 vi.mock("../../../utils/harness/harness-availability.js", () => ({

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.chatbox-environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.chatbox-environment.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Covers the ENVIRONMENT-BACKED CHATBOX half of web/chat-v2 (Phase 5,
+// mcpjam-backend #805): when the chatbox runtime config carries the additive
+// `environment` payload, the turn runs on the environment's resolved server
+// set and skill union — never the request body's — and a present-but-malformed
+// payload stops the turn instead of silently falling back. An absent payload
+// keeps the legacy host-backed behavior byte-identical.
+
+const {
+  prepareChatV2Mock,
+  handleMCPJamFreeChatModelMock,
+  fetchHostRuntimeConfigMock,
+  fetchChatboxRuntimeConfigMock,
+  persistChatSessionToConvexMock,
+  disconnectAllServersMock,
+  convexQueryMock,
+} = vi.hoisted(() => ({
+  prepareChatV2Mock: vi.fn(),
+  handleMCPJamFreeChatModelMock: vi.fn(),
+  fetchHostRuntimeConfigMock: vi.fn(),
+  fetchChatboxRuntimeConfigMock: vi.fn(),
+  persistChatSessionToConvexMock: vi.fn(),
+  disconnectAllServersMock: vi.fn(),
+  convexQueryMock: vi.fn(),
+}));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return { ...actual, convertToModelMessages: vi.fn((messages) => messages) };
+});
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+  })),
+}));
+
+vi.mock("@mcpjam/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
+  return {
+    ...actual,
+    isMCPAuthError: vi.fn().mockReturnValue(false),
+    MCPClientManager: vi.fn().mockImplementation(() => ({
+      disconnectAllServers: disconnectAllServersMock,
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+      readResource: vi.fn().mockResolvedValue({ contents: [] }),
+    })),
+  };
+});
+
+vi.mock("../../../utils/chat-v2-orchestration.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chat-v2-orchestration.js")
+  >("../../../utils/chat-v2-orchestration.js");
+  return { ...actual, prepareChatV2: prepareChatV2Mock };
+});
+
+vi.mock("../../../utils/mcpjam-stream-handler.js", () => ({
+  handleMCPJamFreeChatModel: handleMCPJamFreeChatModelMock,
+  warnIfChatAbortSignalMissing: () => {},
+}));
+
+vi.mock("../../../utils/chat-ingestion.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chat-ingestion.js")
+  >("../../../utils/chat-ingestion.js");
+  return {
+    ...actual,
+    persistChatSessionToConvex: persistChatSessionToConvexMock,
+    pickEnrichmentHeaders: vi.fn(() => ({})),
+  };
+});
+
+vi.mock("../../../utils/host-runtime-config.js", () => ({
+  fetchHostRuntimeConfig: fetchHostRuntimeConfigMock,
+}));
+
+vi.mock("../../../utils/chatbox-runtime-config.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chatbox-runtime-config.js")
+  >("../../../utils/chatbox-runtime-config.js");
+  // The route's parsing (`readChatboxEnvironment`) stays REAL — that is the
+  // seam under test; only the network fetch is mocked.
+  return { ...actual, fetchChatboxRuntimeConfig: fetchChatboxRuntimeConfigMock };
+});
+
+vi.mock("../../../utils/harness/harness-availability.js", () => ({
+  checkHarnessRuntimeAvailable: () => ({ ok: true }),
+}));
+
+vi.mock("../apps.js", () => ({ default: new Hono() }));
+
+import { createWebTestApp, postJson } from "./helpers/test-app.js";
+
+/** The base (host-backed) chatbox runtime config — no environment payload. */
+const CHATBOX_CONFIG = {
+  chatboxId: "cbx_env",
+  accessVersion: 3,
+  modelId: "openai/gpt-5-mini",
+  systemPrompt: "chatbox prompt",
+  temperature: 0.7,
+  requireToolApproval: false,
+  hostStyle: "claude",
+};
+
+/** The additive payload an environment-backed chatbox carries (backend #805). */
+const ENVIRONMENT_PAYLOAD = {
+  environmentRef: { environmentId: "env_1", name: "Staging", revision: 7 },
+  servers: {
+    effectiveServerIds: ["env-server-1", "env-server-2"],
+    connectable: [
+      { serverId: "env-server-1", name: "linear", source: "host_or_group" },
+      { serverId: "env-server-2", name: "asana", source: "plugin" },
+    ],
+  },
+  skills: [
+    {
+      skillId: "sk_env",
+      name: "release-notes",
+      description: "Write release notes",
+      content: "env skill body",
+      aggregateHash: "agg_env",
+      channels: ["environment"],
+      files: [],
+    },
+  ],
+};
+
+const BASE_BODY = {
+  projectId: "project-1",
+  chatboxId: "cbx_env",
+  accessVersion: 3,
+  // Deliberately WRONG/stale: an environment-backed chatbox turn must ignore
+  // this entirely; a host-backed one still honors it (legacy behavior).
+  selectedServerIds: ["body-server-9"],
+  selectedServerNames: ["body-server"],
+  chatSessionId: "chat-session-1",
+  messages: [{ role: "user", content: "hi" }],
+  model: { id: "openai/gpt-5-mini", provider: "openai", name: "GPT-5 Mini" },
+};
+
+describe("web chat-v2 — environment-backed chatbox", () => {
+  const originalFetch = global.fetch;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+  const originalConvexUrl = process.env.CONVEX_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+    process.env.CONVEX_URL = "https://example.convex.cloud";
+
+    prepareChatV2Mock.mockResolvedValue({
+      allTools: {},
+      enhancedSystemPrompt: "system",
+      resolvedTemperature: 0.7,
+    });
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: { ...CHATBOX_CONFIG, environment: ENVIRONMENT_PAYLOAD },
+    });
+    handleMCPJamFreeChatModelMock.mockImplementation(async (options: any) => {
+      await options.onConversationComplete?.(
+        [{ role: "user", content: "hi" }],
+        {
+          turnId: "t",
+          promptIndex: 0,
+          startedAt: 1,
+          endedAt: 2,
+          spans: [],
+          modelId: "test-model",
+        }
+      );
+      options.onStreamComplete?.();
+      return new Response("ok", { status: 200 });
+    });
+
+    global.fetch = vi.fn(async (input, init) => {
+      if (String(input).endsWith("/web/authorize-batch")) {
+        const payload = JSON.parse(String(init?.body ?? "{}"));
+        const serverIds: string[] = Array.isArray(payload?.serverIds)
+          ? payload.serverIds
+          : [];
+        return new Response(
+          JSON.stringify({
+            results: Object.fromEntries(
+              serverIds.map((serverId) => [
+                serverId,
+                {
+                  ok: true,
+                  role: "member",
+                  accessLevel: "shared_chat",
+                  permissions: { chatOnly: false },
+                  internalLogContext: {
+                    authType: "signedIn",
+                    userId: "u-alice",
+                    projectId: payload.projectId ?? null,
+                  },
+                  serverConfig: {
+                    transportType: "http",
+                    url: `https://${serverId}.example.com/mcp`,
+                    headers: {},
+                    useOAuth: false,
+                  },
+                },
+              ])
+            ),
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalConvexHttpUrl === undefined) delete process.env.CONVEX_HTTP_URL;
+    else process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    if (originalConvexUrl === undefined) delete process.env.CONVEX_URL;
+    else process.env.CONVEX_URL = originalConvexUrl;
+  });
+
+  it("runs on the payload's server set everywhere, never the body's", async () => {
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    // Manager authorization batch.
+    const authorizeCall = (global.fetch as any).mock.calls.find(
+      ([url]: [string]) => String(url).endsWith("/web/authorize-batch")
+    );
+    expect(JSON.parse(authorizeCall[1].body).serverIds).toEqual([
+      "env-server-1",
+      "env-server-2",
+    ]);
+
+    // prepareChatV2.
+    expect(prepareChatV2Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedServers: ["env-server-1", "env-server-2"],
+      })
+    );
+
+    // Nothing persisted may carry the body's stale id.
+    const persistArgs = persistChatSessionToConvexMock.mock.calls[0][0];
+    expect(JSON.stringify(persistArgs)).not.toContain("body-server-9");
+  });
+
+  it("delivers the payload's skills to the emulated engine, cloud skills off", async () => {
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    const args = prepareChatV2Mock.mock.calls.at(-1)![0];
+    // Project-wide cloud skills would double-deliver alongside the resolved
+    // set — the same single-channel rule as an environment target.
+    expect(args.cloudSkills).toBeUndefined();
+    expect(args.skillsSource.kind).toBe("resolved");
+    expect(args.skillsSource.capabilities.standaloneSkills).toEqual([
+      {
+        ref: "release-notes",
+        skillId: "sk_env",
+        name: "release-notes",
+        description: "Write release notes",
+        content: "env skill body",
+        aggregateHash: "agg_env",
+        channels: ["environment"],
+        files: [],
+      },
+    ]);
+    // The plugin-sourced server keeps its classification even with no
+    // attribution probe on this path.
+    expect(args.skillsSource.capabilities.pluginServerIds).toEqual([
+      "env-server-2",
+    ]);
+
+    const handlerArgs = handleMCPJamFreeChatModelMock.mock.calls.at(-1)![0];
+    expect(handlerArgs.runtimeSkillsOverride).toEqual([
+      {
+        skillId: "sk_env",
+        name: "release-notes",
+        description: "Write release notes",
+        content: "env skill body",
+        aggregateHash: "agg_env",
+      },
+    ]);
+  });
+
+  it("treats an ABSENT skills array as authoritative-empty, not project-wide fallback", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        ...CHATBOX_CONFIG,
+        environment: {
+          environmentRef: ENVIRONMENT_PAYLOAD.environmentRef,
+          servers: { effectiveServerIds: ["env-server-1"] },
+        },
+      },
+    });
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    const args = prepareChatV2Mock.mock.calls.at(-1)![0];
+    expect(args.cloudSkills).toBeUndefined();
+    expect(args.skillsSource.capabilities.standaloneSkills).toEqual([]);
+    // Deploy-skew fallback: no `connectable` projection ⇒ raw ids connect and
+    // the manager shows the id as the name.
+    expect(args.selectedServers).toEqual(["env-server-1"]);
+    const handlerArgs = handleMCPJamFreeChatModelMock.mock.calls.at(-1)![0];
+    expect(handlerArgs.runtimeSkillsOverride).toEqual([]);
+  });
+
+  it("keeps a host-backed chatbox (no payload) byte-identical to today", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: CHATBOX_CONFIG,
+    });
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    // Legacy path: the body's server list still drives the turn.
+    const authorizeCall = (global.fetch as any).mock.calls.find(
+      ([url]: [string]) => String(url).endsWith("/web/authorize-batch")
+    );
+    expect(JSON.parse(authorizeCall[1].body).serverIds).toEqual([
+      "body-server-9",
+    ]);
+    const args = prepareChatV2Mock.mock.calls.at(-1)![0];
+    expect(args.skillsSource).toBeUndefined();
+    const handlerArgs = handleMCPJamFreeChatModelMock.mock.calls.at(-1)![0];
+    expect(handlerArgs.runtimeSkillsOverride).toBeUndefined();
+  });
+
+  it("stops the turn on a present-but-malformed payload instead of falling back", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        ...CHATBOX_CONFIG,
+        // Present, but missing the closed server set — an UNKNOWN environment.
+        environment: {
+          environmentRef: ENVIRONMENT_PAYLOAD.environmentRef,
+          servers: {},
+        },
+      },
+    });
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(502);
+    expect(prepareChatV2Mock).not.toHaveBeenCalled();
+    expect(handleMCPJamFreeChatModelMock).not.toHaveBeenCalled();
+  });
+
+  it("still fails closed when the runtime-config fetch itself fails", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      error: "boom",
+    });
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(502);
+    expect(prepareChatV2Mock).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -129,9 +129,17 @@ vi.mock("../../../utils/host-runtime-config.js", () => ({
   fetchHostRuntimeConfig: fetchHostRuntimeConfigMock,
 }));
 
-vi.mock("../../../utils/chatbox-runtime-config.js", () => ({
-  fetchChatboxRuntimeConfig: fetchChatboxRuntimeConfigMock,
-}));
+vi.mock("../../../utils/chatbox-runtime-config.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chatbox-runtime-config.js")
+  >("../../../utils/chatbox-runtime-config.js");
+  // Keep `readChatboxEnvironment` REAL (the route parses the environment
+  // payload through it on every chatbox turn); mock only the network fetch.
+  return {
+    ...actual,
+    fetchChatboxRuntimeConfig: fetchChatboxRuntimeConfigMock,
+  };
+});
 
 vi.mock("../apps.js", () => ({
   default: new Hono(),

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -367,6 +367,16 @@ chatV2.post("/", async (c) => {
         }
         if (environmentRead.kind === "present") {
           chatboxEnvironment = environmentRead.environment;
+          // Same projection the environment target uses, so the EMULATED
+          // engine advertises the environment's skills (skillsSource:
+          // "resolved") instead of silently delivering zero. Attribution is
+          // null on purpose: the payload pins no plugin versions (the backend
+          // already re-gated plugins before serving it), so there is nothing
+          // to attribute and no probe to degrade on a guest-reachable turn.
+          effectiveCapabilities = resolveEffectiveCapabilities(
+            chatboxEnvironment,
+            null,
+          );
         }
         hostRuntimeConfig = runtime.config as unknown as Record<
           string,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -441,8 +441,8 @@ chatV2.post("/", async (c) => {
     }
 
     // ── The turn's effective server set ─────────────────────────────────────
-    // For an environment target — or an environment-backed chatbox turn —
-    // this REPLACES the body's `selectedServerIds`
+    // For an environment target — or an environment-backed chatbox turn — this
+    // REPLACES the body's `selectedServerIds`
     // everywhere below — manager authorization/connection, name mapping and
     // elicitation, prepareChatV2, persistence/resume config, telemetry and the
     // tool snapshot. Resolving an environment and then still handing the raw
@@ -704,21 +704,23 @@ chatV2.post("/", async (c) => {
     // on the actual engine (harness id + canonicalized model), not host config
     // alone.
     // An environment target — or an environment-backed chatbox — NEVER also
-    // enables the project-wide cloud skill
-    // tools: its resolved union is authoritative and is delivered through
+    // enables the project-wide cloud skill tools: its resolved union is
+    // authoritative and is delivered through
     // `runtimeSkillsOverride`. Wiring both would double-deliver — an
     // environment-scoped `loadSkill` alongside a project-wide one, with the
     // model free to pull skills the environment deliberately excluded.
-    const cloudSkillsEnabled = !environmentServers && shouldEnableCloudSkillTools({
-      isGuest: Boolean(c.get("guestId")),
-      harness: resolvedExecution.harness,
-      modelId: String(modelDefinition.id),
-      // Provider is required so bare hosted ids canonicalize — without it a
-      // bare-id harness turn would be mis-detected as emulated and get the
-      // emulated skill tools on top of adapter-delivered skills.
-      provider: modelDefinition.provider,
-      hasProjectId: Boolean(hostedBody.projectId),
-    });
+    const cloudSkillsEnabled =
+      !environmentServers &&
+      shouldEnableCloudSkillTools({
+        isGuest: Boolean(c.get("guestId")),
+        harness: resolvedExecution.harness,
+        modelId: String(modelDefinition.id),
+        // Provider is required so bare hosted ids canonicalize — without it a
+        // bare-id harness turn would be mis-detected as emulated and get the
+        // emulated skill tools on top of adapter-delivered skills.
+        provider: modelDefinition.provider,
+        hasProjectId: Boolean(hostedBody.projectId),
+      });
 
     // Registering the callback is what makes the SDK advertise `elicitation`,
     // so "who declares it" and "may we honor it" are one decision — see
@@ -1010,8 +1012,7 @@ chatV2.post("/", async (c) => {
           ? {
               chatbox_environment_backed: true,
               environment_id: chatboxEnvironment.environmentRef.environmentId,
-              environment_revision:
-                chatboxEnvironment.environmentRef.revision,
+              environment_revision: chatboxEnvironment.environmentRef.revision,
               environment_effective_server_count: effectiveServerIds.length,
               environment_skill_count: environmentSkills?.length ?? 0,
             }

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -51,7 +51,11 @@ import {
 } from "./auth.js";
 import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
-import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
+import {
+  fetchChatboxRuntimeConfig,
+  readChatboxEnvironment,
+  type ChatboxEnvironmentRuntime,
+} from "../../utils/chatbox-runtime-config.js";
 import { fetchHostRuntimeConfig } from "../../utils/host-runtime-config.js";
 import {
   parseXaaPolicyValue,
@@ -251,6 +255,12 @@ chatV2.post("/", async (c) => {
     // source for this turn's host config, server set, and skills — nothing
     // downstream may fall back to the body's `selectedServerIds`.
     let environmentSpec: ResolvedEnvironmentRuntime | null = null;
+    // Phase 5: set ONLY for an environment-backed chatbox turn — the additive
+    // `environment` payload on the chatbox runtime config (mcpjam-backend
+    // #805). Once present it is authoritative for the turn's server set and
+    // skills exactly like `environmentSpec` is for an environment target;
+    // absent ⇒ host-backed chatbox, today's behavior byte-identical.
+    let chatboxEnvironment: ChatboxEnvironmentRuntime | null = null;
     // INS-3: the turn's one answer to "what may this run reach?" — the split
     // explicit/plugin server sets, ref-addressed skills, and plugin origin.
     // Derived from `environmentSpec`, never from the body or a HostConfig

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -347,6 +347,27 @@ chatV2.post("/", async (c) => {
         bearer: bearerToken,
       });
       if (runtime.ok) {
+        // Environment-backed chatbox (live-follow): the backend resolved the
+        // environment FRESH and projected its closed server set + skill union
+        // onto the config. A present-but-malformed payload is an UNKNOWN
+        // environment, not a host-backed chatbox — stop the turn (same
+        // fail-closed rationale as the fetch-error branch below) rather than
+        // fall through to the body's server list.
+        const environmentRead = readChatboxEnvironment(runtime.config);
+        if (environmentRead.kind === "invalid") {
+          logger.warn(
+            "[chat-v2] chatbox environment payload malformed; failing closed",
+            { chatboxId, detail: environmentRead.detail },
+          );
+          throw new WebRouteError(
+            502,
+            ErrorCode.INTERNAL_ERROR,
+            "Couldn't load this chatbox's environment, so the turn was stopped to avoid running with the wrong configuration.",
+          );
+        }
+        if (environmentRead.kind === "present") {
+          chatboxEnvironment = environmentRead.environment;
+        }
         hostRuntimeConfig = runtime.config as unknown as Record<
           string,
           unknown
@@ -410,23 +431,25 @@ chatV2.post("/", async (c) => {
     }
 
     // ── The turn's effective server set ─────────────────────────────────────
-    // For an environment target this REPLACES the body's `selectedServerIds`
+    // For an environment target — or an environment-backed chatbox turn —
+    // this REPLACES the body's `selectedServerIds`
     // everywhere below — manager authorization/connection, name mapping and
     // elicitation, prepareChatV2, persistence/resume config, telemetry and the
     // tool snapshot. Resolving an environment and then still handing the raw
     // body list to the manager would connect a set the environment never
     // authorized, which is precisely the hole the atomic resolution closes.
-    const effectiveServerIds = environmentSpec
-      ? runtimeServerIds(environmentSpec)
+    const environmentServers = environmentSpec ?? chatboxEnvironment;
+    const effectiveServerIds = environmentServers
+      ? runtimeServerIds(environmentServers)
       : selectedServerIds;
     // Names stay index-aligned with the ids. An empty array (older backend
     // without the name-carrying projection) makes `buildServerNamesById` return
     // undefined, and the manager falls back to showing the id — the same
     // degradation the legacy path already has when a client omits names.
-    const environmentServerNameList = environmentSpec
-      ? runtimeServerNames(environmentSpec)
+    const environmentServerNameList = environmentServers
+      ? runtimeServerNames(environmentServers)
       : undefined;
-    const effectiveServerNames = environmentSpec
+    const effectiveServerNames = environmentServers
       ? environmentServerNameList && environmentServerNameList.length > 0
         ? environmentServerNameList
         : undefined
@@ -434,10 +457,14 @@ chatV2.post("/", async (c) => {
     // The environment's composed skill union, in the shape both engines
     // consume. Presence — not length — is what makes it authoritative, so an
     // environment that resolves zero skills delivers zero, and never falls back
-    // to the project-wide pool.
+    // to the project-wide pool. For an env-backed chatbox an ABSENT skills
+    // array (older backend) also stays authoritative-empty: the environment
+    // decided the channel set, not the project-wide pool.
     const environmentSkills = environmentSpec
       ? environmentRuntimeSkills(environmentSpec)
-      : undefined;
+      : chatboxEnvironment
+        ? environmentRuntimeSkills({ skills: chatboxEnvironment.skills ?? [] })
+        : undefined;
 
     // Enterprise-managed authorization policy. Server-authoritative wherever
     // a backend host config exists (chatbox / host-bound turns above — the
@@ -574,7 +601,7 @@ chatV2.post("/", async (c) => {
         // "no MCP servers" fail-closed gate. An environment target's resolved
         // set outranks even the host config's own list: it IS the set we are
         // about to connect.
-        hasSelectedMcpServers: environmentSpec
+        hasSelectedMcpServers: environmentServers
           ? effectiveServerIds.length > 0
           : (resolvedExecution.selectedServerIds ?? selectedServerIds).length >
             0,
@@ -666,12 +693,13 @@ chatV2.post("/", async (c) => {
     // on such a host is rejected by the availability preflight above, so gate
     // on the actual engine (harness id + canonicalized model), not host config
     // alone.
-    // An environment target NEVER also enables the project-wide cloud skill
+    // An environment target — or an environment-backed chatbox — NEVER also
+    // enables the project-wide cloud skill
     // tools: its resolved union is authoritative and is delivered through
     // `runtimeSkillsOverride`. Wiring both would double-deliver — an
     // environment-scoped `loadSkill` alongside a project-wide one, with the
     // model free to pull skills the environment deliberately excluded.
-    const cloudSkillsEnabled = !environmentSpec && shouldEnableCloudSkillTools({
+    const cloudSkillsEnabled = !environmentServers && shouldEnableCloudSkillTools({
       isGuest: Boolean(c.get("guestId")),
       harness: resolvedExecution.harness,
       modelId: String(modelDefinition.id),
@@ -961,6 +989,21 @@ chatV2.post("/", async (c) => {
               environment_capability_problems: (
                 effectiveCapabilities?.problems ?? []
               ).map((problem) => problem.code),
+            }
+          : {}),
+        // Environment-BACKED CHATBOX turn (live-follow). A deliberately
+        // smaller slice than the environment-target block above: the payload
+        // carries no host/plugin provenance (the backend already re-gated
+        // plugins before serving it), and `environment_name` is user-authored
+        // so it is not emitted from a share-link-reachable turn.
+        ...(chatboxEnvironment
+          ? {
+              chatbox_environment_backed: true,
+              environment_id: chatboxEnvironment.environmentRef.environmentId,
+              environment_revision:
+                chatboxEnvironment.environmentRef.revision,
+              environment_effective_server_count: effectiveServerIds.length,
+              environment_skill_count: environmentSkills?.length ?? 0,
             }
           : {}),
       });

--- a/mcpjam-inspector/server/services/environments/runtime.ts
+++ b/mcpjam-inspector/server/services/environments/runtime.ts
@@ -264,9 +264,17 @@ export async function resolveEnvironmentForRuntime(
 }
 
 // ── Projections used by the executing caller ────────────────────────────────
+//
+// Parameter types are `Pick`s of the full spec on purpose: the Phase 5
+// environment-backed chatbox payload (`ChatboxEnvironmentRuntime`, see
+// `utils/chatbox-runtime-config.ts`) carries the same `servers`/`skills`
+// shapes without the rest of the spec, and reuses these projections instead of
+// growing a drifting second copy.
 
 /** The server ids to connect this turn (already live-healed by the backend). */
-export function runtimeServerIds(spec: ResolvedEnvironmentRuntime): string[] {
+export function runtimeServerIds(
+  spec: Pick<ResolvedEnvironmentRuntime, "servers">
+): string[] {
   return Array.isArray(spec.servers.connectable)
     ? spec.servers.connectable.map((entry) => entry.serverId)
     : spec.servers.effectiveServerIds;
@@ -277,7 +285,9 @@ export function runtimeServerIds(spec: ResolvedEnvironmentRuntime): string[] {
  * backend omits the name-carrying projection (the manager then falls back to
  * showing the server id) — never a partially-aligned array.
  */
-export function runtimeServerNames(spec: ResolvedEnvironmentRuntime): string[] {
+export function runtimeServerNames(
+  spec: Pick<ResolvedEnvironmentRuntime, "servers">
+): string[] {
   return Array.isArray(spec.servers.connectable)
     ? spec.servers.connectable.map((entry) => entry.name)
     : [];
@@ -302,7 +312,7 @@ export function runtimeServersAreOverridden(
  * cannot leak into skill delivery by accident.
  */
 export function runtimeSkills(
-  spec: ResolvedEnvironmentRuntime
+  spec: Pick<ResolvedEnvironmentRuntime, "skills">
 ): RuntimeSkill[] {
   return (spec.skills ?? []).map((skill) => ({
     skillId: skill.skillId,

--- a/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
@@ -20,6 +20,51 @@ import type {
   ModelVisibleMcpToolResults,
 } from "@mcpjam/sdk/host-config/internal";
 import { type RuntimeExecutionFields } from "./execution-scope.js";
+import type {
+  RuntimeServerSource,
+  RuntimeSkillChannel,
+} from "../services/environments/runtime.js";
+
+/**
+ * Phase 5 (mcpjam-backend PR #805): the additive `environment` payload an
+ * ENVIRONMENT-BACKED chatbox carries on its runtime config. Present iff the
+ * chatbox row points at a Project Environment (live-follow) — the backend
+ * resolves the environment FRESH on every read and projects its closed server
+ * set + composed skill union here. Absent for host-backed chatboxes and for
+ * backends that predate the field (deploy skew ⇒ legacy behavior).
+ *
+ * `servers`/`skills` are shaped to structurally satisfy the projections in
+ * `services/environments/runtime.ts` (`runtimeServerIds` / `runtimeServerNames`
+ * / `runtimeSkills`) and `resolveEffectiveCapabilities`'s
+ * `EffectiveCapabilityInput`, so the chatbox branch reuses the environment
+ * target's helpers instead of growing a second mirror.
+ */
+export type ChatboxEnvironmentRuntime = {
+  environmentRef: {
+    environmentId: string;
+    name: string;
+    revision: number;
+  };
+  servers: {
+    /** The closed set this turn may connect — never the request body's. */
+    effectiveServerIds: string[];
+    connectable?: Array<{
+      serverId: string;
+      name: string;
+      source?: RuntimeServerSource;
+    }>;
+  };
+  skills?: Array<{
+    skillId: string;
+    name: string;
+    description: string;
+    content: string;
+    aggregateHash: string;
+    extraFrontmatter?: unknown;
+    channels?: RuntimeSkillChannel[];
+    files?: Array<{ path: string; size: number; url: string | null }>;
+  }>;
+};
 
 export type ChatboxRuntimeConfig = RuntimeExecutionFields & {
   chatboxId: string;
@@ -77,6 +122,11 @@ export type ChatboxRuntimeConfig = RuntimeExecutionFields & {
   // Optional so a backend that predates the projection returns omitted →
   // policy off (safe: matches pre-feature behavior).
   mcpProfile?: Record<string, unknown>;
+  // Phase 5: present iff this chatbox is environment-backed (live-follow).
+  // Read through `readChatboxEnvironment` — never raw — so a present-but-
+  // malformed payload fails the turn instead of silently falling back to the
+  // request body's server list.
+  environment?: ChatboxEnvironmentRuntime;
 };
 
 export type ChatboxRuntimeConfigResult =
@@ -147,4 +197,159 @@ export async function fetchChatboxRuntimeConfig(args: {
   }
 
   return { ok: true, config: payload.config as ChatboxRuntimeConfig };
+}
+
+export type ChatboxEnvironmentReadResult =
+  | { kind: "absent" }
+  | { kind: "present"; environment: ChatboxEnvironmentRuntime }
+  | { kind: "invalid"; detail: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+const SERVER_SOURCES: ReadonlySet<string> = new Set([
+  "host_or_group",
+  "plugin",
+  "override",
+]);
+const SKILL_CHANNELS: ReadonlySet<string> = new Set([
+  "host",
+  "environment",
+  "plugin",
+]);
+
+/**
+ * Shape-check the additive `environment` payload on a chatbox runtime config.
+ *
+ * Split fail-closed vs tolerant on the SAME line `assertRuntimeInvariants`
+ * (services/environments/runtime.ts) draws for environment targets:
+ *
+ *   - IDENTITY (`environmentRef.environmentId` + numeric `revision`) and the
+ *     CLOSED SERVER SET (`servers.effectiveServerIds`) are invariants. A
+ *     payload that is present but missing them is not a degraded environment,
+ *     it is an unknown one — `invalid`, and the caller must stop the turn
+ *     rather than fall back to the body's server list.
+ *   - Everything additive (connectable names/sources, skills, files, channels)
+ *     is the deploy-skew surface: unknown enum values are dropped to
+ *     `undefined`, malformed entries are dropped, absence means "none".
+ *
+ * `absent` (field omitted / null) means host-backed chatbox or an older
+ * backend — the caller keeps today's behavior byte-identical.
+ */
+export function readChatboxEnvironment(
+  config: ChatboxRuntimeConfig
+): ChatboxEnvironmentReadResult {
+  const raw = (config as { environment?: unknown }).environment;
+  if (raw === undefined || raw === null) return { kind: "absent" };
+  if (!isRecord(raw)) return { kind: "invalid", detail: "not an object" };
+
+  const ref = raw.environmentRef;
+  if (!isRecord(ref) || typeof ref.environmentId !== "string") {
+    return { kind: "invalid", detail: "missing environmentRef" };
+  }
+  if (typeof ref.revision !== "number") {
+    return { kind: "invalid", detail: "missing revision" };
+  }
+
+  const servers = raw.servers;
+  if (!isRecord(servers) || !Array.isArray(servers.effectiveServerIds)) {
+    return { kind: "invalid", detail: "missing effective server set" };
+  }
+  const effectiveServerIds = servers.effectiveServerIds.filter(
+    (id): id is string => typeof id === "string"
+  );
+  if (effectiveServerIds.length !== servers.effectiveServerIds.length) {
+    // A torn id list is an unknown server set, not a smaller one.
+    return { kind: "invalid", detail: "non-string server id" };
+  }
+
+  const connectable = Array.isArray(servers.connectable)
+    ? servers.connectable.flatMap((entry) => {
+        if (
+          !isRecord(entry) ||
+          typeof entry.serverId !== "string" ||
+          typeof entry.name !== "string"
+        ) {
+          return [];
+        }
+        const source =
+          typeof entry.source === "string" && SERVER_SOURCES.has(entry.source)
+            ? (entry.source as RuntimeServerSource)
+            : undefined;
+        return [
+          {
+            serverId: entry.serverId,
+            name: entry.name,
+            ...(source ? { source } : {}),
+          },
+        ];
+      })
+    : undefined;
+
+  const skills = Array.isArray(raw.skills)
+    ? raw.skills.flatMap((entry) => {
+        if (
+          !isRecord(entry) ||
+          typeof entry.skillId !== "string" ||
+          typeof entry.name !== "string" ||
+          typeof entry.content !== "string" ||
+          typeof entry.aggregateHash !== "string"
+        ) {
+          return [];
+        }
+        const channels = Array.isArray(entry.channels)
+          ? entry.channels.filter(
+              (channel): channel is RuntimeSkillChannel =>
+                typeof channel === "string" && SKILL_CHANNELS.has(channel)
+            )
+          : undefined;
+        const files = Array.isArray(entry.files)
+          ? entry.files.flatMap((file) =>
+              isRecord(file) &&
+              typeof file.path === "string" &&
+              typeof file.size === "number"
+                ? [
+                    {
+                      path: file.path,
+                      size: file.size,
+                      url: typeof file.url === "string" ? file.url : null,
+                    },
+                  ]
+                : []
+            )
+          : undefined;
+        return [
+          {
+            skillId: entry.skillId,
+            name: entry.name,
+            description:
+              typeof entry.description === "string" ? entry.description : "",
+            content: entry.content,
+            aggregateHash: entry.aggregateHash,
+            ...(entry.extraFrontmatter !== undefined
+              ? { extraFrontmatter: entry.extraFrontmatter }
+              : {}),
+            ...(channels ? { channels } : {}),
+            ...(files ? { files } : {}),
+          },
+        ];
+      })
+    : undefined;
+
+  return {
+    kind: "present",
+    environment: {
+      environmentRef: {
+        environmentId: ref.environmentId,
+        name: typeof ref.name === "string" ? ref.name : "",
+        revision: ref.revision,
+      },
+      servers: {
+        effectiveServerIds,
+        ...(connectable ? { connectable } : {}),
+      },
+      ...(skills ? { skills } : {}),
+    },
+  };
 }


### PR DESCRIPTION
Inspector half of **Phase 5 — environment-backed chatboxes (live-follow)**; consumes mcpjam-backend #805. With this, the Environments-First program (Phases 0–5) is complete.

## What this does

A Project Environment can be **published as a chatbox** from the Environments route. The chatbox is a pointer, not a snapshot: every turn runs the environment as currently configured (live-follow), and the backend re-resolves servers + skills fresh on every runtime-config read.

### Server: chat-v2 consumes the additive `environment` payload

- `chatbox-runtime-config.ts` gains a typed tri-state reader (`readChatboxEnvironment`): **absent** ⇒ host-backed chatbox or older backend, behavior byte-identical to today; **present** ⇒ the payload is authoritative; **invalid** (present but missing identity or the closed server set) ⇒ the turn stops with 502 — a malformed environment is an *unknown* one, never a fallback to the request body's server list. The additive surface (connectable names/sources, skills, files, channels) stays deploy-skew tolerant.
- The chatbox branch mirrors the environment-target rules: `effectiveServerIds`/names from the resolution (never the body), skills through `resolveEffectiveCapabilities` (emulated engine) + `runtimeSkillsOverride` (harness), and `cloudSkillsEnabled = false` — same single-channel rule as environment targets. An absent `skills` array is authoritative-empty, not project-wide fallback.
- Runtime projections (`runtimeServerIds`/`runtimeServerNames`/`runtimeSkills`) narrowed to `Pick`s so the chatbox payload reuses them instead of growing a drifting second mirror.
- Additive telemetry slice (`chatbox_environment_backed`, id/revision/counts) with no user-authored strings.

### Client: publish UI on the Environments route (flag-gated)

- `EnvironmentChatboxSection` on the environment detail: publish / access preset (reuses `chatbox-access-presets` + `chatboxes:setChatboxMode`) / copy + open share link / unpublish behind a confirm. Read-only members see the link only. Deliberately minimal — `ChatboxShareSection` needs the full members-carrying `ChatboxSettings`, so it is not forked.
- New hooks in the existing `useProjectEnvironments` module: `useEnvironmentChatbox` (reads `chatboxes:listChatboxes`, which carries `environmentId` per row since #805), `usePublishEnvironmentChatbox`, `useUnpublishEnvironmentChatbox`.
- `chatboxCount` joins the archive-confirm consumer counts, with its own copy: a published share link **stops working immediately** on archive (unlike suites/journeys, which fail at next launch).
- `ChatboxListItem` gains optional `environmentId` (absent on older backends ⇒ host-backed).

## Deliberately untouched

ChatboxesTab, the `ui_publish_chatbox` webmcp tools, and ChatboxPublishClientBar — host-first surfaces; env-backed rows are invisible to them via the backend's `getChatboxByHostId` filter. `namedHostId` stays required.

## Tests & gates

- New `chat-v2.chatbox-environment.test.ts` (6): payload drives servers+skills / emulated delivery + cloud skills off / absent-skills authoritative-empty / absent payload byte-identical legacy / malformed payload 502 fail-closed / fetch-failure fail-closed.
- New `environment-chatbox-section.test.tsx` (6, name-keyed mutation dispatcher) + chatbox cases in the consumer-count and archive-confirm tests.
- Full vitest suite green; server tsc zero new errors vs main (diffed sorted lists — this PR actually removes none/adds none); `typecheck:client` clean; prettier 2.8.8 on own lines only (`chat-v2.ts` and `useChatboxes.ts` are pre-existing dirty on main).

## Rollout

Exposure is gated by `project-environments-enabled` (currently @mcpjam.com only). Deploy-skew tolerant both directions; rollback = flag off (publish affordance disappears; existing env chatboxes keep working via backend or can be unpublished individually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chat turn authorization for share-link chatboxes (server set and skills from runtime config, not the client body) and adds publish/unpublish surfaces tied to live external links; behavior is heavily tested and fail-closed on malformed payloads.
> 
> **Overview**
> **Phase 5** lets a project environment be **published as a chatbox** from the environment detail screen. The share link is a live pointer to the environment (not a snapshot): publish, access presets, copy/open link, and confirmed unpublish via new `EnvironmentChatboxSection` and Convex hooks (`useEnvironmentChatbox`, publish/unpublish mutations).
> 
> **Archive UX** now includes `chatboxCount` in consumer scans and warns that a published chatbox link **breaks immediately** on archive (unlike suites/journeys).
> 
> **`web/chat-v2`** reads the additive `environment` payload on chatbox runtime config through `readChatboxEnvironment` (absent = legacy host-backed; present = authoritative servers/skills; invalid = **502 fail-closed**, no body fallback). Environment-backed chatbox turns reuse the same rules as environment targets: effective server IDs, resolved skills, project-wide cloud skills off, plus telemetry for env-backed chatboxes.
> 
> Runtime helpers (`runtimeServerIds` / names / skills) are narrowed to `Pick` types so the chatbox payload shares projections without duplicating logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3df8eea36e6e6442aee90ec1c69d9422d3832d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish Project Environments as live-follow chatboxes and update chat-v2 to run these turns on the environment’s resolved servers and skills. Adds a minimal publish UI on the Environments page; legacy host-backed chatboxes are unchanged.

- New Features
  - Environments page: publish/unpublish, access preset, copy/open link; read-only members see the link only; hidden on archived environments.
  - Hooks: useEnvironmentChatbox, usePublishEnvironmentChatbox, useUnpublishEnvironmentChatbox; chatbox list items now include optional environmentId.
  - Archive confirm includes chatboxCount and warns the share link stops working immediately on archive.
  - Server: chat-v2 reads the additive environment payload from the chatbox runtime config; present ⇒ servers/skills are authoritative; invalid ⇒ 502 fail-closed; absent ⇒ legacy behavior. Emulated engine receives resolved skills; cloud skills off; absent skills array ⇒ authoritative empty. Reuses runtime projections; adds a small telemetry slice.
  - Rollout: behind the project-environments-enabled flag; deploy-skew tolerant both directions; rollback by turning the flag off.

- Tests
  - Server: env-backed chatbox routing, payload validation, legacy host-backed path.
  - Client: publish panel interactions and consumer count warnings.

<sup>Written for commit 5c3df8eea36e6e6442aee90ec1c69d9422d3832d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

