### PR TITLE
Clarify client identity in Playground compare columns

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
@@ -40,7 +40,7 @@ function getMetricRunningSpinnerCount(container: ParentNode): number {
 }
 
 describe("ModelCompareCardHeader", () => {
-  it("renders nothing when comparison chrome is off and trace tabs are hidden", () => {
+  it("renders nothing when comparison chrome is off, trace tabs are hidden, and identity is off", () => {
     const { container } = render(
       <ModelCompareCardHeader
         model={model}
@@ -54,6 +54,53 @@ describe("ModelCompareCardHeader", () => {
     );
 
     expect(container.firstChild).toBeNull();
+  });
+
+  it("shows host identity (logo + name) above tabs without Latency when identity header is on", () => {
+    render(
+      <ModelCompareCardHeader
+        compareLabel="Claude"
+        summary={idleSummary}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={true}
+        showComparisonChrome={false}
+        showIdentityHeader
+        logoSrc="/logos/claude.svg"
+      />,
+    );
+
+    const identity = screen.getByTestId("compare-card-identity");
+    expect(identity).toBeInTheDocument();
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+    expect(identity.querySelector("img")).toHaveAttribute(
+      "src",
+      "/logos/claude.svg",
+    );
+    expect(screen.getByTitle("Trace")).toBeInTheDocument();
+    expect(screen.queryByText("Latency")).not.toBeInTheDocument();
+  });
+
+  it("shows initials fallback when identity header has no logo", () => {
+    render(
+      <ModelCompareCardHeader
+        compareLabel="Custom Host"
+        summary={idleSummary}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={false}
+        showComparisonChrome={false}
+        showIdentityHeader
+        logoSrc={null}
+      />,
+    );
+
+    expect(screen.getByTestId("compare-card-identity")).toBeInTheDocument();
+    expect(screen.getByText("Custom Host")).toBeInTheDocument();
+    expect(screen.getByText("Cu")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
   it("shows trace tabs but not model name or Latency when comparison chrome is off", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
@@ -54,6 +54,8 @@ export function ModelCompareCardHeader({
   showComparisonChrome = true,
   /** When true (default), hides the status dot and Tools row — latency/tokens only. Set false for full compare metrics. */
   compactCompareHeader = true,
+  showIdentityHeader = false,
+  logoSrc = null,
   result,
   showToolsTab = false,
   showStepsTab = false,
@@ -90,6 +92,14 @@ export function ModelCompareCardHeader({
   /** When false, hides model title and Latency/Tokens/Tools rows (single-model-in-compare mode). */
   showComparisonChrome?: boolean;
   compactCompareHeader?: boolean;
+  /**
+   * When true, shows a compact host identity row (logo + name) above the
+   * Trace/Chat/Raw strip. Independent of `showComparisonChrome` so multi-host
+   * columns can brand without Latency/Tokens metrics.
+   */
+  showIdentityHeader?: boolean;
+  /** Host / client logo for the identity header. */
+  logoSrc?: string | null;
   /** When set, shows a Pass/Fail pill instead of the status dot. */
   result?: "passed" | "failed" | null;
   /** Include a Results tab alongside Trace/Chat/Raw. Only applies when `tabsInline` is true. */
@@ -114,7 +124,7 @@ export function ModelCompareCardHeader({
   actionsSlot?: ReactNode;
   className?: string;
 }) {
-  if (!showComparisonChrome && !showTraceTabs) {
+  if (!showComparisonChrome && !showTraceTabs && !showIdentityHeader) {
     return null;
   }
 
@@ -271,8 +281,41 @@ export function ModelCompareCardHeader({
       </div>
     ) : null;
 
+  const identityHeader =
+    showIdentityHeader && displayName ? (
+      <div
+        data-testid="compare-card-identity"
+        className={cn(
+          "flex shrink-0 items-center gap-2.5 border-b border-border/60 px-3 py-2.5",
+          !showComparisonChrome &&
+            !(showTraceTabs && !tabsInline) &&
+            className
+        )}
+      >
+        {logoSrc ? (
+          <img
+            src={logoSrc}
+            alt=""
+            className="size-6 shrink-0 object-contain"
+          />
+        ) : (
+          <span
+            aria-hidden
+            className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-[10px] font-semibold uppercase text-muted-foreground"
+          >
+            {displayName.slice(0, 2)}
+          </span>
+        )}
+        <span className="min-w-0 truncate text-sm font-semibold leading-tight">
+          {displayName}
+        </span>
+      </div>
+    ) : null;
+
   return (
     <>
+      {identityHeader}
+
       {showComparisonChrome ? (
         <div
           className={cn(

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -88,6 +88,7 @@ import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import {
   getChatboxChatBackground,
   getChatboxHostFamily,
+  getChatboxHostLogo,
   getChatboxShellStyle,
   type ChatboxHostStyle,
 } from "@/lib/chatbox-client-style";
@@ -4089,8 +4090,15 @@ export function PlaygroundMain({
                           // model title + Latency/Tokens chrome is redundant
                           // (same model in every column) and noisy. Keep the
                           // Trace/Chat/Raw tab strip — that comes from
-                          // `showTraceTabs` inside the header.
+                          // `showTraceTabs` inside the header. Show the host
+                          // identity row so columns are immediately branded.
                           showComparisonChrome={false}
+                          showIdentityHeader
+                          logoSrc={getChatboxHostLogo(
+                            column.hostSnapshot.hostStyle,
+                            column.hostSnapshot.chatUiOverride,
+                            effectiveThreadTheme
+                          )}
                           suppressThreadEmptyHint={false}
                           compareEnterVersion={multiCompareEnterVersion}
                           compareEnterMessages={multiCompareEnterMessages}

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -801,7 +801,7 @@ describe("PlaygroundMain — multi-host render path", () => {
     expect(leadProps.compareSubLabel).toBe(secondaryProps.compareSubLabel);
   });
 
-  it("multi-host card chrome is hidden — Trace/Chat/Raw tab strip is the only header content", () => {
+  it("multi-host cards hide Latency/Tokens chrome but show host identity", () => {
     const hostA = makeHost("h-A", "Host A", { hostStyle: "chatgpt" });
     const hostB = makeHost("h-B", "Host B", { hostStyle: "claude" });
     multiHostFixture.hostList = [
@@ -816,10 +816,13 @@ describe("PlaygroundMain — multi-host render path", () => {
     const calls = mockMultiModelPlaygroundCard.mock.calls;
     expect(calls.length).toBeGreaterThanOrEqual(2);
     // `showComparisonChrome=false` removes the per-card model title +
-    // Latency/Tokens block. The tab strip stays because it's gated on
-    // `showTraceTabs` inside `ModelCompareCardHeader`.
+    // Latency/Tokens block. Identity header brands each column; the tab
+    // strip stays via `showTraceTabs` inside `ModelCompareCardHeader`.
     for (const [props] of calls) {
       expect(props.showComparisonChrome).toBe(false);
+      expect(props.showIdentityHeader).toBe(true);
+      expect(typeof props.logoSrc).toBe("string");
+      expect(props.logoSrc.length).toBeGreaterThan(0);
     }
   });
 

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -153,6 +153,13 @@ interface MultiModelPlaygroundCardProps {
   onHasMessagesChange?: (compareId: string, hasMessages: boolean) => void;
   /** When false, hides per-card model title and Latency/Tokens/Tools (single selected model in compare mode). */
   showComparisonChrome?: boolean;
+  /**
+   * When true, shows a compact host identity row (logo + name) above the
+   * Trace/Chat/Raw strip. Used for multi-host columns.
+   */
+  showIdentityHeader?: boolean;
+  /** Host / client logo for the identity header. */
+  logoSrc?: string | null;
   /** Hide in-card “send a shared message” empty hint when the parent shows the shared starter strip + footer composer. */
   suppressThreadEmptyHint?: boolean;
   compareEnterVersion?: number;
@@ -224,6 +231,8 @@ export function MultiModelPlaygroundCard({
   onSummaryChange,
   onHasMessagesChange,
   showComparisonChrome = true,
+  showIdentityHeader = false,
+  logoSrc = null,
   suppressThreadEmptyHint = false,
   compareEnterVersion = 0,
   compareEnterMessages = [],
@@ -713,6 +722,8 @@ export function MultiModelPlaygroundCard({
         onModeChange={handleTraceViewModeChange}
         showTraceTabs={showTraceTabs}
         showComparisonChrome={showComparisonChrome}
+        showIdentityHeader={showIdentityHeader}
+        logoSrc={logoSrc}
       />
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">


### PR DESCRIPTION
## Summary
- add a compact logo and client-name identity row above each multi-host Playground column
- preserve the existing Trace/Chat/Raw tabs while keeping redundant model metrics hidden
- retain initials fallback behavior and leave multi-model comparison unchanged

## Test plan
- [x] Run 90 focused Playground and client-style tests
- [x] Run the complete client TypeScript check
- [x] Build the production client bundle
- [x] Verify all built-in client styles provide logo assets


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show each host’s logo and name at the top of each compare column in the Playground, above the Trace/Chat/Raw tabs. This improves multi-host clarity while keeping Latency/Tokens chrome hidden.

- **New Features**
  - Added a compact identity header (logo + name) to `ModelCompareCardHeader` via `showIdentityHeader` and `logoSrc`.
  - In multi-host mode, `PlaygroundMain` enables the identity header and pulls logos with `getChatboxHostLogo`, while keeping `showComparisonChrome=false`.
  - Initials fallback renders when no logo is available; tab strip behavior is unchanged.

<sup>Written for commit 1e55a8cc24070761b94924ceaa4631c29e4de299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

