### PR TITLE
feat(api): public sandboxImageId parity for project environments

### DIFF
--- a/cli/src/commands/environments.ts
+++ b/cli/src/commands/environments.ts
@@ -260,8 +260,12 @@ export function registerEnvironmentsCommands(program: Command): void {
       .option("--host-id <id>", "ID of the host this environment runs against")
       .option("--description <text>", "Optional description")
       .option(
+        "--sandbox-image <id>",
+        "Project-shared sandbox image (see `mcpjam images`) to pin: eval runs boot a fresh sandbox from it"
+      )
+      .option(
         "--file <path>",
-        "Environment JSON file with any of name/hostId/description/serverAttachmentId/skillSelection/pluginVersionIds (or - for stdin)"
+        "Environment JSON file with any of name/hostId/description/serverAttachmentId/skillSelection/pluginVersionIds/sandboxImageId (or - for stdin)"
       )
       .option("--json <json>", "Inline environment JSON (or @file, or -)")
   ).action(
@@ -271,6 +275,7 @@ export function registerEnvironmentsCommands(program: Command): void {
         name?: string;
         hostId?: string;
         description?: string;
+        sandboxImage?: string;
         file?: string;
         json?: string;
       },
@@ -288,6 +293,9 @@ export function registerEnvironmentsCommands(program: Command): void {
         ...(options.description !== undefined
           ? { description: options.description }
           : {}),
+        ...(options.sandboxImage !== undefined
+          ? { sandboxImageId: options.sandboxImage }
+          : {}),
       });
       const result = await runPlatformCommand(
         options,
@@ -303,7 +311,7 @@ export function registerEnvironmentsCommands(program: Command): void {
     environments
       .command("update")
       .description(
-        "Edit an environment. Only the fields you pass change; use --file/--json with a null value to clear serverAttachmentId, skillSelection, or pluginVersionIds"
+        "Edit an environment. Only the fields you pass change; use --file/--json with a null value to clear serverAttachmentId, skillSelection, pluginVersionIds, or sandboxImageId"
       )
       .requiredOption("--environment <id-or-name>", "Environment name or ID")
       .requiredOption(
@@ -316,6 +324,10 @@ export function registerEnvironmentsCommands(program: Command): void {
       .option(
         "--description <text>",
         "New description (empty string clears it)"
+      )
+      .option(
+        "--sandbox-image <id>",
+        "New sandbox-image pin (clear via --json '{\"sandboxImageId\": null}')"
       )
       .option(
         "--file <path>",
@@ -331,6 +343,7 @@ export function registerEnvironmentsCommands(program: Command): void {
         name?: string;
         hostId?: string;
         description?: string;
+        sandboxImage?: string;
         file?: string;
         json?: string;
       },
@@ -347,6 +360,9 @@ export function registerEnvironmentsCommands(program: Command): void {
         ...(options.hostId !== undefined ? { hostId: options.hostId } : {}),
         ...(options.description !== undefined
           ? { description: options.description }
+          : {}),
+        ...(options.sandboxImage !== undefined
+          ? { sandboxImageId: options.sandboxImage }
           : {}),
       });
       const result = await runPlatformCommand(

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -6077,7 +6077,9 @@
           },
           "sandboxImageId": {
             "type": "string",
-            "description": "Sandbox-image pin: a project-shared image (see the images endpoints) that eval runs in this environment boot a fresh sandbox from. Absent when unpinned."
+            "description": "Sandbox-image pin: a project-shared image (see the images endpoints) that eval runs in this environment boot a fresh sandbox from. Absent when unpinned.",
+            "minLength": 1,
+            "pattern": ".*\\S.*"
           },
           "revision": {
             "type": "integer",
@@ -6151,7 +6153,8 @@
           "sandboxImageId": {
             "type": "string",
             "minLength": 1,
-            "description": "Optional sandbox-image pin. Must be a project-shared image; personal drafts are rejected \u2014 promote them first."
+            "description": "Optional sandbox-image pin. Must be a project-shared image; personal drafts are rejected \u2014 promote them first.",
+            "pattern": ".*\\S.*"
           }
         }
       },
@@ -6207,7 +6210,9 @@
               "string",
               "null"
             ],
-            "description": "New sandbox-image pin, or null to clear it. Omit to leave unchanged."
+            "description": "New sandbox-image pin, or null to clear it. Omit to leave unchanged.",
+            "minLength": 1,
+            "pattern": ".*\\S.*"
           }
         }
       },
