### PR TITLE
feat(sdk): propagate OpenTelemetry trace context over MCP _meta (SEP-414)

### DIFF
--- a/.changeset/otel-trace-context-meta.md
+++ b/.changeset/otel-trace-context-meta.md
@@ -1,0 +1,25 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Propagate OpenTelemetry trace context over MCP `_meta` (SEP-414).
+
+The 2026-07-28 spec reserves the unprefixed `traceparent`, `tracestate` and
+`baggage` `_meta` keys for OpenTelemetry trace context. The requirement is
+conditional on presence — when the keys are sent their values MUST follow W3C
+Trace Context / W3C Baggage format — so this is propagation support, not a
+mandate to emit.
+
+`TraceContextMetaClient` is a `ManagedMcpClient` decorator built as a sibling of
+`LogLevelMetaClient`: it merges a caller-supplied context into outbound
+`params._meta` only on a negotiated `modern` era, caller-supplied `_meta` keys
+always win, and a malformed `traceparent` rejects the whole context rather than
+forwarding it. The context comes from the new optional
+`MCPClientManagerOptions.traceContextProvider`, read fresh per request; with no
+provider the decorator is never constructed, so legacy (2025-\*) wire output is
+byte-identical and modern connections send nothing.
+
+Inbound, a valid trace context on a result's `_meta` is surfaced in the tools
+Response panel — collapsed to the trace id, expanding to span id, sampled flag
+and the raw header values. `baggage` is arbitrary server-controlled data and is
+treated as untrusted display-only: it is never sent to analytics.

