### PR TITLE
feat(swarms): capture + replay MCP App widget snapshots for swarm sessions

### DIFF
--- a/mcpjam-inspector/client/src/components/swarms/use-persisted-session-trace.ts
+++ b/mcpjam-inspector/client/src/components/swarms/use-persisted-session-trace.ts
@@ -1,10 +1,14 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useSharedChatThread,
   useSharedChatTurnTraces,
+  useSharedChatWidgetSnapshots,
   type SharedChatTurnTrace,
 } from "@/hooks/useSharedChatThreads";
-import type { TraceEnvelope } from "@/components/evals/trace-viewer-adapter";
+import {
+  snapshotsToTraceWidgetSnapshots,
+  type TraceEnvelope,
+} from "@/components/evals/trace-viewer-adapter";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 
 /** One pinned plugin version recorded on a synthetic session's resume config. */
@@ -70,6 +74,10 @@ export function usePersistedSessionTrace(threadId: string | null): {
 } {
   const { thread } = useSharedChatThread({ threadId });
   const { traces: turnTraces } = useSharedChatTurnTraces({ threadId });
+  // MCP App widget snapshots captured by the swarm runner per turn. Joined
+  // into the envelope (same as ShareUsageThreadDetail) so the Chat view
+  // replays the actual widget instead of collapsing to a plain tool pill.
+  const { snapshots } = useSharedChatWidgetSnapshots({ threadId });
   const [messages, setMessages] = useState<unknown[] | null>(null);
   const [spans, setSpans] = useState<EvalTraceSpan[]>([]);
   const [loadingMessages, setLoadingMessages] = useState(false);
@@ -152,6 +160,11 @@ export function usePersistedSessionTrace(threadId: string | null): {
     };
   }, [threadId, turnTraces]);
 
+  const widgetSnapshots = useMemo(
+    () => (snapshots?.length ? snapshotsToTraceWidgetSnapshots(snapshots) : []),
+    [snapshots],
+  );
+
   const loading = loadingMessages || loadingSpans;
   const trace: TraceEnvelope | null =
     messages == null
