### PR TITLE
Fix Sessions tab defaulting to the auto-preselected persona

### DIFF
--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -267,6 +267,13 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(
     () => deepLink.personaRefId ?? null
   );
+  // Sessions-tab persona filter — independent of the Personas-tab selection:
+  // that tab auto-selects a persona to land on, which must not narrow the flat
+  // Sessions browser away from its all-project default. Session deep-links
+  // still restore their persona filter.
+  const [sessionsPersonaFilter, setSessionsPersonaFilter] = useState<
+    string | null
+  >(() => (deepLink.threadId ? (deepLink.personaRefId ?? null) : null));
   const journeys = useJourneys(selectedPersonaId);
   // Lifted for the agent snapshot (one subscription).
 
@@ -1038,8 +1045,8 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
               projectId={projectId}
               personas={personas ?? []}
               hosts={hosts ?? []}
-              personaRefId={selectedPersonaId}
-              onPersonaRefIdChange={setSelectedPersonaId}
+              personaRefId={sessionsPersonaFilter}
+              onPersonaRefIdChange={setSessionsPersonaFilter}
               initialThreadId={deepLink.threadId}
             />
           </main>


### PR DESCRIPTION
## Problem
Two `SwarmsTab.sessions.test.tsx` tests are failing on main (`Tests` workflow red since #3524; #3525 fixed the other 14 swarm test failures but left these two):

- **top-level Journeys view > defaults to listSessionsByProject** — the query never fires
- **filters the visible list by client (host) without changing the query** — only one host's sessions render

## Cause
#3524's Personas-tab "always land on someone" preselect writes `selectedPersonaId`, and that same state was passed as `personaRefId` to the top-level `SwarmsSessionsPanel`. So opening the Sessions tab silently switched it from the all-project `listSessionsByProject` query to `listSessionsByPersona` scoped to the auto-selected first persona.

## Fix
Give the Sessions tab its own persona-filter state, decoupled from the Personas-tab selection. Session deep-links (`?persona=…&session=…`) still restore their persona filter — the seed applies only when the deep link opens the sessions view; run-only links land on Journeys unchanged.

## Verification
- `client/src/components/swarms/__tests__`: 17 files / 109 tests pass
- Full `@mcpjam/inspector` suite: 973 files / 10716 tests pass (exit 0)
- `npm run typecheck:client` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local React state wiring in SwarmsTab only; no API, auth, or data-model changes.
> 
> **Overview**
> **Fixes the Sessions tab incorrectly scoping to the auto-selected persona** on the Personas tab, which broke the default all-project session list and client-side host filtering tests.
> 
> `SwarmsTab` now keeps **`sessionsPersonaFilter`** separate from **`selectedPersonaId`**. `SwarmsSessionsPanel` reads/writes only the Sessions filter, so opening Sessions no longer inherits the Personas “land on first persona” preselect and stays on **`listSessionsByProject`** until the user picks a persona in the Sessions UI.
> 
> Session deep-links (`?session=…` with optional persona) still seed **`sessionsPersonaFilter`** when the link opens the Sessions view; run-only deep links continue to land on Personas/Journeys unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88a045718eb1d03df416f020acbb1543e947f1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Sessions tab defaulting to the auto-selected persona from the Personas tab so it shows all-project sessions by default. Persona filters now apply only when a session deep link opens the Sessions view.

- **Bug Fixes**
  - Added an independent `sessionsPersonaFilter` state in `SwarmsTab` and wired the Sessions panel to it (no longer uses `selectedPersonaId` from the Personas tab).
  - Seed the filter only when a deep link opens Sessions (`threadId` present), preserving the default `listSessionsByProject` query and fixing the two failing `SwarmsTab.sessions.test.tsx` tests.

<sup>Written for commit d88a045718eb1d03df416f020acbb1543e947f1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

