### PR TITLE
fix(sdk): read 2026 server identity off the _meta stamp; green the SDK suite

### DIFF
--- a/.changeset/discover-identity-meta-stamp.md
+++ b/.changeset/discover-identity-meta-stamp.md
@@ -1,0 +1,9 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Fix `modern-server-discover` failing every spec-correct 2026 server. The check demanded a top-level `serverInfo` in the `server/discover` result, but `DiscoverResult` has no such member — the 2026 encode seam stamps identity into `_meta["io.modelcontextprotocol/serverInfo"]` on every result instead (spec PR #3002). Any server built on the official server SDK, MCPJam's own stateless reference server included, failed the check.
+
+The check now reads the `_meta` stamp, keeps a top-level `serverInfo` as a lenient fallback, and treats identity as the SHOULD it is: a present-but-malformed stamp still fails, an absent one does not, and either way the value is reported in the check details so a silent server stays visible in the run artifact. `supportedVersions` and `capabilities` remain hard MUST failures.
+
+Also repairs test rot from the 2.0.0 client bump so the SDK suite is green again: `connect({ prior })` is now era-discriminated (`{ kind: "modern", discover }`), and upstream's default validators no longer reject a declared draft-07 dialect — that assertion is re-pointed at the boundary that is still real (draft-04). Upstream now covering draft-06/07/2019-09/2020-12 makes `DialectAwareJsonSchemaValidator` and its CSP-safe twin redundant for the dialects they dispatch; retiring them touches the client factory and the browser/workerd bundles, so it is left as a separate deliberate change.

--- a/sdk/src/mcp-conformance/checks/modern.ts
+++ b/sdk/src/mcp-conformance/checks/modern.ts
@@ -361,6 +361,32 @@ function cacheableListMethods(capabilities: Record<string, unknown>): string[] {
   return methods;
 }
 
+/**
+ * Where a 2026 server states its identity.
+ *
+ * `DiscoverResult` has no `serverInfo` member — the 2026 encode seam stamps
+ * identity into `_meta` on EVERY result instead (spec PR #3002), so demanding
+ * a top-level `serverInfo` here failed every spec-correct server, including
+ * ones built on the official server SDK. The top-level read is kept as a
+ * lenient fallback: a server that also mirrors it there is not wrong, and a
+ * conformance check should not punish the more informative answer.
+ */
+const SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
+
+function readServerIdentity(
+  payload: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const meta = payload._meta as Record<string, unknown> | undefined;
+  const stamped = meta?.[SERVER_INFO_META_KEY];
+  if (stamped !== null && typeof stamped === "object") {
+    return stamped as Record<string, unknown>;
+  }
+  const topLevel = payload.serverInfo;
+  return topLevel !== null && typeof topLevel === "object"
+    ? (topLevel as Record<string, unknown>)
+    : undefined;
+}
+
 async function runServerDiscoverCheck(
   ctx: RawHttpCheckContext,
   state: ModernRunState
@@ -383,7 +409,7 @@ async function runServerDiscoverCheck(
   }
 
   const supportedVersions = payload.supportedVersions;
-  const serverInfo = payload.serverInfo as Record<string, unknown> | undefined;
+  const serverInfo = readServerIdentity(payload);
   const problems: string[] = [];
 
   if (
@@ -399,12 +425,16 @@ async function runServerDiscoverCheck(
   ) {
     problems.push("capabilities must be an object");
   }
+  // Identity is a SHOULD (spec PR #3002), not a member of the result: a
+  // present-but-malformed stamp is a real defect, an absent one is not.
   if (
-    !serverInfo ||
-    typeof serverInfo.name !== "string" ||
-    typeof serverInfo.version !== "string"
+    serverInfo !== undefined &&
+    (typeof serverInfo.name !== "string" ||
+      typeof serverInfo.version !== "string")
   ) {
-    problems.push("serverInfo must carry a name and a version");
+    problems.push(
+      `${SERVER_INFO_META_KEY} must carry a string name and a string version`
+    );
   }
 
   return problems.length > 0
@@ -420,7 +450,9 @@ async function runServerDiscoverCheck(
         capabilities: Object.keys(
           payload.capabilities as Record<string, unknown>
         ),
-        serverInfo,
+        // Reported either way so a silent server is visible in the artifact
+        // without being scored as a failure.
+        serverInfo: serverInfo ?? null,
       });
 }
 

--- a/sdk/tests/dialect-aware-json-schema-validator.test.ts
+++ b/sdk/tests/dialect-aware-json-schema-validator.test.ts
@@ -8,7 +8,7 @@ const DRAFT_07 = "http://json-schema.org/draft-07/schema#";
 const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
 
 // Shape of what zod-to-json-schema emits for a v1-SDK server's outputSchema
-// (the Atlas `listFlights` regression: upstream's defaults reject the
+// (the Atlas `listFlights` regression: upstream's defaults rejected the
 // declared draft-07 dialect outright instead of validating with it).
 const draft07Schema = {
   $schema: DRAFT_07,
@@ -20,16 +20,50 @@ const draft07Schema = {
   additionalProperties: false,
 } as const;
 
-describe("upstream defaults reject declared draft-07 (the regression these classes guard against)", () => {
-  it("AjvJsonSchemaValidator (node default)", () => {
-    expect(() =>
-      new AjvJsonSchemaValidator().getValidator(draft07Schema)
-    ).toThrow(/unsupported dialect/);
+/**
+ * Where upstream's own defaults stand today.
+ *
+ * The Atlas regression these classes were written for is FIXED upstream as of
+ * client 2.0.0: both default validators now compile a declared draft-07 schema
+ * and validate with it. This block pins the boundary that is still real —
+ * draft-04 is rejected by both — so the day upstream moves again, this fails
+ * loudly instead of the dialect-aware classes silently carrying a dead load.
+ *
+ * Consequence worth acting on separately: for the two dialects the dispatcher
+ * covers (2020-12 and draft-07) `DialectAwareJsonSchemaValidator` and
+ * `CspSafeDialectAwareJsonSchemaValidator` are now redundant with upstream.
+ * Retiring them touches the factory default and the browser/workerd bundles,
+ * so it is a deliberate product change, not test cleanup — see the tests below
+ * for the behavior any replacement must keep.
+ */
+describe("upstream defaults, post-2.0.0", () => {
+  it("AjvJsonSchemaValidator (node default) now validates declared draft-07", () => {
+    const validate = new AjvJsonSchemaValidator().getValidator(draft07Schema);
+
+    expect(validate({ flights: [] }).valid).toBe(true);
+    expect(validate({ nope: true }).valid).toBe(false);
   });
 
-  it("CfWorkerJsonSchemaValidator (browser/workerd default)", () => {
+  it("CfWorkerJsonSchemaValidator (browser/workerd default) now validates declared draft-07", () => {
+    const validate = new CfWorkerJsonSchemaValidator().getValidator(
+      draft07Schema
+    );
+
+    expect(validate({ flights: [] }).valid).toBe(true);
+    expect(validate({ nope: true }).valid).toBe(false);
+  });
+
+  it("still rejects a dialect neither engine carries (draft-04)", () => {
+    const draft04Schema = {
+      ...draft07Schema,
+      $schema: "http://json-schema.org/draft-04/schema#",
+    };
+
     expect(() =>
-      new CfWorkerJsonSchemaValidator().getValidator(draft07Schema)
+      new AjvJsonSchemaValidator().getValidator(draft04Schema)
+    ).toThrow(/unsupported dialect/);
+    expect(() =>
+      new CfWorkerJsonSchemaValidator().getValidator(draft04Schema)
     ).toThrow(/unsupported dialect/);
   });
 });

--- a/sdk/tests/mcp-conformance/server-discover-identity.test.ts
+++ b/sdk/tests/mcp-conformance/server-discover-identity.test.ts
@@ -1,0 +1,127 @@
+/**
+ * `modern-server-discover` reads identity where 2026 actually puts it.
+ *
+ * `DiscoverResult` has no `serverInfo` member — the 2026 encode seam stamps
+ * `_meta["io.modelcontextprotocol/serverInfo"]` on every result instead (spec
+ * PR #3002). The check used to demand a top-level `serverInfo`, so it failed
+ * every spec-correct server, the official server SDK included.
+ *
+ * These fixtures are raw HTTP rather than a real handler on purpose: the SDK
+ * always stamps, so a server that omits identity — or malforms it — cannot be
+ * expressed with one.
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  MCPConformanceTest,
+  type MCPCheckResult,
+} from "../../src/mcp-conformance/index.js";
+
+const MODERN = "2026-07-28" as const;
+const SERVER_INFO_META_KEY = "io.modelcontextprotocol/serverInfo";
+
+const closers: Array<() => Promise<void>> = [];
+
+/** Answers `server/discover` with the supplied result verbatim. */
+async function serveDiscover(result: Record<string, unknown>): Promise<string> {
+  const httpServer = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      const id = (JSON.parse(body || "{}") as { id?: unknown }).id ?? 1;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ jsonrpc: "2.0", id, result }));
+    });
+  });
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve)
+  );
+  const { port } = httpServer.address() as AddressInfo;
+  closers.push(
+    () => new Promise<void>((resolve) => httpServer.close(() => resolve()))
+  );
+  return `http://127.0.0.1:${port}/mcp`;
+}
+
+async function runDiscoverCheck(
+  result: Record<string, unknown>
+): Promise<MCPCheckResult> {
+  const serverUrl = await serveDiscover(result);
+  const run = await new MCPConformanceTest({
+    serverUrl,
+    protocolVersion: MODERN,
+    checkIds: ["modern-server-discover"],
+  }).run();
+  const check = run.checks.find((c) => c.id === "modern-server-discover");
+  if (!check) throw new Error("modern-server-discover did not run");
+  return check;
+}
+
+const baseResult = {
+  supportedVersions: [MODERN],
+  capabilities: { tools: { listChanged: true } },
+  resultType: "complete",
+  ttlMs: 0,
+  cacheScope: "private",
+} as const;
+
+afterEach(async () => {
+  await Promise.all(closers.splice(0).map((close) => close()));
+});
+
+describe("modern-server-discover identity", () => {
+  it("passes on the _meta stamp, which is where the spec puts identity", async () => {
+    const check = await runDiscoverCheck({
+      ...baseResult,
+      _meta: {
+        [SERVER_INFO_META_KEY]: { name: "fixture", version: "1.0.0" },
+      },
+    });
+
+    expect(check.status).toBe("passed");
+    expect(check.details?.serverInfo).toEqual({
+      name: "fixture",
+      version: "1.0.0",
+    });
+  });
+
+  it("still accepts a top-level serverInfo as a lenient fallback", async () => {
+    const check = await runDiscoverCheck({
+      ...baseResult,
+      serverInfo: { name: "fixture", version: "1.0.0" },
+    });
+
+    expect(check.status).toBe("passed");
+  });
+
+  it("does not fail a server that stays silent — identity is a SHOULD", async () => {
+    const check = await runDiscoverCheck({ ...baseResult });
+
+    expect(check.status).toBe("passed");
+    // Reported as null so the absence is visible in the run artifact rather
+    // than indistinguishable from a check that never looked.
+    expect(check.details?.serverInfo).toBeNull();
+  });
+
+  it("fails a present-but-malformed stamp", async () => {
+    const check = await runDiscoverCheck({
+      ...baseResult,
+      _meta: { [SERVER_INFO_META_KEY]: { name: "fixture" } },
+    });
+
+    expect(check.status).toBe("failed");
+    expect(check.error?.message).toContain(SERVER_INFO_META_KEY);
+  });
+
+  it("still fails on the MUST members", async () => {
+    const check = await runDiscoverCheck({
+      ...baseResult,
+      supportedVersions: [],
+    });
+
+    expect(check.status).toBe("failed");
+    expect(check.error?.message).toContain("supportedVersions");
+  });
+});

