### PR TITLE
fix(sdk): mirror SEP-2243 x-mcp-header params on a cold client

### DIFF
--- a/.changeset/sep-2243-mirroring-cold-client.md
+++ b/.changeset/sep-2243-mirroring-cold-client.md
@@ -1,0 +1,25 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Close a silent SEP-2243 (`x-mcp-header`) spec MUST violation on cold clients.
+
+The 2026-07-28 Streamable HTTP spec requires conforming clients to mirror
+`x-mcp-header`-annotated tool parameters into `Mcp-Param-*` headers. Upstream
+`@modelcontextprotocol/client` reads the tool's `inputSchema` for that scan from
+exactly two places: an explicit `CallToolRequestOptions.toolDefinition`, or the
+aggregated `tools/list` entry in its response cache — and on a miss it sends the
+call with no headers and no warning.
+
+MCPJam surfaces that call a tool without first listing tools on the same
+connection (hosted `/api/web/tools/execute` and `/api/v1 … /tools/call`
+per-request connections, `mcpjam tools call`) therefore skipped the MUST
+silently, as did any surface that walks `tools/list` pagination by hand (an
+explicit-`{ cursor }` list writes no cache).
+
+`MCPClientManager.executeTool` now warms that source once per connection before
+a modern-era `tools/call` over a non-stdio transport, so upstream keeps
+ownership of freshness, `list_changed` eviction and its `HEADER_MISMATCH`
+recovery retry. Surfaces that already called `listTools()` pay no extra round
+trip, and legacy (2025-*) connections and stdio transports are byte-identical —
+mirroring is 2026-07-28 + Streamable-HTTP only.

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -209,6 +209,22 @@ export class MCPClientManager {
   private readonly registeredServers = new Map<string, RegisteredServerState>();
   private readonly liveClientStates = new Map<string, LiveClientState>();
   private readonly toolsMetadataCache = new Map<string, Map<string, any>>();
+  /**
+   * Servers whose CURRENT connection has completed a no-`cursor`
+   * `tools/list` — the only call that writes upstream's aggregated
+   * `tools/list` response-cache entry, which is what upstream `callTool()`
+   * reads to run SEP-2243 `Mcp-Param-*` header mirroring (see
+   * `@modelcontextprotocol/client` `index.d.mts`: "Pass an explicit
+   * `{ cursor }` to fetch a single page ... does not write the response
+   * cache"). A membership miss means "mirroring would silently no-op", which
+   * `ensureXMcpHeaderMirroringSource` repairs before a modern tools/call.
+   *
+   * Lifetime is the CONNECTION, not the server registration: the response
+   * cache is allocated per upstream `Client`, so this is cleared everywhere
+   * `toolsMetadataCache` is (every live-state teardown) and never persists
+   * across a reconnect.
+   */
+  private readonly aggregatedToolsListWarmed = new Set<string>();
   private readonly retryAbortControllers = new Map<
     string,
     Set<AbortController>
@@ -677,6 +693,7 @@ export class MCPClientManager {
     await this.disconnectServer(serverId);
     this.registeredServers.delete(serverId);
     this.toolsMetadataCache.delete(serverId);
+    this.aggregatedToolsListWarmed.delete(serverId);
     this.notificationManager.clearServer(serverId);
     this.elicitationManager.clearServer(serverId);
     this.perRequestLogLevels.delete(serverId);
@@ -704,6 +721,13 @@ export class MCPClientManager {
 
   /**
    * Lists tools available from a server.
+   *
+   * A call with no `cursor` (the common case) auto-aggregates every page in
+   * the upstream client AND writes that aggregate to its response cache — the
+   * view upstream `callTool()` reads for SEP-2243 `Mcp-Param-*` mirroring. An
+   * explicit-`{ cursor }` page walk deliberately writes neither, and
+   * `cacheMode: "bypass"` returns the aggregate without writing it, so only a
+   * no-`cursor` non-bypass call marks the connection warm here.
    */
   async listTools(
     serverId: string,
@@ -717,10 +741,16 @@ export class MCPClientManager {
           this.withTimeout(serverId, options)
         );
         this.cacheToolsMetadata(serverId, result.tools);
+        if (params?.cursor === undefined && options?.cacheMode !== "bypass") {
+          this.aggregatedToolsListWarmed.add(serverId);
+        }
         return result;
       } catch (error) {
         if (isMethodUnavailableError(error, "tools/list")) {
           this.toolsMetadataCache.set(serverId, new Map());
+          // A server without `tools/list` cannot declare `x-mcp-header` on
+          // anything, so the mirroring source is trivially complete.
+          this.aggregatedToolsListWarmed.add(serverId);
           return { tools: [] } as ListToolsResult;
         }
         throw error;
@@ -1020,6 +1050,20 @@ export class MCPClientManager {
         };
       }
 
+      await this.ensureXMcpHeaderMirroringSource(
+        serverId,
+        client,
+        // Signal + timeout only: the warm-up must honor the caller's abort and
+        // deadline, but must NOT inherit the call's progress handler (a
+        // `tools/list` is not the operation the caller is tracking).
+        {
+          ...(signal ? { signal } : {}),
+          ...(request.request?.timeout !== undefined
+            ? { timeout: request.request.timeout }
+            : {}),
+        }
+      );
+
       const plainResult = await this.withElicitationTimeoutSuspension(
         serverId,
         mergedOptions,
@@ -1036,6 +1080,68 @@ export class MCPClientManager {
       request.retry ?? { retries: 0, retryDelayMs: 0 },
       operation
     );
+  }
+
+  /**
+   * Guarantees upstream `callTool()` can run SEP-2243 `Mcp-Param-*` header
+   * mirroring (2026-07-28 Streamable HTTP, "clients **MUST** mirror the
+   * designated parameter values into HTTP headers").
+   *
+   * Upstream reads the tool's `inputSchema` from exactly two places: the
+   * `CallToolRequestOptions.toolDefinition` escape hatch, or the aggregated
+   * `tools/list` entry in its response cache. MCPJam passes the former
+   * nowhere, and several surfaces reach `executeTool` with a cache that was
+   * never written — a hosted/CLI ephemeral connection that only ever calls
+   * the tool, and any surface that walks pagination by hand (an
+   * explicit-`{ cursor }` `listTools()` does not write the cache). Upstream's
+   * miss path is silent: it sends the call with no `Mcp-Param-*` headers and
+   * relies on the server answering `HEADER_MISMATCH` to trigger its
+   * evict-refetch-retry recovery — which a lenient server never does. So the
+   * MUST was being skipped with no warning.
+   *
+   * The repair is to WARM the source rather than to synthesize a
+   * `toolDefinition`: upstream then keeps ownership of freshness, of the
+   * `list_changed` eviction lifecycle, and of the `HEADER_MISMATCH` recovery
+   * retry (which it disables outright when `toolDefinition` is supplied), and
+   * output-schema validation keeps reading the same view it does today. On
+   * the surfaces that DO hold the tool definitions, they hold them because
+   * they called {@link listTools} on this manager — which already warmed the
+   * cache — so those paths pay nothing here.
+   *
+   * Three gates keep this off every path that cannot need it, so no legacy
+   * (2025-*) connection changes by a single byte:
+   * - already warmed on this connection (tracked by
+   *   `aggregatedToolsListWarmed`) — the common case, zero round trips;
+   * - era is not `"modern"`, or is unknown (an adapter that cannot report it)
+   *   — mirroring is 2026-07-28-only and an unknown era fails closed;
+   * - the transport is stdio — mirroring is Streamable-HTTP-only, and unlike
+   *   upstream (which cannot tell an HTTP transport from an in-memory one) we
+   *   own the server config and can skip the useless round trip.
+   *
+   * A failed warm-up is NOT marked warm and NOT fatal: the tool call proceeds
+   * exactly as it does today (upstream's `HEADER_MISMATCH` recovery is still
+   * armed because we pass no `toolDefinition`), and the next call re-attempts
+   * the warm-up rather than disabling mirroring for the connection's life.
+   */
+  private async ensureXMcpHeaderMirroringSource(
+    serverId: string,
+    client: ManagedMcpClient,
+    options: Pick<ClientRequestOptions, "signal" | "timeout">
+  ): Promise<void> {
+    if (this.aggregatedToolsListWarmed.has(serverId)) return;
+    if (client.getProtocolEra?.() !== "modern") return;
+    const config = this.registeredServers.get(serverId)?.config;
+    if (!config || this.isStdioConfig(config)) return;
+
+    try {
+      // No `cursor`, no `cacheMode` override: the one call shape that writes
+      // upstream's aggregated `tools/list` entry. Marks the connection warm
+      // via `listTools` itself, so this runs at most once per connection.
+      await this.listTools(serverId, undefined, options);
+    } catch {
+      // Deliberately swallowed — see the docblock. A `tools/list` failure must
+      // not convert an otherwise-valid `tools/call` into an error.
+    }
   }
 
   // ===========================================================================
@@ -2503,6 +2609,7 @@ export class MCPClientManager {
 
     if (!state) {
       this.toolsMetadataCache.delete(serverId);
+      this.aggregatedToolsListWarmed.delete(serverId);
       return;
     }
 
@@ -2524,6 +2631,7 @@ export class MCPClientManager {
       this.liveClientStates.delete(serverId);
     }
     this.toolsMetadataCache.delete(serverId);
+    this.aggregatedToolsListWarmed.delete(serverId);
   }
 
   private clearClosedPendingConnectionState(
@@ -2554,6 +2662,7 @@ export class MCPClientManager {
       this.liveClientStates.delete(serverId);
     }
     this.toolsMetadataCache.delete(serverId);
+    this.aggregatedToolsListWarmed.delete(serverId);
   }
 
   private async destroyLiveState(
@@ -2973,9 +3082,16 @@ export class MCPClientManager {
   // cache, tool + prompt legs carry the modern per-request log-level `_meta`
   // via the `requestWithSchema` decorator, and the final tool result is
   // re-validated against its output schema (reconstructing what the bypassed
-  // upstream `callTool` would have asserted). The MRTR loop lives OUTSIDE the
-  // per-leg retry/timeout wrappers, so a transient failure on round N retries
-  // only that leg — it never restarts the operation at round zero.
+  // upstream `callTool` would have asserted). SEP-2243 `Mcp-Param-*` mirroring
+  // is the one `callTool` behavior these legs CANNOT reconstruct — it lives in
+  // upstream's private internals and there is no seam to add per-request
+  // headers to a `requestWithSchema` leg, so warming the mirroring source (see
+  // `ensureXMcpHeaderMirroringSource`) would not help here. Local and hosted
+  // MRTR have parity on that gap; see `mrtr-hosted-chat.ts`.
+  //
+  // The MRTR loop lives OUTSIDE the per-leg retry/timeout wrappers, so a
+  // transient failure on round N retries only that leg — it never restarts
+  // the operation at round zero.
   // ===========================================================================
 
   private async executeToolWithInputRequired(

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import { withEphemeralClient } from "../src/operations.js";
 import { serveMultiPageFixtureOnPort, type ServedMultiPageFixture } from "./support/multi-page-fixture.js";
 import { getWireField } from "./support/raw-capture.js";
 
@@ -64,6 +65,64 @@ describe("modern-era (2026-07-28) wire evidence", () => {
     expect(headers["mcp-param-message"]).toBeDefined();
   });
 
+  // ── SEP-2243 mirroring on a COLD client ────────────────────────────────
+  //
+  // The test above warms the client's `tools/list` response cache by hand.
+  // These prove the MUST holds on the surfaces that never do — a hosted or CLI
+  // ephemeral connection that only ever calls the tool, and a surface that
+  // walks pagination itself (an explicit-`{ cursor }` list writes no cache).
+
+  it("mirrors Mcp-Param-* on a cold client — no prior listTools", async () => {
+    const { manager } = await connectModern();
+    await manager.executeTool("fixture", "tool-0", { message: "hi" });
+
+    const calls = byMethod("tools/call");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.request.headers["mcp-param-message"]).toBeDefined();
+    // The mirroring source was warmed: the aggregating walk ran (one request
+    // per fixture page) even though the caller never listed.
+    expect(byMethod("tools/list").length).toBeGreaterThan(0);
+  });
+
+  it("warms the mirroring source at most once per connection", async () => {
+    const { manager } = await connectModern();
+    await manager.executeTool("fixture", "tool-0", { message: "one" });
+    const listsAfterFirstCall = byMethod("tools/list").length;
+    await manager.executeTool("fixture", "tool-0", { message: "two" });
+
+    const calls = byMethod("tools/call");
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call.request.headers["mcp-param-message"]).toBeDefined();
+    }
+    // The second call reuses the warmed source — it must not re-walk the list.
+    expect(byMethod("tools/list")).toHaveLength(listsAfterFirstCall);
+  });
+
+  it("mirrors after an explicit-cursor listTools, which writes no cache", async () => {
+    const { manager } = await connectModern();
+    // A hand-walked page: upstream returns the raw page and deliberately does
+    // not write the response cache, so this leaves the mirroring source cold.
+    await manager.listTools("fixture", { cursor: "page-1" });
+    await manager.executeTool("fixture", "tool-0", { message: "hi" });
+
+    const calls = byMethod("tools/call");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.request.headers["mcp-param-message"]).toBeDefined();
+  });
+
+  it("a no-cursor listTools already warmed it — tools/call adds no second list", async () => {
+    const { manager } = await connectModern();
+    await manager.listTools("fixture");
+    const listsAfterWarm = byMethod("tools/list").length;
+    await manager.executeTool("fixture", "tool-0", { message: "hi" });
+
+    expect(byMethod("tools/list")).toHaveLength(listsAfterWarm);
+    expect(
+      byMethod("tools/call")[0]!.request.headers["mcp-param-message"]
+    ).toBeDefined();
+  });
+
   it("never retains or re-sends Mcp-Session-Id on modern requests", async () => {
     const { manager } = await connectModern();
     await manager.listTools("fixture");
@@ -107,5 +166,73 @@ describe("modern-era (2026-07-28) wire evidence", () => {
     // stream itself — there must be no explicit notifications/cancelled
     // POST alongside it.
     expect(byMethod("notifications/cancelled")).toHaveLength(0);
+  });
+});
+
+/**
+ * SEP-2243 mirroring on the EPHEMERAL surface — `withEphemeralClient` is the
+ * shared connect → one op → disconnect lifecycle behind `mcpjam tools call`
+ * (via the CLI's `withEphemeralManager`) and structurally identical to the
+ * hosted `/api/web/tools/execute` per-request connection. Neither lists tools
+ * before calling one, so this is the surface the MUST was actually being
+ * skipped on — a wrapper-level assertion on the manager alone would not show
+ * it.
+ */
+describe("SEP-2243 mirroring on an ephemeral (connect → call → disconnect) surface", () => {
+  let served: ServedMultiPageFixture | undefined;
+
+  afterEach(async () => {
+    await served?.close();
+    served = undefined;
+  });
+
+  it("mirrors Mcp-Param-* when the only op on the connection is the tools/call", async () => {
+    served = await serveMultiPageFixtureOnPort();
+
+    await withEphemeralClient(
+      {
+        url: served.url,
+        mcpProtocolVersion: "2026-07-28",
+        timeout: 10_000,
+      },
+      async (manager, serverId) => {
+        await manager.executeTool(serverId, "tool-0", { message: "hi" });
+      },
+      { serverId: "__cli__", timeout: 10_000 }
+    );
+
+    const calls = served.exchanges.filter(
+      (e) => getWireField(e.request.json, "method") === "tools/call"
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.request.headers["mcp-param-message"]).toBeDefined();
+  });
+
+  it("legacy (2025-11-25) is untouched: no warm-up list, no Mcp-Param-* header", async () => {
+    served = await serveMultiPageFixtureOnPort();
+
+    await withEphemeralClient(
+      {
+        url: served.url,
+        mcpProtocolVersion: "2025-11-25",
+        timeout: 10_000,
+      },
+      async (manager, serverId) => {
+        await manager.executeTool(serverId, "tool-0", { message: "hi" });
+      },
+      { serverId: "__cli__", timeout: 10_000 }
+    );
+
+    const methods = served.exchanges.map((e) =>
+      getWireField(e.request.json, "method")
+    );
+    // The mirroring warm-up is modern-only: a legacy connection must issue the
+    // exact same wire it did before — a tools/call and nothing else.
+    expect(methods.filter((m) => m === "tools/list")).toHaveLength(0);
+    const calls = served.exchanges.filter(
+      (e) => getWireField(e.request.json, "method") === "tools/call"
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.request.headers["mcp-param-message"]).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

The 2026-07-28 Streamable HTTP spec is explicit: `x-mcp-header` is optional for servers, but **clients MUST support it** and MUST mirror the designated parameter values into HTTP headers ([`basic/transports/streamable-http.mdx`, "Custom Headers from Tool Parameters"](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http)).

Upstream `@modelcontextprotocol/client` reads the tool's `inputSchema` for that scan from exactly two places: an explicit `CallToolRequestOptions.toolDefinition`, or the aggregated `tools/list` entry in its response cache. On a miss it sends the call with no headers and no warning.

`MCPClientManager.executeTool` now warms that source once per connection before a modern-era `tools/call` over a non-stdio transport.

## Why not thread `toolDefinition`

That was the obvious fix and it is a regression. Upstream disables its `HEADER_MISMATCH` recovery whenever `toolDefinition` is set, and takes output-schema validation from that definition instead of the cache. Warming the cache keeps upstream owning freshness, `list_changed` eviction, and the recovery retry.

## Surface audit

Cold before this change — hosted `/api/web/tools/execute` and `/api/v1/…/tools/call` (fresh per-request manager whose only op is the call), `mcpjam tools call`, the CLI MCP server's `call_tool` (an agent can call it without ever calling `list_tools`), the widget renderer (hand-walks pages with explicit `{ cursor }`, which writes no cache), evals' pinned turn, and the widget browser harness.

Already warm and left untouched — the chat/agent loop via `getToolsForAiSdk`, `getTools()` for HostRunner/evals, the OAuth login verify path, the OAuth and Tasks conformance runners, and the inbound HTTP bridge.

Note `cacheMode: "bypass"` also leaves the cache cold, and `/api/web/tools/list` uses bypass deliberately — "the UI listed tools" was never sufficient warmth.

## Scope

Modern era only, non-stdio only, once per connection. Unknown era fails closed. Warmth is tracked per `serverId`, set only by the no-cursor non-bypass `listTools` shape, and cleared at all four sites that clear `toolsMetadataCache`. A failed warm-up is swallowed and not marked warm — a `tools/list` failure must not fail a valid `tools/call`. Legacy (2025-\*) connections and stdio transports are byte-identical.

No interface widening: `ManagedMcpClient.callTool` keeps `RequestOptions` and both implementers are untouched.

## Known gap this does not close

MRTR (`input_required`) legs never mirror, and cannot be fixed from here — they use `requestWithSchema` to carry `requestState`/`inputResponses`, and mirroring lives in upstream's private `callTool` internals with no per-request header seam. **When the hosted MRTR gate is on, every hosted `tools/call` takes that path and therefore never mirrors.** Documented at the sender; needs an upstream ask.

## Testing

Six new tests against the real loopback fixture — real HTTP, real official client, verbatim header capture. Cold client mirrors with no prior `listTools`; warm-up happens at most once per connection; mirroring works after an explicit-`{ cursor }` list; an existing no-cursor list adds no second walk. Plus a downstream-surface test driving `withEphemeralClient` (the connect → one op → disconnect lifecycle behind `mcpjam tools call`, structurally identical to the hosted per-request route) asserting `mcp-param-message` is present, and a legacy-pin `2025-11-25` sibling asserting zero `tools/list` on the wire and no `Mcp-Param-*` header.

Negative control: with the manager change stashed, 4 of the new tests fail, including the ephemeral downstream one. With the fix, 10/10 pass.

`npm run verify` exits 2 on a **pre-existing** unrelated failure — `mcp/src/server.ts(34,3): error TS2416`, duplicate `@modelcontextprotocol/sdk` type instances via `node_modules/agents/`. Confirmed pre-existing by stashing both changed files and re-running `tsc -p mcp/tsconfig.json` for a byte-identical error. Stages run individually: `@mcpjam/sdk` typecheck 0, `@mcpjam/cli` typecheck 0, `@mcpjam/sdk` tests 0 (3101 passed), `@mcpjam/cli` tests 0 (464 passed). `@mcpjam/inspector` tests exit 1 on the known post-teardown `window is not defined` flake in `ServerConnectionCard.tsx:315`, with 10847 passing and no MCP client involvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real HTTP wire for modern-era tool calls on previously cold connections (extra tools/list round trip) but is gated by era/transport/warmth flags; MRTR paths remain a known mirroring gap.
> 
> **Overview**
> Fixes a silent **SEP-2243** gap where modern Streamable HTTP `tools/call` could omit **`Mcp-Param-*`** headers when upstream’s aggregated `tools/list` response cache was never written (ephemeral connect→call paths, cursor-paginated lists, etc.).
> 
> **`MCPClientManager`** now tracks per-connection **`aggregatedToolsListWarmed`**, sets it from a no-cursor, non-bypass **`listTools`**, and runs **`ensureXMcpHeaderMirroringSource`** once before plain **`executeTool` → `callTool`** when era is modern and transport is non-stdio. Warm-up uses **`listTools`** (not injected `toolDefinition`); failures are swallowed so **`tools/call`** still proceeds. Legacy pins and stdio stay byte-identical; MRTR **`input_required`** legs are documented as still unable to mirror.
> 
> Adds integration coverage for cold clients, single warm-up per connection, post-cursor-list repair, **`withEphemeralClient`**, and legacy **`2025-11-25`** negative control, plus a patch changeset for **`@mcpjam/sdk`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d1ac432e5a397b784a3ebdab0ec379525de7f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SEP-2243 compliance by ensuring cold clients mirror `x-mcp-header` tool params into `Mcp-Param-*` headers. We now warm the upstream `tools/list` cache once per connection before modern Streamable-HTTP `tools/call`; hosted/CLI ephemeral calls now send headers, while legacy (2025-*) and stdio paths are unchanged.

- **Bug Fixes**
  - Warm `@modelcontextprotocol/client`’s aggregated `tools/list` cache in `MCPClientManager.executeTool` using a no-cursor, non-bypass `listTools()`; runs at most once per connection.
  - Avoid `toolDefinition`; upstream retains freshness, `list_changed` eviction, and `HEADER_MISMATCH` recovery. Warm-up is skipped if already warm, on legacy eras, or on stdio; failures are ignored so calls proceed.
  - Add integration tests for cold clients, once-per-connection behavior, explicit-cursor lists, and the ephemeral connect→call→disconnect flow; verify legacy stays header-free.

<sup>Written for commit e3d1ac432e5a397b784a3ebdab0ec379525de7f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

