### PR TITLE
fix(protocol): keep automatic reconnect negotiation broad

### DIFF
--- a/docs/inspector/protocol-versions.mdx
+++ b/docs/inspector/protocol-versions.mdx
@@ -19,7 +19,7 @@ There are three places to set a version, and they layer:
 2. **Add Server modal → Connection overrides → Protocol version** — a _per-server override_ set at add time (available when adding a server to a shared project).
 3. **Server card → Edit → Advanced settings → Protocol version** — a _per-server override_ that wins over the host default.
 
-Use the host default when you want every server in a Client to speak the same version. Use per-server overrides when you're testing a mix — for example, a stable 2025-11-25 server alongside one you're upgrading to the 2026 RC.
+Use the host default when you want every server in a Client to speak the same version. Use per-server overrides when you're testing a mix — for example, a November server alongside one you're upgrading to Latest.
 
 ## Available versions
 
@@ -28,8 +28,8 @@ Use the host default when you want every server in a Client to speak the same ve
 | Option                    | Stored pin         | Transport                                       | Use it when                                                                                                                                 |
 | ------------------------- | ------------------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Automatic**             | none               | HTTP + stdio: `server/discover`, then legacy fallback | Detect 2026 support from the server; otherwise use the version negotiated by `initialize`. This is the default.                        |
-| **2026 RC (2026-07-28)**  | `2026-07-28`       | HTTP in MCPJam's preview (Streamable HTTP POST) | You want to test your server against the stateless RC — no `initialize` handshake, `server/discover` for capabilities, per-request `_meta`. |
-| **Latest (2025-11-25)**   | `2025-11-25`       | HTTP, STDIO, SSE                                | Pin to the current stable release. The initialize handshake offers only this version.                                                       |
+| **Latest (2026-07-28)**   | `2026-07-28`       | HTTP in MCPJam's preview (Streamable HTTP POST) | You want to test your server against the newest stateless revision — no `initialize` handshake, `server/discover` for capabilities, per-request `_meta`. |
+| **November (2025-11-25)** | `2025-11-25`       | HTTP, STDIO, SSE                                | Pin to the November stateful release. The initialize handshake offers only this version.                                                    |
 | **2025-06-18**            | `2025-06-18`       | HTTP, STDIO, SSE                                | Test against the June 2025 stable revision.                                                                                                 |
 | **2025-03-26**            | `2025-03-26`       | HTTP, STDIO, SSE                                | Test against the March 2025 stable revision.                                                                                                |
 | **Host default** _(per-server only)_ | —     | —                                               | Inherit whatever the Client's MCP Protocol tab is set to.                                                                                   |
@@ -38,7 +38,7 @@ Use the host default when you want every server in a Client to speak the same ve
 
 When Automatic falls back to the legacy `initialize` handshake, it uses the MCP SDK's complete built-in supported-version list. Persisted per-client accept-lists are ignored in Automatic mode so reconnecting cannot accidentally narrow negotiation; choose an explicit version when you want a strict protocol pin.
 
-**Latest (2025-11-25)** is derived, not hardcoded: it always labels the newest non-RC stable version in the SDK's known-version list. When a newer stable version is added, the "Latest" marker moves forward automatically.
+**Latest** is derived, not hardcoded: it always labels the newest version in the SDK's known-version list. **November** labels the `2025-11-25` stateful release.
 
 The 2026 RC applies the stateless model across transports. MCPJam's initial preview client is narrower: it currently supports the RC over Streamable HTTP POST. The per-server dropdown hides the RC option for STDIO and legacy SSE servers; if a host-level RC default reaches a non-HTTP server, the inspector fails the connection with a clear transport error instead of silently attempting the wrong protocol.
 
@@ -48,7 +48,7 @@ The 2026 RC applies the stateless model across transports. MCPJam's initial prev
   <img
     className="block"
     src="/images/protocol-versions/host-default-dropdown.png"
-    alt="Client editor with the MCP Protocol tab open and the Protocol version dropdown showing Automatic, 2026 RC (2026-07-28), Latest (2025-11-25), 2025-06-18, and 2025-03-26 options"
+    alt="Client editor with the MCP Protocol tab open and the Protocol version dropdown showing Automatic, Latest (2026-07-28), November (2025-11-25), 2025-06-18, and 2025-03-26 options"
     width="1000"
   />
 </Frame>
