### PR TITLE
fix(inspector): re-register the MRTR collector on every connect

### DIFF
--- a/.changeset/mrtr-collector-reregister.md
+++ b/.changeset/mrtr-collector-reregister.md
@@ -1,0 +1,27 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix MRTR elicitation silently dying for the rest of the process after one
+failed connect.
+
+`MCPClientManager.removeServer()` purges `mrtrInputCollectors` by design, and
+the local connect route runs with `removeOnFailure: true` — so any failed
+connect (or an explicit remove from the servers route) drops the collector.
+`registerLocalMrtrCollector` mirrored "already registered" in a module-level
+`WeakMap<manager, Set<serverId>>` that could not observe that purge, so after
+the first failure it answered "already registered" forever and never restored
+the collector.
+
+Downstream, `buildCapabilities` advertises `elicitation` exactly when a
+collector is registered, so every subsequent connection advertised none. A
+2026-07-28 server then correctly refuses to embed `elicitation/create` in an
+`input_required` result, and every MRTR surface — `tools/call`,
+`resources/read`, `prompts/get` — fails with "the request's client capabilities
+do not declare the required capability". The connection succeeds and the tool
+list populates, so nothing looks broken until a tool is actually run.
+
+The mirror is removed: the manager's own collector map is now the single source
+of truth, and registration is unconditional. Re-registering is a `Map.set` with
+a pure factory closure (all round state lives in the module-level
+`pendingRounds`), so the repeat cost is nil.

