### PR TITLE
fix(sdk): register notifications/tasks through the v2 schema overload

### DIFF
--- a/.changeset/tasks-notification-schema-overload.md
+++ b/.changeset/tasks-notification-schema-overload.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Fix every modern `subscriptions/listen` failing with `'notifications/tasks' is not a spec notification method`. The v2 client bump to 2.0.0 tightened the two-argument `setNotificationHandler(method, handler)` overload to methods carried by one of its two spec codecs, and the tasks extension's `notifications/tasks` (SEP-2663) is by definition not one — so the registration threw a `TypeError` and took the whole subscription down, with or without a `taskIds` filter.
+
+`OfficialSdkClientAdapter` now routes extension notification methods through upstream's three-argument schema form and unwraps the handler back to the raw notification the manager and coordinator read. The params schema is a pass-through: upstream has no wire schema for an extension payload, and validating `notifications/tasks` is already MCPJam's job in `tasks-ext-guards.ts`, so narrowing here would strip extension members before those guards run. Because the adapter is the innermost wrapper, this covers both registration sites — the subscription coordinator's `ensureHandlers()` and `MCPClientManager.addNotificationHandler` (reached by the Inspector's `onTaskStatusChanged`). The legacy `notifications/tasks/status` is 2025-11-25 spec and stays on the codec-validated path.

--- a/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
+++ b/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
@@ -32,6 +32,43 @@ import type {
   ManagedMcpClientRequestHandler,
   ManagedMcpClientRequestMethod,
 } from "./managed-mcp-client.js";