--- a/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
@@ -15,7 +15,8 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from "@mcpjam/design-system/toggle-group";
-import type { NormalizedError } from "@mcpjam/sdk/browser";
+import { extractTraceContext, type NormalizedError } from "@mcpjam/sdk/browser";
+import { TraceContextRow } from "@/components/tools/TraceContextRow";
 import { detectUIType, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { copyToClipboard } from "@/lib/clipboard";
 import { JsonEditor } from "@/components/ui/json-editor";
@@ -74,6 +75,12 @@ export function ResultsPanel({
     : null;
   const displayValue =
     extractedDisplay?.kind === "json" ? extractedDisplay.value : rawResult;
+  // Trace context the server put in the result's `_meta` (2026-07-28
+  // reserved keys). Absent for every 2025-era server and for any modern
+  // server that isn't traced, in which case nothing renders.
+  const traceContext = extractTraceContext(
+    rawResult?._meta as Record<string, unknown> | undefined
+  );
   const uiType = detectUIType(toolMeta, rawResult);
   const hasOpenAIComponent = uiType === UIType.OPENAI_SDK;
   const hasMCPAppsComponent = uiType === UIType.MCP_APPS;
@@ -177,6 +184,7 @@ export function ResultsPanel({
         </div>
       ) : rawResult ? (
         <div className="flex-1 min-h-0 p-4 flex flex-col gap-4">
+          {traceContext && <TraceContextRow context={traceContext} />}
           {hasUIComponent && (
             <div className="flex-shrink-0 p-2 bg-muted/50 border border-border rounded flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">

--- a/mcpjam-inspector/client/src/components/tools/TraceContextRow.tsx
+++ b/mcpjam-inspector/client/src/components/tools/TraceContextRow.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { ChevronDown, Waypoints } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@mcpjam/design-system/collapsible";
+import { parseTraceparent, type TraceContext } from "@mcpjam/sdk/browser";
+import { cn } from "@/lib/utils";
+
+/**
+ * The read half of OpenTelemetry trace-context propagation: when a
+ * 2026-07-28 server puts `traceparent` (and optionally `tracestate` /
+ * `baggage`) in a result's `_meta`, show the user which trace their call
+ * belongs to so they can find it in their own tracing backend.
+ *
+ * Collapsed by default and reduced to the one field anybody pastes into a
+ * trace search — the trace id. Span id, sampling, and the vendor lists sit
+ * behind the expand.
+ *
+ * `baggage` is arbitrary server-authored key/value data. It is rendered
+ * verbatim for debugging and goes NOWHERE else: it must never be attached to
+ * a PostHog or Axiom payload.
+ */
+export function TraceContextRow({ context }: { context: TraceContext }) {
+  const [open, setOpen] = useState(false);
+  const parsed = parseTraceparent(context.traceparent);
+  if (!parsed) {
+    return null;
+  }
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="flex-shrink-0 rounded border border-border bg-muted/50"
+    >
+      <CollapsibleTrigger className="flex w-full items-center gap-2 p-2 text-left">
+        <Waypoints className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+        <span className="text-xs text-muted-foreground">Trace</span>
+        <span className="truncate font-mono text-xs text-foreground">
+          {parsed.traceId}
+        </span>
+        <ChevronDown
+          className={cn(
+            "ml-auto h-3.5 w-3.5 flex-shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-180"
+          )}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 border-t border-border p-2 text-xs">
+          <dt className="text-muted-foreground">Span</dt>
+          <dd className="break-all font-mono">{parsed.spanId}</dd>
+          <dt className="text-muted-foreground">Sampled</dt>
+          <dd className="font-mono">{parsed.sampled ? "yes" : "no"}</dd>
+          <dt className="text-muted-foreground">traceparent</dt>
+          <dd className="break-all font-mono">{context.traceparent}</dd>
+          {context.tracestate && (
+            <>
+              <dt className="text-muted-foreground">tracestate</dt>
+              <dd className="break-all font-mono">{context.tracestate}</dd>
+            </>
+          )}
+          {context.baggage && (
+            <>
+              <dt className="text-muted-foreground">baggage</dt>
+              <dd className="break-all font-mono">{context.baggage}</dd>
+            </>
+          )}
+        </dl>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/mcpjam-inspector/client/src/components/tools/__tests__/ResultsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/tools/__tests__/ResultsPanel.test.tsx
@@ -270,4 +270,56 @@ describe("ResultsPanel", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("trace context", () => {
+    const traceparent =
+      "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01";
+
+    it("surfaces the trace id when the result carries a traceparent", async () => {
+      render(
+        <ResultsPanel
+          error=""
+          structuredContentValid={false}
+          result={{
+            content: [{ type: "text", text: "{}" }],
+            _meta: { traceparent, baggage: "userId=alice" },
+          }}
+        />
+      );
+
+      expect(screen.getByText("Trace")).toBeInTheDocument();
+      expect(
+        screen.getByText("0af7651916cd43dd8448eb211c80319c")
+      ).toBeInTheDocument();
+      // Specifics — including the untrusted `baggage` — stay behind the expand.
+      expect(screen.queryByText("userId=alice")).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByText("Trace"));
+      expect(screen.getByText("00f067aa0ba902b7")).toBeInTheDocument();
+      expect(screen.getByText("userId=alice")).toBeInTheDocument();
+    });
+
+    it("renders nothing for a result with no trace context or a malformed one", () => {
+      const { rerender } = render(
+        <ResultsPanel
+          error=""
+          structuredContentValid={false}
+          result={{ content: [{ type: "text", text: "{}" }] }}
+        />
+      );
+      expect(screen.queryByText("Trace")).not.toBeInTheDocument();
+
+      rerender(
+        <ResultsPanel
+          error=""
+          structuredContentValid={false}
+          result={{
+            content: [{ type: "text", text: "{}" }],
+            _meta: { traceparent: "00-nope-01" },
+          }}
+        />
+      );
+      expect(screen.queryByText("Trace")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -371,6 +371,29 @@ export {
   type McpProtocolVersion,
 } from "./mcp-client-manager/mcp-protocol-version.js";
 
+// OpenTelemetry trace context over the 2026-07-28 reserved `_meta` keys.
+// Browser-safe by construction: pure string validation, no transport. The
+// browser side is the READ half — surfacing a trace context a server sent so
+// a user debugging it can see which trace their call joined. `baggage` here
+// is untrusted, display-only data; it must never reach PostHog/Axiom.
+export {
+  BAGGAGE_META_KEY,
+  TRACEPARENT_META_KEY,
+  TRACESTATE_META_KEY,
+  extractTraceContext,
+  isValidBaggage,
+  isValidTraceparent,
+  isValidTracestate,
+  parseTraceparent,
+  sanitizeTraceContext,
+  traceContextToMeta,
+} from "./mcp-client-manager/trace-context.js";
+export type {
+  ParsedTraceparent,
+  TraceContext,
+  TraceContextProvider,
+} from "./mcp-client-manager/trace-context.js";
+
 // HostConfig — the public `Host` builder (also at `@mcpjam/sdk/host-config`).
 // Browser-safe: the class wraps the pure canonicalizer + Web Crypto hash.
 // `McpProtocolVersion` is omitted here — already exported just above.

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -57,6 +57,7 @@ import type {
   Tool,
   AiSdkTool,
 } from "./types.js";
+import type { TraceContextProvider } from "./trace-context.js";
 import type { MCPServerReplayConfig } from "../eval-reporting-types.js";
 
 import {
@@ -314,6 +315,12 @@ export class MCPClientManager {
   private readonly defaultRpcLogger?: RpcLogger;
   private readonly defaultProgressHandler?: ProgressHandler;
   private readonly cacheEventLogger?: CacheEventLogger;
+  /**
+   * Optional accessor for the ambient OpenTelemetry trace context to
+   * propagate. Unset by default — MCPJam runs no tracer, so no
+   * `traceparent`/`tracestate`/`baggage` `_meta` key is ever emitted.
+   */
+  private readonly traceContextProvider?: TraceContextProvider;
   private readonly negotiationOutcomeLogger?: NegotiationOutcomeLogger;
   private readonly defaultRetryPolicy: RetryPolicy;
   private readonly lazyConnect: boolean;
@@ -347,6 +354,7 @@ export class MCPClientManager {
     this.defaultRpcLogger = options.rpcLogger;
     this.defaultProgressHandler = options.progressHandler;
     this.cacheEventLogger = options.cacheEventLogger;
+    this.traceContextProvider = options.traceContextProvider;
     this.negotiationOutcomeLogger = options.negotiationOutcomeLogger;
     this.defaultRetryPolicy = normalizeRetryPolicy(options.retryPolicy);
     this.lazyConnect = options.lazyConnect ?? false;
@@ -2071,9 +2079,15 @@ export class MCPClientManager {
       // `cancelTaskExt`) need to reach a 2026-07-28 server. Registration is
       // inert: the shadow is installed on the first such call, never at
       // connect. See `tasks-ext-era-gate.ts`.
+      // The trace-context decorator is layered only when an embedder supplied
+      // a provider; without one the chain is exactly what it was, so no
+      // `traceparent`/`tracestate`/`baggage` key can reach the wire.
       const managedClient: ManagedMcpClient = wrapLegacyClient(
         upstreamClient,
         () => this.perRequestLogLevels.get(serverId),
+        this.traceContextProvider
+          ? () => this.traceContextProvider?.(serverId)
+          : undefined,
       );
       client = managedClient;
 

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -345,6 +345,27 @@ export {
   LogLevelMetaClient,
   type LogLevelProvider,
 } from "./log-level-meta-client.js";
+// OpenTelemetry trace-context propagation over the 2026-07-28 reserved
+// `_meta` keys. Propagation only: with no provider wired, nothing is emitted.
+export {
+  TraceContextMetaClient,
+  type ConnectionTraceContextProvider,
+} from "./trace-context-meta-client.js";
+export {
+  BAGGAGE_META_KEY,
+  TRACEPARENT_META_KEY,
+  TRACESTATE_META_KEY,
+  extractTraceContext,
+  isValidBaggage,
+  isValidTraceparent,
+  isValidTracestate,
+  parseTraceparent,
+  sanitizeTraceContext,
+  traceContextToMeta,
+  type ParsedTraceparent,
+  type TraceContext,
+  type TraceContextProvider,
+} from "./trace-context.js";
 export {
   DialectAwareJsonSchemaValidator,
   type DialectAwareJsonSchemaValidatorOptions,

--- a/sdk/src/mcp-client-manager/managed-mcp-client-factory.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client-factory.ts
@@ -22,11 +22,15 @@ import {
   LogLevelMetaClient,
   type LogLevelProvider,
 } from "./log-level-meta-client.js";
+import {
+  TraceContextMetaClient,
+  type ConnectionTraceContextProvider,
+} from "./trace-context-meta-client.js";
 import type { McpProtocolVersion } from "./mcp-protocol-version.js";
 import { registerTasksExtensionEraGateTarget } from "./tasks-ext-era-gate.js";
 import type { RpcLogger } from "./types.js";
 
-export type { LogLevelProvider };
+export type { LogLevelProvider, ConnectionTraceContextProvider };
 
 /**
  * Wrap an adapter in the `LogLevelMetaClient` decorator when a
@@ -40,6 +44,21 @@ function withLogLevelMeta(
   return logLevelProvider
     ? new LogLevelMetaClient(adapter, logLevelProvider)
     : adapter;
+}
+
+/**
+ * Wrap in the `TraceContextMetaClient` decorator when a
+ * `traceContextProvider` is supplied, else return the client untouched. No
+ * provider means no `traceparent`/`tracestate`/`baggage` keys ever reach the
+ * wire — the default, since MCPJam runs no OpenTelemetry tracer.
+ */
+function withTraceContextMeta(
+  client: ManagedMcpClient,
+  traceContextProvider?: ConnectionTraceContextProvider,
+): ManagedMcpClient {
+  return traceContextProvider
+    ? new TraceContextMetaClient(client, traceContextProvider)
+    : client;
 }
 
 /**
@@ -58,12 +77,16 @@ function withLogLevelMeta(
 function manage(
   client: Client,
   logLevelProvider?: LogLevelProvider,
+  traceContextProvider?: ConnectionTraceContextProvider,
 ): ManagedMcpClient {
   const adapter = new OfficialSdkClientAdapter(client);
-  const managed = withLogLevelMeta(adapter, logLevelProvider);
-  // Both the adapter and the (possibly decorated) value handed back, so the
-  // lookup works whichever one a caller ends up passing to `tasks-ext.ts`.
+  const logLevelWrapped = withLogLevelMeta(adapter, logLevelProvider);
+  const managed = withTraceContextMeta(logLevelWrapped, traceContextProvider);
+  // Every layer of the chain, so the lookup works whichever one a caller ends
+  // up passing to `tasks-ext.ts` — the adapter, an intermediate decorator, or
+  // the outermost value handed back.
   registerTasksExtensionEraGateTarget(adapter, client);
+  registerTasksExtensionEraGateTarget(logLevelWrapped, client);
   registerTasksExtensionEraGateTarget(managed, client);
   return managed;
 }
@@ -83,6 +106,14 @@ export interface CreateManagedMcpClientArgs {
    * (legacy uses `logging/setLevel`). Omit to opt a connection out entirely.
    */
   logLevelProvider?: LogLevelProvider;
+  /**
+   * Optional live accessor for the ambient OpenTelemetry trace context to
+   * propagate. When provided, the returned client is wrapped in
+   * `TraceContextMetaClient`, which injects the reserved `traceparent` /
+   * `tracestate` / `baggage` `_meta` keys on the modern era only. Omit (the
+   * default everywhere in MCPJam) and no such key is ever emitted.
+   */
+  traceContextProvider?: ConnectionTraceContextProvider;
 }
 
 /**
@@ -108,19 +139,22 @@ export function createManagedMcpClient(
       args.clientOptions.jsonSchemaValidator ??
       new DialectAwareJsonSchemaValidator(),
   });
-  return manage(inner, args.logLevelProvider);
+  return manage(inner, args.logLevelProvider, args.traceContextProvider);
 }
 
 /**
  * Helper for callers that already have an upstream `Client`. Wraps without
  * re-constructing. Pass `logLevelProvider` to layer on the modern
- * per-request logging opt-in (see {@link CreateManagedMcpClientArgs}).
+ * per-request logging opt-in, and `traceContextProvider` to layer on
+ * OpenTelemetry trace-context propagation (see
+ * {@link CreateManagedMcpClientArgs}).
  */
 export function wrapLegacyClient(
   client: Client,
   logLevelProvider?: LogLevelProvider,
+  traceContextProvider?: ConnectionTraceContextProvider,
 ): ManagedMcpClient {
-  return manage(client, logLevelProvider);
+  return manage(client, logLevelProvider, traceContextProvider);
 }
 
 export type { RpcLogger };

--- a/sdk/src/mcp-client-manager/trace-context-meta-client.ts
+++ b/sdk/src/mcp-client-manager/trace-context-meta-client.ts
@@ -1,0 +1,277 @@
+/**
+ * `TraceContextMetaClient` — a `ManagedMcpClient` decorator that propagates an
+ * ambient OpenTelemetry trace context into outbound requests.
+ *
+ * The 2026-07-28 spec reserves `traceparent`, `tracestate`, and `baggage` in
+ * `_meta` as an exception to the prefix rule, and requires only that their
+ * VALUES follow W3C Trace Context / W3C Baggage when present. Sending them is
+ * a documented convention, not a MUST, so this decorator only ever
+ * PROPAGATES: it never mints a trace id or span id to fill the field.
+ *
+ * The injection is applied ONLY WHEN both hold:
+ *   (a) the provider returns a context for this server, and
+ *   (b) the negotiated connection era is `"modern"`.
+ *
+ * (b) is what keeps legacy (2025-era) wire output byte-identical: these keys
+ * are a 2026-07-28 convention, and a 2025 server has no reason to receive
+ * them.
+ *
+ * MCPJam itself supplies NO provider — we do not run an OpenTelemetry tracer
+ * — so by default the keys are ABSENT, which is the honest answer: absence is
+ * semantic in MCP, and a fabricated span would be worse than no span. A
+ * provider that returns a malformed value is likewise treated as no context;
+ * see `trace-context.ts` for the validation and for why `baggage` must never
+ * reach an analytics payload.
+ *
+ * Caller-supplied `_meta` keys always win: the trace keys are spread first
+ * and the caller's `_meta` spread on top.
+ */
+
+import type {
+  CacheableRequestOptions,
+  ProtocolEra,
+  Request,
+  RequestOptions,
+  StandardSchemaV1,
+  LoggingLevel,
+} from "@modelcontextprotocol/client";
+import type {
+  ManagedMcpClient,
+  ManagedMcpClientConnectOptions,
+  ManagedMcpClientNotificationHandler,
+  ManagedMcpClientNotificationMethod,
+  ManagedMcpClientRequestHandler,
+  ManagedMcpClientRequestMethod,
+} from "./managed-mcp-client.js";
+import {
+  sanitizeTraceContext,
+  traceContextToMeta,
+  type TraceContext,
+} from "./trace-context.js";
+
+/**
+ * Live accessor for this connection's ambient trace context, already bound to
+ * a server id by the factory. Returning `undefined` means "no trace": no
+ * `_meta` keys are injected. Read fresh on every call so a caller whose
+ * tracer changes spans per operation propagates the current one without
+ * reconnecting.
+ */
+export type ConnectionTraceContextProvider = () => TraceContext | undefined;
+
+export class TraceContextMetaClient implements ManagedMcpClient {
+  constructor(
+    readonly inner: ManagedMcpClient,
+    private readonly getTraceContext: ConnectionTraceContextProvider,
+  ) {}
+
+  /**
+   * The context to inject on this call, or `undefined` to inject nothing.
+   * `undefined` when the provider has no context, when the value it returned
+   * is malformed (we drop rather than forward — the spec's MUST is about the
+   * value), or when the era is not modern.
+   */
+  private activeContext(): TraceContext | undefined {
+    const context = sanitizeTraceContext(this.getTraceContext());
+    if (context === undefined) {
+      return undefined;
+    }
+    if (this.inner.getProtocolEra?.() !== "modern") {
+      return undefined;
+    }
+    return context;
+  }
+
+  /**
+   * Merge the active trace context into `params._meta`. Caller `_meta` keys
+   * win (spread last). Returns `params` untouched when there is nothing to
+   * inject.
+   */
+  private inject<T extends Record<string, unknown> | undefined>(params: T): T {
+    const context = this.activeContext();
+    if (context === undefined) {
+      return params;
+    }
+    const callerMeta = (params as { _meta?: Record<string, unknown> } | undefined)
+      ?._meta;
+    return {
+      ...(params ?? {}),
+      _meta: { ...traceContextToMeta(context), ...(callerMeta ?? {}) },
+    } as unknown as T;
+  }
+
+  // ---- Lifecycle (pass-through) ----
+  connect(
+    transport: Parameters<ManagedMcpClient["connect"]>[0],
+    options?: ManagedMcpClientConnectOptions,
+  ): Promise<void> {
+    return this.inner.connect(transport, options);
+  }
+  close(): Promise<void> {
+    return this.inner.close();
+  }
+  get onerror(): ((error: Error) => void) | undefined {
+    return this.inner.onerror;
+  }
+  set onerror(handler: ((error: Error) => void) | undefined) {
+    this.inner.onerror = handler;
+  }
+  get onclose(): (() => void) | undefined {
+    return this.inner.onclose;
+  }
+  set onclose(handler: (() => void) | undefined) {
+    this.inner.onclose = handler;
+  }
+
+  // ---- Capability / identity getters (pass-through) ----
+  getServerCapabilities() {
+    return this.inner.getServerCapabilities();
+  }
+  getServerVersion() {
+    return this.inner.getServerVersion();
+  }
+  getInstructions() {
+    return this.inner.getInstructions();
+  }
+  getProtocolEra(): ProtocolEra | undefined {
+    return this.inner.getProtocolEra?.();
+  }
+  getNegotiatedProtocolVersion(): string | undefined {
+    return this.inner.getNegotiatedProtocolVersion?.();
+  }
+
+  // ---- Request-bearing methods (inject `_meta` when modern + context) ----
+  listTools(
+    params?: Parameters<ManagedMcpClient["listTools"]>[0],
+    options?: CacheableRequestOptions,
+  ) {
+    return this.inner.listTools(this.inject(params), options);
+  }
+  callTool(
+    params: Parameters<ManagedMcpClient["callTool"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.callTool(this.inject(params), options);
+  }
+  request<T = unknown>(req: Request, options?: RequestOptions): Promise<T> {
+    const context = this.activeContext();
+    if (context === undefined) {
+      return this.inner.request<T>(req, options);
+    }
+    const params = this.inject(
+      req.params as Record<string, unknown> | undefined,
+    );
+    return this.inner.request<T>({ ...req, params } as Request, options);
+  }
+  requestWithSchema<TSchema extends StandardSchemaV1>(
+    req: Request,
+    resultSchema: TSchema,
+    options?: RequestOptions,
+  ): Promise<StandardSchemaV1.InferOutput<TSchema>> {
+    // Same propagation as `request`. The explicit-schema seam MUST carry it or
+    // the MRTR retry legs would leave their trace, making a multi-round-trip
+    // call look like two unrelated traces on the server side.
+    const context = this.activeContext();
+    if (context === undefined) {
+      return this.inner.requestWithSchema(req, resultSchema, options);
+    }
+    const params = this.inject(
+      req.params as Record<string, unknown> | undefined,
+    );
+    return this.inner.requestWithSchema(
+      { ...req, params } as Request,
+      resultSchema,
+      options,
+    );
+  }
+  listResources(
+    params?: Parameters<ManagedMcpClient["listResources"]>[0],
+    options?: CacheableRequestOptions,
+  ) {
+    return this.inner.listResources(this.inject(params), options);
+  }
+  readResource(
+    params: Parameters<ManagedMcpClient["readResource"]>[0],
+    options?: CacheableRequestOptions,
+  ) {
+    return this.inner.readResource(this.inject(params), options);
+  }
+  listResourceTemplates(
+    params?: Parameters<ManagedMcpClient["listResourceTemplates"]>[0],
+    options?: CacheableRequestOptions,
+  ) {
+    return this.inner.listResourceTemplates(this.inject(params), options);
+  }
+  listPrompts(
+    params?: Parameters<ManagedMcpClient["listPrompts"]>[0],
+    options?: CacheableRequestOptions,
+  ) {
+    return this.inner.listPrompts(this.inject(params), options);
+  }
+  getPrompt(
+    params: Parameters<ManagedMcpClient["getPrompt"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.getPrompt(this.inject(params), options);
+  }
+  subscribeResource(
+    params: Parameters<ManagedMcpClient["subscribeResource"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.subscribeResource(this.inject(params), options);
+  }
+  unsubscribeResource(
+    params: Parameters<ManagedMcpClient["unsubscribeResource"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.unsubscribeResource(this.inject(params), options);
+  }
+
+  listen(
+    filter: Parameters<NonNullable<ManagedMcpClient["listen"]>>[0],
+    options?: RequestOptions,
+  ) {
+    // Long-lived stream, not a request leg: pinning it to whichever span
+    // happened to be current when the stream opened would attribute every
+    // later notification to that one span, so this forwards verbatim.
+    const inner = this.inner.listen?.bind(this.inner);
+    if (!inner) {
+      throw new Error(
+        "The wrapped client does not implement subscriptions/listen.",
+      );
+    }
+    return inner(filter, options);
+  }
+
+  complete(
+    params: Parameters<ManagedMcpClient["complete"]>[0],
+    options?: RequestOptions,
+  ) {
+    return this.inner.complete(this.inject(params), options);
+  }
+
+  // ---- No-params / non-injected methods (pass-through) ----
+  ping(options?: RequestOptions) {
+    return this.inner.ping(options);
+  }
+  setLoggingLevel(level: LoggingLevel, options?: RequestOptions): Promise<void> {
+    // Legacy-era delivery channel — never carries modern `_meta`.
+    return this.inner.setLoggingLevel(level, options);
+  }
+
+  // ---- Handler registration (pass-through) ----
+  setNotificationHandler(
+    method: ManagedMcpClientNotificationMethod,
+    handler: ManagedMcpClientNotificationHandler,
+  ): void {
+    this.inner.setNotificationHandler(method, handler);
+  }
+  setRequestHandler(
+    method: ManagedMcpClientRequestMethod,
+    handler: ManagedMcpClientRequestHandler,
+  ): void {
+    this.inner.setRequestHandler(method, handler);
+  }
+  removeRequestHandler(method: ManagedMcpClientRequestMethod): void {
+    this.inner.removeRequestHandler(method);
+  }
+}

--- a/sdk/src/mcp-client-manager/trace-context.ts
+++ b/sdk/src/mcp-client-manager/trace-context.ts
@@ -1,0 +1,294 @@
+/**
+ * W3C trace-context values as they ride MCP `_meta`.
+ *
+ * The 2026-07-28 spec reserves three `_meta` keys — `traceparent`,
+ * `tracestate`, and `baggage` — as an EXCEPTION to the `_meta` prefix rule
+ * (they are deliberately NOT under `io.modelcontextprotocol/`, so that MCP
+ * matches the OpenTelemetry semantic conventions and existing tracing
+ * middleware). The spec's only normative statement about them is a format
+ * one: "When present, their values MUST follow W3C Trace Context and W3C
+ * Baggage formats respectively." Emitting them at all is a documented
+ * convention, not a requirement — a client that has no trace to propagate
+ * sends nothing, which is exactly what MCPJam does by default.
+ *
+ * This module is the format layer, shared by both directions:
+ *
+ *   - **Outbound** (`TraceContextMetaClient`): a caller-supplied context is
+ *     validated here before it is allowed onto the wire. A malformed value is
+ *     dropped rather than forwarded — the spec's MUST is about the value, so
+ *     propagating garbage would be worse than propagating nothing.
+ *
+ *   - **Inbound** (debugger surfaces): a trace context observed on a server's
+ *     result `_meta` is read back through {@link extractTraceContext} so the
+ *     UI can show the user which trace their call joined.
+ *
+ * **`baggage` is untrusted.** It is arbitrary server- or user-authored
+ * key/value data. It is validated for shape and length here and rendered
+ * verbatim in the UI, but it MUST NOT be forwarded to analytics
+ * (PostHog/Axiom) or any other export path.
+ */
+
+/**
+ * The three reserved key names, spelled locally rather than imported from
+ * `@modelcontextprotocol/client`. This module is reachable from the
+ * browser entry, which must stay free of that package's runtime graph (it
+ * pulls Node builtins); the names are literal W3C header names, not
+ * MCP-prefixed identifiers, so there is nothing to derive. Parity with the
+ * upstream `TRACEPARENT_META_KEY` / `TRACESTATE_META_KEY` /
+ * `BAGGAGE_META_KEY` constants is asserted in `trace-context.test.ts`.
+ */
+export const TRACEPARENT_META_KEY = "traceparent";
+export const TRACESTATE_META_KEY = "tracestate";
+export const BAGGAGE_META_KEY = "baggage";
+
+/**
+ * A validated W3C trace context. `traceparent` is the only required member:
+ * `tracestate` and `baggage` have no meaning without a parent to attach to,
+ * and the spec gives no way to send them alone.
+ */
+export interface TraceContext {
+  /** W3C `traceparent`, e.g. `00-<32 hex>-<16 hex>-01`. */
+  traceparent: string;
+  /** W3C `tracestate` vendor list, when the caller has one. */
+  tracestate?: string;
+  /** W3C `baggage` list. UNTRUSTED — display only, never export. */
+  baggage?: string;
+}
+
+/**
+ * Live accessor for the ambient trace context to propagate on outbound
+ * requests. Returning `undefined` means "no trace" — no `_meta` keys are
+ * injected. Read fresh on every call so a caller whose tracer changes spans
+ * per operation gets the current one without reconnecting.
+ *
+ * MCPJam ships NO implementation of this: we do not run an OpenTelemetry
+ * tracer, so the default is "no provider → no keys emitted". The seam exists
+ * for SDK embedders that do.
+ */
+export type TraceContextProvider = (
+  serverId: string,
+) => TraceContext | undefined;
+
+/** The `version-format` of a `traceparent`, decomposed. */
+export interface ParsedTraceparent {
+  /** Two lowercase hex digits. `00` is the only version defined today. */
+  version: string;
+  /** 32 lowercase hex digits, never all-zero. */
+  traceId: string;
+  /** 16 lowercase hex digits, never all-zero. Also called the parent id. */
+  spanId: string;
+  /** Two lowercase hex digits of trace-flags. */
+  flags: string;
+  /** Bit 0 of `flags` — the caller sampled this trace. */
+  sampled: boolean;
+}
+
+// W3C Trace Context §3.2.2. Lowercase hex only: the spec defines the fields as
+// lowercase and says a receiver MUST NOT accept uppercase, so we do not
+// normalize — an uppercase value is malformed, not fixable.
+const TRACEPARENT_RE =
+  /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+const ALL_ZERO_TRACE_ID = "0".repeat(32);
+const ALL_ZERO_SPAN_ID = "0".repeat(16);
+
+/**
+ * Parse a `traceparent`, or `undefined` if it is not a valid one.
+ *
+ * Rejects, per W3C Trace Context §3.2.2.x: a wrong shape, version `ff`
+ * (reserved / forbidden), an all-zero trace id, and an all-zero parent id.
+ * Versions above `00` are rejected rather than best-effort parsed: the
+ * forward-compatible parse rule ("ignore trailing fields") is for RECEIVERS
+ * that will mutate and re-emit the header, and we neither mutate nor need it
+ * — no such version exists yet.
+ */
+export function parseTraceparent(
+  value: string | undefined,
+): ParsedTraceparent | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const match = TRACEPARENT_RE.exec(value);
+  if (!match) {
+    return undefined;
+  }
+  const [, version, traceId, spanId, flags] = match;
+  if (version === "ff" || version !== "00") {
+    return undefined;
+  }
+  if (traceId === ALL_ZERO_TRACE_ID || spanId === ALL_ZERO_SPAN_ID) {
+    return undefined;
+  }
+  return {
+    version,
+    traceId,
+    spanId,
+    flags,
+    sampled: (Number.parseInt(flags, 16) & 0x01) === 0x01,
+  };
+}
+
+/** Whether `value` is a well-formed `traceparent`. */
+export function isValidTraceparent(value: string | undefined): boolean {
+  return parseTraceparent(value) !== undefined;
+}
+
+// W3C Trace Context §3.3.1: at most 32 list members. A key is either
+// `lcalpha (lcalpha | DIGIT | _ | - | * | /){0,255}` or a `tenant@vendor`
+// pair; a value is printable ASCII excluding `,` and `=`, up to 256 chars.
+const TRACESTATE_MAX_MEMBERS = 32;
+const TRACESTATE_KEY_RE =
+  /^(?:[a-z][a-z0-9_\-*/]{0,255}|[a-z0-9][a-z0-9_\-*/]{0,240}@[a-z][a-z0-9_\-*/]{0,13})$/;
+const TRACESTATE_VALUE_RE = /^[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]$/;
+
+/**
+ * Whether `value` is a well-formed `tracestate` list. Empty members are
+ * permitted between commas (§3.3.1 allows them for deletion), but a member
+ * that is present must be a valid `key=value`.
+ */
+export function isValidTracestate(value: string | undefined): boolean {
+  if (typeof value !== "string" || value.length === 0) {
+    return false;
+  }
+  const members = value.split(",");
+  if (members.length > TRACESTATE_MAX_MEMBERS) {
+    return false;
+  }
+  let present = 0;
+  for (const raw of members) {
+    const member = raw.trim();
+    if (member.length === 0) {
+      continue;
+    }
+    present += 1;
+    const eq = member.indexOf("=");
+    if (eq <= 0) {
+      return false;
+    }
+    if (!TRACESTATE_KEY_RE.test(member.slice(0, eq))) {
+      return false;
+    }
+    if (!TRACESTATE_VALUE_RE.test(member.slice(eq + 1))) {
+      return false;
+    }
+  }
+  return present > 0;
+}
+
+// W3C Baggage §3.2: at most 180 members and 8192 bytes total. A key is an
+// RFC 7230 token; a value is percent-encoded, so printable ASCII excluding
+// the delimiters. Properties (`;k=v`) after a value are allowed and passed
+// through unparsed — we validate their character set only.
+const BAGGAGE_MAX_MEMBERS = 180;
+const BAGGAGE_MAX_BYTES = 8192;
+const BAGGAGE_KEY_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const BAGGAGE_VALUE_RE = /^[\x21\x23-\x2b\x2d-\x3a\x3c-\x5b\x5d-\x7e]*$/;
+
+/**
+ * Whether `value` is a well-formed `baggage` list.
+ *
+ * Shape and size only — the CONTENT is untrusted by definition. Passing this
+ * check says the string is safe to render and to put on the wire; it says
+ * nothing about whether the values are safe to log or export (they are not).
+ */
+export function isValidBaggage(value: string | undefined): boolean {
+  if (typeof value !== "string" || value.length === 0) {
+    return false;
+  }
+  if (value.length > BAGGAGE_MAX_BYTES) {
+    return false;
+  }
+  const members = value.split(",");
+  if (members.length > BAGGAGE_MAX_MEMBERS) {
+    return false;
+  }
+  for (const raw of members) {
+    const member = raw.trim();
+    if (member.length === 0) {
+      return false;
+    }
+    const [pair, ...properties] = member.split(";");
+    const eq = pair.indexOf("=");
+    if (eq <= 0) {
+      return false;
+    }
+    if (!BAGGAGE_KEY_RE.test(pair.slice(0, eq).trim())) {
+      return false;
+    }
+    if (!BAGGAGE_VALUE_RE.test(pair.slice(eq + 1).trim())) {
+      return false;
+    }
+    for (const property of properties) {
+      if (!BAGGAGE_VALUE_RE.test(property.replace(/=/g, "").trim())) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Narrow an arbitrary candidate to the subset of it that is safe to put on
+ * the wire, or `undefined` when there is nothing to send.
+ *
+ * A malformed `traceparent` drops the WHOLE context: `tracestate` and
+ * `baggage` describe a trace we would then not be identifying. A malformed
+ * `tracestate` or `baggage` drops only itself — the parent is still useful,
+ * and the alternative (dropping a valid parent because a vendor list was
+ * mangled) loses the more important half.
+ */
+export function sanitizeTraceContext(
+  candidate: TraceContext | undefined,
+): TraceContext | undefined {
+  if (!candidate || !isValidTraceparent(candidate.traceparent)) {
+    return undefined;
+  }
+  return {
+    traceparent: candidate.traceparent,
+    ...(isValidTracestate(candidate.tracestate)
+      ? { tracestate: candidate.tracestate }
+      : {}),
+    ...(isValidBaggage(candidate.baggage)
+      ? { baggage: candidate.baggage }
+      : {}),
+  };
+}
+
+/**
+ * Read a trace context back out of a `_meta` bag (a result's, a request's, a
+ * notification's). Same validation as the outbound path, so a server that
+ * sends a malformed `traceparent` surfaces as "no trace context" rather than
+ * as a bogus trace id in the UI.
+ */
+export function extractTraceContext(
+  meta: Record<string, unknown> | undefined | null,
+): TraceContext | undefined {
+  if (!meta || typeof meta !== "object") {
+    return undefined;
+  }
+  const read = (key: string): string | undefined => {
+    const value = (meta as Record<string, unknown>)[key];
+    return typeof value === "string" ? value : undefined;
+  };
+  return sanitizeTraceContext({
+    traceparent: read(TRACEPARENT_META_KEY) ?? "",
+    tracestate: read(TRACESTATE_META_KEY),
+    baggage: read(BAGGAGE_META_KEY),
+  });
+}
+
+/**
+ * The `_meta` fragment for a sanitized context: the three reserved keys, each
+ * present only when it has a value. Absence is semantic — we never write a
+ * key with an empty string.
+ */
+export function traceContextToMeta(
+  context: TraceContext,
+): Record<string, string> {
+  return {
+    [TRACEPARENT_META_KEY]: context.traceparent,
+    ...(context.tracestate
+      ? { [TRACESTATE_META_KEY]: context.tracestate }
+      : {}),
+    ...(context.baggage ? { [BAGGAGE_META_KEY]: context.baggage } : {}),
+  };
+}

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -22,6 +22,7 @@ import type {
 import type { StdioServerParameters } from "@modelcontextprotocol/client/stdio";
 import type { RetryPolicy } from "../retry.js";
 import type { RefreshTokenOAuthProvider } from "./refresh-token-auth-provider.js";
+import type { TraceContextProvider } from "./trace-context.js";
 import type { ToolSet } from "ai";
 
 // Re-export ElicitResult for convenience
@@ -504,6 +505,20 @@ export interface MCPClientManagerOptions {
    * `surface` dimension and forwards to PostHog/Axiom.
    */
   negotiationOutcomeLogger?: NegotiationOutcomeLogger;
+  /**
+   * Optional accessor for the ambient OpenTelemetry trace context to
+   * propagate into request `_meta` (the 2026-07-28 reserved `traceparent` /
+   * `tracestate` / `baggage` keys). Called per request with the server id, so
+   * an embedder whose tracer changes spans per operation gets the current one
+   * without reconnecting.
+   *
+   * Propagation only. Returning `undefined` — the default, since MCPJam runs
+   * no OpenTelemetry tracer — means the keys are ABSENT on the wire; the
+   * manager never mints a trace or span id to fill them. Injection happens on
+   * the modern era only, and a malformed value is dropped rather than
+   * forwarded. See `trace-context.ts`.
+   */
+  traceContextProvider?: TraceContextProvider;
   /** Default retry policy for retryable manager operations */
   retryPolicy?: RetryPolicy;
   /**

--- a/sdk/tests/trace-context-meta-client.test.ts
+++ b/sdk/tests/trace-context-meta-client.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+import type { ProtocolEra } from "@modelcontextprotocol/client";
+import type { ManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client.js";
+import { TraceContextMetaClient } from "../src/mcp-client-manager/trace-context-meta-client.js";
+import type { TraceContext } from "../src/mcp-client-manager/trace-context.js";
+import { wrapLegacyClient } from "../src/mcp-client-manager/managed-mcp-client-factory.js";
+
+const TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01";
+
+interface Recorded {
+  method: string;
+  params: Record<string, unknown> | undefined;
+}
+
+/**
+ * Minimal `ManagedMcpClient` that records the params it was handed. Only the
+ * members the decorator touches are implemented; anything else throws so a
+ * missed pass-through shows up as a failure rather than a silent undefined.
+ */
+function makeRecorder(era: ProtocolEra | undefined) {
+  const calls: Recorded[] = [];
+  const record =
+    (method: string) =>
+    async (params?: Record<string, unknown>): Promise<unknown> => {
+      calls.push({ method, params });
+      return {};
+    };
+  const inner = {
+    getProtocolEra: () => era,
+    listTools: record("tools/list"),
+    callTool: record("tools/call"),
+    listResources: record("resources/list"),
+    readResource: record("resources/read"),
+    listResourceTemplates: record("resources/templates/list"),
+    listPrompts: record("prompts/list"),
+    getPrompt: record("prompts/get"),
+    subscribeResource: record("resources/subscribe"),
+    unsubscribeResource: record("resources/unsubscribe"),
+    complete: record("completion/complete"),
+    ping: async () => {
+      calls.push({ method: "ping", params: undefined });
+      return {};
+    },
+    request: async (req: { method: string; params?: unknown }) => {
+      calls.push({
+        method: req.method,
+        params: req.params as Record<string, unknown> | undefined,
+      });
+      return {};
+    },
+    requestWithSchema: async (req: { method: string; params?: unknown }) => {
+      calls.push({
+        method: `schema:${req.method}`,
+        params: req.params as Record<string, unknown> | undefined,
+      });
+      return {};
+    },
+  } as unknown as ManagedMcpClient;
+  return { inner, calls };
+}
+
+function metaOf(call: Recorded): Record<string, unknown> | undefined {
+  return call.params?._meta as Record<string, unknown> | undefined;
+}
+
+describe("TraceContextMetaClient", () => {
+  it("injects nothing when the provider has no context", async () => {
+    const { inner, calls } = makeRecorder("modern");
+    const client = new TraceContextMetaClient(inner, () => undefined);
+    await client.listTools();
+    await client.callTool({ name: "add", arguments: { a: 1 } });
+    expect(calls.map(metaOf)).toEqual([undefined, undefined]);
+    // `listTools()` with no params must stay params-less, not become `{}`.
+    expect(calls[0].params).toBeUndefined();
+  });
+
+  it("injects all three reserved keys on the modern era", async () => {
+    const context: TraceContext = {
+      traceparent: TRACEPARENT,
+      tracestate: "rojo=00f067aa0ba902b7",
+      baggage: "userId=alice",
+    };
+    const { inner, calls } = makeRecorder("modern");
+    const client = new TraceContextMetaClient(inner, () => context);
+    await client.callTool({ name: "add", arguments: { a: 1 } });
+    expect(metaOf(calls[0])).toEqual({
+      traceparent: TRACEPARENT,
+      tracestate: "rojo=00f067aa0ba902b7",
+      baggage: "userId=alice",
+    });
+    // The rest of `params` survives untouched.
+    expect(calls[0].params?.name).toBe("add");
+    expect(calls[0].params?.arguments).toEqual({ a: 1 });
+  });
+
+  it("omits tracestate/baggage when the context has none", async () => {
+    const { inner, calls } = makeRecorder("modern");
+    const client = new TraceContextMetaClient(inner, () => ({
+      traceparent: TRACEPARENT,
+    }));
+    await client.listTools();
+    expect(metaOf(calls[0])).toEqual({ traceparent: TRACEPARENT });
+  });
+
+  it("injects nothing on the legacy era", async () => {
+    const context: TraceContext = {
+      traceparent: TRACEPARENT,
+      tracestate: "rojo=1",
+      baggage: "userId=alice",
+    };
+    for (const era of ["legacy", undefined] as const) {
+      const { inner, calls } = makeRecorder(era);
+      const client = new TraceContextMetaClient(inner, () => context);
+      await client.listTools();
+      await client.callTool({ name: "add", arguments: {} });
+      await client.readResource({ uri: "file:///a" });
+      await client.getPrompt({ name: "p" });
+      await client.complete({
+        ref: { type: "ref/prompt", name: "p" },
+        argument: { name: "a", value: "" },
+      } as Parameters<ManagedMcpClient["complete"]>[0]);
+      await client.request({ method: "tools/list" });
+      await client.requestWithSchema({ method: "tools/list" }, {} as never);
+      // Byte-identical to an undecorated call: no `_meta`, and a params-less
+      // call stays params-less.
+      expect(calls.map(metaOf)).toEqual(calls.map(() => undefined));
+      expect(calls[0].params).toBeUndefined();
+      expect(calls[5].params).toBeUndefined();
+      expect(calls[6].params).toBeUndefined();
+    }
+  });
+
+  it("rejects a malformed traceparent rather than forwarding it", async () => {
+    const { inner, calls } = makeRecorder("modern");
+    const client = new TraceContextMetaClient(inner, () => ({
+      traceparent: "00-not-a-trace-id-01",
+      tracestate: "rojo=1",
+      baggage: "userId=alice",
+    }));
+    await client.listTools();
+    expect(metaOf(calls[0])).toBeUndefined();
+  });
+
+  it("drops a malformed tracestate/baggage but keeps the valid parent", async () => {
+    const { inner, calls } = makeRecorder("modern");
+    const client = new TraceContextMetaClient(inner, () => ({
+      traceparent: TRACEPARENT,
+      tracestate: "ROJO=1",
+      baggage: "no-equals-sign",
+    }));
+    await client.listTools();
+    expect(metaOf(calls[0])).toEqual({ traceparent: TRACEPARENT });
+  });
+
+  it("lets caller-supplied `_meta` keys win", async () => {
+    const { inner, calls } = makeRecorder("modern");
+    const client = new TraceContextMetaClient(inner, () => ({
+      traceparent: TRACEPARENT,
+      tracestate: "rojo=1",
+    }));
+    await client.callTool({
+      name: "add",
+      arguments: {},
+      _meta: {
+        traceparent:
+          "00-11111111111111111111111111111111-2222222222222222-00",
+        progressToken: 7,
+      },
+    } as Parameters<ManagedMcpClient["callTool"]>[0]);
+    expect(metaOf(calls[0])).toEqual({
+      traceparent: "00-11111111111111111111111111111111-2222222222222222-00",
+      tracestate: "rojo=1",
+      progressToken: 7,
+    });
+  });
+
+  it("reads the provider fresh on every request", async () => {
+    const { inner, calls } = makeRecorder("modern");
+    let current: TraceContext | undefined;
+    const client = new TraceContextMetaClient(inner, () => current);
+    await client.listTools();
+    current = { traceparent: TRACEPARENT };
+    await client.listTools();
+    current = undefined;
+    await client.listTools();
+    expect(calls.map(metaOf)).toEqual([
+      undefined,
+      { traceparent: TRACEPARENT },
+      undefined,
+    ]);
+  });
+
+  it("carries the context through the explicit-schema seam (MRTR legs)", async () => {
+    const { inner, calls } = makeRecorder("modern");
+    const client = new TraceContextMetaClient(inner, () => ({
+      traceparent: TRACEPARENT,
+    }));
+    await client.request({ method: "tools/call", params: { name: "add" } });
+    await client.requestWithSchema(
+      { method: "tools/call", params: { name: "add" } },
+      {} as never,
+    );
+    expect(calls.map(metaOf)).toEqual([
+      { traceparent: TRACEPARENT },
+      { traceparent: TRACEPARENT },
+    ]);
+  });
+
+  it("leaves `ping` and the subscriptions stream untouched", async () => {
+    const { inner, calls } = makeRecorder("modern");
+    const client = new TraceContextMetaClient(inner, () => ({
+      traceparent: TRACEPARENT,
+    }));
+    await client.ping();
+    expect(calls[0].params).toBeUndefined();
+    // `listen` is not implemented by the recorder, so the decorator's own
+    // guard is what we observe — proof it does not synthesize params either.
+    expect(() => client.listen?.({} as never)).toThrow(
+      /does not implement subscriptions\/listen/,
+    );
+  });
+});
+
+describe("managed client factory wiring", () => {
+  // `wrapLegacyClient` takes an upstream `Client`; the decorators only ever
+  // call the members `OfficialSdkClientAdapter` forwards, so a structural
+  // stand-in is enough to observe which layers were applied.
+  const fakeUpstream = () =>
+    ({
+      getProtocolEra: () => "modern" as ProtocolEra,
+    }) as never;
+
+  it("does not add the trace decorator when no provider is supplied", () => {
+    const managed = wrapLegacyClient(fakeUpstream());
+    expect(managed).not.toBeInstanceOf(TraceContextMetaClient);
+  });
+
+  it("adds the trace decorator when a provider is supplied", () => {
+    const managed = wrapLegacyClient(fakeUpstream(), undefined, () => ({
+      traceparent: TRACEPARENT,
+    }));
+    expect(managed).toBeInstanceOf(TraceContextMetaClient);
+  });
+});

--- a/sdk/tests/trace-context-wire.integration.test.ts
+++ b/sdk/tests/trace-context-wire.integration.test.ts
@@ -1,0 +1,206 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toNodeHandler } from "@modelcontextprotocol/node";
+import {
+  BAGGAGE_META_KEY,
+  TRACEPARENT_META_KEY,
+  TRACESTATE_META_KEY,
+} from "@modelcontextprotocol/client";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import { createLoggingFixtureHandler } from "./support/logging-fixture.js";
+import {
+  createCapturingFetch,
+  getWireField,
+  hasWireField,
+  type RawExchange,
+} from "./support/raw-capture.js";
+
+/**
+ * Wire-level proof for OpenTelemetry trace-context propagation over `_meta`.
+ *
+ * The three reserved keys are a 2026-07-28 convention, so the guarantee this
+ * file exists to hold is two-sided:
+ *
+ *   - MODERN (2026-07-28): a provider-supplied context rides `_meta` on every
+ *     routed request, under the bare `traceparent` / `tracestate` / `baggage`
+ *     names (NOT under the `io.modelcontextprotocol/` prefix).
+ *   - LEGACY (every 2025 version): the keys NEVER appear, even with the same
+ *     provider wired — the legacy wire is byte-identical to no provider at
+ *     all.
+ *
+ * As in `logging-dual-era.integration.test.ts`, the manager's transport dials
+ * the global `fetch`, so we tee it to read raw frames BEFORE the client
+ * normalizes away the `_meta` envelope.
+ */
+
+const TRACEPARENT =
+  "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01";
+const TRACESTATE = "rojo=00f067aa0ba902b7";
+const BAGGAGE = "userId=alice";
+
+/** Every 2025-era version the debugger can pin. */
+const LEGACY_VERSIONS = ["2025-03-26", "2025-06-18", "2025-11-25"] as const;
+
+interface ServedFixture {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function serveFixture(): Promise<ServedFixture> {
+  const httpServer = http.createServer(
+    toNodeHandler(createLoggingFixtureHandler()),
+  );
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve),
+  );
+  const address = httpServer.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
+  };
+}
+
+/** Client→server JSON-RPC REQUESTS (have both `method` and `id`) in a window. */
+function requestExchanges(exchanges: RawExchange[], from = 0): RawExchange[] {
+  return exchanges.slice(from).filter((e) => {
+    const json = e.request.json as
+      | { method?: unknown; id?: unknown }
+      | undefined;
+    return (
+      json != null &&
+      typeof json.method === "string" &&
+      json.id !== undefined
+    );
+  });
+}
+
+describe("trace context — wire propagation", () => {
+  let served: ServedFixture;
+  let manager: MCPClientManager;
+  let cap: ReturnType<typeof createCapturingFetch>;
+  let realFetch: typeof fetch;
+
+  beforeEach(async () => {
+    served = await serveFixture();
+    realFetch = globalThis.fetch;
+    cap = createCapturingFetch(realFetch);
+    globalThis.fetch = cap.fetch as typeof fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    await manager?.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("MODERN + provider puts all three reserved keys on every request", async () => {
+    manager = new MCPClientManager(
+      {},
+      {
+        traceContextProvider: () => ({
+          traceparent: TRACEPARENT,
+          tracestate: TRACESTATE,
+          baggage: BAGGAGE,
+        }),
+      },
+    );
+    await manager.connectToServer("srv", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+    });
+
+    const start = cap.exchanges.length;
+    await manager.listTools("srv");
+    await manager.listPrompts("srv");
+
+    const routed = requestExchanges(cap.exchanges, start);
+    expect(routed.length).toBeGreaterThan(0);
+    for (const ex of routed) {
+      const method = getWireField(ex.request.json, "method");
+      expect(
+        getWireField(ex.request.json, ["params", "_meta", TRACEPARENT_META_KEY]),
+        `${method} carries traceparent`,
+      ).toBe(TRACEPARENT);
+      expect(
+        getWireField(ex.request.json, ["params", "_meta", TRACESTATE_META_KEY]),
+      ).toBe(TRACESTATE);
+      expect(
+        getWireField(ex.request.json, ["params", "_meta", BAGGAGE_META_KEY]),
+      ).toBe(BAGGAGE);
+      // The keys are deliberately NOT under the MCP prefix.
+      expect(
+        hasWireField(ex.request.json, [
+          "params",
+          "_meta",
+          "io.modelcontextprotocol/traceparent",
+        ]),
+      ).toBe(false);
+    }
+  });
+
+  it("MODERN with no provider emits no trace keys at all", async () => {
+    manager = new MCPClientManager();
+    await manager.connectToServer("srv", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+    });
+
+    await manager.listTools("srv");
+
+    for (const ex of requestExchanges(cap.exchanges)) {
+      for (const key of [
+        TRACEPARENT_META_KEY,
+        TRACESTATE_META_KEY,
+        BAGGAGE_META_KEY,
+      ]) {
+        expect(
+          hasWireField(ex.request.json, ["params", "_meta", key]),
+          `${getWireField(ex.request.json, "method")} omits ${key}`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it.each(LEGACY_VERSIONS)(
+    "LEGACY %s never carries the keys even with a provider wired",
+    async (version) => {
+      manager = new MCPClientManager(
+        {},
+        {
+          traceContextProvider: () => ({
+            traceparent: TRACEPARENT,
+            tracestate: TRACESTATE,
+            baggage: BAGGAGE,
+          }),
+        },
+      );
+      await manager.connectToServer("srv", {
+        url: served.url,
+        mcpProtocolVersion: version,
+        timeout: 10_000,
+      });
+
+      await manager.listTools("srv");
+      await manager.listPrompts("srv");
+
+      const routed = requestExchanges(cap.exchanges);
+      expect(routed.length).toBeGreaterThan(0);
+      for (const ex of routed) {
+        for (const key of [
+          TRACEPARENT_META_KEY,
+          TRACESTATE_META_KEY,
+          BAGGAGE_META_KEY,
+        ]) {
+          expect(
+            hasWireField(ex.request.json, ["params", "_meta", key]),
+            `${version} ${getWireField(ex.request.json, "method")} omits ${key}`,
+          ).toBe(false);
+        }
+      }
+    },
+  );
+});

--- a/sdk/tests/trace-context.test.ts
+++ b/sdk/tests/trace-context.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+import {
+  BAGGAGE_META_KEY,
+  TRACEPARENT_META_KEY,
+  TRACESTATE_META_KEY,
+} from "@modelcontextprotocol/client";
+import {
+  BAGGAGE_META_KEY as LOCAL_BAGGAGE_META_KEY,
+  TRACEPARENT_META_KEY as LOCAL_TRACEPARENT_META_KEY,
+  TRACESTATE_META_KEY as LOCAL_TRACESTATE_META_KEY,
+  extractTraceContext,
+  isValidBaggage,
+  isValidTraceparent,
+  isValidTracestate,
+  parseTraceparent,
+  sanitizeTraceContext,
+  traceContextToMeta,
+} from "../src/mcp-client-manager/trace-context.js";
+
+// Non-normative example from the 2026-07-28 spec's `_meta` section.
+const SPEC_TRACEPARENT =
+  "00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01";
+
+describe("trace-context reserved key names", () => {
+  // The names are spelled locally so the browser entry does not pull the
+  // client package's runtime graph. This is the parity check that keeps the
+  // local spelling honest.
+  it("match the upstream client constants", () => {
+    expect(LOCAL_TRACEPARENT_META_KEY).toBe(TRACEPARENT_META_KEY);
+    expect(LOCAL_TRACESTATE_META_KEY).toBe(TRACESTATE_META_KEY);
+    expect(LOCAL_BAGGAGE_META_KEY).toBe(BAGGAGE_META_KEY);
+  });
+
+  it("are NOT under the io.modelcontextprotocol/ prefix", () => {
+    for (const key of [
+      LOCAL_TRACEPARENT_META_KEY,
+      LOCAL_TRACESTATE_META_KEY,
+      LOCAL_BAGGAGE_META_KEY,
+    ]) {
+      expect(key).not.toContain("/");
+    }
+  });
+});
+
+describe("parseTraceparent", () => {
+  it("parses the spec's example", () => {
+    expect(parseTraceparent(SPEC_TRACEPARENT)).toEqual({
+      version: "00",
+      traceId: "0af7651916cd43dd8448eb211c80319c",
+      spanId: "00f067aa0ba902b7",
+      flags: "01",
+      sampled: true,
+    });
+  });
+
+  it("reads the sampled bit off trace-flags", () => {
+    expect(parseTraceparent(SPEC_TRACEPARENT.replace(/-01$/, "-00"))?.sampled)
+      .toBe(false);
+    expect(parseTraceparent(SPEC_TRACEPARENT.replace(/-01$/, "-03"))?.sampled)
+      .toBe(true);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["empty", ""],
+    ["missing a field", "00-0af7651916cd43dd8448eb211c80319c-01"],
+    ["short trace id", "00-0af7651916cd43dd-00f067aa0ba902b7-01"],
+    ["short span id", "00-0af7651916cd43dd8448eb211c80319c-00f067aa-01"],
+    ["uppercase hex", SPEC_TRACEPARENT.toUpperCase()],
+    ["non-hex", "00-0af7651916cd43dd8448eb211c8031zz-00f067aa0ba902b7-01"],
+    ["trailing junk", `${SPEC_TRACEPARENT}-extra`],
+    ["leading space", ` ${SPEC_TRACEPARENT}`],
+    ["forbidden version ff", SPEC_TRACEPARENT.replace(/^00/, "ff")],
+    ["unknown future version", SPEC_TRACEPARENT.replace(/^00/, "01")],
+    ["all-zero trace id", `00-${"0".repeat(32)}-00f067aa0ba902b7-01`],
+    [
+      "all-zero span id",
+      `00-0af7651916cd43dd8448eb211c80319c-${"0".repeat(16)}-01`,
+    ],
+  ])("rejects %s", (_label, value) => {
+    expect(parseTraceparent(value as string | undefined)).toBeUndefined();
+    expect(isValidTraceparent(value as string | undefined)).toBe(false);
+  });
+});
+
+describe("isValidTracestate", () => {
+  it("accepts single and multi-member lists", () => {
+    expect(isValidTracestate("rojo=00f067aa0ba902b7")).toBe(true);
+    expect(isValidTracestate("rojo=00f067aa0ba902b7,congo=t61rcWkgMzE")).toBe(
+      true,
+    );
+  });
+
+  it("accepts the tenant@vendor key form and surrounding whitespace", () => {
+    expect(isValidTracestate("fw529a3039@dt=fw529a3039")).toBe(true);
+    expect(isValidTracestate(" rojo=1 , congo=2 ")).toBe(true);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["no value", "rojo"],
+    ["no key", "=value"],
+    ["uppercase key", "Rojo=1"],
+    ["an equals sign inside a value", "rojo=a=b"],
+    ["over 32 members", Array.from({ length: 33 }, (_, i) => `k${i}=v`).join(",")],
+  ])("rejects %s", (_label, value) => {
+    expect(isValidTracestate(value)).toBe(false);
+  });
+});
+
+describe("isValidBaggage", () => {
+  it("accepts token keys, properties, and multiple members", () => {
+    expect(isValidBaggage("userId=alice")).toBe(true);
+    expect(isValidBaggage("userId=alice,serverNode=DF%2028")).toBe(true);
+    expect(isValidBaggage("key1=value1;property1;property2")).toBe(true);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["no value delimiter", "userId"],
+    ["no key", "=alice"],
+    ["an empty member", "userId=alice,,serverNode=1"],
+    ["a key with a space", "user Id=alice"],
+    ["over 8192 bytes", `k=${"v".repeat(9000)}`],
+    [
+      "over 180 members",
+      Array.from({ length: 181 }, (_, i) => `k${i}=v`).join(","),
+    ],
+  ])("rejects %s", (_label, value) => {
+    expect(isValidBaggage(value)).toBe(false);
+  });
+});
+
+describe("sanitizeTraceContext", () => {
+  it("returns undefined when there is no context", () => {
+    expect(sanitizeTraceContext(undefined)).toBeUndefined();
+  });
+
+  it("drops the whole context when traceparent is malformed", () => {
+    expect(
+      sanitizeTraceContext({
+        traceparent: "not-a-traceparent",
+        tracestate: "rojo=1",
+        baggage: "userId=alice",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps a valid parent when tracestate/baggage are malformed", () => {
+    expect(
+      sanitizeTraceContext({
+        traceparent: SPEC_TRACEPARENT,
+        tracestate: "Rojo=1",
+        baggage: "=alice",
+      }),
+    ).toEqual({ traceparent: SPEC_TRACEPARENT });
+  });
+
+  it("passes a fully valid context through", () => {
+    const context = {
+      traceparent: SPEC_TRACEPARENT,
+      tracestate: "rojo=1",
+      baggage: "userId=alice",
+    };
+    expect(sanitizeTraceContext(context)).toEqual(context);
+  });
+});
+
+describe("traceContextToMeta", () => {
+  it("omits keys with no value rather than sending empty strings", () => {
+    expect(traceContextToMeta({ traceparent: SPEC_TRACEPARENT })).toEqual({
+      traceparent: SPEC_TRACEPARENT,
+    });
+  });
+
+  it("emits all three keys when all three are present", () => {
+    expect(
+      traceContextToMeta({
+        traceparent: SPEC_TRACEPARENT,
+        tracestate: "rojo=1",
+        baggage: "userId=alice",
+      }),
+    ).toEqual({
+      traceparent: SPEC_TRACEPARENT,
+      tracestate: "rojo=1",
+      baggage: "userId=alice",
+    });
+  });
+});
+
+describe("extractTraceContext", () => {
+  it("reads a context back out of a result `_meta`", () => {
+    expect(
+      extractTraceContext({
+        "io.modelcontextprotocol/serverInfo": { name: "x", version: "1" },
+        traceparent: SPEC_TRACEPARENT,
+        tracestate: "rojo=1",
+        baggage: "userId=alice",
+      }),
+    ).toEqual({
+      traceparent: SPEC_TRACEPARENT,
+      tracestate: "rojo=1",
+      baggage: "userId=alice",
+    });
+  });
+
+  it.each([
+    ["no meta", undefined],
+    ["null meta", null],
+    ["meta without trace keys", { progressToken: 1 }],
+    ["a malformed traceparent", { traceparent: "nope" }],
+    ["a non-string traceparent", { traceparent: 42 }],
+  ])("returns undefined for %s", (_label, meta) => {
+    expect(
+      extractTraceContext(meta as Record<string, unknown> | undefined | null),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

MCP 2026-07-28 reserves the unprefixed `_meta` keys `traceparent`, `tracestate` and `baggage` for OpenTelemetry trace context. We emitted and surfaced none of them.

This adds propagation support plus a read surface in the tools Response panel.

## Requirement strength — this is not a conformance gap

Worth stating plainly, because it was mis-framed when the gap was first raised. From `basic/index.mdx`, "OpenTelemetry trace context":

> As an exception to the prefix requirement above, the keys `traceparent`, `tracestate`, and `baggage` are reserved for OpenTelemetry trace context propagation. **When present**, their values MUST follow W3C Trace Context and W3C Baggage formats respectively.

The only MUST is conditional on presence and constrains the value format. There is no SHOULD to send them at all. So this is a debugger feature, not a spec obligation.

## Design

`TraceContextMetaClient` is a `ManagedMcpClient` decorator built as a method-for-method sibling of `LogLevelMetaClient` — same `inject()` shape, same era gate, same "caller `_meta` wins" spread order, same `requestWithSchema` handling for MRTR legs, same `listen` opt-out. It layers outside `withLogLevelMeta()` in the factory.

Context comes from a new optional `MCPClientManagerOptions.traceContextProvider`, read fresh per request. **Propagation only** — no OpenTelemetry dependency is added, and no span IDs are fabricated to fill the field. With no provider the decorator is never constructed.

A malformed `traceparent` rejects the whole context rather than forwarding it; malformed `tracestate`/`baggage` are dropped while a valid parent is kept.

## Legacy safety

Proven two independent ways:

1. **Structural** — no provider means no decorator, and nothing in MCPJam supplies one today. Asserted for `wrapLegacyClient`.
2. **Wire-level** — a new integration test reuses the `logging-dual-era` harness (real loopback MCP fixture, `createCapturingFetch` teeing global `fetch` to read raw JSON-RPC frames before SDK normalization). With a provider deliberately wired, all three keys are absent on 2025-03-26, 2025-06-18 and 2025-11-25, and present with correct values on 2026-07-28. Also asserts the keys are not written under an `io.modelcontextprotocol/` prefix.

## Inbound surface

`TraceContextRow` renders in the tools Response panel only when the result's `_meta` yields a valid context. Collapsed shows the trace id — the one string you paste into a tracing backend; expanding reveals span id, sampled flag, raw `traceparent`, and `tracestate`/`baggage` when present. `baggage` is arbitrary server-controlled data, rendered verbatim as untrusted display-only; no analytics call was added anywhere in this change.

## Open decisions for the reviewer

1. **The plumbing is dormant by design.** Nothing supplies a provider, because MCPJam runs no tracer. Making it emit needs a product call: an `@opentelemetry/api` peer dep the embedder provides, versus MCPJam minting debug-only root spans itself (the fabrication deliberately avoided here).
2. **One read surface, not all of them.** Result `_meta` also flows through chat tool results, the playground, resources and prompts. Fanning out is mechanical (`extractTraceContext` + `TraceContextRow`) but multiplies UI.
3. **Reserved key names are spelled locally** in `trace-context.ts` rather than imported from `@modelcontextprotocol/client`, because the module is reachable from the browser entry and its no-Node-builtins bundle guard. A parity test asserts the local strings equal upstream's `TRACEPARENT_META_KEY` / `TRACESTATE_META_KEY` / `BAGGAGE_META_KEY`, so drift fails CI. Say if you'd rather take the runtime import and restructure the browser export.

## Testing

Unit coverage: no provider → no keys; modern + provider → correct keys; legacy or undefined era + provider → nothing injected, and a params-less call stays params-less rather than becoming `{}`; malformed input handling; caller `_meta` wins; provider read fresh per request; `requestWithSchema` carries it. Plus the dual-era wire integration test above.

`npm run verify` from the monorepo root: **exit code 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is opt-in via `traceContextProvider`; default paths are unchanged. Changes are additive validation, decorator wiring, and UI display with explicit treatment of untrusted `baggage`.
> 
> **Overview**
> Adds **optional OpenTelemetry trace-context propagation** for MCP 2026-07-28 reserved `_meta` keys (`traceparent`, `tracestate`, `baggage`) plus a **read path** in the tools Response panel.
> 
> **Outbound:** New `trace-context.ts` validates W3C formats and sanitizes malformed values. `TraceContextMetaClient` injects context into outbound `params._meta` on the **modern** era only (mirroring `LogLevelMetaClient`); caller `_meta` wins; `requestWithSchema` legs are covered. Optional `MCPClientManagerOptions.traceContextProvider` is read per request—**with no provider the decorator is not wired**, so legacy wire stays unchanged and MCPJam emits nothing by default.
> 
> **Inbound:** `ResultsPanel` uses `extractTraceContext` and new `TraceContextRow` to show trace id (expand for span, sampling, raw headers); `baggage` is display-only.
> 
> Exports land on `@mcpjam/sdk` and `@mcpjam/sdk/browser`. Unit and dual-era wire integration tests cover injection, era gating, and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d0e531ea83c439e8b7d446fb2db258a95d5a9c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates OpenTelemetry trace context via the reserved `_meta` keys (`traceparent`, `tracestate`, `baggage`) on modern MCP (2026-07-28) and surfaces it in the tools Response panel for easier debugging. Inactive by default; no provider is wired.

- **New Features**
  - `TraceContextMetaClient` decorates managed clients to inject context into `params._meta` only on the modern era; caller `_meta` wins and no IDs are fabricated.
  - New `trace-context` utilities for validation, parsing, and `extractTraceContext`, with browser-safe exports.
  - `MCPClientManagerOptions.traceContextProvider` opt-in; the factory layers the decorator only when a provider is supplied.
  - Inspector UI adds `TraceContextRow`: shows trace id collapsed; expand for span id, sampled flag, and raw headers; `baggage` is display-only.

<sup>Written for commit 0d0e531ea83c439e8b7d446fb2db258a95d5a9c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

