### PR TITLE
feat(sdk): post-negotiation capability re-resolution (eraCapabilities.modern)

### DIFF
--- a/.changeset/era-capability-reresolution.md
+++ b/.changeset/era-capability-reresolution.md
@@ -1,0 +1,34 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": patch
+---
+
+Add the post-negotiation capability re-resolution seam (`eraCapabilities.modern`),
+and use it to declare url-mode elicitation on auto-negotiated modern connections.
+
+Client capabilities are resolved at connect time, before era negotiation has
+run, so the base set must be honest under the most conservative era the
+connection could land on. That forced auto-negotiated (Client default)
+connections to under-advertise on 2026-07-28: url-mode elicitation — which the
+local MRTR bridge fully fulfils — stayed undeclared because the connect-time
+resolver could not rule out a legacy landing, so every url-mode `input_required`
+round died at the server's mode-aware capability gate (`-32021`) unless the
+user explicitly pinned the protocol version.
+
+`MCPServerConfig.eraCapabilities.modern` is a merge-style capability overlay
+the manager applies exactly once, immediately after era classification, when
+the connection lands on a 2026-era revision. The 2026 wire re-declares
+capabilities on every request's `_meta` envelope (the upstream client stamps it
+from the live set), so the widened declaration flows outward from the next
+request on and then stays stable for the connection's lifetime — MRTR rounds of
+one logical operation always see one consistent set. Legacy landings never
+apply the overlay (their `initialize` already carried the conservative base:
+fail-closed), exact `clientCapabilities` pins ignore it entirely, and the
+overlay's `elicitation` key is subject to the same advertise=enforce gate as
+the runtime-added one.
+
+The Inspector's local MRTR helper (`withLocalMrtrElicitationCapability`) now
+rides the seam instead of guessing "provably modern" from the pin and the
+accept-list — a predicate that had to answer "no" for the common unpinned
+connection. url-mode elicitation (`open-dashboard`-style tools) now works on
+Client-default connections that auto-negotiate onto 2026-07-28.

