### PR TITLE
fix(oauth): era-gate the RFC 9207 `iss` mismatch rejection

### DIFF
--- a/.changeset/era-gate-rfc9207-iss-mismatch.md
+++ b/.changeset/era-gate-rfc9207-iss-mismatch.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Scope the RFC 9207 authorization-response `iss` mismatch rejection to the protocol era that mandates it. `MUST validate a present iss` is introduced by SEP-2468 in the 2026-07-28 draft; 2025-11-25 and earlier never mention `iss`, RFC 9207, or issuer identification, so enforcing there applied a rule the selected version does not contain. A mismatch still hard-blocks before code redemption on 2026-07-28; pre-draft flows now surface it as a non-blocking warning and complete.
+
+This completes the era gating started in #3441, which scoped only the reject-on-absence row and deliberately left the present-but-mismatched row firing on every version.
+
+Warning-not-blocking on pre-draft eras is narrow by design: PKCE S256 is already mandatory there, the token endpoint always comes from the recorded metadata (never the callback, so a hostile `iss` cannot redirect the code), and tokens are persisted issuer-keyed to the recorded issuer. RFC 9207 Section 2.4 leaves an unadvertised `iss` to local policy. `validateAuthorizationResponseIssuer` gains an optional `enforcePresentIssMismatch` that defaults to enforcing, so an omitted flag fails closed.
+
+Mismatch diagnostics now name both issuers — the recorded one and the one returned on the callback — because an exact comparison fails on differences too small to infer from "does not match" alone.

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2670,6 +2670,21 @@ export function useServerState({
             );
           }
 
