### PR TITLE
fix(playground): reliable starter prompts, visible with one client

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/multi-model-starters-empty.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/multi-model-starters-empty.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MultiModelStarterPromptsBlock } from "../multi-model-starters-empty";
+import { STARTER_PROMPTS } from "../shared/chat-helpers";
+
+// Starter prompts must be answerable from the model's own tool list alone —
+// the playground chat has no meta-tools (server inventory, activity logs), so
+// prompts that ask for those always dead-end. See the copy review that
+// replaced "List my connected MCP servers…" / "Summarize the most recent
+// activity…" with introspection-friendly phrasing.
+describe("STARTER_PROMPTS", () => {
+  it("only contains prompts answerable from the model's visible tool list", () => {
+    expect(STARTER_PROMPTS).toEqual([
+      { label: "What can this server do?", text: "What can this server do?" },
+      { label: "What tools can I use?", text: "What tools can I use?" },
+      {
+        label: "Give me example prompts to try",
+        text: "Give me example prompts to try",
+      },
+    ]);
+  });
+});
+
+describe("MultiModelStarterPromptsBlock", () => {
+  it("renders a chip per starter prompt and sends the prompt text on click", () => {
+    const onStarterPrompt = vi.fn();
+    render(<MultiModelStarterPromptsBlock onStarterPrompt={onStarterPrompt} />);
+
+    expect(
+      screen.getByText("Try one of these to get started"),
+    ).toBeInTheDocument();
+
+    for (const prompt of STARTER_PROMPTS) {
+      fireEvent.click(screen.getByRole("button", { name: prompt.label }));
+      expect(onStarterPrompt).toHaveBeenLastCalledWith(prompt.text);
+    }
+    expect(onStarterPrompt).toHaveBeenCalledTimes(STARTER_PROMPTS.length);
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -11,18 +11,22 @@ export const DEFAULT_CHAT_COMPOSER_PLACEHOLDER = `Ask something… Use Slash "/"
 /** Match ChatTabV2 minimalMode / compact composer (e.g. overlays, narrow NUX). */
 export const MINIMAL_CHAT_COMPOSER_PLACEHOLDER = "Message…";
 
+// Starter prompts must be answerable from the model's own tool list — the
+// playground/chat model only sees the selected servers' model-visible tools,
+// so prompts that need meta-data (server inventory, activity logs) always
+// dead-end in "I don't have access to that".
 export const STARTER_PROMPTS: Array<{ label: string; text: string }> = [
   {
-    label: "Show me connected tools",
-    text: "List my connected MCP servers and their available tools.",
+    label: "What can this server do?",
+    text: "What can this server do?",
   },
   {
-    label: "Suggest an automation",
-    text: "Suggest an automation I can build with my current MCP setup.",
+    label: "What tools can I use?",
+    text: "What tools can I use?",
   },
   {
-    label: "Summarize recent activity",
-    text: "Summarize the most recent activity across my MCP servers.",
+    label: "Give me example prompts to try",
+    text: "Give me example prompts to try",
   },
 ];
 

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -3402,6 +3402,11 @@ export function PlaygroundMain({
         }
         setModelContextQueue([]);
         composer.setInput("");
+        // Starter sends are text-only: staged prompt/skill results are
+        // discarded like the typed draft and file attachments, so they don't
+        // silently ride along on the next composer submit.
+        setMcpPromptResults([]);
+        setSkillResults([]);
         revokeFileAttachmentUrls(fileAttachments);
         setFileAttachments([]);
         onFirstMessageSent?.();

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -3023,11 +3023,8 @@ export function PlaygroundMain({
     []
   );
 
-  const queueBroadcastRequest = useCallback(
-    (
-      request: Omit<BroadcastChatTurnRequest, "id">,
-      captureProps?: Record<string, unknown>
-    ) => {
+  const trackSendMessage = useCallback(
+    (captureProps?: Record<string, unknown>) => {
       track("app_builder_send_message", {
         location: "app_builder_tab",
         model_id: selectedModel?.id ?? null,
@@ -3037,11 +3034,6 @@ export function PlaygroundMain({
         multi_model_count: isMultiModelMode ? resolvedSelectedModels.length : 1,
         ...(captureProps ?? {}),
       });
-
-      setBroadcastRequest({
-        ...request,
-        id: Date.now(),
-      });
     },
     [
       isMultiModelMode,
@@ -3050,6 +3042,25 @@ export function PlaygroundMain({
       selectedModel?.name,
       selectedModel?.provider,
     ]
+  );
+
+  // Compare mode ONLY. `broadcastRequest` has no consumer in single-model
+  // mode, but freshly mounted compare cards replay whatever request is stored
+  // here — so a single-model send that wrote this state would be re-sent to
+  // every column when the user later enables compare. Single-model paths call
+  // `trackSendMessage` directly instead.
+  const queueBroadcastRequest = useCallback(
+    (
+      request: Omit<BroadcastChatTurnRequest, "id">,
+      captureProps?: Record<string, unknown>
+    ) => {
+      trackSendMessage(captureProps);
+      setBroadcastRequest({
+        ...request,
+        id: Date.now(),
+      });
+    },
+    [trackSendMessage]
   );
 
   const mergedToolRenderOverrides = useMemo(
@@ -3259,14 +3270,7 @@ export function PlaygroundMain({
       });
       setModelContextQueue([]);
     } else {
-      queueBroadcastRequest(
-        {
-          text: composerText,
-          files,
-          prependMessages,
-        },
-        { single_model_send: true }
-      );
+      trackSendMessage({ single_model_send: true });
       // Single-model mode has no broadcast consumer, so the prepends have to
       // land in the thread here — before `sendMessage`, so the request carries
       // them as history rather than arriving after the model answered.
@@ -3301,6 +3305,7 @@ export function PlaygroundMain({
     displayMode,
     isWidgetFullscreen,
     queueBroadcastRequest,
+    trackSendMessage,
     modelContextQueue,
     sendMessage,
     setMessages,
@@ -3388,10 +3393,7 @@ export function PlaygroundMain({
             widgetModelContext: modelContextQueue,
           });
         } else {
-          queueBroadcastRequest(
-            { text: prompt, prependMessages: [] },
-            { single_model_send: true }
-          );
+          trackSendMessage({ single_model_send: true });
           sendMessage({
             text: prompt,
             metadata: outgoingSenderMetadata,
@@ -3417,6 +3419,7 @@ export function PlaygroundMain({
       queueBroadcastRequest,
       sendBlocked,
       sendMessage,
+      trackSendMessage,
     ]
   );
   // "Ask agent to run" (harness built-in tools): the rail builds a structured
@@ -3441,10 +3444,7 @@ export function PlaygroundMain({
         });
         setModelContextQueue([]);
       } else {
-        queueBroadcastRequest(
-          { text, prependMessages: [] },
-          { single_model_send: true }
-        );
+        trackSendMessage({ single_model_send: true });
         sendMessage({
           text,
           metadata: outgoingSenderMetadata,
@@ -3461,6 +3461,7 @@ export function PlaygroundMain({
       ensureSelectedServerReadyForChat,
       isCompareMode,
       queueBroadcastRequest,
+      trackSendMessage,
       sendMessage,
       outgoingSenderMetadata,
       modelContextQueue,

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -58,7 +58,10 @@ import {
 } from "@/components/chat-v2/shared/chat-helpers";
 import { SaveAsTestCaseAction } from "@/components/chat-v2/shared/save-as-test-case-action";
 import { MultiModelEmptyTraceDiagnosticsPanel } from "@/components/chat-v2/multi-model-empty-trace-diagnostics";
-import { MultiModelStartersEmptyLayout } from "@/components/chat-v2/multi-model-starters-empty";
+import {
+  MultiModelStarterPromptsBlock,
+  MultiModelStartersEmptyLayout,
+} from "@/components/chat-v2/multi-model-starters-empty";
 import { ErrorBox } from "@/components/chat-v2/error";
 import { ConfirmChatResetDialog } from "@/components/chat-v2/chat-input/dialogs/confirm-chat-reset-dialog";
 import {
@@ -3363,7 +3366,11 @@ export function PlaygroundMain({
 
   const errorMessage = formatErrorMessage(error);
 
-  const handleMultiModelStarterPrompt = useCallback(
+  // Starter chips render in both empty states (compare grid and single-model
+  // hero), so route by mode like `submitAgentToolPrompt`: compare mode feeds
+  // the broadcast queue, single mode must call `sendMessage` itself — there is
+  // no broadcast consumer in single-model mode.
+  const handleStarterPrompt = useCallback(
     (prompt: string) => {
       if (composerDisabled || sendBlocked) {
         composer.setInput(prompt);
@@ -3374,11 +3381,23 @@ export function PlaygroundMain({
           composer.setInput(prompt);
           return;
         }
-        queueBroadcastRequest({
-          text: prompt,
-          prependMessages: [],
-          widgetModelContext: modelContextQueue,
-        });
+        if (isCompareMode) {
+          queueBroadcastRequest({
+            text: prompt,
+            prependMessages: [],
+            widgetModelContext: modelContextQueue,
+          });
+        } else {
+          queueBroadcastRequest(
+            { text: prompt, prependMessages: [] },
+            { single_model_send: true }
+          );
+          sendMessage({
+            text: prompt,
+            metadata: outgoingSenderMetadata,
+            widgetModelContext: modelContextQueue,
+          });
+        }
         setModelContextQueue([]);
         composer.setInput("");
         revokeFileAttachmentUrls(fileAttachments);
@@ -3391,9 +3410,13 @@ export function PlaygroundMain({
       composerDisabled,
       ensureSelectedServerReadyForChat,
       fileAttachments,
+      isCompareMode,
+      modelContextQueue,
       onFirstMessageSent,
+      outgoingSenderMetadata,
       queueBroadcastRequest,
       sendBlocked,
+      sendMessage,
     ]
   );
   // "Ask agent to run" (harness built-in tools): the rail builds a structured
@@ -3675,6 +3698,9 @@ export function PlaygroundMain({
                         </h3>
                       </div>
                     </div>
+                    <MultiModelStarterPromptsBlock
+                      onStarterPrompt={handleStarterPrompt}
+                    />
                     {errorMessage && (
                       <div className="w-full">
                         <ErrorBox
@@ -3999,7 +4025,7 @@ export function PlaygroundMain({
                       </div>
                     ) : null
                   }
-                  onStarterPrompt={handleMultiModelStarterPrompt}
+                  onStarterPrompt={handleStarterPrompt}
                   chatInputSlot={
                     <ChatInput {...sharedChatInputProps} hasMessages={false} />
                   }

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -313,6 +313,7 @@ vi.mock("@/components/chat-v2/chat-input", () => ({
     pulseSubmit,
     clientSelector,
     onChangeSkillResults,
+    skillResults,
   }: {
     value: string;
     onChange: (v: string) => void;
@@ -324,10 +325,12 @@ vi.mock("@/components/chat-v2/chat-input", () => ({
     pulseSubmit?: boolean;
     clientSelector?: unknown;
     onChangeSkillResults?: (results: unknown[]) => void;
+    skillResults?: unknown[];
   }) => (
     <form
       data-testid="chat-input"
       data-loading={isLoading ? "true" : "false"}
+      data-skill-count={skillResults?.length ?? 0}
       data-client-selector={clientSelector ? "true" : "false"}
       onSubmit={(e) => {
         e.preventDefault();
@@ -1487,6 +1490,28 @@ describe("PlaygroundMain", () => {
       expect(
         screen.queryByText("Try one of these to get started"),
       ).not.toBeInTheDocument();
+    });
+
+    it("clears staged skill results after a starter chip send", async () => {
+      render(<PlaygroundMain {...defaultProps} />);
+
+      fireEvent.click(screen.getByTestId("chat-input-attach-skill"));
+      expect(screen.getByTestId("chat-input")).toHaveAttribute(
+        "data-skill-count",
+        "1",
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
+
+      await waitFor(() => {
+        expect(mockUseChatSession.sendMessage).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("chat-input")).toHaveAttribute(
+          "data-skill-count",
+          "0",
+        );
+      });
     });
 
     it("does not replay a single-model send into compare cards mounted later", async () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -1488,6 +1488,40 @@ describe("PlaygroundMain", () => {
         screen.queryByText("Try one of these to get started"),
       ).not.toBeInTheDocument();
     });
+
+    it("does not replay a single-model send into compare cards mounted later", async () => {
+      const { rerender } = render(
+        <PlaygroundMain {...defaultProps} enableMultiModelChat={true} />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
+      await waitFor(() => {
+        expect(mockUseChatSession.sendMessage).toHaveBeenCalled();
+      });
+
+      mockUseChatSession.availableModels = [
+        { id: "gpt-4", name: "GPT-4", provider: "openai" },
+        {
+          id: "claude-sonnet-4-5",
+          name: "Claude Sonnet 4.5",
+          provider: "anthropic",
+        },
+      ];
+      mockUseChatSession.selectedModelIds = ["gpt-4", "claude-sonnet-4-5"];
+      mockUseChatSession.multiModelEnabled = true;
+      rerender(<PlaygroundMain {...defaultProps} enableMultiModelChat={true} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByTestId("multi-model-playground-card"),
+        ).toHaveLength(2);
+      });
+
+      const staleRequests = mockMultiModelPlaygroundCard.mock.calls
+        .map(([props]) => props.broadcastRequest)
+        .filter(Boolean);
+      expect(staleRequests).toEqual([]);
+    });
   });
 
   describe("chat input", () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -567,7 +567,8 @@ vi.mock("@/state/app-state-context", () => ({
   useSharedAppState: () => mockSharedAppState,
 }));
 
-// Mock chat-helpers (keep real placeholders; stub formatError + empty starters for stable tests)
+// Mock chat-helpers (keep real placeholders; stub formatError + a fixed
+// starter so tests don't churn when the real starter copy changes)
 vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {
   const actual =
     await importOriginal<
@@ -577,7 +578,7 @@ vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {
     ...actual,
     formatErrorMessage: (error: any) =>
       error ? { message: error.message || "Error", details: null } : null,
-    STARTER_PROMPTS: [],
+    STARTER_PROMPTS: [{ label: "Starter chip", text: "Starter chip prompt" }],
   };
 });
 
@@ -1440,6 +1441,49 @@ describe("PlaygroundMain", () => {
       expect(
         screen.getByTestId("playground-multi-model-compare-section"),
       ).toHaveClass("hidden");
+      expect(
+        screen.queryByText("Try one of these to get started"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("single-model starter prompts", () => {
+    it("shows starter prompt chips in the single-model empty state", () => {
+      render(<PlaygroundMain {...defaultProps} />);
+
+      expect(
+        screen.getByText("Try one of these to get started"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Starter chip" }),
+      ).toBeInTheDocument();
+    });
+
+    it("sends the starter prompt through the single-model chat on click", async () => {
+      render(<PlaygroundMain {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
+
+      await waitFor(() => {
+        expect(mockUseChatSession.sendMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ text: "Starter chip prompt" }),
+        );
+      });
+    });
+
+    it("hides starter chips when the welcome hero is suppressed", () => {
+      render(<PlaygroundMain {...defaultProps} hideWelcomeHero />);
+
+      expect(
+        screen.queryByText("Try one of these to get started"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides starter chips when the auth upsell is active", () => {
+      mockUseChatSession.disableForAuthentication = true;
+
+      render(<PlaygroundMain {...defaultProps} />);
+
       expect(
         screen.queryByText("Try one of these to get started"),
       ).not.toBeInTheDocument();


### PR DESCRIPTION
## Problem
As an unauth user in Playground, 2 of the 3 suggested prompts ("Show me connected tools", "Summarize recent activity") always dead-ended: they ask for MCP server inventory / activity logs, which the model has no tool to answer — it only sees the selected server's model-visible tools. Chips also only rendered in compare mode (2+ clients), so first-time users with one client never saw them.

## Changes
- Replace `STARTER_PROMPTS` with the reviewed copy, answerable from the model's own tool list: "What can this server do?", "What tools can I use?", "Give me example prompts to try". Chip label = sent text. Shared with the Chat tab.
- Render the starter chips in the single-model Playground empty state (previously compare-only), with the same auth/upsell gating.
- Route chip sends by mode: compare keeps the broadcast queue; single-model now calls `sendMessage` directly (the broadcast queue has no consumer there, so clicks were a no-op).

## Testing
- Unit: new tests for the prompt copy + chip wiring, plus single-model empty-state coverage (chips shown, click sends, hidden for upsell/suppressed hero). 65 tests green, typecheck clean.
- Manual: ran all 3 prompts as a guest against 3 server types — DeepWiki, Microsoft Learn, Context7. 9/9 useful responses, zero "I don't have access" dead-ends. Note: "What can this server do?" sometimes asks a clarifying question before listing capabilities (still no dead-end). Excalidraw demo couldn't be tested locally (remote endpoint stuck in "Finishing setup."), but it was already verified in prod.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Playground starter prompts reliable and visible with a single client. Prompts now focus on the selected server’s tools, and single‑model sends no longer write to the compare broadcast queue.

- **Bug Fixes**
  - Replaced `STARTER_PROMPTS` with prompts answerable from the model’s tool list: “What can this server do?”, “What tools can I use?”, “Give me example prompts to try”.
  - Show starter chips in the single‑model empty state with the same auth/upsell gating as compare mode.
  - Route all single‑model sends (starter chips, composer, agent tool prompts) outside the compare‑only broadcast queue and send via `sendMessage`; avoids no‑ops and prevents replay when compare mode is enabled later.
  - Clear staged prompt and skill results after a starter send so they don’t ride along on the next composer submit.

<sup>Written for commit 374b8dd0a88b83db9817f2814e50cc03c7868894. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

