### PR TITLE
fix(playground): explain connection failures in plain language

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -229,7 +229,7 @@ describe("formatErrorMessage", () => {
   // OAuth grant rendered as "Authorization failed", an unreachable server as
   // "fetch failed". Accurate, and useless. These pin the human copy.
   describe("connection failures", () => {
-    it("explains an unreachable server and offers a retry", () => {
+    it("explains an unreachable server", () => {
       const result = formatErrorMessage(
         JSON.stringify({
           code: "SERVER_UNREACHABLE",
@@ -240,10 +240,30 @@ describe("formatErrorMessage", () => {
       expect(result?.message).toBe(
         "Couldn't reach the MCP server. It may be offline or blocking the connection.",
       );
-      expect(result?.isRetryable).toBe(true);
-      expect(result?.isMCPJamPlatformError).toBe(false);
       // The server's own wording stays reachable under "More details".
       expect(result?.details).toBe("fetch failed");
+    });
+
+    // Copy-only: every non-message field is passed through untouched, so the
+    // banner's Retry button behaves exactly as it did before this change.
+    it("passes isRetryable through from the server rather than deriving it", () => {
+      const retryable = formatErrorMessage(
+        JSON.stringify({
+          code: "SERVER_UNREACHABLE",
+          message: "fetch failed",
+          isRetryable: true,
+        }),
+      );
+      expect(retryable?.isRetryable).toBe(true);
+
+      const notRetryable = formatErrorMessage(
+        JSON.stringify({
+          code: "SERVER_UNREACHABLE",
+          message: "fetch failed",
+          isRetryable: false,
+        }),
+      );
+      expect(notRetryable?.isRetryable).toBe(false);
     });
 
     it("names the server when the backend supplies one", () => {
@@ -260,7 +280,7 @@ describe("formatErrorMessage", () => {
       );
     });
 
-    it("tells the user to reconnect an expired OAuth grant instead of retrying", () => {
+    it("tells the user to reconnect an expired OAuth grant", () => {
       const result = formatErrorMessage(
         JSON.stringify({
           code: "UNAUTHORIZED",
@@ -276,8 +296,6 @@ describe("formatErrorMessage", () => {
       expect(result?.message).toBe(
         "Your connection to “BART MCP” has expired. Reconnect it to keep chatting.",
       );
-      // Retrying cannot revive a dead grant — the CTA must not suggest it.
-      expect(result?.isRetryable).toBe(false);
     });
 
     it("explains a timeout", () => {
@@ -289,10 +307,7 @@ describe("formatErrorMessage", () => {
         }),
       );
 
-      expect(result?.message).toBe(
-        "“BART MCP” took too long to respond.",
-      );
-      expect(result?.isRetryable).toBe(true);
+      expect(result?.message).toBe("“BART MCP” took too long to respond.");
     });
 
     // UNAUTHORIZED / FORBIDDEN double as MCPJam's OWN auth failures (expired
@@ -334,7 +349,6 @@ describe("formatErrorMessage", () => {
       expect(result?.message).toBe(
         "“BART MCP” rejected the connection. Reconnect it to refresh your access.",
       );
-      expect(result?.isRetryable).toBe(false);
     });
 
     it("leaves unrelated codes on the verbatim path", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -280,6 +280,50 @@ describe("formatErrorMessage", () => {
       );
     });
 
+    // The banner no longer leads with the server's wording, so "More details"
+    // is the only place it survives. Structured details must not displace it.
+    it("keeps the raw server message alongside structured details", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "SERVER_UNREACHABLE",
+          message: "fetch failed",
+          details: { serverName: "BART MCP" },
+        }),
+      );
+
+      expect(result?.details).toContain("fetch failed");
+      expect(result?.details).toContain("BART MCP");
+      // Still JSON, so ErrorBox renders it through JsonEditor rather than <pre>.
+      expect(() => JSON.parse(result!.details!)).not.toThrow();
+    });
+
+    it("keeps both when details is a plain string", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "TIMEOUT",
+          message: "Connection attempt timed out after 20 seconds",
+          details: "upstream did not respond",
+        }),
+      );
+
+      expect(result?.details).toContain(
+        "Connection attempt timed out after 20 seconds",
+      );
+      expect(result?.details).toContain("upstream did not respond");
+    });
+
+    it("does not duplicate a message the details already contain", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "SERVER_UNREACHABLE",
+          message: "fetch failed",
+          details: "fetch failed (ECONNREFUSED)",
+        }),
+      );
+
+      expect(result?.details).toBe("fetch failed (ECONNREFUSED)");
+    });
+
     it("tells the user to reconnect an expired OAuth grant", () => {
       const result = formatErrorMessage(
         JSON.stringify({

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -295,6 +295,48 @@ describe("formatErrorMessage", () => {
       expect(result?.isRetryable).toBe(true);
     });
 
+    // UNAUTHORIZED / FORBIDDEN double as MCPJam's OWN auth failures (expired
+    // session, missing bearer) and project-permission denials. Rewriting those
+    // into "reconnect your MCP server" would send the user to fix something
+    // that isn't broken — strictly worse than the jargon. Only rewrite when a
+    // server is actually named.
+    it("does not blame the MCP server for an unattributed 401", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "UNAUTHORIZED",
+          message: "Missing or invalid bearer token",
+        }),
+      );
+
+      expect(result?.message).toBe("Missing or invalid bearer token");
+    });
+
+    it("does not blame the MCP server for an unattributed 403", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "FORBIDDEN",
+          message: "Authorization denied for server",
+        }),
+      );
+
+      expect(result?.message).toBe("Authorization denied for server");
+    });
+
+    it("rewrites a 401 that names a server", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "UNAUTHORIZED",
+          message: "Authentication failed",
+          details: { serverName: "BART MCP" },
+        }),
+      );
+
+      expect(result?.message).toBe(
+        "“BART MCP” rejected the connection. Reconnect it to refresh your access.",
+      );
+      expect(result?.isRetryable).toBe(false);
+    });
+
     it("leaves unrelated codes on the verbatim path", () => {
       const result = formatErrorMessage(
         JSON.stringify({

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -222,4 +222,101 @@ describe("formatErrorMessage", () => {
     expect(result).not.toHaveProperty("walletLocked");
     expect(result).not.toHaveProperty("limitKind");
   });
+
+  // Connection failures already reached the playground intact — the AI SDK
+  // throws `new Error(await response.text())`, so the server's JSON parses
+  // fine here. What reached the user was the backend's own wording: a dead
+  // OAuth grant rendered as "Authorization failed", an unreachable server as
+  // "fetch failed". Accurate, and useless. These pin the human copy.
+  describe("connection failures", () => {
+    it("explains an unreachable server and offers a retry", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "SERVER_UNREACHABLE",
+          message: "fetch failed",
+        }),
+      );
+
+      expect(result?.message).toBe(
+        "Couldn't reach the MCP server. It may be offline or blocking the connection.",
+      );
+      expect(result?.isRetryable).toBe(true);
+      expect(result?.isMCPJamPlatformError).toBe(false);
+      // The server's own wording stays reachable under "More details".
+      expect(result?.details).toBe("fetch failed");
+    });
+
+    it("names the server when the backend supplies one", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "SERVER_UNREACHABLE",
+          message: "fetch failed",
+          details: { serverName: "BART MCP" },
+        }),
+      );
+
+      expect(result?.message).toBe(
+        "Couldn't reach “BART MCP”. It may be offline or blocking the connection.",
+      );
+    });
+
+    it("tells the user to reconnect an expired OAuth grant instead of retrying", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "UNAUTHORIZED",
+          message: "Hosted OAuth refresh token is invalid. Please reconnect.",
+          details: {
+            oauthRequired: true,
+            refreshTokenInvalid: true,
+            serverName: "BART MCP",
+          },
+        }),
+      );
+
+      expect(result?.message).toBe(
+        "Your connection to “BART MCP” has expired. Reconnect it to keep chatting.",
+      );
+      // Retrying cannot revive a dead grant — the CTA must not suggest it.
+      expect(result?.isRetryable).toBe(false);
+    });
+
+    it("explains a timeout", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "TIMEOUT",
+          message: "Connection attempt timed out after 20 seconds",
+          details: { serverName: "BART MCP" },
+        }),
+      );
+
+      expect(result?.message).toBe(
+        "“BART MCP” took too long to respond.",
+      );
+      expect(result?.isRetryable).toBe(true);
+    });
+
+    it("leaves unrelated codes on the verbatim path", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "VALIDATION_ERROR",
+          message: "projectId is invalid",
+        }),
+      );
+
+      expect(result?.message).toBe("projectId is invalid");
+    });
+
+    it("does not divert a rate-limit error onto the connection path", () => {
+      const result = formatErrorMessage(
+        JSON.stringify({
+          code: "user_rate_limit",
+          error: "Daily MCPJam model limit reached.",
+          retryAfter: 4500000,
+        }),
+      );
+
+      expect(result?.isMCPJamPlatformError).toBe(true);
+      expect(result?.message).toContain("Add your own API key");
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -130,12 +130,21 @@ const humanizeConnectionError = (
         message: `${serverName ? `“${serverName}”` : "The MCP server"} took too long to respond.`,
         isRetryable: true,
       };
+    // UNAUTHORIZED / FORBIDDEN are NOT unambiguous: the same codes carry
+    // MCPJam's own auth failures (expired session, missing bearer via
+    // `assertBearerToken`) and project-permission denials, neither of which is
+    // the user's MCP server misbehaving. Sending someone to reconnect a server
+    // that is working fine is worse than the jargon this replaces, so only
+    // rewrite when the payload actually names a server. Everything else falls
+    // through to the verbatim path.
     case "UNAUTHORIZED":
+      if (!serverName) return null;
       return {
         message: `${server} rejected the connection. Reconnect it to refresh your access.`,
         isRetryable: false,
       };
     case "FORBIDDEN":
+      if (!serverName) return null;
       return {
         message: `${server} refused this request. Your access may not cover the tools this chat needs.`,
         isRetryable: false,

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -138,6 +138,41 @@ const humanizeConnectionError = (
   }
 };
 
+/**
+ * Build the "More details" payload for a humanized banner.
+ *
+ * The banner no longer leads with the server's own wording, so that wording has
+ * to survive here or it is lost outright. Fold it into the structured details
+ * rather than replacing them (a bare `details ?? message` drops one or the
+ * other), and keep the result JSON-shaped when the server sent an object so
+ * `ErrorBox` still renders it through `JsonEditor` instead of a flat `<pre>`.
+ */
+const preserveServerMessageInDetails = (
+  message: string,
+  rawDetails: unknown,
+): string | undefined => {
+  if (rawDetails == null) return message;
+
+  if (
+    typeof rawDetails === "object" &&
+    !Array.isArray(rawDetails) &&
+    // `serverMessage` (not `message`) so a details bag that already carries its
+    // own `message` key can't silently swallow the server's wording.
+    !("serverMessage" in (rawDetails as Record<string, unknown>))
+  ) {
+    return normalizeDetails({
+      ...(rawDetails as Record<string, unknown>),
+      serverMessage: message,
+    });
+  }
+
+  const normalized = normalizeDetails(rawDetails);
+  if (!normalized) return message;
+  return normalized.includes(message)
+    ? normalized
+    : `${message}\n\n${normalized}`;
+};
+
 const normalizeDetails = (details: unknown): string | undefined => {
   if (details == null) return undefined;
   if (typeof details === "string") return details;
@@ -388,7 +423,7 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
       if (humanized) {
         return {
           message: humanized,
-          details: details ?? message,
+          details: preserveServerMessageInDetails(message, parsed.details),
           code,
           statusCode: parsed.statusCode,
           isRetryable: parsed.isRetryable,

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -93,7 +93,7 @@ const describeServer = (serverName: string | undefined) =>
 const humanizeConnectionError = (
   code: unknown,
   rawDetails: unknown,
-): { message: string; isRetryable: boolean } | null => {
+): string | null => {
   if (typeof code !== "string") return null;
 
   const detailBag =
@@ -107,29 +107,19 @@ const humanizeConnectionError = (
   const server = describeServer(serverName);
 
   // An expired/revoked OAuth grant is flagged by the backend regardless of the
-  // code it rides in on (see hosted-oauth-refresh.ts), so check it first — the
-  // fix is "reconnect", never "retry".
+  // code it rides in on (see hosted-oauth-refresh.ts), so check it first.
   if (
     detailBag?.refreshTokenInvalid === true ||
     detailBag?.oauthRequired === true
   ) {
-    return {
-      message: `Your connection to ${server} has expired. Reconnect it to keep chatting.`,
-      isRetryable: false,
-    };
+    return `Your connection to ${server} has expired. Reconnect it to keep chatting.`;
   }
 
   switch (code) {
     case "SERVER_UNREACHABLE":
-      return {
-        message: `Couldn't reach ${server}. It may be offline or blocking the connection.`,
-        isRetryable: true,
-      };
+      return `Couldn't reach ${server}. It may be offline or blocking the connection.`;
     case "TIMEOUT":
-      return {
-        message: `${serverName ? `“${serverName}”` : "The MCP server"} took too long to respond.`,
-        isRetryable: true,
-      };
+      return `${serverName ? `“${serverName}”` : "The MCP server"} took too long to respond.`;
     // UNAUTHORIZED / FORBIDDEN are NOT unambiguous: the same codes carry
     // MCPJam's own auth failures (expired session, missing bearer via
     // `assertBearerToken`) and project-permission denials, neither of which is
@@ -139,16 +129,10 @@ const humanizeConnectionError = (
     // through to the verbatim path.
     case "UNAUTHORIZED":
       if (!serverName) return null;
-      return {
-        message: `${server} rejected the connection. Reconnect it to refresh your access.`,
-        isRetryable: false,
-      };
+      return `${server} rejected the connection. Reconnect it to refresh your access.`;
     case "FORBIDDEN":
       if (!serverName) return null;
-      return {
-        message: `${server} refused this request. Your access may not cover the tools this chat needs.`,
-        isRetryable: false,
-      };
+      return `${server} refused this request. Your access may not cover the tools this chat needs.`;
     default:
       return null;
   }
@@ -397,16 +381,20 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
       }
 
       // Connection failures get human copy; the server's own wording stays
-      // reachable under "More details" rather than leading the banner.
+      // reachable under "More details" rather than leading the banner. Copy
+      // only — `isRetryable` and every other field keep whatever the server
+      // sent, so the banner's affordances are unchanged.
       const humanized = humanizeConnectionError(code, parsed.details);
       if (humanized) {
         return {
-          message: humanized.message,
+          message: humanized,
           details: details ?? message,
           code,
           statusCode: parsed.statusCode,
-          isRetryable: humanized.isRetryable,
-          isMCPJamPlatformError: false,
+          isRetryable: parsed.isRetryable,
+          isMCPJamPlatformError: code
+            ? MCPJAM_PLATFORM_CODES.includes(code)
+            : false,
         };
       }
 

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -74,6 +74,77 @@ const MCPJAM_MODEL_LIMIT_PATTERN = /mcpjam[\w\s-]*model limit/i;
 const MINUTES_PER_HOUR = 60;
 const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
 
+/**
+ * Plain-English copy for the connection failures a chat turn can hit.
+ *
+ * The server already sends an accurate `code` (`WebRouteError` → `webError`),
+ * but the raw `message` beside it is written for us, not for the person in the
+ * playground: a failed OAuth refresh renders as "Authorization failed" and an
+ * unreachable server as "fetch failed". Both leave the user with no idea what
+ * to do next. Translate the codes we understand and leave everything else on
+ * the existing verbatim path.
+ *
+ * The raw message is preserved as `details`, so the "More details" collapsible
+ * still shows exactly what the server said.
+ */
+const describeServer = (serverName: string | undefined) =>
+  serverName ? `“${serverName}”` : "the MCP server";
+
+const humanizeConnectionError = (
+  code: unknown,
+  rawDetails: unknown,
+): { message: string; isRetryable: boolean } | null => {
+  if (typeof code !== "string") return null;
+
+  const detailBag =
+    rawDetails && typeof rawDetails === "object"
+      ? (rawDetails as Record<string, unknown>)
+      : undefined;
+  const serverName =
+    typeof detailBag?.serverName === "string" && detailBag.serverName.length > 0
+      ? detailBag.serverName
+      : undefined;
+  const server = describeServer(serverName);
+
+  // An expired/revoked OAuth grant is flagged by the backend regardless of the
+  // code it rides in on (see hosted-oauth-refresh.ts), so check it first — the
+  // fix is "reconnect", never "retry".
+  if (
+    detailBag?.refreshTokenInvalid === true ||
+    detailBag?.oauthRequired === true
+  ) {
+    return {
+      message: `Your connection to ${server} has expired. Reconnect it to keep chatting.`,
+      isRetryable: false,
+    };
+  }
+
+  switch (code) {
+    case "SERVER_UNREACHABLE":
+      return {
+        message: `Couldn't reach ${server}. It may be offline or blocking the connection.`,
+        isRetryable: true,
+      };
+    case "TIMEOUT":
+      return {
+        message: `${serverName ? `“${serverName}”` : "The MCP server"} took too long to respond.`,
+        isRetryable: true,
+      };
+    case "UNAUTHORIZED":
+      return {
+        message: `${server} rejected the connection. Reconnect it to refresh your access.`,
+        isRetryable: false,
+      };
+    case "FORBIDDEN":
+      return {
+        message: `${server} refused this request. Your access may not cover the tools this chat needs.`,
+        isRetryable: false,
+      };
+    default:
+      return null;
+  }
+};
+
 const normalizeDetails = (details: unknown): string | undefined => {
   if (details == null) return undefined;
   if (typeof details === "string") return details;
@@ -314,6 +385,20 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
             retryAfterMs,
           },
         );
+      }
+
+      // Connection failures get human copy; the server's own wording stays
+      // reachable under "More details" rather than leading the banner.
+      const humanized = humanizeConnectionError(code, parsed.details);
+      if (humanized) {
+        return {
+          message: humanized.message,
+          details: details ?? message,
+          code,
+          statusCode: parsed.statusCode,
+          isRetryable: humanized.isRetryable,
+          isMCPJamPlatformError: false,
+        };
       }
 
       return {


### PR DESCRIPTION
UI wasn't interpreting the error response, just screaming loudly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show plain-language connection errors in the playground chat banner, replacing raw “fetch failed”/“Authorization failed” with clear next steps. Copy-only; preserves server-provided fields and names the MCP server when available.

- Bug Fixes
  - Translate `SERVER_UNREACHABLE`, `TIMEOUT`, `UNAUTHORIZED`, `FORBIDDEN`, and `oauthRequired`/`refreshTokenInvalid` into human messages; only rewrite 401/403 when `details.serverName` is present.
  - Keep the server’s raw message in “More details”: merge it with structured details (objects get `serverMessage` to keep JSON; strings include the message without duplication).
  - Copy-only: pass through `isRetryable`, `statusCode`, and `code`; rate‑limit/model‑limit handling unchanged; added targeted tests.

<sup>Written for commit 1be98a092ed562799c1f55e0eab4da03a35ceb09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