--- a/mcpjam-inspector/server/routes/mcp/__tests__/mrtr.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/mrtr.test.ts
@@ -259,118 +259,76 @@ describe("collector round-trip", () => {
 
 describe("advertised elicitation capability", () => {
   // Bare `{}` is form-ONLY under the spec's back-compat rule, and the SDK
-  // derives the MRTR mode allowlist from what was advertised — so leaving it
-  // bare makes every url round fail validation before `UrlElicitationConsent`
-  // is ever reached. The two eras share one capability on the wire, so `url`
-  // may only be declared when no legacy version can be negotiated.
-  const modern = ["2026-07-28"];
-  const mixed = ["2026-07-28", "2025-11-25"];
+  // derives the MRTR mode allowlist from what was advertised. The two eras
+  // share one capability on the wire and are fulfilled by different bridges
+  // (the legacy inbound bridge is form-only), so `{form, url}` rides the
+  // SDK's `eraCapabilities.modern` overlay: applied by the manager once the
+  // connection actually CLASSIFIES as 2026-era, never guessed from the pin
+  // or the accept-list at config time.
+  type EraShaped = {
+    capabilities?: Record<string, unknown>;
+    eraCapabilities?: { modern?: Record<string, unknown> };
+  };
 
-  it("declares both modes on a modern-only connection", () => {
-    const config = withLocalMrtrElicitationCapability({
-      url: new URL("https://example.test/mcp"),
-      supportedProtocolVersions: modern,
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(config.capabilities?.elicitation).toEqual({ form: {}, url: {} });
-  });
-
-  it("stays form-only when a legacy version can still be negotiated", () => {
-    // `auto` proposes 2026-07-28 but accepts 2025-11-25, whose inbound
-    // `elicitation/create` is fulfilled by the form-only legacy bridge.
-    const config = withLocalMrtrElicitationCapability({
-      url: new URL("https://example.test/mcp"),
-      supportedProtocolVersions: mixed,
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(config.capabilities?.elicitation).toBeUndefined();
-  });
-
-  it("stays form-only with no accept-list and with an unknown version", () => {
-    const noList = withLocalMrtrElicitationCapability({
-      url: new URL("https://example.test/mcp"),
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(noList.capabilities?.elicitation).toBeUndefined();
-
-    const bogus = withLocalMrtrElicitationCapability({
-      url: new URL("https://example.test/mcp"),
-      supportedProtocolVersions: ["2099-01-01"],
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(bogus.capabilities?.elicitation).toBeUndefined();
-  });
-
-  it("declares url from the per-server wire pin alone (no accept-list)", () => {
-    // How a user actually selects 2026-07-28: the version dropdown stamps
-    // `mcpProtocolVersion`, NOT `supportedProtocolVersions` (that one only
-    // comes from `hostConfig.mcpProfile.initialize`). Gating on the accept-list
-    // alone left every pinned modern server advertising bare `{}` — form-only —
-    // so url rounds died at the SDK's mode backstop before the consent dialog.
-    const config = withLocalMrtrElicitationCapability({
-      url: new URL("https://example.test/mcp"),
-      mcpProtocolVersion: "2026-07-28",
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(config.capabilities?.elicitation).toEqual({ form: {}, url: {} });
-  });
-
-  it("a stateful pin stays form-only even with a modern accept-list", () => {
-    // The SDK routes on the pin alone for non-stdio configs, so a 2025-11-25
-    // pin lands on the legacy client whatever the accept-list proposes. The
-    // combination is ambiguous config — fail closed.
-    const config = withLocalMrtrElicitationCapability({
-      url: new URL("https://example.test/mcp"),
-      mcpProtocolVersion: "2025-11-25",
-      supportedProtocolVersions: modern,
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(config.capabilities?.elicitation).toBeUndefined();
-  });
-
-  it("ignores the pin on stdio and falls back to the accept-list", () => {
-    // `MCPClientManager` reads `mcpProtocolVersion` for non-stdio configs only,
-    // so a pin on a stdio server proves nothing about the negotiated era.
-    const pinOnly = withLocalMrtrElicitationCapability({
-      command: "node",
-      args: ["server.js"],
-      mcpProtocolVersion: "2026-07-28",
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(pinOnly.capabilities?.elicitation).toBeUndefined();
-
-    const withList = withLocalMrtrElicitationCapability({
-      command: "node",
-      args: ["server.js"],
-      supportedProtocolVersions: modern,
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(withList.capabilities?.elicitation).toEqual({ form: {}, url: {} });
-  });
-
-  it("stays form-only on an unknown pin", () => {
-    const config = withLocalMrtrElicitationCapability({
-      url: new URL("https://example.test/mcp"),
-      mcpProtocolVersion: "2099-01-01",
-    } as never) as { capabilities?: Record<string, unknown> };
-    expect(config.capabilities?.elicitation).toBeUndefined();
+  it("declares both modes in the modern-era overlay, whatever the config", () => {
+    // The overlay is unconditional config-side — the SDK applies it iff the
+    // era lands modern, which covers the case the old pre-connect predicate
+    // could not: an unpinned Client-default connection that auto-negotiates
+    // onto 2026-07-28.
+    for (const config of [
+      { url: new URL("https://example.test/mcp") },
+      { url: new URL("https://example.test/mcp"), mcpProtocolVersion: "2026-07-28" },
+      { url: new URL("https://example.test/mcp"), supportedProtocolVersions: ["2026-07-28", "2025-11-25"] },
+      { command: "node", args: ["server.js"] },
+    ]) {
+      const out = withLocalMrtrElicitationCapability(config as never) as EraShaped;
+      expect(out.eraCapabilities?.modern?.elicitation).toEqual({
+        form: {},
+        url: {},
+      });
+      // The BASE set is untouched: a legacy landing keeps its conservative
+      // connect-time declaration (form-only via the collector gate).
+      expect(out.capabilities?.elicitation).toBeUndefined();
+    }
   });
 
   it("leaves an exact client capability set untouched", () => {
     // A host profile pins exactly what that host advertises; widening it would
-    // defeat the point of the pin.
+    // defeat the point of the pin. (The SDK also ignores `eraCapabilities`
+    // for exact sets — this keeps the config itself clean.)
     const exact = { elicitation: {} };
     const config = withLocalMrtrElicitationCapability({
       url: new URL("https://example.test/mcp"),
-      supportedProtocolVersions: modern,
       clientCapabilities: exact,
-    } as never) as {
-      clientCapabilities?: Record<string, unknown>;
-      capabilities?: Record<string, unknown>;
-    };
+    } as never) as EraShaped & { clientCapabilities?: Record<string, unknown> };
     expect(config.clientCapabilities).toBe(exact);
-    expect(config.capabilities?.elicitation).toBeUndefined();
+    expect(config.eraCapabilities).toBeUndefined();
   });
 
-  it("preserves other declared capabilities", () => {
+  it("preserves other base capabilities and other overlay keys", () => {
     const config = withLocalMrtrElicitationCapability({
       url: new URL("https://example.test/mcp"),
-      supportedProtocolVersions: modern,
       capabilities: { roots: { listChanged: true } },
-    } as never) as { capabilities?: Record<string, unknown> };
+      eraCapabilities: { modern: { sampling: {} } },
+    } as never) as EraShaped;
     expect(config.capabilities?.roots).toEqual({ listChanged: true });
-    expect(config.capabilities?.elicitation).toEqual({ form: {}, url: {} });
+    expect(config.eraCapabilities?.modern?.sampling).toEqual({});
+    expect(config.eraCapabilities?.modern?.elicitation).toEqual({
+      form: {},
+      url: {},
+    });
+  });
+
+  it("keeps caller-specified elicitation members over the defaults", () => {
+    const config = withLocalMrtrElicitationCapability({
+      url: new URL("https://example.test/mcp"),
+      eraCapabilities: {
+        modern: { elicitation: { form: { applyDefaults: true } } },
+      },
+    } as never) as EraShaped;
+    expect(config.eraCapabilities?.modern?.elicitation).toEqual({
+      form: { applyDefaults: true },
+      url: {},
+    });
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/mrtr.ts
+++ b/mcpjam-inspector/server/routes/mcp/mrtr.ts
@@ -8,10 +8,6 @@ import type {
   MrtrInputCollector,
   MrtrOperationState,
 } from "@mcpjam/sdk";
-import {
-  isKnownProtocolVersion,
-  isStatelessProtocolVersion,
-} from "@mcpjam/sdk";
 import { logger } from "../../utils/logger";
 
 /**
@@ -233,8 +229,9 @@ function makeCollector(serverId: string): MrtrInputCollector {
 const MRTR_ELICITATION_CAPABILITY = { form: {}, url: {} } as const;
 
 /**
- * Widens the advertised `elicitation` capability to include `url` — but ONLY
- * when the connection cannot land on a pre-2026 version.
+ * Declares the full MRTR elicitation capability for the modern era via the
+ * SDK's `eraCapabilities.modern` overlay — the post-negotiation re-resolution
+ * seam.
  *
  * The two eras share ONE capability on the wire, and they are fulfilled by
  * different bridges. On 2026-07-28 elicitation arrives exclusively inside an
@@ -245,49 +242,46 @@ const MRTR_ELICITATION_CAPABILITY = { form: {}, url: {} } as const;
  * `{requestId, message, schema}` with no url, so a url request would ask the
  * user to approve a destination they cannot see.
  *
- * Capabilities are sent in `initialize`, before the negotiated version is
- * known, so declaring `url` is only safe when every acceptable version is
- * modern. An `auto` accept-list that still permits a legacy answer stays
- * form-only — fail closed. Lifting this needs the legacy bridge to carry url
- * (it can reuse the same consent dialog), not a wider declaration here.
+ * The overlay expresses exactly that split without guessing: the SDK merges
+ * it once the connection has actually CLASSIFIED as 2026-era, so a modern
+ * landing (pinned or auto-negotiated) declares `{form, url}` on every
+ * subsequent request's envelope, while a legacy landing keeps the bare
+ * connect-time declaration — form-only, fail-closed. Lifting THAT still
+ * needs the legacy bridge to carry url (it can reuse the same consent
+ * dialog), not a wider declaration here.
  *
- * TWO signals can prove "modern", and they are not interchangeable:
- *
- *  - The per-server wire pin (`mcpProtocolVersion`) — how a user actually
- *    selects 2026-07-28 in the UI. The SDK routes on it alone for non-stdio
- *    configs (`wantsStateless` in `MCPClientManager.connectToServer`): a
- *    stateless pin goes to the preview client no matter what the accept-list
- *    says, so it settles the era outright. It is ignored for stdio, so it
- *    proves nothing there.
- *  - The initialize accept-list (`supportedProtocolVersions`, from
- *    `hostConfig.mcpProfile.initialize`) — the only signal on stdio, and the
- *    fallback when no pin is stamped.
- *
- * Checking only the accept-list (as the first cut did) left every pinned
- * 2026-07-28 HTTP server advertising bare `{}`, i.e. form-only, which is
- * precisely the failure this helper exists to prevent.
+ * This replaced a pre-connect predicate (`isModernOnlyLocalConnection`) that
+ * tried to prove "cannot land pre-2026" from the pin and the accept-list.
+ * It could not say anything about the common case — an unpinned Client
+ * default connection, where auto-negotiation lands modern but the predicate
+ * had to answer `false` — so url-mode MRTR silently required an explicit
+ * version pin. The era seam replaces the guess with the classified fact.
  */
 export function withLocalMrtrElicitationCapability<T extends MCPServerConfig>(
   config: T,
 ): T {
   // An exact set (host profile / explicit client capabilities) is advertised
-  // verbatim — widening it would defeat the point of pinning one.
+  // verbatim — widening it would defeat the point of pinning one. (The SDK
+  // ignores `eraCapabilities` for exact sets too; this early-return keeps the
+  // config itself clean.)
   if ((config as { clientCapabilities?: unknown }).clientCapabilities) {
     return config;
   }
-  if (!isModernOnlyLocalConnection(config)) return config;
 
-  const capabilities = ((config as { capabilities?: Record<string, unknown> })
-    .capabilities ?? {}) as Record<string, unknown>;
+  const era = (config as { eraCapabilities?: { modern?: Record<string, unknown> } })
+    .eraCapabilities;
   return {
     ...config,
-    capabilities: {
-      ...capabilities,
-      elicitation: {
-        ...MRTR_ELICITATION_CAPABILITY,
-        ...(isPlainObject(capabilities.elicitation)
-          ? capabilities.elicitation
-          : {}),
+    eraCapabilities: {
+      ...era,
+      modern: {
+        ...era?.modern,
+        elicitation: {
+          ...MRTR_ELICITATION_CAPABILITY,
+          ...(isPlainObject(era?.modern?.elicitation)
+            ? era.modern.elicitation
+            : {}),
+        },
       },
     },
   } as T;
@@ -295,37 +289,6 @@ export function withLocalMrtrElicitationCapability<T extends MCPServerConfig>(
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
-}
-
-/** Modern iff known AND off the closed stateful list (validate, then route). */
-function isModernVersion(version: unknown): boolean {
-  return (
-    typeof version === "string" &&
-    isKnownProtocolVersion(version) &&
-    isStatelessProtocolVersion(version)
-  );
-}
-
-/**
- * `true` iff this connection cannot land on a pre-2026 version. Fail-closed:
- * an unrecognized, absent, or mixed-era signal answers `false`.
- */
-function isModernOnlyLocalConnection(config: MCPServerConfig): boolean {
-  // The SDK only consults `mcpProtocolVersion` for non-stdio configs, so a pin
-  // on a stdio server says nothing about the negotiated era — fall through to
-  // the accept-list there.
-  const isStdio = "command" in config;
-  const pin = (config as { mcpProtocolVersion?: unknown }).mcpProtocolVersion;
-  if (!isStdio && pin !== undefined) {
-    // A stateless pin routes to the preview client outright; a stateful one
-    // routes legacy regardless of the accept-list. Either way the pin decides.
-    return isModernVersion(pin);
-  }
-
-  const accepted = (config as { supportedProtocolVersions?: unknown })
-    .supportedProtocolVersions;
-  if (!Array.isArray(accepted) || accepted.length === 0) return false;
-  return accepted.every(isModernVersion);
 }
 
 /**

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2235,7 +2235,18 @@ export class MCPClientManager {
 
       state.client = client;
       state.transport = transport;
-      state.initializedClientCapabilities = clientCapabilities;
+      // Post-negotiation re-resolution: now that the era is known, a
+      // modern-classified connection applies the config's
+      // `eraCapabilities.modern` overlay. The stored snapshot is the set
+      // actually in force, so the MRTR mode allowlist
+      // (`negotiatedElicitationCapability`) and `getServerConnectionInfo`
+      // report what the wire really carries.
+      state.initializedClientCapabilities = this.applyModernEraCapabilities(
+        serverId,
+        config,
+        upstreamClient,
+        clientCapabilities
+      );
       state.connectPromise = undefined;
       this.liveClientStates.set(serverId, state);
 
@@ -2928,9 +2939,20 @@ export class MCPClientManager {
     }
   }
 
+  /**
+   * Resolves the client capabilities to advertise to `serverId`.
+   *
+   * `era` is the connection's classified era when it is actually KNOWN —
+   * `undefined` at connect time (pre-negotiation), `"modern"` once the
+   * connection has landed on a 2026-era revision. With `era: "modern"` the
+   * config's `eraCapabilities.modern` overlay is merged over the base set;
+   * see {@link BaseServerConfig.eraCapabilities} for the seam's contract and
+   * {@link applyModernEraCapabilities} for when the re-resolution runs.
+   */
   private buildCapabilities(
     serverId: string,
-    config: MCPServerConfig
+    config: MCPServerConfig,
+    era?: "modern"
   ): ClientCapabilityOptions {
     // Advertise `elicitation` when EITHER a legacy elicitation handler OR a
     // modern MRTR input collector is registered — a 2026-07-28 server checks
@@ -2943,6 +2965,9 @@ export class MCPClientManager {
       this.elicitationManager.hasHandler(serverId) ||
       this.mrtrInputCollectors.has(serverId);
     if (config.clientCapabilities) {
+      // An EXACT set is advertised verbatim (minus the elicitation gate) on
+      // every era — the `eraCapabilities` overlay is deliberately ignored,
+      // since widening a pinned declaration would defeat the pin.
       const exactCapabilities = normalizeClientCapabilities(
         config.clientCapabilities
       ) as Record<string, unknown>;
@@ -2954,14 +2979,84 @@ export class MCPClientManager {
       return exactCapabilities as ClientCapabilityOptions;
     }
 
-    const configuredCapabilities = mergeClientCapabilities(
+    let configuredCapabilities = mergeClientCapabilities(
       this.defaultCapabilities,
       config.capabilities
     );
 
+    if (era === "modern" && config.eraCapabilities?.modern) {
+      // The overlay's `elicitation` key gets the strict advertise=enforce
+      // gate (dropped without a registered fulfiller) rather than the
+      // merge-style leniency `config.capabilities` historically has — it is
+      // a new field, so there is no wire behavior to preserve.
+      const overlay = {
+        ...config.eraCapabilities.modern,
+      } as Record<string, unknown>;
+      if (!hasElicitationHandler) {
+        delete overlay.elicitation;
+      }
+      configuredCapabilities = mergeClientCapabilities(
+        configuredCapabilities,
+        overlay as ClientCapabilityOptions
+      );
+    }
+
     return applyRuntimeClientCapabilities(configuredCapabilities, {
       elicitation: hasElicitationHandler,
     });
+  }
+
+  /**
+   * The post-negotiation capability re-resolution seam: applies the config's
+   * `eraCapabilities.modern` overlay once the connection has classified as
+   * 2026-era, and returns the set actually in force for this connection.
+   *
+   * Runs exactly once per connection, between transport establishment and the
+   * live-state publication in {@link performConnection} — so no caller-visible
+   * request ever races the widening, and the declaration is stable for the
+   * connection's lifetime (MRTR rounds of one logical operation always see one
+   * consistent set). Connections that land on a 2025 era — where capabilities
+   * were already fixed by the `initialize` handshake — return the connect-time
+   * set unchanged, as does any config without an overlay (byte-identical wire
+   * behavior to before this seam existed).
+   *
+   * ## Why this writes the upstream client's private `_capabilities`
+   *
+   * The upstream `Client` stamps the per-request `_meta` envelope from
+   * `this._capabilities` LIVE at request time (`_outboundMetaEnvelope`), so
+   * updating the field is sufficient for every subsequent frame. The public
+   * `registerCapabilities()` refuses to run once a transport is attached —
+   * a guard written for the legacy era, where the declaration really was
+   * frozen by `initialize`, that upstream has not yet relaxed for the modern
+   * era, where the wire re-declares per request and negotiation (which is
+   * what makes the era knowable) cannot complete until after the transport
+   * attaches. Until upstream exposes a post-negotiation capability update,
+   * this assignment is the seam — same pattern as the tasks era-gate shadow
+   * (`tasks-ext-era-gate.ts`). The inbound elicitation mode checks
+   * (`getSupportedElicitationModes`) also read `_capabilities` live, so
+   * client-side enforcement and the wire stay in lockstep.
+   */
+  private applyModernEraCapabilities(
+    serverId: string,
+    config: MCPServerConfig,
+    upstreamClient: Client,
+    connectCapabilities: ClientCapabilityOptions
+  ): ClientCapabilityOptions {
+    if (!config.eraCapabilities?.modern || config.clientCapabilities) {
+      return connectCapabilities;
+    }
+    const negotiatedVersion = upstreamClient.getNegotiatedProtocolVersion?.();
+    if (
+      negotiatedVersion === undefined ||
+      !isStatelessProtocolVersion(negotiatedVersion)
+    ) {
+      return connectCapabilities;
+    }
+    const widened = this.buildCapabilities(serverId, config, "modern");
+    (
+      upstreamClient as unknown as { _capabilities: ClientCapabilityOptions }
+    )._capabilities = widened;
+    return widened;
   }
 
   /**

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -198,6 +198,44 @@ export type BaseServerConfig = {
    * When provided, this bypasses manager defaults and legacy capability merging.
    */
   clientCapabilities?: ClientCapabilityOptions;
+  /**
+   * Era-conditional capability overlays, applied once the connection's era is
+   * actually KNOWN — the post-negotiation re-resolution seam.
+   *
+   * Capabilities are resolved at connect time, before negotiation has run, so
+   * the base set must be honest under the most conservative era the connection
+   * could land on (a capability the legacy bridge cannot fulfil must not ride
+   * an `initialize` that a 2025 server holds for the whole session). That
+   * forces auto-negotiated connections to under-advertise on the modern era —
+   * e.g. url-mode elicitation, perfectly fulfillable on 2026-07-28, stayed
+   * undeclared because the connect-time resolver couldn't rule out a legacy
+   * landing.
+   *
+   * `modern` is a merge-style overlay (same semantics as `capabilities`)
+   * merged over the connect-time set exactly ONCE, immediately after era
+   * classification, when the connection lands on a 2026-era revision:
+   *
+   * - The 2026 wire re-sends capabilities on EVERY request (the `_meta`
+   *   envelope reads the live set), so the widened declaration simply flows
+   *   outward from the next request on; the only frames that carried the
+   *   narrow set are the negotiation probe itself.
+   * - After that single application the declaration is STABLE for the
+   *   connection's lifetime — MRTR rounds of one logical operation always
+   *   see one consistent set.
+   * - A connection that lands on a 2025 era never applies the overlay, and
+   *   its `initialize` already carried the conservative base: fail-closed.
+   *
+   * The overlay's `elicitation` key is subject to the same advertise=enforce
+   * gate as the runtime-added one: it is dropped unless an elicitation
+   * handler or MRTR input collector is actually registered.
+   *
+   * Ignored entirely when `clientCapabilities` (an EXACT set) is configured —
+   * widening a pinned declaration would defeat the point of pinning one.
+   */
+  eraCapabilities?: {
+    /** Overlay merged when the connection classifies as 2026-era (stateless). */
+    modern?: ClientCapabilityOptions;
+  };
   /** Request timeout in milliseconds */
   timeout?: number;
   /** Client version to report */

--- a/sdk/tests/mrtr-manager.integration.test.ts
+++ b/sdk/tests/mrtr-manager.integration.test.ts
@@ -142,3 +142,110 @@ describe("MCPClientManager × modern MRTR fixture over HTTP", () => {
     );
   });
 });
+
+describe("post-negotiation capability re-resolution (eraCapabilities.modern)", () => {
+  let served: ServedFixture;
+  let manager: MCPClientManager;
+
+  beforeEach(async () => {
+    served = await serveFixture();
+    manager = new MCPClientManager();
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("applies the overlay after AUTO negotiation lands modern (url-mode elicitation)", async () => {
+    // The bug this seam fixes: capabilities resolve at connect time, before
+    // the era is known, so an UNPINNED connection had to advertise the
+    // conservative form-only set even when auto-negotiation then landed on
+    // 2026-07-28 — and every url-mode elicitation died at the server's
+    // mode-aware capability gate (-32021). The overlay is applied once the
+    // era is classified, so the same unpinned connection now declares
+    // `{form, url}` on every post-negotiation request envelope.
+    manager.setMrtrInputCollector("fixture", acceptAllCollector());
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      // NO mcpProtocolVersion pin — auto era negotiation.
+      timeout: 10_000,
+      eraCapabilities: { modern: { elicitation: { form: {}, url: {} } } },
+    });
+
+    const info = manager.getInitializationInfo("fixture");
+    const caps = (info?.clientCapabilities ?? {}) as Record<string, unknown>;
+    expect(caps.elicitation).toEqual({ form: {}, url: {} });
+
+    const result = (await manager.executeTool("fixture", "confirm-url", {
+      topic: "x",
+    })) as { content: Array<{ text?: string }> };
+    expect(result.content[0]?.text).toBe("consent:accept");
+  });
+
+  it("without the overlay, an auto-negotiated url-mode elicitation still fails closed", async () => {
+    // Locks the baseline the seam widens FROM: a bare `elicitation: {}`
+    // declaration is form-only under the spec's back-compat rule, so the
+    // server refuses to embed a url-mode request (-32021). If this ever
+    // starts passing, the conservative base has silently widened.
+    manager.setMrtrInputCollector("fixture", acceptAllCollector());
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      timeout: 10_000,
+    });
+    const error = await manager
+      .executeTool("fixture", "confirm-url", { topic: "x" })
+      .then(() => undefined, (e: unknown) => e);
+    expect((error as { code?: number })?.code).toBe(-32021);
+  });
+
+  it("ignores the overlay for an EXACT clientCapabilities set", async () => {
+    // Pinning an exact set means exactly that — the era overlay must not
+    // widen it, or the pin stops being a pin.
+    manager.setMrtrInputCollector("fixture", acceptAllCollector());
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      timeout: 10_000,
+      clientCapabilities: { elicitation: {} },
+      eraCapabilities: { modern: { elicitation: { form: {}, url: {} } } },
+    });
+
+    const info = manager.getInitializationInfo("fixture");
+    const caps = (info?.clientCapabilities ?? {}) as Record<string, unknown>;
+    expect(caps.elicitation).toEqual({});
+
+    const error = await manager
+      .executeTool("fixture", "confirm-url", { topic: "x" })
+      .then(() => undefined, (e: unknown) => e);
+    expect((error as { code?: number })?.code).toBe(-32021);
+  });
+
+  it("gates the overlay's elicitation on a registered fulfiller (advertise=enforce)", async () => {
+    // An overlay must not smuggle `elicitation` past the runtime gate: with
+    // no collector and no handler, the widened set still advertises none.
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      timeout: 10_000,
+      eraCapabilities: { modern: { elicitation: { form: {}, url: {} } } },
+    });
+    const info = manager.getInitializationInfo("fixture");
+    const caps = (info?.clientCapabilities ?? {}) as Record<string, unknown>;
+    expect(caps.elicitation).toBeUndefined();
+  });
+
+  it("also applies the overlay on a PINNED modern connection", async () => {
+    // The seam keys on the classified era, not on how the era was selected —
+    // a pin and a successful auto probe land in the same place.
+    manager.setMrtrInputCollector("fixture", acceptAllCollector());
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+      eraCapabilities: { modern: { elicitation: { form: {}, url: {} } } },
+    });
+    const result = (await manager.executeTool("fixture", "confirm-url", {
+      topic: "x",
+    })) as { content: Array<{ text?: string }> };
+    expect(result.content[0]?.text).toBe("consent:accept");
+  });
+});

--- a/sdk/tests/support/mrtr-fixture.ts
+++ b/sdk/tests/support/mrtr-fixture.ts
@@ -91,6 +91,37 @@ export function buildMrtrFixtureServer(): McpServer {
     },
   );
 
+  // Tool that requests URL-mode input. The server SDK enforces the mode-aware
+  // capability rule before embedding ("a server MUST NOT send a mode the
+  // client did not declare"): this call answers `-32021` unless the request's
+  // declared client capabilities carry `elicitation.url` — which is exactly
+  // what the manager's post-negotiation `eraCapabilities.modern` overlay
+  // exists to declare on an auto-negotiated modern connection.
+  server.registerTool(
+    "confirm-url",
+    {
+      description: "Requests URL-mode consent, then completes.",
+      inputSchema: { topic: z.string() },
+    },
+    async (_args, ctx) => {
+      const consent = ctx.mcpReq.inputResponses?.["u"];
+      if (consent === undefined) {
+        return inputRequired({
+          inputRequests: {
+            u: inputRequired.elicitUrl({
+              message: "Approve at the linked page.",
+              url: "https://example.test/consent",
+            }),
+          },
+          requestState: "url-state-1",
+        });
+      }
+      return {
+        content: [{ type: "text" as const, text: `consent:${consent.action}` }],
+      };
+    },
+  );
+
   // Prompt that requests input then embeds it.
   server.registerPrompt(
     "confirm-prompt",


### PR DESCRIPTION
## Problem

Client capabilities are resolved once, at connect time — **before era negotiation has run**. So the set must be honest under the most conservative era the connection could land on, and auto-negotiated (*Client default*) connections were forced to under-advertise on 2026-07-28:

- url-mode elicitation is fully fulfillable by the local MRTR bridge on the modern era, but declaring it is unsafe if the connection lands on 2025-* (the legacy inbound bridge is form-only, and `initialize` freezes the declaration for the whole session)
- so `withLocalMrtrElicitationCapability` widened to `{form, url}` only when a pre-connect predicate (`isModernOnlyLocalConnection`) could *prove* the connection couldn't land pre-2026 — from the pin or the accept-list
- the common case — an unpinned connection that auto-negotiates onto 2026-07-28 — is exactly the case the predicate cannot prove, so it stayed form-only and every url-mode `input_required` round died at the server's mode-aware capability gate (`-32021`) unless the user explicitly pinned the version

Found demoing `open-dashboard` on `stateless.mcpjam.com`: works with a `2026-07-28` pin, fails on *Client default*, on the same server that just negotiated `2026-07-28`.

## Fix: re-resolve once, when the era is known

New config seam: **`MCPServerConfig.eraCapabilities.modern`** — a merge-style capability overlay the manager applies **exactly once**, between transport establishment and live-state publication, when the connection classifies as 2026-era.

Why once-after-negotiation rather than per-request or connect-time:

- **The 2026 wire re-declares capabilities on every request** — the upstream client stamps the `_meta` envelope from `_capabilities` live (`_outboundMetaEnvelope`). So the widened set flows outward from the next request on; the only frames that carried the narrow set are the negotiation probe itself. Nothing was "already promised."
- **Stability within a connection**: after the single application the declaration never changes, so MRTR rounds of one logical operation always see one consistent set (a per-request resolver could legally shrink between round 1 and round 2 — undefined behavior server-side).
- **Fail-closed on legacy**: a 2025 landing never applies the overlay, and its `initialize` already carried the conservative base.
- **One capability model across all four wire versions** — `buildCapabilities` stays the single resolver; the era is an argument, not a fork.

Guard rails:
- Exact `clientCapabilities` pins ignore the overlay entirely (widening a pinned declaration would defeat the pin).
- The overlay's `elicitation` key is subject to the same advertise=enforce gate as the runtime-added one: dropped unless a handler or MRTR collector is actually registered.
- No overlay configured → byte-identical wire behavior to before this seam existed.

The write goes to the upstream client's private `_capabilities`: `registerCapabilities()` refuses to run once a transport is attached — a guard written for the legacy era (where `initialize` really did freeze the declaration) that upstream hasn't yet relaxed for the modern era, where negotiation *cannot complete* until after the transport attaches. Same documented-workaround pattern as the tasks era-gate shadow (`tasks-ext-era-gate.ts`). The inbound elicitation mode checks read `_capabilities` live too, so client-side enforcement and the wire stay in lockstep. Worth an upstream issue: `registerCapabilities` (or a successor) should be callable post-negotiation on the modern era.

## Inspector consumer

`withLocalMrtrElicitationCapability` now stamps the overlay instead of guessing: `isModernOnlyLocalConnection` and its pin/accept-list heuristics are deleted. Modern landing (pinned **or** auto) → `{form, url}`; legacy landing → form-only, unchanged.

## Tests

The MRTR fixture gains a url-mode tool (`confirm-url`), giving the server SDK's own mode-aware gate something to enforce end-to-end. New integration coverage (`sdk/tests/mrtr-manager.integration.test.ts`):

| Case | Locks |
|---|---|
| auto-negotiated + overlay → url elicitation completes | the fix (**fails without the seam**) |
| pinned + overlay → same | seam keys on classified era, not on how it was selected |
| auto-negotiated, no overlay → `-32021` | the conservative baseline hasn't silently widened |
| exact `clientCapabilities` + overlay → `-32021`, set unchanged | pin exemption |
| overlay with no collector → no `elicitation` advertised | advertise=enforce gate |

Verified the two overlay-application tests fail with the seam reverted and pass with it.

- SDK suite: **3173 passed** (6 pre-existing failures reproduced on clean `main` — draft-07 validator + `connect({prior})` + conformance era fixture, all fallout of the beta.4→2.0.0 bump, untouched here)
- Inspector server suite: **3697 passed**
- `tsc --noEmit` clean on both

## Follow-ups (not in scope)

- Upstream SDK issue: post-negotiation capability updates on the modern era (removes the private-field write).
- Lifting form-only on *legacy* connections needs the legacy inbound bridge to carry url consent — a UI change, orthogonal to this seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connect/capability advertisement and writes upstream `_capabilities` post-negotiation, but behavior is gated on classified modern era, exact pins, and elicitation fulfiller registration—legacy paths stay fail-closed.
> 
> **Overview**
> Adds **`MCPServerConfig.eraCapabilities.modern`**, a merge-style overlay the SDK applies **once after era negotiation** when the connection lands on 2026-era. Connect-time capabilities stay conservative (legacy-safe); the overlay widens what goes on the wire for modern sessions via the upstream client’s live `_capabilities` / per-request `_meta`.
> 
> **Inspector:** `withLocalMrtrElicitationCapability` now stamps `{form, url}` elicitation on **`eraCapabilities.modern`** instead of pre-connect heuristics (`isModernOnlyLocalConnection` removed). Unpinned Client-default connections that auto-negotiate to `2026-07-28` can advertise url-mode MRTR without pinning the protocol version.
> 
> **Guards:** exact `clientCapabilities` pins skip the overlay; overlay `elicitation` still requires a registered handler/collector; legacy landings keep the narrow connect-time set.
> 
> **Tests:** MRTR fixture gains `confirm-url`; integration tests lock auto-negotiated + overlay success, baseline `-32021` without overlay, pin exemption, and advertise=enforce gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4f233edd91d079a7c9f8119a077e90f7e5e2e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds post‑negotiation capability re-resolution via `MCPServerConfig.eraCapabilities.modern`, so modern (2026) connections can safely widen capabilities after negotiation. This fixes url‑mode MRTR elicitation failing on auto‑negotiated connections while keeping legacy behavior fail‑closed.

- New Features
  - `@mcpjam/sdk`: Add `eraCapabilities.modern` overlay applied once after era classification to widen capabilities (e.g., `elicitation: { form, url }`) on modern connections.
  - Overlay is ignored when an exact `clientCapabilities` set is provided; `elicitation` is included only if a handler or MRTR collector is registered.
  - Implementation updates the upstream client’s live `_capabilities` so subsequent requests carry the widened set.

- Bug Fixes
  - Auto‑negotiated modern connections now advertise `{ form, url }` for `elicitation`, enabling url‑mode MRTR without requiring a version pin; legacy stays form‑only unless upgraded.
  - `@mcpjam/inspector`: `withLocalMrtrElicitationCapability` now stamps the modern overlay instead of guessing from pins/accept‑lists; related heuristics removed.

<sup>Written for commit e4f233edd91d079a7c9f8119a077e90f7e5e2e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

