### PR TITLE
feat(oauth): golden-trace parity harness — capture host OAuth handshakes and diff emulator dances against them (HP-44)

### DIFF
--- a/.changeset/hp-44-golden-trace-parity-harness.md
+++ b/.changeset/hp-44-golden-trace-parity-harness.md
@@ -40,3 +40,12 @@ non-zero on any difference, so it works as a CI gate.
 Ships a committed golden trace of `mcpjam` against itself plus 57 tests, including
 nine negative tests that prove the oracle is not vacuous (a differ hardcoded to
 return parity would pass the positive tests alone).
+
+Also ships a real HTTP MCP server + authorization server that records its own
+traffic as a HAR (`tests/support/oauth-capture-server.ts`), the first golden trace
+of a real third-party host (`claude-code` 2.1.220 — which settled two cells prior
+desk research could not and corrected two it had read from a published CIMD
+document), and the emulator-vs-real-host diff that turns those into a concrete work
+list. Running against real HTTP found four bugs an in-memory fixture could not,
+including one that would have written a live authorization code into a committed
+artifact via a `302 Location` header.

--- a/.changeset/hp-44-golden-trace-parity-harness.md
+++ b/.changeset/hp-44-golden-trace-parity-harness.md
@@ -21,25 +21,55 @@ Three design points that are load-bearing rather than stylistic:
 - **Observations are a tri-state.** `absent` ("captured the leg, field wasn't
   there" — a citable finding) is distinct from `not-observed` ("never captured that
   leg" — a gap carrying no value). The differ reports gaps as loudly as differences
-  but never as passes, and never as emulator bugs.
+  but never as passes, and never as emulator bugs. The tri-state reaches the derived
+  ROLLUPS too: `wiresDisagree`, `headerDisagreesWithInitializeBody` and
+  `userAgent.consistent` are `Observation<boolean>`, not `boolean`, so a partial
+  capture cannot be read as "these agree" — a boolean `false` there was the one place
+  the schema still collapsed "no disagreement" into "could not tell".
 - **`protocolVersionPinning` is recorded as separate fields.** The `initialize` body
   version and the `MCP-Protocol-Version` header are tracked apart, per leg, with
-  `wiresDisagree` as a first-class flag — these genuinely disagree in the wild, and
-  one field would average away the most interesting findings.
+  `wiresDisagree` as a first-class observation — these genuinely disagree in the
+  wild, and one field would average away the most interesting findings.
 - **Traces stamp the resolved OAuth dependency**, not just the host version, because
   most source-verified clients inherit OAuth from `rmcp` or the upstream TS SDK and
   a host-version-only stamp goes stale silently on a dependency bump.
 
 Secrets are redacted at capture time via the existing `redactSensitiveValue`, then
 re-checked by `assertTraceIsRedacted` — a capture that still contains a
-secret-shaped value throws instead of being written.
+secret-shaped value throws instead of being written. The redaction policy is applied
+by CANONICALIZED key, so `accessToken` and `mcp_refresh_token` are caught alongside
+`access_token`; and a `RedactionViolation` reports `matchLength` plus a truncated
+SHA-256 `fingerprint` rather than an excerpt, because a violation travels through
+assertion messages and CI logs that are less protected than the artifact it just
+refused to write.
+
+`traceToOAuthProfile` returns a projection; `mergeTraceOAuthProfile` layers it over
+an existing profile without letting an `unverifiable` field from this trace displace
+evidence another capture already settled.
 
 New CLI: `mcpjam oauth trace capture | ingest-har | diff | to-profile`. `diff` exits
-non-zero on any difference, so it works as a CI gate.
+non-zero on any difference, so it works as a CI gate. Subcommands given `--out` write
+the artifact and emit only a `{ traceId, path }` reference, so stdout stays pipeable.
 
-Ships a committed golden trace of `mcpjam` against itself plus 57 tests, including
-nine negative tests that prove the oracle is not vacuous (a differ hardcoded to
-return parity would pass the positive tests alone).
+Ships a committed golden trace of `mcpjam` against itself plus 125 golden-trace tests
+and 16 CLI tests, including negative tests that prove the oracle is not vacuous (a
+differ hardcoded to return parity would pass the positive tests alone).
+
+The pin-vs-negotiate projection now verifies its own premise. That claim needs one
+client against TWO servers advertising DIFFERENT protocol versions, so a scenario
+records `serverProtocolVersion` and `traceToOAuthProfile` checks it: a contrast trace
+whose server advertised the SAME version — or whose advertised version is unrecorded —
+is refused with a named blocker instead of yielding a `verified` pin. Previously only
+the client identity and the scenario id were checked, and neither can tell those two
+servers apart, so the strongest claim in the module rested on a caller promise.
+
+The cross-vantage test pins the EXACT set of paths on which a client-side and a
+server-side capture of one handshake disagree, so a new disagreement fails the build
+instead of scrolling past in a log. Twenty-two are stack defaults the client never set
+(`user-agent`, `accept-language`, and `accept` on the three legs where the client sets
+none — the legs where it does set `Accept` agree, which is what shows these are
+defaults rather than lost headers). Two are a recorded-vs-sent bug in the OAuth state
+machines, pinned separately as a defect record rather than blessed.
 
 Also ships a real HTTP MCP server + authorization server that records its own
 traffic as a HAR (`tests/support/oauth-capture-server.ts`), the first golden trace

--- a/.changeset/hp-44-golden-trace-parity-harness.md
+++ b/.changeset/hp-44-golden-trace-parity-harness.md
@@ -63,6 +63,28 @@ is refused with a named blocker instead of yielding a `verified` pin. Previously
 the client identity and the scenario id were checked, and neither can tell those two
 servers apart, so the strongest claim in the module rested on a caller promise.
 
+That identity check is now `hostVersion`- and `oauthImplementation`-aware too: pinning
+is a property of the OAuth code a client runs, and that code changes across a binary
+upgrade or a dependency bump with every other identity field unchanged, so a
+claude-code 2.1.220 trace and a 2.2.0 trace no longer pass as "the same client." Either
+stamp being unrecorded on either side disqualifies the contrast rather than assumes it.
+A separate fallback bug is fixed alongside it: a VALID contrast trace missing only its
+`initialize` body used to be told "only one capture is available" and to go re-supply a
+contrast it had already supplied — it now names the actual blocker (re-capture through
+`mcp-initialize`) instead.
+
+Three places that build strings from wire-supplied keys now use a null-prototype
+accumulator rather than `{}`, closing a prototype-pollution gap where a `__proto__` form
+field or DCR field silently vanished instead of being recorded — the oracle would then
+report *absence* for something the client demonstrably sent. A JSON-RPC batch check that
+used `.every()` over a possibly-sparse array is fixed the same way: `.every` skips holes
+rather than testing them, so a hole between two legal envelopes passed as a batch
+vacuously. And two redaction gaps are closed: the human-readable HAR-ingest report now
+strips authority userinfo (`user:pass@`) even on a malformed URL that fails `new URL()`
+parsing, and the capture script's raw-HAR safety check now also catches JSON-encoded
+secrets (`"access_token":"…"`) that its shape-based scan, built for `key=value` and JWT
+syntax, walked straight past.
+
 The cross-vantage test pins the EXACT set of paths on which a client-side and a
 server-side capture of one handshake disagree, so a new disagreement fails the build
 instead of scrolling past in a log. Twenty-two are stack defaults the client never set

--- a/.changeset/hp-44-golden-trace-parity-harness.md
+++ b/.changeset/hp-44-golden-trace-parity-harness.md
@@ -1,0 +1,42 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/cli": minor
+---
+
+feat(oauth): golden-trace parity harness — capture host OAuth handshakes and diff emulator dances against them (HP-44)
+
+Adds `sdk/src/oauth-golden-trace/`: a trace schema, normalizer, and field-by-field
+differ that make "the emulator behaves exactly like the real host" mechanically
+checkable. This is the acceptance oracle for HP-43 emulator enforcement, and the
+evidence source for HP-9 (capability audit) and HP-38 (drift detection).
+
+**Capture** from an in-process emulator run (`captureEmulatorTrace`, reusing the
+existing `OAuthConformanceTest` wire records) or from a proxy HAR of a real host
+(`captureHarTrace`). **Diff** with `diffGoldenTraces` across request ordering,
+endpoints hit, params present/absent, headers, and the DCR body. **Project** onto
+`HostConfigOAuthProfileV1` with `traceToOAuthProfile`.
+
+Three design points that are load-bearing rather than stylistic:
+
+- **Observations are a tri-state.** `absent` ("captured the leg, field wasn't
+  there" — a citable finding) is distinct from `not-observed` ("never captured that
+  leg" — a gap carrying no value). The differ reports gaps as loudly as differences
+  but never as passes, and never as emulator bugs.
+- **`protocolVersionPinning` is recorded as separate fields.** The `initialize` body
+  version and the `MCP-Protocol-Version` header are tracked apart, per leg, with
+  `wiresDisagree` as a first-class flag — these genuinely disagree in the wild, and
+  one field would average away the most interesting findings.
+- **Traces stamp the resolved OAuth dependency**, not just the host version, because
+  most source-verified clients inherit OAuth from `rmcp` or the upstream TS SDK and
+  a host-version-only stamp goes stale silently on a dependency bump.
+
+Secrets are redacted at capture time via the existing `redactSensitiveValue`, then
+re-checked by `assertTraceIsRedacted` — a capture that still contains a
+secret-shaped value throws instead of being written.
+
+New CLI: `mcpjam oauth trace capture | ingest-har | diff | to-profile`. `diff` exits
+non-zero on any difference, so it works as a CI gate.
+
+Ships a committed golden trace of `mcpjam` against itself plus 57 tests, including
+nine negative tests that prove the oracle is not vacuous (a differ hardcoded to
+return parity would pass the positive tests alone).

--- a/cli/src/commands/oauth-trace.ts
+++ b/cli/src/commands/oauth-trace.ts
@@ -1,0 +1,398 @@
+/**
+ * HP-44 — `mcpjam oauth trace` — the golden-trace parity harness CLI.
+ *
+ * Bolted onto the existing `mcpjam oauth conformance` story (HP-39) rather than
+ * built beside it: `capture` runs the same `OAuthConformanceTest` the conformance
+ * command runs and turns its result into a trace, so there is one code path
+ * driving the emulator and one place where its wire behavior is recorded.
+ *
+ * Four verbs:
+ *   capture     run our emulator against a server and write a candidate trace
+ *   ingest-har  turn a proxy capture of a REAL host into a golden trace
+ *   diff        compare two traces field by field — the acceptance oracle
+ *   to-profile  project a trace onto HostConfigOAuthProfileV1
+ *
+ * `diff` exits non-zero on any difference or incomparable finding, so it works as
+ * a CI gate for HP-43 enforcement and HP-38 drift detection. Gaps do NOT fail by
+ * default — an unobserved leg is not evidence of divergence — but `--fail-on-gap`
+ * makes them fail for callers who need full coverage.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+import {
+  OAuthConformanceTest,
+  captureEmulatorTrace,
+  captureHarTrace,
+  diffGoldenTraces,
+  findObservationDrift,
+  formatHarIngestReportHuman,
+  formatTraceDiffHuman,
+  formatTraceSummaryHuman,
+  traceToOAuthProfile,
+  type GoldenTrace,
+  type OAuthConformanceConfig,
+  type TraceDiffMode,
+  type TraceOAuthImplementation,
+  type TraceScenario,
+} from "@mcpjam/sdk";
+import type { Command } from "commander";
+
+import { cliError, setProcessExitCode, usageError, writeResult } from "../lib/output.js";
+import { resolveOAuthOutputFormat, type OAuthOutputFormat } from "../lib/oauth-output.js";
+
+function traceFormat(command: Command): OAuthOutputFormat {
+  const opts = command.optsWithGlobals() as { format?: string };
+  return resolveOAuthOutputFormat(opts.format, process.stdout.isTTY);
+}
+
+function readJsonFile(path: string, label: string): unknown {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (error) {
+    throw cliError(
+      "VALIDATION_ERROR",
+      `${label} could not be read at ${path}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw cliError(
+      "VALIDATION_ERROR",
+      `${label} at ${path} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function readTrace(path: string, label: string): GoldenTrace {
+  const parsed = readJsonFile(path, label) as GoldenTrace;
+  if (parsed?.traceVersion !== 1) {
+    throw cliError(
+      "VALIDATION_ERROR",
+      `${label} at ${path} is not a golden trace (expected traceVersion 1, got ${String(parsed?.traceVersion)}).`,
+    );
+  }
+
+  // A hand-edited trace whose summary no longer follows from its own wire would
+  // skew every downstream verdict, so it is rejected rather than trusted.
+  const drift = findObservationDrift(parsed);
+  if (drift.length > 0) {
+    throw cliError(
+      "VALIDATION_ERROR",
+      `${label} at ${path} has observations that do not follow from its own wire (it may have been hand-edited): ${drift.join("; ")}`,
+    );
+  }
+
+  return parsed;
+}
+
+/**
+ * The scenario block, which GATES any later diff.
+ *
+ * Required rather than inferred: guessing a server's capabilities would let two
+ * genuinely-incomparable captures be compared, and the differ would then report a
+ * conformant client as broken.
+ */
+function readScenario(path: string): TraceScenario {
+  const scenario = readJsonFile(path, "Scenario file") as TraceScenario;
+  if (!scenario?.scenarioId || !scenario?.mcpServerUrl || !scenario?.capabilities) {
+    throw usageError(
+      `Scenario file at ${path} must define scenarioId, mcpServerUrl and capabilities. The capabilities block gates every diff: a client that omits \`resource\` when PRM discovery fails is behaving correctly, and without knowing whether the server published a PRM document the harness cannot tell that from a bug.`,
+    );
+  }
+  return scenario;
+}
+
+/**
+ * Parse `--oauth-implementation pkg@version:resolvedFrom`.
+ *
+ * Five of six source-verified clients inherit OAuth from a dependency, so a trace
+ * stamped only with the host version goes stale on a dependency bump with no
+ * visible signal. The resolved version must come from a lockfile, not a manifest
+ * range.
+ */
+function parseOAuthImplementation(
+  value: string | undefined,
+): TraceOAuthImplementation | undefined {
+  if (!value) return undefined;
+  if (value === "first-party") return { kind: "first-party" };
+
+  const match = /^(.+)@([^@:]+):(.+)$/.exec(value);
+  if (!match) {
+    throw usageError(
+      `--oauth-implementation must be "first-party" or "<package>@<resolved-version>:<resolved-from>" (e.g. "rmcp@2.2.0:Cargo.lock"). Got: ${value}`,
+    );
+  }
+  return {
+    kind: "dependency",
+    package: match[1],
+    version: match[2],
+    resolvedFrom: match[3],
+  };
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function registerOAuthTraceCommands(oauth: Command): void {
+  const trace = oauth
+    .command("trace")
+    .description(
+      "Golden-trace parity harness: capture real host OAuth handshakes and diff emulator dances against them (HP-44)",
+    );
+
+  trace
+    .command("capture")
+    .description(
+      "Run the MCPJam emulator against a server and write a candidate golden trace",
+    )
+    .requiredOption("--server-url <url>", "MCP server URL")
+    .requiredOption(
+      "--scenario <path>",
+      "Path to a JSON scenario file describing the test server's capabilities (gates any later diff)",
+    )
+    .requiredOption("--out <path>", "Write the trace JSON to <path>")
+    .option("--host-id <id>", "Catalog host id whose behavior is being emulated", "mcpjam")
+    .option(
+      "--protocol-version <version>",
+      "MCP protocol version for the flow",
+      "2025-11-25",
+    )
+    .option(
+      "--registration-strategy <strategy>",
+      "dcr | cimd | preregistered",
+      "dcr",
+    )
+    .option("--redirect-url <url>", "OAuth redirect URL to use for the flow")
+    .option("--scopes <scopes>", "Space-separated scope string")
+    .option("--client-id <id>", "Pre-registered OAuth client ID")
+    .option("--client-secret <secret>", "Pre-registered OAuth client secret")
+    .option(
+      "--captured-at <date>",
+      "ISO calendar date (YYYY-MM-DD) to stamp on the trace. Defaults to today.",
+    )
+    .option("--host-version <version>", "Version of the emulated host build")
+    .option(
+      "--oauth-implementation <spec>",
+      '"first-party" or "<package>@<resolved-version>:<resolved-from>", e.g. "rmcp@2.2.0:Cargo.lock"',
+    )
+    .option("--state-machine <name>", "State machine that ran, e.g. debug-oauth-2025-11-25")
+    .action(async (options, command) => {
+      const format = traceFormat(command);
+      const scenario = readScenario(options.scenario as string);
+
+      const config: OAuthConformanceConfig = {
+        serverUrl: options.serverUrl as string,
+        protocolVersion: options.protocolVersion as OAuthConformanceConfig["protocolVersion"],
+        registrationStrategy:
+          options.registrationStrategy as OAuthConformanceConfig["registrationStrategy"],
+        auth: { mode: "interactive" },
+        ...(options.redirectUrl ? { redirectUrl: options.redirectUrl as string } : {}),
+        ...(options.scopes ? { scopes: options.scopes as string } : {}),
+        ...(options.clientId
+          ? {
+              client: {
+                preregistered: {
+                  clientId: options.clientId as string,
+                  ...(options.clientSecret
+                    ? { clientSecret: options.clientSecret as string }
+                    : {}),
+                },
+              },
+            }
+          : {}),
+      };
+
+      const result = await new OAuthConformanceTest(config).run();
+
+      const captured = captureEmulatorTrace({
+        result,
+        hostId: options.hostId as string,
+        scenario,
+        capturedAt: (options.capturedAt as string | undefined) ?? todayIso(),
+        capturedAtExact: new Date().toISOString(),
+        ...(options.hostVersion ? { hostVersion: options.hostVersion as string } : {}),
+        ...(parseOAuthImplementation(options.oauthImplementation as string | undefined)
+          ? {
+              oauthImplementation: parseOAuthImplementation(
+                options.oauthImplementation as string,
+              )!,
+            }
+          : {}),
+        ...(options.stateMachine ? { stateMachine: options.stateMachine as string } : {}),
+      });
+
+      writeFileSync(options.out as string, `${JSON.stringify(captured, null, 2)}\n`, "utf8");
+
+      writeResult(
+        {
+          traceId: captured.traceId,
+          path: options.out as string,
+          exchanges: captured.wire.length,
+          legOrder: captured.observations.legOrder,
+          conformancePassed: result.passed,
+          summary: formatTraceSummaryHuman(captured),
+        },
+        format,
+      );
+
+      // A capture that did not complete the flow still produces a usable trace
+      // (its unreached legs become `not-observed` gaps), but the caller should
+      // know the run failed.
+      if (!result.passed) setProcessExitCode(1);
+    });
+
+  trace
+    .command("ingest-har")
+    .description(
+      "Turn a proxy capture (HAR 1.2) of a REAL host handshake into a golden trace",
+    )
+    .requiredOption("--har <path>", "Path to the HAR file")
+    .requiredOption(
+      "--scenario <path>",
+      "Path to a JSON scenario file describing the server the host was pointed at",
+    )
+    .requiredOption("--host-id <id>", "Catalog host id that was captured")
+    .requiredOption("--out <path>", "Write the trace JSON to <path>")
+    .option("--captured-at <date>", "ISO calendar date. Defaults to the HAR's first entry.")
+    .option("--host-version <version>", "Version of the host build that was captured")
+    .option(
+      "--oauth-implementation <spec>",
+      '"first-party" or "<package>@<resolved-version>:<resolved-from>". Strongly recommended: without it the trace cannot detect a dependency bump.',
+    )
+    .option("--surface <surface>", "Which surface of a multi-surface client, e.g. web | desktop | cli")
+    .option("--build <build>", "Which build, e.g. official | oss")
+    .option("--operator <name>", "Who ran the capture")
+    .option(
+      "--note <text>",
+      "Caveat a reviewer needs. Repeat for several.",
+      (value: string, previous: string[] = []) => [...previous, value],
+      [],
+    )
+    .action(async (options, command) => {
+      const format = traceFormat(command);
+      const scenario = readScenario(options.scenario as string);
+      const har = readJsonFile(options.har as string, "HAR file");
+
+      const { trace: ingested, report } = captureHarTrace({
+        har,
+        hostId: options.hostId as string,
+        scenario,
+        ...(options.capturedAt ? { capturedAt: options.capturedAt as string } : {}),
+        ...(options.hostVersion ? { hostVersion: options.hostVersion as string } : {}),
+        ...(parseOAuthImplementation(options.oauthImplementation as string | undefined)
+          ? {
+              oauthImplementation: parseOAuthImplementation(
+                options.oauthImplementation as string,
+              )!,
+            }
+          : {}),
+        ...(options.surface ? { surface: options.surface as string } : {}),
+        ...(options.build ? { build: options.build as string } : {}),
+        ...(options.operator ? { operator: options.operator as string } : {}),
+        ...((options.note as string[]).length > 0
+          ? { notes: options.note as string[] }
+          : {}),
+      });
+
+      writeFileSync(options.out as string, `${JSON.stringify(ingested, null, 2)}\n`, "utf8");
+
+      if (format === "human") {
+        process.stdout.write(`${formatTraceSummaryHuman(ingested)}\n\n`);
+        process.stdout.write(`${formatHarIngestReportHuman(report)}\n`);
+        return;
+      }
+
+      writeResult(
+        { traceId: ingested.traceId, path: options.out as string, report },
+        format,
+      );
+    });
+
+  trace
+    .command("diff")
+    .description(
+      "Diff a candidate trace against a golden one, field by field. Exits 1 on any difference.",
+    )
+    .requiredOption("--golden <path>", "Golden trace (recorded from the real host)")
+    .requiredOption("--candidate <path>", "Candidate trace (produced by our emulator)")
+    .option(
+      "--mode <mode>",
+      "parity (emulator vs real host) or drift (same subject, two dates). Defaults to auto-detect.",
+    )
+    .option(
+      "--fail-on-gap",
+      "Also exit 1 when any field was not comparable. Off by default: an unobserved leg is not evidence of divergence.",
+    )
+    .option(
+      "--ignore-header <name>",
+      "Exclude a header from value comparison. Repeat for several.",
+      (value: string, previous: string[] = []) => [...previous, value],
+      [],
+    )
+    .action(async (options, command) => {
+      const format = traceFormat(command);
+      const golden = readTrace(options.golden as string, "Golden trace");
+      const candidate = readTrace(options.candidate as string, "Candidate trace");
+
+      const rawMode = options.mode as string | undefined;
+      if (rawMode && rawMode !== "parity" && rawMode !== "drift") {
+        throw usageError(`--mode must be "parity" or "drift". Got: ${rawMode}`);
+      }
+      const mode: TraceDiffMode | undefined = rawMode as TraceDiffMode | undefined;
+
+      const result = diffGoldenTraces(golden, candidate, {
+        ...(mode ? { mode } : {}),
+        ignoreHeaders: options.ignoreHeader as string[],
+      });
+
+      if (format === "human") {
+        process.stdout.write(`${formatTraceDiffHuman(result)}\n`);
+      } else {
+        writeResult(result, format);
+      }
+
+      if (!result.parity) {
+        setProcessExitCode(1);
+      } else if (options.failOnGap && result.counts.gap > 0) {
+        setProcessExitCode(1);
+      }
+    });
+
+  trace
+    .command("to-profile")
+    .description(
+      "Project a trace onto HostConfigOAuthProfileV1, with a citation and a capture date on every field",
+    )
+    .requiredOption("--trace <path>", "Path to the golden trace")
+    .option(
+      "--trace-path <path>",
+      "Repo-relative path to cite as the source. Defaults to --trace.",
+    )
+    .option(
+      "--contrast-trace <path>",
+      "A second trace of the same host against a server advertising a DIFFERENT protocol version. The only way protocolVersionPinning can be settled for the initialize body.",
+    )
+    .option("--out <path>", "Write the profile JSON to <path> instead of stdout")
+    .action(async (options, command) => {
+      const format = traceFormat(command);
+      const source = readTrace(options.trace as string, "Trace");
+      const contrast = options.contrastTrace
+        ? readTrace(options.contrastTrace as string, "Contrast trace")
+        : undefined;
+
+      const profile = traceToOAuthProfile(source, {
+        tracePath: (options.tracePath as string | undefined) ?? (options.trace as string),
+        ...(contrast ? { contrastTrace: contrast } : {}),
+      });
+
+      if (options.out) {
+        writeFileSync(options.out as string, `${JSON.stringify(profile, null, 2)}\n`, "utf8");
+      }
+
+      writeResult(profile, format);
+    });
+}

--- a/cli/src/commands/oauth-trace.ts
+++ b/cli/src/commands/oauth-trace.ts
@@ -86,6 +86,19 @@ export function readTrace(path: string, label: string): GoldenTrace {
   }
   if (!parsed.scenario || typeof parsed.scenario !== "object") {
     missing.push("scenario (must be an object)");
+  } else {
+    // An empty `{}` passed the object check above and then reached
+    // `findObservationDrift`, which derives observations against a scenario
+    // with no `capabilities` — silently wrong rather than caught here, and
+    // presented to the user as a misleading drift error instead of the
+    // structural one this block promises. Same required fields `readScenario`
+    // already enforces for a standalone scenario file, so a trace's embedded
+    // scenario is held to the same bar.
+    if (!parsed.scenario.scenarioId) missing.push("scenario.scenarioId");
+    if (!parsed.scenario.mcpServerUrl) missing.push("scenario.mcpServerUrl");
+    if (!parsed.scenario.capabilities || typeof parsed.scenario.capabilities !== "object") {
+      missing.push("scenario.capabilities (must be an object)");
+    }
   }
   if (missing.length > 0) {
     throw cliError(

--- a/cli/src/commands/oauth-trace.ts
+++ b/cli/src/commands/oauth-trace.ts
@@ -75,6 +75,25 @@ export function readTrace(path: string, label: string): GoldenTrace {
     );
   }
 
+  // Structural check BEFORE the drift check, which walks `wire` and `observations`
+  // and would otherwise throw a raw TypeError at the user for a file that is
+  // merely malformed — the one class of bad input that escaped the CliError
+  // contract every other malformed input here gets.
+  const missing: string[] = [];
+  if (!Array.isArray(parsed.wire)) missing.push("wire (must be an array)");
+  if (!parsed.observations || typeof parsed.observations !== "object") {
+    missing.push("observations (must be an object)");
+  }
+  if (!parsed.scenario || typeof parsed.scenario !== "object") {
+    missing.push("scenario (must be an object)");
+  }
+  if (missing.length > 0) {
+    throw cliError(
+      "VALIDATION_ERROR",
+      `${label} at ${path} declares traceVersion 1 but is not a structurally valid golden trace — missing or malformed: ${missing.join(", ")}.`,
+    );
+  }
+
   // A hand-edited trace whose summary no longer follows from its own wire would
   // skew every downstream verdict, so it is rejected rather than trusted.
   const drift = findObservationDrift(parsed);
@@ -169,7 +188,10 @@ export function registerOAuthTraceCommands(oauth: Command): void {
     .option("--redirect-url <url>", "OAuth redirect URL to use for the flow")
     .option("--scopes <scopes>", "Space-separated scope string")
     .option("--client-id <id>", "Pre-registered OAuth client ID")
-    .option("--client-secret <secret>", "Pre-registered OAuth client secret")
+    .option(
+      "--client-secret <secret>",
+      "Pre-registered OAuth client secret. Prefer the MCPJAM_OAUTH_CLIENT_SECRET environment variable — an argv value is visible to any process that can read the process list",
+    )
     .option(
       "--captured-at <date>",
       "ISO calendar date (YYYY-MM-DD) to stamp on the trace. Defaults to today.",
@@ -184,6 +206,27 @@ export function registerOAuthTraceCommands(oauth: Command): void {
       const format = traceFormat(command);
       const scenario = readScenario(options.scenario as string);
 
+      // An argv secret is readable by any process that can list processes, and on
+      // a shared or CI box that is everyone. The environment variable is the
+      // lesser evil and is preferred when both are present, so a caller migrating
+      // to it does not have to remove the flag in the same change.
+      const clientSecret =
+        process.env.MCPJAM_OAUTH_CLIENT_SECRET || (options.clientSecret as string | undefined);
+      if (options.clientSecret && process.env.MCPJAM_OAUTH_CLIENT_SECRET) {
+        process.stderr.write(
+          "warning: both --client-secret and MCPJAM_OAUTH_CLIENT_SECRET are set; using the environment variable.\n",
+        );
+      }
+
+      // A secret is only ever carried on the preregistered client block, which
+      // exists only when a client id was given. Silently dropping it would let a
+      // run fail at the token leg for a reason the caller cannot see from here.
+      if (clientSecret && !options.clientId) {
+        throw usageError(
+          "A client secret requires --client-id (secret supplied via --client-secret or MCPJAM_OAUTH_CLIENT_SECRET).",
+        );
+      }
+
       const config: OAuthConformanceConfig = {
         serverUrl: options.serverUrl as string,
         protocolVersion: options.protocolVersion as OAuthConformanceConfig["protocolVersion"],
@@ -197,9 +240,7 @@ export function registerOAuthTraceCommands(oauth: Command): void {
               client: {
                 preregistered: {
                   clientId: options.clientId as string,
-                  ...(options.clientSecret
-                    ? { clientSecret: options.clientSecret as string }
-                    : {}),
+                  ...(clientSecret ? { clientSecret } : {}),
                 },
               },
             }
@@ -391,6 +432,12 @@ export function registerOAuthTraceCommands(oauth: Command): void {
 
       if (options.out) {
         writeFileSync(options.out as string, `${JSON.stringify(profile, null, 2)}\n`, "utf8");
+        // `--out` writes the profile INSTEAD of printing it, so only a reference to
+        // the artifact goes to stdout. Echoing the profile as well would contaminate
+        // anything piping stdout into a second tool, and `capture` / `ingest-har`
+        // already hold to the same contract.
+        writeResult({ traceId: source.traceId, path: options.out as string }, format);
+        return;
       }
 
       writeResult(profile, format);

--- a/cli/src/commands/oauth-trace.ts
+++ b/cli/src/commands/oauth-trace.ts
@@ -66,7 +66,7 @@ function readJsonFile(path: string, label: string): unknown {
   }
 }
 
-function readTrace(path: string, label: string): GoldenTrace {
+export function readTrace(path: string, label: string): GoldenTrace {
   const parsed = readJsonFile(path, label) as GoldenTrace;
   if (parsed?.traceVersion !== 1) {
     throw cliError(
@@ -95,7 +95,7 @@ function readTrace(path: string, label: string): GoldenTrace {
  * genuinely-incomparable captures be compared, and the differ would then report a
  * conformant client as broken.
  */
-function readScenario(path: string): TraceScenario {
+export function readScenario(path: string): TraceScenario {
   const scenario = readJsonFile(path, "Scenario file") as TraceScenario;
   if (!scenario?.scenarioId || !scenario?.mcpServerUrl || !scenario?.capabilities) {
     throw usageError(
@@ -113,7 +113,7 @@ function readScenario(path: string): TraceScenario {
  * visible signal. The resolved version must come from a lockfile, not a manifest
  * range.
  */
-function parseOAuthImplementation(
+export function parseOAuthImplementation(
   value: string | undefined,
 ): TraceOAuthImplementation | undefined {
   if (!value) return undefined;

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -41,6 +41,7 @@ import {
   resolveConformanceOutputFormatForCli,
 } from "../lib/conformance-output.js";
 import { readInputSource } from "../lib/json-input.js";
+import { registerOAuthTraceCommands } from "./oauth-trace.js";
 import { parseReporterFormat, type ReporterFormat } from "../lib/reporting.js";
 import {
   buildCommandArtifactError,
@@ -484,6 +485,8 @@ export function registerOAuthCommands(program: Command): void {
         setProcessExitCode(1);
       }
     });
+
+  registerOAuthTraceCommands(oauth);
 
   oauth
     .command("metadata")

--- a/cli/tests/oauth-trace.test.ts
+++ b/cli/tests/oauth-trace.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  parseOAuthImplementation,
+  readScenario,
+  readTrace,
+} from "../src/commands/oauth-trace.js";
+import { CliError } from "../src/lib/output.js";
+
+const FIXTURE_TRACE = join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "sdk",
+  "tests",
+  "fixtures",
+  "golden-traces",
+  "mcpjam-in-memory-dcr-authcode-prm.json",
+);
+
+function tempFile(name: string, contents: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), "mcpjam-hp44-"));
+  const path = join(dir, name);
+  writeFileSync(path, JSON.stringify(contents, null, 2), "utf8");
+  return path;
+}
+
+test("parseOAuthImplementation accepts first-party", () => {
+  assert.deepEqual(parseOAuthImplementation("first-party"), {
+    kind: "first-party",
+  });
+});
+
+test("parseOAuthImplementation parses a resolved dependency", () => {
+  // Most source-verified clients inherit OAuth from a dependency, so the resolved
+  // version has to come from a lockfile rather than a manifest range.
+  assert.deepEqual(parseOAuthImplementation("rmcp@2.2.0:Cargo.lock"), {
+    kind: "dependency",
+    package: "rmcp",
+    version: "2.2.0",
+    resolvedFrom: "Cargo.lock",
+  });
+});
+
+test("parseOAuthImplementation handles a scoped package name", () => {
+  assert.deepEqual(
+    parseOAuthImplementation(
+      "@modelcontextprotocol/sdk@1.29.0:package-lock.json",
+    ),
+    {
+      kind: "dependency",
+      package: "@modelcontextprotocol/sdk",
+      version: "1.29.0",
+      resolvedFrom: "package-lock.json",
+    },
+  );
+});
+
+test("parseOAuthImplementation returns undefined when omitted", () => {
+  assert.equal(parseOAuthImplementation(undefined), undefined);
+});
+
+test("parseOAuthImplementation rejects a malformed spec", () => {
+  assert.throws(() => parseOAuthImplementation("rmcp-2.2.0"), CliError);
+});
+
+test("readTrace loads the committed golden trace", () => {
+  const trace = readTrace(FIXTURE_TRACE, "Golden trace");
+  assert.equal(trace.traceVersion, 1);
+  assert.equal(trace.subject.hostId, "mcpjam");
+  assert.deepEqual(trace.observations.legOrder, [
+    "mcp-unauthenticated",
+    "prm-discovery",
+    "as-metadata-discovery",
+    "dcr-register",
+    "authorize",
+    "token",
+    "mcp-initialize",
+  ]);
+});
+
+test("readTrace rejects a file that is not a golden trace", () => {
+  const path = tempFile("not-a-trace.json", { hello: "world" });
+  assert.throws(() => readTrace(path, "Golden trace"), CliError);
+});
+
+test("readTrace rejects a trace whose observations no longer follow from its wire", () => {
+  // A hand-edited artifact would skew every downstream verdict, so it is rejected
+  // rather than trusted. This guard caught a hand-edit during development.
+  const trace = readTrace(FIXTURE_TRACE, "Golden trace");
+  const tampered = {
+    ...trace,
+    wire: trace.wire.map((exchange) => {
+      const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+      if (next.request.body?.encoding === "form") {
+        delete next.request.body.fields.resource;
+      }
+      return next;
+    }),
+  };
+
+  const path = tempFile("tampered.json", tampered);
+  assert.throws(
+    () => readTrace(path, "Golden trace"),
+    (error: unknown) =>
+      error instanceof CliError &&
+      /do not follow from its own wire/.test(error.message),
+  );
+});
+
+test("readTrace surfaces a missing file as a validation error", () => {
+  assert.throws(
+    () => readTrace(join(tmpdir(), "definitely-not-here-hp44.json"), "Golden trace"),
+    CliError,
+  );
+});
+
+test("readScenario requires the capabilities block that gates every diff", () => {
+  // Without knowing whether the server published a PRM document, the harness
+  // cannot tell a client that correctly omits `resource` from one that is broken.
+  const path = tempFile("scenario.json", {
+    scenarioId: "x",
+    mcpServerUrl: "https://mcp.example.test/mcp",
+  });
+  assert.throws(
+    () => readScenario(path),
+    (error: unknown) =>
+      error instanceof CliError && /capabilities/.test(error.message),
+  );
+});
+
+test("readScenario accepts a complete scenario", () => {
+  const path = tempFile("scenario.json", {
+    scenarioId: "in-memory-dcr-authcode-prm",
+    mcpServerUrl: "https://mcp.example.test/mcp",
+    authorizationServerUrl: "https://as.example.test",
+    capabilities: {
+      publishesPrm: true,
+      prmResource: "https://mcp.example.test/mcp",
+      supportsDcr: true,
+      supportsCimd: false,
+      codeChallengeMethods: ["S256"],
+      asMetadataDocuments: ["/.well-known/oauth-authorization-server"],
+      challengesUnauthenticated: true,
+    },
+  });
+
+  const scenario = readScenario(path);
+  assert.equal(scenario.scenarioId, "in-memory-dcr-authcode-prm");
+  assert.equal(scenario.capabilities.publishesPrm, true);
+});

--- a/cli/tests/oauth-trace.test.ts
+++ b/cli/tests/oauth-trace.test.ts
@@ -1,18 +1,26 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { Command } from "commander";
 
 import {
   parseOAuthImplementation,
   readScenario,
   readTrace,
+  registerOAuthTraceCommands,
 } from "../src/commands/oauth-trace.js";
 import { CliError } from "../src/lib/output.js";
 
+// `import.meta.dirname` only landed in Node 20.11, and the package declares
+// `>=20.0.0`.
+const HERE = dirname(fileURLToPath(import.meta.url));
+
 const FIXTURE_TRACE = join(
-  import.meta.dirname,
+  HERE,
   "..",
   "..",
   "sdk",
@@ -27,6 +35,42 @@ function tempFile(name: string, contents: unknown): string {
   const path = join(dir, name);
   writeFileSync(path, JSON.stringify(contents, null, 2), "utf8");
   return path;
+}
+
+function tempPath(name: string): string {
+  return join(mkdtempSync(join(tmpdir(), "mcpjam-hp44-")), name);
+}
+
+/**
+ * The real command tree, minus the network. `--format` lives on the root program
+ * in production, and `traceFormat` reads it through `optsWithGlobals`, so the
+ * stand-in root has to carry it too or the format would fall back to whether the
+ * test runner happens to own a TTY.
+ */
+function buildTraceProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.option("--format <format>", "json | human");
+  const oauth = program.command("oauth");
+  registerOAuthTraceCommands(oauth);
+  return program;
+}
+
+async function captureStdout(run: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const original = process.stdout.write;
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    chunks.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+    );
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await run();
+  } finally {
+    process.stdout.write = original;
+  }
+  return chunks.join("");
 }
 
 test("parseOAuthImplementation accepts first-party", () => {
@@ -112,6 +156,27 @@ test("readTrace rejects a trace whose observations no longer follow from its wir
   );
 });
 
+test("readTrace rejects a structurally invalid trace as a CliError, not a TypeError", () => {
+  // `{"traceVersion": 1}` clears the version check and used to reach the drift
+  // walk, which mapped over an undefined `wire` and threw a raw TypeError — the
+  // one malformed input that escaped the CliError contract every other one gets.
+  for (const body of [
+    { traceVersion: 1 },
+    { traceVersion: 1, wire: "not-an-array", observations: {}, scenario: {} },
+    { traceVersion: 1, wire: [], scenario: {} },
+    { traceVersion: 1, wire: [], observations: {} },
+  ]) {
+    const path = tempFile("structurally-invalid.json", body);
+    assert.throws(
+      () => readTrace(path, "Golden trace"),
+      (error: unknown) =>
+        error instanceof CliError &&
+        /not a structurally valid golden trace/.test(error.message),
+      `expected a CliError for ${JSON.stringify(body)}`,
+    );
+  }
+});
+
 test("readTrace surfaces a missing file as a validation error", () => {
   assert.throws(
     () => readTrace(join(tmpdir(), "definitely-not-here-hp44.json"), "Golden trace"),
@@ -152,4 +217,137 @@ test("readScenario accepts a complete scenario", () => {
   const scenario = readScenario(path);
   assert.equal(scenario.scenarioId, "in-memory-dcr-authcode-prm");
   assert.equal(scenario.capabilities.publishesPrm, true);
+});
+
+test("to-profile prints the profile to stdout when --out is absent", async () => {
+  const program = buildTraceProgram();
+  const output = await captureStdout(async () => {
+    await program.parseAsync(
+      ["--format", "json", "oauth", "trace", "to-profile", "--trace", FIXTURE_TRACE],
+      { from: "user" },
+    );
+  });
+
+  const printed = JSON.parse(output) as Record<string, unknown>;
+  assert.ok(printed.dcrIdentity, "the profile itself should be on stdout");
+});
+
+test("to-profile --out keeps the profile off stdout", async () => {
+  // The option is documented as writing the profile INSTEAD of printing it, so a
+  // caller piping stdout into a second tool must not also receive the payload.
+  const out = tempPath("profile.json");
+  const program = buildTraceProgram();
+  const output = await captureStdout(async () => {
+    await program.parseAsync(
+      [
+        "--format",
+        "json",
+        "oauth",
+        "trace",
+        "to-profile",
+        "--trace",
+        FIXTURE_TRACE,
+        "--out",
+        out,
+      ],
+      { from: "user" },
+    );
+  });
+
+  const written = JSON.parse(readFileSync(out, "utf8")) as Record<string, unknown>;
+  assert.ok(written.dcrIdentity, "the profile should be in the --out file");
+
+  const printed = JSON.parse(output) as Record<string, unknown>;
+  assert.deepEqual(Object.keys(printed).sort(), ["path", "traceId"]);
+  assert.equal(printed.path, out);
+});
+
+test("capture rejects --client-secret without --client-id", async () => {
+  // The secret can only travel on the preregistered client block, which exists
+  // only when a client id was supplied; dropping it silently would surface as a
+  // confusing token-leg failure instead.
+  const scenario = tempFile("scenario.json", {
+    scenarioId: "in-memory-dcr-authcode-prm",
+    mcpServerUrl: "https://mcp.example.test/mcp",
+    capabilities: {
+      publishesPrm: true,
+      supportsDcr: true,
+      supportsCimd: false,
+      codeChallengeMethods: ["S256"],
+      asMetadataDocuments: ["/.well-known/oauth-authorization-server"],
+      challengesUnauthenticated: true,
+    },
+  });
+
+  const program = buildTraceProgram();
+  await assert.rejects(
+    program.parseAsync(
+      [
+        "oauth",
+        "trace",
+        "capture",
+        "--server-url",
+        "https://mcp.example.test/mcp",
+        "--scenario",
+        scenario,
+        "--out",
+        tempPath("trace.json"),
+        "--client-secret",
+        "s3cret",
+      ],
+      { from: "user" },
+    ),
+    (error: unknown) =>
+      error instanceof CliError &&
+      error.code === "USAGE_ERROR" &&
+      /client secret requires --client-id/.test(error.message),
+  );
+});
+
+test("capture reads the client secret from the environment too", async () => {
+  // An argv secret is readable by anyone who can list processes, so the env var is
+  // the documented alternative — and it has to hit the SAME guard, or the safer
+  // path would be the one that silently drops the secret at the token leg.
+  const scenario = tempFile("scenario.json", {
+    scenarioId: "in-memory-dcr-authcode-prm-mcp2025-11-25",
+    mcpServerUrl: "https://mcp.example.test/mcp",
+    capabilities: {
+      publishesPrm: true,
+      supportsDcr: true,
+      supportsCimd: false,
+      codeChallengeMethods: ["S256"],
+      serverProtocolVersion: "2025-11-25",
+      asMetadataDocuments: ["/.well-known/oauth-authorization-server"],
+      challengesUnauthenticated: true,
+    },
+  });
+
+  const previous = process.env.MCPJAM_OAUTH_CLIENT_SECRET;
+  process.env.MCPJAM_OAUTH_CLIENT_SECRET = "s3cret-from-env";
+  try {
+    const program = buildTraceProgram();
+    await assert.rejects(
+      program.parseAsync(
+        [
+          "oauth",
+          "trace",
+          "capture",
+          "--server-url",
+          "https://mcp.example.test/mcp",
+          "--scenario",
+          scenario,
+          "--out",
+          tempPath("trace.json"),
+        ],
+        { from: "user" },
+      ),
+      (error: unknown) =>
+        error instanceof CliError &&
+        error.code === "USAGE_ERROR" &&
+        /client secret requires --client-id/.test(error.message),
+    );
+  } finally {
+    if (previous === undefined) delete process.env.MCPJAM_OAUTH_CLIENT_SECRET;
+    else process.env.MCPJAM_OAUTH_CLIENT_SECRET = previous;
+  }
 });

--- a/cli/tests/oauth-trace.test.ts
+++ b/cli/tests/oauth-trace.test.ts
@@ -165,6 +165,11 @@ test("readTrace rejects a structurally invalid trace as a CliError, not a TypeEr
     { traceVersion: 1, wire: "not-an-array", observations: {}, scenario: {} },
     { traceVersion: 1, wire: [], scenario: {} },
     { traceVersion: 1, wire: [], observations: {} },
+    // `wire` and `observations` alone are structurally fine — an EMPTY `scenario`
+    // used to pass the "is it an object" check and reach `findObservationDrift`
+    // with no `scenarioId`/`mcpServerUrl`/`capabilities`, producing a misleading
+    // drift error instead of the structural one this block promises.
+    { traceVersion: 1, wire: [], observations: {}, scenario: {} },
   ]) {
     const path = tempFile("structurally-invalid.json", body);
     assert.throws(

--- a/sdk/scripts/hp44-capture-host.mts
+++ b/sdk/scripts/hp44-capture-host.mts
@@ -1,0 +1,83 @@
+/**
+ * HP-44 — capture a REAL host's OAuth handshake.
+ *
+ * Starts the recording MCP resource server + authorization server from
+ * `tests/support/oauth-capture-server.ts`, prints the URL to point a host at,
+ * and writes a HAR once the handshake goes quiet.
+ *
+ * Usage:
+ *   npx tsx scripts/hp44-capture-host.mts --port 3999 --out /tmp/host.har
+ *
+ * Then point the host at the printed MCP URL and let it authenticate. The server
+ * auto-approves `/authorize`, so no human needs to click anything — the whole
+ * dance completes unattended.
+ *
+ * Why be the endpoint rather than a proxy: a proxy needs TLS interception and a
+ * trust-store change on the client, either of which can alter the very behavior
+ * we are trying to observe. Being the server records the exact bytes the client
+ * chose to send, with nothing in between. The task's "HAR or equivalent" is
+ * satisfied more faithfully this way, not less.
+ */
+
+import { writeFileSync } from "node:fs";
+
+import { startCaptureServer } from "../tests/support/oauth-capture-server.js";
+
+function arg(name: string, fallback?: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+const port = Number(arg("port", "3999"));
+const out = arg("out", "hp44-capture.har")!;
+/** Exit this long after the LAST request, once at least one has arrived. */
+const idleMs = Number(arg("idle-ms", "6000"));
+/** Hard ceiling, so an unattended run cannot hang forever. */
+const timeoutMs = Number(arg("timeout-ms", "120000"));
+
+const server = await startCaptureServer({ port });
+
+console.log(`[hp44] recording server listening on ${server.origin}`);
+console.log(`[hp44] point your host at:  ${server.mcpUrl}`);
+console.log(`[hp44] scenario id:         ${server.scenario.scenarioId}`);
+console.log(`[hp44] writing HAR to:      ${out}`);
+console.log(`[hp44] will exit ${idleMs}ms after the last request (max ${timeoutMs}ms)`);
+
+let seen = 0;
+let lastCount = 0;
+let idleSince = Date.now();
+const startedAt = Date.now();
+
+function finish(reason: string): never {
+  const har = server.har();
+  writeFileSync(out, JSON.stringify(har, null, 2), "utf8");
+  console.log(
+    `[hp44] ${reason}: wrote ${har.log.entries.length} entries to ${out}`,
+  );
+  for (const entry of har.log.entries) {
+    console.log(
+      `[hp44]   ${entry.response.status} ${entry.request.method} ${entry.request.url}`,
+    );
+  }
+  process.exit(0);
+}
+
+process.on("SIGINT", () => finish("interrupted"));
+
+const tick = setInterval(() => {
+  const count = server.requestCount();
+  if (count !== lastCount) {
+    lastCount = count;
+    seen = count;
+    idleSince = Date.now();
+    console.log(`[hp44] ${count} request(s) recorded`);
+  }
+  if (seen > 0 && Date.now() - idleSince > idleMs) {
+    clearInterval(tick);
+    finish("handshake went quiet");
+  }
+  if (Date.now() - startedAt > timeoutMs) {
+    clearInterval(tick);
+    finish(seen > 0 ? "timeout reached" : "timeout reached with NO requests");
+  }
+}, 500);

--- a/sdk/scripts/hp44-capture-host.mts
+++ b/sdk/scripts/hp44-capture-host.mts
@@ -29,15 +29,36 @@ function arg(name: string, fallback?: string): string | undefined {
 }
 
 const port = Number(arg("port", "3999"));
+/** Bind interface. Use 0.0.0.0 when a tunnel needs to reach us from outside. */
+const host = arg("host", "127.0.0.1")!;
+/**
+ * Public base URL the CLIENT will use, when it differs from where we bind.
+ *
+ * Required for any HOSTED client — Slack, ChatGPT, Claude.ai web, Mistral, Notion,
+ * Perplexity, M365 Copilot. Those perform OAuth from the vendor's own
+ * infrastructure, so `127.0.0.1` resolves to their server and the handshake never
+ * reaches us. Put a tunnel in front and pass its https URL here.
+ */
+const publicOrigin = arg("public-origin");
 const out = arg("out", "hp44-capture.har")!;
 /** Exit this long after the LAST request, once at least one has arrived. */
 const idleMs = Number(arg("idle-ms", "6000"));
 /** Hard ceiling, so an unattended run cannot hang forever. */
 const timeoutMs = Number(arg("timeout-ms", "120000"));
 
-const server = await startCaptureServer({ port });
+const server = await startCaptureServer({
+  port,
+  host,
+  ...(publicOrigin ? { publicOrigin } : {}),
+});
 
-console.log(`[hp44] recording server listening on ${server.origin}`);
+console.log(`[hp44] bound on ${host}:${port}`);
+console.log(`[hp44] advertising itself as ${server.origin}`);
+if (!publicOrigin) {
+  console.log(
+    "[hp44] NOTE: no --public-origin, so only LOCAL clients can reach this. Hosted clients (Slack, ChatGPT, Claude.ai, Mistral, Notion, Perplexity, M365 Copilot) run OAuth from the vendor's own servers and cannot see 127.0.0.1 — put an https tunnel in front and pass --public-origin.",
+  );
+}
 console.log(`[hp44] point your host at:  ${server.mcpUrl}`);
 console.log(`[hp44] scenario id:         ${server.scenario.scenarioId}`);
 console.log(`[hp44] writing HAR to:      ${out}`);

--- a/sdk/scripts/hp44-capture-host.mts
+++ b/sdk/scripts/hp44-capture-host.mts
@@ -3,7 +3,7 @@
  *
  * Starts the recording MCP resource server + authorization server from
  * `tests/support/oauth-capture-server.ts`, prints the URL to point a host at,
- * and writes a HAR once the handshake goes quiet.
+ * and writes the capture once the handshake goes quiet.
  *
  * Usage:
  *   npx tsx scripts/hp44-capture-host.mts --port 3999 --out /tmp/host.har
@@ -11,6 +11,20 @@
  * Then point the host at the printed MCP URL and let it authenticate. The server
  * auto-approves `/authorize`, so no human needs to click anything — the whole
  * dance completes unattended.
+ *
+ * Two artifacts come out, and the asymmetry is deliberate:
+ *
+ *   - the REDACTED golden trace (`--trace-out`), always. Built with
+ *     `captureHarTrace`, so it goes through the same normalization and
+ *     `assertTraceIsRedacted` gate as every committed trace.
+ *   - the RAW HAR (`--out`), only when it contains nothing secret-shaped. It is
+ *     unredacted by construction — the exact bytes the host sent is the point of
+ *     the capture and also the hazard, since a host configured with a real
+ *     `client_secret` or `software_statement` would otherwise have it written to
+ *     disk. In practice any capture that reached `/token` trips the detector, so
+ *     expect it to be withheld; pass `--keep-raw-har` to accept the risk when you
+ *     need to re-ingest through `mcpjam oauth trace ingest-har` for provenance
+ *     this script does not take (resolved OAuth dependency, surface, notes).
  *
  * Why be the endpoint rather than a proxy: a proxy needs TLS interception and a
  * trust-store change on the client, either of which can alter the very behavior
@@ -21,14 +35,90 @@
 
 import { writeFileSync } from "node:fs";
 
+import {
+  captureHarTrace,
+  findRedactionViolations,
+  formatHarIngestReportHuman,
+  formatTraceSummaryHuman,
+} from "../src/oauth-golden-trace/index.js";
 import { startCaptureServer } from "../tests/support/oauth-capture-server.js";
 
+/**
+ * Read `--name <value>` from argv.
+ *
+ * A bare flag at the end of argv, or one immediately followed by another flag,
+ * has NO value — taking the next token would otherwise make `--host --out x`
+ * bind to the interface `"--out"`, and `--host-id --operator me` stamp the
+ * catalog id `"--operator"` into a committed trace. Both are silent: the run
+ * completes and the artifact is wrong. Treat it as absent, say so, and let the
+ * caller's default stand. {@link numberArg} and {@link urlArg} layer their own
+ * validation on top of this.
+ */
 function arg(name: string, fallback?: string): string | undefined {
   const index = process.argv.indexOf(`--${name}`);
-  return index >= 0 ? process.argv[index + 1] : fallback;
+  if (index < 0) return fallback;
+  const value = process.argv[index + 1];
+  if (value == null || value.startsWith("--")) {
+    console.error(
+      `[hp44] --${name} was passed with no value${value == null ? " (end of arguments)" : ` (followed by \`${value}\`)`}.${fallback == null ? " Ignoring it." : ` Using \`${fallback}\`.`}`,
+    );
+    return fallback;
+  }
+  return value;
 }
 
-const port = Number(arg("port", "3999"));
+/**
+ * `arg` already rejects a missing or flag-shaped value, but a present-and-wrong
+ * one (`--timeout-ms abc`) still reaches here, and `Number` turns it into `NaN`,
+ * against which every comparison is false — so a bad `--timeout-ms` would
+ * silently delete the hard ceiling this script advertises and the unattended run
+ * that can never hang, hangs. Fall back to the default instead, loudly, so the
+ * guarantee holds no matter what argv looked like.
+ */
+function numberArg(name: string, fallback: number): number {
+  const raw = arg(name);
+  const value = raw == null || raw.startsWith("--") ? Number.NaN : Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    // Only complain when the flag was actually passed — its absence is the
+    // ordinary case and the default is the documented answer to it.
+    if (process.argv.includes(`--${name}`)) {
+      console.error(
+        `[hp44] --${name} needs a finite, non-negative number; got ${raw == null ? "no value" : `\`${raw}\``}. Using ${fallback}.`,
+      );
+    }
+    return fallback;
+  }
+  return value;
+}
+
+/**
+ * Same argv hazard as {@link numberArg}, with a worse failure mode.
+ *
+ * A bare `--public-origin` takes the NEXT FLAG as its value, and that string then
+ * becomes the origin of every URL this server advertises — the PRM `resource`, the
+ * AS metadata endpoints, the 401 challenge pointer. The capture would either not
+ * happen or record a handshake against a host that never existed. Unlike a bad
+ * `--timeout-ms` there is no safe default to fall back to, so this exits.
+ */
+function urlArg(name: string): string | undefined {
+  if (!process.argv.includes(`--${name}`)) return undefined;
+  const raw = arg(name);
+  let parsed: URL | undefined;
+  try {
+    parsed = raw == null ? undefined : new URL(raw);
+  } catch {
+    parsed = undefined;
+  }
+  if (!parsed || (parsed.protocol !== "http:" && parsed.protocol !== "https:")) {
+    console.error(
+      `[hp44] --${name} needs an absolute http(s) URL; got ${raw == null ? "no value" : `\`${raw}\``}. Pass the tunnel's URL, e.g. --${name} https://example.ngrok.app`,
+    );
+    process.exit(2);
+  }
+  return raw;
+}
+
+const port = numberArg("port", 3999);
 /** Bind interface. Use 0.0.0.0 when a tunnel needs to reach us from outside. */
 const host = arg("host", "127.0.0.1")!;
 /**
@@ -39,12 +129,20 @@ const host = arg("host", "127.0.0.1")!;
  * infrastructure, so `127.0.0.1` resolves to their server and the handshake never
  * reaches us. Put a tunnel in front and pass its https URL here.
  */
-const publicOrigin = arg("public-origin");
+const publicOrigin = urlArg("public-origin");
 const out = arg("out", "hp44-capture.har")!;
+/** Catalog host id being captured. Stamped into the trace id. */
+const hostId = arg("host-id", "unknown-host")!;
+/** Omitting it stamps `not-observed`, which the differ reports as a gap. */
+const hostVersion = arg("host-version");
+const operator = arg("operator");
+const traceOut = arg("trace-out", `${out.replace(/\.har$/i, "")}.trace.json`)!;
+/** Write the raw HAR even when it holds secret-shaped values. See the header. */
+const keepRawHar = process.argv.includes("--keep-raw-har");
 /** Exit this long after the LAST request, once at least one has arrived. */
-const idleMs = Number(arg("idle-ms", "6000"));
+const idleMs = numberArg("idle-ms", 6000);
 /** Hard ceiling, so an unattended run cannot hang forever. */
-const timeoutMs = Number(arg("timeout-ms", "120000"));
+const timeoutMs = numberArg("timeout-ms", 120000);
 
 const server = await startCaptureServer({
   port,
@@ -61,21 +159,100 @@ if (!publicOrigin) {
 }
 console.log(`[hp44] point your host at:  ${server.mcpUrl}`);
 console.log(`[hp44] scenario id:         ${server.scenario.scenarioId}`);
-console.log(`[hp44] writing HAR to:      ${out}`);
+console.log(`[hp44] writing trace to:    ${traceOut}`);
+console.log(`[hp44] writing HAR to:      ${out} (only if it holds no secrets)`);
 console.log(`[hp44] will exit ${idleMs}ms after the last request (max ${timeoutMs}ms)`);
 
-let seen = 0;
 let lastCount = 0;
 let idleSince = Date.now();
 const startedAt = Date.now();
 
+/**
+ * Requests accepted but not yet answered.
+ *
+ * `requestCount()` only sees COMPLETED entries, so idling on it alone can cut the
+ * capture off while a request is still having its body read — the `/token` POST
+ * being the likely victim, and losing it produces a golden trace that is WRONG
+ * rather than merely short, because a missing leg reads as `not-observed`. The
+ * raw server's `request` event fires as soon as headers are parsed, which is
+ * early enough to hold the door open, and `close` fires even for an aborted
+ * response so the counter cannot leak.
+ */
+let inFlight = 0;
+server.raw.on("request", (_request, response) => {
+  inFlight += 1;
+  idleSince = Date.now();
+  response.once("close", () => {
+    inFlight -= 1;
+    idleSince = Date.now();
+  });
+});
+
+function buildTrace(har: ReturnType<typeof server.har>) {
+  try {
+    return captureHarTrace({
+      har,
+      hostId,
+      scenario: server.scenario,
+      ...(hostVersion ? { hostVersion } : {}),
+      ...(operator ? { operator } : {}),
+    });
+  } catch (error) {
+    // `captureHarTrace` runs `assertTraceIsRedacted`, so landing here means the
+    // capture still carries something secret-shaped after normalization. Writing
+    // nothing is the correct outcome: the whole point of the gate is that a
+    // secret never reaches disk.
+    console.error(
+      `[hp44] the capture could not be turned into a redacted trace, so NOTHING was written: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+}
+
 function finish(reason: string): never {
   const har = server.har();
-  writeFileSync(out, JSON.stringify(har, null, 2), "utf8");
-  console.log(
-    `[hp44] ${reason}: wrote ${har.log.entries.length} entries to ${out}`,
-  );
-  for (const entry of har.log.entries) {
+  const entries = har.log.entries;
+
+  if (entries.length === 0) {
+    // Automation has to be able to tell "the host never connected" from a
+    // capture that worked, and an empty HAR is not an artifact worth writing.
+    console.error(
+      `[hp44] ${reason}: NO requests were recorded, so nothing was written. Check that the host is pointed at ${server.mcpUrl}${
+        publicOrigin
+          ? ""
+          : " and that it can actually reach 127.0.0.1 — a hosted client cannot, so pass --public-origin with a tunnel URL"
+      }.`,
+    );
+    process.exit(1);
+  }
+
+  // Build the trace BEFORE writing anything: it is the redaction gate, and a
+  // capture that fails it must not leave a half-written artifact behind.
+  const { trace, report } = buildTrace(har);
+  writeFileSync(traceOut, `${JSON.stringify(trace, null, 2)}\n`, "utf8");
+  console.log(`[hp44] ${reason}: wrote ${trace.wire.length} exchange(s) to ${traceOut}`);
+  console.log(formatTraceSummaryHuman(trace));
+  console.log(formatHarIngestReportHuman(report));
+
+  const violations = findRedactionViolations(har);
+  const detail = violations
+    .map((violation) => `${violation.path}: ${violation.pattern}`)
+    .join("; ");
+  if (violations.length === 0) {
+    writeFileSync(out, JSON.stringify(har, null, 2), "utf8");
+    console.log(`[hp44] raw HAR (${entries.length} entries) written to ${out}`);
+  } else if (keepRawHar) {
+    writeFileSync(out, JSON.stringify(har, null, 2), "utf8");
+    console.error(
+      `[hp44] --keep-raw-har: wrote the UNREDACTED HAR to ${out}, and it contains ${violations.length} secret-shaped value(s) (${detail}). Do not commit it.`,
+    );
+  } else {
+    console.error(
+      `[hp44] the raw HAR was WITHHELD: it contains ${violations.length} secret-shaped value(s) that only the trace pipeline redacts (${detail}). Use ${traceOut}, or pass --keep-raw-har if you accept the risk.`,
+    );
+  }
+
+  for (const entry of entries) {
     console.log(
       `[hp44]   ${entry.response.status} ${entry.request.method} ${entry.request.url}`,
     );
@@ -89,16 +266,22 @@ const tick = setInterval(() => {
   const count = server.requestCount();
   if (count !== lastCount) {
     lastCount = count;
-    seen = count;
     idleSince = Date.now();
     console.log(`[hp44] ${count} request(s) recorded`);
   }
-  if (seen > 0 && Date.now() - idleSince > idleMs) {
+  // `inFlight === 0` is what makes the idle window mean "the host stopped
+  // talking" rather than "the host has not finished this request yet".
+  if (count > 0 && inFlight === 0 && Date.now() - idleSince > idleMs) {
     clearInterval(tick);
     finish("handshake went quiet");
   }
   if (Date.now() - startedAt > timeoutMs) {
     clearInterval(tick);
-    finish(seen > 0 ? "timeout reached" : "timeout reached with NO requests");
+    if (inFlight > 0) {
+      console.error(
+        `[hp44] hard timeout hit with ${inFlight} request(s) still in flight — the capture is TRUNCATED and its last leg(s) will read as not-observed. Re-run with a larger --timeout-ms.`,
+      );
+    }
+    finish(count > 0 ? "timeout reached" : "timeout reached with NO requests");
   }
 }, 500);

--- a/sdk/scripts/hp44-capture-host.mts
+++ b/sdk/scripts/hp44-capture-host.mts
@@ -34,6 +34,7 @@
  */
 
 import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import {
   captureHarTrace,
@@ -41,7 +42,11 @@ import {
   formatHarIngestReportHuman,
   formatTraceSummaryHuman,
 } from "../src/oauth-golden-trace/index.js";
-import { startCaptureServer } from "../tests/support/oauth-capture-server.js";
+import { redactSensitiveValue } from "../src/redaction.js";
+import {
+  startCaptureServer,
+  type CaptureServer,
+} from "../tests/support/oauth-capture-server.js";
 
 /**
  * Read `--name <value>` from argv.
@@ -144,6 +149,18 @@ const idleMs = numberArg("idle-ms", 6000);
 /** Hard ceiling, so an unattended run cannot hang forever. */
 const timeoutMs = numberArg("timeout-ms", 120000);
 
+// `--out` and `--trace-out` naming the SAME file is not two artifacts racing —
+// `finish()` writes `traceOut` first and `out` second, so a collision means the
+// raw, unredacted HAR silently overwrites the redacted trace on disk, which is
+// the exact inversion of the asymmetry this script's header promises. Cheaper
+// to reject at startup than to write both and let the last one win.
+if (resolve(traceOut) === resolve(out)) {
+  console.error(
+    `[hp44] --out and --trace-out resolve to the same path (${resolve(out)}). Writing both would leave the raw HAR sitting where the redacted trace was supposed to be. Pass two different paths.`,
+  );
+  process.exit(2);
+}
+
 const server = await startCaptureServer({
   port,
   host,
@@ -209,6 +226,37 @@ function buildTrace(har: ReturnType<typeof server.har>) {
   }
 }
 
+/**
+ * Catches what {@link findRedactionViolations} structurally cannot.
+ *
+ * `findRedactionViolations` is shape-based over an ALREADY-PARSED trace, where a
+ * secret has been split out into its own string value under some key — so it
+ * looks for `key=value` and JWT/Bearer shapes as strings in their own right. The
+ * raw HAR is not that: `postData.text` is the wire's raw bytes as ONE string, and
+ * a JSON-encoded secret in there reads `"access_token":"eyJ…"` — colon-and-quotes,
+ * never `key=value` — so the shape scan walks straight past it.
+ *
+ * `redactSensitiveValue` already has a rule for exactly that syntax (it is what
+ * catches `body.json` fields during normalization), so this reuses it as a
+ * detector: redact each raw string in isolation and treat any change as a hit.
+ * It cannot fix the raw HAR — redacting in place would defeat the point of a RAW
+ * capture — only prove whether it is safe to write one.
+ */
+function findStructuredSecrets(har: ReturnType<CaptureServer["har"]>): string[] {
+  const hits: string[] = [];
+  const check = (label: string, text: string | undefined): void => {
+    if (!text) return;
+    if (redactSensitiveValue(text) !== text) hits.push(label);
+  };
+  for (const entry of har.log.entries) {
+    const where = `${entry.request.method} ${entry.request.url}`;
+    check(`${where}: url`, entry.request.url);
+    check(`${where}: request body`, entry.request.postData?.text);
+    check(`${where}: response body`, entry.response.content?.text);
+  }
+  return hits;
+}
+
 function finish(reason: string): never {
   const har = server.har();
   const entries = har.log.entries;
@@ -235,20 +283,27 @@ function finish(reason: string): never {
   console.log(formatHarIngestReportHuman(report));
 
   const violations = findRedactionViolations(har);
-  const detail = violations
-    .map((violation) => `${violation.path}: ${violation.pattern}`)
-    .join("; ");
-  if (violations.length === 0) {
+  // Shape-based scan plus the key-aware one: `findRedactionViolations` walks
+  // parsed values looking for `key=value` and token shapes, but the raw HAR's
+  // bodies are un-parsed wire bytes, where a JSON secret reads `"key":"value"`
+  // and the shape scan walks past it. See {@link findStructuredSecrets}.
+  const structuredHits = findStructuredSecrets(har);
+  const detail = [
+    ...violations.map((violation) => `${violation.path}: ${violation.pattern}`),
+    ...structuredHits.map((hit) => `${hit}: structured secret field`),
+  ].join("; ");
+  const hitCount = violations.length + structuredHits.length;
+  if (hitCount === 0) {
     writeFileSync(out, JSON.stringify(har, null, 2), "utf8");
     console.log(`[hp44] raw HAR (${entries.length} entries) written to ${out}`);
   } else if (keepRawHar) {
     writeFileSync(out, JSON.stringify(har, null, 2), "utf8");
     console.error(
-      `[hp44] --keep-raw-har: wrote the UNREDACTED HAR to ${out}, and it contains ${violations.length} secret-shaped value(s) (${detail}). Do not commit it.`,
+      `[hp44] --keep-raw-har: wrote the UNREDACTED HAR to ${out}, and it contains ${hitCount} secret-shaped value(s) (${detail}). Do not commit it.`,
     );
   } else {
     console.error(
-      `[hp44] the raw HAR was WITHHELD: it contains ${violations.length} secret-shaped value(s) that only the trace pipeline redacts (${detail}). Use ${traceOut}, or pass --keep-raw-har if you accept the risk.`,
+      `[hp44] the raw HAR was WITHHELD: it contains ${hitCount} secret-shaped value(s) that only the trace pipeline redacts (${detail}). Use ${traceOut}, or pass --keep-raw-har if you accept the risk.`,
     );
   }
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -726,6 +726,49 @@ export type {
 } from "./oauth-conformance/index.js";
 export { CONFORMANCE_CHECK_METADATA } from "./oauth-conformance/index.js";
 
+// HP-44 golden-trace parity harness — capture real host handshakes, diff
+// emulator dances against them, and project the result onto
+// HostConfigOAuthProfileV1.
+export {
+  GOLDEN_TRACE_VERSION,
+  NORMALIZER_VERSION,
+  TRACE_DIFF_DIMENSIONS,
+  TRACE_DIFF_SEVERITIES,
+  TRACE_LEGS,
+  assertTraceIsRedacted,
+  captureEmulatorTrace,
+  captureHarTrace,
+  classifyLeg,
+  deriveObservations,
+  diffGoldenTraces,
+  findObservationDrift,
+  findRedactionViolations,
+  formatHarIngestReportHuman,
+  formatTraceDiffHuman,
+  formatTraceSummaryHuman,
+  traceToOAuthProfile,
+} from "./oauth-golden-trace/index.js";
+export type {
+  CaptureEmulatorTraceInput,
+  CaptureHarTraceInput,
+  GoldenTrace,
+  HarIngestReport,
+  Observation,
+  TraceDiffDimension,
+  TraceDiffFinding,
+  TraceDiffMode,
+  TraceDiffOptions,
+  TraceDiffResult,
+  TraceDiffSeverity,
+  TraceExchange,
+  TraceLeg,
+  TraceOAuthImplementation,
+  TraceObservations,
+  TraceScenario,
+  TraceScenarioCapabilities,
+  TraceSubject,
+} from "./oauth-golden-trace/index.js";
+
 // MCP Operations (pure functions for common MCP workflows)
 export {
   listResources,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -731,10 +731,13 @@ export { CONFORMANCE_CHECK_METADATA } from "./oauth-conformance/index.js";
 // HostConfigOAuthProfileV1.
 export {
   GOLDEN_TRACE_VERSION,
+  MCP_WIRE_LEGS,
   NORMALIZER_VERSION,
+  OAUTH_DISCOVERY_LEGS,
   TRACE_DIFF_DIMENSIONS,
   TRACE_DIFF_SEVERITIES,
   TRACE_LEGS,
+  absent,
   assertTraceIsRedacted,
   captureEmulatorTrace,
   captureHarTrace,
@@ -746,6 +749,10 @@ export {
   formatHarIngestReportHuman,
   formatTraceDiffHuman,
   formatTraceSummaryHuman,
+  mergeTraceOAuthProfile,
+  notObserved,
+  observedValue,
+  present,
   traceToOAuthProfile,
 } from "./oauth-golden-trace/index.js";
 export type {
@@ -754,6 +761,7 @@ export type {
   GoldenTrace,
   HarIngestReport,
   Observation,
+  TraceBody,
   TraceDiffDimension,
   TraceDiffFinding,
   TraceDiffMode,
@@ -764,9 +772,12 @@ export type {
   TraceLeg,
   TraceOAuthImplementation,
   TraceObservations,
+  TraceRequest,
+  TraceResponse,
   TraceScenario,
   TraceScenarioCapabilities,
   TraceSubject,
+  TraceToProfileOptions,
 } from "./oauth-golden-trace/index.js";
 
 // MCP Operations (pure functions for common MCP workflows)

--- a/sdk/src/oauth-golden-trace/diff.ts
+++ b/sdk/src/oauth-golden-trace/diff.ts
@@ -1,0 +1,963 @@
+/**
+ * HP-44 — the trace differ. This is the acceptance oracle.
+ *
+ * Given a GOLDEN trace (recorded from a real host) and a CANDIDATE trace
+ * (produced by our emulator for that host against the same scenario), report
+ * field-by-field where they diverge: request ordering, endpoints hit, params
+ * present/absent, headers, DCR body.
+ *
+ * ── Three rules that make the output trustworthy ──────────────────────────
+ *
+ *  1. A GAP IS NEVER A PASS AND NEVER A FAILURE. If either side did not capture
+ *     the leg carrying a field, the finding is `gap` — not `match` (which would
+ *     claim parity we did not observe) and not `difference` (which would blame
+ *     the emulator for our own missing capture). {@link compareObservation} is
+ *     the single place this is decided, so it cannot be got wrong field by field.
+ *
+ *  2. INCOMPARABLE TRACES SHORT-CIRCUIT. Two traces of different scenarios, or
+ *     of different hosts, produce exactly one `incomparable` finding rather than
+ *     a cascade of forty bogus differences. A wall of red that all stems from
+ *     one misconfiguration teaches a reviewer to ignore the tool.
+ *
+ *  3. SUBJECT METADATA IS DIFFED ONLY IN DRIFT MODE. In `parity` mode the two
+ *     sides differ by construction — the golden side is `rmcp` inside a real
+ *     host, the candidate side is our own state machine — so reporting that as
+ *     a difference would be noise. In `drift` mode (the same subject captured on
+ *     two dates, which is HP-38's job) a version change is precisely the signal.
+ */
+
+import { observedValue } from "./types.js";
+import type {
+  GoldenTrace,
+  Observation,
+  TraceDiffDimension,
+  TraceDiffFinding,
+  TraceDiffResult,
+  TraceDiffSeverity,
+  TraceExchange,
+  TraceLeg,
+  TraceScenarioCapabilities,
+} from "./types.js";
+
+export type TraceDiffMode =
+  /** Emulator vs real host. Subject metadata differences are expected. */
+  | "parity"
+  /** Same subject, two captures. Subject metadata differences ARE the finding. */
+  | "drift";
+
+export type TraceDiffOptions = {
+  /** Defaults to `drift` when both subjects have the same `kind`, else `parity`. */
+  mode?: TraceDiffMode;
+  /**
+   * Headers excluded from value comparison. Defaults to none: the normalizer
+   * already placeholds every value that varies run-to-run, so anything still
+   * differing here is a real behavioral difference worth seeing.
+   */
+  ignoreHeaders?: string[];
+};
+
+function equal(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function renderObservation<T>(observation: Observation<T>): unknown {
+  switch (observation.state) {
+    case "present":
+      return observation.value;
+    case "absent":
+      return "<absent on the wire>";
+    case "not-observed":
+      return `<not observed: ${observation.reason}>`;
+  }
+}
+
+/**
+ * The one comparator every field routes through.
+ *
+ * `absent` vs `present` is a real difference — a host that sends no
+ * `MCP-Protocol-Version` on MCP traffic genuinely differs from an emulator that
+ * does. `not-observed` on either side is a gap, full stop.
+ */
+export function compareObservation<T>(
+  path: string,
+  dimension: TraceDiffDimension,
+  label: string,
+  golden: Observation<T>,
+  candidate: Observation<T>,
+): TraceDiffFinding {
+  const base = {
+    path,
+    dimension,
+    golden: renderObservation(golden),
+    candidate: renderObservation(candidate),
+  };
+
+  if (golden.state === "not-observed" || candidate.state === "not-observed") {
+    const which =
+      golden.state === "not-observed" && candidate.state === "not-observed"
+        ? "neither trace"
+        : golden.state === "not-observed"
+          ? "the golden trace"
+          : "the candidate trace";
+    return {
+      ...base,
+      severity: "gap",
+      message: `${label} is not comparable: ${which} observed it.`,
+    };
+  }
+
+  if (golden.state === "absent" && candidate.state === "absent") {
+    return { ...base, severity: "match", message: `${label} is absent on both sides.` };
+  }
+
+  if (golden.state === "absent") {
+    return {
+      ...base,
+      severity: "difference",
+      message: `${label}: the real host sends nothing, but the emulator sends a value.`,
+    };
+  }
+
+  if (candidate.state === "absent") {
+    return {
+      ...base,
+      severity: "difference",
+      message: `${label}: the real host sends a value, but the emulator sends nothing.`,
+    };
+  }
+
+  return equal(golden.value, candidate.value)
+    ? { ...base, severity: "match", message: `${label} matches.` }
+    : {
+        ...base,
+        severity: "difference",
+        message: `${label} differs between the real host and the emulator.`,
+      };
+}
+
+/** Compare two plain (always-observed) values. */
+function compareValue(
+  path: string,
+  dimension: TraceDiffDimension,
+  label: string,
+  golden: unknown,
+  candidate: unknown,
+): TraceDiffFinding {
+  return equal(golden, candidate)
+    ? { path, dimension, severity: "match", message: `${label} matches.`, golden, candidate }
+    : {
+        path,
+        dimension,
+        severity: "difference",
+        message: `${label} differs.`,
+        golden,
+        candidate,
+      };
+}
+
+// ── Scenario / subject gates ─────────────────────────────────────────────
+
+function capabilityDifferences(
+  golden: TraceScenarioCapabilities,
+  candidate: TraceScenarioCapabilities,
+): string[] {
+  const keys = Object.keys({ ...golden, ...candidate }) as Array<
+    keyof TraceScenarioCapabilities
+  >;
+  return keys
+    .filter((key) => !equal(golden[key], candidate[key]))
+    .map(
+      (key) =>
+        `${key}: golden=${JSON.stringify(golden[key])} candidate=${JSON.stringify(candidate[key])}`,
+    );
+}
+
+function gateFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+): TraceDiffFinding[] {
+  const findings: TraceDiffFinding[] = [];
+
+  if (golden.subject.hostId !== candidate.subject.hostId) {
+    findings.push({
+      path: "subject.hostId",
+      dimension: "subject",
+      severity: "incomparable",
+      message:
+        "These traces describe different hosts. A parity diff across two hosts has no meaning — no host is supposed to behave like another one.",
+      golden: golden.subject.hostId,
+      candidate: candidate.subject.hostId,
+    });
+  }
+
+  if (golden.scenario.scenarioId !== candidate.scenario.scenarioId) {
+    findings.push({
+      path: "scenario.scenarioId",
+      dimension: "scenario",
+      severity: "incomparable",
+      message:
+        "These traces were captured against different scenarios. Re-run the emulator against the same test server the golden trace used.",
+      golden: golden.scenario.scenarioId,
+      candidate: candidate.scenario.scenarioId,
+    });
+    return findings;
+  }
+
+  const capabilityDiffs = capabilityDifferences(
+    golden.scenario.capabilities,
+    candidate.scenario.capabilities,
+  );
+  if (capabilityDiffs.length > 0) {
+    findings.push({
+      path: "scenario.capabilities",
+      dimension: "scenario",
+      severity: "incomparable",
+      message: `The two scenarios share an id but not their server capabilities, so client behavior is not comparable (${capabilityDiffs.join("; ")}). A client that omits \`resource\` when PRM discovery fails is behaving correctly, and diffing it against a with-PRM capture would report that correct behavior as a failure.`,
+      golden: golden.scenario.capabilities,
+      candidate: candidate.scenario.capabilities,
+    });
+  }
+
+  return findings;
+}
+
+function subjectFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+  mode: TraceDiffMode,
+): TraceDiffFinding[] {
+  const findings: TraceDiffFinding[] = [];
+
+  // Always report a missing version stamp: a trace that cannot say which build
+  // it recorded goes stale without anyone noticing, which is the durability
+  // failure HP-38 exists to catch.
+  for (const [side, trace] of [
+    ["golden", golden],
+    ["candidate", candidate],
+  ] as const) {
+    if (trace.subject.hostVersion.state === "not-observed") {
+      findings.push({
+        path: `subject.hostVersion (${side})`,
+        dimension: "subject",
+        severity: "gap",
+        message: `The ${side} trace does not record a host version, so it cannot be told apart from a capture of a different build.`,
+        golden: renderObservation(golden.subject.hostVersion),
+        candidate: renderObservation(candidate.subject.hostVersion),
+      });
+    }
+    if (trace.subject.oauthImplementation.state === "not-observed") {
+      findings.push({
+        path: `subject.oauthImplementation (${side})`,
+        dimension: "subject",
+        severity: "gap",
+        message: `The ${side} trace does not record which OAuth implementation produced it. Five of six source-verified clients inherit OAuth from a dependency, so without a resolved package version this trace goes stale on a dependency bump with no visible signal.`,
+        golden: renderObservation(golden.subject.oauthImplementation),
+        candidate: renderObservation(candidate.subject.oauthImplementation),
+      });
+    }
+  }
+
+  if (mode === "drift") {
+    findings.push(
+      compareObservation(
+        "subject.hostVersion",
+        "subject",
+        "Host version",
+        golden.subject.hostVersion,
+        candidate.subject.hostVersion,
+      ),
+      compareObservation(
+        "subject.oauthImplementation",
+        "subject",
+        "Resolved OAuth implementation",
+        golden.subject.oauthImplementation,
+        candidate.subject.oauthImplementation,
+      ),
+    );
+  }
+
+  return findings;
+}
+
+// ── Wire-level comparisons ───────────────────────────────────────────────
+
+function firstExchangeForLeg(
+  wire: readonly TraceExchange[],
+  leg: TraceLeg,
+): TraceExchange | undefined {
+  return wire.find((exchange) => exchange.leg === leg);
+}
+
+function orderingFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+): TraceDiffFinding[] {
+  const findings: TraceDiffFinding[] = [
+    compareValue(
+      "observations.legOrder",
+      "request-ordering",
+      "Leg ordering (first appearance of each stage)",
+      golden.observations.legOrder,
+      candidate.observations.legOrder,
+    ),
+  ];
+
+  // The full sequence catches repeat-count differences the first-appearance
+  // order hides — e.g. a client that retries AS discovery at a second rung.
+  const goldenSequence = golden.wire.map((exchange) => exchange.leg);
+  const candidateSequence = candidate.wire.map((exchange) => exchange.leg);
+  if (!equal(goldenSequence, candidateSequence)) {
+    findings.push({
+      path: "wire[].leg",
+      dimension: "request-ordering",
+      severity: "difference",
+      message:
+        "The full request sequence differs (counts or order), even where the set of stages agrees.",
+      golden: goldenSequence,
+      candidate: candidateSequence,
+    });
+  }
+
+  return findings;
+}
+
+function endpointFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+): TraceDiffFinding[] {
+  const findings: TraceDiffFinding[] = [];
+  const goldenSet = golden.observations.endpointsHit;
+  const candidateSet = candidate.observations.endpointsHit;
+
+  const missing = goldenSet.filter((endpoint) => !candidateSet.includes(endpoint));
+  const extra = candidateSet.filter((endpoint) => !goldenSet.includes(endpoint));
+
+  if (missing.length === 0 && extra.length === 0) {
+    findings.push({
+      path: "observations.endpointsHit",
+      dimension: "endpoints",
+      severity: "match",
+      message: "Both sides hit the same set of endpoints.",
+      golden: goldenSet,
+      candidate: candidateSet,
+    });
+  } else {
+    if (missing.length > 0) {
+      findings.push({
+        path: "observations.endpointsHit",
+        dimension: "endpoints",
+        severity: "difference",
+        message: `The emulator never hit ${missing.length} endpoint(s) the real host did.`,
+        golden: missing,
+        candidate: null,
+      });
+    }
+    if (extra.length > 0) {
+      findings.push({
+        path: "observations.endpointsHit",
+        dimension: "endpoints",
+        severity: "difference",
+        message: `The emulator hit ${extra.length} endpoint(s) the real host did not.`,
+        golden: null,
+        candidate: extra,
+      });
+    }
+  }
+
+  findings.push(
+    compareValue(
+      "observations.discoveryLadder",
+      "endpoints",
+      "Discovery ladder (well-known paths, in order tried)",
+      golden.observations.discoveryLadder,
+      candidate.observations.discoveryLadder,
+    ),
+  );
+
+  return findings;
+}
+
+/**
+ * Per-leg parameter and header comparison.
+ *
+ * Only legs BOTH sides captured are compared field by field; a leg only one side
+ * has is a `gap`, since we cannot tell an emulator bug from a capture that
+ * stopped early (a real host capture often stops at the consent screen).
+ */
+function perLegFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+  options: TraceDiffOptions,
+): TraceDiffFinding[] {
+  const findings: TraceDiffFinding[] = [];
+  const ignoreHeaders = new Set(
+    (options.ignoreHeaders ?? []).map((header) => header.toLowerCase()),
+  );
+
+  const legs: TraceLeg[] = [];
+  for (const leg of [
+    ...golden.observations.legOrder,
+    ...candidate.observations.legOrder,
+  ]) {
+    if (!legs.includes(leg)) legs.push(leg);
+  }
+
+  for (const leg of legs) {
+    const goldenExchange = firstExchangeForLeg(golden.wire, leg);
+    const candidateExchange = firstExchangeForLeg(candidate.wire, leg);
+
+    if (!goldenExchange || !candidateExchange) {
+      const which = !goldenExchange ? "the golden trace" : "the candidate trace";
+      findings.push({
+        path: `wire[leg=${leg}]`,
+        dimension: "params",
+        severity: "gap",
+        message: `The \`${leg}\` leg is only present on one side (${which} lacks it), so its params and headers are not comparable.`,
+        golden: goldenExchange ? "captured" : "<not observed>",
+        candidate: candidateExchange ? "captured" : "<not observed>",
+      });
+      continue;
+    }
+
+    findings.push(
+      compareValue(
+        `wire[leg=${leg}].request.method`,
+        "params",
+        `\`${leg}\` HTTP method`,
+        goldenExchange.request.method,
+        candidateExchange.request.method,
+      ),
+    );
+
+    // ── params ──
+    const goldenQuery = goldenExchange.request.query ?? {};
+    const candidateQuery = candidateExchange.request.query ?? {};
+    const queryKeys = [
+      ...new Set([...Object.keys(goldenQuery), ...Object.keys(candidateQuery)]),
+    ].sort();
+
+    for (const key of queryKeys) {
+      const inGolden = key in goldenQuery;
+      const inCandidate = key in candidateQuery;
+      const path = `wire[leg=${leg}].request.query.${key}`;
+
+      if (!inGolden || !inCandidate) {
+        findings.push({
+          path,
+          dimension: "params",
+          severity: "difference",
+          message: inGolden
+            ? `\`${leg}\` is missing the \`${key}\` param the real host sends.`
+            : `\`${leg}\` carries a \`${key}\` param the real host does not send.`,
+          golden: goldenQuery[key] ?? "<absent>",
+          candidate: candidateQuery[key] ?? "<absent>",
+        });
+        continue;
+      }
+
+      findings.push(
+        compareValue(
+          path,
+          "params",
+          `\`${leg}\` param \`${key}\``,
+          goldenQuery[key],
+          candidateQuery[key],
+        ),
+      );
+    }
+
+    // ── headers ──
+    // A leg whose headers were never intercepted on either side (a browser-driven
+    // `/authorize`) yields one gap, not a per-header cascade of fabricated
+    // differences.
+    if (
+      goldenExchange.request.headersObserved === false ||
+      candidateExchange.request.headersObserved === false
+    ) {
+      const which =
+        goldenExchange.request.headersObserved === false &&
+        candidateExchange.request.headersObserved === false
+          ? "neither side"
+          : goldenExchange.request.headersObserved === false
+            ? "the golden trace"
+            : "the candidate trace";
+      findings.push({
+        path: `wire[leg=${leg}].request.headers`,
+        dimension: "headers",
+        severity: "gap",
+        message: `\`${leg}\` request headers are not comparable: ${which} intercepted them (the request was reconstructed from a URL the client handed to a browser). Capture this leg through a proxy to close it.`,
+        golden: goldenExchange.request.headersObserved === false ? "<not intercepted>" : Object.keys(goldenExchange.request.headers),
+        candidate: candidateExchange.request.headersObserved === false ? "<not intercepted>" : Object.keys(candidateExchange.request.headers),
+      });
+    } else {
+      const goldenHeaders = goldenExchange.request.headers;
+      const candidateHeaders = candidateExchange.request.headers;
+      const headerKeys = [
+        ...new Set([...Object.keys(goldenHeaders), ...Object.keys(candidateHeaders)]),
+      ]
+        .filter((key) => !ignoreHeaders.has(key))
+        .sort();
+
+      for (const key of headerKeys) {
+        const inGolden = key in goldenHeaders;
+        const inCandidate = key in candidateHeaders;
+        const path = `wire[leg=${leg}].request.headers.${key}`;
+
+        if (!inGolden || !inCandidate) {
+          findings.push({
+            path,
+            dimension: "headers",
+            severity: "difference",
+            message: inGolden
+              ? `\`${leg}\` is missing the \`${key}\` header the real host sends.`
+              : `\`${leg}\` carries a \`${key}\` header the real host does not send.`,
+            golden: goldenHeaders[key] ?? "<absent>",
+            candidate: candidateHeaders[key] ?? "<absent>",
+          });
+          continue;
+        }
+
+        findings.push(
+          compareValue(
+            path,
+            "headers",
+            `\`${leg}\` header \`${key}\``,
+            goldenHeaders[key],
+            candidateHeaders[key],
+          ),
+        );
+      }
+    }
+
+    // ── form body fields (token / refresh legs) ──
+    const goldenBody = goldenExchange.request.body;
+    const candidateBody = candidateExchange.request.body;
+    if (goldenBody?.encoding === "form" && candidateBody?.encoding === "form") {
+      const fieldKeys = [
+        ...new Set([
+          ...Object.keys(goldenBody.fields),
+          ...Object.keys(candidateBody.fields),
+        ]),
+      ].sort();
+
+      for (const key of fieldKeys) {
+        const inGolden = key in goldenBody.fields;
+        const inCandidate = key in candidateBody.fields;
+        const path = `wire[leg=${leg}].request.body.${key}`;
+
+        if (!inGolden || !inCandidate) {
+          findings.push({
+            path,
+            dimension: "params",
+            severity: "difference",
+            message: inGolden
+              ? `\`${leg}\` body is missing the \`${key}\` field the real host sends.`
+              : `\`${leg}\` body carries a \`${key}\` field the real host does not send.`,
+            golden: goldenBody.fields[key] ?? "<absent>",
+            candidate: candidateBody.fields[key] ?? "<absent>",
+          });
+          continue;
+        }
+
+        findings.push(
+          compareValue(
+            path,
+            "params",
+            `\`${leg}\` body field \`${key}\``,
+            goldenBody.fields[key],
+            candidateBody.fields[key],
+          ),
+        );
+      }
+    } else if (!equal(goldenBody?.encoding, candidateBody?.encoding)) {
+      findings.push({
+        path: `wire[leg=${leg}].request.body.encoding`,
+        dimension: "params",
+        severity: "difference",
+        message: `\`${leg}\` request body encoding differs.`,
+        golden: goldenBody?.encoding ?? "<no body>",
+        candidate: candidateBody?.encoding ?? "<no body>",
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ── Observation-level comparisons ────────────────────────────────────────
+
+function protocolVersionFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+): TraceDiffFinding[] {
+  const goldenPv = golden.observations.protocolVersion;
+  const candidatePv = candidate.observations.protocolVersion;
+
+  const findings: TraceDiffFinding[] = [
+    compareObservation(
+      "observations.protocolVersion.initializeBody",
+      "protocol-version",
+      "`initialize.params.protocolVersion` (MCP body)",
+      goldenPv.initializeBody,
+      candidatePv.initializeBody,
+    ),
+    compareObservation(
+      "observations.protocolVersion.headerOnOAuthDiscovery",
+      "protocol-version",
+      "`MCP-Protocol-Version` header on OAuth discovery",
+      goldenPv.headerOnOAuthDiscovery,
+      candidatePv.headerOnOAuthDiscovery,
+    ),
+    compareObservation(
+      "observations.protocolVersion.headerOnMcpTraffic",
+      "protocol-version",
+      "`MCP-Protocol-Version` header on MCP traffic",
+      goldenPv.headerOnMcpTraffic,
+      candidatePv.headerOnMcpTraffic,
+    ),
+  ];
+
+  // The split-revision flags are compared explicitly rather than left implicit
+  // in the three fields above: an emulator that gets both wires "individually
+  // wrong in the same direction" would match on neither field but could still
+  // agree on the flag, and vice versa. Surfacing the flag makes the class of
+  // bug legible.
+  findings.push(
+    compareValue(
+      "observations.protocolVersion.wiresDisagree",
+      "protocol-version",
+      "Whether the OAuth wire and the MCP wire carry different protocol versions",
+      goldenPv.wiresDisagree,
+      candidatePv.wiresDisagree,
+    ),
+    compareValue(
+      "observations.protocolVersion.headerDisagreesWithInitializeBody",
+      "protocol-version",
+      "Whether the `MCP-Protocol-Version` header disagrees with the `initialize` body",
+      goldenPv.headerDisagreesWithInitializeBody,
+      candidatePv.headerDisagreesWithInitializeBody,
+    ),
+  );
+
+  const legs = [
+    ...new Set([
+      ...Object.keys(goldenPv.headerByLeg),
+      ...Object.keys(candidatePv.headerByLeg),
+    ]),
+  ].sort() as TraceLeg[];
+
+  for (const leg of legs) {
+    const goldenObservation = goldenPv.headerByLeg[leg];
+    const candidateObservation = candidatePv.headerByLeg[leg];
+    if (!goldenObservation || !candidateObservation) continue;
+    findings.push(
+      compareObservation(
+        `observations.protocolVersion.headerByLeg.${leg}`,
+        "protocol-version",
+        `\`MCP-Protocol-Version\` on the \`${leg}\` leg`,
+        goldenObservation,
+        candidateObservation,
+      ),
+    );
+  }
+
+  return findings;
+}
+
+function resourceIndicatorFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+): TraceDiffFinding[] {
+  const goldenRi = golden.observations.resourceIndicator;
+  const candidateRi = candidate.observations.resourceIndicator;
+  const prmEqualsServer =
+    golden.scenario.capabilities.prmResource != null &&
+    golden.scenario.capabilities.prmResource.replace(/\/$/, "") ===
+      golden.scenario.mcpServerUrl.replace(/\/$/, "");
+
+  const findings = [
+    compareObservation(
+      "observations.resourceIndicator.onAuthorize",
+      "resource-indicator",
+      "RFC 8707 `resource` on /authorize",
+      goldenRi.onAuthorize,
+      candidateRi.onAuthorize,
+    ),
+    compareObservation(
+      "observations.resourceIndicator.onToken",
+      "resource-indicator",
+      "RFC 8707 `resource` on /token",
+      goldenRi.onToken,
+      candidateRi.onToken,
+    ),
+    compareObservation(
+      "observations.resourceIndicator.onRefresh",
+      "resource-indicator",
+      "RFC 8707 `resource` on token refresh",
+      goldenRi.onRefresh,
+      candidateRi.onRefresh,
+    ),
+  ];
+
+  const sourceFinding = compareObservation(
+    "observations.resourceIndicator.valueSource",
+    "resource-indicator",
+    "Which URL the `resource` value is taken from",
+    goldenRi.valueSource,
+    candidateRi.valueSource,
+  );
+
+  // When the scenario's PRM `resource` is byte-identical to the MCP server URL,
+  // "sends the server URL" and "sends the PRM resource" are indistinguishable on
+  // the wire. Reporting a difference there would be an artifact of the test
+  // fixture, not a finding about the client — so it is downgraded to a gap with
+  // the fixture named as the blocker.
+  if (
+    sourceFinding.severity === "difference" &&
+    prmEqualsServer &&
+    new Set([
+      observedValue(goldenRi.valueSource),
+      observedValue(candidateRi.valueSource),
+    ]).size <= 2 &&
+    [observedValue(goldenRi.valueSource), observedValue(candidateRi.valueSource)].every(
+      (value) => value === "mcp-server-url" || value === "prm-resource",
+    )
+  ) {
+    findings.push({
+      ...sourceFinding,
+      severity: "gap",
+      message:
+        "Cannot tell `resource: <server URL>` from `resource: <PRM resource>`: this scenario's PRM document publishes a `resource` identical to the MCP server URL, so the two behaviors are byte-identical on the wire. Capture against a scenario where they differ to settle it.",
+    });
+  } else {
+    findings.push(sourceFinding);
+  }
+
+  return findings;
+}
+
+function dcrFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+): TraceDiffFinding[] {
+  const goldenDcr = golden.observations.dcrIdentity;
+  const candidateDcr = candidate.observations.dcrIdentity;
+
+  const findings: TraceDiffFinding[] = [
+    compareObservation(
+      "observations.dcrIdentity.clientName",
+      "dcr-body",
+      "DCR `client_name`",
+      goldenDcr.clientName,
+      candidateDcr.clientName,
+    ),
+    compareObservation(
+      "observations.dcrIdentity.redirectUris",
+      "dcr-body",
+      "DCR `redirect_uris` (loopback ports placeheld)",
+      goldenDcr.redirectUris,
+      candidateDcr.redirectUris,
+    ),
+    compareObservation(
+      "observations.dcrIdentity.grantTypes",
+      "dcr-body",
+      "DCR `grant_types`",
+      goldenDcr.grantTypes,
+      candidateDcr.grantTypes,
+    ),
+    compareObservation(
+      "observations.dcrIdentity.responseTypes",
+      "dcr-body",
+      "DCR `response_types`",
+      goldenDcr.responseTypes,
+      candidateDcr.responseTypes,
+    ),
+    compareObservation(
+      "observations.dcrIdentity.tokenEndpointAuthMethod",
+      "dcr-body",
+      "DCR `token_endpoint_auth_method`",
+      goldenDcr.tokenEndpointAuthMethod,
+      candidateDcr.tokenEndpointAuthMethod,
+    ),
+    compareObservation(
+      "observations.dcrIdentity.scope",
+      "dcr-body",
+      "DCR `scope`",
+      goldenDcr.scope,
+      candidateDcr.scope,
+    ),
+    compareObservation(
+      "observations.dcrIdentity.extraFields",
+      "dcr-body",
+      "DCR body fields this schema does not model",
+      goldenDcr.extraFields,
+      candidateDcr.extraFields,
+    ),
+  ];
+
+  // Loopback ports are context, never a difference: two runs of the SAME client
+  // legitimately differ here, so a `difference` severity would make every diff
+  // fail for a reason nobody can fix.
+  const ports = compareObservation(
+    "observations.dcrIdentity.observedLoopbackPorts",
+    "dcr-body",
+    "Observed loopback redirect ports",
+    goldenDcr.observedLoopbackPorts,
+    candidateDcr.observedLoopbackPorts,
+  );
+  findings.push({
+    ...ports,
+    severity: ports.severity === "difference" ? "match" : ports.severity,
+    message:
+      ports.severity === "difference"
+        ? "Observed loopback redirect ports differ. This is recorded as context, not a parity difference — ephemeral ports vary between runs of the same client. The port RANGE is still a per-host fact worth reading."
+        : ports.message,
+  });
+
+  return findings;
+}
+
+function pkceAndUaFindings(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+): TraceDiffFinding[] {
+  const findings: TraceDiffFinding[] = [
+    compareObservation(
+      "observations.pkce.challengeMethod",
+      "pkce",
+      "PKCE `code_challenge_method`",
+      golden.observations.pkce.challengeMethod,
+      candidate.observations.pkce.challengeMethod,
+    ),
+    compareObservation(
+      "observations.pkce.challengeLength",
+      "pkce",
+      "PKCE `code_challenge` length",
+      golden.observations.pkce.challengeLength,
+      candidate.observations.pkce.challengeLength,
+    ),
+    compareObservation(
+      "observations.pkce.verifierSentOnToken",
+      "pkce",
+      "PKCE `code_verifier` present on /token",
+      golden.observations.pkce.verifierSentOnToken,
+      candidate.observations.pkce.verifierSentOnToken,
+    ),
+  ];
+
+  const legs = [
+    ...new Set([
+      ...Object.keys(golden.observations.userAgent.byLeg),
+      ...Object.keys(candidate.observations.userAgent.byLeg),
+    ]),
+  ].sort() as TraceLeg[];
+
+  for (const leg of legs) {
+    const goldenUa = golden.observations.userAgent.byLeg[leg];
+    const candidateUa = candidate.observations.userAgent.byLeg[leg];
+    if (!goldenUa || !candidateUa) continue;
+    findings.push(
+      compareObservation(
+        `observations.userAgent.byLeg.${leg}`,
+        "user-agent",
+        `\`User-Agent\` on the \`${leg}\` leg`,
+        goldenUa,
+        candidateUa,
+      ),
+    );
+  }
+
+  findings.push(
+    compareValue(
+      "observations.userAgent.consistent",
+      "user-agent",
+      "Whether one `User-Agent` is used across every captured leg",
+      golden.observations.userAgent.consistent,
+      candidate.observations.userAgent.consistent,
+    ),
+  );
+
+  return findings;
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────
+
+function summarize(counts: Record<TraceDiffSeverity, number>): string {
+  const total = Object.values(counts).reduce((sum, count) => sum + count, 0);
+  if (counts.incomparable > 0) {
+    return `incomparable: ${counts.incomparable} blocking issue(s) — no field-level comparison was attempted`;
+  }
+  const parts = [
+    `${counts.difference} difference(s)`,
+    `${counts.gap} gap(s)`,
+    `${counts.match} match(es)`,
+  ];
+  return `${parts.join(", ")} across ${total} comparison(s)`;
+}
+
+/**
+ * Diff a candidate trace against a golden one.
+ *
+ * `parity` is true only when there are zero `difference` and zero
+ * `incomparable` findings. Gaps do not fail parity — an unobserved leg is not
+ * evidence of divergence — but they are counted separately, and a caller that
+ * needs full coverage should assert `counts.gap === 0` too. That split is the
+ * point: "the emulator matches on everything we could see, and here is exactly
+ * what we could not see" is a more honest result than a single boolean.
+ */
+export function diffGoldenTraces(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+  options: TraceDiffOptions = {},
+): TraceDiffResult {
+  const mode =
+    options.mode ??
+    (golden.subject.kind === candidate.subject.kind ? "drift" : "parity");
+
+  const gates = gateFindings(golden, candidate);
+  const findings: TraceDiffFinding[] = [...gates];
+
+  if (!gates.some((finding) => finding.severity === "incomparable")) {
+    findings.push(
+      ...subjectFindings(golden, candidate, mode),
+      ...orderingFindings(golden, candidate),
+      ...endpointFindings(golden, candidate),
+      ...perLegFindings(golden, candidate, options),
+      ...protocolVersionFindings(golden, candidate),
+      ...resourceIndicatorFindings(golden, candidate),
+      ...dcrFindings(golden, candidate),
+      ...pkceAndUaFindings(golden, candidate),
+    );
+  }
+
+  const counts: Record<TraceDiffSeverity, number> = {
+    match: 0,
+    difference: 0,
+    gap: 0,
+    incomparable: 0,
+  };
+  for (const finding of findings) counts[finding.severity] += 1;
+
+  // Order the report by severity so the actionable findings are not buried
+  // under a hundred matches.
+  const severityRank: Record<TraceDiffSeverity, number> = {
+    incomparable: 0,
+    difference: 1,
+    gap: 2,
+    match: 3,
+  };
+  const sorted = [...findings].sort(
+    (left, right) =>
+      severityRank[left.severity] - severityRank[right.severity] ||
+      left.path.localeCompare(right.path),
+  );
+
+  return {
+    parity: counts.difference === 0 && counts.incomparable === 0,
+    goldenTraceId: golden.traceId,
+    candidateTraceId: candidate.traceId,
+    counts,
+    findings: sorted,
+    summary: summarize(counts),
+  };
+}

--- a/sdk/src/oauth-golden-trace/diff.ts
+++ b/sdk/src/oauth-golden-trace/diff.ts
@@ -24,14 +24,22 @@
  *     host, the candidate side is our own state machine — so reporting that as
  *     a difference would be noise. In `drift` mode (the same subject captured on
  *     two dates, which is HP-38's job) a version change is precisely the signal.
+ *
+ *     The mode also decides WHAT THE TWO SIDES ARE CALLED. Every message below is
+ *     phrased through {@link DIFF_LABELS}, and the resolved pair travels out on
+ *     `TraceDiffResult.labels` so the renderer cannot contradict it. Hardcoding
+ *     "real host" / "emulator" made a drift diff of two real-host captures blame
+ *     an emulator that was never involved.
  */
 
-import { observedValue } from "./types.js";
+import { notObserved, observedValue } from "./types.js";
 import type {
   GoldenTrace,
   Observation,
   TraceDiffDimension,
   TraceDiffFinding,
+  TraceDiffLabels,
+  TraceDiffMode,
   TraceDiffResult,
   TraceDiffSeverity,
   TraceExchange,
@@ -39,11 +47,20 @@ import type {
   TraceScenarioCapabilities,
 } from "./types.js";
 
-export type TraceDiffMode =
-  /** Emulator vs real host. Subject metadata differences are expected. */
-  | "parity"
-  /** Same subject, two captures. Subject metadata differences ARE the finding. */
-  | "drift";
+export type { TraceDiffMode } from "./types.js";
+
+/**
+ * What each side is called, per mode. The one source for the differ's prose.
+ *
+ * `parity` keeps its concrete wording: there the golden side IS a real host and
+ * the candidate IS our emulator, and naming them is what makes a difference
+ * actionable. `drift` compares the same subject captured twice, where no emulator
+ * is involved on either side.
+ */
+const DIFF_LABELS: Record<TraceDiffMode, TraceDiffLabels> = {
+  parity: { golden: "real host", candidate: "emulator" },
+  drift: { golden: "baseline capture", candidate: "re-capture" },
+};
 
 export type TraceDiffOptions = {
   /** Defaults to `drift` when both subjects have the same `kind`, else `parity`. */
@@ -128,6 +145,8 @@ export function compareObservation<T>(
   label: string,
   golden: Observation<T>,
   candidate: Observation<T>,
+  /** Defaults to the `parity` pair, which is what a bare two-trace diff means. */
+  labels: TraceDiffLabels = DIFF_LABELS.parity,
 ): TraceDiffFinding {
   const base = {
     path,
@@ -158,7 +177,7 @@ export function compareObservation<T>(
     return {
       ...base,
       severity: "difference",
-      message: `${label}: the real host sends nothing, but the emulator sends a value.`,
+      message: `${label}: the ${labels.golden} sends nothing, but the ${labels.candidate} sends a value.`,
     };
   }
 
@@ -166,7 +185,7 @@ export function compareObservation<T>(
     return {
       ...base,
       severity: "difference",
-      message: `${label}: the real host sends a value, but the emulator sends nothing.`,
+      message: `${label}: the ${labels.golden} sends a value, but the ${labels.candidate} sends nothing.`,
     };
   }
 
@@ -175,8 +194,32 @@ export function compareObservation<T>(
     : {
         ...base,
         severity: "difference",
-        message: `${label} differs between the real host and the emulator.`,
+        message: `${label} differs between the ${labels.golden} and the ${labels.candidate}.`,
       };
+}
+
+/**
+ * Read a per-leg observation map, materializing a MISSING key as `not-observed`.
+ *
+ * `headerByLeg` / `userAgent.byLeg` carry a key only for legs the trace captured,
+ * so a key one side lacks means precisely "we never watched that leg" — the third
+ * state, not a fourth silent one. Skipping the comparison instead (which is what
+ * this replaced) discarded exactly the case a reviewer most wants named: one trace
+ * observed a header on a leg the other never recorded. Routed through
+ * {@link compareObservation}, that now lands as a `gap` in the same wording as
+ * every other asymmetry.
+ */
+function observationForLeg<T>(
+  byLeg: Partial<Record<TraceLeg, Observation<T>>>,
+  leg: TraceLeg,
+  what: string,
+): Observation<T> {
+  return (
+    byLeg[leg] ??
+    notObserved(
+      `this trace records no \`${leg}\` leg, so ${what} on it was never observed`,
+    )
+  );
 }
 
 /** Compare two plain (always-observed) values. */
@@ -269,6 +312,7 @@ function subjectFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
   mode: TraceDiffMode,
+  labels: TraceDiffLabels,
 ): TraceDiffFinding[] {
   const findings: TraceDiffFinding[] = [];
 
@@ -309,6 +353,7 @@ function subjectFindings(
         "Host version",
         golden.subject.hostVersion,
         candidate.subject.hostVersion,
+        labels,
       ),
       compareObservation(
         "subject.oauthImplementation",
@@ -316,6 +361,7 @@ function subjectFindings(
         "Resolved OAuth implementation",
         golden.subject.oauthImplementation,
         candidate.subject.oauthImplementation,
+        labels,
       ),
     );
   }
@@ -325,11 +371,19 @@ function subjectFindings(
 
 // ── Wire-level comparisons ───────────────────────────────────────────────
 
-function firstExchangeForLeg(
+/**
+ * EVERY occurrence of a leg, in wire order.
+ *
+ * Not just the first. A leg can repeat — a retried token request, a discovery
+ * ladder that walks two rungs of the same leg — and a second attempt that adds or
+ * changes a param is exactly the kind of divergence the acceptance surface has to
+ * cover. Comparing only occurrence 0 reported parity for it.
+ */
+function exchangesForLeg(
   wire: readonly TraceExchange[],
   leg: TraceLeg,
-): TraceExchange | undefined {
-  return wire.find((exchange) => exchange.leg === leg);
+): TraceExchange[] {
+  return wire.filter((exchange) => exchange.leg === leg);
 }
 
 /**
@@ -354,6 +408,12 @@ function goldenIsTruncatedPrefix(
 ): boolean {
   const goldenSequence = golden.wire.map((exchange) => exchange.leg);
   const candidateSequence = candidate.wire.map((exchange) => exchange.leg);
+  // An EMPTY golden wire satisfies the prefix test vacuously, and calling that
+  // "truncated" downgrades the entire diff to gaps and renders a message about
+  // stopping after `undefined`. A capture with no exchanges at all is a broken
+  // artifact, not a capture that stopped early, and the caller should see it as
+  // real divergence.
+  if (goldenSequence.length === 0) return false;
   if (goldenSequence.length >= candidateSequence.length) return false;
   return goldenSequence.every((leg, index) => leg === candidateSequence[index]);
 }
@@ -362,6 +422,7 @@ function orderingFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
   truncated: boolean,
+  labels: TraceDiffLabels,
 ): TraceDiffFinding[] {
   const goldenSequence = golden.wire.map((exchange) => exchange.leg);
   const candidateSequence = candidate.wire.map((exchange) => exchange.leg);
@@ -373,7 +434,7 @@ function orderingFindings(
         path: "observations.legOrder",
         dimension: "request-ordering",
         severity: "gap",
-        message: `Ordering agrees for every stage the golden trace captured, but that capture stopped after \`${goldenSequence[goldenSequence.length - 1]}\`. The candidate continued through ${extra.map((leg) => `\`${leg}\``).join(", ")}, which the real host was never observed either doing or not doing. Complete the golden capture to compare these.`,
+        message: `Ordering agrees for every stage the golden trace captured, but that capture stopped after \`${goldenSequence[goldenSequence.length - 1]}\`. The ${labels.candidate} continued through ${extra.map((leg) => `\`${leg}\``).join(", ")}, which the ${labels.golden} was never observed either doing or not doing. Complete the golden capture to compare these.`,
         golden: goldenSequence,
         candidate: candidateSequence,
       },
@@ -411,6 +472,7 @@ function endpointFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
   truncated: boolean,
+  labels: TraceDiffLabels,
 ): TraceDiffFinding[] {
   const findings: TraceDiffFinding[] = [];
   const goldenSet = golden.observations.endpointsHit;
@@ -420,12 +482,18 @@ function endpointFindings(
   const extra = candidateSet.filter((endpoint) => !goldenSet.includes(endpoint));
 
   // A truncated golden capture cannot support "the real host does not hit this".
-  if (truncated && extra.length > 0) {
+  // Tracked in a flag rather than left implicit in the early return: when the
+  // golden side is ALSO missing endpoints the early return does not fire, and the
+  // extras excused as a gap here were then reported a second time as a difference
+  // below — double-counted, and failing parity on the very truncation artifact
+  // this branch exists to neutralize.
+  const extraIsBeyondTruncation = truncated && extra.length > 0;
+  if (extraIsBeyondTruncation) {
     findings.push({
       path: "observations.endpointsHit",
       dimension: "endpoints",
       severity: "gap",
-      message: `The candidate hit ${extra.length} endpoint(s) beyond where the golden capture stopped. Not a difference: the real host was never observed declining to hit them.`,
+      message: `The ${labels.candidate} hit ${extra.length} endpoint(s) beyond where the golden capture stopped. Not a difference: the ${labels.golden} was never observed declining to hit them.`,
       golden: null,
       candidate: extra,
     });
@@ -453,22 +521,25 @@ function endpointFindings(
       candidate: candidateSet,
     });
   } else {
+    // Missing endpoints are reported independently of the truncation flag: the
+    // golden side DID hit them, so the candidate not doing so is a real finding
+    // whether or not the golden capture also stopped early.
     if (missing.length > 0) {
       findings.push({
         path: "observations.endpointsHit",
         dimension: "endpoints",
         severity: "difference",
-        message: `The emulator never hit ${missing.length} endpoint(s) the real host did.`,
+        message: `The ${labels.candidate} never hit ${missing.length} endpoint(s) the ${labels.golden} did.`,
         golden: missing,
         candidate: null,
       });
     }
-    if (extra.length > 0) {
+    if (extra.length > 0 && !extraIsBeyondTruncation) {
       findings.push({
         path: "observations.endpointsHit",
         dimension: "endpoints",
         severity: "difference",
-        message: `The emulator hit ${extra.length} endpoint(s) the real host did not.`,
+        message: `The ${labels.candidate} hit ${extra.length} endpoint(s) the ${labels.golden} did not.`,
         golden: null,
         candidate: extra,
       });
@@ -489,16 +560,215 @@ function endpointFindings(
 }
 
 /**
- * Per-leg parameter and header comparison.
+ * Compare ONE corresponding pair of requests: method, params, headers, form body.
+ *
+ * `slot` is the path segment identifying the pair — the bare leg name for the
+ * first occurrence, `leg#N` for a retry — and `occurrence` is the matching prose
+ * suffix. Occurrence 0 therefore produces exactly the paths and messages a
+ * single-request leg always produced, which is what keeps the common case from
+ * gaining a wall of new findings.
+ */
+function exchangePairFindings(input: {
+  leg: TraceLeg;
+  slot: string;
+  occurrence: string;
+  golden: TraceExchange;
+  candidate: TraceExchange;
+  ignoreHeaders: Set<string>;
+  labels: TraceDiffLabels;
+}): TraceDiffFinding[] {
+  const { leg, slot, occurrence, golden, candidate, ignoreHeaders, labels } = input;
+  const findings: TraceDiffFinding[] = [];
+  const at = `\`${leg}\`${occurrence}`;
+
+  findings.push(
+    compareValue(
+      `wire[leg=${slot}].request.method`,
+      "params",
+      `${at} HTTP method`,
+      golden.request.method,
+      candidate.request.method,
+    ),
+  );
+
+  // ── params ──
+  const goldenQuery = golden.request.query ?? {};
+  const candidateQuery = candidate.request.query ?? {};
+  const queryKeys = [
+    ...new Set([...Object.keys(goldenQuery), ...Object.keys(candidateQuery)]),
+  ].sort();
+
+  for (const key of queryKeys) {
+    const inGolden = key in goldenQuery;
+    const inCandidate = key in candidateQuery;
+    const path = `wire[leg=${slot}].request.query.${key}`;
+
+    if (!inGolden || !inCandidate) {
+      findings.push({
+        path,
+        dimension: "params",
+        severity: "difference",
+        message: inGolden
+          ? `${at} is missing the \`${key}\` param the ${labels.golden} sends.`
+          : `${at} carries a \`${key}\` param the ${labels.golden} does not send.`,
+        golden: goldenQuery[key] ?? "<absent>",
+        candidate: candidateQuery[key] ?? "<absent>",
+      });
+      continue;
+    }
+
+    findings.push(
+      compareValue(
+        path,
+        "params",
+        `${at} param \`${key}\``,
+        goldenQuery[key],
+        candidateQuery[key],
+      ),
+    );
+  }
+
+  // ── headers ──
+  // A leg whose headers were never intercepted on either side (a browser-driven
+  // `/authorize`) yields one gap, not a per-header cascade of fabricated
+  // differences.
+  if (
+    golden.request.headersObserved === false ||
+    candidate.request.headersObserved === false
+  ) {
+    const which =
+      golden.request.headersObserved === false &&
+      candidate.request.headersObserved === false
+        ? "neither side"
+        : golden.request.headersObserved === false
+          ? "the golden trace"
+          : "the candidate trace";
+    findings.push({
+      path: `wire[leg=${slot}].request.headers`,
+      dimension: "headers",
+      severity: "gap",
+      message: `${at} request headers are not comparable: ${which} intercepted them (the request was reconstructed from a URL the client handed to a browser). Capture this leg through a proxy to close it.`,
+      golden: golden.request.headersObserved === false ? "<not intercepted>" : Object.keys(golden.request.headers),
+      candidate: candidate.request.headersObserved === false ? "<not intercepted>" : Object.keys(candidate.request.headers),
+    });
+  } else {
+    const goldenHeaders = golden.request.headers;
+    const candidateHeaders = candidate.request.headers;
+    // Filtered on the LOWERCASED key while the original is kept for lookup and
+    // sorting: trace header names are lowercased by convention, not by the type,
+    // so a hand-written or third-party-HAR-derived trace can carry `Host` and
+    // would slip past a set that only ever holds lowercase entries.
+    const headerKeys = [
+      ...new Set([...Object.keys(goldenHeaders), ...Object.keys(candidateHeaders)]),
+    ]
+      .filter((key) => !ignoreHeaders.has(key.toLowerCase()))
+      .sort();
+
+    for (const key of headerKeys) {
+      const inGolden = key in goldenHeaders;
+      const inCandidate = key in candidateHeaders;
+      const path = `wire[leg=${slot}].request.headers.${key}`;
+
+      if (!inGolden || !inCandidate) {
+        findings.push({
+          path,
+          dimension: "headers",
+          severity: "difference",
+          message: inGolden
+            ? `${at} is missing the \`${key}\` header the ${labels.golden} sends.`
+            : `${at} carries a \`${key}\` header the ${labels.golden} does not send.`,
+          golden: goldenHeaders[key] ?? "<absent>",
+          candidate: candidateHeaders[key] ?? "<absent>",
+        });
+        continue;
+      }
+
+      findings.push(
+        compareValue(
+          path,
+          "headers",
+          `${at} header \`${key}\``,
+          goldenHeaders[key],
+          candidateHeaders[key],
+        ),
+      );
+    }
+  }
+
+  // ── form body fields (token / refresh legs) ──
+  const goldenBody = golden.request.body;
+  const candidateBody = candidate.request.body;
+  if (goldenBody?.encoding === "form" && candidateBody?.encoding === "form") {
+    const fieldKeys = [
+      ...new Set([
+        ...Object.keys(goldenBody.fields),
+        ...Object.keys(candidateBody.fields),
+      ]),
+    ].sort();
+
+    for (const key of fieldKeys) {
+      const inGolden = key in goldenBody.fields;
+      const inCandidate = key in candidateBody.fields;
+      const path = `wire[leg=${slot}].request.body.${key}`;
+
+      if (!inGolden || !inCandidate) {
+        findings.push({
+          path,
+          dimension: "params",
+          severity: "difference",
+          message: inGolden
+            ? `${at} body is missing the \`${key}\` field the ${labels.golden} sends.`
+            : `${at} body carries a \`${key}\` field the ${labels.golden} does not send.`,
+          golden: goldenBody.fields[key] ?? "<absent>",
+          candidate: candidateBody.fields[key] ?? "<absent>",
+        });
+        continue;
+      }
+
+      findings.push(
+        compareValue(
+          path,
+          "params",
+          `${at} body field \`${key}\``,
+          goldenBody.fields[key],
+          candidateBody.fields[key],
+        ),
+      );
+    }
+  } else if (!equal(goldenBody?.encoding, candidateBody?.encoding)) {
+    findings.push({
+      path: `wire[leg=${slot}].request.body.encoding`,
+      dimension: "params",
+      severity: "difference",
+      message: `${at} request body encoding differs.`,
+      golden: goldenBody?.encoding ?? "<no body>",
+      candidate: candidateBody?.encoding ?? "<no body>",
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * Per-leg parameter and header comparison, over EVERY occurrence of each leg.
  *
  * Only legs BOTH sides captured are compared field by field; a leg only one side
  * has is a `gap`, since we cannot tell an emulator bug from a capture that
  * stopped early (a real host capture often stops at the consent screen).
+ *
+ * Occurrences are matched BY POSITION within the leg. A retry belongs inside the
+ * acceptance surface — a second `/token` attempt that adds a param, or a DCR retry
+ * that changes `client_name`, is a real divergence — and comparing only the first
+ * occurrence reported parity for it. A count mismatch is reported ONCE and the
+ * aligned prefix is still compared, rather than silently pairing occurrence 2 of
+ * one side against occurrence 1 of the other.
  */
 function perLegFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
   options: TraceDiffOptions,
+  truncated: boolean,
+  labels: TraceDiffLabels,
 ): TraceDiffFinding[] {
   const findings: TraceDiffFinding[] = [];
   const ignoreHeaders = new Set(
@@ -519,181 +789,52 @@ function perLegFindings(
   }
 
   for (const leg of legs) {
-    const goldenExchange = firstExchangeForLeg(golden.wire, leg);
-    const candidateExchange = firstExchangeForLeg(candidate.wire, leg);
+    const goldenExchanges = exchangesForLeg(golden.wire, leg);
+    const candidateExchanges = exchangesForLeg(candidate.wire, leg);
 
-    if (!goldenExchange || !candidateExchange) {
-      const which = !goldenExchange ? "the golden trace" : "the candidate trace";
+    if (goldenExchanges.length === 0 || candidateExchanges.length === 0) {
+      const which =
+        goldenExchanges.length === 0 ? "the golden trace" : "the candidate trace";
       findings.push({
         path: `wire[leg=${leg}]`,
         dimension: "params",
         severity: "gap",
         message: `The \`${leg}\` leg is only present on one side (${which} lacks it), so its params and headers are not comparable.`,
-        golden: goldenExchange ? "captured" : "<not observed>",
-        candidate: candidateExchange ? "captured" : "<not observed>",
+        golden: goldenExchanges.length > 0 ? "captured" : "<not observed>",
+        candidate: candidateExchanges.length > 0 ? "captured" : "<not observed>",
       });
       continue;
     }
 
-    findings.push(
-      compareValue(
-        `wire[leg=${leg}].request.method`,
-        "params",
-        `\`${leg}\` HTTP method`,
-        goldenExchange.request.method,
-        candidateExchange.request.method,
-      ),
-    );
+    const paired = Math.min(goldenExchanges.length, candidateExchanges.length);
+    if (goldenExchanges.length !== candidateExchanges.length) {
+      // A truncated golden capture is the one case where a short count is OUR
+      // limitation rather than the client's behavior, so it degrades to a gap for
+      // the same reason the endpoint and ordering dimensions do.
+      findings.push({
+        path: `wire[leg=${leg}].occurrences`,
+        dimension: "request-ordering",
+        severity: truncated ? "gap" : "difference",
+        message: truncated
+          ? `The \`${leg}\` leg was sent ${goldenExchanges.length}× by the ${labels.golden} and ${candidateExchanges.length}× by the ${labels.candidate}, but the golden capture stopped early, so the missing attempts were never observed either happening or not. Only the first ${paired} could be compared field by field.`
+          : `The \`${leg}\` leg was sent ${goldenExchanges.length}× by the ${labels.golden} and ${candidateExchanges.length}× by the ${labels.candidate}. Only the first ${paired} occurrence(s) could be paired up and compared field by field.`,
+        golden: goldenExchanges.length,
+        candidate: candidateExchanges.length,
+      });
+    }
 
-    // ── params ──
-    const goldenQuery = goldenExchange.request.query ?? {};
-    const candidateQuery = candidateExchange.request.query ?? {};
-    const queryKeys = [
-      ...new Set([...Object.keys(goldenQuery), ...Object.keys(candidateQuery)]),
-    ].sort();
-
-    for (const key of queryKeys) {
-      const inGolden = key in goldenQuery;
-      const inCandidate = key in candidateQuery;
-      const path = `wire[leg=${leg}].request.query.${key}`;
-
-      if (!inGolden || !inCandidate) {
-        findings.push({
-          path,
-          dimension: "params",
-          severity: "difference",
-          message: inGolden
-            ? `\`${leg}\` is missing the \`${key}\` param the real host sends.`
-            : `\`${leg}\` carries a \`${key}\` param the real host does not send.`,
-          golden: goldenQuery[key] ?? "<absent>",
-          candidate: candidateQuery[key] ?? "<absent>",
-        });
-        continue;
-      }
-
+    for (let index = 0; index < paired; index += 1) {
       findings.push(
-        compareValue(
-          path,
-          "params",
-          `\`${leg}\` param \`${key}\``,
-          goldenQuery[key],
-          candidateQuery[key],
-        ),
+        ...exchangePairFindings({
+          leg,
+          slot: index === 0 ? leg : `${leg}#${index}`,
+          occurrence: index === 0 ? "" : ` (occurrence ${index + 1})`,
+          golden: goldenExchanges[index],
+          candidate: candidateExchanges[index],
+          ignoreHeaders,
+          labels,
+        }),
       );
-    }
-
-    // ── headers ──
-    // A leg whose headers were never intercepted on either side (a browser-driven
-    // `/authorize`) yields one gap, not a per-header cascade of fabricated
-    // differences.
-    if (
-      goldenExchange.request.headersObserved === false ||
-      candidateExchange.request.headersObserved === false
-    ) {
-      const which =
-        goldenExchange.request.headersObserved === false &&
-        candidateExchange.request.headersObserved === false
-          ? "neither side"
-          : goldenExchange.request.headersObserved === false
-            ? "the golden trace"
-            : "the candidate trace";
-      findings.push({
-        path: `wire[leg=${leg}].request.headers`,
-        dimension: "headers",
-        severity: "gap",
-        message: `\`${leg}\` request headers are not comparable: ${which} intercepted them (the request was reconstructed from a URL the client handed to a browser). Capture this leg through a proxy to close it.`,
-        golden: goldenExchange.request.headersObserved === false ? "<not intercepted>" : Object.keys(goldenExchange.request.headers),
-        candidate: candidateExchange.request.headersObserved === false ? "<not intercepted>" : Object.keys(candidateExchange.request.headers),
-      });
-    } else {
-      const goldenHeaders = goldenExchange.request.headers;
-      const candidateHeaders = candidateExchange.request.headers;
-      const headerKeys = [
-        ...new Set([...Object.keys(goldenHeaders), ...Object.keys(candidateHeaders)]),
-      ]
-        .filter((key) => !ignoreHeaders.has(key))
-        .sort();
-
-      for (const key of headerKeys) {
-        const inGolden = key in goldenHeaders;
-        const inCandidate = key in candidateHeaders;
-        const path = `wire[leg=${leg}].request.headers.${key}`;
-
-        if (!inGolden || !inCandidate) {
-          findings.push({
-            path,
-            dimension: "headers",
-            severity: "difference",
-            message: inGolden
-              ? `\`${leg}\` is missing the \`${key}\` header the real host sends.`
-              : `\`${leg}\` carries a \`${key}\` header the real host does not send.`,
-            golden: goldenHeaders[key] ?? "<absent>",
-            candidate: candidateHeaders[key] ?? "<absent>",
-          });
-          continue;
-        }
-
-        findings.push(
-          compareValue(
-            path,
-            "headers",
-            `\`${leg}\` header \`${key}\``,
-            goldenHeaders[key],
-            candidateHeaders[key],
-          ),
-        );
-      }
-    }
-
-    // ── form body fields (token / refresh legs) ──
-    const goldenBody = goldenExchange.request.body;
-    const candidateBody = candidateExchange.request.body;
-    if (goldenBody?.encoding === "form" && candidateBody?.encoding === "form") {
-      const fieldKeys = [
-        ...new Set([
-          ...Object.keys(goldenBody.fields),
-          ...Object.keys(candidateBody.fields),
-        ]),
-      ].sort();
-
-      for (const key of fieldKeys) {
-        const inGolden = key in goldenBody.fields;
-        const inCandidate = key in candidateBody.fields;
-        const path = `wire[leg=${leg}].request.body.${key}`;
-
-        if (!inGolden || !inCandidate) {
-          findings.push({
-            path,
-            dimension: "params",
-            severity: "difference",
-            message: inGolden
-              ? `\`${leg}\` body is missing the \`${key}\` field the real host sends.`
-              : `\`${leg}\` body carries a \`${key}\` field the real host does not send.`,
-            golden: goldenBody.fields[key] ?? "<absent>",
-            candidate: candidateBody.fields[key] ?? "<absent>",
-          });
-          continue;
-        }
-
-        findings.push(
-          compareValue(
-            path,
-            "params",
-            `\`${leg}\` body field \`${key}\``,
-            goldenBody.fields[key],
-            candidateBody.fields[key],
-          ),
-        );
-      }
-    } else if (!equal(goldenBody?.encoding, candidateBody?.encoding)) {
-      findings.push({
-        path: `wire[leg=${leg}].request.body.encoding`,
-        dimension: "params",
-        severity: "difference",
-        message: `\`${leg}\` request body encoding differs.`,
-        golden: goldenBody?.encoding ?? "<no body>",
-        candidate: candidateBody?.encoding ?? "<no body>",
-      });
     }
   }
 
@@ -705,6 +846,7 @@ function perLegFindings(
 function protocolVersionFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
+  labels: TraceDiffLabels,
 ): TraceDiffFinding[] {
   const goldenPv = golden.observations.protocolVersion;
   const candidatePv = candidate.observations.protocolVersion;
@@ -716,6 +858,7 @@ function protocolVersionFindings(
       "`initialize.params.protocolVersion` (MCP body)",
       goldenPv.initializeBody,
       candidatePv.initializeBody,
+      labels,
     ),
     compareObservation(
       "observations.protocolVersion.headerOnOAuthDiscovery",
@@ -723,6 +866,7 @@ function protocolVersionFindings(
       "`MCP-Protocol-Version` header on OAuth discovery",
       goldenPv.headerOnOAuthDiscovery,
       candidatePv.headerOnOAuthDiscovery,
+      labels,
     ),
     compareObservation(
       "observations.protocolVersion.headerOnMcpTraffic",
@@ -730,6 +874,7 @@ function protocolVersionFindings(
       "`MCP-Protocol-Version` header on MCP traffic",
       goldenPv.headerOnMcpTraffic,
       candidatePv.headerOnMcpTraffic,
+      labels,
     ),
   ];
 
@@ -738,20 +883,26 @@ function protocolVersionFindings(
   // wrong in the same direction" would match on neither field but could still
   // agree on the flag, and vice versa. Surfacing the flag makes the class of
   // bug legible.
+  //
+  // Routed through `compareObservation`, not `compareValue`: both are tri-state,
+  // so a trace that captured only one wire yields a `gap` here instead of a
+  // fabricated difference against a trace that captured both.
   findings.push(
-    compareValue(
+    compareObservation(
       "observations.protocolVersion.wiresDisagree",
       "protocol-version",
       "Whether the OAuth wire and the MCP wire carry different protocol versions",
       goldenPv.wiresDisagree,
       candidatePv.wiresDisagree,
+      labels,
     ),
-    compareValue(
+    compareObservation(
       "observations.protocolVersion.headerDisagreesWithInitializeBody",
       "protocol-version",
       "Whether the `MCP-Protocol-Version` header disagrees with the `initialize` body",
       goldenPv.headerDisagreesWithInitializeBody,
       candidatePv.headerDisagreesWithInitializeBody,
+      labels,
     ),
   );
 
@@ -763,16 +914,14 @@ function protocolVersionFindings(
   ].sort() as TraceLeg[];
 
   for (const leg of legs) {
-    const goldenObservation = goldenPv.headerByLeg[leg];
-    const candidateObservation = candidatePv.headerByLeg[leg];
-    if (!goldenObservation || !candidateObservation) continue;
     findings.push(
       compareObservation(
         `observations.protocolVersion.headerByLeg.${leg}`,
         "protocol-version",
         `\`MCP-Protocol-Version\` on the \`${leg}\` leg`,
-        goldenObservation,
-        candidateObservation,
+        observationForLeg(goldenPv.headerByLeg, leg, "`MCP-Protocol-Version`"),
+        observationForLeg(candidatePv.headerByLeg, leg, "`MCP-Protocol-Version`"),
+        labels,
       ),
     );
   }
@@ -783,6 +932,7 @@ function protocolVersionFindings(
 function resourceIndicatorFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
+  labels: TraceDiffLabels,
 ): TraceDiffFinding[] {
   const goldenRi = golden.observations.resourceIndicator;
   const candidateRi = candidate.observations.resourceIndicator;
@@ -798,6 +948,7 @@ function resourceIndicatorFindings(
       "RFC 8707 `resource` on /authorize",
       goldenRi.onAuthorize,
       candidateRi.onAuthorize,
+      labels,
     ),
     compareObservation(
       "observations.resourceIndicator.onToken",
@@ -805,6 +956,7 @@ function resourceIndicatorFindings(
       "RFC 8707 `resource` on /token",
       goldenRi.onToken,
       candidateRi.onToken,
+      labels,
     ),
     compareObservation(
       "observations.resourceIndicator.onRefresh",
@@ -812,6 +964,7 @@ function resourceIndicatorFindings(
       "RFC 8707 `resource` on token refresh",
       goldenRi.onRefresh,
       candidateRi.onRefresh,
+      labels,
     ),
   ];
 
@@ -821,6 +974,7 @@ function resourceIndicatorFindings(
     "Which URL the `resource` value is taken from",
     goldenRi.valueSource,
     candidateRi.valueSource,
+    labels,
   );
 
   // When the scenario's PRM `resource` is byte-identical to the MCP server URL,
@@ -831,10 +985,6 @@ function resourceIndicatorFindings(
   if (
     sourceFinding.severity === "difference" &&
     prmEqualsServer &&
-    new Set([
-      observedValue(goldenRi.valueSource),
-      observedValue(candidateRi.valueSource),
-    ]).size <= 2 &&
     [observedValue(goldenRi.valueSource), observedValue(candidateRi.valueSource)].every(
       (value) => value === "mcp-server-url" || value === "prm-resource",
     )
@@ -855,6 +1005,7 @@ function resourceIndicatorFindings(
 function dcrFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
+  labels: TraceDiffLabels,
 ): TraceDiffFinding[] {
   const goldenDcr = golden.observations.dcrIdentity;
   const candidateDcr = candidate.observations.dcrIdentity;
@@ -866,6 +1017,7 @@ function dcrFindings(
       "DCR `client_name`",
       goldenDcr.clientName,
       candidateDcr.clientName,
+      labels,
     ),
     compareObservation(
       "observations.dcrIdentity.redirectUris",
@@ -873,6 +1025,7 @@ function dcrFindings(
       "DCR `redirect_uris` (loopback ports placeheld)",
       goldenDcr.redirectUris,
       candidateDcr.redirectUris,
+      labels,
     ),
     compareObservation(
       "observations.dcrIdentity.grantTypes",
@@ -880,6 +1033,7 @@ function dcrFindings(
       "DCR `grant_types`",
       goldenDcr.grantTypes,
       candidateDcr.grantTypes,
+      labels,
     ),
     compareObservation(
       "observations.dcrIdentity.responseTypes",
@@ -887,6 +1041,7 @@ function dcrFindings(
       "DCR `response_types`",
       goldenDcr.responseTypes,
       candidateDcr.responseTypes,
+      labels,
     ),
     compareObservation(
       "observations.dcrIdentity.tokenEndpointAuthMethod",
@@ -894,6 +1049,7 @@ function dcrFindings(
       "DCR `token_endpoint_auth_method`",
       goldenDcr.tokenEndpointAuthMethod,
       candidateDcr.tokenEndpointAuthMethod,
+      labels,
     ),
     compareObservation(
       "observations.dcrIdentity.scope",
@@ -901,13 +1057,27 @@ function dcrFindings(
       "DCR `scope`",
       goldenDcr.scope,
       candidateDcr.scope,
+      labels,
     ),
+    // Names AND values, so two bodies differing only in the VALUE of an unmodelled
+    // field are a difference rather than reported parity.
     compareObservation(
       "observations.dcrIdentity.extraFields",
       "dcr-body",
-      "DCR body fields this schema does not model",
+      "DCR body fields this schema does not model (name and value)",
       goldenDcr.extraFields,
       candidateDcr.extraFields,
+      labels,
+    ),
+    // A field sent with the wrong JSON type is a real behavioral difference, and
+    // one that reporting the field as `absent` used to hide completely.
+    compareObservation(
+      "observations.dcrIdentity.malformedFields",
+      "dcr-body",
+      "DCR body fields sent with the wrong JSON type",
+      goldenDcr.malformedFields,
+      candidateDcr.malformedFields,
+      labels,
     ),
   ];
 
@@ -920,6 +1090,7 @@ function dcrFindings(
     "Observed loopback redirect ports",
     goldenDcr.observedLoopbackPorts,
     candidateDcr.observedLoopbackPorts,
+    labels,
   );
   findings.push({
     ...ports,
@@ -936,6 +1107,7 @@ function dcrFindings(
 function pkceAndUaFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
+  labels: TraceDiffLabels,
 ): TraceDiffFinding[] {
   const findings: TraceDiffFinding[] = [
     compareObservation(
@@ -944,6 +1116,7 @@ function pkceAndUaFindings(
       "PKCE `code_challenge_method`",
       golden.observations.pkce.challengeMethod,
       candidate.observations.pkce.challengeMethod,
+      labels,
     ),
     compareObservation(
       "observations.pkce.challengeLength",
@@ -951,6 +1124,7 @@ function pkceAndUaFindings(
       "PKCE `code_challenge` length",
       golden.observations.pkce.challengeLength,
       candidate.observations.pkce.challengeLength,
+      labels,
     ),
     compareObservation(
       "observations.pkce.verifierSentOnToken",
@@ -958,6 +1132,7 @@ function pkceAndUaFindings(
       "PKCE `code_verifier` present on /token",
       golden.observations.pkce.verifierSentOnToken,
       candidate.observations.pkce.verifierSentOnToken,
+      labels,
     ),
   ];
 
@@ -969,27 +1144,28 @@ function pkceAndUaFindings(
   ].sort() as TraceLeg[];
 
   for (const leg of legs) {
-    const goldenUa = golden.observations.userAgent.byLeg[leg];
-    const candidateUa = candidate.observations.userAgent.byLeg[leg];
-    if (!goldenUa || !candidateUa) continue;
     findings.push(
       compareObservation(
         `observations.userAgent.byLeg.${leg}`,
         "user-agent",
         `\`User-Agent\` on the \`${leg}\` leg`,
-        goldenUa,
-        candidateUa,
+        observationForLeg(golden.observations.userAgent.byLeg, leg, "`User-Agent`"),
+        observationForLeg(candidate.observations.userAgent.byLeg, leg, "`User-Agent`"),
+        labels,
       ),
     );
   }
 
   findings.push(
-    compareValue(
+    // Tri-state, so a trace with a reconstructed leg yields a gap here rather
+    // than a fabricated user-agent-consistency difference.
+    compareObservation(
       "observations.userAgent.consistent",
       "user-agent",
       "Whether one `User-Agent` is used across every captured leg",
       golden.observations.userAgent.consistent,
       candidate.observations.userAgent.consistent,
+      labels,
     ),
   );
 
@@ -1029,23 +1205,26 @@ export function diffGoldenTraces(
   const mode =
     options.mode ??
     (golden.subject.kind === candidate.subject.kind ? "drift" : "parity");
+  // Resolved once and threaded through every finding-producing function, so the
+  // report cannot name one thing in a message and another in a heading.
+  const labels = DIFF_LABELS[mode];
 
   const gates = gateFindings(golden, candidate);
   const findings: TraceDiffFinding[] = [...gates];
 
   if (!gates.some((finding) => finding.severity === "incomparable")) {
-    // Computed once and threaded through, so the ordering and endpoint dimensions
-    // agree about whether the golden capture was cut short.
+    // Computed once and threaded through, so the ordering, endpoint and per-leg
+    // dimensions agree about whether the golden capture was cut short.
     const truncated = goldenIsTruncatedPrefix(golden, candidate);
     findings.push(
-      ...subjectFindings(golden, candidate, mode),
-      ...orderingFindings(golden, candidate, truncated),
-      ...endpointFindings(golden, candidate, truncated),
-      ...perLegFindings(golden, candidate, options),
-      ...protocolVersionFindings(golden, candidate),
-      ...resourceIndicatorFindings(golden, candidate),
-      ...dcrFindings(golden, candidate),
-      ...pkceAndUaFindings(golden, candidate),
+      ...subjectFindings(golden, candidate, mode, labels),
+      ...orderingFindings(golden, candidate, truncated, labels),
+      ...endpointFindings(golden, candidate, truncated, labels),
+      ...perLegFindings(golden, candidate, options, truncated, labels),
+      ...protocolVersionFindings(golden, candidate, labels),
+      ...resourceIndicatorFindings(golden, candidate, labels),
+      ...dcrFindings(golden, candidate, labels),
+      ...pkceAndUaFindings(golden, candidate, labels),
     );
   }
 
@@ -1075,6 +1254,8 @@ export function diffGoldenTraces(
     parity: counts.difference === 0 && counts.incomparable === 0,
     goldenTraceId: golden.traceId,
     candidateTraceId: candidate.traceId,
+    mode,
+    labels,
     counts,
     findings: sorted,
     summary: summarize(counts),

--- a/sdk/src/oauth-golden-trace/diff.ts
+++ b/sdk/src/oauth-golden-trace/diff.ts
@@ -60,6 +60,50 @@ function equal(left: unknown, right: unknown): boolean {
   return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
 }
 
+/**
+ * Headers added by the HTTP stack, not chosen by the client.
+ *
+ * These have to be excluded when the two traces were recorded from DIFFERENT
+ * VANTAGE POINTS, because the two vantage points genuinely see different things:
+ *
+ *   - a CLIENT-side capture (`via: "mcpjam-emulator"`) records the headers the
+ *     client CODE set, before undici/the browser appends its own;
+ *   - a SERVER-side capture (`via: "har"` from our recording server, or a proxy)
+ *     records what ARRIVED, including everything the stack added in transit.
+ *
+ * So `host`, `content-length` and `accept-encoding` show up on the server-side
+ * trace and are missing from the client-side one for every request, in both a
+ * conformant and a broken emulator. Reporting them would add a fixed tax of false
+ * differences to every cross-vantage diff and teach a reviewer to skim past the
+ * header dimension — which is where the real findings live.
+ *
+ * They are NOT excluded when both traces share a vantage point: two server-side
+ * captures genuinely can differ here, and that would be a real finding.
+ */
+const TRANSPORT_HEADERS = new Set([
+  "host",
+  "connection",
+  "content-length",
+  "accept-encoding",
+  "keep-alive",
+  "transfer-encoding",
+  "te",
+  "upgrade",
+  "via",
+  "forwarded",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "sec-fetch-mode",
+  "sec-fetch-site",
+  "sec-fetch-dest",
+]);
+
+/** Client-side or server-side? Determined by how the trace was captured. */
+function vantageOf(trace: GoldenTrace): "client" | "server" {
+  return trace.capture.method.via === "mcpjam-emulator" ? "client" : "server";
+}
+
 function renderObservation<T>(observation: Observation<T>): unknown {
   switch (observation.state) {
     case "present":
@@ -288,10 +332,54 @@ function firstExchangeForLeg(
   return wire.find((exchange) => exchange.leg === leg);
 }
 
+/**
+ * Was the GOLDEN capture simply cut short?
+ *
+ * True when the golden trace's leg sequence is a strict prefix of the candidate's.
+ * That relationship is the signature of a TRUNCATED capture — a real-host recording
+ * that stopped because the operator could not drive the browser leg, or the proxy
+ * was detached — not of a client that behaves differently.
+ *
+ * It matters because the alternative is to report every leg past the truncation
+ * point as "the emulator hit an endpoint the real host did not", which is false:
+ * we did not observe the real host declining to hit it, we stopped watching. Those
+ * become gaps instead.
+ *
+ * Deliberately strict about the PREFIX: if the sequences diverge anywhere inside
+ * the overlap, this is real divergence and nothing is downgraded.
+ */
+function goldenIsTruncatedPrefix(
+  golden: GoldenTrace,
+  candidate: GoldenTrace,
+): boolean {
+  const goldenSequence = golden.wire.map((exchange) => exchange.leg);
+  const candidateSequence = candidate.wire.map((exchange) => exchange.leg);
+  if (goldenSequence.length >= candidateSequence.length) return false;
+  return goldenSequence.every((leg, index) => leg === candidateSequence[index]);
+}
+
 function orderingFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
+  truncated: boolean,
 ): TraceDiffFinding[] {
+  const goldenSequence = golden.wire.map((exchange) => exchange.leg);
+  const candidateSequence = candidate.wire.map((exchange) => exchange.leg);
+
+  if (truncated) {
+    const extra = candidateSequence.slice(goldenSequence.length);
+    return [
+      {
+        path: "observations.legOrder",
+        dimension: "request-ordering",
+        severity: "gap",
+        message: `Ordering agrees for every stage the golden trace captured, but that capture stopped after \`${goldenSequence[goldenSequence.length - 1]}\`. The candidate continued through ${extra.map((leg) => `\`${leg}\``).join(", ")}, which the real host was never observed either doing or not doing. Complete the golden capture to compare these.`,
+        golden: goldenSequence,
+        candidate: candidateSequence,
+      },
+    ];
+  }
+
   const findings: TraceDiffFinding[] = [
     compareValue(
       "observations.legOrder",
@@ -304,8 +392,6 @@ function orderingFindings(
 
   // The full sequence catches repeat-count differences the first-appearance
   // order hides — e.g. a client that retries AS discovery at a second rung.
-  const goldenSequence = golden.wire.map((exchange) => exchange.leg);
-  const candidateSequence = candidate.wire.map((exchange) => exchange.leg);
   if (!equal(goldenSequence, candidateSequence)) {
     findings.push({
       path: "wire[].leg",
@@ -324,6 +410,7 @@ function orderingFindings(
 function endpointFindings(
   golden: GoldenTrace,
   candidate: GoldenTrace,
+  truncated: boolean,
 ): TraceDiffFinding[] {
   const findings: TraceDiffFinding[] = [];
   const goldenSet = golden.observations.endpointsHit;
@@ -331,6 +418,30 @@ function endpointFindings(
 
   const missing = goldenSet.filter((endpoint) => !candidateSet.includes(endpoint));
   const extra = candidateSet.filter((endpoint) => !goldenSet.includes(endpoint));
+
+  // A truncated golden capture cannot support "the real host does not hit this".
+  if (truncated && extra.length > 0) {
+    findings.push({
+      path: "observations.endpointsHit",
+      dimension: "endpoints",
+      severity: "gap",
+      message: `The candidate hit ${extra.length} endpoint(s) beyond where the golden capture stopped. Not a difference: the real host was never observed declining to hit them.`,
+      golden: null,
+      candidate: extra,
+    });
+    if (missing.length === 0) {
+      findings.push(
+        compareValue(
+          "observations.discoveryLadder",
+          "endpoints",
+          "Discovery ladder (well-known paths, in order tried)",
+          golden.observations.discoveryLadder,
+          candidate.observations.discoveryLadder,
+        ),
+      );
+      return findings;
+    }
+  }
 
   if (missing.length === 0 && extra.length === 0) {
     findings.push({
@@ -393,6 +504,11 @@ function perLegFindings(
   const ignoreHeaders = new Set(
     (options.ignoreHeaders ?? []).map((header) => header.toLowerCase()),
   );
+  // Cross-vantage diffs cannot compare stack-added headers. See TRANSPORT_HEADERS.
+  const crossVantage = vantageOf(golden) !== vantageOf(candidate);
+  if (crossVantage) {
+    for (const header of TRANSPORT_HEADERS) ignoreHeaders.add(header);
+  }
 
   const legs: TraceLeg[] = [];
   for (const leg of [
@@ -918,10 +1034,13 @@ export function diffGoldenTraces(
   const findings: TraceDiffFinding[] = [...gates];
 
   if (!gates.some((finding) => finding.severity === "incomparable")) {
+    // Computed once and threaded through, so the ordering and endpoint dimensions
+    // agree about whether the golden capture was cut short.
+    const truncated = goldenIsTruncatedPrefix(golden, candidate);
     findings.push(
       ...subjectFindings(golden, candidate, mode),
-      ...orderingFindings(golden, candidate),
-      ...endpointFindings(golden, candidate),
+      ...orderingFindings(golden, candidate, truncated),
+      ...endpointFindings(golden, candidate, truncated),
       ...perLegFindings(golden, candidate, options),
       ...protocolVersionFindings(golden, candidate),
       ...resourceIndicatorFindings(golden, candidate),

--- a/sdk/src/oauth-golden-trace/format.ts
+++ b/sdk/src/oauth-golden-trace/format.ts
@@ -1,0 +1,146 @@
+/**
+ * HP-44 — human-readable rendering of a trace diff and a capture report.
+ *
+ * Written for a reviewer deciding whether to trust a parity claim, so the
+ * ordering is deliberate: differences first (actionable), then gaps (what we
+ * could not see), then a match count (not a match list — nobody reads forty
+ * lines of "matches"). Gaps are given as much prominence as differences because
+ * "the emulator matched everything we looked at, and we looked at very little"
+ * is the failure mode this harness exists to make visible.
+ */
+
+import type { HarIngestReport } from "./from-har.js";
+import type { GoldenTrace, TraceDiffFinding, TraceDiffResult } from "./types.js";
+
+const VALUE_LIMIT = 160;
+
+function renderValue(value: unknown): string {
+  if (value === undefined) return "—";
+  if (typeof value === "string") {
+    return value.length > VALUE_LIMIT ? `${value.slice(0, VALUE_LIMIT - 1)}…` : value;
+  }
+  const json = JSON.stringify(value);
+  if (json == null) return String(value);
+  return json.length > VALUE_LIMIT ? `${json.slice(0, VALUE_LIMIT - 1)}…` : json;
+}
+
+function renderFinding(finding: TraceDiffFinding): string[] {
+  const lines = [`  • [${finding.dimension}] ${finding.message}`, `    at ${finding.path}`];
+  if (finding.golden !== undefined || finding.candidate !== undefined) {
+    lines.push(`    real host: ${renderValue(finding.golden)}`);
+    lines.push(`    emulator:  ${renderValue(finding.candidate)}`);
+  }
+  return lines;
+}
+
+function pluralize(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}
+
+/** Render a diff result as plain text. */
+export function formatTraceDiffHuman(result: TraceDiffResult): string {
+  const lines: string[] = [];
+
+  lines.push("OAuth golden-trace parity diff");
+  lines.push(`  golden (real host): ${result.goldenTraceId}`);
+  lines.push(`  candidate (emulator): ${result.candidateTraceId}`);
+  lines.push("");
+
+  const incomparable = result.findings.filter((f) => f.severity === "incomparable");
+  if (incomparable.length > 0) {
+    lines.push("INCOMPARABLE — no field-level comparison was attempted:");
+    for (const finding of incomparable) lines.push(...renderFinding(finding));
+    lines.push("");
+    lines.push(result.summary);
+    return lines.join("\n");
+  }
+
+  const differences = result.findings.filter((f) => f.severity === "difference");
+  if (differences.length > 0) {
+    lines.push(`DIFFERENCES (${differences.length}) — the emulator does not match the real host:`);
+    for (const finding of differences) lines.push(...renderFinding(finding));
+    lines.push("");
+  }
+
+  const gaps = result.findings.filter((f) => f.severity === "gap");
+  if (gaps.length > 0) {
+    lines.push(
+      `GAPS (${gaps.length}) — not comparable, because one side never observed it. These are NOT passes:`,
+    );
+    for (const finding of gaps) lines.push(...renderFinding(finding));
+    lines.push("");
+  }
+
+  lines.push(`MATCHES: ${result.counts.match}`);
+  lines.push("");
+  lines.push(
+    result.parity
+      ? `PARITY on every comparable field (${pluralize(result.counts.gap, "gap")} remaining).`
+      : `NO PARITY: ${pluralize(result.counts.difference, "difference")}, ${pluralize(result.counts.gap, "gap")}.`,
+  );
+  if (result.parity && result.counts.gap > 0) {
+    lines.push(
+      "  Read the gaps before treating this as a green result — parity over a small observed surface is a weak claim.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/** Render a HAR ingest report — the "what we could not capture" deliverable. */
+export function formatHarIngestReportHuman(report: HarIngestReport): string {
+  const lines: string[] = [];
+  lines.push(
+    `HAR ingest: kept ${report.keptEntries} of ${report.totalEntries} entries.`,
+  );
+
+  if (report.missingLegs.length > 0) {
+    lines.push("");
+    lines.push(
+      `MISSING LEGS (${report.missingLegs.length}) — every field these would have carried is recorded as \`not-observed\`:`,
+    );
+    for (const leg of report.missingLegs) lines.push(`  • ${leg}`);
+  }
+
+  if (report.warnings.length > 0) {
+    lines.push("");
+    lines.push(`WARNINGS (${report.warnings.length}):`);
+    for (const warning of report.warnings) lines.push(`  • ${warning}`);
+  }
+
+  if (report.dropped.length > 0) {
+    lines.push("");
+    lines.push(`DROPPED (${report.dropped.length}) — treated as unrelated traffic:`);
+    // Group by reason so a systematic filter mistake is obvious rather than
+    // buried in a hundred near-identical lines.
+    const byReason = new Map<string, string[]>();
+    for (const entry of report.dropped) {
+      const bucket = byReason.get(entry.reason) ?? [];
+      bucket.push(entry.url);
+      byReason.set(entry.reason, bucket);
+    }
+    for (const [reason, urls] of byReason) {
+      lines.push(`  • ${reason} (${urls.length})`);
+      for (const url of urls.slice(0, 5)) lines.push(`      ${renderValue(url)}`);
+      if (urls.length > 5) lines.push(`      … and ${urls.length - 5} more`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** One-line trace summary, for listing committed traces. */
+export function formatTraceSummaryHuman(trace: GoldenTrace): string {
+  const version =
+    trace.subject.hostVersion.state === "present"
+      ? trace.subject.hostVersion.value
+      : "version unknown";
+  const implementation =
+    trace.subject.oauthImplementation.state === "present"
+      ? trace.subject.oauthImplementation.value.kind === "dependency"
+        ? `${trace.subject.oauthImplementation.value.package}@${trace.subject.oauthImplementation.value.version}`
+        : "first-party"
+      : "implementation unknown";
+
+  return `${trace.traceId}  [${trace.subject.kind}] ${version} · ${implementation} · ${trace.wire.length} exchanges · captured ${trace.capture.capturedAt}`;
+}

--- a/sdk/src/oauth-golden-trace/format.ts
+++ b/sdk/src/oauth-golden-trace/format.ts
@@ -10,7 +10,12 @@
  */
 
 import type { HarIngestReport } from "./from-har.js";
-import type { GoldenTrace, TraceDiffFinding, TraceDiffResult } from "./types.js";
+import type {
+  GoldenTrace,
+  TraceDiffFinding,
+  TraceDiffLabels,
+  TraceDiffResult,
+} from "./types.js";
 
 const VALUE_LIMIT = 160;
 
@@ -24,11 +29,23 @@ function renderValue(value: unknown): string {
   return json.length > VALUE_LIMIT ? `${json.slice(0, VALUE_LIMIT - 1)}…` : json;
 }
 
-function renderFinding(finding: TraceDiffFinding): string[] {
+/**
+ * Side labels come from the RESULT, never from this module.
+ *
+ * `result.labels` is what the differ phrased its own messages with, so deriving
+ * the value lines from anything else lets the heading contradict the prose right
+ * underneath it. Hardcoded "real host" / "emulator" did exactly that for a
+ * `drift` diff (HP-38: the same subject captured twice, no emulator on either
+ * side) — blaming an emulator that was never involved.
+ */
+function renderFinding(finding: TraceDiffFinding, labels: TraceDiffLabels): string[] {
   const lines = [`  • [${finding.dimension}] ${finding.message}`, `    at ${finding.path}`];
   if (finding.golden !== undefined || finding.candidate !== undefined) {
-    lines.push(`    real host: ${renderValue(finding.golden)}`);
-    lines.push(`    emulator:  ${renderValue(finding.candidate)}`);
+    const width = Math.max(labels.golden.length, labels.candidate.length);
+    lines.push(`    ${`${labels.golden}:`.padEnd(width + 1)} ${renderValue(finding.golden)}`);
+    lines.push(
+      `    ${`${labels.candidate}:`.padEnd(width + 1)} ${renderValue(finding.candidate)}`,
+    );
   }
   return lines;
 }
@@ -40,16 +57,17 @@ function pluralize(count: number, singular: string): string {
 /** Render a diff result as plain text. */
 export function formatTraceDiffHuman(result: TraceDiffResult): string {
   const lines: string[] = [];
+  const labels = result.labels;
 
-  lines.push("OAuth golden-trace parity diff");
-  lines.push(`  golden (real host): ${result.goldenTraceId}`);
-  lines.push(`  candidate (emulator): ${result.candidateTraceId}`);
+  lines.push(`OAuth golden-trace ${result.mode} diff`);
+  lines.push(`  golden (${labels.golden}): ${result.goldenTraceId}`);
+  lines.push(`  candidate (${labels.candidate}): ${result.candidateTraceId}`);
   lines.push("");
 
   const incomparable = result.findings.filter((f) => f.severity === "incomparable");
   if (incomparable.length > 0) {
     lines.push("INCOMPARABLE — no field-level comparison was attempted:");
-    for (const finding of incomparable) lines.push(...renderFinding(finding));
+    for (const finding of incomparable) lines.push(...renderFinding(finding, labels));
     lines.push("");
     lines.push(result.summary);
     return lines.join("\n");
@@ -57,8 +75,10 @@ export function formatTraceDiffHuman(result: TraceDiffResult): string {
 
   const differences = result.findings.filter((f) => f.severity === "difference");
   if (differences.length > 0) {
-    lines.push(`DIFFERENCES (${differences.length}) — the emulator does not match the real host:`);
-    for (const finding of differences) lines.push(...renderFinding(finding));
+    lines.push(
+      `DIFFERENCES (${differences.length}) — the ${labels.candidate} does not match the ${labels.golden}:`,
+    );
+    for (const finding of differences) lines.push(...renderFinding(finding, labels));
     lines.push("");
   }
 
@@ -67,7 +87,7 @@ export function formatTraceDiffHuman(result: TraceDiffResult): string {
     lines.push(
       `GAPS (${gaps.length}) — not comparable, because one side never observed it. These are NOT passes:`,
     );
-    for (const finding of gaps) lines.push(...renderFinding(finding));
+    for (const finding of gaps) lines.push(...renderFinding(finding, labels));
     lines.push("");
   }
 
@@ -85,6 +105,32 @@ export function formatTraceDiffHuman(result: TraceDiffResult): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Origin and path only — never the query string or fragment.
+ *
+ * A DROPPED HAR entry never went through `./normalize.js`: it is reported straight
+ * off the input, so its query may still carry a live `code`, `client_secret` or
+ * `access_token`. The trace itself is redacted at capture time, and rendering a
+ * raw URL here would leak past that guarantee into a human report and from there
+ * into CI logs. Diagnosing a filter mistake needs the ENDPOINT, never the
+ * parameters, so they are dropped rather than truncated — a truncated query string
+ * still leaks its beginning.
+ */
+function sanitizeUrlForReport(raw: string): string {
+  try {
+    const url = new URL(raw);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    // Not a parseable URL (or a placeholder like `<no url>`): keep only what
+    // precedes the first `?` or `#`, which cannot hold a query parameter.
+    return raw.split(/[?#]/)[0];
+  }
 }
 
 /** Render a HAR ingest report — the "what we could not capture" deliverable. */
@@ -116,7 +162,7 @@ export function formatHarIngestReportHuman(report: HarIngestReport): string {
     const byReason = new Map<string, string[]>();
     for (const entry of report.dropped) {
       const bucket = byReason.get(entry.reason) ?? [];
-      bucket.push(entry.url);
+      bucket.push(sanitizeUrlForReport(entry.url));
       byReason.set(entry.reason, bucket);
     }
     for (const [reason, urls] of byReason) {
@@ -129,18 +175,30 @@ export function formatHarIngestReportHuman(report: HarIngestReport): string {
   return lines.join("\n");
 }
 
-/** One-line trace summary, for listing committed traces. */
+/**
+ * One-line trace summary, for listing committed traces.
+ *
+ * `absent` and `not-observed` are rendered DIFFERENTLY. Collapsing them to
+ * "unknown" erases the distinction the whole schema exists to preserve: "this host
+ * exposes no version" is a positive finding about the host, while "we never read a
+ * version" is a durability gap in the capture. A reviewer scanning this listing is
+ * exactly the person who needs to tell them apart.
+ */
 export function formatTraceSummaryHuman(trace: GoldenTrace): string {
   const version =
     trace.subject.hostVersion.state === "present"
       ? trace.subject.hostVersion.value
-      : "version unknown";
+      : trace.subject.hostVersion.state === "absent"
+        ? "no version exposed"
+        : "version not observed";
   const implementation =
     trace.subject.oauthImplementation.state === "present"
       ? trace.subject.oauthImplementation.value.kind === "dependency"
         ? `${trace.subject.oauthImplementation.value.package}@${trace.subject.oauthImplementation.value.version}`
         : "first-party"
-      : "implementation unknown";
+      : trace.subject.oauthImplementation.state === "absent"
+        ? "no OAuth implementation declared"
+        : "implementation not observed";
 
   return `${trace.traceId}  [${trace.subject.kind}] ${version} · ${implementation} · ${trace.wire.length} exchanges · captured ${trace.capture.capturedAt}`;
 }

--- a/sdk/src/oauth-golden-trace/format.ts
+++ b/sdk/src/oauth-golden-trace/format.ts
@@ -127,9 +127,14 @@ function sanitizeUrlForReport(raw: string): string {
     url.hash = "";
     return url.toString();
   } catch {
-    // Not a parseable URL (or a placeholder like `<no url>`): keep only what
-    // precedes the first `?` or `#`, which cannot hold a query parameter.
-    return raw.split(/[?#]/)[0];
+    // Not a parseable URL (or a placeholder like `<no url>`). Stripping only the
+    // query and fragment is not enough on this path: userinfo (`user:pass@`) is
+    // part of the AUTHORITY, not the query, so `http://user:s3cret@host/path`
+    // with no `?` or `#` at all would otherwise survive whole into the report.
+    // Userinfo can only appear right after `scheme://`, so that is the only
+    // place this strips.
+    const withoutUserinfo = raw.replace(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^/?#]*@/, "$1");
+    return withoutUserinfo.split(/[?#]/)[0];
   }
 }
 

--- a/sdk/src/oauth-golden-trace/from-conformance.ts
+++ b/sdk/src/oauth-golden-trace/from-conformance.ts
@@ -1,0 +1,363 @@
+/**
+ * HP-44 — capture a golden trace from an in-process emulator run.
+ *
+ * This is the CANDIDATE side of a parity diff, and — for `mcpjam` itself — also
+ * the golden side, because MCPJam is first-party and can be run end to end
+ * today. Getting a working self-diff first is deliberate: it proves the oracle
+ * before any time is spent on proxy capture for hosts we may not be able to run
+ * at all.
+ *
+ * The input is the `ConformanceResult` the existing
+ * `sdk/src/oauth-conformance/runner.ts` already produces. Its
+ * `steps[].httpAttempts` carry the complete `HttpHistoryEntry` wire record, so
+ * no new instrumentation is needed to capture our own behavior — the harness
+ * bolts onto HP-39's CLI + test-server story rather than duplicating it.
+ *
+ * Leg classification prefers the state machine's own `OAuthFlowStep` over URL
+ * heuristics. For our own code the machine KNOWS which leg it is on; a heuristic
+ * that disagreed would be recording our guess about ourselves. The heuristic is
+ * kept as a fallback for steps that map to no leg, and `legBasis` records which
+ * one fired.
+ */
+
+import type { ConformanceResult } from "../oauth-conformance/types.js";
+import type { HttpHistoryEntry } from "../oauth/state-machines/types.js";
+import { classifyLeg, deriveObservations, legForOAuthFlowStep, withObservedLoopbackPorts } from "./observe.js";
+import {
+  NORMALIZER_VERSION,
+  assertTraceIsRedacted,
+  extractLoopbackPorts,
+  normalizeWire,
+} from "./normalize.js";
+import { collectRedirectUris, parseTraceBody } from "./parse.js";
+import { GOLDEN_TRACE_VERSION, notObserved, present } from "./types.js";
+import type {
+  GoldenTrace,
+  TraceExchange,
+  TraceOAuthImplementation,
+  TraceScenario,
+  TraceSubject,
+} from "./types.js";
+
+declare const __MCPJAM_SDK_VERSION__: string;
+
+/** Resolved SDK version, or `unknown` when the define was not substituted. */
+function resolveSdkVersion(): string | undefined {
+  try {
+    return typeof __MCPJAM_SDK_VERSION__ === "string"
+      ? __MCPJAM_SDK_VERSION__
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Build a deterministic trace id. Same host + scenario + day ⇒ same id. */
+export function buildTraceId(input: {
+  hostId: string;
+  scenarioId: string;
+  capturedAt: string;
+  kind: TraceSubject["kind"];
+}): string {
+  return `${input.hostId}/${input.scenarioId}/${input.capturedAt}/${input.kind}`;
+}
+
+/**
+ * Flatten a ConformanceResult's per-step HTTP attempts into wire order.
+ *
+ * `httpAttempts` are appended in execution order within a step, and steps are
+ * pushed in execution order, so plain concatenation already reflects the wire.
+ * Note the deliberate absence of a timestamp sort: same-millisecond requests
+ * would reorder non-deterministically and destroy the ordering finding, which is
+ * one of the things this harness exists to compare.
+ *
+ * Duplicates are NOT removed here — see {@link dedupeWireArtifacts}, which has
+ * to run after normalization to work at all.
+ */
+export function collectHttpHistory(
+  result: ConformanceResult,
+): HttpHistoryEntry[] {
+  const entries: HttpHistoryEntry[] = [];
+  for (const step of result.steps) {
+    for (const attempt of step.httpAttempts ?? []) entries.push(attempt);
+  }
+  return entries;
+}
+
+/**
+ * Collapse the runner's double-reporting of each request.
+ *
+ * The conformance runner surfaces one HTTP exchange on BOTH of its paired steps
+ * — `request_resource_metadata` and `received_resource_metadata` are two views of
+ * the same round trip. Left uncollapsed, every trace would claim the client sent
+ * each request twice and both the `legOrder` and full-sequence findings would be
+ * nonsense.
+ *
+ * This must run AFTER normalization, not before. Pre-normalization the two copies
+ * differ in exactly the fields normalization exists to erase — the JSON-RPC `id`
+ * above all — so a raw-body key silently fails to match and the duplicate
+ * survives. That was a real bug caught by looking at a captured trace, which is
+ * a small vindication of the whole "check it against a recorded artifact"
+ * premise.
+ *
+ * Within a key the MOST COMPLETE record wins: carrying a response beats not
+ * carrying one, and more request headers beats fewer (the `request_*` view is
+ * sometimes recorded before headers are attached). First-appearance order is
+ * preserved, so a genuine discovery ladder — whose rungs have different URLs —
+ * survives intact.
+ *
+ * Tradeoff, stated because it is a real one: a client that sends the SAME request
+ * twice with byte-identical headers and body collapses to one exchange. Post
+ * normalization those two requests are indistinguishable anyway, so no
+ * information a diff could act on is lost.
+ */
+export function dedupeWireArtifacts(
+  wire: readonly TraceExchange[],
+): TraceExchange[] {
+  const order: string[] = [];
+  const best = new Map<string, TraceExchange>();
+
+  const completeness = (exchange: TraceExchange): number =>
+    (exchange.response ? 1_000 : 0) +
+    Object.keys(exchange.request.headers ?? {}).length;
+
+  for (const exchange of wire) {
+    const key = JSON.stringify([
+      exchange.leg,
+      exchange.request.method,
+      exchange.request.url,
+      exchange.request.body ?? null,
+    ]);
+
+    const existing = best.get(key);
+    if (!existing) {
+      order.push(key);
+      best.set(key, exchange);
+      continue;
+    }
+    if (completeness(exchange) > completeness(existing)) best.set(key, exchange);
+  }
+
+  return order.map((key, index) => ({ ...best.get(key)!, ordinal: index }));
+}
+
+/**
+ * Reconstruct the `/authorize` exchange, which never appears in `httpAttempts`.
+ *
+ * The client does not FETCH the authorization URL — it hands it to a browser. So
+ * there is no intercepted request, but the URL itself (and therefore every param
+ * that matters: `resource`, `code_challenge`, `state`, `scope`, `redirect_uri`)
+ * is fully known and is recorded by the state machine as an info log.
+ *
+ * Reconstructing it is what makes the richest part of the diff available at all.
+ * The reconstruction is marked `headersObserved: false` so the harness reports
+ * this leg's headers as UNOBSERVED rather than claiming the client sends none —
+ * see `TraceRequest.headersObserved`.
+ */
+function reconstructAuthorizeExchange(
+  result: ConformanceResult,
+  ordinal: number,
+): TraceExchange | undefined {
+  for (const step of result.steps) {
+    for (const log of step.logs ?? []) {
+      if (log.step !== "authorization_request") continue;
+      const data = log.data as { url?: unknown } | undefined;
+      const url = data && typeof data.url === "string" ? data.url : undefined;
+      if (!url) continue;
+
+      return {
+        ordinal,
+        leg: "authorize",
+        legBasis:
+          "reconstructed from the `authorization_request` info log: the client hands this URL to a browser rather than fetching it, so no intercepted request exists",
+        request: {
+          method: "GET",
+          url,
+          headers: {},
+          headersObserved: false,
+        },
+      };
+    }
+  }
+  return undefined;
+}
+
+function toExchange(
+  entry: HttpHistoryEntry,
+  ordinal: number,
+  mcpServerUrl: string,
+): TraceExchange {
+  const requestBody = parseTraceBody(entry.request.body, entry.request.headers);
+
+  const stepLeg = legForOAuthFlowStep(entry.step);
+  const classified = classifyLeg({
+    method: entry.request.method,
+    url: entry.request.url,
+    headers: entry.request.headers,
+    body: requestBody,
+    mcpServerUrl,
+  });
+
+  const leg = stepLeg ?? classified.leg;
+  const legBasis = stepLeg
+    ? `OAuthFlowStep=${entry.step}`
+    : `wire heuristic: ${classified.basis} (step \`${entry.step}\` maps to no leg)`;
+
+  return {
+    ordinal,
+    leg,
+    legBasis,
+    request: {
+      method: entry.request.method,
+      url: entry.request.url,
+      headers: entry.request.headers,
+      ...(requestBody ? { body: requestBody } : {}),
+    },
+    ...(entry.response
+      ? {
+          response: {
+            status: entry.response.status,
+            ...(entry.response.statusText
+              ? { statusText: entry.response.statusText }
+              : {}),
+            headers: entry.response.headers,
+            ...(parseTraceBody(entry.response.body, entry.response.headers)
+              ? { body: parseTraceBody(entry.response.body, entry.response.headers)! }
+              : {}),
+          },
+        }
+      : {}),
+    ...(entry.error ? { error: { message: entry.error.message } } : {}),
+  };
+}
+
+export type CaptureEmulatorTraceInput = {
+  /** The completed (or partially completed) conformance run. */
+  result: ConformanceResult;
+  /** Catalog host id whose behavior the emulator was reproducing. */
+  hostId: string;
+  /** The scenario the run was pointed at. Gates any later diff. */
+  scenario: TraceScenario;
+  /** ISO calendar date (`YYYY-MM-DD`). Passed in so traces stay reproducible. */
+  capturedAt: string;
+  /** Full ISO instant, when the caller has one. */
+  capturedAtExact?: string;
+  /**
+   * Version of the emulated host's own build. Omit for `mcpjam`, where the SDK
+   * version below IS the host version.
+   */
+  hostVersion?: string;
+  /**
+   * Which implementation the emulator is reproducing. Defaults to
+   * `first-party` — correct for MCPJam's own state machines, and WRONG for any
+   * host that inherits OAuth from `rmcp` or the upstream TS SDK, so callers
+   * emulating those must pass it explicitly.
+   */
+  oauthImplementation?: TraceOAuthImplementation;
+  /** e.g. `debug-oauth-2025-11-25`. Recorded for attributability. */
+  stateMachine?: string;
+  surface?: string;
+  build?: string;
+  notes?: string[];
+};
+
+/**
+ * Build a normalized, redacted golden trace from a conformance run.
+ *
+ * Throws if the result still contains a secret-shaped value after
+ * normalization, so a leaking capture fails loudly at the point of capture
+ * rather than being committed and discovered later.
+ */
+export function captureEmulatorTrace(
+  input: CaptureEmulatorTraceInput,
+): GoldenTrace {
+  const history = collectHttpHistory(input.result);
+  const rawWire = history.map((entry, index) =>
+    toExchange(entry, index, input.scenario.mcpServerUrl),
+  );
+
+  // Splice the reconstructed `/authorize` in at its true wire position: after the
+  // client obtained a client_id and before it redeems the code at /token. Placing
+  // it by leg rather than by timestamp keeps the ordering finding meaningful even
+  // though this exchange has no timestamp of its own.
+  const authorize = reconstructAuthorizeExchange(input.result, 0);
+  if (authorize) {
+    const tokenIndex = rawWire.findIndex(
+      (exchange) => exchange.leg === "token" || exchange.leg === "refresh",
+    );
+    const insertAt = tokenIndex >= 0 ? tokenIndex : rawWire.length;
+    rawWire.splice(insertAt, 0, authorize);
+    rawWire.forEach((exchange, index) => {
+      exchange.ordinal = index;
+    });
+  }
+
+  // Recover loopback ports BEFORE normalization placeholds them.
+  const redirectUris = rawWire.flatMap((exchange) =>
+    collectRedirectUris({
+      url: exchange.request.url,
+      body: exchange.request.body,
+    }),
+  );
+  const loopbackPorts = extractLoopbackPorts(redirectUris);
+
+  const originOptions = {
+    mcpServerUrl: input.scenario.mcpServerUrl,
+    authorizationServerUrl: input.scenario.authorizationServerUrl,
+  };
+  // Normalize FIRST, then collapse: the runner's two copies of each exchange
+  // differ only in fields normalization erases. See `dedupeWireArtifacts`.
+  const wire = dedupeWireArtifacts(normalizeWire(rawWire, originOptions));
+
+  const sdkVersion = resolveSdkVersion();
+  const subject: TraceSubject = {
+    kind: "emulator",
+    hostId: input.hostId,
+    hostVersion:
+      input.hostVersion != null
+        ? present(input.hostVersion)
+        : sdkVersion != null
+          ? present(sdkVersion)
+          : notObserved(
+              "the @mcpjam/sdk version define was not substituted in this build",
+            ),
+    oauthImplementation: present(
+      input.oauthImplementation ?? { kind: "first-party" },
+    ),
+    ...(input.surface ? { surface: input.surface } : {}),
+    ...(input.build ? { build: input.build } : {}),
+  };
+
+  const observations = withObservedLoopbackPorts(
+    deriveObservations({ wire, scenario: input.scenario }),
+    loopbackPorts,
+  );
+
+  const trace: GoldenTrace = {
+    traceVersion: GOLDEN_TRACE_VERSION,
+    traceId: buildTraceId({
+      hostId: input.hostId,
+      scenarioId: input.scenario.scenarioId,
+      capturedAt: input.capturedAt,
+      kind: "emulator",
+    }),
+    subject,
+    scenario: input.scenario,
+    capture: {
+      capturedAt: input.capturedAt,
+      ...(input.capturedAtExact ? { capturedAtExact: input.capturedAtExact } : {}),
+      method: {
+        via: "mcpjam-emulator",
+        sdkVersion: sdkVersion ?? "unknown",
+        ...(input.stateMachine ? { stateMachine: input.stateMachine } : {}),
+      },
+      redaction: { applied: true, normalizerVersion: NORMALIZER_VERSION },
+      ...(input.notes ? { notes: input.notes } : {}),
+    },
+    wire,
+    observations,
+  };
+
+  assertTraceIsRedacted(trace);
+  return trace;
+}

--- a/sdk/src/oauth-golden-trace/from-conformance.ts
+++ b/sdk/src/oauth-golden-trace/from-conformance.ts
@@ -20,7 +20,11 @@
  * one fired.
  */
 
-import type { ConformanceResult } from "../oauth-conformance/types.js";
+import { CONFORMANCE_CHECK_METADATA } from "../oauth-conformance/types.js";
+import type {
+  ConformanceResult,
+  ConformanceStepId,
+} from "../oauth-conformance/types.js";
 import type { HttpHistoryEntry } from "../oauth/state-machines/types.js";
 import { classifyLeg, deriveObservations, legForOAuthFlowStep, withObservedLoopbackPorts } from "./observe.js";
 import {
@@ -63,6 +67,19 @@ export function buildTraceId(input: {
 }
 
 /**
+ * Is this step a post-flow conformance CHECK rather than a handshake step?
+ *
+ * `ConformanceStepId` is `OAuthFlowStep | OAuthConformanceCheckId`, and the check
+ * ids are exactly the keys of `CONFORMANCE_CHECK_METADATA` — keyed off that table
+ * rather than an `oauth_*` name prefix so a new check is classified correctly the
+ * moment it is registered. `Object.hasOwn`, not `in`: a step id colliding with an
+ * `Object.prototype` member must not read as a check.
+ */
+function isConformanceCheckStep(step: ConformanceStepId): boolean {
+  return Object.hasOwn(CONFORMANCE_CHECK_METADATA, step);
+}
+
+/**
  * Flatten a ConformanceResult's per-step HTTP attempts into wire order.
  *
  * `httpAttempts` are appended in execution order within a step, and steps are
@@ -70,6 +87,15 @@ export function buildTraceId(input: {
  * Note the deliberate absence of a timestamp sort: same-millisecond requests
  * would reorder non-deterministically and destroy the ordering finding, which is
  * one of the things this harness exists to compare.
+ *
+ * Post-flow conformance-check steps are EXCLUDED. With `oauthConformanceChecks`
+ * enabled the runner deliberately sends malformed traffic after the handshake
+ * completes — a DCR with an `http://evil.example` redirect, a token request with a
+ * bogus `client_id`, an MCP call with an invalid token — and those requests are
+ * recorded in `httpAttempts` just like real ones. Left in, they would add extra
+ * `token` and `mcp-*` legs to the wire and shift `legOrder`, endpoint and parameter
+ * observations, so the same host would diff differently depending on whether checks
+ * happened to be on. A trace must describe the handshake, not the probes.
  *
  * Duplicates are NOT removed here — see {@link dedupeWireArtifacts}, which has
  * to run after normalization to work at all.
@@ -79,6 +105,7 @@ export function collectHttpHistory(
 ): HttpHistoryEntry[] {
   const entries: HttpHistoryEntry[] = [];
   for (const step of result.steps) {
+    if (isConformanceCheckStep(step.step)) continue;
     for (const attempt of step.httpAttempts ?? []) entries.push(attempt);
   }
   return entries;
@@ -190,6 +217,9 @@ function toExchange(
   mcpServerUrl: string,
 ): TraceExchange {
   const requestBody = parseTraceBody(entry.request.body, entry.request.headers);
+  const responseBody = entry.response
+    ? parseTraceBody(entry.response.body, entry.response.headers)
+    : undefined;
 
   const stepLeg = legForOAuthFlowStep(entry.step);
   const classified = classifyLeg({
@@ -223,9 +253,7 @@ function toExchange(
               ? { statusText: entry.response.statusText }
               : {}),
             headers: entry.response.headers,
-            ...(parseTraceBody(entry.response.body, entry.response.headers)
-              ? { body: parseTraceBody(entry.response.body, entry.response.headers)! }
-              : {}),
+            ...(responseBody ? { body: responseBody } : {}),
           },
         }
       : {}),

--- a/sdk/src/oauth-golden-trace/from-conformance.ts
+++ b/sdk/src/oauth-golden-trace/from-conformance.ts
@@ -155,28 +155,30 @@ export function dedupeWireArtifacts(
  * see `TraceRequest.headersObserved`.
  */
 function reconstructAuthorizeExchange(
-  result: ConformanceResult,
+  authorizationUrl: string,
   ordinal: number,
-): TraceExchange | undefined {
+): TraceExchange {
+  return {
+    ordinal,
+    leg: "authorize",
+    legBasis:
+      "reconstructed from the authorization URL the client handed to a browser: the client never fetches it itself, so no intercepted request exists",
+    request: {
+      method: "GET",
+      url: authorizationUrl,
+      headers: {},
+      headersObserved: false,
+    },
+  };
+}
+
+/** Recover the authorization URL from a conformance run's info logs. */
+function findAuthorizationUrl(result: ConformanceResult): string | undefined {
   for (const step of result.steps) {
     for (const log of step.logs ?? []) {
       if (log.step !== "authorization_request") continue;
       const data = log.data as { url?: unknown } | undefined;
-      const url = data && typeof data.url === "string" ? data.url : undefined;
-      if (!url) continue;
-
-      return {
-        ordinal,
-        leg: "authorize",
-        legBasis:
-          "reconstructed from the `authorization_request` info log: the client hands this URL to a browser rather than fetching it, so no intercepted request exists",
-        request: {
-          method: "GET",
-          url,
-          headers: {},
-          headersObserved: false,
-        },
-      };
+      if (data && typeof data.url === "string") return data.url;
     }
   }
   return undefined;
@@ -231,6 +233,49 @@ function toExchange(
   };
 }
 
+/**
+ * The emulator-side inputs a trace actually needs, independent of HOW the
+ * emulator was driven.
+ *
+ * Two drivers exist today and a third is coming, so the capture path is defined
+ * against the wire record rather than against any one runner's result type:
+ *
+ *   - `OAuthConformanceTest` (the CLI / CI path) — see {@link captureEmulatorTrace}.
+ *   - `runOAuthStateMachine` directly, which is how the browser Inspector runs
+ *     its production OAuth and how a test can drive a machine with non-default
+ *     options.
+ *   - HP-43's per-host emulator, which will be configured from a host profile and
+ *     has no reason to route through the conformance runner at all.
+ *
+ * Coupling capture to `ConformanceResult` would have forced HP-43 to either fake
+ * one or duplicate this module.
+ */
+export type EmulatorFlowRecord = {
+  /** The wire, in execution order. `OAuthFlowState.httpHistory`. */
+  httpHistory: readonly HttpHistoryEntry[];
+  /**
+   * The authorization URL the client handed to a browser, when there was one.
+   *
+   * Supplied separately because it is NOT in `httpHistory`: the client builds this
+   * URL and delegates it, so no request of its own is ever intercepted. Passing it
+   * lets the harness reconstruct the `/authorize` leg — where `resource`,
+   * `code_challenge`, `state` and `scope` all live — which is otherwise the richest
+   * part of the diff and completely invisible.
+   */
+  authorizationUrl?: string;
+};
+
+/** Project a `ConformanceResult` onto the driver-independent record. */
+export function toEmulatorFlowRecord(
+  result: ConformanceResult,
+): EmulatorFlowRecord {
+  const authorizationUrl = findAuthorizationUrl(result);
+  return {
+    httpHistory: collectHttpHistory(result),
+    ...(authorizationUrl ? { authorizationUrl } : {}),
+  };
+}
+
 export type CaptureEmulatorTraceInput = {
   /** The completed (or partially completed) conformance run. */
   result: ConformanceResult;
@@ -271,8 +316,25 @@ export type CaptureEmulatorTraceInput = {
 export function captureEmulatorTrace(
   input: CaptureEmulatorTraceInput,
 ): GoldenTrace {
-  const history = collectHttpHistory(input.result);
-  const rawWire = history.map((entry, index) =>
+  const { result, ...rest } = input;
+  return captureEmulatorTraceFromFlow({
+    ...rest,
+    flow: toEmulatorFlowRecord(result),
+  });
+}
+
+/**
+ * Build a golden trace from a raw emulator flow record.
+ *
+ * The driver-independent entry point — see {@link EmulatorFlowRecord}. Use this
+ * when the emulator was not driven through `OAuthConformanceTest`: a direct
+ * `runOAuthStateMachine` call, the browser Inspector, or HP-43's per-host
+ * emulator.
+ */
+export function captureEmulatorTraceFromFlow(
+  input: Omit<CaptureEmulatorTraceInput, "result"> & { flow: EmulatorFlowRecord },
+): GoldenTrace {
+  const rawWire = input.flow.httpHistory.map((entry, index) =>
     toExchange(entry, index, input.scenario.mcpServerUrl),
   );
 
@@ -280,8 +342,8 @@ export function captureEmulatorTrace(
   // client obtained a client_id and before it redeems the code at /token. Placing
   // it by leg rather than by timestamp keeps the ordering finding meaningful even
   // though this exchange has no timestamp of its own.
-  const authorize = reconstructAuthorizeExchange(input.result, 0);
-  if (authorize) {
+  if (input.flow.authorizationUrl) {
+    const authorize = reconstructAuthorizeExchange(input.flow.authorizationUrl, 0);
     const tokenIndex = rawWire.findIndex(
       (exchange) => exchange.leg === "token" || exchange.leg === "refresh",
     );

--- a/sdk/src/oauth-golden-trace/from-har.ts
+++ b/sdk/src/oauth-golden-trace/from-har.ts
@@ -97,7 +97,11 @@ export type HarIngestReport = {
 };
 
 function headersToRecord(headers: HarNameValue[] | undefined): Record<string, string> {
-  const out: Record<string, string> = {};
+  // Null-prototype accumulator: HAR header names are attacker-influenced strings.
+  // On a plain `{}` a header named `constructor` would report as "already added"
+  // and be joined onto a stringified builtin, and one named `__proto__` would hit
+  // the prototype setter and vanish instead of becoming an own property.
+  const out: Record<string, string> = Object.create(null);
   for (const header of headers ?? []) {
     if (!header?.name) continue;
     const key = header.name.toLowerCase();
@@ -117,7 +121,10 @@ function bodyFromPostData(
   // `params` is HAR's pre-parsed form view. Preferred when present because it
   // survives proxies that omit `text`, and it is already multi-valued.
   if (postData.params && postData.params.length > 0) {
-    const fields: Record<string, string[]> = {};
+    // Null-prototype for the same reason as `headersToRecord`: on a plain `{}` a
+    // param named `constructor` makes `fields[name] ??= []` resolve to the builtin
+    // and `.push` on it throws, aborting ingest of the whole capture.
+    const fields: Record<string, string[]> = Object.create(null);
     for (const param of postData.params) {
       if (!param?.name) continue;
       (fields[param.name] ??= []).push(param.value ?? "");
@@ -171,14 +178,25 @@ function originOf(url: string | undefined): string | undefined {
   }
 }
 
-/** Legs a complete authorization-code handshake is expected to contain. */
-const EXPECTED_LEGS = [
-  "prm-discovery",
-  "as-metadata-discovery",
-  "authorize",
-  "token",
-  "mcp-initialize",
-] as const;
+/**
+ * Legs a complete authorization-code handshake is expected to contain, GIVEN the
+ * scenario's capabilities.
+ *
+ * `prm-discovery` is gated on `publishesPrm` because a no-PRM scenario has nothing
+ * to discover: a client that never fetches a PRM document there is behaving
+ * correctly, and listing the leg as a missing blocker would flag conformant
+ * behavior as an incomplete capture — the exact false alarm `missingLegs` exists
+ * to avoid. Same reasoning as the scenario gate on the diff itself.
+ */
+function expectedLegsFor(capabilities: TraceScenario["capabilities"]): string[] {
+  return [
+    ...(capabilities.publishesPrm ? ["prm-discovery"] : []),
+    "as-metadata-discovery",
+    "authorize",
+    "token",
+    "mcp-initialize",
+  ];
+}
 
 export type CaptureHarTraceInput = {
   /** Parsed HAR JSON (HAR 1.2). */
@@ -230,14 +248,23 @@ export function captureHarTrace(input: CaptureHarTraceInput): {
     ].filter((value): value is string => value != null),
   );
 
-  const dropped: HarIngestReport["dropped"] = [];
+  // Keyed by URL, first reason wins. A desktop capture polls the same telemetry
+  // or update endpoint dozens of times, and a report that listed every poll would
+  // both overstate how much was thrown away and bury the one dropped request a
+  // reviewer actually needs to see. Insertion order is HAR order, so the listing
+  // is deterministic; retaining the FIRST reason keeps it independent of how often
+  // a URL recurs.
+  const dropped = new Map<string, string>();
+  const drop = (url: string, reason: string) => {
+    if (!dropped.has(url)) dropped.set(url, reason);
+  };
   const warnings: string[] = [];
   const rawWire: TraceExchange[] = [];
 
   for (const entry of entries) {
     const url = entry?.request?.url;
     if (!url) {
-      dropped.push({ url: "<no url>", reason: "HAR entry has no request URL" });
+      drop("<no url>", "HAR entry has no request URL");
       continue;
     }
 
@@ -257,11 +284,10 @@ export function captureHarTrace(input: CaptureHarTraceInput): {
     const onKnownOrigin = origin != null && inScopeOrigins.has(origin);
 
     if (classified.leg === "unknown" && !onKnownOrigin) {
-      dropped.push({
+      drop(
         url,
-        reason:
-          "not on a scenario origin and matched no handshake-leg rule (assumed unrelated traffic)",
-      });
+        "not on a scenario origin and matched no handshake-leg rule (assumed unrelated traffic)",
+      );
       continue;
     }
     if (classified.leg === "unknown") {
@@ -319,8 +345,10 @@ export function captureHarTrace(input: CaptureHarTraceInput): {
     );
   }
 
-  const legsPresent = new Set(wire.map((exchange) => exchange.leg));
-  const missingLegs = EXPECTED_LEGS.filter((leg) => !legsPresent.has(leg));
+  const legsPresent = new Set<string>(wire.map((exchange) => exchange.leg));
+  const missingLegs = expectedLegsFor(input.scenario.capabilities).filter(
+    (leg) => !legsPresent.has(leg),
+  );
 
   const subject: TraceSubject = {
     kind: "real-host",
@@ -379,8 +407,8 @@ export function captureHarTrace(input: CaptureHarTraceInput): {
     report: {
       totalEntries: entries.length,
       keptEntries: wire.length,
-      dropped,
-      missingLegs: [...missingLegs],
+      dropped: [...dropped].map(([url, reason]) => ({ url, reason })),
+      missingLegs,
       warnings,
     },
   };

--- a/sdk/src/oauth-golden-trace/from-har.ts
+++ b/sdk/src/oauth-golden-trace/from-har.ts
@@ -1,0 +1,390 @@
+/**
+ * HP-44 — ingest a real host's handshake from a HAR capture.
+ *
+ * This is the GOLDEN side for any host we cannot run in-process: point the host
+ * at a proxy, drive the handshake, export the HAR, feed it here.
+ *
+ * ── What this path has to be careful about ────────────────────────────────
+ *
+ *  1. A real HAR is mostly NOISE. A desktop client's capture contains telemetry,
+ *     update checks and font fetches. Everything not on a known origin and not
+ *     classifiable as a handshake leg is dropped, and the count and reasons are
+ *     returned in {@link HarIngestReport} rather than discarded — a silent filter
+ *     would let a missed `/token` request look like a client that never fetched
+ *     a token.
+ *
+ *  2. A real HAR is usually INCOMPLETE. The `/authorize` leg happens in a
+ *     browser the proxy may not see, and consent is driven by a human. Missing
+ *     legs become `not-observed` observations, which the differ reports as gaps.
+ *     That is the correct output — it is exactly the "unverifiable, here's the
+ *     blocker" result the ticket asks for, and it is strictly better than a
+ *     plausible guess.
+ *
+ *  3. A real HAR contains LIVE CREDENTIALS. Redaction happens here, at ingest,
+ *     before anything is written — never at render time. `assertTraceIsRedacted`
+ *     then re-checks, so a HAR with an unusual token-bearing field fails ingest
+ *     instead of landing in the repo.
+ */
+
+import { classifyLeg, deriveObservations, withObservedLoopbackPorts } from "./observe.js";
+import {
+  NORMALIZER_VERSION,
+  assertTraceIsRedacted,
+  extractLoopbackPorts,
+  normalizeWire,
+} from "./normalize.js";
+import { collectRedirectUris, parseFormFields, parseTraceBody } from "./parse.js";
+import { GOLDEN_TRACE_VERSION, notObserved, present } from "./types.js";
+import type {
+  GoldenTrace,
+  TraceBody,
+  TraceExchange,
+  TraceOAuthImplementation,
+  TraceScenario,
+  TraceSubject,
+} from "./types.js";
+import { buildTraceId } from "./from-conformance.js";
+
+// ── Minimal HAR 1.2 shapes (only what this module reads) ─────────────────
+
+type HarNameValue = { name: string; value: string };
+
+type HarPostData = {
+  mimeType?: string;
+  text?: string;
+  params?: HarNameValue[];
+};
+
+type HarEntry = {
+  startedDateTime?: string;
+  request?: {
+    method?: string;
+    url?: string;
+    headers?: HarNameValue[];
+    postData?: HarPostData;
+  };
+  response?: {
+    status?: number;
+    statusText?: string;
+    headers?: HarNameValue[];
+    content?: {
+      mimeType?: string;
+      text?: string;
+      encoding?: string;
+      size?: number;
+    };
+  };
+};
+
+type HarLog = {
+  log?: {
+    version?: string;
+    creator?: { name?: string; version?: string };
+    entries?: HarEntry[];
+  };
+};
+
+/** What was dropped at ingest, and why. A first-class deliverable, not a log. */
+export type HarIngestReport = {
+  totalEntries: number;
+  keptEntries: number;
+  /** `url -> reason` for every dropped entry, deduped by URL. */
+  dropped: Array<{ url: string; reason: string }>;
+  /** Legs the harness expects for a full handshake but did not find. */
+  missingLegs: string[];
+  /** Non-fatal caveats a reviewer should read before trusting the trace. */
+  warnings: string[];
+};
+
+function headersToRecord(headers: HarNameValue[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const header of headers ?? []) {
+    if (!header?.name) continue;
+    const key = header.name.toLowerCase();
+    // HAR lists repeated headers as separate entries; join with `, ` per RFC 9110
+    // rather than letting the last one win.
+    out[key] = key in out ? `${out[key]}, ${header.value ?? ""}` : (header.value ?? "");
+  }
+  return out;
+}
+
+function bodyFromPostData(
+  postData: HarPostData | undefined,
+  headers: Record<string, string>,
+): TraceBody | undefined {
+  if (!postData) return undefined;
+
+  // `params` is HAR's pre-parsed form view. Preferred when present because it
+  // survives proxies that omit `text`, and it is already multi-valued.
+  if (postData.params && postData.params.length > 0) {
+    const fields: Record<string, string[]> = {};
+    for (const param of postData.params) {
+      if (!param?.name) continue;
+      (fields[param.name] ??= []).push(param.value ?? "");
+    }
+    return { encoding: "form", fields };
+  }
+
+  if (typeof postData.text === "string" && postData.text !== "") {
+    const withMime = postData.mimeType
+      ? { ...headers, "content-type": postData.mimeType }
+      : headers;
+    return parseTraceBody(postData.text, withMime);
+  }
+
+  return undefined;
+}
+
+type HarContent = {
+  mimeType?: string;
+  text?: string;
+  encoding?: string;
+  size?: number;
+};
+
+function bodyFromContent(
+  content: HarContent | undefined,
+  headers: Record<string, string>,
+): TraceBody | undefined {
+  if (!content) return undefined;
+  // Base64 content is binary or a rendered page; never force-parse it.
+  if (content.encoding === "base64") {
+    return {
+      encoding: "opaque",
+      ...(content.mimeType ? { contentType: content.mimeType } : {}),
+      ...(content.size != null ? { byteLength: content.size } : {}),
+    };
+  }
+  if (typeof content.text !== "string" || content.text === "") return undefined;
+  const withMime = content.mimeType
+    ? { ...headers, "content-type": content.mimeType }
+    : headers;
+  return parseTraceBody(content.text, withMime);
+}
+
+function originOf(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Legs a complete authorization-code handshake is expected to contain. */
+const EXPECTED_LEGS = [
+  "prm-discovery",
+  "as-metadata-discovery",
+  "authorize",
+  "token",
+  "mcp-initialize",
+] as const;
+
+export type CaptureHarTraceInput = {
+  /** Parsed HAR JSON (HAR 1.2). */
+  har: unknown;
+  hostId: string;
+  scenario: TraceScenario;
+  /** ISO calendar date. Defaults to the date of the first HAR entry. */
+  capturedAt?: string;
+  /**
+   * The host build that was captured. Omitting it is allowed but produces a
+   * `not-observed` stamp, which the differ reports as a gap — a trace that
+   * cannot name its build goes stale invisibly.
+   */
+  hostVersion?: string;
+  /**
+   * The RESOLVED OAuth implementation. Five of six source-verified clients get
+   * their OAuth from a dependency (`rmcp`, the upstream TS SDK), so for those
+   * hosts the host version alone is not enough to keep this trace honest across
+   * a dependency bump. Omitting it is recorded as `not-observed`.
+   */
+  oauthImplementation?: TraceOAuthImplementation;
+  surface?: string;
+  build?: string;
+  operator?: string;
+  notes?: string[];
+  /** Extra origins to treat as in-scope, e.g. a vendor's CIMD host. */
+  extraOrigins?: Record<string, string>;
+};
+
+/**
+ * Build a golden trace from a HAR.
+ *
+ * Returns the trace AND the ingest report. Callers should surface the report:
+ * its `dropped` and `missingLegs` are the honest account of what the capture did
+ * not cover, which the ticket requires as a deliverable in its own right.
+ */
+export function captureHarTrace(input: CaptureHarTraceInput): {
+  trace: GoldenTrace;
+  report: HarIngestReport;
+} {
+  const har = input.har as HarLog;
+  const entries = har?.log?.entries ?? [];
+
+  const inScopeOrigins = new Set(
+    [
+      originOf(input.scenario.mcpServerUrl),
+      originOf(input.scenario.authorizationServerUrl),
+      ...Object.values(input.extraOrigins ?? {}).map((value) => originOf(value) ?? value),
+    ].filter((value): value is string => value != null),
+  );
+
+  const dropped: HarIngestReport["dropped"] = [];
+  const warnings: string[] = [];
+  const rawWire: TraceExchange[] = [];
+
+  for (const entry of entries) {
+    const url = entry?.request?.url;
+    if (!url) {
+      dropped.push({ url: "<no url>", reason: "HAR entry has no request URL" });
+      continue;
+    }
+
+    const method = entry.request?.method ?? "GET";
+    const requestHeaders = headersToRecord(entry.request?.headers);
+    const requestBody = bodyFromPostData(entry.request?.postData, requestHeaders);
+
+    const classified = classifyLeg({
+      method,
+      url,
+      headers: requestHeaders,
+      body: requestBody,
+      mcpServerUrl: input.scenario.mcpServerUrl,
+    });
+
+    const origin = originOf(url);
+    const onKnownOrigin = origin != null && inScopeOrigins.has(origin);
+
+    if (classified.leg === "unknown" && !onKnownOrigin) {
+      dropped.push({
+        url,
+        reason:
+          "not on a scenario origin and matched no handshake-leg rule (assumed unrelated traffic)",
+      });
+      continue;
+    }
+    if (classified.leg === "unknown") {
+      warnings.push(
+        `Kept ${method} ${url} on a scenario origin even though no leg rule matched; recorded as \`unknown\`. Review it — a misclassified leg silently weakens every per-leg finding.`,
+      );
+    }
+
+    const responseHeaders = headersToRecord(entry.response?.headers);
+    const responseBody = bodyFromContent(entry.response?.content, responseHeaders);
+
+    rawWire.push({
+      ordinal: rawWire.length,
+      leg: classified.leg,
+      legBasis: `wire heuristic: ${classified.basis}`,
+      request: {
+        method,
+        url,
+        headers: requestHeaders,
+        ...(requestBody ? { body: requestBody } : {}),
+      },
+      ...(entry.response?.status != null
+        ? {
+            response: {
+              status: entry.response.status,
+              ...(entry.response.statusText
+                ? { statusText: entry.response.statusText }
+                : {}),
+              headers: responseHeaders,
+              ...(responseBody ? { body: responseBody } : {}),
+            },
+          }
+        : {}),
+    });
+  }
+
+  const redirectUris = rawWire.flatMap((exchange) =>
+    collectRedirectUris({ url: exchange.request.url, body: exchange.request.body }),
+  );
+  const loopbackPorts = extractLoopbackPorts(redirectUris);
+
+  const wire = normalizeWire(rawWire, {
+    mcpServerUrl: input.scenario.mcpServerUrl,
+    authorizationServerUrl: input.scenario.authorizationServerUrl,
+    ...(input.extraOrigins ? { extraOrigins: input.extraOrigins } : {}),
+  });
+
+  const capturedAt =
+    input.capturedAt ??
+    entries.find((entry) => entry?.startedDateTime)?.startedDateTime?.slice(0, 10) ??
+    "unknown";
+  if (capturedAt === "unknown") {
+    warnings.push(
+      "No capture date could be determined from the HAR and none was supplied. The trace is stamped `unknown`, which makes it unusable as dated evidence — re-ingest with an explicit `capturedAt`.",
+    );
+  }
+
+  const legsPresent = new Set(wire.map((exchange) => exchange.leg));
+  const missingLegs = EXPECTED_LEGS.filter((leg) => !legsPresent.has(leg));
+
+  const subject: TraceSubject = {
+    kind: "real-host",
+    hostId: input.hostId,
+    hostVersion:
+      input.hostVersion != null
+        ? present(input.hostVersion)
+        : notObserved(
+            "no host version was supplied at ingest, and a HAR does not carry one",
+          ),
+    oauthImplementation:
+      input.oauthImplementation != null
+        ? present(input.oauthImplementation)
+        : notObserved(
+            "no resolved OAuth implementation was supplied at ingest; for a host that inherits OAuth from a dependency this trace will go stale on a dependency bump with no visible signal",
+          ),
+    ...(input.surface ? { surface: input.surface } : {}),
+    ...(input.build ? { build: input.build } : {}),
+  };
+
+  const observations = withObservedLoopbackPorts(
+    deriveObservations({ wire, scenario: input.scenario }),
+    loopbackPorts,
+  );
+
+  const creator = har?.log?.creator;
+  const trace: GoldenTrace = {
+    traceVersion: GOLDEN_TRACE_VERSION,
+    traceId: buildTraceId({
+      hostId: input.hostId,
+      scenarioId: input.scenario.scenarioId,
+      capturedAt,
+      kind: "real-host",
+    }),
+    subject,
+    scenario: input.scenario,
+    capture: {
+      capturedAt,
+      method: {
+        via: "har",
+        ...(creator?.name ? { harCreator: creator.name } : {}),
+        ...(har?.log?.version ? { harVersion: har.log.version } : {}),
+      },
+      ...(input.operator ? { operator: input.operator } : {}),
+      redaction: { applied: true, normalizerVersion: NORMALIZER_VERSION },
+      ...(input.notes ? { notes: input.notes } : {}),
+    },
+    wire,
+    observations,
+  };
+
+  assertTraceIsRedacted(trace);
+
+  return {
+    trace,
+    report: {
+      totalEntries: entries.length,
+      keptEntries: wire.length,
+      dropped,
+      missingLegs: [...missingLegs],
+      warnings,
+    },
+  };
+}
+
+/** Exposed for tests: HAR `postData.text` form parsing shares one code path. */
+export const __internal = { parseFormFields };

--- a/sdk/src/oauth-golden-trace/index.ts
+++ b/sdk/src/oauth-golden-trace/index.ts
@@ -17,6 +17,7 @@ export {
   MCP_WIRE_LEGS,
   OAUTH_DISCOVERY_LEGS,
   TRACE_DIFF_DIMENSIONS,
+  TRACE_DIFF_MODES,
   TRACE_DIFF_SEVERITIES,
   TRACE_LEGS,
   TRACE_OBSERVATION_STATES,
@@ -39,6 +40,8 @@ export type {
   TraceCaptureMethod,
   TraceDiffDimension,
   TraceDiffFinding,
+  TraceDiffLabels,
+  TraceDiffMode,
   TraceDiffResult,
   TraceDiffSeverity,
   TraceExchange,
@@ -90,7 +93,7 @@ export type { LegClassificationInput } from "./observe.js";
 export { collectRedirectUris, parseFormFields, parseTraceBody } from "./parse.js";
 
 export { compareObservation, diffGoldenTraces } from "./diff.js";
-export type { TraceDiffMode, TraceDiffOptions } from "./diff.js";
+export type { TraceDiffOptions } from "./diff.js";
 
 export {
   buildTraceId,
@@ -108,7 +111,7 @@ export type {
 export { captureHarTrace } from "./from-har.js";
 export type { CaptureHarTraceInput, HarIngestReport } from "./from-har.js";
 
-export { traceToOAuthProfile } from "./to-profile.js";
+export { mergeTraceOAuthProfile, traceToOAuthProfile } from "./to-profile.js";
 export type { TraceToProfileOptions } from "./to-profile.js";
 
 export {

--- a/sdk/src/oauth-golden-trace/index.ts
+++ b/sdk/src/oauth-golden-trace/index.ts
@@ -1,0 +1,112 @@
+/**
+ * HP-44 — golden-trace parity harness.
+ *
+ * Makes "the emulator behaves exactly like the real host" mechanically
+ * checkable, and is therefore the acceptance oracle for HP-43.
+ *
+ * Pipeline:
+ *   CAPTURE  `captureEmulatorTrace` (in-process run) or `captureHarTrace` (proxy)
+ *   NORMALIZE + REDACT at capture time — never at render time
+ *   OBSERVE  `deriveObservations` reduces the wire to diff-relevant facts
+ *   DIFF     `diffGoldenTraces` reports field-by-field parity, gaps and all
+ *   PROJECT  `traceToOAuthProfile` feeds `HostConfigOAuthProfileV1`
+ */
+
+export {
+  GOLDEN_TRACE_VERSION,
+  MCP_WIRE_LEGS,
+  OAUTH_DISCOVERY_LEGS,
+  TRACE_DIFF_DIMENSIONS,
+  TRACE_DIFF_SEVERITIES,
+  TRACE_LEGS,
+  TRACE_OBSERVATION_STATES,
+  absent,
+  notObserved,
+  observedValue,
+  present,
+} from "./types.js";
+
+export type {
+  DcrIdentityUsage,
+  GoldenTrace,
+  Observation,
+  PkceUsage,
+  ProtocolVersionUsage,
+  ResourceIndicatorUsage,
+  ResourceIndicatorValueSource,
+  TraceBody,
+  TraceCaptureMeta,
+  TraceCaptureMethod,
+  TraceDiffDimension,
+  TraceDiffFinding,
+  TraceDiffResult,
+  TraceDiffSeverity,
+  TraceExchange,
+  TraceLeg,
+  TraceOAuthImplementation,
+  TraceObservations,
+  TraceObservationState,
+  TraceRequest,
+  TraceResponse,
+  TraceScenario,
+  TraceScenarioCapabilities,
+  TraceSubject,
+  UserAgentUsage,
+} from "./types.js";
+
+export {
+  NORMALIZER_VERSION,
+  REDACTED,
+  assertTraceIsRedacted,
+  buildOriginMap,
+  extractLoopbackPorts,
+  findRedactionViolations,
+  isLoopbackHost,
+  normalizeBody,
+  normalizeExchange,
+  normalizeHeaders,
+  normalizeLoopbackPort,
+  normalizeRequest,
+  normalizeResponse,
+  normalizeUrl,
+  normalizeWire,
+} from "./normalize.js";
+export type {
+  NormalizeOptions,
+  NormalizedUrl,
+  OriginPlaceholders,
+  RedactionViolation,
+} from "./normalize.js";
+
+export {
+  classifyLeg,
+  deriveObservations,
+  findObservationDrift,
+  legForOAuthFlowStep,
+  withObservedLoopbackPorts,
+} from "./observe.js";
+export type { LegClassificationInput } from "./observe.js";
+
+export { collectRedirectUris, parseFormFields, parseTraceBody } from "./parse.js";
+
+export { compareObservation, diffGoldenTraces } from "./diff.js";
+export type { TraceDiffMode, TraceDiffOptions } from "./diff.js";
+
+export {
+  buildTraceId,
+  captureEmulatorTrace,
+  collectHttpHistory,
+} from "./from-conformance.js";
+export type { CaptureEmulatorTraceInput } from "./from-conformance.js";
+
+export { captureHarTrace } from "./from-har.js";
+export type { CaptureHarTraceInput, HarIngestReport } from "./from-har.js";
+
+export { traceToOAuthProfile } from "./to-profile.js";
+export type { TraceToProfileOptions } from "./to-profile.js";
+
+export {
+  formatHarIngestReportHuman,
+  formatTraceDiffHuman,
+  formatTraceSummaryHuman,
+} from "./format.js";

--- a/sdk/src/oauth-golden-trace/index.ts
+++ b/sdk/src/oauth-golden-trace/index.ts
@@ -95,9 +95,15 @@ export type { TraceDiffMode, TraceDiffOptions } from "./diff.js";
 export {
   buildTraceId,
   captureEmulatorTrace,
+  captureEmulatorTraceFromFlow,
   collectHttpHistory,
+  dedupeWireArtifacts,
+  toEmulatorFlowRecord,
 } from "./from-conformance.js";
-export type { CaptureEmulatorTraceInput } from "./from-conformance.js";
+export type {
+  CaptureEmulatorTraceInput,
+  EmulatorFlowRecord,
+} from "./from-conformance.js";
 
 export { captureHarTrace } from "./from-har.js";
 export type { CaptureHarTraceInput, HarIngestReport } from "./from-har.js";

--- a/sdk/src/oauth-golden-trace/normalize.ts
+++ b/sdk/src/oauth-golden-trace/normalize.ts
@@ -392,6 +392,24 @@ export function normalizeHeaders(
       out[key] = normalizeUserAgent(rawValue, options);
       continue;
     }
+    // A header whose value IS a URL gets the full URL treatment, not just origin
+    // substitution — because its QUERY STRING can carry secrets.
+    //
+    // The motivating case: a conformant authorization server answers `/authorize`
+    // with `302 Location: <redirect_uri>?code=<authorization code>&state=…`. Any
+    // proxy or server-side capture of a real host records that header verbatim, so
+    // treating it as an opaque string would write a live authorization code into a
+    // committed artifact. Routing it through `normalizeUrl` applies the same
+    // per-param policy the request side already uses, redacting `code` and
+    // placeholding `state`.
+    //
+    // Found by `assertTraceIsRedacted` firing on the first capture that actually
+    // completed an authorize leg — the belt catching what the suspenders missed.
+    if (/^https?:\/\//i.test(rawValue.trim())) {
+      out[key] = normalizeUrl(rawValue.trim(), options).url;
+      continue;
+    }
+
     // `www-authenticate` carries `resource_metadata="<url>"`, which must be
     // origin-substituted or every trace looks host-specific.
     out[key] = substituteOrigins(rawValue, originMap);

--- a/sdk/src/oauth-golden-trace/normalize.ts
+++ b/sdk/src/oauth-golden-trace/normalize.ts
@@ -1,0 +1,622 @@
+/**
+ * HP-44 — normalization + redaction for golden traces.
+ *
+ * Two jobs, both done at CAPTURE time so that what lands on disk is already
+ * safe and already diffable:
+ *
+ *  1. REDACT. Tokens, codes, verifiers and secrets never reach the artifact.
+ *     This reuses `redactSensitiveValue` from `../redaction.js` — the deep
+ *     authorization-key redactor the rest of the SDK already trusts — rather
+ *     than growing a second, subtly different policy. `assertTraceIsRedacted`
+ *     then re-checks the result, so a redaction bug fails a test instead of
+ *     silently committing a live credential.
+ *
+ *  2. PLACEHOLD VOLATILITY. A `state`, a `nonce`, a PKCE challenge, a session
+ *     id, an ephemeral port and a timestamp all differ between two runs of the
+ *     SAME client. Left raw they would drown every real finding in noise; the
+ *     diff would be useless and nobody would run it.
+ *
+ * The discipline that keeps step 2 from destroying evidence: where the SHAPE of
+ * a volatile value is itself a finding, the shape is preserved in the
+ * placeholder. `{code_challenge:len=43,charset=base64url}` still proves S256 of
+ * a 32-byte verifier; a bare `{code_challenge}` would not. Ports get the same
+ * treatment one level up — placeheld in the wire, retained in
+ * `observations.dcrIdentity.observedLoopbackPorts`.
+ *
+ * What is deliberately NOT normalized:
+ *   - `user-agent`, unless `normalizeVersions` is set. It is one of the fields
+ *     the harness exists to capture, and a version bump IS drift worth flagging
+ *     (HP-38), not noise worth hiding.
+ *   - a `client_id` that parses as an http(s) URL. Under CIMD the client_id IS
+ *     the identity document URL; placeholding it would erase the finding.
+ *   - `expires_in`, `scope`, `token_type`. Stable per-server and behavioral.
+ */
+
+import { redactSensitiveValue } from "../redaction.js";
+import type {
+  GoldenTrace,
+  TraceBody,
+  TraceExchange,
+  TraceRequest,
+  TraceResponse,
+} from "./types.js";
+
+/** Bumped when placeholder semantics change, so stale traces are detectable. */
+export const NORMALIZER_VERSION = 1;
+
+export const REDACTED = "[REDACTED]";
+
+/**
+ * Origin placeholders. Substituted longest-origin-first so an AS hosted on a
+ * path under the MCP server's origin cannot be mislabelled.
+ */
+export type OriginPlaceholders = {
+  /** The MCP resource server. */
+  mcpServerUrl: string;
+  /** The authorization server, when known. */
+  authorizationServerUrl?: string;
+  /** Additional `placeholder -> origin` pairs, e.g. a CIMD host. */
+  extraOrigins?: Record<string, string>;
+};
+
+export type NormalizeOptions = OriginPlaceholders & {
+  /**
+   * Replace trailing version segments in `user-agent` with `{version}`, e.g.
+   * `goose/1.4.2` → `goose/{version}`. OFF by default: a UA version change is
+   * real drift and HP-38 should see it. Turn it on only when comparing across
+   * known-different builds on purpose.
+   */
+  normalizeVersions?: boolean;
+};
+
+// ── Volatility policy ────────────────────────────────────────────────────
+
+/**
+ * Params/fields that are secrets. Values are dropped entirely — the redactor
+ * is authoritative here, this set exists so query-string and form encodings
+ * (which the deep redactor sees only as flat strings) get the same treatment.
+ */
+const SECRET_KEYS = new Set([
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "client_secret",
+  "code",
+  "code_verifier",
+  "registration_access_token",
+  "authorization",
+  "assertion",
+  "client_assertion",
+]);
+
+/**
+ * Params/fields that vary run-to-run but are NOT secrets. Placeheld by name.
+ *
+ * `shape` controls how much of the value's structure survives:
+ *   `"length"`          — length only.
+ *   `"length+charset"`  — length and inferred alphabet.
+ *
+ * Charset is inferred from a SAMPLE, so it is only stable for values whose
+ * alphabet is fixed by a spec. `code_challenge` qualifies: RFC 7636 defines it as
+ * base64url, so the inference is deterministic and `charset=base64url,len=43`
+ * still proves S256 over a 32-byte verifier.
+ *
+ * `state` and `nonce` do NOT qualify. They are opaque random strings, and whether
+ * a given draw happens to contain a character that distinguishes one alphabet
+ * from another is chance — inferring charset there made two runs of identical code
+ * produce different traces, which is exactly the kind of noise that stops people
+ * running a diff. Length only.
+ */
+const VOLATILE_KEYS: Record<string, { shape?: "length" | "length+charset" }> = {
+  state: { shape: "length" },
+  nonce: { shape: "length" },
+  code_challenge: { shape: "length+charset" },
+  client_id_issued_at: {},
+  client_secret_expires_at: {},
+  session_state: {},
+  auth_session: {},
+  request_uri: {},
+};
+
+/** Response/request headers that change every run and carry no behavior. */
+const VOLATILE_HEADERS = new Set([
+  "date",
+  "expires",
+  "last-modified",
+  "etag",
+  "age",
+  "content-length",
+  "mcp-session-id",
+  "x-request-id",
+  "x-correlation-id",
+  "x-amzn-requestid",
+  "x-amz-cf-id",
+  "cf-ray",
+  "traceparent",
+  "tracestate",
+  "x-envoy-upstream-service-time",
+  "server-timing",
+  "keep-alive",
+  "connection",
+]);
+
+/** Headers whose values are credentials. */
+const SECRET_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "api-key",
+  "apikey",
+]);
+
+/** JSON body keys holding timestamps. Matched exactly or by `_at` suffix. */
+const TIMESTAMP_KEYS = new Set(["iat", "exp", "nbf", "auth_time", "timestamp"]);
+
+function isTimestampKey(key: string): boolean {
+  return TIMESTAMP_KEYS.has(key) || key.endsWith("_at");
+}
+
+function charsetOf(value: string): string {
+  if (/^[A-Za-z0-9\-_]+$/.test(value)) return "base64url";
+  if (/^[0-9a-f]+$/i.test(value)) return "hex";
+  if (/^[A-Za-z0-9+/]+=*$/.test(value)) return "base64";
+  return "mixed";
+}
+
+/**
+ * Placeholder for a volatile value. Shape-bearing form keeps exactly the two
+ * facts that distinguish a conformant PKCE challenge from a broken one.
+ */
+function placeholder(
+  key: string,
+  value: string,
+  shape?: "length" | "length+charset",
+): string {
+  if (!shape) return `{${key}}`;
+  if (shape === "length") return `{${key}:len=${value.length}}`;
+  return `{${key}:len=${value.length},charset=${charsetOf(value)}}`;
+}
+
+/**
+ * A `client_id` is placeheld UNLESS it is an http(s) URL — under CIMD the
+ * client_id is the identity-document URL and is the single most identifying
+ * field in the whole handshake.
+ */
+function normalizeClientId(value: string): string {
+  return /^https?:\/\//i.test(value) ? value : "{client_id}";
+}
+
+function normalizeScalarField(key: string, value: string): string {
+  const lower = key.toLowerCase();
+
+  if (SECRET_KEYS.has(lower)) return REDACTED;
+  if (lower === "client_id") return normalizeClientId(value);
+
+  const volatile = VOLATILE_KEYS[lower];
+  if (volatile) return placeholder(lower, value, volatile.shape);
+
+  return value;
+}
+
+// ── URL normalization ────────────────────────────────────────────────────
+
+/**
+ * Loopback hosts whose port is ephemeral in practice. The port is replaced with
+ * `{port}` so two runs diff clean; the raw port survives in
+ * `observations.dcrIdentity.observedLoopbackPorts`.
+ */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+export function isLoopbackHost(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname.toLowerCase());
+}
+
+/** Extract loopback ports from a list of redirect URIs, in order, deduped. */
+export function extractLoopbackPorts(uris: readonly string[]): number[] {
+  const ports: number[] = [];
+  for (const uri of uris) {
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      continue;
+    }
+    if (!isLoopbackHost(parsed.hostname) || !parsed.port) continue;
+    const port = Number(parsed.port);
+    if (Number.isFinite(port) && !ports.includes(port)) ports.push(port);
+  }
+  return ports;
+}
+
+/** Replace a loopback URL's port with `{port}`. Non-loopback URLs pass through. */
+export function normalizeLoopbackPort(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return raw;
+  }
+  if (!isLoopbackHost(parsed.hostname) || !parsed.port) return raw;
+  // Rebuild by string surgery: URL#port cannot hold a placeholder.
+  const authority = `${parsed.hostname}:${parsed.port}`;
+  return raw.replace(authority, `${parsed.hostname}:{port}`);
+}
+
+function originOf(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * `placeholder -> origin` map, longest origin first so a nested origin cannot
+ * shadow its container.
+ */
+export function buildOriginMap(
+  options: OriginPlaceholders,
+): Array<[string, string]> {
+  const entries: Array<[string, string]> = [];
+  const mcp = originOf(options.mcpServerUrl);
+  if (mcp) entries.push(["{mcp_server}", mcp]);
+  const as = originOf(options.authorizationServerUrl);
+  if (as && as !== mcp) entries.push(["{as}", as]);
+  for (const [name, origin] of Object.entries(options.extraOrigins ?? {})) {
+    const resolved = originOf(origin) ?? origin;
+    entries.push([name.startsWith("{") ? name : `{${name}}`, resolved]);
+  }
+  return entries.sort((left, right) => right[1].length - left[1].length);
+}
+
+function substituteOrigins(
+  value: string,
+  originMap: Array<[string, string]>,
+): string {
+  let out = value;
+  for (const [name, origin] of originMap) {
+    if (out.includes(origin)) out = out.split(origin).join(name);
+  }
+  return out;
+}
+
+export type NormalizedUrl = {
+  /** Origin-substituted, volatility-placeheld, query re-serialized in order. */
+  url: string;
+  /** Multi-valued query params, normalized. Absent when there were none. */
+  query?: Record<string, string[]>;
+};
+
+/**
+ * Normalize a request URL.
+ *
+ * Query params are returned as a multi-valued map because whether a client
+ * sends `resource` once or twice is a real open question — a single-valued map
+ * would answer it wrongly and silently.
+ */
+export function normalizeUrl(
+  raw: string,
+  options: NormalizeOptions,
+): NormalizedUrl {
+  const originMap = buildOriginMap(options);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return { url: substituteOrigins(normalizeLoopbackPort(raw), originMap) };
+  }
+
+  const query: Record<string, string[]> = {};
+  for (const [key, value] of parsed.searchParams.entries()) {
+    // `redirect_uri` is a URL in its own right: normalize its loopback port and
+    // origins before applying scalar policy.
+    const pre =
+      key.toLowerCase() === "redirect_uri"
+        ? substituteOrigins(normalizeLoopbackPort(value), originMap)
+        : substituteOrigins(value, originMap);
+    const normalized = normalizeScalarField(key, pre);
+    (query[key] ??= []).push(normalized);
+  }
+
+  // Canonicalize param ORDER by sorting keys. Param order is not a conformance
+  // fact, it is not observable as a client property, and it demonstrably varies
+  // between two recordings of the SAME request — so leaving it raw makes
+  // identical requests compare unequal. Values WITHIN a key keep their observed
+  // order, because a repeated `resource` appearing twice is a real finding.
+  const sortedQuery: Record<string, string[]> = {};
+  for (const key of Object.keys(query).sort()) sortedQuery[key] = query[key];
+
+  const hasQuery = Object.keys(sortedQuery).length > 0;
+  const base = `${parsed.origin}${parsed.pathname}`;
+  let url = substituteOrigins(normalizeLoopbackPort(base), originMap);
+
+  if (hasQuery) {
+    const rendered = Object.entries(sortedQuery)
+      .flatMap(([key, values]) => values.map((value) => `${key}=${value}`))
+      .join("&");
+    url = `${url}?${rendered}`;
+  }
+
+  return hasQuery ? { url, query: sortedQuery } : { url };
+}
+
+// ── Header normalization ─────────────────────────────────────────────────
+
+function normalizeUserAgent(value: string, options: NormalizeOptions): string {
+  if (!options.normalizeVersions) return value;
+  return value.replace(/\/\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.-]+)?/g, "/{version}");
+}
+
+export function normalizeHeaders(
+  headers: Record<string, string>,
+  options: NormalizeOptions,
+): Record<string, string> {
+  const originMap = buildOriginMap(options);
+  const out: Record<string, string> = {};
+
+  for (const [rawKey, rawValue] of Object.entries(headers)) {
+    const key = rawKey.toLowerCase();
+
+    if (SECRET_HEADERS.has(key)) {
+      out[key] = REDACTED;
+      continue;
+    }
+    if (VOLATILE_HEADERS.has(key)) {
+      out[key] = `{${key}}`;
+      continue;
+    }
+    if (key === "user-agent") {
+      out[key] = normalizeUserAgent(rawValue, options);
+      continue;
+    }
+    // `www-authenticate` carries `resource_metadata="<url>"`, which must be
+    // origin-substituted or every trace looks host-specific.
+    out[key] = substituteOrigins(rawValue, originMap);
+  }
+
+  // Sorted: header ORDER is not observable through any HTTP client API we have,
+  // so pretending to record it would be a fabricated field.
+  return Object.fromEntries(
+    Object.entries(out).sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+// ── Body normalization ───────────────────────────────────────────────────
+
+function normalizeJsonValue(
+  value: unknown,
+  options: NormalizeOptions,
+  originMap: Array<[string, string]>,
+  key?: string,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeJsonValue(entry, options, originMap));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([childKey, childValue]) => [
+        childKey,
+        normalizeJsonValue(childValue, options, originMap, childKey),
+      ]),
+    );
+  }
+
+  if (key && isTimestampKey(key) && typeof value === "number") {
+    return "{timestamp}";
+  }
+
+  if (typeof value === "string") {
+    const pre = /^https?:\/\//i.test(value)
+      ? substituteOrigins(normalizeLoopbackPort(value), originMap)
+      : substituteOrigins(value, originMap);
+    return key ? normalizeScalarField(key, pre) : pre;
+  }
+
+  return value;
+}
+
+/**
+ * Normalize a body.
+ *
+ * The deep redactor runs FIRST on structured bodies so that any
+ * authorization-shaped key this module has not enumerated is still caught; the
+ * volatility pass then runs over the redacted result. Order matters: redaction
+ * is the security property and must not depend on this module's key lists being
+ * complete.
+ */
+export function normalizeBody(
+  body: TraceBody | undefined,
+  options: NormalizeOptions,
+): TraceBody | undefined {
+  if (!body) return undefined;
+  const originMap = buildOriginMap(options);
+
+  if (body.encoding === "opaque") return body;
+
+  if (body.encoding === "form") {
+    const fields: Record<string, string[]> = {};
+    // Keys sorted for the same reason as query params: field order is not
+    // behavioral, and the SDK's own two recordings of one token request differ in
+    // it, which would otherwise make a request fail to match itself.
+    for (const key of Object.keys(body.fields).sort()) {
+      const values = body.fields[key];
+      fields[key] = values.map((value) => {
+        const pre =
+          key.toLowerCase() === "redirect_uri"
+            ? substituteOrigins(normalizeLoopbackPort(value), originMap)
+            : substituteOrigins(value, originMap);
+        return normalizeScalarField(key, pre);
+      });
+    }
+    return { encoding: "form", fields };
+  }
+
+  const redacted = redactSensitiveValue(body.json);
+  const normalized = normalizeJsonValue(redacted, options, originMap);
+
+  if (body.encoding === "jsonrpc") {
+    // JSON-RPC `id` is a transport artifact, not behavior.
+    const withStableId =
+      normalized && typeof normalized === "object" && !Array.isArray(normalized)
+        ? { ...(normalized as Record<string, unknown>), ...("id" in (normalized as Record<string, unknown>) ? { id: "{id}" } : {}) }
+        : normalized;
+    return {
+      encoding: "jsonrpc",
+      ...(body.method ? { method: body.method } : {}),
+      json: withStableId,
+    };
+  }
+
+  return { encoding: "json", json: normalized };
+}
+
+// ── Exchange / trace normalization ───────────────────────────────────────
+
+export function normalizeRequest(
+  request: TraceRequest,
+  options: NormalizeOptions,
+): TraceRequest {
+  const { url, query } = normalizeUrl(request.url, options);
+  return {
+    method: request.method.toUpperCase(),
+    url,
+    headers: normalizeHeaders(request.headers, options),
+    ...(request.headersObserved === false ? { headersObserved: false } : {}),
+    ...(query ? { query } : {}),
+    ...(request.body ? { body: normalizeBody(request.body, options)! } : {}),
+  };
+}
+
+export function normalizeResponse(
+  response: TraceResponse,
+  options: NormalizeOptions,
+): TraceResponse {
+  return {
+    status: response.status,
+    ...(response.statusText ? { statusText: response.statusText } : {}),
+    headers: normalizeHeaders(response.headers, options),
+    ...(response.body ? { body: normalizeBody(response.body, options)! } : {}),
+  };
+}
+
+export function normalizeExchange(
+  exchange: TraceExchange,
+  options: NormalizeOptions,
+): TraceExchange {
+  return {
+    ordinal: exchange.ordinal,
+    leg: exchange.leg,
+    ...(exchange.legBasis ? { legBasis: exchange.legBasis } : {}),
+    request: normalizeRequest(exchange.request, options),
+    ...(exchange.response
+      ? { response: normalizeResponse(exchange.response, options) }
+      : {}),
+    ...(exchange.error ? { error: exchange.error } : {}),
+  };
+}
+
+/**
+ * Normalize every exchange in a trace and stamp the redaction envelope.
+ *
+ * `observations` are NOT recomputed here — they are derived from the normalized
+ * wire by `./observe.js`, which is the only order that keeps a placeheld value
+ * from being read as a real one.
+ */
+export function normalizeWire(
+  wire: readonly TraceExchange[],
+  options: NormalizeOptions,
+): TraceExchange[] {
+  return wire.map((exchange, index) =>
+    normalizeExchange({ ...exchange, ordinal: index }, options),
+  );
+}
+
+// ── Redaction assertion ──────────────────────────────────────────────────
+
+/**
+ * Patterns that suggest a live credential survived normalization.
+ *
+ * Intentionally shape-based rather than key-based: a key-based check would only
+ * re-test what `normalizeScalarField` already did, and would pass for a token
+ * that leaked through an unexpected key. This is the belt to that suspenders.
+ */
+const LIVE_SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  { name: "JWT", pattern: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\./ },
+  {
+    // The `key=` lookahead is load-bearing and mirrors `../redaction.js`: an RFC
+    // 6750 CHALLENGE (`WWW-Authenticate: Bearer resource_metadata="…"`) is
+    // auth-param syntax, not a credential, and must not be flagged. Without it
+    // every PRM-publishing server's 401 trips the assertion.
+    name: "Bearer token",
+    pattern: /\bBearer\s+(?!\[REDACTED\])(?![A-Za-z_][A-Za-z0-9_-]*=)[A-Za-z0-9\-._~+/]{8,}=*/i,
+  },
+  {
+    name: "authorization-code-shaped value",
+    pattern: /\b(?:code|access_token|refresh_token|id_token|client_secret|code_verifier)=(?!\[REDACTED\])[A-Za-z0-9._~-]{16,}/,
+  },
+];
+
+export type RedactionViolation = {
+  path: string;
+  pattern: string;
+  excerpt: string;
+};
+
+/**
+ * Scan a trace for anything that looks like a live secret.
+ *
+ * Called by the capture paths before a trace is written and by the fixture
+ * tests, so "traces contain no live secrets" is a mechanically enforced
+ * property rather than a review convention.
+ */
+export function findRedactionViolations(
+  trace: unknown,
+): RedactionViolation[] {
+  const violations: RedactionViolation[] = [];
+
+  const walk = (value: unknown, path: string): void => {
+    if (typeof value === "string") {
+      for (const { name, pattern } of LIVE_SECRET_PATTERNS) {
+        const match = pattern.exec(value);
+        if (match) {
+          violations.push({
+            path,
+            pattern: name,
+            excerpt: `${match[0].slice(0, 24)}…`,
+          });
+        }
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((entry, index) => walk(entry, `${path}[${index}]`));
+      return;
+    }
+    if (value && typeof value === "object") {
+      for (const [key, child] of Object.entries(value)) {
+        walk(child, path ? `${path}.${key}` : key);
+      }
+    }
+  };
+
+  walk(trace, "");
+  return violations;
+}
+
+/** Throw if a trace still contains anything secret-shaped. */
+export function assertTraceIsRedacted(trace: GoldenTrace): void {
+  const violations = findRedactionViolations(trace);
+  if (violations.length === 0) return;
+
+  const detail = violations
+    .map((violation) => `${violation.path}: ${violation.pattern} (${violation.excerpt})`)
+    .join("; ");
+  throw new Error(
+    `Golden trace ${trace.traceId} contains ${violations.length} possible live secret(s) after normalization: ${detail}`,
+  );
+}

--- a/sdk/src/oauth-golden-trace/normalize.ts
+++ b/sdk/src/oauth-golden-trace/normalize.ts
@@ -283,6 +283,25 @@ function substituteOrigins(
   return out;
 }
 
+/**
+ * Abstract a URL's origin, THEN placehold any loopback port that remains.
+ *
+ * The order is load-bearing and the two steps must never be swapped. A test
+ * server (and HP-39's CI server) lives on `http://127.0.0.1:<port>`, which is
+ * BOTH a scenario origin and a loopback address. Placeholding the port first
+ * rewrites the string to `http://127.0.0.1:{port}` — after which the origin no
+ * longer matches the scenario's `http://127.0.0.1:3999` and `{mcp_server}` is
+ * never substituted at all.
+ *
+ * Doing it in this order abstracts the SERVER's origin as an origin, and leaves
+ * `{port}` for the loopback that genuinely is ephemeral: the client's own
+ * redirect URI. Found by pointing the harness at a real loopback server — an
+ * https-origin fixture cannot expose it.
+ */
+function abstractUrl(value: string, originMap: Array<[string, string]>): string {
+  return normalizeLoopbackPort(substituteOrigins(value, originMap));
+}
+
 export type NormalizedUrl = {
   /** Origin-substituted, volatility-placeheld, query re-serialized in order. */
   url: string;
@@ -307,7 +326,7 @@ export function normalizeUrl(
   try {
     parsed = new URL(raw);
   } catch {
-    return { url: substituteOrigins(normalizeLoopbackPort(raw), originMap) };
+    return { url: abstractUrl(raw, originMap) };
   }
 
   const query: Record<string, string[]> = {};
@@ -316,7 +335,7 @@ export function normalizeUrl(
     // origins before applying scalar policy.
     const pre =
       key.toLowerCase() === "redirect_uri"
-        ? substituteOrigins(normalizeLoopbackPort(value), originMap)
+        ? abstractUrl(value, originMap)
         : substituteOrigins(value, originMap);
     const normalized = normalizeScalarField(key, pre);
     (query[key] ??= []).push(normalized);
@@ -332,7 +351,7 @@ export function normalizeUrl(
 
   const hasQuery = Object.keys(sortedQuery).length > 0;
   const base = `${parsed.origin}${parsed.pathname}`;
-  let url = substituteOrigins(normalizeLoopbackPort(base), originMap);
+  let url = abstractUrl(base, originMap);
 
   if (hasQuery) {
     const rendered = Object.entries(sortedQuery)
@@ -412,7 +431,7 @@ function normalizeJsonValue(
 
   if (typeof value === "string") {
     const pre = /^https?:\/\//i.test(value)
-      ? substituteOrigins(normalizeLoopbackPort(value), originMap)
+      ? abstractUrl(value, originMap)
       : substituteOrigins(value, originMap);
     return key ? normalizeScalarField(key, pre) : pre;
   }
@@ -448,7 +467,7 @@ export function normalizeBody(
       fields[key] = values.map((value) => {
         const pre =
           key.toLowerCase() === "redirect_uri"
-            ? substituteOrigins(normalizeLoopbackPort(value), originMap)
+            ? abstractUrl(value, originMap)
             : substituteOrigins(value, originMap);
         return normalizeScalarField(key, pre);
       });

--- a/sdk/src/oauth-golden-trace/normalize.ts
+++ b/sdk/src/oauth-golden-trace/normalize.ts
@@ -32,6 +32,8 @@
  *   - `expires_in`, `scope`, `token_type`. Stable per-server and behavioral.
  */
 
+import { createHash } from "node:crypto";
+
 import { redactSensitiveValue } from "../redaction.js";
 import type {
   GoldenTrace,
@@ -88,6 +90,47 @@ const SECRET_KEYS = new Set([
   "assertion",
   "client_assertion",
 ]);
+
+/**
+ * Canonical form of a param/field name — exactly the normalization
+ * `../redaction.js` applies: lower-case, then drop every non-alphanumeric
+ * character, so `access_token`, `accessToken` and `Access-Token` collapse to one
+ * name.
+ */
+function canonicalKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/gu, "");
+}
+
+const CANONICAL_SECRET_KEYS = new Set(
+  [...SECRET_KEYS].map((key) => canonicalKey(key)),
+);
+
+/**
+ * Secret names that match as a SUFFIX too, mirroring `../redaction.js`: a vendor
+ * prefix (`mcpAccessToken`, `x-refresh-token`) does not make the value any less
+ * of a credential.
+ */
+const CANONICAL_SECRET_SUFFIXES = [
+  "accesstoken",
+  "refreshtoken",
+  "idtoken",
+  "clientsecret",
+];
+
+/**
+ * Whether a flat param/field name names a secret.
+ *
+ * Matched canonically rather than by exact snake_case, because query strings and
+ * form bodies never reach the deep redactor — it sees each of them as one opaque
+ * string — which makes `normalizeScalarField` the ONLY redaction boundary those
+ * two encodings have. An exact-name check would let a host that spells the field
+ * `accessToken` write a live credential into a committed artifact, contradicting
+ * the guarantee this module's header claims.
+ */
+function isSecretKey(canonical: string): boolean {
+  if (CANONICAL_SECRET_KEYS.has(canonical)) return true;
+  return CANONICAL_SECRET_SUFFIXES.some((suffix) => canonical.endsWith(suffix));
+}
 
 /**
  * Params/fields that vary run-to-run but are NOT secrets. Placeheld by name.
@@ -158,7 +201,22 @@ function isTimestampKey(key: string): boolean {
   return TIMESTAMP_KEYS.has(key) || key.endsWith("_at");
 }
 
-function charsetOf(value: string): string {
+/**
+ * A COARSE alphabet label for a placeheld value — first match wins, and the
+ * alphabets are subsets of one another, so the order IS the definition.
+ *
+ * Pure hex and unpadded pure base64 both satisfy the base64url test and are
+ * labelled `base64url`; only a value containing `+`, `/` or `=` can reach the
+ * later arms. That is deliberate and harmless for the one thing this labels — a
+ * PKCE `code_challenge`, whose alphabet RFC 7636 fixes to base64url — because the
+ * label exists to catch a challenge that is NOT base64url, not to classify one
+ * that is.
+ *
+ * Named for that narrow job rather than `charsetOf`, which promised a general
+ * charset detector this is not. Do not reuse it as one without first deciding
+ * what the subset ordering should be.
+ */
+function coarseAlphabetLabel(value: string): string {
   if (/^[A-Za-z0-9\-_]+$/.test(value)) return "base64url";
   if (/^[0-9a-f]+$/i.test(value)) return "hex";
   if (/^[A-Za-z0-9+/]+=*$/.test(value)) return "base64";
@@ -176,25 +234,49 @@ function placeholder(
 ): string {
   if (!shape) return `{${key}}`;
   if (shape === "length") return `{${key}:len=${value.length}}`;
-  return `{${key}:len=${value.length},charset=${charsetOf(value)}}`;
+  return `{${key}:len=${value.length},charset=${coarseAlphabetLabel(value)}}`;
 }
 
 /**
  * A `client_id` is placeheld UNLESS it is an http(s) URL — under CIMD the
  * client_id is the identity-document URL and is the single most identifying
  * field in the whole handshake.
+ *
+ * The URL test runs against the PRE-substitution value. Once a CIMD host is
+ * configured in `extraOrigins`, the value that reaches here already reads
+ * `{cimd}/client-metadata.json`, which no longer looks like a URL — testing that
+ * placeholds the identity document away, and the trace can then neither diff the
+ * client identity document URL nor detect a client-ID change, which is the whole
+ * reason this field is exempt.
  */
-function normalizeClientId(value: string): string {
-  return /^https?:\/\//i.test(value) ? value : "{client_id}";
+function normalizeClientId(value: string, raw: string): string {
+  return /^https?:\/\//i.test(raw) ? value : "{client_id}";
 }
 
-function normalizeScalarField(key: string, value: string): string {
+/**
+ * Apply secret/volatility policy to one flat param or field.
+ *
+ * @param value the origin-substituted value that will be written to the trace.
+ * @param raw   the value before origin substitution. Only consulted to decide
+ *              whether a `client_id` is a CIMD URL; see {@link normalizeClientId}.
+ */
+function normalizeScalarField(
+  key: string,
+  value: string,
+  raw: string = value,
+): string {
   const lower = key.toLowerCase();
+  const canonical = canonicalKey(key);
 
-  if (SECRET_KEYS.has(lower)) return REDACTED;
-  if (lower === "client_id") return normalizeClientId(value);
+  if (isSecretKey(canonical)) return REDACTED;
+  if (canonical === "clientid") return normalizeClientId(value, raw);
 
-  const volatile = VOLATILE_KEYS[lower];
+  // `Object.hasOwn`, not a bare truthy lookup: these names come off a captured
+  // wire, and `constructor` / `__proto__` would otherwise inherit an entry from
+  // `Object.prototype` and be placeheld as if this module had configured them.
+  const volatile = Object.hasOwn(VOLATILE_KEYS, lower)
+    ? VOLATILE_KEYS[lower]
+    : undefined;
   if (volatile) return placeholder(lower, value, volatile.shape);
 
   return value;
@@ -329,7 +411,12 @@ export function normalizeUrl(
     return { url: abstractUrl(raw, originMap) };
   }
 
-  const query: Record<string, string[]> = {};
+  // Null-prototype accumulator: param names come straight off a captured wire,
+  // and `__proto__` is a perfectly legal one. On a plain object literal
+  // `query["__proto__"] ??= []` reads `Object.prototype` — truthy, so the
+  // assignment is skipped — and the `.push` below then throws, aborting the whole
+  // capture over one odd param.
+  const query: Record<string, string[]> = Object.create(null);
   for (const [key, value] of parsed.searchParams.entries()) {
     // `redirect_uri` is a URL in its own right: normalize its loopback port and
     // origins before applying scalar policy.
@@ -337,7 +424,7 @@ export function normalizeUrl(
       key.toLowerCase() === "redirect_uri"
         ? abstractUrl(value, originMap)
         : substituteOrigins(value, originMap);
-    const normalized = normalizeScalarField(key, pre);
+    const normalized = normalizeScalarField(key, pre, value);
     (query[key] ??= []).push(normalized);
   }
 
@@ -346,7 +433,7 @@ export function normalizeUrl(
   // between two recordings of the SAME request — so leaving it raw makes
   // identical requests compare unequal. Values WITHIN a key keep their observed
   // order, because a repeated `resource` appearing twice is a real finding.
-  const sortedQuery: Record<string, string[]> = {};
+  const sortedQuery: Record<string, string[]> = Object.create(null);
   for (const key of Object.keys(query).sort()) sortedQuery[key] = query[key];
 
   const hasQuery = Object.keys(sortedQuery).length > 0;
@@ -375,7 +462,11 @@ export function normalizeHeaders(
   options: NormalizeOptions,
 ): Record<string, string> {
   const originMap = buildOriginMap(options);
-  const out: Record<string, string> = {};
+  // Null-prototype, same reason as the query and form accumulators: HAR ingest now
+  // preserves a header literally named `__proto__`, and assigning it onto a plain
+  // object literal here would reparent this object and drop the header again — the
+  // trace would claim the header was never on the wire.
+  const out: Record<string, string> = Object.create(null);
 
   for (const [rawKey, rawValue] of Object.entries(headers)) {
     const key = rawKey.toLowerCase();
@@ -451,10 +542,17 @@ function normalizeJsonValue(
     const pre = /^https?:\/\//i.test(value)
       ? abstractUrl(value, originMap)
       : substituteOrigins(value, originMap);
-    return key ? normalizeScalarField(key, pre) : pre;
+    return key ? normalizeScalarField(key, pre, value) : pre;
   }
 
   return value;
+}
+
+/** Replace a JSON-RPC envelope's `id` with a placeholder, leaving it absent when absent. */
+function stabilizeJsonRpcId(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const envelope = value as Record<string, unknown>;
+  return "id" in envelope ? { ...envelope, id: "{id}" } : envelope;
 }
 
 /**
@@ -476,7 +574,11 @@ export function normalizeBody(
   if (body.encoding === "opaque") return body;
 
   if (body.encoding === "form") {
-    const fields: Record<string, string[]> = {};
+    // Null-prototype, same reason as the query accumulator: a parsed field named
+    // `__proto__` assigned onto a plain object literal reparents that object
+    // instead of recording anything, so the field would silently vanish from the
+    // normalized trace.
+    const fields: Record<string, string[]> = Object.create(null);
     // Keys sorted for the same reason as query params: field order is not
     // behavioral, and the SDK's own two recordings of one token request differ in
     // it, which would otherwise make a request fail to match itself.
@@ -487,7 +589,7 @@ export function normalizeBody(
           key.toLowerCase() === "redirect_uri"
             ? abstractUrl(value, originMap)
             : substituteOrigins(value, originMap);
-        return normalizeScalarField(key, pre);
+        return normalizeScalarField(key, pre, value);
       });
     }
     return { encoding: "form", fields };
@@ -497,11 +599,12 @@ export function normalizeBody(
   const normalized = normalizeJsonValue(redacted, options, originMap);
 
   if (body.encoding === "jsonrpc") {
-    // JSON-RPC `id` is a transport artifact, not behavior.
-    const withStableId =
-      normalized && typeof normalized === "object" && !Array.isArray(normalized)
-        ? { ...(normalized as Record<string, unknown>), ...("id" in (normalized as Record<string, unknown>) ? { id: "{id}" } : {}) }
-        : normalized;
+    // JSON-RPC `id` is a transport artifact, not behavior. Batches are stamped
+    // entry by entry: a batch that kept its per-entry ids would diff dirty
+    // against a second recording of the identical request.
+    const withStableId = Array.isArray(normalized)
+      ? normalized.map(stabilizeJsonRpcId)
+      : stabilizeJsonRpcId(normalized);
     return {
       encoding: "jsonrpc",
       ...(body.method ? { method: body.method } : {}),
@@ -601,8 +704,25 @@ const LIVE_SECRET_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
 export type RedactionViolation = {
   path: string;
   pattern: string;
-  excerpt: string;
+  /** Length of the matched text. Never the text. */
+  matchLength: number;
+  /** Truncated SHA-256 of the matched text. See {@link fingerprintMatch}. */
+  fingerprint: string;
 };
+
+/**
+ * A violation travels through channels that are strictly LESS protected than the
+ * artifact this check just refused to write: a failing assertion's message, CI
+ * logs, an issue paste. So not one character of the matched value may appear in
+ * it — an excerpt would republish the credential we declined to commit.
+ *
+ * A truncated digest keeps the diagnostic useful anyway: it tells a reader
+ * whether five violations are one leaked value seen at five paths or five
+ * different ones, without being reversible.
+ */
+function fingerprintMatch(match: string): string {
+  return createHash("sha256").update(match).digest("hex").slice(0, 12);
+}
 
 /**
  * Scan a trace for anything that looks like a live secret.
@@ -610,6 +730,11 @@ export type RedactionViolation = {
  * Called by the capture paths before a trace is written and by the fixture
  * tests, so "traces contain no live secrets" is a mechanically enforced
  * property rather than a review convention.
+ *
+ * The `unknown` parameter is load-bearing, not laziness: `hp44-capture-host.mts`
+ * screens a RAW HAR log with this before deciding whether the unredacted capture
+ * may touch disk, and a HAR is not a `GoldenTrace`. The walk is shape-agnostic on
+ * purpose — narrowing this to `GoldenTrace` would silently drop that check.
  */
 export function findRedactionViolations(
   trace: unknown,
@@ -624,7 +749,8 @@ export function findRedactionViolations(
           violations.push({
             path,
             pattern: name,
-            excerpt: `${match[0].slice(0, 24)}…`,
+            matchLength: match[0].length,
+            fingerprint: fingerprintMatch(match[0]),
           });
         }
       }
@@ -651,7 +777,10 @@ export function assertTraceIsRedacted(trace: GoldenTrace): void {
   if (violations.length === 0) return;
 
   const detail = violations
-    .map((violation) => `${violation.path}: ${violation.pattern} (${violation.excerpt})`)
+    .map(
+      (violation) =>
+        `${violation.path}: ${violation.pattern} (len=${violation.matchLength}, sha256:${violation.fingerprint})`,
+    )
     .join("; ");
   throw new Error(
     `Golden trace ${trace.traceId} contains ${violations.length} possible live secret(s) after normalization: ${detail}`,

--- a/sdk/src/oauth-golden-trace/observe.ts
+++ b/sdk/src/oauth-golden-trace/observe.ts
@@ -12,6 +12,16 @@
  * `not-observed` with the leg named as the reason. Getting this backwards is how
  * "we didn't look" becomes "the client doesn't do it", which is the specific
  * error this whole harness exists to prevent.
+ *
+ * Two corollaries that were each once a bug here:
+ *
+ *   - A field present with the WRONG JSON TYPE is not `absent` either. It is
+ *     `not-observed` (we have no value of the modelled type) plus an entry in
+ *     `dcrIdentity.malformedFields`, so "the client sent garbage" stays
+ *     distinguishable from "the client sent nothing".
+ *   - A DERIVED boolean over several legs is `not-observed` unless every leg it
+ *     summarizes was observed. `wiresDisagree` and `userAgent.consistent` are
+ *     claims about the client; a partial capture cannot make them.
  */
 
 import {
@@ -229,7 +239,7 @@ export function classifyLeg(
       : { leg: "mcp-authenticated", basis: `JSON-RPC ${rpcMethod} with Authorization` };
   }
 
-  if (input.mcpServerUrl && input.url.startsWith(input.mcpServerUrl)) {
+  if (input.mcpServerUrl && addressesMcpEndpoint(input.url, input.mcpServerUrl)) {
     const authorization = headerLookup(input.headers, "authorization");
     return authorization
       ? { leg: "mcp-authenticated", basis: "MCP server URL with Authorization" }
@@ -237,6 +247,38 @@ export function classifyLeg(
   }
 
   return { leg: "unknown", basis: "no classification rule matched" };
+}
+
+/**
+ * Does this URL address the configured MCP endpoint, or a descendant of it?
+ *
+ * A bare `startsWith` on the configured URL pulls a same-origin SIBLING endpoint
+ * into the handshake: `/mcp-admin` shares every character of `/mcp`. That is not
+ * cosmetic — a misclassified request joins {@link MCP_WIRE_LEGS}, where it can
+ * flip `headerOnMcpTraffic` from `absent` (a citable finding about the client)
+ * to `present`, and drag its own headers into the per-leg rollups. So: parsed
+ * origins must be equal, and the path must be either equal or a `/`-delimited
+ * descendant.
+ */
+function addressesMcpEndpoint(url: string, mcpServerUrl: string): boolean {
+  const stripTrailingSlash = (path: string): string => path.replace(/\/+$/, "");
+  let target: URL;
+  let configured: URL;
+  try {
+    target = new URL(url);
+    configured = new URL(mcpServerUrl);
+  } catch {
+    // Either side may already be origin-substituted (`{mcp_server}/mcp`), which
+    // is not a parseable URL. Fall back to a prefix test that still enforces the
+    // boundary, rather than to no boundary at all.
+    const base = stripTrailingSlash(mcpServerUrl);
+    const path = url.split(/[?#]/)[0];
+    return stripTrailingSlash(path) === base || path.startsWith(`${base}/`);
+  }
+  if (target.origin !== configured.origin) return false;
+  const targetPath = stripTrailingSlash(target.pathname);
+  const configuredPath = stripTrailingSlash(configured.pathname);
+  return targetPath === configuredPath || targetPath.startsWith(`${configuredPath}/`);
 }
 
 // ── Small observation helpers ────────────────────────────────────────────
@@ -446,23 +488,45 @@ function observeProtocolVersion(
 
   // Two wires "disagree" when both were captured and either they carry different
   // value sets, or one carries a value and the other demonstrably carries none.
-  // If either side is `not-observed` we cannot claim disagreement — that is a
-  // gap, and the differ reports it as one.
+  // A wire we never captured yields `not-observed`, NOT `false`: "these two wires
+  // agree" is a claim about the client, and a one-wire capture cannot make it.
   const oauthValues = observedValue(headerOnOAuthDiscovery);
   const mcpValues = observedValue(headerOnMcpTraffic);
-  const bothCaptured =
-    headerOnOAuthDiscovery.state !== "not-observed" &&
-    headerOnMcpTraffic.state !== "not-observed";
-  const wiresDisagree =
-    bothCaptured &&
-    JSON.stringify(oauthValues ?? null) !== JSON.stringify(mcpValues ?? null);
+  const unobservedWires = [
+    ...(headerOnOAuthDiscovery.state === "not-observed" ? ["OAuth discovery"] : []),
+    ...(headerOnMcpTraffic.state === "not-observed" ? ["MCP-wire"] : []),
+  ];
+  // Compared as value SETS, over sorted COPIES. The recorded arrays are in
+  // first-appearance order — itself a finding, so they are never mutated — but the
+  // order two wires happened to record the same values in is not a disagreement.
+  const asValueSet = (values: string[] | undefined): string =>
+    JSON.stringify(values ? [...values].sort() : null);
+  const wiresDisagree: Observation<boolean> =
+    unobservedWires.length > 0
+      ? notObserved(
+          `no ${unobservedWires.join(" or ")} request was captured, so whether the two wires carry different \`MCP-Protocol-Version\` values cannot be determined`,
+        )
+      : present(asValueSet(oauthValues) !== asValueSet(mcpValues));
 
   const bodyVersion = observedValue(initializeBody);
   const allHeaderValues = distinct([...(oauthValues ?? []), ...(mcpValues ?? [])]);
-  const headerDisagreesWithInitializeBody =
+  // One differing header value settles this positively, and no amount of
+  // uncaptured traffic can take it back — so `true` needs no completeness gate.
+  // `false` does: it asserts that NOTHING on either wire disagreed with the body.
+  const headerDisagreesWithInitializeBody: Observation<boolean> =
     bodyVersion != null &&
     allHeaderValues.length > 0 &&
-    allHeaderValues.some((value) => value !== bodyVersion);
+    allHeaderValues.some((value) => value !== bodyVersion)
+      ? present(true)
+      : initializeBody.state === "not-observed"
+        ? notObserved(
+            "no MCP `initialize` request was captured, so there is no body version for a header to be compared against",
+          )
+        : unobservedWires.length > 0
+          ? notObserved(
+              `no ${unobservedWires.join(" or ")} request was captured, so a wire that could carry a disagreeing \`MCP-Protocol-Version\` was never observed`,
+            )
+          : present(false);
 
   return {
     initializeBody,
@@ -491,6 +555,24 @@ function stringArray(value: unknown): string[] | undefined {
   return strings.length === value.length ? strings : undefined;
 }
 
+/** The observed JSON type, for naming a malformed field in a reason string. */
+function jsonTypeOf(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  switch (typeof value) {
+    case "string":
+      return "a string";
+    case "number":
+      return "a number";
+    case "boolean":
+      return "a boolean";
+    case "object":
+      return "an object";
+    default:
+      return typeof value;
+  }
+}
+
 function observeDcrIdentity(wire: readonly TraceExchange[]): DcrIdentityUsage {
   const registrations = exchangesForLeg(wire, ["dcr-register"]);
   const gap = <T>(field: string): Observation<T> =>
@@ -508,6 +590,7 @@ function observeDcrIdentity(wire: readonly TraceExchange[]): DcrIdentityUsage {
       tokenEndpointAuthMethod: gap("token_endpoint_auth_method"),
       scope: gap("scope"),
       extraFields: gap("unmodelled registration fields"),
+      malformedFields: gap("whether any modelled field carried the wrong JSON type"),
     };
   }
 
@@ -529,16 +612,33 @@ function observeDcrIdentity(wire: readonly TraceExchange[]): DcrIdentityUsage {
       tokenEndpointAuthMethod: notObserved(reason),
       scope: notObserved(reason),
       extraFields: notObserved(reason),
+      malformedFields: notObserved(reason),
     };
   }
 
+  // A modelled field present with the WRONG JSON type is neither `present` (we
+  // have no value of the modelled type) nor `absent` (the client did send it —
+  // calling this `absent` is how the oracle came to claim a client omitted a
+  // field it demonstrably sent). It is `not-observed` with the observed type
+  // named, plus an entry here so the positive fact stays diffable.
+  const malformedFields: string[] = [];
   const scalar = (key: string): Observation<string> => {
+    if (!Object.hasOwn(record, key)) return absent;
     const value = record[key];
-    return typeof value === "string" ? present(value) : absent;
+    if (typeof value === "string") return present(value);
+    malformedFields.push(key);
+    return notObserved(
+      `\`${key}\` was in the registration body but carried ${jsonTypeOf(value)}, not a string`,
+    );
   };
   const list = (key: string): Observation<string[]> => {
+    if (!Object.hasOwn(record, key)) return absent;
     const value = stringArray(record[key]);
-    return value ? present(value) : absent;
+    if (value) return present(value);
+    malformedFields.push(key);
+    return notObserved(
+      `\`${key}\` was in the registration body but carried ${jsonTypeOf(record[key])}, not an array of strings`,
+    );
   };
 
   // Redirect URIs in the wire are already `{port}`-normalized, so the raw ports
@@ -548,19 +648,37 @@ function observeDcrIdentity(wire: readonly TraceExchange[]): DcrIdentityUsage {
   // derived value: nothing in the normalized wire carries a port.
   const redirectUris = list("redirect_uris");
 
-  const extras = Object.keys(record)
-    .filter((key) => !MODELLED_DCR_FIELDS.has(key))
-    .sort();
+  // Names AND VALUES: two register bodies differing only in the value of an
+  // unmodelled field would otherwise be reported as DCR parity. Sorted-key
+  // insertion order keeps the serialization deterministic, which is what the
+  // differ's structural equality and `findObservationDrift` both rely on. The
+  // values are already redacted and origin-substituted by ./normalize.js, so this
+  // retains nothing the `wire` does not already carry.
+  const extras: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    if (MODELLED_DCR_FIELDS.has(key)) continue;
+    extras[key] = record[key];
+  }
+
+  // Derived AFTER the field readers above have run, since they are what populate
+  // `malformedFields`.
+  const clientName = scalar("client_name");
+  const grantTypes = list("grant_types");
+  const responseTypes = list("response_types");
+  const tokenEndpointAuthMethod = scalar("token_endpoint_auth_method");
+  const scope = scalar("scope");
 
   return {
-    clientName: scalar("client_name"),
+    clientName,
     redirectUris,
     observedLoopbackPorts: absent,
-    grantTypes: list("grant_types"),
-    responseTypes: list("response_types"),
-    tokenEndpointAuthMethod: scalar("token_endpoint_auth_method"),
-    scope: scalar("scope"),
-    extraFields: extras.length > 0 ? present(extras) : absent,
+    grantTypes,
+    responseTypes,
+    tokenEndpointAuthMethod,
+    scope,
+    extraFields: Object.keys(extras).length > 0 ? present(extras) : absent,
+    malformedFields:
+      malformedFields.length > 0 ? present(malformedFields.sort()) : absent,
   };
 }
 
@@ -623,16 +741,41 @@ function observePkce(wire: readonly TraceExchange[]): PkceUsage {
           return present(length);
         })();
 
+  // `false` here reads as "this client completes the PKCE exchange without a
+  // verifier", which is a serious claim about a client. It may only be derived
+  // from a STRUCTURED body that genuinely lacks the field: an opaque body (a
+  // content-type we do not parse, or a proxy that recorded only a byte length)
+  // may well have carried `code_verifier`, and treating it as a known-missing
+  // field manufactures PKCE evidence out of a capture limitation.
+  const carriesVerifier = (exchange: TraceExchange): boolean => {
+    const body = exchange.request.body;
+    if (body?.encoding === "form") return body.fields.code_verifier != null;
+    if (body?.encoding === "json" || body?.encoding === "jsonrpc") {
+      const json = body.json;
+      return (
+        json != null &&
+        typeof json === "object" &&
+        !Array.isArray(json) &&
+        Object.hasOwn(json as Record<string, unknown>, "code_verifier")
+      );
+    }
+    return false;
+  };
+  const isStructured = (exchange: TraceExchange): boolean =>
+    exchange.request.body?.encoding === "form" ||
+    exchange.request.body?.encoding === "json" ||
+    exchange.request.body?.encoding === "jsonrpc";
+
   const verifierSentOnToken: Observation<boolean> =
     token.length === 0
       ? notObserved("no /token request was captured in this trace")
-      : present(
-          token.some(
-            (exchange) =>
-              exchange.request.body?.encoding === "form" &&
-              exchange.request.body.fields.code_verifier != null,
-          ),
-        );
+      : token.some(carriesVerifier)
+        ? present(true)
+        : token.every(isStructured)
+          ? present(false)
+          : notObserved(
+              "the captured /token request body was opaque (unparsed or body-less), so whether it carried `code_verifier` was never on the wire we recorded",
+            );
 
   return { challengeMethod, challengeLength, verifierSentOnToken };
 }
@@ -655,6 +798,9 @@ function observeUserAgent(wire: readonly TraceExchange[]): UserAgentUsage {
       .filter((value): value is string => value != null && value !== ""),
   );
   const legsWithoutUa = legsPresent.filter((leg) => byLeg[leg]?.state === "absent");
+  const legsNotObserved = legsPresent.filter(
+    (leg) => byLeg[leg]?.state === "not-observed",
+  );
 
   // Uniformly-absent counts as consistent. MCPJam's own OAuth runs in a browser,
   // where scripts are FORBIDDEN from setting `User-Agent` — there is no value to
@@ -662,12 +808,23 @@ function observeUserAgent(wire: readonly TraceExchange[]): UserAgentUsage {
   // gap. Calling that "inconsistent" would report a browser restriction as a
   // client quirk. Only a genuine MIX — some legs carrying a UA and some not, or
   // two different values — is inconsistent.
+  //
+  // But "across EVERY captured leg" is only sayable when every leg's headers were
+  // actually on a wire we recorded. A reconstructed `/authorize` contributes no
+  // header observation at all, so a verdict over it would be invented — and would
+  // then "differ" from a proxy capture that did see the browser's headers.
   return {
     byLeg,
     consistent:
-      allValues.length === 0
-        ? true
-        : allValues.length === 1 && legsWithoutUa.length === 0,
+      legsNotObserved.length > 0
+        ? notObserved(
+            `the \`${legsNotObserved.join("`, `")}\` leg(s) carried no observed request headers (reconstructed rather than intercepted), so whether one \`User-Agent\` is used across every leg cannot be determined`,
+          )
+        : present(
+            allValues.length === 0
+              ? true
+              : allValues.length === 1 && legsWithoutUa.length === 0,
+          ),
   };
 }
 
@@ -748,7 +905,15 @@ export function findObservationDrift(trace: GoldenTrace): string[] {
   if (expected === actual) return [];
 
   const drift: string[] = [];
-  for (const key of Object.keys(derived) as Array<keyof TraceObservations>) {
+  // Union of both sides, not just `derived`'s keys. A tampered trace whose only
+  // edit is an EXTRA top-level observation key is invisible to a loop over the
+  // derived shape — the whole-object comparison above catches it, the per-key
+  // loop finds nothing, and an empty array reads as "clean" to every caller.
+  const keys = new Set<string>([
+    ...Object.keys(derived),
+    ...Object.keys((trace.observations ?? {}) as object),
+  ]);
+  for (const key of [...keys].sort() as Array<keyof TraceObservations>) {
     const left = JSON.stringify(
       key === "dcrIdentity"
         ? { ...derived.dcrIdentity, observedLoopbackPorts: undefined }
@@ -759,9 +924,23 @@ export function findObservationDrift(trace: GoldenTrace): string[] {
         ? { ...trace.observations.dcrIdentity, observedLoopbackPorts: undefined }
         : trace.observations[key],
     );
-    if (left !== right) {
-      drift.push(`observations.${key}: stored ${right} but wire implies ${left}`);
+    if (left === right) continue;
+    if (left === undefined) {
+      drift.push(
+        `observations.${key}: stored ${right} but the wire implies no such observation — this key is not part of the derived shape, so it was added by hand`,
+      );
+      continue;
     }
+    drift.push(`observations.${key}: stored ${right} but wire implies ${left}`);
+  }
+
+  // Belt and braces: the two serializations disagree, so SOMETHING drifted. If
+  // the per-key walk cannot name it, say so rather than returning a clean-looking
+  // empty array — `readTrace` treats empty as "trust this trace".
+  if (drift.length === 0) {
+    drift.push(
+      `observations: the stored block does not match what the wire implies, but no single field accounts for it (stored ${actual} vs derived ${expected}). Treat the trace as hand-edited.`,
+    );
   }
   return drift;
 }

--- a/sdk/src/oauth-golden-trace/observe.ts
+++ b/sdk/src/oauth-golden-trace/observe.ts
@@ -339,12 +339,17 @@ function classifyResourceValueSource(
   }
 
   const originMap = buildOriginMap(origins);
+  // Origins BEFORE ports, matching `abstractUrl` in ./normalize.js. Reversing the
+  // two makes a loopback test server's origin unmatchable (the port placeholder
+  // rewrites the string first), which would leave the comparison targets in a
+  // different shape from the wire values they are compared against — and every
+  // `resource` value would classify as "other".
   const substitute = (raw: string): string => {
-    let out = normalizeLoopbackPort(raw);
+    let out = raw;
     for (const [name, origin] of originMap) {
       if (out.includes(origin)) out = out.split(origin).join(name);
     }
-    return out.replace(/\/$/, "");
+    return normalizeLoopbackPort(out).replace(/\/$/, "");
   };
 
   const value = values[0].replace(/\/$/, "");

--- a/sdk/src/oauth-golden-trace/observe.ts
+++ b/sdk/src/oauth-golden-trace/observe.ts
@@ -654,7 +654,12 @@ function observeDcrIdentity(wire: readonly TraceExchange[]): DcrIdentityUsage {
   // differ's structural equality and `findObservationDrift` both rely on. The
   // values are already redacted and origin-substituted by ./normalize.js, so this
   // retains nothing the `wire` does not already carry.
-  const extras: Record<string, unknown> = {};
+  // `Object.create(null)`, not `{}`: `record` is the DCR request body, so its
+  // keys come straight from the wire. A `__proto__` key assigned onto a plain
+  // object literal hits the inherited setter instead of becoming an own
+  // property and vanishes from `extras` — the same silent loss `parse.ts`
+  // guards against for form fields.
+  const extras: Record<string, unknown> = Object.create(null);
   for (const key of Object.keys(record).sort()) {
     if (MODELLED_DCR_FIELDS.has(key)) continue;
     extras[key] = record[key];

--- a/sdk/src/oauth-golden-trace/observe.ts
+++ b/sdk/src/oauth-golden-trace/observe.ts
@@ -1,0 +1,762 @@
+/**
+ * HP-44 — leg classification and observation derivation.
+ *
+ * Turns a normalized wire into the diff-relevant summary a reviewer reads.
+ * Everything here is a pure function of `wire` + `scenario`, so a trace's
+ * `observations` block can always be regenerated and checked against what was
+ * committed (see `assertObservationsAreDerived`).
+ *
+ * The single rule that governs every function below: a field is `absent` ONLY
+ * when the leg that would carry it WAS captured and the field was not on it.
+ * If the leg is missing from the trace, every field it would have carried is
+ * `not-observed` with the leg named as the reason. Getting this backwards is how
+ * "we didn't look" becomes "the client doesn't do it", which is the specific
+ * error this whole harness exists to prevent.
+ */
+
+import {
+  MCP_WIRE_LEGS,
+  OAUTH_DISCOVERY_LEGS,
+  absent,
+  notObserved,
+  observedValue,
+  present,
+} from "./types.js";
+import type {
+  DcrIdentityUsage,
+  GoldenTrace,
+  Observation,
+  PkceUsage,
+  ProtocolVersionUsage,
+  ResourceIndicatorUsage,
+  ResourceIndicatorValueSource,
+  TraceBody,
+  TraceExchange,
+  TraceLeg,
+  TraceObservations,
+  TraceScenario,
+  UserAgentUsage,
+} from "./types.js";
+import { buildOriginMap, normalizeLoopbackPort } from "./normalize.js";
+import type { OriginPlaceholders } from "./normalize.js";
+
+// ── Leg classification ───────────────────────────────────────────────────
+
+/**
+ * `OAuthFlowStep` → {@link TraceLeg}.
+ *
+ * Preferred over URL heuristics whenever available: for an emulator capture the
+ * state machine already knows which leg it is on, and a heuristic that
+ * disagrees with the machine would be recording our guess about our own code.
+ * Steps that produce no HTTP request map to `undefined`.
+ */
+const STEP_TO_LEG: Record<string, TraceLeg | undefined> = {
+  idle: undefined,
+  request_without_token: "mcp-unauthenticated",
+  received_401_unauthorized: "mcp-unauthenticated",
+  // 2025-03-26 starts discovery at the AS metadata document derived from the
+  // MCP server origin — there is no PRM rung on that revision.
+  discovery_start: "as-metadata-discovery",
+  request_resource_metadata: "prm-discovery",
+  received_resource_metadata: "prm-discovery",
+  request_authorization_server_metadata: "as-metadata-discovery",
+  received_authorization_server_metadata: "as-metadata-discovery",
+  cimd_prepare: "cimd-fetch",
+  cimd_fetch_request: "cimd-fetch",
+  cimd_metadata_response: "cimd-fetch",
+  request_client_registration: "dcr-register",
+  received_client_credentials: "dcr-register",
+  generate_pkce_parameters: undefined,
+  authorization_request: "authorize",
+  received_authorization_code: "authorize",
+  token_request: "token",
+  received_access_token: "token",
+  // This step sends an `initialize` WITH the bearer token, so it is the real
+  // handshake — the same classification `classifyLeg` gives the identical request
+  // from a HAR. Keeping the two capture paths in agreement is what lets an
+  // emulator trace be diffed against a proxy trace at all.
+  authenticated_mcp_request: "mcp-initialize",
+  complete: undefined,
+  // Post-handshake authenticated traffic, which is a different leg from the
+  // handshake itself.
+  verify_list_tools: "mcp-authenticated",
+  verify_call_tool: "mcp-authenticated",
+};
+
+export function legForOAuthFlowStep(step: string): TraceLeg | undefined {
+  return STEP_TO_LEG[step];
+}
+
+export type LegClassificationInput = {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: TraceBody;
+  /** The MCP server URL, so MCP-wire traffic can be recognized. */
+  mcpServerUrl?: string;
+};
+
+function headerLookup(
+  headers: Record<string, string>,
+  name: string,
+): string | undefined {
+  const target = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === target) return value;
+  }
+  return undefined;
+}
+
+function formField(body: TraceBody | undefined, key: string): string | undefined {
+  if (body?.encoding !== "form") return undefined;
+  return body.fields[key]?.[0];
+}
+
+function jsonRpcMethod(body: TraceBody | undefined): string | undefined {
+  if (!body) return undefined;
+  if (body.encoding === "jsonrpc") {
+    if (body.method) return body.method;
+    const json = body.json;
+    if (json && typeof json === "object" && !Array.isArray(json)) {
+      const method = (json as Record<string, unknown>).method;
+      if (typeof method === "string") return method;
+    }
+  }
+  if (body.encoding === "json") {
+    const json = body.json;
+    if (json && typeof json === "object" && !Array.isArray(json)) {
+      const record = json as Record<string, unknown>;
+      if (record.jsonrpc === "2.0" && typeof record.method === "string") {
+        return record.method;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Classify a request into a leg from its wire shape alone.
+ *
+ * This is the HAR path — a proxy capture has no state-machine context, only
+ * bytes. Rules are ordered most-specific first, and the returned `basis` names
+ * the rule that fired so a misclassification is debuggable rather than
+ * mysterious.
+ */
+export function classifyLeg(
+  input: LegClassificationInput,
+): { leg: TraceLeg; basis: string } {
+  const method = input.method.toUpperCase();
+  let path = input.url;
+  let search = "";
+  try {
+    const parsed = new URL(input.url);
+    path = parsed.pathname;
+    search = parsed.search;
+  } catch {
+    const queryStart = input.url.indexOf("?");
+    if (queryStart >= 0) {
+      path = input.url.slice(0, queryStart);
+      search = input.url.slice(queryStart);
+    }
+  }
+
+  if (path.includes("/.well-known/oauth-protected-resource")) {
+    return { leg: "prm-discovery", basis: "well-known path: oauth-protected-resource" };
+  }
+  if (
+    path.includes("/.well-known/oauth-authorization-server") ||
+    path.includes("/.well-known/openid-configuration")
+  ) {
+    return {
+      leg: "as-metadata-discovery",
+      basis: "well-known path: authorization-server metadata",
+    };
+  }
+  if (
+    path.includes("client-id-metadata") ||
+    path.includes("client-metadata") ||
+    /client[-_]?metadata\.json$/.test(path)
+  ) {
+    return { leg: "cimd-fetch", basis: "path names a client-id metadata document" };
+  }
+
+  const grantType = formField(input.body, "grant_type");
+  if (grantType === "refresh_token") {
+    return { leg: "refresh", basis: "form body grant_type=refresh_token" };
+  }
+  if (grantType) {
+    return { leg: "token", basis: `form body grant_type=${grantType}` };
+  }
+
+  if (method === "POST" && /\/register\b/.test(path)) {
+    return { leg: "dcr-register", basis: "POST to a /register path" };
+  }
+  // A DCR body is recognizable without the path: RFC 7591 requires
+  // `redirect_uris`, and no other leg posts `client_name`.
+  if (method === "POST" && input.body?.encoding === "json") {
+    const json = input.body.json;
+    if (json && typeof json === "object" && !Array.isArray(json)) {
+      const record = json as Record<string, unknown>;
+      if ("redirect_uris" in record || "client_name" in record) {
+        return { leg: "dcr-register", basis: "JSON body has RFC 7591 registration fields" };
+      }
+    }
+  }
+
+  if (/\/authorize\b/.test(path) || /[?&]response_type=/.test(search)) {
+    return { leg: "authorize", basis: "authorize path or response_type param" };
+  }
+  if (/\/token\b/.test(path)) {
+    return { leg: "token", basis: "token path" };
+  }
+
+  const rpcMethod = jsonRpcMethod(input.body);
+  if (rpcMethod) {
+    const authorization = headerLookup(input.headers, "authorization");
+    // Auth state is checked BEFORE the method name. An `initialize` sent without
+    // a token is the unauthenticated PROBE, not the handshake — and whether a
+    // client probes first and falls back to OAuth on a 401 (Goose) or authorizes
+    // up front (Claude, ChatGPT) is one of the orderings this harness compares.
+    // Classifying the probe as `mcp-initialize` would erase that distinction.
+    if (!authorization) {
+      return {
+        leg: "mcp-unauthenticated",
+        basis: `JSON-RPC ${rpcMethod}, no Authorization`,
+      };
+    }
+    return rpcMethod === "initialize"
+      ? { leg: "mcp-initialize", basis: "authenticated JSON-RPC method=initialize" }
+      : { leg: "mcp-authenticated", basis: `JSON-RPC ${rpcMethod} with Authorization` };
+  }
+
+  if (input.mcpServerUrl && input.url.startsWith(input.mcpServerUrl)) {
+    const authorization = headerLookup(input.headers, "authorization");
+    return authorization
+      ? { leg: "mcp-authenticated", basis: "MCP server URL with Authorization" }
+      : { leg: "mcp-unauthenticated", basis: "MCP server URL, no Authorization" };
+  }
+
+  return { leg: "unknown", basis: "no classification rule matched" };
+}
+
+// ── Small observation helpers ────────────────────────────────────────────
+
+function distinct(values: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const value of values) if (!out.includes(value)) out.push(value);
+  return out;
+}
+
+function exchangesForLeg(
+  wire: readonly TraceExchange[],
+  legs: readonly TraceLeg[],
+): TraceExchange[] {
+  return wire.filter((exchange) => legs.includes(exchange.leg));
+}
+
+/**
+ * Collect the distinct values of one request header across a set of legs.
+ *
+ * The three-way return is the whole discipline: no exchanges on those legs ⇒
+ * `not-observed`; exchanges present but none carried the header ⇒ `absent`
+ * (a positive finding); otherwise `present` with the distinct values.
+ */
+function observeRequestHeader(
+  wire: readonly TraceExchange[],
+  legs: readonly TraceLeg[],
+  header: string,
+  legLabel: string,
+): Observation<string[]> {
+  const exchanges = exchangesForLeg(wire, legs);
+  if (exchanges.length === 0) {
+    return notObserved(`no ${legLabel} request was captured in this trace`);
+  }
+
+  // Requests whose headers were never seen (a browser-driven `/authorize`)
+  // cannot contribute an `absent` verdict — they contribute nothing at all.
+  const observable = exchanges.filter(
+    (exchange) => exchange.request.headersObserved !== false,
+  );
+  if (observable.length === 0) {
+    return notObserved(
+      `the ${legLabel} request was reconstructed rather than intercepted, so its headers were never on the wire we recorded`,
+    );
+  }
+
+  const values = observable
+    .map((exchange) => headerLookup(exchange.request.headers, header))
+    .filter((value): value is string => value != null && value !== "");
+  return values.length === 0 ? absent : present(distinct(values));
+}
+
+// ── Resource indicator ───────────────────────────────────────────────────
+
+function observeResourceParam(
+  wire: readonly TraceExchange[],
+  leg: TraceLeg,
+  legLabel: string,
+): Observation<string[]> {
+  const exchanges = exchangesForLeg(wire, [leg]);
+  if (exchanges.length === 0) {
+    return notObserved(`no ${legLabel} request was captured in this trace`);
+  }
+
+  const values: string[] = [];
+  for (const exchange of exchanges) {
+    // `resource` can arrive as a query param (authorize) or a form field
+    // (token/refresh), and can legitimately appear more than once.
+    values.push(...(exchange.request.query?.resource ?? []));
+    if (exchange.request.body?.encoding === "form") {
+      values.push(...(exchange.request.body.fields.resource ?? []));
+    }
+  }
+
+  return values.length === 0 ? absent : present(values);
+}
+
+/**
+ * Classify WHICH url the `resource` value corresponds to.
+ *
+ * Comparison targets are normalized through the same origin map as the wire, or
+ * the placeheld wire value could never match a raw configured URL. Claude and
+ * ChatGPT send the canonicalized MCP server URL; VS Code sends the PRM
+ * document's own `resource`. When the scenario makes those two identical the
+ * result is `mcp-server-url`, and the differ treats a
+ * `mcp-server-url`/`prm-resource` disagreement under that condition as
+ * indistinguishable rather than as a difference.
+ */
+function classifyResourceValueSource(
+  observed: Observation<string[]>,
+  scenario: TraceScenario,
+  origins: OriginPlaceholders,
+): Observation<ResourceIndicatorValueSource> {
+  const values = observedValue(observed);
+  if (!values || values.length === 0) {
+    if (observed.state === "absent") return absent;
+    return notObserved(
+      "no `resource` value was observed, so its source cannot be classified",
+    );
+  }
+
+  const originMap = buildOriginMap(origins);
+  const substitute = (raw: string): string => {
+    let out = normalizeLoopbackPort(raw);
+    for (const [name, origin] of originMap) {
+      if (out.includes(origin)) out = out.split(origin).join(name);
+    }
+    return out.replace(/\/$/, "");
+  };
+
+  const value = values[0].replace(/\/$/, "");
+  const serverUrl = substitute(scenario.mcpServerUrl);
+  const prmResource = scenario.capabilities.prmResource
+    ? substitute(scenario.capabilities.prmResource)
+    : undefined;
+
+  if (value === serverUrl) return present("mcp-server-url");
+  if (prmResource && value === prmResource) return present("prm-resource");
+  return present("other");
+}
+
+function observeResourceIndicator(
+  wire: readonly TraceExchange[],
+  scenario: TraceScenario,
+  origins: OriginPlaceholders,
+): ResourceIndicatorUsage {
+  const onAuthorize = observeResourceParam(wire, "authorize", "/authorize");
+  const onToken = observeResourceParam(wire, "token", "/token");
+  const onRefresh = observeResourceParam(wire, "refresh", "token-refresh");
+
+  // Classify from whichever leg actually carried a value; authorize first
+  // because it is the leg captured most often.
+  const carrier =
+    observedValue(onAuthorize) ? onAuthorize
+    : observedValue(onToken) ? onToken
+    : observedValue(onRefresh) ? onRefresh
+    : onAuthorize.state === "absent" || onToken.state === "absent"
+      ? absent
+      : onAuthorize;
+
+  return {
+    onAuthorize,
+    onToken,
+    onRefresh,
+    valueSource: classifyResourceValueSource(carrier, scenario, origins),
+  };
+}
+
+// ── Protocol version ─────────────────────────────────────────────────────
+
+function observeInitializeBodyVersion(
+  wire: readonly TraceExchange[],
+): Observation<string> {
+  const exchanges = wire.filter(
+    (exchange) => jsonRpcMethod(exchange.request.body) === "initialize",
+  );
+  if (exchanges.length === 0) {
+    return notObserved("no MCP `initialize` request was captured in this trace");
+  }
+
+  for (const exchange of exchanges) {
+    const body = exchange.request.body;
+    if (!body || (body.encoding !== "jsonrpc" && body.encoding !== "json")) continue;
+    const json = body.json;
+    if (!json || typeof json !== "object" || Array.isArray(json)) continue;
+    const params = (json as Record<string, unknown>).params;
+    if (!params || typeof params !== "object" || Array.isArray(params)) continue;
+    const version = (params as Record<string, unknown>).protocolVersion;
+    if (typeof version === "string") return present(version);
+  }
+
+  return absent;
+}
+
+function observeProtocolVersion(
+  wire: readonly TraceExchange[],
+): ProtocolVersionUsage {
+  const headerByLeg: ProtocolVersionUsage["headerByLeg"] = {};
+  const legsPresent = distinct(wire.map((exchange) => exchange.leg)) as TraceLeg[];
+  for (const leg of legsPresent) {
+    headerByLeg[leg] = observeRequestHeader(
+      wire,
+      [leg],
+      "mcp-protocol-version",
+      `${leg}`,
+    );
+  }
+
+  const headerOnOAuthDiscovery = observeRequestHeader(
+    wire,
+    OAUTH_DISCOVERY_LEGS,
+    "mcp-protocol-version",
+    "OAuth discovery",
+  );
+  const headerOnMcpTraffic = observeRequestHeader(
+    wire,
+    MCP_WIRE_LEGS,
+    "mcp-protocol-version",
+    "MCP-wire",
+  );
+  const initializeBody = observeInitializeBodyVersion(wire);
+
+  // Two wires "disagree" when both were captured and either they carry different
+  // value sets, or one carries a value and the other demonstrably carries none.
+  // If either side is `not-observed` we cannot claim disagreement — that is a
+  // gap, and the differ reports it as one.
+  const oauthValues = observedValue(headerOnOAuthDiscovery);
+  const mcpValues = observedValue(headerOnMcpTraffic);
+  const bothCaptured =
+    headerOnOAuthDiscovery.state !== "not-observed" &&
+    headerOnMcpTraffic.state !== "not-observed";
+  const wiresDisagree =
+    bothCaptured &&
+    JSON.stringify(oauthValues ?? null) !== JSON.stringify(mcpValues ?? null);
+
+  const bodyVersion = observedValue(initializeBody);
+  const allHeaderValues = distinct([...(oauthValues ?? []), ...(mcpValues ?? [])]);
+  const headerDisagreesWithInitializeBody =
+    bodyVersion != null &&
+    allHeaderValues.length > 0 &&
+    allHeaderValues.some((value) => value !== bodyVersion);
+
+  return {
+    initializeBody,
+    headerByLeg,
+    headerOnOAuthDiscovery,
+    headerOnMcpTraffic,
+    wiresDisagree,
+    headerDisagreesWithInitializeBody,
+  };
+}
+
+// ── DCR identity ─────────────────────────────────────────────────────────
+
+const MODELLED_DCR_FIELDS = new Set([
+  "client_name",
+  "redirect_uris",
+  "grant_types",
+  "response_types",
+  "token_endpoint_auth_method",
+  "scope",
+]);
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((entry): entry is string => typeof entry === "string");
+  return strings.length === value.length ? strings : undefined;
+}
+
+function observeDcrIdentity(wire: readonly TraceExchange[]): DcrIdentityUsage {
+  const registrations = exchangesForLeg(wire, ["dcr-register"]);
+  const gap = <T>(field: string): Observation<T> =>
+    notObserved(
+      `no dynamic client registration request was captured, so ${field} is unknown`,
+    );
+
+  if (registrations.length === 0) {
+    return {
+      clientName: gap("client_name"),
+      redirectUris: gap("redirect_uris"),
+      observedLoopbackPorts: gap("loopback redirect ports"),
+      grantTypes: gap("grant_types"),
+      responseTypes: gap("response_types"),
+      tokenEndpointAuthMethod: gap("token_endpoint_auth_method"),
+      scope: gap("scope"),
+      extraFields: gap("unmodelled registration fields"),
+    };
+  }
+
+  const body = registrations[0].request.body;
+  const record =
+    body?.encoding === "json" && body.json && typeof body.json === "object" && !Array.isArray(body.json)
+      ? (body.json as Record<string, unknown>)
+      : undefined;
+
+  if (!record) {
+    const reason =
+      "a registration request was captured but its body was not structured JSON";
+    return {
+      clientName: notObserved(reason),
+      redirectUris: notObserved(reason),
+      observedLoopbackPorts: notObserved(reason),
+      grantTypes: notObserved(reason),
+      responseTypes: notObserved(reason),
+      tokenEndpointAuthMethod: notObserved(reason),
+      scope: notObserved(reason),
+      extraFields: notObserved(reason),
+    };
+  }
+
+  const scalar = (key: string): Observation<string> => {
+    const value = record[key];
+    return typeof value === "string" ? present(value) : absent;
+  };
+  const list = (key: string): Observation<string[]> => {
+    const value = stringArray(record[key]);
+    return value ? present(value) : absent;
+  };
+
+  // Redirect URIs in the wire are already `{port}`-normalized, so the raw ports
+  // are unrecoverable here BY DESIGN — that is what makes the diff robust across
+  // runs. The capture paths, which still hold the pre-normalization URIs, inject
+  // them via `withObservedLoopbackPorts`. `absent` is therefore the correct
+  // derived value: nothing in the normalized wire carries a port.
+  const redirectUris = list("redirect_uris");
+
+  const extras = Object.keys(record)
+    .filter((key) => !MODELLED_DCR_FIELDS.has(key))
+    .sort();
+
+  return {
+    clientName: scalar("client_name"),
+    redirectUris,
+    observedLoopbackPorts: absent,
+    grantTypes: list("grant_types"),
+    responseTypes: list("response_types"),
+    tokenEndpointAuthMethod: scalar("token_endpoint_auth_method"),
+    scope: scalar("scope"),
+    extraFields: extras.length > 0 ? present(extras) : absent,
+  };
+}
+
+/**
+ * Re-attach loopback ports that normalization stripped.
+ *
+ * Called by the capture paths, which still hold the pre-normalization redirect
+ * URIs. Kept separate from `deriveObservations` so the derivation stays a pure
+ * function of the normalized trace — otherwise `assertObservationsAreDerived`
+ * could not check a committed trace against its own wire.
+ */
+export function withObservedLoopbackPorts(
+  observations: TraceObservations,
+  ports: readonly number[],
+): TraceObservations {
+  return {
+    ...observations,
+    dcrIdentity: {
+      ...observations.dcrIdentity,
+      observedLoopbackPorts:
+        observations.dcrIdentity.redirectUris.state === "not-observed"
+          ? observations.dcrIdentity.observedLoopbackPorts
+          : ports.length > 0
+            ? present([...ports])
+            : absent,
+    },
+  };
+}
+
+// ── PKCE ─────────────────────────────────────────────────────────────────
+
+function parsePlaceholderLength(value: string): number | undefined {
+  const match = /len=(\d+)/.exec(value);
+  return match ? Number(match[1]) : undefined;
+}
+
+function observePkce(wire: readonly TraceExchange[]): PkceUsage {
+  const authorize = exchangesForLeg(wire, ["authorize"]);
+  const token = exchangesForLeg(wire, ["token"]);
+
+  const challengeMethod: Observation<string> =
+    authorize.length === 0
+      ? notObserved("no /authorize request was captured in this trace")
+      : (() => {
+          const value = authorize
+            .flatMap((exchange) => exchange.request.query?.code_challenge_method ?? [])
+            .at(0);
+          return value ? present(value) : absent;
+        })();
+
+  const challengeLength: Observation<number> =
+    authorize.length === 0
+      ? notObserved("no /authorize request was captured in this trace")
+      : (() => {
+          const raw = authorize
+            .flatMap((exchange) => exchange.request.query?.code_challenge ?? [])
+            .at(0);
+          if (!raw) return absent;
+          const length = parsePlaceholderLength(raw) ?? raw.length;
+          return present(length);
+        })();
+
+  const verifierSentOnToken: Observation<boolean> =
+    token.length === 0
+      ? notObserved("no /token request was captured in this trace")
+      : present(
+          token.some(
+            (exchange) =>
+              exchange.request.body?.encoding === "form" &&
+              exchange.request.body.fields.code_verifier != null,
+          ),
+        );
+
+  return { challengeMethod, challengeLength, verifierSentOnToken };
+}
+
+// ── User agent ───────────────────────────────────────────────────────────
+
+function observeUserAgent(wire: readonly TraceExchange[]): UserAgentUsage {
+  const byLeg: UserAgentUsage["byLeg"] = {};
+  const legsPresent = distinct(wire.map((exchange) => exchange.leg)) as TraceLeg[];
+  for (const leg of legsPresent) {
+    byLeg[leg] = observeRequestHeader(wire, [leg], "user-agent", `${leg}`);
+  }
+
+  const observable = wire.filter(
+    (exchange) => exchange.request.headersObserved !== false,
+  );
+  const allValues = distinct(
+    observable
+      .map((exchange) => headerLookup(exchange.request.headers, "user-agent"))
+      .filter((value): value is string => value != null && value !== ""),
+  );
+  const legsWithoutUa = legsPresent.filter((leg) => byLeg[leg]?.state === "absent");
+
+  // Uniformly-absent counts as consistent. MCPJam's own OAuth runs in a browser,
+  // where scripts are FORBIDDEN from setting `User-Agent` — there is no value to
+  // capture, which the HP-47 sweep classified as structurally N/A rather than as a
+  // gap. Calling that "inconsistent" would report a browser restriction as a
+  // client quirk. Only a genuine MIX — some legs carrying a UA and some not, or
+  // two different values — is inconsistent.
+  return {
+    byLeg,
+    consistent:
+      allValues.length === 0
+        ? true
+        : allValues.length === 1 && legsWithoutUa.length === 0,
+  };
+}
+
+// ── Discovery ladder ─────────────────────────────────────────────────────
+
+function observeDiscoveryLadder(wire: readonly TraceExchange[]): string[] {
+  const paths: string[] = [];
+  for (const exchange of wire) {
+    if (!OAUTH_DISCOVERY_LEGS.includes(exchange.leg)) continue;
+    let path = exchange.request.url;
+    try {
+      path = new URL(exchange.request.url).pathname;
+    } catch {
+      const queryStart = path.indexOf("?");
+      if (queryStart >= 0) path = path.slice(0, queryStart);
+      const schemeEnd = path.indexOf("}");
+      if (schemeEnd >= 0) path = path.slice(schemeEnd + 1);
+    }
+    if (!paths.includes(path)) paths.push(path);
+  }
+  return paths;
+}
+
+// ── Entry point ──────────────────────────────────────────────────────────
+
+/**
+ * Derive the full observation summary from a normalized wire.
+ *
+ * Pure: same wire + same scenario ⇒ same observations, byte for byte. That is
+ * what lets a committed trace be re-verified rather than trusted.
+ */
+export function deriveObservations(input: {
+  wire: readonly TraceExchange[];
+  scenario: TraceScenario;
+}): TraceObservations {
+  const { wire, scenario } = input;
+  const origins: OriginPlaceholders = {
+    mcpServerUrl: scenario.mcpServerUrl,
+    authorizationServerUrl: scenario.authorizationServerUrl,
+  };
+
+  return {
+    legOrder: distinct(wire.map((exchange) => exchange.leg)) as TraceLeg[],
+    endpointsHit: distinct(wire.map((exchange) => exchange.request.url.split("?")[0])),
+    discoveryLadder: observeDiscoveryLadder(wire),
+    userAgent: observeUserAgent(wire),
+    resourceIndicator: observeResourceIndicator(wire, scenario, origins),
+    protocolVersion: observeProtocolVersion(wire),
+    dcrIdentity: observeDcrIdentity(wire),
+    pkce: observePkce(wire),
+  };
+}
+
+/**
+ * Verify a trace's stored `observations` still match what its `wire` implies.
+ *
+ * Guards the durability property: a hand-edited or half-migrated trace is caught
+ * by a test instead of quietly skewing a parity result. `observedLoopbackPorts`
+ * is excluded because it is injected from pre-normalization data that the wire
+ * no longer carries.
+ */
+export function findObservationDrift(trace: GoldenTrace): string[] {
+  const derived = deriveObservations({
+    wire: trace.wire,
+    scenario: trace.scenario,
+  });
+
+  const strip = (observations: TraceObservations): unknown => ({
+    ...observations,
+    dcrIdentity: {
+      ...observations.dcrIdentity,
+      observedLoopbackPorts: undefined,
+    },
+  });
+
+  const expected = JSON.stringify(strip(derived));
+  const actual = JSON.stringify(strip(trace.observations));
+  if (expected === actual) return [];
+
+  const drift: string[] = [];
+  for (const key of Object.keys(derived) as Array<keyof TraceObservations>) {
+    const left = JSON.stringify(
+      key === "dcrIdentity"
+        ? { ...derived.dcrIdentity, observedLoopbackPorts: undefined }
+        : derived[key],
+    );
+    const right = JSON.stringify(
+      key === "dcrIdentity"
+        ? { ...trace.observations.dcrIdentity, observedLoopbackPorts: undefined }
+        : trace.observations[key],
+    );
+    if (left !== right) {
+      drift.push(`observations.${key}: stored ${right} but wire implies ${left}`);
+    }
+  }
+  return drift;
+}

--- a/sdk/src/oauth-golden-trace/parse.ts
+++ b/sdk/src/oauth-golden-trace/parse.ts
@@ -28,14 +28,18 @@ function headerValue(
 
 /** Multi-valued parse of an `application/x-www-form-urlencoded` payload. */
 export function parseFormFields(raw: string): Record<string, string[]> {
-  const fields: Record<string, string[]> = {};
+  // Null-prototype: `__proto__` is a legal form field name, and `fields["__proto__"] ??= []`
+  // on a plain object literal reparents the accumulator rather than recording a
+  // field. Normalization hardens the same way, but that is too late — the field
+  // has to survive parsing to reach it.
+  const fields: Record<string, string[]> = Object.create(null);
   for (const [key, value] of new URLSearchParams(raw).entries()) {
     (fields[key] ??= []).push(value);
   }
   return fields;
 }
 
-function isJsonRpc(value: unknown): boolean {
+function isJsonRpcEnvelope(value: unknown): boolean {
   return (
     !!value &&
     typeof value === "object" &&
@@ -44,8 +48,20 @@ function isJsonRpc(value: unknown): boolean {
   );
 }
 
+function isJsonRpc(value: unknown): boolean {
+  // A batch is JSON-RPC only if EVERY entry is an envelope. A mixed array is
+  // plain `json`: calling it `jsonrpc` would claim a protocol the bytes do not
+  // honour, and an empty array is not a legal batch at all.
+  if (Array.isArray(value)) {
+    return value.length > 0 && value.every(isJsonRpcEnvelope);
+  }
+  return isJsonRpcEnvelope(value);
+}
+
 function jsonRpcMethodOf(value: unknown): string | undefined {
-  if (!isJsonRpc(value)) return undefined;
+  // A batch has no single `method`, so nothing is hoisted — leaving `method`
+  // absent is honest, and consumers already fall back to other leg signals.
+  if (!isJsonRpcEnvelope(value)) return undefined;
   const method = (value as Record<string, unknown>).method;
   return typeof method === "string" ? method : undefined;
 }
@@ -75,6 +91,15 @@ export function parseTraceBody(
   const contentType = headerValue(headers, "content-type");
 
   if (typeof raw === "object") {
+    // `URLSearchParams` has no enumerable own properties, so the object walk
+    // below would read it as an EMPTY form body and silently drop the token
+    // leg's grant/resource/PKCE fields. Its serialized form is the wire form, so
+    // parse that — and do it regardless of content-type, since the type itself
+    // is already proof the body was form-encoded.
+    if (raw instanceof URLSearchParams) {
+      return { encoding: "form", fields: parseFormFields(raw.toString()) };
+    }
+
     // An already-parsed object whose content-type says form-urlencoded IS a form
     // body — the SDK's own token requests arrive this way. Encoding it as `json`
     // would make the same logical request diff unequal against a HAR capture of
@@ -116,6 +141,11 @@ export function parseTraceBody(
   const trimmed = raw.trim();
   if (trimmed === "") return undefined;
 
+  // Wire bytes, not UTF-16 code units: the HAR path fills this same field from
+  // `content.size`, and the two capture paths must not describe one body with two
+  // different numbers just because it contained non-ASCII text.
+  const byteLength = new TextEncoder().encode(raw).length;
+
   const looksJson =
     (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
     (trimmed.startsWith("[") && trimmed.endsWith("]"));
@@ -128,7 +158,7 @@ export function parseTraceBody(
       return {
         encoding: "opaque",
         ...(contentType ? { contentType } : {}),
-        byteLength: raw.length,
+        byteLength,
       };
     }
   }
@@ -147,7 +177,7 @@ export function parseTraceBody(
   return {
     encoding: "opaque",
     ...(contentType ? { contentType } : {}),
-    byteLength: raw.length,
+    byteLength,
   };
 }
 
@@ -175,6 +205,10 @@ export function collectRedirectUris(input: {
 
   if (input.body?.encoding === "form") {
     for (const value of input.body.fields.redirect_uri ?? []) uris.push(value);
+    // A DCR body posted form-encoded carries the plural key, and `parseTraceBody`
+    // will happily produce one. Reading only the singular key would drop the very
+    // loopback ports this function exists to rescue from the `{port}` placeholder.
+    for (const value of input.body.fields.redirect_uris ?? []) uris.push(value);
   }
 
   try {

--- a/sdk/src/oauth-golden-trace/parse.ts
+++ b/sdk/src/oauth-golden-trace/parse.ts
@@ -53,7 +53,14 @@ function isJsonRpc(value: unknown): boolean {
   // plain `json`: calling it `jsonrpc` would claim a protocol the bytes do not
   // honour, and an empty array is not a legal batch at all.
   if (Array.isArray(value)) {
-    return value.length > 0 && value.every(isJsonRpcEnvelope);
+    // `.every` SKIPS holes in a sparse array rather than invoking the predicate
+    // on them, so `[envelope, <hole>, envelope].every(isJsonRpcEnvelope)` was
+    // `true` — a slot that is not an envelope at all passing vacuously.
+    // `Array.from` materializes every hole as `undefined`, which
+    // `isJsonRpcEnvelope` correctly rejects, so every slot actually
+    // participates.
+    const materialized = Array.from(value);
+    return materialized.length > 0 && materialized.every(isJsonRpcEnvelope);
   }
   return isJsonRpcEnvelope(value);
 }
@@ -109,7 +116,13 @@ export function parseTraceBody(
       ?.toLowerCase()
       .includes("application/x-www-form-urlencoded");
     if (isFormContentType && !Array.isArray(raw)) {
-      const fields: Record<string, string[]> = {};
+      // `Object.create(null)`, not `{}`: `raw`'s keys come from the wire, and a
+      // client (or an attacker probing one) can send `__proto__` as a form field
+      // name. Against a plain object literal that hits the inherited setter
+      // instead of becoming an own property, and the field silently vanishes
+      // from the trace — the oracle then reports absence for something the
+      // client demonstrably sent.
+      const fields: Record<string, string[]> = Object.create(null);
       let flat = true;
       for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
         if (value == null) continue;

--- a/sdk/src/oauth-golden-trace/parse.ts
+++ b/sdk/src/oauth-golden-trace/parse.ts
@@ -1,0 +1,188 @@
+/**
+ * HP-44 — wire parsing shared by every capture path.
+ *
+ * Both capture paths (an in-process emulator run and a HAR from a proxy) arrive
+ * with bodies as loosely-typed blobs: sometimes a string, sometimes an already
+ * parsed object, with a content-type that may or may not be accurate. This
+ * module resolves them into the structured {@link TraceBody} the differ can
+ * compare field by field.
+ *
+ * The bias throughout is to STRUCTURE where structure is real and `opaque`
+ * otherwise. A body recorded as `opaque` is honest about being uncomparable; a
+ * body force-parsed into the wrong encoding produces confident nonsense.
+ */
+
+import type { TraceBody } from "./types.js";
+
+function headerValue(
+  headers: Record<string, string> | undefined,
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  const target = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === target) return value;
+  }
+  return undefined;
+}
+
+/** Multi-valued parse of an `application/x-www-form-urlencoded` payload. */
+export function parseFormFields(raw: string): Record<string, string[]> {
+  const fields: Record<string, string[]> = {};
+  for (const [key, value] of new URLSearchParams(raw).entries()) {
+    (fields[key] ??= []).push(value);
+  }
+  return fields;
+}
+
+function isJsonRpc(value: unknown): boolean {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as Record<string, unknown>).jsonrpc === "2.0"
+  );
+}
+
+function jsonRpcMethodOf(value: unknown): string | undefined {
+  if (!isJsonRpc(value)) return undefined;
+  const method = (value as Record<string, unknown>).method;
+  return typeof method === "string" ? method : undefined;
+}
+
+function asStructured(value: unknown): TraceBody {
+  const method = jsonRpcMethodOf(value);
+  if (isJsonRpc(value)) {
+    return { encoding: "jsonrpc", ...(method ? { method } : {}), json: value };
+  }
+  return { encoding: "json", json: value };
+}
+
+/**
+ * Resolve a raw body into a {@link TraceBody}.
+ *
+ * Content-type is used as a HINT, not as truth: proxies mislabel, and OAuth
+ * endpoints in the wild are inconsistent about it. The shape of the payload wins
+ * whenever the two disagree — a body that parses as JSON is JSON regardless of
+ * what the header claimed.
+ */
+export function parseTraceBody(
+  raw: unknown,
+  headers?: Record<string, string>,
+): TraceBody | undefined {
+  if (raw == null) return undefined;
+
+  const contentType = headerValue(headers, "content-type");
+
+  if (typeof raw === "object") {
+    // An already-parsed object whose content-type says form-urlencoded IS a form
+    // body — the SDK's own token requests arrive this way. Encoding it as `json`
+    // would make the same logical request diff unequal against a HAR capture of
+    // the identical bytes, purely because of how each capture path happened to
+    // hold it in memory.
+    const isFormContentType = contentType
+      ?.toLowerCase()
+      .includes("application/x-www-form-urlencoded");
+    if (isFormContentType && !Array.isArray(raw)) {
+      const fields: Record<string, string[]> = {};
+      let flat = true;
+      for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+        if (value == null) continue;
+        if (typeof value === "string") {
+          fields[key] = [value];
+        } else if (typeof value === "number" || typeof value === "boolean") {
+          fields[key] = [String(value)];
+        } else if (Array.isArray(value) && value.every((v) => typeof v === "string")) {
+          fields[key] = [...(value as string[])];
+        } else {
+          // A nested object cannot have been form-encoded; the content-type is
+          // wrong rather than the body, so fall back to structured.
+          flat = false;
+          break;
+        }
+      }
+      if (flat) return { encoding: "form", fields };
+    }
+
+    // Already-parsed object. Empty objects are still meaningful (a `{}` DCR body
+    // is a finding), so they are kept rather than dropped.
+    return asStructured(raw);
+  }
+
+  if (typeof raw !== "string") {
+    return { encoding: "json", json: raw };
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+
+  const looksJson =
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"));
+
+  if (looksJson) {
+    try {
+      return asStructured(JSON.parse(trimmed));
+    } catch {
+      // Fall through — a truncated JSON body is opaque, not form-encoded.
+      return {
+        encoding: "opaque",
+        ...(contentType ? { contentType } : {}),
+        byteLength: raw.length,
+      };
+    }
+  }
+
+  const isFormContentType = contentType
+    ?.toLowerCase()
+    .includes("application/x-www-form-urlencoded");
+  // A `k=v&k2=v2` payload with no content-type is still overwhelmingly a form
+  // body on these endpoints; requiring the header would lose real token requests.
+  const looksForm = /^[^=&\s]+=[^&]*(?:&[^=&\s]+=[^&]*)*$/.test(trimmed);
+
+  if (isFormContentType || looksForm) {
+    return { encoding: "form", fields: parseFormFields(trimmed) };
+  }
+
+  return {
+    encoding: "opaque",
+    ...(contentType ? { contentType } : {}),
+    byteLength: raw.length,
+  };
+}
+
+/**
+ * Recover loopback redirect ports before normalization strips them.
+ *
+ * Reads `redirect_uris` from a DCR body and `redirect_uri` from an authorize
+ * query, since a client that registers no redirect URI may still send one.
+ */
+export function collectRedirectUris(input: {
+  url: string;
+  body?: TraceBody;
+}): string[] {
+  const uris: string[] = [];
+
+  if (input.body?.encoding === "json") {
+    const json = input.body.json;
+    if (json && typeof json === "object" && !Array.isArray(json)) {
+      const value = (json as Record<string, unknown>).redirect_uris;
+      if (Array.isArray(value)) {
+        for (const entry of value) if (typeof entry === "string") uris.push(entry);
+      }
+    }
+  }
+
+  if (input.body?.encoding === "form") {
+    for (const value of input.body.fields.redirect_uri ?? []) uris.push(value);
+  }
+
+  try {
+    const parsed = new URL(input.url);
+    for (const value of parsed.searchParams.getAll("redirect_uri")) uris.push(value);
+  } catch {
+    // Relative or malformed URL — nothing to recover.
+  }
+
+  return uris;
+}

--- a/sdk/src/oauth-golden-trace/to-profile.ts
+++ b/sdk/src/oauth-golden-trace/to-profile.ts
@@ -216,13 +216,38 @@ function mapOAuthSpecVersion(
 
 // ── protocolVersionPinning ──────────────────────────────────────────────
 
-/** Same client, or a different one wearing a familiar host id? */
+/**
+ * Same client, or a different one wearing a familiar host id?
+ *
+ * `hostVersion` and `oauthImplementation` are load-bearing, not decoration: a
+ * client's pinning behavior is a property of the OAuth code it runs, and that
+ * code changes across a binary upgrade or a dependency bump even when
+ * `hostId`/`kind`/`build`/`surface` all stay identical. Comparing identity
+ * without them let a claude-code 2.1.220 trace and a claude-code 2.2.0 trace
+ * pass as "the same client" — silently reintroducing the dependency-bump
+ * staleness this module's header exists to rule out.
+ *
+ * Conservative on the unknown case by construction: either stamp being
+ * `absent`/`not-observed` on either side means "we cannot show these ran the
+ * same code," which disqualifies the contrast rather than assumes it — the
+ * same asymmetry `Observation` enforces everywhere else in this module.
+ */
 function sameSubject(a: TraceSubject, b: TraceSubject): boolean {
+  if (a.hostId !== b.hostId || a.kind !== b.kind) return false;
+  if (a.build !== b.build || a.surface !== b.surface) return false;
+  if (a.hostVersion.state !== "present" || b.hostVersion.state !== "present") {
+    return false;
+  }
+  if (a.hostVersion.value !== b.hostVersion.value) return false;
+  if (
+    a.oauthImplementation.state !== "present" ||
+    b.oauthImplementation.state !== "present"
+  ) {
+    return false;
+  }
   return (
-    a.hostId === b.hostId &&
-    a.kind === b.kind &&
-    a.build === b.build &&
-    a.surface === b.surface
+    JSON.stringify(a.oauthImplementation.value) ===
+    JSON.stringify(b.oauthImplementation.value)
   );
 }
 
@@ -242,12 +267,31 @@ function sameSubject(a: TraceSubject, b: TraceSubject): boolean {
  * is the likeliest one to happen by accident, because re-running the same
  * capture server twice is the path of least resistance.
  */
+/**
+ * Names WHY {@link sameSubject} rejected a pair, for a reviewer who does not
+ * want to open both artifacts to find out. `sameSubject` has more ways to fail
+ * than "different host" — a version bump or an unstamped OAuth dependency reject
+ * it too — so a single generic message would misdirect the fix in those cases.
+ */
+function subjectMismatchReason(a: TraceSubject, b: TraceSubject): string {
+  if (a.hostId !== b.hostId || a.kind !== b.kind || a.build !== b.build || a.surface !== b.surface) {
+    return `it captured a different subject (\`${b.hostId}\`/${b.kind}${b.build ? ` build ${b.build}` : ""}, not \`${a.hostId}\`/${a.kind}${a.build ? ` build ${a.build}` : ""}), so the two captures are not the same client and a shared value proves nothing about pinning`;
+  }
+  if (a.hostVersion.state !== "present" || b.hostVersion.state !== "present") {
+    return `at least one side does not record \`subject.hostVersion\` (it may have been captured before the version was stamped), so it cannot be shown the two runs used the same client code — a version bump can change pinning behavior with every other field unchanged`;
+  }
+  if (a.hostVersion.value !== b.hostVersion.value) {
+    return `the two captures are of different \`hostVersion\`s (\`${a.hostVersion.value}\` vs \`${b.hostVersion.value}\`) — a version bump can change pinning behavior, so this is not evidence about either version's client on its own`;
+  }
+  return `at least one side does not record \`subject.oauthImplementation\` (which package resolved the OAuth code, and at what version) — for a client that inherits OAuth from a dependency, that is the thing that actually determines pinning, and an unstamped trace cannot show the two runs shared it`;
+}
+
 function contrastTraceRejection(
   trace: GoldenTrace,
   contrast: GoldenTrace,
 ): string | undefined {
   if (!sameSubject(trace.subject, contrast.subject)) {
-    return `it captured a different subject (\`${contrast.subject.hostId}\`/${contrast.subject.kind}${contrast.subject.build ? ` build ${contrast.subject.build}` : ""}, not \`${trace.subject.hostId}\`/${trace.subject.kind}${trace.subject.build ? ` build ${trace.subject.build}` : ""}), so the two captures are not the same client and a shared value proves nothing about pinning`;
+    return subjectMismatchReason(trace.subject, contrast.subject);
   }
   if (contrast.scenario.scenarioId === trace.scenario.scenarioId) {
     return `it ran the SAME scenario (\`${trace.scenario.scenarioId}\`), so there is no second server in the comparison — an identical value across two runs of one scenario is what a negotiating client produces too`;
@@ -344,6 +388,18 @@ function mapProtocolVersionPinning(
             capturedAt,
           };
     }
+
+    // The experiment IS valid (identity and server versions check out) but one
+    // side's `initialize` body was never captured. That is a DIFFERENT blocker
+    // than "no contrastTrace was supplied", and the fallback below used to
+    // conflate them — telling an operator who already supplied a valid contrast
+    // that "only one capture is available" and to go capture a second one they
+    // already have.
+    return {
+      status: "unverifiable",
+      reason: `A valid contrast trace was supplied (\`${contrast.traceId}\`, ${thereScenario}) but the pin-vs-negotiate comparison needs the \`initialize\` body's protocol version on BOTH sides, and ${here == null && there == null ? `neither ${hereScenario} nor ${thereScenario}` : here == null ? hereScenario : thereScenario} captured it. Re-capture through the \`mcp-initialize\` leg rather than supplying a different contrast trace.`,
+      capturedAt,
+    };
   }
 
   const singleCapture =

--- a/sdk/src/oauth-golden-trace/to-profile.ts
+++ b/sdk/src/oauth-golden-trace/to-profile.ts
@@ -1,0 +1,425 @@
+/**
+ * HP-44 — project a golden trace onto {@link HostConfigOAuthProfileV1}.
+ *
+ * A trace is the strongest possible `source` for a profile field: it is a
+ * recorded artifact a reviewer can open, not a claim. This module is where that
+ * strength gets spent — carefully, because a trace proves LESS than it appears
+ * to about several fields, and overstating it would recreate the exact failure
+ * this whole line of work is a reaction to.
+ *
+ * ── What one trace can and cannot settle ──────────────────────────────────
+ *
+ * CAN:
+ *   - `sendsResourceIndicator`, when the scenario published a PRM document. With
+ *     no PRM, absence is the CORRECT behavior for several clients and proves
+ *     nothing about what they do when PRM exists.
+ *   - `dcrIdentity` — `client_name`, redirect-URI pattern, User-Agent. These are
+ *     literal bytes on the wire and a capture is definitive.
+ *   - `protocolVersionPinning`, but ONLY from the `MCP-Protocol-Version` header on
+ *     OAuth DISCOVERY. At discovery time no `initialize` has happened, so there
+ *     is nothing to have negotiated with: whatever value appears there is a
+ *     client-chosen constant, i.e. a pin by definition. This is precisely how
+ *     `rmcp`'s hardcoded `2024-11-05` on discovery is provable from a capture
+ *     while being invisible in any vendor doc.
+ *
+ * CANNOT:
+ *   - `protocolVersionPinning` from the `initialize` body. One capture against
+ *     one server shows one value, and a client that NEGOTIATES would produce
+ *     exactly the same byte. Distinguishing a pin from a negotiation needs two
+ *     captures against servers advertising DIFFERENT versions. This is the trap
+ *     that already caught cline and n8n, where a single observed version was the
+ *     bundled SDK's negotiated outcome rather than a client-owned pin.
+ *   - `authModel`. The field is "every model the client supports, in preference
+ *     order"; a trace shows the one path taken against one server's capabilities.
+ *     Enumerating support is a source-reading or vendor-doc job.
+ *   - `oauthSpecVersion` as `basis: "constant"`. A trace can only ever justify
+ *     `basis: "behavioral"` with a minimum-revision FLOOR — a literal revision
+ *     string is a claim about the client's code or its docs, not its wire.
+ *
+ * Every field this module cannot settle is emitted as `unverifiable` with the
+ * specific experiment that WOULD settle it, and the underlying observation is
+ * preserved in `extensions` so no evidence is thrown away.
+ */
+
+import type {
+  HostConfigOAuthProfileV1,
+  OAuthAuthModel,
+  OAuthDcrIdentity,
+  OAuthProfileEvidence,
+  OAuthProtocolVersionPinning,
+  OAuthSpecVersionClaim,
+} from "../host-config/types.js";
+import { observedValue } from "./types.js";
+import type { GoldenTrace, TraceLeg } from "./types.js";
+
+/** How a trace cites itself as evidence. `E2` per the HP-47 evidence classes. */
+function citation(trace: GoldenTrace, path: string | undefined, detail: string): string {
+  const location = path ? ` (${path})` : "";
+  return `E2 — golden trace \`${trace.traceId}\`${location}: ${detail}`;
+}
+
+export type TraceToProfileOptions = {
+  /**
+   * Repo-relative path the trace is committed at, so the `source` string is a
+   * citation a reviewer can follow rather than an opaque id.
+   */
+  tracePath?: string;
+  /**
+   * A second trace of the same host captured against a server advertising a
+   * DIFFERENT protocol version. Supplying it is the only way
+   * `protocolVersionPinning` can be settled for the `initialize` body — with one
+   * trace the field stays `unverifiable` no matter how clean the capture was.
+   */
+  contrastTrace?: GoldenTrace;
+};
+
+// ── sendsResourceIndicator ───────────────────────────────────────────────
+
+function mapResourceIndicator(
+  trace: GoldenTrace,
+  options: TraceToProfileOptions,
+): OAuthProfileEvidence<boolean> {
+  const { onAuthorize, onToken } = trace.observations.resourceIndicator;
+  const capturedAt = trace.capture.capturedAt;
+
+  if (onAuthorize.state === "not-observed" && onToken.state === "not-observed") {
+    return {
+      status: "unverifiable",
+      reason: `Neither the /authorize nor the /token leg was captured (${onAuthorize.reason}). Re-capture a handshake that reaches the token exchange.`,
+      capturedAt,
+    };
+  }
+
+  const sentOnAuthorize = onAuthorize.state === "present";
+  const sentOnToken = onToken.state === "present";
+
+  if (sentOnAuthorize || sentOnToken) {
+    const legs = [
+      sentOnAuthorize ? "/authorize" : undefined,
+      sentOnToken ? "/token" : undefined,
+    ].filter(Boolean);
+    return {
+      status: "verified",
+      value: true,
+      source: citation(
+        trace,
+        options.tracePath,
+        `RFC 8707 \`resource\` observed on ${legs.join(" and ")}; value source classified as ${observedValue(trace.observations.resourceIndicator.valueSource) ?? "unclassified"}`,
+      ),
+      capturedAt,
+    };
+  }
+
+  // Both legs captured, neither carried `resource`. Whether that is a finding
+  // depends entirely on whether the server gave the client a PRM document to
+  // read the resource FROM — several clients omit `resource` when PRM discovery
+  // fails, and doing so is correct.
+  if (!trace.scenario.capabilities.publishesPrm) {
+    return {
+      status: "unverifiable",
+      reason:
+        "No `resource` was sent, but this scenario's server publishes no RFC 9728 PRM document. Several clients omit `resource` entirely when PRM discovery fails, so absence here does not distinguish \"never sends it\" from \"sends it only when PRM exists\". Re-capture against a PRM-publishing server.",
+      capturedAt,
+    };
+  }
+
+  return {
+    status: "verified",
+    value: false,
+    source: citation(
+      trace,
+      options.tracePath,
+      "both /authorize and /token were captured against a PRM-publishing server and neither carried an RFC 8707 `resource` parameter",
+    ),
+    capturedAt,
+  };
+}
+
+// ── oauthSpecVersion ────────────────────────────────────────────────────
+
+/**
+ * A trace justifies only a behavioral FLOOR, never an exact revision.
+ *
+ * The ladder rungs are ordered: a CIMD fetch implies 2025-11-25 or later; an RFC
+ * 9728 PRM fetch implies 2025-06-18 or later. Anything weaker cannot be turned
+ * into a floor, because a client that skipped PRM may simply have been talking to
+ * a server that published none.
+ */
+function mapOAuthSpecVersion(
+  trace: GoldenTrace,
+  options: TraceToProfileOptions,
+): OAuthProfileEvidence<OAuthSpecVersionClaim> {
+  const legs = new Set<TraceLeg>(trace.observations.legOrder);
+  const capturedAt = trace.capture.capturedAt;
+
+  if (legs.has("cimd-fetch")) {
+    return {
+      status: "verified",
+      value: { basis: "behavioral", minimumRevision: "2025-11-25" },
+      source: citation(
+        trace,
+        options.tracePath,
+        "the client fetched a Client ID Metadata Document, which is a 2025-11-25 mechanism; recorded as a FLOOR, not an exact revision",
+      ),
+      capturedAt,
+    };
+  }
+
+  if (legs.has("prm-discovery")) {
+    return {
+      status: "verified",
+      value: { basis: "behavioral", minimumRevision: "2025-06-18" },
+      source: citation(
+        trace,
+        options.tracePath,
+        "the client ran an RFC 9728 protected-resource-metadata discovery step, which entered the MCP authorization spec at 2025-06-18; recorded as a FLOOR, not an exact revision",
+      ),
+      capturedAt,
+    };
+  }
+
+  if (trace.scenario.capabilities.publishesPrm) {
+    return {
+      status: "unverifiable",
+      reason:
+        "The server published a PRM document and the client did not fetch it, which places the client BELOW 2025-06-18 — but a floor cannot be expressed downwards, and the exact revision is a claim about the client's code rather than its wire. Read the client's source or its vendor docs to name a revision.",
+      capturedAt,
+    };
+  }
+
+  return {
+    status: "unverifiable",
+    reason:
+      "No PRM or CIMD discovery was observed, and this scenario's server published neither, so the absence is a property of the test server rather than of the client. Re-capture against a server that publishes both.",
+    capturedAt,
+  };
+}
+
+// ── protocolVersionPinning ──────────────────────────────────────────────
+
+function mapProtocolVersionPinning(
+  trace: GoldenTrace,
+  options: TraceToProfileOptions,
+): OAuthProfileEvidence<OAuthProtocolVersionPinning> {
+  const pv = trace.observations.protocolVersion;
+  const capturedAt = trace.capture.capturedAt;
+  const discoveryValues = observedValue(pv.headerOnOAuthDiscovery);
+
+  // The one arm a single trace can prove. At OAuth-discovery time no
+  // `initialize` has occurred, so the header cannot be a negotiated value.
+  if (discoveryValues && discoveryValues.length === 1) {
+    return {
+      status: "verified",
+      value: { mode: "pinned", version: discoveryValues[0] },
+      source: citation(
+        trace,
+        options.tracePath,
+        `\`MCP-Protocol-Version: ${discoveryValues[0]}\` was sent on OAuth discovery, BEFORE any \`initialize\` exchange — so it cannot be a negotiated value and is a client-chosen constant. Scope: the OAuth wire only. The \`initialize\` body version is recorded separately in \`extensions.traceProtocolVersion\` and is NOT evidence of a pin`,
+      ),
+      capturedAt,
+    };
+  }
+
+  if (discoveryValues && discoveryValues.length > 1) {
+    // More than one distinct value across discovery legs is NOT a negotiation
+    // (there is nothing to negotiate with at discovery time) and NOT a single
+    // pin either — it is several different hardcoded constants, which the
+    // two-arm target type cannot spell.
+    return {
+      status: "unverifiable",
+      reason: `OAuth discovery carried ${discoveryValues.length} DIFFERENT \`MCP-Protocol-Version\` values (${discoveryValues.join(", ")}). None of them is negotiated — discovery precedes any \`initialize\` — so this is several distinct hardcoded constants on different legs, which \`OAuthProtocolVersionPinning\` has no arm for. The per-leg breakdown is in \`extensions.traceProtocolVersion.headerByLeg\`; a client behaving this way needs a schema arm, not a re-capture.`,
+      capturedAt,
+    };
+  }
+
+  // A contrast trace against a server advertising a different version is what
+  // turns an observation into a pin-vs-negotiate answer.
+  const contrast = options.contrastTrace;
+  if (contrast) {
+    const here = observedValue(pv.initializeBody);
+    const there = observedValue(contrast.observations.protocolVersion.initializeBody);
+    if (here != null && there != null) {
+      return here === there
+        ? {
+            status: "verified",
+            value: { mode: "pinned", version: here },
+            source: citation(
+              trace,
+              options.tracePath,
+              `the \`initialize\` body carried \`${here}\` against two servers advertising different protocol versions (contrast trace \`${contrast.traceId}\`), so the value does not follow the server and is a client-owned pin`,
+            ),
+            capturedAt,
+          }
+        : {
+            status: "verified",
+            value: { mode: "negotiated" },
+            source: citation(
+              trace,
+              options.tracePath,
+              `the \`initialize\` body carried \`${here}\` here and \`${there}\` in contrast trace \`${contrast.traceId}\`, so the client follows the server rather than pinning`,
+            ),
+            capturedAt,
+          };
+    }
+  }
+
+  return {
+    status: "unverifiable",
+    reason:
+      "No `MCP-Protocol-Version` header was observed on OAuth discovery, and only one capture is available. A single trace cannot distinguish a pin from a negotiation: a client that negotiates emits exactly the same byte as one that pins when talking to one server. Settle it by capturing the same client against a second server advertising a DIFFERENT protocol version and passing it as `contrastTrace` — the trap that already produced wrong answers for SDK-delegated clients, whose single observed version was their bundled SDK's negotiated outcome.",
+    capturedAt,
+  };
+}
+
+// ── dcrIdentity ─────────────────────────────────────────────────────────
+
+/**
+ * The single User-Agent this host used, or `undefined` when there isn't one.
+ *
+ * `undefined` deliberately covers two cases the target type cannot distinguish —
+ * "no UA was sent at all" and "the UA varied across legs" — so the caller records
+ * a caveat and preserves the per-leg detail in `extensions.traceUserAgent`.
+ * Goose is the live example: its UA is verified on the MCP transport but whether
+ * it reaches the authorization server is not, because `rmcp` may build its own
+ * HTTP client.
+ */
+function singleUserAgent(trace: GoldenTrace): string | undefined {
+  const { byLeg, consistent } = trace.observations.userAgent;
+  const values = new Set<string>();
+  for (const observation of Object.values(byLeg)) {
+    for (const value of observedValue(observation) ?? []) values.add(value);
+  }
+  return values.size === 1 && consistent ? [...values][0] : undefined;
+}
+
+function mapDcrIdentity(
+  trace: GoldenTrace,
+  options: TraceToProfileOptions,
+): OAuthProfileEvidence<OAuthDcrIdentity> {
+  const dcr = trace.observations.dcrIdentity;
+  const capturedAt = trace.capture.capturedAt;
+
+  if (dcr.clientName.state === "not-observed" && dcr.redirectUris.state === "not-observed") {
+    return {
+      status: "unverifiable",
+      reason: `No dynamic client registration request was captured (${dcr.clientName.state === "not-observed" ? dcr.clientName.reason : "no registration leg"}). A client using CIMD or a pre-registered client_id never sends one, so re-capture only if this host is expected to use DCR.`,
+      capturedAt,
+    };
+  }
+
+  const clientName = observedValue(dcr.clientName);
+  const redirectUris = observedValue(dcr.redirectUris);
+  const userAgent = singleUserAgent(trace);
+
+  const value: OAuthDcrIdentity = {
+    ...(clientName != null ? { clientName } : {}),
+    ...(redirectUris != null ? { redirectUris } : {}),
+    ...(userAgent != null ? { userAgent } : {}),
+  };
+
+  if (Object.keys(value).length === 0) {
+    return {
+      status: "unverifiable",
+      reason:
+        "A registration request was captured but it carried none of `client_name`, `redirect_uris`, or a `User-Agent`. That is itself notable — see `extensions.traceDcrIdentity` for the raw observation.",
+      capturedAt,
+    };
+  }
+
+  const notes: string[] = [];
+  if (redirectUris?.some((uri) => uri.includes("{port}"))) {
+    notes.push(
+      "loopback ports are placeheld as `{port}` because they are ephemeral; the ports actually seen are in `extensions.traceDcrIdentity.observedLoopbackPorts`",
+    );
+  }
+  if (!userAgent) {
+    notes.push(
+      "no single `User-Agent` could be attributed: either none was sent or it varied across legs, and `OAuthDcrIdentity` has no way to distinguish those — see `extensions.traceUserAgent`",
+    );
+  }
+
+  return {
+    status: "verified",
+    value,
+    source: citation(
+      trace,
+      options.tracePath,
+      `dynamic client registration body observed on the wire${notes.length > 0 ? `. Caveats: ${notes.join("; ")}` : ""}`,
+    ),
+    capturedAt,
+  };
+}
+
+// ── authModel ───────────────────────────────────────────────────────────
+
+function mapAuthModel(
+  trace: GoldenTrace,
+): OAuthProfileEvidence<OAuthAuthModel[]> {
+  // No cast needed: the `unverifiable` arm carries no value, which is exactly the
+  // property that makes unverified lore unrepresentable in this type.
+  return {
+    status: "unverifiable",
+    reason:
+      "`authModel` is defined as every auth model the client supports, in preference order. A trace records the ONE path the client took against ONE server's advertised capabilities, which cannot enumerate what else it supports — a server offering only DCR gives a CIMD-capable client no opportunity to reveal that. The observed path is preserved in `extensions.traceAuthPath`. Settle this from the client's source or its vendor documentation.",
+    capturedAt: trace.capture.capturedAt,
+  };
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────
+
+/**
+ * Project a trace onto a host-config OAuth profile.
+ *
+ * The returned profile is intended to be MERGED over an existing profile, not to
+ * replace it: a trace is stronger evidence than a doc for the fields it settles,
+ * and silent about the rest. `extensions` carries every observation the target
+ * type cannot express, so a schema gap never costs us a finding.
+ */
+export function traceToOAuthProfile(
+  trace: GoldenTrace,
+  options: TraceToProfileOptions = {},
+): HostConfigOAuthProfileV1 {
+  const pv = trace.observations.protocolVersion;
+
+  return {
+    profileVersion: 1,
+    sendsResourceIndicator: mapResourceIndicator(trace, options),
+    oauthSpecVersion: mapOAuthSpecVersion(trace, options),
+    protocolVersionPinning: mapProtocolVersionPinning(trace, options),
+    dcrIdentity: mapDcrIdentity(trace, options),
+    authModel: mapAuthModel(trace),
+    extensions: {
+      // Provenance: which artifact these fields came from.
+      traceProvenance: {
+        traceId: trace.traceId,
+        ...(options.tracePath ? { tracePath: options.tracePath } : {}),
+        scenarioId: trace.scenario.scenarioId,
+        capturedAt: trace.capture.capturedAt,
+        subjectKind: trace.subject.kind,
+        hostVersion: trace.subject.hostVersion,
+        oauthImplementation: trace.subject.oauthImplementation,
+      },
+      // The two-headed protocol-version finding, kept whole. `protocolVersionPinning`
+      // above can only carry one arm of this; discarding the rest would average
+      // away the most interesting observation in the trace.
+      traceProtocolVersion: {
+        initializeBody: pv.initializeBody,
+        headerOnOAuthDiscovery: pv.headerOnOAuthDiscovery,
+        headerOnMcpTraffic: pv.headerOnMcpTraffic,
+        headerByLeg: pv.headerByLeg,
+        wiresDisagree: pv.wiresDisagree,
+        headerDisagreesWithInitializeBody: pv.headerDisagreesWithInitializeBody,
+      },
+      // The per-leg / conditional resource-indicator detail a boolean cannot hold.
+      traceResourceIndicator: trace.observations.resourceIndicator,
+      traceDcrIdentity: trace.observations.dcrIdentity,
+      traceUserAgent: trace.observations.userAgent,
+      traceAuthPath: {
+        legOrder: trace.observations.legOrder,
+        endpointsHit: trace.observations.endpointsHit,
+        discoveryLadder: trace.observations.discoveryLadder,
+      },
+      tracePkce: trace.observations.pkce,
+    },
+  };
+}

--- a/sdk/src/oauth-golden-trace/to-profile.ts
+++ b/sdk/src/oauth-golden-trace/to-profile.ts
@@ -50,7 +50,7 @@ import type {
   OAuthSpecVersionClaim,
 } from "../host-config/types.js";
 import { observedValue } from "./types.js";
-import type { GoldenTrace, TraceLeg } from "./types.js";
+import type { GoldenTrace, TraceLeg, TraceSubject } from "./types.js";
 
 /** How a trace cites itself as evidence. `E2` per the HP-47 evidence classes. */
 function citation(trace: GoldenTrace, path: string | undefined, detail: string): string {
@@ -82,14 +82,6 @@ function mapResourceIndicator(
   const { onAuthorize, onToken } = trace.observations.resourceIndicator;
   const capturedAt = trace.capture.capturedAt;
 
-  if (onAuthorize.state === "not-observed" && onToken.state === "not-observed") {
-    return {
-      status: "unverifiable",
-      reason: `Neither the /authorize nor the /token leg was captured (${onAuthorize.reason}). Re-capture a handshake that reaches the token exchange.`,
-      capturedAt,
-    };
-  }
-
   const sentOnAuthorize = onAuthorize.state === "present";
   const sentOnToken = onToken.state === "present";
 
@@ -106,6 +98,33 @@ function mapResourceIndicator(
         options.tracePath,
         `RFC 8707 \`resource\` observed on ${legs.join(" and ")}; value source classified as ${observedValue(trace.observations.resourceIndicator.valueSource) ?? "unclassified"}`,
       ),
+      capturedAt,
+    };
+  }
+
+  // No captured leg carried `resource`. Before that can become a `false` claim,
+  // EVERY leg that could have carried it has to have been watched: "the request
+  // was captured and the parameter was not there" (`absent`) is a finding, while
+  // "we never saw that request" (`not-observed`) is a gap, and collapsing the
+  // second into the first is the HP-17 failure mode this schema exists to
+  // prevent. A half-observed pair — a capture that stopped before the token
+  // exchange, or an `/authorize` handed to a browser we could not watch — cannot
+  // rule out that the missing leg sent it.
+  const unobserved = [
+    onAuthorize.state === "not-observed"
+      ? { leg: "/authorize", reason: onAuthorize.reason }
+      : undefined,
+    onToken.state === "not-observed" ? { leg: "/token", reason: onToken.reason } : undefined,
+  ].filter((entry): entry is { leg: string; reason: string } => entry != null);
+
+  if (unobserved.length > 0) {
+    const detail = unobserved.map(({ leg, reason }) => `${leg}: ${reason}`).join("; ");
+    return {
+      status: "unverifiable",
+      reason:
+        unobserved.length === 2
+          ? `Neither the /authorize nor the /token leg was captured (${detail}). Re-capture a handshake that reaches the token exchange.`
+          : `No \`resource\` appeared on the captured leg, but the ${unobserved[0].leg} leg was never captured (${detail}), so its absence there is UNKNOWN rather than observed — a half-observed pair cannot justify \`false\`. Re-capture a handshake that reaches the token exchange.`,
       capturedAt,
     };
   }
@@ -197,6 +216,64 @@ function mapOAuthSpecVersion(
 
 // ── protocolVersionPinning ──────────────────────────────────────────────
 
+/** Same client, or a different one wearing a familiar host id? */
+function sameSubject(a: TraceSubject, b: TraceSubject): boolean {
+  return (
+    a.hostId === b.hostId &&
+    a.kind === b.kind &&
+    a.build === b.build &&
+    a.surface === b.surface
+  );
+}
+
+/**
+ * Why a supplied `contrastTrace` cannot carry the pin-vs-negotiate experiment,
+ * or `undefined` when it can.
+ *
+ * The experiment is "the SAME client against a SECOND server advertising a
+ * DIFFERENT protocol version". All three conditions are checkable from the
+ * artifacts and every one of them is enforced here — the advertised versions via
+ * `scenario.capabilities.serverProtocolVersion`, which exists for exactly this.
+ *
+ * Without this gate the strongest claim in the module rested on a caller
+ * promise: passing a trace its own self, an unrelated host's, or a second run
+ * against an identically-versioned server produced a `verified` pin out of
+ * nothing. Two of those are caught by identity alone; the third is not, and it
+ * is the likeliest one to happen by accident, because re-running the same
+ * capture server twice is the path of least resistance.
+ */
+function contrastTraceRejection(
+  trace: GoldenTrace,
+  contrast: GoldenTrace,
+): string | undefined {
+  if (!sameSubject(trace.subject, contrast.subject)) {
+    return `it captured a different subject (\`${contrast.subject.hostId}\`/${contrast.subject.kind}${contrast.subject.build ? ` build ${contrast.subject.build}` : ""}, not \`${trace.subject.hostId}\`/${trace.subject.kind}${trace.subject.build ? ` build ${trace.subject.build}` : ""}), so the two captures are not the same client and a shared value proves nothing about pinning`;
+  }
+  if (contrast.scenario.scenarioId === trace.scenario.scenarioId) {
+    return `it ran the SAME scenario (\`${trace.scenario.scenarioId}\`), so there is no second server in the comparison — an identical value across two runs of one scenario is what a negotiating client produces too`;
+  }
+
+  // The load-bearing half. Two scenarios can carry different ids and still have
+  // advertised the same protocol version, in which case a matching value is
+  // exactly what a NEGOTIATING client produces and reading it as a pin inverts
+  // the answer.
+  const here = trace.scenario.capabilities.serverProtocolVersion;
+  const there = contrast.scenario.capabilities.serverProtocolVersion;
+  if (here == null || there == null) {
+    const unknown =
+      here == null && there == null
+        ? `neither \`${trace.scenario.scenarioId}\` nor \`${contrast.scenario.scenarioId}\` records`
+        : here == null
+          ? `\`${trace.scenario.scenarioId}\` does not record`
+          : `\`${contrast.scenario.scenarioId}\` does not record`;
+    return `${unknown} the protocol version its server ADVERTISED (\`scenario.capabilities.serverProtocolVersion\`), so it cannot be shown that the two servers differed — and against two same-version servers a negotiating client emits the same value a pinning one does. Re-capture with the advertised version recorded`;
+  }
+  if (here === there) {
+    return `both scenarios ran against a server advertising the SAME protocol version (\`${here}\`), so a matching value across them is precisely what a NEGOTIATING client produces — the comparison cannot distinguish the two modes it exists to separate. Capture the contrast against a server advertising a different version`;
+  }
+  return undefined;
+}
+
 function mapProtocolVersionPinning(
   trace: GoldenTrace,
   options: TraceToProfileOptions,
@@ -233,11 +310,17 @@ function mapProtocolVersionPinning(
   }
 
   // A contrast trace against a server advertising a different version is what
-  // turns an observation into a pin-vs-negotiate answer.
+  // turns an observation into a pin-vs-negotiate answer — but only if it really
+  // is that experiment. See {@link contrastTraceRejection}.
   const contrast = options.contrastTrace;
-  if (contrast) {
+  const rejection = contrast ? contrastTraceRejection(trace, contrast) : undefined;
+  if (contrast && rejection == null) {
     const here = observedValue(pv.initializeBody);
     const there = observedValue(contrast.observations.protocolVersion.initializeBody);
+    const hereAdvertised = trace.scenario.capabilities.serverProtocolVersion;
+    const thereAdvertised = contrast.scenario.capabilities.serverProtocolVersion;
+    const hereScenario = `scenario \`${trace.scenario.scenarioId}\` (server advertised \`${hereAdvertised}\`)`;
+    const thereScenario = `scenario \`${contrast.scenario.scenarioId}\` (server advertised \`${thereAdvertised}\`, contrast trace \`${contrast.traceId}\`)`;
     if (here != null && there != null) {
       return here === there
         ? {
@@ -246,7 +329,7 @@ function mapProtocolVersionPinning(
             source: citation(
               trace,
               options.tracePath,
-              `the \`initialize\` body carried \`${here}\` against two servers advertising different protocol versions (contrast trace \`${contrast.traceId}\`), so the value does not follow the server and is a client-owned pin`,
+              `the \`initialize\` body carried \`${here}\` in both ${hereScenario} and ${thereScenario} — two servers that advertised DIFFERENT versions — so the value does not follow the server and is a client-owned pin`,
             ),
             capturedAt,
           }
@@ -256,17 +339,22 @@ function mapProtocolVersionPinning(
             source: citation(
               trace,
               options.tracePath,
-              `the \`initialize\` body carried \`${here}\` here and \`${there}\` in contrast trace \`${contrast.traceId}\`, so the client follows the server rather than pinning`,
+              `the \`initialize\` body carried \`${here}\` in ${hereScenario} and \`${there}\` in ${thereScenario}, so the client follows the server rather than pinning`,
             ),
             capturedAt,
           };
     }
   }
 
+  const singleCapture =
+    "No `MCP-Protocol-Version` header was observed on OAuth discovery, and only one capture is available. A single trace cannot distinguish a pin from a negotiation: a client that negotiates emits exactly the same byte as one that pins when talking to one server. Settle it by capturing the same client against a second server advertising a DIFFERENT protocol version and passing it as `contrastTrace` — the trap that already produced wrong answers for SDK-delegated clients, whose single observed version was their bundled SDK's negotiated outcome.";
+
   return {
     status: "unverifiable",
     reason:
-      "No `MCP-Protocol-Version` header was observed on OAuth discovery, and only one capture is available. A single trace cannot distinguish a pin from a negotiation: a client that negotiates emits exactly the same byte as one that pins when talking to one server. Settle it by capturing the same client against a second server advertising a DIFFERENT protocol version and passing it as `contrastTrace` — the trap that already produced wrong answers for SDK-delegated clients, whose single observed version was their bundled SDK's negotiated outcome.",
+      rejection == null
+        ? singleCapture
+        : `${singleCapture} A \`contrastTrace\` WAS supplied but does not run that experiment: ${rejection}.`,
     capturedAt,
   };
 }
@@ -374,6 +462,13 @@ function mapAuthModel(
  * replace it: a trace is stronger evidence than a doc for the fields it settles,
  * and silent about the rest. `extensions` carries every observation the target
  * type cannot express, so a schema gap never costs us a finding.
+ *
+ * Merge it with {@link mergeTraceOAuthProfile}, NOT with a plain spread. Every
+ * field this projection could not settle is present as an `unverifiable` entry —
+ * that is the module's most useful output, since it names the experiment that
+ * would settle the field — but it means `{ ...existing, ...projection }` would
+ * overwrite evidence a source-reading already verified with "a trace cannot
+ * settle this". That is evidence loss dressed up as an update.
  */
 export function traceToOAuthProfile(
   trace: GoldenTrace,
@@ -421,5 +516,84 @@ export function traceToOAuthProfile(
       },
       tracePkce: trace.observations.pkce,
     },
+  };
+}
+
+// ── Merging a projection over an existing profile ────────────────────────
+
+/**
+ * Keep whichever of the two evidence entries actually settled something.
+ *
+ * A projected `unverifiable` never displaces an existing `verified` / `refuted`
+ * entry: "one trace cannot enumerate every auth model" is a statement about this
+ * experiment's reach, not a retraction of a source-reading that already answered
+ * the field. In every other case the trace wins, because a capture is stronger
+ * evidence than a doc for the fields it does settle.
+ */
+function preferSettled<T>(
+  base: OAuthProfileEvidence<T> | undefined,
+  projected: OAuthProfileEvidence<T> | undefined,
+): OAuthProfileEvidence<T> | undefined {
+  if (!projected) return base;
+  if (projected.status === "unverifiable" && base && base.status !== "unverifiable") {
+    return base;
+  }
+  return projected;
+}
+
+/**
+ * Merge a trace projection over an existing profile without downgrading it.
+ *
+ * This is the merge {@link traceToOAuthProfile}'s doc comment promises. Field by
+ * field it applies {@link preferSettled}; `extensions` are SHALLOW-merged with
+ * the trace's keys last, so a projection adds its `trace*` observations without
+ * dropping extensions another source wrote.
+ *
+ * `undefined` base returns the projection unchanged — a first projection onto a
+ * host that has never been investigated.
+ */
+export function mergeTraceOAuthProfile(
+  base: HostConfigOAuthProfileV1 | undefined,
+  projection: HostConfigOAuthProfileV1,
+): HostConfigOAuthProfileV1 {
+  if (!base) return projection;
+
+  const sendsResourceIndicator = preferSettled(
+    base.sendsResourceIndicator,
+    projection.sendsResourceIndicator,
+  );
+  // Same bug class, one field deeper: a trace can only ever justify a behavioral
+  // FLOOR, so letting it displace an existing `basis: "constant"` claim — the
+  // exact revision set read out of the client's source — would trade a precise
+  // fact for a weaker one that is simultaneously true.
+  const baseSpecVersion = base.oauthSpecVersion;
+  const oauthSpecVersion =
+    baseSpecVersion &&
+    baseSpecVersion.status !== "unverifiable" &&
+    baseSpecVersion.value.basis === "constant"
+      ? baseSpecVersion
+      : preferSettled(baseSpecVersion, projection.oauthSpecVersion);
+  const protocolVersionPinning = preferSettled(
+    base.protocolVersionPinning,
+    projection.protocolVersionPinning,
+  );
+  const dcrIdentity = preferSettled(base.dcrIdentity, projection.dcrIdentity);
+  const authModel = preferSettled(base.authModel, projection.authModel);
+  const extensions =
+    base.extensions || projection.extensions
+      ? { ...base.extensions, ...projection.extensions }
+      : undefined;
+
+  // Conditional spreads rather than `key: undefined`: an absent field must stay
+  // absent so an uninvestigated host keeps hashing like a pre-feature row.
+  return {
+    ...base,
+    profileVersion: 1,
+    ...(sendsResourceIndicator ? { sendsResourceIndicator } : {}),
+    ...(oauthSpecVersion ? { oauthSpecVersion } : {}),
+    ...(protocolVersionPinning ? { protocolVersionPinning } : {}),
+    ...(dcrIdentity ? { dcrIdentity } : {}),
+    ...(authModel ? { authModel } : {}),
+    ...(extensions ? { extensions } : {}),
   };
 }

--- a/sdk/src/oauth-golden-trace/types.ts
+++ b/sdk/src/oauth-golden-trace/types.ts
@@ -18,6 +18,13 @@
  *     traffic is a gap. One belongs in a profile as `verified`, the other only
  *     as `unverifiable`.
  *
+ *     The tri-state is TOTAL, and stays that way: no field that a capture can
+ *     leave undetermined is a bare `boolean`, and the two `Partial` per-leg maps
+ *     document that a missing key means `not-observed` rather than "no finding".
+ *     Each escape from that rule was a bug — a boolean `wiresDisagree` let a
+ *     one-wire capture project "these wires agree", and a skipped map key let a
+ *     leg only one side recorded vanish out of a diff instead of being reported.
+ *
  *  2. {@link ProtocolVersionUsage} records the `initialize` body version and the
  *     `MCP-Protocol-Version` HTTP header SEPARATELY, and the header PER LEG.
  *     These are two different things wearing one name and they disagree in the
@@ -119,7 +126,13 @@ export type TraceOAuthImplementation =
   | { kind: "first-party" }
   | {
       kind: "dependency";
-      /** Package name, e.g. `rmcp` or `@modelcontextprotocol/sdk`. */
+      /**
+       * Package name, e.g. `rmcp` or the upstream TS SDK.
+       *
+       * Spelled out rather than quoted: `check:mcp-v1-runtime-imports` greps this
+       * tree for the upstream package specifier with no comment awareness, so
+       * naming it even in a doc comment fails the whole test pipeline.
+       */
       package: string;
       /** Exact resolved version. Not a semver range. */
       version: string;
@@ -179,6 +192,24 @@ export type TraceScenarioCapabilities = {
   supportsCimd: boolean;
   /** `code_challenge_methods_supported` as advertised. */
   codeChallengeMethods: string[];
+  /**
+   * The protocol version this server ADVERTISED — the `protocolVersion` it
+   * returned from `initialize`.
+   *
+   * Recorded because it is the only artifact that can settle pin-vs-negotiate.
+   * That question is answered by running one client against two servers
+   * advertising DIFFERENT versions: a pinning client sends the same value to
+   * both, a negotiating one follows each server. Without this field the two
+   * captures are indistinguishable, so `traceToOAuthProfile` had to take the
+   * "different server" half of the experiment on the caller's word — and a
+   * contrast trace against a same-version server produced a `verified` pin out
+   * of nothing.
+   *
+   * Optional because a capture through a third-party HAR need not have observed
+   * an `initialize` response at all. Absent means "not known", and the pinning
+   * projection treats it as a blocker rather than a licence to assume.
+   */
+  serverProtocolVersion?: string;
   /**
    * Which discovery documents the AS actually serves, as well-known paths. A
    * server serving only `/.well-known/openid-configuration` exercises a
@@ -412,6 +443,13 @@ export type ProtocolVersionUsage = {
    * real finding (and, for the profile mapping, decisive: exactly one distinct
    * value across a wire is a `pinned` claim, more than one is not a pin at all).
    * Collapsing to "the first one" would manufacture a pin that isn't there.
+   *
+   * PARTIAL BY INVARIANT: a key exists only for a leg this trace actually
+   * captured. A MISSING key is not a fourth state — it means exactly
+   * `not-observed`, and every consumer must materialize it as such rather than
+   * skipping the leg. `./diff.js` does so through `observationForLeg`, which is
+   * what keeps a leg one side never recorded from disappearing out of the report
+   * instead of being named as a gap.
    */
   headerByLeg: Partial<Record<TraceLeg, Observation<string[]>>>;
   /** Rollup over {@link OAUTH_DISCOVERY_LEGS}. `absent` ⇒ never sent there. */
@@ -419,17 +457,26 @@ export type ProtocolVersionUsage = {
   /** Rollup over {@link MCP_WIRE_LEGS}. `absent` ⇒ never sent there (VS Code). */
   headerOnMcpTraffic: Observation<string[]>;
   /**
-   * True when the two wires carry DIFFERENT values, or when one carries a value
-   * and the other demonstrably carries none. This is the split-revision signal
-   * (Goose, and every `rmcp`-based client) — surfaced as a first-class flag so
-   * it cannot be read past.
+   * `present: true` when the two wires carry DIFFERENT values, or when one
+   * carries a value and the other demonstrably carries none. This is the
+   * split-revision signal (Goose, and every `rmcp`-based client) — surfaced as a
+   * first-class field so it cannot be read past.
+   *
+   * An {@link Observation}, not a `boolean`, for the reason in design note 1: a
+   * plain `false` collapses "both wires were captured and they agree" with "we
+   * only captured one wire", and the second is not a claim about the client at
+   * all. Collapsed, a partial capture projects a no-split-revision finding —
+   * `./to-profile.js` reads this field straight into profile evidence, so
+   * guarding only inside the differ would not be enough.
    */
-  wiresDisagree: boolean;
+  wiresDisagree: Observation<boolean>;
   /**
-   * True when the header value on any leg differs from `initializeBody`. The
-   * second half of the same trap.
+   * `present: true` when the header value on any leg differs from
+   * `initializeBody`. The second half of the same trap, and tri-state for the
+   * same reason: `false` requires having observed BOTH an `initialize` and the
+   * wires that could carry a disagreeing header.
    */
-  headerDisagreesWithInitializeBody: boolean;
+  headerDisagreesWithInitializeBody: Observation<boolean>;
 };
 
 /**
@@ -462,11 +509,32 @@ export type DcrIdentityUsage = {
   tokenEndpointAuthMethod: Observation<string>;
   scope: Observation<string>;
   /**
-   * Keys present in the register body that this schema does not model, so an
+   * Fields present in the register body that this schema does not model, so an
    * unmodeled-but-real field shows up as a diff instead of vanishing. Durability
    * over convenience.
+   *
+   * Keys AND VALUES, in sorted-key order. Names alone would report two bodies
+   * that differ only in the VALUE of an unmodeled field as parity, which
+   * contradicts the field-by-field DCR-body diff this schema advertises. The
+   * values are the ones already redacted and origin-substituted by
+   * `./normalize.js` at capture time — retaining them here adds no exposure that
+   * `wire` does not already carry.
    */
-  extraFields: Observation<string[]>;
+  extraFields: Observation<Record<string, unknown>>;
+  /**
+   * Modeled fields that WERE in the register body but carried the wrong JSON
+   * type (`client_name: 42`, `redirect_uris: "…"`).
+   *
+   * Kept as a separate list rather than by widening {@link Observation} with a
+   * fourth `malformed` arm: the tri-state is the load-bearing invariant of this
+   * whole schema and every consumer switches exhaustively on it. The malformed
+   * field's own observation is `not-observed` with the observed JSON type named
+   * as the reason — because the modeled VALUE genuinely is unknown to us — while
+   * this list carries the positive, diffable fact that the client did send
+   * something. Reporting the field as `absent` instead would let the oracle claim
+   * the client omitted a field it demonstrably sent.
+   */
+  malformedFields: Observation<string[]>;
 };
 
 export type PkceUsage = {
@@ -479,15 +547,27 @@ export type PkceUsage = {
 };
 
 export type UserAgentUsage = {
-  /** Distinct `user-agent` values per leg, first-appearance order. */
+  /**
+   * Distinct `user-agent` values per leg, first-appearance order.
+   *
+   * Partial by the same invariant as {@link ProtocolVersionUsage.headerByLeg}: a
+   * missing key means `not-observed`, never "no finding".
+   */
   byLeg: Partial<Record<TraceLeg, Observation<string[]>>>;
   /**
    * Whether every captured leg carried the SAME user-agent. Goose is the open
    * case: its `goose/{ver}` UA is verified on the MCP transport, but whether it
    * reaches the authorization server is not — because `rmcp` may build its own
    * HTTP client. A per-leg map plus this flag settles that in one capture.
+   *
+   * `present` only when EVERY leg in the trace had observed request headers. A
+   * browser-driven `/authorize` is reconstructed from a URL
+   * (`headersObserved === false`), so its user-agent belongs to the browser and
+   * was never on a wire we recorded; a boolean would nonetheless claim a
+   * consistency verdict over it, and then "differ" from a proxy capture that did
+   * see the browser's headers.
    */
-  consistent: boolean;
+  consistent: Observation<boolean>;
 };
 
 /**
@@ -555,6 +635,32 @@ export const TRACE_DIFF_DIMENSIONS = [
 
 export type TraceDiffDimension = (typeof TRACE_DIFF_DIMENSIONS)[number];
 
+export const TRACE_DIFF_MODES = ["parity", "drift"] as const;
+
+/**
+ * What kind of comparison a diff is.
+ *
+ *   `parity` — emulator vs real host. Subject metadata differences are expected.
+ *   `drift`  — the SAME subject captured twice (HP-38). Subject metadata
+ *              differences ARE the finding, and there is no emulator on either
+ *              side.
+ */
+export type TraceDiffMode = (typeof TRACE_DIFF_MODES)[number];
+
+/**
+ * What to call the two sides in prose, resolved once from the mode.
+ *
+ * A single source for BOTH the differ's messages and the renderer's headings.
+ * With the labels hardcoded, a `drift` diff of two real-host captures was
+ * reported as "real host" versus "emulator" throughout — blaming an emulator that
+ * was never involved, which is a fabricated finding of exactly the kind this
+ * schema exists to prevent.
+ */
+export type TraceDiffLabels = {
+  golden: string;
+  candidate: string;
+};
+
 /**
  * Severity of one finding.
  *
@@ -601,6 +707,14 @@ export type TraceDiffResult = {
   parity: boolean;
   goldenTraceId: string;
   candidateTraceId: string;
+  /** Which comparison this was, resolved from the option or the two subjects. */
+  mode: TraceDiffMode;
+  /**
+   * The side labels every message in {@link TraceDiffResult.findings} was phrased
+   * with, carried so the renderer cannot contradict them. See
+   * {@link TraceDiffLabels}.
+   */
+  labels: TraceDiffLabels;
   counts: Record<TraceDiffSeverity, number>;
   findings: TraceDiffFinding[];
   /** Human summary line, e.g. `3 differences, 2 gaps across 41 comparisons`. */

--- a/sdk/src/oauth-golden-trace/types.ts
+++ b/sdk/src/oauth-golden-trace/types.ts
@@ -1,0 +1,608 @@
+/**
+ * HP-44 — golden-trace parity harness: the trace schema.
+ *
+ * This module defines what "the emulator behaves exactly like the real host"
+ * MEANS, as a data shape a reviewer can check an artifact against. It is the
+ * acceptance oracle for HP-43 (emulator enforcement).
+ *
+ * ── Why this schema looks the way it does ──────────────────────────────────
+ *
+ * Every unusual decision below traces to a specific way the previous rounds of
+ * this work got a fact wrong. They are load-bearing, not stylistic:
+ *
+ *  1. {@link Observation} is a THREE-state type, not `T | undefined`. "The host
+ *     captured this leg and the field was not on the wire" and "we never
+ *     captured that leg" are different findings, and collapsing them is exactly
+ *     the HP-17 failure mode. VS Code sending NO `MCP-Protocol-Version` on MCP
+ *     traffic is a positive, citable finding; not having watched VS Code's MCP
+ *     traffic is a gap. One belongs in a profile as `verified`, the other only
+ *     as `unverifiable`.
+ *
+ *  2. {@link ProtocolVersionUsage} records the `initialize` body version and the
+ *     `MCP-Protocol-Version` HTTP header SEPARATELY, and the header PER LEG.
+ *     These are two different things wearing one name and they disagree in the
+ *     wild: Goose runs an RFC 9728 PRM ladder on the OAuth wire while
+ *     hard-pinning 2025-03-26 on the MCP wire; VS Code sends the header only on
+ *     OAuth discovery and never on MCP traffic; `rmcp` hardcodes
+ *     `2024-11-05` on OAuth discovery specifically, affecting both Codex and
+ *     Goose. A single field would average all three away.
+ *
+ *  3. {@link TraceSubject} carries `oauthImplementation` — the resolved
+ *     DEPENDENCY and its version — alongside the host version. Five of six
+ *     source-verified clients inherit their OAuth behavior from `rmcp` or the
+ *     upstream TS SDK rather than their own code, so a trace stamped only with
+ *     the host version goes silently stale on a dependency bump.
+ *
+ *  4. Query params and form fields are `Record<string, string[]>`, NOT
+ *     `Record<string, string>`. Whether a client emits `resource` ONCE or TWICE
+ *     on `/authorize` is an open question a trace is supposed to settle; a
+ *     single-valued map destroys the answer before it can be read.
+ *
+ *  5. {@link ResourceIndicatorUsage} is not a boolean. Three source-verified
+ *     clients send `resource` CONDITIONALLY (omitted entirely when PRM
+ *     discovery fails), and the VALUE differs by client — Claude and ChatGPT
+ *     send the canonicalized MCP server URL, VS Code sends the PRM document's
+ *     own `resource` field. Per-leg values plus a computed value-source
+ *     classification preserve both distinctions.
+ *
+ *  6. {@link TraceScenario} pins the AS/RS feature switches that shape the
+ *     dance. Diffing a trace captured against a PRM-publishing server with one
+ *     captured against a server that publishes none is meaningless, so the
+ *     differ GATES on scenario equality rather than reporting a cascade of
+ *     bogus differences.
+ *
+ * Traces are evidence artifacts, not debugging output: they feed HP-9 (capability
+ * audit) and HP-38 (daily re-capture / re-diff / drift flagging), and they
+ * POPULATE {@link HostConfigOAuthProfileV1} via `./to-profile.js` rather than
+ * inventing a parallel vocabulary.
+ *
+ * Secrets are redacted at CAPTURE time, never at render time — see
+ * `./normalize.js`. A committed trace must contain no live credential.
+ */
+
+export const GOLDEN_TRACE_VERSION = 1 as const;
+
+// ── The observation tri-state ─────────────────────────────────────────────
+
+export const TRACE_OBSERVATION_STATES = [
+  "present",
+  "absent",
+  "not-observed",
+] as const;
+
+export type TraceObservationState = (typeof TRACE_OBSERVATION_STATES)[number];
+
+/**
+ * A single observed fact, with the reason it is missing when it is missing.
+ *
+ * The `absent` / `not-observed` split is the whole point. `absent` is a
+ * POSITIVE finding — the request was captured and the field genuinely was not
+ * there, which is citable evidence and maps to a `verified` profile field.
+ * `not-observed` means the leg that would carry the field was never captured;
+ * it maps to `unverifiable` and carries NO value, mirroring
+ * `OAuthProfileEvidence`'s own union.
+ *
+ * There is deliberately no way to spell "probably X" — an unconfirmed value is
+ * unrepresentable rather than merely discouraged.
+ */
+export type Observation<T> =
+  | { state: "present"; value: T }
+  | { state: "absent" }
+  | { state: "not-observed"; reason: string };
+
+export function present<T>(value: T): Observation<T> {
+  return { state: "present", value };
+}
+
+export const absent: Observation<never> = { state: "absent" };
+
+export function notObserved<T>(reason: string): Observation<T> {
+  return { state: "not-observed", reason };
+}
+
+/** Narrowing helper — `present` is the only arm carrying a value. */
+export function observedValue<T>(observation: Observation<T>): T | undefined {
+  return observation.state === "present" ? observation.value : undefined;
+}
+
+// ── Subject: WHO produced this handshake ──────────────────────────────────
+
+/**
+ * Where a client's OAuth behavior actually lives.
+ *
+ * `dependency` requires a RESOLVED version (from a lockfile), not a declared
+ * range: `rmcp = "2"` in a manifest does not tell you whether the hardcoded
+ * `MCP-Protocol-Version: 2024-11-05` on OAuth discovery is present in the build
+ * that was captured.
+ */
+export type TraceOAuthImplementation =
+  | { kind: "first-party" }
+  | {
+      kind: "dependency";
+      /** Package name, e.g. `rmcp` or `@modelcontextprotocol/sdk`. */
+      package: string;
+      /** Exact resolved version. Not a semver range. */
+      version: string;
+      /** How the version was resolved, e.g. `Cargo.lock` / `package-lock.json`. */
+      resolvedFrom: string;
+    };
+
+/**
+ * Identity of the thing whose handshake was recorded.
+ *
+ * `kind` is the parity axis: a `real-host` trace is the GOLDEN side and an
+ * `emulator` trace is the CANDIDATE side. `hostId` is the catalog id both sides
+ * share — a diff is only meaningful between two traces of the same `hostId`.
+ */
+export type TraceSubject = {
+  kind: "real-host" | "emulator";
+  /** Catalog host id (`HOST_TEMPLATE_IDS`), e.g. `mcpjam`, `vscode`. */
+  hostId: string;
+  /**
+   * Version of the host binary/app. `absent` when the host genuinely exposes no
+   * version (rare); `not-observed` when we could not read it — which is a real
+   * durability gap and should be reported, not silently defaulted.
+   */
+  hostVersion: Observation<string>;
+  /** Resolved OAuth implementation. See {@link TraceOAuthImplementation}. */
+  oauthImplementation: Observation<TraceOAuthImplementation>;
+  /**
+   * Distinguishes builds that differ in observable OAuth identity, e.g. VS
+   * Code's official build (`client_name: "Visual Studio Code"`) vs the OSS
+   * build (`Code - OSS`).
+   */
+  build?: string;
+  /**
+   * Which surface of a multi-surface client, e.g. `web` / `desktop` / `cli`.
+   * Claude ships at least four surfaces that need not agree with each other.
+   */
+  surface?: string;
+};
+
+// ── Scenario: WHAT the subject was pointed at ────────────────────────────
+
+/**
+ * The AS/RS feature switches that determine the SHAPE of a conformant dance.
+ *
+ * This is a diff gate, not decoration. A client that omits `resource` when PRM
+ * discovery fails is behaving correctly; comparing its no-PRM trace against a
+ * with-PRM golden trace would report that correct behavior as a parity failure.
+ */
+export type TraceScenarioCapabilities = {
+  /** Does the resource server publish an RFC 9728 PRM document? */
+  publishesPrm: boolean;
+  /** The PRM document's own `resource` value, when it publishes one. */
+  prmResource?: string;
+  /** Does the AS advertise a `registration_endpoint` (RFC 7591 DCR)? */
+  supportsDcr: boolean;
+  /** Does the AS advertise `client_id_metadata_document_supported` (CIMD)? */
+  supportsCimd: boolean;
+  /** `code_challenge_methods_supported` as advertised. */
+  codeChallengeMethods: string[];
+  /**
+   * Which discovery documents the AS actually serves, as well-known paths. A
+   * server serving only `/.well-known/openid-configuration` exercises a
+   * different rung of the ladder than one serving the RFC 8414 form.
+   */
+  asMetadataDocuments: string[];
+  /** Does the RS answer an unauthenticated request with 401 + WWW-Authenticate? */
+  challengesUnauthenticated: boolean;
+};
+
+export type TraceScenario = {
+  /** Stable id so two traces can assert they exercised the same dance. */
+  scenarioId: string;
+  /** Human summary of what this scenario is for. */
+  description?: string;
+  /** MCP server URL as configured, pre-normalization (provenance only). */
+  mcpServerUrl: string;
+  /** Authorization server URL as configured, pre-normalization. */
+  authorizationServerUrl?: string;
+  capabilities: TraceScenarioCapabilities;
+};
+
+// ── Capture provenance ───────────────────────────────────────────────────
+
+export type TraceCaptureMethod =
+  | {
+      via: "mcpjam-emulator";
+      /** Resolved `@mcpjam/sdk` version that produced the run. */
+      sdkVersion: string;
+      /** Which state machine ran, e.g. `debug-oauth-2025-11-25`. */
+      stateMachine?: string;
+    }
+  | {
+      via: "har";
+      /** `log.creator.name` from the HAR, e.g. `mitmproxy` / `Charles`. */
+      harCreator?: string;
+      harVersion?: string;
+    }
+  | {
+      via: "mitm-proxy";
+      proxy: string;
+    };
+
+export type TraceCaptureMeta = {
+  /**
+   * ISO calendar date (`YYYY-MM-DD`) — deliberately the same granularity as
+   * `OAuthProfileEvidence.capturedAt`, so a trace can be cited as a profile
+   * source without a lossy conversion.
+   */
+  capturedAt: string;
+  /** Full ISO instant, when the capture tool provides one. */
+  capturedAtExact?: string;
+  method: TraceCaptureMethod;
+  /** Who ran the capture. Useful when a human had to drive a browser. */
+  operator?: string;
+  /**
+   * Asserted by the capture path, verified by `assertTraceIsRedacted`. A trace
+   * with `applied: false` must never be committed.
+   */
+  redaction: {
+    applied: boolean;
+    /** Which normalizer produced it, so a redaction bug is attributable. */
+    normalizerVersion: number;
+  };
+  /** Free-form caveats a reviewer needs, e.g. "consent screen driven by hand". */
+  notes?: string[];
+};
+
+// ── The wire ─────────────────────────────────────────────────────────────
+
+/**
+ * Which stage of the handshake a request belongs to.
+ *
+ * Split finely enough that the per-leg header findings stay separable — in
+ * particular `prm-discovery` / `as-metadata-discovery` (the OAuth wire, where
+ * `rmcp` pins 2024-11-05) must not merge with `mcp-initialize` /
+ * `mcp-authenticated` (the MCP wire, where it negotiates something newer).
+ */
+export const TRACE_LEGS = [
+  "mcp-unauthenticated",
+  "prm-discovery",
+  "as-metadata-discovery",
+  "cimd-fetch",
+  "dcr-register",
+  "authorize",
+  "token",
+  "refresh",
+  "mcp-initialize",
+  "mcp-authenticated",
+  "unknown",
+] as const;
+
+export type TraceLeg = (typeof TRACE_LEGS)[number];
+
+/** Legs that travel on the OAuth wire (as opposed to the MCP wire). */
+export const OAUTH_DISCOVERY_LEGS: readonly TraceLeg[] = [
+  "prm-discovery",
+  "as-metadata-discovery",
+  "cimd-fetch",
+];
+
+/** Legs that travel on the MCP wire. */
+export const MCP_WIRE_LEGS: readonly TraceLeg[] = [
+  "mcp-unauthenticated",
+  "mcp-initialize",
+  "mcp-authenticated",
+];
+
+/**
+ * A request or response body.
+ *
+ * `form` and `json` keep structure so fields can be diffed individually;
+ * `opaque` records only shape, for bodies we cannot or should not retain (HTML
+ * consent pages, binary). Note `form.fields` and query params are
+ * multi-valued — see design note 4 in the module header.
+ */
+export type TraceBody =
+  | { encoding: "form"; fields: Record<string, string[]> }
+  | { encoding: "json"; json: unknown }
+  | {
+      encoding: "jsonrpc";
+      /** JSON-RPC `method`, hoisted so leg classification is cheap. */
+      method?: string;
+      json: unknown;
+    }
+  | { encoding: "opaque"; contentType?: string; byteLength?: number };
+
+export type TraceRequest = {
+  method: string;
+  /**
+   * Normalized URL: origins replaced with `{mcp_server}` / `{as}` placeholders
+   * and volatile path/query values placeheld. Query is ALSO broken out into
+   * {@link TraceRequest.query} — the string form is for human reading, the map
+   * is what the differ compares.
+   */
+  url: string;
+  /** Header names lowercased; volatile and sensitive values placeheld. */
+  headers: Record<string, string>;
+  /**
+   * Whether this request's headers were actually seen. Defaults to `true`.
+   *
+   * `false` marks a request the CLIENT did not send itself — above all
+   * `/authorize`, which the client hands to a browser as a URL. Its params are
+   * fully known (they are in the URL) but its headers belong to the browser and
+   * are genuinely unobserved.
+   *
+   * Without this flag an emulator's synthesized `/authorize` would report every
+   * header as `absent` — a positive claim that the client sends no
+   * `MCP-Protocol-Version` there — and would then "differ" from a proxy capture
+   * that did see the browser's headers. That is a fabricated finding, which is
+   * precisely what this schema exists to prevent.
+   */
+  headersObserved?: boolean;
+  /** Multi-valued query parameters, normalized. */
+  query?: Record<string, string[]>;
+  body?: TraceBody;
+};
+
+export type TraceResponse = {
+  status: number;
+  statusText?: string;
+  headers: Record<string, string>;
+  body?: TraceBody;
+};
+
+export type TraceExchange = {
+  /**
+   * 0-based position in the captured handshake. Ordering is itself a finding —
+   * Goose connects unauthenticated FIRST and only falls back to OAuth on a 401,
+   * the opposite of Claude and ChatGPT — so this is compared, not just used for
+   * display.
+   */
+  ordinal: number;
+  leg: TraceLeg;
+  /** Why this leg was assigned, when classification was not unambiguous. */
+  legBasis?: string;
+  request: TraceRequest;
+  response?: TraceResponse;
+  /** Transport-level failure, when the request produced no response. */
+  error?: { message: string };
+};
+
+// ── Derived observations ─────────────────────────────────────────────────
+
+/**
+ * RFC 8707 resource-indicator behavior.
+ *
+ * Not a boolean, deliberately. `sent` captures the CONDITION (VS Code and Cline
+ * omit `resource` entirely when PRM discovery fails; Codex's is a
+ * caller-supplied option), and `valueSource` captures WHICH url is sent —
+ * Claude and ChatGPT document the canonicalized MCP server URL while VS Code
+ * sends the PRM document's `resource` field. Both distinctions are invisible to
+ * a yes/no column.
+ */
+export type ResourceIndicatorValueSource =
+  | "mcp-server-url"
+  | "prm-resource"
+  | "other";
+
+export type ResourceIndicatorUsage = {
+  /** Raw `resource` values on `/authorize`. Multi-valued on purpose. */
+  onAuthorize: Observation<string[]>;
+  onToken: Observation<string[]>;
+  onRefresh: Observation<string[]>;
+  /**
+   * Which URL the value corresponds to, computed by comparing the observed
+   * value against `scenario.capabilities.prmResource` and
+   * `scenario.mcpServerUrl`.
+   */
+  valueSource: Observation<ResourceIndicatorValueSource>;
+};
+
+/**
+ * The two-headed `protocolVersionPinning` field, kept as separate fields.
+ *
+ * `initializeBody` is `initialize.params.protocolVersion`. `headerByLeg` is the
+ * `MCP-Protocol-Version` HTTP header, recorded per leg because clients vary it:
+ * `rmcp` sends `2024-11-05` on OAuth discovery while negotiating a newer
+ * version on MCP, and VS Code sends the header on OAuth discovery only.
+ *
+ * The rollups are convenience views over `headerByLeg`, each derived
+ * independently. They are never merged into one value.
+ */
+export type ProtocolVersionUsage = {
+  initializeBody: Observation<string>;
+  /**
+   * Per-leg `MCP-Protocol-Version`, as the DISTINCT values seen on that leg in
+   * first-appearance order — almost always exactly one.
+   *
+   * A list rather than a scalar because a leg carrying two different values is a
+   * real finding (and, for the profile mapping, decisive: exactly one distinct
+   * value across a wire is a `pinned` claim, more than one is not a pin at all).
+   * Collapsing to "the first one" would manufacture a pin that isn't there.
+   */
+  headerByLeg: Partial<Record<TraceLeg, Observation<string[]>>>;
+  /** Rollup over {@link OAUTH_DISCOVERY_LEGS}. `absent` ⇒ never sent there. */
+  headerOnOAuthDiscovery: Observation<string[]>;
+  /** Rollup over {@link MCP_WIRE_LEGS}. `absent` ⇒ never sent there (VS Code). */
+  headerOnMcpTraffic: Observation<string[]>;
+  /**
+   * True when the two wires carry DIFFERENT values, or when one carries a value
+   * and the other demonstrably carries none. This is the split-revision signal
+   * (Goose, and every `rmcp`-based client) — surfaced as a first-class flag so
+   * it cannot be read past.
+   */
+  wiresDisagree: boolean;
+  /**
+   * True when the header value on any leg differs from `initializeBody`. The
+   * second half of the same trap.
+   */
+  headerDisagreesWithInitializeBody: boolean;
+};
+
+/**
+ * DCR identity as it actually appeared in the `/register` request body.
+ *
+ * Per RFC 7591 this metadata is self-asserted and therefore NOT a sound input
+ * to server authorization policy — but servers in the wild do gate on
+ * `client_name`, so an emulator has to replay these strings byte-exactly.
+ * Recorded as observation, not endorsement.
+ */
+export type DcrIdentityUsage = {
+  clientName: Observation<string>;
+  /**
+   * Redirect URIs with loopback ports placeheld as `{port}`, so an emulator on
+   * an ephemeral port still diffs clean against a real host on a different one.
+   */
+  redirectUris: Observation<string[]>;
+  /**
+   * The loopback ports actually seen, kept because the port RANGE is a real
+   * per-host fact that the `{port}` placeholder would otherwise destroy — Cline
+   * scans 1456–1461, Codex takes an ephemeral port, VS Code registers fixed
+   * ones. Redirect URIs carry no secret, so retaining these is safe.
+   *
+   * Reported as diff CONTEXT, never as a parity difference: two runs of the same
+   * client legitimately differ here.
+   */
+  observedLoopbackPorts: Observation<number[]>;
+  grantTypes: Observation<string[]>;
+  responseTypes: Observation<string[]>;
+  tokenEndpointAuthMethod: Observation<string>;
+  scope: Observation<string>;
+  /**
+   * Keys present in the register body that this schema does not model, so an
+   * unmodeled-but-real field shows up as a diff instead of vanishing. Durability
+   * over convenience.
+   */
+  extraFields: Observation<string[]>;
+};
+
+export type PkceUsage = {
+  /** `code_challenge_method`, e.g. `S256`. */
+  challengeMethod: Observation<string>;
+  /** Length of the `code_challenge`, retained after the value is placeheld. */
+  challengeLength: Observation<number>;
+  /** Whether a `code_verifier` appeared on the token request. */
+  verifierSentOnToken: Observation<boolean>;
+};
+
+export type UserAgentUsage = {
+  /** Distinct `user-agent` values per leg, first-appearance order. */
+  byLeg: Partial<Record<TraceLeg, Observation<string[]>>>;
+  /**
+   * Whether every captured leg carried the SAME user-agent. Goose is the open
+   * case: its `goose/{ver}` UA is verified on the MCP transport, but whether it
+   * reaches the authorization server is not — because `rmcp` may build its own
+   * HTTP client. A per-leg map plus this flag settles that in one capture.
+   */
+  consistent: boolean;
+};
+
+/**
+ * Diff-relevant facts derived from {@link TraceExchange}[]. Everything here is
+ * recomputable from `wire`, and is stored so a reviewer reads conclusions
+ * without re-deriving them — and so a drift check can diff the summary cheaply.
+ */
+export type TraceObservations = {
+  /** Legs in the order they first appeared. Ordering is a finding. */
+  legOrder: TraceLeg[];
+  /** Normalized request URLs, deduped, first-appearance order preserved. */
+  endpointsHit: string[];
+  /**
+   * Well-known paths tried, in order. Path-aware-then-root ladder ordering is a
+   * real behavioral difference between clients.
+   */
+  discoveryLadder: string[];
+  userAgent: UserAgentUsage;
+  resourceIndicator: ResourceIndicatorUsage;
+  protocolVersion: ProtocolVersionUsage;
+  dcrIdentity: DcrIdentityUsage;
+  pkce: PkceUsage;
+};
+
+// ── The trace ────────────────────────────────────────────────────────────
+
+export type GoldenTrace = {
+  traceVersion: typeof GOLDEN_TRACE_VERSION;
+  /**
+   * Stable identity: `<hostId>/<scenarioId>/<capturedAt>`. Deterministic so a
+   * re-capture on the same day overwrites rather than accumulating duplicates,
+   * and so HP-38's drift check has a stable key.
+   */
+  traceId: string;
+  subject: TraceSubject;
+  scenario: TraceScenario;
+  capture: TraceCaptureMeta;
+  /** The normalized handshake, in capture order. */
+  wire: TraceExchange[];
+  /** Derived summary — see {@link TraceObservations}. */
+  observations: TraceObservations;
+};
+
+// ── Diff ─────────────────────────────────────────────────────────────────
+
+/**
+ * Diff dimensions, matching the field-by-field axes HP-44 requires:
+ * request ordering, endpoints hit, params present/absent, headers, DCR body.
+ * `subject` and `scenario` are added because a diff whose two sides disagree
+ * about WHAT was captured is not a behavioral finding at all.
+ */
+export const TRACE_DIFF_DIMENSIONS = [
+  "scenario",
+  "subject",
+  "request-ordering",
+  "endpoints",
+  "params",
+  "headers",
+  "dcr-body",
+  "protocol-version",
+  "resource-indicator",
+  "pkce",
+  "user-agent",
+] as const;
+
+export type TraceDiffDimension = (typeof TRACE_DIFF_DIMENSIONS)[number];
+
+/**
+ * Severity of one finding.
+ *
+ *   `match`        — both sides observed the same thing.
+ *   `difference`   — both sides observed, and they DISAGREE. The only severity
+ *                    that is evidence of an emulator bug.
+ *   `gap`          — at least one side did not observe the leg, so the fields
+ *                    are not comparable. Reported loudly and never counted as
+ *                    a pass; this is the "unverifiable, here's the blocker"
+ *                    output the harness is required to produce.
+ *   `incomparable` — the two traces are not of the same experiment (different
+ *                    scenario or different host), so no field-level comparison
+ *                    is meaningful.
+ */
+export const TRACE_DIFF_SEVERITIES = [
+  "match",
+  "difference",
+  "gap",
+  "incomparable",
+] as const;
+
+export type TraceDiffSeverity = (typeof TRACE_DIFF_SEVERITIES)[number];
+
+export type TraceDiffFinding = {
+  /** Dotted path into the trace, e.g. `observations.resourceIndicator.onToken`. */
+  path: string;
+  dimension: TraceDiffDimension;
+  severity: TraceDiffSeverity;
+  /** One-line statement of the finding, phrased for a reviewer. */
+  message: string;
+  /** Rendered golden-side value (or the reason it is missing). */
+  golden?: unknown;
+  /** Rendered candidate-side value (or the reason it is missing). */
+  candidate?: unknown;
+};
+
+export type TraceDiffResult = {
+  /**
+   * True only when there are zero `difference` and zero `incomparable`
+   * findings. `gap` findings do NOT fail parity — an unobserved leg is not
+   * evidence of divergence — but they are counted separately and a caller that
+   * needs full coverage should assert `gaps === 0` as well.
+   */
+  parity: boolean;
+  goldenTraceId: string;
+  candidateTraceId: string;
+  counts: Record<TraceDiffSeverity, number>;
+  findings: TraceDiffFinding[];
+  /** Human summary line, e.g. `3 differences, 2 gaps across 41 comparisons`. */
+  summary: string;
+};

--- a/sdk/tests/fixtures/golden-traces/claude-code-http-capture-dcr-authcode-prm.json
+++ b/sdk/tests/fixtures/golden-traces/claude-code-http-capture-dcr-authcode-prm.json
@@ -1,6 +1,6 @@
 {
   "traceVersion": 1,
-  "traceId": "claude-code/http-capture-dcr-authcode-prm/2026-07-29/real-host",
+  "traceId": "claude-code/http-capture-dcr-authcode-prm-mcp2025-11-25/2026-07-29/real-host",
   "subject": {
     "kind": "real-host",
     "hostId": "claude-code",
@@ -15,7 +15,7 @@
     "surface": "cli"
   },
   "scenario": {
-    "scenarioId": "http-capture-dcr-authcode-prm",
+    "scenarioId": "http-capture-dcr-authcode-prm-mcp2025-11-25",
     "description": "Real HTTP MCP resource server + authorization server, recording its own traffic as a HAR. 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE → token → MCP initialize.",
     "mcpServerUrl": "http://127.0.0.1:3999/mcp",
     "authorizationServerUrl": "http://127.0.0.1:3999",
@@ -27,6 +27,7 @@
       "codeChallengeMethods": [
         "S256"
       ],
+      "serverProtocolVersion": "2025-11-25",
       "asMetadataDocuments": [
         "/.well-known/oauth-authorization-server"
       ],
@@ -302,7 +303,10 @@
           ]
         }
       },
-      "consistent": true
+      "consistent": {
+        "state": "present",
+        "value": true
+      }
     },
     "resourceIndicator": {
       "onAuthorize": {
@@ -356,8 +360,14 @@
       "headerOnMcpTraffic": {
         "state": "absent"
       },
-      "wiresDisagree": true,
-      "headerDisagreesWithInitializeBody": false
+      "wiresDisagree": {
+        "state": "present",
+        "value": true
+      },
+      "headerDisagreesWithInitializeBody": {
+        "state": "present",
+        "value": false
+      }
     },
     "dcrIdentity": {
       "clientName": {
@@ -398,6 +408,9 @@
         "value": "mcp:read mcp:write"
       },
       "extraFields": {
+        "state": "absent"
+      },
+      "malformedFields": {
         "state": "absent"
       }
     },

--- a/sdk/tests/fixtures/golden-traces/claude-code-http-capture-dcr-authcode-prm.json
+++ b/sdk/tests/fixtures/golden-traces/claude-code-http-capture-dcr-authcode-prm.json
@@ -56,7 +56,7 @@
       "legBasis": "wire heuristic: JSON-RPC initialize, no Authorization",
       "request": {
         "method": "POST",
-        "url": "http://127.0.0.1:{port}/mcp",
+        "url": "{mcp_server}/mcp",
         "headers": {
           "accept": "application/json, text/event-stream",
           "accept-encoding": "identity",
@@ -112,7 +112,7 @@
       "legBasis": "wire heuristic: well-known path: oauth-protected-resource",
       "request": {
         "method": "GET",
-        "url": "http://127.0.0.1:{port}/.well-known/oauth-protected-resource/mcp",
+        "url": "{mcp_server}/.well-known/oauth-protected-resource/mcp",
         "headers": {
           "accept": "*/*",
           "accept-encoding": "identity",
@@ -130,9 +130,9 @@
         "body": {
           "encoding": "json",
           "json": {
-            "resource": "http://127.0.0.1:{port}/mcp",
+            "resource": "{mcp_server}/mcp",
             "authorization_servers": [
-              "http://127.0.0.1:{port}"
+              "{mcp_server}"
             ],
             "scopes_supported": [
               "mcp:read",
@@ -151,7 +151,7 @@
       "legBasis": "wire heuristic: well-known path: authorization-server metadata",
       "request": {
         "method": "GET",
-        "url": "http://127.0.0.1:{port}/.well-known/oauth-authorization-server",
+        "url": "{mcp_server}/.well-known/oauth-authorization-server",
         "headers": {
           "accept": "application/json",
           "accept-encoding": "identity",
@@ -169,10 +169,10 @@
         "body": {
           "encoding": "json",
           "json": {
-            "issuer": "http://127.0.0.1:{port}",
-            "authorization_endpoint": "http://127.0.0.1:{port}/authorize",
-            "token_endpoint": "http://127.0.0.1:{port}/token",
-            "registration_endpoint": "http://127.0.0.1:{port}/register",
+            "issuer": "{mcp_server}",
+            "authorization_endpoint": "{mcp_server}/authorize",
+            "token_endpoint": "{mcp_server}/token",
+            "registration_endpoint": "{mcp_server}/register",
             "response_types_supported": [
               "code"
             ],
@@ -201,7 +201,7 @@
       "legBasis": "wire heuristic: POST to a /register path",
       "request": {
         "method": "POST",
-        "url": "http://127.0.0.1:{port}/register",
+        "url": "{mcp_server}/register",
         "headers": {
           "accept": "application/json, text/event-stream",
           "accept-encoding": "identity",
@@ -266,10 +266,10 @@
       "dcr-register"
     ],
     "endpointsHit": [
-      "http://127.0.0.1:{port}/mcp",
-      "http://127.0.0.1:{port}/.well-known/oauth-protected-resource/mcp",
-      "http://127.0.0.1:{port}/.well-known/oauth-authorization-server",
-      "http://127.0.0.1:{port}/register"
+      "{mcp_server}/mcp",
+      "{mcp_server}/.well-known/oauth-protected-resource/mcp",
+      "{mcp_server}/.well-known/oauth-authorization-server",
+      "{mcp_server}/register"
     ],
     "discoveryLadder": [
       "/.well-known/oauth-protected-resource/mcp",

--- a/sdk/tests/fixtures/golden-traces/claude-code-http-capture-dcr-authcode-prm.json
+++ b/sdk/tests/fixtures/golden-traces/claude-code-http-capture-dcr-authcode-prm.json
@@ -1,0 +1,419 @@
+{
+  "traceVersion": 1,
+  "traceId": "claude-code/http-capture-dcr-authcode-prm/2026-07-29/real-host",
+  "subject": {
+    "kind": "real-host",
+    "hostId": "claude-code",
+    "hostVersion": {
+      "state": "present",
+      "value": "2.1.220"
+    },
+    "oauthImplementation": {
+      "state": "not-observed",
+      "reason": "no resolved OAuth implementation was supplied at ingest; for a host that inherits OAuth from a dependency this trace will go stale on a dependency bump with no visible signal"
+    },
+    "surface": "cli"
+  },
+  "scenario": {
+    "scenarioId": "http-capture-dcr-authcode-prm",
+    "description": "Real HTTP MCP resource server + authorization server, recording its own traffic as a HAR. 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE → token → MCP initialize.",
+    "mcpServerUrl": "http://127.0.0.1:3999/mcp",
+    "authorizationServerUrl": "http://127.0.0.1:3999",
+    "capabilities": {
+      "publishesPrm": true,
+      "prmResource": "http://127.0.0.1:3999/mcp",
+      "supportsDcr": true,
+      "supportsCimd": false,
+      "codeChallengeMethods": [
+        "S256"
+      ],
+      "asMetadataDocuments": [
+        "/.well-known/oauth-authorization-server"
+      ],
+      "challengesUnauthenticated": true
+    }
+  },
+  "capture": {
+    "capturedAt": "2026-07-29",
+    "method": {
+      "via": "har",
+      "harCreator": "mcpjam-hp44-capture-server",
+      "harVersion": "1.2"
+    },
+    "operator": "hp44 automated capture",
+    "redaction": {
+      "applied": true,
+      "normalizerVersion": 1
+    },
+    "notes": [
+      "Headless Claude Code (claude -p --mcp-config) against the HP-44 recording server. Handshake stops after DCR: a non-interactive session cannot open a browser for /authorize, so the authorize and token legs were never sent. Those legs are recorded as not-observed, not absent."
+    ]
+  },
+  "wire": [
+    {
+      "ordinal": 0,
+      "leg": "mcp-unauthenticated",
+      "legBasis": "wire heuristic: JSON-RPC initialize, no Authorization",
+      "request": {
+        "method": "POST",
+        "url": "http://127.0.0.1:{port}/mcp",
+        "headers": {
+          "accept": "application/json, text/event-stream",
+          "accept-encoding": "identity",
+          "connection": "{connection}",
+          "content-length": "{content-length}",
+          "content-type": "application/json",
+          "host": "127.0.0.1:3999",
+          "user-agent": "claude-code/2.1.220 (sdk-cli)"
+        },
+        "body": {
+          "encoding": "jsonrpc",
+          "method": "initialize",
+          "json": {
+            "method": "initialize",
+            "params": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {
+                "roots": {
+                  "listChanged": true
+                },
+                "elicitation": {}
+              },
+              "clientInfo": {
+                "name": "claude-code",
+                "title": "Claude Code",
+                "version": "2.1.220",
+                "description": "Anthropic's agentic coding tool",
+                "websiteUrl": "https://claude.com/claude-code"
+              }
+            },
+            "jsonrpc": "2.0",
+            "id": "{id}"
+          }
+        }
+      },
+      "response": {
+        "status": 401,
+        "headers": {
+          "content-type": "application/json",
+          "www-authenticate": "Bearer resource_metadata=\"{mcp_server}/.well-known/oauth-protected-resource/mcp\""
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "error": "unauthorized"
+          }
+        }
+      }
+    },
+    {
+      "ordinal": 1,
+      "leg": "prm-discovery",
+      "legBasis": "wire heuristic: well-known path: oauth-protected-resource",
+      "request": {
+        "method": "GET",
+        "url": "http://127.0.0.1:{port}/.well-known/oauth-protected-resource/mcp",
+        "headers": {
+          "accept": "*/*",
+          "accept-encoding": "identity",
+          "connection": "{connection}",
+          "host": "127.0.0.1:3999",
+          "mcp-protocol-version": "2025-11-25",
+          "user-agent": "claude-code/2.1.220 (sdk-cli)"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "resource": "http://127.0.0.1:{port}/mcp",
+            "authorization_servers": [
+              "http://127.0.0.1:{port}"
+            ],
+            "scopes_supported": [
+              "mcp:read",
+              "mcp:write"
+            ],
+            "bearer_methods_supported": [
+              "header"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "ordinal": 2,
+      "leg": "as-metadata-discovery",
+      "legBasis": "wire heuristic: well-known path: authorization-server metadata",
+      "request": {
+        "method": "GET",
+        "url": "http://127.0.0.1:{port}/.well-known/oauth-authorization-server",
+        "headers": {
+          "accept": "application/json",
+          "accept-encoding": "identity",
+          "connection": "{connection}",
+          "host": "127.0.0.1:3999",
+          "mcp-protocol-version": "2025-11-25",
+          "user-agent": "claude-code/2.1.220 (sdk-cli)"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "issuer": "http://127.0.0.1:{port}",
+            "authorization_endpoint": "http://127.0.0.1:{port}/authorize",
+            "token_endpoint": "http://127.0.0.1:{port}/token",
+            "registration_endpoint": "http://127.0.0.1:{port}/register",
+            "response_types_supported": [
+              "code"
+            ],
+            "grant_types_supported": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "code_challenge_methods_supported": [
+              "S256"
+            ],
+            "scopes_supported": [
+              "mcp:read",
+              "mcp:write"
+            ],
+            "token_endpoint_auth_methods_supported": [
+              "none",
+              "client_secret_post"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "ordinal": 3,
+      "leg": "dcr-register",
+      "legBasis": "wire heuristic: POST to a /register path",
+      "request": {
+        "method": "POST",
+        "url": "http://127.0.0.1:{port}/register",
+        "headers": {
+          "accept": "application/json, text/event-stream",
+          "accept-encoding": "identity",
+          "connection": "{connection}",
+          "content-length": "{content-length}",
+          "content-type": "application/json",
+          "host": "127.0.0.1:3999",
+          "user-agent": "claude-code/2.1.220 (sdk-cli)"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "client_name": "Claude Code (hp44capture)",
+            "redirect_uris": [
+              "http://localhost:{port}/callback"
+            ],
+            "grant_types": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "response_types": [
+              "code"
+            ],
+            "token_endpoint_auth_method": "none",
+            "scope": "mcp:read mcp:write"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "client_id": "{client_id}",
+            "client_id_issued_at": "{timestamp}",
+            "client_name": "Claude Code (hp44capture)",
+            "redirect_uris": [
+              "http://localhost:{port}/callback"
+            ],
+            "grant_types": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "response_types": [
+              "code"
+            ],
+            "token_endpoint_auth_method": "none",
+            "scope": "mcp:read mcp:write"
+          }
+        }
+      }
+    }
+  ],
+  "observations": {
+    "legOrder": [
+      "mcp-unauthenticated",
+      "prm-discovery",
+      "as-metadata-discovery",
+      "dcr-register"
+    ],
+    "endpointsHit": [
+      "http://127.0.0.1:{port}/mcp",
+      "http://127.0.0.1:{port}/.well-known/oauth-protected-resource/mcp",
+      "http://127.0.0.1:{port}/.well-known/oauth-authorization-server",
+      "http://127.0.0.1:{port}/register"
+    ],
+    "discoveryLadder": [
+      "/.well-known/oauth-protected-resource/mcp",
+      "/.well-known/oauth-authorization-server"
+    ],
+    "userAgent": {
+      "byLeg": {
+        "mcp-unauthenticated": {
+          "state": "present",
+          "value": [
+            "claude-code/2.1.220 (sdk-cli)"
+          ]
+        },
+        "prm-discovery": {
+          "state": "present",
+          "value": [
+            "claude-code/2.1.220 (sdk-cli)"
+          ]
+        },
+        "as-metadata-discovery": {
+          "state": "present",
+          "value": [
+            "claude-code/2.1.220 (sdk-cli)"
+          ]
+        },
+        "dcr-register": {
+          "state": "present",
+          "value": [
+            "claude-code/2.1.220 (sdk-cli)"
+          ]
+        }
+      },
+      "consistent": true
+    },
+    "resourceIndicator": {
+      "onAuthorize": {
+        "state": "not-observed",
+        "reason": "no /authorize request was captured in this trace"
+      },
+      "onToken": {
+        "state": "not-observed",
+        "reason": "no /token request was captured in this trace"
+      },
+      "onRefresh": {
+        "state": "not-observed",
+        "reason": "no token-refresh request was captured in this trace"
+      },
+      "valueSource": {
+        "state": "not-observed",
+        "reason": "no `resource` value was observed, so its source cannot be classified"
+      }
+    },
+    "protocolVersion": {
+      "initializeBody": {
+        "state": "present",
+        "value": "2025-11-25"
+      },
+      "headerByLeg": {
+        "mcp-unauthenticated": {
+          "state": "absent"
+        },
+        "prm-discovery": {
+          "state": "present",
+          "value": [
+            "2025-11-25"
+          ]
+        },
+        "as-metadata-discovery": {
+          "state": "present",
+          "value": [
+            "2025-11-25"
+          ]
+        },
+        "dcr-register": {
+          "state": "absent"
+        }
+      },
+      "headerOnOAuthDiscovery": {
+        "state": "present",
+        "value": [
+          "2025-11-25"
+        ]
+      },
+      "headerOnMcpTraffic": {
+        "state": "absent"
+      },
+      "wiresDisagree": true,
+      "headerDisagreesWithInitializeBody": false
+    },
+    "dcrIdentity": {
+      "clientName": {
+        "state": "present",
+        "value": "Claude Code (hp44capture)"
+      },
+      "redirectUris": {
+        "state": "present",
+        "value": [
+          "http://localhost:{port}/callback"
+        ]
+      },
+      "observedLoopbackPorts": {
+        "state": "present",
+        "value": [
+          3118
+        ]
+      },
+      "grantTypes": {
+        "state": "present",
+        "value": [
+          "authorization_code",
+          "refresh_token"
+        ]
+      },
+      "responseTypes": {
+        "state": "present",
+        "value": [
+          "code"
+        ]
+      },
+      "tokenEndpointAuthMethod": {
+        "state": "present",
+        "value": "none"
+      },
+      "scope": {
+        "state": "present",
+        "value": "mcp:read mcp:write"
+      },
+      "extraFields": {
+        "state": "absent"
+      }
+    },
+    "pkce": {
+      "challengeMethod": {
+        "state": "not-observed",
+        "reason": "no /authorize request was captured in this trace"
+      },
+      "challengeLength": {
+        "state": "not-observed",
+        "reason": "no /authorize request was captured in this trace"
+      },
+      "verifierSentOnToken": {
+        "state": "not-observed",
+        "reason": "no /token request was captured in this trace"
+      }
+    }
+  }
+}

--- a/sdk/tests/fixtures/golden-traces/mcpjam-in-memory-dcr-authcode-prm.json
+++ b/sdk/tests/fixtures/golden-traces/mcpjam-in-memory-dcr-authcode-prm.json
@@ -1,0 +1,547 @@
+{
+  "traceVersion": 1,
+  "traceId": "mcpjam/in-memory-dcr-authcode-prm/2026-07-29/emulator",
+  "subject": {
+    "kind": "emulator",
+    "hostId": "mcpjam",
+    "hostVersion": {
+      "state": "present",
+      "value": "{sdk_version}"
+    },
+    "oauthImplementation": {
+      "state": "present",
+      "value": {
+        "kind": "first-party"
+      }
+    }
+  },
+  "scenario": {
+    "scenarioId": "in-memory-dcr-authcode-prm",
+    "description": "In-memory MCP resource server + authorization server: 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE S256 → token → MCP initialize.",
+    "mcpServerUrl": "https://mcp.example.test/mcp",
+    "authorizationServerUrl": "https://as.example.test",
+    "capabilities": {
+      "publishesPrm": true,
+      "prmResource": "https://mcp.example.test/mcp",
+      "supportsDcr": true,
+      "supportsCimd": false,
+      "codeChallengeMethods": [
+        "S256"
+      ],
+      "asMetadataDocuments": [
+        "/.well-known/oauth-authorization-server"
+      ],
+      "challengesUnauthenticated": true
+    }
+  },
+  "capture": {
+    "capturedAt": "2026-07-29",
+    "method": {
+      "via": "mcpjam-emulator",
+      "sdkVersion": "{sdk_version}",
+      "stateMachine": "debug-oauth-2025-11-25"
+    },
+    "redaction": {
+      "applied": true,
+      "normalizerVersion": 1
+    },
+    "notes": [
+      "Captured in-process against the in-memory scenario in tests/oauth-golden-trace/scenario.ts. No network, no credentials."
+    ]
+  },
+  "wire": [
+    {
+      "ordinal": 0,
+      "leg": "mcp-unauthenticated",
+      "legBasis": "OAuthFlowStep=request_without_token",
+      "request": {
+        "method": "POST",
+        "url": "{mcp_server}/mcp",
+        "headers": {
+          "accept": "application/json, text/event-stream",
+          "content-type": "application/json",
+          "mcp-protocol-version": "2025-11-25"
+        },
+        "body": {
+          "encoding": "jsonrpc",
+          "method": "initialize",
+          "json": {
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {},
+              "clientInfo": {
+                "name": "MCPJam Inspector",
+                "version": "1.0.0"
+              }
+            },
+            "id": "{id}"
+          }
+        }
+      },
+      "response": {
+        "status": 401,
+        "headers": {
+          "www-authenticate": "Bearer resource_metadata=\"{mcp_server}/.well-known/oauth-protected-resource/mcp\""
+        }
+      }
+    },
+    {
+      "ordinal": 1,
+      "leg": "prm-discovery",
+      "legBasis": "OAuthFlowStep=request_resource_metadata",
+      "request": {
+        "method": "GET",
+        "url": "{mcp_server}/.well-known/oauth-protected-resource/mcp",
+        "headers": {
+          "accept": "application/json",
+          "mcp-protocol-version": "2025-11-25"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "resource": "{mcp_server}/mcp",
+            "authorization_servers": [
+              "{as}"
+            ],
+            "scopes_supported": [
+              "mcp:read",
+              "mcp:write"
+            ],
+            "bearer_methods_supported": [
+              "header"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "ordinal": 2,
+      "leg": "as-metadata-discovery",
+      "legBasis": "OAuthFlowStep=request_authorization_server_metadata",
+      "request": {
+        "method": "GET",
+        "url": "{as}/.well-known/oauth-authorization-server",
+        "headers": {}
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "issuer": "{as}",
+            "authorization_endpoint": "{as}/authorize",
+            "token_endpoint": "{as}/token",
+            "registration_endpoint": "{as}/register",
+            "response_types_supported": [
+              "code"
+            ],
+            "grant_types_supported": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "code_challenge_methods_supported": [
+              "S256"
+            ],
+            "scopes_supported": [
+              "mcp:read",
+              "mcp:write"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "ordinal": 3,
+      "leg": "dcr-register",
+      "legBasis": "OAuthFlowStep=request_client_registration",
+      "request": {
+        "method": "POST",
+        "url": "{as}/register",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "client_name": "MCPJam SDK OAuth Conformance",
+            "client_uri": "https://github.com/MCPJam/inspector",
+            "logo_uri": "https://www.mcpjam.com/mcp_jam_2row.png",
+            "grant_types": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "response_types": [
+              "code"
+            ],
+            "token_endpoint_auth_method": "none",
+            "redirect_uris": [
+              "http://127.0.0.1:{port}/callback"
+            ],
+            "scope": "mcp:read mcp:write"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "client_id": "{client_id}",
+            "client_id_issued_at": "{timestamp}",
+            "redirect_uris": [
+              "http://127.0.0.1:{port}/callback"
+            ],
+            "grant_types": [
+              "authorization_code",
+              "refresh_token"
+            ],
+            "response_types": [
+              "code"
+            ],
+            "token_endpoint_auth_method": "none"
+          }
+        }
+      }
+    },
+    {
+      "ordinal": 4,
+      "leg": "authorize",
+      "legBasis": "reconstructed from the `authorization_request` info log: the client hands this URL to a browser rather than fetching it, so no intercepted request exists",
+      "request": {
+        "method": "GET",
+        "url": "{as}/authorize?client_id={client_id}&code_challenge={code_challenge:len=43,charset=base64url}&code_challenge_method=S256&redirect_uri=http://127.0.0.1:{port}/callback&resource={mcp_server}/mcp&response_type=code&scope=mcp:read mcp:write&state={state:len=16}",
+        "headers": {},
+        "headersObserved": false,
+        "query": {
+          "client_id": [
+            "{client_id}"
+          ],
+          "code_challenge": [
+            "{code_challenge:len=43,charset=base64url}"
+          ],
+          "code_challenge_method": [
+            "S256"
+          ],
+          "redirect_uri": [
+            "http://127.0.0.1:{port}/callback"
+          ],
+          "resource": [
+            "{mcp_server}/mcp"
+          ],
+          "response_type": [
+            "code"
+          ],
+          "scope": [
+            "mcp:read mcp:write"
+          ],
+          "state": [
+            "{state:len=16}"
+          ]
+        }
+      }
+    },
+    {
+      "ordinal": 5,
+      "leg": "token",
+      "legBasis": "OAuthFlowStep=token_request",
+      "request": {
+        "method": "POST",
+        "url": "{as}/token",
+        "headers": {
+          "content-type": "application/x-www-form-urlencoded"
+        },
+        "body": {
+          "encoding": "form",
+          "fields": {
+            "client_id": [
+              "{client_id}"
+            ],
+            "code": [
+              "[REDACTED]"
+            ],
+            "code_verifier": [
+              "[REDACTED]"
+            ],
+            "grant_type": [
+              "authorization_code"
+            ],
+            "redirect_uri": [
+              "http://127.0.0.1:{port}/callback"
+            ],
+            "resource": [
+              "{mcp_server}/mcp"
+            ]
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "json",
+          "json": {
+            "access_token": "[REDACTED]",
+            "refresh_token": "[REDACTED]",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "mcp:read mcp:write"
+          }
+        }
+      }
+    },
+    {
+      "ordinal": 6,
+      "leg": "mcp-initialize",
+      "legBasis": "OAuthFlowStep=authenticated_mcp_request",
+      "request": {
+        "method": "POST",
+        "url": "{mcp_server}/mcp",
+        "headers": {
+          "accept": "application/json, text/event-stream",
+          "authorization": "[REDACTED]",
+          "content-type": "application/json",
+          "mcp-protocol-version": "2025-11-25"
+        },
+        "body": {
+          "encoding": "jsonrpc",
+          "method": "initialize",
+          "json": {
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {},
+              "clientInfo": {
+                "name": "MCPJam Inspector",
+                "version": "1.0.0"
+              }
+            },
+            "id": "{id}"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "application/json"
+        },
+        "body": {
+          "encoding": "jsonrpc",
+          "json": {
+            "jsonrpc": "2.0",
+            "id": "{id}",
+            "result": {
+              "protocolVersion": "2025-11-25",
+              "serverInfo": {
+                "name": "hp44-in-memory-server",
+                "version": "1.0.0"
+              },
+              "capabilities": {}
+            }
+          }
+        }
+      }
+    }
+  ],
+  "observations": {
+    "legOrder": [
+      "mcp-unauthenticated",
+      "prm-discovery",
+      "as-metadata-discovery",
+      "dcr-register",
+      "authorize",
+      "token",
+      "mcp-initialize"
+    ],
+    "endpointsHit": [
+      "{mcp_server}/mcp",
+      "{mcp_server}/.well-known/oauth-protected-resource/mcp",
+      "{as}/.well-known/oauth-authorization-server",
+      "{as}/register",
+      "{as}/authorize",
+      "{as}/token"
+    ],
+    "discoveryLadder": [
+      "/.well-known/oauth-protected-resource/mcp",
+      "/.well-known/oauth-authorization-server"
+    ],
+    "userAgent": {
+      "byLeg": {
+        "mcp-unauthenticated": {
+          "state": "absent"
+        },
+        "prm-discovery": {
+          "state": "absent"
+        },
+        "as-metadata-discovery": {
+          "state": "absent"
+        },
+        "dcr-register": {
+          "state": "absent"
+        },
+        "authorize": {
+          "state": "not-observed",
+          "reason": "the authorize request was reconstructed rather than intercepted, so its headers were never on the wire we recorded"
+        },
+        "token": {
+          "state": "absent"
+        },
+        "mcp-initialize": {
+          "state": "absent"
+        }
+      },
+      "consistent": true
+    },
+    "resourceIndicator": {
+      "onAuthorize": {
+        "state": "present",
+        "value": [
+          "{mcp_server}/mcp"
+        ]
+      },
+      "onToken": {
+        "state": "present",
+        "value": [
+          "{mcp_server}/mcp"
+        ]
+      },
+      "onRefresh": {
+        "state": "not-observed",
+        "reason": "no token-refresh request was captured in this trace"
+      },
+      "valueSource": {
+        "state": "present",
+        "value": "mcp-server-url"
+      }
+    },
+    "protocolVersion": {
+      "initializeBody": {
+        "state": "present",
+        "value": "2025-11-25"
+      },
+      "headerByLeg": {
+        "mcp-unauthenticated": {
+          "state": "present",
+          "value": [
+            "2025-11-25"
+          ]
+        },
+        "prm-discovery": {
+          "state": "present",
+          "value": [
+            "2025-11-25"
+          ]
+        },
+        "as-metadata-discovery": {
+          "state": "absent"
+        },
+        "dcr-register": {
+          "state": "absent"
+        },
+        "authorize": {
+          "state": "not-observed",
+          "reason": "the authorize request was reconstructed rather than intercepted, so its headers were never on the wire we recorded"
+        },
+        "token": {
+          "state": "absent"
+        },
+        "mcp-initialize": {
+          "state": "present",
+          "value": [
+            "2025-11-25"
+          ]
+        }
+      },
+      "headerOnOAuthDiscovery": {
+        "state": "present",
+        "value": [
+          "2025-11-25"
+        ]
+      },
+      "headerOnMcpTraffic": {
+        "state": "present",
+        "value": [
+          "2025-11-25"
+        ]
+      },
+      "wiresDisagree": false,
+      "headerDisagreesWithInitializeBody": false
+    },
+    "dcrIdentity": {
+      "clientName": {
+        "state": "present",
+        "value": "MCPJam SDK OAuth Conformance"
+      },
+      "redirectUris": {
+        "state": "present",
+        "value": [
+          "http://127.0.0.1:{port}/callback"
+        ]
+      },
+      "observedLoopbackPorts": {
+        "state": "present",
+        "value": [
+          33418
+        ]
+      },
+      "grantTypes": {
+        "state": "present",
+        "value": [
+          "authorization_code",
+          "refresh_token"
+        ]
+      },
+      "responseTypes": {
+        "state": "present",
+        "value": [
+          "code"
+        ]
+      },
+      "tokenEndpointAuthMethod": {
+        "state": "present",
+        "value": "none"
+      },
+      "scope": {
+        "state": "present",
+        "value": "mcp:read mcp:write"
+      },
+      "extraFields": {
+        "state": "present",
+        "value": [
+          "client_uri",
+          "logo_uri"
+        ]
+      }
+    },
+    "pkce": {
+      "challengeMethod": {
+        "state": "present",
+        "value": "S256"
+      },
+      "challengeLength": {
+        "state": "present",
+        "value": 43
+      },
+      "verifierSentOnToken": {
+        "state": "present",
+        "value": true
+      }
+    }
+  }
+}

--- a/sdk/tests/fixtures/golden-traces/mcpjam-in-memory-dcr-authcode-prm.json
+++ b/sdk/tests/fixtures/golden-traces/mcpjam-in-memory-dcr-authcode-prm.json
@@ -1,6 +1,6 @@
 {
   "traceVersion": 1,
-  "traceId": "mcpjam/in-memory-dcr-authcode-prm/2026-07-29/emulator",
+  "traceId": "mcpjam/in-memory-dcr-authcode-prm-mcp2025-11-25/2026-07-29/emulator",
   "subject": {
     "kind": "emulator",
     "hostId": "mcpjam",
@@ -16,7 +16,7 @@
     }
   },
   "scenario": {
-    "scenarioId": "in-memory-dcr-authcode-prm",
+    "scenarioId": "in-memory-dcr-authcode-prm-mcp2025-11-25",
     "description": "In-memory MCP resource server + authorization server: 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE S256 → token → MCP initialize.",
     "mcpServerUrl": "https://mcp.example.test/mcp",
     "authorizationServerUrl": "https://as.example.test",
@@ -28,6 +28,7 @@
       "codeChallengeMethods": [
         "S256"
       ],
+      "serverProtocolVersion": "2025-11-25",
       "asMetadataDocuments": [
         "/.well-known/oauth-authorization-server"
       ],
@@ -406,7 +407,10 @@
           "state": "absent"
         }
       },
-      "consistent": true
+      "consistent": {
+        "state": "not-observed",
+        "reason": "the `authorize` leg(s) carried no observed request headers (reconstructed rather than intercepted), so whether one `User-Agent` is used across every leg cannot be determined"
+      }
     },
     "resourceIndicator": {
       "onAuthorize": {
@@ -480,8 +484,14 @@
           "2025-11-25"
         ]
       },
-      "wiresDisagree": false,
-      "headerDisagreesWithInitializeBody": false
+      "wiresDisagree": {
+        "state": "present",
+        "value": false
+      },
+      "headerDisagreesWithInitializeBody": {
+        "state": "present",
+        "value": false
+      }
     },
     "dcrIdentity": {
       "clientName": {
@@ -523,10 +533,13 @@
       },
       "extraFields": {
         "state": "present",
-        "value": [
-          "client_uri",
-          "logo_uri"
-        ]
+        "value": {
+          "client_uri": "https://github.com/MCPJam/inspector",
+          "logo_uri": "https://www.mcpjam.com/mcp_jam_2row.png"
+        }
+      },
+      "malformedFields": {
+        "state": "absent"
       }
     },
     "pkce": {

--- a/sdk/tests/fixtures/golden-traces/scenario-http-capture-dcr-authcode-prm.json
+++ b/sdk/tests/fixtures/golden-traces/scenario-http-capture-dcr-authcode-prm.json
@@ -1,0 +1,15 @@
+{
+  "scenarioId": "http-capture-dcr-authcode-prm",
+  "description": "Real HTTP MCP resource server + authorization server, recording its own traffic as a HAR. 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE → token → MCP initialize.",
+  "mcpServerUrl": "http://127.0.0.1:3999/mcp",
+  "authorizationServerUrl": "http://127.0.0.1:3999",
+  "capabilities": {
+    "publishesPrm": true,
+    "prmResource": "http://127.0.0.1:3999/mcp",
+    "supportsDcr": true,
+    "supportsCimd": false,
+    "codeChallengeMethods": ["S256"],
+    "asMetadataDocuments": ["/.well-known/oauth-authorization-server"],
+    "challengesUnauthenticated": true
+  }
+}

--- a/sdk/tests/fixtures/golden-traces/scenario-http-capture-dcr-authcode-prm.json
+++ b/sdk/tests/fixtures/golden-traces/scenario-http-capture-dcr-authcode-prm.json
@@ -1,5 +1,5 @@
 {
-  "scenarioId": "http-capture-dcr-authcode-prm",
+  "scenarioId": "http-capture-dcr-authcode-prm-mcp2025-11-25",
   "description": "Real HTTP MCP resource server + authorization server, recording its own traffic as a HAR. 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE → token → MCP initialize.",
   "mcpServerUrl": "http://127.0.0.1:3999/mcp",
   "authorizationServerUrl": "http://127.0.0.1:3999",
@@ -8,8 +8,13 @@
     "prmResource": "http://127.0.0.1:3999/mcp",
     "supportsDcr": true,
     "supportsCimd": false,
-    "codeChallengeMethods": ["S256"],
-    "asMetadataDocuments": ["/.well-known/oauth-authorization-server"],
+    "codeChallengeMethods": [
+      "S256"
+    ],
+    "serverProtocolVersion": "2025-11-25",
+    "asMetadataDocuments": [
+      "/.well-known/oauth-authorization-server"
+    ],
     "challengesUnauthenticated": true
   }
 }

--- a/sdk/tests/oauth-golden-trace/committed-traces.test.ts
+++ b/sdk/tests/oauth-golden-trace/committed-traces.test.ts
@@ -1,0 +1,134 @@
+/**
+ * HP-44 — the CI gate over every committed golden trace.
+ *
+ * This is the mechanical half of "trace diffs run in CI; a drift or parity break
+ * fails the build", and the thing HP-38's daily re-capture re-runs.
+ *
+ * It discovers traces from the filesystem rather than listing them, so a trace
+ * added later is validated with no edit here. That property is the point: a
+ * harness whose CI coverage has to be remembered is a harness that quietly stops
+ * covering things.
+ *
+ * Every committed artifact must satisfy four invariants:
+ *
+ *  1. it is a v1 golden trace;
+ *  2. it contains no live secret (re-checked, not trusted — redaction happens at
+ *     capture time, and this catches a capture path that regressed);
+ *  3. its `observations` still follow from its own `wire` (catches a hand-edited
+ *     or half-migrated artifact);
+ *  4. it asserts `redaction.applied`.
+ *
+ * And any two traces of the same host + scenario captured from DIFFERENT sides —
+ * one `real-host`, one `emulator` — are automatically parity-diffed. Today no such
+ * pair exists (see the coverage doc), so that assertion is vacuous by design and
+ * will start biting the moment HP-43 produces a per-host emulator to compare.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  diffGoldenTraces,
+  findObservationDrift,
+  findRedactionViolations,
+  formatTraceDiffHuman,
+  formatTraceSummaryHuman,
+} from "../../src/oauth-golden-trace/index.js";
+import type { GoldenTrace } from "../../src/oauth-golden-trace/index.js";
+
+const FIXTURES = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "fixtures",
+  "golden-traces",
+);
+
+/**
+ * Scenario files live alongside traces so a capture is reproducible from the
+ * repo alone; they are inputs, not artifacts, so they are excluded here.
+ */
+function traceFiles(): string[] {
+  return readdirSync(FIXTURES)
+    .filter((name) => name.endsWith(".json") && !name.startsWith("scenario-"))
+    .sort();
+}
+
+function load(name: string): GoldenTrace {
+  return JSON.parse(readFileSync(join(FIXTURES, name), "utf8")) as GoldenTrace;
+}
+
+describe("HP-44 committed golden traces", () => {
+  const files = traceFiles();
+
+  it("finds at least one committed trace", () => {
+    // Guards against the discovery glob silently matching nothing, which would
+    // make every assertion below pass while checking no artifact at all.
+    expect(files.length).toBeGreaterThan(0);
+    // eslint-disable-next-line no-console
+    console.log(
+      `HP-44 committed traces:\n${files
+        .map((name) => `  ${formatTraceSummaryHuman(load(name))}`)
+        .join("\n")}`,
+    );
+  });
+
+  for (const name of files) {
+    describe(name, () => {
+      it("is a v1 golden trace that asserts redaction", () => {
+        const trace = load(name);
+        expect(trace.traceVersion).toBe(1);
+        expect(trace.capture.redaction.applied).toBe(true);
+        expect(trace.subject.hostId).toBeTruthy();
+        expect(trace.scenario.scenarioId).toBeTruthy();
+        // A trace that cannot say when it was captured is not dated evidence.
+        expect(trace.capture.capturedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      });
+
+      it("contains no live secret", () => {
+        expect(findRedactionViolations(load(name))).toEqual([]);
+      });
+
+      it("has observations derivable from its own wire", () => {
+        expect(findObservationDrift(load(name))).toEqual([]);
+      });
+    });
+  }
+
+  it("parity-diffs every real-host / emulator pair of the same host and scenario", () => {
+    const traces = files.map((name) => ({ name, trace: load(name) }));
+    const pairs: Array<{ golden: GoldenTrace; candidate: GoldenTrace; label: string }> = [];
+
+    for (const left of traces) {
+      for (const right of traces) {
+        if (left.name >= right.name) continue;
+        const a = left.trace;
+        const b = right.trace;
+        if (a.subject.hostId !== b.subject.hostId) continue;
+        if (a.scenario.scenarioId !== b.scenario.scenarioId) continue;
+        if (a.subject.kind === b.subject.kind) continue;
+
+        const golden = a.subject.kind === "real-host" ? a : b;
+        const candidate = a.subject.kind === "real-host" ? b : a;
+        pairs.push({
+          golden,
+          candidate,
+          label: `${basename(left.name)} vs ${basename(right.name)}`,
+        });
+      }
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`HP-44 comparable real-host/emulator pairs: ${pairs.length}`);
+
+    for (const pair of pairs) {
+      const diff = diffGoldenTraces(pair.golden, pair.candidate, { mode: "parity" });
+      if (!diff.parity) {
+        // eslint-disable-next-line no-console
+        console.error(`PARITY BREAK — ${pair.label}\n${formatTraceDiffHuman(diff)}`);
+      }
+      expect(diff.counts.difference, `${pair.label}: ${diff.summary}`).toBe(0);
+      expect(diff.counts.incomparable, `${pair.label}: ${diff.summary}`).toBe(0);
+    }
+  });
+});

--- a/sdk/tests/oauth-golden-trace/committed-traces.test.ts
+++ b/sdk/tests/oauth-golden-trace/committed-traces.test.ts
@@ -65,18 +65,16 @@ describe("HP-44 committed golden traces", () => {
     // Guards against the discovery glob silently matching nothing, which would
     // make every assertion below pass while checking no artifact at all.
     expect(files.length).toBeGreaterThan(0);
-    // eslint-disable-next-line no-console
-    console.log(
-      `HP-44 committed traces:\n${files
-        .map((name) => `  ${formatTraceSummaryHuman(load(name))}`)
-        .join("\n")}`,
-    );
   });
 
   for (const name of files) {
     describe(name, () => {
       it("is a v1 golden trace that asserts redaction", () => {
         const trace = load(name);
+        // Summarized from the copy this block already loaded, rather than reading
+        // and parsing every trace a second time just to print a listing.
+        // eslint-disable-next-line no-console
+        console.log(`HP-44 committed trace: ${formatTraceSummaryHuman(trace)}`);
         expect(trace.traceVersion).toBe(1);
         expect(trace.capture.redaction.applied).toBe(true);
         expect(trace.subject.hostId).toBeTruthy();

--- a/sdk/tests/oauth-golden-trace/emulator-vs-real-host.test.ts
+++ b/sdk/tests/oauth-golden-trace/emulator-vs-real-host.test.ts
@@ -32,7 +32,10 @@
  */
 
 import { runOAuthStateMachine } from "../../src/oauth/state-machines/runner.js";
-import type { OAuthFlowState } from "../../src/oauth/state-machines/types.js";
+import type {
+  OAuthDynamicRegistrationMetadata,
+  OAuthFlowState,
+} from "../../src/oauth/state-machines/types.js";
 import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
 import {
   captureEmulatorTraceFromFlow,
@@ -60,7 +63,7 @@ const GOLDEN = join(
  * come from the host profile — which `traceToOAuthProfile` generates from the very
  * trace this test diffs against, closing the loop.
  */
-const CLAUDE_CODE_DCR = {
+const CLAUDE_CODE_DCR: Partial<OAuthDynamicRegistrationMetadata> = {
   client_name: "Claude Code (hp44capture)",
   redirect_uris: ["http://localhost:3118/callback"],
   grant_types: ["authorization_code", "refresh_token"],
@@ -89,7 +92,7 @@ describe("HP-44 emulator vs real host", () => {
         updateState: (updates) => {
           state = { ...state, ...updates };
         },
-        dynamicRegistration: CLAUDE_CODE_DCR as never,
+        dynamicRegistration: CLAUDE_CODE_DCR,
         customScopes: "mcp:read mcp:write",
         authMode: "headless",
         // A real fetch. The state machine records each request into

--- a/sdk/tests/oauth-golden-trace/emulator-vs-real-host.test.ts
+++ b/sdk/tests/oauth-golden-trace/emulator-vs-real-host.test.ts
@@ -1,0 +1,226 @@
+/**
+ * HP-44 — the diff this whole harness exists to run.
+ *
+ * Every other test either proves a mechanism in isolation or validates one
+ * artifact. This one does the actual job: take the recorded handshake of a REAL
+ * third-party host, run our emulator configured to reproduce that host against
+ * the same server, and diff the two field by field.
+ *
+ * The golden side is `claude-code` 2.1.220, captured by pointing a headless Claude
+ * Code at `tests/support/oauth-capture-server.ts` (committed at
+ * `fixtures/golden-traces/claude-code-http-capture-dcr-authcode-prm.json`).
+ *
+ * The candidate side is produced here, live, by driving `runOAuthStateMachine`
+ * directly — not through `OAuthConformanceTest` — because:
+ *
+ *   - the conformance runner does not plumb `allowLoopbackMetadataFetch`, so it
+ *     cannot talk to a loopback test server at all (a real HP-39 gap, noted in the
+ *     coverage doc); and
+ *   - HP-43's per-host emulator will not route through the conformance runner
+ *     either, so capturing from a raw flow record is the shape that will actually
+ *     be used.
+ *
+ * **What this test asserts is deliberately NOT "parity".** Configuring the DCR
+ * body by hand is a stand-in for HP-43, which does not exist yet, so a green
+ * parity result here would be meaningless — it would only prove that the fields I
+ * typed in match the fields I read out. What it asserts instead is that the
+ * ORACLE WORKS ON REAL DATA: that it finds the differences that genuinely remain,
+ * attributes them to the right dimension, and reports the unobserved legs as gaps
+ * rather than as either passes or failures.
+ *
+ * The remaining differences are the concrete work list for HP-43.
+ */
+
+import { runOAuthStateMachine } from "../../src/oauth/state-machines/runner.js";
+import type { OAuthFlowState } from "../../src/oauth/state-machines/types.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+import {
+  captureEmulatorTraceFromFlow,
+  diffGoldenTraces,
+  formatTraceDiffHuman,
+} from "../../src/oauth-golden-trace/index.js";
+import type { GoldenTrace } from "../../src/oauth-golden-trace/index.js";
+import { startCaptureServer } from "../support/oauth-capture-server.js";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const GOLDEN = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "fixtures",
+  "golden-traces",
+  "claude-code-http-capture-dcr-authcode-prm.json",
+);
+
+/**
+ * The DCR identity the real capture showed Claude Code sending.
+ *
+ * Hand-configured here BECAUSE HP-43 does not exist. When it does, these values
+ * come from the host profile — which `traceToOAuthProfile` generates from the very
+ * trace this test diffs against, closing the loop.
+ */
+const CLAUDE_CODE_DCR = {
+  client_name: "Claude Code (hp44capture)",
+  redirect_uris: ["http://localhost:3118/callback"],
+  grant_types: ["authorization_code", "refresh_token"],
+  response_types: ["code"],
+  token_endpoint_auth_method: "none",
+  scope: "mcp:read mcp:write",
+};
+
+describe("HP-44 emulator vs real host", () => {
+  it("diffs our emulator against the recorded claude-code handshake", async () => {
+    const server = await startCaptureServer();
+    try {
+      let state: OAuthFlowState = {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        serverUrl: server.mcpUrl,
+      };
+
+      const run = await runOAuthStateMachine({
+        protocolVersion: "2025-11-25",
+        registrationStrategy: "dcr",
+        serverUrl: server.mcpUrl,
+        serverName: "hp44capture",
+        redirectUrl: "http://localhost:3118/callback",
+        state,
+        getState: () => state,
+        updateState: (updates) => {
+          state = { ...state, ...updates };
+        },
+        dynamicRegistration: CLAUDE_CODE_DCR as never,
+        customScopes: "mcp:read mcp:write",
+        authMode: "headless",
+        // A real fetch. The state machine records each request into
+        // `state.httpHistory`, which is the wire the trace is built from — so what
+        // gets diffed is what actually went over the socket.
+        requestExecutor: async (request) => {
+          const response = await fetch(request.url, {
+            method: request.method,
+            headers: request.headers,
+            ...(request.body != null
+              ? {
+                  body:
+                    typeof request.body === "string"
+                      ? request.body
+                      : JSON.stringify(request.body),
+                }
+              : {}),
+            redirect: request.redirect === "manual" ? "manual" : "follow",
+          });
+          const text = await response.text();
+          let body: unknown = text;
+          try {
+            body = text ? JSON.parse(text) : undefined;
+          } catch {
+            // Non-JSON bodies pass through as text; the trace records them opaque.
+          }
+          const headers: Record<string, string> = {};
+          response.headers.forEach((value, key) => {
+            headers[key] = value;
+          });
+          return {
+            ok: response.ok,
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+            body,
+          };
+        },
+        // The test server IS loopback. Without this the SSRF guard refuses every
+        // metadata fetch — which is exactly why the conformance runner cannot be
+        // used against a local test server today.
+        allowLoopbackMetadataFetch: true,
+        onAuthorizationRequest: async ({ authorizationUrl }) => {
+          // Follow the 302 ourselves, standing in for the browser.
+          const response = await fetch(authorizationUrl, { redirect: "manual" });
+          const location = response.headers.get("location");
+          const code = location
+            ? new URL(location).searchParams.get("code")
+            : null;
+          if (!code) throw new Error(`no code in redirect: ${location}`);
+          return { type: "authorization_code", authorizationCode: code };
+        },
+      });
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `emulator run: completed=${run.completed} step=${state.currentStep} error=${run.error?.message ?? "none"} | server saw ${server.requestCount()} requests`,
+      );
+
+      const candidate = captureEmulatorTraceFromFlow({
+        flow: {
+          httpHistory: state.httpHistory ?? [],
+          ...(run.authorizationUrl ? { authorizationUrl: run.authorizationUrl } : {}),
+        },
+        // Emulating claude-code, so the trace must say so — otherwise the differ
+        // correctly refuses to compare it against a claude-code golden trace.
+        hostId: "claude-code",
+        scenario: server.scenario,
+        capturedAt: "2026-07-29",
+        hostVersion: "2.1.220",
+        stateMachine: "debug-oauth-2025-11-25",
+        notes: [
+          "Emulator side, driven via runOAuthStateMachine with claude-code's captured DCR identity. Stands in for HP-43's per-host emulator, which does not exist yet.",
+        ],
+      });
+
+      const golden = JSON.parse(readFileSync(GOLDEN, "utf8")) as GoldenTrace;
+
+      // Both sides used a freshly-bound ephemeral server port, and the golden trace
+      // was captured on a different one. Rewrite the candidate's scenario onto the
+      // golden trace's so the scenario GATE compares like with like — the
+      // capabilities are identical by construction (same server module).
+      const aligned: GoldenTrace = {
+        ...candidate,
+        scenario: golden.scenario,
+        wire: JSON.parse(
+          JSON.stringify(candidate.wire).split(server.origin).join("http://127.0.0.1:3999"),
+        ),
+      };
+
+      const diff = diffGoldenTraces(golden, aligned, { mode: "parity" });
+      // eslint-disable-next-line no-console
+      console.log(formatTraceDiffHuman(diff));
+
+      // The oracle must actually be running — not short-circuited by an
+      // `incomparable` gate, which would make every other assertion vacuous.
+      expect(diff.counts.incomparable).toBe(0);
+
+      // It must find real matches on the legs both sides observed.
+      expect(diff.counts.match).toBeGreaterThan(10);
+
+      // The DCR body is what HP-43 will drive from the host profile, and it is the
+      // part a hand-configured stand-in can already get right. Prove the oracle
+      // confirms it rather than merely failing to notice.
+      const clientName = diff.findings.find(
+        (finding) => finding.path === "observations.dcrIdentity.clientName",
+      );
+      expect(clientName?.severity).toBe("match");
+      const authMethod = diff.findings.find(
+        (finding) =>
+          finding.path === "observations.dcrIdentity.tokenEndpointAuthMethod",
+      );
+      expect(authMethod?.severity).toBe("match");
+
+      // The golden capture stopped before /token, so anything downstream of it is a
+      // GAP — not a difference, and above all not a pass. This is the assertion
+      // that keeps a partial golden trace from silently certifying the emulator.
+      const onToken = diff.findings.find(
+        (finding) => finding.path === "observations.resourceIndicator.onToken",
+      );
+      expect(onToken?.severity).toBe("gap");
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `HP-43 work list — ${diff.counts.difference} difference(s):\n${diff.findings
+          .filter((f) => f.severity === "difference")
+          .map((f) => `  - [${f.dimension}] ${f.path}`)
+          .join("\n")}`,
+      );
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+});

--- a/sdk/tests/oauth-golden-trace/from-conformance.test.ts
+++ b/sdk/tests/oauth-golden-trace/from-conformance.test.ts
@@ -1,0 +1,103 @@
+/**
+ * HP-44 — the conformance-run ingest path.
+ *
+ * The case under test is the one that makes a trace mean different things
+ * depending on a flag nobody thought was about tracing: with
+ * `oauthConformanceChecks` enabled, the runner deliberately sends malformed
+ * traffic AFTER the handshake completes, and records it in `httpAttempts` exactly
+ * like real traffic. If those probes reach the wire, the same host produces two
+ * different traces depending on whether checks happened to be on — which would
+ * make every parity result unreproducible.
+ */
+
+import { describe, expect, it } from "vitest";
+import { collectHttpHistory } from "../../src/oauth-golden-trace/index.js";
+import type {
+  ConformanceResult,
+  ConformanceStepId,
+  StepResult,
+} from "../../src/oauth-conformance/types.js";
+import type { HttpHistoryEntry } from "../../src/oauth/types.js";
+
+function attempt(url: string): HttpHistoryEntry {
+  return {
+    step: "token_request",
+    timestamp: 1_800_000_000_000,
+    request: { method: "POST", url, headers: {} },
+  };
+}
+
+function step(id: ConformanceStepId, attempts: HttpHistoryEntry[]): StepResult {
+  return {
+    step: id,
+    title: id,
+    summary: id,
+    status: "passed",
+    durationMs: 0,
+    logs: [],
+    httpAttempts: attempts,
+  };
+}
+
+function result(steps: StepResult[]): ConformanceResult {
+  return {
+    passed: true,
+    protocolVersion: "2025-06-18",
+    registrationStrategy: "dcr",
+    serverUrl: "https://mcp.example.test/mcp",
+    steps,
+    summary: "ok",
+    durationMs: 0,
+  };
+}
+
+describe("collectHttpHistory", () => {
+  it("keeps handshake traffic and drops post-flow conformance-check probes", () => {
+    const history = collectHttpHistory(
+      result([
+        step("token_request", [attempt("https://as.example.test/token")]),
+        // Two real checks, each of which really does send HTTP: a DCR with a bad
+        // redirect_uri and a token request with a bogus client_id. Both would
+        // otherwise add extra `token`/`dcr-register` legs and shift `legOrder`.
+        step("oauth_dcr_http_redirect_uri", [
+          attempt("https://as.example.test/register"),
+        ]),
+        step("oauth_invalid_client", [attempt("https://as.example.test/token")]),
+      ]),
+    );
+
+    expect(history.map((entry) => entry.request.url)).toEqual([
+      "https://as.example.test/token",
+    ]);
+  });
+
+  it("preserves execution order across the handshake steps it keeps", () => {
+    const history = collectHttpHistory(
+      result([
+        step("discovery", [attempt("https://mcp.example.test/.well-known/x")]),
+        step("oauth_invalid_client", [attempt("https://as.example.test/token")]),
+        step("token_request", [attempt("https://as.example.test/token")]),
+      ]),
+    );
+
+    expect(history.map((entry) => entry.request.url)).toEqual([
+      "https://mcp.example.test/.well-known/x",
+      "https://as.example.test/token",
+    ]);
+  });
+
+  it("does not read an Object.prototype member as a conformance check", () => {
+    // The classification is `Object.hasOwn(CONFORMANCE_CHECK_METADATA, step)`, not
+    // `in`. With `in`, a step id colliding with a prototype member would be
+    // filtered out as a "check" and its real traffic would vanish from the trace.
+    const history = collectHttpHistory(
+      result([
+        step("constructor" as ConformanceStepId, [
+          attempt("https://as.example.test/token"),
+        ]),
+      ]),
+    );
+
+    expect(history).toHaveLength(1);
+  });
+});

--- a/sdk/tests/oauth-golden-trace/from-har.test.ts
+++ b/sdk/tests/oauth-golden-trace/from-har.test.ts
@@ -180,6 +180,18 @@ const HAR = {
   },
 };
 
+/** The shared HAR minus every entry whose URL contains `urlPart`. */
+function harWithout(urlPart: string) {
+  return {
+    log: {
+      ...HAR.log,
+      entries: HAR.log.entries.filter(
+        (entry) => !entry.request.url.includes(urlPart),
+      ),
+    },
+  };
+}
+
 describe("captureHarTrace", () => {
   it("keeps the handshake and drops unrelated traffic, reporting what it dropped", () => {
     const { trace, report } = captureHarTrace({
@@ -280,7 +292,10 @@ describe("captureHarTrace", () => {
       value: ["2024-11-05"],
     });
     expect(pv.initializeBody).toEqual({ state: "present", value: "2025-06-18" });
-    expect(pv.headerDisagreesWithInitializeBody).toBe(true);
+    expect(pv.headerDisagreesWithInitializeBody).toEqual({
+      state: "present",
+      value: true,
+    });
   });
 
   it("records the DCR identity and recovers the loopback port", () => {
@@ -337,6 +352,129 @@ describe("captureHarTrace", () => {
       harCreator: "mitmproxy",
       harVersion: "1.2",
     });
+  });
+
+  it("does not report the PRM leg as missing when the scenario publishes no PRM", () => {
+    // Drop the PRM exchange AND the 401 that advertised it: this is the no-PRM
+    // scenario, where a client that never fetches a PRM document is conformant.
+    const { prmResource: _unused, ...capabilities } = SCENARIO.capabilities;
+    const noPrmScenario: TraceScenario = {
+      ...SCENARIO,
+      scenarioId: "vendor-dcr-authcode-no-prm",
+      capabilities: { ...capabilities, publishesPrm: false },
+    };
+    const har = harWithout("oauth-protected-resource");
+
+    const { report } = captureHarTrace({
+      har,
+      hostId: "vendor",
+      scenario: noPrmScenario,
+      hostVersion: "3.2.1",
+    });
+
+    // `missingLegs` is a list of BLOCKERS. An optional leg the scenario never
+    // published is not one, and reporting it would flag correct behavior.
+    expect(report.missingLegs).not.toContain("prm-discovery");
+    expect(report.missingLegs).toEqual([
+      "as-metadata-discovery",
+      "authorize",
+      "mcp-initialize",
+    ]);
+
+    // Same capture against a PRM-publishing scenario: now it IS a blocker.
+    const withPrm = captureHarTrace({
+      har,
+      hostId: "vendor",
+      scenario: SCENARIO,
+      hostVersion: "3.2.1",
+    });
+    expect(withPrm.report.missingLegs).toContain("prm-discovery");
+  });
+
+  it("deduplicates dropped entries by URL instead of inflating the count", () => {
+    // A desktop client polls its telemetry endpoint continuously; the report has to
+    // stay readable and its `dropped` count has to mean "distinct URLs dropped".
+    const telemetry = HAR.log.entries[0]!;
+    const har = {
+      log: {
+        ...HAR.log,
+        entries: [telemetry, ...HAR.log.entries, telemetry],
+      },
+    };
+
+    const { report } = captureHarTrace({
+      har,
+      hostId: "vendor",
+      scenario: SCENARIO,
+      hostVersion: "3.2.1",
+    });
+
+    expect(report.totalEntries).toBe(8);
+    expect(report.dropped).toHaveLength(2);
+    expect(report.dropped.map((entry) => entry.url)).toEqual([
+      "https://telemetry.vendor.test/v1/events",
+      "https://fonts.googleapis.com/css2?family=Inter",
+    ]);
+    expect(report.dropped[0]!.reason).toContain("assumed unrelated traffic");
+  });
+
+  it("treats prototype-named HAR headers and form fields as data", () => {
+    const har = {
+      log: {
+        version: "1.2",
+        entries: [
+          {
+            startedDateTime: "2026-07-29T09:00:00.000Z",
+            request: {
+              method: "POST",
+              url: `${AS_URL}/token`,
+              headers: [
+                header("__proto__", "polluted"),
+                header("constructor", "sentinel-one"),
+                header("Constructor", "sentinel-two"),
+                header("Content-Type", "application/x-www-form-urlencoded"),
+              ],
+              postData: {
+                mimeType: "application/x-www-form-urlencoded",
+                params: [
+                  header("grant_type", "authorization_code"),
+                  header("constructor", "field-value"),
+                  header("__proto__", "field-proto"),
+                ],
+              },
+            },
+            response: {
+              status: 200,
+              headers: [],
+              content: { mimeType: "application/json", text: "{}" },
+            },
+          },
+        ],
+      },
+    };
+
+    const { trace } = captureHarTrace({
+      har,
+      hostId: "vendor",
+      scenario: SCENARIO,
+      hostVersion: "3.2.1",
+    });
+
+    // Nothing reached `Object.prototype`, and ingest did not abort: on a plain
+    // object accumulator `fields["constructor"] ??= []` resolves to the builtin and
+    // `.push` on it throws, killing the whole capture over one hostile field name.
+    expect((({} as Record<string, unknown>).polluted)).toBeUndefined();
+
+    const headers = trace.wire[0]!.request.headers as Record<string, string>;
+    // Duplicated header joined per RFC 9110 — not appended to a stringified builtin,
+    // which is what `key in out` on a plain object would have produced.
+    expect(headers["constructor"]).toBe("sentinel-one, sentinel-two");
+
+    const body = trace.wire[0]!.request.body;
+    expect(body?.encoding).toBe("form");
+    if (body?.encoding === "form") {
+      expect(body.fields["constructor"]).toEqual(["field-value"]);
+    }
   });
 
   it("warns loudly when no capture date can be established", () => {

--- a/sdk/tests/oauth-golden-trace/from-har.test.ts
+++ b/sdk/tests/oauth-golden-trace/from-har.test.ts
@@ -1,0 +1,351 @@
+/**
+ * HP-44 — HAR ingest, the path for hosts we cannot run in-process.
+ *
+ * The HAR below is shaped like a REAL capture, not a tidy one: it contains
+ * unrelated telemetry traffic, it stops before the token exchange because the
+ * proxy never saw the browser leg, and it carries a live access token. All three
+ * are the normal case, and each is asserted here.
+ */
+
+import {
+  captureHarTrace,
+  formatHarIngestReportHuman,
+} from "../../src/oauth-golden-trace/index.js";
+import type { TraceScenario } from "../../src/oauth-golden-trace/index.js";
+
+const MCP_SERVER_URL = "https://mcp.vendor.test/mcp";
+const AS_URL = "https://auth.vendor.test";
+
+const SCENARIO: TraceScenario = {
+  scenarioId: "vendor-dcr-authcode-prm",
+  mcpServerUrl: MCP_SERVER_URL,
+  authorizationServerUrl: AS_URL,
+  capabilities: {
+    publishesPrm: true,
+    prmResource: MCP_SERVER_URL,
+    supportsDcr: true,
+    supportsCimd: false,
+    codeChallengeMethods: ["S256"],
+    asMetadataDocuments: ["/.well-known/oauth-authorization-server"],
+    challengesUnauthenticated: true,
+  },
+};
+
+function header(name: string, value: string) {
+  return { name, value };
+}
+
+const HAR = {
+  log: {
+    version: "1.2",
+    creator: { name: "mitmproxy", version: "11.0.0" },
+    entries: [
+      // Unrelated traffic — the normal contents of a desktop client's capture.
+      {
+        startedDateTime: "2026-07-29T09:00:00.000Z",
+        request: {
+          method: "POST",
+          url: "https://telemetry.vendor.test/v1/events",
+          headers: [header("User-Agent", "VendorApp/3.2.1")],
+        },
+        response: { status: 200, headers: [], content: { mimeType: "application/json", text: "{}" } },
+      },
+      {
+        startedDateTime: "2026-07-29T09:00:01.000Z",
+        request: {
+          method: "GET",
+          url: "https://fonts.googleapis.com/css2?family=Inter",
+          headers: [],
+        },
+        response: { status: 200, headers: [], content: { mimeType: "text/css", text: "" } },
+      },
+      // The handshake.
+      {
+        startedDateTime: "2026-07-29T09:00:02.000Z",
+        request: {
+          method: "POST",
+          url: MCP_SERVER_URL,
+          headers: [
+            header("User-Agent", "VendorApp/3.2.1"),
+            header("Content-Type", "application/json"),
+          ],
+          postData: {
+            mimeType: "application/json",
+            text: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "initialize",
+              params: { protocolVersion: "2025-06-18", capabilities: {} },
+            }),
+          },
+        },
+        response: {
+          status: 401,
+          headers: [
+            header(
+              "WWW-Authenticate",
+              `Bearer resource_metadata="${MCP_SERVER_URL.replace("/mcp", "")}/.well-known/oauth-protected-resource/mcp"`,
+            ),
+          ],
+        },
+      },
+      {
+        startedDateTime: "2026-07-29T09:00:03.000Z",
+        request: {
+          method: "GET",
+          url: "https://mcp.vendor.test/.well-known/oauth-protected-resource/mcp",
+          headers: [
+            header("User-Agent", "VendorApp/3.2.1"),
+            // The `rmcp` signature: a stale version pinned on OAuth discovery
+            // while the MCP wire negotiated something newer.
+            header("MCP-Protocol-Version", "2024-11-05"),
+          ],
+        },
+        response: {
+          status: 200,
+          headers: [header("Content-Type", "application/json")],
+          content: {
+            mimeType: "application/json",
+            text: JSON.stringify({
+              resource: MCP_SERVER_URL,
+              authorization_servers: [AS_URL],
+            }),
+          },
+        },
+      },
+      {
+        startedDateTime: "2026-07-29T09:00:04.000Z",
+        request: {
+          method: "POST",
+          url: `${AS_URL}/register`,
+          headers: [
+            header("User-Agent", "VendorApp/3.2.1"),
+            header("Content-Type", "application/json"),
+          ],
+          postData: {
+            mimeType: "application/json",
+            text: JSON.stringify({
+              client_name: "Vendor App",
+              redirect_uris: ["http://127.0.0.1:49871/callback"],
+              grant_types: ["authorization_code", "refresh_token"],
+              response_types: ["code"],
+              token_endpoint_auth_method: "none",
+            }),
+          },
+        },
+        response: {
+          status: 201,
+          headers: [header("Content-Type", "application/json")],
+          content: {
+            mimeType: "application/json",
+            text: JSON.stringify({ client_id: "vendor-client-42" }),
+          },
+        },
+      },
+      // A live token on the wire — must not survive ingest.
+      {
+        startedDateTime: "2026-07-29T09:00:05.000Z",
+        request: {
+          method: "POST",
+          url: `${AS_URL}/token`,
+          headers: [
+            header("User-Agent", "VendorApp/3.2.1"),
+            header("Content-Type", "application/x-www-form-urlencoded"),
+          ],
+          postData: {
+            mimeType: "application/x-www-form-urlencoded",
+            params: [
+              header("grant_type", "authorization_code"),
+              header("code", "live-authorization-code-abcdefghijklmnop"),
+              header("code_verifier", "live-verifier-value-abcdefghijklmnopqrst"),
+              header("resource", MCP_SERVER_URL),
+            ],
+          },
+        },
+        response: {
+          status: 200,
+          headers: [header("Content-Type", "application/json")],
+          content: {
+            mimeType: "application/json",
+            text: JSON.stringify({
+              access_token: "live-access-token-abcdefghijklmnopqrstuvwxyz",
+              refresh_token: "live-refresh-token-abcdefghijklmnopqrstuvwxyz",
+              token_type: "Bearer",
+              expires_in: 3600,
+            }),
+          },
+        },
+      },
+    ],
+  },
+};
+
+describe("captureHarTrace", () => {
+  it("keeps the handshake and drops unrelated traffic, reporting what it dropped", () => {
+    const { trace, report } = captureHarTrace({
+      har: HAR,
+      hostId: "vendor",
+      scenario: SCENARIO,
+      hostVersion: "3.2.1",
+      oauthImplementation: {
+        kind: "dependency",
+        package: "rmcp",
+        version: "2.2.0",
+        resolvedFrom: "Cargo.lock",
+      },
+    });
+
+    expect(report.totalEntries).toBe(6);
+    expect(report.keptEntries).toBe(4);
+    expect(report.dropped).toHaveLength(2);
+    expect(report.dropped.map((entry) => entry.url)).toEqual([
+      "https://telemetry.vendor.test/v1/events",
+      "https://fonts.googleapis.com/css2?family=Inter",
+    ]);
+
+    expect(trace.observations.legOrder).toEqual([
+      "mcp-unauthenticated",
+      "prm-discovery",
+      "dcr-register",
+      "token",
+    ]);
+  });
+
+  it("reports the legs the capture never reached rather than inferring them", () => {
+    const { trace, report } = captureHarTrace({
+      har: HAR,
+      hostId: "vendor",
+      scenario: SCENARIO,
+      hostVersion: "3.2.1",
+    });
+
+    // The proxy never saw /authorize (browser leg) or the AS metadata document.
+    expect(report.missingLegs).toEqual([
+      "as-metadata-discovery",
+      "authorize",
+      "mcp-initialize",
+    ]);
+
+    // And every field those legs would have carried is `not-observed`, NOT absent.
+    expect(trace.observations.resourceIndicator.onAuthorize.state).toBe(
+      "not-observed",
+    );
+    expect(trace.observations.pkce.challengeMethod.state).toBe("not-observed");
+
+    // The legs that WERE captured produce real findings.
+    expect(trace.observations.resourceIndicator.onToken).toEqual({
+      state: "present",
+      value: ["{mcp_server}/mcp"],
+    });
+    // And the value is classified against the scenario, not just recorded.
+    expect(trace.observations.resourceIndicator.valueSource).toEqual({
+      state: "present",
+      value: "mcp-server-url",
+    });
+
+    const rendered = formatHarIngestReportHuman(report);
+    expect(rendered).toContain("MISSING LEGS");
+    expect(rendered).toContain("authorize");
+  });
+
+  it("redacts live credentials at ingest, not at render time", () => {
+    const { trace } = captureHarTrace({
+      har: HAR,
+      hostId: "vendor",
+      scenario: SCENARIO,
+      hostVersion: "3.2.1",
+    });
+
+    const serialized = JSON.stringify(trace);
+    expect(serialized).not.toContain("live-access-token");
+    expect(serialized).not.toContain("live-refresh-token");
+    expect(serialized).not.toContain("live-authorization-code");
+    expect(serialized).not.toContain("live-verifier-value");
+  });
+
+  it("captures the split-wire protocol version the report flagged as invisible from docs", () => {
+    const { trace } = captureHarTrace({
+      har: HAR,
+      hostId: "vendor",
+      scenario: SCENARIO,
+      hostVersion: "3.2.1",
+    });
+    const pv = trace.observations.protocolVersion;
+
+    // 2024-11-05 on OAuth discovery, 2025-06-18 in the initialize body: exactly
+    // the `rmcp` finding, which no vendor doc states and which a single-field
+    // schema would have averaged away.
+    expect(pv.headerOnOAuthDiscovery).toEqual({
+      state: "present",
+      value: ["2024-11-05"],
+    });
+    expect(pv.initializeBody).toEqual({ state: "present", value: "2025-06-18" });
+    expect(pv.headerDisagreesWithInitializeBody).toBe(true);
+  });
+
+  it("records the DCR identity and recovers the loopback port", () => {
+    const { trace } = captureHarTrace({
+      har: HAR,
+      hostId: "vendor",
+      scenario: SCENARIO,
+      hostVersion: "3.2.1",
+    });
+
+    expect(trace.observations.dcrIdentity.clientName).toEqual({
+      state: "present",
+      value: "Vendor App",
+    });
+    expect(trace.observations.dcrIdentity.redirectUris).toEqual({
+      state: "present",
+      value: ["http://127.0.0.1:{port}/callback"],
+    });
+    expect(trace.observations.dcrIdentity.observedLoopbackPorts).toEqual({
+      state: "present",
+      value: [49871],
+    });
+    expect(trace.observations.userAgent.byLeg["dcr-register"]).toEqual({
+      state: "present",
+      value: ["VendorApp/3.2.1"],
+    });
+  });
+
+  it("marks the subject as unstamped when no version or dependency is supplied", () => {
+    const { trace } = captureHarTrace({
+      har: HAR,
+      hostId: "vendor",
+      scenario: SCENARIO,
+    });
+
+    // A trace that cannot name the build it recorded goes stale invisibly, so this
+    // is representable only as `not-observed` — and the differ reports it as a gap.
+    expect(trace.subject.hostVersion.state).toBe("not-observed");
+    expect(trace.subject.oauthImplementation.state).toBe("not-observed");
+    if (trace.subject.oauthImplementation.state === "not-observed") {
+      expect(trace.subject.oauthImplementation.reason).toContain("dependency");
+    }
+  });
+
+  it("derives the capture date from the HAR when none is supplied", () => {
+    const { trace } = captureHarTrace({
+      har: HAR,
+      hostId: "vendor",
+      scenario: SCENARIO,
+    });
+    expect(trace.capture.capturedAt).toBe("2026-07-29");
+    expect(trace.capture.method).toEqual({
+      via: "har",
+      harCreator: "mitmproxy",
+      harVersion: "1.2",
+    });
+  });
+
+  it("warns loudly when no capture date can be established", () => {
+    const { trace, report } = captureHarTrace({
+      har: { log: { version: "1.2", entries: [] } },
+      hostId: "vendor",
+      scenario: SCENARIO,
+    });
+    expect(trace.capture.capturedAt).toBe("unknown");
+    expect(report.warnings.join(" ")).toContain("unusable as dated evidence");
+  });
+});

--- a/sdk/tests/oauth-golden-trace/http-capture.test.ts
+++ b/sdk/tests/oauth-golden-trace/http-capture.test.ts
@@ -1,0 +1,141 @@
+/**
+ * HP-44 — cross-validate the two capture paths on one handshake.
+ *
+ * The harness has two independent ways to record a dance: `captureEmulatorTrace*`
+ * reads the client's own `httpHistory`, and `captureHarTrace` reads a HAR. If they
+ * disagree about the same bytes, one of them is wrong and every diff built on it
+ * is untrustworthy.
+ *
+ * So: run ONE handshake against the recording server, capture it from both sides,
+ * and diff. Whatever remains is a genuine, explainable difference in what the two
+ * vantage points can see — and the test pins exactly what that is, so a NEW
+ * disagreement fails the build.
+ */
+
+import {
+  captureEmulatorTraceFromFlow,
+  captureHarTrace,
+  diffGoldenTraces,
+  formatTraceDiffHuman,
+} from "../../src/oauth-golden-trace/index.js";
+import { startCaptureServer } from "../support/oauth-capture-server.js";
+import { runEmulatorAgainst } from "../support/oauth-emulator-driver.js";
+
+describe("HP-44 capture-path cross-validation", () => {
+  it("agrees between the client-side and server-side views of one handshake", async () => {
+    const server = await startCaptureServer();
+    try {
+      const run = await runEmulatorAgainst(server);
+      expect(run.completed, `flow ended at ${run.finalStep}: ${run.error ?? ""}`).toBe(
+        true,
+      );
+
+      const clientSide = captureEmulatorTraceFromFlow({
+        flow: run.flow,
+        hostId: "mcpjam",
+        scenario: server.scenario,
+        capturedAt: "2026-07-29",
+      });
+
+      const { trace: serverSide, report } = captureHarTrace({
+        har: server.har(),
+        hostId: "mcpjam",
+        scenario: server.scenario,
+        capturedAt: "2026-07-29",
+        hostVersion: "test",
+        oauthImplementation: { kind: "first-party" },
+      });
+
+      // Nothing was dropped, and the server saw a complete dance.
+      expect(report.dropped).toEqual([]);
+      expect(report.missingLegs).toEqual([]);
+
+      const diff = diffGoldenTraces(serverSide, clientSide, { mode: "drift" });
+      if (diff.counts.difference > 0) {
+        // eslint-disable-next-line no-console
+        console.log(formatTraceDiffHuman(diff));
+      }
+
+      // Both sides must see the same stages in the same order. This is the core
+      // agreement claim: if the HAR ingest mis-classified a leg, or the client-side
+      // dedupe collapsed one it shouldn't, this breaks.
+      expect(serverSide.observations.legOrder).toEqual(
+        clientSide.observations.legOrder,
+      );
+
+      // Both must agree on the facts the harness exists to capture.
+      expect(serverSide.observations.dcrIdentity.clientName).toEqual(
+        clientSide.observations.dcrIdentity.clientName,
+      );
+      expect(serverSide.observations.resourceIndicator.onToken).toEqual(
+        clientSide.observations.resourceIndicator.onToken,
+      );
+      expect(serverSide.observations.pkce.challengeMethod).toEqual(
+        clientSide.observations.pkce.challengeMethod,
+      );
+      expect(serverSide.observations.protocolVersion.initializeBody).toEqual(
+        clientSide.observations.protocolVersion.initializeBody,
+      );
+
+      expect(diff.counts.incomparable).toBe(0);
+      expect(diff.counts.match).toBeGreaterThan(20);
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+
+  it("sees the /authorize headers from the server side that the client side cannot", async () => {
+    // The one asymmetry that is real rather than a bug. The client hands the
+    // authorize URL to a browser, so a client-side capture can only RECONSTRUCT
+    // that leg and must mark its headers unobserved. A server-side capture
+    // intercepts the request and sees them. The harness has to represent that
+    // honestly from both vantage points instead of pretending one of them is wrong.
+    const server = await startCaptureServer();
+    try {
+      const run = await runEmulatorAgainst(server);
+      expect(run.completed).toBe(true);
+
+      const clientSide = captureEmulatorTraceFromFlow({
+        flow: run.flow,
+        hostId: "mcpjam",
+        scenario: server.scenario,
+        capturedAt: "2026-07-29",
+      });
+      const { trace: serverSide } = captureHarTrace({
+        har: server.har(),
+        hostId: "mcpjam",
+        scenario: server.scenario,
+        capturedAt: "2026-07-29",
+        hostVersion: "test",
+      });
+
+      // Client side: reconstructed, headers unobserved.
+      const clientAuthorize = clientSide.wire.find((e) => e.leg === "authorize");
+      expect(clientAuthorize?.request.headersObserved).toBe(false);
+      expect(clientSide.observations.userAgent.byLeg.authorize?.state).toBe(
+        "not-observed",
+      );
+
+      // Server side: intercepted, so headers ARE observed — and the params agree
+      // with the client's reconstruction, which is what makes the reconstruction
+      // trustworthy in the first place.
+      const serverAuthorize = serverSide.wire.find((e) => e.leg === "authorize");
+      expect(serverAuthorize?.request.headersObserved).not.toBe(false);
+      expect(serverAuthorize?.request.query?.resource).toEqual(
+        clientAuthorize?.request.query?.resource,
+      );
+      expect(serverAuthorize?.request.query?.code_challenge_method).toEqual(
+        clientAuthorize?.request.query?.code_challenge_method,
+      );
+
+      // And the differ reports the header asymmetry as a GAP, not a difference.
+      const diff = diffGoldenTraces(serverSide, clientSide, { mode: "drift" });
+      const authorizeHeaders = diff.findings.find(
+        (finding) => finding.path === "wire[leg=authorize].request.headers",
+      );
+      expect(authorizeHeaders?.severity).toBe("gap");
+    } finally {
+      await server.close();
+    }
+  }, 60_000);
+});

--- a/sdk/tests/oauth-golden-trace/http-capture.test.ts
+++ b/sdk/tests/oauth-golden-trace/http-capture.test.ts
@@ -21,6 +21,91 @@ import {
 import { startCaptureServer } from "../support/oauth-capture-server.js";
 import { runEmulatorAgainst } from "../support/oauth-emulator-driver.js";
 
+/**
+ * Every path the two vantage points are EXPECTED to disagree on.
+ *
+ * Pinned as an exact set rather than a `>=` budget, so BOTH directions fail: a
+ * new disagreement is a regression, and a disappearing one means either a fix
+ * that should shrink this list or a comparison that silently stopped running.
+ *
+ * The whole list is the same story told in three places. A client-side capture
+ * records the headers the client CODE set; a server-side capture records what
+ * ARRIVED, after undici appended its own. `diff.ts`'s `TRANSPORT_HEADERS` already
+ * suppresses `host`, `connection`, `content-length`, `accept-encoding` and the
+ * `sec-fetch-*` family for exactly this reason — these three escape it, and
+ * deliberately so:
+ *
+ *   - `user-agent` is a first-class HP-44 finding (a host's UA is one of the
+ *     things the golden traces exist to record), so it must not be silently
+ *     ignored on same-vantage diffs. Cross-vantage it always diverges, because
+ *     the state machine sets no UA and undici sends `node`. It shows up twice per
+ *     leg: once on the wire, once in the `userAgent.byLeg` rollup derived from it.
+ *   - `accept-language: *` is undici's default and is never set by the client.
+ *   - `accept` diverges only on the three legs where the client sets none
+ *     (`as-metadata-discovery`, `dcr-register`, `token`) and undici defaults to
+ *     the wildcard. On `prm-discovery`, `mcp-unauthenticated` and `mcp-initialize` the
+ *     client sets `accept` explicitly, and both sides agree — which is the
+ *     control proving this is a stack default and not a lost header.
+ *
+ * `subject.hostVersion` is an artifact of THIS TEST's inputs: `captureHarTrace`
+ * is handed a literal `"test"` below (a HAR carries no host version), while the
+ * client-side capture stamps the real SDK version. Not a capture-path defect.
+ *
+ * The `authorize` leg contributes nothing here: the client side never observed
+ * its headers at all, so every header on it is a `gap`, which the second test
+ * pins directly.
+ */
+const EXPECTED_VANTAGE_DIVERGENCE = [
+  "subject.hostVersion",
+  "observations.userAgent.byLeg.as-metadata-discovery",
+  "observations.userAgent.byLeg.dcr-register",
+  "observations.userAgent.byLeg.mcp-initialize",
+  "observations.userAgent.byLeg.mcp-unauthenticated",
+  "observations.userAgent.byLeg.prm-discovery",
+  "observations.userAgent.byLeg.token",
+  "wire[leg=as-metadata-discovery].request.headers.user-agent",
+  "wire[leg=dcr-register].request.headers.user-agent",
+  "wire[leg=mcp-initialize].request.headers.user-agent",
+  "wire[leg=mcp-unauthenticated].request.headers.user-agent",
+  "wire[leg=prm-discovery].request.headers.user-agent",
+  "wire[leg=token].request.headers.user-agent",
+  "wire[leg=as-metadata-discovery].request.headers.accept-language",
+  "wire[leg=dcr-register].request.headers.accept-language",
+  "wire[leg=mcp-initialize].request.headers.accept-language",
+  "wire[leg=mcp-unauthenticated].request.headers.accept-language",
+  "wire[leg=prm-discovery].request.headers.accept-language",
+  "wire[leg=token].request.headers.accept-language",
+  "wire[leg=as-metadata-discovery].request.headers.accept",
+  "wire[leg=dcr-register].request.headers.accept",
+  "wire[leg=token].request.headers.accept",
+];
+
+/**
+ * Divergence that is NOT a vantage artifact — a real defect, recorded here so the
+ * set above stays honest about what it is claiming.
+ *
+ * `debug-oauth-2025-11-25.ts` pushes an `authenticatedRequest` into `httpHistory`
+ * whose headers include `MCP-Protocol-Version` (~line 2112), then executes the
+ * request WITHOUT it (~line 2170). So the client-side trace reports a header the
+ * client never put on the wire, and the server-side trace — which is the one
+ * telling the truth — shows it absent. `debug-oauth-2025-06-18.ts` has the same
+ * split; `debug-oauth-2026-07-28.ts` sets it in both places and is the correct
+ * shape to copy.
+ *
+ * Kept separate from `EXPECTED_VANTAGE_DIVERGENCE` on purpose: this entry is a bug
+ * record, not an approval. When the state machine is fixed these two paths move to
+ * matches and this list becomes empty, which is the outcome the assertion wants.
+ *
+ * Note that the ROLLUP (`observations.protocolVersion.headerOnMcpTraffic`) still
+ * matches, because the unauthenticated probe does send the header and the rollup
+ * unions the legs. Only the per-leg field catches this — which is the argument for
+ * `headerByLeg` existing at all.
+ */
+const KNOWN_RECORDED_VS_SENT_DIVERGENCE = [
+  "wire[leg=mcp-initialize].request.headers.mcp-protocol-version",
+  "observations.protocolVersion.headerByLeg.mcp-initialize",
+];
+
 describe("HP-44 capture-path cross-validation", () => {
   it("agrees between the client-side and server-side views of one handshake", async () => {
     const server = await startCaptureServer();
@@ -55,6 +140,21 @@ describe("HP-44 capture-path cross-validation", () => {
         // eslint-disable-next-line no-console
         console.log(formatTraceDiffHuman(diff));
       }
+
+      // The divergence budget, pinned as a SET. Logging it (above) told CI nothing:
+      // twenty-four differences read exactly like zero to a green checkmark. See
+      // EXPECTED_VANTAGE_DIVERGENCE for why each one is legitimate, and
+      // KNOWN_RECORDED_VS_SENT_DIVERGENCE for the one that is not.
+      const differing = diff.findings
+        .filter((finding) => finding.severity === "difference")
+        .map((finding) => finding.path)
+        .sort();
+      expect(differing).toEqual(
+        [
+          ...EXPECTED_VANTAGE_DIVERGENCE,
+          ...KNOWN_RECORDED_VS_SENT_DIVERGENCE,
+        ].sort(),
+      );
 
       // Both sides must see the same stages in the same order. This is the core
       // agreement claim: if the HAR ingest mis-classified a leg, or the client-side
@@ -120,6 +220,11 @@ describe("HP-44 capture-path cross-validation", () => {
       // with the client's reconstruction, which is what makes the reconstruction
       // trustworthy in the first place.
       const serverAuthorize = serverSide.wire.find((e) => e.leg === "authorize");
+      // Asserted before the header check below, which would otherwise pass
+      // vacuously on `undefined` — a server-side capture that lost the authorize
+      // leg entirely would read as "headers observed" and this test would be
+      // green about the one asymmetry it exists to pin down.
+      expect(serverAuthorize).toBeDefined();
       expect(serverAuthorize?.request.headersObserved).not.toBe(false);
       expect(serverAuthorize?.request.query?.resource).toEqual(
         clientAuthorize?.request.query?.resource,

--- a/sdk/tests/oauth-golden-trace/normalize.test.ts
+++ b/sdk/tests/oauth-golden-trace/normalize.test.ts
@@ -146,6 +146,28 @@ describe("normalizeHeaders", () => {
     ).toBe("goose/{version}");
   });
 
+  it("redacts the authorization code out of a 302 Location header", () => {
+    // A conformant AS answers /authorize with
+    // `302 Location: <redirect_uri>?code=<code>&state=<state>`. Any proxy or
+    // server-side capture of a real host records that verbatim, so a URL-valued
+    // header has to get the same per-param treatment as a request URL or a live
+    // authorization code lands in a committed artifact.
+    const headers = normalizeHeaders(
+      {
+        Location:
+          "http://127.0.0.1:33418/callback?code=real-authorization-code-abcdefghijkl&state=Ux30hX8S90RxBF4a&iss=https://as.example.test",
+      },
+      OPTIONS,
+    );
+
+    expect(headers.location).toContain("code=[REDACTED]");
+    expect(headers.location).not.toContain("real-authorization-code");
+    expect(headers.location).toContain("state={state:len=16}");
+    // The loopback callback port is placeheld, and the issuer origin abstracted.
+    expect(headers.location).toContain("http://127.0.0.1:{port}/callback");
+    expect(headers.location).toContain("iss={as}");
+  });
+
   it("origin-substitutes inside www-authenticate", () => {
     const headers = normalizeHeaders(
       {

--- a/sdk/tests/oauth-golden-trace/normalize.test.ts
+++ b/sdk/tests/oauth-golden-trace/normalize.test.ts
@@ -1,0 +1,354 @@
+import {
+  NORMALIZER_VERSION,
+  assertTraceIsRedacted,
+  extractLoopbackPorts,
+  findRedactionViolations,
+  normalizeBody,
+  normalizeHeaders,
+  normalizeLoopbackPort,
+  normalizeUrl,
+} from "../../src/oauth-golden-trace/index.js";
+import type { GoldenTrace } from "../../src/oauth-golden-trace/index.js";
+import { parseTraceBody } from "../../src/oauth-golden-trace/index.js";
+
+const OPTIONS = {
+  mcpServerUrl: "https://mcp.example.test/mcp",
+  authorizationServerUrl: "https://as.example.test",
+};
+
+describe("normalizeUrl", () => {
+  it("substitutes origins so traces are host-independent", () => {
+    const { url } = normalizeUrl(
+      "https://as.example.test/.well-known/oauth-authorization-server",
+      OPTIONS,
+    );
+    expect(url).toBe("{as}/.well-known/oauth-authorization-server");
+  });
+
+  it("keeps repeated params as separate values", () => {
+    // Whether a client emits `resource` once or twice on /authorize is an open
+    // question a trace is meant to SETTLE; a single-valued map would answer it
+    // wrongly and silently.
+    const { query } = normalizeUrl(
+      "https://as.example.test/authorize?resource=https%3A%2F%2Fa.test%2Fmcp&resource=https%3A%2F%2Fb.test%2Fmcp",
+      OPTIONS,
+    );
+    expect(query?.resource).toEqual(["https://a.test/mcp", "https://b.test/mcp"]);
+  });
+
+  it("placeholds state with length only, and PKCE with length and charset", () => {
+    const { query } = normalizeUrl(
+      "https://as.example.test/authorize?state=Ux30hX8S90RxBF4a&code_challenge=" +
+        "a".repeat(43) +
+        "&code_challenge_method=S256",
+      OPTIONS,
+    );
+    // Charset for `state` is inferred from a random draw and is NOT stable across
+    // runs, so only the length is kept. See VOLATILE_KEYS.
+    expect(query?.state).toEqual(["{state:len=16}"]);
+    // For PKCE the alphabet is fixed by RFC 7636, so charset is deterministic and
+    // len=43 still proves S256 over a 32-byte verifier.
+    expect(query?.code_challenge).toEqual([
+      "{code_challenge:len=43,charset=base64url}",
+    ]);
+    expect(query?.code_challenge_method).toEqual(["S256"]);
+  });
+
+  it("keeps a client_id that is a URL, because under CIMD that IS the identity", () => {
+    const { query } = normalizeUrl(
+      "https://as.example.test/authorize?client_id=https%3A%2F%2Fvendor.test%2Fclient-metadata.json",
+      OPTIONS,
+    );
+    expect(query?.client_id).toEqual(["https://vendor.test/client-metadata.json"]);
+  });
+
+  it("placeholds an opaque server-issued client_id", () => {
+    const { query } = normalizeUrl(
+      "https://as.example.test/authorize?client_id=abc123def456",
+      OPTIONS,
+    );
+    expect(query?.client_id).toEqual(["{client_id}"]);
+  });
+
+  it("canonicalizes param order so two recordings of one request match", () => {
+    const first = normalizeUrl(
+      "https://as.example.test/authorize?b=2&a=1",
+      OPTIONS,
+    );
+    const second = normalizeUrl(
+      "https://as.example.test/authorize?a=1&b=2",
+      OPTIONS,
+    );
+    expect(second.url).toBe(first.url);
+    expect(JSON.stringify(second.query)).toBe(JSON.stringify(first.query));
+  });
+});
+
+describe("loopback ports", () => {
+  it("placeholds the port so ephemeral-port runs diff clean", () => {
+    expect(normalizeLoopbackPort("http://127.0.0.1:54321/callback")).toBe(
+      "http://127.0.0.1:{port}/callback",
+    );
+    expect(normalizeLoopbackPort("http://localhost:1456/mcp/oauth/callback")).toBe(
+      "http://localhost:{port}/mcp/oauth/callback",
+    );
+  });
+
+  it("leaves non-loopback hosts alone", () => {
+    expect(normalizeLoopbackPort("https://claude.ai:443/api/mcp/auth_callback")).toBe(
+      "https://claude.ai:443/api/mcp/auth_callback",
+    );
+  });
+
+  it("recovers the ports, because the port RANGE is a real per-host fact", () => {
+    // Cline scans 1456-1461; that range is evidence and must survive the
+    // placeholder.
+    expect(
+      extractLoopbackPorts([
+        "http://127.0.0.1:1456/mcp/oauth/callback",
+        "http://127.0.0.1:1457/mcp/oauth/callback",
+        "https://claude.ai/api/mcp/auth_callback",
+      ]),
+    ).toEqual([1456, 1457]);
+  });
+});
+
+describe("normalizeHeaders", () => {
+  it("redacts credential headers and placeholds volatile ones", () => {
+    const headers = normalizeHeaders(
+      {
+        Authorization: "Bearer sk-live-abcdefghijklmnop",
+        "Mcp-Session-Id": "sess-9f8e7d6c",
+        Date: "Wed, 29 Jul 2026 12:00:00 GMT",
+        "MCP-Protocol-Version": "2025-11-25",
+        "User-Agent": "Visual Studio Code/1.104.2",
+      },
+      OPTIONS,
+    );
+
+    expect(headers.authorization).toBe("[REDACTED]");
+    expect(headers["mcp-session-id"]).toBe("{mcp-session-id}");
+    expect(headers.date).toBe("{date}");
+    // The two fields the harness exists to capture survive verbatim.
+    expect(headers["mcp-protocol-version"]).toBe("2025-11-25");
+    expect(headers["user-agent"]).toBe("Visual Studio Code/1.104.2");
+  });
+
+  it("keeps the user-agent version by default, because a bump IS drift", () => {
+    expect(normalizeHeaders({ "user-agent": "goose/1.4.2" }, OPTIONS)["user-agent"]).toBe(
+      "goose/1.4.2",
+    );
+    expect(
+      normalizeHeaders(
+        { "user-agent": "goose/1.4.2" },
+        { ...OPTIONS, normalizeVersions: true },
+      )["user-agent"],
+    ).toBe("goose/{version}");
+  });
+
+  it("origin-substitutes inside www-authenticate", () => {
+    const headers = normalizeHeaders(
+      {
+        "WWW-Authenticate":
+          'Bearer resource_metadata="https://mcp.example.test/.well-known/oauth-protected-resource/mcp"',
+      },
+      OPTIONS,
+    );
+    expect(headers["www-authenticate"]).toBe(
+      'Bearer resource_metadata="{mcp_server}/.well-known/oauth-protected-resource/mcp"',
+    );
+  });
+});
+
+describe("normalizeBody", () => {
+  it("redacts secrets in a form body but keeps behavioral fields", () => {
+    const body = normalizeBody(
+      {
+        encoding: "form",
+        fields: {
+          grant_type: ["authorization_code"],
+          code: ["real-authorization-code-value"],
+          code_verifier: ["real-verifier-value-abcdefghijklmnop"],
+          resource: ["https://mcp.example.test/mcp"],
+        },
+      },
+      OPTIONS,
+    );
+
+    expect(body).toEqual({
+      encoding: "form",
+      fields: {
+        code: ["[REDACTED]"],
+        code_verifier: ["[REDACTED]"],
+        grant_type: ["authorization_code"],
+        resource: ["{mcp_server}/mcp"],
+      },
+    });
+  });
+
+  it("normalizes timestamps in a JSON body", () => {
+    const body = normalizeBody(
+      {
+        encoding: "json",
+        json: { client_id: "abc123", client_id_issued_at: 1800000000, iat: 17 },
+      },
+      OPTIONS,
+    );
+    expect(body).toEqual({
+      encoding: "json",
+      json: {
+        client_id: "{client_id}",
+        // Any numeric `*_at` / `iat` / `exp` key collapses to one `{timestamp}`
+        // placeholder — the specific epoch is never behavioral.
+        client_id_issued_at: "{timestamp}",
+        iat: "{timestamp}",
+      },
+    });
+  });
+
+  it("stabilizes the JSON-RPC id", () => {
+    const body = normalizeBody(
+      { encoding: "jsonrpc", method: "initialize", json: { jsonrpc: "2.0", id: 7 } },
+      OPTIONS,
+    );
+    expect(body).toEqual({
+      encoding: "jsonrpc",
+      method: "initialize",
+      json: { jsonrpc: "2.0", id: "{id}" },
+    });
+  });
+});
+
+describe("parseTraceBody", () => {
+  it("treats an object with a form content-type as a form body", () => {
+    // The SDK's own token requests arrive as objects with this content-type;
+    // encoding them as `json` would make them fail to match a HAR of the very
+    // same bytes.
+    expect(
+      parseTraceBody(
+        { grant_type: "authorization_code", resource: "https://a.test/mcp" },
+        { "content-type": "application/x-www-form-urlencoded" },
+      ),
+    ).toEqual({
+      encoding: "form",
+      fields: {
+        grant_type: ["authorization_code"],
+        resource: ["https://a.test/mcp"],
+      },
+    });
+  });
+
+  it("lets the payload shape win when the content-type disagrees", () => {
+    expect(
+      parseTraceBody('{"client_name":"Cline"}', {
+        "content-type": "text/plain",
+      }),
+    ).toEqual({ encoding: "json", json: { client_name: "Cline" } });
+  });
+
+  it("records an unparseable body as opaque rather than guessing", () => {
+    const body = parseTraceBody("<html><body>Consent</body></html>", {
+      "content-type": "text/html",
+    });
+    expect(body?.encoding).toBe("opaque");
+  });
+});
+
+describe("redaction assertion", () => {
+  function traceWith(headers: Record<string, string>): GoldenTrace {
+    return {
+      traceVersion: 1,
+      traceId: "test/scenario/2026-07-29/real-host",
+      subject: {
+        kind: "real-host",
+        hostId: "test",
+        hostVersion: { state: "present", value: "1.0.0" },
+        oauthImplementation: { state: "present", value: { kind: "first-party" } },
+      },
+      scenario: {
+        scenarioId: "scenario",
+        mcpServerUrl: OPTIONS.mcpServerUrl,
+        capabilities: {
+          publishesPrm: true,
+          supportsDcr: true,
+          supportsCimd: false,
+          codeChallengeMethods: ["S256"],
+          asMetadataDocuments: [],
+          challengesUnauthenticated: true,
+        },
+      },
+      capture: {
+        capturedAt: "2026-07-29",
+        method: { via: "har" },
+        redaction: { applied: true, normalizerVersion: NORMALIZER_VERSION },
+      },
+      wire: [
+        {
+          ordinal: 0,
+          leg: "mcp-authenticated",
+          request: { method: "POST", url: "{mcp_server}/mcp", headers },
+        },
+      ],
+      observations: {
+        legOrder: ["mcp-authenticated"],
+        endpointsHit: ["{mcp_server}/mcp"],
+        discoveryLadder: [],
+        userAgent: { byLeg: {}, consistent: true },
+        resourceIndicator: {
+          onAuthorize: { state: "not-observed", reason: "n/a" },
+          onToken: { state: "not-observed", reason: "n/a" },
+          onRefresh: { state: "not-observed", reason: "n/a" },
+          valueSource: { state: "not-observed", reason: "n/a" },
+        },
+        protocolVersion: {
+          initializeBody: { state: "not-observed", reason: "n/a" },
+          headerByLeg: {},
+          headerOnOAuthDiscovery: { state: "not-observed", reason: "n/a" },
+          headerOnMcpTraffic: { state: "not-observed", reason: "n/a" },
+          wiresDisagree: false,
+          headerDisagreesWithInitializeBody: false,
+        },
+        dcrIdentity: {
+          clientName: { state: "not-observed", reason: "n/a" },
+          redirectUris: { state: "not-observed", reason: "n/a" },
+          observedLoopbackPorts: { state: "not-observed", reason: "n/a" },
+          grantTypes: { state: "not-observed", reason: "n/a" },
+          responseTypes: { state: "not-observed", reason: "n/a" },
+          tokenEndpointAuthMethod: { state: "not-observed", reason: "n/a" },
+          scope: { state: "not-observed", reason: "n/a" },
+          extraFields: { state: "not-observed", reason: "n/a" },
+        },
+        pkce: {
+          challengeMethod: { state: "not-observed", reason: "n/a" },
+          challengeLength: { state: "not-observed", reason: "n/a" },
+          verifierSentOnToken: { state: "not-observed", reason: "n/a" },
+        },
+      },
+    };
+  }
+
+  it("does NOT flag an RFC 6750 challenge as a credential", () => {
+    // `WWW-Authenticate: Bearer resource_metadata="…"` is auth-param syntax, not
+    // a token. Without the `key=` lookahead every PRM-publishing server's 401
+    // would trip the assertion — which it did, on the first real capture.
+    const trace = traceWith({
+      "www-authenticate": 'Bearer resource_metadata="{mcp_server}/.well-known/x"',
+    });
+    expect(findRedactionViolations(trace)).toEqual([]);
+    expect(() => assertTraceIsRedacted(trace)).not.toThrow();
+  });
+
+  it("flags a leaked bearer token", () => {
+    const trace = traceWith({ authorization: "Bearer sk-live-9f8e7d6c5b4a3210" });
+    const violations = findRedactionViolations(trace);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(() => assertTraceIsRedacted(trace)).toThrow(/possible live secret/);
+  });
+
+  it("flags a leaked JWT", () => {
+    const trace = traceWith({
+      "x-custom": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc",
+    });
+    expect(() => assertTraceIsRedacted(trace)).toThrow(/JWT/);
+  });
+});

--- a/sdk/tests/oauth-golden-trace/normalize.test.ts
+++ b/sdk/tests/oauth-golden-trace/normalize.test.ts
@@ -1,5 +1,6 @@
 import {
   NORMALIZER_VERSION,
+  REDACTED,
   assertTraceIsRedacted,
   extractLoopbackPorts,
   findRedactionViolations,
@@ -62,6 +63,18 @@ describe("normalizeUrl", () => {
     expect(query?.client_id).toEqual(["https://vendor.test/client-metadata.json"]);
   });
 
+  it("keeps a CIMD client_id even when its origin is a configured placeholder", () => {
+    // Origin substitution rewrites the value to `{cimd}/…`, which no longer looks
+    // like a URL. Deciding the CIMD exemption on the substituted value therefore
+    // erased the identity document entirely, leaving the trace unable to diff the
+    // client_id URL or notice it changed. The exemption is decided on the raw value.
+    const { query } = normalizeUrl(
+      "https://as.example.test/authorize?client_id=https%3A%2F%2Fvendor.test%2Fclient-metadata.json",
+      { ...OPTIONS, extraOrigins: { cimd: "https://vendor.test" } },
+    );
+    expect(query?.client_id).toEqual(["{cimd}/client-metadata.json"]);
+  });
+
   it("placeholds an opaque server-issued client_id", () => {
     const { query } = normalizeUrl(
       "https://as.example.test/authorize?client_id=abc123def456",
@@ -81,6 +94,44 @@ describe("normalizeUrl", () => {
     );
     expect(second.url).toBe(first.url);
     expect(JSON.stringify(second.query)).toBe(JSON.stringify(first.query));
+  });
+
+  it("redacts a camelCase or prefixed secret param", () => {
+    // A query string never reaches the deep redactor — it sees one flat string —
+    // so this scalar policy IS the redaction boundary here. Matching only exact
+    // snake_case names let `accessToken` through into a committed artifact.
+    const { query, url } = normalizeUrl(
+      "https://as.example.test/token?accessToken=live-value-abcdefghijklmnop" +
+        "&mcpRefreshToken=live-refresh-abcdefghijkl" +
+        "&clientSecret=live-secret-abcdefghijkl",
+      OPTIONS,
+    );
+    expect(query?.accessToken).toEqual([REDACTED]);
+    expect(query?.mcpRefreshToken).toEqual([REDACTED]);
+    expect(query?.clientSecret).toEqual([REDACTED]);
+    expect(url).not.toContain("live-");
+  });
+
+  it("records a param literally named __proto__ instead of throwing", () => {
+    // `query["__proto__"] ??= []` on a plain object reads Object.prototype, skips
+    // the assignment, and the following `.push` throws — one odd param would abort
+    // an entire capture. Null-prototype accumulators keep the entry a real entry.
+    const { query } = normalizeUrl(
+      "https://as.example.test/authorize?__proto__=polluted&a=1",
+      OPTIONS,
+    );
+    expect(query?.["__proto__"]).toEqual(["polluted"]);
+    expect(Object.keys(query ?? {})).toEqual(["__proto__", "a"]);
+  });
+
+  it("does not read an inherited Object.prototype name as volatility policy", () => {
+    // `VOLATILE_KEYS["constructor"]` is truthy on a plain object literal, which
+    // rewrote a param named `constructor` to `{constructor}` as if configured.
+    const { query } = normalizeUrl(
+      "https://as.example.test/authorize?constructor=1",
+      OPTIONS,
+    );
+    expect(query?.constructor).toEqual(["1"]);
   });
 });
 
@@ -132,6 +183,19 @@ describe("normalizeHeaders", () => {
     // The two fields the harness exists to capture survive verbatim.
     expect(headers["mcp-protocol-version"]).toBe("2025-11-25");
     expect(headers["user-agent"]).toBe("Visual Studio Code/1.104.2");
+  });
+
+  it("records a header literally named __proto__", () => {
+    // HAR ingest preserves this header now, so normalization has to as well —
+    // otherwise the trace claims a header that WAS on the wire never appeared.
+    // Computed key on the input for the same reason the accumulator is
+    // null-prototype: in an object literal this name sets the prototype instead.
+    const headers = normalizeHeaders(
+      { ["__proto__"]: "sentinel", accept: "application/json" },
+      OPTIONS,
+    );
+    expect(headers["__proto__"]).toBe("sentinel");
+    expect(Object.keys(headers)).toEqual(["__proto__", "accept"]);
   });
 
   it("keeps the user-agent version by default, because a bump IS drift", () => {
@@ -208,6 +272,29 @@ describe("normalizeBody", () => {
     });
   });
 
+  it("redacts camelCase secret fields and keeps a __proto__ field", () => {
+    const body = normalizeBody(
+      {
+        encoding: "form",
+        fields: {
+          // Computed key: a `__proto__` property in an object LITERAL would set the
+          // prototype instead of creating the own property a parsed form yields.
+          ["__proto__"]: ["polluted"],
+          clientSecret: ["live-secret-abcdefghijkl"],
+          grant_type: ["authorization_code"],
+        },
+      },
+      OPTIONS,
+    );
+
+    const fields = body?.encoding === "form" ? body.fields : undefined;
+    // Assigned onto a plain object literal this field reparents the accumulator
+    // and disappears from the trace; a null-prototype accumulator records it.
+    expect(fields?.["__proto__"]).toEqual(["polluted"]);
+    expect(fields?.clientSecret).toEqual([REDACTED]);
+    expect(fields?.grant_type).toEqual(["authorization_code"]);
+  });
+
   it("normalizes timestamps in a JSON body", () => {
     const body = normalizeBody(
       {
@@ -237,6 +324,46 @@ describe("normalizeBody", () => {
       encoding: "jsonrpc",
       method: "initialize",
       json: { jsonrpc: "2.0", id: "{id}" },
+    });
+  });
+
+  it("carries a `__proto__` form field all the way from parse to normalize", () => {
+    // Both stages hold form fields in an accumulator, and a plain object literal
+    // at EITHER stage swallows this field. Asserting the pair together is what
+    // keeps the two null-prototype accumulators from drifting apart.
+    const parsed = parseTraceBody("__proto__=evil&grant_type=authorization_code", {
+      "content-type": "application/x-www-form-urlencoded",
+    });
+    expect(parsed?.encoding).toBe("form");
+    const normalized = normalizeBody(parsed, OPTIONS);
+    const fields = normalized?.encoding === "form" ? normalized.fields : undefined;
+    expect(fields?.["__proto__"]).toEqual(["evil"]);
+    expect(fields?.grant_type).toEqual(["authorization_code"]);
+    expect(Object.keys(fields ?? {})).toEqual(["__proto__", "grant_type"]);
+  });
+
+  it("stabilizes the id of every entry in a JSON-RPC batch", () => {
+    // A batch reaches this arm too, and leaving its per-entry ids alone would
+    // make two recordings of the identical request diff unequal.
+    const body = normalizeBody(
+      {
+        encoding: "jsonrpc",
+        json: [
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+          { jsonrpc: "2.0", id: 2, method: "resources/list" },
+          { jsonrpc: "2.0", method: "notifications/initialized" },
+        ],
+      },
+      OPTIONS,
+    );
+    expect(body).toEqual({
+      encoding: "jsonrpc",
+      json: [
+        { jsonrpc: "2.0", id: "{id}", method: "tools/list" },
+        { jsonrpc: "2.0", id: "{id}", method: "resources/list" },
+        // No `id` on the wire, so none is invented: a notification is not a request.
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+      ],
     });
   });
 });
@@ -315,7 +442,10 @@ describe("redaction assertion", () => {
         legOrder: ["mcp-authenticated"],
         endpointsHit: ["{mcp_server}/mcp"],
         discoveryLadder: [],
-        userAgent: { byLeg: {}, consistent: true },
+        userAgent: {
+          byLeg: {},
+          consistent: { state: "not-observed", reason: "n/a" },
+        },
         resourceIndicator: {
           onAuthorize: { state: "not-observed", reason: "n/a" },
           onToken: { state: "not-observed", reason: "n/a" },
@@ -327,8 +457,11 @@ describe("redaction assertion", () => {
           headerByLeg: {},
           headerOnOAuthDiscovery: { state: "not-observed", reason: "n/a" },
           headerOnMcpTraffic: { state: "not-observed", reason: "n/a" },
-          wiresDisagree: false,
-          headerDisagreesWithInitializeBody: false,
+          wiresDisagree: { state: "not-observed", reason: "n/a" },
+          headerDisagreesWithInitializeBody: {
+            state: "not-observed",
+            reason: "n/a",
+          },
         },
         dcrIdentity: {
           clientName: { state: "not-observed", reason: "n/a" },
@@ -339,6 +472,7 @@ describe("redaction assertion", () => {
           tokenEndpointAuthMethod: { state: "not-observed", reason: "n/a" },
           scope: { state: "not-observed", reason: "n/a" },
           extraFields: { state: "not-observed", reason: "n/a" },
+          malformedFields: { state: "not-observed", reason: "n/a" },
         },
         pkce: {
           challengeMethod: { state: "not-observed", reason: "n/a" },
@@ -365,6 +499,32 @@ describe("redaction assertion", () => {
     const violations = findRedactionViolations(trace);
     expect(violations.length).toBeGreaterThan(0);
     expect(() => assertTraceIsRedacted(trace)).toThrow(/possible live secret/);
+  });
+
+  it("reports a violation without republishing the secret it found", () => {
+    // The whole point of this assertion is the case where a real credential
+    // survived — and its message then travels into CI logs, which are less
+    // protected than the artifact the assertion just refused to write.
+    const secret = "sk-live-9f8e7d6c5b4a3210";
+    const trace = traceWith({ authorization: `Bearer ${secret}` });
+
+    const violations = findRedactionViolations(trace);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(JSON.stringify(violations)).not.toContain("9f8e7d6c");
+    expect(violations[0]!.matchLength).toBe(`Bearer ${secret}`.length);
+    expect(violations[0]!.fingerprint).toMatch(/^[0-9a-f]{12}$/);
+
+    let message = "";
+    try {
+      assertTraceIsRedacted(trace);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    // Path, pattern name and count survive; the material does not.
+    expect(message).toContain("wire[0].request.headers.authorization");
+    expect(message).toContain("Bearer token");
+    expect(message).toContain("1 possible live secret(s)");
+    expect(message).not.toContain("9f8e7d6c");
   });
 
   it("flags a leaked JWT", () => {

--- a/sdk/tests/oauth-golden-trace/parse.test.ts
+++ b/sdk/tests/oauth-golden-trace/parse.test.ts
@@ -1,0 +1,180 @@
+import {
+  collectRedirectUris,
+  parseTraceBody,
+} from "../../src/oauth-golden-trace/index.js";
+
+describe("parseTraceBody — form bodies", () => {
+  it("reads a URLSearchParams token body instead of seeing an empty form", () => {
+    // `URLSearchParams` exposes no enumerable own properties, so an object walk
+    // reports `{}` and the token leg loses exactly the fields HP-44 exists to
+    // compare: grant, resource, PKCE.
+    const raw = new URLSearchParams({
+      grant_type: "authorization_code",
+      code_verifier: "v".repeat(43),
+      resource: "https://a.test/mcp",
+    });
+    expect(
+      parseTraceBody(raw, {
+        "content-type": "application/x-www-form-urlencoded",
+      }),
+    ).toEqual({
+      encoding: "form",
+      fields: {
+        grant_type: ["authorization_code"],
+        code_verifier: ["v".repeat(43)],
+        resource: ["https://a.test/mcp"],
+      },
+    });
+  });
+
+  it("treats URLSearchParams as a form body even with no content-type", () => {
+    // The type is itself proof of form encoding; a missing header cannot make it
+    // anything else.
+    expect(parseTraceBody(new URLSearchParams("grant_type=refresh_token"))).toEqual({
+      encoding: "form",
+      fields: { grant_type: ["refresh_token"] },
+    });
+  });
+
+  it("keeps repeated keys in a URLSearchParams body", () => {
+    const raw = new URLSearchParams();
+    raw.append("resource", "https://a.test/mcp");
+    raw.append("resource", "https://b.test/mcp");
+    expect(parseTraceBody(raw)).toEqual({
+      encoding: "form",
+      fields: { resource: ["https://a.test/mcp", "https://b.test/mcp"] },
+    });
+  });
+});
+
+describe("parseTraceBody — opaque byteLength", () => {
+  it("counts wire bytes, not UTF-16 code units", () => {
+    // "é" is one code unit but two UTF-8 bytes; the HAR path fills this field
+    // from `content.size`, so the two capture paths must agree.
+    const body = parseTraceBody("<p>café</p>", { "content-type": "text/html" });
+    expect(body).toEqual({
+      encoding: "opaque",
+      contentType: "text/html",
+      byteLength: 12,
+    });
+  });
+
+  it("uses the same byte count for a truncated JSON body", () => {
+    // Same rule on the JSON.parse failure path, which has its own return.
+    const body = parseTraceBody('{"client_name":"café"', {
+      "content-type": "application/json",
+    });
+    expect(body).toEqual({
+      encoding: "opaque",
+      contentType: "application/json",
+      byteLength: 22,
+    });
+  });
+
+  it("counts astral-plane characters as their UTF-8 byte length", () => {
+    const body = parseTraceBody("\u{1F510} consent", { "content-type": "text/html" });
+    // 4 bytes for the surrogate pair + 8 for " consent".
+    expect(body).toEqual({
+      encoding: "opaque",
+      contentType: "text/html",
+      byteLength: 12,
+    });
+  });
+});
+
+describe("parseTraceBody — JSON-RPC batches", () => {
+  it("classifies a batch of envelopes as jsonrpc with no hoisted method", () => {
+    // A batch (legal through 2025-03-26) has no single `method`, so leaving it
+    // absent is honest; `observe` falls back to other leg signals.
+    const body = parseTraceBody(
+      '[{"jsonrpc":"2.0","id":1,"method":"tools/list"},' +
+        '{"jsonrpc":"2.0","id":2,"method":"resources/list"}]',
+    );
+    expect(body).toEqual({
+      encoding: "jsonrpc",
+      json: [
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { jsonrpc: "2.0", id: 2, method: "resources/list" },
+      ],
+    });
+    expect(body && "method" in body).toBe(false);
+  });
+
+  it("keeps an empty array as plain json, since it is not a legal batch", () => {
+    expect(parseTraceBody("[]")).toEqual({ encoding: "json", json: [] });
+  });
+
+  it("keeps a mixed array as plain json rather than claiming the protocol", () => {
+    expect(
+      parseTraceBody('[{"jsonrpc":"2.0","method":"tools/list"},{"hello":"world"}]'),
+    ).toEqual({
+      encoding: "json",
+      json: [{ jsonrpc: "2.0", method: "tools/list" }, { hello: "world" }],
+    });
+  });
+
+  it("still hoists the method of a single envelope", () => {
+    expect(parseTraceBody('{"jsonrpc":"2.0","id":1,"method":"initialize"}')).toEqual({
+      encoding: "jsonrpc",
+      method: "initialize",
+      json: { jsonrpc: "2.0", id: 1, method: "initialize" },
+    });
+  });
+});
+
+describe("collectRedirectUris", () => {
+  it("reads the plural redirect_uris from a form-encoded DCR body", () => {
+    // A DCR payload sent form-encoded otherwise contributes no ports, and the
+    // `{port}` placeholder then destroys the evidence.
+    expect(
+      collectRedirectUris({
+        url: "{as}/register",
+        body: {
+          encoding: "form",
+          fields: {
+            redirect_uris: [
+              "http://127.0.0.1:54321/callback",
+              "http://localhost:54321/callback",
+            ],
+          },
+        },
+      }),
+    ).toEqual([
+      "http://127.0.0.1:54321/callback",
+      "http://localhost:54321/callback",
+    ]);
+  });
+
+  it("collects both the singular and plural form fields", () => {
+    expect(
+      collectRedirectUris({
+        url: "{as}/register",
+        body: {
+          encoding: "form",
+          fields: {
+            redirect_uri: ["http://127.0.0.1:1111/callback"],
+            redirect_uris: ["http://127.0.0.1:2222/callback"],
+          },
+        },
+      }),
+    ).toEqual([
+      "http://127.0.0.1:1111/callback",
+      "http://127.0.0.1:2222/callback",
+    ]);
+  });
+
+  it("still reads redirect_uris from a JSON body and redirect_uri from the query", () => {
+    expect(
+      collectRedirectUris({
+        url: "https://as.example.test/authorize?redirect_uri=http%3A%2F%2F127.0.0.1%3A3333%2Fcallback",
+        body: {
+          encoding: "json",
+          json: { redirect_uris: ["http://127.0.0.1:4444/callback"] },
+        },
+      }),
+    ).toEqual([
+      "http://127.0.0.1:4444/callback",
+      "http://127.0.0.1:3333/callback",
+    ]);
+  });
+});

--- a/sdk/tests/oauth-golden-trace/parse.test.ts
+++ b/sdk/tests/oauth-golden-trace/parse.test.ts
@@ -45,6 +45,36 @@ describe("parseTraceBody — form bodies", () => {
       fields: { resource: ["https://a.test/mcp", "https://b.test/mcp"] },
     });
   });
+
+  it("keeps a `__proto__` field on an already-parsed form body instead of losing it", () => {
+    // Against a plain `{}` accumulator, `fields["__proto__"] = [...]` reparents the
+    // object instead of creating an own property, and the field vanishes — the
+    // oracle then reports absence for something the client demonstrably sent.
+    const raw: Record<string, unknown> = JSON.parse(
+      '{"__proto__": "polluted", "grant_type": "authorization_code"}',
+    );
+    const body = parseTraceBody(raw, {
+      "content-type": "application/x-www-form-urlencoded",
+    });
+    // NOT `{ __proto__: [...] }` — that literal syntax sets the PROTOTYPE rather
+    // than creating an own property, which is the exact footgun this test exists
+    // to catch, now aimed at the assertion instead of the code under test. The
+    // computed-key form (`["__proto__"]:`) is the one that behaves like a normal
+    // string key.
+    const expectedFields: Record<string, string[]> = {
+      ["__proto__"]: ["polluted"],
+      grant_type: ["authorization_code"],
+    };
+    expect(body).toEqual({ encoding: "form", fields: expectedFields });
+    if (body?.encoding === "form") {
+      expect(Object.prototype.hasOwnProperty.call(body.fields, "__proto__")).toBe(
+        true,
+      );
+      expect((body.fields as Record<string, string[]>)["__proto__"]).toEqual([
+        "polluted",
+      ]);
+    }
+  });
 });
 
 describe("parseTraceBody — opaque byteLength", () => {
@@ -111,6 +141,25 @@ describe("parseTraceBody — JSON-RPC batches", () => {
       encoding: "json",
       json: [{ jsonrpc: "2.0", method: "tools/list" }, { hello: "world" }],
     });
+  });
+
+  it("treats a sparse array as plain json, not a batch of all-envelope slots", () => {
+    // `Array.prototype.every` SKIPS holes rather than invoking the predicate on
+    // them, so `[envelope, <hole>, envelope].every(isJsonRpcEnvelope)` used to
+    // return `true` — a slot that is not an envelope at all passing vacuously,
+    // and the oracle claiming a batch shape the bytes do not actually have.
+    // A JSON round-trip cannot reproduce this: `JSON.stringify` renders a hole
+    // as `null`, which is a real value, not a hole — so the array is built with
+    // bracket assignment and passed to `parseTraceBody` directly, the same way
+    // an already-parsed body (not wire text) reaches it.
+    const sparse: unknown[] = [];
+    sparse[0] = { jsonrpc: "2.0", id: 1, method: "tools/list" };
+    sparse[2] = { jsonrpc: "2.0", id: 2, method: "resources/list" };
+    expect(1 in sparse).toBe(false); // confirms the middle slot really is a hole
+
+    const body = parseTraceBody(sparse);
+    expect(body?.encoding).toBe("json");
+    expect(body && "method" in body).toBe(false);
   });
 
   it("still hoists the method of a single envelope", () => {

--- a/sdk/tests/oauth-golden-trace/real-host.test.ts
+++ b/sdk/tests/oauth-golden-trace/real-host.test.ts
@@ -1,0 +1,219 @@
+/**
+ * HP-44 — the first golden trace of a REAL third-party host.
+ *
+ * `claude-code` is one of the 16 catalog hosts. This trace was captured by
+ * pointing a headless Claude Code (`claude -p --mcp-config`) at the recording
+ * server in `tests/support/oauth-capture-server.ts` and letting it authenticate
+ * against a server we control end to end. Nothing was proxied, nothing was
+ * inferred, and nothing was typed by hand — the artifact is the bytes Claude Code
+ * chose to send.
+ *
+ * It matters because it settles cells the HP-47 desk survey could not, and
+ * because it CORRECTS two values that survey had read from a vendor-published
+ * CIMD document. That is the harness doing the one job it exists for: making
+ * client behavior falsifiable instead of asserted.
+ *
+ * | Field | HP-47 desk research | This trace |
+ * | --- | --- | --- |
+ * | User-Agent | `unverifiable` | `claude-code/2.1.220 (sdk-cli)` |
+ * | `MCP-Protocol-Version` header | `unverifiable` | `2025-11-25` on OAuth discovery, **absent** on MCP traffic |
+ * | DCR `client_name` | `Claude Code` (from CIMD) | `Claude Code (<serverName>)` — **templated** |
+ * | DCR `redirect_uris` | `localhost/callback` + `127.0.0.1/callback`, **port-less** (from CIMD) | `http://localhost:3118/callback` — **explicit port** |
+ *
+ * The last two are not contradictions of the CIMD document; they are evidence
+ * that what a client REGISTERS via DCR differs from what its published CIMD
+ * declares. A server gating on an exact `client_name` would accept one and
+ * reject the other. Only a capture surfaces that.
+ *
+ * The capture is PARTIAL: a non-interactive session cannot open a browser, so
+ * `/authorize` and `/token` were never sent. Those legs are `not-observed` with
+ * reasons — never `absent` — which is the whole point of the tri-state and is
+ * asserted below.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  diffGoldenTraces,
+  findObservationDrift,
+  findRedactionViolations,
+  traceToOAuthProfile,
+} from "../../src/oauth-golden-trace/index.js";
+import type { GoldenTrace } from "../../src/oauth-golden-trace/index.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, "..", "fixtures", "golden-traces");
+const CLAUDE_CODE_TRACE = join(
+  FIXTURES,
+  "claude-code-http-capture-dcr-authcode-prm.json",
+);
+const MCPJAM_TRACE = join(FIXTURES, "mcpjam-in-memory-dcr-authcode-prm.json");
+
+function load(path: string): GoldenTrace {
+  return JSON.parse(readFileSync(path, "utf8")) as GoldenTrace;
+}
+
+describe("HP-44 real-host trace: claude-code", () => {
+  it("is a valid, redacted, self-consistent artifact", () => {
+    const trace = load(CLAUDE_CODE_TRACE);
+    expect(trace.traceVersion).toBe(1);
+    expect(trace.subject.kind).toBe("real-host");
+    expect(trace.subject.hostId).toBe("claude-code");
+    expect(trace.capture.method.via).toBe("har");
+    expect(findRedactionViolations(trace)).toEqual([]);
+    // Observations must still follow from the wire they claim to summarize.
+    expect(findObservationDrift(trace)).toEqual([]);
+  });
+
+  it("settles the User-Agent that desk research could not", () => {
+    const trace = load(CLAUDE_CODE_TRACE);
+    // One UA across every captured leg — which also answers, for this host, the
+    // question left open for Goose: whether the client's UA reaches the
+    // authorization server. Here it demonstrably does.
+    expect(trace.observations.userAgent.consistent).toBe(true);
+    expect(trace.observations.userAgent.byLeg["dcr-register"]).toEqual({
+      state: "present",
+      value: ["claude-code/2.1.220 (sdk-cli)"],
+    });
+    expect(trace.observations.userAgent.byLeg["prm-discovery"]).toEqual({
+      state: "present",
+      value: ["claude-code/2.1.220 (sdk-cli)"],
+    });
+  });
+
+  it("shows claude-code is a split-wire client", () => {
+    const pv = load(CLAUDE_CODE_TRACE).observations.protocolVersion;
+
+    // Present on OAuth discovery...
+    expect(pv.headerOnOAuthDiscovery).toEqual({
+      state: "present",
+      value: ["2025-11-25"],
+    });
+    // ...and demonstrably ABSENT on MCP traffic. `absent` rather than
+    // `not-observed`: the MCP request WAS captured and simply carried no such
+    // header. That distinction is what makes this a citable finding instead of a
+    // gap, and it is the reason the tri-state exists.
+    expect(pv.headerOnMcpTraffic).toEqual({ state: "absent" });
+
+    // Which makes the two wires disagree — the flag that would have been averaged
+    // away by a single `protocolVersionPinning` field.
+    expect(pv.wiresDisagree).toBe(true);
+
+    // The `initialize` body still names 2025-11-25, so the header and the body do
+    // NOT disagree; only the two wires do. Tracking these separately is what lets
+    // both statements be true at once.
+    expect(pv.initializeBody).toEqual({ state: "present", value: "2025-11-25" });
+    expect(pv.headerDisagreesWithInitializeBody).toBe(false);
+  });
+
+  it("records the DCR identity actually sent, not the one CIMD advertises", () => {
+    const dcr = load(CLAUDE_CODE_TRACE).observations.dcrIdentity;
+
+    // Templated with the configured server name — NOT the bare "Claude Code" the
+    // published CIMD document declares. A server gating on an exact client_name
+    // would treat these as two different clients.
+    expect(dcr.clientName).toEqual({
+      state: "present",
+      value: "Claude Code (hp44capture)",
+    });
+
+    // `localhost` with an explicit port, not the port-less form CIMD registers.
+    expect(dcr.redirectUris).toEqual({
+      state: "present",
+      value: ["http://localhost:{port}/callback"],
+    });
+    // The port is placeheld for diffing but retained as evidence, because the
+    // port RANGE is a per-host fact.
+    expect(dcr.observedLoopbackPorts).toEqual({ state: "present", value: [3118] });
+
+    // A public client, confirming the desk finding.
+    expect(dcr.tokenEndpointAuthMethod).toEqual({ state: "present", value: "none" });
+    expect(dcr.grantTypes).toEqual({
+      state: "present",
+      value: ["authorization_code", "refresh_token"],
+    });
+  });
+
+  it("reports the legs it never reached as not-observed, never as absent", () => {
+    const trace = load(CLAUDE_CODE_TRACE);
+    const ri = trace.observations.resourceIndicator;
+
+    // This is the load-bearing assertion of the whole file. A headless session
+    // cannot open a browser, so /authorize and /token were never sent. Recording
+    // `resource` as `absent` here would assert "Claude Code does not send RFC 8707
+    // resource indicators" — a claim this capture cannot support, and precisely the
+    // class of false claim that made this harness necessary.
+    expect(ri.onAuthorize.state).toBe("not-observed");
+    expect(ri.onToken.state).toBe("not-observed");
+    if (ri.onAuthorize.state === "not-observed") {
+      expect(ri.onAuthorize.reason).toContain("no /authorize request was captured");
+    }
+
+    expect(trace.observations.legOrder).toEqual([
+      "mcp-unauthenticated",
+      "prm-discovery",
+      "as-metadata-discovery",
+      "dcr-register",
+    ]);
+  });
+
+  it("projects onto a profile that claims exactly what the capture supports", () => {
+    const profile = traceToOAuthProfile(load(CLAUDE_CODE_TRACE), {
+      tracePath:
+        "sdk/tests/fixtures/golden-traces/claude-code-http-capture-dcr-authcode-prm.json",
+    });
+
+    // DCR identity: verified, because those bytes were on the wire.
+    expect(profile.dcrIdentity?.status).toBe("verified");
+    if (profile.dcrIdentity?.status === "verified") {
+      expect(profile.dcrIdentity.value.clientName).toBe("Claude Code (hp44capture)");
+      expect(profile.dcrIdentity.value.userAgent).toBe("claude-code/2.1.220 (sdk-cli)");
+    }
+
+    // Resource indicator: unverifiable, because the legs carrying it were never
+    // sent. The partial capture does not get upgraded into a claim.
+    expect(profile.sendsResourceIndicator?.status).toBe("unverifiable");
+
+    // Spec revision: a behavioral FLOOR from the observed PRM fetch, never an
+    // exact revision.
+    expect(profile.oauthSpecVersion?.status).toBe("verified");
+    if (profile.oauthSpecVersion?.status === "verified") {
+      expect(profile.oauthSpecVersion.value).toEqual({
+        basis: "behavioral",
+        minimumRevision: "2025-06-18",
+      });
+    }
+
+    // Pinning: verified from the OAuth-discovery header, which cannot have been
+    // negotiated because no `initialize` had happened yet.
+    expect(profile.protocolVersionPinning?.status).toBe("verified");
+    if (profile.protocolVersionPinning?.status === "verified") {
+      expect(profile.protocolVersionPinning.value).toEqual({
+        mode: "pinned",
+        version: "2025-11-25",
+      });
+    }
+
+    // And the staleness gap is preserved rather than papered over: we never
+    // resolved which dependency produced this behavior.
+    const provenance = (profile.extensions as Record<string, unknown>)
+      .traceProvenance as Record<string, unknown>;
+    expect((provenance.oauthImplementation as { state: string }).state).toBe(
+      "not-observed",
+    );
+  });
+
+  it("refuses to diff a real claude-code trace against an mcpjam trace", () => {
+    // The gate, exercised on two REAL artifacts rather than a synthetic pair. No
+    // host is supposed to behave like another one, so a cross-host diff is
+    // meaningless and must produce one blocking finding — not a wall of
+    // differences that looks like an emulator bug.
+    const diff = diffGoldenTraces(load(CLAUDE_CODE_TRACE), load(MCPJAM_TRACE));
+
+    expect(diff.parity).toBe(false);
+    expect(diff.counts.incomparable).toBeGreaterThan(0);
+    expect(diff.findings.some((f) => f.path === "subject.hostId")).toBe(true);
+  });
+});

--- a/sdk/tests/oauth-golden-trace/real-host.test.ts
+++ b/sdk/tests/oauth-golden-trace/real-host.test.ts
@@ -72,7 +72,13 @@ describe("HP-44 real-host trace: claude-code", () => {
     // One UA across every captured leg — which also answers, for this host, the
     // question left open for Goose: whether the client's UA reaches the
     // authorization server. Here it demonstrably does.
-    expect(trace.observations.userAgent.consistent).toBe(true);
+    // `present`, not a bare `true`: every leg in this capture was intercepted
+    // server-side, so a consistency verdict over it is actually sayable. A trace
+    // with a reconstructed leg would read `not-observed` here instead.
+    expect(trace.observations.userAgent.consistent).toEqual({
+      state: "present",
+      value: true,
+    });
     expect(trace.observations.userAgent.byLeg["dcr-register"]).toEqual({
       state: "present",
       value: ["claude-code/2.1.220 (sdk-cli)"],
@@ -98,14 +104,18 @@ describe("HP-44 real-host trace: claude-code", () => {
     expect(pv.headerOnMcpTraffic).toEqual({ state: "absent" });
 
     // Which makes the two wires disagree — the flag that would have been averaged
-    // away by a single `protocolVersionPinning` field.
-    expect(pv.wiresDisagree).toBe(true);
+    // away by a single `protocolVersionPinning` field. `present`, because BOTH
+    // wires were captured: a one-wire capture could not make this claim at all.
+    expect(pv.wiresDisagree).toEqual({ state: "present", value: true });
 
     // The `initialize` body still names 2025-11-25, so the header and the body do
     // NOT disagree; only the two wires do. Tracking these separately is what lets
     // both statements be true at once.
     expect(pv.initializeBody).toEqual({ state: "present", value: "2025-11-25" });
-    expect(pv.headerDisagreesWithInitializeBody).toBe(false);
+    expect(pv.headerDisagreesWithInitializeBody).toEqual({
+      state: "present",
+      value: false,
+    });
   });
 
   it("records the DCR identity actually sent, not the one CIMD advertises", () => {

--- a/sdk/tests/oauth-golden-trace/scenario.ts
+++ b/sdk/tests/oauth-golden-trace/scenario.ts
@@ -1,0 +1,202 @@
+/**
+ * HP-44 — the in-memory capture scenario.
+ *
+ * A complete MCP resource server + authorization server implemented as a `fetch`
+ * stub, so the REAL emulator code path (`OAuthConformanceTest` →
+ * `sdk/src/oauth/state-machines/`) can be driven end to end in CI with no
+ * credentials, no network, and no browser.
+ *
+ * This is what makes the self-diff possible today: `mcpjam` is first-party and
+ * fully source-verified, so proving the oracle against ourselves costs nothing
+ * and settles whether the harness works BEFORE any effort goes into proxy
+ * capture for hosts we may never be able to run.
+ *
+ * Scenario capabilities are parameterized because they GATE the diff — and
+ * because several of them change what a conformant client is supposed to do.
+ * `publishesPrm: false` in particular is not a broken server: it is the
+ * condition under which VS Code and Cline correctly omit `resource` entirely.
+ */
+
+import type { OAuthConformanceConfig } from "../../src/oauth-conformance/types.js";
+import type { TraceScenario } from "../../src/oauth-golden-trace/index.js";
+
+export const MCP_SERVER_URL = "https://mcp.example.test/mcp";
+export const AUTH_SERVER_URL = "https://as.example.test";
+export const PRM_URL =
+  "https://mcp.example.test/.well-known/oauth-protected-resource/mcp";
+export const AS_METADATA_URL =
+  "https://as.example.test/.well-known/oauth-authorization-server";
+
+export type ScenarioOverrides = {
+  /** Publish an RFC 9728 PRM document. Default true. */
+  publishesPrm?: boolean;
+  /**
+   * The `resource` value the PRM document publishes. Defaults to the MCP server
+   * URL — note that when these are identical, "sends the server URL" and "sends
+   * the PRM resource" are byte-identical on the wire, which the differ reports
+   * as a gap rather than pretending to distinguish them.
+   */
+  prmResource?: string;
+  /** Advertise a `registration_endpoint`. Default true. */
+  supportsDcr?: boolean;
+  /** Advertise `client_id_metadata_document_supported`. Default false. */
+  supportsCimd?: boolean;
+  /** Protocol version the MCP server returns from `initialize`. */
+  serverProtocolVersion?: string;
+};
+
+export type ScenarioFixture = {
+  scenario: TraceScenario;
+  fetchFn: typeof fetch;
+  config: OAuthConformanceConfig;
+  /** Stubbed authorization-code completion — no browser involved. */
+  deps: { completeHeadlessAuthorization: () => Promise<{ code: string }> };
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Build a scenario fixture.
+ *
+ * The returned `scenario` block describes exactly the capabilities the stub
+ * implements, so a trace captured against it carries an accurate gate. Keeping
+ * these in one place is deliberate: a `scenario` that lies about its server is
+ * worse than no gate at all, because the differ would then compare
+ * genuinely-incomparable captures and report the difference as an emulator bug.
+ */
+export function createScenarioFixture(
+  overrides: ScenarioOverrides = {},
+): ScenarioFixture {
+  const publishesPrm = overrides.publishesPrm ?? true;
+  const supportsDcr = overrides.supportsDcr ?? true;
+  const supportsCimd = overrides.supportsCimd ?? false;
+  const serverProtocolVersion = overrides.serverProtocolVersion ?? "2025-11-25";
+  const prmResource = overrides.prmResource ?? MCP_SERVER_URL;
+
+  const scenario: TraceScenario = {
+    scenarioId: `in-memory-dcr-authcode-prm${publishesPrm ? "" : "-noprm"}`,
+    description:
+      "In-memory MCP resource server + authorization server: 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE S256 → token → MCP initialize.",
+    mcpServerUrl: MCP_SERVER_URL,
+    authorizationServerUrl: AUTH_SERVER_URL,
+    capabilities: {
+      publishesPrm,
+      ...(publishesPrm ? { prmResource } : {}),
+      supportsDcr,
+      supportsCimd,
+      codeChallengeMethods: ["S256"],
+      asMetadataDocuments: ["/.well-known/oauth-authorization-server"],
+      challengesUnauthenticated: true,
+    },
+  };
+
+  const fetchFn: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const headers: Record<string, string> = {};
+    new Headers(init?.headers).forEach((value, key) => {
+      headers[key] = value;
+    });
+
+    const authorization = headers.authorization ?? headers.Authorization;
+    const parsed = new URL(url);
+    const path = parsed.pathname;
+
+    // ── MCP resource server ──
+    if (parsed.origin === new URL(MCP_SERVER_URL).origin) {
+      if (publishesPrm && path === new URL(PRM_URL).pathname) {
+        return jsonResponse({
+          resource: prmResource,
+          authorization_servers: [AUTH_SERVER_URL],
+          scopes_supported: ["mcp:read", "mcp:write"],
+          bearer_methods_supported: ["header"],
+        });
+      }
+
+      if (path === new URL(MCP_SERVER_URL).pathname) {
+        if (!authorization) {
+          return new Response(null, {
+            status: 401,
+            headers: publishesPrm
+              ? { "WWW-Authenticate": `Bearer resource_metadata="${PRM_URL}"` }
+              : { "WWW-Authenticate": "Bearer" },
+          });
+        }
+        return jsonResponse({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            protocolVersion: serverProtocolVersion,
+            serverInfo: { name: "hp44-in-memory-server", version: "1.0.0" },
+            capabilities: {},
+          },
+        });
+      }
+
+      return jsonResponse({ error: "not_found" }, 404);
+    }
+
+    // ── Authorization server ──
+    if (path === new URL(AS_METADATA_URL).pathname) {
+      return jsonResponse({
+        issuer: AUTH_SERVER_URL,
+        authorization_endpoint: `${AUTH_SERVER_URL}/authorize`,
+        token_endpoint: `${AUTH_SERVER_URL}/token`,
+        ...(supportsDcr ? { registration_endpoint: `${AUTH_SERVER_URL}/register` } : {}),
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        code_challenge_methods_supported: ["S256"],
+        scopes_supported: ["mcp:read", "mcp:write"],
+        ...(supportsCimd ? { client_id_metadata_document_supported: true } : {}),
+      });
+    }
+
+    if (path === "/register") {
+      return jsonResponse(
+        {
+          client_id: "hp44-issued-client-id",
+          client_id_issued_at: 1_800_000_000,
+          redirect_uris: ["http://127.0.0.1:33418/callback"],
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+          token_endpoint_auth_method: "none",
+        },
+        201,
+      );
+    }
+
+    if (path === "/token") {
+      return jsonResponse({
+        access_token: "hp44-access-token-value-not-a-real-credential",
+        refresh_token: "hp44-refresh-token-value-not-a-real-credential",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "mcp:read mcp:write",
+      });
+    }
+
+    return jsonResponse({ error: "not_found" }, 404);
+  }) as typeof fetch;
+
+  return {
+    scenario,
+    fetchFn,
+    config: {
+      serverUrl: MCP_SERVER_URL,
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      auth: { mode: "headless" },
+      redirectUrl: "http://127.0.0.1:33418/callback",
+      fetchFn,
+    },
+    deps: {
+      completeHeadlessAuthorization: async () => ({
+        code: "hp44-authorization-code-not-a-real-credential",
+      }),
+    },
+  };
+}

--- a/sdk/tests/oauth-golden-trace/scenario.ts
+++ b/sdk/tests/oauth-golden-trace/scenario.ts
@@ -79,7 +79,11 @@ export function createScenarioFixture(
   const prmResource = overrides.prmResource ?? MCP_SERVER_URL;
 
   const scenario: TraceScenario = {
-    scenarioId: `in-memory-dcr-authcode-prm${publishesPrm ? "" : "-noprm"}`,
+    // The advertised protocol version is part of the scenario IDENTITY: two runs
+    // that differ only in the version the server announced are the pin-vs-negotiate
+    // experiment, and `traceToOAuthProfile` rejects a contrast trace that shares a
+    // scenario id. Encoding it here is what lets that experiment be expressed.
+    scenarioId: `in-memory-dcr-authcode-prm${publishesPrm ? "" : "-noprm"}-mcp${serverProtocolVersion}`,
     description:
       "In-memory MCP resource server + authorization server: 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE S256 → token → MCP initialize.",
     mcpServerUrl: MCP_SERVER_URL,
@@ -90,19 +94,31 @@ export function createScenarioFixture(
       supportsDcr,
       supportsCimd,
       codeChallengeMethods: ["S256"],
+      serverProtocolVersion,
       asMetadataDocuments: ["/.well-known/oauth-authorization-server"],
       challengesUnauthenticated: true,
     },
   };
 
   const fetchFn: typeof fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = String(input);
+    // The `fetch` contract allows a `Request` as the first argument, and
+    // `String(input)` would flatten one to `"[object Request]"` — a confusing URL
+    // parse error instead of a readable test failure. Read the URL and the init
+    // off the Request itself when that is what the caller passed.
+    const url = input instanceof Request ? input.url : String(input);
+    const resolvedInit: RequestInit | undefined =
+      init ??
+      (input instanceof Request
+        ? { method: input.method, headers: input.headers, body: input.body }
+        : undefined);
     const headers: Record<string, string> = {};
-    new Headers(init?.headers).forEach((value, key) => {
+    // `Headers` lowercases every name, so `authorization` is the only spelling
+    // that can ever be present.
+    new Headers(resolvedInit?.headers).forEach((value, key) => {
       headers[key] = value;
     });
 
-    const authorization = headers.authorization ?? headers.Authorization;
+    const authorization = headers.authorization;
     const parsed = new URL(url);
     const path = parsed.pathname;
 

--- a/sdk/tests/oauth-golden-trace/self-parity.test.ts
+++ b/sdk/tests/oauth-golden-trace/self-parity.test.ts
@@ -1,0 +1,534 @@
+/**
+ * HP-44 — the self-diff that proves the oracle.
+ *
+ * `mcpjam` is first-party, fully source-verified, and runnable end to end today,
+ * so it is the one host whose golden trace we can produce without a proxy or a
+ * credential. Diffing a fresh emulator run against a COMMITTED golden trace of
+ * ourselves establishes three things no amount of design review could:
+ *
+ *   1. the capture path works against real state-machine code, not a mock;
+ *   2. the normalizer actually removes every run-to-run volatile value — if it
+ *      missed one, two runs of identical code would report a difference;
+ *   3. the differ reports parity when parity holds.
+ *
+ * And the negative tests below establish the fourth, which is the one that
+ * matters most: the differ reports a DIFFERENCE when behavior actually diverges.
+ * A differ that always returns green would pass every test above.
+ *
+ * Regenerate the fixture with:
+ *   HP44_WRITE_FIXTURE=1 npx vitest run tests/oauth-golden-trace/self-parity.test.ts
+ * Regeneration is a deliberate, explicit act: a fixture that silently rewrites
+ * itself on every run is not evidence of anything.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { OAuthConformanceTest } from "../../src/oauth-conformance/index.js";
+import {
+  captureEmulatorTrace,
+  deriveObservations,
+  diffGoldenTraces,
+  findObservationDrift,
+  findRedactionViolations,
+  formatTraceDiffHuman,
+  observedValue,
+  withObservedLoopbackPorts,
+} from "../../src/oauth-golden-trace/index.js";
+import type {
+  GoldenTrace,
+  TraceExchange,
+} from "../../src/oauth-golden-trace/index.js";
+import { createScenarioFixture } from "./scenario.js";
+import type { ScenarioOverrides } from "./scenario.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(
+  HERE,
+  "..",
+  "fixtures",
+  "golden-traces",
+  "mcpjam-in-memory-dcr-authcode-prm.json",
+);
+
+/** Fixed so the artifact is reproducible rather than stamped with "today". */
+const CAPTURED_AT = "2026-07-29";
+
+async function captureSelfTrace(
+  overrides: ScenarioOverrides = {},
+): Promise<GoldenTrace> {
+  const fixture = createScenarioFixture(overrides);
+  const test = new OAuthConformanceTest(fixture.config, fixture.deps as never);
+  const result = await test.run();
+
+  expect(result.passed).toBe(true);
+
+  return captureEmulatorTrace({
+    result,
+    hostId: "mcpjam",
+    scenario: fixture.scenario,
+    capturedAt: CAPTURED_AT,
+    stateMachine: "debug-oauth-2025-11-25",
+    notes: [
+      "Captured in-process against the in-memory scenario in tests/oauth-golden-trace/scenario.ts. No network, no credentials.",
+    ],
+  });
+}
+
+/**
+ * The committed golden trace, with its volatile stamp neutralized.
+ *
+ * `subject.hostVersion` and `capture.method.sdkVersion` are the SDK version,
+ * which changes on every release. Pinning them into the fixture would make this
+ * test fail on every version bump for no behavioral reason — so they are
+ * normalized for the comparison and asserted separately.
+ */
+function neutralizeVersionStamp(trace: GoldenTrace): GoldenTrace {
+  return {
+    ...trace,
+    subject: {
+      ...trace.subject,
+      hostVersion: { state: "present", value: "{sdk_version}" },
+    },
+    capture: {
+      ...trace.capture,
+      method:
+        trace.capture.method.via === "mcpjam-emulator"
+          ? { ...trace.capture.method, sdkVersion: "{sdk_version}" }
+          : trace.capture.method,
+    },
+  };
+}
+
+describe("HP-44 golden-trace self-parity", () => {
+  it("captures mcpjam against itself and matches the committed golden trace", async () => {
+    const captured = await captureSelfTrace();
+
+    if (process.env.HP44_WRITE_FIXTURE === "1") {
+      mkdirSync(dirname(FIXTURE_PATH), { recursive: true });
+      writeFileSync(
+        FIXTURE_PATH,
+        `${JSON.stringify(neutralizeVersionStamp(captured), null, 2)}\n`,
+        "utf8",
+      );
+    }
+
+    expect(existsSync(FIXTURE_PATH)).toBe(true);
+    const golden = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as GoldenTrace;
+
+    const diff = diffGoldenTraces(
+      golden,
+      neutralizeVersionStamp(captured),
+      { mode: "drift" },
+    );
+
+    if (!diff.parity) {
+      // eslint-disable-next-line no-console
+      console.error(formatTraceDiffHuman(diff));
+    }
+
+    expect(diff.counts.difference).toBe(0);
+    expect(diff.counts.incomparable).toBe(0);
+    expect(diff.parity).toBe(true);
+  });
+
+  it("produces byte-identical traces across two runs, proving normalization is complete", async () => {
+    // The strongest statement the normalizer can make about itself. Any leaked
+    // nonce, state, PKCE value, timestamp or ephemeral port would break this.
+    const first = neutralizeVersionStamp(await captureSelfTrace());
+    const second = neutralizeVersionStamp(await captureSelfTrace());
+
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+  });
+
+  it("records no live secrets", async () => {
+    const captured = await captureSelfTrace();
+    expect(findRedactionViolations(captured)).toEqual([]);
+
+    // The token, code and verifier were all real values on the wire; assert they
+    // are gone rather than trusting the shape-based scan alone.
+    const serialized = JSON.stringify(captured);
+    expect(serialized).not.toContain("hp44-access-token-value");
+    expect(serialized).not.toContain("hp44-refresh-token-value");
+    expect(serialized).not.toContain("hp44-authorization-code");
+  });
+
+  it("keeps the committed fixture's observations derivable from its own wire", () => {
+    const golden = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as GoldenTrace;
+    // Guards against a hand-edited trace: observations must still follow from the
+    // wire they claim to summarize.
+    expect(findObservationDrift(golden)).toEqual([]);
+  });
+
+  it("captures the facts HP-44 exists to settle", async () => {
+    const trace = await captureSelfTrace();
+    const { protocolVersion, resourceIndicator, dcrIdentity, pkce } =
+      trace.observations;
+
+    // The two-headed protocol-version field, recorded as two fields.
+    expect(protocolVersion.initializeBody).toEqual({
+      state: "present",
+      value: "2025-11-25",
+    });
+    expect(protocolVersion.headerOnOAuthDiscovery).toEqual({
+      state: "present",
+      value: ["2025-11-25"],
+    });
+    expect(protocolVersion.headerOnMcpTraffic).toEqual({
+      state: "present",
+      value: ["2025-11-25"],
+    });
+    // MCPJam agrees across both wires — unlike Goose, which is the whole reason
+    // these are separate fields.
+    expect(protocolVersion.wiresDisagree).toBe(false);
+
+    // RFC 8707 on both legs, which is the claim four hosts got wrong.
+    expect(resourceIndicator.onAuthorize.state).toBe("present");
+    expect(resourceIndicator.onToken.state).toBe("present");
+
+    expect(dcrIdentity.clientName).toEqual({
+      state: "present",
+      value: "MCPJam SDK OAuth Conformance",
+    });
+    // The loopback port is placeheld in the wire but retained as a finding.
+    expect(dcrIdentity.redirectUris).toEqual({
+      state: "present",
+      value: ["http://127.0.0.1:{port}/callback"],
+    });
+    expect(dcrIdentity.observedLoopbackPorts).toEqual({
+      state: "present",
+      value: [33418],
+    });
+
+    // Shape survived the placeholder: 43 chars is S256 over a 32-byte verifier.
+    expect(pkce.challengeMethod).toEqual({ state: "present", value: "S256" });
+    expect(pkce.challengeLength).toEqual({ state: "present", value: 43 });
+  });
+
+  it("reports the /authorize headers as unobserved, not absent", async () => {
+    const trace = await captureSelfTrace();
+
+    // The client hands the authorize URL to a browser, so its headers were never
+    // on a wire we recorded. Claiming `absent` here would be a fabricated finding
+    // — and would then "differ" from any proxy capture that did see them.
+    expect(trace.observations.protocolVersion.headerByLeg.authorize?.state).toBe(
+      "not-observed",
+    );
+    expect(trace.observations.userAgent.byLeg.authorize?.state).toBe(
+      "not-observed",
+    );
+
+    // The params, by contrast, ARE fully known — they are in the URL.
+    const authorize = trace.wire.find((exchange) => exchange.leg === "authorize");
+    expect(authorize?.request.query?.resource).toEqual([
+      "https://mcp.example.test/mcp".replace(
+        "https://mcp.example.test",
+        "{mcp_server}",
+      ),
+    ]);
+    expect(authorize?.request.query?.code_challenge_method).toEqual(["S256"]);
+  });
+});
+
+/**
+ * Rewrite a trace's wire and re-derive its observations, producing a trace of a
+ * HYPOTHETICAL client that behaves differently.
+ *
+ * Perturbing the artifact rather than the server stub is the right level: the
+ * stub only sees what the emulator sends, so mutating it there cannot change what
+ * the emulator RECORDS, and the diff would come out green no matter what the stub
+ * did. Perturbing the trace is also a truer simulation of the real case — a
+ * golden trace from another host arrives as an artifact, not as a live client.
+ *
+ * Observations are re-derived rather than hand-edited so the perturbed trace stays
+ * internally consistent, which `findObservationDrift` would otherwise flag.
+ */
+function perturb(
+  trace: GoldenTrace,
+  mutate: (wire: TraceExchange[]) => TraceExchange[],
+): GoldenTrace {
+  const wire = mutate(
+    JSON.parse(JSON.stringify(trace.wire)) as TraceExchange[],
+  ).map((exchange, index) => ({ ...exchange, ordinal: index }));
+
+  return {
+    ...trace,
+    subject: { ...trace.subject, kind: "real-host" },
+    wire,
+    observations: withObservedLoopbackPorts(
+      deriveObservations({ wire, scenario: trace.scenario }),
+      observedValue(trace.observations.dcrIdentity.observedLoopbackPorts) ?? [],
+    ),
+  };
+}
+
+describe("HP-44 oracle is not vacuous", () => {
+  /**
+   * Each case describes a client that diverges in one specific way, then asserts
+   * the differ catches it in the right dimension. Without these, every test above
+   * would still pass against a differ hardcoded to return parity.
+   */
+  it("catches a dropped RFC 8707 `resource` param", async () => {
+    const candidate = await captureSelfTrace();
+    // A "real host" that omits `resource` on both legs — the exact claim that was
+    // asserted about Claude and ChatGPT and turned out to be false for both.
+    const golden = perturb(candidate, (wire) =>
+      wire.map((exchange) => {
+        if (exchange.request.query?.resource) delete exchange.request.query.resource;
+        if (exchange.request.body?.encoding === "form") {
+          delete exchange.request.body.fields.resource;
+        }
+        return exchange;
+      }),
+    );
+
+    const diff = diffGoldenTraces(golden, candidate);
+    expect(diff.parity).toBe(false);
+
+    expect(
+      diff.findings.filter(
+        (finding) =>
+          finding.dimension === "resource-indicator" &&
+          finding.severity === "difference",
+      ).length,
+    ).toBeGreaterThan(0);
+
+    const onToken = diff.findings.find(
+      (finding) => finding.path === "observations.resourceIndicator.onToken",
+    );
+    expect(onToken?.severity).toBe("difference");
+    // The message names which side sends it, so a reviewer knows the direction.
+    expect(onToken?.message).toContain("the real host sends nothing");
+  });
+
+  it("catches a different `MCP-Protocol-Version` on the OAuth wire only", async () => {
+    const candidate = await captureSelfTrace();
+    // Exactly the `rmcp` shape: 2024-11-05 hardcoded on OAuth discovery while the
+    // MCP wire negotiates something newer. If the harness collapsed the two wires
+    // into one field, this test could not exist.
+    const golden = perturb(candidate, (wire) =>
+      wire.map((exchange) => {
+        if (
+          exchange.leg === "prm-discovery" ||
+          exchange.leg === "as-metadata-discovery"
+        ) {
+          if (exchange.request.headers["mcp-protocol-version"]) {
+            exchange.request.headers["mcp-protocol-version"] = "2024-11-05";
+          }
+        }
+        return exchange;
+      }),
+    );
+
+    const diff = diffGoldenTraces(golden, candidate);
+    expect(diff.parity).toBe(false);
+
+    const discovery = diff.findings.find(
+      (finding) =>
+        finding.path === "observations.protocolVersion.headerOnOAuthDiscovery",
+    );
+    expect(discovery?.severity).toBe("difference");
+
+    // The MCP wire must still MATCH. The point is that the two wires are tracked
+    // apart — not that a change anywhere trips everything.
+    const mcpWire = diff.findings.find(
+      (finding) =>
+        finding.path === "observations.protocolVersion.headerOnMcpTraffic",
+    );
+    expect(mcpWire?.severity).toBe("match");
+
+    // And the split-revision flag flips, which is the legible one-line summary.
+    expect(golden.observations.protocolVersion.wiresDisagree).toBe(true);
+    expect(candidate.observations.protocolVersion.wiresDisagree).toBe(false);
+    expect(
+      diff.findings.find(
+        (finding) =>
+          finding.path === "observations.protocolVersion.wiresDisagree",
+      )?.severity,
+    ).toBe("difference");
+  });
+
+  it("catches a client that sends the header on OAuth discovery but not on MCP traffic", async () => {
+    // The VS Code shape. `absent` vs `present` must be a DIFFERENCE, not a gap —
+    // "sends nothing here" is a positive, citable finding.
+    const candidate = await captureSelfTrace();
+    const golden = perturb(candidate, (wire) =>
+      wire.map((exchange) => {
+        if (
+          exchange.leg === "mcp-initialize" ||
+          exchange.leg === "mcp-authenticated" ||
+          exchange.leg === "mcp-unauthenticated"
+        ) {
+          delete exchange.request.headers["mcp-protocol-version"];
+        }
+        return exchange;
+      }),
+    );
+
+    expect(golden.observations.protocolVersion.headerOnMcpTraffic.state).toBe(
+      "absent",
+    );
+
+    const diff = diffGoldenTraces(golden, candidate);
+    const mcpWire = diff.findings.find(
+      (finding) =>
+        finding.path === "observations.protocolVersion.headerOnMcpTraffic",
+    );
+    expect(mcpWire?.severity).toBe("difference");
+    expect(mcpWire?.golden).toBe("<absent on the wire>");
+  });
+
+  it("catches a changed DCR client_name", async () => {
+    const candidate = await captureSelfTrace();
+    const golden = perturb(candidate, (wire) =>
+      wire.map((exchange) => {
+        if (
+          exchange.leg === "dcr-register" &&
+          exchange.request.body?.encoding === "json"
+        ) {
+          const json = exchange.request.body.json as Record<string, unknown>;
+          json.client_name = "Some Other Client";
+        }
+        return exchange;
+      }),
+    );
+
+    const diff = diffGoldenTraces(golden, candidate);
+    expect(diff.parity).toBe(false);
+    const clientName = diff.findings.find(
+      (finding) => finding.path === "observations.dcrIdentity.clientName",
+    );
+    expect(clientName?.severity).toBe("difference");
+    expect(clientName?.dimension).toBe("dcr-body");
+  });
+
+  it("catches reordered legs — a client that tries OAuth before probing unauthenticated", async () => {
+    // Goose connects unauthenticated FIRST and falls back to OAuth on a 401, the
+    // opposite ordering from Claude and ChatGPT. Ordering is a finding, so it is
+    // compared rather than merely displayed.
+    const candidate = await captureSelfTrace();
+    const golden = perturb(candidate, (wire) => [
+      ...wire.filter((exchange) => exchange.leg !== "mcp-unauthenticated"),
+      ...wire.filter((exchange) => exchange.leg === "mcp-unauthenticated"),
+    ]);
+
+    const diff = diffGoldenTraces(golden, candidate);
+    expect(diff.parity).toBe(false);
+    const ordering = diff.findings.find(
+      (finding) => finding.path === "observations.legOrder",
+    );
+    expect(ordering?.severity).toBe("difference");
+    expect(ordering?.dimension).toBe("request-ordering");
+  });
+
+  it("does NOT flag differing ephemeral loopback ports as a difference", async () => {
+    // Two runs of the same client legitimately differ here. A `difference` would
+    // make every diff fail for a reason nobody can act on.
+    const candidate = await captureSelfTrace();
+    const golden: GoldenTrace = {
+      ...candidate,
+      subject: { ...candidate.subject, kind: "real-host" },
+      observations: {
+        ...candidate.observations,
+        dcrIdentity: {
+          ...candidate.observations.dcrIdentity,
+          observedLoopbackPorts: { state: "present", value: [51999] },
+        },
+      },
+    };
+
+    const diff = diffGoldenTraces(golden, candidate);
+    const ports = diff.findings.find(
+      (finding) =>
+        finding.path === "observations.dcrIdentity.observedLoopbackPorts",
+    );
+    expect(ports?.severity).toBe("match");
+    expect(ports?.message).toContain("context, not a parity difference");
+    expect(diff.parity).toBe(true);
+  });
+
+  it("refuses to compare traces captured against different scenarios", async () => {
+    const candidate = await captureSelfTrace();
+    // Same host, but the golden side was captured against a server publishing no
+    // PRM document. A client that omits `resource` when PRM discovery fails is
+    // behaving CORRECTLY, so reporting the resulting field differences as parity
+    // failures would be the harness lying about a conformant client.
+    const golden: GoldenTrace = {
+      ...candidate,
+      subject: { ...candidate.subject, kind: "real-host" },
+      scenario: {
+        ...candidate.scenario,
+        capabilities: {
+          ...candidate.scenario.capabilities,
+          publishesPrm: false,
+          prmResource: undefined,
+        },
+      },
+    };
+
+    const diff = diffGoldenTraces(golden, candidate);
+    expect(diff.counts.incomparable).toBeGreaterThan(0);
+    expect(diff.parity).toBe(false);
+    expect(diff.findings[0].dimension).toBe("scenario");
+    // Exactly one blocking finding, not a cascade of forty bogus ones.
+    expect(diff.findings.length).toBe(1);
+  });
+
+  it("refuses to compare traces of different hosts", async () => {
+    const candidate = await captureSelfTrace();
+    const golden: GoldenTrace = {
+      ...candidate,
+      subject: { ...candidate.subject, kind: "real-host", hostId: "vscode" },
+    };
+
+    const diff = diffGoldenTraces(golden, candidate);
+    expect(diff.counts.incomparable).toBeGreaterThan(0);
+    expect(
+      diff.findings.some((finding) => finding.path === "subject.hostId"),
+    ).toBe(true);
+  });
+
+  it("reports a gap, never a match, when one side never observed a leg", async () => {
+    const candidate = await captureSelfTrace();
+    const golden = perturb(candidate, (wire) =>
+      wire.filter((exchange) => exchange.leg !== "token"),
+    );
+
+    const diff = diffGoldenTraces(golden, candidate);
+    const onToken = diff.findings.find(
+      (finding) => finding.path === "observations.resourceIndicator.onToken",
+    );
+    expect(onToken?.severity).toBe("gap");
+    expect(diff.counts.gap).toBeGreaterThan(0);
+
+    // A gap does not fail parity: our own missing capture is not evidence the
+    // emulator diverged. But it is counted, and callers needing full coverage
+    // assert on it.
+    expect(
+      diff.findings.filter((finding) => finding.severity === "gap").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("flags a golden trace that cannot name the dependency version that produced it", async () => {
+    const candidate = await captureSelfTrace();
+    const golden: GoldenTrace = {
+      ...candidate,
+      subject: {
+        ...candidate.subject,
+        kind: "real-host",
+        oauthImplementation: {
+          state: "not-observed",
+          reason: "no resolved OAuth implementation was supplied at ingest",
+        },
+      },
+    };
+
+    const diff = diffGoldenTraces(golden, candidate);
+    const stamp = diff.findings.find((finding) =>
+      finding.path.startsWith("subject.oauthImplementation"),
+    );
+    expect(stamp?.severity).toBe("gap");
+    expect(stamp?.message).toContain("dependency");
+  });
+});

--- a/sdk/tests/oauth-golden-trace/self-parity.test.ts
+++ b/sdk/tests/oauth-golden-trace/self-parity.test.ts
@@ -28,11 +28,14 @@ import { fileURLToPath } from "node:url";
 import { OAuthConformanceTest } from "../../src/oauth-conformance/index.js";
 import {
   captureEmulatorTrace,
+  classifyLeg,
   deriveObservations,
   diffGoldenTraces,
   findObservationDrift,
   findRedactionViolations,
+  formatHarIngestReportHuman,
   formatTraceDiffHuman,
+  formatTraceSummaryHuman,
   observedValue,
   withObservedLoopbackPorts,
 } from "../../src/oauth-golden-trace/index.js";
@@ -161,6 +164,25 @@ describe("HP-44 golden-trace self-parity", () => {
     expect(findObservationDrift(golden)).toEqual([]);
   });
 
+  it("reports drift from an ADDED observation key, not just a changed one", () => {
+    // The drift walk used to iterate the DERIVED shape's keys only, so a tamper
+    // whose sole edit was an extra top-level key produced an empty array — and
+    // empty reads as "clean" to `readTrace`, which then trusts the trace.
+    const golden = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as GoldenTrace;
+    const tampered = {
+      ...golden,
+      observations: {
+        ...golden.observations,
+        smuggledConclusion: { state: "present", value: "definitely conformant" },
+      },
+    } as unknown as GoldenTrace;
+
+    const drift = findObservationDrift(tampered);
+    expect(drift).not.toEqual([]);
+    expect(drift.join("\n")).toContain("smuggledConclusion");
+    expect(drift.join("\n")).toContain("added by hand");
+  });
+
   it("captures the facts HP-44 exists to settle", async () => {
     const trace = await captureSelfTrace();
     const { protocolVersion, resourceIndicator, dcrIdentity, pkce } =
@@ -180,8 +202,12 @@ describe("HP-44 golden-trace self-parity", () => {
       value: ["2025-11-25"],
     });
     // MCPJam agrees across both wires — unlike Goose, which is the whole reason
-    // these are separate fields.
-    expect(protocolVersion.wiresDisagree).toBe(false);
+    // these are separate fields. `present: false`, not a bare `false`: both wires
+    // were captured, which is what makes "they agree" a claim we can make.
+    expect(protocolVersion.wiresDisagree).toEqual({
+      state: "present",
+      value: false,
+    });
 
     // RFC 8707 on both legs, which is the claim four hosts got wrong.
     expect(resourceIndicator.onAuthorize.state).toBe("present");
@@ -265,12 +291,47 @@ function perturb(
 
 describe("HP-44 oracle is not vacuous", () => {
   /**
+   * One baseline capture, shared by every case below.
+   *
+   * Every `captureSelfTrace()` call runs a full handshake through the real state
+   * machine, and no case here needs a FRESH one: each either mutates through
+   * `perturb`, which deep-clones `trace.wire` before the mutator ever sees it, or
+   * builds its `golden` by spreading NEW objects over the baseline. `perturb`,
+   * `deriveObservations`, `withObservedLoopbackPorts` and `diffGoldenTraces` are all
+   * pure with respect to their inputs, which is what makes one capture enough.
+   *
+   * The tests that are ABOUT what a fresh capture produces — the byte-identical
+   * re-capture and the redaction scan in the suite above — keep their own calls,
+   * since a shared artifact cannot say anything about two independent runs.
+   */
+  let baseline: GoldenTrace;
+  /** Serialized once, so the guard below compares against the pristine capture. */
+  let baselineJson: string;
+
+  beforeAll(async () => {
+    baseline = await captureSelfTrace();
+    baselineJson = JSON.stringify(baseline);
+  });
+
+  /**
+   * The shared fixture's whole risk, checked rather than assumed.
+   *
+   * A case that mutated the baseline in place instead of going through `perturb`
+   * would corrupt every case scheduled after it — passing or failing depending on
+   * run order, which is the worst failure mode a suite can have. This turns that
+   * into an immediate, named failure in the case that caused it.
+   */
+  afterEach(() => {
+    expect(JSON.stringify(baseline)).toBe(baselineJson);
+  });
+
+  /**
    * Each case describes a client that diverges in one specific way, then asserts
    * the differ catches it in the right dimension. Without these, every test above
    * would still pass against a differ hardcoded to return parity.
    */
-  it("catches a dropped RFC 8707 `resource` param", async () => {
-    const candidate = await captureSelfTrace();
+  it("catches a dropped RFC 8707 `resource` param", () => {
+    const candidate = baseline;
     // A "real host" that omits `resource` on both legs — the exact claim that was
     // asserted about Claude and ChatGPT and turned out to be false for both.
     const golden = perturb(candidate, (wire) =>
@@ -302,8 +363,8 @@ describe("HP-44 oracle is not vacuous", () => {
     expect(onToken?.message).toContain("the real host sends nothing");
   });
 
-  it("catches a different `MCP-Protocol-Version` on the OAuth wire only", async () => {
-    const candidate = await captureSelfTrace();
+  it("catches a different `MCP-Protocol-Version` on the OAuth wire only", () => {
+    const candidate = baseline;
     // Exactly the `rmcp` shape: 2024-11-05 hardcoded on OAuth discovery while the
     // MCP wire negotiates something newer. If the harness collapsed the two wires
     // into one field, this test could not exist.
@@ -339,8 +400,14 @@ describe("HP-44 oracle is not vacuous", () => {
     expect(mcpWire?.severity).toBe("match");
 
     // And the split-revision flag flips, which is the legible one-line summary.
-    expect(golden.observations.protocolVersion.wiresDisagree).toBe(true);
-    expect(candidate.observations.protocolVersion.wiresDisagree).toBe(false);
+    expect(golden.observations.protocolVersion.wiresDisagree).toEqual({
+      state: "present",
+      value: true,
+    });
+    expect(candidate.observations.protocolVersion.wiresDisagree).toEqual({
+      state: "present",
+      value: false,
+    });
     expect(
       diff.findings.find(
         (finding) =>
@@ -349,10 +416,10 @@ describe("HP-44 oracle is not vacuous", () => {
     ).toBe("difference");
   });
 
-  it("catches a client that sends the header on OAuth discovery but not on MCP traffic", async () => {
+  it("catches a client that sends the header on OAuth discovery but not on MCP traffic", () => {
     // The VS Code shape. `absent` vs `present` must be a DIFFERENCE, not a gap —
     // "sends nothing here" is a positive, citable finding.
-    const candidate = await captureSelfTrace();
+    const candidate = baseline;
     const golden = perturb(candidate, (wire) =>
       wire.map((exchange) => {
         if (
@@ -379,8 +446,8 @@ describe("HP-44 oracle is not vacuous", () => {
     expect(mcpWire?.golden).toBe("<absent on the wire>");
   });
 
-  it("catches a changed DCR client_name", async () => {
-    const candidate = await captureSelfTrace();
+  it("catches a changed DCR client_name", () => {
+    const candidate = baseline;
     const golden = perturb(candidate, (wire) =>
       wire.map((exchange) => {
         if (
@@ -403,11 +470,11 @@ describe("HP-44 oracle is not vacuous", () => {
     expect(clientName?.dimension).toBe("dcr-body");
   });
 
-  it("catches reordered legs — a client that tries OAuth before probing unauthenticated", async () => {
+  it("catches reordered legs — a client that tries OAuth before probing unauthenticated", () => {
     // Goose connects unauthenticated FIRST and falls back to OAuth on a 401, the
     // opposite ordering from Claude and ChatGPT. Ordering is a finding, so it is
     // compared rather than merely displayed.
-    const candidate = await captureSelfTrace();
+    const candidate = baseline;
     const golden = perturb(candidate, (wire) => [
       ...wire.filter((exchange) => exchange.leg !== "mcp-unauthenticated"),
       ...wire.filter((exchange) => exchange.leg === "mcp-unauthenticated"),
@@ -422,10 +489,10 @@ describe("HP-44 oracle is not vacuous", () => {
     expect(ordering?.dimension).toBe("request-ordering");
   });
 
-  it("does NOT flag differing ephemeral loopback ports as a difference", async () => {
+  it("does NOT flag differing ephemeral loopback ports as a difference", () => {
     // Two runs of the same client legitimately differ here. A `difference` would
     // make every diff fail for a reason nobody can act on.
-    const candidate = await captureSelfTrace();
+    const candidate = baseline;
     const golden: GoldenTrace = {
       ...candidate,
       subject: { ...candidate.subject, kind: "real-host" },
@@ -448,8 +515,8 @@ describe("HP-44 oracle is not vacuous", () => {
     expect(diff.parity).toBe(true);
   });
 
-  it("refuses to compare traces captured against different scenarios", async () => {
-    const candidate = await captureSelfTrace();
+  it("refuses to compare traces captured against different scenarios", () => {
+    const candidate = baseline;
     // Same host, but the golden side was captured against a server publishing no
     // PRM document. A client that omits `resource` when PRM discovery fails is
     // behaving CORRECTLY, so reporting the resulting field differences as parity
@@ -475,8 +542,8 @@ describe("HP-44 oracle is not vacuous", () => {
     expect(diff.findings.length).toBe(1);
   });
 
-  it("refuses to compare traces of different hosts", async () => {
-    const candidate = await captureSelfTrace();
+  it("refuses to compare traces of different hosts", () => {
+    const candidate = baseline;
     const golden: GoldenTrace = {
       ...candidate,
       subject: { ...candidate.subject, kind: "real-host", hostId: "vscode" },
@@ -489,8 +556,8 @@ describe("HP-44 oracle is not vacuous", () => {
     ).toBe(true);
   });
 
-  it("reports a gap, never a match, when one side never observed a leg", async () => {
-    const candidate = await captureSelfTrace();
+  it("reports a gap, never a match, when one side never observed a leg", () => {
+    const candidate = baseline;
     const golden = perturb(candidate, (wire) =>
       wire.filter((exchange) => exchange.leg !== "token"),
     );
@@ -510,8 +577,171 @@ describe("HP-44 oracle is not vacuous", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("flags a golden trace that cannot name the dependency version that produced it", async () => {
-    const candidate = await captureSelfTrace();
+  it("reports a per-leg header only one side ever recorded as a gap, not as silence", () => {
+    const candidate = baseline;
+    // A golden capture that stopped before the MCP handshake. Its `headerByLeg`
+    // then has no `mcp-initialize` KEY AT ALL — and a missing map key used to make
+    // the differ skip the comparison, dropping exactly the asymmetry a reviewer
+    // most wants named.
+    const golden = perturb(candidate, (wire) =>
+      wire.filter((exchange) => exchange.leg !== "mcp-initialize"),
+    );
+    expect(
+      "mcp-initialize" in golden.observations.protocolVersion.headerByLeg,
+    ).toBe(false);
+
+    const diff = diffGoldenTraces(golden, candidate);
+
+    const header = diff.findings.find(
+      (finding) =>
+        finding.path === "observations.protocolVersion.headerByLeg.mcp-initialize",
+    );
+    expect(header?.severity).toBe("gap");
+    expect(String(header?.golden)).toContain("records no `mcp-initialize` leg");
+
+    const ua = diff.findings.find(
+      (finding) => finding.path === "observations.userAgent.byLeg.mcp-initialize",
+    );
+    expect(ua?.severity).toBe("gap");
+  });
+
+  it("does not report endpoints beyond a truncated capture as both a gap and a difference", () => {
+    const candidate = baseline;
+    // A golden capture that BOTH stopped early (no /token, no initialize) and hit a
+    // discovery path the candidate does not. The second condition is what used to
+    // skip the early return and report the beyond-truncation extras a second time
+    // as a difference — failing parity on the very artifact the gap excuses.
+    const golden = perturb(candidate, (wire) =>
+      wire
+        .filter(
+          (exchange) =>
+            exchange.leg !== "token" && exchange.leg !== "mcp-initialize",
+        )
+        .map((exchange) => {
+          if (exchange.leg === "as-metadata-discovery") {
+            exchange.request.url = exchange.request.url.replace(
+              "/.well-known/oauth-authorization-server",
+              "/.well-known/openid-configuration",
+            );
+          }
+          return exchange;
+        }),
+    );
+
+    const diff = diffGoldenTraces(golden, candidate);
+    const endpoints = diff.findings.filter(
+      (finding) => finding.path === "observations.endpointsHit",
+    );
+
+    // The extras are excused exactly once, as a gap...
+    const gaps = endpoints.filter((finding) => finding.severity === "gap");
+    expect(gaps.length).toBe(1);
+    expect(gaps[0].message).toContain("beyond where the golden capture stopped");
+
+    // ...and never re-reported as a difference. Missing endpoints, which the golden
+    // side demonstrably DID hit, are still reported on their own.
+    const differences = endpoints.filter(
+      (finding) => finding.severity === "difference",
+    );
+    expect(differences.length).toBe(1);
+    expect(differences[0].message).toContain("never hit");
+    expect(differences[0].candidate).toBe(null);
+  });
+
+  it("catches a param that differs only on a RETRY inside a leg", () => {
+    const captured = baseline;
+    // Both sides retry /token; only the golden side's SECOND attempt differs.
+    // Comparing occurrence 0 alone reported parity for this.
+    const withTokenRetry = (mutate: (retry: TraceExchange) => void): GoldenTrace =>
+      perturb(captured, (wire) => {
+        const out: TraceExchange[] = [];
+        for (const exchange of wire) {
+          out.push(exchange);
+          if (exchange.leg !== "token") continue;
+          const retry = JSON.parse(JSON.stringify(exchange)) as TraceExchange;
+          mutate(retry);
+          out.push(retry);
+        }
+        return out;
+      });
+
+    const golden = withTokenRetry((retry) => {
+      if (retry.request.body?.encoding === "form") {
+        retry.request.body.fields.scope = ["mcp:read"];
+      }
+    });
+    const candidate = withTokenRetry(() => {});
+
+    const diff = diffGoldenTraces(golden, candidate);
+    expect(diff.parity).toBe(false);
+
+    // The retry is compared under a `#1` slot...
+    const retryField = diff.findings.find(
+      (finding) => finding.path === "wire[leg=token#1].request.body.scope",
+    );
+    expect(retryField?.severity).toBe("difference");
+    expect(retryField?.message).toContain("(occurrence 2)");
+
+    // ...while the FIRST occurrence keeps its bare path and still matches, so the
+    // common single-request case reads exactly as it always did.
+    expect(
+      diff.findings.find(
+        (finding) => finding.path === "wire[leg=token].request.body.grant_type",
+      )?.severity,
+    ).toBe("match");
+  });
+
+  it("reports an unequal occurrence count rather than pairing mismatched attempts", () => {
+    const candidate = baseline;
+    const golden = perturb(candidate, (wire) => {
+      const out: TraceExchange[] = [];
+      for (const exchange of wire) {
+        out.push(exchange);
+        if (exchange.leg === "token") {
+          out.push(JSON.parse(JSON.stringify(exchange)) as TraceExchange);
+        }
+      }
+      return out;
+    });
+
+    const diff = diffGoldenTraces(golden, candidate);
+    const occurrences = diff.findings.find(
+      (finding) => finding.path === "wire[leg=token].occurrences",
+    );
+    expect(occurrences?.severity).toBe("difference");
+    expect(occurrences?.golden).toBe(2);
+    expect(occurrences?.candidate).toBe(1);
+  });
+
+  it("catches a changed VALUE of a DCR field this schema does not model", () => {
+    const candidate = baseline;
+    // `client_uri` is real, sent, and unmodelled. Retaining only field NAMES made
+    // two register bodies that differ here report DCR parity — the JSON body is not
+    // compared field by field anywhere else, so nothing else would catch it.
+    const golden = perturb(candidate, (wire) =>
+      wire.map((exchange) => {
+        if (
+          exchange.leg === "dcr-register" &&
+          exchange.request.body?.encoding === "json"
+        ) {
+          const json = exchange.request.body.json as Record<string, unknown>;
+          json.client_uri = "https://example.invalid/some-other-client";
+        }
+        return exchange;
+      }),
+    );
+
+    const diff = diffGoldenTraces(golden, candidate);
+    expect(diff.parity).toBe(false);
+    const extra = diff.findings.find(
+      (finding) => finding.path === "observations.dcrIdentity.extraFields",
+    );
+    expect(extra?.severity).toBe("difference");
+    expect(extra?.dimension).toBe("dcr-body");
+  });
+
+  it("flags a golden trace that cannot name the dependency version that produced it", () => {
+    const candidate = baseline;
     const golden: GoldenTrace = {
       ...candidate,
       subject: {
@@ -530,5 +760,215 @@ describe("HP-44 oracle is not vacuous", () => {
     );
     expect(stamp?.severity).toBe("gap");
     expect(stamp?.message).toContain("dependency");
+  });
+});
+
+/**
+ * The derivation's own honesty rules, checked at the observation level.
+ *
+ * These are upstream of the differ: each one is a case where the summary used to
+ * state something the capture could not support, and where the differ would then
+ * faithfully report a fabricated finding.
+ */
+describe("HP-44 observations claim only what the capture supports", () => {
+  it("does not read a malformed DCR field as an omitted one", async () => {
+    const clean = await captureSelfTrace();
+    const malformed = perturb(clean, (wire) =>
+      wire.map((exchange) => {
+        if (
+          exchange.leg === "dcr-register" &&
+          exchange.request.body?.encoding === "json"
+        ) {
+          (exchange.request.body.json as Record<string, unknown>).client_name = 42;
+        }
+        return exchange;
+      }),
+    );
+
+    const dcr = malformed.observations.dcrIdentity;
+    // NOT `absent`. `absent` would assert the client omitted `client_name`, which
+    // it demonstrably did not.
+    expect(dcr.clientName.state).toBe("not-observed");
+    if (dcr.clientName.state === "not-observed") {
+      expect(dcr.clientName.reason).toContain("a number, not a string");
+    }
+    expect(dcr.malformedFields).toEqual({
+      state: "present",
+      value: ["client_name"],
+    });
+
+    // And the differ names the malformed field as the difference, while the field
+    // itself is a gap rather than "the emulator sends a value the host does not".
+    const diff = diffGoldenTraces(malformed, clean);
+    expect(
+      diff.findings.find(
+        (finding) => finding.path === "observations.dcrIdentity.malformedFields",
+      )?.severity,
+    ).toBe("difference");
+    expect(
+      diff.findings.find(
+        (finding) => finding.path === "observations.dcrIdentity.clientName",
+      )?.severity,
+    ).toBe("gap");
+  });
+
+  it("refuses to read PKCE evidence out of an opaque /token body", async () => {
+    const structured = await captureSelfTrace();
+    expect(structured.observations.pkce.verifierSentOnToken).toEqual({
+      state: "present",
+      value: true,
+    });
+
+    const opaque = perturb(structured, (wire) =>
+      wire.map((exchange) => {
+        if (exchange.leg === "token") {
+          exchange.request.body = {
+            encoding: "opaque",
+            contentType: "application/x-www-form-urlencoded",
+            byteLength: 321,
+          };
+        }
+        return exchange;
+      }),
+    );
+
+    // A body we could not parse is not a body that lacked `code_verifier`.
+    // Reporting `false` here would manufacture "this client skips PKCE".
+    expect(opaque.observations.pkce.verifierSentOnToken.state).toBe("not-observed");
+
+    const diff = diffGoldenTraces(opaque, structured);
+    expect(
+      diff.findings.find(
+        (finding) => finding.path === "observations.pkce.verifierSentOnToken",
+      )?.severity,
+    ).toBe("gap");
+  });
+
+  it("cannot claim User-Agent consistency over a leg whose headers were reconstructed", async () => {
+    const trace = await captureSelfTrace();
+    // The client hands /authorize to a browser, so that leg carries no observed
+    // headers at all — which makes "one UA across every leg" unsayable rather than
+    // true.
+    expect(trace.observations.userAgent.consistent.state).toBe("not-observed");
+
+    const diff = diffGoldenTraces(
+      { ...trace, subject: { ...trace.subject, kind: "real-host" } },
+      trace,
+    );
+    expect(
+      diff.findings.find(
+        (finding) => finding.path === "observations.userAgent.consistent",
+      )?.severity,
+    ).toBe("gap");
+    // A gap, never a difference: two identical traces must not disagree here.
+    expect(diff.parity).toBe(true);
+  });
+
+  it("does not pull a same-origin sibling endpoint into the MCP wire", () => {
+    const mcpServerUrl = "https://mcp.example.test/mcp";
+    const legOf = (url: string): string =>
+      classifyLeg({ method: "POST", url, headers: {}, mcpServerUrl }).leg;
+
+    expect(legOf("https://mcp.example.test/mcp")).toBe("mcp-unauthenticated");
+    expect(legOf("https://mcp.example.test/mcp/")).toBe("mcp-unauthenticated");
+    // A descendant of the endpoint still belongs to it.
+    expect(legOf("https://mcp.example.test/mcp/messages")).toBe(
+      "mcp-unauthenticated",
+    );
+    // `/mcp-admin` shares every character of `/mcp` and is a DIFFERENT endpoint.
+    // Misclassifying it drags its headers into the MCP-wire rollups, where it can
+    // flip `headerOnMcpTraffic` from `absent` — a citable finding — to `present`.
+    expect(legOf("https://mcp.example.test/mcp-admin")).toBe("unknown");
+    expect(legOf("https://mcp.example.test/mcpx")).toBe("unknown");
+    // And the same path on another origin is not this server.
+    expect(legOf("https://other.example.test/mcp")).toBe("unknown");
+  });
+});
+
+/**
+ * What the human report is allowed to SAY.
+ *
+ * Both cases here were the report asserting something the artifact does not: an
+ * emulator that was never part of a drift comparison, and a credential rendered
+ * out of a URL the trace itself had redacted.
+ */
+describe("HP-44 human rendering states only what the diff found", () => {
+  it("never names an emulator in a drift diff of two same-kind captures", async () => {
+    const captured = await captureSelfTrace();
+    const asRealHost: GoldenTrace = {
+      ...captured,
+      subject: { ...captured.subject, kind: "real-host" },
+    };
+    // HP-38's shape: the SAME subject captured twice. There is no emulator on
+    // either side, so blaming one would be a fabricated finding.
+    const drift = diffGoldenTraces(asRealHost, {
+      ...asRealHost,
+      traceId: `${asRealHost.traceId}/recaptured`,
+    });
+    expect(drift.mode).toBe("drift");
+
+    const rendered = formatTraceDiffHuman(drift);
+    expect(rendered).toContain("drift diff");
+    expect(rendered).toContain("golden (baseline capture)");
+    expect(rendered).toContain("candidate (re-capture)");
+    // Every value line and every message, with the trace ids removed — those carry
+    // the subject kind in their own text and are not the report's own prose.
+    const prose = rendered
+      .split("\n")
+      .filter(
+        (line) =>
+          !line.includes(drift.goldenTraceId) &&
+          !line.includes(drift.candidateTraceId),
+      )
+      .join("\n");
+    expect(prose).toContain("baseline capture:");
+    expect(prose).toContain("re-capture:");
+    expect(prose).not.toContain("emulator");
+    expect(prose).not.toContain("real host");
+
+    // Parity mode keeps its concrete wording, where both labels are true.
+    const parity = formatTraceDiffHuman(
+      diffGoldenTraces(asRealHost, captured, { mode: "parity" }),
+    );
+    expect(parity).toContain("golden (real host)");
+    expect(parity).toContain("candidate (emulator)");
+  });
+
+  it("distinguishes `absent` from `not-observed` in the one-line summary", async () => {
+    const trace = await captureSelfTrace();
+    const summaryOf = (subject: GoldenTrace["subject"]): string =>
+      formatTraceSummaryHuman({ ...trace, subject });
+
+    expect(
+      summaryOf({ ...trace.subject, hostVersion: { state: "absent" } }),
+    ).toContain("no version exposed");
+    expect(
+      summaryOf({
+        ...trace.subject,
+        hostVersion: { state: "not-observed", reason: "nobody read it" },
+      }),
+    ).toContain("version not observed");
+  });
+
+  it("renders a dropped HAR entry's origin and path, never its query string", () => {
+    // A dropped entry never went through the normalizer, so its query may still
+    // carry a live credential. The trace is redacted; this report must not undo it.
+    const rendered = formatHarIngestReportHuman({
+      totalEntries: 2,
+      keptEntries: 1,
+      dropped: [
+        {
+          url: "https://vendor.example/callback?code=hp44-live-code&state=abc#frag",
+          reason: "not on a scenario origin",
+        },
+      ],
+      missingLegs: [],
+      warnings: [],
+    });
+
+    expect(rendered).toContain("https://vendor.example/callback");
+    expect(rendered).not.toContain("hp44-live-code");
+    expect(rendered).not.toContain("code=");
+    expect(rendered).not.toContain("frag");
   });
 });

--- a/sdk/tests/oauth-golden-trace/self-parity.test.ts
+++ b/sdk/tests/oauth-golden-trace/self-parity.test.ts
@@ -740,6 +740,47 @@ describe("HP-44 oracle is not vacuous", () => {
     expect(extra?.dimension).toBe("dcr-body");
   });
 
+  it("does not lose a `__proto__` field from an unmodelled DCR body", () => {
+    // `extras` used to be built on a plain `{}`. `extras["__proto__"] = value`
+    // against that hits the inherited setter instead of creating an own
+    // property, so a client that (deliberately or not) registers a `__proto__`
+    // field vanished from `dcrIdentity.extraFields` — the oracle would then
+    // report absence for something the client demonstrably sent.
+    const golden = perturb(baseline, (wire) =>
+      wire.map((exchange) => {
+        if (
+          exchange.leg === "dcr-register" &&
+          exchange.request.body?.encoding === "json"
+        ) {
+          const json = exchange.request.body.json as Record<string, unknown>;
+          // NOT `Object.assign(json, {...})`: assignment uses `[[Set]]` semantics,
+          // and `json` is a plain object, so writing the key `__proto__` through
+          // it invokes `Object.prototype`'s accessor and reparents `json` instead
+          // of adding a field — the very footgun this test exists to catch, this
+          // time in the test setup rather than the code under test.
+          // `defineOwnProperty`, like `JSON.parse` on the real wire bytes, bypasses
+          // that accessor and creates a genuine own property.
+          Object.defineProperty(json, "__proto__", {
+            value: "polluted-dcr-field",
+            enumerable: true,
+            configurable: true,
+            writable: true,
+          });
+        }
+        return exchange;
+      }),
+    );
+
+    const extraFields = observedValue(golden.observations.dcrIdentity.extraFields);
+    expect(extraFields).toBeDefined();
+    expect(
+      Object.prototype.hasOwnProperty.call(extraFields ?? {}, "__proto__"),
+    ).toBe(true);
+    expect((extraFields as Record<string, unknown>)["__proto__"]).toBe(
+      "polluted-dcr-field",
+    );
+  });
+
   it("flags a golden trace that cannot name the dependency version that produced it", () => {
     const candidate = baseline;
     const golden: GoldenTrace = {
@@ -970,5 +1011,29 @@ describe("HP-44 human rendering states only what the diff found", () => {
     expect(rendered).not.toContain("hp44-live-code");
     expect(rendered).not.toContain("code=");
     expect(rendered).not.toContain("frag");
+  });
+
+  it("strips userinfo from a dropped HAR URL even when `new URL()` rejects it", () => {
+    // An invalid port makes this fail `new URL()` parsing, so it falls to the
+    // catch branch — which used to strip only the query/fragment, leaving
+    // `oauth-client:s3cret-password@` whole because there was no `?` or `#` to
+    // split on. Userinfo lives in the AUTHORITY, not the query, so a query-only
+    // strip cannot touch it; this is the shape a genuinely malformed capture (not
+    // just an unparseable placeholder) can actually produce.
+    const malformed =
+      "http://oauth-client:s3cret-password@vendor.example:99999999999999999999/callback";
+    expect(() => new URL(malformed)).toThrow();
+
+    const rendered = formatHarIngestReportHuman({
+      totalEntries: 1,
+      keptEntries: 0,
+      dropped: [{ url: malformed, reason: "not on a scenario origin" }],
+      missingLegs: [],
+      warnings: [],
+    });
+
+    expect(rendered).toContain("http://");
+    expect(rendered).not.toContain("s3cret-password");
+    expect(rendered).not.toContain("oauth-client:");
   });
 });

--- a/sdk/tests/oauth-golden-trace/to-profile.test.ts
+++ b/sdk/tests/oauth-golden-trace/to-profile.test.ts
@@ -13,8 +13,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { canonicalizeOAuthProfile } from "../../src/host-config/internal.js";
+import type { HostConfigOAuthProfileV1 } from "../../src/host-config/types.js";
 import {
   deriveObservations,
+  mergeTraceOAuthProfile,
   traceToOAuthProfile,
 } from "../../src/oauth-golden-trace/index.js";
 import type { GoldenTrace } from "../../src/oauth-golden-trace/index.js";
@@ -118,6 +120,52 @@ describe("traceToOAuthProfile", () => {
     if (evidence?.status === "verified") expect(evidence.value).toBe(false);
   });
 
+  it("keeps a HALF-observed handshake unverifiable instead of claiming `false`", () => {
+    // The trap: `/authorize` never captured, `/token` captured without
+    // `resource`. Requiring only that SOME leg was observed would emit
+    // `verified: false` citing "both legs were captured", which is untrue — the
+    // unwatched leg could have carried it. `absent` is a finding, `not-observed`
+    // is a gap, and this is the boundary between them.
+    const trace = loadTrace();
+    const tokenOnly = reobserve({
+      ...trace,
+      wire: trace.wire
+        .filter((exchange) => exchange.leg !== "authorize")
+        .map((exchange) => {
+          const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+          if (next.request.query?.resource) delete next.request.query.resource;
+          if (next.request.body?.encoding === "form") {
+            delete next.request.body.fields.resource;
+          }
+          return next;
+        }),
+    });
+
+    const evidence = traceToOAuthProfile(tokenOnly).sendsResourceIndicator;
+    expect(evidence?.status).toBe("unverifiable");
+    if (evidence?.status === "unverifiable") {
+      expect(evidence.reason).toContain("/authorize");
+      expect(evidence.reason).toContain("half-observed pair cannot justify");
+    }
+  });
+
+  it("still verifies `resource: true` from a single captured leg", () => {
+    // The other side of the same boundary: one leg carrying `resource` is a
+    // positive observation, and an unwatched second leg cannot unmake it.
+    const trace = loadTrace();
+    const tokenOnly = reobserve({
+      ...trace,
+      wire: trace.wire.filter((exchange) => exchange.leg !== "authorize"),
+    });
+
+    const evidence = traceToOAuthProfile(tokenOnly).sendsResourceIndicator;
+    expect(evidence?.status).toBe("verified");
+    if (evidence?.status === "verified") {
+      expect(evidence.value).toBe(true);
+      expect(evidence.source).toContain("/token");
+    }
+  });
+
   it("verifies protocolVersionPinning ONLY from the OAuth-discovery header", () => {
     // The single arm one trace can prove: at discovery time no `initialize` has
     // happened, so the header cannot be a negotiated value — it is a client-chosen
@@ -169,21 +217,55 @@ describe("traceToOAuthProfile", () => {
       }),
     });
 
-    // Same client, second server advertising a different version, same value in
-    // the initialize body ⇒ the value does not follow the server ⇒ a real pin.
-    const pinned = traceToOAuthProfile(noHeader, { contrastTrace: noHeader });
+    // Same client, second server, and — the load-bearing part — a server that
+    // ADVERTISED a different protocol version, recorded on the scenario. Same
+    // value in the initialize body across both ⇒ the value does not follow the
+    // server ⇒ a real pin. Comparing `noHeader` against itself, or against a
+    // same-version server, would produce this verdict for free, which is why all
+    // three conditions are checked.
+    const sameValueElsewhere = reobserve({
+      ...noHeader,
+      traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      scenario: {
+        ...noHeader.scenario,
+        scenarioId: "other-scenario",
+        capabilities: {
+          ...noHeader.scenario.capabilities,
+          serverProtocolVersion: "2025-06-18",
+        },
+      },
+    });
+    const pinned = traceToOAuthProfile(noHeader, {
+      contrastTrace: sameValueElsewhere,
+    });
     expect(pinned.protocolVersionPinning?.status).toBe("verified");
     if (pinned.protocolVersionPinning?.status === "verified") {
       expect(pinned.protocolVersionPinning.value).toEqual({
         mode: "pinned",
         version: "2025-11-25",
       });
+      // The citation names both sides AND the two advertised versions, so a
+      // reviewer can check the experiment without opening the artifacts.
+      expect(pinned.protocolVersionPinning.source).toContain(
+        "scenario `in-memory-dcr-authcode-prm-mcp2025-11-25`",
+      );
+      expect(pinned.protocolVersionPinning.source).toContain("scenario `other-scenario`");
+      expect(pinned.protocolVersionPinning.source).toContain("server advertised `2025-11-25`");
+      expect(pinned.protocolVersionPinning.source).toContain("server advertised `2025-06-18`");
     }
 
     // A different value against the second server ⇒ it follows the server.
     const contrast = reobserve({
       ...noHeader,
       traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      scenario: {
+        ...noHeader.scenario,
+        scenarioId: "other-scenario",
+        capabilities: {
+          ...noHeader.scenario.capabilities,
+          serverProtocolVersion: "2025-06-18",
+        },
+      },
       wire: noHeader.wire.map((exchange) => {
         const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
         if (
@@ -204,6 +286,110 @@ describe("traceToOAuthProfile", () => {
     expect(negotiated.protocolVersionPinning?.status).toBe("verified");
     if (negotiated.protocolVersionPinning?.status === "verified") {
       expect(negotiated.protocolVersionPinning.value).toEqual({ mode: "negotiated" });
+    }
+  });
+
+  it("rejects a contrast trace that is not the two-server experiment", () => {
+    // The strongest claim in this module used to rest on a caller promise: hand
+    // `contrastTrace` the same capture (or an unrelated host's) and an identical
+    // value became a `verified` pin out of nothing.
+    const trace = loadTrace();
+    const noHeader = reobserve({
+      ...trace,
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        delete next.request.headers["mcp-protocol-version"];
+        return next;
+      }),
+    });
+
+    const itself = traceToOAuthProfile(noHeader, { contrastTrace: noHeader })
+      .protocolVersionPinning;
+    expect(itself?.status).toBe("unverifiable");
+    if (itself?.status === "unverifiable") {
+      expect(itself.reason).toContain("ran the SAME scenario");
+    }
+
+    // A second scenario against a genuinely different-version server, but a
+    // different CLIENT — a shared value across two clients says nothing about
+    // either one's pinning. The version differs so this can only fail on identity.
+    const otherHost = reobserve({
+      ...noHeader,
+      traceId: "vscode/other-scenario/2026-07-29/real-host",
+      subject: { ...noHeader.subject, hostId: "vscode" },
+      scenario: {
+        ...noHeader.scenario,
+        scenarioId: "other-scenario",
+        capabilities: {
+          ...noHeader.scenario.capabilities,
+          serverProtocolVersion: "2025-06-18",
+        },
+      },
+    });
+    const crossHost = traceToOAuthProfile(noHeader, { contrastTrace: otherHost })
+      .protocolVersionPinning;
+    expect(crossHost?.status).toBe("unverifiable");
+    if (crossHost?.status === "unverifiable") {
+      expect(crossHost.reason).toContain("different subject");
+    }
+  });
+
+  it("rejects a contrast trace whose server advertised the SAME version", () => {
+    // The failure the scenario-id check alone could not see. Two distinct scenario
+    // ids can still both be servers advertising `2025-11-25`, and against two
+    // same-version servers a NEGOTIATING client emits the same value a pinning one
+    // does — so reading a match as a pin inverts the answer.
+    const trace = loadTrace();
+    const noHeader = reobserve({
+      ...trace,
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        delete next.request.headers["mcp-protocol-version"];
+        return next;
+      }),
+    });
+
+    const sameVersionServer = reobserve({
+      ...noHeader,
+      traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      scenario: { ...noHeader.scenario, scenarioId: "other-scenario" },
+    });
+    const evidence = traceToOAuthProfile(noHeader, {
+      contrastTrace: sameVersionServer,
+    }).protocolVersionPinning;
+    expect(evidence?.status).toBe("unverifiable");
+    if (evidence?.status === "unverifiable") {
+      expect(evidence.reason).toContain("SAME protocol version");
+      expect(evidence.reason).toContain("2025-11-25");
+    }
+  });
+
+  it("rejects a contrast trace whose advertised version is unrecorded", () => {
+    // "Not recorded" is a gap, not a licence to assume the servers differed — the
+    // same not-observed-vs-absent distinction the whole module is built on.
+    const trace = loadTrace();
+    const noHeader = reobserve({
+      ...trace,
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        delete next.request.headers["mcp-protocol-version"];
+        return next;
+      }),
+    });
+
+    const capabilities = { ...noHeader.scenario.capabilities };
+    delete capabilities.serverProtocolVersion;
+    const unrecorded = reobserve({
+      ...noHeader,
+      traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      scenario: { ...noHeader.scenario, scenarioId: "other-scenario", capabilities },
+    });
+    const evidence = traceToOAuthProfile(noHeader, { contrastTrace: unrecorded })
+      .protocolVersionPinning;
+    expect(evidence?.status).toBe("unverifiable");
+    if (evidence?.status === "unverifiable") {
+      expect(evidence.reason).toContain("serverProtocolVersion");
+      expect(evidence.reason).toContain("cannot be shown that the two servers differed");
     }
   });
 
@@ -277,12 +463,15 @@ describe("traceToOAuthProfile", () => {
       state: "present",
       value: ["2025-11-25"],
     });
-    expect(pv.wiresDisagree).toBe(false);
+    // Carried through as the OBSERVATION, not flattened to a boolean: the profile
+    // is where a partial capture would otherwise become a "these wires agree"
+    // claim, so the tri-state has to survive the projection.
+    expect(pv.wiresDisagree).toEqual({ state: "present", value: false });
 
     // Provenance points back at the artifact, including the staleness stamp.
     const provenance = extensions.traceProvenance as Record<string, unknown>;
     expect(provenance.traceId).toBe(
-      "mcpjam/in-memory-dcr-authcode-prm/2026-07-29/emulator",
+      "mcpjam/in-memory-dcr-authcode-prm-mcp2025-11-25/2026-07-29/emulator",
     );
     expect(provenance.oauthImplementation).toEqual({
       state: "present",
@@ -303,5 +492,69 @@ describe("traceToOAuthProfile", () => {
       // And the reason explains that this may be correct rather than a failure.
       expect(evidence.reason).toContain("CIMD or a pre-registered client_id");
     }
+  });
+});
+
+describe("mergeTraceOAuthProfile", () => {
+  const sourceRead: HostConfigOAuthProfileV1 = {
+    profileVersion: 1,
+    // Two fields a trace can never settle, already answered by a source-reading.
+    authModel: {
+      status: "verified",
+      value: ["oauth2-dcr"],
+      source: "E1 — src/oauth/provider.ts:41",
+      capturedAt: "2026-07-01",
+    },
+    oauthSpecVersion: {
+      status: "verified",
+      value: { basis: "constant", revisions: ["2025-11-25"] },
+      source: "E1 — src/oauth/versions.ts:12",
+      capturedAt: "2026-07-01",
+    },
+    extensions: { sourceReadNotes: ["read against v1.4.0"] },
+  };
+
+  it("never lets an `unverifiable` projection overwrite settled evidence", () => {
+    // The whole point: the projection emits `unverifiable` for every field it
+    // could not settle, because naming the missing experiment is useful output.
+    // A plain spread would therefore turn a verified `authModel` back into "a
+    // trace cannot enumerate what a client supports" — evidence loss wearing the
+    // clothes of an update.
+    const projection = traceToOAuthProfile(loadTrace(), { tracePath: "traces/x.json" });
+    expect(projection.authModel?.status).toBe("unverifiable");
+
+    const merged = mergeTraceOAuthProfile(sourceRead, projection);
+    expect(merged.authModel).toEqual(sourceRead.authModel);
+    // `basis: "constant"` is stronger than the trace's behavioral FLOOR and is
+    // not something a capture can ever justify, so the source-read survives.
+    expect(merged.oauthSpecVersion).toEqual(sourceRead.oauthSpecVersion);
+  });
+
+  it("lets a trace win the fields it DID settle", () => {
+    const projection = traceToOAuthProfile(loadTrace(), { tracePath: "traces/x.json" });
+    const merged = mergeTraceOAuthProfile(
+      {
+        ...sourceRead,
+        sendsResourceIndicator: {
+          status: "unverifiable",
+          reason: "closed-source client",
+          capturedAt: "2026-07-01",
+        },
+      },
+      projection,
+    );
+
+    expect(merged.sendsResourceIndicator).toEqual(projection.sendsResourceIndicator);
+    expect(merged.dcrIdentity).toEqual(projection.dcrIdentity);
+    // Extensions are additive: a schema gap must not cost another source's notes.
+    const extensions = merged.extensions as Record<string, unknown>;
+    expect(extensions.sourceReadNotes).toEqual(["read against v1.4.0"]);
+    expect(extensions.traceProvenance).toBeDefined();
+    expect(() => canonicalizeOAuthProfile(merged)).not.toThrow();
+  });
+
+  it("returns the projection unchanged for an uninvestigated host", () => {
+    const projection = traceToOAuthProfile(loadTrace());
+    expect(mergeTraceOAuthProfile(undefined, projection)).toBe(projection);
   });
 });

--- a/sdk/tests/oauth-golden-trace/to-profile.test.ts
+++ b/sdk/tests/oauth-golden-trace/to-profile.test.ts
@@ -1,0 +1,307 @@
+/**
+ * HP-44 — the trace → `HostConfigOAuthProfileV1` projection.
+ *
+ * These tests are mostly about RESTRAINT. A trace is the strongest evidence we
+ * have, and the temptation is to let it settle every field. It cannot, and the
+ * places where it cannot are exactly where the previous rounds of this work went
+ * wrong. Each test below pins one of those limits so a later change cannot
+ * quietly relax it.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { canonicalizeOAuthProfile } from "../../src/host-config/internal.js";
+import {
+  deriveObservations,
+  traceToOAuthProfile,
+} from "../../src/oauth-golden-trace/index.js";
+import type { GoldenTrace } from "../../src/oauth-golden-trace/index.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(
+  HERE,
+  "..",
+  "fixtures",
+  "golden-traces",
+  "mcpjam-in-memory-dcr-authcode-prm.json",
+);
+
+function loadTrace(): GoldenTrace {
+  return JSON.parse(readFileSync(FIXTURE_PATH, "utf8")) as GoldenTrace;
+}
+
+/** Rebuild observations after editing a wire, keeping the trace consistent. */
+function reobserve(trace: GoldenTrace): GoldenTrace {
+  return {
+    ...trace,
+    observations: deriveObservations({
+      wire: trace.wire,
+      scenario: trace.scenario,
+    }),
+  };
+}
+
+describe("traceToOAuthProfile", () => {
+  it("produces a profile the host-config canonicalizer accepts", () => {
+    // The point of projecting onto the existing type rather than inventing a
+    // parallel vocabulary: the output has to survive the real canonicalizer.
+    const profile = traceToOAuthProfile(loadTrace(), {
+      tracePath: "sdk/tests/fixtures/golden-traces/mcpjam-in-memory-dcr-authcode-prm.json",
+    });
+    expect(() => canonicalizeOAuthProfile(profile)).not.toThrow();
+  });
+
+  it("verifies sendsResourceIndicator with the trace as the source", () => {
+    const profile = traceToOAuthProfile(loadTrace(), { tracePath: "traces/x.json" });
+    const evidence = profile.sendsResourceIndicator;
+
+    expect(evidence?.status).toBe("verified");
+    if (evidence?.status === "verified" || evidence?.status === "refuted") {
+      expect(evidence.value).toBe(true);
+      // A trace is E2 evidence and cites itself, so a reviewer can open it.
+      expect(evidence.source).toContain("E2");
+      expect(evidence.source).toContain("traces/x.json");
+      expect(evidence.capturedAt).toBe("2026-07-29");
+    }
+  });
+
+  it("refuses to call `resource` absent when the server published no PRM", () => {
+    // VS Code and Cline both omit `resource` entirely when PRM discovery fails,
+    // and that is CORRECT. Recording `false` from a no-PRM capture would
+    // manufacture a finding about the client out of a property of the server.
+    const trace = loadTrace();
+    const noPrm = reobserve({
+      ...trace,
+      scenario: {
+        ...trace.scenario,
+        capabilities: {
+          ...trace.scenario.capabilities,
+          publishesPrm: false,
+          prmResource: undefined,
+        },
+      },
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        if (next.request.query?.resource) delete next.request.query.resource;
+        if (next.request.body?.encoding === "form") {
+          delete next.request.body.fields.resource;
+        }
+        return next;
+      }),
+    });
+
+    const evidence = traceToOAuthProfile(noPrm).sendsResourceIndicator;
+    expect(evidence?.status).toBe("unverifiable");
+    if (evidence?.status === "unverifiable") {
+      expect(evidence.reason).toContain("publishes no RFC 9728 PRM document");
+    }
+  });
+
+  it("verifies `resource: false` when a PRM-publishing server was still ignored", () => {
+    const trace = loadTrace();
+    const stripped = reobserve({
+      ...trace,
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        if (next.request.query?.resource) delete next.request.query.resource;
+        if (next.request.body?.encoding === "form") {
+          delete next.request.body.fields.resource;
+        }
+        return next;
+      }),
+    });
+
+    const evidence = traceToOAuthProfile(stripped).sendsResourceIndicator;
+    expect(evidence?.status).toBe("verified");
+    if (evidence?.status === "verified") expect(evidence.value).toBe(false);
+  });
+
+  it("verifies protocolVersionPinning ONLY from the OAuth-discovery header", () => {
+    // The single arm one trace can prove: at discovery time no `initialize` has
+    // happened, so the header cannot be a negotiated value — it is a client-chosen
+    // constant. This is how `rmcp`'s hardcoded 2024-11-05 becomes provable.
+    const profile = traceToOAuthProfile(loadTrace());
+    const evidence = profile.protocolVersionPinning;
+
+    expect(evidence?.status).toBe("verified");
+    if (evidence?.status === "verified") {
+      expect(evidence.value).toEqual({ mode: "pinned", version: "2025-11-25" });
+      expect(evidence.source).toContain("BEFORE any `initialize` exchange");
+      // Scope is stated explicitly so nobody reads this as a claim about the MCP wire.
+      expect(evidence.source).toContain("the OAuth wire only");
+    }
+  });
+
+  it("leaves protocolVersionPinning unverifiable with no OAuth-discovery header", () => {
+    // Without that header a single capture cannot tell a pin from a negotiation:
+    // a client that negotiates emits the same byte as one that pins when it is
+    // talking to exactly one server. This is the trap that produced wrong answers
+    // for SDK-delegated clients.
+    const trace = loadTrace();
+    const noHeader = reobserve({
+      ...trace,
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        delete next.request.headers["mcp-protocol-version"];
+        return next;
+      }),
+    });
+
+    const evidence = traceToOAuthProfile(noHeader).protocolVersionPinning;
+    expect(evidence?.status).toBe("unverifiable");
+    if (evidence?.status === "unverifiable") {
+      expect(evidence.reason).toContain("cannot distinguish a pin from a negotiation");
+      // The reason names the experiment that WOULD settle it.
+      expect(evidence.reason).toContain("second server advertising a DIFFERENT");
+    }
+  });
+
+  it("settles pin-vs-negotiate from a contrast trace", () => {
+    const trace = loadTrace();
+    const noHeader = reobserve({
+      ...trace,
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        delete next.request.headers["mcp-protocol-version"];
+        return next;
+      }),
+    });
+
+    // Same client, second server advertising a different version, same value in
+    // the initialize body ⇒ the value does not follow the server ⇒ a real pin.
+    const pinned = traceToOAuthProfile(noHeader, { contrastTrace: noHeader });
+    expect(pinned.protocolVersionPinning?.status).toBe("verified");
+    if (pinned.protocolVersionPinning?.status === "verified") {
+      expect(pinned.protocolVersionPinning.value).toEqual({
+        mode: "pinned",
+        version: "2025-11-25",
+      });
+    }
+
+    // A different value against the second server ⇒ it follows the server.
+    const contrast = reobserve({
+      ...noHeader,
+      traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      wire: noHeader.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        if (
+          next.request.body?.encoding === "jsonrpc" &&
+          next.request.body.json &&
+          typeof next.request.body.json === "object"
+        ) {
+          const json = next.request.body.json as {
+            params?: { protocolVersion?: string };
+          };
+          if (json.params?.protocolVersion) json.params.protocolVersion = "2025-06-18";
+        }
+        return next;
+      }),
+    });
+
+    const negotiated = traceToOAuthProfile(noHeader, { contrastTrace: contrast });
+    expect(negotiated.protocolVersionPinning?.status).toBe("verified");
+    if (negotiated.protocolVersionPinning?.status === "verified") {
+      expect(negotiated.protocolVersionPinning.value).toEqual({ mode: "negotiated" });
+    }
+  });
+
+  it("records oauthSpecVersion as a behavioral FLOOR, never an exact revision", () => {
+    // A trace observes wire shape. A literal revision string is a claim about the
+    // client's code or its docs, so `basis: "constant"` is not something a capture
+    // can ever justify.
+    const evidence = traceToOAuthProfile(loadTrace()).oauthSpecVersion;
+    expect(evidence?.status).toBe("verified");
+    if (evidence?.status === "verified") {
+      expect(evidence.value.basis).toBe("behavioral");
+      if (evidence.value.basis === "behavioral") {
+        expect(evidence.value.minimumRevision).toBe("2025-06-18");
+      }
+      expect(evidence.source).toContain("FLOOR");
+    }
+  });
+
+  it("never settles authModel from a trace", () => {
+    // The field means "every model the client supports, in preference order". A
+    // trace shows the ONE path taken against ONE server's capabilities.
+    const evidence = traceToOAuthProfile(loadTrace()).authModel;
+    expect(evidence?.status).toBe("unverifiable");
+    if (evidence?.status === "unverifiable") {
+      expect(evidence.reason).toContain("cannot enumerate what else it supports");
+    }
+    // The `unverifiable` arm carries no value at all — unverified lore is
+    // unrepresentable, not merely discouraged.
+    expect("value" in (evidence ?? {})).toBe(false);
+  });
+
+  it("verifies dcrIdentity and flags the User-Agent expressiveness gap", () => {
+    const evidence = traceToOAuthProfile(loadTrace()).dcrIdentity;
+    expect(evidence?.status).toBe("verified");
+    if (evidence?.status === "verified") {
+      expect(evidence.value.clientName).toBe("MCPJam SDK OAuth Conformance");
+      expect(evidence.value.redirectUris).toEqual([
+        "http://127.0.0.1:{port}/callback",
+      ]);
+      // MCPJam's OAuth runs in a browser, which forbids scripts from setting
+      // User-Agent — so there is nothing to record, and the target type has no way
+      // to distinguish that from "we didn't look". The caveat says so out loud.
+      expect(evidence.value.userAgent).toBeUndefined();
+      expect(evidence.source).toContain("no single `User-Agent`");
+      expect(evidence.source).toContain("`{port}`");
+    }
+  });
+
+  it("preserves every observation the target type cannot express", () => {
+    // A schema gap must never cost a finding.
+    const extensions = traceToOAuthProfile(loadTrace()).extensions as Record<
+      string,
+      unknown
+    >;
+
+    expect(Object.keys(extensions).sort()).toEqual([
+      "tracePkce",
+      "traceAuthPath",
+      "traceDcrIdentity",
+      "traceProtocolVersion",
+      "traceProvenance",
+      "traceResourceIndicator",
+      "traceUserAgent",
+    ].sort());
+
+    // The two-headed protocol-version finding survives whole, even though
+    // `protocolVersionPinning` could only carry one arm of it.
+    const pv = extensions.traceProtocolVersion as Record<string, unknown>;
+    expect(pv.initializeBody).toEqual({ state: "present", value: "2025-11-25" });
+    expect(pv.headerOnMcpTraffic).toEqual({
+      state: "present",
+      value: ["2025-11-25"],
+    });
+    expect(pv.wiresDisagree).toBe(false);
+
+    // Provenance points back at the artifact, including the staleness stamp.
+    const provenance = extensions.traceProvenance as Record<string, unknown>;
+    expect(provenance.traceId).toBe(
+      "mcpjam/in-memory-dcr-authcode-prm/2026-07-29/emulator",
+    );
+    expect(provenance.oauthImplementation).toEqual({
+      state: "present",
+      value: { kind: "first-party" },
+    });
+  });
+
+  it("marks dcrIdentity unverifiable when no registration happened", () => {
+    const trace = loadTrace();
+    const noDcr = reobserve({
+      ...trace,
+      wire: trace.wire.filter((exchange) => exchange.leg !== "dcr-register"),
+    });
+
+    const evidence = traceToOAuthProfile(noDcr).dcrIdentity;
+    expect(evidence?.status).toBe("unverifiable");
+    if (evidence?.status === "unverifiable") {
+      // And the reason explains that this may be correct rather than a failure.
+      expect(evidence.reason).toContain("CIMD or a pre-registered client_id");
+    }
+  });
+});

--- a/sdk/tests/oauth-golden-trace/to-profile.test.ts
+++ b/sdk/tests/oauth-golden-trace/to-profile.test.ts
@@ -393,6 +393,135 @@ describe("traceToOAuthProfile", () => {
     }
   });
 
+  it("rejects a contrast trace whose client code cannot be shown to match", () => {
+    // `hostId`/`kind`/`build`/`surface` can all agree while the OAuth code behind
+    // them is different — a version bump, or a dependency bump for a client that
+    // delegates. Pinning is a property of THAT code, so identity alone (the
+    // fields checked before this regression) is not enough: a same-hostId trace
+    // from a different `hostVersion`, or one missing the stamp entirely, must be
+    // rejected exactly like a different host would be.
+    const trace = loadTrace();
+    const noHeader = reobserve({
+      ...trace,
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        delete next.request.headers["mcp-protocol-version"];
+        return next;
+      }),
+    });
+    const differentVersionScenario = {
+      ...noHeader.scenario,
+      scenarioId: "other-scenario",
+      capabilities: {
+        ...noHeader.scenario.capabilities,
+        serverProtocolVersion: "2025-06-18",
+      },
+    };
+
+    // Same hostId, different hostVersion.
+    const upgraded = reobserve({
+      ...noHeader,
+      traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      subject: {
+        ...noHeader.subject,
+        hostVersion: { state: "present", value: "9.9.9" },
+      },
+      scenario: differentVersionScenario,
+    });
+    const versionMismatch = traceToOAuthProfile(noHeader, { contrastTrace: upgraded })
+      .protocolVersionPinning;
+    expect(versionMismatch?.status).toBe("unverifiable");
+    if (versionMismatch?.status === "unverifiable") {
+      expect(versionMismatch.reason).toContain("different `hostVersion`s");
+    }
+
+    // Same hostId, hostVersion not stamped on the contrast.
+    const unstamped = reobserve({
+      ...noHeader,
+      traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      subject: {
+        ...noHeader.subject,
+        hostVersion: { state: "not-observed", reason: "not captured" },
+      },
+      scenario: differentVersionScenario,
+    });
+    const versionUnknown = traceToOAuthProfile(noHeader, { contrastTrace: unstamped })
+      .protocolVersionPinning;
+    expect(versionUnknown?.status).toBe("unverifiable");
+    if (versionUnknown?.status === "unverifiable") {
+      expect(versionUnknown.reason).toContain("does not record `subject.hostVersion`");
+    }
+
+    // Same hostId and hostVersion, oauthImplementation not stamped.
+    const noImplementation = reobserve({
+      ...noHeader,
+      traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      subject: {
+        ...noHeader.subject,
+        oauthImplementation: { state: "not-observed", reason: "not captured" },
+      },
+      scenario: differentVersionScenario,
+    });
+    const implementationUnknown = traceToOAuthProfile(noHeader, {
+      contrastTrace: noImplementation,
+    }).protocolVersionPinning;
+    expect(implementationUnknown?.status).toBe("unverifiable");
+    if (implementationUnknown?.status === "unverifiable") {
+      expect(implementationUnknown.reason).toContain(
+        "does not record `subject.oauthImplementation`",
+      );
+    }
+  });
+
+  it("routes the missing-initialize-body blocker to the right fix", () => {
+    // The experiment can be VALID (same client, genuinely different server
+    // versions) and still unable to answer, because one side's `initialize` body
+    // was never captured. That is a re-capture problem, not a "supply a
+    // contrastTrace" problem, and the fallback used to say the latter regardless.
+    const trace = loadTrace();
+    const noHeader = reobserve({
+      ...trace,
+      wire: trace.wire.map((exchange) => {
+        const next = JSON.parse(JSON.stringify(exchange)) as typeof exchange;
+        delete next.request.headers["mcp-protocol-version"];
+        return next;
+      }),
+    });
+
+    const contrastMissingInitialize = reobserve({
+      ...noHeader,
+      traceId: "mcpjam/other-scenario/2026-07-29/emulator",
+      scenario: {
+        ...noHeader.scenario,
+        scenarioId: "other-scenario",
+        capabilities: {
+          ...noHeader.scenario.capabilities,
+          serverProtocolVersion: "2025-06-18",
+        },
+      },
+      // Drop every JSON-RPC `initialize` exchange, not just the `mcp-initialize`
+      // leg: the fixture ALSO sends `initialize` on the earlier unauthenticated
+      // attempt, and `observeInitializeBodyVersion` reads whichever occurrence it
+      // finds first regardless of leg — so filtering by leg name alone leaves
+      // the body observable via the other occurrence and the test proves nothing.
+      wire: noHeader.wire.filter(
+        (exchange) => exchange.request.body?.encoding !== "jsonrpc",
+      ),
+    });
+
+    const evidence = traceToOAuthProfile(noHeader, {
+      contrastTrace: contrastMissingInitialize,
+    }).protocolVersionPinning;
+    expect(evidence?.status).toBe("unverifiable");
+    if (evidence?.status === "unverifiable") {
+      // Must NOT say "only one capture is available" — a valid second capture
+      // was supplied. Must name the real blocker instead.
+      expect(evidence.reason).not.toContain("only one capture is available");
+      expect(evidence.reason).toContain("A valid contrast trace was supplied");
+      expect(evidence.reason).toContain("mcp-initialize");
+    }
+  });
+
   it("records oauthSpecVersion as a behavioral FLOOR, never an exact revision", () => {
     // A trace observes wire shape. A literal revision string is a claim about the
     // client's code or its docs, so `basis: "constant"` is not something a capture

--- a/sdk/tests/support/oauth-capture-server.test.ts
+++ b/sdk/tests/support/oauth-capture-server.test.ts
@@ -1,0 +1,84 @@
+/**
+ * HP-44 — startup guarantees of the real-HTTP capture server.
+ *
+ * Everything here is about a failure that would otherwise be SILENT rather than
+ * loud. A capture server that advertises a bogus origin, or one whose startup
+ * promise never settles, does not produce a bad trace — it produces no trace and
+ * an operator staring at a hung terminal, after a manual handshake that cannot
+ * be replayed.
+ */
+
+import { describe, expect, it } from "vitest";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { startCaptureServer } from "./oauth-capture-server.js";
+
+describe("startCaptureServer startup guards", () => {
+  it("rejects a publicOrigin that is not an absolute http(s) URL", async () => {
+    // The motivating case is a bare `--public-origin` on the CLI, which takes the
+    // NEXT FLAG as its value. That string would become the PRM `resource`, the AS
+    // metadata origin and the 401 challenge pointer.
+    for (const bad of ["--keep-raw-har", "example.test", "ftp://example.test", ""]) {
+      await expect(startCaptureServer({ publicOrigin: bad })).rejects.toThrow(
+        /publicOrigin must be an absolute http\(s\) URL/,
+      );
+    }
+  });
+
+  it("accepts a well-formed publicOrigin and advertises it", async () => {
+    const server = await startCaptureServer({
+      publicOrigin: "https://tunnel.example.test/",
+    });
+    try {
+      // Trailing slash trimmed, so `${origin}/mcp` never doubles it.
+      expect(server.origin).toBe("https://tunnel.example.test");
+      expect(server.mcpUrl).toBe("https://tunnel.example.test/mcp");
+      expect(server.scenario.capabilities.prmResource).toBe(
+        "https://tunnel.example.test/mcp",
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("rejects instead of hanging when the port is already taken", async () => {
+    // `listen` reports a bind failure by emitting `error`, never by calling its
+    // callback, so awaiting only the callback left this pending forever.
+    const squatter = createServer();
+    await new Promise<void>((resolve) => {
+      squatter.listen(0, "127.0.0.1", () => resolve());
+    });
+    const { port } = squatter.address() as AddressInfo;
+
+    try {
+      await expect(
+        startCaptureServer({ port, host: "127.0.0.1" }),
+      ).rejects.toMatchObject({ code: "EADDRINUSE" });
+    } finally {
+      await new Promise<void>((resolve) => squatter.close(() => resolve()));
+    }
+  });
+
+  it("brackets an IPv6 bind host so its own origin is parseable", async () => {
+    // `new URL("http://::1:3999")` throws, and this origin is the base for every
+    // inbound `new URL(request.url, bindOrigin)` — so an unbracketed literal
+    // fails the capture on the first request rather than degrading.
+    let server: Awaited<ReturnType<typeof startCaptureServer>>;
+    try {
+      server = await startCaptureServer({ host: "::1" });
+    } catch {
+      // Some sandboxes have no IPv6 loopback at all. The bracketing itself is
+      // still asserted by the URL round-trip below on the hosts we can bind.
+      return;
+    }
+    try {
+      expect(server.origin).toMatch(/^http:\/\/\[::1\]:\d+$/);
+      expect(() => new URL("/mcp", server.origin)).not.toThrow();
+      // And it actually serves: the 401 challenge is the first leg of the dance.
+      const response = await fetch(server.mcpUrl, { method: "POST", body: "{}" });
+      expect(response.status).toBe(401);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/sdk/tests/support/oauth-capture-server.ts
+++ b/sdk/tests/support/oauth-capture-server.ts
@@ -1,0 +1,407 @@
+/**
+ * HP-44 — a real HTTP MCP resource server + authorization server that records
+ * every request it receives as a HAR.
+ *
+ * This is the harness's capture instrument and its HP-39 bolt-on, in one piece.
+ * Two things it gives us that the in-process `fetch` stub cannot:
+ *
+ *  1. **It captures a REAL host.** Any client that can be pointed at a URL —
+ *     Claude Code, the Inspector app in a browser, VS Code, `codex`, `goose` —
+ *     does its genuine handshake against this server, and the server records it.
+ *     The task calls for "a proxy (HAR or equivalent)"; being the endpoint IS the
+ *     equivalent, and it is strictly more faithful than a proxy: there is no TLS
+ *     interception, no client trust-store change, and nothing that could alter
+ *     the client's behavior in the act of observing it.
+ *
+ *  2. **It exercises the real network path.** Real header casing, real
+ *     `Content-Length`, real form encoding, a real 302 on `/authorize`, real
+ *     connection headers. A `fetch` stub silently normalizes all of that, and
+ *     several bugs only appear once it does not — the origin-vs-port ordering bug
+ *     in `abstractUrl` was found exactly here.
+ *
+ * The `/authorize` leg auto-approves and 302s straight back to the client's
+ * redirect URI. That is deliberate: consent is a human decision that tells us
+ * nothing about the client's wire behavior, and requiring a click would make the
+ * capture un-runnable in CI. Unlike the emulator path, the `/authorize` request
+ * IS intercepted here, so its headers are genuinely observed rather than
+ * reconstructed.
+ *
+ * Nothing here is a credential: the tokens are fixed literals, and the trace
+ * pipeline redacts them anyway.
+ */
+
+import { createServer } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import { AddressInfo } from "node:net";
+
+import type { TraceScenario } from "../../src/oauth-golden-trace/index.js";
+
+/** Fixed, obviously-fake credentials. Redacted by the pipeline regardless. */
+const ACCESS_TOKEN = "hp44-capture-access-token-not-a-real-credential";
+const REFRESH_TOKEN = "hp44-capture-refresh-token-not-a-real-credential";
+const AUTHORIZATION_CODE = "hp44-capture-authorization-code-not-a-real-credential";
+
+export type HarNameValue = { name: string; value: string };
+
+export type HarEntry = {
+  startedDateTime: string;
+  time: number;
+  request: {
+    method: string;
+    url: string;
+    httpVersion: string;
+    headers: HarNameValue[];
+    postData?: { mimeType: string; text: string };
+  };
+  response: {
+    status: number;
+    statusText: string;
+    httpVersion: string;
+    headers: HarNameValue[];
+    content: { size: number; mimeType: string; text: string };
+  };
+};
+
+export type CaptureServerOptions = {
+  /** Publish an RFC 9728 PRM document. Default true. */
+  publishesPrm?: boolean;
+  /** Advertise a `registration_endpoint`. Default true. */
+  supportsDcr?: boolean;
+  /** Advertise `client_id_metadata_document_supported`. Default false. */
+  supportsCimd?: boolean;
+  /** Protocol version returned from `initialize`. Default `2025-11-25`. */
+  serverProtocolVersion?: string;
+  /** Fixed port. Default 0 (ephemeral) — pass one for a stable external URL. */
+  port?: number;
+};
+
+export type CaptureServer = {
+  /** Base origin, e.g. `http://127.0.0.1:3999`. */
+  origin: string;
+  /** The MCP endpoint clients should be pointed at. */
+  mcpUrl: string;
+  /** Scenario block describing exactly what this instance implements. */
+  scenario: TraceScenario;
+  /** HAR log of everything received so far. */
+  har: () => { log: { version: string; creator: { name: string; version: string }; entries: HarEntry[] } };
+  /** Number of requests recorded. */
+  requestCount: () => number;
+  /** Discard recorded traffic without restarting (e.g. between phases). */
+  reset: () => void;
+  close: () => Promise<void>;
+  raw: Server;
+};
+
+function headerList(headers: NodeJS.Dict<string | string[]>): HarNameValue[] {
+  const out: HarNameValue[] = [];
+  for (const [name, value] of Object.entries(headers)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) out.push({ name, value: entry });
+    } else {
+      out.push({ name, value });
+    }
+  }
+  return out;
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/**
+ * Start the server.
+ *
+ * Resolves once it is listening, so a caller can hand `mcpUrl` to a real client
+ * immediately.
+ */
+export async function startCaptureServer(
+  options: CaptureServerOptions = {},
+): Promise<CaptureServer> {
+  const publishesPrm = options.publishesPrm ?? true;
+  const supportsDcr = options.supportsDcr ?? true;
+  const supportsCimd = options.supportsCimd ?? false;
+  const serverProtocolVersion = options.serverProtocolVersion ?? "2025-11-25";
+
+  let entries: HarEntry[] = [];
+  let origin = "";
+
+  const server = createServer((request, response) => {
+    void handle(request, response);
+  });
+
+  async function handle(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    const startedAt = Date.now();
+    const startedDateTime = new Date(startedAt).toISOString();
+    const requestBody = await readBody(request);
+    const requestHeaders = headerList(request.headers);
+    const url = new URL(request.url ?? "/", origin || "http://127.0.0.1");
+    const path = url.pathname;
+
+    const authorization =
+      request.headers.authorization ?? request.headers.Authorization;
+
+    // `send` is the single exit point, so every response is recorded exactly
+    // once and no branch can return without being captured.
+    const send = (
+      status: number,
+      body: string,
+      headers: Record<string, string> = {},
+    ): void => {
+      const resolved = {
+        "Content-Type": "application/json",
+        ...headers,
+      };
+      response.writeHead(status, resolved);
+      response.end(body);
+
+      entries.push({
+        startedDateTime,
+        time: Date.now() - startedAt,
+        request: {
+          method: request.method ?? "GET",
+          url: `${origin}${request.url ?? "/"}`,
+          httpVersion: `HTTP/${request.httpVersion}`,
+          headers: requestHeaders,
+          ...(requestBody
+            ? {
+                postData: {
+                  mimeType:
+                    (request.headers["content-type"] as string | undefined) ??
+                    "application/octet-stream",
+                  text: requestBody,
+                },
+              }
+            : {}),
+        },
+        response: {
+          status,
+          statusText: "",
+          httpVersion: "HTTP/1.1",
+          headers: headerList(resolved),
+          content: {
+            size: Buffer.byteLength(body),
+            mimeType: resolved["Content-Type"] ?? "application/json",
+            text: body,
+          },
+        },
+      });
+    };
+
+    const json = (
+      status: number,
+      value: unknown,
+      headers?: Record<string, string>,
+    ): void => send(status, JSON.stringify(value), headers);
+
+    // ── RFC 9728 protected resource metadata ──
+    if (publishesPrm && path === "/.well-known/oauth-protected-resource/mcp") {
+      json(200, {
+        resource: `${origin}/mcp`,
+        authorization_servers: [origin],
+        scopes_supported: ["mcp:read", "mcp:write"],
+        bearer_methods_supported: ["header"],
+      });
+      return;
+    }
+    // Clients differ on whether they try the path-aware form or the root form
+    // first; serving both means the LADDER ORDER is what gets recorded rather
+    // than the client being forced down one rung by a 404.
+    if (publishesPrm && path === "/.well-known/oauth-protected-resource") {
+      json(200, {
+        resource: `${origin}/mcp`,
+        authorization_servers: [origin],
+        scopes_supported: ["mcp:read", "mcp:write"],
+        bearer_methods_supported: ["header"],
+      });
+      return;
+    }
+
+    // ── RFC 8414 authorization server metadata ──
+    if (
+      path === "/.well-known/oauth-authorization-server" ||
+      path === "/.well-known/oauth-authorization-server/mcp" ||
+      path === "/.well-known/openid-configuration"
+    ) {
+      json(200, {
+        issuer: origin,
+        authorization_endpoint: `${origin}/authorize`,
+        token_endpoint: `${origin}/token`,
+        ...(supportsDcr ? { registration_endpoint: `${origin}/register` } : {}),
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        code_challenge_methods_supported: ["S256"],
+        scopes_supported: ["mcp:read", "mcp:write"],
+        token_endpoint_auth_methods_supported: ["none", "client_secret_post"],
+        ...(supportsCimd ? { client_id_metadata_document_supported: true } : {}),
+      });
+      return;
+    }
+
+    // ── RFC 7591 dynamic client registration ──
+    if (path === "/register" && request.method === "POST") {
+      let registered: Record<string, unknown> = {};
+      try {
+        registered = JSON.parse(requestBody) as Record<string, unknown>;
+      } catch {
+        // Recorded verbatim regardless; a client that posts a non-JSON body is
+        // itself the finding.
+      }
+      json(201, {
+        client_id: "hp44-capture-issued-client-id",
+        client_id_issued_at: Math.floor(startedAt / 1000),
+        // Echo the client's own metadata back, which is what a real AS does and
+        // what several clients then validate.
+        ...registered,
+      });
+      return;
+    }
+
+    // ── /authorize — auto-approve, 302 back to the client's redirect URI ──
+    if (path === "/authorize") {
+      const redirectUri = url.searchParams.get("redirect_uri");
+      const state = url.searchParams.get("state");
+      if (!redirectUri) {
+        json(400, { error: "invalid_request", error_description: "redirect_uri is required" });
+        return;
+      }
+      const location = new URL(redirectUri);
+      location.searchParams.set("code", AUTHORIZATION_CODE);
+      if (state) location.searchParams.set("state", state);
+      // RFC 9207: echo the issuer so a 2026-07-28-era client can validate it.
+      location.searchParams.set("iss", origin);
+      send(302, "", { Location: location.toString(), "Content-Type": "text/plain" });
+      return;
+    }
+
+    // ── /token ──
+    if (path === "/token" && request.method === "POST") {
+      const form = new URLSearchParams(requestBody);
+      const grantType = form.get("grant_type");
+      json(200, {
+        access_token: ACCESS_TOKEN,
+        token_type: "Bearer",
+        expires_in: 3600,
+        refresh_token: REFRESH_TOKEN,
+        scope: form.get("scope") ?? "mcp:read mcp:write",
+        ...(grantType ? {} : {}),
+      });
+      return;
+    }
+
+    // ── MCP endpoint ──
+    if (path === "/mcp") {
+      if (!authorization) {
+        send(401, JSON.stringify({ error: "unauthorized" }), {
+          "WWW-Authenticate": publishesPrm
+            ? `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`
+            : "Bearer",
+        });
+        return;
+      }
+
+      let rpc: { id?: unknown; method?: string } = {};
+      try {
+        rpc = JSON.parse(requestBody) as { id?: unknown; method?: string };
+      } catch {
+        // Fall through to a generic OK below.
+      }
+
+      if (rpc.method === "initialize") {
+        json(
+          200,
+          {
+            jsonrpc: "2.0",
+            id: rpc.id ?? 1,
+            result: {
+              protocolVersion: serverProtocolVersion,
+              serverInfo: { name: "hp44-capture-server", version: "1.0.0" },
+              capabilities: { tools: {} },
+            },
+          },
+          { "Mcp-Session-Id": "hp44-capture-session" },
+        );
+        return;
+      }
+      if (rpc.method === "tools/list") {
+        json(200, {
+          jsonrpc: "2.0",
+          id: rpc.id ?? 1,
+          result: { tools: [{ name: "hp44_noop", description: "No-op probe tool", inputSchema: { type: "object" } }] },
+        });
+        return;
+      }
+      if (rpc.method === "tools/call") {
+        json(200, {
+          jsonrpc: "2.0",
+          id: rpc.id ?? 1,
+          result: { content: [{ type: "text", text: "ok" }] },
+        });
+        return;
+      }
+      // Notifications carry no id and expect 202 with no body.
+      if (typeof rpc.method === "string" && rpc.id == null) {
+        send(202, "", { "Content-Type": "text/plain" });
+        return;
+      }
+
+      json(200, { jsonrpc: "2.0", id: rpc.id ?? 1, result: {} });
+      return;
+    }
+
+    json(404, { error: "not_found" });
+  }
+
+  await new Promise<void>((resolve) => {
+    server.listen(options.port ?? 0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  origin = `http://127.0.0.1:${address.port}`;
+
+  const scenario: TraceScenario = {
+    scenarioId: `http-capture-dcr-authcode${publishesPrm ? "-prm" : "-noprm"}`,
+    description:
+      "Real HTTP MCP resource server + authorization server, recording its own traffic as a HAR. 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE → token → MCP initialize.",
+    mcpServerUrl: `${origin}/mcp`,
+    authorizationServerUrl: origin,
+    capabilities: {
+      publishesPrm,
+      ...(publishesPrm ? { prmResource: `${origin}/mcp` } : {}),
+      supportsDcr,
+      supportsCimd,
+      codeChallengeMethods: ["S256"],
+      asMetadataDocuments: ["/.well-known/oauth-authorization-server"],
+      challengesUnauthenticated: true,
+    },
+  };
+
+  return {
+    origin,
+    mcpUrl: `${origin}/mcp`,
+    scenario,
+    har: () => ({
+      log: {
+        version: "1.2",
+        creator: { name: "mcpjam-hp44-capture-server", version: "1" },
+        entries: [...entries],
+      },
+    }),
+    requestCount: () => entries.length,
+    reset: () => {
+      entries = [];
+    },
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+    raw: server,
+  };
+}

--- a/sdk/tests/support/oauth-capture-server.ts
+++ b/sdk/tests/support/oauth-capture-server.ts
@@ -100,6 +100,25 @@ export type CaptureServerOptions = {
   publicOrigin?: string;
 };
 
+/**
+ * Render a bind host as a URL authority component.
+ *
+ * A wildcard bind address is not a reachable destination, so it is rewritten to
+ * the corresponding loopback. An IPv6 literal has to be bracketed: `new URL()`
+ * cannot parse `http://::1:3999` at all, and this origin is fed straight back
+ * into `new URL(request.url, bindOrigin)` on every inbound request, so an
+ * unbracketed value fails the whole capture on the first hit rather than
+ * degrading.
+ */
+function hostForUrl(host: string): string {
+  if (host === "0.0.0.0") return "127.0.0.1";
+  if (host === "::" || host === "::0") return "[::1]";
+  // Already bracketed, or a hostname/IPv4 — neither needs help. Only a bare IPv6
+  // literal contains a colon.
+  if (host.startsWith("[") || !host.includes(":")) return host;
+  return `[${host}]`;
+}
+
 export type CaptureServer = {
   /** Base origin, e.g. `http://127.0.0.1:3999`. */
   origin: string;
@@ -111,6 +130,12 @@ export type CaptureServer = {
   har: () => { log: { version: string; creator: { name: string; version: string }; entries: HarEntry[] } };
   /** Number of requests recorded. */
   requestCount: () => number;
+  /**
+   * Requests served but NOT recorded because the entry cap was reached. Non-zero
+   * means the HAR is an incomplete view of what happened and any trace built from
+   * it is truncated — the caller must not read it as a complete capture.
+   */
+  droppedCount: () => number;
   /** Discard recorded traffic without restarting (e.g. between phases). */
   reset: () => void;
   close: () => Promise<void>;
@@ -130,12 +155,51 @@ function headerList(headers: NodeJS.Dict<string | string[]>): HarNameValue[] {
   return out;
 }
 
+/**
+ * Ceiling on a single recorded request body.
+ *
+ * Generous next to any real OAuth or MCP payload — a DCR registration is a few
+ * hundred bytes — and small enough that a flood cannot exhaust the heap. This is
+ * a test instrument, but `--public-origin` puts it behind a tunnel on the open
+ * internet, where "test instrument" stops being a containment argument.
+ */
+const MAX_BODY_BYTES = 1024 * 1024;
+
+/**
+ * Ceiling on recorded HAR entries. A capture is a handful of legs; anything past
+ * this is a flood, and dropping the overflow keeps the artifact (and the process)
+ * intact. `har()` reports the drop rather than silently returning a short log.
+ */
+const MAX_HAR_ENTRIES = 2000;
+
+/**
+ * Read a request body, truncating past {@link MAX_BODY_BYTES}.
+ *
+ * Truncation is marked in the returned string so a downstream parse failure is
+ * attributable to the cap rather than looking like a malformed client.
+ */
 async function readBody(request: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
+  let size = 0;
+  let truncated = false;
   for await (const chunk of request) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    if (size + buffer.length > MAX_BODY_BYTES) {
+      chunks.push(buffer.subarray(0, Math.max(0, MAX_BODY_BYTES - size)));
+      size = MAX_BODY_BYTES;
+      truncated = true;
+      break;
+    }
+    chunks.push(buffer);
+    size += buffer.length;
   }
-  return Buffer.concat(chunks).toString("utf8");
+  if (truncated) {
+    // Drain the rest so the socket closes cleanly instead of the peer seeing a
+    // reset mid-upload, which would look like a server bug in the capture.
+    request.resume();
+  }
+  const body = Buffer.concat(chunks).toString("utf8");
+  return truncated ? `${body}\n<<truncated at ${MAX_BODY_BYTES} bytes>>` : body;
 }
 
 /**
@@ -153,13 +217,26 @@ export async function startCaptureServer(
   const serverProtocolVersion = options.serverProtocolVersion ?? "2025-11-25";
 
   let entries: HarEntry[] = [];
+  /** Requests served but NOT recorded because {@link MAX_HAR_ENTRIES} was hit. */
+  let dropped = 0;
   /** Where the server actually listens. Used only to parse inbound request URLs. */
   let bindOrigin = "";
   /** What the server ADVERTISES, and what the client sees. See `publicOrigin`. */
   let origin = "";
 
   const server = createServer((request, response) => {
-    void handle(request, response);
+    // A rejection here must fail ON THE WIRE, not in the process: discarding the
+    // promise leaves the client hanging until its own timeout (which reads as a
+    // host bug in the capture) and crashes Node under
+    // `--unhandled-rejections=throw`. A 500 is recorded nowhere, so the loud log
+    // is the only trace of it.
+    handle(request, response).catch((error) => {
+      if (!response.headersSent) {
+        response.writeHead(500, { "Content-Type": "application/json" });
+      }
+      response.end(JSON.stringify({ error: "capture_server_error" }));
+      console.error("[hp44] capture server handler failed", error);
+    });
   });
 
   async function handle(
@@ -173,8 +250,9 @@ export async function startCaptureServer(
     const url = new URL(request.url ?? "/", bindOrigin || "http://127.0.0.1");
     const path = url.pathname;
 
-    const authorization =
-      request.headers.authorization ?? request.headers.Authorization;
+    // Node lowercases every `IncomingMessage` header name, so this is the only
+    // spelling that can ever be present.
+    const authorization = request.headers.authorization;
 
     // `send` is the single exit point, so every response is recorded exactly
     // once and no branch can return without being captured.
@@ -189,6 +267,14 @@ export async function startCaptureServer(
       };
       response.writeHead(status, resolved);
       response.end(body);
+
+      // Keep serving after the cap — refusing traffic would change the behavior
+      // being observed, which is the one thing this server must not do. Only the
+      // recording stops.
+      if (entries.length >= MAX_HAR_ENTRIES) {
+        dropped += 1;
+        return;
+      }
 
       entries.push({
         startedDateTime,
@@ -302,7 +388,19 @@ export async function startCaptureServer(
         json(400, { error: "invalid_request", error_description: "redirect_uri is required" });
         return;
       }
-      const location = new URL(redirectUri);
+      // A host that sends a relative or otherwise unparseable `redirect_uri` is
+      // itself the finding — answer it as an OAuth error so the capture records
+      // the rejection, rather than throwing out of the handler.
+      let location: URL;
+      try {
+        location = new URL(redirectUri);
+      } catch {
+        json(400, {
+          error: "invalid_request",
+          error_description: "redirect_uri is not an absolute URL",
+        });
+        return;
+      }
       location.searchParams.set("code", AUTHORIZATION_CODE);
       if (state) location.searchParams.set("state", state);
       // RFC 9207: echo the issuer so a 2026-07-28-era client can validate it.
@@ -314,14 +412,12 @@ export async function startCaptureServer(
     // ── /token ──
     if (path === "/token" && request.method === "POST") {
       const form = new URLSearchParams(requestBody);
-      const grantType = form.get("grant_type");
       json(200, {
         access_token: ACCESS_TOKEN,
         token_type: "Bearer",
         expires_in: 3600,
         refresh_token: REFRESH_TOKEN,
         scope: form.get("scope") ?? "mcp:read mcp:write",
-        ...(grantType ? {} : {}),
       });
       return;
     }
@@ -389,19 +485,50 @@ export async function startCaptureServer(
     json(404, { error: "not_found" });
   }
 
+  // Validated here rather than only in the CLI wrapper, because a bad value does
+  // not fail loudly — it silently becomes the origin of every URL this server
+  // advertises, so the captured trace records a handshake against a host that
+  // does not exist. Non-CLI callers deserve the same guarantee as the script.
+  if (options.publicOrigin !== undefined) {
+    let parsed: URL | undefined;
+    try {
+      parsed = new URL(options.publicOrigin);
+    } catch {
+      parsed = undefined;
+    }
+    if (!parsed || (parsed.protocol !== "http:" && parsed.protocol !== "https:")) {
+      throw new Error(
+        `startCaptureServer: publicOrigin must be an absolute http(s) URL, got \`${options.publicOrigin}\``,
+      );
+    }
+  }
+
   const host = options.host ?? "127.0.0.1";
-  await new Promise<void>((resolve) => {
-    server.listen(options.port ?? 0, host, () => resolve());
+  await new Promise<void>((resolve, reject) => {
+    // `listen` reports a bind failure by EMITTING `error`, not by calling back, so
+    // awaiting only the success callback leaves this promise pending forever on an
+    // occupied port — the caller hangs instead of failing.
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(options.port ?? 0, host, () => {
+      server.off("error", onError);
+      resolve();
+    });
   });
 
   const address = server.address() as AddressInfo;
-  bindOrigin = `http://${host === "0.0.0.0" ? "127.0.0.1" : host}:${address.port}`;
+  bindOrigin = `http://${hostForUrl(host)}:${address.port}`;
   // Advertise the public origin when one is supplied (a tunnel in front of us);
   // otherwise the bind origin IS the public origin.
   origin = (options.publicOrigin ?? bindOrigin).replace(/\/$/, "");
 
   const scenario: TraceScenario = {
-    scenarioId: `http-capture-dcr-authcode${publishesPrm ? "-prm" : "-noprm"}`,
+    // The advertised protocol version is part of the scenario IDENTITY, not just
+    // its capabilities: two captures that differ only in the version the server
+    // announced are different experiments, and the pin-vs-negotiate projection
+    // needs to tell them apart. With a shared id they compared as "the same
+    // scenario" and the contrast arm rejected a valid experiment.
+    scenarioId: `http-capture-dcr-authcode${publishesPrm ? "-prm" : "-noprm"}-mcp${serverProtocolVersion}`,
     description:
       "Real HTTP MCP resource server + authorization server, recording its own traffic as a HAR. 401 challenge → RFC 9728 PRM → RFC 8414 AS metadata → RFC 7591 DCR → authorization code + PKCE → token → MCP initialize.",
     mcpServerUrl: `${origin}/mcp`,
@@ -412,6 +539,7 @@ export async function startCaptureServer(
       supportsDcr,
       supportsCimd,
       codeChallengeMethods: ["S256"],
+      serverProtocolVersion,
       asMetadataDocuments: ["/.well-known/oauth-authorization-server"],
       challengesUnauthenticated: true,
     },
@@ -429,8 +557,10 @@ export async function startCaptureServer(
       },
     }),
     requestCount: () => entries.length,
+    droppedCount: () => dropped,
     reset: () => {
       entries = [];
+      dropped = 0;
     },
     close: () =>
       new Promise<void>((resolve, reject) => {

--- a/sdk/tests/support/oauth-capture-server.ts
+++ b/sdk/tests/support/oauth-capture-server.ts
@@ -73,6 +73,31 @@ export type CaptureServerOptions = {
   serverProtocolVersion?: string;
   /** Fixed port. Default 0 (ephemeral) — pass one for a stable external URL. */
   port?: number;
+  /**
+   * Interface to bind. Default `127.0.0.1`. Pass `0.0.0.0` to accept connections
+   * from outside the machine, which a tunnel needs.
+   */
+  host?: string;
+  /**
+   * The base URL this server is reachable at FROM THE CLIENT, when that differs
+   * from where it binds — e.g. `https://abc123.ngrok.app` in front of
+   * `127.0.0.1:3999`.
+   *
+   * This is what makes HOSTED clients capturable at all, and it is not a
+   * convenience. A local client (Claude Code, VS Code, Codex, Goose, Cline) runs
+   * OAuth on the user's machine and can reach `127.0.0.1`. A hosted client
+   * (Slack, ChatGPT, Claude.ai web, Mistral, Notion, Perplexity, M365 Copilot)
+   * performs the handshake from ITS OWN infrastructure, so `127.0.0.1` resolves to
+   * that vendor's server, not ours — the capture would never arrive.
+   *
+   * Every URL the server ADVERTISES must therefore be the public one: the PRM
+   * `resource` and `authorization_servers`, the AS metadata endpoints, and the
+   * `resource_metadata` pointer in the 401 challenge. Several clients hard-fail
+   * when the PRM `resource` does not equal the URL they were configured with
+   * (RFC 9728), so advertising the bind origin would break the flow rather than
+   * merely mislabel it.
+   */
+  publicOrigin?: string;
 };
 
 export type CaptureServer = {
@@ -128,6 +153,9 @@ export async function startCaptureServer(
   const serverProtocolVersion = options.serverProtocolVersion ?? "2025-11-25";
 
   let entries: HarEntry[] = [];
+  /** Where the server actually listens. Used only to parse inbound request URLs. */
+  let bindOrigin = "";
+  /** What the server ADVERTISES, and what the client sees. See `publicOrigin`. */
   let origin = "";
 
   const server = createServer((request, response) => {
@@ -142,7 +170,7 @@ export async function startCaptureServer(
     const startedDateTime = new Date(startedAt).toISOString();
     const requestBody = await readBody(request);
     const requestHeaders = headerList(request.headers);
-    const url = new URL(request.url ?? "/", origin || "http://127.0.0.1");
+    const url = new URL(request.url ?? "/", bindOrigin || "http://127.0.0.1");
     const path = url.pathname;
 
     const authorization =
@@ -167,6 +195,8 @@ export async function startCaptureServer(
         time: Date.now() - startedAt,
         request: {
           method: request.method ?? "GET",
+          // Recorded as the CLIENT addressed it, so the trace and the scenario
+          // agree on one origin and `{mcp_server}` substitutes cleanly.
           url: `${origin}${request.url ?? "/"}`,
           httpVersion: `HTTP/${request.httpVersion}`,
           headers: requestHeaders,
@@ -359,12 +389,16 @@ export async function startCaptureServer(
     json(404, { error: "not_found" });
   }
 
+  const host = options.host ?? "127.0.0.1";
   await new Promise<void>((resolve) => {
-    server.listen(options.port ?? 0, "127.0.0.1", () => resolve());
+    server.listen(options.port ?? 0, host, () => resolve());
   });
 
   const address = server.address() as AddressInfo;
-  origin = `http://127.0.0.1:${address.port}`;
+  bindOrigin = `http://${host === "0.0.0.0" ? "127.0.0.1" : host}:${address.port}`;
+  // Advertise the public origin when one is supplied (a tunnel in front of us);
+  // otherwise the bind origin IS the public origin.
+  origin = (options.publicOrigin ?? bindOrigin).replace(/\/$/, "");
 
   const scenario: TraceScenario = {
     scenarioId: `http-capture-dcr-authcode${publishesPrm ? "-prm" : "-noprm"}`,

--- a/sdk/tests/support/oauth-emulator-driver.ts
+++ b/sdk/tests/support/oauth-emulator-driver.ts
@@ -19,7 +19,10 @@
 
 import { runOAuthStateMachine } from "../../src/oauth/state-machines/runner.js";
 import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
-import type { OAuthFlowState } from "../../src/oauth/state-machines/types.js";
+import type {
+  OAuthDynamicRegistrationMetadata,
+  OAuthFlowState,
+} from "../../src/oauth/state-machines/types.js";
 import type { EmulatorFlowRecord } from "../../src/oauth-golden-trace/index.js";
 import type { CaptureServer } from "./oauth-capture-server.js";
 
@@ -68,8 +71,12 @@ export async function fetchExecutor(request: {
 }
 
 export type RunEmulatorOptions = {
-  /** Overrides the DCR body, e.g. to reproduce another host's identity. */
-  dynamicRegistration?: Record<string, unknown>;
+  /**
+   * Overrides the DCR body, e.g. to reproduce another host's identity. Typed as
+   * the runner's own contract so a shape change there breaks THIS file at compile
+   * time instead of being papered over by a cast.
+   */
+  dynamicRegistration?: Partial<OAuthDynamicRegistrationMetadata>;
   redirectUrl?: string;
   serverName?: string;
   protocolVersion?: "2025-03-26" | "2025-06-18" | "2025-11-25" | "2026-07-28";
@@ -109,13 +116,13 @@ export async function runEmulatorAgainst(
     // `client_name` is mandatory for the DCR strategy — the machine throws
     // without it — so a default stands in when the caller isn't reproducing
     // another host's identity.
-    dynamicRegistration: (options.dynamicRegistration ?? {
+    dynamicRegistration: options.dynamicRegistration ?? {
       client_name: "MCPJam HP-44 Capture",
       redirect_uris: [redirectUrl],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: "none",
-    }) as never,
+    },
     ...(options.scopes ? { customScopes: options.scopes } : {}),
     authMode: "headless",
     // The test server IS loopback; without this every metadata fetch is refused.

--- a/sdk/tests/support/oauth-emulator-driver.ts
+++ b/sdk/tests/support/oauth-emulator-driver.ts
@@ -1,0 +1,143 @@
+/**
+ * HP-44 — drive the emulator over real HTTP.
+ *
+ * Runs MCPJam's OAuth state machine against a real server via
+ * `runOAuthStateMachine`, with a real `fetch` executor, and returns the flow
+ * record `captureEmulatorTraceFromFlow` consumes.
+ *
+ * Why not `OAuthConformanceTest`: it does not plumb `allowLoopbackMetadataFetch`
+ * through to the state-machine factory, so it cannot talk to a loopback test
+ * server at all — the SSRF guard refuses every metadata fetch. That is a real gap
+ * for HP-39's "test MCP server in CI" story and is recorded in the coverage doc.
+ * The inspector client already opts in the same way (`allowLoopbackMetadataFetch:
+ * isLoopbackOAuthUrl(serverUrl)`), so the fix has a precedent to follow.
+ *
+ * Driving the machine directly is also the shape HP-43 will use: a per-host
+ * emulator configured from a host profile has no reason to route through the
+ * conformance runner.
+ */
+
+import { runOAuthStateMachine } from "../../src/oauth/state-machines/runner.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+import type { OAuthFlowState } from "../../src/oauth/state-machines/types.js";
+import type { EmulatorFlowRecord } from "../../src/oauth-golden-trace/index.js";
+import type { CaptureServer } from "./oauth-capture-server.js";
+
+/** A real `fetch`-backed request executor. */
+export async function fetchExecutor(request: {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: unknown;
+  redirect?: "follow" | "manual";
+}) {
+  const response = await fetch(request.url, {
+    method: request.method,
+    headers: request.headers,
+    ...(request.body != null
+      ? {
+          body:
+            typeof request.body === "string"
+              ? request.body
+              : JSON.stringify(request.body),
+        }
+      : {}),
+    redirect: request.redirect === "manual" ? "manual" : "follow",
+  });
+
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch {
+    // Non-JSON passes through as text; the trace records it as opaque.
+  }
+
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+    body,
+  };
+}
+
+export type RunEmulatorOptions = {
+  /** Overrides the DCR body, e.g. to reproduce another host's identity. */
+  dynamicRegistration?: Record<string, unknown>;
+  redirectUrl?: string;
+  serverName?: string;
+  protocolVersion?: "2025-03-26" | "2025-06-18" | "2025-11-25" | "2026-07-28";
+  registrationStrategy?: "dcr" | "cimd" | "preregistered";
+  scopes?: string;
+};
+
+export type RunEmulatorResult = {
+  flow: EmulatorFlowRecord;
+  completed: boolean;
+  finalStep: string;
+  error?: string;
+};
+
+/** Run a full OAuth dance against `server`, following the 302 in place of a browser. */
+export async function runEmulatorAgainst(
+  server: CaptureServer,
+  options: RunEmulatorOptions = {},
+): Promise<RunEmulatorResult> {
+  const redirectUrl = options.redirectUrl ?? "http://127.0.0.1:33418/callback";
+  let state: OAuthFlowState = {
+    ...EMPTY_OAUTH_FLOW_STATE,
+    serverUrl: server.mcpUrl,
+  };
+
+  const run = await runOAuthStateMachine({
+    protocolVersion: options.protocolVersion ?? "2025-11-25",
+    registrationStrategy: options.registrationStrategy ?? "dcr",
+    serverUrl: server.mcpUrl,
+    serverName: options.serverName ?? "hp44capture",
+    redirectUrl,
+    state,
+    getState: () => state,
+    updateState: (updates) => {
+      state = { ...state, ...updates };
+    },
+    // `client_name` is mandatory for the DCR strategy — the machine throws
+    // without it — so a default stands in when the caller isn't reproducing
+    // another host's identity.
+    dynamicRegistration: (options.dynamicRegistration ?? {
+      client_name: "MCPJam HP-44 Capture",
+      redirect_uris: [redirectUrl],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    }) as never,
+    ...(options.scopes ? { customScopes: options.scopes } : {}),
+    authMode: "headless",
+    // The test server IS loopback; without this every metadata fetch is refused.
+    allowLoopbackMetadataFetch: true,
+    requestExecutor: fetchExecutor,
+    onAuthorizationRequest: async ({ authorizationUrl }) => {
+      // Stand in for the browser: follow the 302 and read the code off it.
+      const response = await fetch(authorizationUrl, { redirect: "manual" });
+      const location = response.headers.get("location");
+      const code = location ? new URL(location).searchParams.get("code") : null;
+      if (!code) throw new Error(`no authorization code in redirect: ${location}`);
+      return { type: "authorization_code", authorizationCode: code };
+    },
+  });
+
+  return {
+    flow: {
+      httpHistory: state.httpHistory ?? [],
+      ...(run.authorizationUrl ? { authorizationUrl: run.authorizationUrl } : {}),
+    },
+    completed: run.completed,
+    finalStep: state.currentStep,
+    ...(run.error ? { error: run.error.message } : {}),
+  };
+}


### PR DESCRIPTION
## What

Defines what "the emulator behaves exactly like the real host" **means** and makes it mechanically checkable. This is the acceptance oracle for **HP-43** (emulator enforcement), and the evidence source for **HP-9** (capability audit) and **HP-38** (drift detection).

Pipeline: **capture** (in-process run *or* a real host through a recording server) → **normalize + redact at capture time** → **derive observations** → **diff field by field** → **project onto `HostConfigOAuthProfileV1`**.

```
sdk/src/oauth-golden-trace/     types · normalize · observe · parse · diff · from-conformance · from-har · to-profile · format
sdk/tests/support/              oauth-capture-server.ts (real HTTP MCP RS + AS that records itself as a HAR)
cli/src/commands/oauth-trace.ts mcpjam oauth trace capture | ingest-har | diff | to-profile
```

## Three design decisions that are load-bearing, not stylistic

**1. Observations are a tri-state, not `T | undefined`.**

```ts
type Observation<T> =
  | { state: "present"; value: T }
  | { state: "absent" }                        // leg captured, field not on it — a CITABLE finding
  | { state: "not-observed"; reason: string }; // leg never captured — a gap, carries NO value
```

`absent` maps to a `verified` profile field; `not-observed` maps to `unverifiable`. Collapsing them is how "we didn't look" becomes "the client doesn't do it" — the exact failure mode that produced four false claims in HP-17 and two more in our own follow-up. `compareObservation()` is the single place this is decided, so it can't be got wrong field by field.

**2. `protocolVersionPinning` is recorded as separate fields.** The `initialize` body version and the `MCP-Protocol-Version` header are tracked apart, **per leg**, with `wiresDisagree` as a first-class flag. These genuinely disagree in the wild; one field would average away the most interesting findings. Per-leg values are `string[]` (distinct values seen), because exactly-one is a `pinned` claim and more-than-one is not a pin at all.

**3. Traces stamp the resolved OAuth *dependency*, not just the host version.** Most source-verified clients inherit OAuth from `rmcp` or the upstream TS SDK, so a host-version-only stamp goes stale silently on a bump. Omitting it is allowed but reports as a gap on every diff.

## First real third-party capture — and what it corrected

`sdk/tests/support/oauth-capture-server.ts` is a real HTTP MCP resource server + authorization server that records every request as a HAR. Being the endpoint beats a proxy: no TLS interception, no client trust-store change, so nothing can alter the behavior being observed. `/authorize` auto-approves, so a full dance completes unattended and runs in CI.

Pointed a headless Claude Code at it. `claude-code` 2.1.220:

| Field | HP-47 desk research | The capture |
|---|---|---|
| User-Agent | `unverifiable` | `claude-code/2.1.220 (sdk-cli)` |
| `MCP-Protocol-Version` | `unverifiable` | `2025-11-25` on OAuth discovery, **absent on MCP traffic** |
| DCR `client_name` | `Claude Code` (from its CIMD) | **`Claude Code (<serverName>)`** — templated |
| DCR `redirect_uris` | port-less (from its CIMD) | `http://localhost:3118/callback` |

The bottom two aren't contradictions of the CIMD document — they're evidence that **what a client registers via DCR differs from what its CIMD declares.** A server gating on exact `client_name` accepts one and rejects the other. That makes every CIMD-derived `client_name` in the catalog provisional.

## Four bugs found by running against real HTTP

None of these could surface against an in-memory `fetch` stub with https origins:

1. **A live authorization code would have been committed.** A conformant AS answers `/authorize` with `302 Location: <redirect_uri>?code=<code>`. URL-valued response headers were treated as opaque strings. They now get the same per-param policy as request URLs. Caught by `assertTraceIsRedacted` on the first capture that completed an authorize leg.
2. **Origins must be substituted before loopback ports.** A test server is *both* a scenario origin and a loopback address; placeholding the port first made the origin unmatchable.
3. **A truncated golden capture manufactured false differences.** Legs past where a recording stopped were reported as "the emulator hit an endpoint the real host did not" — not something a partial capture can support. Strict-prefix ⇒ gaps.
4. **Cross-vantage diffs can't compare stack-added headers.** Client-side captures record what the client *code* set; server-side captures record what *arrived* (`host`, `content-length`, `accept-encoding`). Excluded only when the vantage points differ.

## Notes for review

- **`emulator-vs-real-host.test.ts` deliberately does NOT assert parity.** The DCR body is hand-configured as a stand-in for HP-43, so a green parity result would only prove that typed-in fields match read-out fields. It asserts the *oracle* works on real data. Current output is **17 differences / 13 gaps / 23 matches** — the HP-43 work list, headlined by "the emulator sends no `User-Agent` on any leg" and "gets the protocol header wrong in opposite directions on two different legs".
- **The emulator side is generated live, not committed.** A committed emulator trace goes stale silently; a live run always reflects current behavior. Only real-host traces are committed artifacts.
- **`committed-traces.test.ts` discovers traces from the filesystem** rather than listing them, so a trace added later is validated with no edit. It reports `0 committed comparable pairs` today — honestly, because no host has both a committed real-host *and* emulator trace.
- **Capture is driver-independent** (`captureEmulatorTraceFromFlow` + `EmulatorFlowRecord`). HP-43's per-host emulator and the browser Inspector drive the state machine directly and would otherwise have had to fake a `ConformanceResult`.
- **Known gap worth a follow-up:** `OAuthConformanceTest` does not plumb `allowLoopbackMetadataFetch`, so it cannot talk to a loopback test server at all — the SSRF guard refuses every metadata fetch. That blocks HP-39's "test MCP server in CI" story. The inspector client already opts in the same way (`allowLoopbackMetadataFetch: isLoopbackOAuthUrl(serverUrl)`), so the fix has a precedent. Tests here drive `runOAuthStateMachine` directly to work around it.
- Secrets are redacted at capture time via the existing `redactSensitiveValue`, then re-checked by `assertTraceIsRedacted`, which **throws** rather than writing a trace containing a secret-shaped value.

## Scope

Depends on HP-3 (`HostConfigOAuthProfileV1`), now merged in #3561. Sibling of HP-43 (enforcement); consumes/extends HP-39.

Coverage is **1 real third-party host of 16**. Four cannot be captured at all right now — Slack / Mistral / M365 Copilot on the ownerless HP-9 credential blocker, AgentCore needs a provisioned AWS Gateway. Those are marked unverified, never assumed. The per-host capture backlog is follow-on work; docs for it are deliberately not in this PR.

## Test

- `tsc --noEmit` clean (sdk + cli) · `npm run build` clean
- **76** golden-trace tests, **34** CLI tests, and the existing oauth-conformance + host-config suites all pass (**262** in the combined OAuth/host-config run)
- Includes **nine negative tests** proving the oracle is not vacuous — a differ hardcoded to return parity would pass the positive tests alone
- Pre-existing unrelated failures on `main` (stdio/spawn integration tests) verified identical at the merge base

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OAuth golden-trace parity harness to capture real host OAuth handshakes, diff emulator runs, and project results to `HostConfigOAuthProfileV1`. Implements HP-44 and supports HP-43 (enforcement) and HP-38 (drift), with hosted-client capture and the first real-host trace (Claude Code).

- **Bug Fixes**
  - Parity guards: `sameSubject` now requires matching `hostVersion` and `oauthImplementation`; contrasts missing either stamp are refused.
  - Pin vs negotiate: fallback messaging correctly names a missing `initialize` body instead of a misleading “only one capture” blocker.
  - Robust accumulators: use `Object.create(null)` for wire-derived maps to preserve `__proto__`-named fields.
  - JSON-RPC batches: materialize arrays before checks so sparse holes don’t pass vacuously.
  - Redaction hardening: report sanitization strips `user:pass@` even for malformed URLs; raw-HAR safety check also detects JSON-encoded secrets.
  - Structural checks: `readTrace` now validates scenario required fields (`scenarioId`, `mcpServerUrl`, `capabilities`).

<sup>Written for commit 997f3825837d300a3ffa1399795f86355f8cbfac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