+import { TasksExtNotificationMethod } from "./tasks-ext.js";
+
+/**
+ * Notification methods MCPJam registers that live outside both spec codecs.
+ *
+ * Upstream 2.0.0 tightened the two-argument `setNotificationHandler(method,
+ * handler)` overload to `isSpecNotificationMethod(method)` and throws a
+ * `TypeError` otherwise, so an extension method must go through the
+ * three-argument schema form. Only the tasks extension's `notifications/tasks`
+ * (SEP-2663) qualifies today: the legacy `notifications/tasks/status` is
+ * 2025-11-25 spec and stays on the two-argument path.
+ */
+const EXTENSION_NOTIFICATION_METHODS: ReadonlySet<string> = new Set([
+  TasksExtNotificationMethod,
+]);
+
+function isExtensionNotificationMethod(method: string): boolean {
+  return EXTENSION_NOTIFICATION_METHODS.has(method);
+}
+
+/**
+ * Params schema for the three-argument form above. Upstream has no wire schema
+ * for an extension payload — validating `notifications/tasks` is MCPJam's job
+ * (`tasks-ext-guards.ts`, which the coordinator and manager already run on
+ * delivery) — so this only satisfies the overload and forwards params verbatim.
+ * Anything narrower would drop extension members before our own guards see them.
+ */
+const PassthroughNotificationParamsSchema: StandardSchemaV1<
+  Record<string, unknown>,
+  Record<string, unknown>
+> = {
+  "~standard": {
+    version: 1,
+    vendor: "mcpjam",
+    validate: (value: unknown) => ({ value: value as Record<string, unknown> }),
+  },
+};
 
 export class OfficialSdkClientAdapter implements ManagedMcpClient {
   readonly inner: Client;
@@ -213,6 +250,17 @@ export class OfficialSdkClientAdapter implements ManagedMcpClient {
     method: ManagedMcpClientNotificationMethod,
     handler: ManagedMcpClientNotificationHandler,
   ): void {
+    if (isExtensionNotificationMethod(method)) {
+      // Three-argument form: the handler is called with the validated params,
+      // so drop them and forward the raw notification the manager expects.
+      this.inner.setNotificationHandler(
+        method as never,
+        { params: PassthroughNotificationParamsSchema } as never,
+        ((_params: unknown, notification: unknown) =>
+          handler(notification as never)) as never,
+      );
+      return;
+    }
     // beta.4 overloaded this (typed `NotificationMethod` vs Standard-Schema).
     // The manager keys by method string; cast to the pass-through form.
     this.inner.setNotificationHandler(method as never, handler as never);

--- a/sdk/tests/official-sdk-client-adapter-notifications.test.ts
+++ b/sdk/tests/official-sdk-client-adapter-notifications.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { createManagedMcpClient } from "../src/mcp-client-manager/managed-mcp-client-factory.js";
+import { OfficialSdkClientAdapter } from "../src/mcp-client-manager/official-sdk-client-adapter.js";
+import { TasksExtNotificationMethod } from "../src/mcp-client-manager/tasks-ext.js";
+import { ResourceUpdatedNotificationMethod } from "../src/mcp-client-manager/subscription-coordinator.js";
+
+const clientInfo = { name: "test", version: "0.0.0" };
+
+function newAdapter(): OfficialSdkClientAdapter {
+  return createManagedMcpClient({
+    clientInfo,
+    clientOptions: { capabilities: {} },
+  }) as OfficialSdkClientAdapter;
+}
+
+/**
+ * Reach the handler upstream actually stored, and invoke it the way the
+ * protocol layer does. Going through the real `Client` is the point: the bug
+ * this covers lived entirely in upstream's overload dispatch, so a fake client
+ * would have passed while every `subscriptions/listen` failed.
+ */
+function storedHandler(
+  adapter: OfficialSdkClientAdapter,
+  method: string
+): ((notification: unknown, codec: unknown) => Promise<unknown>) | undefined {
+  return (
+    adapter.inner as unknown as {
+      _notificationHandlers: Map<
+        string,
+        (notification: unknown, codec: unknown) => Promise<unknown>
+      >;
+    }
+  )._notificationHandlers.get(method);
+}
+
+describe("OfficialSdkClientAdapter.setNotificationHandler", () => {
+  it("registers the tasks extension notification without throwing", () => {
+    // Upstream 2.0.0 rejects the two-argument overload for any method outside
+    // its two spec codecs, which broke every subscription the coordinator
+    // opened — it registers this method unconditionally, task filter or not.
+    const adapter = newAdapter();
+
+    expect(() =>
+      adapter.setNotificationHandler(TasksExtNotificationMethod, () => {})
+    ).not.toThrow();
+    expect(storedHandler(adapter, TasksExtNotificationMethod)).toBeDefined();
+  });
+
+  it("delivers the raw extension notification, params untouched", async () => {
+    const adapter = newAdapter();
+    const handler = vi.fn();
+    adapter.setNotificationHandler(TasksExtNotificationMethod, handler);
+
+    const notification = {
+      method: TasksExtNotificationMethod,
+      params: {
+        taskId: "task-1",
+        status: "completed",
+        _meta: { "io.modelcontextprotocol/subscriptionId": "listen:0" },
+      },
+    };
+    await storedHandler(adapter, TasksExtNotificationMethod)?.(
+      notification,
+      undefined
+    );
+
+    // The manager and coordinator read `notification.method` and the full
+    // params (including extension-only members), so neither may be reshaped.
+    expect(handler).toHaveBeenCalledWith(notification);
+  });
+
+  it("keeps spec notifications on the codec-validated path", async () => {
+    const adapter = newAdapter();
+    const handler = vi.fn();
+    adapter.setNotificationHandler(ResourceUpdatedNotificationMethod, handler);
+
+    const notification = {
+      method: ResourceUpdatedNotificationMethod,
+      params: { uri: "demo://counter" },
+    };
+    const codec = {
+      validateNotification: vi.fn(() => ({ ok: true, value: notification })),
+    };
+    await storedHandler(adapter, ResourceUpdatedNotificationMethod)?.(
+      notification,
+      codec
+    );
+
+    expect(codec.validateNotification).toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledWith(notification);
+  });
+});


### PR DESCRIPTION
## What's broken

Every modern `subscriptions/listen` fails on `main`:

```
SUBSCRIPTION_FAILED: 'notifications/tasks' is not a spec notification method;
pass schemas as the second argument to setNotificationHandler().
```

Found while driving the 2026 stateless reference server with the CLI. The error comes from `@modelcontextprotocol/client` 2.0.0, not from any server. The 2.0.0 bump (#3543) tightened the two-argument `setNotificationHandler(method, handler)` overload to `isSpecNotificationMethod(method)` and throws a `TypeError` otherwise. The tasks extension's `notifications/tasks` (SEP-2663) is by definition not a spec method, and `SubscriptionCoordinator.ensureHandlers()` registers it unconditionally — so the throw takes down the whole subscription whether or not a `taskIds` filter was requested.

`MCPClientManager.addNotificationHandler` had the same latent throw on the path the Inspector's `onTaskStatusChanged` uses.

## The fix

`OfficialSdkClientAdapter` routes extension notification methods through upstream's three-argument schema form and unwraps the handler back to the raw notification the manager and coordinator read.

The params schema is a deliberate pass-through. Upstream has no wire schema for an extension payload, and validating `notifications/tasks` is already MCPJam's job (`tasks-ext-guards.ts`, which both consumers run on delivery) — narrowing here would strip extension members before those guards ever see them.

The adapter is the innermost wrapper, so one seam covers both registration sites. Legacy `notifications/tasks/status` is 2025-11-25 spec and stays on the codec-validated path; the method set is keyed off the imported `TasksExtNotificationMethod` rather than a new string literal.

## Verification

- New `sdk/tests/official-sdk-client-adapter-notifications.test.ts` drives a **real** upstream `Client` — the defect lived entirely in upstream's overload dispatch, so a fake client would have passed while every listen failed. Confirmed red before the fix (2 failures, exact `TypeError`), green after.
- Live against the 2026 stateless server: `subscriptions listen` acks and delivers both `resources/updated` and `tools/list_changed`, exit 0.
- `subscription-coordinator` suites: 39 passed. Full SDK suite: 3171 passed, 6 failed — those 6 also fail on unmodified `main` (validator dialect, `tasks-ext-listen-meta`, conformance era integration), so they are pre-existing 2.0.0-bump fallout and are **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the central notification registration path for all managed clients; scope is narrow (one extension method + passthrough schema) but subscription and Inspector task callbacks depend on it.
> 
> **Overview**
> **Fixes `subscriptions/listen` failing** after `@modelcontextprotocol/client` 2.0.0, which now throws when `setNotificationHandler` is called with two arguments for non-spec methods like SEP-2663 **`notifications/tasks`**.
> 
> `OfficialSdkClientAdapter.setNotificationHandler` **detects extension notification methods** (today only `notifications/tasks`) and registers them via upstream’s **three-argument schema overload**, using a **passthrough params schema** so payloads stay intact for `tasks-ext-guards.ts`. Handlers are **rewrapped** so callers still receive the full raw notification. **Spec methods** (e.g. `resources/updated`, legacy `notifications/tasks/status`) **unchanged** on the two-argument path.
> 
> Adds **`official-sdk-client-adapter-notifications.test.ts`** against a real upstream `Client` to assert registration no longer throws and delivery semantics are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0715292ee6478ad28de86d9977faca559042e54a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes modern `subscriptions/listen` failures by registering the tasks extension notification (`notifications/tasks`) through the v2 schema overload, avoiding the `TypeError` introduced by `@modelcontextprotocol/client` 2.0.0. Listens now ack and deliver as expected.

- **Bug Fixes**
  - Route `notifications/tasks` via the three-arg `setNotificationHandler` with a passthrough params schema; forward the raw notification to consumers.
  - Leave spec methods (e.g., `notifications/tasks/status`) on the codec-validated path.
  - Apply at the adapter seam to cover both registration sites: the subscription coordinator and `MCPClientManager.addNotificationHandler`.
  - Add a test using the real upstream `Client` to verify registration and delivery paths.

<sup>Written for commit 0715292ee6478ad28de86d9977faca559042e54a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

