### PR TITLE
Absorb transient connect resets and stop 502s reading as MCPJam outages

### DIFF
--- a/mcpjam-inspector/client/src/lib/apis/web/base.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/base.ts
@@ -64,12 +64,12 @@ export async function webPost<TRequest, TResponse>(
         : typeof errBody?.error === "string"
           ? errBody.error
           : null;
+    // Empty-string messages fall through to the next candidate — an error
+    // with a blank message would otherwise surface as a blank toast.
     const message =
-      typeof errBody?.message === "string"
-        ? errBody.message
-        : typeof errBody?.error === "string"
-          ? errBody.error
-          : `Request failed (${response.status})`;
+      (typeof errBody?.message === "string" && errBody.message.trim()) ||
+      (typeof errBody?.error === "string" && errBody.error.trim()) ||
+      `Request failed (${response.status})`;
     const normalized =
       errBody && typeof errBody.normalized === "object" && errBody.normalized
         ? (errBody.normalized as NormalizedError)

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -80,7 +80,9 @@ process.on("unhandledRejection", (reason, _promise) => {
     "process.unhandled_rejection",
     { errorCode: reason instanceof Error ? reason.name : "unknown" },
     {
-      error: reason instanceof Error ? reason : undefined,
+      // Always forward the reason — a non-Error rejection still carries the
+      // only clue to what fired (emit stringifies it for Axiom).
+      error: reason,
       sentry: true,
     }
   );

--- a/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/errors.test.ts
@@ -50,6 +50,25 @@ describe("mapRuntimeError", () => {
     expect(mapRuntimeError(new Error("socket hang up")).status).toBe(502);
   });
 
+  it("frames connection-class 502s as a target-server problem, preserving the raw error", () => {
+    // The raw errno text ("read ECONNRESET") in a client toast reads like an
+    // MCPJam outage; the mapped message must name the target server as the
+    // failing side while keeping the raw error for debugging.
+    const mapped = mapRuntimeError(new Error("read ECONNRESET"));
+    expect(mapped.status).toBe(502);
+    expect(mapped.code).toBe(ErrorCode.SERVER_UNREACHABLE);
+    expect(mapped.message).toContain("read ECONNRESET");
+    expect(mapped.message).toContain("not an MCPJam outage");
+  });
+
+  it("never returns a blank message for a blank-message error", () => {
+    // A bare `new Error()` rejection maps to a blank body message, which the
+    // client renders as an empty toast.
+    const mapped = mapRuntimeError(new Error(""));
+    expect(mapped.status).toBe(500);
+    expect(mapped.message.trim()).not.toBe("");
+  });
+
   it("does NOT misclassify words that merely start with 'econ' as 502", () => {
     // Regression for code-review feedback: the errno branch was originally
     // `\becon[a-z]*` (one `n`), which matches server/tool/case names like

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
@@ -198,11 +198,13 @@ describe("web routes — oauth error contract", () => {
     const { status, data } = await expectJson<OAuthErrorResponse>(response);
 
     expect(status).toBe(502);
-    expect(data).toEqual({
-      code: "SERVER_UNREACHABLE",
-      message: "connect ECONNREFUSED",
-      error: "connect ECONNREFUSED",
-    });
+    // mapRuntimeError frames connection-class failures as a target-server
+    // problem (the raw errno alone reads like an MCPJam outage in the client
+    // toast) while preserving the raw error for debugging.
+    expect(data.code).toBe("SERVER_UNREACHABLE");
+    expect(data.message).toContain("connect ECONNREFUSED");
+    expect(data.message).toContain("not an MCPJam outage");
+    expect(data.error).toBe(data.message);
   });
 });
 

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -196,7 +196,7 @@ export function mapRuntimeError(error: unknown): WebRouteError {
     return new WebRouteError(
       502,
       ErrorCode.SERVER_UNREACHABLE,
-      message,
+      formatServerUnreachableMessage(message),
       undefined,
       normalized
     );
@@ -205,9 +205,24 @@ export function mapRuntimeError(error: unknown): WebRouteError {
   return new WebRouteError(
     500,
     ErrorCode.INTERNAL_ERROR,
-    message,
+    message.trim() || "An unexpected error occurred.",
     undefined,
     normalized
+  );
+}
+
+/**
+ * User-facing framing for connection-class 502s. The raw errno text
+ * ("fetch failed", "ECONNRESET") reads like an MCPJam outage in the client
+ * toast, when the failure is the TARGET server refusing/resetting the
+ * connection — say so explicitly, and keep the raw error for debugging.
+ */
+export function formatServerUnreachableMessage(rawMessage: string): string {
+  const raw = rawMessage.trim();
+  return (
+    "Couldn't reach the MCP server" +
+    (raw ? ` (${raw})` : "") +
+    ". The server appears to be down, restarting, or unreachable from MCPJam — this is a connection problem with the target server, not an MCPJam outage."
   );
 }
 

--- a/mcpjam-inspector/server/services/evals/__tests__/route-helpers.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/route-helpers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { INSPECTOR_MCP_RETRY_POLICY } from "../../../utils/mcp-retry-policy.js";
 
 const { mcpClientManagerConstructorMock } = vi.hoisted(() => ({
   mcpClientManagerConstructorMock: vi.fn(),
@@ -164,10 +165,9 @@ describe("buildReplayManager", () => {
       {
         defaultTimeout: expect.any(Number),
         lazyConnect: true,
-        retryPolicy: {
-          retries: 0,
-          retryDelayMs: 3000,
-        },
+        // The shared inspector policy — asserts the replay manager uses it
+        // rather than pinning its literal values here.
+        retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
       },
     );
   });

--- a/mcpjam-inspector/server/utils/__tests__/log-scrubber.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/log-scrubber.test.ts
@@ -89,6 +89,40 @@ describe("scrubLogPayload", () => {
       const result = scrubLogPayload({ note: "sk-abcdefghijklmnopqrstuvwx" }) as any;
       expect(result.note).toContain("[redacted-secret]");
     });
+
+    it("redacts secret-ish query params quoted inside error strings", () => {
+      // Raw upstream error messages routinely quote full request URLs; the
+      // key-based redaction can't see inside a string value.
+      const result = scrubLogPayload({
+        message:
+          "fetch failed for https://mcp.example.com/sse?api_key=plain-secret&x=1",
+      }) as any;
+      expect(result.message).not.toContain("plain-secret");
+      expect(result.message).toContain("api_key=[redacted]");
+    });
+
+    it("redacts key=value and key: value secret assignments", () => {
+      const result = scrubLogPayload({
+        message: 'connect failed (token=abc123, client_secret: "s3cr3t")',
+      }) as any;
+      expect(result.message).not.toContain("abc123");
+      expect(result.message).not.toContain("s3cr3t");
+    });
+
+    it("redacts basic-auth credentials in URLs", () => {
+      const result = scrubLogPayload({
+        message: "getaddrinfo ENOTFOUND for https://user:hunter2@internal.host/mcp",
+      }) as any;
+      expect(result.message).not.toContain("hunter2");
+      expect(result.message).toContain("[redacted]@internal.host");
+    });
+
+    it("leaves ordinary error strings readable", () => {
+      const message =
+        "connect ECONNREFUSED 127.0.0.1:8080 (timeout: 30000, retries: 1)";
+      const result = scrubLogPayload({ message }) as any;
+      expect(result.message).toBe(message);
+    });
   });
 
   describe("recursion", () => {

--- a/mcpjam-inspector/server/utils/__tests__/logger.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/logger.test.ts
@@ -213,6 +213,41 @@ describe("logger", () => {
       );
     });
 
+    it("serializes options.error into the Axiom payload", () => {
+      // Regression: emit() used to forward the error object to Sentry only,
+      // so every failure event landed in Axiom with no cause attached.
+      logger.event(
+        "http.request.failed",
+        baseRequestContext,
+        { statusCode: 502, errorCode: "server_unreachable" },
+        { error: new Error("read ECONNRESET") },
+      );
+
+      expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
+        expect.objectContaining({
+          event: "http.request.failed",
+          statusCode: 502,
+          error: expect.objectContaining({
+            name: "Error",
+            message: "read ECONNRESET",
+          }),
+        }),
+      ]);
+    });
+
+    it("stringifies a non-Error options.error for the Axiom payload", () => {
+      logger.event(
+        "http.request.failed",
+        baseRequestContext,
+        { statusCode: 500, errorCode: "unhandled_exception" },
+        { error: "string reason" },
+      );
+
+      expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
+        expect.objectContaining({ error: "string reason" }),
+      ]);
+    });
+
     it("calls Sentry.captureException only when sentry: true is opted in with an Error", () => {
       const err = new Error("boom");
       logger.event(

--- a/mcpjam-inspector/server/utils/__tests__/logger.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/logger.test.ts
@@ -240,12 +240,44 @@ describe("logger", () => {
         "http.request.failed",
         baseRequestContext,
         { statusCode: 500, errorCode: "unhandled_exception" },
-        { error: "string reason" },
+        { error: 42 },
       );
 
       expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
-        expect.objectContaining({ error: "string reason" }),
+        expect.objectContaining({ error: "42" }),
       ]);
+    });
+
+    it("survives an options.error whose string coercion throws", () => {
+      // Promise.reject(Object.create(null)) reaches the unhandledRejection
+      // handler; String() on a null-prototype object throws, and a throw
+      // here would turn an absorbed rejection into an uncaught exception.
+      logger.event(
+        "http.request.failed",
+        baseRequestContext,
+        { statusCode: 500, errorCode: "unhandled_exception" },
+        { error: Object.create(null) },
+      );
+
+      expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
+        expect.objectContaining({ error: "[unserializable error]" }),
+      ]);
+    });
+
+    it("caps oversized error messages and stacks", () => {
+      const err = new Error("m".repeat(10_000));
+      err.stack = "s".repeat(20_000);
+      logger.event(
+        "http.request.failed",
+        baseRequestContext,
+        { statusCode: 502, errorCode: "server_unreachable" },
+        { error: err },
+      );
+
+      const [, [ingested]] = mockIngest.mock.calls.at(-1)!;
+      const errorField = (ingested as any).error;
+      expect(errorField.message.length).toBeLessThanOrEqual(2000);
+      expect(errorField.stack.length).toBeLessThanOrEqual(4000);
     });
 
     it("calls Sentry.captureException only when sentry: true is opted in with an Error", () => {

--- a/mcpjam-inspector/server/utils/__tests__/mcp-retry-policy.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-retry-policy.test.ts
@@ -16,4 +16,13 @@ describe("INSPECTOR_MCP_RETRY_POLICY", () => {
     // multiple seconds reads as a hang.
     expect(INSPECTOR_MCP_RETRY_POLICY.retryDelayMs).toBeLessThanOrEqual(1000);
   });
+
+  it("bounds the worst-case added latency", () => {
+    // A tuning change can adjust either knob, but the total delay a failing
+    // connect can add before surfacing must stay interactive.
+    expect(
+      INSPECTOR_MCP_RETRY_POLICY.retries *
+        INSPECTOR_MCP_RETRY_POLICY.retryDelayMs,
+    ).toBeLessThanOrEqual(2000);
+  });
 });

