### PR TITLE
fix: era-aware pingServer (server/discover on modern) + Tasks tab capability-probe race

### DIFF
--- a/.changeset/era-aware-ping.md
+++ b/.changeset/era-aware-ping.md
@@ -1,0 +1,20 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Make `pingServer` era-aware: probe modern (2026-07-28) connections with
+`server/discover` instead of the retired `ping` method.
+
+`ping` was removed from the 2026 vocabulary, so the upstream client refuses to
+send it on a modern-classified connection (`MethodNotSupportedByProtocolVersion`).
+Every caller that health-checked a modern connection — most visibly the MRTR
+resume path, which pings before driving the retry leg — failed with
+"Method 'ping' is not supported by the negotiated protocol version" right after
+the user answered an elicitation dialog.
+
+`pingServer` now probes with `server/discover` (the modern era's only
+universally available request) when the connection's era is modern, discarding
+the result and returning the ping contract's `EmptyResult` so callers stay
+era-agnostic. Legacy connections keep the wire-identical `ping`. `discover` is
+forwarded through the managed-client surface (adapter + both meta decorators)
+as an optional member; a client without it falls back to `ping`.

--- a/.changeset/era-aware-ping.md
+++ b/.changeset/era-aware-ping.md
@@ -5,7 +5,7 @@
 Make `pingServer` era-aware: probe modern (2026-07-28) connections with
 `server/discover` instead of the retired `ping` method.
 
-`ping` was removed from the 2026 vocabulary, so the upstream client refuses to
+`ping` was removed from the 2026 vocabulary (SEP-2575), so the upstream client refuses to
 send it on a modern-classified connection (`MethodNotSupportedByProtocolVersion`).
 Every caller that health-checked a modern connection — most visibly the MRTR
 resume path, which pings before driving the retry leg — failed with
@@ -17,4 +17,7 @@ universally available request) when the connection's era is modern, discarding
 the result and returning the ping contract's `EmptyResult` so callers stay
 era-agnostic. Legacy connections keep the wire-identical `ping`. `discover` is
 forwarded through the managed-client surface (adapter + both meta decorators)
-as an optional member; a client without it falls back to `ping`.
+as an optional member; the decorators bind it only when the inner client
+carries it, so absence propagates through the stack and a client without
+`discover` falls back to `ping` rather than reporting a health check that
+never touched the wire.

--- a/.changeset/tasks-tab-capability-probe-race.md
+++ b/.changeset/tasks-tab-capability-probe-race.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Stop the Tasks tab sticking on "Tasks not supported" when the capabilities
+probe races the connect.
+
+The probe fails closed to `wire: "none"` against a server that is still
+connecting, and the fetch was keyed only on server identity — so a probe that
+landed before the connection came up left the tab permanently claiming the
+server has no tasks support. The effect is now keyed on the connection status
+too, re-probing once the connection is actually up (and again after a
+reconnect).
+
+A probe that THROWS (network, auth, connect race) is also no longer conflated
+with a server declaring no tasks support: it renders a retryable error state
+instead of a false "Tasks not supported".

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1327,6 +1327,9 @@ export function TasksRoute() {
         serverConfig={selectedMCPConfig}
         serverName={appState.selectedServer}
         isActive
+        connectionStatus={
+          appState.servers[appState.selectedServer]?.connectionStatus
+        }
       />
     </div>
   );

--- a/mcpjam-inspector/client/src/components/TasksTab.tsx
+++ b/mcpjam-inspector/client/src/components/TasksTab.tsx
@@ -96,6 +96,13 @@ interface TasksTabProps {
   serverConfig?: MCPServerConfig;
   serverName?: string;
   isActive?: boolean;
+  /**
+   * Connection status of the selected server. The capabilities probe fails
+   * closed to `wire: "none"` while the connection is still coming up, so the
+   * tab must refetch when this reaches "connected" — otherwise a fetch that
+   * raced the connect leaves a sticky "Tasks not supported".
+   */
+  connectionStatus?: string;
 }
 
 /** Unknown statuses should never reach the UI, but must not crash it. */