@@ -160,6 +173,7 @@ export function usePersistedSessionTrace(threadId: string | null): {
           traceVersion: 1,
           messages: messages as TraceEnvelope["messages"],
           ...(spans.length > 0 ? { spans } : {}),
+          ...(widgetSnapshots.length > 0 ? { widgetSnapshots } : {}),
         };
 
   return {

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -181,7 +181,22 @@ describe("swarm single-host runner — attempt ordering", () => {
       mcpClientManager: fakeManager,
       convexAuthToken: "token",
       chatSessionId: "synth_run-1_host-1_0",
+      capturedToolCallIds: expect.any(Set),
     });
+    // The captured-ids set is ATTEMPT-scoped: the same instance rides every
+    // turn of this session, so ids marked persisted on turn N are skipped
+    // (no readResource/upload) on turn N+1.
+    await adapter.onTurnPersisted({
+      messages: fakeMessages,
+      manager: fakeManager,
+      browser: { tag: "browser" },
+      connectedServerIds: ["server-1"],
+      promptIndex: 1,
+    });
+    expect(captureWidgetSnapshotsMock).toHaveBeenCalledTimes(2);
+    expect(
+      captureWidgetSnapshotsMock.mock.calls[0]![0].capturedToolCallIds
+    ).toBe(captureWidgetSnapshotsMock.mock.calls[1]![0].capturedToolCallIds);
     // Persona driver routes through the swarm backend client.
     await adapter.nextPersonaTurn([{ role: "user", content: "hi" }]);
     expect(swarmPersonaNextTurnMock).toHaveBeenCalledWith(

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.test.ts
@@ -14,6 +14,7 @@ const reportAttemptMock = vi.fn();
 const swarmPersonaNextTurnMock = vi.fn();
 const heartbeatJourneyRunMock = vi.fn();
 const runSyntheticHostSessionMock = vi.fn();
+const captureWidgetSnapshotsMock = vi.fn();
 
 const finalizePendingAttemptsMock = vi.fn();
 const fetchPinnedSkillMock = vi.fn();
@@ -43,6 +44,8 @@ vi.mock("../runner.js", async () => {
     ...actual,
     runSyntheticHostSession: (...args: unknown[]) =>
       runSyntheticHostSessionMock(...args),
+    captureAndPersistWidgetSnapshotsForSession: (...args: unknown[]) =>
+      captureWidgetSnapshotsMock(...args),
   };
 });
 
@@ -159,8 +162,26 @@ describe("swarm single-host runner — attempt ordering", () => {
       personaId: "p1",
       personaLabel: "Persona One",
     });
-    // Swarm has no chatbox surface — no chatbox-scoped side-persistence.
-    expect(adapter.onTurnPersisted).toBeUndefined();
+    // Per-turn widget-snapshot capture rides `onTurnPersisted`, through the
+    // mutation's DIRECT auth branch: launcher bearer + session id, and NO
+    // chatboxId/accessVersion (swarm has no chatbox surface).
+    expect(adapter.onTurnPersisted).toBeTypeOf("function");
+    const fakeMessages = [{ role: "assistant", content: "done" }];
+    const fakeManager = { tag: "manager" };
+    await adapter.onTurnPersisted({
+      messages: fakeMessages,
+      manager: fakeManager,
+      browser: { tag: "browser" },
+      connectedServerIds: ["server-1"],
+      promptIndex: 0,
+    });
+    expect(captureWidgetSnapshotsMock).toHaveBeenCalledTimes(1);
+    expect(captureWidgetSnapshotsMock).toHaveBeenCalledWith({
+      messages: fakeMessages,
+      mcpClientManager: fakeManager,
+      convexAuthToken: "token",
+      chatSessionId: "synth_run-1_host-1_0",
+    });
     // Persona driver routes through the swarm backend client.
     await adapter.nextPersonaTurn([{ role: "user", content: "hi" }]);
     expect(swarmPersonaNextTurnMock).toHaveBeenCalledWith(

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -607,9 +607,11 @@ export interface SyntheticHostSessionAdapter {
   /** Persistence attribution tags (chatbox vs swarm). */
   persist: SyntheticPersistAttribution;
   /**
-   * Optional per-turn side-persistence (chatbox-scoped MCP App widget snapshots
-   * + browser artifacts). The chatbox surface injects it; the swarm single-host
-   * slice omits it — those rows are keyed by `chatboxId`, which swarm has none.
+   * Optional per-turn side-persistence. The chatbox surface injects widget
+   * snapshots + browser artifacts (chatbox-scoped auth); the swarm surface
+   * injects widget snapshots via the mutation's direct-session path (session
+   * owner + per-snapshot `serverId` — no chatbox). Browser-artifact rows
+   * remain chatbox-only: `recordBrowserArtifacts` still requires a chatbox.
    */
   onTurnPersisted?(args: {
     messages: ModelMessage[];
@@ -1321,14 +1323,20 @@ async function runOneSession(args: {
  * error, transient network) is logged and swallowed — never aborts the
  * synthetic run. The Convex mutation patches existing rows on
  * `(sessionId, toolCallId)` so re-running this per turn is idempotent.
+ *
+ * `chatboxId`/`accessVersion` select the mutation's hosted-chatbox auth
+ * branch; callers without a chatbox (the swarm surface) omit both and the
+ * mutation authorizes via its direct-session path instead (session owner +
+ * per-snapshot `serverId`, which `captureMcpAppWidgetSnapshots` always
+ * stamps from the tool call's originating server).
  */
-async function captureAndPersistWidgetSnapshotsForSession(args: {
+export async function captureAndPersistWidgetSnapshotsForSession(args: {
   messages: ModelMessage[];
   mcpClientManager: MCPClientManager;
   convexAuthToken: string;
   chatSessionId: string;
-  chatboxId: string;
-  accessVersion: number | undefined;
+  chatboxId?: string;
+  accessVersion?: number;
 }): Promise<void> {
   const {
     messages,
@@ -1403,7 +1411,7 @@ async function captureAndPersistWidgetSnapshotsForSession(args: {
         await convexClient.mutation(
           "chatSessions:createWidgetSnapshot" as any,
           {
-            chatboxId,
+            ...(chatboxId !== undefined ? { chatboxId } : {}),
             ...(accessVersion !== undefined ? { accessVersion } : {}),
             chatSessionId,
             ...sanitized,

--- a/mcpjam-inspector/server/services/sessionSimulation/runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/runner.ts
@@ -1247,6 +1247,10 @@ async function runOneSession(args: {
 }): Promise<SessionResult> {
   const { persona, sessionIdx, runId, chatboxId, convexHttpUrl } = args;
   const chatSessionId = `synth_${runId}_${persona.id}_${sessionIdx}`;
+  // Session-scoped: per-turn widget capture walks the FULL accumulated
+  // transcript, so without this an early widget is re-fetched and
+  // re-uploaded on every later turn.
+  const capturedWidgetToolCallIds = new Set<string>();
 
   return runSyntheticHostSession({
     runId,
@@ -1297,6 +1301,7 @@ async function runOneSession(args: {
         chatSessionId,
         chatboxId,
         accessVersion: args.accessVersion,
+        capturedToolCallIds: capturedWidgetToolCallIds,
       });
       await persistBrowserArtifactsForTurn({
         browser,
@@ -1337,6 +1342,16 @@ export async function captureAndPersistWidgetSnapshotsForSession(args: {
   chatSessionId: string;
   chatboxId?: string;
   accessVersion?: number;
+  /**
+   * Session-scoped set of tool-call ids whose snapshot row is already
+   * persisted. Callers invoking this per turn over a growing transcript
+   * pass one set per session: already-persisted calls are skipped before
+   * `readResource`/upload (the walk is otherwise quadratic in turns), and
+   * an id is added only after its mutation succeeds — a transient failure
+   * (including the mutation's null return while `/ingest-chat` hasn't
+   * written the session row yet) retries naturally on the next turn.
+   */
+  capturedToolCallIds?: Set<string>;
 }): Promise<void> {
   const {
     messages,
@@ -1345,6 +1360,7 @@ export async function captureAndPersistWidgetSnapshotsForSession(args: {
     chatSessionId,
     chatboxId,
     accessVersion,
+    capturedToolCallIds,
   } = args;
 
   // `convexHttpUrl` is the `.convex.site` HTTP-actions endpoint (the runner
@@ -1382,6 +1398,7 @@ export async function captureAndPersistWidgetSnapshotsForSession(args: {
       messages,
       mcpClientManager,
       convexClient,
+      ...(capturedToolCallIds ? { skipToolCallIds: capturedToolCallIds } : {}),
     });
   } catch (err) {
     logger.warn("[sessionSimulation.runner] widget snapshot capture failed", {
@@ -1408,7 +1425,7 @@ export async function captureAndPersistWidgetSnapshotsForSession(args: {
       // which Convex rejects at the argument-validator boundary.
       const sanitized = sanitizeWidgetForBackend(widgetPayload);
       try {
-        await convexClient.mutation(
+        const result = await convexClient.mutation(
           "chatSessions:createWidgetSnapshot" as any,
           {
             ...(chatboxId !== undefined ? { chatboxId } : {}),
@@ -1417,6 +1434,11 @@ export async function captureAndPersistWidgetSnapshotsForSession(args: {
             ...sanitized,
           }
         );
+        // Null = the ingest race (session row not written yet) — leave the
+        // id unmarked so the next turn retries. Anything else is the row id.
+        if (result != null) {
+          capturedToolCallIds?.add(snap.toolCallId);
+        }
       } catch (err) {
         logger.warn("[sessionSimulation.runner] createWidgetSnapshot failed", {
           chatSessionId,

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -392,6 +392,10 @@ async function runJourneyFanOut(
           targetSessionIdentity(target),
           sessionIdx
         );
+        // Attempt-scoped: per-turn widget capture walks the FULL accumulated
+        // transcript, so without this an early widget is re-fetched and
+        // re-uploaded on every later turn.
+        const capturedWidgetToolCallIds = new Set<string>();
 
         // CLAIM before executing: the `running` transition requires the
         // chatSessionId and is immutable thereafter. Persistence is LAUNCHER-gated
@@ -531,6 +535,7 @@ async function runJourneyFanOut(
               mcpClientManager: manager,
               convexAuthToken: bearer,
               chatSessionId,
+              capturedToolCallIds: capturedWidgetToolCallIds,
             });
           },
         });

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -1,6 +1,7 @@
 import { logger } from "../../utils/logger.js";
 import { buildSyntheticModelDefinition } from "../../utils/org-model-config.js";
 import {
+  captureAndPersistWidgetSnapshotsForSession,
   runSyntheticHostSession,
   type SimulationManagerFactory,
 } from "./runner.js";
@@ -515,8 +516,23 @@ async function runJourneyFanOut(
             personaLabel: personaSnapshot.name,
           },
           emit,
-          // No chatbox-scoped side-persistence on the swarm surface (widget /
-          // browser-artifact rows are keyed by chatboxId, which swarm has none).
+          // Per-turn MCP App widget-snapshot capture, same as the chatbox
+          // surface but through `createWidgetSnapshot`'s direct-session auth
+          // branch (no chatboxId/accessVersion): the runner authenticates as
+          // the run launcher, who owns every swarm session row, and each
+          // snapshot carries its originating `serverId`. Without this the
+          // Swarms session viewers have no `sharedChatWidgetSnapshots` rows
+          // and MCP App tool calls collapse to plain pills. Best-effort — the
+          // helper logs and swallows every failure. Browser-artifact rows are
+          // NOT persisted here: `recordBrowserArtifacts` is chatbox-only.
+          onTurnPersisted: async ({ messages, manager }) => {
+            await captureAndPersistWidgetSnapshotsForSession({
+              messages,
+              mcpClientManager: manager,
+              convexAuthToken: bearer,
+              chatSessionId,
+            });
+          },
         });
 
         // Report the terminal with the SAME chatSessionId ONLY after the

--- a/mcpjam-inspector/server/utils/__tests__/mcp-app-widget-capture.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-app-widget-capture.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { ConvexHttpClient } from "convex/browser";
+import type { ModelMessage } from "ai";
+import type { MCPClientManager } from "@mcpjam/sdk";
 import {
+  captureMcpAppWidgetSnapshots,
   uploadScreenshotBlob,
   uploadVideoBlob,
 } from "../mcp-app-widget-capture.js";
@@ -147,5 +150,101 @@ describe("uploadVideoBlob", () => {
     await expect(uploadVideoBlob(client, Buffer.from([1]))).rejects.toThrow(
       /500/,
     );
+  });
+});
+
+describe("captureMcpAppWidgetSnapshots — skipToolCallIds", () => {
+  const widgetToolMessages = (toolCallId: string): ModelMessage[] =>
+    [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool-call", toolCallId, toolName: "show_widget", input: {} },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId,
+            toolName: "show_widget",
+            serverId: "server-1",
+            output: { type: "json", value: {} },
+          },
+        ],
+      },
+    ] as unknown as ModelMessage[];
+
+  const makeManager = () => {
+    const readResource = vi.fn(async () => ({
+      contents: [{ mimeType: "text/html", text: "<html>widget</html>" }],
+    }));
+    const manager = {
+      getAllToolsMetadata: vi.fn(() => ({
+        show_widget: { ui: { resourceUri: "ui://widget/main" } },
+      })),
+      readResource,
+    } as unknown as MCPClientManager;
+    return { manager, readResource };
+  };
+
+  test("skips already-captured tool calls entirely (no readResource, no upload)", async () => {
+    const { manager, readResource } = makeManager();
+    const { client, mutation } = makeClient("https://convex.example/upload");
+    const fetchMock = vi.fn(async () => okJson({ storageId: "html-1" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const messages = [
+      ...widgetToolMessages("call-1"),
+      ...widgetToolMessages("call-2"),
+    ];
+
+    const snapshots = await captureMcpAppWidgetSnapshots({
+      messages,
+      mcpClientManager: manager,
+      convexClient: client,
+      skipToolCallIds: new Set(["call-1"]),
+    });
+
+    expect(snapshots?.map((s) => s.toolCallId)).toEqual(["call-2"]);
+    expect(readResource).toHaveBeenCalledTimes(1);
+    expect(mutation).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns undefined (and touches nothing) when every call is skipped", async () => {
+    const { manager, readResource } = makeManager();
+    const { client, mutation } = makeClient("https://convex.example/upload");
+    vi.stubGlobal("fetch", vi.fn());
+
+    const snapshots = await captureMcpAppWidgetSnapshots({
+      messages: widgetToolMessages("call-1"),
+      mcpClientManager: manager,
+      convexClient: client,
+      skipToolCallIds: new Set(["call-1"]),
+    });
+
+    expect(snapshots).toBeUndefined();
+    expect(readResource).not.toHaveBeenCalled();
+    expect(mutation).not.toHaveBeenCalled();
+  });
+
+  test("captures everything when no skip set is passed", async () => {
+    const { manager, readResource } = makeManager();
+    const { client } = makeClient("https://convex.example/upload");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => okJson({ storageId: "html-1" })),
+    );
+
+    const snapshots = await captureMcpAppWidgetSnapshots({
+      messages: widgetToolMessages("call-1"),
+      mcpClientManager: manager,
+      convexClient: client,
+    });
+
+    expect(snapshots?.map((s) => s.toolCallId)).toEqual(["call-1"]);
+    expect(readResource).toHaveBeenCalledTimes(1);
+    expect(snapshots?.[0]?.widgetHtmlBlobId).toBe("html-1");
   });
 });

--- a/mcpjam-inspector/server/utils/mcp-app-widget-capture.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-widget-capture.ts
@@ -376,8 +376,19 @@ export async function captureMcpAppWidgetSnapshots(params: {
    * matching the rest of the widget injection paths.
    */
   injectOpenAiCompat?: boolean;
+  /**
+   * Tool-call ids already captured on a previous invocation over the same
+   * (growing) transcript. Per-turn callers pass their session-scoped set so
+   * an early widget isn't re-fetched and re-uploaded on every later turn —
+   * without it the walk is quadratic in turns (readResource + blob upload
+   * per prior widget, per turn).
+   */
+  skipToolCallIds?: ReadonlySet<string>;
 }): Promise<EvalTraceWidgetSnapshot[] | undefined> {
-  const sources = collectToolSnapshotSources(params.messages);
+  const skip = params.skipToolCallIds;
+  const sources = collectToolSnapshotSources(params.messages).filter(
+    (source) => !skip?.has(source.toolCallId),
+  );
   if (sources.length === 0) {
     return undefined;
   }


### PR DESCRIPTION
## Why

Swarm session viewers render MCP App tool calls as plain tool pills, while the same tools render full interactive widgets in the Playground. The renderer chain (`PartSwitch` → `WidgetReplay` → `MCPAppsRenderer`) is shared — the data isn't:

1. **No snapshots were ever captured.** The swarm runner omitted the shared core's `onTurnPersisted` widget-capture hook behind a stale comment claiming snapshot rows require a `chatboxId`. In fact `chatSessions:createWidgetSnapshot` has a direct-session auth branch (session owner + per-snapshot `serverId`) that swarm sessions already satisfy — the runner authenticates as the run launcher, who owns every swarm session row. Since capture must run while the per-attempt `MCPClientManager` is still alive (the `ui://` HTML can't be fetched after the run), skipping the hook made widgets unrecoverable post-hoc.
2. **The inline swarm session pane never joined snapshots.** `usePersistedSessionTrace` built its `TraceEnvelope` with only `messages` + `spans`, so even existing rows couldn't replay there (the `ShareUsageThreadDetail`-based swarm views were already wired and start working with capture alone).

## What

- **`runner.ts`**: make `chatboxId`/`accessVersion` optional on `captureAndPersistWidgetSnapshotsForSession` and export it; omit `chatboxId` from the mutation args when absent so the direct-session branch authorizes. Browser artifacts stay chatbox-only (`recordBrowserArtifacts` genuinely requires a chatbox).
- **`swarm-runner.ts`**: inject `onTurnPersisted` per-turn widget capture (best-effort; the helper logs and swallows every failure).
- **`use-persisted-session-trace.ts`**: join `useSharedChatWidgetSnapshots` → `snapshotsToTraceWidgetSnapshots` into the envelope, same as `ShareUsageThreadDetail`.
- **`swarm-runner.test.ts`**: coverage that the hook fires per turn with the live manager and the session's `chatSessionId`.

Not covered (inherent): live-streamed swarm attempts still show pills mid-run — the SSE trace events carry no widget payload; widgets appear once persisted snapshots land.

## Testing

- `npm run typecheck:client` clean.
- `server/services/sessionSimulation/__tests__/` — 6 files, 72 tests, all passing.
- Server tsc errors are pre-existing on main in unrelated files; none in the 4 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds per-turn Convex persistence and changes mutation args for swarm paths, but failures are best-effort and browser artifacts remain chatbox-scoped.
> 
> **Overview**
> **Swarm sessions can now persist and replay MCP App widgets** instead of showing plain tool pills in the inline session trace.
> 
> The swarm runner wires **per-turn `onTurnPersisted` widget capture** through the shared `captureAndPersistWidgetSnapshotsForSession` helper, using `createWidgetSnapshot`'s **direct-session auth** (launcher bearer + `serverId` on each snapshot; no `chatboxId`). Browser artifacts stay chatbox-only.
> 
> **Runner/capture improvements** apply to chatbox synthesis too: `chatboxId`/`accessVersion` are optional on the capture helper (exported for swarm), and a **session-scoped `capturedToolCallIds` set** plus `skipToolCallIds` in `captureMcpAppWidgetSnapshots` avoid re-fetching and re-uploading widgets on every turn as the transcript grows. IDs are marked only after a successful mutation; a null result (e.g. ingest race) retries on the next turn.
> 
> **Client:** `usePersistedSessionTrace` loads `useSharedChatWidgetSnapshots` and adds `widgetSnapshots` to the `TraceEnvelope`, matching `ShareUsageThreadDetail`. Tests cover the swarm hook and skip-set behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e71f898db9d3ec52e5fbcd457f21d1056a90d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and replay MCP App widget snapshots for swarm sessions so Chat views show interactive widgets instead of tool pills. Also optimize per-turn capture to skip already-saved widgets.

- **New Features**
  - Swarm runner captures MCP App widget snapshots on each turn via `onTurnPersisted` using direct-session auth (no `chatboxId`); errors are logged and ignored. Browser artifacts remain chatbox-only.
  - Runner core exports the capture helper with optional `chatboxId`/`accessVersion` and omits them when absent to authorize via the direct-session path.
  - Client joins `sharedChatWidgetSnapshots` into the `TraceEnvelope` in `usePersistedSessionTrace` for proper widget replay.

- **Performance**
  - Per-turn capture skips already-persisted tool calls using a session-scoped `capturedToolCallIds` set, marking ids only after the mutation succeeds. Avoids re-fetch/re-upload across turns for both swarm and chatbox surfaces.

<sup>Written for commit 6e71f898db9d3ec52e5fbcd457f21d1056a90d01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

