### PR TITLE
Swarms: move sessions into journey block and polish personas UX

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/EditableTitle.tsx
+++ b/mcpjam-inspector/client/src/components/evals/EditableTitle.tsx
@@ -9,6 +9,12 @@ interface EditableTitleProps {
   inputClassName?: string;
   placeholder?: string;
   variant?: "h1" | "h2" | "h3" | "text";
+  /** Begin in edit mode on mount (e.g. after inline create). */
+  startInEditMode?: boolean;
+  /** Stretch the trigger/input to the container width. */
+  fullWidth?: boolean;
+  /** Truncate the read-only label. */
+  truncate?: boolean;
 }
 
 const variantStyles = {
@@ -25,8 +31,11 @@ export function EditableTitle({
   inputClassName,
   placeholder = "Untitled",
   variant = "h2",
+  startInEditMode = false,
+  fullWidth = false,
+  truncate = true,
 }: EditableTitleProps) {
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(startInEditMode);
   const [editedValue, setEditedValue] = useState(value);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -65,7 +74,7 @@ export function EditableTitle({
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      handleSave();
+      void handleSave();
     } else if (e.key === "Escape") {
       handleCancel();
     }
@@ -77,34 +86,48 @@ export function EditableTitle({
         type="text"
         value={editedValue}
         onChange={(e) => setEditedValue(e.target.value)}
-        onBlur={handleSave}
+        onBlur={() => void handleSave()}
         onKeyDown={handleKeyDown}
         autoFocus
         disabled={isSaving}
         placeholder={placeholder}
+        title={value}
         className={cn(
-          "px-3 py-2 border border-input rounded-md",
+          "rounded-md border border-input bg-background px-3 py-2",
           "focus:outline-none focus:ring-2 focus:ring-ring",
-          "bg-background",
           variantStyles[variant],
-          isSaving && "opacity-50 cursor-wait",
+          fullWidth && "w-full min-w-0",
+          isSaving && "cursor-wait opacity-50",
           inputClassName,
         )}
       />
     );
   }
 
+  const display = value || placeholder;
+  const showingPlaceholder = !value;
+
   return (
     <Button
+      type="button"
       variant="ghost"
       onClick={() => setIsEditing(true)}
+      title={value || undefined}
       className={cn(
-        "px-3 py-2 h-auto hover:bg-accent",
+        "h-auto gap-0 px-3 py-2 hover:bg-accent",
+        fullWidth && "w-full min-w-0 max-w-full justify-start text-left",
         variantStyles[variant],
         className,
       )}
     >
-      {value || <span className="text-muted-foreground">{placeholder}</span>}
+      <span
+        className={cn(
+          truncate && "truncate",
+          showingPlaceholder && "text-muted-foreground",
+        )}
+      >
+        {display}
+      </span>
     </Button>
   );
 }

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -35,6 +35,7 @@ import {
   Info,
   Loader2,
   Plus,
+  Trash2,
   Users,
   X,
 } from "lucide-react";
@@ -275,7 +276,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   type SwarmViewMode = "journeys" | "sessions";
   const SWARM_VIEW_OPTIONS = [
     { value: "journeys" as const, label: "Personas" },
-    { value: "sessions" as const, label: "Journeys" },
+    { value: "sessions" as const, label: "Sessions" },
   ];
   // Session deep-links open the flat Sessions browser; run-only links stay on
   // Journeys so the matrix / live stream can restore.
@@ -314,6 +315,27 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
       }
     },
     [updatePersona]
+  );
+
+  const handleDeletePersona = useCallback(
+    async (persona: Persona) => {
+      if (
+        !window.confirm(
+          `Delete persona "${persona.name}"? Its journeys are hidden but historical runs are kept.`
+        )
+      ) {
+        return;
+      }
+      try {
+        await deletePersona({ personaRefId: persona._id } as any);
+        setSelectedPersonaId(null);
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "Failed to delete persona"
+        );
+      }
+    },
+    [deletePersona]
   );
 
   const selectedPersona = useMemo(
@@ -808,31 +830,54 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                   personas.map((p) => {
                     const selected = p._id === selectedPersonaId;
                     return (
-                      <button
+                      <div
                         key={p._id}
-                        type="button"
-                        onClick={() => setSelectedPersonaId(p._id)}
                         className={cn(
-                          "flex w-full items-center gap-3 border-b px-4 py-3 text-left hover:bg-muted/50",
+                          "group flex w-full items-center border-b",
                           selected && "bg-muted"
                         )}
                       >
-                        <PersonaPixelAvatar
-                          seed={p._id}
-                          shapeIndex={p.avatarShape}
-                          paletteIndex={p.avatarPalette}
-                          size="md"
-                          state={runningSet.has(p._id) ? "running" : "idle"}
-                        />
-                        <span className="flex min-w-0 flex-col items-start gap-0.5">
-                          <span className="truncate text-sm font-medium">
-                            {p.name}
+                        <button
+                          type="button"
+                          onClick={() => setSelectedPersonaId(p._id)}
+                          className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left hover:bg-muted/50"
+                        >
+                          <PersonaPixelAvatar
+                            seed={p._id}
+                            shapeIndex={p.avatarShape}
+                            paletteIndex={p.avatarPalette}
+                            size="md"
+                            state={runningSet.has(p._id) ? "running" : "idle"}
+                          />
+                          <span className="flex min-w-0 flex-col items-start gap-0.5">
+                            <span className="truncate text-sm font-medium">
+                              {p.name}
+                            </span>
+                            <span className="truncate text-xs text-muted-foreground">
+                              {p.role}
+                            </span>
                           </span>
-                          <span className="truncate text-xs text-muted-foreground">
-                            {p.role}
-                          </span>
-                        </span>
-                      </button>
+                        </button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          aria-label={`Delete ${p.name}`}
+                          title="Delete persona"
+                          className={cn(
+                            "mr-2 size-8 shrink-0 p-0 text-muted-foreground hover:text-destructive",
+                            selected
+                              ? "opacity-100"
+                              : "opacity-0 group-hover:opacity-100"
+                          )}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void handleDeletePersona(p);
+                          }}
+                        >
+                          <Trash2 className="size-3.5" />
+                        </Button>
+                      </div>
                     );
                   })
                 )}
@@ -864,19 +909,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                         onSave={(patch) =>
                           savePersonaField(selectedPersona._id, patch)
                         }
-                        onDelete={async () => {
-                          if (
-                            !window.confirm(
-                              `Delete persona "${selectedPersona.name}"? Its journeys are hidden but historical runs are kept.`
-                            )
-                          ) {
-                            return;
-                          }
-                          await deletePersona({
-                            personaRefId: selectedPersona._id,
-                          } as any);
-                          setSelectedPersonaId(null);
-                        }}
+                        onDelete={() => handleDeletePersona(selectedPersona)}
                       />
 
                       <div

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -346,7 +346,30 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   // config, so the human finishes and submits it).
   const [journeyFormOpen, setJourneyFormOpen] = useState(false);
   const [journeyGoalSeed, setJourneyGoalSeed] = useState("");
-  const [personaDialogOpen, setPersonaDialogOpen] = useState(false);
+  const [creatingPersona, setCreatingPersona] = useState(false);
+  const [personaAutoEditId, setPersonaAutoEditId] = useState<string | null>(
+    null
+  );
+
+  const handleCreatePersona = useCallback(async () => {
+    if (!projectId || creatingPersona) return;
+    setCreatingPersona(true);
+    try {
+      const row = await createPersona({
+        projectId,
+        name: "New persona",
+        role: "Role",
+      } as any);
+      setPersonaAutoEditId(row._id);
+      setSelectedPersonaId(row._id);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to create persona"
+      );
+    } finally {
+      setCreatingPersona(false);
+    }
+  }, [projectId, creatingPersona, createPersona]);
 
   // Run detail opened in the right-hand panel. `runSnapshot` seeds the panel
   // until its own `listJourneyRuns` subscription resolves the run (identical
@@ -732,17 +755,20 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
             <aside className="flex w-72 shrink-0 flex-col border-r">
               <div className="flex items-center justify-between border-b px-4 py-3">
                 <h2 className="text-sm font-semibold">Personas</h2>
