### PR TITLE
feat(environments): Sandbox image section in the environment editor

### DIFF
--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
@@ -5,6 +5,9 @@ import { Button } from "@mcpjam/design-system/button";
 import { Label } from "@mcpjam/design-system/label";
 import { HostPicker } from "@/components/hosts/HostPicker";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
+import { EnvironmentBuildBadge } from "@/components/computer/EnvironmentBuildBadge";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useSandboxImages } from "@/hooks/useSandboxImages";
 import { convexErrMessage } from "@/lib/convex-error";
 import {
   isRevisionConflictError,
@@ -21,6 +24,7 @@ type EnvironmentDraft = {
   hostId: string | null;
   serverAttachmentId: string | null;
   skillSelection: ProjectEnvironmentSkillSelection | null;
+  computerEnvironmentId: string | null;
 };
 
 function draftFromEnvironment(env: ProjectEnvironmentView): EnvironmentDraft {
@@ -30,6 +34,7 @@ function draftFromEnvironment(env: ProjectEnvironmentView): EnvironmentDraft {
     hostId: env.hostId,
     serverAttachmentId: env.serverAttachmentId ?? null,
     skillSelection: env.skillSelection ?? null,
+    computerEnvironmentId: env.computerEnvironmentId ?? null,
   };
 }
 
@@ -72,6 +77,15 @@ export function ProjectEnvironmentEditor({
 }) {
   const createEnvironment = useCreateProjectEnvironment();
   const updateEnvironment = useUpdateProjectEnvironment();
+  // Double gate: the editor already sits behind `project-environments-enabled`
+  // (the route); the sandbox-image section additionally requires
+  // `computers-enabled` (fail-closed) — mirroring how the eval suite settings
+  // gate their adjacent "Computer environment" row. When the flag is off the
+  // picker never renders, the draft field never diverges, and the update
+  // payload omits it (see the save() comment) — so a flag-off save can never
+  // clear a pin set through the API/CLI.
+  const computersEnabled = useComputersEnabled();
+  const sandboxImages = useSandboxImages(computersEnabled ? projectId : null);
 
   const [draft, setDraft] = useState<EnvironmentDraft>(() =>
     environment
@@ -82,6 +96,7 @@ export function ProjectEnvironmentEditor({
           hostId: null,
           serverAttachmentId: null,
           skillSelection: null,
+          computerEnvironmentId: null,
         }
   );
   // Captured at draft init/reset — the ONLY revision update may send.
@@ -104,12 +119,14 @@ export function ProjectEnvironmentEditor({
       !sameSkillSelection(
         draft.skillSelection,
         environment.skillSelection ?? null
-      )
+      ) ||
+      draft.computerEnvironmentId !== (environment.computerEnvironmentId ?? null)
     : trimmedName.length > 0 ||
       trimmedDescription.length > 0 ||
       draft.hostId !== null ||
       draft.serverAttachmentId !== null ||
-      draft.skillSelection !== null;
+      draft.skillSelection !== null ||
+      draft.computerEnvironmentId !== null;
 
   // Reactivity observed someone else's edit while this draft diverged.
   const stale =
@@ -142,6 +159,7 @@ export function ProjectEnvironmentEditor({
             hostId: null,
             serverAttachmentId: null,
             skillSelection: null,
+            computerEnvironmentId: null,
           }
     );
     setBaseRevision(environment?.revision ?? null);
@@ -174,6 +192,9 @@ export function ProjectEnvironmentEditor({
           ...(draft.skillSelection
             ? { skillSelection: draft.skillSelection }
             : {}),
+          ...(draft.computerEnvironmentId
+            ? { computerEnvironmentId: draft.computerEnvironmentId }
+            : {}),
         });
         toast.success(`Created “${created.name}”.`);
         onCreated?.(created);
@@ -201,6 +222,14 @@ export function ProjectEnvironmentEditor({
           environment.skillSelection ?? null
         )
           ? { skillSelection: draft.skillSelection }
+          : {}),
+        // Included only when CHANGED — this is what keeps a flag-off save from
+        // clearing an API/CLI-set pin: with the picker unrendered the draft
+        // value never diverges from the row, so the field is omitted entirely
+        // (tri-state contract: omitted = unchanged, null = clear).
+        ...(draft.computerEnvironmentId !==
+        (environment.computerEnvironmentId ?? null)
+          ? { computerEnvironmentId: draft.computerEnvironmentId }
           : {}),
       });
       setDraft(draftFromEnvironment(updated));
@@ -331,6 +360,81 @@ export function ProjectEnvironmentEditor({
           disabled={readOnly}
         />
       </div>
+
+      {computersEnabled ? (
+        <div className="space-y-1.5">
+          <Label htmlFor="project-environment-sandbox-image" className="text-xs">
+            Sandbox image
+          </Label>
+          <div className="flex items-center gap-2">
+            <select
+              id="project-environment-sandbox-image"
+              data-testid="project-environment-sandbox-image"
+              value={draft.computerEnvironmentId ?? ""}
+              disabled={readOnly}
+              onChange={(e) =>
+                setDraft((d) => ({
+                  ...d,
+                  computerEnvironmentId: e.target.value || null,
+                }))
+              }
+              className="h-9 w-full rounded-md border bg-background px-3 text-sm outline-none focus:ring-1 focus:ring-ring disabled:opacity-60"
+            >
+              <option value="">None (default image)</option>
+              {(sandboxImages ?? []).map((img) => {
+                const ready = img.currentBuild?.status === "ready";
+                // Personal drafts are listed but not selectable — the backend
+                // rejects them (a draft would resolve for every member while
+                // being visible/mutable only to its owner). Showing them
+                // disabled keeps the promote step discoverable.
+                const isDraft = img.sharing !== "project";
+                return (
+                  <option
+                    key={img.environmentId}
+                    value={img.environmentId}
+                    disabled={isDraft}
+                  >
+                    {img.name}
+                    {isDraft
+                      ? " (draft — promote to project first)"
+                      : ready
+                        ? ""
+                        : " (not built)"}
+                  </option>
+                );
+              })}
+              {/* A pinned image that vanished from the list (deleted) must stay
+                  visible and explicitly clearable — silently coercing to "None"
+                  would clear the pin on the next unrelated save. */}
+              {draft.computerEnvironmentId &&
+              !(sandboxImages ?? []).some(
+                (img) => img.environmentId === draft.computerEnvironmentId
+              ) ? (
+                <option value={draft.computerEnvironmentId} disabled>
+                  Unknown image ({draft.computerEnvironmentId})
+                </option>
+              ) : null}
+            </select>
+            {/* Badge only for a real selection — "None" has no build status
+                (the badge component renders "Not built" for null/undefined). */}
+            {draft.computerEnvironmentId ? (
+              <EnvironmentBuildBadge
+                build={
+                  (sandboxImages ?? []).find(
+                    (img) => img.environmentId === draft.computerEnvironmentId
+                  )?.currentBuild ?? null
+                }
+              />
+            ) : null}
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Applies to eval runs in this environment: each run boots a fresh,
+            isolated sandbox from this image. Playground, chatboxes, and swarms
+            don&apos;t use the sandbox image yet. A not-built image fails at
+            launch — build it first under Computer → Images.
+          </p>
+        </div>
+      ) : null}
 
       {readOnly ? (
         <p className="text-[11px] text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
@@ -80,10 +80,14 @@ export function ProjectEnvironmentEditor({
   // Double gate: the editor already sits behind `project-environments-enabled`
   // (the route); the sandbox-image section additionally requires
   // `computers-enabled` (fail-closed) — mirroring how the eval suite settings
-  // gate their adjacent "Computer environment" row. When the flag is off the
-  // picker never renders, the draft field never diverges, and the update
-  // payload omits it (see the save() comment) — so a flag-off save can never
-  // clear a pin set through the API/CLI.
+  // gate their adjacent "Computer environment" row.
+  //
+  // This flag is load-bearing for the WRITE path, not just visibility: while the
+  // picker is hidden the pin must be treated as if it weren't part of this form
+  // at all — excluded from `dirty` and omitted from both payloads — so a
+  // flag-off save can never set or clear a pin configured through the API/CLI.
+  // Draft divergence alone is NOT a sufficient guard, because the flag can flip
+  // false after an edit and leave a diverged value behind a vanished control.
   const computersEnabled = useComputersEnabled();
   const sandboxImages = useSandboxImages(computersEnabled ? projectId : null);
 
@@ -120,13 +124,18 @@ export function ProjectEnvironmentEditor({
         draft.skillSelection,
         environment.skillSelection ?? null
       ) ||
-      draft.computerEnvironmentId !== (environment.computerEnvironmentId ?? null)
+      // Only counts while the picker is rendered — otherwise a flag flip would
+      // leave Save enabled for a field the payload deliberately omits, i.e. a
+      // "Saved." that changes nothing but bumps the revision.
+      (computersEnabled &&
+        draft.computerEnvironmentId !==
+          (environment.computerEnvironmentId ?? null))
     : trimmedName.length > 0 ||
       trimmedDescription.length > 0 ||
       draft.hostId !== null ||
       draft.serverAttachmentId !== null ||
       draft.skillSelection !== null ||
-      draft.computerEnvironmentId !== null;
+      (computersEnabled && draft.computerEnvironmentId !== null);
 
   // Reactivity observed someone else's edit while this draft diverged.
   const stale =
@@ -192,7 +201,11 @@ export function ProjectEnvironmentEditor({
           ...(draft.skillSelection
             ? { skillSelection: draft.skillSelection }
             : {}),
-          ...(draft.computerEnvironmentId
+          // Gated on the LIVE flag, not just the draft: PostHog can flip
+          // `computers-enabled` false after the user picked an image, which
+          // unmounts the picker but leaves the draft value — shipping it then
+          // would contradict the fail-closed contract.
+          ...(computersEnabled && draft.computerEnvironmentId
             ? { computerEnvironmentId: draft.computerEnvironmentId }
             : {}),
         });
@@ -223,12 +236,16 @@ export function ProjectEnvironmentEditor({
         )
           ? { skillSelection: draft.skillSelection }
           : {}),
-        // Included only when CHANGED — this is what keeps a flag-off save from
-        // clearing an API/CLI-set pin: with the picker unrendered the draft
-        // value never diverges from the row, so the field is omitted entirely
-        // (tri-state contract: omitted = unchanged, null = clear).
-        ...(draft.computerEnvironmentId !==
-        (environment.computerEnvironmentId ?? null)
+        // Included only when CHANGED **and** the picker is currently rendered.
+        // Draft divergence alone is not enough: if the flag flips false after
+        // an edit the picker unmounts while the diverged draft value survives,
+        // and a "flag-off" save would then set or clear the pin — exactly what
+        // the fail-closed contract promises it cannot do. Gating on the live
+        // flag makes a hidden picker always omit the field (tri-state:
+        // omitted = unchanged, null = clear).
+        ...(computersEnabled &&
+        draft.computerEnvironmentId !==
+          (environment.computerEnvironmentId ?? null)
           ? { computerEnvironmentId: draft.computerEnvironmentId }
           : {}),
       });
@@ -403,11 +420,24 @@ export function ProjectEnvironmentEditor({
                   </option>
                 );
               })}
-              {/* A pinned image that vanished from the list (deleted) must stay
-                  visible and explicitly clearable — silently coercing to "None"
-                  would clear the pin on the next unrelated save. */}
-              {draft.computerEnvironmentId &&
-              !(sandboxImages ?? []).some(
+              {/* A pinned id with no matching option would leave the <select>
+                  displaying "None" — a pinned environment reading as unpinned.
+                  Two DIFFERENT causes need two different labels:
+
+                  1. still loading: say so. Labeling it "Unknown image" here
+                     would alarm an admin about a perfectly valid pin on every
+                     mount until the query resolves.
+                  2. resolved and genuinely absent (deleted image): name it, so
+                     the pin stays visible and explicitly clearable instead of
+                     being silently coerced to "None" on the next save. */}
+              {draft.computerEnvironmentId && sandboxImages === undefined ? (
+                <option value={draft.computerEnvironmentId} disabled>
+                  Loading image…
+                </option>
+              ) : null}
+              {sandboxImages !== undefined &&
+              draft.computerEnvironmentId &&
+              !sandboxImages.some(
                 (img) => img.environmentId === draft.computerEnvironmentId
               ) ? (
                 <option value={draft.computerEnvironmentId} disabled>

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.sandbox-image.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.sandbox-image.test.tsx
@@ -176,6 +176,82 @@ describe("flag gating + the omission contract", () => {
   });
 });
 
+describe("flag flips false AFTER an edit (review regression)", () => {
+  it("omits the pin when the flag turns off between editing and saving", async () => {
+    const { rerender } = renderEditor(envRow({ computerEnvironmentId: "img-ready" }));
+    // Admin clears the pin while the picker is visible…
+    fireEvent.change(select(), { target: { value: "" } });
+    // …then PostHog re-evaluates the flag to false and the picker unmounts.
+    mockComputersEnabled.value = false;
+    rerender(
+      <ProjectEnvironmentEditor
+        projectId="proj-1"
+        environment={envRow({ computerEnvironmentId: "img-ready" })}
+        canManage
+      />
+    );
+    expect(
+      screen.queryByTestId("project-environment-sandbox-image")
+    ).not.toBeInTheDocument();
+
+    // The diverged draft value must NOT ship: a hidden picker always omits.
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    const args = mockUpdateEnvironment.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(args.name).toBe("Renamed");
+    expect("computerEnvironmentId" in args).toBe(false);
+  });
+
+  it("create also omits a picked image once the flag turns off", async () => {
+    const { rerender } = renderEditor(null);
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "New env" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "pick-host" }));
+    fireEvent.change(select(), { target: { value: "img-ready" } });
+
+    mockComputersEnabled.value = false;
+    rerender(
+      <ProjectEnvironmentEditor
+        projectId="proj-1"
+        environment={null}
+        canManage
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(mockCreateEnvironment).toHaveBeenCalled());
+    expect(
+      "computerEnvironmentId" in
+        (mockCreateEnvironment.mock.calls[0]![0] as Record<string, unknown>)
+    ).toBe(false);
+  });
+});
+
+describe("loading state (review regression)", () => {
+  it("does not flash 'Unknown image' while the image list is still loading", () => {
+    mockSandboxImages.value = undefined;
+    renderEditor(envRow({ computerEnvironmentId: "img-ready" }));
+    expect(
+      Array.from(select().options).some((o) =>
+        o.text.startsWith("Unknown image")
+      )
+    ).toBe(false);
+    // …and the pin still reads as selected rather than collapsing to "None"
+    // (a <select> whose value matches no option renders as the first option,
+    // which would make a pinned environment look unpinned mid-load).
+    expect(select().value).toBe("img-ready");
+    expect(
+      Array.from(select().options).some((o) => o.text === "Loading image…")
+    ).toBe(true);
+  });
+});
+
 describe("wire shapes", () => {
   it("attach sends the id on update", async () => {
     renderEditor(envRow());

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.sandbox-image.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.sandbox-image.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * ProjectEnvironmentEditor — the "Sandbox image" section.
+ *
+ * The load-bearing case is the OMISSION contract: when the `computers-enabled`
+ * flag is off the picker never renders, so a save of an environment that
+ * already carries a pin (set via API/CLI) must OMIT `computerEnvironmentId`
+ * from the update payload entirely — sending `null` would silently clear it.
+ * The rest covers the attach/clear wire shapes, create-mode inclusion, and the
+ * option-list states (not-built suffix, personal drafts disabled, deleted pin
+ * kept visible instead of coerced to "None").
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockCreateEnvironment,
+  mockUpdateEnvironment,
+  mockComputersEnabled,
+  mockSandboxImages,
+} = vi.hoisted(() => ({
+  mockCreateEnvironment: vi.fn(),
+  mockUpdateEnvironment: vi.fn(),
+  mockComputersEnabled: { value: true },
+  mockSandboxImages: { value: [] as unknown[] | undefined },
+}));
+
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useCreateProjectEnvironment: () => mockCreateEnvironment,
+  useUpdateProjectEnvironment: () => mockUpdateEnvironment,
+  isRevisionConflictError: () => false,
+}));
+vi.mock("@/hooks/useComputersEnabled", () => ({
+  useComputersEnabled: () => mockComputersEnabled.value,
+}));
+vi.mock("@/hooks/useSandboxImages", () => ({
+  useSandboxImages: (projectId: string | null) =>
+    projectId ? mockSandboxImages.value : undefined,
+}));
+// Sibling sections are not under test — render inert placeholders.
+vi.mock("@/components/hosts/HostPicker", () => ({
+  HostPicker: ({
+    onChange,
+  }: {
+    onChange: (hostId: string | null) => void;
+  }) => (
+    <button type="button" onClick={() => onChange("host-1")}>
+      pick-host
+    </button>
+  ),
+}));
+vi.mock("@/components/hosts/ServerGroupPicker", () => ({
+  ServerGroupPicker: () => <div data-testid="server-group-picker" />,
+}));
+vi.mock("../ProjectEnvironmentSkillsPicker", () => ({
+  ProjectEnvironmentSkillsPicker: () => <div data-testid="skills-picker" />,
+}));
+vi.mock("@/components/computer/EnvironmentBuildBadge", () => ({
+  EnvironmentBuildBadge: ({ build }: { build: unknown }) => (
+    <span data-testid="build-badge">{build ? "has-build" : "no-build"}</span>
+  ),
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+vi.mock("@/lib/convex-error", () => ({
+  convexErrMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+import { ProjectEnvironmentEditor } from "../ProjectEnvironmentEditor";
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+
+const IMAGE_READY = {
+  environmentId: "img-ready",
+  projectId: "proj-1",
+  name: "Node 20",
+  blueprint: "",
+  contentHash: "h1",
+  sharing: "project",
+  isOwner: false,
+  currentBuild: { buildId: "b1", status: "ready", provider: "e2b" },
+  createdAt: 0,
+  updatedAt: 0,
+};
+const IMAGE_UNBUILT = {
+  ...IMAGE_READY,
+  environmentId: "img-unbuilt",
+  name: "Py 3.12",
+  currentBuild: null,
+};
+const IMAGE_DRAFT = {
+  ...IMAGE_READY,
+  environmentId: "img-draft",
+  name: "My draft",
+  sharing: "user",
+  isOwner: true,
+};
+
+function envRow(
+  overrides: Partial<ProjectEnvironmentView> = {}
+): ProjectEnvironmentView {
+  return {
+    environmentId: "env-1",
+    projectId: "proj-1",
+    name: "Staging",
+    hostId: "host-1",
+    revision: 3,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockComputersEnabled.value = true;
+  mockSandboxImages.value = [IMAGE_READY, IMAGE_UNBUILT, IMAGE_DRAFT];
+  mockCreateEnvironment.mockResolvedValue(envRow({ name: "created" }));
+  mockUpdateEnvironment.mockResolvedValue(envRow({ revision: 4 }));
+});
+
+function renderEditor(environment: ProjectEnvironmentView | null) {
+  return render(
+    <ProjectEnvironmentEditor
+      projectId="proj-1"
+      environment={environment}
+      canManage
+    />
+  );
+}
+
+const select = () =>
+  screen.getByTestId(
+    "project-environment-sandbox-image"
+  ) as HTMLSelectElement;
+
+describe("flag gating + the omission contract", () => {
+  it("hides the picker when computers-enabled is off", () => {
+    mockComputersEnabled.value = false;
+    renderEditor(envRow());
+    expect(
+      screen.queryByTestId("project-environment-sandbox-image")
+    ).not.toBeInTheDocument();
+  });
+
+  it("flag-off save of a pinned env OMITS computerEnvironmentId (pin survives)", async () => {
+    mockComputersEnabled.value = false;
+    renderEditor(envRow({ computerEnvironmentId: "img-ready" }));
+
+    // Name-only edit, then save.
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    const args = mockUpdateEnvironment.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(args.name).toBe("Renamed");
+    // Omitted entirely — not null, not the old value.
+    expect("computerEnvironmentId" in args).toBe(false);
+  });
+
+  it("flag-on untouched pin is also omitted on an unrelated edit", async () => {
+    renderEditor(envRow({ computerEnvironmentId: "img-ready" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    expect(
+      "computerEnvironmentId" in
+        (mockUpdateEnvironment.mock.calls[0]![0] as Record<string, unknown>)
+    ).toBe(false);
+  });
+});
+
+describe("wire shapes", () => {
+  it("attach sends the id on update", async () => {
+    renderEditor(envRow());
+    fireEvent.change(select(), { target: { value: "img-ready" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    expect(mockUpdateEnvironment.mock.calls[0]![0]).toMatchObject({
+      expectedRevision: 3,
+      computerEnvironmentId: "img-ready",
+    });
+  });
+
+  it("clear sends null on update", async () => {
+    renderEditor(envRow({ computerEnvironmentId: "img-ready" }));
+    fireEvent.change(select(), { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    expect(
+      (mockUpdateEnvironment.mock.calls[0]![0] as Record<string, unknown>)
+        .computerEnvironmentId
+    ).toBeNull();
+  });
+
+  it("create includes the id only when selected", async () => {
+    renderEditor(null);
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "New env" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "pick-host" }));
+    fireEvent.change(select(), { target: { value: "img-ready" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(mockCreateEnvironment).toHaveBeenCalled());
+    expect(mockCreateEnvironment.mock.calls[0]![0]).toMatchObject({
+      projectId: "proj-1",
+      hostId: "host-1",
+      computerEnvironmentId: "img-ready",
+    });
+  });
+});
+
+describe("option list states", () => {
+  it("suffixes not-built images and disables personal drafts", () => {
+    renderEditor(envRow());
+    const options = Array.from(select().options).map((o) => ({
+      label: o.text,
+      disabled: o.disabled,
+    }));
+    expect(options).toContainEqual({ label: "Node 20", disabled: false });
+    expect(options).toContainEqual({
+      label: "Py 3.12 (not built)",
+      disabled: false,
+    });
+    expect(options).toContainEqual({
+      label: "My draft (draft — promote to project first)",
+      disabled: true,
+    });
+  });
+
+  it("keeps a deleted pinned image visible instead of coercing to None", () => {
+    mockSandboxImages.value = [IMAGE_READY];
+    renderEditor(envRow({ computerEnvironmentId: "img-gone" }));
+    expect(select().value).toBe("img-gone");
+    const orphan = Array.from(select().options).find((o) =>
+      o.text.startsWith("Unknown image")
+    );
+    expect(orphan).toBeDefined();
+    expect(orphan!.disabled).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
@@ -47,6 +47,14 @@ export interface ProjectEnvironmentView {
    * (undefined = unchanged) rather than sending it and clearing the pins.
    */
   pluginVersionIds?: string[];
+  /**
+   * Sandbox-image pin: the `computerEnvironments` image (see
+   * `useSandboxImages.ts` — NOT another project environment, despite the
+   * backend field name) that reproducibility runs boot a fresh ephemeral
+   * sandbox from. Backend accepts project-shared images only. Absent ⇒
+   * provider default base image.
+   */
+  computerEnvironmentId?: string | null;
   /** Bumped on every effective edit; optimistic-concurrency token. */
   revision: number;
   /** Present ⇒ archived (hidden from pickers; launches fail fast). */
@@ -131,6 +139,8 @@ export function useCreateProjectEnvironment(): (args: {
    * is REJECTED by the backend — omit the field to mean "no pins".
    */
   pluginVersionIds?: string[];
+  /** Sandbox-image pin; omit for the default base image (create never clears). */
+  computerEnvironmentId?: string;
 }) => Promise<ProjectEnvironmentView> {
   return useMutation("projectEnvironments:createEnvironment" as any) as never;
 }
@@ -160,6 +170,13 @@ export function useUpdateProjectEnvironment(): (args: {
    * the API or CLI. An empty array is rejected by the backend.
    */
   pluginVersionIds?: string[] | null;
+  /**
+   * Sandbox-image pin. Tri-state like the fields above: OMIT to leave the pin
+   * untouched, `null` to clear it, a value to set it. A form that does not
+   * RENDER the picker (e.g. the `computers-enabled` flag is off) must omit the
+   * field — sending `null` would silently drop a pin set through the API/CLI.
+   */
+  computerEnvironmentId?: string | null;
 }) => Promise<ProjectEnvironmentView> {
   return useMutation("projectEnvironments:updateEnvironment" as any) as never;
 }


### PR DESCRIPTION
## What

Inspector half of MCPJam/mcpjam-backend#813: mirrors the new `projectEnvironments.computerEnvironmentId` and adds a **Sandbox image** section to the project-environment editor, so an environment fully specifies its execution context (host + server group + skills + plugin pins + image).

⚠️ **Merge gate: deploy MCPJam/mcpjam-backend#813 first** — the create/update mutations reject the new arg until then.

## Changes

- `useProjectEnvironments.ts`: 3-place hand-mirror (view + create args + update args), documented with the same tri-state warning as `pluginVersionIds`.
- `ProjectEnvironmentEditor.tsx`: 4th section, double-gated (`project-environments-enabled` route × `computers-enabled` fail-closed), modeled on the eval suite settings' "Computer environment" row but editing the **draft** (save via the existing button, expectedRevision semantics unchanged):
  - inline select over `useSandboxImages`; ` (not built)` suffix; build badge for the selection
  - personal drafts listed but **disabled** with "promote to project first" (backend rejects them — a draft would resolve for every member while visible/mutable only to its owner)
  - a pinned image deleted from the list stays visible as an explicit disabled option — never silently coerced to "None" (which would clear the pin on the next unrelated save)
  - helper copy states the tranche-1 blast radius honestly: **applies to eval runs; Playground/chatboxes/swarms don't use the image yet**

## The load-bearing invariant

Flag-off saves must OMIT the field (null would wipe API/CLI-set pins). This falls out of the changed-only update spread and is pinned by a dedicated test.

## Tests

8 new (all green): flag gating, flag-off omission on a pinned env, flag-on untouched omission, attach → id / clear → null / create inclusion wire shapes, option-list states (suffix, disabled draft, deleted-pin fallback). Full project-environments + hooks suites green (691 tests); `typecheck:client` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how project environments are persisted and can affect eval sandbox selection; the omission contract is critical to avoid clearing pins set outside the UI. Requires backend #813 deployed first or mutations will reject the new field.
> 
> **Overview**
> Adds a **Sandbox image** control to the project environment editor so admins can pin a `computerEnvironmentId` (eval runs boot from that image; copy notes Playground/chat/swarms are out of scope for now).
> 
> The hook layer mirrors the new field on **view**, **create**, and **update**, with the same **tri-state** contract as other optional pins: omit = unchanged, value = set, `null` = clear.
> 
> The UI is shown only when **`computers-enabled`** is on (on top of the existing environments route gate). Saves are **fail-closed**: if the picker is hidden— including when the flag flips off after an edit—`computerEnvironmentId` is left out of create/update payloads so API/CLI pins are never accidentally set or cleared. **Dirty** state ignores the pin when the section is hidden so “Save” cannot no-op a hidden field.
> 
> The picker lists project sandbox images from `useSandboxImages`, marks unbuilt images, disables personal drafts, shows build status via `EnvironmentBuildBadge`, and keeps missing/deleted pins visible (“Loading…” / “Unknown image”) instead of collapsing to None.
> 
> New Vitest coverage focuses on flag gating, omission on save, flag-flip regressions, wire shapes, and option-list edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f05cd20ddff1159dbab228629ac86b217294d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Sandbox image picker to the environment editor and mirrors `computerEnvironmentId` so an environment fully defines its runtime. The pin applies to eval runs only; Playground, chatboxes, and swarms don’t use it yet.

- **New Features**
  - Mirror `projectEnvironments.computerEnvironmentId` in `useProjectEnvironments` (view/create/update) with tri‑state semantics: omit = unchanged, value = set, `null` = clear.
  - New “Sandbox image” section in `ProjectEnvironmentEditor` (double‑gated by `project-environments-enabled` and `computers-enabled`) using `useSandboxImages` and `EnvironmentBuildBadge`.
  - Fail‑closed save/dirty behavior: gated on the live flag so a hidden picker omits the field even after a mid‑edit flag flip; UX: “(not built)” suffix, personal drafts disabled with a promote hint, deleted pins shown as “Unknown image”, and pinned IDs show “Loading image…” while options load.

- **Dependencies**
  - Requires MCPJam/mcpjam-backend#813 to be deployed before merge; create/update reject the new arg until then.

<sup>Written for commit 3f05cd20ddff1159dbab228629ac86b217294d56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

