### PR TITLE
Fix local chat scope step-up handling (nov & july)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -140,6 +140,10 @@ import { useApiContext } from "./hooks/hosted/use-hosted-api-context";
 import { useLocalStateMigration } from "./hooks/use-local-state-migration";
 import { AppReadyProvider } from "./hooks/use-app-ready";
 import { useInspectorCommandBus } from "./hooks/use-inspector-command-bus";
+import {
+  driveScopeStepUp,
+  resolveScopeStepUpServer,
+} from "./lib/scope-step-up";
 import { HOSTED_MODE, NON_PROD_LOCKDOWN } from "./lib/config";
 import {
   createInspectorCommandClientError,
@@ -2120,7 +2124,23 @@ export default function App() {
       }
     }
   }, [appState.servers, handleDisconnect]);
-  useInspectorCommandBus();
+  const handleInspectorScopeStepUp = useCallback(
+    (event: {
+      serverId: string;
+      requiredScope?: string;
+      resourceMetadataUrl?: string;
+    }) => {
+      const server = resolveScopeStepUpServer(appState, {
+        serverId: event.serverId,
+      });
+      driveScopeStepUp(server, {
+        requiredScope: event.requiredScope,
+        resourceMetadataUrl: event.resourceMetadataUrl,
+      });
+    },
+    [appState],
+  );
+  useInspectorCommandBus({ onScopeStepUp: handleInspectorScopeStepUp });
   // MCPJam UI tools: registered in both modes for the in-app "Ask MCPJam"
   // agent (the registry's only consumer); the always-available side panel
   // drives whichever inspector surface is open, so registration lives at the

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-inspector-command-bus.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-inspector-command-bus.test.tsx
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useInspectorCommandBus } from "../use-inspector-command-bus";
+
+const mocks = vi.hoisted(() => ({
+  authFetch: vi.fn(async () => new Response(null, { status: 200 })),
+  executeInspectorCommand: vi.fn(),
+}));
+
+vi.mock("@/lib/config", () => ({ HOSTED_MODE: false }));
+vi.mock("@/lib/session-token", () => ({
+  addTokenToUrl: (url: string) => url,
+  authFetch: (...args: unknown[]) => mocks.authFetch(...args),
+}));
+vi.mock("@/lib/inspector-command-handlers", () => ({
+  executeInspectorCommand: (...args: unknown[]) =>
+    mocks.executeInspectorCommand(...args),
+}));
+
+class FakeEventSource {
+  static latest: FakeEventSource | undefined;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: (() => void) | null = null;
+  private listeners = new Map<
+    string,
+    Array<(event: MessageEvent<string>) => void>
+  >();
+
+  constructor(public readonly url: string) {
+    FakeEventSource.latest = this;
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: MessageEvent<string>) => void
+  ): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  emit(type: string, data: unknown): void {
+    const event = { data: JSON.stringify(data) } as MessageEvent<string>;
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  close(): void {}
+}
+
+describe("useInspectorCommandBus events", () => {
+  beforeEach(() => {
+    vi.stubGlobal("EventSource", FakeEventSource);
+    FakeEventSource.latest = undefined;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("delivers a scope-step-up event without treating it as a command", () => {
+    const onScopeStepUp = vi.fn();
+    renderHook(() => useInspectorCommandBus({ onScopeStepUp }));
+
+    act(() => {
+      FakeEventSource.latest?.emit("inspector-event", {
+        kind: "scope_step_up",
+        serverId: "auth-bench",
+        requiredScope: "bench:write",
+        resourceMetadataUrl:
+          "https://bench.example/.well-known/oauth-protected-resource",
+      });
+    });
+
+    expect(onScopeStepUp).toHaveBeenCalledWith({
+      kind: "scope_step_up",
+      serverId: "auth-bench",
+      requiredScope: "bench:write",
+      resourceMetadataUrl:
+        "https://bench.example/.well-known/oauth-protected-resource",
+    });
+    expect(mocks.executeInspectorCommand).not.toHaveBeenCalled();
+    expect(mocks.authFetch).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -37,7 +37,11 @@ import {
   recordAppToolInvocation,
 } from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
 import { scrubAppToolResultForModel } from "@/components/chat-v2/thread/mcp-apps/app-tools-sanitizer";
-import { driveScopeStepUp, resetScopeStepUp } from "@/lib/scope-step-up";
+import {
+  driveScopeStepUp,
+  resetScopeStepUp,
+  resolveScopeStepUpServer,
+} from "@/lib/scope-step-up";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvex, useConvexAuth } from "convex/react";
 import { ModelDefinition, type ModelProvider } from "@/shared/types";
@@ -1673,17 +1677,11 @@ export function useChatSession(
             // visitor (even an authenticated one) does not own the host's MCP
             // servers and cannot re-authorize the owner's OAuth; connect-time
             // chatbox OAuth is handled separately by `useHostedOAuthGate`.
-            const activeProject =
-              appState?.projects?.[
-                hostedProjectId ?? appState?.activeProjectId ?? ""
-              ];
-            const server =
-              (event.serverName
-                ? (appState?.servers?.[event.serverName] ??
-                  activeProject?.servers?.[event.serverName])
-                : undefined) ??
-              appState?.servers?.[event.serverId] ??
-              activeProject?.servers?.[event.serverId];
+            const server = resolveScopeStepUpServer(appState, {
+              serverId: event.serverId,
+              serverName: event.serverName,
+              projectId: hostedProjectId,
+            });
             // The shared lifecycle applies the same actionable-challenge gate
             // (a `requiredScope` OR a `resourceMetadataUrl` is now actionable —
             // discovery consumes the PRM pointer, SEP-2350 follow-up to #3427)

--- a/mcpjam-inspector/client/src/hooks/use-inspector-command-bus.ts
+++ b/mcpjam-inspector/client/src/hooks/use-inspector-command-bus.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { HOSTED_MODE } from "@/lib/config";
 import { addTokenToUrl, authFetch } from "@/lib/session-token";
 import { executeInspectorCommand } from "@/lib/inspector-command-handlers";
@@ -6,6 +6,10 @@ import type {
   InspectorCommand,
   InspectorCommandResponse,
 } from "@/shared/inspector-command.js";
+import {
+  isInspectorScopeStepUpEvent,
+  type InspectorScopeStepUpEvent,
+} from "@/shared/inspector-event.js";
 
 function buildCommandBusClientId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -24,7 +28,11 @@ async function postCommandResult(
   });
 }
 
-export function useInspectorCommandBus(): void {
+export function useInspectorCommandBus(options?: {
+  onScopeStepUp?: (event: InspectorScopeStepUpEvent) => void;
+}): void {
+  const onScopeStepUpRef = useRef(options?.onScopeStepUp);
+  onScopeStepUpRef.current = options?.onScopeStepUp;
   useEffect(() => {
     if (HOSTED_MODE) {
       return;
@@ -66,6 +74,17 @@ export function useInspectorCommandBus(): void {
         "[inspector-command-bus] command SSE connection error, browser will retry",
       );
     };
+
+    eventSource.addEventListener("inspector-event", (message) => {
+      try {
+        const event = JSON.parse(message.data) as unknown;
+        if (isInspectorScopeStepUpEvent(event)) {
+          onScopeStepUpRef.current?.(event);
+        }
+      } catch (error) {
+        console.warn("[inspector-command-bus] Invalid event payload", error);
+      }
+    });
 
     eventSource.addEventListener("superseded", () => {
       eventSource.close();

--- a/mcpjam-inspector/client/src/lib/__tests__/scope-step-up.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/scope-step-up.test.ts
@@ -141,28 +141,33 @@ describe("scope step-up lifecycle", () => {
     expect(applyToolCallStepUp).toHaveBeenCalledTimes(2);
   });
 
-  it("resolves the same server from runtime and active-project maps", () => {
-    const runtimeServer = {
-      name: "runtime",
-    } as unknown as ServerWithName;
-    const projectServer = {
-      name: "auth-bench",
-    } as unknown as ServerWithName;
-    const appState = {
-      activeProjectId: "project-1",
-      servers: { runtime: runtimeServer },
-      projects: {
-        "project-1": {
-          servers: { "auth-bench": projectServer },
-        },
+  const runtimeServer = {
+    name: "runtime",
+  } as unknown as ServerWithName;
+  const projectServer = {
+    name: "auth-bench",
+  } as unknown as ServerWithName;
+  const resolutionAppState = {
+    activeProjectId: "project-1",
+    servers: { runtime: runtimeServer },
+    projects: {
+      "project-1": {
+        servers: { "auth-bench": projectServer },
       },
-    } as unknown as AppState;
+    },
+  } as unknown as AppState;
 
+  it("resolves a server from the runtime map", () => {
     expect(
-      resolveScopeStepUpServer(appState, { serverId: "runtime" }),
+      resolveScopeStepUpServer(resolutionAppState, { serverId: "runtime" }),
     ).toBe(runtimeServer);
+  });
+
+  it("resolves a server from the active-project map", () => {
     expect(
-      resolveScopeStepUpServer(appState, { serverId: "auth-bench" }),
+      resolveScopeStepUpServer(resolutionAppState, {
+        serverId: "auth-bench",
+      }),
     ).toBe(projectServer);
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/scope-step-up.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/scope-step-up.test.ts
@@ -13,10 +13,11 @@ import {
   driveScopeStepUpFromChallenge,
   driveScopeStepUpFromError,
   resetScopeStepUp,
+  resolveScopeStepUpServer,
   runWithScopeStepUp,
 } from "../scope-step-up";
 import { McpRequestError } from "@/lib/apis/insufficient-scope";
-import type { ServerWithName } from "@/state/app-types";
+import type { AppState, ServerWithName } from "@/state/app-types";
 
 const applyToolCallStepUp = vi.fn();
 const resetToolCallStepUp = vi.fn();
@@ -138,5 +139,30 @@ describe("scope step-up lifecycle", () => {
     // The in-flight guard must clear so a later attempt is still possible.
     driveScopeStepUpFromError(server, insufficientScopeError());
     expect(applyToolCallStepUp).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves the same server from runtime and active-project maps", () => {
+    const runtimeServer = {
+      name: "runtime",
+    } as unknown as ServerWithName;
+    const projectServer = {
+      name: "auth-bench",
+    } as unknown as ServerWithName;
+    const appState = {
+      activeProjectId: "project-1",
+      servers: { runtime: runtimeServer },
+      projects: {
+        "project-1": {
+          servers: { "auth-bench": projectServer },
+        },
+      },
+    } as unknown as AppState;
+
+    expect(
+      resolveScopeStepUpServer(appState, { serverId: "runtime" }),
+    ).toBe(runtimeServer);
+    expect(
+      resolveScopeStepUpServer(appState, { serverId: "auth-bench" }),
+    ).toBe(projectServer);
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/scope-step-up.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/scope-step-up.test.ts
@@ -152,6 +152,7 @@ describe("scope step-up lifecycle", () => {
     servers: { runtime: runtimeServer },
     projects: {
       "project-1": {
+        sharedProjectId: "convex-project-1",
         servers: { "auth-bench": projectServer },
       },
     },
@@ -167,6 +168,16 @@ describe("scope step-up lifecycle", () => {
     expect(
       resolveScopeStepUpServer(resolutionAppState, {
         serverId: "auth-bench",
+      }),
+    ).toBe(projectServer);
+  });
+
+  it("resolves a project named by its Convex/shared id", () => {
+    // Hosted events can carry the shared id, which is NOT the `projects` key.
+    expect(
+      resolveScopeStepUpServer(resolutionAppState, {
+        serverId: "auth-bench",
+        projectId: "convex-project-1",
       }),
     ).toBe(projectServer);
   });

--- a/mcpjam-inspector/client/src/lib/scope-step-up.ts
+++ b/mcpjam-inspector/client/src/lib/scope-step-up.ts
@@ -33,7 +33,11 @@ import {
   applyToolCallStepUp,
   resetToolCallStepUp,
 } from "@/state/oauth-orchestrator";
-import type { AppState, ServerWithName } from "@/state/app-types";
+import {
+  findProjectByAnyId,
+  type AppState,
+  type ServerWithName,
+} from "@/state/app-types";
 
 /**
  * Servers with a step-up in flight. Module-level so the dedup holds ACROSS
@@ -44,6 +48,11 @@ const inFlight = new Set<string>();
 /**
  * Resolve a stream/app event's server identifier against the same local and
  * project-scoped maps on every scope-step-up delivery path.
+ *
+ * The project goes through `findProjectByAnyId` because a hosted event's
+ * `projectId` can be the Convex/shared id rather than the local key
+ * `AppState.projects` is keyed by; a bare key lookup would miss the project
+ * and dead-end the step-up for a server held only in the project map.
  */
 export function resolveScopeStepUpServer(
   appState: AppState | null | undefined,
@@ -54,8 +63,10 @@ export function resolveScopeStepUpServer(
   },
 ): ServerWithName | undefined {
   if (!appState) return undefined;
-  const activeProject =
-    appState.projects[input.projectId ?? appState.activeProjectId];
+  const activeProject = findProjectByAnyId(
+    appState.projects,
+    input.projectId ?? appState.activeProjectId,
+  );
   return (
     (input.serverName
       ? (appState.servers[input.serverName] ??

--- a/mcpjam-inspector/client/src/lib/scope-step-up.ts
+++ b/mcpjam-inspector/client/src/lib/scope-step-up.ts
@@ -33,13 +33,38 @@ import {
   applyToolCallStepUp,
   resetToolCallStepUp,
 } from "@/state/oauth-orchestrator";
-import type { ServerWithName } from "@/state/app-types";
+import type { AppState, ServerWithName } from "@/state/app-types";
 
 /**
  * Servers with a step-up in flight. Module-level so the dedup holds ACROSS
  * surfaces; keyed by server name, cleared when the attempt settles.
  */
 const inFlight = new Set<string>();
+
+/**
+ * Resolve a stream/app event's server identifier against the same local and
+ * project-scoped maps on every scope-step-up delivery path.
+ */
+export function resolveScopeStepUpServer(
+  appState: AppState | null | undefined,
+  input: {
+    serverId: string;
+    serverName?: string;
+    projectId?: string | null;
+  },
+): ServerWithName | undefined {
+  if (!appState) return undefined;
+  const activeProject =
+    appState.projects[input.projectId ?? appState.activeProjectId];
+  return (
+    (input.serverName
+      ? (appState.servers[input.serverName] ??
+        activeProject?.servers[input.serverName])
+      : undefined) ??
+    appState.servers[input.serverId] ??
+    activeProject?.servers[input.serverId]
+  );
+}
 
 /** Test seam: no production caller should need this. */
 export function __resetScopeStepUpInFlightForTests(): void {

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.step-up.test.ts
@@ -265,6 +265,30 @@ describe("resolveInsufficientScopeStepUp (SEP-2350)", () => {
     expect(retry.action).toBe("throw");
   });
 
+  it("recovers a stale pre-marker attempt left by an older broken run", async () => {
+    readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
+    initiateOAuthMock.mockResolvedValue({ success: true });
+
+    // Older builds stored only this counter. With no companion pending marker,
+    // it does not prove that a real browser step-up is still in progress.
+    resolveInsufficientScopeStepUp({
+      serverName: "asana",
+      issuer: ISSUER,
+      challengedScopes: ["admin"],
+      authMode: "interactive",
+      maxRetries: 1,
+    });
+
+    const outcome = await applyToolCallStepUp(createServer(), {
+      requiredScope: "admin",
+    });
+
+    expect(outcome.action).toBe("reauthorize");
+    expect(outcome.attempt).toBe(0);
+    expect(outcome.reauthorization).toEqual({ kind: "redirect" });
+    expect(initiateOAuthMock).toHaveBeenCalledTimes(1);
+  });
+
   it("applyToolCallStepUp KEEPS the attempt on a no-op `ready` (prevents an infinite step-up loop)", async () => {
     readStoredOAuthConfigMock.mockReturnValue({ scopes: ["read"] });
     // initiateOAuth resolves WITHOUT navigating: an already-authorized server

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -361,10 +361,15 @@ export async function ensureAuthorizedForReconnect(
 // to clear the counter so a future legitimate step-up starts fresh.
 
 const STEP_UP_ATTEMPTS_PREFIX = "mcp-stepup-attempts-";
+const STEP_UP_PENDING_PREFIX = "mcp-stepup-pending-";
 const DEFAULT_STEP_UP_MAX_RETRIES = 1;
 
 function stepUpAttemptsKey(serverName: string): string {
   return `${STEP_UP_ATTEMPTS_PREFIX}${serverName}`;
+}
+
+function stepUpPendingKey(serverName: string): string {
+  return `${STEP_UP_PENDING_PREFIX}${serverName}`;
 }
 
 // The bounded step-up counter lives in `sessionStorage`, NOT `localStorage`: it
@@ -434,6 +439,60 @@ function writeStepUpAttempts(
     // Best-effort: a full/unavailable store must not abort the OAuth flow. The
     // upstream transport still bounds retries within a single request; only the
     // cross-redirect count is lost, so the guard degrades, never disappears.
+  }
+}
+
+function hasPendingStepUp(
+  serverName: string,
+  issuer: string | undefined,
+): boolean {
+  try {
+    const store = stepUpAttemptsStore();
+    if (!store) return false;
+    const raw = store.getItem(stepUpPendingKey(serverName));
+    if (!raw) return false;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return parsed?.[issuerBucket(issuer)] === true;
+  } catch {
+    return false;
+  }
+}
+
+function writePendingStepUp(
+  serverName: string,
+  issuer: string | undefined,
+  pending: boolean,
+): void {
+  try {
+    const store = stepUpAttemptsStore();
+    if (!store) return;
+    const key = stepUpPendingKey(serverName);
+    const raw = store.getItem(key);
+    let map: Record<string, boolean> = {};
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object") {
+          map = parsed as Record<string, boolean>;
+        }
+      } catch {
+        // Corrupt record — replace it with the current issuer's state.
+      }
+    }
+    const bucket = issuerBucket(issuer);
+    if (pending) {
+      map[bucket] = true;
+    } else {
+      delete map[bucket];
+    }
+    if (Object.keys(map).length === 0) {
+      store.removeItem(key);
+    } else {
+      store.setItem(key, JSON.stringify(map));
+    }
+  } catch {
+    // Best-effort. Losing this marker can allow one extra redirect, while the
+    // transport still keeps its per-request retry bound.
   }
 }
 
@@ -513,20 +572,22 @@ export function resetInsufficientScopeStepUp(
 ): void {
   try {
     const store = stepUpAttemptsStore();
-    if (!store) return;
-    const raw = store.getItem(stepUpAttemptsKey(serverName));
-    if (!raw) return;
-    const parsed = JSON.parse(raw) as Record<string, number>;
-    if (!parsed || typeof parsed !== "object") return;
-    delete parsed[issuerBucket(issuer)];
-    if (Object.keys(parsed).length === 0) {
-      store.removeItem(stepUpAttemptsKey(serverName));
-    } else {
-      store.setItem(stepUpAttemptsKey(serverName), JSON.stringify(parsed));
+    const raw = store?.getItem(stepUpAttemptsKey(serverName));
+    if (store && raw) {
+      const parsed = JSON.parse(raw) as Record<string, number>;
+      if (parsed && typeof parsed === "object") {
+        delete parsed[issuerBucket(issuer)];
+        if (Object.keys(parsed).length === 0) {
+          store.removeItem(stepUpAttemptsKey(serverName));
+        } else {
+          store.setItem(stepUpAttemptsKey(serverName), JSON.stringify(parsed));
+        }
+      }
     }
   } catch {
     // Best-effort reset.
   }
+  writePendingStepUp(serverName, issuer, false);
 }
 
 // ===========================================================================
@@ -632,6 +693,20 @@ export async function applyToolCallStepUp(
 ): Promise<ToolCallStepUpOutcome> {
   const serverUrl = readServerUrlForStepUp(server);
   const issuer = resolveStoredIssuer(server.name, serverUrl);
+
+  // Migration/recovery: older builds persisted only the numeric attempt. If a
+  // broken delivery path consumed that attempt without ever starting a real
+  // step-up, every later challenge in this tab was silently bounded to
+  // `throw`, even after reconnecting with a fresh normal token. A current
+  // in-progress step-up always carries the companion marker below; an attempt
+  // without it is stale and safe to clear once.
+  if (
+    readStepUpAttempts(server.name, issuer) > 0 &&
+    !hasPendingStepUp(server.name, issuer)
+  ) {
+    resetInsufficientScopeStepUp(server.name, issuer);
+  }
+
   const challengedScopes = parseOAuthScopes(challenge.requiredScope);
   // The challenge's `resource_metadata` hint is untrusted: thread it only when
   // it parses as an absolute https URL (RFC 9728). A valid cross-origin pointer
@@ -672,17 +747,25 @@ export async function applyToolCallStepUp(
     };
   }
 
-  const reauthorization = await ensureAuthorizedForReconnect(server, {
-    allowInteractiveOAuthFlow: true,
-    // A resolved `reauthorize` IS the confirmed escalation — without this an
-    // auto server's tokenless guard would short-circuit to
-    // ready-unauthenticated instead of redirecting for the widened scopes.
-    interactiveOAuthConfirmed: true,
-    stepUpScopes: decision.scopes,
-    resourceMetadataUrl,
-    onTraceUpdate: options?.onTraceUpdate,
-    beforeRedirect: options?.beforeRedirect,
-  });
+  writePendingStepUp(server.name, issuer, true);
+  let reauthorization: OAuthResult;
+  try {
+    reauthorization = await ensureAuthorizedForReconnect(server, {
+      allowInteractiveOAuthFlow: true,
+      // A resolved `reauthorize` IS the confirmed escalation — without this an
+      // auto server's tokenless guard would short-circuit to
+      // ready-unauthenticated instead of redirecting for the widened scopes.
+      interactiveOAuthConfirmed: true,
+      stepUpScopes: decision.scopes,
+      resourceMetadataUrl,
+      onTraceUpdate: options?.onTraceUpdate,
+      beforeRedirect: options?.beforeRedirect,
+    });
+  } catch (error) {
+    writeStepUpAttempts(server.name, issuer, decision.attempt);
+    writePendingStepUp(server.name, issuer, false);
+    throw error;
+  }
 
   // The resolver already bumped the per-session counter (it must persist BEFORE
   // the redirect so the bound survives the round-trip). Roll it back to its
@@ -706,6 +789,7 @@ export async function applyToolCallStepUp(
     reauthorization.kind === "reauth_required"
   ) {
     writeStepUpAttempts(server.name, issuer, decision.attempt);
+    writePendingStepUp(server.name, issuer, false);
   }
 
   return {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/harness-proxy.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/harness-proxy.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import type { Hono } from "hono";
+import { InsufficientScopeError } from "@modelcontextprotocol/client";
 import {
   createMockMcpClientManager,
   createTestApp,
@@ -16,19 +17,27 @@ import {
   type MockMCPClientManager,
 } from "./helpers/index.js";
 import { signTestProxyToken } from "../../../utils/harness/__tests__/sign-test-token.js";
+import {
+  __resetHarnessScopeStepUpForTests,
+  HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER,
+  subscribeHarnessScopeStepUp,
+} from "../../../utils/harness/harness-scope-step-up.js";
 
 const mintLocal = (serverId: string) => signTestProxyToken({ serverId });
+const TURN_ID = "11111111-1111-4111-8111-111111111111";
 
 describe("adapter-http harness proxy-token (validate-when-present)", () => {
   let manager: MockMCPClientManager;
   let app: Hono;
 
   beforeAll(() => {
-    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET = "test-harness-proxy-secret-32-chars";
+    process.env.COMPUTERS_TERMINAL_TOKEN_SECRET =
+      "test-harness-proxy-secret-32-chars";
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetHarnessScopeStepUpForTests();
     manager = createMockMcpClientManager({
       listServers: vi.fn().mockReturnValue(["test-server"]),
       getManagedClient: vi
@@ -36,7 +45,9 @@ describe("adapter-http harness proxy-token (validate-when-present)", () => {
         .mockImplementation((id: string) =>
           id === "test-server" ? {} : undefined,
         ),
-      hasServer: vi.fn().mockImplementation((id: string) => id === "test-server"),
+      hasServer: vi
+        .fn()
+        .mockImplementation((id: string) => id === "test-server"),
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: "echo" }] }),
     });
     app = createTestApp(manager, ["adapter-http"]);
@@ -62,7 +73,9 @@ describe("adapter-http harness proxy-token (validate-when-present)", () => {
   });
 
   it("200s with a valid token (header)", async () => {
-    const res = await toolsList({ "X-MCPJam-Proxy-Token": mintLocal("test-server") });
+    const res = await toolsList({
+      "X-MCPJam-Proxy-Token": mintLocal("test-server"),
+    });
     expect(res.status).toBe(200);
   });
 
@@ -74,7 +87,9 @@ describe("adapter-http harness proxy-token (validate-when-present)", () => {
   });
 
   it("401s a token minted for another server (server-scoped)", async () => {
-    const res = await toolsList({ "X-MCPJam-Proxy-Token": mintLocal("other-server") });
+    const res = await toolsList({
+      "X-MCPJam-Proxy-Token": mintLocal("other-server"),
+    });
     expect(res.status).toBe(401);
   });
 
@@ -84,5 +99,129 @@ describe("adapter-http harness proxy-token (validate-when-present)", () => {
       headers: { "X-MCPJam-Proxy-Token": "bogus" },
     });
     expect(res.status).toBe(401);
+  });
+
+  it("forwards an actionable direct-POST tool error to only its harness turn", async () => {
+    const challenge = new InsufficientScopeError({
+      requiredScope: "bench:write",
+      resourceMetadataUrl: new URL(
+        "https://bench.example/.well-known/oauth-protected-resource",
+      ),
+    });
+    manager.executeTool.mockRejectedValueOnce(challenge);
+    const received: unknown[] = [];
+    subscribeHarnessScopeStepUp(TURN_ID, (info) => received.push(info));
+
+    const res = await app.request("/api/mcp/adapter-http/test-server", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER]: TURN_ID,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "call-1",
+        method: "tools/call",
+        params: { name: "bench_write", arguments: { value: "x" } },
+      }),
+    });
+
+    const { status, data } = await expectJson(res);
+    expect(status).toBe(200);
+    expect(data.error.code).toBe(-32000);
+    expect(received).toEqual([
+      {
+        serverId: "test-server",
+        toolCallId: "call-1",
+        requiredScope: "bench:write",
+        resourceMetadataUrl:
+          "https://bench.example/.well-known/oauth-protected-resource",
+        errorDescription: undefined,
+      },
+    ]);
+  });
+
+  it("retains the turn correlation across the legacy SSE messages endpoint", async () => {
+    manager.executeTool.mockRejectedValueOnce(
+      new InsufficientScopeError({ requiredScope: "bench:write" }),
+    );
+    const received: unknown[] = [];
+    subscribeHarnessScopeStepUp(TURN_ID, (info) => received.push(info));
+
+    const streamResponse = await app.request(
+      "/api/mcp/adapter-http/test-server",
+      {
+        method: "GET",
+        headers: {
+          [HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER]: TURN_ID,
+        },
+      },
+    );
+    const reader = streamResponse.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    for (let i = 0; i < 8; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("sessionId=")) break;
+    }
+    const sessionId = /sessionId=([^"&\s]+)/.exec(buffer)?.[1];
+    expect(sessionId).toBeTruthy();
+
+    const messageResponse = await app.request(
+      `/api/mcp/adapter-http/test-server/messages?sessionId=${encodeURIComponent(
+        sessionId!,
+      )}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 7,
+          method: "tools/call",
+          params: { name: "bench_write", arguments: { value: "x" } },
+        }),
+      },
+    );
+    expect(messageResponse.status).toBe(202);
+    expect(received).toEqual([
+      {
+        serverId: "test-server",
+        toolCallId: "7",
+        requiredScope: "bench:write",
+        resourceMetadataUrl: undefined,
+        errorDescription: undefined,
+      },
+    ]);
+    await reader.cancel();
+  });
+
+  it("does not forward ordinary or errorDescription-only failures", async () => {
+    const received: unknown[] = [];
+    subscribeHarnessScopeStepUp(TURN_ID, (info) => received.push(info));
+    for (const error of [
+      new Error("ordinary failure"),
+      new InsufficientScopeError({
+        errorDescription: "More access is required",
+      }),
+    ]) {
+      manager.executeTool.mockRejectedValueOnce(error);
+      const res = await app.request("/api/mcp/adapter-http/test-server", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER]: TURN_ID,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 8,
+          method: "tools/call",
+          params: { name: "bench_write", arguments: {} },
+        }),
+      });
+      expect(res.status).toBe(200);
+    }
+    expect(received).toEqual([]);
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/__tests__/harness-proxy.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/harness-proxy.test.ts
@@ -20,6 +20,7 @@ import { signTestProxyToken } from "../../../utils/harness/__tests__/sign-test-t
 import {
   __resetHarnessScopeStepUpForTests,
   HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER,
+  HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY,
   subscribeHarnessScopeStepUp,
 } from "../../../utils/harness/harness-scope-step-up.js";
 
@@ -101,7 +102,7 @@ describe("adapter-http harness proxy-token (validate-when-present)", () => {
     expect(res.status).toBe(401);
   });
 
-  it("forwards an actionable direct-POST tool error to only its harness turn", async () => {
+  it("forwards an actionable direct-POST tool error from the URL correlation", async () => {
     const challenge = new InsufficientScopeError({
       requiredScope: "bench:write",
       resourceMetadataUrl: new URL(
@@ -112,19 +113,21 @@ describe("adapter-http harness proxy-token (validate-when-present)", () => {
     const received: unknown[] = [];
     subscribeHarnessScopeStepUp(TURN_ID, (info) => received.push(info));
 
-    const res = await app.request("/api/mcp/adapter-http/test-server", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER]: TURN_ID,
+    const res = await app.request(
+      `/api/mcp/adapter-http/test-server?${HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY}=${TURN_ID}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "call-1",
+          method: "tools/call",
+          params: { name: "bench_write", arguments: { value: "x" } },
+        }),
       },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: "call-1",
-        method: "tools/call",
-        params: { name: "bench_write", arguments: { value: "x" } },
-      }),
-    });
+    );
 
     const { status, data } = await expectJson(res);
     expect(status).toBe(200);
@@ -149,12 +152,9 @@ describe("adapter-http harness proxy-token (validate-when-present)", () => {
     subscribeHarnessScopeStepUp(TURN_ID, (info) => received.push(info));
 
     const streamResponse = await app.request(
-      "/api/mcp/adapter-http/test-server",
+      `/api/mcp/adapter-http/test-server?${HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY}=${TURN_ID}`,
       {
         method: "GET",
-        headers: {
-          [HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER]: TURN_ID,
-        },
       },
     );
     const reader = streamResponse.body!.getReader();

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -77,6 +77,8 @@ import { BASH_TOOL_NAME } from "../../utils/built-in-tools/bash.js";
 import { maybeAppendEnvironmentContext } from "../../utils/computers/environment-context.js";
 import { convertToMcpjamModelMessages } from "../../utils/mcp-tool-result-model-output.js";
 import { type ExecutionScope } from "../../utils/execution-scope.js";
+import { wrapToolsWithScopeStepUp } from "../../utils/insufficient-scope-step-up.js";
+import type { ElicitationChunkWriter } from "../web/hosted-elicitation.js";
 
 function formatStreamError(error: unknown, provider?: ModelProvider): string {
   if (!(error instanceof Error)) {
@@ -845,13 +847,20 @@ chatV2.post("/", async (c) => {
     }
 
     const {
-      allTools,
+      allTools: preparedTools,
       enhancedSystemPrompt,
       resolvedTemperature,
       scrubMessages,
       progressivePlan,
       discoveryState,
     } = prepared;
+    // The stream writer is created after tools are prepared, so the wrapper
+    // resolves it lazily when a tool actually reports a scope challenge.
+    let scopeChallengeWriter: ElicitationChunkWriter | null = null;
+    const allTools = wrapToolsWithScopeStepUp(
+      preparedTools,
+      () => scopeChallengeWriter,
+    );
     const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
       validatedWidgetModelContext,
     );
@@ -935,13 +944,12 @@ chatV2.post("/", async (c) => {
         selectedServers,
         requireToolApproval,
         modelVisibleMcpToolResults,
-        ...(taskCreatedBridge
-          ? {
-              onStreamWriterReady: (writer: {
-                write: (chunk: UIMessageChunk) => void;
-              }) => taskCreatedBridge.attachStreamWriter(writer),
-            }
-          : {}),
+        onStreamWriterReady: (writer: {
+          write: (chunk: UIMessageChunk) => void;
+        }) => {
+          scopeChallengeWriter = writer;
+          taskCreatedBridge?.attachStreamWriter(writer);
+        },
         ...(resolvedExecution.harness
           ? {
               harness: resolvedExecution.harness,
@@ -1149,13 +1157,12 @@ chatV2.post("/", async (c) => {
           // synchronously from the tool loop, so a missing attach means the
           // bridge warn-drops the task-created part and the task is orphaned
           // (see `server/utils/web-chat-turn.ts`).
-          ...(taskCreatedBridge
-            ? {
-                onStreamWriterReady: (writer: {
-                  write: (chunk: UIMessageChunk) => void;
-                }) => taskCreatedBridge.attachStreamWriter(writer),
-              }
-            : {}),
+          onStreamWriterReady: (writer: {
+            write: (chunk: UIMessageChunk) => void;
+          }) => {
+            scopeChallengeWriter = writer;
+            taskCreatedBridge?.attachStreamWriter(writer);
+          },
         });
       }
 
@@ -1180,13 +1187,12 @@ chatV2.post("/", async (c) => {
         onConversationComplete,
         // Same invariant as the local-org call above: attach the bridge
         // before the first tool call, or created tasks are orphaned.
-        ...(taskCreatedBridge
-          ? {
-              onStreamWriterReady: (writer: {
-                write: (chunk: UIMessageChunk) => void;
-              }) => taskCreatedBridge.attachStreamWriter(writer),
-            }
-          : {}),
+        onStreamWriterReady: (writer: {
+          write: (chunk: UIMessageChunk) => void;
+        }) => {
+          scopeChallengeWriter = writer;
+          taskCreatedBridge?.attachStreamWriter(writer);
+        },
       });
     }
 
@@ -1260,13 +1266,12 @@ chatV2.post("/", async (c) => {
       abortSignal: inboundAbortSignalDirect,
       // Same invariant as the org-BYOK calls above: attach the bridge before
       // the first tool call, or created tasks are orphaned.
-      ...(taskCreatedBridge
-        ? {
-            onStreamWriterReady: (writer: {
-              write: (chunk: UIMessageChunk) => void;
-            }) => taskCreatedBridge.attachStreamWriter(writer),
-          }
-        : {}),
+      onStreamWriterReady: (writer: {
+        write: (chunk: UIMessageChunk) => void;
+      }) => {
+        scopeChallengeWriter = writer;
+        taskCreatedBridge?.attachStreamWriter(writer);
+      },
       onPersist: chatSessionId
         ? async ({
             responseMessages,

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -953,6 +953,11 @@ chatV2.post("/", async (c) => {
         ...(resolvedExecution.harness
           ? {
               harness: resolvedExecution.harness,
+              // SEP-2350 contract boundary: harness MCP-server tools execute
+              // out of process through `.mcp.json`, bypassing `allTools`.
+              // Supporting their scope challenges requires a correlated
+              // adapter-http → chat-stream side channel. Host-executed harness
+              // tools remain covered by the wrapper above.
               // LOCAL-MCP plane: this is an /api/mcp request (desktop), so the
               // harness reaches the private inspector via a tunnel landing on
               // adapter-http (the persistent singleton manager).

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -953,11 +953,11 @@ chatV2.post("/", async (c) => {
         ...(resolvedExecution.harness
           ? {
               harness: resolvedExecution.harness,
-              // SEP-2350 contract boundary: harness MCP-server tools execute
-              // out of process through `.mcp.json`, bypassing `allTools`.
-              // Supporting their scope challenges requires a correlated
-              // adapter-http → chat-stream side channel. Host-executed harness
-              // tools remain covered by the wrapper above.
+              // Harness MCP-server tools execute out of process through
+              // `.mcp.json`, bypassing `allTools`. runHarnessTurn adds a
+              // per-turn correlation header and bridges actionable challenges
+              // from adapter-http back into this chat stream. Host-executed
+              // harness tools remain covered by the wrapper above.
               // LOCAL-MCP plane: this is an /api/mcp request (desktop), so the
               // harness reaches the private inspector via a tunnel landing on
               // adapter-http (the persistent singleton manager).

--- a/mcpjam-inspector/server/routes/mcp/http-adapters.ts
+++ b/mcpjam-inspector/server/routes/mcp/http-adapters.ts
@@ -14,6 +14,7 @@ import { getRequestLogger } from "../../utils/request-logger";
 import { verifyHarnessProxyToken } from "../../utils/harness/harness-proxy-token";
 import {
   HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER,
+  HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY,
   normalizeHarnessScopeStepUpCorrelationId,
   publishHarnessScopeStepUpFromToolError,
 } from "../../utils/harness/harness-scope-step-up.js";
@@ -177,8 +178,14 @@ function readProxyToken(c: any): string | undefined {
 }
 
 function readScopeStepUpCorrelationId(c: any): string | undefined {
-  return normalizeHarnessScopeStepUpCorrelationId(
+  const fromHeader = normalizeHarnessScopeStepUpCorrelationId(
     c.req.header(HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER),
+  );
+  if (fromHeader) return fromHeader;
+  return normalizeHarnessScopeStepUpCorrelationId(
+    new URL(c.req.url).searchParams.get(
+      HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY,
+    ),
   );
 }
 

--- a/mcpjam-inspector/server/routes/mcp/http-adapters.ts
+++ b/mcpjam-inspector/server/routes/mcp/http-adapters.ts
@@ -12,11 +12,17 @@ import {
 import { recordTunnelRequest } from "../../services/tunnel-request-log";
 import { getRequestLogger } from "../../utils/request-logger";
 import { verifyHarnessProxyToken } from "../../utils/harness/harness-proxy-token";
+import {
+  HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER,
+  normalizeHarnessScopeStepUpCorrelationId,
+  publishHarnessScopeStepUpFromToolError,
+} from "../../utils/harness/harness-scope-step-up.js";
 
 // In-memory SSE session store per serverId:sessionId
 type Session = {
   send: (event: string, data: string) => void;
   close: () => void;
+  scopeStepUpCorrelationId?: string;
 };
 const sessions: Map<string, Session> = new Map();
 const latestSessionByServer: Map<string, string> = new Map();
@@ -170,6 +176,12 @@ function readProxyToken(c: any): string | undefined {
   return c.req.header("x-mcpjam-proxy-token") || undefined;
 }
 
+function readScopeStepUpCorrelationId(c: any): string | undefined {
+  return normalizeHarnessScopeStepUpCorrelationId(
+    c.req.header(HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER),
+  );
+}
+
 // Unified HTTP adapter for adapter-http + manager-http (same robust
 // implementation, different JSON-RPC response modes).
 function createHttpHandler(mode: BridgeMode, routePrefix: string) {
@@ -259,7 +271,12 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
           };
 
           // Register session
-          sessions.set(`${serverId}:${sessionId}`, { send, close });
+          const scopeStepUpCorrelationId = readScopeStepUpCorrelationId(c);
+          sessions.set(`${serverId}:${sessionId}`, {
+            send,
+            close,
+            ...(scopeStepUpCorrelationId ? { scopeStepUpCorrelationId } : {}),
+          });
           latestSessionByServer.set(serverId, sessionId);
 
           // Relay real server notifications down this SSE stream.
@@ -346,7 +363,14 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
       normalizedServerId,
       body as any,
       clientManager,
-      mode
+      mode,
+      {
+        onToolCallError: (context) =>
+          publishHarnessScopeStepUpFromToolError(
+            readScopeStepUpCorrelationId(c),
+            context,
+          ),
+      },
     );
     if (!response) {
       // Notification → 202 Accepted
@@ -408,7 +432,14 @@ function createHttpHandler(mode: BridgeMode, routePrefix: string) {
         normalizedServerId,
         { id, method, params },
         c.mcpClientManager,
-        mode
+        mode,
+        {
+          onToolCallError: (context) =>
+            publishHarnessScopeStepUpFromToolError(
+              readScopeStepUpCorrelationId(c) ?? sess.scopeStepUpCorrelationId,
+              context,
+            ),
+        },
       );
       // If there is a JSON-RPC response, emit it over SSE to the client
       if (responseMessage) {

--- a/mcpjam-inspector/server/routes/mcp/subscribe.ts
+++ b/mcpjam-inspector/server/routes/mcp/subscribe.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { InspectorCommand } from "@/shared/inspector-command.js";
+import type { InspectorEvent } from "@/shared/inspector-event.js";
 import { inspectorCommandBus } from "../../services/inspector-command-bus.js";
 
 const subscribe = new Hono();
@@ -18,6 +19,13 @@ subscribe.get("/", async (c) => {
       const send = (command: InspectorCommand) => {
         controller.enqueue(
           encoder.encode(`data: ${JSON.stringify(command)}\n\n`),
+        );
+      };
+      const sendEvent = (event: InspectorEvent) => {
+        controller.enqueue(
+          encoder.encode(
+            `event: inspector-event\ndata: ${JSON.stringify(event)}\n\n`,
+          ),
         );
       };
 
@@ -63,6 +71,7 @@ subscribe.get("/", async (c) => {
       unregister = inspectorCommandBus.registerSubscriber({
         clientId,
         send,
+        sendEvent,
         supersede,
         close,
       });

--- a/mcpjam-inspector/server/services/__tests__/inspector-command-bus.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/inspector-command-bus.test.ts
@@ -6,12 +6,40 @@ function createSubscriber(clientId: string) {
   return {
     clientId,
     send: vi.fn(),
+    sendEvent: vi.fn(),
     supersede: vi.fn(),
     close: vi.fn(),
   };
 }
 
 describe("InspectorCommandBus", () => {
+  it("delivers one-way events without creating pending command state", () => {
+    const bus = new InspectorCommandBus();
+    const subscriber = createSubscriber("active-tab");
+    bus.registerSubscriber(subscriber);
+    const event = {
+      kind: "scope_step_up" as const,
+      serverId: "auth-bench",
+      requiredScope: "bench:write",
+    };
+
+    expect(bus.notify(event)).toBe(true);
+    expect(subscriber.sendEvent).toHaveBeenCalledWith(event);
+    expect(subscriber.send).not.toHaveBeenCalled();
+  });
+
+  it("drops one-way events when no Inspector client is active", () => {
+    const bus = new InspectorCommandBus();
+
+    expect(
+      bus.notify({
+        kind: "scope_step_up",
+        serverId: "auth-bench",
+        requiredScope: "bench:write",
+      }),
+    ).toBe(false);
+  });
+
   it("keeps a superseded EventSource reconnect from evicting the active subscriber", async () => {
     const bus = new InspectorCommandBus();
     const first = createSubscriber("first-tab");

--- a/mcpjam-inspector/server/services/inspector-command-bus.ts
+++ b/mcpjam-inspector/server/services/inspector-command-bus.ts
@@ -6,11 +6,13 @@ import {
   INSPECTOR_COMMAND_DEFAULT_TIMEOUT_MS,
   buildInspectorCommandError,
 } from "@/shared/inspector-command.js";
+import type { InspectorEvent } from "@/shared/inspector-event.js";
 import { logger } from "../utils/logger.js";
 
 type Subscriber = {
   clientId: string;
   send: (command: InspectorCommand) => void;
+  sendEvent: (event: InspectorEvent) => void;
   supersede: () => void;
   close: () => void;
 };
@@ -35,6 +37,21 @@ export class InspectorCommandBus {
 
   hasActiveClient(): boolean {
     return this.subscriber !== null;
+  }
+
+  /** Best-effort one-way delivery; events never create pending command state. */
+  notify(event: InspectorEvent): boolean {
+    if (!this.subscriber) return false;
+    try {
+      this.subscriber.sendEvent(event);
+      return true;
+    } catch (error) {
+      logger.debug("[inspector-command-bus] Event delivery threw", {
+        kind: event.kind,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
   }
 
   registerSubscriber(subscriber: Subscriber): () => void {

--- a/mcpjam-inspector/server/services/mcp-http-bridge.ts
+++ b/mcpjam-inspector/server/services/mcp-http-bridge.ts
@@ -6,6 +6,18 @@ import { z } from "zod";
 
 export type BridgeMode = "adapter" | "manager";
 
+export type JsonRpcBridgeOptions = {
+  /**
+   * Observation-only hook for a failed `tools/call`. Failures in the hook are
+   * isolated so they can never change the JSON-RPC response.
+   */
+  onToolCallError?: (context: {
+    error: unknown;
+    serverId: string;
+    toolCallId?: string;
+  }) => void;
+};
+
 type JsonRpcBody = {
   id?: string | number | null;
   method?: string;
@@ -155,7 +167,8 @@ export async function handleJsonRpc(
   serverId: string,
   body: JsonRpcBody,
   clientManager: MCPClientManager,
-  mode: BridgeMode
+  mode: BridgeMode,
+  options: JsonRpcBridgeOptions = {},
 ): Promise<any | null> {
   const id = (body?.id ?? null) as any;
   const method = body?.method as string | undefined;
@@ -217,8 +230,8 @@ export async function handleJsonRpc(
         return respond({ result: { tools } });
       }
       case "tools/call": {
+        let targetServerId = serverId;
         try {
-          let targetServerId = serverId;
           let toolName = params?.name as string | undefined;
           if (toolName?.includes(":")) {
             const [prefix, actualName] = toolName.split(":", 2);
@@ -243,6 +256,18 @@ export async function handleJsonRpc(
           // adapter mode returns raw call-tool result for compatibility
           return respond({ result: exec });
         } catch (e: any) {
+          try {
+            options.onToolCallError?.({
+              error: e,
+              serverId: targetServerId,
+              ...(typeof id === "string" || typeof id === "number"
+                ? { toolCallId: String(id) }
+                : {}),
+            });
+          } catch {
+            // Observation-only: never turn a side-channel failure into an MCP
+            // tool failure different from the upstream error.
+          }
           if (mode === "manager") {
             const result = {
               content: [

--- a/mcpjam-inspector/server/utils/__tests__/insufficient-scope-step-up.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/insufficient-scope-step-up.test.ts
@@ -1,0 +1,154 @@
+import { InsufficientScopeError } from "@modelcontextprotocol/client";
+import type { UIMessageChunk } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { wrapToolsWithScopeStepUp } from "../insufficient-scope-step-up.js";
+
+type CapturedChunk = {
+  type: string;
+  transient?: boolean;
+  data: Record<string, unknown>;
+};
+
+function makeWriter() {
+  const chunks: CapturedChunk[] = [];
+  return {
+    chunks,
+    writer: {
+      write: (chunk: UIMessageChunk) => {
+        chunks.push(chunk as unknown as CapturedChunk);
+      },
+    },
+  };
+}
+
+describe("wrapToolsWithScopeStepUp", () => {
+  it("emits an actionable insufficient_scope chunk and rethrows", async () => {
+    const error = new InsufficientScopeError({
+      requiredScope: "bench:write",
+      resourceMetadataUrl: new URL(
+        "https://bench.example/.well-known/oauth-protected-resource",
+      ),
+    });
+    const { chunks, writer } = makeWriter();
+    const wrapped = wrapToolsWithScopeStepUp(
+      {
+        bench_write: {
+          description: "Write to the bench",
+          inputSchema: {},
+          _serverId: "auth-bench",
+          execute: vi.fn(async () => {
+            throw error;
+          }),
+        },
+      } as any,
+      () => writer,
+    );
+
+    await expect(
+      wrapped.bench_write.execute?.({}, { toolCallId: "call-1" } as any),
+    ).rejects.toBe(error);
+    expect(chunks).toEqual([
+      {
+        type: "data-elicitation",
+        transient: true,
+        data: {
+          kind: "insufficient_scope",
+          serverId: "auth-bench",
+          toolCallId: "call-1",
+          requiredScope: "bench:write",
+          resourceMetadataUrl:
+            "https://bench.example/.well-known/oauth-protected-resource",
+        },
+      },
+    ]);
+    expect(chunks[0]?.data).not.toHaveProperty("serverName");
+  });
+
+  it("suppresses an errorDescription-only challenge and rethrows", async () => {
+    const error = new InsufficientScopeError({
+      errorDescription: "More access is required",
+    });
+    const { chunks, writer } = makeWriter();
+    const wrapped = wrapToolsWithScopeStepUp(
+      {
+        bench_write: {
+          inputSchema: {},
+          execute: async () => {
+            throw error;
+          },
+        },
+      } as any,
+      () => writer,
+    );
+
+    await expect(wrapped.bench_write.execute?.({}, {} as any)).rejects.toBe(
+      error,
+    );
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("ignores ordinary tool errors and rethrows", async () => {
+    const error = new Error("tool failed");
+    const { chunks, writer } = makeWriter();
+    const wrapped = wrapToolsWithScopeStepUp(
+      {
+        bench_write: {
+          inputSchema: {},
+          execute: async () => {
+            throw error;
+          },
+        },
+      } as any,
+      () => writer,
+    );
+
+    await expect(wrapped.bench_write.execute?.({}, {} as any)).rejects.toBe(
+      error,
+    );
+    expect(chunks).toHaveLength(0);
+  });
+
+  it("rethrows without crashing when the writer is not ready", async () => {
+    const error = new InsufficientScopeError({
+      requiredScope: "bench:write",
+    });
+    const wrapped = wrapToolsWithScopeStepUp(
+      {
+        bench_write: {
+          inputSchema: {},
+          execute: async () => {
+            throw error;
+          },
+        },
+      } as any,
+      () => null,
+    );
+
+    await expect(wrapped.bench_write.execute?.({}, {} as any)).rejects.toBe(
+      error,
+    );
+  });
+
+  it("preserves successful results and tools without execute", async () => {
+    const result = { content: [{ type: "text", text: "ok" }] };
+    const withoutExecute = {
+      description: "Provider-executed tool",
+      inputSchema: {},
+    };
+    const wrapped = wrapToolsWithScopeStepUp(
+      {
+        bench_read: {
+          inputSchema: {},
+          execute: async () => result,
+        },
+        provider_tool: withoutExecute,
+      } as any,
+      () => null,
+    );
+
+    await expect(wrapped.bench_read.execute?.({}, {} as any)).resolves.toBe(
+      result,
+    );
+    expect(wrapped.provider_tool).toBe(withoutExecute);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/insufficient-scope-step-up.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/insufficient-scope-step-up.test.ts
@@ -129,6 +129,44 @@ describe("wrapToolsWithScopeStepUp", () => {
     );
   });
 
+  it("shares extraction and gating with custom hosted observers", async () => {
+    const error = new InsufficientScopeError({
+      requiredScope: "bench:write",
+      errorDescription: "Write access required",
+    });
+    const onToolError = vi.fn();
+    const emitInsufficientScope = vi.fn();
+    const wrapped = wrapToolsWithScopeStepUp(
+      {
+        bench_write: {
+          inputSchema: {},
+          _serverId: "server-1",
+          execute: async () => {
+            throw error;
+          },
+        },
+      } as any,
+      () => null,
+      { onToolError, emitInsufficientScope },
+    );
+
+    await expect(
+      wrapped.bench_write.execute?.({}, { toolCallId: "call-1" } as any),
+    ).rejects.toBe(error);
+    expect(onToolError).toHaveBeenCalledWith({
+      error,
+      serverId: "server-1",
+      toolCallId: "call-1",
+    });
+    expect(emitInsufficientScope).toHaveBeenCalledWith({
+      serverId: "server-1",
+      toolCallId: "call-1",
+      requiredScope: "bench:write",
+      resourceMetadataUrl: undefined,
+      errorDescription: "Write access required",
+    });
+  });
+
   it("preserves successful results and tools without execute", async () => {
     const result = { content: [{ type: "text", text: "ok" }] };
     const withoutExecute = {

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
@@ -1,0 +1,88 @@
+import { InsufficientScopeError } from "@modelcontextprotocol/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetHarnessScopeStepUpForTests,
+  normalizeHarnessScopeStepUpCorrelationId,
+  publishHarnessScopeStepUp,
+  publishHarnessScopeStepUpFromToolError,
+  subscribeHarnessScopeStepUp,
+} from "../harness-scope-step-up.js";
+
+const TURN_A = "11111111-1111-4111-8111-111111111111";
+const TURN_B = "22222222-2222-4222-8222-222222222222";
+
+describe("harness scope step-up correlation", () => {
+  beforeEach(() => {
+    __resetHarnessScopeStepUpForTests();
+  });
+
+  it("isolates concurrent turns and ignores late events after teardown", () => {
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+    const stopA = subscribeHarnessScopeStepUp(TURN_A, listenerA);
+    subscribeHarnessScopeStepUp(TURN_B, listenerB);
+
+    publishHarnessScopeStepUp(TURN_A, {
+      serverId: "auth-bench",
+      requiredScope: "bench:write",
+    });
+    expect(listenerA).toHaveBeenCalledTimes(1);
+    expect(listenerB).not.toHaveBeenCalled();
+
+    stopA();
+    publishHarnessScopeStepUp(TURN_A, {
+      serverId: "auth-bench",
+      requiredScope: "bench:write",
+    });
+    expect(listenerA).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares the branded-error extraction and actionable-field gate", () => {
+    const listener = vi.fn();
+    subscribeHarnessScopeStepUp(TURN_A, listener);
+
+    publishHarnessScopeStepUpFromToolError(TURN_A, {
+      serverId: "auth-bench",
+      toolCallId: "call-1",
+      error: new InsufficientScopeError({
+        requiredScope: "bench:write",
+        resourceMetadataUrl: new URL(
+          "https://bench.example/.well-known/oauth-protected-resource",
+        ),
+      }),
+    });
+    expect(listener).toHaveBeenCalledWith({
+      serverId: "auth-bench",
+      toolCallId: "call-1",
+      requiredScope: "bench:write",
+      resourceMetadataUrl:
+        "https://bench.example/.well-known/oauth-protected-resource",
+      errorDescription: undefined,
+    });
+
+    publishHarnessScopeStepUpFromToolError(TURN_A, {
+      serverId: "auth-bench",
+      error: new InsufficientScopeError({
+        errorDescription: "More access is required",
+      }),
+    });
+    publishHarnessScopeStepUpFromToolError(TURN_A, {
+      serverId: "auth-bench",
+      error: new Error("ordinary failure"),
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects malformed correlation ids", () => {
+    expect(
+      normalizeHarnessScopeStepUpCorrelationId("not-a-turn"),
+    ).toBeUndefined();
+    const listener = vi.fn();
+    subscribeHarnessScopeStepUp("not-a-turn", listener);
+    publishHarnessScopeStepUp("not-a-turn", {
+      serverId: "auth-bench",
+      requiredScope: "bench:write",
+    });
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
@@ -2,6 +2,7 @@ import { InsufficientScopeError } from "@modelcontextprotocol/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetHarnessScopeStepUpForTests,
+  harnessScopeStepUpServerMatches,
   normalizeHarnessScopeStepUpCorrelationId,
   publishHarnessScopeStepUp,
   publishHarnessScopeStepUpFromToolError,
@@ -182,5 +183,23 @@ describe("harness scope step-up correlation", () => {
       requiredScope: "bench:write",
     });
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("matches a subscriber's server filter the way routing does", () => {
+    // A subscriber that filtered with a bare `includes` would drop a variant
+    // this registry had already routed (and already told Inspector about).
+    expect(harnessScopeStepUpServerMatches(["auth-bench"], "AUTH-BENCH")).toBe(
+      true,
+    );
+    expect(
+      harnessScopeStepUpServerMatches(["AUTH-BENCH"], " auth-bench "),
+    ).toBe(true);
+    expect(harnessScopeStepUpServerMatches(["auth-bench"], "other")).toBe(
+      false,
+    );
+    expect(harnessScopeStepUpServerMatches([], "auth-bench")).toBe(false);
+    expect(harnessScopeStepUpServerMatches(undefined, "auth-bench")).toBe(
+      false,
+    );
   });
 });

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
@@ -82,6 +82,44 @@ describe("harness scope step-up correlation", () => {
     unregister();
   });
 
+  it("does not notify Inspector when a valid correlation names an unselected server", () => {
+    const sendEvent = vi.fn();
+    const unregister = inspectorCommandBus.registerSubscriber({
+      clientId: "scope-step-up-mismatch-test",
+      send: vi.fn(),
+      sendEvent,
+      supersede: vi.fn(),
+      close: vi.fn(),
+    });
+    const listener = vi.fn();
+    subscribeHarnessScopeStepUp(TURN_A, listener, ["auth-bench"]);
+
+    try {
+      publishHarnessScopeStepUp(TURN_A, {
+        serverId: "other-server",
+        requiredScope: "other:write",
+      });
+
+      // Correlation delivery is unchanged; run-harness-turn applies its
+      // selectedServers filter before writing this event into the chat stream.
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(sendEvent).not.toHaveBeenCalled();
+
+      publishHarnessScopeStepUp(TURN_A, {
+        serverId: "AUTH-BENCH",
+        requiredScope: "bench:write",
+      });
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(sendEvent).toHaveBeenCalledWith({
+        kind: "scope_step_up",
+        serverId: "AUTH-BENCH",
+        requiredScope: "bench:write",
+      });
+    } finally {
+      unregister();
+    }
+  });
+
   it("drops an uncorrelated challenge when two live turns share the server", () => {
     const listenerA = vi.fn();
     const listenerB = vi.fn();

--- a/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/harness-scope-step-up.test.ts
@@ -7,6 +7,7 @@ import {
   publishHarnessScopeStepUpFromToolError,
   subscribeHarnessScopeStepUp,
 } from "../harness-scope-step-up.js";
+import { inspectorCommandBus } from "../../../services/inspector-command-bus.js";
 
 const TURN_A = "11111111-1111-4111-8111-111111111111";
 const TURN_B = "22222222-2222-4222-8222-222222222222";
@@ -19,8 +20,10 @@ describe("harness scope step-up correlation", () => {
   it("isolates concurrent turns and ignores late events after teardown", () => {
     const listenerA = vi.fn();
     const listenerB = vi.fn();
-    const stopA = subscribeHarnessScopeStepUp(TURN_A, listenerA);
-    subscribeHarnessScopeStepUp(TURN_B, listenerB);
+    const stopA = subscribeHarnessScopeStepUp(TURN_A, listenerA, [
+      "auth-bench",
+    ]);
+    subscribeHarnessScopeStepUp(TURN_B, listenerB, ["other-server"]);
 
     publishHarnessScopeStepUp(TURN_A, {
       serverId: "auth-bench",
@@ -35,6 +38,63 @@ describe("harness scope step-up correlation", () => {
       requiredScope: "bench:write",
     });
     expect(listenerA).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers a missing or stale turn id for one live turn on the server", () => {
+    const listener = vi.fn();
+    subscribeHarnessScopeStepUp(TURN_A, listener, ["auth-bench"]);
+
+    publishHarnessScopeStepUp(undefined, {
+      serverId: "auth-bench",
+      requiredScope: "bench:write",
+    });
+    publishHarnessScopeStepUp(TURN_B, {
+      serverId: "AUTH-BENCH",
+      requiredScope: "bench:write",
+    });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("also notifies the active local Inspector client", () => {
+    const sendEvent = vi.fn();
+    const unregister = inspectorCommandBus.registerSubscriber({
+      clientId: "scope-step-up-test",
+      send: vi.fn(),
+      sendEvent,
+      supersede: vi.fn(),
+      close: vi.fn(),
+    });
+    subscribeHarnessScopeStepUp(TURN_A, vi.fn(), ["auth-bench"]);
+
+    publishHarnessScopeStepUp(undefined, {
+      serverId: "auth-bench",
+      toolCallId: "call-1",
+      requiredScope: "bench:write",
+    });
+
+    expect(sendEvent).toHaveBeenCalledWith({
+      kind: "scope_step_up",
+      serverId: "auth-bench",
+      toolCallId: "call-1",
+      requiredScope: "bench:write",
+    });
+    unregister();
+  });
+
+  it("drops an uncorrelated challenge when two live turns share the server", () => {
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+    subscribeHarnessScopeStepUp(TURN_A, listenerA, ["auth-bench"]);
+    subscribeHarnessScopeStepUp(TURN_B, listenerB, ["auth-bench"]);
+
+    publishHarnessScopeStepUp(undefined, {
+      serverId: "auth-bench",
+      requiredScope: "bench:write",
+    });
+
+    expect(listenerA).not.toHaveBeenCalled();
+    expect(listenerB).not.toHaveBeenCalled();
   });
 
   it("shares the branded-error extraction and actionable-field gate", () => {

--- a/mcpjam-inspector/server/utils/harness/__tests__/mcp-config.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/mcp-config.test.ts
@@ -6,7 +6,10 @@ import {
   serializeHarnessMcpJson,
   type HarnessProxyServerInput,
 } from "../mcp-config.js";
-import { HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER } from "../harness-scope-step-up.js";
+import {
+  HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER,
+  HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY,
+} from "../harness-scope-step-up.js";
 
 const srv = (
   name: string,
@@ -69,6 +72,9 @@ describe("buildHarnessProxyMcpJson", () => {
         scopeStepUpCorrelationId: correlationId,
       },
     ]);
+    expect(out.mcpServers.local.url).toBe(
+      `https://t/api/mcp/adapter-http/local?k=1&${HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY}=${correlationId}`,
+    );
     expect(out.mcpServers.local.headers).toEqual({
       [HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER]: correlationId,
     });

--- a/mcpjam-inspector/server/utils/harness/__tests__/mcp-config.test.ts
+++ b/mcpjam-inspector/server/utils/harness/__tests__/mcp-config.test.ts
@@ -6,6 +6,7 @@ import {
   serializeHarnessMcpJson,
   type HarnessProxyServerInput,
 } from "../mcp-config.js";
+import { HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER } from "../harness-scope-step-up.js";
 
 const srv = (
   name: string,
@@ -57,6 +58,21 @@ describe("buildHarnessProxyMcpJson", () => {
       url: "https://t/api/mcp/adapter-http/local?k=1",
     });
     expect(out.mcpServers.local.headers).toBeUndefined();
+  });
+
+  it("carries the opaque scope-step-up correlation on the local plane", () => {
+    const correlationId = "11111111-1111-4111-8111-111111111111";
+    const out = buildHarnessProxyMcpJson([
+      {
+        name: "local",
+        proxyUrl: "https://t/api/mcp/adapter-http/local?k=1",
+        scopeStepUpCorrelationId: correlationId,
+      },
+    ]);
+    expect(out.mcpServers.local.headers).toEqual({
+      [HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER]: correlationId,
+    });
+    expect(JSON.stringify(out).toLowerCase()).not.toContain("authorization");
   });
 });
 

--- a/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
@@ -27,12 +27,19 @@ export function normalizeHarnessScopeStepUpCorrelationId(
 }
 
 type Listener = (info: InsufficientScopeInfo) => void;
-const listenersByCorrelationId = new Map<string, Set<Listener>>();
-type ServerSubscription = {
+type ScopeStepUpSubscription = {
   correlationId: string;
   listener: Listener;
+  serverIds: ReadonlySet<string>;
 };
-const subscriptionsByServerId = new Map<string, Set<ServerSubscription>>();
+const subscriptionsByCorrelationId = new Map<
+  string,
+  Set<ScopeStepUpSubscription>
+>();
+const subscriptionsByServerId = new Map<
+  string,
+  Set<ScopeStepUpSubscription>
+>();
 
 function normalizeServerId(serverId: string): string {
   return serverId.trim().toLowerCase();
@@ -75,31 +82,33 @@ export function subscribeHarnessScopeStepUp(
   const normalized = normalizeHarnessScopeStepUpCorrelationId(correlationId);
   if (!normalized) return () => {};
 
-  const listeners = listenersByCorrelationId.get(normalized) ?? new Set();
-  listeners.add(listener);
-  listenersByCorrelationId.set(normalized, listeners);
+  const normalizedServerIds = new Set(
+    serverIds.map(normalizeServerId).filter(Boolean),
+  );
+  const subscription: ScopeStepUpSubscription = {
+    correlationId: normalized,
+    listener,
+    serverIds: normalizedServerIds,
+  };
+  const correlatedSubscriptions =
+    subscriptionsByCorrelationId.get(normalized) ?? new Set();
+  correlatedSubscriptions.add(subscription);
+  subscriptionsByCorrelationId.set(normalized, correlatedSubscriptions);
 
-  const serverSubscriptions: Array<{
-    serverId: string;
-    subscription: ServerSubscription;
-  }> = [];
-  for (const rawServerId of new Set(serverIds)) {
-    const serverId = normalizeServerId(rawServerId);
-    if (!serverId) continue;
+  for (const serverId of normalizedServerIds) {
     const subscriptions =
-      subscriptionsByServerId.get(serverId) ?? new Set<ServerSubscription>();
-    const subscription = { correlationId: normalized, listener };
+      subscriptionsByServerId.get(serverId) ??
+      new Set<ScopeStepUpSubscription>();
     subscriptions.add(subscription);
     subscriptionsByServerId.set(serverId, subscriptions);
-    serverSubscriptions.push({ serverId, subscription });
   }
 
   return () => {
-    listeners.delete(listener);
-    if (listeners.size === 0) {
-      listenersByCorrelationId.delete(normalized);
+    correlatedSubscriptions.delete(subscription);
+    if (correlatedSubscriptions.size === 0) {
+      subscriptionsByCorrelationId.delete(normalized);
     }
-    for (const { serverId, subscription } of serverSubscriptions) {
+    for (const serverId of normalizedServerIds) {
       const subscriptions = subscriptionsByServerId.get(serverId);
       subscriptions?.delete(subscription);
       if (subscriptions?.size === 0) {
@@ -114,13 +123,23 @@ export function publishHarnessScopeStepUp(
   info: InsufficientScopeInfo,
 ): void {
   const normalized = normalizeHarnessScopeStepUpCorrelationId(correlationId);
-  const correlatedListeners = normalized
-    ? listenersByCorrelationId.get(normalized)
+  const correlatedSubscriptions = normalized
+    ? subscriptionsByCorrelationId.get(normalized)
     : undefined;
-  if (correlatedListeners?.size) {
-    notifyInspector(info);
-    for (const listener of correlatedListeners) {
-      notifyListener(listener, info);
+  if (correlatedSubscriptions?.size) {
+    const serverId = normalizeServerId(info.serverId);
+    if (
+      [...correlatedSubscriptions].some((subscription) =>
+        subscription.serverIds.has(serverId),
+      )
+    ) {
+      notifyInspector(info);
+    }
+    const notifiedListeners = new Set<Listener>();
+    for (const subscription of correlatedSubscriptions) {
+      if (notifiedListeners.has(subscription.listener)) continue;
+      notifiedListeners.add(subscription.listener);
+      notifyListener(subscription.listener, info);
     }
     return;
   }
@@ -152,6 +171,6 @@ export function publishHarnessScopeStepUpFromToolError(
 
 /** Test seam: production cleanup happens through each subscription disposer. */
 export function __resetHarnessScopeStepUpForTests(): void {
-  listenersByCorrelationId.clear();
+  subscriptionsByCorrelationId.clear();
   subscriptionsByServerId.clear();
 }

--- a/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
@@ -45,6 +45,24 @@ function normalizeServerId(serverId: string): string {
   return serverId.trim().toLowerCase();
 }
 
+/**
+ * Whether a published challenge names one of these server ids, using the SAME
+ * normalization this registry routes with. Subscribers must filter through
+ * this rather than a bare `includes`: otherwise a case or whitespace variant
+ * could be routed here and then dropped by the subscriber, so the Inspector
+ * would open OAuth for a challenge the chat stream never showed.
+ */
+export function harnessScopeStepUpServerMatches(
+  serverIds: readonly string[] | undefined,
+  serverId: string,
+): boolean {
+  if (!serverIds?.length) return false;
+  const normalized = normalizeServerId(serverId);
+  return serverIds.some(
+    (candidate) => normalizeServerId(candidate) === normalized,
+  );
+}
+
 function notifyListener(
   listener: Listener,
   info: InsufficientScopeInfo,

--- a/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
@@ -4,10 +4,13 @@ import {
   type ScopeStepUpToolError,
 } from "../insufficient-scope-step-up.js";
 import { logger } from "../logger.js";
-export { HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER } from "./mcp-config.js";
+export {
+  HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER,
+  HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY,
+} from "./mcp-config.js";
 
 /**
- * Opaque per-turn header carried by every generated harness `.mcp.json` entry.
+ * Opaque per-turn marker carried by every generated harness `.mcp.json` entry.
  * It correlates a proxy-observed tool failure back to exactly one live chat
  * stream without broadcasting by server id.
  */

--- a/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
@@ -4,6 +4,7 @@ import {
   type ScopeStepUpToolError,
 } from "../insufficient-scope-step-up.js";
 import { logger } from "../logger.js";
+import { inspectorCommandBus } from "../../services/inspector-command-bus.js";
 export {
   HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER,
   HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY,
@@ -27,10 +28,49 @@ export function normalizeHarnessScopeStepUpCorrelationId(
 
 type Listener = (info: InsufficientScopeInfo) => void;
 const listenersByCorrelationId = new Map<string, Set<Listener>>();
+type ServerSubscription = {
+  correlationId: string;
+  listener: Listener;
+};
+const subscriptionsByServerId = new Map<string, Set<ServerSubscription>>();
+
+function normalizeServerId(serverId: string): string {
+  return serverId.trim().toLowerCase();
+}
+
+function notifyListener(
+  listener: Listener,
+  info: InsufficientScopeInfo,
+): void {
+  try {
+    listener(info);
+  } catch (error) {
+    logger.warn("[harness-scope-step-up] subscriber failed", {
+      serverId: info.serverId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function notifyInspector(info: InsufficientScopeInfo): void {
+  inspectorCommandBus.notify({
+    kind: "scope_step_up",
+    serverId: info.serverId,
+    ...(info.toolCallId ? { toolCallId: info.toolCallId } : {}),
+    ...(info.requiredScope ? { requiredScope: info.requiredScope } : {}),
+    ...(info.resourceMetadataUrl
+      ? { resourceMetadataUrl: info.resourceMetadataUrl }
+      : {}),
+    ...(info.errorDescription
+      ? { errorDescription: info.errorDescription }
+      : {}),
+  });
+}
 
 export function subscribeHarnessScopeStepUp(
   correlationId: string,
   listener: Listener,
+  serverIds: readonly string[] = [],
 ): () => void {
   const normalized = normalizeHarnessScopeStepUpCorrelationId(correlationId);
   if (!normalized) return () => {};
@@ -39,10 +79,32 @@ export function subscribeHarnessScopeStepUp(
   listeners.add(listener);
   listenersByCorrelationId.set(normalized, listeners);
 
+  const serverSubscriptions: Array<{
+    serverId: string;
+    subscription: ServerSubscription;
+  }> = [];
+  for (const rawServerId of new Set(serverIds)) {
+    const serverId = normalizeServerId(rawServerId);
+    if (!serverId) continue;
+    const subscriptions =
+      subscriptionsByServerId.get(serverId) ?? new Set<ServerSubscription>();
+    const subscription = { correlationId: normalized, listener };
+    subscriptions.add(subscription);
+    subscriptionsByServerId.set(serverId, subscriptions);
+    serverSubscriptions.push({ serverId, subscription });
+  }
+
   return () => {
     listeners.delete(listener);
     if (listeners.size === 0) {
       listenersByCorrelationId.delete(normalized);
+    }
+    for (const { serverId, subscription } of serverSubscriptions) {
+      const subscriptions = subscriptionsByServerId.get(serverId);
+      subscriptions?.delete(subscription);
+      if (subscriptions?.size === 0) {
+        subscriptionsByServerId.delete(serverId);
+      }
     }
   };
 }
@@ -52,17 +114,29 @@ export function publishHarnessScopeStepUp(
   info: InsufficientScopeInfo,
 ): void {
   const normalized = normalizeHarnessScopeStepUpCorrelationId(correlationId);
-  if (!normalized) return;
-
-  for (const listener of listenersByCorrelationId.get(normalized) ?? []) {
-    try {
-      listener(info);
-    } catch (error) {
-      logger.warn("[harness-scope-step-up] subscriber failed", {
-        serverId: info.serverId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+  const correlatedListeners = normalized
+    ? listenersByCorrelationId.get(normalized)
+    : undefined;
+  if (correlatedListeners?.size) {
+    notifyInspector(info);
+    for (const listener of correlatedListeners) {
+      notifyListener(listener, info);
     }
+    return;
+  }
+
+  // A resumed harness session can keep an MCP connection created by an older
+  // turn, so its configured correlation may be absent or stale even though the
+  // tool call still reaches this proxy. Recover only when exactly one live
+  // harness turn selected this server. If two turns could receive the event,
+  // drop it instead of opening OAuth in the wrong chat.
+  const serverSubscriptions = subscriptionsByServerId.get(
+    normalizeServerId(info.serverId),
+  );
+  if (serverSubscriptions?.size !== 1) return;
+  notifyInspector(info);
+  for (const subscription of serverSubscriptions) {
+    notifyListener(subscription.listener, info);
   }
 }
 
@@ -79,4 +153,5 @@ export function publishHarnessScopeStepUpFromToolError(
 /** Test seam: production cleanup happens through each subscription disposer. */
 export function __resetHarnessScopeStepUpForTests(): void {
   listenersByCorrelationId.clear();
+  subscriptionsByServerId.clear();
 }

--- a/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/harness/harness-scope-step-up.ts
@@ -1,0 +1,79 @@
+import type { InsufficientScopeInfo } from "../../routes/web/hosted-elicitation.js";
+import {
+  scopeStepUpInfoFromToolError,
+  type ScopeStepUpToolError,
+} from "../insufficient-scope-step-up.js";
+import { logger } from "../logger.js";
+export { HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER } from "./mcp-config.js";
+
+/**
+ * Opaque per-turn header carried by every generated harness `.mcp.json` entry.
+ * It correlates a proxy-observed tool failure back to exactly one live chat
+ * stream without broadcasting by server id.
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function normalizeHarnessScopeStepUpCorrelationId(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return UUID_PATTERN.test(trimmed) ? trimmed.toLowerCase() : undefined;
+}
+
+type Listener = (info: InsufficientScopeInfo) => void;
+const listenersByCorrelationId = new Map<string, Set<Listener>>();
+
+export function subscribeHarnessScopeStepUp(
+  correlationId: string,
+  listener: Listener,
+): () => void {
+  const normalized = normalizeHarnessScopeStepUpCorrelationId(correlationId);
+  if (!normalized) return () => {};
+
+  const listeners = listenersByCorrelationId.get(normalized) ?? new Set();
+  listeners.add(listener);
+  listenersByCorrelationId.set(normalized, listeners);
+
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      listenersByCorrelationId.delete(normalized);
+    }
+  };
+}
+
+export function publishHarnessScopeStepUp(
+  correlationId: string | undefined,
+  info: InsufficientScopeInfo,
+): void {
+  const normalized = normalizeHarnessScopeStepUpCorrelationId(correlationId);
+  if (!normalized) return;
+
+  for (const listener of listenersByCorrelationId.get(normalized) ?? []) {
+    try {
+      listener(info);
+    } catch (error) {
+      logger.warn("[harness-scope-step-up] subscriber failed", {
+        serverId: info.serverId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+export function publishHarnessScopeStepUpFromToolError(
+  correlationId: string | undefined,
+  context: ScopeStepUpToolError,
+): void {
+  const info = scopeStepUpInfoFromToolError(context);
+  if (info) {
+    publishHarnessScopeStepUp(correlationId, info);
+  }
+}
+
+/** Test seam: production cleanup happens through each subscription disposer. */
+export function __resetHarnessScopeStepUpForTests(): void {
+  listenersByCorrelationId.clear();
+}

--- a/mcpjam-inspector/server/utils/harness/mcp-config.ts
+++ b/mcpjam-inspector/server/utils/harness/mcp-config.ts
@@ -15,6 +15,8 @@
  * This is the pure generator. Resolving each server's tunnel URL + minting its
  * token is the caller's job — see `run-harness-turn`.
  */
+export const HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER =
+  "X-MCPJam-Scope-Step-Up-Correlation";
 
 /** One server, resolved to its MCPJam proxy endpoint + per-turn token. */
 export interface HarnessProxyServerInput {
@@ -30,6 +32,8 @@ export interface HarnessProxyServerInput {
    * tunnel's `?k=` secret is the auth (`adapter-http` is validate-when-present).
    */
   proxyToken?: string;
+  /** Opaque live-turn id used only to route proxy-observed scope challenges. */
+  scopeStepUpCorrelationId?: string;
 }
 
 /** A single Claude Code `.mcp.json` server entry (http transport). */
@@ -88,10 +92,20 @@ export function buildHarnessProxyMcpJson(
     mcpServers[key] = {
       type: "http",
       url: server.proxyUrl,
-      // Header only when a token was minted (hosted plane); the local plane is
-      // gated by the tunnel `?k=` and sends none.
-      ...(server.proxyToken
-        ? { headers: { "X-MCPJam-Proxy-Token": server.proxyToken } }
+      ...(server.proxyToken || server.scopeStepUpCorrelationId
+        ? {
+            headers: {
+              ...(server.proxyToken
+                ? { "X-MCPJam-Proxy-Token": server.proxyToken }
+                : {}),
+              ...(server.scopeStepUpCorrelationId
+                ? {
+                    [HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER]:
+                      server.scopeStepUpCorrelationId,
+                  }
+                : {}),
+            },
+          }
         : {}),
     };
   }

--- a/mcpjam-inspector/server/utils/harness/mcp-config.ts
+++ b/mcpjam-inspector/server/utils/harness/mcp-config.ts
@@ -11,12 +11,16 @@
  *     `.mcp.json` are the tunnel's per-server `?k=` bearer and a per-turn,
  *     server-scoped `X-MCPJam-Proxy-Token` (validated-when-present by
  *     `adapter-http`; see `harness-proxy-token.ts`).
+ *   - the non-secret scope step-up correlation travels in both the proxy URL
+ *     and a header so every supported harness transport preserves it.
  *
  * This is the pure generator. Resolving each server's tunnel URL + minting its
  * token is the caller's job — see `run-harness-turn`.
  */
 export const HARNESS_SCOPE_STEP_UP_CORRELATION_HEADER =
   "X-MCPJam-Scope-Step-Up-Correlation";
+export const HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY =
+  "mcpjam-scope-step-up-correlation";
 
 /** One server, resolved to its MCPJam proxy endpoint + per-turn token. */
 export interface HarnessProxyServerInput {
@@ -91,7 +95,17 @@ export function buildHarnessProxyMcpJson(
   for (const { key, server } of assignServerKeys(servers)) {
     mcpServers[key] = {
       type: "http",
-      url: server.proxyUrl,
+      // Carry the non-secret correlation in the URL as well as the custom
+      // header. Some harness MCP clients/proxy hops omit configured headers
+      // when resuming or posting through the legacy SSE endpoint; the URL is
+      // the one value every transport leg preserves.
+      url: server.scopeStepUpCorrelationId
+        ? appendQueryParam(
+            server.proxyUrl,
+            HARNESS_SCOPE_STEP_UP_CORRELATION_QUERY,
+            server.scopeStepUpCorrelationId,
+          )
+        : server.proxyUrl,
       ...(server.proxyToken || server.scopeStepUpCorrelationId
         ? {
             headers: {
@@ -110,6 +124,12 @@ export function buildHarnessProxyMcpJson(
     };
   }
   return { mcpServers };
+}
+
+function appendQueryParam(url: string, name: string, value: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set(name, value);
+  return parsed.toString();
 }
 
 /** Map each sanitized `.mcp.json` key → the input's original name (the MCPJam

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -122,7 +122,10 @@ import {
   type HarnessMcpProxyStrategy,
 } from "./harness-proxy-strategy.js";
 import { fetchHarnessProxyTokens } from "./harness-proxy-token-client.js";
-import { subscribeHarnessScopeStepUp } from "./harness-scope-step-up.js";
+import {
+  harnessScopeStepUpServerMatches,
+  subscribeHarnessScopeStepUp,
+} from "./harness-scope-step-up.js";
 import { emitInsufficientScopeChunk } from "../../routes/web/hosted-elicitation.js";
 
 /** A minimal writer matching what `createUIMessageStream` hands `execute` and
@@ -512,7 +515,11 @@ export async function runHarnessTurn(
         ? subscribeHarnessScopeStepUp(
             turnId,
             (info) => {
-              if (!selectedServers?.includes(info.serverId)) return;
+              if (
+                !harnessScopeStepUpServerMatches(selectedServers, info.serverId)
+              ) {
+                return;
+              }
               emitInsufficientScopeChunk(writer, undefined, info);
             },
             selectedServers,

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -122,6 +122,8 @@ import {
   type HarnessMcpProxyStrategy,
 } from "./harness-proxy-strategy.js";
 import { fetchHarnessProxyTokens } from "./harness-proxy-token-client.js";
+import { subscribeHarnessScopeStepUp } from "./harness-scope-step-up.js";
+import { emitInsufficientScopeChunk } from "../../routes/web/hosted-elicitation.js";
 
 /** A minimal writer matching what `createUIMessageStream` hands `execute` and
  *  what the no-op (`streamSink: "none"`) path supplies. */
@@ -145,6 +147,7 @@ async function buildHarnessProxyMcpJsonFromManager(args: {
   authHeader: string;
   projectId: string;
   strategy: HarnessMcpProxyStrategy;
+  scopeStepUpCorrelationId: string;
   /** Plugin origin per server id (INS-7). A plugin-contributed server that
    *  can't be delivered fails the turn instead of being skipped. */
   pluginOrigins?: Record<string, RuntimePluginVersion>;
@@ -156,6 +159,7 @@ async function buildHarnessProxyMcpJsonFromManager(args: {
     projectId,
     strategy,
     pluginOrigins,
+    scopeStepUpCorrelationId,
   } = args;
   const configured = selectDeliverableServerIds({
     selectedServerIds,
@@ -213,7 +217,7 @@ async function buildHarnessProxyMcpJsonFromManager(args: {
         serverId: id,
         authHeader,
       });
-      inputs.push({ name: id, proxyUrl: url });
+      inputs.push({ name: id, proxyUrl: url, scopeStepUpCorrelationId });
     }
   }
   return {
@@ -497,6 +501,19 @@ export async function runHarnessTurn(
       aborted = true;
       return;
     }
+    // Harness MCP-server tools run out of process through the generated
+    // `.mcp.json`. The proxy publishes an actionable scope challenge under
+    // this turn's opaque id; bridge it into the same transient stream part the
+    // in-process tool wrapper emits. Correlation by turn (not server) prevents
+    // concurrent chats using the same MCP server from receiving each other's
+    // authorization request.
+    const stopScopeStepUpBridge =
+      harnessMcpProxy?.plane === "local-mcp"
+        ? subscribeHarnessScopeStepUp(turnId, (info) => {
+            if (!selectedServers?.includes(info.serverId)) return;
+            emitInsufficientScopeChunk(writer, undefined, info);
+          })
+        : () => {};
 
     // Hoisted so the catch can close an open text block if the turn fails
     // after emitting text-start.
@@ -642,6 +659,7 @@ export async function runHarnessTurn(
               authHeader,
               projectId,
               strategy: harnessMcpProxy ?? { plane: "local-mcp" },
+              scopeStepUpCorrelationId: turnId,
               // INS-7: plugin-contributed servers ride this SAME proxy path as
               // ordinary server ids (they are ordinary server ids) — the origin
               // map only decides how a delivery failure is reported.
@@ -2035,6 +2053,8 @@ export async function runHarnessTurn(
         rawText: errorText,
         promptIndex,
       });
+    } finally {
+      stopScopeStepUpBridge();
     }
   };
 

--- a/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
+++ b/mcpjam-inspector/server/utils/harness/run-harness-turn.ts
@@ -504,15 +504,19 @@ export async function runHarnessTurn(
     // Harness MCP-server tools run out of process through the generated
     // `.mcp.json`. The proxy publishes an actionable scope challenge under
     // this turn's opaque id; bridge it into the same transient stream part the
-    // in-process tool wrapper emits. Correlation by turn (not server) prevents
-    // concurrent chats using the same MCP server from receiving each other's
-    // authorization request.
+    // in-process tool wrapper emits. Exact turn correlation handles concurrent
+    // chats; the registry's server fallback is used only when one live turn can
+    // possibly receive a stale resumed-session event.
     const stopScopeStepUpBridge =
       harnessMcpProxy?.plane === "local-mcp"
-        ? subscribeHarnessScopeStepUp(turnId, (info) => {
-            if (!selectedServers?.includes(info.serverId)) return;
-            emitInsufficientScopeChunk(writer, undefined, info);
-          })
+        ? subscribeHarnessScopeStepUp(
+            turnId,
+            (info) => {
+              if (!selectedServers?.includes(info.serverId)) return;
+              emitInsufficientScopeChunk(writer, undefined, info);
+            },
+            selectedServers,
+          )
         : () => {};
 
     // Hoisted so the catch can close an open text block if the turn fails

--- a/mcpjam-inspector/server/utils/insufficient-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/insufficient-scope-step-up.ts
@@ -20,6 +20,27 @@ export type ScopeStepUpObserverOptions = {
 };
 
 /**
+ * Convert a thrown MCP tool error into the actionable, serializable step-up
+ * payload shared by both in-process tools and the harness proxy.
+ */
+export function scopeStepUpInfoFromToolError(
+  context: ScopeStepUpToolError,
+): InsufficientScopeInfo | undefined {
+  const challenge = extractInsufficientScopeChallenge(context.error);
+  if (
+    !challenge ||
+    (!challenge.requiredScope?.trim() && !challenge.resourceMetadataUrl?.trim())
+  ) {
+    return undefined;
+  }
+  return {
+    serverId: context.serverId,
+    ...(context.toolCallId ? { toolCallId: context.toolCallId } : {}),
+    ...challenge,
+  };
+}
+
+/**
  * Observe in-process chat tool failures and surface actionable SEP-2350 scope
  * challenges before the AI SDK turns them into model-facing error text.
  *
@@ -27,9 +48,9 @@ export type ScopeStepUpObserverOptions = {
  * stream starts. Tool errors are always rethrown so this wrapper only observes
  * execution; the existing tool-loop error handling remains authoritative.
  *
- * Contract boundary: harness MCP-server tools execute out of process through
- * the generated `.mcp.json`, not through this ToolSet. Supporting scope step-up
- * there requires a correlated harness-proxy-to-chat side channel.
+ * Harness MCP-server tools execute out of process through the generated
+ * `.mcp.json`; their proxy path calls {@link scopeStepUpInfoFromToolError}
+ * directly and forwards the result through the harness turn bridge.
  */
 export function wrapToolsWithScopeStepUp<TTools extends ToolSet>(
   tools: TTools,
@@ -53,13 +74,12 @@ export function wrapToolsWithScopeStepUp<TTools extends ToolSet>(
               const toolCallId = options?.toolCallId;
               observerOptions.onToolError?.({ error, serverId, toolCallId });
 
-              const challenge = extractInsufficientScopeChallenge(error);
-              if (
-                challenge &&
-                (challenge.requiredScope?.trim() ||
-                  challenge.resourceMetadataUrl?.trim())
-              ) {
-                const info = { serverId, toolCallId, ...challenge };
+              const info = scopeStepUpInfoFromToolError({
+                error,
+                serverId,
+                toolCallId,
+              });
+              if (info) {
                 if (observerOptions.emitInsufficientScope) {
                   observerOptions.emitInsufficientScope(info);
                 } else {

--- a/mcpjam-inspector/server/utils/insufficient-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/insufficient-scope-step-up.ts
@@ -2,21 +2,39 @@ import type { ToolSet } from "ai";
 import {
   emitInsufficientScopeChunk,
   type ElicitationChunkWriter,
+  type InsufficientScopeInfo,
 } from "../routes/web/hosted-elicitation.js";
 import { extractInsufficientScopeChallenge } from "./mcp-error-serialize.js";
 
+export type ScopeStepUpToolError = {
+  error: unknown;
+  serverId: string;
+  toolCallId?: string;
+};
+
+export type ScopeStepUpObserverOptions = {
+  /** Observe every tool error before scope-specific handling (for URL elicitation). */
+  onToolError?: (context: ScopeStepUpToolError) => void;
+  /** Override delivery while retaining the shared extraction/actionability gate. */
+  emitInsufficientScope?: (info: InsufficientScopeInfo) => void;
+};
+
 /**
- * Observe local-chat tool failures and surface actionable SEP-2350 scope
- * challenges on the chat stream before the AI SDK turns them into model-facing
- * error text.
+ * Observe in-process chat tool failures and surface actionable SEP-2350 scope
+ * challenges before the AI SDK turns them into model-facing error text.
  *
  * The writer is late-bound because tool preparation completes before the
  * stream starts. Tool errors are always rethrown so this wrapper only observes
  * execution; the existing tool-loop error handling remains authoritative.
+ *
+ * Contract boundary: harness MCP-server tools execute out of process through
+ * the generated `.mcp.json`, not through this ToolSet. Supporting scope step-up
+ * there requires a correlated harness-proxy-to-chat side channel.
  */
 export function wrapToolsWithScopeStepUp<TTools extends ToolSet>(
   tools: TTools,
   getScopeChallengeWriter: () => ElicitationChunkWriter | null,
+  observerOptions: ScopeStepUpObserverOptions = {},
 ): TTools {
   return Object.fromEntries(
     Object.entries(tools as Record<string, any>).map(([name, tool]) => {
@@ -31,21 +49,26 @@ export function wrapToolsWithScopeStepUp<TTools extends ToolSet>(
             try {
               return await execute(input, options);
             } catch (error) {
+              const serverId = tool._serverId ?? "unknown";
+              const toolCallId = options?.toolCallId;
+              observerOptions.onToolError?.({ error, serverId, toolCallId });
+
               const challenge = extractInsufficientScopeChallenge(error);
               if (
                 challenge &&
                 (challenge.requiredScope?.trim() ||
                   challenge.resourceMetadataUrl?.trim())
               ) {
-                emitInsufficientScopeChunk(
-                  getScopeChallengeWriter(),
-                  undefined,
-                  {
-                    serverId: tool._serverId ?? "unknown",
-                    toolCallId: options?.toolCallId,
-                    ...challenge,
-                  },
-                );
+                const info = { serverId, toolCallId, ...challenge };
+                if (observerOptions.emitInsufficientScope) {
+                  observerOptions.emitInsufficientScope(info);
+                } else {
+                  emitInsufficientScopeChunk(
+                    getScopeChallengeWriter(),
+                    undefined,
+                    info,
+                  );
+                }
               }
               throw error;
             }

--- a/mcpjam-inspector/server/utils/insufficient-scope-step-up.ts
+++ b/mcpjam-inspector/server/utils/insufficient-scope-step-up.ts
@@ -1,0 +1,57 @@
+import type { ToolSet } from "ai";
+import {
+  emitInsufficientScopeChunk,
+  type ElicitationChunkWriter,
+} from "../routes/web/hosted-elicitation.js";
+import { extractInsufficientScopeChallenge } from "./mcp-error-serialize.js";
+
+/**
+ * Observe local-chat tool failures and surface actionable SEP-2350 scope
+ * challenges on the chat stream before the AI SDK turns them into model-facing
+ * error text.
+ *
+ * The writer is late-bound because tool preparation completes before the
+ * stream starts. Tool errors are always rethrown so this wrapper only observes
+ * execution; the existing tool-loop error handling remains authoritative.
+ */
+export function wrapToolsWithScopeStepUp<TTools extends ToolSet>(
+  tools: TTools,
+  getScopeChallengeWriter: () => ElicitationChunkWriter | null,
+): TTools {
+  return Object.fromEntries(
+    Object.entries(tools as Record<string, any>).map(([name, tool]) => {
+      if (typeof tool?.execute !== "function") return [name, tool];
+
+      const execute = tool.execute.bind(tool);
+      return [
+        name,
+        {
+          ...tool,
+          execute: async (input: unknown, options: any) => {
+            try {
+              return await execute(input, options);
+            } catch (error) {
+              const challenge = extractInsufficientScopeChallenge(error);
+              if (
+                challenge &&
+                (challenge.requiredScope?.trim() ||
+                  challenge.resourceMetadataUrl?.trim())
+              ) {
+                emitInsufficientScopeChunk(
+                  getScopeChallengeWriter(),
+                  undefined,
+                  {
+                    serverId: tool._serverId ?? "unknown",
+                    toolCallId: options?.toolCallId,
+                    ...challenge,
+                  },
+                );
+              }
+              throw error;
+            }
+          },
+        },
+      ];
+    }),
+  ) as TTools;
+}

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -74,7 +74,7 @@ import type { EffectiveCapabilitySet } from "../services/environments/effective-
 import { exportConnectedServerToolSnapshotForEvalAuthoring } from "./export-helpers.js";
 import { ErrorCode, WebRouteError } from "./../routes/web/errors.js";
 import { readUrlElicitations } from "@/shared/http-tool-calls";
-import { extractInsufficientScopeChallenge } from "./mcp-error-serialize.js";
+import { wrapToolsWithScopeStepUp } from "./insufficient-scope-step-up.js";
 import {
   classifyUiToolApprovals,
   type UiToolApprovalClassification,
@@ -512,7 +512,8 @@ export async function streamWebChatTurn(
     {};
 
   /**
-   * Observe tool-call failures from ANY engine to surface out-of-band notices.
+   * Observe in-process tool-call failures from every ToolSet-driven engine to
+   * surface out-of-band notices.
    *
    * Wrapped here, on the tool set, rather than in the engines: `prepareChatV2`
    * builds this set once and all three consumers share it (MCPJam-free,
@@ -529,80 +530,47 @@ export async function streamWebChatTurn(
    * advertised, so it falls back to the raw stream writer when there is no
    * bridge (SEP-2350).
    *
-   * Rethrows always: this only observes. The engines' own error handling still
-   * produces the tool result the model sees.
+   * Harness MCP-server tools are deliberately outside this contract: the
+   * harness executes them out of process through `.mcp.json`, bypassing this
+   * ToolSet. Supporting their step-up challenges requires a correlated
+   * harness-proxy-to-chat side channel. Host-executed harness tools still pass
+   * through this set.
+   *
+   * The shared wrapper rethrows always: this only observes. The engines' own
+   * error handling still produces the tool result the model sees.
    */
-  const allTools = Object.fromEntries(
-    Object.entries(preparedTools as Record<string, any>).map(([name, tool]) => {
-      if (typeof tool?.execute !== "function") return [name, tool];
-      const execute = tool.execute.bind(tool);
-      return [
-        name,
-        {
-          ...tool,
-          execute: async (input: unknown, options: any) => {
-            try {
-              return await execute(input, options);
-            } catch (error) {
-              const serverId = (tool as any)._serverId ?? "unknown";
-              const elicitations = readUrlElicitations(error);
-              if (elicitations) {
-                runtime.elicitationBridge?.emitUrlRequired({
-                  serverId,
-                  toolCallId: options?.toolCallId,
-                  elicitations,
-                });
-              }
-              // SEP-2350: a runtime `403 insufficient_scope` thrown here is
-              // about to be collapsed by the AI-SDK into a model-facing
-              // error-text part, so route the challenge out-of-band on the
-              // display channel. The client drives the union-scope step-up.
-              const insufficientScope =
-                extractInsufficientScopeChallenge(error);
-              // Only emit a step-up notice the client can ACT on: a
-              // `requiredScope` (the scope to fold into the re-auth union) OR a
-              // `resourceMetadataUrl` (a PRM pointer the client's OAuth flow now
-              // discovers from — SEP-2350 follow-up to #3427). An
-              // `errorDescription`-only challenge carries nothing to
-              // re-authorize with — redirecting for it would burn the bounded
-              // one-attempt budget — so it stays plain error text the model
-              // already sees, consistent with the shared
-              // `isActionableStepUpChallenge` gate.
-              if (
-                insufficientScope &&
-                (insufficientScope.requiredScope?.trim() ||
-                  insufficientScope.resourceMetadataUrl?.trim())
-              ) {
-                const challenge = {
-                  serverId,
-                  toolCallId: options?.toolCallId,
-                  requiredScope: insufficientScope.requiredScope,
-                  resourceMetadataUrl: insufficientScope.resourceMetadataUrl,
-                  errorDescription: insufficientScope.errorDescription,
-                };
-                if (runtime.elicitationBridge) {
-                  // Bridge enriches with the server name from its id→name map.
-                  runtime.elicitationBridge.emitInsufficientScope(challenge);
-                } else {
-                  // No bridge (elicitation unadvertised): still surface the
-                  // step-up display-only on the raw writer. Resolve the display
-                  // name from the same id→name map the bridge uses so a hosted
-                  // Convex `serverId` matches the name-keyed client store; the
-                  // client falls back to `serverId` only when no name resolves.
-                  emitInsufficientScopeChunk(
-                    scopeChallengeWriter,
-                    scopeStepUpServerNamesById[serverId],
-                    challenge,
-                  );
-                }
-              }
-              throw error;
-            }
-          },
-        },
-      ];
-    })
-  ) as typeof preparedTools;
+  const allTools = wrapToolsWithScopeStepUp(
+    preparedTools,
+    () => scopeChallengeWriter,
+    {
+      onToolError: ({ error, serverId, toolCallId }) => {
+        const elicitations = readUrlElicitations(error);
+        if (elicitations) {
+          runtime.elicitationBridge?.emitUrlRequired({
+            serverId,
+            toolCallId,
+            elicitations,
+          });
+        }
+      },
+      emitInsufficientScope: (challenge) => {
+        if (runtime.elicitationBridge) {
+          // Bridge enriches with the server name from its id→name map.
+          runtime.elicitationBridge.emitInsufficientScope(challenge);
+        } else {
+          // No bridge (elicitation unadvertised): still surface the step-up
+          // display-only on the raw writer. Resolve the display name from the
+          // same id→name map the bridge uses so a hosted Convex `serverId`
+          // matches the name-keyed client store.
+          emitInsufficientScopeChunk(
+            scopeChallengeWriter,
+            scopeStepUpServerNamesById[challenge.serverId],
+            challenge,
+          );
+        }
+      },
+    }
+  );
 
   const widgetModelContextSystemPrompt = buildWidgetModelContextSystemPrompt(
     prepare.widgetModelContext ?? []

--- a/mcpjam-inspector/shared/__tests__/inspector-event.test.ts
+++ b/mcpjam-inspector/shared/__tests__/inspector-event.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { isInspectorScopeStepUpEvent } from "../inspector-event";
+
+const validEvent = {
+  kind: "scope_step_up",
+  serverId: "auth-bench",
+  toolCallId: "call-1",
+  requiredScope: "bench:write",
+  resourceMetadataUrl:
+    "https://bench.example/.well-known/oauth-protected-resource",
+  errorDescription: "Additional access required",
+};
+
+describe("isInspectorScopeStepUpEvent", () => {
+  it("accepts a valid event", () => {
+    expect(isInspectorScopeStepUpEvent(validEvent)).toBe(true);
+  });
+
+  it.each([
+    null,
+    undefined,
+    {},
+    { ...validEvent, serverId: "" },
+    { ...validEvent, serverId: " \t " },
+  ])("rejects a missing or blank required field", (value) => {
+    expect(isInspectorScopeStepUpEvent(value)).toBe(false);
+  });
+
+  it.each([
+    ["toolCallId", 1],
+    ["requiredScope", null],
+    ["resourceMetadataUrl", false],
+    ["errorDescription", {}],
+  ])("rejects a non-string optional field: %s", (key, value) => {
+    expect(
+      isInspectorScopeStepUpEvent({ ...validEvent, [key]: value }),
+    ).toBe(false);
+  });
+});

--- a/mcpjam-inspector/shared/inspector-event.ts
+++ b/mcpjam-inspector/shared/inspector-event.ts
@@ -1,0 +1,35 @@
+/**
+ * One-way server → Inspector UI events carried on the local command-bus SSE
+ * connection. Unlike Inspector commands, events require no response and are
+ * not accepted by the command HTTP endpoint.
+ */
+export interface InspectorScopeStepUpEvent {
+  kind: "scope_step_up";
+  serverId: string;
+  toolCallId?: string;
+  requiredScope?: string;
+  resourceMetadataUrl?: string;
+  errorDescription?: string;
+}
+
+export type InspectorEvent = InspectorScopeStepUpEvent;
+
+export function isInspectorScopeStepUpEvent(
+  value: unknown
+): value is InspectorScopeStepUpEvent {
+  if (!value || typeof value !== "object") return false;
+  const event = value as Record<string, unknown>;
+  if (event.kind !== "scope_step_up") return false;
+  if (typeof event.serverId !== "string" || !event.serverId.trim()) {
+    return false;
+  }
+  return (
+    (event.requiredScope === undefined ||
+      typeof event.requiredScope === "string") &&
+    (event.resourceMetadataUrl === undefined ||
+      typeof event.resourceMetadataUrl === "string") &&
+    (event.errorDescription === undefined ||
+      typeof event.errorDescription === "string") &&
+    (event.toolCallId === undefined || typeof event.toolCallId === "string")
+  );
+}


### PR DESCRIPTION
## Summary

- wrap local chat MCP tools so actionable SEP-2350 `insufficient_scope` challenges are emitted as transient `data-elicitation` stream parts
- use one shared scope-observation wrapper for local and hosted chat, while retaining hosted URL elicitation and server-name enrichment through hooks
- late-bind the stream writer across all four local chat dispatch paths while preserving the existing task-created bridge
- add focused tests for challenge emission, gating, custom hosted observers, rethrowing, absent writers, and passthrough behavior

## Root cause

The hosted chat path observed `InsufficientScopeError` failures and surfaced them to the client, but `/api/mcp/chat-v2` passed prepared tools directly to its stream handlers. The AI SDK therefore collapsed the exception into model-facing error text before the existing client step-up handler could see the challenge.

## Impact

Non-harness local playground chat can now drive OAuth scope step-up and retry when an in-process MCP tool returns an actionable SEP-2350 `403 insufficient_scope` challenge. Error-description-only challenges remain suppressed so they do not consume the client's bounded re-auth attempt.

## Harness boundary

Harness MCP-server tools are intentionally outside this change's contract. They execute out of process through the generated `.mcp.json`, bypass the in-process `ToolSet`, and return through `adapter-http`/the hosted harness proxy. Supporting scope step-up there requires a separate correlated proxy-to-chat side channel. Host-executed harness tools that use the in-process tool set remain covered.

## Validation

- focused scope-step-up, hosted elicitation, hosted dispatch, and local chat tests passed
- deterministic MCP route and related regression suite: 515/515 passed
- changed production files produced no TypeScript diagnostics under `server/tsconfig.json`
- formatting and `git diff --check` passed

The real-Chromium `widget-render.integration.test.ts` remains excluded because it is environment-sensitive and unrelated to this change. Repository-wide TypeScript checking also reports existing errors on current `main` outside these changed production files.