### PR TITLE
MCP Tasks: wire extension task-filtered notifications (B2)

### DIFF
--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -70,6 +70,12 @@ import {
   type NormalizedTask,
   type TaskDisplayStatus,
 } from "@/lib/task-utils";
+import {
+  fetchSubscriptionState,
+  setDesiredSubscriptionInterests,
+} from "@/lib/apis/mcp-subscriptions-api";
+import { addTokenToUrl } from "@/lib/session-token";
+import type { SubscriptionBridgeEvent } from "@/shared/subscription-bridge.js";
 import { useTaskElicitation } from "@/hooks/use-task-elicitation";
 import { ElicitationDialog } from "./ElicitationDialog";
 import type { DialogElicitation } from "./ToolsTab";
@@ -78,6 +84,12 @@ import { buildTasksSnapshot } from "@/lib/webmcp/review-surface-snapshots";
 
 const POLL_INTERVAL_STORAGE_KEY = "mcp-inspector-tasks-poll-interval";
 const DEFAULT_POLL_INTERVAL = 3000;
+/**
+ * Debounce for re-posting the task-notification interest set. A listen filter
+ * is immutable, so every change is a close+reopen on the wire — worth batching
+ * a burst of status flips into one revision.
+ */
+const TASK_INTEREST_DEBOUNCE_MS = 300;
 
 interface TasksTabProps {
   serverConfig?: MCPServerConfig;
@@ -178,6 +190,16 @@ export function TasksTab({
   // server change and on manual refresh; a failed read leaves it unset so the
   // next tick retries.
   const registryReadDoneRef = useRef<string | null>(null);
+
+  // Signature of the last `taskIds` interest set POSTED to the subscription
+  // bridge, so an unchanged active set never re-posts (each post can be a
+  // close+reopen of the listen stream). `null` = nothing posted yet this
+  // server: an initially-empty set then leaves the panel-owned desired filter
+  // completely untouched.
+  const postedTaskInterestsRef = useRef<string | null>(null);
+  // Task ids with a notification-triggered `tasks/get` already in flight —
+  // one notification burst, ONE immediate read.
+  const notifiedRefreshInFlightRef = useRef<Set<string>>(new Set());
 
   // Collapsible sidebar state
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
@@ -830,6 +852,154 @@ export function TasksTab({
     void fetchTasks();
   }, [scheduler, recoveryReads, fetchTasks]);
 
+  // -------------------------------------------------------------------------
+  // Extension task notifications (local persistent connections only).
+  //
+  // The Tasks tab OWNS the `taskIds` member of the desired subscription
+  // interests: the ids worth being told about are exactly the ones this
+  // browser tracks — extension wire, not dismissed, not terminal. The
+  // SubscriptionStreamsPanel owns every other member, so writes here are
+  // fetch-merge-post, never replace. A delivered `notifications/tasks` is a
+  // POLL-NOW HINT and nothing more: it triggers one immediate `tasks/get`
+  // through the same observation path a scheduled poll uses, and the
+  // notification params are never written into state as truth. Polling stays
+  // fully sufficient; hosted mode (reconnect-per-op, no persistent stream)
+  // posts no `taskIds` at all.
+  // -------------------------------------------------------------------------
+
+  /** The active notification interest set, sorted for a stable signature. */
+  const notificationTaskIds = useMemo(() => {
+    if (!serverName || hosted || !isExtensionWire) return [] as string[];
+    const dismissed = getDismissedTaskIds(serverName);
+    const tracked = new Set(
+      getTrackedTasksForServer(serverName).map((t) => t.taskId)
+    );
+    return tasks
+      .filter(
+        (t) =>
+          tracked.has(t.taskId) &&
+          !dismissed.has(t.taskId) &&
+          !t.expired &&
+          !isTerminalStatus(t.status)
+      )
+      .map((t) => t.taskId)
+      .sort();
+  }, [serverName, hosted, isExtensionWire, tasks]);
+
+  // Debounced fetch-merge-post of the interest set on active-set change.
+  useEffect(() => {
+    if (!serverName || hosted || !isExtensionWire) return;
+    const signature = JSON.stringify(notificationTaskIds);
+    if (postedTaskInterestsRef.current === signature) return;
+    if (
+      postedTaskInterestsRef.current === null &&
+      notificationTaskIds.length === 0
+    ) {
+      // Nothing to declare and nothing declared before: do not touch the
+      // panel-owned desired filter at all.
+      postedTaskInterestsRef.current = signature;
+      return;
+    }
+    const timer = setTimeout(async () => {
+      try {
+        // Merge over the CURRENT bridge state so the interests the
+        // Subscriptions panel owns survive; only `taskIds` is ours to write
+        // (and to remove, once the set empties).
+        const state = await fetchSubscriptionState(serverName);
+        const { taskIds: _ours, ...panelOwned } = state.desired;
+        await setDesiredSubscriptionInterests(serverName, {
+          ...panelOwned,
+          ...(notificationTaskIds.length > 0
+            ? { taskIds: notificationTaskIds }
+            : {}),
+        });
+        postedTaskInterestsRef.current = signature;
+      } catch {
+        // Notifications only ever reduce polling latency; a failed post
+        // changes nothing about correctness. The ref stays unset, so the
+        // next active-set change (or effect re-run) retries.
+      }
+    }, TASK_INTEREST_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [serverName, hosted, isExtensionWire, notificationTaskIds]);
+
+  /**
+   * The poll-now hint's landing: ONE immediate `tasks/get` for the notified
+   * task, folded back through the scheduler exactly like a scheduled read.
+   * `tasks/get` stays the source of truth — the notification's own params are
+   * discarded.
+   */
+  const refreshNotifiedTask = useCallback(
+    async (taskId: string) => {
+      if (!serverName) return;
+      // Untracked or dismissed ids are ignored: the interest filter should
+      // exclude them already, but the server chooses what it sends.
+      const tracked = getTrackedTasksForServer(serverName).some(
+        (t) => t.taskId === taskId
+      );
+      if (!tracked) return;
+      if (getDismissedTaskIds(serverName).has(taskId)) return;
+      const inFlight = notifiedRefreshInFlightRef.current;
+      if (inFlight.has(taskId)) return;
+      inFlight.add(taskId);
+      try {
+        const envelope = await getTask(serverName, taskId);
+        const refreshed = normalizeTask(envelope.wire, envelope.task);
+        // Same fold-back as a scheduled poll: the observation reschedules the
+        // handle by its own advertised floor.
+        scheduler.recordObservations([
+          {
+            taskId: refreshed.taskId,
+            status: refreshed.status,
+            pollIntervalMs: refreshed.pollInterval,
+            ttlMs: refreshed.ttl ?? null,
+            lastUpdatedAt: refreshed.lastUpdatedAt,
+          },
+        ]);
+        setTasks((prev) =>
+          prev.some((t) => t.taskId === taskId)
+            ? prev.map((t) => (t.taskId === taskId ? refreshed : t))
+            : [refreshed, ...prev]
+        );
+      } catch (err) {
+        if (err instanceof TaskUnknownOrExpiredError) {
+          scheduler.forget([taskId]);
+          markTaskExpired(taskId, serverName);
+        }
+        // Anything else is transient; the ordinary poll loop retries on its
+        // own schedule — the hint carried no obligation.
+      } finally {
+        inFlight.delete(taskId);
+      }
+    },
+    [serverName, scheduler]
+  );
+
+  // Observe the bridge's SSE broadcast for `tasks` notifications. Local mode
+  // only: hosted connections are reconnect-per-op and never hold the
+  // persistent stream a listen rides on.
+  useEffect(() => {
+    if (!serverName || hosted || !isExtensionWire || !isActive) return;
+    // Environments without SSE (jsdom without a stub, SSR) simply keep
+    // polling; the notification channel is an optional latency win.
+    if (typeof EventSource === "undefined") return;
+    const es = new EventSource(addTokenToUrl("/api/mcp/subscriptions/stream"));
+    es.onmessage = (ev) => {
+      let event: SubscriptionBridgeEvent;
+      try {
+        event = JSON.parse(ev.data) as SubscriptionBridgeEvent;
+      } catch {
+        return;
+      }
+      if (event.type !== "subscription_notification") return;
+      if (event.serverId !== serverName) return;
+      const notification = event.notification;
+      if (notification.kind !== "tasks" || !notification.taskId) return;
+      void refreshNotifiedTask(notification.taskId);
+    };
+    return () => es.close();
+  }, [serverName, hosted, isExtensionWire, isActive, refreshNotifiedTask]);
+
   // Handle elicitation response from the dialog
   const handleElicitationResponse = useCallback(
     async (
@@ -989,6 +1159,9 @@ export function TasksTab({
     // re-arm the one recovery read for the new one.
     registryHandlesRef.current = new Map();
     registryReadDoneRef.current = null;
+    // The notification interest set is per server too: the new server's
+    // bridge has no `taskIds` posted yet, whatever the old one had.
+    postedTaskInterestsRef.current = null;
 
     const fetchCapabilities = async () => {
       try {

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.notifications.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.notifications.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * Extension task notifications in the Tasks tab (local persistent connections).
+ *
+ * The tab owns the `taskIds` member of the desired subscription interests
+ * (tracked ∧ extension wire ∧ not dismissed ∧ not terminal) and merges it over
+ * the panel-owned members via fetch-merge-post. A delivered
+ * `notifications/tasks` is a POLL-NOW HINT only: it triggers exactly one
+ * immediate `tasks/get` for that task — `tasks/get` stays the source of truth,
+ * the notification params are never written into state. Hosted mode
+ * (reconnect-per-op, no persistent stream) posts no `taskIds` and opens no
+ * stream; polling remains fully sufficient everywhere.
+ */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { MCPServerConfig } from "@mcpjam/sdk/browser";
+
+const { MockTaskUnknownOrExpiredError } = vi.hoisted(() => ({
+  MockTaskUnknownOrExpiredError: class extends Error {
+    readonly code = "task-unknown-or-expired";
+  },
+}));
+
+const mockGetTask = vi.fn();
+const mockGetTasksBatch = vi.fn();
+const mockListTasks = vi.fn();
+const mockGetTaskCapabilities = vi.fn();
+const mockGetTrackedTasksForServer = vi.fn();
+const mockGetDismissedTaskIds = vi.fn();
+const mockFetchSubscriptionState = vi.fn();
+const mockSetDesired = vi.fn();
+const mockIsHostedMode = vi.fn(() => false);
+
+vi.mock("@/lib/apis/mcp-tasks-api", () => ({
+  listTasks: (...args: unknown[]) => mockListTasks(...args),
+  getTask: (...args: unknown[]) => mockGetTask(...args),
+  getTasksBatch: (...args: unknown[]) => mockGetTasksBatch(...args),
+  getTaskResult: vi.fn(),
+  cancelTask: vi.fn(),
+  updateTask: vi.fn(),
+  getLatestProgress: vi.fn().mockResolvedValue(null),
+  getTaskCapabilities: (...args: unknown[]) => mockGetTaskCapabilities(...args),
+  TaskUnknownOrExpiredError: MockTaskUnknownOrExpiredError,
+}));
+
+vi.mock("@/lib/apis/mcp-subscriptions-api", () => ({
+  fetchSubscriptionState: (...args: unknown[]) =>
+    mockFetchSubscriptionState(...args),
+  setDesiredSubscriptionInterests: (...args: unknown[]) =>
+    mockSetDesired(...args),
+  cancelSubscriptionStream: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/mode-client", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  isHostedMode: () => mockIsHostedMode(),
+}));
+
+vi.mock("@/lib/task-tracker", () => ({
+  getTrackedTasksForServer: (...args: unknown[]) =>
+    mockGetTrackedTasksForServer(...args),
+  getTrackedTaskById: vi.fn().mockReturnValue(null),
+  markTaskExpired: vi.fn(),
+  clearTrackedTasksForServer: vi.fn(),
+  getDismissedTaskIds: (...args: unknown[]) => mockGetDismissedTaskIds(...args),
+  dismissTasksForServer: vi.fn(),
+  recordTaskObservation: vi.fn(),
+  recordTaskObservations: vi.fn(),
+  getTrackedTaskSchedule: vi.fn().mockReturnValue(undefined),
+  getTrackedTaskRestoreStates: vi.fn().mockReturnValue(new Map()),
+  taskIdentity: (t: {
+    serverId: string;
+    wire: string;
+    taskId: string;
+    scope?: string;
+  }) => `${t.scope ?? ""}\u0000${t.serverId}\u0000${t.wire}\u0000${t.taskId}`,
+  recordRespondedInputKeys: vi.fn(),
+  getRespondedInputKeys: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("@/hooks/use-task-elicitation", () => ({
+  useTaskElicitation: () => ({
+    elicitation: null,
+    isResponding: false,
+    respond: vi.fn(),
+  }),
+}));
+
+vi.mock("../ElicitationDialog", () => ({ ElicitationDialog: () => null }));
+
+vi.mock("../ui/three-panel-layout", () => ({
+  ThreePanelLayout: ({
+    sidebar,
+    content,
+  }: {
+    sidebar: React.ReactNode;
+    content: React.ReactNode;
+  }) => (
+    <div>
+      <div data-testid="tasks-sidebar">{sidebar}</div>
+      <div data-testid="tasks-content">{content}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/json-editor", () => ({
+  JsonEditor: (props: any) => (
+    <div data-testid="json-editor">{JSON.stringify(props.value)}</div>
+  ),
+}));
+
+import { TasksTab } from "../TasksTab";
+
+const SERVER = "test-server";
+
+const serverConfig = () =>
+  ({
+    transportType: "stdio",
+    command: "node",
+    args: ["server.js"],
+  }) as MCPServerConfig;
+
+const trackedWorking = (taskId: string) => ({
+  taskId,
+  serverId: SERVER,
+  wire: "extension" as const,
+  createdAt: "2026-07-28T00:00:00.000Z",
+  status: "working",
+});
+
+const workingTask = (taskId: string) => ({
+  taskId,
+  status: "working",
+  createdAt: "2026-07-28T00:00:00.000Z",
+  lastUpdatedAt: "2026-07-28T00:01:00.000Z",
+  ttlMs: null,
+});
+
+/** jsdom has no EventSource; the tab treats an absent one as "keep polling". */
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  closed = false;
+  constructor(public readonly url: string) {
+    FakeEventSource.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+function emit(event: unknown) {
+  for (const es of FakeEventSource.instances) {
+    if (!es.closed) es.onmessage?.({ data: JSON.stringify(event) });
+  }
+}
+
+const tasksNotification = (taskId: string) => ({
+  type: "subscription_notification",
+  serverId: SERVER,
+  notification: {
+    method: "notifications/tasks",
+    kind: "tasks",
+    taskId,
+    localSubscriptionId: "local-1",
+    at: Date.now(),
+  },
+});
+
+const bridgeState = (desired: Record<string, unknown>) => ({
+  serverId: SERVER,
+  era: "modern",
+  supportsListen: true,
+  supportsTaskDeclaredListen: true,
+  desired,
+  streams: [],
+  notifications: [],
+  rejectedNotifications: [],
+});
+
+describe("TasksTab extension task notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    FakeEventSource.instances = [];
+    Object.assign(globalThis, { EventSource: FakeEventSource });
+    mockIsHostedMode.mockReturnValue(false);
+    mockGetTaskCapabilities.mockResolvedValue({
+      wire: "extension",
+      toolCalls: true,
+      list: false,
+      cancel: true,
+      update: true,
+      inlineResult: true,
+    });
+    mockGetTrackedTasksForServer.mockReturnValue([trackedWorking("t-1")]);
+    mockGetDismissedTaskIds.mockReturnValue(new Set());
+    mockGetTask.mockImplementation(async (_server: string, taskId: string) => ({
+      wire: "extension",
+      task: workingTask(taskId),
+    }));
+    // Panel-owned interests already on the bridge: the tab must MERGE its
+    // taskIds over them, never replace them.
+    mockFetchSubscriptionState.mockResolvedValue(
+      bridgeState({ toolsListChanged: true }),
+    );
+    mockSetDesired.mockResolvedValue(bridgeState({ toolsListChanged: true }));
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).EventSource;
+  });
+
+  it("posts the active tracked set as taskIds, merged over panel-owned interests", async () => {
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+
+    await waitFor(() => expect(mockSetDesired).toHaveBeenCalledTimes(1));
+    expect(mockSetDesired).toHaveBeenCalledWith(SERVER, {
+      toolsListChanged: true,
+      taskIds: ["t-1"],
+    });
+    // Fetch-merge-post: the current bridge state was read first.
+    expect(mockFetchSubscriptionState).toHaveBeenCalledWith(SERVER);
+  });
+
+  it("does not re-post an unchanged active set", async () => {
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+
+    await waitFor(() => expect(mockSetDesired).toHaveBeenCalledTimes(1));
+    // Give any queued debounce a chance to fire wrongly.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    });
+    expect(mockSetDesired).toHaveBeenCalledTimes(1);
+  });
+
+  it("a tasks notification triggers exactly one immediate tasks/get for that task", async () => {
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+    await waitFor(() => {
+      expect(screen.getByText("t-1")).toBeInTheDocument();
+    });
+    await waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const baseline = mockGetTask.mock.calls.length;
+
+    await act(async () => {
+      emit(tasksNotification("t-1"));
+    });
+
+    await waitFor(() => {
+      expect(mockGetTask.mock.calls.length).toBe(baseline + 1);
+    });
+    expect(mockGetTask).toHaveBeenLastCalledWith(SERVER, "t-1");
+    // One notification, ONE read — nothing else trailing behind it.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+    expect(mockGetTask.mock.calls.length).toBe(baseline + 1);
+  });
+
+  it("ignores a notification for a task this browser does not track", async () => {
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+    await waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const baseline = mockGetTask.mock.calls.length;
+
+    await act(async () => {
+      emit(tasksNotification("someone-elses-task"));
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    });
+
+    expect(mockGetTask.mock.calls.length).toBe(baseline);
+  });
+
+  it("hosted mode posts no taskIds and opens no notification stream", async () => {
+    mockIsHostedMode.mockReturnValue(true);
+    mockListTasks.mockResolvedValue({
+      tasks: [],
+      wire: "extension",
+      registryTasks: [],
+    });
+    mockGetTasksBatch.mockResolvedValue({ wire: "extension", tasks: [] });
+
+    render(<TasksTab serverConfig={serverConfig()} serverName={SERVER} />);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    });
+    expect(mockSetDesired).not.toHaveBeenCalled();
+    expect(mockFetchSubscriptionState).not.toHaveBeenCalled();
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+});

--- a/mcpjam-inspector/client/src/components/subscriptions/SubscriptionStreamsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/subscriptions/SubscriptionStreamsPanel.tsx
@@ -181,6 +181,13 @@ export function SubscriptionStreamsPanel({
         <Badge variant="secondary" data-testid="subscription-era">
           {era === "modern" ? "subscriptions/listen" : "resources/subscribe"}
         </Badge>
+        {/* Observation only: the Tasks tab owns the `taskIds` interest. When
+            absent, task state is polled — which is always sufficient. */}
+        {server?.supportsTaskDeclaredListen && (
+          <Badge variant="outline" data-testid="task-notifications-supported">
+            task notifications
+          </Badge>
+        )}
         {busy && <span className="text-muted-foreground">Updating…</span>}
       </div>
 

--- a/mcpjam-inspector/client/src/components/subscriptions/__tests__/SubscriptionStreamsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/subscriptions/__tests__/SubscriptionStreamsPanel.test.tsx
@@ -75,6 +75,7 @@ function serverState(
     serverId: "srv",
     era: "modern",
     supportsListen: true,
+    supportsTaskDeclaredListen: false,
     desired: { toolsListChanged: true, promptsListChanged: true },
     streams: [stream()],
     notifications: [],

--- a/mcpjam-inspector/client/src/components/subscriptions/subscription-stream-state.ts
+++ b/mcpjam-inspector/client/src/components/subscriptions/subscription-stream-state.ts
@@ -65,6 +65,7 @@ export function formatFilter(filter?: SubscriptionFilterView): string {
   if (filter.promptsListChanged) parts.push("prompts/list_changed");
   if (filter.resourcesListChanged) parts.push("resources/list_changed");
   for (const uri of filter.resourceSubscriptions ?? []) parts.push(uri);
+  for (const taskId of filter.taskIds ?? []) parts.push(`task:${taskId}`);
   return parts.length ? parts.join(", ") : "(empty)";
 }
 
@@ -85,10 +86,18 @@ export function unacknowledgedInterests(
   stream: SubscriptionStreamView,
 ): string[] {
   return stream.rejectedInterests.map((rejection) => {
-    const what = rejection.uri ?? rejection.interest;
-    return rejection.reason === "capability-not-advertised"
-      ? `${what} (not advertised)`
-      : `${what} (not acknowledged)`;
+    const what = rejection.uri ?? rejection.taskId ?? rejection.interest;
+    switch (rejection.reason) {
+      case "capability-not-advertised":
+        return `${what} (not advertised)`;
+      // The connection cannot put the tasks declaration on the listen, so the
+      // task-id selection was dropped rather than sent undeclared (-32003).
+      // Polling continues — nothing is lost but latency.
+      case "tasks-declaration-unavailable":
+        return `${what} (cannot declare tasks extension; polling instead)`;
+      default:
+        return `${what} (not acknowledged)`;
+    }
   });
 }
 
@@ -203,6 +212,10 @@ export function applySubscriptionEvent(
         serverId,
         era: event.era,
         supportsListen: event.era === "modern",
+        // A placeholder built from a stream event alone cannot know the
+        // declared-listen probe; false is the safe default until a snapshot
+        // or REST response replaces it.
+        supportsTaskDeclaredListen: false,
         desired: {},
         streams: [],
         notifications: [],

--- a/mcpjam-inspector/server/routes/mcp/__tests__/subscriptions.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/subscriptions.test.ts
@@ -29,6 +29,8 @@ type FakeHandle = {
 
 function modernClient(options?: {
   honor?: (filter: SubscriptionFilterShape) => SubscriptionFilterShape;
+  /** Advertise the SEP-2663 tasks extension capability. */
+  tasksExtension?: boolean;
 }) {
   const handlers = new Map<string, (n: any) => void>();
   const opened: SubscriptionFilterShape[] = [];
@@ -43,6 +45,9 @@ function modernClient(options?: {
       tools: { listChanged: true },
       prompts: { listChanged: true },
       resources: { listChanged: true, subscribe: true },
+      ...(options?.tasksExtension
+        ? { extensions: { "io.modelcontextprotocol/tasks": {} } }
+        : {}),
     }),
     getProtocolEra: () => "modern" as const,
     setNotificationHandler: (method: string, handler: (n: any) => void) => {
@@ -50,23 +55,26 @@ function modernClient(options?: {
     },
     subscribeResource: vi.fn(async () => ({})),
     unsubscribeResource: vi.fn(async () => ({})),
-    listen: vi.fn(async (filter: SubscriptionFilterShape) => {
-      opened.push(filter);
-      let settle!: (r: "local" | "graceful" | "remote") => void;
-      const closed = new Promise<"local" | "graceful" | "remote">((resolve) => {
-        settle = resolve;
-      });
-      const handle: FakeHandle = {
-        honoredFilter: options?.honor ? options.honor(filter) : filter,
-        close: async () => settle("local"),
-        closed,
-        subscriptionId: `sub-${++seq}`,
-      };
-      handles.push({ handle, settle });
-      return handle;
-    }),
+    listen: vi.fn(async (filter: SubscriptionFilterShape) => open(filter)),
   };
-  return { client, opened, handles, handlers };
+  // Shared handle machinery: the ordinary listen and the manager's
+  // declared-listen opener produce structurally identical handles.
+  function open(filter: SubscriptionFilterShape): FakeHandle {
+    opened.push(filter);
+    let settle!: (r: "local" | "graceful" | "remote") => void;
+    const closed = new Promise<"local" | "graceful" | "remote">((resolve) => {
+      settle = resolve;
+    });
+    const handle: FakeHandle = {
+      honoredFilter: options?.honor ? options.honor(filter) : filter,
+      close: async () => settle("local"),
+      closed,
+      subscriptionId: `sub-${++seq}`,
+    };
+    handles.push({ handle, settle });
+    return handle;
+  }
+  return { client, opened, handles, handlers, open };
 }
 
 function legacyClient() {
@@ -83,9 +91,29 @@ function legacyClient() {
   return { client };
 }
 
-function appFor(client: unknown) {
+function appFor(
+  client: unknown,
+  options?: {
+    /** The manager's probe; the route installs the opener only when true. */
+    supportsTaskDeclaredListen?: boolean;
+    listenWithTasksDeclaration?: (
+      filter: SubscriptionFilterShape,
+    ) => Promise<FakeHandle>;
+  },
+) {
   const manager = {
     getManagedClient: () => client,
+    supportsTaskDeclaredListen: vi.fn(
+      () => options?.supportsTaskDeclaredListen ?? false,
+    ),
+    listenWithTasksDeclaration: vi.fn(
+      async (_serverId: string, filter: SubscriptionFilterShape) => {
+        if (!options?.listenWithTasksDeclaration) {
+          throw new Error("declared listen not wired in this test");
+        }
+        return options.listenWithTasksDeclaration(filter);
+      },
+    ),
   } as any;
   resetSubscriptionRegistry(manager);
   const app = new Hono();
@@ -358,5 +386,121 @@ describe("subscription bridge validation", () => {
       body: JSON.stringify({ serverId: "srv" }),
     });
     expect(res.status).toBe(404);
+  });
+});
+
+describe("task-filtered notifications (extension wire, B2)", () => {
+  it("round-trips desired taskIds un-stripped into a DECLARED listen", async () => {
+    const { client, opened } = modernClient({ tasksExtension: true });
+    const { app, manager } = appFor(client, {
+      supportsTaskDeclaredListen: true,
+      // The declared opener rides the same handle machinery as plain listen;
+      // in production it is the manager's listenWithTasksDeclaration.
+      listenWithTasksDeclaration: async (filter) =>
+        (await client.listen(filter)) as FakeHandle,
+    });
+
+    const state = await postDesired(app, {
+      toolsListChanged: true,
+      taskIds: ["task-1", "task-2"],
+    });
+
+    // The filter reached the wire through the DECLARED opener, verbatim.
+    expect(manager.listenWithTasksDeclaration).toHaveBeenCalledTimes(1);
+    expect(manager.listenWithTasksDeclaration).toHaveBeenCalledWith("srv", {
+      toolsListChanged: true,
+      taskIds: ["task-1", "task-2"],
+    });
+    expect(opened[0].taskIds).toEqual(["task-1", "task-2"]);
+
+    expect(state.supportsTaskDeclaredListen).toBe(true);
+    expect(state.desired.taskIds).toEqual(["task-1", "task-2"]);
+    expect(state.streams).toHaveLength(1);
+    expect(state.streams[0].status).toBe("active");
+    expect(state.streams[0].requestedFilter.taskIds).toEqual([
+      "task-1",
+      "task-2",
+    ]);
+    expect(state.streams[0].acknowledgedFilter?.taskIds).toEqual([
+      "task-1",
+      "task-2",
+    ]);
+  });
+
+  it("omits the declared-listen method when the probe fails: taskIds dropped, not sent", async () => {
+    // Extension advertised by the server, but the CONNECTION cannot declare
+    // (probe false) — the port must not carry the method at all, so the
+    // coordinator records the drop and never sends an undeclared filter.
+    const { client } = modernClient({ tasksExtension: true });
+    const { app, manager } = appFor(client, {
+      supportsTaskDeclaredListen: false,
+    });
+
+    const state = await postDesired(app, { taskIds: ["task-1"] });
+
+    expect(manager.listenWithTasksDeclaration).not.toHaveBeenCalled();
+    expect(client.listen).not.toHaveBeenCalled();
+    expect(state.supportsTaskDeclaredListen).toBe(false);
+    // The refusal is a first-class fact: an unopened stream record carrying
+    // the tasks-declaration-unavailable rejection, so the UI can explain why
+    // notifications never arrive while polling continues.
+    expect(state.streams).toHaveLength(1);
+    expect(state.streams[0].rejectedInterests).toContainEqual({
+      interest: "tasks",
+      taskId: "task-1",
+      reason: "tasks-declaration-unavailable",
+    });
+  });
+
+  it("forwards the taskId on a delivered notifications/tasks broadcast", async () => {
+    const { client, handlers } = modernClient({ tasksExtension: true });
+    const { app } = appFor(client, {
+      supportsTaskDeclaredListen: true,
+      listenWithTasksDeclaration: async (filter) =>
+        (await client.listen(filter)) as FakeHandle,
+    });
+    await postDesired(app, { taskIds: ["task-1"] });
+
+    const events = await readEvents(app, 2, async () => {
+      handlers.get("notifications/tasks")?.({
+        method: "notifications/tasks",
+        params: {
+          taskId: "task-1",
+          status: "working",
+          createdAt: "2026-07-28T00:00:00Z",
+          lastUpdatedAt: "2026-07-28T00:00:01Z",
+          _meta: { "io.modelcontextprotocol/subscriptionId": "sub-1" },
+        },
+      });
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    const delivered = events.find(
+      (e) => e.type === "subscription_notification",
+    );
+    if (delivered?.type !== "subscription_notification") throw new Error("bad");
+    expect(delivered.notification.kind).toBe("tasks");
+    // The taskId is the poll-now hint's target; the DetailedTask params are
+    // NOT forwarded as state — tasks/get stays the source of truth.
+    expect(delivered.notification.taskId).toBe("task-1");
+  });
+
+  it("normalizeDesired keeps only string task ids and the state view carries the probe", async () => {
+    const { client } = modernClient({ tasksExtension: true });
+    const { app, manager } = appFor(client, {
+      supportsTaskDeclaredListen: true,
+      listenWithTasksDeclaration: async (filter) =>
+        (await client.listen(filter)) as FakeHandle,
+    });
+
+    const state = await postDesired(app, {
+      taskIds: ["task-1", 42, null, "task-2"],
+    });
+
+    expect(manager.listenWithTasksDeclaration).toHaveBeenCalledWith("srv", {
+      taskIds: ["task-1", "task-2"],
+    });
+    expect(state.desired.taskIds).toEqual(["task-1", "task-2"]);
+    expect(state.supportsTaskDeclaredListen).toBe(true);
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/subscriptions.ts
+++ b/mcpjam-inspector/server/routes/mcp/subscriptions.ts
@@ -71,6 +71,8 @@ type ServerEntry = {
   serverId: string;
   coordinator: SubscriptionCoordinator;
   supportsListen: boolean;
+  /** Computed once per entry — the manager's probe on the live connection. */
+  supportsTaskDeclaredListen: boolean;
   desired: SubscriptionDesiredInterestsView;
   /** Local stream id → latest view. Closed streams are retained for History. */
   streams: Map<string, SubscriptionStreamView>;
@@ -126,6 +128,9 @@ function toNotificationView(
     method: event.method,
     kind: event.kind,
     ...(event.uri ? { uri: event.uri } : {}),
+    // The poll-now hint's target: the browser refreshes this task via
+    // `tasks/get` — the notification params are never treated as state.
+    ...(event.taskId ? { taskId: event.taskId } : {}),
     ...(event.subscriptionId ? { subscriptionId: event.subscriptionId } : {}),
     localSubscriptionId: event.localSubscriptionId,
     at: event.at,
@@ -153,11 +158,52 @@ export function toServerStateView(
     serverId: entry.serverId,
     era: entry.coordinator.era,
     supportsListen: entry.supportsListen,
+    supportsTaskDeclaredListen: entry.supportsTaskDeclaredListen,
     desired: { ...entry.desired },
     streams: [...entry.streams.values()],
     notifications: [...entry.notifications],
     rejectedNotifications: [...entry.rejectedNotifications],
   };
+}
+
+/**
+ * The coordinator's port over the managed client — explicit delegation, not a
+ * cast, because the port's OPTIONAL methods are semantic: on
+ * `SubscriptionClientPort`, availability is method PRESENCE. In particular
+ * `listenWithTasksDeclaration` is installed ONLY when the manager's probe
+ * passes; when it is absent the coordinator drops the `taskIds` selection,
+ * records it as `tasks-declaration-unavailable`, and polling (always
+ * sufficient) remains the only channel. A cast would have advertised a method
+ * the connection cannot honor — or hidden one it could.
+ */
+function buildSubscriptionPort(
+  manager: MCPClientManager,
+  serverId: string,
+  client: NonNullable<ReturnType<MCPClientManager["getManagedClient"]>>,
+  supportsTaskDeclaredListen: boolean,
+): SubscriptionClientPort {
+  const port: SubscriptionClientPort = {
+    getServerCapabilities: () => client.getServerCapabilities(),
+    getProtocolEra: () => client.getProtocolEra?.(),
+    setNotificationHandler: (method, handler) =>
+      client.setNotificationHandler(
+        method as Parameters<typeof client.setNotificationHandler>[0],
+        handler as Parameters<typeof client.setNotificationHandler>[1],
+      ),
+    subscribeResource: (params) => client.subscribeResource(params),
+    unsubscribeResource: (params) => client.unsubscribeResource(params),
+    ...(typeof client.listen === "function"
+      ? {
+          listen: (filter: Parameters<NonNullable<typeof client.listen>>[0]) =>
+            client.listen!(filter),
+        }
+      : {}),
+  };
+  if (supportsTaskDeclaredListen) {
+    port.listenWithTasksDeclaration = (filter) =>
+      manager.listenWithTasksDeclaration(serverId, filter);
+  }
+  return port;
 }
 
 /**
@@ -178,11 +224,14 @@ export function getOrCreateEntry(
   const client = manager.getManagedClient(serverId);
   if (!client) return undefined;
 
+  const supportsTaskDeclaredListen =
+    manager.supportsTaskDeclaredListen(serverId);
   const entry: ServerEntry = {
     serverId,
     // Assigned below; the coordinator's callbacks close over `entry`.
     coordinator: undefined as unknown as SubscriptionCoordinator,
     supportsListen: typeof client.listen === "function",
+    supportsTaskDeclaredListen,
     desired: {},
     streams: new Map(),
     notifications: [],
@@ -190,7 +239,12 @@ export function getOrCreateEntry(
   };
 
   entry.coordinator = new SubscriptionCoordinator({
-    client: client as unknown as SubscriptionClientPort,
+    client: buildSubscriptionPort(
+      manager,
+      serverId,
+      client,
+      supportsTaskDeclaredListen,
+    ),
     onStreamChange: (stream) => {
       const view = toStreamView(stream);
       entry.streams.set(view.localId, view);
@@ -242,6 +296,8 @@ function normalizeDesired(
   const raw = input as Record<string, unknown>;
   const uris = raw.resourceUris;
   if (uris !== undefined && !Array.isArray(uris)) return undefined;
+  const taskIds = raw.taskIds;
+  if (taskIds !== undefined && !Array.isArray(taskIds)) return undefined;
   return {
     ...(raw.toolsListChanged !== undefined
       ? { toolsListChanged: Boolean(raw.toolsListChanged) }
@@ -254,6 +310,14 @@ function normalizeDesired(
       : {}),
     ...(uris
       ? { resourceUris: uris.filter((u): u is string => typeof u === "string") }
+      : {}),
+    // Not stripped: `taskIds` is the Tasks tab's slice of the desired filter
+    // (extension `notifications/tasks`). The coordinator gates it on the
+    // extension capability and the declared-listen opener.
+    ...(taskIds
+      ? {
+          taskIds: taskIds.filter((t): t is string => typeof t === "string"),
+        }
       : {}),
   };
 }

--- a/mcpjam-inspector/shared/subscription-bridge.ts
+++ b/mcpjam-inspector/shared/subscription-bridge.ts
@@ -35,19 +35,34 @@ export type SubscriptionInterestKindView =
   | "tools-list-changed"
   | "prompts-list-changed"
   | "resources-list-changed"
-  | "resource-updated";
+  | "resource-updated"
+  /** `notifications/tasks` (SEP-2663 extension; modern era only). */
+  | "tasks";
 
 export interface SubscriptionFilterView {
   toolsListChanged?: boolean;
   promptsListChanged?: boolean;
   resourcesListChanged?: boolean;
   resourceSubscriptions?: string[];
+  /** Task ids watched for `notifications/tasks` (extension wire only). */
+  taskIds?: string[];
 }
 
 export interface SubscriptionInterestRejectionView {
   interest: SubscriptionInterestKindView;
   uri?: string;
-  reason: "capability-not-advertised" | "not-acknowledged-by-server";
+  /** Present for `tasks` rejections. */
+  taskId?: string;
+  reason:
+    | "capability-not-advertised"
+    | "not-acknowledged-by-server"
+    /**
+     * A task-filtered listen was wanted but this connection cannot put the
+     * extension's per-request eligibility declaration on the listen request
+     * (sending it undeclared would earn `-32003`). Polling continues — a
+     * notification is only ever a poll-now hint, so the handle is not lost.
+     */
+    | "tasks-declaration-unavailable";
 }
 
 export interface SubscriptionStreamView {
@@ -72,12 +87,20 @@ export interface SubscriptionDesiredInterestsView {
   promptsListChanged?: boolean;
   resourcesListChanged?: boolean;
   resourceUris?: string[];
+  /**
+   * Task ids to watch for `notifications/tasks`. Extension wire only; the
+   * Tasks tab owns this member (tracked ∧ not dismissed ∧ not terminal) while
+   * the Subscriptions panel owns the rest — writers merge, never replace.
+   */
+  taskIds?: string[];
 }
 
 export interface SubscriptionNotificationView {
   method: string;
   kind: SubscriptionInterestKindView;
   uri?: string;
+  /** Task id for `tasks` notifications — the poll-now hint's target. */
+  taskId?: string;
   subscriptionId?: string;
   localSubscriptionId: string;
   at: number;
@@ -101,6 +124,13 @@ export interface SubscriptionServerStateView {
   era: SubscriptionEra;
   /** Whether the connection can open a modern `subscriptions/listen` stream. */
   supportsListen: boolean;
+  /**
+   * Whether a task-filtered listen can go out DECLARED (extension tasks wire ∧
+   * listen ∧ the declaration seam). When false, posting `taskIds` records a
+   * `tasks-declaration-unavailable` rejection and polling stays the only
+   * channel — which is always sufficient.
+   */
+  supportsTaskDeclaredListen: boolean;
   desired: SubscriptionDesiredInterestsView;
   streams: SubscriptionStreamView[];
   notifications: SubscriptionNotificationView[];

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -125,11 +125,17 @@ import {
 } from "./tasks-dispatch.js";
 import {
   TasksExtNotificationMethod,
+  canOpenTaskDeclaredListen,
   cancelTaskExt,
   getTaskExt,
+  openTaskDeclaredListen,
   updateTaskExt,
   withTasksExtensionDeclaration,
 } from "./tasks-ext.js";
+import type {
+  McpSubscriptionHandle,
+  SubscriptionFilterShape,
+} from "./subscription-coordinator.js";
 import {
   assertCreateTaskExtResult,
   parseTaskExtNotificationParams,
@@ -1697,6 +1703,67 @@ export class MCPClientManager {
       },
       taskId
     );
+  }
+
+  /**
+   * Opens a task-filtered `subscriptions/listen` carrying the extension's
+   * per-request eligibility declaration (SEP-2663). A non-declaring
+   * task-filtered listen MUST be answered `-32003`, so this is the ONLY way a
+   * `taskIds` filter may reach the wire.
+   *
+   * Port contract: on `SubscriptionClientPort`, availability is expressed by
+   * method PRESENCE — callers probe {@link supportsTaskDeclaredListen} and
+   * install this method onto the port only when it answers true. A defined
+   * method must therefore never answer `undefined`; when the underlying seam
+   * is unavailable despite the probe, this throws instead of silently sending
+   * nothing.
+   *
+   * `TasksExtListenMetaSeamError` propagates deliberately: the coordinator
+   * records the failed open on the stream record and polling continues —
+   * task notifications are OPTIONAL, so nothing is lost but latency.
+   */
+  async listenWithTasksDeclaration(
+    serverId: string,
+    filter: SubscriptionFilterShape
+  ): Promise<McpSubscriptionHandle> {
+    await this.ensureConnected(serverId);
+    const client = this.getClientOrThrow(serverId);
+    this.assertExtensionTasksWire(
+      serverId,
+      "a task-filtered subscriptions/listen"
+    );
+    const handle = await openTaskDeclaredListen(
+      {
+        client,
+        declaredCapabilities: this.declaredCapabilitiesFor(serverId),
+      },
+      filter as Record<string, unknown>
+    );
+    if (handle === undefined) {
+      throw new Error(
+        `Server "${serverId}"'s connection cannot open a task-declared ` +
+          `subscriptions/listen (no listen method, or no upstream client ` +
+          `behind the managed client). Probe supportsTaskDeclaredListen() ` +
+          `before calling; polling via tasks/get remains sufficient.`
+      );
+    }
+    return handle as McpSubscriptionHandle;
+  }
+
+  /**
+   * Whether {@link listenWithTasksDeclaration} can put a declared,
+   * task-filtered listen on this connection's wire: extension tasks wire ∧
+   * the client can listen ∧ the listen-meta seam target resolves. Consumers
+   * building a `SubscriptionClientPort` install the opener onto the port only
+   * when this answers true — absence of the method IS the coordinator's signal
+   * to drop `taskIds` (recording `tasks-declaration-unavailable`) and keep
+   * polling.
+   */
+  supportsTaskDeclaredListen(serverId: string): boolean {
+    if (this.getTasksWire(serverId) !== "extension") return false;
+    const client = this.liveClientStates.get(serverId)?.client;
+    if (!client) return false;
+    return canOpenTaskDeclaredListen(client);
   }
 
   private declaredCapabilitiesFor(

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -183,6 +183,7 @@ export {
   getTaskExt,
   updateTaskExt,
   cancelTaskExt,
+  canOpenTaskDeclaredListen,
   openTaskDeclaredListen,
 } from "./tasks-ext.js";
 export type {

--- a/sdk/src/mcp-client-manager/tasks-ext.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext.ts
@@ -217,18 +217,39 @@ async function sendTasksExtRequest(
  * on purpose: a silent fallback would hide a client bump that broke the
  * declaration, and the caller can catch it to degrade to polling deliberately.
  */
+/**
+ * Whether {@link openTaskDeclaredListen} would have a wire to ride on this
+ * client: the managed client exposes `listen`, AND an upstream `Client` with
+ * the outbound-envelope seam is reachable behind it. A test double with no
+ * upstream client probes false — it has no envelope to widen, so a declared
+ * listen through it could never carry the declaration.
+ *
+ * This is the SAME availability check `openTaskDeclaredListen` performs before
+ * returning `undefined`, extracted so callers that install the opener onto a
+ * port (where availability is expressed by method PRESENCE, per
+ * `SubscriptionClientPort.listenWithTasksDeclaration`) probe the one shared
+ * predicate instead of re-deriving it.
+ */
+export function canOpenTaskDeclaredListen(client: ManagedMcpClient): boolean {
+  return (
+    typeof (client as { listen?: unknown }).listen === "function" &&
+    resolveListenMetaTarget(client as unknown as object) !== undefined
+  );
+}
+
 export async function openTaskDeclaredListen(
   ctx: Omit<TasksExtCallContext, "options">,
   filter: Record<string, unknown>
 ): Promise<unknown | undefined> {
+  // One shared availability predicate with the callers that probe before
+  // installing the opener onto a port — see `canOpenTaskDeclaredListen`.
+  if (!canOpenTaskDeclaredListen(ctx.client)) return undefined;
   const listen = (
     ctx.client as {
-      listen?: (filter: unknown, options?: unknown) => Promise<unknown>;
+      listen: (filter: unknown, options?: unknown) => Promise<unknown>;
     }
   ).listen;
-  if (typeof listen !== "function") return undefined;
-  const target = resolveListenMetaTarget(ctx.client as unknown as object);
-  if (target === undefined) return undefined;
+  const target = resolveListenMetaTarget(ctx.client as unknown as object)!;
   return withTasksExtensionEnvelope(
     target,
     ctx.declaredCapabilities,

--- a/sdk/tests/extension-tasks-wire.integration.test.ts
+++ b/sdk/tests/extension-tasks-wire.integration.test.ts
@@ -841,3 +841,53 @@ describe("tasks extension wire — resultType on tasks/* results", () => {
     expect((await wire.cancel(taskId)).result).toEqual({});
   });
 });
+
+describe("tasks extension wire — declared subscriptions/listen (real client)", () => {
+  it("puts the eligibility declaration on a task-filtered listen", async () => {
+    const fixture = await serve();
+    const manager = await connect(fixture.url);
+
+    // The probe agrees with what the open below relies on: extension wire,
+    // a listen-capable client, and the listen-meta seam behind it.
+    expect(manager.supportsTaskDeclaredListen(SERVER_ID)).toBe(true);
+
+    // The fixture is POST-only: it validates and acknowledges the listen
+    // request but can never deliver notifications (nor the modern ack
+    // notification), so the returned promise may not settle usefully.
+    // What is pinned here is the WIRE: the request that reached the server
+    // carried the declaration. The fixture answers -32003 to an UNDECLARED
+    // task-filtered listen (asserted above), so the recorded params are the
+    // exact complement of that case.
+    const pending = manager
+      .listenWithTasksDeclaration(SERVER_ID, { taskIds: ["ext-task-1"] })
+      .catch(() => undefined);
+
+    const deadline = Date.now() + 5_000;
+    while (
+      !fixture.received.some((r) => r.method === "subscriptions/listen") &&
+      Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    const listen = fixture.received.find(
+      (r) => r.method === "subscriptions/listen"
+    );
+    expect(listen, "listen request reached the fixture").toBeDefined();
+    expect(
+      (listen!.params?.notifications as { taskIds?: string[] })?.taskIds
+    ).toEqual(["ext-task-1"]);
+    const declared = (
+      listen!.params?._meta as Record<string, unknown> | undefined
+    )?.["io.modelcontextprotocol/clientCapabilities"] as
+      | { extensions?: Record<string, unknown> }
+      | undefined;
+    expect(declared?.extensions?.[TASKS_EXTENSION_ID]).toEqual({});
+
+    // Bounded settle so a hanging listen cannot leak past the test body; the
+    // afterEach disconnect tears the connection down either way.
+    await Promise.race([
+      pending,
+      new Promise((resolve) => setTimeout(resolve, 250)),
+    ]);
+  });
+});

--- a/sdk/tests/tasks-extension-wire.test.ts
+++ b/sdk/tests/tasks-extension-wire.test.ts
@@ -1019,3 +1019,138 @@ describe("MRTR composition (one result state machine)", () => {
     expect(sent[1].params.requestState).toBe("state-1");
   });
 });
+
+describe("task-declared subscriptions/listen (manager)", () => {
+  /**
+   * `seedManager`'s client has no `listen` and no upstream envelope member.
+   * These helpers add the two facts the declared-listen path keys on.
+   */
+  function seedListenManager(options: {
+    protocolVersion?: string;
+    capabilities?: Record<string, unknown>;
+    withListen?: boolean;
+    withEnvelope?: boolean;
+    declaredCapabilities?: Record<string, unknown>;
+  }) {
+    const seeded = seedManager({
+      protocolVersion: options.protocolVersion ?? "2026-07-28",
+      capabilities: options.capabilities ?? EXT_CAPS,
+      declaredCapabilities: options.declaredCapabilities,
+    });
+    const client = (seeded.manager as any).liveClientStates.get(
+      seeded.serverId
+    ).client as Record<string, unknown>;
+
+    const observedEnvelopes: Array<Record<string, unknown> | undefined> = [];
+    const listenedFilters: Array<Record<string, unknown>> = [];
+    const handle = {
+      honoredFilter: { taskIds: ["t-1"] },
+      close: vi.fn(async () => {}),
+      closed: new Promise<never>(() => {}),
+    };
+
+    if (options.withEnvelope) {
+      client._outboundMetaEnvelope = function (): Record<string, unknown> {
+        return { existing: "envelope-key" };
+      };
+    }
+    if (options.withListen) {
+      client.listen = function (filter: Record<string, unknown>) {
+        listenedFilters.push(filter);
+        // Mirror upstream: the envelope is read SYNCHRONOUSLY while building
+        // the request, which is the window the per-call shadow covers.
+        const envelope = (
+          this as { _outboundMetaEnvelope?: () => Record<string, unknown> }
+        )._outboundMetaEnvelope?.();
+        observedEnvelopes.push(envelope);
+        return Promise.resolve(handle);
+      };
+    }
+    return { ...seeded, observedEnvelopes, listenedFilters, handle };
+  }
+
+  it("refuses to send a task-filtered listen on a non-extension wire", async () => {
+    const { manager, serverId } = seedListenManager({
+      protocolVersion: "2025-11-25",
+      capabilities: LEGACY_CAPS,
+      withListen: true,
+      withEnvelope: true,
+    });
+    await expect(
+      manager.listenWithTasksDeclaration(serverId, { taskIds: ["t-1"] })
+    ).rejects.toBeInstanceOf(MCPTasksWireError);
+  });
+
+  it("throws (never resolves undefined) when the connection cannot declare", async () => {
+    // Port contract: availability is method PRESENCE on the port, so a
+    // defined opener answering `undefined` would read as "opened nothing,
+    // successfully" — it must throw instead.
+    const { manager, serverId } = seedListenManager({ withListen: false });
+    await expect(
+      manager.listenWithTasksDeclaration(serverId, { taskIds: ["t-1"] })
+    ).rejects.toThrow(/cannot open a task-declared/);
+  });
+
+  it("puts the tasks declaration on the listen envelope and hands back the handle", async () => {
+    const { manager, serverId, observedEnvelopes, listenedFilters, handle } =
+      seedListenManager({
+        withListen: true,
+        withEnvelope: true,
+        declaredCapabilities: { roots: { listChanged: true } },
+      });
+
+    const opened = await manager.listenWithTasksDeclaration(serverId, {
+      taskIds: ["t-1"],
+    });
+
+    expect(opened).toBe(handle);
+    expect(listenedFilters).toEqual([{ taskIds: ["t-1"] }]);
+    expect(observedEnvelopes).toHaveLength(1);
+    const envelope = observedEnvelopes[0] as Record<string, any>;
+    // Upstream's own envelope keys survive; only the capabilities key is
+    // replaced, and it carries the extension MERGED into the declared caps.
+    expect(envelope.existing).toBe("envelope-key");
+    const declared = envelope[CLIENT_CAPABILITIES_META_KEY];
+    expect(declared.extensions[EXT_ID]).toEqual({});
+    expect(declared.roots).toEqual({ listChanged: true });
+  });
+
+  it("supportsTaskDeclaredListen requires the wire, the listen method and the seam", () => {
+    const cases = [
+      {
+        name: "legacy wire",
+        seed: seedListenManager({
+          protocolVersion: "2025-11-25",
+          capabilities: LEGACY_CAPS,
+          withListen: true,
+          withEnvelope: true,
+        }),
+        expected: false,
+      },
+      {
+        name: "no listen method",
+        seed: seedListenManager({ withListen: false, withEnvelope: true }),
+        expected: false,
+      },
+      {
+        name: "no envelope seam behind the client",
+        seed: seedListenManager({ withListen: true, withEnvelope: false }),
+        expected: false,
+      },
+      {
+        name: "extension wire + listen + seam",
+        seed: seedListenManager({ withListen: true, withEnvelope: true }),
+        expected: true,
+      },
+    ];
+    for (const { name, seed, expected } of cases) {
+      expect(seed.manager.supportsTaskDeclaredListen(seed.serverId), name).toBe(
+        expected
+      );
+    }
+    // Unknown server: probe is false, never a throw.
+    expect(cases[3].seed.manager.supportsTaskDeclaredListen("missing")).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
Stacked on #3527 (`claude/mcp-tasks-execution-wiring-3mdvi0`) — retarget to `main` after that merges.

## The finding (re-review finding 7, B2 slice)

The SDK's `SubscriptionCoordinator` was already complete for SEP-2663 task notifications — `taskIds` filter handling, the `tasks` notification kind, the declared-listen port method, the `tasks-declaration-unavailable` refusal — but **no production edge could reach it**:

- Nothing production ever called `openTaskDeclaredListen`, because it needs the connection's `declaredCapabilities`, which live in `MCPClientManager.liveClientStates`. The manager — not the adapter — is the right home for the opener.
- The subscriptions route handed the coordinator the managed client via a bare `as unknown as SubscriptionClientPort` cast, so the port could never carry the manager-owned `listenWithTasksDeclaration`, and `normalizeDesired` stripped `taskIds` off every desired-interests POST.
- No client surface stated the `taskIds` desire or reacted to a `tasks` broadcast.

## What this wires

**SDK** — `MCPClientManager.listenWithTasksDeclaration(serverId, filter)`: ensureConnected → assert extension wire → `openTaskDeclaredListen` with the connection's declared capabilities. It **throws** rather than resolving `undefined` (on `SubscriptionClientPort`, availability is method *presence* — a defined opener answering `undefined` would read as "opened nothing, successfully"), and lets `TasksExtListenMetaSeamError` propagate so the coordinator records the failed open and polling continues. Plus `supportsTaskDeclaredListen(serverId)` (extension wire ∧ listen ∧ listen-meta seam), sharing one availability predicate (`canOpenTaskDeclaredListen`) with the opener itself.

**Route + shared views** — the cast becomes an explicit wrapper port that installs `listenWithTasksDeclaration` **only when the probe passes**; absent, the coordinator drops `taskIds` and records `tasks-declaration-unavailable` instead of ever sending an undeclared task-filtered listen (a guaranteed `-32003`). `normalizeDesired` accepts `taskIds`; the notification view forwards `taskId`; the server-state view carries `supportsTaskDeclaredListen` (computed once per entry). `shared/subscription-bridge.ts` extends the view types accordingly, and the Subscriptions panel surfaces the probe and the refusal.

**Client** — `TasksTab` owns the `taskIds` member of the desired interests (tracked ∧ extension wire ∧ not dismissed ∧ not terminal, per server), debounced and written **fetch-merge-post** so the panel-owned interests survive. On a `kind === "tasks"` broadcast whose `taskId` this browser tracks, it issues **one** immediate `tasks/get`, folded back through the per-task scheduler exactly like a scheduled read.

## Invariant: a notification is a poll-now hint, never required for correctness

`tasks/get` stays the sole source of truth — the notification's `DetailedTask` params are never written into state. Every path here can fail (probe false, declaration seam gone, server refuses the ack, stream lost) and the outcome is always the same: the refusal is *recorded and visible*, and the existing polling loop keeps working unchanged.

## Scope: local persistent connections only

Hosted mode is reconnect-per-op — there is no persistent stream for a listen to ride — so hosted posts no `taskIds`, opens no EventSource, and stays polling-only (with the registry recovery path from #3527).

## Tests

- SDK: non-extension wire refuses; undeclarable connection throws; declaration lands on the listen envelope merged into declared caps; probe matrix; real-client integration case pinning the declaration bytes against the extension fixture (POST-only, so delivery stays on the fake-port coordinator tests). `subscription-coordinator.tasks.test.ts` untouched and green.
- Route: desired `taskIds` round-trip un-stripped into the declared opener; probe false ⇒ method omitted + recorded refusal, nothing sent; notification broadcast carries `taskId`; state view carries the probe.
- Client: active-set change posts merged desired with `taskIds`; one notification ⇒ exactly one targeted `tasks/get`; untracked id ignored; hosted posts none.
- Typechecks: client clean; SDK `tsc --noEmit` clean; server tsconfig error count *dropped* 90 → 88 (none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription listen lifecycle and shared desired-interests merging between TasksTab and Subscriptions panel; failures degrade to existing polling only, but incorrect merge or interest posting could cause extra stream reopen churn or missed hints.
> 
> **Overview**
> **End-to-end wiring for SEP-2663 task notifications** on local persistent connections: the coordinator could already handle `taskIds`, but production never reached it until this PR.
> 
> The **SDK** adds `MCPClientManager.listenWithTasksDeclaration` and `supportsTaskDeclaredListen` (via shared `canOpenTaskDeclaredListen`), opening task-filtered listens only with the extension eligibility declaration on the wire.
> 
> The **subscription route** replaces the client cast with `buildSubscriptionPort`, which installs the declared opener only when the probe passes; `normalizeDesired` now keeps `taskIds`, and bridge views expose `supportsTaskDeclaredListen`, `taskId` on notifications, and `tasks-declaration-unavailable` rejections when declaration is impossible.
> 
> **TasksTab** owns the `taskIds` slice of desired interests (tracked, non-terminal, extension wire), posts it debounced with fetch-merge-post so Subscriptions panel interests survive, listens on the subscription SSE, and treats each `notifications/tasks` as a single immediate `tasks/get` hint—never writing notification params into state. **Hosted mode** skips `taskIds` and EventSource entirely.
> 
> The **Subscriptions UI** shows a task-notifications badge and formats `taskIds` / declaration-unavailable refusals in filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e363b70e4fdd4a8a2266896ef8df750e99ecd697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired SEP-2663 task-filtered notifications end-to-end so local persistent connections get faster task updates; polling remains the fallback. Adds a declared `subscriptions/listen` path, carries `taskIds` through the bridge, treats notifications as poll-now hints only, and respects registry dismissals.

- **New Features**
  - SDK: `MCPClientManager.listenWithTasksDeclaration(serverId, filter)` to open a declared, task-filtered listen; throws if the seam is unavailable. `MCPClientManager.supportsTaskDeclaredListen(serverId)` and shared `canOpenTaskDeclaredListen` predicate gate installation.
  - Server: replaces the cast with an explicit `SubscriptionClientPort` wrapper and installs `listenWithTasksDeclaration` only when the probe passes. Accepts `taskIds` in desired interests, forwards them on the declared listen, includes `taskId` in notifications, exposes `supportsTaskDeclaredListen` on state, and records `tasks-declaration-unavailable` instead of sending undeclared filters.
  - Client: `TasksTab` owns the `taskIds` interest (tracked ∧ not dismissed ∧ not terminal), unions the dismissed‑registry store with tracker dismissals, posts it debounced via fetch‑merge‑post, and on a `kind: "tasks"` event triggers exactly one `tasks/get` for that id. Hosted mode posts no `taskIds` and opens no SSE stream.
  - UI: Subscriptions panel shows a “task notifications” badge when supported, formats `taskIds` as `task:<id>`, and explains rejections when the declaration is unavailable.

<sup>Written for commit e363b70e4fdd4a8a2266896ef8df750e99ecd697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