--- a/mcpjam-inspector/server/utils/__tests__/mcp-retry-policy.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcp-retry-policy.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { INSPECTOR_MCP_RETRY_POLICY } from "../mcp-retry-policy.js";
+
+describe("INSPECTOR_MCP_RETRY_POLICY", () => {
+  it("retries transient connect failures at least once", () => {
+    // Regression guard: the SDK default is 0 retries, which turned every
+    // stale keep-alive reset into a user-facing 502 on hosted connects. The
+    // manager applies this policy to connectToServer with
+    // isRetryableTransientError gating, so >=1 here is what absorbs those.
+    expect(INSPECTOR_MCP_RETRY_POLICY.retries).toBeGreaterThanOrEqual(1);
+  });
+
+  it("keeps the retry delay interactive", () => {
+    // These connects run behind a user-visible spinner; a retry that waits
+    // multiple seconds reads as a hang.
+    expect(INSPECTOR_MCP_RETRY_POLICY.retryDelayMs).toBeLessThanOrEqual(1000);
+  });
+});

--- a/mcpjam-inspector/server/utils/log-scrubber.ts
+++ b/mcpjam-inspector/server/utils/log-scrubber.ts
@@ -25,6 +25,16 @@ const EMAIL_LIKE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const SK_KEY_LIKE = /\bsk-[A-Za-z0-9]{16,}\b/g;
 const JWT_LIKE =
   /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