@@ -127,6 +134,7 @@ export function TasksTab({
   serverConfig,
   serverName,
   isActive = true,
+  connectionStatus,
 }: TasksTabProps) {
   const [tasks, setTasks] = useState<NormalizedTask[]>([]);
   // Read inside `fetchTasks` to carry not-yet-due handles forward without
@@ -161,10 +169,14 @@ export function TasksTab({
   const [userOverride, setUserOverride] = useState<number | null>(null);
   const [progress, setProgress] = useState<ProgressEvent | null>(null);
   // Task capabilities from server (MCP Tasks spec 2025-11-25)
-  // undefined = not yet fetched, null = server doesn't support, object = loaded
+  // undefined = not yet fetched, null = the probe itself FAILED (transient:
+  // network, auth, connect race — NOT "server doesn't support"), object = loaded
   const [taskCapabilities, setTaskCapabilities] = useState<
     TasksSupport | null | undefined
   >(undefined);
+  // Bumped by the "Retry" button on the probe-failed state to re-run the
+  // capabilities fetch without switching servers.
+  const [capabilitiesFetchAttempt, setCapabilitiesFetchAttempt] = useState(0);
   // Extension cancellation is cooperative: after the empty ack the task may
   // keep working, complete, or be purged. Stop auto-polling and say so.
   const [cancellationRequested, setCancellationRequested] = useState<
@@ -1210,8 +1222,14 @@ export function TasksTab({
     });
   }, [tasks]);
 
-  // Fetch task capabilities when server changes
-  // Per MCP Tasks spec (2025-11-25): clients SHOULD check capabilities before using task features
+  // Fetch task capabilities when the server changes AND when its connection
+  // comes up. Per MCP Tasks spec (2025-11-25) clients SHOULD check
+  // capabilities before using task features — but the probe fails closed to
+  // `wire: "none"` against a not-yet-connected server, so a fetch keyed only
+  // on server identity can race the connect and stick on "Tasks not
+  // supported" forever. Keying on `isServerConnected` re-probes once the
+  // connection is actually up (and again after a reconnect).
+  const isServerConnected = connectionStatus === "connected";
   useEffect(() => {
     if (!serverConfig || !serverName) {
       setTaskCapabilities(undefined);
@@ -1233,13 +1251,14 @@ export function TasksTab({
         const capabilities = await getTaskCapabilities(serverName);
         setTaskCapabilities(capabilities);
       } catch {
-        // Server may not support tasks - set to null (vs undefined = loading)
+        // The PROBE failed (transient), which is not the same thing as the
+        // server declaring no tasks — null renders a retryable error state.
         setTaskCapabilities(null);
       }
     };
 
     fetchCapabilities();
-  }, [serverConfig, serverName]);
+  }, [serverConfig, serverName, isServerConnected, capabilitiesFetchAttempt]);
 
   // Fetch tasks on mount and when server changes (only when tab is active)
   // Wait for capabilities to be fetched first (undefined = still loading)
@@ -1413,6 +1432,28 @@ export function TasksTab({
         title="No Server Selected"
         description="Connect to an MCP server to browse and manage its tasks."
       />
+    );
+  }
+
+  // The capabilities probe itself failed (network, auth, or it raced the
+  // connect). That says nothing about the server's tasks support — offer a
+  // retry instead of a false "not supported".
+  if (taskCapabilities === null) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="Couldn't check tasks support"
+        description="The tasks capability check failed — the server may still be connecting."
+      >
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setCapabilitiesFetchAttempt((n) => n + 1)}
+        >
+          <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+          Retry
+        </Button>
+      </EmptyState>
     );
   }
 

--- a/mcpjam-inspector/client/src/components/__tests__/TasksTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/TasksTab.test.tsx
@@ -240,6 +240,89 @@ describe("TasksTab", () => {
     expect(mockListTasks).not.toHaveBeenCalled();
   });
 