@@ -6275,7 +6280,9 @@
           },
           "sandboxImageId": {
             "type": "string",
-            "description": "The environment's sandbox-image pin, when set."
+            "description": "The environment's sandbox-image pin, when set.",
+            "minLength": 1,
+            "pattern": ".*\\S.*"
           },
           "selectedServerIds": {
             "type": "array",

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -6075,6 +6075,10 @@
             },
             "description": "Pinned plugin VERSION IDs. Narrow by design: the plugin must be installed and enabled, the version must be `ready`, at most one version per plugin may be pinned, and none of its skills may carry supporting files. Not a general-purpose plugin list."
           },
+          "sandboxImageId": {
+            "type": "string",
+            "description": "Sandbox-image pin: a project-shared image (see the images endpoints) that eval runs in this environment boot a fresh sandbox from. Absent when unpinned."
+          },
           "revision": {
             "type": "integer",
             "description": "Optimistic-concurrency counter. Pass this back as `expectedRevision` on the next write; if it no longer matches, the write is rejected with 409 instead of overwriting a concurrent edit."
@@ -6143,6 +6147,11 @@
               "type": "string"
             },
             "description": "Pinned plugin VERSION IDs. Narrow by design: the plugin must be installed and enabled, the version must be `ready`, at most one version per plugin may be pinned, and none of its skills may carry supporting files. Not a general-purpose plugin list."
+          },
+          "sandboxImageId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Optional sandbox-image pin. Must be a project-shared image; personal drafts are rejected \u2014 promote them first."
           }
         }
       },
@@ -6192,6 +6201,13 @@
             },
             "nullable": true,
             "description": "Pinned plugin VERSION IDs. Narrow by design: the plugin must be installed and enabled, the version must be `ready`, at most one version per plugin may be pinned, and none of its skills may carry supporting files. Not a general-purpose plugin list. `null` clears all pins."
+          },
+          "sandboxImageId": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "New sandbox-image pin, or null to clear it. Omit to leave unchanged."
           }
         }
       },
@@ -6256,6 +6272,10 @@
           },
           "serverAttachmentId": {
             "type": "string"
+          },
+          "sandboxImageId": {
+            "type": "string",
+            "description": "The environment's sandbox-image pin, when set."
           },
           "selectedServerIds": {
             "type": "array",

--- a/mcpjam-inspector/server/routes/v1/__tests__/environments.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/environments.test.ts
@@ -583,4 +583,92 @@ describe("v1 project environment routes", () => {
       expect(res.status).toBe(409);
     });
   });
