### PR TITLE
fix(connect): move the client selector into the Connect nav row

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/GlobalHostBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/GlobalHostBar.tsx
@@ -12,9 +12,10 @@ export function GlobalHostBar({
   const location = useLocation();
   const [previewedHostId, setPreviewedHostId] = usePreviewedHostId(projectId);
 
-  // While the Connect host canvas is open, the client selector lives INSIDE
-  // the canvas (`HostCanvasSelector`) — hide the header instance so the
-  // control isn't duplicated. Mirrors HostsTab's open-canvas condition:
+  // While the Connect host canvas is open, the client selector lives in the
+  // canvas's own nav row (`HostCanvasSelector`, beside Servers|Client) — hide
+  // the header instance so the control isn't duplicated. Mirrors HostsTab's
+  // open-canvas condition:
   // on the hosts route with either a URL host id or a previewed fallback.
   const onHostsRoute =
     location.pathname === routePaths.hosts ||

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -452,13 +452,19 @@ export function HostBuilderViewRedesigned({
     <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
       <div className="@container relative shrink-0 border-b border-border/40 px-4 py-2.5 md:px-8">
         {/* 3-column grid mirrors the Servers view (ConnectViewHeader): the
-            centered selector and the right-side controls each own a column so
-            they can never overlap. The switch is gated on the header's own
-            width via `@container` (not the viewport) so it stacks correctly
-            when the sidebar is open and the container — not the window — is
-            narrow. Below the container breakpoint it stacks into one column. */}
+            client selector, the centered view selector, and the right-side
+            controls each own a column so they can never overlap. The switch is
+            gated on the header's own width via `@container` (not the viewport)
+            so it stacks correctly when the sidebar is open and the container —
+            not the window — is narrow. Below the container breakpoint it
+            stacks into one column. */}
         <div className="flex flex-col items-stretch gap-2 @2xl:grid @2xl:grid-cols-[1fr_auto_1fr] @2xl:items-center @2xl:gap-3">
-          <div className="hidden @2xl:block" aria-hidden="true" />
+          {/* Client selector lives in the nav row rather than floating over
+              the canvas, so Add client / the switcher sit on the same line as
+              Servers|Client instead of overlapping the flow. */}
+          <div className="flex min-w-0 justify-center @2xl:justify-start">
+            <HostCanvasSelector projectId={projectId} activeHostId={hostId} />
+          </div>
           <div className="flex min-w-0 justify-center">
             <ViewModeSelector
               value="host"
@@ -567,19 +573,6 @@ export function HostBuilderViewRedesigned({
                     shellStyle={canvasShellStyle}
                   />
                 </ReactFlowProvider>
-                {/* Client selector pinned top-left over the canvas (fixed
-                    position — it does not pan/zoom with the flow) so it stays
-                    accessible without blocking the canvas content. The
-                    header's GlobalHostBar hides itself while this canvas is
-                    open. */}
-                <div className="pointer-events-none absolute inset-x-0 top-5 z-20 flex justify-start pl-5 pr-2">
-                  <div className="pointer-events-auto">
-                    <HostCanvasSelector
-                      projectId={projectId}
-                      activeHostId={hostId}
-                    />
-                  </div>
-                </div>
               </div>
             </ResizablePanel>
             {focusState.open ? (

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
@@ -22,17 +22,18 @@ import { CreateHostDialog } from "@/components/hosts/CreateHostDialog";
 import { getCatalogHost } from "@mcpjam/sdk/host-compat";
 
 /**
- * Client selector pinned to the top-left of the Connect host canvas.
+ * Client selector for the Connect host canvas, mounted in the canvas nav row
+ * beside the Servers|Client view selector (it used to float over the flow —
+ * one nav row reads as chrome instead of covering canvas content).
  *
  * Replaces the header `HostOverlayBar` while the canvas is open (the header
  * instance hides itself — see `GlobalHostBar`). Layout settled in the #3269
- * review round: two pills pinned top-left so they stay accessible without
- * blocking the canvas —
+ * review round: two pills —
  *   1. an "Add client" pill (left-most) carrying the quick-add template
  *      logos, and
  *   2. a switcher pill (to its right) that opens the full client list.
  * The add action lives only in the left pill; the switcher menu no longer
- * duplicates it. The menu opens downward, over empty canvas below the pills.
+ * duplicates it. The menu opens downward, under its trigger.
  */
 
 const QUICK_ADD_TEMPLATES = ["claude", "chatgpt", "copilot"] as const;
@@ -42,8 +43,13 @@ const LAST_HOST_DELETE_REASON =
   "A project needs at least one client. Create another client first.";
 const ANALYTICS_LOCATION = "host_canvas";
 
+// Sits on the nav row's own surface, so no elevation/blur — just a bordered
+// pill sized to line up with the view selector and the Save button.
 const PILL_CLASS =
-  "flex items-center rounded-2xl border border-border/60 bg-card/95 p-1.5 shadow-lg shadow-black/[0.06] backdrop-blur-sm";
+  "flex items-center rounded-xl border border-border/60 bg-card/60 p-0.5";
+
+/** Height of the interactive controls inside each pill. */
+const CONTROL_HEIGHT = "h-8";
 
 /**
  * Hosts don't persist which catalog template they came from, so the logo is
@@ -192,22 +198,22 @@ export function HostCanvasSelector({
 
   if (isLoading || !active) {
     return (
-      <div className="flex items-center gap-2">
-        <div className="h-14 w-40 animate-pulse rounded-2xl border border-border/60 bg-card/80" />
-        <div className="h-14 w-56 animate-pulse rounded-2xl border border-border/60 bg-card/80" />
+      <div className="flex items-center gap-1.5">
+        <div className="h-9 w-32 animate-pulse rounded-xl border border-border/60 bg-card/80" />
+        <div className="h-9 w-40 animate-pulse rounded-xl border border-border/60 bg-card/80" />
       </div>
     );
   }
 
   return (
     <div
-      className="flex items-center gap-2"
+      className="flex min-w-0 items-center gap-1.5"
       data-testid="host-canvas-selector"
     >
       {/* Add client — left-most. Carries the quick-add template logos so the
           add path stays a single control (the switcher menu no longer has its
           own add action). */}
-      <div className={PILL_CLASS}>
+      <div className={cn(PILL_CLASS, "shrink-0")}>
         <button
           type="button"
           data-testid="host-canvas-add"
@@ -219,7 +225,8 @@ export function HostCanvasSelector({
             openCreateWithTemplate(undefined);
           }}
           className={cn(
-            "inline-flex h-11 items-center gap-1.5 rounded-xl px-3 text-sm font-medium text-primary transition-colors",
+            "inline-flex items-center gap-1.5 rounded-lg px-2.5 text-sm font-medium text-primary transition-colors",
+            CONTROL_HEIGHT,
             "hover:bg-primary/10",
             "focus-visible:ring-2 focus-visible:ring-ring/45 focus-visible:outline-none"
           )}
@@ -228,7 +235,7 @@ export function HostCanvasSelector({
           Add client
         </button>
         <span
-          className="ml-0.5 flex shrink-0 items-center gap-0.5 pr-1"
+          className="ml-0.5 flex shrink-0 items-center gap-0.5 pr-0.5"
           data-testid="host-canvas-quick-add"
         >
           {QUICK_ADD_TEMPLATES.map((id) => {
@@ -246,7 +253,7 @@ export function HostCanvasSelector({
                 data-testid={`host-canvas-quick-add-${id}`}
                 onClick={() => openCreateWithTemplate(id)}
                 className={cn(
-                  "inline-flex size-7 items-center justify-center rounded-md transition-colors",
+                  "inline-flex size-6 items-center justify-center rounded-md transition-colors",
                   "hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
                 )}
               >
@@ -263,7 +270,7 @@ export function HostCanvasSelector({
 
       {/* Switcher — to the right of Add client. Click to see all clients and
           switch between them; per-client delete lives on hover. */}
-      <div className={PILL_CLASS}>
+      <div className={cn(PILL_CLASS, "min-w-0")}>
         <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
           <DropdownMenuTrigger asChild>
             <button
@@ -271,7 +278,8 @@ export function HostCanvasSelector({
               aria-label="Client used for preview"
               data-testid="host-canvas-current"
               className={cn(
-                "flex h-11 items-center gap-2.5 rounded-xl pr-2.5 pl-3.5 outline-none transition-colors",
+                "flex min-w-0 items-center gap-1.5 rounded-lg pr-1.5 pl-2 outline-none transition-colors",
+                CONTROL_HEIGHT,
                 "hover:bg-muted/50 data-[state=open]:bg-muted/50",
                 "focus-visible:ring-2 focus-visible:ring-ring/45"
               )}
@@ -279,18 +287,18 @@ export function HostCanvasSelector({
               <img
                 src={logoFor(active.name)}
                 alt=""
-                className="size-5 shrink-0 object-contain"
+                className="size-4 shrink-0 object-contain"
               />
-              <span className="max-w-[16rem] truncate text-[15px] font-semibold">
+              <span className="max-w-[10rem] truncate text-sm font-semibold">
                 {active.name}
               </span>
-              <span className="rounded-full border border-border/60 px-2 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+              <span className="shrink-0 rounded-full border border-border/60 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-muted-foreground">
                 {activeIndex + 1} / {sortedHosts.length}
               </span>
-              <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+              <ChevronsUpDown className="size-3.5 shrink-0 text-muted-foreground" />
             </button>
           </DropdownMenuTrigger>
-          {/* Opens downward, over the empty canvas below the top-left pills. */}
+          {/* Opens downward, under the trigger — over the canvas below the nav row. */}
           <DropdownMenuContent
             side="bottom"
             align="start"

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
@@ -113,7 +113,7 @@ describe("HostCanvasSelector", () => {
     });
   });
 
-  it("opens the client menu downward, below the top-left pills", async () => {
+  it("opens the client menu downward, below the nav-row pills", async () => {
     const user = userEvent.setup();
     mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
     render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);


### PR DESCRIPTION
## What

The **Add client** pill and the client switcher (`ChatGPT 3/6`) were absolutely positioned over the top-left of the Connect host canvas, floating on top of the flow. They now live in the canvas header's left grid column — the same row as the `Servers | Client` selector.

## Changes

- `HostBuilderViewRedesigned` renders `HostCanvasSelector` in the header's left column (previously an empty spacer) and drops the `absolute … top-5 z-20` overlay wrapper.
- `HostCanvasSelector` restyled for the nav row: flat bordered pills (no `shadow-lg` / `backdrop-blur`), `h-8` controls that line up with the view selector and the Save button, `size-4` logos, `size-6` quick-add buttons, a smaller count chip.
- The client name truncates at `10rem` and both pills carry `min-w-0` / `shrink-0`, so a long client name can't push the centered `Servers | Client` selector off-center. Below the header's `@2xl` container breakpoint the row stacks as it already did.
- Comment in `GlobalHostBar` updated — it still hides the global bar while the canvas is open; the selector just lives in the nav row now rather than over the canvas.

## Verification

- `npm run typecheck:client` — clean.
- `HostCanvasSelector.test.tsx` — 7/7 pass (behavior untouched; only a stale test name updated).
- Not visually smoke-tested in a running app; the change is layout-only, so worth an eyeball on a narrow window before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and styling only in the Connect host builder UI; switching, create, and delete flows are unchanged.
> 
> **Overview**
> Moves **Add client** and the client switcher off the Connect host canvas overlay and into the builder header’s **left column**, on the same row as **Servers | Client** and Save.
> 
> `HostBuilderViewRedesigned` mounts `HostCanvasSelector` in that grid slot (replacing the empty spacer) and removes the `absolute` / `z-20` wrapper over the flow. `HostCanvasSelector` is restyled for nav chrome: flatter bordered pills (`h-8`, no shadow/blur), tighter quick-add controls, and `min-w-0` / shorter name truncation so long client names don’t shove the centered view selector. `GlobalHostBar` behavior is unchanged—it still hides on the open canvas; comments only reflect the new placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c72f0281687d009479b516fae8df542347512a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Connect client selector into the canvas header’s left column so it no longer overlays the canvas, and restyled it to match the nav row. This keeps the Servers | Client selector centered and improves readability on narrow layouts.

- **Bug Fixes**
  - Mounted `HostCanvasSelector` in the header’s left column; removed the absolute overlay.
  - Restyled to flat bordered pills with `h-8` controls, smaller logo/count, and `size-6` quick-add buttons.
  - Truncated client name to 10rem and applied `min-w-0`/`shrink-0` so long names don’t push the centered selector.
  - Updated `GlobalHostBar` comment; it still hides while the canvas is open. Typecheck clean and tests updated/passing.

<sup>Written for commit 73c72f0281687d009479b516fae8df542347512a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