+  it("shows a retryable error (not 'not supported') when the capabilities probe fails", async () => {
+    mockGetTaskCapabilities.mockRejectedValueOnce(new Error("connect refused"));
+    mockGetTaskCapabilities.mockResolvedValue({
+      wire: "extension",
+      toolCalls: true,
+      list: false,
+      cancel: true,
+      update: true,
+      inlineResult: true,
+    });
+
+    render(
+      <TasksTab serverConfig={createServerConfig()} serverName="test-server" />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Couldn't check tasks support"),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Tasks not supported")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Couldn't check tasks support"),
+      ).not.toBeInTheDocument();
+    });
+    expect(mockGetTaskCapabilities).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-probes capabilities when the server connection comes up", async () => {
+    // While connecting the probe fails closed to wire "none"…
+    mockGetTaskCapabilities.mockResolvedValueOnce({
+      wire: "none",
+      toolCalls: false,
+      list: false,
+      cancel: false,
+      update: false,
+      inlineResult: false,
+    });
+    // …and succeeds once the connection is actually up.
+    mockGetTaskCapabilities.mockResolvedValue({
+      wire: "extension",
+      toolCalls: true,
+      list: false,
+      cancel: true,
+      update: true,
+      inlineResult: true,
+    });
+
+    // One stable config object across rerenders, so the only effect trigger
+    // under test is the connectionStatus flip.
+    const config = createServerConfig();
+    const { rerender } = render(
+      <TasksTab
+        serverConfig={config}
+        serverName="test-server"
+        connectionStatus="connecting"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Tasks not supported")).toBeInTheDocument();
+    });
+
+    rerender(
+      <TasksTab
+        serverConfig={config}
+        serverName="test-server"
+        connectionStatus="connected"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Tasks not supported"),
+      ).not.toBeInTheDocument();
+    });
+    expect(mockGetTaskCapabilities).toHaveBeenCalledTimes(2);
+  });
+
   describe("extension wire", () => {
     const extensionSupport = {
       wire: "extension",

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1287,15 +1287,27 @@ export class MCPClientManager {
   // ===========================================================================
 
   /**
-   * Pings a server to check connectivity.
+   * Pings a server to check connectivity — era-aware.
+   *
+   * `ping` was removed from the 2026-07-28 vocabulary, so the upstream
+   * client refuses to send it on a modern-classified connection
+   * (`MethodNotSupportedByProtocolVersion`). The modern era's universally
+   * available request is `server/discover`, so that is the liveness probe
+   * there; its result is discarded and the ping contract's `EmptyResult`
+   * returned, so callers stay era-agnostic. Legacy connections keep the
+   * wire-identical `ping`.
    */
   async pingServer(
     serverId: string,
     options?: RequestOptions
   ): Promise<Awaited<ReturnType<Client["ping"]>>> {
-    return this.runRetryableReadOperation(serverId, options, async (client) =>
-      client.ping(options)
-    );
+    return this.runRetryableReadOperation(serverId, options, async (client) => {
+      if (client.getProtocolEra?.() === "modern" && client.discover) {
+        await client.discover(options);
+        return {} as Awaited<ReturnType<Client["ping"]>>;
+      }
+      return client.ping(options);
+    });
   }
 
   /**

--- a/sdk/src/mcp-client-manager/log-level-meta-client.ts
+++ b/sdk/src/mcp-client-manager/log-level-meta-client.ts
@@ -245,6 +245,11 @@ export class LogLevelMetaClient implements ManagedMcpClient {
   ping(options?: RequestOptions) {
     return this.inner.ping(options);
   }
+  discover(options?: RequestOptions) {
+    // Upstream stamps the discover envelope itself; no log-level injection
+    // (the reserved key rides operation requests, not the discovery probe).
+    return this.inner.discover?.(options) ?? Promise.resolve(undefined);
+  }
   setLoggingLevel(level: LoggingLevel, options?: RequestOptions): Promise<void> {
     // Legacy delivery channel — always forwarded verbatim, never gated.
     return this.inner.setLoggingLevel(level, options);

--- a/sdk/src/mcp-client-manager/log-level-meta-client.ts
+++ b/sdk/src/mcp-client-manager/log-level-meta-client.ts
@@ -50,10 +50,24 @@ import type {
 export type LogLevelProvider = () => LoggingLevel | undefined;
 
 export class LogLevelMetaClient implements ManagedMcpClient {
+  /**
+   * `server/discover` pass-through — bound only when the inner client
+   * carries it, so absence propagates through the decorator stack and
+   * `MCPClientManager.pingServer` can fall back to `ping` instead of
+   * seeing a probe that "succeeds" with no wire traffic. No log-level
+   * injection: the reserved key rides operation requests, not the
+   * discovery probe (upstream stamps the discover envelope itself).
+   */
+  readonly discover?: (options?: RequestOptions) => Promise<unknown>;
+
   constructor(
     readonly inner: ManagedMcpClient,
     private readonly getLevel: LogLevelProvider,
-  ) {}
+  ) {
+    if (inner.discover) {
+      this.discover = inner.discover.bind(inner);
+    }
+  }
 
   /**
    * The level to inject on this call, or `undefined` to inject nothing.
@@ -244,11 +258,6 @@ export class LogLevelMetaClient implements ManagedMcpClient {
   // ---- No-params / non-injected methods (pass-through) ----
   ping(options?: RequestOptions) {
     return this.inner.ping(options);
-  }
-  discover(options?: RequestOptions) {
-    // Upstream stamps the discover envelope itself; no log-level injection
-    // (the reserved key rides operation requests, not the discovery probe).
-    return this.inner.discover?.(options) ?? Promise.resolve(undefined);
   }
   setLoggingLevel(level: LoggingLevel, options?: RequestOptions): Promise<void> {
     // Legacy delivery channel — always forwarded verbatim, never gated.

--- a/sdk/src/mcp-client-manager/managed-mcp-client.ts
+++ b/sdk/src/mcp-client-manager/managed-mcp-client.ts
@@ -238,6 +238,15 @@ export interface ManagedMcpClient {
 
   // ---- Health ----
   ping(options?: RequestOptions): Promise<EmptyResult>;
+  /**
+   * `server/discover` (2026-07-28+): the modern era's only universally
+   * available request, and therefore its liveness probe — `ping` was removed
+   * from the 2026 vocabulary, so the upstream client refuses to send it on a
+   * modern-classified connection (`MethodNotSupportedByProtocolVersion`).
+   * Optional because non-upstream adapters (test doubles) may not carry it;
+   * `MCPClientManager.pingServer` era-gates before reaching for it.
+   */
+  discover?(options?: RequestOptions): Promise<unknown>;
 
   // ---- Subscriptions (passthrough; stateless preview throws) ----
   subscribeResource(

--- a/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
+++ b/sdk/src/mcp-client-manager/official-sdk-client-adapter.ts
@@ -214,6 +214,9 @@ export class OfficialSdkClientAdapter implements ManagedMcpClient {
   ping(options?: Parameters<Client["ping"]>[0]) {
     return this.inner.ping(options) as ReturnType<ManagedMcpClient["ping"]>;
   }
+  discover(options?: Parameters<Client["discover"]>[0]) {
+    return this.inner.discover(options);
+  }
   subscribeResource(
     params: Parameters<Client["subscribeResource"]>[0],
     options?: Parameters<Client["subscribeResource"]>[1],

--- a/sdk/src/mcp-client-manager/trace-context-meta-client.ts
+++ b/sdk/src/mcp-client-manager/trace-context-meta-client.ts
@@ -253,6 +253,9 @@ export class TraceContextMetaClient implements ManagedMcpClient {
   ping(options?: RequestOptions) {
     return this.inner.ping(options);
   }
+  discover(options?: RequestOptions) {
+    return this.inner.discover?.(options) ?? Promise.resolve(undefined);
+  }
   setLoggingLevel(level: LoggingLevel, options?: RequestOptions): Promise<void> {
     // Legacy-era delivery channel — never carries modern `_meta`.
     return this.inner.setLoggingLevel(level, options);

--- a/sdk/src/mcp-client-manager/trace-context-meta-client.ts
+++ b/sdk/src/mcp-client-manager/trace-context-meta-client.ts
@@ -59,10 +59,23 @@ import {
 export type ConnectionTraceContextProvider = () => TraceContext | undefined;
 
 export class TraceContextMetaClient implements ManagedMcpClient {
+  /**
+   * `server/discover` pass-through — bound only when the inner client
+   * carries it, so absence propagates through the decorator stack and
+   * `MCPClientManager.pingServer` can fall back to `ping` instead of
+   * seeing a probe that "succeeds" with no wire traffic. No trace-context
+   * injection (upstream stamps the discover envelope itself).
+   */
+  readonly discover?: (options?: RequestOptions) => Promise<unknown>;
+
   constructor(
     readonly inner: ManagedMcpClient,
     private readonly getTraceContext: ConnectionTraceContextProvider,
-  ) {}
+  ) {
+    if (inner.discover) {
+      this.discover = inner.discover.bind(inner);
+    }
+  }
 
   /**
    * The context to inject on this call, or `undefined` to inject nothing.
@@ -252,9 +265,6 @@ export class TraceContextMetaClient implements ManagedMcpClient {
   // ---- No-params / non-injected methods (pass-through) ----
   ping(options?: RequestOptions) {
     return this.inner.ping(options);
-  }
-  discover(options?: RequestOptions) {
-    return this.inner.discover?.(options) ?? Promise.resolve(undefined);
   }
   setLoggingLevel(level: LoggingLevel, options?: RequestOptions): Promise<void> {
     // Legacy-era delivery channel — never carries modern `_meta`.

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -833,6 +833,45 @@ describe("MCPClientManager", () => {
       expect(fakeClient.ping).toHaveBeenCalledTimes(2);
     });
 
+    it("probes with server/discover instead of ping on a modern-era connection", async () => {
+      // `ping` was removed from the 2026-07-28 vocabulary — the upstream
+      // client throws MethodNotSupportedByProtocolVersion rather than send it
+      // on a modern-classified connection. The modern liveness probe is
+      // `server/discover`; the ping contract's EmptyResult is preserved.
+      const fakeClient = {
+        getProtocolEra: jest.fn().mockReturnValue("modern"),
+        discover: jest.fn().mockResolvedValue({ supportedVersions: ["2026-07-28"] }),
+        ping: jest.fn(),
+      };
+
+      seedRegisteredServer(manager, "modern-ping", {
+        url: new URL("https://example.test/mcp"),
+      });
+      seedLiveState(manager, "modern-ping", { client: fakeClient });
+
+      await expect(manager.pingServer("modern-ping")).resolves.toEqual({});
+
+      expect(fakeClient.discover).toHaveBeenCalledTimes(1);
+      expect(fakeClient.ping).not.toHaveBeenCalled();
+    });
+
+    it("falls back to ping when a modern-shaped client lacks discover", async () => {
+      // Test doubles / non-upstream adapters may not carry `discover` — the
+      // probe must not become a TypeError.
+      const fakeClient = {
+        getProtocolEra: jest.fn().mockReturnValue("modern"),
+        ping: jest.fn().mockResolvedValue({}),
+      };
+
+      seedRegisteredServer(manager, "modern-noprobe", {
+        url: new URL("https://example.test/mcp"),
+      });
+      seedLiveState(manager, "modern-noprobe", { client: fakeClient });
+
+      await expect(manager.pingServer("modern-noprobe")).resolves.toEqual({});
+      expect(fakeClient.ping).toHaveBeenCalledTimes(1);
+    });
+
     it("retries read operations without tearing down an existing live session", async () => {
       const fakeClient = {
         listTools: jest

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -1,4 +1,9 @@
-import { MCPAuthError, MCPClientManager } from "../src/mcp-client-manager";
+import {
+  MCPAuthError,
+  MCPClientManager,
+  LogLevelMetaClient,
+  TraceContextMetaClient,
+} from "../src/mcp-client-manager";
 import { realpathSync, rmSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -869,6 +874,32 @@ describe("MCPClientManager", () => {
       seedLiveState(manager, "modern-noprobe", { client: fakeClient });
 
       await expect(manager.pingServer("modern-noprobe")).resolves.toEqual({});
+      expect(fakeClient.ping).toHaveBeenCalledTimes(1);
+    });
+
+    it("still falls back to ping when a discover-less client is wrapped in the meta decorators", async () => {
+      // The decorators must propagate `discover` ABSENCE, not synthesize a
+      // stub — otherwise `pingServer` sees a truthy `discover` on the
+      // outermost client, sends nothing, and reports a healthy connection
+      // without any wire traffic.
+      const fakeClient = {
+        getProtocolEra: jest.fn().mockReturnValue("modern"),
+        ping: jest.fn().mockResolvedValue({}),
+      };
+      const decorated = new TraceContextMetaClient(
+        new LogLevelMetaClient(fakeClient as any, () => undefined),
+        () => undefined
+      );
+      expect(decorated.discover).toBeUndefined();
+
+      seedRegisteredServer(manager, "modern-decorated-noprobe", {
+        url: new URL("https://example.test/mcp"),
+      });
+      seedLiveState(manager, "modern-decorated-noprobe", { client: decorated });
+
+      await expect(
+        manager.pingServer("modern-decorated-noprobe")
+      ).resolves.toEqual({});
       expect(fakeClient.ping).toHaveBeenCalledTimes(1);
     });
 

--- a/sdk/tests/mrtr-manager.integration.test.ts
+++ b/sdk/tests/mrtr-manager.integration.test.ts
@@ -233,6 +233,19 @@ describe("post-negotiation capability re-resolution (eraCapabilities.modern)", (
     expect(caps.elicitation).toBeUndefined();
   });
 
+  it("pingServer probes a modern connection without sending the retired ping method", async () => {
+    // The MRTR resume path health-checks with pingServer before driving the
+    // retry leg; `ping` does not exist on the 2026 wire, so the probe must be
+    // `server/discover` there or every modern resume dies with
+    // MethodNotSupportedByProtocolVersion.
+    manager.setMrtrInputCollector("fixture", acceptAllCollector());
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      timeout: 10_000,
+    });
+    await expect(manager.pingServer("fixture")).resolves.toEqual({});
+  });
+
   it("also applies the overlay on a PINNED modern connection", async () => {
     // The seam keys on the classified era, not on how the era was selected —
     // a pin and a successful auto probe land in the same place.


### PR DESCRIPTION
## Symptom

On a 2026-07-28 connection, answering an MRTR elicitation dialog fails with:

> Method 'ping' is not supported by the negotiated protocol version (wire era 2026-07-28)

The round itself succeeded — the failure is the resume path's health check. Found live on `stateless.mcpjam.com` running `ask-name` right after the `eraCapabilities` seam (#3550) fixed the capability declaration; this was the next bug in the chain.

## Root cause

`ping` was removed from the 2026 vocabulary (SEP-2575). The upstream client's era gate correctly refuses to send it on a modern-classified connection (`MethodNotSupportedByProtocolVersion`). But `MCPClientManager.pingServer` called `client.ping()` unconditionally, and the MRTR continuation route deliberately uses it as its capability-neutral liveness probe before driving the retry leg (`mrtr-continuation.ts` — "ping is deliberately capability-NEUTRAL … not an MRTR verb"). Both premises were correct on 2025; on 2026 the method simply doesn't exist. The status route (`servers.ts /status/:serverId`) had the same latent failure.

## Fix

`pingServer` is now era-aware: on a modern connection it probes with **`server/discover`** — the modern era's only universally available request, the same role `ping` played on legacy — discards the result, and returns the ping contract's `EmptyResult` so callers stay era-agnostic. Legacy connections keep the wire-identical `ping`.

`discover` joins the `ManagedMcpClient` surface as an **optional** member, forwarded through the official-SDK adapter and both meta decorators (no `_meta` injection — upstream stamps the discover envelope itself). A client without it (test doubles, non-upstream adapters) falls back to `ping` rather than TypeError.

## Tests

- unit: modern era → `discover` called, `ping` never; modern double without `discover` → `ping` fallback; existing legacy retry test untouched
- integration: `pingServer` against the real modern MRTR fixture over HTTP — **fails without the fix** (reproduced), passes with it
- `tsc --noEmit` clean; affected suites green (72/72)

## Note for reviewers

This closes the last error in the modern MRTR chain: #3544 (collector purge) → #3550 (capability declaration) → this (resume health check). With all three, the full elicitation ladder (`ask-name`, `confirm-launch`, `open-dashboard`, vault resource, greeting prompt) runs on an unpinned Client-default connection end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protocol liveness probing on the MRTR resume path and server status checks, but behavior is era-gated with fallbacks and covered by unit and integration tests.
> 
> **Overview**
> **Modern MCP health checks** no longer call the removed `ping` method. `MCPClientManager.pingServer` uses **`server/discover`** on modern-era connections (discards the payload, still returns an empty ping result) and keeps **`ping`** on legacy; if `discover` is missing on the client, it falls back to `ping`. Optional **`discover`** is wired through `ManagedMcpClient`, the official SDK adapter, and the log-level / trace meta decorators (bound only when the inner client has it).
> 
> This unblocks **MRTR resume** and other callers that ping before continuing on 2026-07-28 wire.
> 
> **Inspector Tasks tab:** passes **`connectionStatus`** from the route, re-runs the capabilities probe when the server becomes **`connected`**, treats probe **errors** as a retryable state (not “Tasks not supported”), and adds tests for retry and connect-race behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7f92776dea0fd5ed83b93b6450e8385174dd78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `pingServer` era-aware to probe modern (2026-07-28) connections via `server/discover`, and fix the Inspector Tasks tab so it no longer sticks on “Tasks not supported” when the probe races the connect.

- **Bug Fixes**
  - `@mcpjam/sdk`: Use `server/discover` for modern-era liveness and keep the `EmptyResult` shape; fall back to `ping` when `discover` is unavailable. Expose optional `discover` on `ManagedMcpClient` and forward it via the official adapter; meta clients (`log-level-meta-client`, `trace-context-meta-client`) now bind `discover` only when present. Tests cover modern probe, decorator absence propagation, fallback, and the modern fixture.
  - `@mcpjam/inspector`: Key the Tasks capability probe on `connectionStatus` to re-run on connect/reconnect, and show a retryable error when the probe throws instead of “Tasks not supported”. Tests added.

<sup>Written for commit d44d6f8c5f3668743486de7cbf22ba88f2b3e764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

