### PR TITLE
feat(tracing): show HTTP headers for MCP exchanges (SEP-2243)

### DIFF
--- a/.changeset/tracing-http-headers.md
+++ b/.changeset/tracing-http-headers.md
@@ -1,0 +1,16 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Add an HTTP-exchange log channel: `httpLogger` on the manager options and per
+server config, plus `wrapFetchForHttpLogging` and the SEP-2243 header helpers
+(`classifyMcpHeader`, `decodeMcpHeaderValue`, `findMcpHeaderIssues`, exported
+from `@mcpjam/sdk/browser`).
+
+`rpcLogger` carries JSON-RPC bodies; from `2026-07-28` the routing and
+cross-check metadata a `-32020 HeaderMismatch` is about rides in HTTP headers
+instead, which a body-only log cannot show. The new channel captures the header
+halves of each exchange — never bodies — with credential headers redacted at
+the capture point. Capture is opt-in and applies to every protocol version:
+`MCP-Protocol-Version` exists from `2025-06-18`, and the session/resumption
+headers exist only in the legacy eras.

--- a/mcpjam-inspector/client/src/components/TracingTab.tsx
+++ b/mcpjam-inspector/client/src/components/TracingTab.tsx
@@ -22,7 +22,12 @@ export function TracingTab() {
       const state = useTrafficLogStore.getState();
       const serverItems: TraceLogEntryView[] = state.mcpServerItems.map(
         (item) => ({
-          source: item.kind === "oauth" ? "oauth" : "mcp-server",
+          source:
+            item.kind === "oauth"
+              ? "oauth"
+              : item.kind === "http"
+                ? "http"
+                : "mcp-server",
           method: item.method,
           direction: item.direction,
           serverId: item.serverId,

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -55,8 +55,10 @@ import {
   requestOpenOAuthDebugger,
 } from "@/lib/oauth/oauth-debugger-navigation";
 import { cn } from "@/lib/utils";
+import { HttpExchangeDetails } from "@/components/tracing/HttpExchangeDetails";
+import type { HttpExchangeLogEvent } from "@mcpjam/sdk/browser";
 
-type TrafficSource = "mcp-server" | "mcp-apps" | "oauth";
+type TrafficSource = "mcp-server" | "mcp-apps" | "oauth" | "http";
 
 interface RenderableRpcItem {
   id: string;
@@ -269,6 +271,14 @@ function DirectionLabel({
     );
   }
 
+  if (source === "http") {
+    return (
+      <span className="font-mono text-[10px] leading-none flex-shrink-0 text-amber-600 dark:text-amber-400">
+        http
+      </span>
+    );
+  }
+
   const isSend = direction === "SEND";
   return (
     <span
@@ -371,6 +381,8 @@ export function LoggerView({
       source:
         item.kind === "oauth"
           ? ("oauth" as TrafficSource)
+          : item.kind === "http"
+          ? ("http" as TrafficSource)
           : ("mcp-server" as TrafficSource),
       oauthStatus: item.oauthStatus,
       oauthRecovered: item.oauthRecovered,
@@ -594,6 +606,9 @@ export function LoggerView({
                     </DropdownMenuRadioItem>
                     <DropdownMenuRadioItem value="oauth" className="text-xs">
                       OAuth
+                    </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="http" className="text-xs">
+                      HTTP
                     </DropdownMenuRadioItem>
                     <DropdownMenuRadioItem value="mcp-apps" className="text-xs">
                       Apps
@@ -837,6 +852,10 @@ export function LoggerView({
               const isExpanded = expanded.has(it.id);
               const isAppsTraffic = it.source === "mcp-apps";
               const isOAuthTraffic = it.source === "oauth";
+              const isHttpExchange = it.source === "http";
+              const httpExchange = isHttpExchange
+                ? (it.payload as HttpExchangeLogEvent)
+                : undefined;
               const oauthInlineSummary = isOAuthTraffic
                 ? getOAuthInlineSummary(it.payload)
                 : undefined;
@@ -847,7 +866,13 @@ export function LoggerView({
               const isError =
                 it.method === "error" ||
                 it.method === "csp-violation" ||
-                (isOAuthTraffic && it.oauthStatus === "error");
+                (isOAuthTraffic && it.oauthStatus === "error") ||
+                // A 4xx/5xx or a fetch that never got a response. `401` is not
+                // excluded here the way the OAuth card excludes its expected
+                // challenge: on the RPC endpoint a 401 IS the failure.
+                (httpExchange !== undefined &&
+                  (httpExchange.error !== undefined ||
+                    (httpExchange.response?.status ?? 0) >= 400));
 
               // Left border: 2px — red for errors (incl. OAuth failures), purple for Apps,
               // transparent otherwise (OAuth success has no rail)
@@ -884,7 +909,7 @@ export function LoggerView({
                         isExpanded && "rotate-90"
                       )}
                     />
-                    {isError && !isOAuthTraffic ? (
+                    {isError && !isOAuthTraffic && !isHttpExchange ? (
                       <AlertCircle className="h-3 w-3 flex-shrink-0 text-destructive" />
                     ) : (
                       <DirectionLabel
@@ -962,15 +987,21 @@ export function LoggerView({
                   {isExpanded && (
                     <div className="border-t border-border bg-muted/10 p-2">
                       <div className="max-h-[40vh] overflow-auto">
-                        <JsonEditor
-                          height="100%"
-                          value={normalizePayload(it.payload) as object}
-                          readOnly
-                          showToolbar={false}
-                          collapsible
-                          defaultExpandDepth={2}
-                          collapseStringsAfterLength={100}
-                        />
+                        {isHttpExchange ? (
+                          <HttpExchangeDetails
+                            exchange={it.payload as HttpExchangeLogEvent}
+                          />
+                        ) : (
+                          <JsonEditor
+                            height="100%"
+                            value={normalizePayload(it.payload) as object}
+                            readOnly
+                            showToolbar={false}
+                            collapsible
+                            defaultExpandDepth={2}
+                            collapseStringsAfterLength={100}
+                          />
+                        )}
                       </div>
                     </div>
                   )}

--- a/mcpjam-inspector/client/src/components/tracing/HttpExchangeDetails.tsx
+++ b/mcpjam-inspector/client/src/components/tracing/HttpExchangeDetails.tsx
@@ -1,0 +1,213 @@
+/**
+ * The expanded body of an HTTP-exchange row in Tracing.
+ *
+ * Deliberately NOT `HTTPHistoryEntry`: that component is shared by the OAuth
+ * and XAA flow loggers and renders headers as an opaque JSON blob. What this
+ * screen needs is the opposite — the mirrored `Mcp-*` headers pulled to the
+ * top, sentinel values decoded, and the header/body cross-check run — so it
+ * gets its own presentation rather than growing options on a shared card.
+ */
+
+import { useMemo } from "react";
+import { AlertTriangle } from "lucide-react";
+import { ScrollableJsonView } from "@/components/ui/json-editor";
+import { cn } from "@/lib/utils";
+import {
+  classifyMcpHeader,
+  decodeMcpHeaderValue,
+  findMcpHeaderIssues,
+  type HttpExchangeLogEvent,
+  type McpHeaderFamily,
+  type McpHeaderIssue,
+} from "@mcpjam/sdk/browser";
+
+/** Display order: the routing/cross-check headers first, params after. */
+const FAMILY_ORDER: McpHeaderFamily[] = [
+  "protocol-version",
+  "method",
+  "name",
+  "param",
+  "session",
+  "resumption",
+];
+
+const FAMILY_LABEL: Record<McpHeaderFamily, string> = {
+  "protocol-version": "protocol version",
+  method: "routing",
+  name: "routing",
+  param: "mirrored argument",
+  session: "session",
+  resumption: "resumption",
+};
+
+type ProtocolHeaderRow = {
+  name: string;
+  family: McpHeaderFamily;
+  raw: string;
+  decoded?: string;
+  decodeError?: string;
+};
+
+function collectProtocolHeaders(
+  headers: Record<string, string>,
+): ProtocolHeaderRow[] {
+  const rows: ProtocolHeaderRow[] = [];
+  for (const [name, raw] of Object.entries(headers)) {
+    const family = classifyMcpHeader(name);
+    if (!family) continue;
+    const decoded = decodeMcpHeaderValue(raw);
+    rows.push({
+      name,
+      family,
+      raw,
+      // Show the decoded value only when it adds something — an unencoded
+      // value shown twice reads as if the two could differ.
+      decoded: decoded.encoded ? decoded.value : undefined,
+      decodeError: decoded.decodeError,
+    });
+  }
+  return rows.sort(
+    (a, b) =>
+      FAMILY_ORDER.indexOf(a.family) - FAMILY_ORDER.indexOf(b.family) ||
+      a.name.localeCompare(b.name),
+  );
+}
+
+function describeIssue(issue: McpHeaderIssue): string {
+  switch (issue.kind) {
+    case "missing":
+      return `${issue.header} is required for this request and was not sent (body has "${issue.bodyValue}")`;
+    case "mismatch":
+      return `${issue.header} is "${issue.headerValue}" but the body says "${issue.bodyValue}"`;
+    case "undecodable":
+      return `${issue.header} carries the base64 sentinel but did not decode: "${issue.headerValue}"`;
+  }
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="text-xs font-medium text-muted-foreground mb-1">
+      {children}
+    </div>
+  );
+}
+
+export function HttpExchangeDetails({
+  exchange,
+}: {
+  exchange: HttpExchangeLogEvent;
+}) {
+  const requestProtocolHeaders = useMemo(
+    () => collectProtocolHeaders(exchange.request.headers),
+    [exchange.request.headers],
+  );
+  const issues = useMemo(
+    () => findMcpHeaderIssues(exchange.request.headers, exchange.bodyValues),
+    [exchange.request.headers, exchange.bodyValues],
+  );
+
+  const status = exchange.response?.status;
+  const statusColor =
+    status === undefined
+      ? "text-muted-foreground"
+      : status >= 500
+        ? "text-red-700 dark:text-red-500"
+        : status >= 400
+          ? "text-red-600 dark:text-red-400"
+          : status >= 300
+            ? "text-yellow-600 dark:text-yellow-400"
+            : "text-green-600 dark:text-green-400";
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 font-mono text-xs">
+        <span className="text-foreground">{exchange.request.method}</span>
+        <span className="text-muted-foreground truncate">
+          {exchange.request.url}
+        </span>
+        {exchange.response ? (
+          <span className={cn("flex-shrink-0", statusColor)}>
+            {exchange.response.status} {exchange.response.statusText}
+          </span>
+        ) : (
+          <span className="flex-shrink-0 text-red-600 dark:text-red-400">
+            {exchange.error ?? "no response"}
+          </span>
+        )}
+        <span className="flex-shrink-0 text-muted-foreground">
+          {exchange.durationMs}ms
+        </span>
+      </div>
+
+      {issues.length > 0 && (
+        <div className="rounded-sm border border-red-400 bg-red-50/50 p-2 dark:border-red-500 dark:bg-red-950/20">
+          <div className="mb-1 flex items-center gap-1 text-xs font-medium text-red-600 dark:text-red-400">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            Header/body disagreement — this is what a -32020 HeaderMismatch
+            reports
+          </div>
+          <ul className="space-y-0.5">
+            {issues.map((issue) => (
+              <li
+                key={`${issue.kind}:${issue.header}`}
+                className="font-mono text-[11px] text-red-600 dark:text-red-400"
+              >
+                {describeIssue(issue)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {requestProtocolHeaders.length > 0 && (
+        <div>
+          <SectionLabel>MCP headers</SectionLabel>
+          <div className="rounded-sm bg-background/60 p-2 space-y-1">
+            {requestProtocolHeaders.map((row) => (
+              <div
+                key={row.name}
+                className="flex flex-wrap items-baseline gap-x-2 font-mono text-[11px]"
+              >
+                <span className="text-foreground">{row.name}</span>
+                <span className="text-muted-foreground break-all">
+                  {row.raw}
+                </span>
+                {row.decoded !== undefined && (
+                  <span className="text-sky-600 dark:text-sky-400 break-all">
+                    → {row.decoded}
+                  </span>
+                )}
+                {row.decodeError && (
+                  <span className="text-red-600 dark:text-red-400">
+                    → does not decode
+                  </span>
+                )}
+                <span className="text-muted-foreground/70">
+                  {FAMILY_LABEL[row.family]}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div>
+        <SectionLabel>Request headers</SectionLabel>
+        <ScrollableJsonView
+          value={exchange.request.headers}
+          containerClassName="rounded-sm bg-background/60 p-2 max-h-[200px]"
+        />
+      </div>
+
+      {exchange.response && (
+        <div>
+          <SectionLabel>Response headers</SectionLabel>
+          <ScrollableJsonView
+            value={exchange.response.headers}
+            containerClassName="rounded-sm bg-background/60 p-2 max-h-[200px]"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/review-surface-snapshots.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/review-surface-snapshots.test.ts
@@ -30,6 +30,39 @@ function expectNoSecrets(value: unknown) {
 }
 
 describe("review-surface snapshots redact and bound", () => {
+  it("tracing: counts HTTP exchanges without letting their headers through", () => {
+    // An HTTP-exchange row's payload is the captured header sets. Credential
+    // headers are already redacted at capture, but the snapshot must not carry
+    // ANY header — the row is summarized by its request line alone.
+    const snapshot = buildTracingSnapshot({
+      serverItems: [
+        {
+          source: "http",
+          method: "POST /mcp",
+          direction: "HTTP",
+          serverId: "srv-1",
+          serverName: "Server 1",
+          timestamp: "2026-07-28T00:00:00Z",
+          payload: {
+            request: { headers: { authorization: SECRET } },
+          },
+        } as never,
+      ],
+      appItems: [],
+    });
+
+    expectNoSecrets(snapshot);
+    expect(snapshot.counts.http).toBe(1);
+    expect(snapshot.counts.other).toBe(0);
+    expect(snapshot.recent[0]).toEqual({
+      source: "http",
+      method: "POST /mcp",
+      direction: "HTTP",
+      server: "Server 1",
+      timestamp: "2026-07-28T00:00:00Z",
+    });
+  });
+
   it("tracing: summarizes traffic by shape, never the payloads", () => {
     // Each entry carries a secret `payload` the builder must ignore.
     const serverItems = Array.from({ length: 50 }, (_, i) => ({

--- a/mcpjam-inspector/client/src/lib/webmcp/review-surface-snapshots.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/review-surface-snapshots.ts
@@ -42,11 +42,14 @@ export interface TracingSnapshotInput {
  */
 export function buildTracingSnapshot(input: TracingSnapshotInput) {
   const combined = [...input.serverItems, ...input.appItems];
-  const counts = { mcpServer: 0, mcpApps: 0, oauth: 0, other: 0 };
+  const counts = { mcpServer: 0, mcpApps: 0, oauth: 0, http: 0, other: 0 };
   for (const entry of combined) {
     if (entry.source === "mcp-server") counts.mcpServer += 1;
     else if (entry.source === "mcp-apps") counts.mcpApps += 1;
     else if (entry.source === "oauth") counts.oauth += 1;
+    // HTTP exchanges are counted, and their request line is listed, but their
+    // headers stay out of the snapshot along with every other payload.
+    else if (entry.source === "http") counts.http += 1;
     else counts.other += 1;
   }
   // Both slices are newest-first INDEPENDENTLY; concatenating and slicing would

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -4,6 +4,8 @@
  * Includes:
  * - MCP Apps / OpenAI Apps SDK traffic (iframe ↔ host messages)
  * - MCP Server RPC traffic (client ↔ server messages)
+ * - The HTTP exchanges those messages rode in (headers only) — the `Mcp-*`
+ *   mirrored headers are wire state the JSON-RPC body cannot show
  *
  * This is a singleton store - no provider required.
  * The SSE subscription is also a singleton to prevent duplicate connections.
@@ -21,9 +23,23 @@ import type {
 // `extractMethod` relocated to the SDK widget-runtime (Phase 3d-ii); imported
 // for internal use and re-exported below so existing import sites are unchanged.
 import { extractMethod } from "@mcpjam/sdk/widget-runtime";
+import type { HttpExchangeLogEvent } from "@mcpjam/sdk/browser";
+
+/**
+ * The path of an exchange URL — the row label. The query string is dropped on
+ * purpose: this label feeds the Tracing agent snapshot, and a query can carry
+ * a token. The full URL stays on the payload, which the snapshot never reads.
+ */
+function describeHttpTarget(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
 
 export type UiProtocol = "mcp-apps" | "openai-apps";
-export type McpServerLogKind = "rpc" | "oauth";
+export type McpServerLogKind = "rpc" | "oauth" | "http";
 
 export interface UiLogEvent {
   id: string;
@@ -217,8 +233,26 @@ export function subscribeToRpcStream(): () => void {
           direction?: string;
           message?: unknown;
           timestamp?: string;
+          exchange?: HttpExchangeLogEvent;
         };
-        if (!data || data.type !== "rpc") return;
+        if (!data) return;
+
+        if (data.type === "http") {
+          if (!data.exchange) return;
+          const exchange = data.exchange;
+          useTrafficLogStore.getState().addMcpServerLog({
+            serverId:
+              typeof data.serverId === "string" ? data.serverId : "unknown",
+            direction: "HTTP",
+            method: `${exchange.request.method} ${describeHttpTarget(exchange.request.url)}`,
+            timestamp: data.timestamp ?? new Date().toISOString(),
+            payload: exchange,
+            kind: "http",
+          });
+          return;
+        }
+
+        if (data.type !== "rpc") return;
 
         const { serverId, direction, message, timestamp } = data;
         useTrafficLogStore.getState().addMcpServerLog({

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -146,6 +146,19 @@ export async function createHonoApp() {
           message,
         });
       },
+      // HTTP-exchange capture (headers only). A separate SDK channel from
+      // `rpcLogger`: from 2026-07-28 the routing/cross-check metadata a
+      // `-32020 HeaderMismatch` is about lives in HTTP headers, which the
+      // JSON-RPC body log cannot show. Every era is captured — the legacy
+      // session/resumption headers are just as debuggable.
+      httpLogger: (exchange) => {
+        rpcLogBus.publish({
+          kind: "http",
+          serverId: exchange.serverId,
+          timestamp: new Date().toISOString(),
+          exchange,
+        });
+      },
       progressHandler: ({
         serverId,
         progressToken,

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -300,6 +300,19 @@ const mcpClientManager = new MCPClientManager(
         message,
       });
     },
+    // HTTP-exchange capture (headers only). A separate SDK channel from
+    // `rpcLogger`: from 2026-07-28 the routing/cross-check metadata a
+    // `-32020 HeaderMismatch` is about lives in HTTP headers, which the
+    // JSON-RPC body log cannot show. Every era is captured — the legacy
+    // session/resumption headers are just as debuggable.
+    httpLogger: (exchange) => {
+      rpcLogBus.publish({
+        kind: "http",
+        serverId: exchange.serverId,
+        timestamp: new Date().toISOString(),
+        exchange,
+      });
+    },
     // SEP-2549 cache-serve provenance — a channel SEPARATE from rpcLogger
     // (see server/utils/cache-events.ts). Routes opt in per-request via
     // `withCacheEventCapture`; this callback is a no-op outside that scope.

--- a/mcpjam-inspector/server/routes/mcp/servers.ts
+++ b/mcpjam-inspector/server/routes/mcp/servers.ts
@@ -258,13 +258,13 @@ servers.get("/rpc/stream", async (c) => {
           isNaN(replay) ? 0 : replay
         );
         for (const evt of recent) {
-          send({ type: "rpc", ...evt });
+          send({ type: evt.kind === "http" ? "http" : "rpc", ...evt });
         }
       } catch {}
 
       // Subscribe to live events for all known servers
       const unsubscribe = rpcLogBus.subscribe(serverIds, (evt: RpcLogEvent) => {
-        send({ type: "rpc", ...evt });
+        send({ type: evt.kind === "http" ? "http" : "rpc", ...evt });
       });
 
       // Keepalive comments

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -1,6 +1,9 @@
 import type { UIMessageChunk } from "ai";
 import type { RpcLogger } from "@mcpjam/sdk";
-import { rpcLogBus } from "../../services/rpc-log-bus.js";
+import {
+  isRpcMessageLogEvent,
+  rpcLogBus,
+} from "../../services/rpc-log-bus.js";
 import { logger } from "../../utils/logger.js";
 import {
   isRpcLogSinkConfigured,
@@ -207,6 +210,11 @@ export function bridgeHarnessRpcLogsToCollector(
   // a harness turn with no MCP servers has nothing to bridge.
   if (serverIds.length === 0) return () => {};
   return rpcLogBus.subscribe(serverIds, (event) => {
+    // HTTP-exchange events are local-Tracing only. The hosted delivery
+    // (`data-rpc-log` parts, the Convex sink, `isHostedRpcLogEvent`) is a
+    // closed JSON-RPC-frame shape defined across two repos; widening it is its
+    // own change, so hosted stays header-blind rather than half-wired.
+    if (!isRpcMessageLogEvent(event)) return;
     collector.rpcLogger({
       direction: event.direction,
       message: event.message,

--- a/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { rpcLogBus, type RpcLogEvent } from "../rpc-log-bus";
+import {
+  isRpcMessageLogEvent,
+  rpcLogBus,
+  type RpcLogEvent,
+} from "../rpc-log-bus";
 
 function event(serverId: string, id: number): RpcLogEvent {
   return {
@@ -10,6 +14,12 @@ function event(serverId: string, id: number): RpcLogEvent {
   };
 }
 
+/** Narrows to a JSON-RPC frame before reading `message` off the bus union. */
+function idOf(event: RpcLogEvent): number | undefined {
+  if (!isRpcMessageLogEvent(event)) return undefined;
+  return (event.message as { id: number }).id;
+}
+
 describe("rpcLogBus", () => {
   it("caps the per-server replay buffer on write (oldest evicted)", () => {
     const serverId = `cap-test-${crypto.randomUUID()}`;
@@ -18,8 +28,8 @@ describe("rpcLogBus", () => {
     const all = rpcLogBus.getBuffer([serverId], -1);
     expect(all).toHaveLength(500);
     // Oldest entries were evicted; the newest survive.
-    expect((all[0].message as { id: number }).id).toBe(120);
-    expect((all[all.length - 1].message as { id: number }).id).toBe(619);
+    expect(idOf(all[0])).toBe(120);
+    expect(idOf(all[all.length - 1])).toBe(619);
   });
 
   it("isolates a throwing subscriber: publish never throws and later subscribers still fire", () => {
@@ -46,5 +56,37 @@ describe("rpcLogBus", () => {
     stop();
     rpcLogBus.publish(event(serverId, 1));
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("carries HTTP-exchange events alongside frames, distinguished by kind", () => {
+    const serverId = `http-test-${crypto.randomUUID()}`;
+    const seen: RpcLogEvent[] = [];
+    const stop = rpcLogBus.subscribe([serverId], (e) => seen.push(e));
+    try {
+      rpcLogBus.publish(event(serverId, 1));
+      rpcLogBus.publish({
+        kind: "http",
+        serverId,
+        timestamp: new Date().toISOString(),
+        exchange: {
+          serverId,
+          request: {
+            method: "POST",
+            url: "https://example.test/mcp",
+            headers: { "mcp-method": "tools/call" },
+          },
+          response: { status: 200, statusText: "OK", headers: {} },
+          durationMs: 3,
+        },
+      });
+    } finally {
+      stop();
+    }
+
+    expect(seen).toHaveLength(2);
+    // The frame narrows to a message event; the exchange does not, so a
+    // frame-only consumer (the hosted bridge) can skip it.
+    expect(seen.filter(isRpcMessageLogEvent)).toHaveLength(1);
+    expect(idOf(seen[1])).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/services/rpc-log-bus.ts
+++ b/mcpjam-inspector/server/services/rpc-log-bus.ts
@@ -1,12 +1,40 @@
 import { EventEmitter } from "events";
+import type { HttpExchangeLogEvent } from "@mcpjam/sdk";
 import { logger } from "../utils/logger";
 
-export type RpcLogEvent = {
+/** A JSON-RPC frame. `kind` is optional so existing publishers are unchanged. */
+export type RpcMessageLogEvent = {
+  kind?: "rpc";
   serverId: string;
   direction: "send" | "receive";
   timestamp: string; // ISO
   message: unknown;
 };
+
+/**
+ * One HTTP exchange, headers only — the envelope the frames rode in.
+ *
+ * A SEPARATE event kind rather than a field on the frame: the transport hands
+ * us the headers when the fetch resolves, which is after the `send` frame was
+ * already logged and before the `receive` frames are parsed out of the
+ * response. There is no moment at which a frame and its headers are both in
+ * hand, so pretending otherwise would mean holding frames back or attaching
+ * headers to the wrong one.
+ */
+export type HttpExchangeBusEvent = {
+  kind: "http";
+  serverId: string;
+  timestamp: string; // ISO
+  exchange: HttpExchangeLogEvent;
+};
+
+export type RpcLogEvent = RpcMessageLogEvent | HttpExchangeBusEvent;
+
+export function isRpcMessageLogEvent(
+  event: RpcLogEvent,
+): event is RpcMessageLogEvent {
+  return event.kind !== "http";
+}
 
 /** Per-server replay-buffer cap, enforced on WRITE. The buffer exists only to
  *  seed the Logs SSE with recent history (`getBuffer`); without a cap a

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -371,6 +371,26 @@ export {
   type McpProtocolVersion,
 } from "./mcp-client-manager/mcp-protocol-version.js";
 
+// SEP-2243 mirrored request-metadata headers. Browser-safe by construction
+// (pure string work, no transport): the Tracing panel runs the SAME decode and
+// header/body cross-check a server runs, so a `-32020 HeaderMismatch` can be
+// explained against the captured wire instead of guessed at.
+export {
+  MCP_HEADER_SENTINEL_PREFIX,
+  MCP_HEADER_SENTINEL_SUFFIX,
+  MCP_PARAM_HEADER_PREFIX,
+  classifyMcpHeader,
+  decodeMcpHeaderValue,
+  findMcpHeaderIssues,
+} from "./mcp-client-manager/mcp-header-mirror.js";
+export type {
+  DecodedMcpHeaderValue,
+  McpHeaderFamily,
+  McpHeaderIssue,
+  MirroredBodyValues,
+} from "./mcp-client-manager/mcp-header-mirror.js";
+export type { HttpExchangeLogEvent } from "./mcp-client-manager/http-exchange-log.js";
+
 // OpenTelemetry trace context over the 2026-07-28 reserved `_meta` keys.
 // Browser-safe by construction: pure string validation, no transport. The
 // browser side is the READ half — surfacing a trace context a server sent so

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -38,6 +38,8 @@ export type {
   ProgressEvent,
   RpcLogger,
   RpcLogEvent,
+  HttpExchangeLogEvent,
+  HttpExchangeLogger,
 } from "./mcp-client-manager/index.js";
 
 // Tool and task types

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -93,6 +93,10 @@ import {
   TASK_CREATED_META_KEY,
   createDefaultRpcLogger,
 } from "./transport-utils.js";
+import {
+  wrapFetchForHttpLogging,
+  type HttpExchangeLogger,
+} from "./http-exchange-log.js";
 import { RefreshTokenOAuthProvider } from "./refresh-token-auth-provider.js";
 import {
   NotificationManager,
@@ -303,6 +307,7 @@ export class MCPClientManager {
   private readonly defaultTimeout: number;
   private readonly defaultLogJsonRpc: boolean;
   private readonly defaultRpcLogger?: RpcLogger;
+  private readonly defaultHttpLogger?: HttpExchangeLogger;
   private readonly defaultProgressHandler?: ProgressHandler;
   private readonly cacheEventLogger?: CacheEventLogger;
   /**
@@ -342,6 +347,7 @@ export class MCPClientManager {
     this.defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT;
     this.defaultLogJsonRpc = options.defaultLogJsonRpc ?? false;
     this.defaultRpcLogger = options.rpcLogger;
+    this.defaultHttpLogger = options.httpLogger;
     this.defaultProgressHandler = options.progressHandler;
     this.cacheEventLogger = options.cacheEventLogger;
     this.traceContextProvider = options.traceContextProvider;
@@ -2377,7 +2383,9 @@ export class MCPClientManager {
         // `Mcp-Name: <taskId>`. beta.4 derives `mcp-name` from
         // `params.name|uri` only, so the header is injected in the fetch seam
         // (hosted inherits it, since hosted builds transports through here).
-        fetch: wrapFetchForTaskRouting(),
+        // The same seam captures HTTP headers for the wire log when a
+        // `httpLogger` is configured — see `buildTransportFetch`.
+        fetch: this.buildTransportFetch(serverId, config),
         reconnectionOptions: config.reconnectionOptions,
         authProvider: effectiveAuthProvider,
         sessionId: config.sessionId,
@@ -2430,7 +2438,7 @@ export class MCPClientManager {
 
     const sseTransport = new SSEClientTransport(url, {
       requestInit,
-      fetch: wrapFetchForTaskRouting(),
+      fetch: this.buildTransportFetch(serverId, config),
       eventSourceInit: config.eventSourceInit,
       authProvider: effectiveAuthProvider,
     });
@@ -3025,6 +3033,37 @@ export class MCPClientManager {
       return createDefaultRpcLogger();
     if (this.defaultRpcLogger) return this.defaultRpcLogger;
     return undefined;
+  }
+
+  /**
+   * Unlike `resolveRpcLogger` there is no console fallback: `logJsonRpc` is
+   * about JSON-RPC bodies, and quietly printing every HTTP header set to the
+   * console because a caller asked for body logging would leak more than they
+   * asked for. Opt in explicitly, per server or globally.
+   */
+  private resolveHttpLogger(
+    config: MCPServerConfig
+  ): HttpExchangeLogger | undefined {
+    return config.httpLogger ?? this.defaultHttpLogger;
+  }
+
+  /**
+   * Builds the transport `fetch`. Ordering is load-bearing: the HTTP-log
+   * wrapper is the BASE, so it records the headers that actually leave —
+   * including the SEP-2663 routing headers `wrapFetchForTaskRouting` injects
+   * on top. Without a logger this is byte-identical to the previous
+   * `wrapFetchForTaskRouting()`.
+   */
+  private buildTransportFetch(
+    serverId: string,
+    config: MCPServerConfig
+  ): typeof fetch {
+    const httpLogger = this.resolveHttpLogger(config);
+    return wrapFetchForTaskRouting(
+      httpLogger
+        ? wrapFetchForHttpLogging(serverId, httpLogger)
+        : undefined
+    );
   }
 
   private cacheToolsMetadata(

--- a/sdk/src/mcp-client-manager/http-exchange-log.ts
+++ b/sdk/src/mcp-client-manager/http-exchange-log.ts
@@ -1,0 +1,218 @@
+/**
+ * HTTP-exchange capture for the wire log.
+ *
+ * The JSON-RPC log (`rpcLogger`) carries message bodies only. From
+ * `2026-07-28` the Streamable HTTP transport mirrors routing and cross-check
+ * metadata into HTTP *headers* (`Mcp-Method`, `Mcp-Name`, `Mcp-Param-*`,
+ * `MCP-Protocol-Version`), so a body-only log cannot explain a
+ * `-32020 HeaderMismatch` — the body looks fine and the disagreeing header is
+ * invisible. This module captures the header halves of each exchange.
+ *
+ * Placement: this wrapper must be the INNERMOST fetch so it records the bytes
+ * that actually leave — after `wrapFetchForTaskRouting` has injected the
+ * SEP-2663 routing headers.
+ *
+ * Bodies are deliberately NOT captured. The request body is already in the
+ * JSON-RPC log, and reading the response body here would consume the stream
+ * the transport is about to parse. The one thing derived from the request
+ * body is the small set of values the mirrored headers are supposed to equal,
+ * so the cross-check can run later without retaining the body.
+ */
+
+import type { MirroredBodyValues } from "./mcp-header-mirror.js";
+
+/** `_meta` key carrying the per-request protocol version in the modern era. */
+const PROTOCOL_VERSION_META_KEY = "io.modelcontextprotocol/protocolVersion";
+
+/**
+ * Headers whose VALUE never reaches the log. Tracing is a screenshot, export,
+ * and agent-snapshot surface, and these carry credentials rather than protocol
+ * metadata. The header NAME is kept — knowing an `Authorization` header was
+ * present (and with which scheme) is exactly what auth debugging needs.
+ *
+ * Deliberately NOT `redactHeadersForLog` from the conformance raw harness:
+ * that one blanks the whole value (its output feeds golden traces, where a
+ * preserved scheme would be one more thing to diff) and it lives in a
+ * subsystem this transport path should not import. Same intent, different
+ * output contract — keep both, and keep them honest.
+ */
+const REDACTED_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "api-key",
+]);
+
+const REDACTED_PLACEHOLDER = "<redacted>";
+
+function redactHeaderValue(name: string, value: string): string {
+  if (!REDACTED_HEADERS.has(name.toLowerCase())) return value;
+  // Preserve the auth scheme (`Bearer`, `Basic`, `DPoP`) — it is protocol
+  // information, not a secret, and it is the first thing you check.
+  const scheme = /^([A-Za-z][A-Za-z0-9-]*)\s+\S/.exec(value)?.[1];
+  return scheme ? `${scheme} ${REDACTED_PLACEHOLDER}` : REDACTED_PLACEHOLDER;
+}
+
+function collectHeaders(headers: HeadersInit | Headers | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!headers) return out;
+  try {
+    new Headers(headers as HeadersInit).forEach((value, key) => {
+      out[key] = redactHeaderValue(key, value);
+    });
+  } catch {
+    // A malformed HeadersInit must never fail the request it describes.
+  }
+  return out;
+}
+
+/** Request-body facts the mirrored headers are supposed to agree with. */
+export function deriveMirroredBodyValues(
+  body: BodyInit | null | undefined
+): MirroredBodyValues | undefined {
+  if (typeof body !== "string") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  // Only a single request mirrors headers; a batch has no single method/name.
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const { method, params } = parsed as {
+    method?: unknown;
+    params?: {
+      name?: unknown;
+      uri?: unknown;
+      _meta?: Record<string, unknown>;
+    };
+  };
+  const name = params?.name ?? params?.uri;
+  const protocolVersion = params?._meta?.[PROTOCOL_VERSION_META_KEY];
+  const derived: MirroredBodyValues = {
+    method: typeof method === "string" ? method : undefined,
+    name: typeof name === "string" ? name : undefined,
+    protocolVersion:
+      typeof protocolVersion === "string" ? protocolVersion : undefined,
+  };
+  return derived.method === undefined &&
+    derived.name === undefined &&
+    derived.protocolVersion === undefined
+    ? undefined
+    : derived;
+}
+
+/** One HTTP exchange, headers only. */
+export type HttpExchangeLogEvent = {
+  serverId: string;
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+  };
+  response?: {
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+  };
+  /** Set when the fetch itself rejected (DNS, TLS, abort) — no response. */
+  error?: string;
+  durationMs: number;
+  /** Present only when the request body was a single JSON-RPC request. */
+  bodyValues?: MirroredBodyValues;
+};
+
+export type HttpExchangeLogger = (event: HttpExchangeLogEvent) => void;
+
+function requestMethodOf(input: Parameters<typeof fetch>[0], init?: RequestInit): string {
+  if (init?.method) return init.method.toUpperCase();
+  if (typeof input === "object" && input !== null && "method" in input) {
+    return String((input as Request).method).toUpperCase();
+  }
+  return "GET";
+}
+
+function requestHeadersOf(
+  input: Parameters<typeof fetch>[0],
+  init?: RequestInit
+): HeadersInit | Headers | undefined {
+  if (init?.headers) return init.headers;
+  if (typeof input === "object" && input !== null && "headers" in input) {
+    return (input as Request).headers;
+  }
+  return undefined;
+}
+
+function requestUrlOf(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  if (typeof input === "object" && input !== null && "url" in input) {
+    return String((input as Request).url);
+  }
+  return String(input);
+}
+
+/**
+ * Wraps `fetch` so every HTTP exchange is reported to `logger`, headers only.
+ *
+ * Applies to ALL protocol versions, not just modern: `MCP-Protocol-Version`
+ * exists from `2025-06-18`, and `Mcp-Session-Id` / `Last-Event-ID` exist only
+ * in the legacy eras — where a missing session id or a failed resume is
+ * precisely the bug being chased. Era-specific meaning is applied at render
+ * time, not by dropping the capture here.
+ *
+ * The logger is guarded and the wrapper adds nothing to the request, so a
+ * failure to log can never fail the RPC.
+ */
+export function wrapFetchForHttpLogging(
+  serverId: string,
+  logger: HttpExchangeLogger,
+  fetchFn?: typeof fetch
+): typeof fetch {
+  const base = fetchFn ?? ((...args: Parameters<typeof fetch>) => fetch(...args));
+  return (async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+    const startedAt = Date.now();
+    const emit = (event: Omit<HttpExchangeLogEvent, "serverId">) => {
+      try {
+        logger({ serverId, ...event });
+      } catch {
+        // Logging is a side-effect; it must not surface as an RPC failure.
+      }
+    };
+    // Snapshot the request BEFORE awaiting: `init.headers` may be a live
+    // `Headers` the caller reuses across retries.
+    const request = {
+      method: requestMethodOf(input, init),
+      url: requestUrlOf(input),
+      headers: collectHeaders(requestHeadersOf(input, init)),
+    };
+    const bodyValues = deriveMirroredBodyValues(init?.body);
+
+    try {
+      const response = await base(input as never, init as never);
+      emit({
+        request,
+        response: {
+          status: response.status,
+          statusText: response.statusText,
+          headers: collectHeaders(response.headers),
+        },
+        durationMs: Date.now() - startedAt,
+        bodyValues,
+      });
+      return response;
+    } catch (error) {
+      emit({
+        request,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - startedAt,
+        bodyValues,
+      });
+      throw error;
+    }
+  }) as typeof fetch;
+}

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -317,6 +317,14 @@ export {
   wrapFetchForTaskRouting,
   wrapTransportForTaskResults,
 } from "./transport-utils.js";
+export {
+  wrapFetchForHttpLogging,
+  deriveMirroredBodyValues,
+} from "./http-exchange-log.js";
+export type {
+  HttpExchangeLogEvent,
+  HttpExchangeLogger,
+} from "./http-exchange-log.js";
 
 // Notification schemas (for advanced use cases)
 export {

--- a/sdk/src/mcp-client-manager/mcp-header-mirror.ts
+++ b/sdk/src/mcp-client-manager/mcp-header-mirror.ts
@@ -1,0 +1,210 @@
+/**
+ * The Streamable HTTP "request metadata" headers — the body fields the
+ * transport mirrors into HTTP so intermediaries can route without parsing the
+ * body (SEP-2243, integrated into `2026-07-28`).
+ *
+ * Pure data + pure functions, no transport and no Node built-ins, so this
+ * module is safe to re-export from the browser entry: the Tracing panel does
+ * the same decode/cross-check a server does, on headers captured on the wire.
+ *
+ * Scope note: `MCP-Protocol-Version` exists from `2025-06-18` onward and the
+ * session/resumption headers exist ONLY in `2025-03-26`..`2025-11-25`. This
+ * module therefore classifies every era's headers, and gates only the
+ * *modern-only* assertions (required `Mcp-Method`/`Mcp-Name`, header/body
+ * agreement) on a modern protocol version.
+ */
+
+import { isKnownProtocolVersion, isStatelessProtocolVersion } from "./mcp-protocol-version.js";
+
+/** Sentinel wrapper for header values that cannot ride as plain ASCII. */
+export const MCP_HEADER_SENTINEL_PREFIX = "=?base64?";
+export const MCP_HEADER_SENTINEL_SUFFIX = "?=";
+
+/** Prefix for the per-argument mirrored headers driven by `x-mcp-header`. */
+export const MCP_PARAM_HEADER_PREFIX = "mcp-param-";
+
+/**
+ * Which mirrored family a header belongs to, or `undefined` for an ordinary
+ * header (`content-type`, `authorization`, …).
+ */
+export type McpHeaderFamily =
+  | "protocol-version"
+  | "method"
+  | "name"
+  | "param"
+  | "session"
+  | "resumption";
+
+/**
+ * Classifies a header name. RFC 9110 field names are case-insensitive and the
+ * spec requires case-insensitive comparison, so callers may pass any casing —
+ * note the spec text itself writes `Mcp-Session-Id` in `2025-06-18` and
+ * `MCP-Session-Id` in `2025-11-25`.
+ */
+export function classifyMcpHeader(name: string): McpHeaderFamily | undefined {
+  const lower = name.toLowerCase();
+  if (lower === "mcp-protocol-version") return "protocol-version";
+  if (lower === "mcp-method") return "method";
+  if (lower === "mcp-name") return "name";
+  if (lower === "mcp-session-id") return "session";
+  if (lower === "last-event-id") return "resumption";
+  if (lower.startsWith(MCP_PARAM_HEADER_PREFIX)) return "param";
+  return undefined;
+}
+
+function base64ToUtf8(encoded: string): string {
+  const scope = globalThis as {
+    atob?: (data: string) => string;
+    Buffer?: { from: (data: string, enc: string) => { toString: (enc: string) => string } };
+  };
+  if (typeof scope.atob === "function") {
+    const binary = scope.atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  }
+  if (scope.Buffer) {
+    return scope.Buffer.from(encoded, "base64").toString("utf8");
+  }
+  throw new Error("no base64 decoder available");
+}
+
+export type DecodedMcpHeaderValue = {
+  /** The value exactly as it appeared on the wire. */
+  raw: string;
+  /** True when `raw` carried the `=?base64?…?=` sentinel. */
+  encoded: boolean;
+  /** The comparison value: decoded when encoded, otherwise `raw`. */
+  value: string;
+  /** Set when the sentinel was present but the payload would not decode. */
+  decodeError?: string;
+};
+
+/**
+ * Decodes the sentinel form. Applies to `Mcp-Name` as well as
+ * `Mcp-Param-{Name}` — a non-ASCII tool name is carried encoded, so a UI that
+ * decodes params but not names shows a conforming request as gibberish.
+ *
+ * The markers are case-sensitive and MUST appear exactly as lowercase, so a
+ * value that merely resembles them is left alone.
+ */
+export function decodeMcpHeaderValue(raw: string): DecodedMcpHeaderValue {
+  if (
+    !raw.startsWith(MCP_HEADER_SENTINEL_PREFIX) ||
+    !raw.endsWith(MCP_HEADER_SENTINEL_SUFFIX) ||
+    raw.length < MCP_HEADER_SENTINEL_PREFIX.length + MCP_HEADER_SENTINEL_SUFFIX.length
+  ) {
+    return { raw, encoded: false, value: raw };
+  }
+  const payload = raw.slice(
+    MCP_HEADER_SENTINEL_PREFIX.length,
+    raw.length - MCP_HEADER_SENTINEL_SUFFIX.length
+  );
+  try {
+    return { raw, encoded: true, value: base64ToUtf8(payload) };
+  } catch (error) {
+    return {
+      raw,
+      encoded: true,
+      value: raw,
+      decodeError: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * The values the request BODY carries for the mirrored headers. Captured at
+ * request time so the cross-check can run later without ever storing the body.
+ */
+export type MirroredBodyValues = {
+  /** JSON-RPC `method`. */
+  method?: string;
+  /** `params.name`, or `params.uri` for `resources/read`. */
+  name?: string;
+  /** `_meta["io.modelcontextprotocol/protocolVersion"]`. */
+  protocolVersion?: string;
+};
+
+/** Methods for which `Mcp-Name` is REQUIRED. */
+const NAME_REQUIRED_METHODS = new Set([
+  "tools/call",
+  "resources/read",
+  "prompts/get",
+]);
+
+export type McpHeaderIssue =
+  | { kind: "mismatch"; header: string; headerValue: string; bodyValue: string }
+  | { kind: "missing"; header: string; bodyValue: string }
+  | { kind: "undecodable"; header: string; headerValue: string };
+
+/**
+ * Runs the server-side validation a `-32020 HeaderMismatch` reports, locally,
+ * against the captured headers. Covers all three failure conditions the spec
+ * lists: a required standard header missing, a value disagreeing with the
+ * body, and a value that will not decode.
+ *
+ * Returns an empty list for any non-modern request: `Mcp-Method`/`Mcp-Name`
+ * are not required before `2026-07-28`, so asserting them on a `2025-11-25`
+ * connection would invent failures.
+ */
+export function findMcpHeaderIssues(
+  headers: Record<string, string>,
+  body: MirroredBodyValues | undefined
+): McpHeaderIssue[] {
+  const lookup = new Map<string, { name: string; value: string }>();
+  for (const [name, value] of Object.entries(headers)) {
+    lookup.set(name.toLowerCase(), { name, value });
+  }
+
+  const versionHeader = lookup.get("mcp-protocol-version")?.value;
+  const version = versionHeader ?? body?.protocolVersion;
+  const isModern =
+    !!version && isKnownProtocolVersion(version) && isStatelessProtocolVersion(version);
+  if (!isModern || !body) return [];
+
+  const issues: McpHeaderIssue[] = [];
+
+  const check = (
+    headerName: string,
+    bodyValue: string | undefined,
+    required: boolean
+  ) => {
+    const found = lookup.get(headerName);
+    if (bodyValue === undefined) return;
+    if (!found) {
+      if (required) {
+        issues.push({ kind: "missing", header: headerName, bodyValue });
+      }
+      return;
+    }
+    const decoded = decodeMcpHeaderValue(found.value);
+    if (decoded.decodeError) {
+      issues.push({
+        kind: "undecodable",
+        header: found.name,
+        headerValue: found.value,
+      });
+      return;
+    }
+    if (decoded.value !== bodyValue) {
+      issues.push({
+        kind: "mismatch",
+        header: found.name,
+        headerValue: decoded.value,
+        bodyValue,
+      });
+    }
+  };
+
+  check("mcp-protocol-version", body.protocolVersion, true);
+  check("mcp-method", body.method, true);
+  check(
+    "mcp-name",
+    body.name,
+    body.method !== undefined && NAME_REQUIRED_METHODS.has(body.method)
+  );
+
+  return issues;
+}

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -23,6 +23,7 @@ import type { StdioServerParameters } from "@modelcontextprotocol/client/stdio";
 import type { RetryPolicy } from "../retry.js";
 import type { RefreshTokenOAuthProvider } from "./refresh-token-auth-provider.js";
 import type { TraceContextProvider } from "./trace-context.js";
+import type { HttpExchangeLogger } from "./http-exchange-log.js";
 import type { ToolSet } from "ai";
 
 // Re-export ElicitResult for convenience
@@ -234,6 +235,14 @@ export type BaseServerConfig = {
   logJsonRpc?: boolean;
   /** Custom logger for JSON-RPC traffic (overrides logJsonRpc) */
   rpcLogger?: RpcLogger;
+  /**
+   * Custom sink for HTTP exchanges (headers only). A DISTINCT channel from
+   * `rpcLogger`: that one carries JSON-RPC bodies, this one carries the HTTP
+   * envelope those bodies rode in — the `Mcp-*` mirrored headers a
+   * `-32020 HeaderMismatch` is about. HTTP transports only; stdio never
+   * reaches a fetch, so it emits nothing.
+   */
+  httpLogger?: HttpExchangeLogger;
 };
 
 /**
@@ -481,6 +490,9 @@ export interface MCPClientManagerOptions {
   defaultLogJsonRpc?: boolean;
   /** Global JSON-RPC logger */
   rpcLogger?: RpcLogger;
+  /** Global HTTP-exchange (headers-only) logger. See `httpLogger` on the
+   *  server config for why this is a separate channel from `rpcLogger`. */
+  httpLogger?: HttpExchangeLogger;
   /** Global progress handler */
   progressHandler?: ProgressHandler;
   /**

--- a/sdk/tests/http-exchange-log.test.ts
+++ b/sdk/tests/http-exchange-log.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  deriveMirroredBodyValues,
+  wrapFetchForHttpLogging,
+  type HttpExchangeLogEvent,
+} from "../src/mcp-client-manager/http-exchange-log.js";
+import { wrapFetchForTaskRouting } from "../src/mcp-client-manager/transport-utils.js";
+
+const MODERN = "2026-07-28";
+
+function okResponse(headers: Record<string, string> = {}): Response {
+  return new Response("{}", { status: 200, statusText: "OK", headers });
+}
+
+function collector() {
+  const events: HttpExchangeLogEvent[] = [];
+  return { events, log: (event: HttpExchangeLogEvent) => events.push(event) };
+}
+
+describe("wrapFetchForHttpLogging", () => {
+  it("records the request and response header sets", async () => {
+    const { events, log } = collector();
+    const base = vi.fn(async () =>
+      okResponse({ "mcp-session-id": "sess-1", "content-type": "application/json" }),
+    ) as unknown as typeof fetch;
+
+    const wrapped = wrapFetchForHttpLogging("srv", log, base);
+    await wrapped("https://example.test/mcp", {
+      method: "POST",
+      headers: { "Mcp-Method": "tools/list", "MCP-Protocol-Version": MODERN },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].serverId).toBe("srv");
+    expect(events[0].request.method).toBe("POST");
+    expect(events[0].request.url).toBe("https://example.test/mcp");
+    // Header NAMES normalize to lowercase through `Headers`; comparisons are
+    // case-insensitive per RFC 9110, and the UI classifies accordingly.
+    expect(events[0].request.headers["mcp-method"]).toBe("tools/list");
+    expect(events[0].request.headers["mcp-protocol-version"]).toBe(MODERN);
+    expect(events[0].response?.status).toBe(200);
+    expect(events[0].response?.headers["mcp-session-id"]).toBe("sess-1");
+  });
+
+  it("redacts credential headers but keeps the auth scheme", async () => {
+    const { events, log } = collector();
+    const base = vi.fn(async () =>
+      okResponse({ "set-cookie": "session=abc" }),
+    ) as unknown as typeof fetch;
+
+    const wrapped = wrapFetchForHttpLogging("srv", log, base);
+    await wrapped("https://example.test/mcp", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer super-secret-token",
+        Cookie: "a=b",
+        "x-api-key": "k",
+      },
+    });
+
+    const headers = events[0].request.headers;
+    expect(headers["authorization"]).toBe("Bearer <redacted>");
+    expect(headers["authorization"]).not.toContain("super-secret-token");
+    expect(headers["cookie"]).toBe("<redacted>");
+    expect(headers["x-api-key"]).toBe("<redacted>");
+    expect(events[0].response?.headers["set-cookie"]).toBe("<redacted>");
+  });
+
+  it("records the exchange and rethrows when the fetch itself fails", async () => {
+    const { events, log } = collector();
+    const base = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const wrapped = wrapFetchForHttpLogging("srv", log, base);
+    await expect(
+      wrapped("https://example.test/mcp", { method: "POST" }),
+    ).rejects.toThrow("ECONNREFUSED");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].response).toBeUndefined();
+    expect(events[0].error).toBe("ECONNREFUSED");
+  });
+
+  it("never lets a throwing logger fail the request", async () => {
+    const base = vi.fn(async () => okResponse()) as unknown as typeof fetch;
+    const wrapped = wrapFetchForHttpLogging(
+      "srv",
+      () => {
+        throw new Error("logger bug");
+      },
+      base,
+    );
+    await expect(
+      wrapped("https://example.test/mcp", { method: "POST" }),
+    ).resolves.toBeInstanceOf(Response);
+  });
+
+  it("does not read the response body", async () => {
+    const { log } = collector();
+    const response = okResponse();
+    const base = vi.fn(async () => response) as unknown as typeof fetch;
+    const wrapped = wrapFetchForHttpLogging("srv", log, base);
+
+    const returned = await wrapped("https://example.test/mcp", { method: "POST" });
+    expect(returned.bodyUsed).toBe(false);
+    await expect(returned.text()).resolves.toBe("{}");
+  });
+
+  it("captures the headers that actually leave, including task routing's", async () => {
+    // Composition order is load-bearing: the log wrapper is the BASE, so
+    // `wrapFetchForTaskRouting` has already injected `mcp-name` by the time
+    // the exchange is recorded.
+    const { events, log } = collector();
+    const base = vi.fn(async () => okResponse()) as unknown as typeof fetch;
+    const fetchFn = wrapFetchForTaskRouting(
+      wrapFetchForHttpLogging("srv", log, base),
+    );
+
+    await fetchFn("https://example.test/mcp", {
+      method: "POST",
+      headers: { "mcp-protocol-version": MODERN },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tasks/get",
+        params: { taskId: "task-7" },
+      }),
+    });
+
+    expect(events[0].request.headers["mcp-name"]).toBe("task-7");
+    expect(events[0].request.headers["mcp-method"]).toBe("tasks/get");
+  });
+});
+
+describe("deriveMirroredBodyValues", () => {
+  it("pulls the values the mirrored headers must equal", () => {
+    expect(
+      deriveMirroredBodyValues(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: {
+            name: "execute_sql",
+            _meta: { "io.modelcontextprotocol/protocolVersion": MODERN },
+          },
+        }),
+      ),
+    ).toEqual({
+      method: "tools/call",
+      name: "execute_sql",
+      protocolVersion: MODERN,
+    });
+  });
+
+  it("reads params.uri as the name source for resources/read", () => {
+    expect(
+      deriveMirroredBodyValues(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "resources/read",
+          params: { uri: "file:///a.txt" },
+        }),
+      ),
+    ).toEqual({
+      method: "resources/read",
+      name: "file:///a.txt",
+      protocolVersion: undefined,
+    });
+  });
+
+  it("returns nothing for a batch, a non-JSON body, or a non-string body", () => {
+    expect(deriveMirroredBodyValues(JSON.stringify([{ method: "a" }]))).toBeUndefined();
+    expect(deriveMirroredBodyValues("not json")).toBeUndefined();
+    expect(deriveMirroredBodyValues(undefined)).toBeUndefined();
+    expect(deriveMirroredBodyValues(new Uint8Array([1, 2]))).toBeUndefined();
+  });
+});

--- a/sdk/tests/mcp-header-mirror.test.ts
+++ b/sdk/tests/mcp-header-mirror.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyMcpHeader,
+  decodeMcpHeaderValue,
+  findMcpHeaderIssues,
+} from "../src/mcp-client-manager/mcp-header-mirror.js";
+
+const MODERN = "2026-07-28";
+
+describe("classifyMcpHeader", () => {
+  it("matches case-insensitively — the spec text itself changes casing between versions", () => {
+    // `Mcp-Session-Id` in 2025-06-18, `MCP-Session-Id` in 2025-11-25.
+    expect(classifyMcpHeader("Mcp-Session-Id")).toBe("session");
+    expect(classifyMcpHeader("MCP-Session-Id")).toBe("session");
+    // A literal `Mcp-` prefix test would drop this one.
+    expect(classifyMcpHeader("MCP-Protocol-Version")).toBe("protocol-version");
+    expect(classifyMcpHeader("mcp-protocol-version")).toBe("protocol-version");
+  });
+
+  it("classifies the mirrored families and leaves ordinary headers alone", () => {
+    expect(classifyMcpHeader("Mcp-Method")).toBe("method");
+    expect(classifyMcpHeader("Mcp-Name")).toBe("name");
+    expect(classifyMcpHeader("Mcp-Param-Region")).toBe("param");
+    expect(classifyMcpHeader("Last-Event-ID")).toBe("resumption");
+    expect(classifyMcpHeader("content-type")).toBeUndefined();
+    expect(classifyMcpHeader("authorization")).toBeUndefined();
+  });
+});
+
+describe("decodeMcpHeaderValue", () => {
+  it("passes a plain ASCII value through untouched", () => {
+    expect(decodeMcpHeaderValue("us-west1")).toEqual({
+      raw: "us-west1",
+      encoded: false,
+      value: "us-west1",
+    });
+  });
+
+  it("decodes the sentinel back to UTF-8 (spec example)", () => {
+    const decoded = decodeMcpHeaderValue("=?base64?SGVsbG8sIOS4lueVjA==?=");
+    expect(decoded.encoded).toBe(true);
+    expect(decoded.value).toBe("Hello, 世界");
+  });
+
+  it("decodes a value that merely LOOKS like the sentinel back to the literal", () => {
+    // Clients must encode a plain value matching the sentinel pattern, so the
+    // decoded form here is the literal `=?base64?literal?=`. The payload
+    // itself contains `?`, which is why the suffix is matched at the END of
+    // the value rather than at the first `?=` seen.
+    const decoded = decodeMcpHeaderValue("=?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?=");
+    expect(decoded.encoded).toBe(true);
+    expect(decoded.value).toBe("=?base64?literal?=");
+  });
+
+  it("treats the markers as case-sensitive", () => {
+    const decoded = decodeMcpHeaderValue("=?BASE64?SGVsbG8=?=");
+    expect(decoded.encoded).toBe(false);
+    expect(decoded.value).toBe("=?BASE64?SGVsbG8=?=");
+  });
+
+  it("reports a sentinel whose payload will not decode instead of throwing", () => {
+    const decoded = decodeMcpHeaderValue("=?base64?not valid base64!?=");
+    expect(decoded.encoded).toBe(true);
+    expect(decoded.decodeError).toBeTruthy();
+    expect(decoded.value).toBe("=?base64?not valid base64!?=");
+  });
+});
+
+describe("findMcpHeaderIssues", () => {
+  const modernBody = {
+    method: "tools/call",
+    name: "execute_sql",
+    protocolVersion: MODERN,
+  };
+
+  it("is silent when every mirrored header agrees with the body", () => {
+    expect(
+      findMcpHeaderIssues(
+        {
+          "MCP-Protocol-Version": MODERN,
+          "Mcp-Method": "tools/call",
+          "Mcp-Name": "execute_sql",
+        },
+        modernBody,
+      ),
+    ).toEqual([]);
+  });
+
+  it("names the header that disagrees — the -32020 case", () => {
+    const issues = findMcpHeaderIssues(
+      {
+        "MCP-Protocol-Version": MODERN,
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "bar",
+      },
+      modernBody,
+    );
+    expect(issues).toEqual([
+      {
+        kind: "mismatch",
+        header: "Mcp-Name",
+        headerValue: "bar",
+        bodyValue: "execute_sql",
+      },
+    ]);
+  });
+
+  it("compares Mcp-Name AFTER decoding, so an encoded name is not a false mismatch", () => {
+    const encodedName = {
+      "MCP-Protocol-Version": MODERN,
+      "Mcp-Method": "tools/call",
+      // base64("Hello, 世界")
+      "Mcp-Name": "=?base64?SGVsbG8sIOS4lueVjA==?=",
+    };
+    expect(
+      findMcpHeaderIssues(encodedName, {
+        ...modernBody,
+        name: "Hello, 世界",
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags a REQUIRED header that was never sent", () => {
+    const issues = findMcpHeaderIssues(
+      { "MCP-Protocol-Version": MODERN, "Mcp-Method": "tools/call" },
+      modernBody,
+    );
+    expect(issues).toEqual([
+      { kind: "missing", header: "mcp-name", bodyValue: "execute_sql" },
+    ]);
+  });
+
+  it("does not require Mcp-Name for a method that does not carry one", () => {
+    expect(
+      findMcpHeaderIssues(
+        { "MCP-Protocol-Version": MODERN, "Mcp-Method": "tools/list" },
+        { method: "tools/list", protocolVersion: MODERN },
+      ),
+    ).toEqual([]);
+  });
+
+  it("flags a sentinel value that will not decode", () => {
+    const issues = findMcpHeaderIssues(
+      {
+        "MCP-Protocol-Version": MODERN,
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "=?base64?not valid!?=",
+      },
+      modernBody,
+    );
+    expect(issues).toEqual([
+      {
+        kind: "undecodable",
+        header: "Mcp-Name",
+        headerValue: "=?base64?not valid!?=",
+      },
+    ]);
+  });
+
+  it("flags a protocol-version header that disagrees with the body envelope", () => {
+    const issues = findMcpHeaderIssues(
+      {
+        "MCP-Protocol-Version": MODERN,
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "execute_sql",
+      },
+      { ...modernBody, protocolVersion: "2025-11-25" },
+    );
+    expect(issues).toEqual([
+      {
+        kind: "mismatch",
+        header: "MCP-Protocol-Version",
+        headerValue: MODERN,
+        bodyValue: "2025-11-25",
+      },
+    ]);
+  });
+
+  describe("version scope", () => {
+    it("asserts nothing on a 2025-11-25 request, where the headers are not required", () => {
+      expect(
+        findMcpHeaderIssues(
+          { "MCP-Protocol-Version": "2025-11-25" },
+          { method: "tools/call", name: "execute_sql" },
+        ),
+      ).toEqual([]);
+    });
+
+    it("asserts nothing on a 2025-06-18 request", () => {
+      expect(
+        findMcpHeaderIssues(
+          { "MCP-Protocol-Version": "2025-06-18" },
+          { method: "tools/call", name: "execute_sql" },
+        ),
+      ).toEqual([]);
+    });
+
+    it("asserts nothing when no version is known at all", () => {
+      expect(
+        findMcpHeaderIssues({}, { method: "tools/call", name: "x" }),
+      ).toEqual([]);
+    });
+
+    it("asserts nothing for an unrecognized version string", () => {
+      expect(
+        findMcpHeaderIssues(
+          { "MCP-Protocol-Version": "not-a-version" },
+          { method: "tools/call", name: "x", protocolVersion: "not-a-version" },
+        ),
+      ).toEqual([]);
+    });
+
+    it("uses the BODY version when the header is missing, so a dropped header is still caught", () => {
+      const issues = findMcpHeaderIssues(
+        { "Mcp-Method": "tools/list" },
+        { method: "tools/list", protocolVersion: MODERN },
+      );
+      expect(issues).toEqual([
+        {
+          kind: "missing",
+          header: "mcp-protocol-version",
+          bodyValue: MODERN,
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #3545.

## The problem

Tracing logged JSON-RPC frames only. From `2026-07-28` the Streamable HTTP transport mirrors routing and cross-check metadata into HTTP **headers** — `Mcp-Method`, `Mcp-Name`, `Mcp-Param-*`, `MCP-Protocol-Version` — so a `-32020 HeaderMismatch` showed a body that looked completely fine, with no way to see which header disagreed with it. Verifying that MCPJam itself mirrors `Mcp-Param-*` correctly meant `curl -v`.

## What this does

**Capture (SDK).** A new `httpLogger` channel, separate from `rpcLogger`, on the transport `fetch` seam. It is composed **under** `wrapFetchForTaskRouting`, so it records the headers that actually leave — including the SEP-2663 routing headers that wrapper injects.

Headers only. Request bodies are already in the RPC log, and reading the response body here would consume the stream the transport is about to parse. The one thing derived from the request body is the small set of values the mirrored headers are supposed to equal (`method`, `params.name|uri`, the `_meta` protocol version), so the cross-check can run later without ever retaining the body.

**Render (Inspector).** HTTP exchanges appear as their own rows in the Tracing timeline, collapsed, filterable via the existing source dropdown. Expanded, a row shows the mirrored headers pulled to the top with families labeled, the `=?base64?…?=` sentinel decoded inline (raw → decoded), and the full request/response header sets.

## Three deviations from the issue as filed

**1. `Mcp-Name` is sentinel-decoded too, not just `Mcp-Param-*`.** The spec applies the same encoding rule to `Mcp-Name` and requires servers to decode it before comparison. Decoding params but not names would make a conforming request with a non-ASCII tool name look broken.

**2. All three `-32020` causes, not just disagreement.** The spec lists three: a required standard header *missing*, a value that *doesn't match* the body, and a value with *invalid characters*. "Point at the header that disagreed" only covers the middle one — and the missing-header case is the one where there is nothing to point at.

**3. Capture is not gated to modern-era frames.** `MCP-Protocol-Version` exists from `2025-06-18`; `Mcp-Session-Id` and `Last-Event-ID` exist **only** in `2025-03-26`..`2025-11-25` and were dropped in 2026. A missing session id or a failed resume is exactly the legacy-era bug you open Tracing for, so gating capture on modern would leave the panel header-blind where it is most needed. Only the *modern-only assertions* are era-gated: `findMcpHeaderIssues` returns nothing for a `2025-11-25` request, where `Mcp-Method`/`Mcp-Name` are not required and asserting them would invent failures.

Header **names** are matched case-insensitively throughout — the spec text itself writes `Mcp-Session-Id` in 2025-06-18 and `MCP-Session-Id` in 2025-11-25, and a literal `Mcp-` prefix test would drop `MCP-Protocol-Version`. Values stay case-sensitive.

## Security

Headers are where the credentials are. Tracing is a screenshot, export, and agent-snapshot surface, so `authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`, and `api-key` are redacted **at the capture point**, not at render. The auth scheme survives (`Bearer <redacted>`) because the scheme is protocol information and the first thing you check.

The Tracing agent snapshot still carries shape only — no headers, no payloads — and the HTTP row's label drops the URL query string, since a query can carry a token and that label is the one field the snapshot reads. Covered by a test.

## Not in this PR

**Hosted stays header-blind.** The hosted delivery (`data-rpc-log` parts, the Convex sink, `isHostedRpcLogEvent`) is a closed JSON-RPC-frame shape defined across two repos; widening it is its own change. The harness bridge explicitly skips HTTP events rather than half-wiring them.

**Exchanges are their own rows, not headers attached to frames.** The transport hands us headers when the fetch resolves — after the `send` frame was logged, before the `receive` frames are parsed out of the response. There is no moment where a frame and its headers are both in hand, so attaching them would mean holding frames back or attaching them to the wrong one.

## Verification

- `npm run typecheck -w @mcpjam/sdk`, `npm run build -w @mcpjam/sdk`, `typecheck:client` — clean.
- 28 new SDK tests: sentinel decode (incl. the spec's own sentinel-literal example, whose payload contains `?`), case-insensitive classification, all three `-32020` causes, per-version scope (2025-06-18 / 2025-11-25 / unknown / absent all assert nothing), redaction, error path, throwing-logger isolation, response body untouched, and composition order under task routing.
- Full inspector suite: **984 files / 10863 tests green**.
- SDK suite: 3196 passed, 6 pre-existing failures in `dialect-aware-json-schema-validator`, `era.integration`, and `tasks-ext-listen-meta` — **verified identical on a clean `main` checkout**, not introduced here.

Not manually exercised against a live `stateless.mcpjam.com` session — worth a quick look before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HTTP-exchange logging to capture MCP request/response headers and shows them in Tracing so `-32020 HeaderMismatch` and routing issues are easy to diagnose.

- **New Features**
  - SDK: new `httpLogger` channel on `MCPClientManager` and per-server config. `wrapFetchForHttpLogging` records request/response headers and derived body values, and is composed under `wrapFetchForTaskRouting` so injected SEP-2663 headers are logged. Bodies are not read. Credential headers are redacted at capture (scheme kept).
  - SDK: exports from `@mcpjam/sdk/browser` — `classifyMcpHeader`, `decodeMcpHeaderValue`, `findMcpHeaderIssues`, and `HttpExchangeLogEvent`. Header names are matched case-insensitively. Modern-only assertions are gated by `MCP-Protocol-Version`; capture applies to all eras.
  - Inspector: Tracing shows filterable “HTTP” rows. Expanded view highlights mirrored `Mcp-*` headers first, decodes `=?base64?…?=` (for `Mcp-Name` and `Mcp-Param-*`), and runs the same header/body check as servers (missing, mismatch, undecodable). Full header sets and status are shown. Snapshots count HTTP events but exclude headers and drop URL query from labels.

- **Migration**
  - Optional: enable by passing `httpLogger` globally or per server. Hosted log delivery stays JSON‑RPC–only and will not include HTTP events. No breaking changes.

<sup>Written for commit e0863308b05447a57d76e3c4d08e1d1421f0e7ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the MCP transport fetch seam and expands what Tracing can display (including redacted auth schemes); hosted paths are intentionally unchanged, but local copy/export of logs now can include HTTP header metadata.
> 
> **Overview**
> Adds an **opt-in `httpLogger`** path alongside `rpcLogger` so Tracing can show the HTTP envelope (headers only) for Streamable HTTP MCP calls, where routing and `-32020 HeaderMismatch` metadata live on the wire from `2026-07-28` onward.
> 
> **SDK:** `wrapFetchForHttpLogging` sits under `wrapFetchForTaskRouting` so logged headers include injected routing headers; credential headers are redacted at capture; small `bodyValues` are derived from the JSON-RPC body for cross-checks without storing bodies. Browser exports add `classifyMcpHeader`, `decodeMcpHeaderValue`, and `findMcpHeaderIssues` (modern-era assertions only).
> 
> **Inspector:** Manager `httpLogger` publishes `kind: "http"` on `rpcLogBus`; the RPC SSE stream replays and streams those events. Tracing gets filterable **HTTP** rows with `HttpExchangeDetails` (mirrored `Mcp-*` headers, sentinel decode, header/body issues). Agent snapshots count HTTP traffic by request line only—no headers; row labels use pathname without query strings. Hosted RPC log bridging still drops HTTP events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0863308b05447a57d76e3c4d08e1d1421f0e7ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->