@@ -58,8 +58,8 @@ The 2026 RC applies the stateless model across transports. MCPJam's initial prev
 3. Open the **MCP Protocol** tab.
 4. In the **Protocol version** dropdown, pick a version:
    - **Automatic** — no pin stored; the SDK picks the version at connect time (default).
-   - **2026 RC (2026-07-28)** — pin to the stateless RC.
-   - **Latest (2025-11-25)** — pin to the current stable release.
+   - **Latest (2026-07-28)** — pin to the newest stateless revision.
+   - **November (2025-11-25)** — pin to the November stateful release.
    - **2025-06-18** or **2025-03-26** — pin to an earlier stable revision.
 5. Save.
 
@@ -76,7 +76,7 @@ When adding a server to a shared project, the **Connection overrides** section o
 1. Click **Add server** in the **Servers** tab.
 2. Fill in the server details.
 3. Expand **Connection overrides**.
-4. Pick **Client default**, **Latest (2025-11-25)**, **2026 RC (2026-07-28)**, or an earlier stable revision from the **Protocol version** dropdown.
+4. Pick **Client default**, **Latest (2026-07-28)**, **November (2025-11-25)**, or an earlier stable revision from the **Protocol version** dropdown.
 5. Submit the form.
 
 The pin is applied once the server is created and the connection is established.
@@ -86,7 +86,7 @@ The pin is applied once the server is created and the connection is established.
 1. Go to the **Servers** tab.
 2. Click the three dots on the server card → **Edit** (or open **View server info** → **Edit**).
 3. Expand **Advanced settings**.
-4. Find **Protocol version** and pick **Host default**, **Latest (2025-11-25)**, **2026 RC (2026-07-28)**, or an earlier stable revision.
+4. Find **Protocol version** and pick **Host default**, **Latest (2026-07-28)**, **November (2025-11-25)**, or an earlier stable revision.
 5. Save and reconnect the server.
 
 The per-server override is the more specific signal — it wins over whatever the Client's MCP Protocol tab says.
@@ -106,7 +106,7 @@ The last case is an authentication-gated compatibility fallback, not version det
 
 OAuth callback security follows the concrete version recorded for that flow. Every version validates `state`. The 2026-07-28 flow also validates a returned RFC 9207 `iss` against the discovered authorization-server issuer; 2025 flows retain compatibility and ignore callback `iss`.
 
-## What changes when you pick the 2026 RC
+## What changes when you pick Latest (2026-07-28)
 
 If your server already speaks `2026-07-28`, you mostly won't notice. A few things to know when you're testing:
 
@@ -134,13 +134,13 @@ For everything else — `tools/list`, `tools/call`, `resources/*`, `prompts/*`, 
 
 ## Recommended testing flow
 
-1. Build a Client called something like `2026 RC sandbox` with **MCP Protocol → 2026 RC** as the host default.
+1. Build a Client called something like `Latest protocol sandbox` with **MCP Protocol → Latest** as the host default.
 2. Attach the HTTP server you're upgrading.
 3. Connect — confirm the server card shows the server info populated from `server/discover` (name, version, capabilities, instructions).
 4. Run a `tools/list` and a `tools/call` from the **Tools** tab.
 5. Watch the **Activity** log for the request `_meta` and the `MCP-Protocol-Version` header.
 6. Try an unsupported version on a second test server to confirm your `-32004` error envelope looks right.
-7. Once your server is happy on the RC, keep one Client on **Automatic** (or pinned to **Latest (2025-11-25)**) so you can flip between versions without rewriting settings.
+7. Once your server is happy on Latest, keep one Client on **Automatic** (or pinned to **November (2025-11-25)**) so you can flip between versions without rewriting settings.
 
 If you need to talk to a mix of servers on different versions in the same Client, use per-server overrides — the RC server stays pinned to `2026-07-28`, the rest fall back to the host default.
 

--- a/docs/inspector/protocol-versions.mdx
+++ b/docs/inspector/protocol-versions.mdx
@@ -36,6 +36,8 @@ Use the host default when you want every server in a Client to speak the same ve
 
 **Automatic** stores no pin — the absence of a pin is the meaning, not a hidden default. Picking any other option stores that exact version literal and narrows the `initialize` handshake's accept-list to that single revision.
 