-                <NewPersonaDialog
-                  open={personaDialogOpen}
-                  onOpenChange={setPersonaDialogOpen}
-                  onCreate={async (draft) => {
-                    const row = await createPersona({
-                      projectId,
-                      ...draft,
-                    } as any);
-                    setSelectedPersonaId(row._id);
-                  }}
-                />
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={creatingPersona}
+                  onClick={() => void handleCreatePersona()}
+                >
+                  {creatingPersona ? (
+                    <Loader2 className="mr-1 size-3 animate-spin" />
+                  ) : (
+                    <Plus className="mr-1 size-3" />
+                  )}
+                  New
+                </Button>
               </div>
               <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
                 {personas === undefined ? (
@@ -767,9 +793,14 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                       type="button"
                       size="sm"
                       className="font-semibold shadow-sm"
-                      onClick={() => setPersonaDialogOpen(true)}
+                      disabled={creatingPersona}
+                      onClick={() => void handleCreatePersona()}
                     >
-                      <Plus className="h-3.5 w-3.5" />
+                      {creatingPersona ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Plus className="h-3.5 w-3.5" />
+                      )}
                       Create your first persona
                     </Button>
                   </div>
@@ -816,7 +847,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                 </div>
               ) : personas.length === 0 ? (
                 <SwarmsEmptyHero
-                  onCreatePersona={() => setPersonaDialogOpen(true)}
+                  onCreatePersona={() => void handleCreatePersona()}
                 />
               ) : !selectedPersona ? (
                 <JourneyNetworkBackdrop />
@@ -827,6 +858,9 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                       <PersonaDetailHeader
                         persona={selectedPersona}
                         running={runningSet.has(selectedPersona._id)}
+                        autoEditName={
+                          personaAutoEditId === selectedPersona._id
+                        }
                         onSave={(patch) =>
                           savePersonaField(selectedPersona._id, patch)
                         }
@@ -1167,11 +1201,13 @@ function RunSessionsView({ personaRefId }: { personaRefId: string }) {
 function PersonaDetailHeader({
   persona,
   running,
+  autoEditName = false,
   onSave,
   onDelete,
 }: {
   persona: Persona;
   running: boolean;
+  autoEditName?: boolean;
   onSave: (patch: {
     name?: string;
     role?: string;
@@ -1212,6 +1248,7 @@ function PersonaDetailHeader({
           <InlineEditableText
             value={persona.name}
             onSave={(name) => onSave({ name })}
+            startInEditMode={autoEditName}
             className="block w-full text-lg font-semibold tracking-tight sm:text-xl"
             truncate={false}
           />
@@ -1247,144 +1284,6 @@ function PersonaDetailHeader({
         Delete persona
       </Button>
     </div>
-  );
-}
-
-// ── create persona dialog (design-system; replaces the floating raw form) ────
-function NewPersonaDialog({
-  open,
-  onOpenChange,
-  onCreate,
-}: {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onCreate: (draft: {
-    name: string;
-    role: string;
-    notes?: string;
-  }) => Promise<void>;
-}) {
-  const [name, setName] = useState("");
-  const [role, setRole] = useState("");
-  const [notes, setNotes] = useState("");
-  const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    if (!open) {
-      setName("");
-      setRole("");
-      setNotes("");
-      setSaving(false);
-    }
-  }, [open]);
-
-  const handleCreate = async () => {
-    if (!name.trim() || !role.trim()) {
-      toast.error("Name and role are required");
-      return;
-    }
-    setSaving(true);
-    try {
-      await onCreate({
-        name: name.trim(),
-        role: role.trim(),
-        notes: notes.trim() || undefined,
-      });
-      toast.success("Persona created");
-      onOpenChange(false);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to create persona"
-      );
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <>
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        onClick={() => onOpenChange(true)}
-      >
-        <Plus className="mr-1 size-3" />
-        New
-      </Button>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>New persona</DialogTitle>
-            <DialogDescription>
-              A synthetic user who pursues journeys across your clients.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex flex-col gap-3 py-1">
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="swarm-persona-name">Name</Label>
-              <Input
-                id="swarm-persona-name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="Test User"
-                autoFocus
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    void handleCreate();
-                  }
-                }}
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="swarm-persona-role">Role</Label>
-              <Input
-                id="swarm-persona-role"
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
-                placeholder="SWE evaluating the product"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    void handleCreate();
-                  }
-                }}
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="swarm-persona-notes">Notes / personality</Label>
-              <Textarea
-                id="swarm-persona-notes"
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                placeholder="Background, tone, what they care about…"
-                rows={4}
-                className="leading-relaxed"
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={saving}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              disabled={saving || !name.trim() || !role.trim()}
-              onClick={() => void handleCreate()}
-            >
-              {saving ? <Loader2 className="mr-1 size-3 animate-spin" /> : null}
-              Create persona
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -63,7 +63,7 @@ import {
 import { toast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
-import { InlineEditableText } from "@/components/ui/inline-editable-text";
+import { EditableTitle } from "@/components/evals/EditableTitle";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { PersonaPixelAvatar } from "@/components/swarms/persona-pixel-avatar";
 import { PersonaAvatarLookPicker } from "@/components/swarms/persona-avatar-look-picker";
@@ -1245,18 +1245,26 @@ function PersonaDetailHeader({
           onSave={(look) => onSave(look)}
         />
         <div className="min-w-0 flex-1">
-          <InlineEditableText
+          <EditableTitle
             value={persona.name}
             onSave={(name) => onSave({ name })}
             startInEditMode={autoEditName}
-            className="block w-full text-lg font-semibold tracking-tight sm:text-xl"
+            variant="h2"
+            fullWidth
             truncate={false}
+            placeholder="Persona name"
+            className="-ml-2 px-2 text-lg font-semibold tracking-tight sm:text-xl"
+            inputClassName="text-lg font-semibold tracking-tight sm:text-xl"
           />
-          <InlineEditableText
+          <EditableTitle
             value={persona.role}
             onSave={(role) => onSave({ role })}
-            className="mt-0.5 block w-full text-sm text-muted-foreground"
+            variant="text"
+            fullWidth
             truncate={false}
+            placeholder="Role"
+            className="-ml-2 mt-0.5 px-2 font-normal text-muted-foreground"
+            inputClassName="font-normal text-muted-foreground"
           />
           <TextareaAutosize
             aria-label="Notes / personality"

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -68,6 +68,7 @@ import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { PersonaPixelAvatar } from "@/components/swarms/persona-pixel-avatar";
 import { PersonaAvatarLookPicker } from "@/components/swarms/persona-avatar-look-picker";
 import { JourneyNetworkBackdrop } from "@/components/swarms/journey-network-backdrop";
+import { SwarmsEmptyHero } from "@/components/swarms/swarms-empty-hero";
 import {
   launchJourneyRun,
   LaunchJourneyRunError,
@@ -319,6 +320,19 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
     () => personas?.find((p) => p._id === selectedPersonaId) ?? null,
     [personas, selectedPersonaId]
   );
+
+  // Personas tab: always land on someone — pick the first list entry when none
+  // is selected or the current id no longer exists (deleted / stale deep link).
+  useEffect(() => {
+    if (viewMode !== "journeys") return;
+    if (personas === undefined || personas.length === 0) return;
+    const currentValid =
+      selectedPersonaId !== null &&
+      personas.some((p) => p._id === selectedPersonaId);
+    if (!currentValid) {
+      setSelectedPersonaId(personas[0]._id);
+    }
+  }, [viewMode, personas, selectedPersonaId]);
   // Gate on the VALIDATED persona, not the raw URL-derived id: a copied
   // /swarms?persona=... deep link opened while signed out (or with a stale id)
   // must not subscribe getPersonaTrackRecord before the allowed persona list
@@ -332,6 +346,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   // config, so the human finishes and submits it).
   const [journeyFormOpen, setJourneyFormOpen] = useState(false);
   const [journeyGoalSeed, setJourneyGoalSeed] = useState("");
+  const [personaDialogOpen, setPersonaDialogOpen] = useState(false);
 
   // Run detail opened in the right-hand panel. `runSnapshot` seeds the panel
   // until its own `listJourneyRuns` subscription resolves the run (identical
@@ -718,6 +733,8 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
               <div className="flex items-center justify-between border-b px-4 py-3">
                 <h2 className="text-sm font-semibold">Personas</h2>
                 <NewPersonaDialog
+                  open={personaDialogOpen}
+                  onOpenChange={setPersonaDialogOpen}
                   onCreate={async (draft) => {
                     const row = await createPersona({
                       projectId,
@@ -727,14 +744,34 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                   }}
                 />
               </div>
-              <div className="min-h-0 flex-1 overflow-y-auto">
+              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
                 {personas === undefined ? (
                   <div className="p-4 text-sm text-muted-foreground">
                     Loading…
                   </div>
                 ) : personas.length === 0 ? (
-                  <div className="p-4 text-sm text-muted-foreground">
-                    No personas yet. Create one to get started.
+                  <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-16 text-center">
+                    <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 ring-1 ring-primary/20">
+                      <Users className="h-7 w-7 text-primary" />
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-foreground">
+                        No personas yet
+                      </p>
+                      <p className="max-w-xs text-xs text-muted-foreground">
+                        Create a persona to simulate user journeys across your
+                        clients.
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="font-semibold shadow-sm"
+                      onClick={() => setPersonaDialogOpen(true)}
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      Create your first persona
+                    </Button>
                   </div>
                 ) : (
                   personas.map((p) => {
@@ -772,8 +809,16 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
             </aside>
 
             {/* Persona detail + journey blocks; run detail opens on the right */}
-            <main className="min-w-0 flex-1 overflow-hidden">
-              {!selectedPersona ? (
+            <main className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+              {personas === undefined ? (
+                <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                  Loading…
+                </div>
+              ) : personas.length === 0 ? (
+                <SwarmsEmptyHero
+                  onCreatePersona={() => setPersonaDialogOpen(true)}
+                />
+              ) : !selectedPersona ? (
                 <JourneyNetworkBackdrop />
               ) : (
                 (() => {
@@ -1207,15 +1252,18 @@ function PersonaDetailHeader({
 
 // ── create persona dialog (design-system; replaces the floating raw form) ────
 function NewPersonaDialog({
+  open,
+  onOpenChange,
   onCreate,
 }: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onCreate: (draft: {
     name: string;
     role: string;
     notes?: string;
   }) => Promise<void>;
 }) {
-  const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [role, setRole] = useState("");
   const [notes, setNotes] = useState("");
@@ -1243,7 +1291,7 @@ function NewPersonaDialog({
         notes: notes.trim() || undefined,
       });
       toast.success("Persona created");
-      setOpen(false);
+      onOpenChange(false);
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to create persona"
@@ -1259,12 +1307,12 @@ function NewPersonaDialog({
         type="button"
         size="sm"
         variant="outline"
-        onClick={() => setOpen(true)}
+        onClick={() => onOpenChange(true)}
       >
         <Plus className="mr-1 size-3" />
         New
       </Button>
-      <Dialog open={open} onOpenChange={setOpen}>
+      <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>New persona</DialogTitle>
@@ -1320,7 +1368,7 @@ function NewPersonaDialog({
             <Button
               type="button"
               variant="outline"
-              onClick={() => setOpen(false)}
+              onClick={() => onOpenChange(false)}
               disabled={saving}
             >
               Cancel

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -73,18 +73,11 @@ import {
   LaunchJourneyRunError,
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
-  swarmAttemptChatSessionId,
   type JourneyRun,
-  type JourneyRollup,
   type JourneySessionRow,
   type PersonaTrackRecord,
 } from "@/lib/swarm-api";
 import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
-import {
-  buildSwarmRunTargets,
-  findTargetCellForChatSessionId,
-  type SwarmTargetColumn,
-} from "@/components/swarms/swarm-targets";
 import {
   buildEnvJourneyPayload,
   MAX_ENVIRONMENTS_PER_JOURNEY,
@@ -112,11 +105,8 @@ import {
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
 import { SwarmsSessionsPanel } from "@/components/swarms/SwarmsSessionsPanel";
-import {
-  SwarmLiveStreamPane,
-  SwarmSessionsMatrix,
-  type SwarmMatrixSelection,
-} from "@/components/swarms/journey-run-results";
+import { SwarmLiveStreamPane } from "@/components/swarms/journey-run-results";
+import { RunSessionsProvider, useRunSessionsContext } from "@/components/swarms/run-sessions-context";
 import {
   JourneyList,
   type JourneyListJourney,
@@ -136,10 +126,6 @@ import {
 } from "@/components/ui/resizable";
 // Re-exported for the goal-score unit test, which imports from `../SwarmsTab`.
 export { goalScoreAvgLabel } from "@/components/swarms/journey-run-format";
-import {
-  liveSessionTrace,
-  useJourneyRunStream,
-} from "@/components/swarms/use-journey-run-stream";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
 import { useSurfaceAgentBridge } from "@/lib/webmcp/use-surface-agent-bridge";
@@ -883,35 +869,40 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                     );
                   }
                   return (
-                    <ResizablePanelGroup
-                      direction="horizontal"
-                      className="h-full"
+                    <RunSessionsProvider
+                      runId={runDetail.runId}
+                      runSnapshot={runDetail.runSnapshot}
+                      journeyRefId={runDetail.journeyId}
+                      hosts={hosts ?? []}
+                      sessionsPerHost={detailJourney.config.sessionsPerHost}
+                      initialTargetKey={runDetail.targetKey}
+                      initialThreadId={
+                        deepLink.runId === runDetail.runId
+                          ? deepLink.threadId
+                          : undefined
+                      }
                     >
-                      <ResizablePanel defaultSize={38} minSize={26}>
-                        <div className="h-full overflow-y-auto px-6 py-6">
-                          {personaDetail}
-                        </div>
-                      </ResizablePanel>
-                      <ResizableHandle withHandle />
-                      <ResizablePanel defaultSize={62} minSize={35}>
-                        <RunDetailPanel
-                          key={`${runDetail.runId}:${
-                            runDetail.targetKey ?? ""
-                          }`}
-                          journey={detailJourney}
-                          runId={runDetail.runId}
-                          runSnapshot={runDetail.runSnapshot}
-                          targetKey={runDetail.targetKey}
-                          hosts={hosts ?? []}
-                          initialThreadId={
-                            deepLink.runId === runDetail.runId
-                              ? deepLink.threadId
-                              : undefined
-                          }
-                          onClose={closeRunDetail}
-                        />
-                      </ResizablePanel>
-                    </ResizablePanelGroup>
+                      <ResizablePanelGroup
+                        direction="horizontal"
+                        className="h-full"
+                      >
+                        <ResizablePanel defaultSize={38} minSize={26}>
+                          <div className="h-full overflow-y-auto px-6 py-6">
+                            {personaDetail}
+                          </div>
+                        </ResizablePanel>
+                        <ResizableHandle withHandle />
+                        <ResizablePanel defaultSize={62} minSize={35}>
+                          <RunDetailPanel
+                            key={`${runDetail.runId}:${
+                              runDetail.targetKey ?? ""
+                            }`}
+                            journey={detailJourney}
+                            onClose={closeRunDetail}
+                          />
+                        </ResizablePanel>
+                      </ResizablePanelGroup>
+                    </RunSessionsProvider>
                   );
                 })()
               )}
@@ -937,43 +928,21 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
 // ── run detail (right panel): header + sessions matrix + live stream ─────────
 function RunDetailPanel({
   journey,
-  runId,
-  runSnapshot,
-  targetKey,
-  hosts,
-  initialThreadId,
   onClose,
 }: {
   journey: Journey;
-  runId: string;
-  /** Seed until this panel's own runs subscription resolves the run. */
-  runSnapshot: JourneyRun;
-  /** Canonical target key (`targetId ?? hostId`) to preselect, if any. */
-  targetKey: string | null;
-  hosts: HostItem[];
-  initialThreadId?: string;
   onClose: () => void;
 }) {
-  // Same (name, args) as the journey block's subscription — Convex dedupes it —
-  // so a running run keeps updating even though the panel was opened from a
-  // snapshot. Old runs past the first page fall back to the (terminal,
-  // immutable) snapshot.
-  const { results: runs } = usePaginatedQuery(
-    SWARM_QUERIES.listJourneyRuns as any,
-    { journeyRefId: journey._id } as any,
-    { initialNumItems: DEFAULT_PAGE_SIZE }
-  );
-  const rollup = useQuery(
-    SWARM_QUERIES.journeyRollup as any,
-    { journeyRefId: journey._id } as any
-  ) as JourneyRollup | undefined;
-  const typedRuns = runs as JourneyRun[];
-  const runIndex = typedRuns.findIndex((r) => r._id === runId);
-  const run = (runIndex >= 0 ? typedRuns[runIndex] : null) ?? runSnapshot;
-  const runName =
-    runIndex >= 0
-      ? runNumberLabel(rollup?.runCount ?? typedRuns.length, runIndex)
-      : "Run";
+  const runSessions = useRunSessionsContext();
+  if (!runSessions) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading run…
+      </div>
+    );
+  }
+
+  const { run } = runSessions;
   const clientCount = run.hostSummaries.length || journey.hostIds.length;
 
   return (
@@ -981,7 +950,7 @@ function RunDetailPanel({
       <div className="flex shrink-0 items-start justify-between gap-3 border-b border-border/40 px-4 py-3">
         <div className="min-w-0">
           <p className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm font-medium">
-            <span>{runName}</span>
+            <span>{runSessions.runLabel}</span>
             <span
               className={cn(
                 "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
@@ -1017,236 +986,58 @@ function RunDetailPanel({
       </div>
       <div className="min-h-0 flex-1">
         <RunSessionsView
-          run={run}
           personaRefId={journey.personaRefId}
-          hosts={hosts}
-          runStatus={run.status}
-          sessionsPerHost={journey.config.sessionsPerHost}
-          initialTargetKey={targetKey ?? undefined}
-          initialThreadId={initialThreadId}
         />
       </div>
     </div>
   );
 }
 
-// ── sessions × hosts matrix + live stream (per run) ──────────────────────────
-function RunSessionsView({
-  run,
-  personaRefId,
-  hosts,
-  runStatus,
-  sessionsPerHost,
-  initialTargetKey,
-  initialThreadId,
-}: {
-  /** The run (live row or terminal snapshot) — targets join `hostSummaries`
-   * to `snapshot.hosts` for per-target columns/labels (B6). */
-  run: JourneyRun;
-  /** Owning persona — encoded into copied session links for deep-link restore. */
-  personaRefId: string;
-  hosts: HostItem[];
-  runStatus: JourneyRun["status"];
-  sessionsPerHost: number;
-  /** Matrix drill-in: preselect this target's first session (deferred to `initialThreadId`). */
-  initialTargetKey?: string;
-  /** Deep-link session (`id`) to auto-select once it's on a loaded page. */
-  initialThreadId?: string;
-}) {
-  const runId = run._id;
-  const {
-    results: sessions,
-    status,
-    loadMore,
-  } = usePaginatedQuery(
-    SWARM_QUERIES.listSessionsByJourneyRun as any,
-    { journeyRunId: runId } as any,
-    { initialNumItems: Math.max(DEFAULT_PAGE_SIZE, sessionsPerHost * 4) }
-  );
-
-  const streamEnabled = runStatus === "running";
-  const stream = useJourneyRunStream(runId, streamEnabled);
-
-  const [selection, setSelection] = useState<SwarmMatrixSelection | null>(null);
+// ── live stream + session detail (per run; matrix lives in JourneyBlock) ────
+function RunSessionsView({ personaRefId }: { personaRefId: string }) {
+  const runSessions = useRunSessionsContext();
   const [detailSession, setDetailSession] = useState<JourneySessionRow | null>(
     null
   );
   const [sessionToPromote, setSessionToPromote] =
     useState<JourneySessionRow | null>(null);
 
-  // Returns undefined for a host no longer in the project so
-  // `buildSwarmRunTargets` can fall back to the run snapshot's `hostName`
-  // before truncating the id.
-  const hostName = (id: string) => hosts.find((h) => h.hostId === id)?.name;
-  const hostNameOrId = (id: string) => hostName(id) ?? id.slice(0, 8);
-
-  const rows = sessions as JourneySessionRow[];
-  const hostSummaries = run.hostSummaries;
-  // Per-TARGET column model (D2/B6): one column per hostSummaries row, joined
-  // to snapshot.hosts by targetId (env columns get environment-name labels,
-  // #n-suffixed on collisions). Fallback for degenerate rows-only data:
-  // synthesize host columns from the session rows.
-  const targets = useMemo<SwarmTargetColumn[]>(() => {
-    if (hostSummaries.length > 0) {
-      return buildSwarmRunTargets({
-        hostSummaries,
-        snapshotHosts: run.snapshot?.hosts,
-        hostName,
-      });
-    }
-    const seen = new Set<string>();
-    for (const s of rows) seen.add(s.hostId);
-    return Array.from(seen).map((hostId) => ({
-      key: hostId,
-      hostId,
-      label: hostNameOrId(hostId),
-      identity: { hostId },
-    }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hostSummaries, run.snapshot, rows, hosts]);
-
-  const convexByChatId = useMemo(() => {
-    const map = new Map<string, JourneySessionRow>();
-    for (const s of rows) map.set(s.chatSessionId, s);
-    return map;
-  }, [rows]);
-
-  const selectedConvex = selection
-    ? convexByChatId.get(selection.chatSessionId) ?? null
-    : null;
-
-  const fallbackTrace = useMemo(
-    () =>
-      selection
-        ? liveSessionTrace(stream.sessions[selection.chatSessionId])
-        : null,
-    [selection, stream.sessions]
-  );
-
-  // Deep-link restore: select the matrix cell whose MINTED session id matches
-  // the linked Convex session (bounded ≤ targets × sessionsPerHost — B6).
-  const appliedInitialThreadRef = useRef(false);
-  useEffect(() => {
-    if (appliedInitialThreadRef.current || !initialThreadId) return;
-    const match = rows.find((s) => s.id === initialThreadId);
-    if (!match) return;
-    appliedInitialThreadRef.current = true;
-    const cell = findTargetCellForChatSessionId({
-      runId,
-      targets,
-      sessionsPerHost,
-      chatSessionId: match.chatSessionId,
-    });
-    setSelection({
-      targetKey: cell?.target.key ?? match.hostId,
-      hostId: match.hostId,
-      sessionIndex: cell?.sessionIndex ?? 0,
-      chatSessionId: match.chatSessionId,
-    });
-    setDetailSession(match);
-  }, [initialThreadId, rows, runId, targets, sessionsPerHost]);
-
-  // Matrix drill-in: preselect the clicked target's first session.
-  // `initialThreadId` (an explicit deep-linked session) always wins.
-  const appliedInitialTargetRef = useRef(false);
-  useEffect(() => {
-    if (
-      appliedInitialTargetRef.current ||
-      !initialTargetKey ||
-      initialThreadId
-    ) {
-      return;
-    }
-    const target = targets.find((t) => t.key === initialTargetKey);
-    if (!target) return;
-    const mintedIds = Array.from(
-      { length: Math.max(1, sessionsPerHost) },
-      (_, i) => swarmAttemptChatSessionId(runId, target.identity, i)
+  if (!runSessions) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading sessions…
+      </div>
     );
-    const matchIdx = mintedIds.findIndex((id) =>
-      rows.some((s) => s.chatSessionId === id)
-    );
-    if (matchIdx >= 0) {
-      appliedInitialTargetRef.current = true;
-      setSelection({
-        targetKey: target.key,
-        hostId: target.hostId,
-        sessionIndex: matchIdx,
-        chatSessionId: mintedIds[matchIdx],
-      });
-      return;
-    }
-    // No persisted row yet: for a terminal run with attempts on this target,
-    // synthesize the first attempt's cell so the pane opens on that target.
-    if (
-      runStatus !== "running" &&
-      hostSummaries.some(
-        (h) =>
-          (h.targetId ?? h.hostId) === initialTargetKey ||
-          h.hostId === initialTargetKey
-      )
-    ) {
-      appliedInitialTargetRef.current = true;
-      setSelection({
-        targetKey: target.key,
-        hostId: target.hostId,
-        sessionIndex: 0,
-        chatSessionId: mintedIds[0],
-      });
-    }
-  }, [
-    initialTargetKey,
-    initialThreadId,
-    rows,
-    runStatus,
-    hostSummaries,
+  }
+
+  const {
     runId,
-    targets,
-    sessionsPerHost,
-  ]);
+    runStatus,
+    sessionsStatus,
+    loadMoreSessions,
+    stream,
+    matrixSelection,
+    selectedConvex,
+    fallbackTrace,
+  } = runSessions;
 
-  // Auto-select the first running cell when a live stream starts. Cell keys
-  // are `${targetKey}:${sessionIndex}` and target keys may themselves contain
-  // ":" (opaque ids), so split on the LAST colon.
   useEffect(() => {
-    if (selection || !streamEnabled) return;
-    const runningEntry = Object.entries(stream.cellStatus).find(
-      ([, status]) => status === "running"
-    );
-    if (!runningEntry) return;
-    const [key] = runningEntry;
-    const cut = key.lastIndexOf(":");
-    if (cut <= 0) return;
-    const targetKey = key.slice(0, cut);
-    const sessionIndex = Number(key.slice(cut + 1));
-    if (!Number.isFinite(sessionIndex)) return;
-    const target = targets.find((t) => t.key === targetKey);
-    if (!target) return;
-    setSelection({
-      targetKey,
-      hostId: target.hostId,
-      sessionIndex,
-      chatSessionId: swarmAttemptChatSessionId(
-        runId,
-        target.identity,
-        sessionIndex
-      ),
-    });
-  }, [selection, streamEnabled, stream.cellStatus, runId, targets]);
+    setDetailSession(null);
+  }, [matrixSelection?.chatSessionId]);
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-4">
-      {stream.connected || stream.error || status === "CanLoadMore" ? (
+      {stream.connected || stream.error || sessionsStatus === "CanLoadMore" ? (
         <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
           <p className="text-[10px] text-muted-foreground">
             {stream.connected ? "live" : null}
             {stream.error ? `stream error: ${stream.error}` : null}
           </p>
-          {status === "CanLoadMore" ? (
+          {sessionsStatus === "CanLoadMore" ? (
             <button
               type="button"
               className="text-[11px] font-medium text-primary hover:underline"
-              onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
+              onClick={() => loadMoreSessions(DEFAULT_PAGE_SIZE)}
             >
               Load more sessions
             </button>
@@ -1254,25 +1045,9 @@ function RunSessionsView({
         </div>
       ) : null}
 
-      <div className="shrink-0">
-        <SwarmSessionsMatrix
-          runId={runId}
-          targets={targets}
-          sessionsPerHost={sessionsPerHost}
-          sessions={rows}
-          hostSummaries={hostSummaries}
-          stream={stream}
-          runStatus={String(runStatus)}
-          selection={selection}
-          onSelect={(sel) => {
-            setSelection(sel);
-            setDetailSession(null);
-          }}
-        />
-      </div>
       <div className="flex min-h-[24rem] flex-1 flex-col">
         <SwarmLiveStreamPane
-          selection={selection}
+          selection={matrixSelection}
           stream={stream}
           convexSession={selectedConvex}
           fallbackTrace={fallbackTrace}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.agent.test.tsx
@@ -120,9 +120,11 @@ async function dispatch(command: Omit<InspectorCommand, "id">) {
   return response;
 }
 
-function renderAndSelectPersona() {
+async function renderAndSelectPersona() {
   render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-  fireEvent.click(screen.getByText("Persona One"));
+  await waitFor(() => {
+    expect(screen.getByLabelText("Notes / personality")).toBeTruthy();
+  });
 }
 
 beforeEach(() => {
@@ -168,7 +170,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
   });
 
   it("openJourneyForm opens the new-journey form with a goal prefill — no journey is created", async () => {
-    renderAndSelectPersona();
+    await renderAndSelectPersona();
 
     const response = await dispatch({
       type: "openJourneyForm",
@@ -203,7 +205,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
 
   it("launchSwarmRun routes through launchJourneyRun with a launch key and reports the run id", async () => {
     launchJourneyRunMock.mockResolvedValue({ runId: "run-1" });
-    renderAndSelectPersona();
+    await renderAndSelectPersona();
 
     const response = await dispatch({
       type: "launchSwarmRun",
@@ -230,7 +232,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
     launchJourneyRunMock.mockRejectedValue(
       new LaunchJourneyRunError(402, "Swarm run limit reached"),
     );
-    renderAndSelectPersona();
+    await renderAndSelectPersona();
 
     const response = await dispatch({
       type: "launchSwarmRun",
@@ -248,7 +250,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
   });
 
   it("launchSwarmRun rejects an unknown journey without calling the launch path", async () => {
-    renderAndSelectPersona();
+    await renderAndSelectPersona();
 
     const response = await dispatch({
       type: "launchSwarmRun",
@@ -263,7 +265,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
   });
 
   it("reuses the SAME launch key on retry after a failure (no duplicate run/spend)", async () => {
-    renderAndSelectPersona();
+    await renderAndSelectPersona();
 
     // First attempt fails — the key must be RETAINED for the retry so the
     // backend dedupes rather than creating a second run.
@@ -315,7 +317,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
   });
 
   it("snapshot reports redacted state — persona/journey names, ids, host target names, counts", async () => {
-    renderAndSelectPersona();
+    await renderAndSelectPersona();
 
     const snapshot = await readSurfaceSnapshot("swarms");
     expect(snapshot).toMatchObject({

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
@@ -110,37 +110,27 @@ describe("SwarmsTab — persona create/edit", () => {
     ).toBeNull();
   });
 
-  it("opens a labeled create dialog instead of a floating raw form", async () => {
+  it("creates a persona row immediately instead of opening a modal", async () => {
+    createPersonaMutation.mockResolvedValue({
+      _id: "persona-new",
+      name: "New persona",
+      role: "Role",
+      notes: "",
+    });
+
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
 
     const aside = screen.getByRole("complementary");
     fireEvent.click(within(aside).getByRole("button", { name: /^new$/i }));
 
-    const dialog = screen.getByRole("dialog");
-    expect(screen.getByRole("heading", { name: "New persona" })).toBeTruthy();
-    expect(within(dialog).getByLabelText("Name")).toBeTruthy();
-    expect(within(dialog).getByLabelText("Role")).toBeTruthy();
-    expect(within(dialog).getByLabelText("Notes / personality")).toBeTruthy();
-
-    fireEvent.change(within(dialog).getByLabelText("Name"), {
-      target: { value: "Nacho" },
-    });
-    fireEvent.change(within(dialog).getByLabelText("Role"), {
-      target: { value: "SWE" },
-    });
-    fireEvent.change(within(dialog).getByLabelText("Notes / personality"), {
-      target: { value: "pragmatic" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /create persona/i }));
-
     await waitFor(() => {
       expect(createPersonaMutation).toHaveBeenCalledWith({
         projectId: "proj-1",
-        name: "Nacho",
-        role: "SWE",
-        notes: "pragmatic",
+        name: "New persona",
+        role: "Role",
       });
     });
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("saves personality notes on blur via updatePersona", async () => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
@@ -96,23 +96,39 @@ beforeEach(() => {
 });
 
 describe("SwarmsTab — persona create/edit", () => {
+  it("preselects the first persona on the Personas tab", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Notes / personality")).toBeTruthy();
+    });
+    expect(
+      (screen.getByLabelText("Notes / personality") as HTMLTextAreaElement).value
+    ).toBe("curious and impatient");
+    expect(
+      screen.queryByText("Select a persona to see its journeys.")
+    ).toBeNull();
+  });
+
   it("opens a labeled create dialog instead of a floating raw form", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
 
-    fireEvent.click(screen.getByRole("button", { name: /new/i }));
+    const aside = screen.getByRole("complementary");
+    fireEvent.click(within(aside).getByRole("button", { name: /^new$/i }));
 
+    const dialog = screen.getByRole("dialog");
     expect(screen.getByRole("heading", { name: "New persona" })).toBeTruthy();
-    expect(screen.getByLabelText("Name")).toBeTruthy();
-    expect(screen.getByLabelText("Role")).toBeTruthy();
-    expect(screen.getByLabelText("Notes / personality")).toBeTruthy();
+    expect(within(dialog).getByLabelText("Name")).toBeTruthy();
+    expect(within(dialog).getByLabelText("Role")).toBeTruthy();
+    expect(within(dialog).getByLabelText("Notes / personality")).toBeTruthy();
 
-    fireEvent.change(screen.getByLabelText("Name"), {
+    fireEvent.change(within(dialog).getByLabelText("Name"), {
       target: { value: "Nacho" },
     });
-    fireEvent.change(screen.getByLabelText("Role"), {
+    fireEvent.change(within(dialog).getByLabelText("Role"), {
       target: { value: "SWE" },
     });
-    fireEvent.change(screen.getByLabelText("Notes / personality"), {
+    fireEvent.change(within(dialog).getByLabelText("Notes / personality"), {
       target: { value: "pragmatic" },
     });
     fireEvent.click(screen.getByRole("button", { name: /create persona/i }));
@@ -129,9 +145,8 @@ describe("SwarmsTab — persona create/edit", () => {
 
   it("saves personality notes on blur via updatePersona", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    fireEvent.click(screen.getByText("Persona One"));
 
-    const notes = screen.getByLabelText("Notes / personality");
+    const notes = await screen.findByLabelText("Notes / personality");
     expect((notes as HTMLTextAreaElement).value).toBe("curious and impatient");
 
     fireEvent.change(notes, { target: { value: "calm and thorough" } });
@@ -147,10 +162,8 @@ describe("SwarmsTab — persona create/edit", () => {
 
   it("saves an inline name edit via updatePersona", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    fireEvent.click(screen.getByText("Persona One"));
 
-    // Sidebar + detail header both render the name; edit the detail copy.
-    const nameLabels = screen.getAllByText("Persona One");
+    const nameLabels = await screen.findAllByText("Persona One");
     fireEvent.click(nameLabels[nameLabels.length - 1]!);
     const input = screen.getByDisplayValue("Persona One");
     fireEvent.change(input, { target: { value: "Persona Two" } });
@@ -171,9 +184,7 @@ describe("SwarmsTab — persona create/edit", () => {
     const seeded = resolvePersonaPixelLook("persona-1");
 
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    fireEvent.click(screen.getByText("Persona One"));
-
-    fireEvent.click(screen.getByTestId("persona-avatar-look-trigger"));
+    fireEvent.click(await screen.findByTestId("persona-avatar-look-trigger"));
     fireEvent.click(screen.getByTestId("persona-avatar-next-shape"));
 
     await waitFor(() => {
@@ -201,7 +212,6 @@ describe("SwarmsTab — persona create/edit", () => {
   it("does not mark a selected idle persona as busy", async () => {
     runningPersonaRefIds.current = [];
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    fireEvent.click(await screen.findByText("Persona One"));
 
     await waitFor(() => {
       const aside = screen.getByRole("complementary");

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
@@ -22,10 +22,12 @@ const persona = {
 const {
   createPersonaMutation,
   updatePersonaMutation,
+  deletePersonaMutation,
   runningPersonaRefIds,
 } = vi.hoisted(() => ({
   createPersonaMutation: vi.fn(),
   updatePersonaMutation: vi.fn(),
+  deletePersonaMutation: vi.fn(),
   runningPersonaRefIds: { current: [] as string[] },
 }));
 
@@ -48,6 +50,7 @@ vi.mock("convex/react", () => ({
   useMutation: (name: string) => {
     if (name === "personas:createPersona") return createPersonaMutation;
     if (name === "personas:updatePersona") return updatePersonaMutation;
+    if (name === "personas:deletePersona") return deletePersonaMutation;
     return vi.fn().mockResolvedValue(undefined);
   },
   usePaginatedQuery: () => ({
@@ -93,6 +96,8 @@ beforeEach(() => {
   runningPersonaRefIds.current = [];
   createPersonaMutation.mockResolvedValue({ _id: "persona-new" });
   updatePersonaMutation.mockResolvedValue({ ...persona });
+  deletePersonaMutation.mockResolvedValue(undefined);
+  vi.spyOn(window, "confirm").mockReturnValue(true);
 });
 
 describe("SwarmsTab — persona create/edit", () => {
@@ -163,6 +168,21 @@ describe("SwarmsTab — persona create/edit", () => {
       expect(updatePersonaMutation).toHaveBeenCalledWith({
         personaRefId: "persona-1",
         name: "Persona Two",
+      });
+    });
+  });
+
+  it("deletes a persona from the sidebar trash button", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+
+    const aside = await screen.findByRole("complementary");
+    fireEvent.click(
+      within(aside).getByRole("button", { name: "Delete Persona One" })
+    );
+
+    await waitFor(() => {
+      expect(deletePersonaMutation).toHaveBeenCalledWith({
+        personaRefId: "persona-1",
       });
     });
   });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -239,8 +239,8 @@ afterEach(() => {
 /**
  * Progressive discovery: click Host One's matrix cell (opens the LATEST run,
  * which the fixtures make `run-fail`/partial), then — for the completed run —
- * pick it from the run history list. The partial run is already the latest, so
- * the cell click alone opens it.
+ * pick it from the host cell's trend strip. The partial run is already the
+ * latest, so the cell click alone opens it.
  */
 async function expandJourneyAndOpenRunSessions(
   target: "completed" | "partial" = "completed",
@@ -253,7 +253,7 @@ async function expandJourneyAndOpenRunSessions(
   if (target === "completed") {
     fireEvent.click(
       await screen.findByRole("button", {
-        name: /view sessions for run completed/i,
+        name: /open run completed .* on host one/i,
       }),
     );
   }
@@ -360,9 +360,13 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
     fireEvent.click(screen.getByText("Persona One"));
     await expandJourneyAndOpenRunSessions("partial");
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: /open runs for book a flight on host two/i,
+      }),
+    );
 
     const matrix = await screen.findByTestId("swarm-sessions-matrix");
-    // One chip per (host, session) — Host Two appears on each of its chips.
     expect(within(matrix).getAllByText("Host Two").length).toBeGreaterThan(0);
     // Host Two's unpersisted failures surface as Fail chips.
     const failCells = within(matrix)

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -268,10 +268,10 @@ async function selectFirstDoneCell() {
   fireEvent.click(doneCell!);
 }
 
-function openJourneysTab() {
+function openSessionsTab() {
   fireEvent.click(
     within(screen.getByLabelText("Swarm view")).getByRole("button", {
-      name: /^journeys$/i,
+      name: /^sessions$/i,
     }),
   );
 }
@@ -411,7 +411,7 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
 describe("SwarmsTab — top-level Journeys view", () => {
   it("defaults to listSessionsByProject and opens the viewer on `id`", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    openJourneysTab();
+    openSessionsTab();
 
     await waitFor(() => {
       const call = paginatedCalls.find(
@@ -438,7 +438,7 @@ describe("SwarmsTab — top-level Journeys view", () => {
 
   it("filters the visible list by client (host) without changing the query", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    openJourneysTab();
+    openSessionsTab();
 
     // Both hosts' sessions are listed before filtering.
     const panel = await screen.findByTestId("swarms-sessions-panel");
@@ -472,7 +472,7 @@ describe("SwarmsTab — top-level Journeys view", () => {
 
   it("narrows to listSessionsByPersona when a persona is selected, and clears back to all", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-    openJourneysTab();
+    openSessionsTab();
     await selectPersonaFilter("Persona One");
 
     await waitFor(() => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarms-empty-hero.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarms-empty-hero.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SwarmsEmptyHero } from "../swarms-empty-hero";
+
+describe("SwarmsEmptyHero", () => {
+  it("renders the evals-style empty hero and wires the create CTA", () => {
+    const onCreatePersona = vi.fn();
+    render(<SwarmsEmptyHero onCreatePersona={onCreatePersona} />);
+
+    expect(screen.getByTestId("swarms-empty-hero")).toBeTruthy();
+    expect(screen.getByText("Create your first persona")).toBeTruthy();
+    expect(screen.getByText("What swarms looks like")).toBeTruthy();
+    expect(screen.getByText("Journey trend")).toBeTruthy();
+    expect(screen.getByText("Client matrix")).toBeTruthy();
+    expect(screen.getByText("Session trace")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /create persona/i }));
+    expect(onCreatePersona).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -40,6 +40,8 @@ import {
   runStatusChipClass,
   runSummaryLine,
 } from "./journey-run-format";
+import { SwarmSessionsMatrix } from "./journey-run-results";
+import { useRunSessionsContext } from "./run-sessions-context";
 
 // Structural view of the SwarmsTab `Journey` / `HostItem` shapes — kept local so
 // this module stays decoupled from the surface component (no import cycle).
@@ -93,23 +95,6 @@ const SEGMENT_CLASS: Record<Exclude<JourneyCellOutcome, "none">, string> = {
   part: "bg-amber-500/70 dark:bg-amber-400/70",
   running: "bg-warning/50 animate-pulse",
 };
-
-/** Run-level status dot for the run rows (status string, not per-host). */
-function runStatusDotClass(status: string): string {
-  switch (status) {
-    case "completed":
-      return "bg-success";
-    case "failed":
-      return "bg-destructive";
-    case "partial":
-    case "rate_limited":
-      return "bg-amber-500";
-    case "stale":
-      return "bg-muted-foreground/50";
-    default:
-      return "bg-muted-foreground animate-pulse"; // running
-  }
-}
 
 const MAX_TREND_SEGMENTS = 12;
 
@@ -272,11 +257,7 @@ function JourneyBlock({
   environments?: ProjectEnvironmentView[];
   environmentsEnabled?: boolean;
 }) {
-  const {
-    results: runs,
-    status: runsStatus,
-    loadMore,
-  } = usePaginatedQuery(
+  const { results: runs } = usePaginatedQuery(
     SWARM_QUERIES.listJourneyRuns as any,
     { journeyRefId: journey._id } as any,
     { initialNumItems: DEFAULT_PAGE_SIZE }
@@ -288,6 +269,7 @@ function JourneyBlock({
 
   const [launching, setLaunching] = useState(false);
   const [launchError, setLaunchError] = useState<string | null>(null);
+  const runSessions = useRunSessionsContext();
 
   const typedRuns = runs as JourneyRun[];
   const latestRun = typedRuns[0] ?? null;
@@ -470,8 +452,8 @@ function JourneyBlock({
             )
             .slice(-MAX_TREND_SEGMENTS);
           const cellSelected =
-            selection?.runId === latestRun._id &&
-            selection.targetKey === col.key;
+            selection?.targetKey === col.key &&
+            selection?.runId === runSessions?.runId;
 
           return (
             <div
@@ -547,68 +529,26 @@ function JourneyBlock({
                   ))}
                 </div>
               ) : null}
+              {cellSelected && selection?.targetKey && runSessions ? (
+                <div className="mt-2 w-full border-t border-border/40 pt-2">
+                  <SwarmSessionsMatrix
+                    runId={runSessions.runId}
+                    targets={runSessions.targets}
+                    sessionsPerHost={runSessions.sessionsPerHost}
+                    sessions={runSessions.sessions}
+                    hostSummaries={runSessions.hostSummaries}
+                    stream={runSessions.stream}
+                    runStatus={String(runSessions.runStatus)}
+                    selection={runSessions.matrixSelection}
+                    onSelect={runSessions.onMatrixSelect}
+                    targetKeyFilter={col.key}
+                  />
+                </div>
+              ) : null}
             </div>
           );
         })}
       </div>
-
-      {/* Run history — visible while one of this journey's runs is open. */}
-      {selection ? (
-        <div className="mt-2 space-y-0.5 border-t border-border/40 pt-2">
-          <p className="px-1.5 pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-            Runs
-          </p>
-          {typedRuns.map((r, index) => {
-            const isOpen = selection.runId === r._id;
-            return (
-              <button
-                key={r._id}
-                type="button"
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-xs outline-none transition-colors",
-                  "hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring",
-                  isOpen && "bg-muted/40"
-                )}
-                aria-expanded={isOpen}
-                aria-label={
-                  isOpen
-                    ? `Hide sessions for run ${r.status}`
-                    : `View sessions for run ${r.status}`
-                }
-                onClick={() => (isOpen ? onCloseRun() : openRun(r, null))}
-              >
-                <span
-                  className={cn(
-                    "size-1.5 shrink-0 rounded-full",
-                    runStatusDotClass(r.status)
-                  )}
-                />
-                <span className="shrink-0 font-medium text-foreground/90">
-                  {runNumberLabel(runCount, index)}
-                </span>
-                <span className="capitalize text-muted-foreground">
-                  {r.status.replace(/_/g, " ")}
-                </span>
-                <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                  {runSummaryLine(r)}
-                </span>
-                <span className="shrink-0 text-[10px] text-muted-foreground">
-                  {formatJourneyRelativeTime(r.createdAt)}
-                </span>
-              </button>
-            );
-          })}
-          {runsStatus === "CanLoadMore" ? (
-            <button
-              type="button"
-              className="mt-0.5 px-1.5 text-[11px] font-medium text-primary hover:underline"
-              onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
-            >
-              Load more runs
-            </button>
-          ) : null}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
@@ -155,6 +155,7 @@ export function SwarmSessionsMatrix({
   runStatus,
   selection,
   onSelect,
+  targetKeyFilter,
 }: {
   runId: string;
   /** One column per execution target (per-target model — B6). */
@@ -173,6 +174,8 @@ export function SwarmSessionsMatrix({
   runStatus: string;
   selection: SwarmMatrixSelection | null;
   onSelect: (sel: SwarmMatrixSelection) => void;
+  /** When set, only render session chips for this target. */
+  targetKeyFilter?: string;
 }) {
   const sessionByChatId = useMemo(() => {
     const map = new Map<string, JourneySessionRow>();
@@ -183,6 +186,9 @@ export function SwarmSessionsMatrix({
   }, [sessions]);
 
   const rows = Math.max(1, sessionsPerHost);
+  const visibleTargets = targetKeyFilter
+    ? targets.filter((target) => target.key === targetKeyFilter)
+    : targets;
 
   return (
     <div className="min-w-0" data-testid="swarm-sessions-matrix">
@@ -190,7 +196,7 @@ export function SwarmSessionsMatrix({
         Sessions
       </p>
       <div className="flex flex-wrap gap-1.5">
-        {targets.flatMap((target) => {
+        {visibleTargets.flatMap((target) => {
           // Per-TARGET minted cell ids (shared mint — env targets key on the
           // environmentId identity, so two same-host targets never collide).
           const cellIds = Array.from({ length: rows }, (_, sessionIndex) =>

--- a/mcpjam-inspector/client/src/components/swarms/run-sessions-context.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/run-sessions-context.tsx
@@ -1,0 +1,297 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePaginatedQuery, useQuery } from "convex/react";
+import {
+  SWARM_QUERIES,
+  DEFAULT_PAGE_SIZE,
+  swarmAttemptChatSessionId,
+  type JourneyRun,
+  type JourneyRollup,
+  type JourneySessionRow,
+} from "@/lib/swarm-api";
+import {
+  buildSwarmRunTargets,
+  findTargetCellForChatSessionId,
+  type SwarmTargetColumn,
+} from "@/components/swarms/swarm-targets";
+import {
+  liveSessionTrace,
+  useJourneyRunStream,
+  type JourneyRunStreamState,
+} from "@/components/swarms/use-journey-run-stream";
+import type { SwarmMatrixSelection } from "@/components/swarms/journey-run-results";
+import type { TraceEnvelope } from "@/components/evals/trace-viewer-adapter";
+import { runNumberLabel } from "@/components/swarms/journey-run-format";
+
+type HostItem = { hostId: string; name: string };
+
+export type RunSessionsContextValue = {
+  run: JourneyRun;
+  runId: string;
+  runLabel: string;
+  runStatus: JourneyRun["status"];
+  sessionsPerHost: number;
+  sessions: JourneySessionRow[];
+  sessionsStatus: string;
+  loadMoreSessions: (n: number) => void;
+  targets: SwarmTargetColumn[];
+  hostSummaries: JourneyRun["hostSummaries"];
+  stream: JourneyRunStreamState;
+  matrixSelection: SwarmMatrixSelection | null;
+  onMatrixSelect: (sel: SwarmMatrixSelection) => void;
+  selectedConvex: JourneySessionRow | null;
+  fallbackTrace: TraceEnvelope | null;
+};
+
+const RunSessionsContext = createContext<RunSessionsContextValue | null>(null);
+
+export function useRunSessionsContext() {
+  return useContext(RunSessionsContext);
+}
+
+export function RunSessionsProvider({
+  runId,
+  runSnapshot,
+  journeyRefId,
+  hosts,
+  sessionsPerHost,
+  initialTargetKey,
+  initialThreadId,
+  children,
+}: {
+  runId: string;
+  runSnapshot: JourneyRun;
+  journeyRefId: string;
+  hosts: HostItem[];
+  sessionsPerHost: number;
+  initialTargetKey?: string | null;
+  initialThreadId?: string;
+  children: ReactNode;
+}) {
+  const { results: runs } = usePaginatedQuery(
+    SWARM_QUERIES.listJourneyRuns as any,
+    { journeyRefId } as any,
+    { initialNumItems: DEFAULT_PAGE_SIZE }
+  );
+  const rollup = useQuery(
+    SWARM_QUERIES.journeyRollup as any,
+    { journeyRefId } as any
+  ) as JourneyRollup | undefined;
+  const typedRuns = runs as JourneyRun[];
+  const runIndex = typedRuns.findIndex((r) => r._id === runId);
+  const run = (runIndex >= 0 ? typedRuns[runIndex] : null) ?? runSnapshot;
+  const runLabel =
+    runIndex >= 0
+      ? runNumberLabel(rollup?.runCount ?? typedRuns.length, runIndex)
+      : "Run";
+  const runStatus = run.status;
+
+  const {
+    results: sessions,
+    status: sessionsStatus,
+    loadMore,
+  } = usePaginatedQuery(
+    SWARM_QUERIES.listSessionsByJourneyRun as any,
+    { journeyRunId: runId } as any,
+    { initialNumItems: Math.max(DEFAULT_PAGE_SIZE, sessionsPerHost * 4) }
+  );
+
+  const streamEnabled = runStatus === "running";
+  const stream = useJourneyRunStream(runId, streamEnabled);
+
+  const [matrixSelection, setMatrixSelection] =
+    useState<SwarmMatrixSelection | null>(null);
+
+  const hostName = (id: string) => hosts.find((h) => h.hostId === id)?.name;
+  const hostNameOrId = (id: string) => hostName(id) ?? id.slice(0, 8);
+
+  const rows = sessions as JourneySessionRow[];
+  const hostSummaries = run.hostSummaries;
+
+  const targets = useMemo<SwarmTargetColumn[]>(() => {
+    if (hostSummaries.length > 0) {
+      return buildSwarmRunTargets({
+        hostSummaries,
+        snapshotHosts: run.snapshot?.hosts,
+        hostName,
+      });
+    }
+    const seen = new Set<string>();
+    for (const s of rows) seen.add(s.hostId);
+    return Array.from(seen).map((hostId) => ({
+      key: hostId,
+      hostId,
+      label: hostNameOrId(hostId),
+      identity: { hostId },
+    }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hostSummaries, run.snapshot, rows, hosts]);
+
+  const convexByChatId = useMemo(() => {
+    const map = new Map<string, JourneySessionRow>();
+    for (const s of rows) map.set(s.chatSessionId, s);
+    return map;
+  }, [rows]);
+
+  const selectedConvex = matrixSelection
+    ? convexByChatId.get(matrixSelection.chatSessionId) ?? null
+    : null;
+
+  const fallbackTrace = useMemo(
+    () =>
+      matrixSelection
+        ? liveSessionTrace(stream.sessions[matrixSelection.chatSessionId])
+        : null,
+    [matrixSelection, stream.sessions]
+  );
+
+  const appliedInitialThreadRef = useRef(false);
+  useEffect(() => {
+    if (appliedInitialThreadRef.current || !initialThreadId) return;
+    const match = rows.find((s) => s.id === initialThreadId);
+    if (!match) return;
+    appliedInitialThreadRef.current = true;
+    const cell = findTargetCellForChatSessionId({
+      runId,
+      targets,
+      sessionsPerHost,
+      chatSessionId: match.chatSessionId,
+    });
+    setMatrixSelection({
+      targetKey: cell?.target.key ?? match.hostId,
+      hostId: match.hostId,
+      sessionIndex: cell?.sessionIndex ?? 0,
+      chatSessionId: match.chatSessionId,
+    });
+  }, [initialThreadId, rows, runId, targets, sessionsPerHost]);
+
+  const appliedInitialTargetRef = useRef(false);
+  useEffect(() => {
+    if (
+      appliedInitialTargetRef.current ||
+      !initialTargetKey ||
+      initialThreadId
+    ) {
+      return;
+    }
+    const target = targets.find((t) => t.key === initialTargetKey);
+    if (!target) return;
+    const mintedIds = Array.from(
+      { length: Math.max(1, sessionsPerHost) },
+      (_, i) => swarmAttemptChatSessionId(runId, target.identity, i)
+    );
+    const matchIdx = mintedIds.findIndex((id) =>
+      rows.some((s) => s.chatSessionId === id)
+    );
+    if (matchIdx >= 0) {
+      appliedInitialTargetRef.current = true;
+      setMatrixSelection({
+        targetKey: target.key,
+        hostId: target.hostId,
+        sessionIndex: matchIdx,
+        chatSessionId: mintedIds[matchIdx],
+      });
+      return;
+    }
+    if (
+      runStatus !== "running" &&
+      hostSummaries.some(
+        (h) =>
+          (h.targetId ?? h.hostId) === initialTargetKey ||
+          h.hostId === initialTargetKey
+      )
+    ) {
+      appliedInitialTargetRef.current = true;
+      setMatrixSelection({
+        targetKey: target.key,
+        hostId: target.hostId,
+        sessionIndex: 0,
+        chatSessionId: mintedIds[0],
+      });
+    }
+  }, [
+    initialTargetKey,
+    initialThreadId,
+    rows,
+    runStatus,
+    hostSummaries,
+    runId,
+    targets,
+    sessionsPerHost,
+  ]);
+
+  useEffect(() => {
+    if (matrixSelection || !streamEnabled) return;
+    const runningEntry = Object.entries(stream.cellStatus).find(
+      ([, status]) => status === "running"
+    );
+    if (!runningEntry) return;
+    const [key] = runningEntry;
+    const cut = key.lastIndexOf(":");
+    if (cut <= 0) return;
+    const targetKey = key.slice(0, cut);
+    const sessionIndex = Number(key.slice(cut + 1));
+    if (!Number.isFinite(sessionIndex)) return;
+    const target = targets.find((t) => t.key === targetKey);
+    if (!target) return;
+    setMatrixSelection({
+      targetKey,
+      hostId: target.hostId,
+      sessionIndex,
+      chatSessionId: swarmAttemptChatSessionId(
+        runId,
+        target.identity,
+        sessionIndex
+      ),
+    });
+  }, [matrixSelection, streamEnabled, stream.cellStatus, runId, targets]);
+
+  const value = useMemo<RunSessionsContextValue>(
+    () => ({
+      run,
+      runId,
+      runLabel,
+      runStatus,
+      sessionsPerHost,
+      sessions: rows,
+      sessionsStatus,
+      loadMoreSessions: loadMore,
+      targets,
+      hostSummaries,
+      stream,
+      matrixSelection,
+      onMatrixSelect: setMatrixSelection,
+      selectedConvex,
+      fallbackTrace,
+    }),
+    [
+      run,
+      runId,
+      runLabel,
+      runStatus,
+      sessionsPerHost,
+      rows,
+      sessionsStatus,
+      loadMore,
+      targets,
+      hostSummaries,
+      stream,
+      matrixSelection,
+      selectedConvex,
+      fallbackTrace,
+    ]
+  );
+
+  return (
+    <RunSessionsContext.Provider value={value}>
+      {children}
+    </RunSessionsContext.Provider>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/swarms-empty-hero.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarms-empty-hero.tsx
@@ -1,0 +1,230 @@
+import { Users } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { cn } from "@/lib/utils";
+
+const FIRST_PERSONA_EMPTY_DESCRIPTION =
+  "Personas simulate how product managers and developers pursue real goals across your clients. Run journeys to learn common use cases, spot friction, and promote winning sessions into evals for CI.";
+
+interface SwarmsEmptyHeroProps {
+  onCreatePersona: () => void;
+}
+
+export function SwarmsEmptyHero({ onCreatePersona }: SwarmsEmptyHeroProps) {
+  return (
+    <div
+      className="flex min-h-0 flex-1 items-center justify-center overflow-auto px-6 py-10"
+      data-testid="swarms-empty-hero"
+    >
+      <div className="my-auto flex w-full max-w-3xl flex-col items-center gap-8">
+        <div className="flex flex-col items-center text-center">
+          <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+            <Users className="h-8 w-8 text-muted-foreground" />
+          </div>
+          <h3 className="mb-2 text-lg font-semibold text-foreground">
+            Create your first persona
+          </h3>
+          <p className="max-w-md text-pretty text-sm text-muted-foreground">
+            {FIRST_PERSONA_EMPTY_DESCRIPTION}
+          </p>
+
+          <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
+            <Button type="button" onClick={onCreatePersona}>
+              Create persona
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex w-full items-center gap-3">
+          <div className="h-px flex-1 bg-border/50" />
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            What swarms looks like
+          </span>
+          <div className="h-px flex-1 bg-border/50" />
+        </div>
+
+        <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-3">
+          <PreviewCard title="Journey trend" subtitle="Outcomes across runs">
+            <JourneyTrendPreview />
+          </PreviewCard>
+          <PreviewCard title="Client matrix" subtitle="Per-client session results">
+            <ClientMatrixPreview />
+          </PreviewCard>
+          <PreviewCard title="Session trace" subtitle="Steps + latency">
+            <SessionTracePreview />
+          </PreviewCard>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PreviewCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      aria-hidden
+      className="flex flex-col gap-3 rounded-lg border border-border/50 bg-muted/15 p-4"
+    >
+      <div className="space-y-0.5">
+        <div className="text-xs font-semibold text-foreground">{title}</div>
+        <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          {subtitle}
+        </div>
+      </div>
+      <div className="min-h-[120px]">{children}</div>
+    </div>
+  );
+}
+
+const PREVIEW_JOURNEY_PERCENTS = [38, 52, 61, 68, 74, 81, 88];
+
+function JourneyTrendPreview() {
+  const latest = PREVIEW_JOURNEY_PERCENTS[PREVIEW_JOURNEY_PERCENTS.length - 1];
+  const delta = latest - PREVIEW_JOURNEY_PERCENTS[0];
+  return (
+    <div className="flex h-full flex-col justify-between gap-3">
+      <div className="flex items-end justify-between gap-2">
+        <div className="text-2xl font-semibold tabular-nums text-foreground">
+          {latest}%
+        </div>
+        <div className="text-[10px] tabular-nums text-success">
+          ▲ {delta}% vs. first run
+        </div>
+      </div>
+      <div className="flex h-12 items-end gap-1">
+        {PREVIEW_JOURNEY_PERCENTS.map((value, idx) => (
+          <div
+            key={idx}
+            className={cn(
+              "flex-1 rounded-sm",
+              value >= 80
+                ? "bg-success/50"
+                : value >= 50
+                  ? "bg-warning/50"
+                  : "bg-destructive/50",
+            )}
+            style={{ height: `${Math.max(15, value)}%` }}
+          />
+        ))}
+      </div>
+      <div className="flex justify-between text-[9px] tabular-nums text-muted-foreground">
+        <span>run 1</span>
+        <span>run 7</span>
+      </div>
+    </div>
+  );
+}
+
+const PREVIEW_CLIENT_ROWS = [
+  { label: "Claude Code", ok: 0, total: 2, tone: "fail" as const },
+  { label: "Copilot", ok: 2, total: 2, tone: "pass" as const },
+];
+
+function ClientMatrixPreview() {
+  return (
+    <div className="flex h-full flex-col justify-center gap-2">
+      {PREVIEW_CLIENT_ROWS.map((row) => (
+        <div
+          key={row.label}
+          className="flex items-center justify-between gap-2 rounded-md border border-border/50 bg-background/40 px-2 py-1.5"
+        >
+          <span className="truncate text-[11px] font-medium text-foreground/90">
+            {row.label}
+          </span>
+          <span className="inline-flex items-center gap-1.5 shrink-0">
+            <span
+              className={cn(
+                "size-1.5 rounded-full",
+                row.tone === "pass" ? "bg-success" : "bg-destructive",
+              )}
+            />
+            <span
+              className={cn(
+                "text-[11px] font-semibold tabular-nums",
+                row.tone === "pass" ? "text-success" : "text-destructive",
+              )}
+            >
+              {row.ok}/{row.total} ok
+            </span>
+          </span>
+        </div>
+      ))}
+      <div className="mt-1 flex h-4 items-stretch gap-[2px]">
+        {[0, 1, 0, 1, 1, 1, 1].map((pass, idx) => (
+          <div
+            key={idx}
+            className={cn(
+              "min-w-[4px] flex-1 rounded-[2px]",
+              pass ? "bg-success/70" : "bg-destructive/70",
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const TRACE_ROWS = [
+  {
+    actor: "Persona",
+    latencyMs: 118,
+    barClass: "bg-chart-4/60",
+    offsetPct: 0,
+    widthPct: 42,
+  },
+  {
+    actor: "Agent",
+    latencyMs: 64,
+    barClass: "bg-chart-1/60",
+    offsetPct: 20,
+    widthPct: 22,
+  },
+  {
+    actor: "Tool",
+    latencyMs: 51,
+    barClass: "bg-warning/50",
+    offsetPct: 44,
+    widthPct: 18,
+  },
+  {
+    actor: "Agent",
+    latencyMs: 88,
+    barClass: "bg-chart-1/60",
+    offsetPct: 66,
+    widthPct: 30,
+  },
+];
+
+function SessionTracePreview() {
+  return (
+    <div className="flex h-full flex-col gap-1.5">
+      {TRACE_ROWS.map((row, idx) => (
+        <div
+          key={idx}
+          className="grid grid-cols-[60px_1fr_38px] items-center gap-2 text-[10px]"
+        >
+          <span className="truncate text-muted-foreground">{row.actor}</span>
+          <div className="relative h-3 rounded bg-muted/30">
+            <div
+              className={cn("absolute top-0 h-full rounded", row.barClass)}
+              style={{
+                left: `${row.offsetPct}%`,
+                width: `${row.widthPct}%`,
+              }}
+            />
+          </div>
+          <span className="text-right tabular-nums text-muted-foreground">
+            {row.latencyMs}ms
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/ui/inline-editable-text.tsx
+++ b/mcpjam-inspector/client/src/components/ui/inline-editable-text.tsx
@@ -8,6 +8,8 @@ interface InlineEditableTextProps {
   inputClassName?: string;
   disabled?: boolean;
   truncate?: boolean;
+  /** Begin in edit mode on mount (e.g. after inline create). */
+  startInEditMode?: boolean;
   /** Called on click events (useful for stopPropagation in lists) */
   onClick?: (e: React.MouseEvent) => void;
 }
@@ -24,9 +26,10 @@ export function InlineEditableText({
   inputClassName,
   disabled = false,
   truncate = true,
+  startInEditMode = false,
   onClick,
 }: InlineEditableTextProps) {
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(startInEditMode);
   const [editedValue, setEditedValue] = useState(value);
   const [isSaving, setIsSaving] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Summary
- Move the session matrix from the right run-detail panel into the selected journey host cell on the left, using shared `RunSessionsProvider` state between panels.
- Improve Personas UX: evals-style empty state, auto-select first persona, inline persona creation (no modal), evals `EditableTitle` for name/role editing, and sidebar delete.
- Rename the top-level Swarm tab from "Journeys" to "Sessions" for clarity.

## Test plan
- [ ] Open Swarms → Personas, confirm first persona is auto-selected when personas exist
- [ ] Create a persona via **New** — row appears immediately and name field is editable inline
- [ ] Edit persona name/role via click-to-edit (evals-style ghost button → input)
- [ ] Delete a persona from the sidebar trash icon and from the detail header
- [ ] Run a journey, select a host cell, confirm session chips/matrix appear below that cell (not in the right panel)
- [ ] Confirm right panel shows live stream + session detail only
- [ ] Switch to **Sessions** tab and browse/filter project sessions
- [ ] Verify empty state when no personas exist


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the sessions matrix into the selected journey host cell and keeps the right panel focused on live stream + session details, while polishing Personas with inline create/edit, a friendly empty state, and quick delete. Also renames the top tab label to “Sessions” for clarity.

- New Features
  - Sessions matrix now renders under the selected host cell in the journey block; the right panel shows only the live stream and session detail.
  - Introduced `RunSessionsProvider` to share run state across panels, preserving deep-link restore and auto-selecting the first running cell.
  - Personas UX:
    - Added `SwarmsEmptyHero` when no personas exist, with a create CTA.
    - Auto-selects the first persona on the Personas tab.
    - Inline persona creation (no modal) and auto-focus name using `EditableTitle`.
    - Inline edit for name/role with `EditableTitle`; delete from sidebar or header.
  - Renamed the top-level tab label from “Journeys” to “Sessions”.
  - Component tweaks: `EditableTitle` adds `startInEditMode`, `fullWidth`, `truncate`; `inline-editable-text` adds `startInEditMode`.

<sup>Written for commit ddcbc6f8cc1c3a773dac22db71de198984ae777b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