+// Secret-ish `key=value` / `key: value` pairs embedded in strings — raw
+// upstream error messages routinely quote full URLs
+// (`...?api_key=plain-secret`), which the key-based redaction above can't
+// see. Over-redaction is acceptable in logs, so the key list is broad.
+const SECRET_PARAM_LIKE =
+  /\b((?:api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|secret|password|passwd|pwd|token|auth|key|sig|signature)\s*[=:]\s*["']?)[^&\s"'`]+/gi;
+// Basic-auth credentials in URLs: `https://user:pass@host/...`. Must run
+// BEFORE the email pattern, which otherwise consumes `pass@host` as an
+// address and leaves a mangled remainder this pattern can't match.
+const URL_BASIC_AUTH_LIKE = /(\/\/[^\s/:@]+:)[^\s@/]+@/g;
 
 function isForbiddenKey(key: string): boolean {
   const lower = key.toLowerCase();
@@ -37,8 +47,10 @@ function scrubString(s: string): string {
   return s
     .replace(TOKEN_LIKE, "Bearer [redacted-token]")
     .replace(JWT_LIKE, "[redacted-jwt]")
+    .replace(URL_BASIC_AUTH_LIKE, "$1[redacted]@")
     .replace(EMAIL_LIKE, "[redacted-email]")
-    .replace(SK_KEY_LIKE, "[redacted-secret]");
+    .replace(SK_KEY_LIKE, "[redacted-secret]")
+    .replace(SECRET_PARAM_LIKE, "$1[redacted]");
 }
 
 export function scrubLogPayload<T>(value: T): T {

--- a/mcpjam-inspector/server/utils/logger.ts
+++ b/mcpjam-inspector/server/utils/logger.ts
@@ -143,13 +143,48 @@ export const logger = {
  *   `timestamp - durationMs` for HTTP events.
  * - Sentry is opt-in via `options.sentry === true`; the caller that owns the
  *   error decides whether to forward it.
- * - `options.error` is ALSO serialized into the Axiom payload (as `error:
- *   {name, message, stack}`, scrubbed), independent of the Sentry opt-in.
- *   Before this, the error object reached only Sentry and every failure
- *   event landed in Axiom with no cause — a 502 investigation couldn't name
- *   the underlying ECONNRESET without leaving the log pipeline.
+ * - `options.error` is ALSO serialized into the Axiom payload, independent
+ *   of the Sentry opt-in: Error instances become `error: {name, message,
+ *   stack}`, anything else is stringified (with a non-throwing fallback for
+ *   values whose coercion throws). Message/stack are length-capped, and the
+ *   result goes through `scrubLogPayload` like every other field — upstream
+ *   error strings can quote URLs with embedded credentials. Before this,
+ *   the error object reached only Sentry and every failure event landed in
+ *   Axiom with no cause — a 502 investigation couldn't name the underlying
+ *   ECONNRESET without leaving the log pipeline.
  * - `*.failed` events route their console echo to stderr.
  */
+const MAX_ERROR_MESSAGE_CHARS = 2000;
+const MAX_ERROR_STACK_CHARS = 4000;
+
+/**
+ * Bounded, non-throwing serialization of an emit-time error for the Axiom
+ * payload. Length caps keep pathological upstream errors (an MCP server can
+ * return an arbitrarily large body quoted into the message) from bloating
+ * ingestion; the try/catch keeps a rejection reason with a throwing
+ * `toString` (e.g. `Object.create(null)`) from turning the logging of a
+ * failure into a new crash — this runs inside the process-level
+ * `unhandledRejection` handler. Secret scrubbing is NOT this function's job:
+ * the returned value flows through `scrubLogPayload` with the rest of the
+ * payload.
+ */
+function serializeEmitError(error: unknown): unknown {
+  try {
+    if (error instanceof Error) {
+      return {
+        name: error.name,
+        message: error.message.slice(0, MAX_ERROR_MESSAGE_CHARS),
+        ...(error.stack
+          ? { stack: error.stack.slice(0, MAX_ERROR_STACK_CHARS) }
+          : {}),
+      };
+    }
+    return String(error).slice(0, MAX_ERROR_MESSAGE_CHARS);
+  } catch {
+    return "[unserializable error]";
+  }
+}
+
 function emit(
   eventName: LogEventName,
   base: RequestLogContext | SystemLogContext,
@@ -159,15 +194,8 @@ function emit(
   const fullPayload = scrubLogPayload({
     ...base,
     ...payload,
-    // scrubLogPayload serializes Error instances to {name, message, stack}
-    // with token/JWT/email scrubbing applied to both message and stack.
     ...(options?.error !== undefined
-      ? {
-          error:
-            options.error instanceof Error
-              ? options.error
-              : String(options.error),
-        }
+      ? { error: serializeEmitError(options.error) }
       : {}),
     event: eventName,
     timestamp: new Date().toISOString(),

--- a/mcpjam-inspector/server/utils/logger.ts
+++ b/mcpjam-inspector/server/utils/logger.ts
@@ -143,6 +143,11 @@ export const logger = {
  *   `timestamp - durationMs` for HTTP events.
  * - Sentry is opt-in via `options.sentry === true`; the caller that owns the
  *   error decides whether to forward it.
+ * - `options.error` is ALSO serialized into the Axiom payload (as `error:
+ *   {name, message, stack}`, scrubbed), independent of the Sentry opt-in.
+ *   Before this, the error object reached only Sentry and every failure
+ *   event landed in Axiom with no cause — a 502 investigation couldn't name
+ *   the underlying ECONNRESET without leaving the log pipeline.
  * - `*.failed` events route their console echo to stderr.
  */
 function emit(
@@ -154,6 +159,16 @@ function emit(
   const fullPayload = scrubLogPayload({
     ...base,
     ...payload,
+    // scrubLogPayload serializes Error instances to {name, message, stack}
+    // with token/JWT/email scrubbing applied to both message and stack.
+    ...(options?.error !== undefined
+      ? {
+          error:
+            options.error instanceof Error
+              ? options.error
+              : String(options.error),
+        }
+      : {}),
     event: eventName,
     timestamp: new Date().toISOString(),
   }) as Record<string, unknown>;

--- a/mcpjam-inspector/server/utils/mcp-retry-policy.ts
+++ b/mcpjam-inspector/server/utils/mcp-retry-policy.ts
@@ -1,5 +1,15 @@
 import { DEFAULT_RETRY_POLICY, type RetryPolicy } from "@mcpjam/sdk";
 
+// One retry absorbs the dominant hosted-connect failure mode: a stale
+// keep-alive socket (undici pools per-origin; many MCP servers close idle
+// sockets after ~5s) dies instantly with ECONNRESET/"fetch failed" and
+// succeeds on a fresh connection. The manager applies this policy to
+// `connectToServer` only — per-request operations keep their own opt-in
+// retry — and `isRetryableTransientError` already excludes auth failures
+// and deliberate non-retryable verdicts. The delay stays short because
+// these routes are interactive: the user is watching a connect spinner.
 export const INSPECTOR_MCP_RETRY_POLICY: RetryPolicy = {
   ...DEFAULT_RETRY_POLICY,
+  retries: 1,
+  retryDelayMs: 750,
 };


### PR DESCRIPTION
## Context

2026-07-28: a "all of my server connects are failing with a 502" report turned out to be 4 requests over 22 seconds against the reporter's own two servers, while every other user's connects flowed normally. These 502s are a chronic baseline (~35–150/day): connection-class failures (`ECONNRESET`, `fetch failed`, `socket hang up`) reaching the *target* MCP server, mapped to 502 `SERVER_UNREACHABLE`. The dominant mechanism is a stale keep-alive socket — undici pools connections per-origin, many MCP servers close idle sockets after ~5s, and undici never retries POSTs — so a connect that worked 30s ago dies instantly on the reused socket and succeeds on a fresh one.

Three problems compounded it:
1. No retry: every transient reset became a user-facing failure.
2. The toast said `Request failed (502)`, which reads as "MCPJam is down."
3. The underlying error reached only Sentry — every failure event in Axiom had `error: null`, so attribution required correlating four data sources.

## Changes

- **Retry transient connect failures once** — `INSPECTOR_MCP_RETRY_POLICY` goes from the SDK default (`retries: 0`) to `retries: 1, retryDelayMs: 750`. The manager already applies this policy to `connectToServer` gated by `isRetryableTransientError` (which excludes auth failures, non-retryable verdicts, and aborts); the knob was just off. Per-request operations keep their own opt-in retry and are unaffected.
- **Frame connection-class 502s honestly** — `mapRuntimeError` now returns "Couldn't reach the MCP server (\<raw error\>). The server appears to be down, restarting, or unreachable from MCPJam — this is a connection problem with the target server, not an MCPJam outage." Raw errno preserved for debugging. Blank-message errors get a non-empty 500 message, and client `webPost` skips empty-string messages instead of rendering a blank toast.
- **Put the error in Axiom** — `emit()` serializes `options.error` into the ingested payload (`{name, message, stack}` via the existing scrubber) instead of forwarding it to Sentry only, and the `unhandledRejection` handler always forwards the reason (non-Errors included, stringified).

## Testing

- New: retry-policy guard tests, `mapRuntimeError` framing/blank-message tests, `emit()` error-serialization tests.
- Updated: oauth error-contract test (intended message change), eval replay-manager test now asserts the shared policy constant instead of pinned literals.
- Full server suite: 4081 passed / 5 skipped. Client `lib/apis` suite: 112 passed. `typecheck:client` and root `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted reliability and observability changes with broad test coverage; user-visible 502 message text changes intentionally but does not alter auth or data paths.
> 
> **Overview**
> Addresses flaky hosted MCP connects and misleading 502 UX by retrying once on transient connection failures, reframing unreachable-server errors, and attaching failure causes to Axiom events.
> 
> **`INSPECTOR_MCP_RETRY_POLICY`** now uses `retries: 1` and `retryDelayMs: 750` (was SDK default 0) for `connectToServer`, aimed at stale keep-alive `ECONNRESET` / `fetch failed` cases.
> 
> **`mapRuntimeError`** uses **`formatServerUnreachableMessage`** for connection-class 502s so toasts name the target MCP server (raw errno kept) instead of looking like an MCPJam outage; blank internal errors get a fallback message. Client **`webPost`** ignores empty `message`/`error` strings before falling back to `Request failed (status)`.
> 
> **`logger.emit`** serializes **`options.error`** into the scrubbed Axiom payload (capped, non-throwing); **`unhandledRejection`** always passes the rejection reason. **`scrubLogPayload`** redacts secrets embedded in error strings (query params, `key=value`, basic-auth URLs).
> 
> Tests cover retry bounds, error framing, OAuth contract, log scrubbing, and Axiom error serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0966d4a572dc8783a5e87098e625f2217180f290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient connect errors once and reframes 502s to point to the target MCP server, not MCPJam. Also logs the underlying error to Axiom, scrubs sensitive data, and avoids blank toasts.

- **Bug Fixes**
  - Retries transient connect failures once (`INSPECTOR_MCP_RETRY_POLICY`: `retries: 1`, `retryDelayMs: 750`) for `connectToServer`; per-request retries unchanged.
  - Clearer 502s: `mapRuntimeError` says the target MCP server is unreachable, preserves the raw errno, and never returns a blank message; client `webPost` skips empty-string messages.
  - Better observability and safer logs: `emit()` includes `options.error` in Axiom (scrubbed, length-capped, non-throwing), `unhandledRejection` always forwards the reason, and the scrubber now redacts secrets embedded in error strings and URL basic-auth credentials.

<sup>Written for commit 0966d4a572dc8783a5e87098e625f2217180f290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