+When Automatic falls back to the legacy `initialize` handshake, it uses the MCP SDK's complete built-in supported-version list. Persisted per-client accept-lists are ignored in Automatic mode so reconnecting cannot accidentally narrow negotiation; choose an explicit version when you want a strict protocol pin.
+
 **Latest (2025-11-25)** is derived, not hardcoded: it always labels the newest non-RC stable version in the SDK's known-version list. When a newer stable version is added, the "Latest" marker moves forward automatically.
 
 The 2026 RC applies the stateless model across transports. MCPJam's initial preview client is narrower: it currently supports the RC over Streamable HTTP POST. The per-server dropdown hides the RC option for STDIO and legacy SSE servers; if a host-level RC default reaches a non-HTTP server, the inspector fails the connection with a clear transport error instead of silently attempting the wrong protocol.

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AdvancedConnectionSettingsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AdvancedConnectionSettingsSection.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { AdvancedConnectionSettingsSection } from "../shared/AdvancedConnectionSettingsSection";
 
@@ -17,17 +18,17 @@ describe("AdvancedConnectionSettingsSection", () => {
         onAddHeader={vi.fn()}
         onRemoveHeader={vi.fn()}
         onUpdateHeader={vi.fn()}
-      />,
+      />
     );
 
     expect(
-      screen.getByRole("button", { name: /connection overrides/i }),
+      screen.getByRole("button", { name: /connection overrides/i })
     ).toHaveTextContent("Connection overrides");
     expect(screen.queryByText("1 header configured")).not.toBeInTheDocument();
     expect(screen.queryByText("Timeout: 30000ms")).not.toBeInTheDocument();
 
     fireEvent.click(
-      screen.getByRole("button", { name: /connection overrides/i }),
+      screen.getByRole("button", { name: /connection overrides/i })
     );
 
     expect(onToggle).toHaveBeenCalledTimes(1);
@@ -50,12 +51,43 @@ describe("AdvancedConnectionSettingsSection", () => {
         clientCapabilitiesOverrideText={"{}"}
         onClientCapabilitiesOverrideTextChange={vi.fn()}
         clientCapabilitiesOverrideError={null}
-      />,
+      />
     );
 
     expect(screen.getByText("Headers")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^add$/i })).toBeInTheDocument();
     expect(screen.getByText(/Timeout/)).toBeInTheDocument();
     expect(screen.getByText("Capabilities override")).toBeInTheDocument();
