### PR TITLE
fix(host-templates): restore the Copilot label to "Copilot"

### DIFF
--- a/.changeset/copilot-host-label.md
+++ b/.changeset/copilot-host-label.md
@@ -1,0 +1,29 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Restore the Copilot host label to `Copilot` (it read `Copilot 1.0.1`).
+
+The versioned label arrived as a drive-by in the VS Code 1.130 profile update
+and made Copilot the only host of sixteen carrying a version in its name — VS
+Code itself, whose real build number that change bumped, kept the bare label.
+`1.0.1` is not a Microsoft build number either; it labels MCPJam's own
+vendor-doc profile.
+
+It also isn't cosmetic, because the template label becomes the created host's
+name:
+
+- Hosts created from the template (`App.tsx` quick-add, `CreateHostDialog`
+  prefill) were named `Copilot 1.0.1`. `resolveHostLogoByDisplayName`
+  normalizes that to `copilot1.0.1`, which matches neither the style id
+  (`copilot`), label, nor shortLabel — so the Copilot mark fell back to a
+  letter tile in the Playground client selector, the evals client bars, and the
+  publish bar. Every other template label still matched.
+- `?template=copilot` looks up an existing host by `name === template.label`,
+  so anyone holding a pre-rename host named `Copilot` got a duplicate created
+  instead of the one they had opened.
+
+The emulated profile version is unchanged: `clientInfo` and `hostInfo` still
+send `1.0.1`, so nothing a widget branches on moves. `compatibilityEvidence`'s
+`profileLabel` drops the suffix with the label.

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -1581,12 +1581,12 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
     },
     copilot: {
       id: "copilot",
-      label: "Copilot 1.0.1",
+      label: "Copilot",
       provenance: "vendor-doc",
       rendersMcpApps: true,
       verifiedAt: 1784764800000,
       compatibilityEvidence: {
-        profileLabel: "Copilot 1.0.1",
+        profileLabel: "Copilot",
         sourceUrl:
           "https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/plugin-mcp-apps",
         sourceUpdatedAt: 1784160000000,

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -1409,9 +1409,13 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
   },
   {
     id: "copilot",
-    label: "Copilot 1.0.1",
-    description:
-      "Microsoft 365 Copilot 1.0.1 compatibility profile. OpenAI-shaped Apps SDK.",
+    // Bare product name, like every other template here. The emulated profile
+    // version stays in `mcpProfile` (clientInfo/hostInfo) and must not ride
+    // along in the label: callers turn `label` into the created host's NAME
+    // (App.tsx, CreateHostDialog), and host names are what logo-by-name
+    // resolution and the `?template=copilot` open-vs-create lookup match on.
+    label: "Copilot",
+    description: "Microsoft 365 Copilot host. OpenAI-shaped Apps SDK.",
     seed: (opts) => {
       const base = emptyHostConfigInputV2({
         hostStyle: "copilot",

--- a/sdk/tests/host-compat-catalog.test.ts
+++ b/sdk/tests/host-compat-catalog.test.ts
@@ -102,13 +102,15 @@ describe("bundledHostCompatCatalog", () => {
     });
   });
 
-  it("preserves Copilot 1.0.1 evidence without leaking it into host config", () => {
+  it("preserves Copilot vendor-doc evidence without leaking it into host config", () => {
     const catalog = bundledHostCompatCatalog();
     const copilot = getCatalogHost(catalog, "copilot");
     const template = getCatalogTemplate(catalog, "copilot");
 
-    expect(copilot?.label).toBe("Copilot 1.0.1");
-    expect(copilot?.compatibilityEvidence?.profileLabel).toBe("Copilot 1.0.1");
+    // Bare product name: callers turn `label` into a host name, so a version
+    // suffix here breaks logo-by-name resolution and template dedupe.
+    expect(copilot?.label).toBe("Copilot");
+    expect(copilot?.compatibilityEvidence?.profileLabel).toBe("Copilot");
     expect(
       copilot?.compatibilityEvidence?.componentBridge[
         "window.openai.requestDisplayMode"

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -151,7 +151,7 @@ describe("seedHostTemplate", () => {
     expect(config.hostCapabilitiesOverride).not.toHaveProperty("downloadFile");
   });
 
-  it("labels and persists the Copilot 1.0.1 documented runtime surface", () => {
+  it("labels and persists the Copilot documented runtime surface", () => {
     const config = seedHostTemplate("copilot", { theme: "dark" });
     const profile = config.mcpProfile;
 


### PR DESCRIPTION
SDK half of the Copilot label fix. Backend (the half that changes what production serves): MCPJam/mcpjam-backend#815

The seed template and bundled fallback snapshot both read `Copilot 1.0.1`, synced from the backend seed in `d7c7935df` (VS Code 1.130 profile update). Copilot was the only host of sixteen carrying a version in its name — VS Code itself, whose real build number that change bumped, kept the bare label — and `1.0.1` is not a Microsoft build number; our own comments say it labels MCPJam's vendor-doc profile.

## Why it isn't cosmetic

The template label becomes the created host's **name**:

- [`App.tsx:801`](https://github.com/MCPJam/inspector/blob/main/mcpjam-inspector/client/src/App.tsx#L801) creates with `name: template.label`; [`CreateHostDialog.tsx:127`](https://github.com/MCPJam/inspector/blob/main/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx#L127) prefills the name field from the catalog label. Quick-add Copilot produced a host named `Copilot 1.0.1`.
- `resolveHostLogoByDisplayName` normalizes that to `copilot1.0.1`, which matches neither the style id (`copilot`), label, nor shortLabel → `null`. The Copilot mark fell back to a letter tile in the Playground client selector, the evals client bars, and the publish bar. Every other template label still matched — Copilot was the only one that stopped.
- [`App.tsx:785`](https://github.com/MCPJam/inspector/blob/main/mcpjam-inspector/client/src/App.tsx#L785) resolves an existing host via `name === template.label`, so a pre-rename `Copilot` host got a **duplicate** created on `?template=copilot` instead of being opened.

## Changes

- `seed-host-template.ts` — label back to `Copilot`, description back to "Microsoft 365 Copilot host. OpenAI-shaped Apps SDK."
- `catalog.generated.ts` — **regenerated** via `MCPJAM_BACKEND_DIR=… npm run generate:host-catalog-fallback -w @mcpjam/sdk` against the fixed backend seed, not hand-edited. Diff is exactly the two label lines, which also confirms the snapshot was otherwise in sync.
- The two pinned assertions + changeset.

The **emulated profile version is unchanged**: `clientInfo` and `hostInfo` still send `1.0.1`, so nothing a widget branches on moves, and the seed snapshot is untouched.

## Test

`npx vitest run tests/host-compat-catalog.test.ts tests/host-config-seed-host-template.test.ts tests/host-compat-market-hosts.test.ts` (in `sdk/`) → 62 passed (3 files).

## Merge order

Backend first. The UI reads the live catalog (`source: "live"`); this snapshot is only the offline fallback, so merging this alone would leave production serving `Copilot 1.0.1`. Until the backend deploys, the release workflow's fallback-vs-staging parity step warns (warning-only, non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the Copilot host label to "Copilot" in the SDK templates and bundled catalog to fix icon resolution and prevent duplicate hosts. The emulated profile stays at 1.0.1; only the display label changes.

- **Bug Fixes**
  - Set `label: "Copilot"` in `seed-host-template.ts`; updated description.
  - Regenerated `catalog.generated.ts` from the fixed backend seed; `compatibilityEvidence.profileLabel` now "Copilot".
  - Updated tests; added changesets for `@mcpjam/sdk` and `@mcpjam/inspector`.
  - Kept `clientInfo`/`hostInfo` profile version at 1.0.1 (no runtime behavior change).

- **Migration**
  - Merge the backend catalog fix first; the UI reads the live catalog.

<sup>Written for commit 199546eb3c96c7ed260fa5b20b6748f65a8b825c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

