### PR TITLE
ci(release): deploy backend before publishing packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,11 +261,20 @@ jobs:
     needs:
       - preflight
       - artifact-gate
+      - deploy-backend-prod
+    # Publishing is gated on the backend deployment because a released client
+    # can start sending a new field the moment it lands on npm. Shipping the
+    # Convex schema first means the window where a fresh client talks to a
+    # backend that does not understand it yet never opens.
     if: |
       always() &&
       needs.preflight.result == 'success' &&
       needs.artifact-gate.result == 'success' &&
-      needs.preflight.outputs.publish_any == 'true'
+      needs.preflight.outputs.publish_any == 'true' &&
+      (
+        !fromJSON(inputs.deploy_backend_prod) ||
+        needs.deploy-backend-prod.result == 'success'
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -338,10 +347,15 @@ jobs:
   deploy-backend-prod:
     needs:
       - preflight
-      - publish-packages
+      - artifact-gate
+    # Runs ahead of publish-packages. `publish_any` is still required so a run
+    # that publishes nothing does not deploy the backend on its own — that was
+    # the effect of the old gate on publish-packages having succeeded.
     if: |
       always() &&
-      needs.publish-packages.result == 'success' &&
+      needs.preflight.result == 'success' &&
+      needs.artifact-gate.result == 'success' &&
+      needs.preflight.outputs.publish_any == 'true' &&
       fromJSON(inputs.deploy_backend_prod)
     runs-on: ubuntu-latest
     environment: backend-production


### PR DESCRIPTION
## What

Inverts two `needs` blocks in `.github/workflows/release.yml` so the backend production deployment runs **before** packages are published to npm.

- `deploy-backend-prod` now hangs off `artifact-gate` instead of `publish-packages`
- `publish-packages` now waits on `deploy-backend-prod`

Resulting job order:

```
preflight → build-mac/build-windows → artifact-gate → deploy-backend-prod → publish-packages → promote-production → finalize
```

## Why

`publish-packages` ran ahead of `deploy-backend-prod`, so a released client reached npm before the Convex schema it depends on was live. Any release that adds a new field to a client payload opens a window where a fresh client talks to a backend that rejects it.

This is not hypothetical — it happened on the 2026-07-29 release:

| Job | Finished (UTC) |
|---|---|
| `publish-packages` | 17:30:41 |
| `deploy-backend-prod` | 17:42:26 |

For those ~12 minutes, clients installed from npm sent the new `oauthProtocolMode` field while production Convex still ran a validator that predated it. One user's server-add failed 6 times (3 clicks, each retried once internally) with `ArgumentValidationError: Object contains extra field 'oauthProtocolMode'` before the deploy caught up and the errors stopped on their own.

About 6 of those 12 minutes were runner queue time between the two jobs, so the gap was both wrongly ordered and wider than the work required.

## Behavior changes to be aware of

**A failed backend deploy now blocks the npm publish.** Previously it couldn't, because publishing had already happened. This is the intended safety property, but it does mean a flaky backend deploy will stop a release rather than half-complete it.

**`deploy-backend-prod` now requires `publish_any == 'true'` explicitly.** The old gate got this implicitly by depending on `publish-packages`, which is itself gated on `publish_any`. Without carrying it over, a release run that publishes nothing would start deploying the backend on its own.

`promote-production` (hosted frontend) was already correctly ordered after the backend and is unchanged.

## Verification

Parsed the workflow YAML and walked the job graph: no cycles, no dangling job references, topological order is as shown above. Not lint-verified locally — `actionlint` isn't installed here, so CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploy the backend to production before publishing packages to npm to avoid client-backend schema mismatches. Publishing now waits for a successful backend deploy, preventing broken installs during releases.

- **Bug Fixes**
  - Inverted CI order: `deploy-backend-prod` runs after `artifact-gate` and before `publish-packages`.
  - A failed backend deploy now blocks the npm publish.
  - `deploy-backend-prod` still requires `publish_any == 'true'` to avoid deploying when nothing is being published.

<sup>Written for commit a39da4c5ff0d9cc22c80e2bef2170e1175470241. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