--- a/sdk/tests/tasks-ext-listen-meta.test.ts
+++ b/sdk/tests/tasks-ext-listen-meta.test.ts
@@ -271,11 +271,19 @@ describe("the declaration on a real subscriptions/listen frame", () => {
     // establishes the 2026-07-28 era from a supplied `DiscoverResult` with no
     // handshake, which is all `listen()`'s era gate needs. Nothing private is
     // touched to get here.
+    //
+    // Client 2.0.0 made the blob era-discriminated (`validatePrior`): the
+    // verdict is the `kind`, and the `DiscoverResult` moved under `discover`
+    // so a corrupt blob can never era-choose by shape alone. `discover` is
+    // schema-parsed, and that schema has no `serverInfo` — 2026 identity is
+    // `_meta`-stamped per result (spec PR #3002), not a discover member.
     await client.connect(transport as never, {
       prior: {
-        supportedVersions: [MODERN_PROTOCOL_VERSION],
-        capabilities: {},
-        serverInfo: { name: "fake", version: "0.0.0" },
+        kind: "modern",
+        discover: {
+          supportedVersions: [MODERN_PROTOCOL_VERSION],
+          capabilities: {},
+        },
       } as never,
     });
     return { client, transport };


### PR DESCRIPTION
Follow-up to #3547. `main`'s SDK suite has 6 failures, all fallout from the 2.0.0 client bump (#3543). Two of them turn out to be a real product bug; four are test rot. This fixes all six.

## The product bug: `modern-server-discover` fails every spec-correct 2026 server

The check demanded a top-level `serverInfo` in the `server/discover` result. `DiscoverResult` has no such member — the 2026 encode seam stamps identity into `_meta["io.modelcontextprotocol/serverInfo"]` on **every** result instead (spec PR #3002). So any server built on the official server SDK failed, including our own stateless reference server:

```
failed modern-server-discover
  server/discover result is incomplete: serverInfo must carry a name and a version
```

The check now reads the `_meta` stamp, with a top-level `serverInfo` kept as a lenient fallback — a server that also mirrors it there is not wrong, and a conformance check shouldn't punish the more informative answer.

Identity is also scored as the SHOULD it is: a present-but-malformed stamp still **fails**, an absent one does **not**, and the value is reported in the check details either way so a silent server stays visible in the run artifact instead of looking like a check that never ran. `supportedVersions` and `capabilities` remain hard MUST failures.

Live against the stateless server: `discover: passed {"name":"mcpjam-stateless","version":"0.3.1"}`.

## The test rot

- **`connect({ prior })`** is now era-discriminated — `{ kind: "modern", discover }` — so the verdict rides on `kind` and a corrupt blob can never era-choose by shape alone. The `discover` payload is schema-parsed, and that schema has no `serverInfo`: the same spec fact as above. `prior` appears only in tests, never in SDK source, which is why nothing broke at runtime.
- **Upstream's default validators no longer reject a declared draft-07 dialect** — the Atlas `listFlights` regression these classes were written for is fixed upstream. Asserting that they throw is obsolete, so the block now pins the boundary that is still real: draft-04, rejected by both engines.

## One thing deliberately NOT done here

I probed upstream's dialect coverage: draft-06, draft-07, 2019-09 and 2020-12 all compile and validate correctly now; only draft-04 is rejected. That makes `DialectAwareJsonSchemaValidator` and `CspSafeDialectAwareJsonSchemaValidator` redundant for the two dialects they dispatch. Retiring them touches the client factory default and the browser/workerd bundles, so it's a deliberate product change rather than test cleanup — flagged in the test file and changeset, not smuggled in.

## Verification

- New `tests/mcp-conformance/server-discover-identity.test.ts` (5 cases): `_meta` stamp passes, top-level fallback passes, silence passes with `serverInfo: null` in details, malformed stamp fails, MUST members still fail. Raw HTTP fixtures on purpose — the SDK always stamps, so an omitting or malforming server can't be expressed with a real handler. Confirmed red before the fix (3 of 5), green after.
- Full SDK suite: **180 files, 3183 passed, 1 skipped, 0 failed** (was 6 failed). `tsc --noEmit` clean.
- Live `protocol conformance` against the 2026 stateless server re-run end to end.

The one remaining live failure, `logging-set-level`, is a separate check-selection issue — the SDK itself refuses that method on a modern connection, so the check should era-skip rather than fail. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Conformance scoring and test expectations change in the SDK; runtime product surface is limited to conformance check behavior, with no auth or data-path changes.
> 
> **Overview**
> Fixes **`modern-server-discover`** so it no longer fails spec-correct 2026 servers that only expose identity via `_meta["io.modelcontextprotocol/serverInfo"]` instead of a top-level `serverInfo`. The check uses **`readServerIdentity`** (meta stamp first, optional top-level fallback), treats missing identity as a **SHOULD** (pass), still fails malformed stamps, and always surfaces **`serverInfo`** in check details (including `null` when absent). **`supportedVersions`** and **`capabilities`** stay hard MUST failures.
> 
> Brings the SDK test suite in line with **MCP client 2.0.0**: **`connect({ prior })`** tests use `{ kind: "modern", discover: { … } }` without `serverInfo`; dialect tests expect upstream validators to accept **draft-07** and only assert rejection for **draft-04**. Adds **`server-discover-identity.test.ts`** with raw HTTP fixtures for the identity rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d86dc10f26145dab344a8e75169d514389d5c338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `modern-server-discover` check to read 2026 server identity from the `_meta["io.modelcontextprotocol/serverInfo"]` stamp instead of a top‑level `serverInfo`. Also greens the `@mcpjam/sdk` suite after the 2.0.0 client bump.

- **Bug Fixes**
  - Read identity from `_meta["io.modelcontextprotocol/serverInfo"]`; keep top‑level `serverInfo` as a lenient fallback.
  - Treat identity as a SHOULD: malformed stamp fails; missing stamp does not; always surface `serverInfo` (or null) in check details.
  - `supportedVersions` and `capabilities` remain MUST; spec‑correct servers (including the stateless reference) now pass discover.

- **Refactors**
  - Update `connect({ prior })` tests to `{ kind: "modern", discover }`; `discover` is schema‑parsed and has no `serverInfo`.
  - Refresh validator tests: defaults now accept draft‑07; assert draft‑04 is rejected by both engines.
  - Add conformance tests for discover identity; full SDK suite now passes (3183 tests, 0 failed).

<sup>Written for commit d86dc10f26145dab344a8e75169d514389d5c338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