+  });
+
+  it("maps Latest and November labels to their exact wire versions", async () => {
+    const user = userEvent.setup();
+    const onProtocolChange = vi.fn();
+    render(
+      <AdvancedConnectionSettingsSection
+        showConfiguration={true}
+        onToggle={vi.fn()}
+        requestTimeout="10000"
+        onRequestTimeoutChange={vi.fn()}
+        showMcpProtocolVersionOverride={true}
+        onMcpProtocolVersionOverrideChange={onProtocolChange}
+        transportKind="http"
+      />
+    );
+
+    const protocolSelect = screen.getByRole("combobox", {
+      name: /protocol version/i,
+    });
+    await user.click(protocolSelect);
+    await user.click(
+      screen.getByRole("option", { name: "Latest (2026-07-28)" })
+    );
+    expect(onProtocolChange).toHaveBeenLastCalledWith("2026-07-28");
+
+    await user.click(protocolSelect);
+    await user.click(
+      screen.getByRole("option", { name: "November (2025-11-25)" })
+    );
+    expect(onProtocolChange).toHaveBeenLastCalledWith("2025-11-25");
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -365,7 +365,7 @@ describe("ServerDetailModal", () => {
 
     await user.click(protocolSelect);
     await user.click(
-      await screen.findByRole("option", { name: "Latest (2025-11-25)" })
+      await screen.findByRole("option", { name: "November (2025-11-25)" })
     );
 
     await waitFor(() => {
@@ -412,7 +412,7 @@ describe("ServerDetailModal", () => {
 
     await user.click(hostDefaultSelect);
     await user.click(
-      await screen.findByRole("option", { name: "Latest (2025-11-25)" })
+      await screen.findByRole("option", { name: "November (2025-11-25)" })
     );
 
     await waitFor(() => {
@@ -430,7 +430,7 @@ describe("ServerDetailModal", () => {
     });
     await waitFor(() => {
       expect(
-        screen.queryByRole("option", { name: "Latest (2025-11-25)" })
+        screen.queryByRole("option", { name: "November (2025-11-25)" })
       ).not.toBeInTheDocument();
     });
     unmount();
@@ -452,7 +452,7 @@ describe("ServerDetailModal", () => {
     );
 
     const latestSelect = getProtocolVersionCombobox();
-    expect(latestSelect).toHaveTextContent("Latest (2025-11-25)");
+    expect(latestSelect).toHaveTextContent("November (2025-11-25)");
 
     await user.click(latestSelect);
     await user.click(
@@ -497,7 +497,7 @@ describe("ServerDetailModal", () => {
       screen.getByRole("button", { name: /connection overrides/i })
     );
     const protocolSelect = getProtocolVersionCombobox();
-    expect(protocolSelect).toHaveTextContent("Latest (2025-11-25)");
+    expect(protocolSelect).toHaveTextContent("November (2025-11-25)");
 
     await user.click(protocolSelect);
     await user.click(

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -16,19 +16,18 @@ import type { McpProtocolVersion } from "@/lib/client-config-v2";
  * Per-server protocol-version pin. Three-state picker:
  *   - "inherit" → `undefined`, defers to the host default (or SDK default if
  *     no host default is set).
- *   - "latest"  → `"2025-11-25"`, explicit stable pin — overrides a
- *     host-level RC default.
- *   - "rc"      → `"2026-07-28"`, the stateless RC preview client.
+ *   - "november" → `"2025-11-25"`, explicit stateful pin.
+ *   - "latest"   → `"2026-07-28"`, the newest stateless preview client.
  */
-type DropdownValue = "inherit" | "latest" | "rc";
+type DropdownValue = "inherit" | "november" | "latest";
 
 const MCP_PROTOCOL_OPTIONS: Array<{
   value: DropdownValue;
   label: string;
 }> = [
   { value: "inherit", label: "Client default" },
-  { value: "latest", label: "Latest (2025-11-25)" },
-  { value: "rc", label: "2026 RC (2026-07-28)" },
+  { value: "latest", label: "Latest (2026-07-28)" },
+  { value: "november", label: "November (2025-11-25)" },
 ];
 
 interface HeaderEntry {
@@ -134,7 +133,7 @@ export function AdvancedConnectionSettingsSection({
   // Hide it on non-HTTP transports as the user-friendly safety net.
   const isHttp = transportKind === "http";
   const visibleOptions = MCP_PROTOCOL_OPTIONS.filter((opt) => {
-    if (opt.value === "rc" && !isHttp) return false;
+    if (opt.value === "latest" && !isHttp) return false;
     return true;
   });
   // Per-instance so several of these forms can be mounted at once without
@@ -146,9 +145,9 @@ export function AdvancedConnectionSettingsSection({
   const protocolTriggerId = `${bodyId}-protocol-trigger`;
   const selectedDropdownValue: DropdownValue =
     mcpProtocolVersionOverride === "2026-07-28"
-      ? "rc"
-      : mcpProtocolVersionOverride === "2025-11-25"
       ? "latest"
+      : mcpProtocolVersionOverride === "2025-11-25"
+      ? "november"
       : "inherit";
 
   return (
@@ -354,9 +353,9 @@ export function AdvancedConnectionSettingsSection({
             )}
 
             {/* Per-server MCP protocol-version pin. Tri-state picker:
-                "Latest" → `"2025-11-25"` (legacy adapter + initialize
-                handshake); "2026 RC" → `"2026-07-28"` (stateless RC
-                preview client). The RC option is hidden on non-HTTP
+                "November" → `"2025-11-25"` (legacy adapter + initialize
+                handshake); "Latest" → `"2026-07-28"` (stateless preview
+                client). The Latest option is hidden on non-HTTP
                 transports because MCPJam's current stateless client
                 requires Streamable HTTP. */}
             {showProtocolVersionControl && (
@@ -364,7 +363,7 @@ export function AdvancedConnectionSettingsSection({
                 <label
                   id={protocolLabelId}
                   className="text-xs font-medium text-foreground"
-                  title="Latest: the current stable MCP wire version (2025-11-25). 2026 RC: MCPJam's current 2026-07-28 stateless preview over Streamable HTTP POST."
+                  title="Latest: MCPJam's newest 2026-07-28 stateless preview over Streamable HTTP POST. November: the 2025-11-25 stateful MCP wire version."
                 >
                   Protocol version
                 </label>
@@ -374,9 +373,9 @@ export function AdvancedConnectionSettingsSection({
                   onValueChange={(next) => {
                     if (!onMcpProtocolVersionOverrideChange) return;
                     onMcpProtocolVersionOverrideChange(
-                      next === "rc"
+                      next === "latest"
                         ? "2026-07-28"
-                        : next === "latest"
+                        : next === "november"
                         ? "2025-11-25"
                         : undefined
                     );
@@ -402,8 +401,8 @@ export function AdvancedConnectionSettingsSection({
                 </Select>
                 {!isHttp && (
                   <p className="text-xs text-muted-foreground">
-                    MCPJam's current 2026 RC preview requires Streamable HTTP —
-                    only Latest is selectable for this transport.
+                    Latest requires Streamable HTTP and is unavailable for this
+                    transport.
                   </p>
                 )}
                 {!canEditProtocolVersion && (

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -47,32 +47,21 @@ import { useJsonDraftBuffer } from "./useJsonDraftBuffer";
 type HostProtocolDropdownValue = "auto" | McpProtocolVersion;
 
 /**
- * Decorate the two revisions that carry meaning beyond their date, and
- * derive both markers rather than hardcoding them:
+ * Decorate the two newest revisions with their product labels:
  *
- * - **Latest** = newest non-stateless revision. Computed via
- *   `isStatelessProtocolVersion` so the marker walks forward on its own
- *   when a newer stable version is appended to `MCP_PROTOCOL_VERSIONS` —
- *   a hardcoded "Latest (2025-11-25)" would quietly become a lie.
- * - **RC** = any stateless revision, i.e. the 2026-era preview.
+ * - **Latest** = newest known revision. Derived from
+ *   `MCP_PROTOCOL_VERSIONS` so the marker walks forward automatically.
+ * - **November** = the 2025-11-25 revision.
  *
  * `MCP_PROTOCOL_VERSIONS` is ordered oldest-first; the dropdown lists
- * newest-first, which puts the two versions anyone actually picks at the
- * top and leaves the archaeology below.
+ * newest-first.
  */
-const LATEST_STABLE_PROTOCOL_VERSION: McpProtocolVersion | undefined = [
-  ...MCP_PROTOCOL_VERSIONS,
-]
-  .reverse()
-  .find((v) => !isStatelessProtocolVersion(v));
+const LATEST_PROTOCOL_VERSION: McpProtocolVersion | undefined =
+  MCP_PROTOCOL_VERSIONS[MCP_PROTOCOL_VERSIONS.length - 1];
 
 function protocolVersionLabel(version: McpProtocolVersion): string {
-  // "2026-07-28" → "2026 RC (2026-07-28)": the era year is how the RC is
-  // spoken about, the full date is what actually goes on the wire.
-  if (isStatelessProtocolVersion(version)) {
-    return `${version.slice(0, 4)} RC (${version})`;
-  }
-  if (version === LATEST_STABLE_PROTOCOL_VERSION) return `Latest (${version})`;
+  if (version === LATEST_PROTOCOL_VERSION) return `Latest (${version})`;
+  if (version === "2025-11-25") return `November (${version})`;
   return version;
 }
 

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.saveGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.saveGate.test.tsx
@@ -149,16 +149,16 @@ describe("ProtocolTab arms the Save gate on edit", () => {
     expect(screen.getByTestId("dirty").textContent).toBe("dirty");
   });
 
-  it("selecting the 2026 RC protocol version marks dirty", async () => {
+  it("selecting the latest protocol version marks dirty", async () => {
     const user = userEvent.setup();
     const initial = realisticHost();
     render(<Harness initial={initial} />);
 
     expect(screen.getByTestId("dirty").textContent).toBe("clean");
 
-    // Radix Select: open then pick the RC option.
+    // Radix Select: open then pick the latest option.
     await user.click(screen.getByRole("combobox"));
-    await user.click(screen.getByText(/2026 RC/i));
+    await user.click(screen.getByText(/Latest \(2026-07-28\)/i));
 
     expect(screen.getByTestId("dirty").textContent).toBe("dirty");
   });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.versionDropdown.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.versionDropdown.test.tsx
@@ -48,15 +48,8 @@ function Harness({ initial }: { initial: HostConfigInputV2 }) {
  * The host-level protocol dropdown must NOT advertise a version number for
  * its unpinned state.
  *
- * `undefined` means "the SDK chooses at connect time". Labelling that
- * "Latest (2025-11-25)" bakes today's SDK default into user-facing copy, so
- * the sequenced Phase-5 `versionNegotiation: 'auto'` activation would
- * silently make every client labelled "Latest (2025-11-25)" negotiate a
- * different revision than its own label claims.
- *
- * The per-server control in `AdvancedConnectionSettingsSection` keeps
- * "Latest (2025-11-25)" on purpose — there the option writes that literal,
- * and inheritance has its own "Client default" entry.
+ * `undefined` means "the SDK chooses at connect time". Latest always labels
+ * the newest concrete wire revision; Automatic remains the unpinned option.
  */
 describe("ProtocolTab protocol-version dropdown", () => {
   it("offers Automatic plus every known protocol version, newest first", async () => {
@@ -66,29 +59,29 @@ describe("ProtocolTab protocol-version dropdown", () => {
     await user.click(screen.getByRole("combobox"));
 
     expect(
-      (await screen.findAllByRole("option")).map((o) => o.textContent),
+      (await screen.findAllByRole("option")).map((o) => o.textContent)
     ).toEqual([
       "Automatic",
-      "2026 RC (2026-07-28)",
-      "Latest (2025-11-25)",
+      "Latest (2026-07-28)",
+      "November (2025-11-25)",
       "2025-06-18",
       "2025-03-26",
     ]);
   });
 
-  it("pins 'Latest' to the newest non-stateless version, not a hardcoded date", async () => {
+  it("pins 'Latest' to the newest known protocol version", async () => {
     const user = userEvent.setup();
     render(<Harness initial={emptyHostConfigInputV2()} />);
 
     await user.click(screen.getByRole("combobox"));
 
     // Exactly one option may carry the Latest marker, and it must be the
-    // newest stateful revision — 2026-07-28 is stateless, so it is the RC.
-    const latest = screen.getAllByRole("option").filter((o) =>
-      /^Latest \(/.test(o.textContent ?? ""),
-    );
+    // newest entry in MCP_PROTOCOL_VERSIONS.
+    const latest = screen
+      .getAllByRole("option")
+      .filter((o) => /^Latest \(/.test(o.textContent ?? ""));
     expect(latest).toHaveLength(1);
-    expect(latest[0].textContent).toBe("Latest (2025-11-25)");
+    expect(latest[0].textContent).toBe("Latest (2026-07-28)");
   });
 
   it("writes the exact literal for a non-RC version", async () => {
@@ -96,7 +89,9 @@ describe("ProtocolTab protocol-version dropdown", () => {
     render(<Harness initial={emptyHostConfigInputV2()} />);
 
     await user.click(screen.getByRole("combobox"));
-    await user.click(screen.getByRole("option", { name: "Latest (2025-11-25)" }));
+    await user.click(
+      screen.getByRole("option", { name: "November (2025-11-25)" })
+    );
 
     // A stateful pin is not cosmetic: it narrows the initialize accept-list.
     expect(screen.getByTestId("pin").textContent).toBe("2025-11-25");
@@ -113,12 +108,12 @@ describe("ProtocolTab protocol-version dropdown", () => {
     expect(screen.getByTestId("pin").textContent).toBe("<undefined>");
   });
 
-  it("selecting 2026 RC pins 2026-07-28; returning to Automatic clears it", async () => {
+  it("selecting Latest pins 2026-07-28; returning to Automatic clears it", async () => {
     const user = userEvent.setup();
     render(<Harness initial={emptyHostConfigInputV2()} />);
 
     await user.click(screen.getByRole("combobox"));
-    await user.click(screen.getByRole("option", { name: /2026 RC/i }));
+    await user.click(screen.getByRole("option", { name: /Latest/i }));
     expect(screen.getByTestId("pin").textContent).toBe("2026-07-28");
 
     // Back to Automatic must restore ABSENCE, not a 2025 literal — a stored

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1855,27 +1855,37 @@ export class MCPClientManager {
       const wantsStateless =
         resolvedProtocolVersion !== undefined &&
         isStatelessProtocolVersion(resolvedProtocolVersion);
+      // Resolve negotiation before the legacy initialize accept-list so Auto
+      // has one source of truth. An unpinned connection probes the modern era
+      // first and, on a legacy signal, must fall back with the upstream SDK's
+      // complete built-in supported-version list. Forwarding a persisted
+      // per-server or manager-default list here can make the first connection
+      // succeed but a later reconnect reject the server's valid counter-offer.
+      const versionNegotiation = resolveVersionNegotiation(
+        resolvedProtocolVersion
+      );
+      const wantsAutoNegotiation = versionNegotiation?.mode === "auto";
       // Stateful `mcpProtocolVersion` pin (e.g. `"2025-11-25"`) propagates
       // into the legacy `Client`'s `supportedProtocolVersions` accept-list
       // so `initialize.params.protocolVersion` actually goes out as the
       // pinned value rather than the SDK's built-in newest default. An
       // explicit `supportedProtocolVersions` (per-server or default) still
-      // wins — pinning at one layer while overriding the other would be
-      // ambiguous and the override is the more specific signal.
-      const supportedProtocolVersions =
-        config.supportedProtocolVersions ??
-        this.defaultSupportedProtocolVersions ??
-        (!wantsStateless && resolvedProtocolVersion !== undefined
-          ? [resolvedProtocolVersion]
-          : undefined);
+      // wins for an explicit pin — pinning at one layer while overriding the
+      // other would be ambiguous and the override is the more specific signal.
+      // Auto deliberately ignores both lists so its legacy fallback negotiates
+      // against every version supported by the upstream SDK.
+      const supportedProtocolVersions = wantsAutoNegotiation
+        ? undefined
+        : config.supportedProtocolVersions ??
+          this.defaultSupportedProtocolVersions ??
+          (!wantsStateless && resolvedProtocolVersion !== undefined
+            ? [resolvedProtocolVersion]
+            : undefined);
       // Automatic era negotiation is always on and transport-agnostic: an
       // unconfigured connection resolves to `{ mode: "auto" }` on both HTTP
       // and stdio (on stdio the `server/discover` probe runs on a sibling
       // process). Explicit pins are honored identically — a modern pin
       // negotiates modern with no legacy fallback, a legacy pin is byte-stable.
-      const versionNegotiation = resolveVersionNegotiation(
-        resolvedProtocolVersion
-      );
       const clientOptions: ClientOptions = {
         capabilities: clientCapabilities,
         // Manual multi-round-trip mode (2026-07-28 `input_required`, spec §12).

--- a/sdk/tests/MCPClientManager.auto-protocol-reconnect.test.ts
+++ b/sdk/tests/MCPClientManager.auto-protocol-reconnect.test.ts
@@ -1,0 +1,182 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+
+const NEGOTIATED_VERSION = "2025-06-18";
+const STALE_ACCEPT_LIST = ["2025-11-25"];
+
+interface CapturedRequest {
+  httpMethod: string;
+  rpcMethod?: string;
+  proposedProtocolVersion?: string;
+}
+
+interface ServedLegacyFixture {
+  url: string;
+  requests: CapturedRequest[];
+  close: () => Promise<void>;
+}
+
+async function serveLegacyFixture(): Promise<ServedLegacyFixture> {
+  const requests: CapturedRequest[] = [];
+  const server = http.createServer(async (req, res) => {
+    if (req.method !== "POST") {
+      requests.push({ httpMethod: req.method ?? "unknown" });
+      res.writeHead(405, { allow: "POST" });
+      res.end();
+      return;
+    }
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+      id?: string | number;
+      method?: string;
+      params?: { protocolVersion?: string };
+    };
+    requests.push({
+      httpMethod: "POST",
+      rpcMethod: body.method,
+      proposedProtocolVersion: body.params?.protocolVersion,
+    });
+
+    const respond = (payload: unknown) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(payload));
+    };
+
+    if (body.method === "server/discover") {
+      respond({
+        jsonrpc: "2.0",
+        id: body.id,
+        error: { code: -32601, message: "Method not found" },
+      });
+      return;
+    }
+
+    if (body.method === "initialize") {
+      respond({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          protocolVersion: NEGOTIATED_VERSION,
+          capabilities: {},
+          serverInfo: { name: "bart-fixture", version: "1.0.0" },
+        },
+      });
+      return;
+    }
+
+    if (body.method === "notifications/initialized") {
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+
+    respond({
+      jsonrpc: "2.0",
+      id: body.id,
+      error: { code: -32601, message: "Method not found" },
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    requests,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      ),
+  };
+}
+
+describe("MCPClientManager Automatic legacy fallback", () => {
+  let fixture: ServedLegacyFixture;
+  let manager: MCPClientManager;
+
+  beforeEach(async () => {
+    fixture = await serveLegacyFixture();
+    manager = new MCPClientManager();
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAllServers().catch(() => {});
+    await fixture.close();
+  });
+
+  it("accepts 2025-06-18 after disconnect and reconnect despite a stale list", async () => {
+    await manager.connectToServer("bart", {
+      url: fixture.url,
+      timeout: 5_000,
+    });
+    expect(manager.getInitializationInfo("bart")?.protocolVersion).toBe(
+      NEGOTIATED_VERSION
+    );
+
+    await manager.removeServer("bart");
+    await manager.connectToServer("bart", {
+      url: fixture.url,
+      timeout: 5_000,
+      supportedProtocolVersions: STALE_ACCEPT_LIST,
+    });
+
+    expect(manager.getInitializationInfo("bart")?.protocolVersion).toBe(
+      NEGOTIATED_VERSION
+    );
+    const initializeRequests = fixture.requests.filter(
+      (request) => request.rpcMethod === "initialize"
+    );
+    expect(initializeRequests).toHaveLength(2);
+    expect(
+      initializeRequests.map((request) => request.proposedProtocolVersion)
+    ).toEqual(["2025-11-25", "2025-11-25"]);
+    expect(
+      fixture.requests.filter((request) => request.httpMethod === "GET")
+    ).toHaveLength(0);
+  });
+
+  it("ignores a stale manager-default accept-list in Automatic mode", async () => {
+    await manager.disconnectAllServers();
+    manager = new MCPClientManager(
+      {},
+      { defaultSupportedProtocolVersions: STALE_ACCEPT_LIST }
+    );
+
+    await manager.connectToServer("bart", {
+      url: fixture.url,
+      timeout: 5_000,
+    });
+
+    expect(manager.getInitializationInfo("bart")?.protocolVersion).toBe(
+      NEGOTIATED_VERSION
+    );
+  });
+
+  it("keeps an explicit legacy protocol pin strict", async () => {
+    await expect(
+      manager.connectToServer("bart", {
+        url: fixture.url,
+        timeout: 5_000,
+        mcpProtocolVersion: "2025-11-25",
+      })
+    ).rejects.toThrow(/2025-06-18/);
+  });
+
+  it("preserves an explicit legacy multi-version accept-list", async () => {
+    await manager.connectToServer("bart", {
+      url: fixture.url,
+      timeout: 5_000,
+      mcpProtocolVersion: "2025-11-25",
+      supportedProtocolVersions: ["2025-11-25", NEGOTIATED_VERSION],
+    });
+
+    expect(manager.getInitializationInfo("bart")?.protocolVersion).toBe(
+      NEGOTIATED_VERSION
+    );
+  });
+});

--- a/sdk/tests/MCPClientManager.auto-protocol-reconnect.test.ts
+++ b/sdk/tests/MCPClientManager.auto-protocol-reconnect.test.ts
@@ -1,7 +1,27 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let sseConstructedCount = 0;
+
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@modelcontextprotocol/client")>();
+  class SpySSEClientTransport extends actual.SSEClientTransport {
+    constructor(url: URL, opts?: Record<string, unknown>) {
+      super(url, opts as never);
+      sseConstructedCount += 1;
+    }
+  }
+  return {
+    ...actual,
+    SSEClientTransport: SpySSEClientTransport,
+  };
+});
+
+const { MCPClientManager } = await import(
+  "../src/mcp-client-manager/index.js"
+);
 
 const NEGOTIATED_VERSION = "2025-06-18";
 const STALE_ACCEPT_LIST = ["2025-11-25"];
@@ -100,6 +120,7 @@ describe("MCPClientManager Automatic legacy fallback", () => {
   let manager: MCPClientManager;
 
   beforeEach(async () => {
+    sseConstructedCount = 0;
     fixture = await serveLegacyFixture();
     manager = new MCPClientManager();
   });
@@ -135,9 +156,7 @@ describe("MCPClientManager Automatic legacy fallback", () => {
     expect(
       initializeRequests.map((request) => request.proposedProtocolVersion)
     ).toEqual(["2025-11-25", "2025-11-25"]);
-    expect(
-      fixture.requests.filter((request) => request.httpMethod === "GET")
-    ).toHaveLength(0);
+    expect(sseConstructedCount).toBe(0);
   });
 
   it("ignores a stale manager-default accept-list in Automatic mode", async () => {


### PR DESCRIPTION
First connection succeeds.
You click **Disconnect**.
You click **Reconnect**.
The fresh reconnect client rejects the server’s 2025-06-18 response.