--- a/mcpjam-inspector/server/routes/mcp/__tests__/mrtr.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/mrtr.test.ts
@@ -110,14 +110,51 @@ describe("projectInputRequests", () => {
 });
 
 describe("registerLocalMrtrCollector", () => {
-  it("registers exactly once per (manager, serverId)", () => {
+  it("re-registers on every call so a removeServer() purge is repaired", () => {
     const { manager } = fakeManager();
     const spy = vi.spyOn(manager, "setMrtrInputCollector");
     registerLocalMrtrCollector(manager, "srv");
     registerLocalMrtrCollector(manager, "srv");
-    expect(spy).toHaveBeenCalledTimes(1);
-    registerLocalMrtrCollector(manager, "other");
+    // Not deduped: the manager's own map is the source of truth for whether a
+    // collector is installed, and `removeServer()` can empty it behind our
+    // back (the local connect route runs with `removeOnFailure: true`).
     expect(spy).toHaveBeenCalledTimes(2);
+    registerLocalMrtrCollector(manager, "other");
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it("restores the collector after the manager purges it", () => {
+    // The regression: connect fails -> removeServer() purges the collector ->
+    // reconnect must re-register, or `elicitation` is never advertised again
+    // and every MRTR tool fails with a capability error on a healthy-looking
+    // connection.
+    const collectors = new Map<string, MrtrInputCollector>();
+    const manager = {
+      setMrtrInputCollector: (serverId: string, c: MrtrInputCollector) => {
+        collectors.set(serverId, c);
+      },
+      removeServer: (serverId: string) => {
+        collectors.delete(serverId);
+      },
+    } as any;
+
+    registerLocalMrtrCollector(manager, "srv");
+    expect(collectors.has("srv")).toBe(true);
+
+    manager.removeServer("srv");
+    expect(collectors.has("srv")).toBe(false);
+
+    registerLocalMrtrCollector(manager, "srv");
+    expect(collectors.has("srv")).toBe(true);
+  });
+
+  it("does not throw when the manager rejects the registration", () => {
+    const manager = {
+      setMrtrInputCollector: () => {
+        throw new Error("boom");
+      },
+    } as any;
+    expect(() => registerLocalMrtrCollector(manager, "srv")).not.toThrow();
   });
 });
 

--- a/mcpjam-inspector/server/routes/mcp/mrtr.ts
+++ b/mcpjam-inspector/server/routes/mcp/mrtr.ts
@@ -220,10 +220,6 @@ function makeCollector(serverId: string): MrtrInputCollector {
 // Registration (before connect)
 // ---------------------------------------------------------------------------
 
-// Per-manager set of server ids whose collector is already registered. WeakMap
-// so a discarded manager (hot reload) is collected with its set.
-const registered = new WeakMap<MCPClientManager, Set<string>>();
-
 /**
  * The `elicitation` capability a local MRTR connection may advertise.
  *
@@ -333,24 +329,41 @@ function isModernOnlyLocalConnection(config: MCPServerConfig): boolean {
 }
 
 /**
- * Idempotently registers the MRTR input collector for `serverId` on `manager`.
+ * Registers the MRTR input collector for `serverId` on `manager`.
  * MUST be called BEFORE `manager.connectToServer(serverId, …)` so the
  * `elicitation` client capability is advertised on the connect envelope (see
  * the module header).
+ *
+ * ## Why this re-registers unconditionally
+ *
+ * `MCPClientManager.removeServer()` PURGES `mrtrInputCollectors` (deliberately
+ * — a re-registered server must not inherit the previous owner's collector
+ * closure). The local connect route runs with `removeOnFailure: true`, so
+ * every failed connect, and every explicit remove from the servers route,
+ * silently drops the collector.
+ *
+ * This function used to mirror "already registered" in a module-level
+ * `WeakMap<manager, Set<serverId>>`. That mirror had no way to observe the
+ * purge, so after ONE failed connect it answered "already registered" forever:
+ * the collector was never restored, `buildCapabilities` saw no collector, and
+ * every subsequent connection advertised no `elicitation` at all. A 2026-07-28
+ * server then correctly refuses to embed `elicitation/create` in an
+ * `input_required` result, and every MRTR tool fails with "the request's
+ * client capabilities do not declare the required capability" — with a
+ * successful connect and a full tool list, so nothing looks wrong.
+ *
+ * Re-registering is cheap and safe: `setMrtrInputCollector` is a `Map.set`,
+ * and `makeCollector` is a pure factory closing over `serverId` (all round
+ * state lives in the module-level `pendingRounds` / `subscribers`). The
+ * manager's own map is the single source of truth for whether a collector is
+ * installed — this module keeps no second copy of that fact.
  */
 export function registerLocalMrtrCollector(
   manager: MCPClientManager,
   serverId: string,
 ): void {
-  let ids = registered.get(manager);
-  if (!ids) {
-    ids = new Set<string>();
-    registered.set(manager, ids);
-  }
-  if (ids.has(serverId)) return;
   try {
     manager.setMrtrInputCollector(serverId, makeCollector(serverId));
-    ids.add(serverId);
   } catch (err) {
     // Pass the original error as the 2nd (error) arg so Sentry captures a stack
     // and Axiom serializes the real message; serverId is the context (3rd) arg.


### PR DESCRIPTION
## Symptom

Every MRTR tool against a 2026-07-28 server fails with:

> Cannot request input 'name' (elicitation/create): the request's client capabilities do not declare the required capability

The connection succeeds, `server/discover` returns cleanly, and the full tool list populates — so nothing looks wrong until a tool is actually run. Confirmed against `stateless.mcpjam.com` (`ask-name`, `confirm-launch`, `open-dashboard`, `demo://vault`, `personalized-greeting`).

The per-request envelope shows the cause directly:

```json
"io.modelcontextprotocol/clientCapabilities": {
  "extensions": { "io.modelcontextprotocol/ui": { ... } }
}
```

No `elicitation` — so the server is right to refuse.

## Root cause

Three pieces that are each individually correct:

1. `MCPClientManager.removeServer()` **purges** `mrtrInputCollectors`, deliberately — *"otherwise a re-registered server inherits the previous owner's collector closure and stale `elicitation` capability"* (`MCPClientManager.ts:684`).
2. The local connect route runs with `removeOnFailure: true` (`routes/mcp/connect.ts:33`), so **every failed connect** calls `removeServer`. `routes/mcp/servers.ts:185` does too.
3. `buildCapabilities` advertises `elicitation` exactly when a collector is registered, and *"registering a collector AFTER connect does not retroactively re-advertise"* (`MCPClientManager.ts:2941`, and the `mrtr.ts` module header).

`registerLocalMrtrCollector` mirrored "already registered" in a module-level `WeakMap<manager, Set<serverId>>` and early-returned on a hit. That mirror cannot observe the purge in (1). So the sequence is:

```
connect #1  -> register collector, connect FAILS -> removeServer() purges it
connect #2  -> mirror says "already registered" -> early return, no collector
            -> connect SUCCEEDS, advertises no elicitation
            -> every MRTR tool fails, for the life of the process
```

One transient failure disables MRTR permanently, with no log line and a healthy-looking connection. It reproduces trivially: point the Inspector at a server that's down, start it, reconnect.

This is the same class of bug already called out in `routes/mcp/http-adapters.ts:50` — *"removeServer() clears the manager's stored handlers, so a re-run must re-register"* — which that module handles correctly.

## Fix

Delete the mirror. The manager's own collector map is the single source of truth for whether a collector is installed, and this module no longer keeps a second copy of that fact.

Re-registering unconditionally is cheap and safe: `setMrtrInputCollector` is a `Map.set`, and `makeCollector` is a pure factory closing over `serverId` — all round state lives in the module-level `pendingRounds` / `subscribers`, so a fresh closure is interchangeable with the old one.

## Tests

The existing case asserted `toHaveBeenCalledTimes(1)` for a repeat call — it encoded the bug as the contract. Replaced with:

- the purge/repair round trip (register → `removeServer` → register → collector present again), which fails on `main`
- the unconditional re-register contract
- throw-tolerance, so a manager that rejects registration still doesn't break connect

`npx vitest run --project server` → **286 files, 3702 tests, all passing.**

## Not in scope

- **`Mcp-Param-*` mirroring** — same demo session surfaced this, already fixed by #3540 on `main`.
- **`elicitation.url` on auto-negotiated connections.** `withLocalMrtrElicitationCapability` only widens to `{form, url}` when the connection provably cannot land pre-2026 (explicit pin, or an all-modern accept-list). With *Client default* it stays bare `{}`, i.e. form-only. That is a deliberate fail-closed choice — the legacy inbound bridge is form-only — and it is documented as such. So after this fix, `ask-name` and `confirm-launch` work on an auto-negotiated connection but `open-dashboard` (url mode) still needs an explicit `2026-07-28` pin. Worth revisiting separately; lifting it needs the legacy bridge to carry url, not a wider declaration.
- **HTTP header capture in Tracing.** Raw headers are only recorded by the OAuth/XAA debuggers and the conformance raw harness, so `Mcp-Method` / `Mcp-Name` / `Mcp-Param-*` are invisible in the main trace view. On a protocol whose routing metadata lives in headers that's a real gap, but it's a feature, not this fix. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fix in MRTR registration with regression tests; no auth or data-path changes.
> 
> **Overview**
> Fixes MRTR elicitation staying broken for the rest of the inspector process after a single failed connect or server remove.
> 
> **`registerLocalMrtrCollector`** no longer tracks “already registered” in a module-level `WeakMap`. It always calls `manager.setMrtrInputCollector` so a collector purged by `removeServer()` (failed connect with `removeOnFailure`, explicit remove) is restored on the next connect. Without that, reconnects looked healthy but advertised no `elicitation`, so 2026-07-28 MRTR tools failed with a client-capability error until restart.
> 
> Tests now expect unconditional re-registration, cover purge → re-register, and assert registration errors are swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 537914b628265157d6b06d5ce61e3a095ae3cf78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MRTR tools failing with "client capabilities do not declare the required capability" by re-registering the MRTR input collector on every connect so `elicitation` is always advertised. This prevents a failed connect from silently disabling MRTR for the session.

- **Bug Fixes**
  - Removed the module-level mirror and now always register via `manager.setMrtrInputCollector`.
  - Handles `MCPClientManager.removeServer()` purging collectors (connect uses `removeOnFailure: true`).
  - Ensures `elicitation` is advertised on connect; tools like `ask-name`, `confirm-launch`, and `open-dashboard` work again.
  - Tests updated: purge/repair round trip, unconditional re-register, and throw-tolerance.
  - Added a patch changeset for `@mcpjam/inspector`.

<sup>Written for commit 537914b628265157d6b06d5ce61e3a095ae3cf78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