+
+  describe("sandboxImageId boundary rename", () => {
+    it("exposes the row's computerEnvironmentId as sandboxImageId in DTOs", async () => {
+      mockQuery({
+        "projectEnvironments:getEnvironment": {
+          ...ENV_ROW,
+          computerEnvironmentId: "img1",
+        },
+      });
+      const res = await request(
+        "GET",
+        "/api/v1/projects/p1/environments/env1"
+      );
+      expect(res.status).toBe(200);
+      const dto = (await res.json()) as Record<string, unknown>;
+      expect(dto.sandboxImageId).toBe("img1");
+      // The internal name never leaks.
+      expect(dto).not.toHaveProperty("computerEnvironmentId");
+    });
+
+    it("create maps sandboxImageId -> computerEnvironmentId and never forwards the public name", async () => {
+      convexMutationMock.mockResolvedValue(ENV_ROW);
+      const res = await request("POST", "/api/v1/projects/p1/environments", {
+        body: { name: "Staging", hostId: "h1", sandboxImageId: "img1" },
+      });
+      expect(res.status).toBe(201);
+      const args = mutationArgs("projectEnvironments:createEnvironment");
+      expect(args.computerEnvironmentId).toBe("img1");
+      expect(args).not.toHaveProperty("sandboxImageId");
+    });
+
+    it("PATCH tri-state: null clears, value sets, omitted stays absent", async () => {
+      convexMutationMock.mockResolvedValue(ENV_ROW);
+      await request("PATCH", "/api/v1/projects/p1/environments/env1", {
+        body: { expectedRevision: 3, sandboxImageId: null },
+      });
+      expect(
+        mutationArgs("projectEnvironments:updateEnvironment")
+          .computerEnvironmentId
+      ).toBeNull();
+
+      convexMutationMock.mockClear();
+      convexMutationMock.mockResolvedValue(ENV_ROW);
+      await request("PATCH", "/api/v1/projects/p1/environments/env1", {
+        body: { expectedRevision: 3, sandboxImageId: "img2" },
+      });
+      expect(
+        mutationArgs("projectEnvironments:updateEnvironment")
+          .computerEnvironmentId
+      ).toBe("img2");
+
+      convexMutationMock.mockClear();
+      convexMutationMock.mockResolvedValue(ENV_ROW);
+      await request("PATCH", "/api/v1/projects/p1/environments/env1", {
+        body: { expectedRevision: 3, name: "Renamed" },
+      });
+      const args = mutationArgs("projectEnvironments:updateEnvironment");
+      expect(args).not.toHaveProperty("computerEnvironmentId");
+      expect(args).not.toHaveProperty("sandboxImageId");
+    });
+
+    it("a sandboxImageId-only PATCH satisfies the at-least-one-field refine", async () => {
+      convexMutationMock.mockResolvedValue(ENV_ROW);
+      const res = await request(
+        "PATCH",
+        "/api/v1/projects/p1/environments/env1",
+        { body: { expectedRevision: 3, sandboxImageId: "img1" } }
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it("resolve exposes the pin as sandboxImageId when the backend carries it", async () => {
+      mockQuery({
+        "projectEnvironments:resolveEnvironmentForLaunch": {
+          ...RESOLVED_ROW,
+          computerEnvironmentId: "img1",
+        },
+      });
+      const res = await request(
+        "GET",
+        "/api/v1/projects/p1/environments/env1/resolve"
+      );
+      expect(res.status).toBe(200);
+      const dto = (await res.json()) as Record<string, unknown>;
+      expect(dto.sandboxImageId).toBe("img1");
+      expect(dto).not.toHaveProperty("computerEnvironmentId");
+    });
+  });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/environments.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/environments.test.ts
@@ -654,6 +654,25 @@ describe("v1 project environment routes", () => {
       expect(res.status).toBe(200);
     });
 
+    it("rejects blank and whitespace-only ids (matches the published minLength/pattern)", async () => {
+      for (const value of ["", "   "]) {
+        convexMutationMock.mockClear();
+        const created = await request("POST", "/api/v1/projects/p1/environments", {
+          body: { name: "Staging", hostId: "h1", sandboxImageId: value },
+        });
+        expect(created.status).toBe(400);
+        expect(convexMutationMock).not.toHaveBeenCalled();
+
+        const patched = await request(
+          "PATCH",
+          "/api/v1/projects/p1/environments/env1",
+          { body: { expectedRevision: 3, sandboxImageId: value } }
+        );
+        expect(patched.status).toBe(400);
+        expect(convexMutationMock).not.toHaveBeenCalled();
+      }
+    });
+
     it("resolve exposes the pin as sandboxImageId when the backend carries it", async () => {
       mockQuery({
         "projectEnvironments:resolveEnvironmentForLaunch": {

--- a/mcpjam-inspector/server/routes/v1/environments.ts
+++ b/mcpjam-inspector/server/routes/v1/environments.ts
@@ -59,6 +59,9 @@ type EnvironmentRow = {
   serverAttachmentId?: string;
   skillSelection?: SkillSelection;
   pluginVersionIds?: string[];
+  /** Internal (Convex) name for the sandbox-image pin — public DTOs expose it
+   *  as `sandboxImageId`, matching the SDK's `PlatformImage` vocabulary. */
+  computerEnvironmentId?: string;
   revision: number;
   archivedAt?: number;
   createdAt: number;
@@ -71,6 +74,9 @@ type ResolvedEnvironmentRow = {
   hostName: string;
   hostConfigId: string;
   serverAttachmentId?: string;
+  /** Optional for deploy skew: present once the backend resolve carries the
+   *  env-level sandbox-image pin through. */
+  computerEnvironmentId?: string;
   selectedServerIds: string[];
   effectiveServerIds: string[];
   pluginVersions: Array<{
@@ -99,6 +105,12 @@ function toEnvironmentDto(row: EnvironmentRow) {
     ...(row.pluginVersionIds !== undefined
       ? { pluginVersionIds: row.pluginVersionIds }
       : {}),
+    // Public name: `sandboxImageId` (a `PlatformImage` / `mcpjam images` id).
+    // The internal Convex field keeps its historical name; the rename lives
+    // ONLY at this DTO boundary and its inverse in the write handlers.
+    ...(row.computerEnvironmentId !== undefined
+      ? { sandboxImageId: row.computerEnvironmentId }
+      : {}),
     revision: row.revision,
     // Presence is the live/archived signal; `archived` is derived so callers
     // don't have to know that.
@@ -121,6 +133,9 @@ function toResolvedDto(resolved: ResolvedEnvironmentRow) {
     hostConfigId: resolved.hostConfigId,
     ...(resolved.serverAttachmentId !== undefined
       ? { serverAttachmentId: resolved.serverAttachmentId }
+      : {}),
+    ...(resolved.computerEnvironmentId !== undefined
+      ? { sandboxImageId: resolved.computerEnvironmentId }
       : {}),
     selectedServerIds: resolved.selectedServerIds ?? [],
     effectiveServerIds: resolved.effectiveServerIds ?? [],
@@ -345,6 +360,9 @@ const createEnvironmentSchema = z.strictObject({
   serverAttachmentId: z.string().trim().min(1).optional(),
   skillSelection: skillSelectionSchema.optional(),
   pluginVersionIds: pluginVersionIdsSchema.optional(),
+  /** Public name for the internal `computerEnvironmentId` pin; must be a
+   *  project-shared image (backend rejects personal drafts). */
+  sandboxImageId: z.string().trim().min(1).optional(),
 });
 
 /**
@@ -360,6 +378,7 @@ const updateEnvironmentSchema = z
     serverAttachmentId: z.string().trim().min(1).nullable().optional(),
     skillSelection: skillSelectionSchema.nullable().optional(),
     pluginVersionIds: pluginVersionIdsSchema.nullable().optional(),
+    sandboxImageId: z.string().trim().min(1).nullable().optional(),
   })
   .refine(
     (value) =>
@@ -368,10 +387,11 @@ const updateEnvironmentSchema = z
       value.hostId !== undefined ||
       value.serverAttachmentId !== undefined ||
       value.skillSelection !== undefined ||
-      value.pluginVersionIds !== undefined,
+      value.pluginVersionIds !== undefined ||
+      value.sandboxImageId !== undefined,
     {
       message:
-        "Provide at least one of `name`, `description`, `hostId`, `serverAttachmentId`, `skillSelection`, or `pluginVersionIds` to update.",
+        "Provide at least one of `name`, `description`, `hostId`, `serverAttachmentId`, `skillSelection`, `pluginVersionIds`, or `sandboxImageId` to update.",
     }
   );
 
@@ -456,11 +476,20 @@ environments.post("/projects/:projectId/environments", async (c) => {
   const token = await getConvexBearerForRequest(c);
   const convexClient = createConvexClient(token);
 
+  // Rename at the boundary: the public `sandboxImageId` becomes the internal
+  // `computerEnvironmentId` — the spread must not forward the public name.
+  const { sandboxImageId, ...createRest } = body;
   let created: EnvironmentRow;
   try {
     created = (await convexClient.mutation(
       "projectEnvironments:createEnvironment" as any,
-      { projectId, ...body } as any
+      {
+        projectId,
+        ...createRest,
+        ...(sandboxImageId !== undefined
+          ? { computerEnvironmentId: sandboxImageId }
+          : {}),
+      } as any
     )) as EnvironmentRow;
   } catch (error) {
     throw translateConvexError(error);
@@ -500,6 +529,10 @@ environments.patch(
       updateArgs.skillSelection = body.skillSelection;
     if (body.pluginVersionIds !== undefined)
       updateArgs.pluginVersionIds = body.pluginVersionIds;
+    // Boundary rename (public sandboxImageId ↔ internal computerEnvironmentId);
+    // `null` forwards as null (clear), omitted stays absent (unchanged).
+    if (body.sandboxImageId !== undefined)
+      updateArgs.computerEnvironmentId = body.sandboxImageId;
 
     const convexClient = createConvexClient(token);
     let updated: EnvironmentRow;

--- a/mcpjam-inspector/server/routes/v1/environments.ts
+++ b/mcpjam-inspector/server/routes/v1/environments.ts
@@ -366,8 +366,11 @@ const createEnvironmentSchema = z.strictObject({
 });
 
 /**
- * `.nullable().optional()` on the three clearable fields encodes the backend's
- * tri-state: omitted = unchanged, `null` = clear, value = set.
+ * `.nullable().optional()` on every clearable field (`serverAttachmentId`,
+ * `skillSelection`, `pluginVersionIds`, `sandboxImageId`) encodes the backend's
+ * tri-state: omitted = unchanged, `null` = clear, value = set. A new clearable
+ * field must join BOTH that shape and the `.refine` below, or it silently
+ * becomes unclearable / unable to be the only field in a PATCH.
  */
 const updateEnvironmentSchema = z
   .strictObject({

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -2989,6 +2989,14 @@ const createEnvironmentInput = z.object({
     ),
   skillSelection: skillSelectionInput.optional(),
   pluginVersionIds: pluginVersionIdsInput.optional(),
+  sandboxImageId: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional sandbox image (see the images operations) to pin: eval runs in this environment boot a fresh sandbox from it. Must be project-shared; personal drafts are rejected — promote first."
+    ),
 });
 export type CreateEnvironmentInput = z.infer<typeof createEnvironmentInput>;
 
@@ -3025,6 +3033,9 @@ export const createEnvironmentOperation: PlatformOperation<
             : {}),
           ...(input.pluginVersionIds !== undefined
             ? { pluginVersionIds: input.pluginVersionIds }
+            : {}),
+          ...(input.sandboxImageId !== undefined
+            ? { sandboxImageId: input.sandboxImageId }
             : {}),
         },
       },
@@ -3083,6 +3094,15 @@ const updateEnvironmentInput = z
       .describe(
         "New pinned plugin versions, or null to clear them. Omit to leave unchanged."
       ),
+    sandboxImageId: z
+      .string()
+      .trim()
+      .min(1)
+      .nullable()
+      .optional()
+      .describe(
+        "New sandbox-image pin (project-shared image id), or null to clear it and use the default image. Omit to leave unchanged."
+      ),
   })
   .refine(
     (value) =>
@@ -3091,10 +3111,11 @@ const updateEnvironmentInput = z
       value.hostId !== undefined ||
       value.serverAttachmentId !== undefined ||
       value.skillSelection !== undefined ||
-      value.pluginVersionIds !== undefined,
+      value.pluginVersionIds !== undefined ||
+      value.sandboxImageId !== undefined,
     {
       message:
-        "Provide at least one of `name`, `description`, `hostId`, `serverAttachmentId`, `skillSelection`, or `pluginVersionIds` to update.",
+        "Provide at least one of `name`, `description`, `hostId`, `serverAttachmentId`, `skillSelection`, `pluginVersionIds`, or `sandboxImageId` to update.",
     }
   );
 export type UpdateEnvironmentInput = z.infer<typeof updateEnvironmentInput>;
@@ -3135,6 +3156,8 @@ export const updateEnvironmentOperation: PlatformOperation<
       body.skillSelection = input.skillSelection;
     if (input.pluginVersionIds !== undefined)
       body.pluginVersionIds = input.pluginVersionIds;
+    if (input.sandboxImageId !== undefined)
+      body.sandboxImageId = input.sandboxImageId;
     return client.updateEnvironment(
       { projectId: project.id, environmentId: environment.id, body },
       { signal }

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -346,6 +346,12 @@ export interface PlatformEnvironment {
    * files. Not a general-purpose plugin list.
    */
   pluginVersionIds?: string[];
+  /**
+   * Sandbox-image pin: a `PlatformImage` id this environment's reproducibility
+   * runs boot a fresh sandbox from. Must be a project-shared image (personal
+   * drafts are rejected — promote first). Applies to eval runs today.
+   */
+  sandboxImageId?: string;
   /** Pass back as `expectedRevision` on the next mutation. */
   revision: number;
   /** Archived environments cannot be edited or launched until restored. */
@@ -362,6 +368,8 @@ export interface PlatformEnvironmentCreateBody {
   serverAttachmentId?: string;
   skillSelection?: PlatformEnvironmentSkillSelection;
   pluginVersionIds?: string[];
+  /** Project-shared `PlatformImage` id to pin; omit for the default image. */
+  sandboxImageId?: string;
 }
 
 /**
@@ -379,6 +387,8 @@ export interface PlatformEnvironmentUpdateBody {
   serverAttachmentId?: string | null;
   skillSelection?: PlatformEnvironmentSkillSelection | null;
   pluginVersionIds?: string[] | null;
+  /** New sandbox-image pin, or null to clear it. Omit to leave unchanged. */
+  sandboxImageId?: string | null;
 }
 
 /** Body for the archive/restore sub-actions — the precondition only. */
@@ -415,6 +425,9 @@ export interface PlatformEnvironmentResolved {
   }>;
   /** Connectable projection of `effectiveServerIds`, healed to live servers. */
   servers: Array<{ serverId: string; name: string }>;
+  /** The environment's sandbox-image pin, when set (and the backend is new
+   *  enough to carry it through the resolve). */
+  sandboxImageId?: string;
 }
 
 // ── Sandbox images ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Public-surface parity for the env-level sandbox-image pin (backend MCPJam/mcpjam-backend#813, editor #3578): without this, the strict v1 schemas **400** on the new field, so a UI-set pin is invisible and unmanageable over the API/SDK/CLI.

Public name is **`sandboxImageId`** — consistent with the SDK's existing `PlatformImage` / `mcpjam images` vocabulary. The internal Convex field keeps `computerEnvironmentId`; the rename lives only at the DTO boundary, both directions.

⚠️ **Merge gate: deploy MCPJam/mcpjam-backend#813 first** (writes forward the new Convex arg). The resolve projection additionally lights up when #814 deploys — optional/deploy-skew-tolerant until then.

## Changes

- **/v1** (`server/routes/v1/environments.ts`): create/update strict schemas + at-least-one-field refine; boundary rename in both write handlers (`{ sandboxImageId, ...rest }` destructure on create so the spread can't leak the public name); DTO + resolve projections.
- **SDK** (`sdk/src/platform/{types,operations}.ts`): `PlatformEnvironment`, create/update bodies, `PlatformEnvironmentResolved`; both mutation operations forward with the existing `!== undefined` tri-state discipline. Additive only.
- **CLI** (`cli/src/commands/environments.ts`): `--sandbox-image` on create/update; clearing stays on the existing `--json '{"sandboxImageId": null}'` convention.
- **OpenAPI**: the four environment schemas.

## Tests

5 new route tests (34/34 green): DTO exposes `sandboxImageId` and never leaks the internal name; create maps and never forwards the public name; PATCH tri-state (null clears / value sets / omitted absent); sandboxImageId-only PATCH passes the refine; resolve projection. SDK env-operation tests green; sdk/cli/client typechecks clean (server tsconfig has pre-existing unrelated TS6133 noise on main; touched files clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches environment mutation and resolve contracts with deploy ordering on the backend; changes are additive but incorrect mapping could mis-pin eval sandboxes.
> 
> **Overview**
> Adds public **`sandboxImageId`** support for the environment-level sandbox-image pin so create/update/get/resolve can set, clear, and read it without strict schemas rejecting the field.
> 
> The v1 layer accepts **`sandboxImageId`** on writes and returns it on environment and resolve DTOs, mapping to internal **`computerEnvironmentId`** at the boundary only (create destructures so the public name never reaches Convex). PATCH treats it like other clearable fields: omit unchanged, **`null`** clears, string sets; the at-least-one-field refine now counts **`sandboxImageId`**.
> 
> SDK types and create/update operations forward the field; CLI adds **`--sandbox-image`** on **`environments create`** and **`update`**. OpenAPI documents the four environment schemas. New route tests cover DTO mapping, tri-state PATCH, validation, and resolve projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165247da09944e199ed0c2869dee66b407668bbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the environment-level sandbox-image pin as `sandboxImageId` across the API, SDK, and CLI so projects can set, clear, and read pins. Also align validation to reject blank IDs; the field maps to internal `computerEnvironmentId`.

- **New Features**
  - API: `/v1/projects/:projectId/environments` accepts/returns `sandboxImageId`; boundary maps to `computerEnvironmentId`. PATCH supports tri-state (omit = unchanged, string = set, null = clear) and the “at least one field” refine includes it. Resolve responses expose it when present. Routes reject blank/whitespace-only IDs.
  - SDK: added `sandboxImageId` to `PlatformEnvironment`, create/update bodies, and resolved type; operations forward it with the same tri-state rules.
  - CLI: added `--sandbox-image` to `environments create` and `environments update`; clear via `--json '{"sandboxImageId": null}'`.
  - OpenAPI: environment schemas include `sandboxImageId` and now enforce `minLength: 1` with a non-whitespace pattern to match route/SDK behavior.

- **Migration**
  - Deploy backend support for the `computerEnvironmentId` argument before enabling this.
  - Changes are additive; existing calls continue to work.

<sup>Written for commit 165247da09944e199ed0c2869dee66b407668bbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

