### PR TITLE
SDK: observe manager connect rejections instead of leaking unhandledRejections

### DIFF
--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -348,7 +348,13 @@ export class MCPClientManager {
     // Start connecting to all configured servers (unless replay/trace-repair use explicit connect)
     if (!this.lazyConnect) {
       for (const [id, config] of Object.entries(servers)) {
-        void this.connectToServer(id, config);
+        // Fire-and-forget prefetch: a failure here is NOT lost — the failed
+        // attempt clears its live state, so the first operation that needs
+        // this server re-attempts the connect and observes the error itself
+        // (in-flight attempts are deduped via retryPromise/connectPromise).
+        // Without the catch, every failed eager connect ALSO escapes as a
+        // process-level unhandledRejection.
+        this.connectToServer(id, config).catch(() => {});
       }
     }
   }
@@ -1798,6 +1804,11 @@ export class MCPClientManager {
         state
       )
     );
+    // Mark handled without affecting awaiters (they hold the original
+    // promise): awaitWithAbort abandons connectionPromise when the caller's
+    // signal fires first, and an abandoned rejection escapes as a
+    // process-level unhandledRejection.
+    connectionPromise.catch(() => {});
     state.connectPromise = connectionPromise;
     this.liveClientStates.set(serverId, state);
     return this.awaitWithAbort(connectionPromise, signal);

--- a/sdk/tests/mcp-client-manager.connect-rejection.test.ts
+++ b/sdk/tests/mcp-client-manager.connect-rejection.test.ts
@@ -1,3 +1,6 @@
+import { createServer, type Server } from "node:http";
+import { setImmediate as setImmediateAsync } from "node:timers/promises";
+
 import { MCPClientManager } from "../src/mcp-client-manager";
 
 // The constructor kicks off eager connects and discards the promise; a
