### PR TITLE
deploy workflow failing

### DIFF
--- a/.github/scripts/smoke-packed-npm-packages.mjs
+++ b/.github/scripts/smoke-packed-npm-packages.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 
 const rootDir = process.cwd();
-const expectedMcpV2PackageVersion = "2.0.0-beta.4";
+const expectedMcpV2PackageVersion = "2.0.0";
 const expectedMcpV2Packages = [
   "@modelcontextprotocol/client",
   "@modelcontextprotocol/node",

--- a/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-era-gate.ts
@@ -115,7 +115,7 @@ import { TasksExtRequestMethods } from "./tasks-ext.js";
 const ERA_GATE_MEMBER = "_assertOutboundRequestInEra" as const;
 
 /** Client package version this shadow was verified against. */
-const VERIFIED_CLIENT_VERSION = "2.0.0-beta.4 / 2.0.0-beta.5";
+const VERIFIED_CLIENT_VERSION = "2.0.0";
 
 /**
  * `rev2026Codec.era` (`src-*.mjs:3790`) — the ONLY era on which the exemption

--- a/sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts
+++ b/sdk/src/mcp-client-manager/tasks-ext-listen-meta.ts
@@ -77,7 +77,7 @@ import type { ClientCapabilityOptions } from "./types.js";
 const ENVELOPE_MEMBER = "_outboundMetaEnvelope" as const;
 
 /** Client package version this shadow was verified against. */
-const VERIFIED_CLIENT_VERSION = "2.0.0-beta.4 / 2.0.0-beta.5";
+const VERIFIED_CLIENT_VERSION = "2.0.0";
 
 /** Thrown when the seam this shadow depends on is no longer where it was. */
 export class TasksExtListenMetaSeamError extends Error {

--- a/sdk/tests/tasks-ext-era-gate.test.ts
+++ b/sdk/tests/tasks-ext-era-gate.test.ts
@@ -269,7 +269,7 @@ describe("tasks extension era-gate shadow", () => {
         message = (error as Error).message;
       }
       expect(message).toContain("tasks/get, tasks/update, tasks/cancel");
-      expect(message).toContain("2.0.0-beta.4");
+      expect(message).toContain("2.0.0");
       expect(message).toContain(MODERN_ERA);
     });
   });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix deploy workflow by updating the smoke test to expect MCP v2 at `2.0.0` instead of `2.0.0-beta.4`, so CI correctly validates `@modelcontextprotocol/client` and `@modelcontextprotocol/node`. Also update SDK shadows’ verified version strings and the related test to `2.0.0`; diagnostic-only, no behavior change.

<sup>Written for commit 8387e3091d637efa64a25659d7b655f77ef210f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