+          // A conformance problem that did not block the OAuth flow (today: an
+          // RFC 9207 `iss` mismatch on a version that does not mandate the
+          // check). Surfaced here, on the successful OAuth completion, rather
+          // than alongside the connection result: the MCP connection test that
+          // follows can fail for entirely unrelated reasons, and the mismatch
+          // must not disappear behind that error. The trace step alone lives in
+          // the OAuth logs panel, which nobody is looking at while connecting.
+          if (result.warning) {
+            logger.warn("OAuth conformance warning", {
+              serverName,
+              warning: result.warning,
+            });
+            toast.warning(result.warning);
+          }
+
           dispatch({
             type: "CONNECT_REQUEST",
             name: serverName,
@@ -2695,17 +2710,6 @@ export function useServerState({
               toast.success(
                 `OAuth connection successful! Connected to ${serverName}.`
               );
-              // A conformance problem that did not block the flow (today: an
-              // RFC 9207 `iss` mismatch on a version that does not mandate the
-              // check). The trace step alone lives in the OAuth logs panel,
-              // which nobody is looking at while connecting — so say it here.
-              if (result.warning) {
-                logger.warn("OAuth conformance warning", {
-                  serverName,
-                  warning: result.warning,
-                });
-                toast.warning(result.warning);
-              }
               storeInitInfo(serverName, connectionResult.initInfo).catch(
                 (err) =>
                   logger.warn("Failed to fetch init info", {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2695,6 +2695,17 @@ export function useServerState({
               toast.success(
                 `OAuth connection successful! Connected to ${serverName}.`
               );
+              // A conformance problem that did not block the flow (today: an
+              // RFC 9207 `iss` mismatch on a version that does not mandate the
+              // check). The trace step alone lives in the OAuth logs panel,
+              // which nobody is looking at while connecting — so say it here.
+              if (result.warning) {
+                logger.warn("OAuth conformance warning", {
+                  serverName,
+                  warning: result.warning,
+                });
+                toast.warning(result.warning);
+              }
               storeInitInfo(serverName, connectionResult.initInfo).catch(
                 (err) =>
                   logger.warn("Failed to fetch init info", {

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -1752,11 +1752,10 @@ describe("mcp-oauth", () => {
       expect(mockExchangeAuthorization).not.toHaveBeenCalled();
     });
 
-    it("stops a 2025 issuer mismatch before token exchange too", async () => {
-      // RFC 9207 Section 2.4's local-policy row: a PRESENT `iss` is compared
-      // on every era. Pre-draft specs are silent on `iss`, so comparing is
-      // permitted — and it protects our own token handling rather than
-      // changing anything the user is debugging server-side.
+    it("warns but still exchanges on a 2025 issuer mismatch", async () => {
+      // `MUST validate a present iss` is SEP-2468, introduced in the
+      // 2026-07-28 draft. 2025-11-25 never mentions `iss`, so blocking here
+      // would enforce a rule the selected version does not contain.
       await seedPendingOAuth(
         undefined,
         createAsanaDiscoveryState(),
@@ -1772,12 +1771,29 @@ describe("mcp-oauth", () => {
         callbackIss: "https://different.example.com",
       });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/issuer validation failed/i);
-      expect(mockExchangeAuthorization).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(mockExchangeAuthorization).toHaveBeenCalledTimes(1);
+      // Surfaced on the result so the connection layer can toast it. A trace
+      // step alone only shows in the OAuth logs panel, which is not where
+      // someone completing a connection is looking.
+      expect(result.warning).toMatch(/does not match/i);
+      // ...and still on the trace, for the logs panel.
+      const issSteps = (result.oauthTrace?.steps ?? []).filter((step) =>
+        step.message?.includes("RFC 9207")
+      );
+      expect(issSteps).toHaveLength(1);
+      expect(issSteps[0]?.details).toMatchObject({
+        recordedIssuer: "https://app.asana.com",
+        returnedIss: "https://different.example.com",
+        protocolVersion: "2025-11-25",
+      });
+      // The warning must not rewind a completed flow's progress state.
+      expect(result.oauthTrace?.currentStep).not.toBe(
+        "received_authorization_code"
+      );
     });
 
-    it("stops an issuer mismatch on an old stored session with no version", async () => {
+    it("warns but still exchanges on an old stored session with no version", async () => {
       await seedPendingOAuth(
         undefined,
         createAsanaDiscoveryState(),
@@ -1797,9 +1813,10 @@ describe("mcp-oauth", () => {
         callbackIss: "https://different.example.com",
       });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/issuer validation failed/i);
-      expect(mockExchangeAuthorization).not.toHaveBeenCalled();
+      // An unrecoverable version is treated as pre-draft, matching how the
+      // reject-on-absence row already handles a missing version.
+      expect(result.success).toBe(true);
+      expect(mockExchangeAuthorization).toHaveBeenCalledTimes(1);
     });
 
     it("still exchanges a 2025 flow whose AS omits iss entirely", async () => {
@@ -3496,20 +3513,45 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
   });
 
   it.each(["2025-03-26", "2025-06-18", "2025-11-25", undefined] as const)(
-    "rejects a mismatched iss on a %s flow (RFC 9207 local policy)",
+    "warns but does not reject a mismatched iss on a %s flow",
     async (protocolVersion) => {
-      // Pre-draft versions are silent on `iss`, so comparing a PRESENT one is
-      // permitted — and the mix-up attack it blocks targets our own token
-      // handling, not any server-observable behavior being debugged.
+      // `MUST validate a present iss` is introduced by SEP-2468 in the
+      // 2026-07-28 draft. Pre-draft specs never mention `iss` at all, so
+      // rejecting there would enforce a rule the selected version does not
+      // contain. An unknown version is treated as pre-draft, matching how the
+      // reject-on-absence row already handles `undefined`.
       const { evaluateCallbackSecurity } = await import("../mcp-oauth");
       const result = evaluateCallbackSecurity({
         ...base,
         protocolVersion,
         callbackIss: "https://different.example.com",
       });
-      expect(result.ok).toBe(false);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // The finding must survive as a visible warning — dropping it would
+        // be a silent downgrade rather than an era gate.
+        expect(result.warning).toContain("`https://as.example.com`");
+        expect(result.warning).toContain("`https://different.example.com`");
+      }
     }
   );
+
+  it("still rejects a mismatched iss on the modern era", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    const result = evaluateCallbackSecurity({
+      ...base,
+      protocolVersion: "2026-07-28",
+      callbackIss: "https://different.example.com",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("a matching iss carries no warning on a pre-draft flow", async () => {
+    const { evaluateCallbackSecurity } = await import("../mcp-oauth");
+    expect(
+      evaluateCallbackSecurity({ ...base, protocolVersion: "2025-11-25" })
+    ).toEqual({ ok: true });
+  });
 
   it.each(["2025-11-25", undefined] as const)(
     "does not reject an absent-but-advertised iss on a %s flow",

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1673,6 +1673,14 @@ export interface OAuthResult {
   error?: string;
   oauthTrace?: OAuthTrace;
   oauthResourceUrl?: string;
+  /**
+   * A conformance problem that did not stop the flow — currently only an RFC
+   * 9207 `iss` mismatch on a protocol version that does not mandate the check.
+   * Carried on the result (not just the trace) so the connection layer can
+   * surface it: a trace step alone is only visible in the OAuth logs panel,
+   * which is not where someone completing a connection is looking.
+   */
+  warning?: string;
 }
 
 export function buildMCPOAuthState(): string {
@@ -3458,13 +3466,22 @@ export async function completeHostedOAuthCallback(
  *
  * - CSRF `state` is validated on every version (2025-11-25 makes it a SHOULD;
  *   we treat it as mandatory whenever this flow issued one).
- * - A PRESENT `iss` is compared against the recorded issuer on every version.
- *   The draft table's third row applies RFC 9207 Section 2.4's local-policy
- *   provision — compare regardless of advertisement — and pre-draft versions
- *   are silent on `iss`, so comparing is permitted there. This defends our own
- *   token handling; it changes nothing a user is debugging server-side.
- * - Rejecting an ABSENT `iss` that the AS advertised support for is the rule
- *   the draft actually introduces, so it fires on the modern era only.
+ * - A PRESENT `iss` is compared against the recorded issuer on every version,
+ *   but only the modern era REJECTS on a mismatch. SEP-2468 introduces
+ *   `MUST validate a present iss` in the 2026-07-28 draft; 2025-11-25 and
+ *   earlier never mention `iss`, RFC 9207, or issuer identification at all, so
+ *   enforcing there would apply a rule the selected version does not contain.
+ *   Pre-draft eras surface the mismatch as a `warning` and let the flow finish.
+ * - Rejecting an ABSENT `iss` that the AS advertised support for is likewise
+ *   the rule the draft introduces, so it too fires on the modern era only.
+ *
+ * Warning-not-blocking on pre-draft eras is a deliberate, narrow concession:
+ * PKCE S256 is already mandatory there and defeats code injection, the token
+ * endpoint always comes from the RECORDED metadata (never from the callback,
+ * so a hostile `iss` cannot redirect the code), and tokens are persisted
+ * issuer-keyed to the recorded issuer. RFC 9207 Section 2.4 explicitly leaves
+ * this to local policy. The warning MUST stay visible — a silent downgrade
+ * would be a regression rather than a fix.
  *
  * On failure the caller must reject without touching the token endpoint or
  * echoing attacker-controlled callback error parameters.
@@ -3480,7 +3497,7 @@ export function evaluateCallbackSecurity(input: {
   issParameterSupported: boolean | undefined;
   /** Concrete version frozen when this OAuth flow started. */
   protocolVersion?: OAuthProtocolVersion;
-}): { ok: true } | { ok: false; error: string } {
+}): { ok: true; warning?: string } | { ok: false; error: string } {
   // CSRF: if this flow issued a `state`, the callback MUST return it exactly.
   if (input.expectedState && input.callbackState !== input.expectedState) {
     return {
@@ -3495,9 +3512,11 @@ export function evaluateCallbackSecurity(input: {
     input.protocolVersion !== undefined &&
     isStatelessProtocolVersion(input.protocolVersion);
   const issCheck = validateAuthorizationResponseIssuer({
-    // Suppressing the advertisement flag disables ONLY the reject-on-absence
-    // row for pre-draft eras; the present-`iss` comparison still runs.
+    // Both rows are draft-era rules, so both are scoped to the modern era:
+    // suppressing the advertisement flag disables reject-on-absence, and
+    // `enforcePresentIssMismatch` downgrades the mismatch row to a warning.
     issParameterSupported: isModernEra ? input.issParameterSupported : false,
+    enforcePresentIssMismatch: isModernEra,
     recordedIssuer: input.recordedIssuer,
     returnedIss: input.callbackIss ?? undefined,
   });
@@ -3507,7 +3526,68 @@ export function evaluateCallbackSecurity(input: {
       error: `OAuth issuer validation failed (RFC 9207): ${issCheck.reason}. Authorization was not completed.`,
     };
   }
-  return { ok: true };
+  return issCheck.warning
+    ? { ok: true, warning: issCheck.warning }
+    : { ok: true };
+}
+
+/**
+ * Record a non-blocking RFC 9207 mismatch on the OAuth TRACE, not as an info
+ * log. `infoLogs` only reach the Debug OAuth tab's own flow state; the callback
+ * path here surfaces through the trace (App.tsx ingests it into server logs),
+ * and `projectOAuthTraceSnapshot` never reads `infoLogs`. Era-gating the
+ * REJECTION is the fix — dropping the finding as well would be the silent
+ * downgrade this change explicitly avoids, so it has to land where it renders.
+ *
+ * Must be applied to the FINAL merged trace. Seeding the merge base does not
+ * work: the flow-state trace contributes its own `received_authorization_code`
+ * step, and `mergeTraceSteps` lets that one win.
+ *
+ * Augments that existing step in place rather than calling
+ * `completeOAuthTraceStep`. That helper only updates a step still marked
+ * `pending`; by merge time this one is already `success`, so it would push a
+ * DUPLICATE step and — worse — reset `trace.currentStep` back to the
+ * authorization-code step, rewinding the progress UI on a completed flow.
+ */
+function recordIssMismatchWarning(
+  trace: OAuthTrace,
+  warning: string,
+  details: {
+    recordedIssuer: string | undefined;
+    returnedIss: string | null | undefined;
+    protocolVersion: OAuthProtocolVersion | undefined;
+  }
+): void {
+  const summary =
+    "RFC 9207 — authorization response `iss` mismatch (not enforced on this protocol version).";
+  const payload = {
+    recordedIssuer: details.recordedIssuer ?? "(none recorded)",
+    returnedIss: details.returnedIss ?? "(absent)",
+    protocolVersion: details.protocolVersion ?? "(unknown)",
+    issMismatchWarning: warning,
+  };
+
+  const existing = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.step === "received_authorization_code");
+
+  if (existing) {
+    existing.message = existing.message
+      ? `${existing.message} ${summary}`
+      : summary;
+    existing.details = { ...(existing.details ?? {}), ...payload };
+    return;
+  }
+
+  trace.steps.push({
+    step: "received_authorization_code",
+    title: "Received authorization code",
+    status: "success",
+    message: summary,
+    details: payload,
+    startedAt: Date.now(),
+    completedAt: Date.now(),
+  });
 }
 
 export async function handleOAuthCallback(
@@ -3577,6 +3657,19 @@ export async function handleOAuthCallback(
         return { success: false, error: security.error, serverName };
       }
       let state = cloneFlowState(storedSession.state);
+      // Applied AFTER the trace merge below: the flow-state trace carries its
+      // own `received_authorization_code` step, which would overwrite anything
+      // seeded on the merge base.
+      const issWarning = security.warning
+        ? {
+            warning: security.warning,
+            recordedIssuer:
+              storedSession.state.recordedIssuer ??
+              storedSession.state.authorizationServerMetadata?.issuer,
+            returnedIss: options.callbackIss,
+            protocolVersion: storedSession.protocolVersion,
+          }
+        : undefined;
       const updateState = (updates: Partial<OAuthFlowState>) => {
         state = { ...state, ...updates };
       };
@@ -3668,6 +3761,9 @@ export async function handleOAuthCallback(
           | undefined,
       });
       const mergedTrace = mergeOAuthTraces(previousTrace, callbackTrace);
+      if (issWarning) {
+        recordIssMismatchWarning(mergedTrace, issWarning.warning, issWarning);
+      }
       publishOAuthTraceUpdate(serverName, mergedTrace, options.onTraceUpdate);
 
       if (
@@ -3702,6 +3798,7 @@ export async function handleOAuthCallback(
         serverName,
         oauthTrace: mergedTrace,
         oauthResourceUrl,
+        ...(issWarning ? { warning: issWarning.warning } : {}),
       };
     }
 
@@ -3770,10 +3867,24 @@ export async function handleOAuthCallback(
       localStorage.removeItem("mcp-oauth-pending");
       return { success: false, error: fallbackSecurity.error, serverName };
     }
+    // This recovery path carries no OAuthFlowState, so the non-blocking RFC
+    // 9207 finding rides on the trace step instead of an info log. Same rule as
+    // the stored-session branch: warn visibly, do not drop it.
     completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
-      message: "Callback state restored.",
+      message: fallbackSecurity.warning
+        ? "Callback state restored. RFC 9207 — authorization response `iss` mismatch (not enforced on this protocol version)."
+        : "Callback state restored.",
       details: {
         clientId: clientInformation.client_id,
+        ...(fallbackSecurity.warning
+          ? {
+              issMismatchWarning: fallbackSecurity.warning,
+              recordedIssuer:
+                fallbackIssuerMetadata?.issuer ?? "(none recorded)",
+              returnedIss: options.callbackIss ?? "(absent)",
+              protocolVersion: oauthConfig.protocolVersion ?? "(unknown)",
+            }
+          : {}),
       },
     });
     emitTrace(callbackTrace);
@@ -3837,6 +3948,9 @@ export async function handleOAuthCallback(
       serverName, // Return server name so caller doesn't need to look it up
       oauthTrace: mergedTrace,
       oauthResourceUrl,
+      ...(fallbackSecurity.warning
+        ? { warning: fallbackSecurity.warning }
+        : {}),
     };
   } catch (error) {
     const callbackTrace = buildOAuthTraceFromFlowState({

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -179,9 +179,9 @@ export {
   isLoopbackOAuthUrl,
   OAuthOutboundUrlBlockedError,
 } from "./oauth/ssrf-guard.js";
-// RFC 9207 authorization-response `iss` validation. Era-agnostic (validating a
-// present `iss` is permitted on every version), so the browser callback gate
-// reuses it across 2025/2026 flows.
+// RFC 9207 authorization-response `iss` validation. The comparison itself is
+// era-agnostic, but REJECTING on a mismatch is a 2026-07-28 (SEP-2468) rule —
+// callers pass `enforcePresentIssMismatch` so pre-draft flows warn instead.
 export {
   validateAuthorizationResponseIssuer,
   type AuthorizationResponseIssuerCheck,

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -560,8 +560,22 @@ function buildAuthServerMetadataUrls(authServerUrl: string): string[] {
 }
 
 export type AuthorizationResponseIssuerCheck =
-  | { ok: true }
+  /** `warning` is set when a mismatch was found but the era does not enforce it. */
+  | { ok: true; warning?: string }
   | { ok: false; reason: string };
+
+/**
+ * Render a callback-supplied value inside a diagnostic. Control characters are
+ * flattened so a hostile `iss` cannot forge additional message lines, and the
+ * value is capped so it cannot crowd out the diagnostic around it.
+ */
+function quoteUntrusted(value: string): string {
+  // eslint-disable-next-line no-control-regex
+  const flattened = value.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+  const capped =
+    flattened.length > 256 ? `${flattened.slice(0, 256)}…` : flattened;
+  return `\`${capped}\``;
+}
 
 /**
  * RFC 9207 authorization-response `iss` validation — a 2026-07-28 requirement.
@@ -576,21 +590,54 @@ export type AuthorizationResponseIssuerCheck =
  * discipline as the RFC 8414 §3.3 issuer check. On a mismatch the caller emits
  * a fixed diagnostic and MUST NOT surface any server-supplied `error*` callback
  * parameters.
+ *
+ * Row 2 names both issuers, because an exact comparison fails on differences
+ * too small to see (trailing slash, scheme, port) and the mismatch is otherwise
+ * undiagnosable — the gate returns before anything reaches the OAuth trace. The
+ * RFC 9207 prohibition covers `error`/`error_description`, which carry AS-authored
+ * prose; `iss` is the compared value itself, and quoting it is what makes the
+ * rejection actionable. It is still attacker-controlled, hence `quoteUntrusted`.
+ *
+ * `enforcePresentIssMismatch` scopes row 2 to the era that actually mandates it.
+ * SEP-2468 introduces `MUST validate a present iss` in the 2026-07-28 draft;
+ * 2025-11-25 and earlier never mention `iss`, so a caller on those versions
+ * passes `false` to downgrade row 2 to a `warning` and let the flow continue.
+ * Defaults to enforcing: an omitted flag must fail closed, and the value that
+ * carries the era lives with the caller, not here.
  */
 export function validateAuthorizationResponseIssuer(input: {
   recordedIssuer: string | undefined;
   returnedIss: string | undefined;
   issParameterSupported: boolean | undefined;
+  enforcePresentIssMismatch?: boolean;
 }): AuthorizationResponseIssuerCheck {
-  const { recordedIssuer, returnedIss, issParameterSupported } = input;
+  const {
+    recordedIssuer,
+    returnedIss,
+    issParameterSupported,
+    enforcePresentIssMismatch = true,
+  } = input;
 
   if (returnedIss !== undefined && returnedIss !== "") {
     if (recordedIssuer !== undefined && returnedIss !== recordedIssuer) {
+      const mismatch =
+        "Authorization response `iss` does not match the issuer this flow " +
+        "started with. Recorded from authorization-server metadata: " +
+        `${quoteUntrusted(recordedIssuer)}; returned on the callback: ` +
+        `${quoteUntrusted(returnedIss)}.`;
+      if (!enforcePresentIssMismatch) {
+        return {
+          ok: true,
+          warning:
+            `${mismatch} This protocol version does not require RFC 9207 ` +
+            "issuer validation, so the flow continues; on 2026-07-28 this " +
+            "stops the flow before the authorization code is redeemed.",
+        };
+      }
       return {
         ok: false,
         reason:
-          "Authorization response `iss` does not match the issuer this flow " +
-          "started with. Refusing to exchange the authorization code; not " +
+          `${mismatch} Refusing to exchange the authorization code; not ` +
           "displaying any server-supplied error parameters (RFC 9207).",
       };
     }
@@ -1950,6 +1997,10 @@ export const createDebugOAuthStateMachine = (
               recordedIssuer: state.recordedIssuer,
               returnedIss: state.authorizationResponseIss,
               issParameterSupported: undefined,
+              // This machine IS the 2026-07-28 era, where SEP-2468 makes the
+              // present-`iss` comparison a MUST. Stated explicitly rather than
+              // leaning on the default, so the era rule is visible here.
+              enforcePresentIssMismatch: true,
             });
             if (!issCheck.ok) {
               updateState({

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -565,13 +565,18 @@ export type AuthorizationResponseIssuerCheck =
   | { ok: false; reason: string };
 
 /**
- * Render a callback-supplied value inside a diagnostic. Control characters are
- * flattened so a hostile `iss` cannot forge additional message lines, and the
- * value is capped so it cannot crowd out the diagnostic around it.
+ * Render a callback-supplied value inside a diagnostic. Line-breaking
+ * characters are flattened so a hostile `iss` cannot forge additional message
+ * lines, and the value is capped so it cannot crowd out the diagnostic around
+ * it. C0 and DEL are not sufficient on their own: NEL (U+0085) and the Unicode
+ * LINE/PARAGRAPH SEPARATORs (U+2028/U+2029) also break lines when a diagnostic
+ * is rendered, so they are flattened too.
  */
 function quoteUntrusted(value: string): string {
   // eslint-disable-next-line no-control-regex
-  const flattened = value.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+  const flattened = value
+    .replace(/[\u0000-\u001f\u007f\u0085\u2028\u2029]+/g, " ")
+    .trim();
   const capped =
     flattened.length > 256 ? `${flattened.slice(0, 256)}…` : flattened;
   return `\`${capped}\``;

--- a/sdk/tests/oauth/debug-oauth-2026.test.ts
+++ b/sdk/tests/oauth/debug-oauth-2026.test.ts
@@ -172,6 +172,67 @@ describe("validateAuthorizationResponseIssuer (RFC 9207)", () => {
     if (!result.ok) expect(result.reason).toMatch(/RFC 9207/);
   });
 
+  it("row 2 names both issuers so a same-looking mismatch is diagnosable", () => {
+    const result = validateAuthorizationResponseIssuer({
+      recordedIssuer: ISS,
+      returnedIss: `${ISS}/`,
+      issParameterSupported: true,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain(`\`${ISS}\``);
+      expect(result.reason).toContain(`\`${ISS}/\``);
+    }
+  });
+
+  it("row 2 neutralizes a hostile `iss` that tries to forge message lines", () => {
+    const result = validateAuthorizationResponseIssuer({
+      recordedIssuer: ISS,
+      returnedIss: "https://evil.example.com\n\nAuthorization succeeded.",
+      issParameterSupported: true,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).not.toContain("\n");
+      expect(result.reason).toContain("https://evil.example.com");
+    }
+  });
+
+  it("row 2 warns instead of rejecting when the era does not enforce it", () => {
+    const result = validateAuthorizationResponseIssuer({
+      recordedIssuer: ISS,
+      returnedIss: "https://evil.example.com",
+      issParameterSupported: true,
+      enforcePresentIssMismatch: false,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.warning).toContain(`\`${ISS}\``);
+      expect(result.warning).toContain("`https://evil.example.com`");
+    }
+  });
+
+  it("row 2 fails closed when the enforcement flag is omitted", () => {
+    const result = validateAuthorizationResponseIssuer({
+      recordedIssuer: ISS,
+      returnedIss: "https://evil.example.com",
+      issParameterSupported: true,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("a matching iss never warns, enforced or not", () => {
+    for (const enforce of [true, false]) {
+      const result = validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: ISS,
+        issParameterSupported: true,
+        enforcePresentIssMismatch: enforce,
+      });
+      expect(result).toEqual({ ok: true });
+    }
+  });
+
   it("row 3: absent but advertised supported → reject (missing required iss)", () => {
     const result = validateAuthorizationResponseIssuer({
       recordedIssuer: ISS,

--- a/sdk/tests/oauth/debug-oauth-2026.test.ts
+++ b/sdk/tests/oauth/debug-oauth-2026.test.ts
@@ -186,15 +186,19 @@ describe("validateAuthorizationResponseIssuer (RFC 9207)", () => {
   });
 
   it("row 2 neutralizes a hostile `iss` that tries to forge message lines", () => {
-    const result = validateAuthorizationResponseIssuer({
-      recordedIssuer: ISS,
-      returnedIss: "https://evil.example.com\n\nAuthorization succeeded.",
-      issParameterSupported: true,
-    });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).not.toContain("\n");
-      expect(result.reason).toContain("https://evil.example.com");
+    // C0/DEL are not the only line breakers: NEL and the Unicode LINE/PARAGRAPH
+    // separators also split lines when the diagnostic is rendered.
+    for (const breaker of ["\n", "\r", "\u0085", "\u2028", "\u2029"]) {
+      const result = validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: `https://evil.example.com${breaker}${breaker}Authorization succeeded.`,
+        issParameterSupported: true,
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).not.toContain(breaker);
+        expect(result.reason).toContain("https://evil.example.com");
+      }
     }
   });
 


### PR DESCRIPTION
**Before:** auth server returns an `iss` that doesn't match its metadata → MCPJam refuses to finish, on every protocol version. The error only said "does not match", so you had to go dig up both values yourself.

**After:** still refuses on the RC, where the spec makes it a MUST. On November it connects and warns instead. Both paths print the two issuers, so you can compare them without leaving the error.

Follow-up to #3441, which era-gated the "server sent no `iss`" half of this and left the "server sent the wrong `iss`" half firing everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Era-gated RFC 9207 authorization-response `iss` mismatch handling: still rejects on 2026-07-28, but warns and continues on 2025-11-25 and earlier with clear issuer diagnostics; also hardens diagnostics by flattening Unicode line separators to prevent message-line forgery.

- **Bug Fixes**
  - Gate both mismatch and “absent but advertised” checks to the modern era; pre-draft flows emit a non-blocking warning for mismatches and complete.
  - Surface the warning on successful OAuth completion (not the connection result), toast it, and record it on the OAuth trace without rewinding progress.
  - Diagnostics now name both issuers and quote/sanitize untrusted `iss` values, flattening C0/DEL plus NEL/LS/PS to prevent log/UX injection.
  - SDK: `validateAuthorizationResponseIssuer` adds `enforcePresentIssMismatch` (defaults to enforcing); the 2026 debug machine sets it explicitly. Tests added across inspector and SDK. Patch release prepared for `@mcpjam/sdk`.

<sup>Written for commit 1682c4a4c9cac5c0dc61890ecac6f733f4ebc55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