@@ -6,6 +9,29 @@ import { MCPClientManager } from "../src/mcp-client-manager";
 // every transient hosted-connect failure emitted a paired
 // process.unhandled_rejection event because of this.
 describe("MCPClientManager connect rejection handling", () => {
+  let server: Server;
+  let url: string;
+
+  // A server we own that destroys every connection: a deterministic
+  // connection-class failure, with no dependence on which ports happen to
+  // be free on the host.
+  beforeAll(async () => {
+    server = createServer();
+    server.on("connection", (socket) => socket.destroy());
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected an AddressInfo from the test server");
+    }
+    url = `http://127.0.0.1:${address.port}/mcp`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
+  });
+
   it("does not leak an unhandledRejection when an eager connect fails", async () => {
     const rejections: unknown[] = [];
     const onRejection = (reason: unknown) => {
@@ -13,23 +39,37 @@ describe("MCPClientManager connect rejection handling", () => {
     };
     process.on("unhandledRejection", onRejection);
 
-    const manager = new MCPClientManager({
-      // TCP port 1 on localhost is never listening — the connect fails
-      // fast with a connection-class error.
-      failing: { url: "http://127.0.0.1:1/mcp" },
+    // Resolves when the manager reports the eager attempt as settled, so
+    // the assertion never races the connect.
+    let signalAttemptSettled: () => void;
+    const attemptSettled = new Promise<void>((resolve) => {
+      signalAttemptSettled = resolve;
     });
 
+    const manager = new MCPClientManager(
+      { failing: { url } },
+      {
+        negotiationOutcomeLogger: (event) => {
+          if (event.serverId === "failing" && event.outcome === "failed") {
+            signalAttemptSettled();
+          }
+        },
+      }
+    );
+
     try {
-      // Let the eager connect fail and give Node a macrotask turn to emit
-      // unhandledRejection for any unobserved promise.
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await attemptSettled;
+      // unhandledRejection is emitted after the microtask queue drains;
+      // yield the macrotask turn so any unobserved rejection has fired.
+      await setImmediateAsync();
+      await setImmediateAsync();
       expect(rejections).toEqual([]);
 
       // The failure is still observable: the failed attempt cleared its
       // live state, so an explicit connect re-attempts and rejects to the
       // caller.
       await expect(
-        manager.connectToServer("failing", { url: "http://127.0.0.1:1/mcp" })
+        manager.connectToServer("failing", { url })
       ).rejects.toThrow();
     } finally {
       process.off("unhandledRejection", onRejection);

--- a/sdk/tests/mcp-client-manager.connect-rejection.test.ts
+++ b/sdk/tests/mcp-client-manager.connect-rejection.test.ts
@@ -1,0 +1,39 @@
+import { MCPClientManager } from "../src/mcp-client-manager";
+
+// The constructor kicks off eager connects and discards the promise; a
+// failed connect must be re-surfaced to the first caller that uses the
+// server, NOT escape as a process-level unhandledRejection. In production
+// every transient hosted-connect failure emitted a paired
+// process.unhandled_rejection event because of this.
+describe("MCPClientManager connect rejection handling", () => {
+  it("does not leak an unhandledRejection when an eager connect fails", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onRejection);
+
+    const manager = new MCPClientManager({
+      // TCP port 1 on localhost is never listening — the connect fails
+      // fast with a connection-class error.
+      failing: { url: "http://127.0.0.1:1/mcp" },
+    });
+
+    try {
+      // Let the eager connect fail and give Node a macrotask turn to emit
+      // unhandledRejection for any unobserved promise.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(rejections).toEqual([]);
+
+      // The failure is still observable: the failed attempt cleared its
+      // live state, so an explicit connect re-attempts and rejects to the
+      // caller.
+      await expect(
+        manager.connectToServer("failing", { url: "http://127.0.0.1:1/mcp" })
+      ).rejects.toThrow();
+    } finally {
+      process.off("unhandledRejection", onRejection);
+      await manager.disconnectAllServers();
+    }
+  }, 15000);
+});


### PR DESCRIPTION
## Context

Follow-up to #3531 (transient connect 502s). In prod, every failed hosted connect pairs an `http.request.failed` event with a `process.unhandled_rejection` event at the same timestamp (~300+/day). Mechanism: the `MCPClientManager` constructor kicks off eager connects with `void this.connectToServer(...)`, and `connectToServer` rethrows the connect failure into that discarded promise — so the same error that the route already handles ALSO escapes to `process.on("unhandledRejection")`.

## Changes

- **Constructor prefetch**: attach a no-op catch to the fire-and-forget connect. The failure is not lost — a failed attempt clears its live state, so the first operation that needs the server re-attempts the connect and observes the error itself (in-flight attempts are deduped via `retryPromise`/`connectPromise`).
- **`connectToServerOnce`**: mark `connectionPromise` handled before handing it to `awaitWithAbort`, which abandons the inner promise when the caller's abort signal fires first. Awaiters hold the original promise, so error propagation is unaffected.

## Testing

- New regression test: constructs a manager with an unreachable server (`127.0.0.1:1`), asserts no `unhandledRejection` escapes, and asserts the failure still rejects to an explicit `connectToServer` caller. Verified red without the fix.
- Full SDK suite: 3061 passed. Inspector server suite against the rebuilt SDK: 4071 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow promise-handling change in connection setup; errors remain visible to callers who await connect, with regression test coverage.
> 
> **Overview**
> Stops **process-level `unhandledRejection` noise** when `MCPClientManager` prefetches connections or aborts an in-flight connect, without hiding failures from real callers.
> 
> **Eager constructor connects** now attach a no-op `.catch()` to fire-and-forget `connectToServer` calls. Failed prefetch still clears live state so the first operation that needs the server reconnects and gets the same error (deduped via `connectPromise` / `retryPromise`).
> 
> **`connectToServerOnce`** marks `connectionPromise` as handled before `awaitWithAbort`, so if the caller’s abort wins and abandons the inner connect promise, its rejection no longer escapes globally. Awaiters still use the original promise and see rejections as before.
> 
> Adds a regression test: eager connect to a server that destroys sockets → no `unhandledRejection`, and explicit `connectToServer` still rejects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9530548e743e611cc550ea3831309d09f2ec288c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `process.unhandledRejection` leaks from eager server connects by observing connect failures in the SDK. Errors still surface to callers, and retries remain deduped.

- **Bug Fixes**
  - Attach a no-op `.catch()` to fire-and-forget connects in `MCPClientManager` to avoid `process.unhandledRejection`.
  - Mark `connectionPromise` handled before `awaitWithAbort` to prevent abandoned promise leaks; awaiting callers still get the original rejection.
  - Add a deterministic regression test: run a local server that destroys connections, wait for `negotiationOutcomeLogger` to report `outcome: "failed"`, yield two macrotask turns, assert no leak, and confirm `connectToServer` still rejects.

<sup>Written for commit 9530548e743e611cc550ea3831309d09f2ec288c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

