### PR TITLE
GitHub App for MCP PR testing — sandbox + worker (walking skeleton)

### DIFF
--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -792,8 +792,8 @@ async function shutdown() {
   }, shutdownForceExitMs);
   forceExitTimer.unref();
 
-  await scheduledEvalsWorker?.stop();
-  await githubChecksWorker?.stop();
+  // Cleared BEFORE the worker awaits: a `stop()` that rejects must not leave a
+  // live interval behind, and this needs no await of its own.
   if (orphanCheckInterval) {
     clearInterval(orphanCheckInterval);
     orphanCheckInterval = undefined;
@@ -801,6 +801,10 @@ async function shutdown() {
 
   appLogger.info("Shutting down gracefully...");
   try {
+    // Inside the guarded path so a rejecting worker still reaches the rest of
+    // shutdown rather than skipping straight to the force-exit deadline.
+    await scheduledEvalsWorker?.stop();
+    await githubChecksWorker?.stop();
     // Abort active synthetic-session runs and write a terminal "failed"
     // status so the dialog/UI doesn't see a stuck "running" run. Bounded
     // by an internal timeout; the outer `forceExitTimer` still wins.

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -778,13 +778,11 @@ async function shutdown() {
   }
 
   shuttingDown = true;
-  await scheduledEvalsWorker?.stop();
-  await githubChecksWorker?.stop();
-  if (orphanCheckInterval) {
-    clearInterval(orphanCheckInterval);
-    orphanCheckInterval = undefined;
-  }
 
+  // Arm the force-exit deadline FIRST. Both worker `stop()` calls wait for their
+  // in-flight work to settle, and a github check legitimately runs for tens of
+  // minutes — created after the awaits, this timer would never bound the case it
+  // exists for, and a deploy would hang until the platform killed the process.
   const forceExitTimer = setTimeout(() => {
     appLogger.error(
       "Shutdown timed out; forcing process exit.",
@@ -793,6 +791,13 @@ async function shutdown() {
     exitAfterLogFlush(1);
   }, shutdownForceExitMs);
   forceExitTimer.unref();
+
+  await scheduledEvalsWorker?.stop();
+  await githubChecksWorker?.stop();
+  if (orphanCheckInterval) {
+    clearInterval(orphanCheckInterval);
+    orphanCheckInterval = undefined;
+  }
 
   appLogger.info("Shutting down gracefully...");
   try {

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -142,6 +142,11 @@ import {
   type ScheduledEvalsWorkerHandle,
 } from "./services/scheduled-evals-worker";
 import {
+  isGithubChecksWorkerEnabled,
+  startGithubChecksWorker,
+  type GithubChecksWorkerHandle,
+} from "./services/github-checks-worker";
+import {
   SERVER_PORT,
   CORS_ORIGINS,
   HOSTED_MODE,
@@ -657,8 +662,7 @@ if (process.env.NODE_ENV === "production") {
         })
       ) {
         try {
-          const { session, setCookies } =
-            await mintGuestSessionForDocument(c);
+          const { session, setCookies } = await mintGuestSessionForDocument(c);
           if (session && session.expiresAt > Date.now()) {
             const bootstrapScript = buildGuestBootstrapScript(session);
             htmlContent = htmlContent.replace(
@@ -737,6 +741,14 @@ if (isScheduledEvalsWorkerEnabled()) {
   scheduledEvalsWorker = startScheduledEvalsWorker();
 }
 
+// GitHub PR check runs: claim a PR trigger, build its MCP server in a sandbox,
+// run the dedicated eval suite, report an outcome. Env-gated; the backend has
+// its own GITHUB_CHECKS_ENABLED gate and 404s the routes when it is off.
+let githubChecksWorker: GithubChecksWorkerHandle | undefined;
+if (isGithubChecksWorkerEnabled()) {
+  githubChecksWorker = startGithubChecksWorker();
+}
+
 const expectedParentPid = Number.parseInt(
   process.env.MCPJAM_INSPECTOR_PARENT_PID ?? "",
   10
@@ -767,6 +779,7 @@ async function shutdown() {
 
   shuttingDown = true;
   await scheduledEvalsWorker?.stop();
+  await githubChecksWorker?.stop();
   if (orphanCheckInterval) {
     clearInterval(orphanCheckInterval);
     orphanCheckInterval = undefined;
@@ -786,7 +799,7 @@ async function shutdown() {
     // Abort active synthetic-session runs and write a terminal "failed"
     // status so the dialog/UI doesn't see a stuck "running" run. Bounded
     // by an internal timeout; the outer `forceExitTimer` still wins.
-      // Abort active swarm (journey-execution) runs — stops each run's heartbeat
+    // Abort active swarm (journey-execution) runs — stops each run's heartbeat
     // and lets in-flight sessions report a terminal attempt. Bounded internally.
     await shutdownRunningJourneyRuns();
     await tunnelManager.closeAll();

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -54,7 +54,15 @@ type Harness = {
   heartbeats: string[];
 };
 
-function harness(overrides?: Partial<CheckExecutionDeps>): Harness {
+/**
+ * `liveness` scripts what the post-failure in-box liveness check finds: the stdout
+ * the node one-liner prints, or "throws" for a box that no longer answers at all.
+ * Default is empty stdout — no sentinel, so "could not tell", so neutral.
+ */
+function harness(
+  overrides?: Partial<CheckExecutionDeps>,
+  liveness?: string
+): Harness {
   const reports: CheckReport[] = [];
   const events: string[] = [];
   const heartbeats: string[] = [];
@@ -62,7 +70,17 @@ function harness(overrides?: Partial<CheckExecutionDeps>): Harness {
   const sandbox = {
     sandboxId: "sb_1",
     getHost: (port: number) => `${port}-sb_1.e2b.app`,
-    commands: { run: async () => ({}) },
+    commands: {
+      run: async (command: string) => {
+        // The post-failure liveness check is the only command this fake sees.
+        if (command.includes("MCPJAM_CHECK_PORT_OPEN")) {
+          events.push("livenessCheck");
+          if (liveness === "throws") throw new Error("sandbox not found");
+          return { stdout: liveness ?? "" };
+        }
+        return {};
+      },
+    },
     updateNetwork: async () => {},
     kill: async () => {},
   } as unknown as Awaited<ReturnType<CheckExecutionDeps["provisionSandbox"]>>;
@@ -116,13 +134,6 @@ function harness(overrides?: Partial<CheckExecutionDeps>): Harness {
       heartbeats.push(triggerId);
     },
     heartbeatIntervalMs: 1_000,
-    // The eval-failure discriminator's default answer: the PR's server is still
-    // answering, so a failed run stays OUR problem unless a test says otherwise.
-    // Also keeps these tests off the network — the real default would fetch.
-    probeServer: async () => {
-      events.push("probeServer");
-      return true;
-    },
     ...overrides,
   };
 
@@ -266,74 +277,71 @@ describe("executeClaimedCheck — failure attribution", () => {
     expect(h.reports[0].detailsMarkdown).toContain("EADDRINUSE");
   });
 
-  it("blames the PR when its server stops answering during the eval", async () => {
-    // The server passed the health probe and then died. The box is still reachable,
-    // so this is not an outage of ours — it is the PR's server, and it must earn
-    // `server_unhealthy` rather than hiding behind a neutral `infra_error`.
-    const h = harness({
-      runEvalSuite: async () => {
-        throw new Error("fetch failed: ECONNREFUSED");
-      },
-      probeServer: async () => false,
-    });
+  const evalDies = {
+    runEvalSuite: async () => {
+      throw new Error("fetch failed: ECONNREFUSED");
+    },
+  };
+
+  it("blames the PR when its server stops listening during the eval", async () => {
+    // The server passed the health probe and then died. Asked from inside the box,
+    // nothing is listening on its port — so this is the PR's server, not a network
+    // path of ours, and it must earn `server_unhealthy`.
+    const h = harness(evalDies, "MCPJAM_CHECK_PORT_CLOSED\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0]).toMatchObject({ outcome: "server_unhealthy" });
     expect(h.reports[0].detailsMarkdown).toContain("ECONNREFUSED");
-    expect(h.reports[0].detailsMarkdown).toContain("stopped responding");
+    expect(h.reports[0].detailsMarkdown).toContain("stopped listening");
+    expect(h.events).toContain("livenessCheck");
   });
 
-  it("stays neutral when the eval fails but the PR's server is still up", async () => {
-    // Same transport-shaped error, but the server answers when asked. The failure
-    // came from somewhere else — ours, so the check must not blame the PR.
-    const h = harness({
-      runEvalSuite: async () => {
-        throw new Error("fetch failed: ECONNREFUSED");
-      },
-      probeServer: async () => true,
-    });
+  it("stays neutral when the eval fails but the PR's server is still listening", async () => {
+    // Same transport-shaped error, but the process is alive. The failure came from
+    // somewhere else — ours — so the check must not blame the PR.
+    const h = harness(evalDies, "MCPJAM_CHECK_PORT_OPEN\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0].outcome).toBe("infra_error");
   });
 
-  it("stays neutral when the sandbox itself has gone away", async () => {
-    // The box is unreachable, so we cannot tell whose fault the eval failure was —
-    // and an E2B outage is ours. Ambiguity must never produce a red X.
-    const sandboxGone = {
-      sandboxId: "sb_1",
-      getHost: (port: number) => `${port}-sb_1.e2b.app`,
-      commands: {
-        run: async () => {
-          throw new Error("sandbox not found");
-        },
-      },
-      updateNetwork: async () => {},
-      kill: async () => {},
-    } as unknown as Awaited<ReturnType<CheckExecutionDeps["provisionSandbox"]>>;
-    const h = harness({
-      provisionSandbox: async () => sandboxGone,
-      runEvalSuite: async () => {
-        throw new Error("fetch failed: ECONNREFUSED");
-      },
-      // Would say "server gone" — but must never be consulted, because the box
-      // being unreachable already makes this ours.
-      probeServer: async () => false,
-    });
+  it("stays neutral when the sandbox command channel has gone away", async () => {
+    // The box no longer answers, so we cannot tell whose fault the eval failure
+    // was — and an E2B outage is ours. Ambiguity must never produce a red X.
+    const h = harness(evalDies, "throws");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0].outcome).toBe("infra_error");
-    expect(h.events).not.toContain("probeServer");
   });
 
-  it("stays neutral when the discriminator itself fails", async () => {
-    const h = harness({
-      runEvalSuite: async () => {
-        throw new Error("fetch failed: ECONNREFUSED");
-      },
-      probeServer: async () => {
-        throw new Error("probe blew up");
-      },
-    });
+  it("stays neutral when the liveness check answers with neither sentinel", async () => {
+    // A connect that timed out, or a node that printed nothing. Silence is not
+    // evidence against the PR.
+    const h = harness(evalDies, "");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0].outcome).toBe("infra_error");
+  });
+
+  it("checks liveness over the command RPC, never the public URL", async () => {
+    // The load-bearing property: a fetch to `getHost(port)` traverses E2B ingress,
+    // DNS and TLS, and reports every one of those outages exactly like a dead
+    // server. Attribution must not rest on that path, so the probe runs in-box
+    // against loopback.
+    const commands: string[] = [];
+    const h = harness(evalDies, "MCPJAM_CHECK_PORT_CLOSED\n");
+    const provision = h.deps.provisionSandbox!;
+    h.deps.provisionSandbox = async (args) => {
+      const box = await provision(args);
+      const inner = box.commands.run;
+      box.commands.run = async (command: string, opts?: unknown) => {
+        commands.push(command);
+        return inner.call(box.commands, command, opts as never);
+      };
+      return box;
+    };
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    const liveness = commands.find((c) => c.includes("MCPJAM_CHECK_PORT_OPEN"));
+    expect(liveness).toBeDefined();
+    expect(liveness).toContain("127.0.0.1");
+    expect(liveness).toContain(String(RECIPE.port));
+    expect(liveness).not.toContain("e2b.app");
   });
 
   it("reports infra_error — not evals_failed — when the org is out of credits", async () => {

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from "vitest";
 import {
   classifyCheckFailure,
   executeClaimedCheck,
@@ -146,6 +154,31 @@ describe("executeClaimedCheck — happy path", () => {
     expect(h.events.indexOf("recordServer:trig-1:server-1")).toBeLessThan(
       h.events.indexOf("runEvalSuite")
     );
+  });
+
+  it("targets the run at THIS check's server and refreshes the suite snapshot", async () => {
+    // `serverIds` alone is not enough: it never reaches the run-start mutation,
+    // so the run's configSnapshot.environment comes from the suite's persisted
+    // environment — which names the PREVIOUS check's deleted server unless the
+    // snapshot is refreshed. Without this the runner fails on a dead reference
+    // instead of testing the PR.
+    const prepared: Array<Record<string, unknown>> = [];
+    const h = harness({
+      runEvalSuite: async (args) => {
+        prepared.push({ ...args });
+        return { runId: "run-1", result: "passed" };
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    // The suite-snapshot refresh itself lives in `defaultRunEvalSuite`, which
+    // needs a live Convex + connected manager and is covered by the end-to-end
+    // pass; what is checkable here is that the run is handed THIS check's
+    // freshly-created server rather than anything the suite has stored.
+    expect(prepared[0]).toMatchObject({
+      serverId: "server-1",
+      serverName: "gh-check-trig-1",
+    });
   });
 
   it("reports evals_failed with the pass counts when the run does not pass", async () => {
@@ -350,6 +383,12 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
     const rejections: unknown[] = [];
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
     vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "service-token");
+    // Cleaned up explicitly: this describe block has no env/global teardown, and
+    // a leaked `fetch` stub makes an unrelated later test fail confusingly.
+    onTestFinished(() => {
+      vi.unstubAllEnvs();
+      vi.unstubAllGlobals();
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn(

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -74,7 +74,7 @@ function harness(
     commands: {
       run: async (command: string) => {
         // The post-failure liveness check is the only command this fake sees.
-        if (command.includes("MCPJAM_CHECK_PORT_OPEN")) {
+        if (command.includes("MCPJAM_CHECK_HTTP_ANSWERED")) {
           events.push("livenessCheck");
           if (liveness === "throws") throw new Error("sandbox not found");
           return { stdout: liveness ?? "" };
@@ -284,24 +284,35 @@ describe("executeClaimedCheck — failure attribution", () => {
     },
   };
 
-  it("blames the PR when its server stops listening during the eval", async () => {
+  it("blames the PR when its server stops accepting connections during the eval", async () => {
     // The server passed the health probe and then died. Asked from inside the box,
-    // nothing is listening on its port — so this is the PR's server, not a network
-    // path of ours, and it must earn `server_unhealthy`.
+    // the connection is refused — so this is the PR's server, not a network path of
+    // ours, and it must earn `server_unhealthy`.
     const h = harness(evalDies, "MCPJAM_CHECK_PORT_CLOSED\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0]).toMatchObject({ outcome: "server_unhealthy" });
     expect(h.reports[0].detailsMarkdown).toContain("ECONNREFUSED");
-    expect(h.reports[0].detailsMarkdown).toContain("stopped listening");
+    expect(h.reports[0].detailsMarkdown).toContain("stopped answering");
     expect(h.events).toContain("livenessCheck");
   });
 
-  it("stays neutral when the eval fails but the PR's server is still listening", async () => {
+  it("stays neutral when the eval fails but the PR's server still answers", async () => {
     // Same transport-shaped error, but the process is alive. The failure came from
     // somewhere else — ours — so the check must not blame the PR.
-    const h = harness(evalDies, "MCPJAM_CHECK_PORT_OPEN\n");
+    const h = harness(evalDies, "MCPJAM_CHECK_HTTP_ANSWERED 200\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0].outcome).toBe("infra_error");
+  });
+
+  it("blames the PR when its listener stays bound but answers nothing", async () => {
+    // A bound socket proves very little: an event loop that is wedged, deadlocked
+    // or thrashing still accepts connections while answering nothing. That is the
+    // PR's bug, and a TCP-connect-only diagnostic would have called it healthy and
+    // left the eval failure neutral.
+    const h = harness(evalDies, "MCPJAM_CHECK_HTTP_SILENT\n");
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0]).toMatchObject({ outcome: "server_unhealthy" });
+    expect(h.reports[0].detailsMarkdown).toContain("sent nothing back");
   });
 
   it("stays neutral when the sandbox command channel has gone away", async () => {
@@ -345,7 +356,7 @@ describe("executeClaimedCheck — failure attribution", () => {
       const box = await provision(args);
       const inner = box.commands.run;
       box.commands.run = async (command: string, opts?: unknown) => {
-        if (command.includes("MCPJAM_CHECK_PORT_OPEN")) {
+        if (command.includes("MCPJAM_CHECK_HTTP_ANSWERED")) {
           inDiagnostic = true;
           // Let the 1ms heartbeat fire and register the loss mid-diagnostic.
           await new Promise((resolve) => setTimeout(resolve, 20));
@@ -379,7 +390,9 @@ describe("executeClaimedCheck — failure attribution", () => {
       return box;
     };
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    const liveness = commands.find((c) => c.includes("MCPJAM_CHECK_PORT_OPEN"));
+    const liveness = commands.find((c) =>
+      c.includes("MCPJAM_CHECK_HTTP_ANSWERED")
+    );
     expect(liveness).toBeDefined();
     expect(liveness).toContain("127.0.0.1");
     expect(liveness).toContain(String(RECIPE.port));

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -246,8 +246,10 @@ describe("executeClaimedCheck — failure attribution", () => {
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0].outcome).toBe("infra_error");
-    // No server row was created, so nothing to delete.
+    // No server row was created, so nothing to delete…
     expect(h.events.some((e) => e.startsWith("deleteServer"))).toBe(false);
+    // …but the sandbox was already provisioned, and a leaked box costs money.
+    expect(h.events).toContain("killSandbox");
   });
 
   it("still reports and cleans up when the clone drifts from the claimed sha", async () => {
@@ -340,6 +342,30 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("reports a rejected heartbeat instead of counting it as a success", async () => {
+    // The route answering 401/409/500 must not look like a refreshed lease: the
+    // backend's sweep would take the check away while this worker still runs it.
+    const rejections: unknown[] = [];
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "service-token");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ ok: false, error: "Unauthorized" }), {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          })
+      )
+    );
+    const { sendHeartbeatForTests } = await import("../github-checks-worker");
+    await sendHeartbeatForTests("trig-1", "worker-1").catch((error) =>
+      rejections.push(error)
+    );
+    expect(rejections).toHaveLength(1);
+    expect(String(rejections[0])).toMatch(/heartbeat rejected \(401\)/);
   });
 
   it("keeps going when a heartbeat request fails", async () => {

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -1,0 +1,504 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  classifyCheckFailure,
+  executeClaimedCheck,
+  outcomeForRunResult,
+  startGithubChecksWorker,
+  type CheckExecutionDeps,
+  type CheckReport,
+  type ClaimedGithubCheck,
+} from "../github-checks-worker";
+import { CheckStepError } from "../github-checks/sandbox";
+
+// Two invariants drive every test here, because both are visible on somebody's
+// pull request when they break:
+//
+//   1. A claimed trigger ALWAYS gets exactly one reported outcome, on every
+//      path, and the sandbox is always torn down. An unreported claim shows up
+//      as a check that hangs for five minutes and then goes neutral.
+//   2. The outcome distinguishes the PR's fault from ours. `build_failed` and
+//      `server_unhealthy` are the PR's; `infra_error` is ours. Backwards, and a
+//      good PR gets a red X (or a real breakage is hidden).
+
+const CLAIM: ClaimedGithubCheck = {
+  triggerId: "trig-1",
+  repoFullName: "mcpjam/mcp-check-fixture",
+  prNumber: 12,
+  headSha: "a".repeat(40),
+  organizationId: "org-1",
+  projectId: "proj-1",
+  createdByExternalId: "user_workos_1",
+  suiteId: "suite-1",
+};
+
+const RECIPE = {
+  build: "npm ci && npm run build",
+  start: "npm start",
+  port: 3001,
+  mcpPath: "/mcp",
+};
+
+type Harness = {
+  deps: Partial<CheckExecutionDeps>;
+  reports: CheckReport[];
+  events: string[];
+  heartbeats: string[];
+};
+
+function harness(overrides?: Partial<CheckExecutionDeps>): Harness {
+  const reports: CheckReport[] = [];
+  const events: string[] = [];
+  const heartbeats: string[] = [];
+
+  const sandbox = {
+    sandboxId: "sb_1",
+    getHost: (port: number) => `${port}-sb_1.e2b.app`,
+    commands: { run: async () => ({}) },
+    updateNetwork: async () => {},
+    kill: async () => {},
+  } as unknown as Awaited<ReturnType<CheckExecutionDeps["provisionSandbox"]>>;
+
+  const deps: Partial<CheckExecutionDeps> = {
+    resolveRecipe: () => RECIPE,
+    provisionSandbox: async () => {
+      events.push("provision");
+      return sandbox;
+    },
+    cloneAndCheckout: async () => {
+      events.push("clone");
+    },
+    buildAndStart: async () => {
+      events.push("buildAndStart");
+      return {
+        url: "https://3001-sb_1.e2b.app/mcp",
+        readStderrTail: () => "",
+      };
+    },
+    killSandbox: async () => {
+      events.push("killSandbox");
+    },
+    getBearer: async () => {
+      events.push("getBearer");
+      return "delegated-jwt";
+    },
+    createEphemeralServer: async (args) => {
+      events.push(`createServer:${args.name}:${args.url}`);
+      return "server-1";
+    },
+    deleteEphemeralServer: async (args) => {
+      events.push(`deleteServer:${args.serverId}`);
+    },
+    recordServer: async (triggerId, serverId) => {
+      events.push(`recordServer:${triggerId}:${serverId}`);
+    },
+    runEvalSuite: async () => {
+      events.push("runEvalSuite");
+      return {
+        runId: "run-1",
+        result: "passed",
+        summary: { total: 3, passed: 3, failed: 0, passRate: 1 },
+      };
+    },
+    report: async (report) => {
+      reports.push(report);
+      events.push(`report:${report.outcome}`);
+    },
+    heartbeat: async (triggerId) => {
+      heartbeats.push(triggerId);
+    },
+    heartbeatIntervalMs: 1_000,
+    ...overrides,
+  };
+
+  return { deps, reports, events, heartbeats };
+}
+
+describe("executeClaimedCheck — happy path", () => {
+  it("builds, creates the ephemeral server, runs the suite, reports passed, cleans up", async () => {
+    const h = harness();
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.events).toEqual([
+      "provision",
+      "clone",
+      "buildAndStart",
+      "getBearer",
+      "createServer:gh-check-trig-1:https://3001-sb_1.e2b.app/mcp",
+      "recordServer:trig-1:server-1",
+      "runEvalSuite",
+      "report:passed",
+      "deleteServer:server-1",
+      "killSandbox",
+    ]);
+    expect(h.reports).toEqual([
+      {
+        triggerId: "trig-1",
+        outcome: "passed",
+        runId: "run-1",
+        summary: { total: 3, passed: 3, failed: 0, passRate: 1 },
+      },
+    ]);
+  });
+
+  it("records the ephemeral server BEFORE running the suite, so a mid-run death is recoverable", async () => {
+    const h = harness();
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.events.indexOf("recordServer:trig-1:server-1")).toBeLessThan(
+      h.events.indexOf("runEvalSuite")
+    );
+  });
+
+  it("reports evals_failed with the pass counts when the run does not pass", async () => {
+    const h = harness({
+      runEvalSuite: async () => ({
+        runId: "run-2",
+        result: "failed",
+        summary: { total: 4, passed: 1, failed: 3, passRate: 0.25 },
+      }),
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0]).toMatchObject({
+      outcome: "evals_failed",
+      runId: "run-2",
+      summary: { total: 4, passed: 1, failed: 3 },
+    });
+  });
+});
+
+describe("executeClaimedCheck — failure attribution", () => {
+  it("reports recipe_unresolvable and touches no sandbox when there is no recipe", async () => {
+    const h = harness({ resolveRecipe: () => null });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.reports[0]).toMatchObject({ outcome: "recipe_unresolvable" });
+    expect(h.events).not.toContain("provision");
+  });
+
+  it("reports infra_error when the sandbox cannot be provisioned", async () => {
+    const h = harness({
+      provisionSandbox: async () => {
+        throw new CheckStepError("infra_error", "E2B 503");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0]).toMatchObject({
+      outcome: "infra_error",
+      failureReason: "E2B 503",
+    });
+    // Nothing to delete, but teardown still runs.
+    expect(h.events).toContain("killSandbox");
+  });
+
+  it("reports build_failed — the PR's fault — with the clamped log tail", async () => {
+    const h = harness({
+      buildAndStart: async () => {
+        throw new CheckStepError(
+          "build_failed",
+          "build command exited 1",
+          "```text\nnpm ERR! missing script: build\n```"
+        );
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.reports[0].outcome).toBe("build_failed");
+    expect(h.reports[0].detailsMarkdown).toContain("missing script: build");
+    // Re-clamping our own already-fenced block must not double-fence it.
+    expect(h.reports[0].detailsMarkdown).not.toContain("```text\n```text");
+    // No eval run was attempted, and the box was killed.
+    expect(h.events).not.toContain("runEvalSuite");
+    expect(h.events).toContain("killSandbox");
+  });
+
+  it("reports server_unhealthy when the built server never speaks MCP", async () => {
+    const h = harness({
+      buildAndStart: async () => {
+        throw new CheckStepError(
+          "server_unhealthy",
+          "server never completed MCP initialize on port 3001/mcp",
+          "```text\nlisten EADDRINUSE 127.0.0.1:3001\n```"
+        );
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0].outcome).toBe("server_unhealthy");
+    expect(h.reports[0].detailsMarkdown).toContain("EADDRINUSE");
+  });
+
+  it("reports infra_error — not evals_failed — when the org is out of credits", async () => {
+    const h = harness({
+      runEvalSuite: async () => {
+        throw new Error("billing_limit_reached: eval iterations");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0]).toMatchObject({
+      outcome: "infra_error",
+      failureReason: "billing_limit_reached",
+    });
+  });
+
+  it("reports infra_error when the delegated token cannot be minted", async () => {
+    const h = harness({
+      getBearer: async () => {
+        throw new Error("Delegated token exchange failed (403)");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0].outcome).toBe("infra_error");
+    // No server row was created, so nothing to delete.
+    expect(h.events.some((e) => e.startsWith("deleteServer"))).toBe(false);
+  });
+
+  it("still reports and cleans up when the clone drifts from the claimed sha", async () => {
+    const h = harness({
+      cloneAndCheckout: async () => {
+        throw new CheckStepError("infra_error", "checkout drifted");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports).toHaveLength(1);
+    expect(h.events).toContain("killSandbox");
+  });
+});
+
+describe("executeClaimedCheck — cleanup and heartbeat", () => {
+  it("deletes the ephemeral server row and kills the box even when the run throws", async () => {
+    const h = harness({
+      runEvalSuite: async () => {
+        throw new Error("runner exploded");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.events).toContain("deleteServer:server-1");
+    expect(h.events).toContain("killSandbox");
+  });
+
+  it("kills the box even if deleting the server row fails", async () => {
+    const h = harness({
+      deleteEphemeralServer: async () => {
+        throw new Error("convex down");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    // A cleanup failure that costs money (a live sandbox) must not be skipped
+    // because a cheaper one (a soft-deletable row) failed first.
+    expect(h.events).toContain("killSandbox");
+    expect(h.reports[0].outcome).toBe("passed");
+  });
+
+  it("does not fail the check when recording the ephemeral server fails", async () => {
+    const h = harness({
+      recordServer: async () => {
+        throw new Error("route 500");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    // Recovery loses its cleanup pointer, but the PR still gets its verdict.
+    expect(h.reports[0].outcome).toBe("passed");
+  });
+
+  it("never throws, even when reporting itself fails", async () => {
+    const h = harness({
+      report: async () => {
+        throw new Error("convex unreachable");
+      },
+      runEvalSuite: async () => {
+        throw new Error("boom");
+      },
+    });
+    await expect(
+      executeClaimedCheck(CLAIM, "worker-1", h.deps)
+    ).resolves.toBeUndefined();
+  });
+
+  it("heartbeats while the check runs and stops the moment it settles", async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseRun: () => void = () => {};
+      const runGate = new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      const h = harness({
+        runEvalSuite: async () => {
+          await runGate;
+          return { runId: "run-1", result: "passed" };
+        },
+        heartbeatIntervalMs: 1_000,
+      });
+
+      const pending = executeClaimedCheck(CLAIM, "worker-1", h.deps);
+      await vi.advanceTimersByTimeAsync(3_500);
+      expect(h.heartbeats.length).toBeGreaterThanOrEqual(3);
+
+      releaseRun();
+      await pending;
+
+      const afterSettle = h.heartbeats.length;
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(h.heartbeats.length).toBe(afterSettle);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps going when a heartbeat request fails", async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseRun: () => void = () => {};
+      const runGate = new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      const h = harness({
+        heartbeat: async () => {
+          throw new Error("convex 502");
+        },
+        runEvalSuite: async () => {
+          await runGate;
+          return { runId: "run-1", result: "passed" };
+        },
+      });
+      const pending = executeClaimedCheck(CLAIM, "worker-1", h.deps);
+      await vi.advanceTimersByTimeAsync(3_000);
+      releaseRun();
+      await expect(pending).resolves.toBeUndefined();
+      expect(h.reports[0].outcome).toBe("passed");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("classifyCheckFailure", () => {
+  it("keeps a CheckStepError's own verdict rather than re-deriving one", () => {
+    expect(
+      classifyCheckFailure(
+        new CheckStepError("build_failed", "exit 1", "```text\nlog\n```")
+      )
+    ).toMatchObject({
+      outcome: "build_failed",
+      detailsMarkdown: expect.any(String),
+    });
+    expect(
+      classifyCheckFailure(new CheckStepError("server_unhealthy", "no init"))
+    ).toMatchObject({ outcome: "server_unhealthy" });
+  });
+
+  it("maps only the canonical billing marker, never a loose substring", () => {
+    expect(
+      classifyCheckFailure(new Error("billing_limit_reached: iterations"))
+    ).toMatchObject({ failureReason: "billing_limit_reached" });
+    // An MCP server error that merely mentions billing must not be reclassified.
+    expect(
+      classifyCheckFailure(new Error("tool failed: check your billing page"))
+    ).toMatchObject({
+      outcome: "infra_error",
+      failureReason: "tool failed: check your billing page",
+    });
+  });
+
+  it("defaults unknown failures to infra_error, never to the PR's fault", () => {
+    // Guessing from a message would mean a red X on a good PR when we guess
+    // wrong, so an unrecognized failure is always OURS.
+    expect(classifyCheckFailure(new Error("???")).outcome).toBe("infra_error");
+    expect(classifyCheckFailure("a bare string").outcome).toBe("infra_error");
+  });
+
+  it("bounds the failure reason", () => {
+    expect(
+      classifyCheckFailure(new Error("x".repeat(1_000))).failureReason.length
+    ).toBe(200);
+  });
+});
+
+describe("outcomeForRunResult", () => {
+  it("treats only `passed` as a pass", () => {
+    expect(outcomeForRunResult("passed")).toBe("passed");
+    for (const result of [
+      "failed",
+      "cancelled",
+      "timed_out",
+      "pending",
+      null,
+      undefined,
+    ]) {
+      expect(outcomeForRunResult(result)).toBe("evals_failed");
+    }
+  });
+});
+
+describe("startGithubChecksWorker loop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "service-token");
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  async function flush(times = 6) {
+    for (let i = 0; i < times; i += 1) {
+      await vi.advanceTimersByTimeAsync(20_000);
+    }
+  }
+
+  it("executes one claim at a time and keeps polling", async () => {
+    const claim = vi.fn().mockResolvedValueOnce(CLAIM).mockResolvedValue(null);
+    const execute = vi.fn().mockResolvedValue(undefined);
+
+    const handle = startGithubChecksWorker({ claim, execute });
+    await flush();
+    await handle.stop();
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0][0]).toEqual(CLAIM);
+    // The claimedBy identity is threaded through so heartbeats match the claim.
+    expect(execute.mock.calls[0][1]).toEqual(claim.mock.calls[0][0]);
+    expect(claim.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("backs off without executing when the backend reports the feature disabled", async () => {
+    const claim = vi.fn().mockResolvedValue("disabled" as const);
+    const execute = vi.fn();
+    const handle = startGithubChecksWorker({ claim, execute });
+    await flush(3);
+    await handle.stop();
+    expect(execute).not.toHaveBeenCalled();
+    expect(claim).toHaveBeenCalled();
+  });
+
+  it("survives claim errors instead of crashing the loop", async () => {
+    const claim = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("backend down"))
+      .mockResolvedValue(null);
+    const handle = startGithubChecksWorker({ claim, execute: vi.fn() });
+    await flush(8);
+    await handle.stop();
+    expect(claim.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("stop() ends the loop", async () => {
+    const claim = vi.fn().mockResolvedValue(null);
+    const handle = startGithubChecksWorker({ claim, execute: vi.fn() });
+    await flush(2);
+    const stopped = handle.stop();
+    await vi.advanceTimersByTimeAsync(1);
+    await stopped;
+    const callsAtStop = claim.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(claim.mock.calls.length).toBe(callsAtStop);
+  });
+
+  it("does not start without the service credentials", async () => {
+    vi.unstubAllEnvs();
+    const claim = vi.fn();
+    const handle = startGithubChecksWorker({ claim, execute: vi.fn() });
+    await flush(2);
+    await handle.stop();
+    expect(claim).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -494,28 +494,46 @@ describe("outcomeForRunResult", () => {
 });
 
 describe("effectiveRunResult", () => {
+  // Every fixture here carries `passRate` in the shape the runner ACTUALLY
+  // persists — a 0-1 fraction (`passed / total`) — because the threshold it is
+  // compared against is a 0-100 percentage. A fixture written as a percentage
+  // would let the unit bug back in unnoticed.
   it("derives the verdict for a completed run whose record omits `result`", () => {
     // The recorder finalizes with `status: "completed"` and a summary but does
     // not always populate `result`. Reading `result` alone puts a red X on a PR
     // that passed every single test.
+    const perfect = {
+      status: "completed",
+      summary: { total: 4, passed: 4, failed: 0, passRate: 1 },
+    };
+    expect(effectiveRunResult(perfect)).toBe("passed");
+    expect(outcomeForRunResult(effectiveRunResult(perfect))).toBe("passed");
+  });
+
+  it("compares a PERCENTAGE against the threshold, not the stored fraction", () => {
+    // The regression this pins: `summary.passRate` is `passed / total`, so a
+    // perfect run stores 1. Comparing that to `minimumPassRate` (0-100) fails
+    // every run, including one that passed everything — the exact false failure
+    // the derivation exists to prevent.
     expect(
       effectiveRunResult({
         status: "completed",
-        summary: { total: 4, passed: 4, failed: 0, passRate: 100 },
+        summary: { total: 2, passed: 2, failed: 0, passRate: 1 },
+        passCriteria: { minimumPassRate: 100 },
       })
     ).toBe("passed");
+    // And a stored rate that disagrees with the counts does not get a vote.
     expect(
-      outcomeForRunResult(
-        effectiveRunResult({
-          status: "completed",
-          summary: { total: 4, passed: 4, failed: 0, passRate: 100 },
-        })
-      )
-    ).toBe("passed");
+      effectiveRunResult({
+        status: "completed",
+        summary: { total: 4, passed: 1, failed: 3, passRate: 99 },
+        passCriteria: { minimumPassRate: 90 },
+      })
+    ).toBe("failed");
   });
 
   it("honors the suite's own pass criteria", () => {
-    const summary = { total: 10, passed: 8, failed: 2, passRate: 80 };
+    const summary = { total: 10, passed: 8, failed: 2, passRate: 0.8 };
     expect(
       effectiveRunResult({
         status: "completed",
@@ -539,7 +557,7 @@ describe("effectiveRunResult", () => {
       effectiveRunResult({
         status: "completed",
         result: "failed",
-        summary: { total: 1, passed: 1, failed: 0, passRate: 100 },
+        summary: { total: 1, passed: 1, failed: 0, passRate: 1 },
       })
     ).toBe("failed");
   });

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -12,6 +12,7 @@ import {
   effectiveRunResult,
   executeClaimedCheck,
   outcomeForRunResult,
+  LeaseLostError,
   startGithubChecksWorker,
   type CheckExecutionDeps,
   type CheckReport,
@@ -317,6 +318,47 @@ describe("executeClaimedCheck — failure attribution", () => {
     const h = harness(evalDies, "");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0].outcome).toBe("infra_error");
+  });
+
+  it("abandons the check when the lease is lost during the liveness diagnostic", async () => {
+    // The diagnostic talks to the box, so it takes real time — and the lease can be
+    // taken away inside that window, AFTER the last step boundary checked it.
+    // Reporting `server_unhealthy` for a claim somebody else has already concluded
+    // is what the lease guard exists to prevent, so the re-check has to happen
+    // after the diagnostic and not only before the eval.
+    let inDiagnostic = false;
+    const h = harness(
+      {
+        runEvalSuite: async () => {
+          throw new Error("fetch failed: ECONNREFUSED");
+        },
+        heartbeat: async () => {
+          // Only once the diagnostic is under way, so the earlier boundaries pass.
+          if (inDiagnostic) throw new LeaseLostError("taken over");
+        },
+        heartbeatIntervalMs: 1,
+      },
+      "MCPJAM_CHECK_PORT_CLOSED\n"
+    );
+    const provision = h.deps.provisionSandbox!;
+    h.deps.provisionSandbox = async (args) => {
+      const box = await provision(args);
+      const inner = box.commands.run;
+      box.commands.run = async (command: string, opts?: unknown) => {
+        if (command.includes("MCPJAM_CHECK_PORT_OPEN")) {
+          inDiagnostic = true;
+          // Let the 1ms heartbeat fire and register the loss mid-diagnostic.
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        return inner.call(box.commands, command, opts as never);
+      };
+      return box;
+    };
+
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    // Abandoned, not reported — and the box is still torn down.
+    expect(h.reports).toHaveLength(0);
+    expect(h.events).toContain("killSandbox");
   });
 
   it("checks liveness over the command RPC, never the public URL", async () => {

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 import {
   classifyCheckFailure,
+  effectiveRunResult,
   executeClaimedCheck,
   outcomeForRunResult,
   startGithubChecksWorker,
@@ -489,6 +490,67 @@ describe("outcomeForRunResult", () => {
     ]) {
       expect(outcomeForRunResult(result)).toBe("evals_failed");
     }
+  });
+});
+
+describe("effectiveRunResult", () => {
+  it("derives the verdict for a completed run whose record omits `result`", () => {
+    // The recorder finalizes with `status: "completed"` and a summary but does
+    // not always populate `result`. Reading `result` alone puts a red X on a PR
+    // that passed every single test.
+    expect(
+      effectiveRunResult({
+        status: "completed",
+        summary: { total: 4, passed: 4, failed: 0, passRate: 100 },
+      })
+    ).toBe("passed");
+    expect(
+      outcomeForRunResult(
+        effectiveRunResult({
+          status: "completed",
+          summary: { total: 4, passed: 4, failed: 0, passRate: 100 },
+        })
+      )
+    ).toBe("passed");
+  });
+
+  it("honors the suite's own pass criteria", () => {
+    const summary = { total: 10, passed: 8, failed: 2, passRate: 80 };
+    expect(
+      effectiveRunResult({
+        status: "completed",
+        summary,
+        passCriteria: { minimumPassRate: 80 },
+      })
+    ).toBe("passed");
+    expect(
+      effectiveRunResult({
+        status: "completed",
+        summary,
+        passCriteria: { minimumPassRate: 90 },
+      })
+    ).toBe("failed");
+    // No criteria ⇒ 100% required, matching the client's derivation.
+    expect(effectiveRunResult({ status: "completed", summary })).toBe("failed");
+  });
+
+  it("prefers an explicit result over anything derived", () => {
+    expect(
+      effectiveRunResult({
+        status: "completed",
+        result: "failed",
+        summary: { total: 1, passed: 1, failed: 0, passRate: 100 },
+      })
+    ).toBe("failed");
+  });
+
+  it("never invents a pass when there is nothing to derive from", () => {
+    expect(effectiveRunResult({ status: "completed" })).toBeUndefined();
+    expect(effectiveRunResult(null)).toBeUndefined();
+    expect(effectiveRunResult({ status: "running" })).toBeUndefined();
+    expect(effectiveRunResult({ status: "timed_out" })).toBe("timed_out");
+    expect(effectiveRunResult({ status: "cancelled" })).toBe("cancelled");
+    expect(effectiveRunResult({ status: "failed" })).toBe("failed");
   });
 });
 

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -12,6 +12,7 @@ import {
   effectiveRunResult,
   executeClaimedCheck,
   outcomeForRunResult,
+  snapshotBelongsToAnotherCheck,
   LeaseLostError,
   startGithubChecksWorker,
   type CheckExecutionDeps,
@@ -855,5 +856,92 @@ describe("startGithubChecksWorker loop", () => {
     await flush(2);
     await handle.stop();
     expect(claim).not.toHaveBeenCalled();
+  });
+});
+
+describe("snapshotBelongsToAnotherCheck", () => {
+  // The dedicated suite is shared and `refreshSnapshot` rewrites its environment
+  // before the run freezes it, so two concurrent checks can interleave and one can
+  // end up evaluating the other's server. This cannot prevent that; it decides when
+  // the theft is PROVEN, because a verdict about somebody else's PR is worse than
+  // no verdict.
+  const clientWith = (snapshot: unknown) =>
+    ({
+      query: async () => ({ configSnapshot: { environment: snapshot } }),
+    } as unknown as Parameters<typeof snapshotBelongsToAnotherCheck>[0]);
+
+  it("passes a snapshot naming our own check", async () => {
+    const snapshot = {
+      servers: ["srv_1"],
+      serverBindings: [{ name: "gh-check-trig-1", id: "srv_1" }],
+    };
+    expect(
+      await snapshotBelongsToAnotherCheck(
+        clientWith(snapshot),
+        "run-1",
+        "trig-1"
+      )
+    ).toBe(false);
+  });
+
+  it("catches a snapshot naming a different check", async () => {
+    const snapshot = {
+      servers: ["srv_2"],
+      serverBindings: [{ name: "gh-check-trig-9", id: "srv_2" }],
+    };
+    expect(
+      await snapshotBelongsToAnotherCheck(
+        clientWith(snapshot),
+        "run-1",
+        "trig-1"
+      )
+    ).toBe(true);
+  });
+
+  it("passes when ours appears alongside another", async () => {
+    // A display list can carry stale entries; ours being present is what matters.
+    const snapshot = {
+      serverBindings: [
+        { name: "gh-check-trig-9", id: "srv_2" },
+        { name: "gh-check-trig-1", id: "srv_1" },
+      ],
+    };
+    expect(
+      await snapshotBelongsToAnotherCheck(
+        clientWith(snapshot),
+        "run-1",
+        "trig-1"
+      )
+    ).toBe(false);
+  });
+
+  it("proves nothing from a snapshot naming no check server", async () => {
+    // The snapshot's shape is the backend's, not this module's, so an unrecognised
+    // one must not fail every check.
+    expect(
+      await snapshotBelongsToAnotherCheck(
+        clientWith({ servers: ["srv_manual"] }),
+        "run-1",
+        "trig-1"
+      )
+    ).toBe(false);
+  });
+
+  it("proves nothing when there is no snapshot, or the query fails", async () => {
+    expect(
+      await snapshotBelongsToAnotherCheck(
+        clientWith(undefined),
+        "run-1",
+        "trig-1"
+      )
+    ).toBe(false);
+    const broken = {
+      query: async () => {
+        throw new Error("convex down");
+      },
+    } as unknown as Parameters<typeof snapshotBelongsToAnotherCheck>[0];
+    expect(await snapshotBelongsToAnotherCheck(broken, "run-1", "trig-1")).toBe(
+      false
+    );
   });
 });

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -13,7 +13,7 @@ import {
   executeClaimedCheck,
   outcomeForRunResult,
   runReachedAVerdict,
-  snapshotBelongsToAnotherCheck,
+  verifyRunSnapshot,
   LeaseLostError,
   startGithubChecksWorker,
   type CheckExecutionDeps,
@@ -860,16 +860,16 @@ describe("startGithubChecksWorker loop", () => {
   });
 });
 
-describe("snapshotBelongsToAnotherCheck", () => {
+describe("verifyRunSnapshot", () => {
   // The dedicated suite is shared and `refreshSnapshot` rewrites its environment
   // before the run freezes it, so two concurrent checks can interleave and one can
   // end up evaluating the other's server. This cannot prevent that; it decides when
-  // the theft is PROVEN, because a verdict about somebody else's PR is worse than
-  // no verdict.
+  // the theft is PROVEN, and when we simply could not look — a verdict about
+  // somebody else's PR being worse than no verdict.
   const clientWith = (snapshot: unknown) =>
     ({
       query: async () => ({ configSnapshot: { environment: snapshot } }),
-    } as unknown as Parameters<typeof snapshotBelongsToAnotherCheck>[0]);
+    } as unknown as Parameters<typeof verifyRunSnapshot>[0]);
 
   it("passes a snapshot naming our own check", async () => {
     const snapshot = {
@@ -877,12 +877,8 @@ describe("snapshotBelongsToAnotherCheck", () => {
       serverBindings: [{ name: "gh-check-trig-1", id: "srv_1" }],
     };
     expect(
-      await snapshotBelongsToAnotherCheck(
-        clientWith(snapshot),
-        "run-1",
-        "trig-1"
-      )
-    ).toBe(false);
+      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1")
+    ).toBe("ours");
   });
 
   it("catches a snapshot naming a different check", async () => {
@@ -891,12 +887,8 @@ describe("snapshotBelongsToAnotherCheck", () => {
       serverBindings: [{ name: "gh-check-trig-9", id: "srv_2" }],
     };
     expect(
-      await snapshotBelongsToAnotherCheck(
-        clientWith(snapshot),
-        "run-1",
-        "trig-1"
-      )
-    ).toBe(true);
+      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1")
+    ).toBe("stolen");
   });
 
   it("passes when ours appears alongside another", async () => {
@@ -908,41 +900,36 @@ describe("snapshotBelongsToAnotherCheck", () => {
       ],
     };
     expect(
-      await snapshotBelongsToAnotherCheck(
-        clientWith(snapshot),
-        "run-1",
-        "trig-1"
-      )
-    ).toBe(false);
+      await verifyRunSnapshot(clientWith(snapshot), "run-1", "trig-1")
+    ).toBe("ours");
   });
 
-  it("proves nothing from a snapshot naming no check server", async () => {
-    // The snapshot's shape is the backend's, not this module's, so an unrecognised
-    // one must not fail every check.
+  it("proceeds on a snapshot naming no check server", async () => {
+    // The snapshot's shape is the backend's contract, not this module's, so an
+    // unrecognised one must not fail every check.
     expect(
-      await snapshotBelongsToAnotherCheck(
+      await verifyRunSnapshot(
         clientWith({ servers: ["srv_manual"] }),
         "run-1",
         "trig-1"
       )
-    ).toBe(false);
+    ).toBe("ours");
+    expect(
+      await verifyRunSnapshot(clientWith(undefined), "run-1", "trig-1")
+    ).toBe("ours");
   });
 
-  it("proves nothing when there is no snapshot, or the query fails", async () => {
-    expect(
-      await snapshotBelongsToAnotherCheck(
-        clientWith(undefined),
-        "run-1",
-        "trig-1"
-      )
-    ).toBe(false);
+  it("refuses to proceed when the snapshot cannot be read at all", async () => {
+    // Being unable to LOOK is different from looking and finding nothing: it removes
+    // the only guard against publishing a verdict about another PR's server. The
+    // caller turns this into a neutral check.
     const broken = {
       query: async () => {
         throw new Error("convex down");
       },
-    } as unknown as Parameters<typeof snapshotBelongsToAnotherCheck>[0];
-    expect(await snapshotBelongsToAnotherCheck(broken, "run-1", "trig-1")).toBe(
-      false
+    } as unknown as Parameters<typeof verifyRunSnapshot>[0];
+    expect(await verifyRunSnapshot(broken, "run-1", "trig-1")).toBe(
+      "unverifiable"
     );
   });
 });

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -12,6 +12,7 @@ import {
   effectiveRunResult,
   executeClaimedCheck,
   outcomeForRunResult,
+  runReachedAVerdict,
   snapshotBelongsToAnotherCheck,
   LeaseLostError,
   startGithubChecksWorker,
@@ -943,5 +944,31 @@ describe("snapshotBelongsToAnotherCheck", () => {
     expect(await snapshotBelongsToAnotherCheck(broken, "run-1", "trig-1")).toBe(
       false
     );
+  });
+});
+
+describe("runReachedAVerdict", () => {
+  it("trusts only a completed run", async () => {
+    expect(runReachedAVerdict("completed")).toBe(true);
+    // Each of these means the machinery stopped, not that the PR failed — and
+    // `timed_out`/`cancelled` reach the verdict path WITHOUT a throw, because a
+    // lifecycle stop is finalized and returned normally. `outcomeForRunResult`
+    // would turn every one of them into `evals_failed`.
+    for (const status of [
+      "timed_out",
+      "cancelled",
+      "failed",
+      "running",
+      undefined,
+    ]) {
+      expect(runReachedAVerdict(status)).toBe(false);
+    }
+  });
+
+  it("guards exactly the statuses outcomeForRunResult would misread", async () => {
+    // The pairing is the point: anything not `passed` is a PR failure downstream,
+    // so anything not `completed` has to be stopped before it gets there.
+    expect(outcomeForRunResult("timed_out")).toBe("evals_failed");
+    expect(runReachedAVerdict("timed_out")).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -736,6 +736,37 @@ describe("startGithubChecksWorker loop", () => {
     expect(claim.mock.calls.length).toBeGreaterThan(1);
   });
 
+  it("stops promptly when the abort lands while a claim is in flight", async () => {
+    // The loop only tests `aborted` at the top, so a claim that settles AFTER
+    // `stop()` falls through to the backoff sleep with an already-aborted signal.
+    // An `abort` event that has already fired never fires again, so a listener
+    // registered at that point waits out the full 60s backoff and the caller's
+    // shutdown timer force-exits an otherwise idle worker.
+    vi.useRealTimers();
+    let releaseClaim: (value: null) => void = () => {};
+    const claim = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseClaim = resolve;
+        })
+    );
+    const handle = startGithubChecksWorker({ claim, execute: vi.fn() });
+    // Wait until the loop is parked inside claim().
+    while (claim.mock.calls.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+
+    const stopped = handle.stop();
+    // Settle the claim after the abort, which is the race under test.
+    releaseClaim(null);
+
+    const outcome = await Promise.race([
+      stopped.then(() => "stopped" as const),
+      new Promise<"hung">((resolve) => setTimeout(() => resolve("hung"), 500)),
+    ]);
+    expect(outcome).toBe("stopped");
+  });
+
   it("backs off without executing when the backend reports the feature disabled", async () => {
     const claim = vi.fn().mockResolvedValue("disabled" as const);
     const execute = vi.fn();

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -80,7 +80,7 @@ function harness(overrides?: Partial<CheckExecutionDeps>): Harness {
       events.push("buildAndStart");
       return {
         url: "https://3001-sb_1.e2b.app/mcp",
-        readStderrTail: () => "",
+        readStderrTail: async () => "",
       };
     },
     killSandbox: async () => {

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -315,6 +315,24 @@ describe("executeClaimedCheck — failure attribution", () => {
     expect(h.reports[0].detailsMarkdown).toContain("sent nothing back");
   });
 
+  it("blames the PR when its server answers the liveness request with a 5xx", async () => {
+    // Running but not serving: a 500 is the server failing on its own terms, and
+    // the eval transport would fail on it too.
+    const h = harness(evalDies, "MCPJAM_CHECK_HTTP_ANSWERED 500\n");
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0]).toMatchObject({ outcome: "server_unhealthy" });
+  });
+
+  it("stays neutral when the liveness request draws a 4xx", async () => {
+    // The liveness request is a simplified, legacy-shaped `initialize` without the
+    // modern `_meta` envelope headers the real client sends, so a modern-only server
+    // can reject it correctly while still being drivable by the eval run. A 4xx is
+    // therefore evidence about OUR request, not about the PR's server.
+    const h = harness(evalDies, "MCPJAM_CHECK_HTTP_ANSWERED 400\n");
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0].outcome).toBe("infra_error");
+  });
+
   it("stays neutral when the sandbox command channel has gone away", async () => {
     // The box no longer answers, so we cannot tell whose fault the eval failure
     // was — and an E2B outage is ours. Ambiguity must never produce a red X.

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -761,6 +761,9 @@ describe("startGithubChecksWorker loop", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+    // A SEPARATE variable from the one above, read much later (when the ephemeral
+    // server is created) and therefore also part of the startup gate.
+    vi.stubEnv("CONVEX_URL", "https://convex.test");
     vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "service-token");
     // The sandbox configuration is part of the startup gate: without it the
     // worker refuses to poll (see the test at the end of this block).
@@ -833,6 +836,23 @@ describe("startGithubChecksWorker loop", () => {
     await handle.stop();
     expect(execute).not.toHaveBeenCalled();
     expect(claim).toHaveBeenCalled();
+  });
+
+  it("refuses to poll when CONVEX_URL is missing", async () => {
+    // `CONVEX_URL` is only read when the ephemeral server is created — after the
+    // box is provisioned and the PR is built. Claiming without it would spend ten
+    // minutes on a trigger and then conclude `infra_error`, permanently, since a
+    // verdict is final. Not polling leaves the check claimable until the deploy is
+    // fixed, which is the same reasoning as the sandbox gate.
+    vi.stubEnv("CONVEX_URL", "");
+    const claim = vi.fn().mockResolvedValue(null);
+
+    const worker = startGithubChecksWorker({ claim, claimedBy: "worker-1" });
+    onTestFinished(async () => {
+      await worker.stop();
+    });
+    await flush();
+    expect(claim).not.toHaveBeenCalled();
   });
 
   it("refuses to poll when the sandbox is not configured", async () => {

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -577,6 +577,10 @@ describe("startGithubChecksWorker loop", () => {
     vi.useFakeTimers();
     vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
     vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "service-token");
+    // The sandbox configuration is part of the startup gate: without it the
+    // worker refuses to poll (see the test at the end of this block).
+    vi.stubEnv("E2B_API_KEY", "e2b_test");
+    vi.stubEnv("GITHUB_CHECKS_E2B_TEMPLATE_ID", "tmpl_test");
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -613,6 +617,23 @@ describe("startGithubChecksWorker loop", () => {
     await handle.stop();
     expect(execute).not.toHaveBeenCalled();
     expect(claim).toHaveBeenCalled();
+  });
+
+  it("refuses to poll when the sandbox is not configured", async () => {
+    // Claiming without E2B is worse than not starting: every queued trigger would
+    // be claimed, fail to provision, and be concluded `infra_error` — and a
+    // verdict is final. Not polling leaves them claimable until the deploy is fixed.
+    vi.stubEnv("E2B_API_KEY", "");
+    vi.stubEnv("GITHUB_CHECKS_E2B_TEMPLATE_ID", "");
+    const claim = vi.fn().mockResolvedValue(null);
+
+    const worker = startGithubChecksWorker({ claim, claimedBy: "worker-1" });
+    onTestFinished(async () => {
+      await worker.stop();
+    });
+    await flush();
+
+    expect(claim).not.toHaveBeenCalled();
   });
 
   it("survives claim errors instead of crashing the loop", async () => {

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -351,6 +351,31 @@ describe("executeClaimedCheck — failure attribution", () => {
     expect(h.reports[0].outcome).toBe("infra_error");
   });
 
+  it("abandons the check when the lease is lost during a SUCCESSFUL eval", async () => {
+    // The eval is the widest window in the flow, and it can lose the lease and still
+    // resolve normally — in which case the failure path's re-check is never reached.
+    // Reporting a verdict over a check the backend already concluded is exactly what
+    // the lease guard exists to prevent.
+    let inEval = false;
+    const h = harness({
+      runEvalSuite: async () => {
+        inEval = true;
+        // Let the 1ms heartbeat fire and register the loss mid-eval.
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return { runId: "run-1", result: "passed" };
+      },
+      heartbeat: async () => {
+        if (inEval) throw new LeaseLostError("taken over");
+      },
+      heartbeatIntervalMs: 1,
+    });
+
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    // Abandoned rather than reported, and the box is still torn down.
+    expect(h.reports).toHaveLength(0);
+    expect(h.events).toContain("killSandbox");
+  });
+
   it("abandons the check when the lease is lost during the liveness diagnostic", async () => {
     // The diagnostic talks to the box, so it takes real time — and the lease can be
     // taken away inside that window, AFTER the last step boundary checked it.

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -116,6 +116,13 @@ function harness(overrides?: Partial<CheckExecutionDeps>): Harness {
       heartbeats.push(triggerId);
     },
     heartbeatIntervalMs: 1_000,
+    // The eval-failure discriminator's default answer: the PR's server is still
+    // answering, so a failed run stays OUR problem unless a test says otherwise.
+    // Also keeps these tests off the network — the real default would fetch.
+    probeServer: async () => {
+      events.push("probeServer");
+      return true;
+    },
     ...overrides,
   };
 
@@ -257,6 +264,76 @@ describe("executeClaimedCheck — failure attribution", () => {
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     expect(h.reports[0].outcome).toBe("server_unhealthy");
     expect(h.reports[0].detailsMarkdown).toContain("EADDRINUSE");
+  });
+
+  it("blames the PR when its server stops answering during the eval", async () => {
+    // The server passed the health probe and then died. The box is still reachable,
+    // so this is not an outage of ours — it is the PR's server, and it must earn
+    // `server_unhealthy` rather than hiding behind a neutral `infra_error`.
+    const h = harness({
+      runEvalSuite: async () => {
+        throw new Error("fetch failed: ECONNREFUSED");
+      },
+      probeServer: async () => false,
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0]).toMatchObject({ outcome: "server_unhealthy" });
+    expect(h.reports[0].detailsMarkdown).toContain("ECONNREFUSED");
+    expect(h.reports[0].detailsMarkdown).toContain("stopped responding");
+  });
+
+  it("stays neutral when the eval fails but the PR's server is still up", async () => {
+    // Same transport-shaped error, but the server answers when asked. The failure
+    // came from somewhere else — ours, so the check must not blame the PR.
+    const h = harness({
+      runEvalSuite: async () => {
+        throw new Error("fetch failed: ECONNREFUSED");
+      },
+      probeServer: async () => true,
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0].outcome).toBe("infra_error");
+  });
+
+  it("stays neutral when the sandbox itself has gone away", async () => {
+    // The box is unreachable, so we cannot tell whose fault the eval failure was —
+    // and an E2B outage is ours. Ambiguity must never produce a red X.
+    const sandboxGone = {
+      sandboxId: "sb_1",
+      getHost: (port: number) => `${port}-sb_1.e2b.app`,
+      commands: {
+        run: async () => {
+          throw new Error("sandbox not found");
+        },
+      },
+      updateNetwork: async () => {},
+      kill: async () => {},
+    } as unknown as Awaited<ReturnType<CheckExecutionDeps["provisionSandbox"]>>;
+    const h = harness({
+      provisionSandbox: async () => sandboxGone,
+      runEvalSuite: async () => {
+        throw new Error("fetch failed: ECONNREFUSED");
+      },
+      // Would say "server gone" — but must never be consulted, because the box
+      // being unreachable already makes this ours.
+      probeServer: async () => false,
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0].outcome).toBe("infra_error");
+    expect(h.events).not.toContain("probeServer");
+  });
+
+  it("stays neutral when the discriminator itself fails", async () => {
+    const h = harness({
+      runEvalSuite: async () => {
+        throw new Error("fetch failed: ECONNREFUSED");
+      },
+      probeServer: async () => {
+        throw new Error("probe blew up");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+    expect(h.reports[0].outcome).toBe("infra_error");
   });
 
   it("reports infra_error — not evals_failed — when the org is out of credits", async () => {

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -133,9 +133,11 @@ async function postServiceRoute(
     () => controller.abort(),
     SERVICE_ROUTE_TIMEOUT_MS
   );
-  let response: Response;
+  // The timer stays armed through the BODY read, not just the headers: a
+  // response that stalls mid-body would otherwise hang the poll loop for as long
+  // as the socket stays open, and the loop is what recovers from a sick backend.
   try {
-    response = await fetch(`${env.convexUrl}${path}`, {
+    const response = await fetch(`${env.convexUrl}${path}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -144,16 +146,16 @@ async function postServiceRoute(
       body: JSON.stringify(body),
       signal: controller.signal,
     });
+    let parsed: any = null;
+    try {
+      parsed = await response.json();
+    } catch {
+      // Tolerated; status carries the signal.
+    }
+    return { status: response.status, body: parsed };
   } finally {
     clearTimeout(timeout);
   }
-  let parsed: any = null;
-  try {
-    parsed = await response.json();
-  } catch {
-    // Tolerated; status carries the signal.
-  }
-  return { status: response.status, body: parsed };
 }
 
 async function claimNext(
@@ -194,12 +196,36 @@ async function reportOutcome(report: CheckReport): Promise<void> {
   }
 }
 
+/**
+ * Refresh the lease, and THROW if the backend refused.
+ *
+ * A silently-discarded status is the dangerous version of this call: the
+ * interval would treat every rejected heartbeat as a success, and after five
+ * minutes of that the backend's sweep concludes the check `infra_error` while
+ * this worker is still happily running it. Failing loudly at least puts the
+ * reason in the logs next to the check that got taken away.
+ */
 async function sendHeartbeat(
   triggerId: string,
   claimedBy: string
 ): Promise<void> {
-  await postServiceRoute(`${SERVICE_BASE}/heartbeat`, { triggerId, claimedBy });
+  const { status, body } = await postServiceRoute(`${SERVICE_BASE}/heartbeat`, {
+    triggerId,
+    claimedBy,
+  });
+  if (status !== 200 || !body?.ok) {
+    throw new Error(`heartbeat rejected (${status}): ${JSON.stringify(body)}`);
+  }
+  // The route answers 200 with `result.ok: false` when this worker no longer
+  // holds the claim (lease recovered, row superseded). Nothing to retry, but the
+  // lease is gone and that belongs in the logs beside the lost check.
+  if (body.result && body.result.ok === false) {
+    throw new Error(`heartbeat not applied: ${body.result.error ?? "unknown"}`);
+  }
 }
+
+/** Test seam: the heartbeat's response validation is the whole point of it. */
+export const sendHeartbeatForTests = sendHeartbeat;
 
 async function recordEphemeralServer(
   triggerId: string,
@@ -315,6 +341,35 @@ async function defaultDeleteEphemeralServer(args: {
 }
 
 /**
+ * Run statuses the eval runner treats as final. `timed_out` is included because
+ * the runner stamps it before rethrowing — re-finalizing as `failed` would
+ * overwrite a real timeout verdict.
+ */
+const TERMINAL_RUN_STATUSES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "timed_out",
+]);
+
+async function isRunTerminal(
+  client: { query: (name: any, args: any) => Promise<any> },
+  runId: string
+): Promise<boolean> {
+  try {
+    const run = (await client.query("testSuites:getTestSuiteRun" as any, {
+      runId,
+    })) as { status?: string } | null;
+    return TERMINAL_RUN_STATUSES.has(String(run?.status));
+  } catch {
+    // Can't tell. Let the defensive finalize proceed — `recorder.finalize`
+    // tolerates an already-terminal run, so the worst case is a duplicate
+    // terminal write rather than a run stranded mid-flight.
+    return false;
+  }
+}
+
+/**
  * Run the dedicated suite against the just-built server.
  *
  * The `serverIds` override is what makes this work at all: the suite is a
@@ -358,26 +413,62 @@ async function defaultRunEvalSuite(args: {
       idempotencyKey: args.claimed.triggerId,
     });
 
+    const client = createConvexClient(args.bearer);
+
     try {
       await prepared.execute();
     } catch (error) {
-      // The runner owns terminal run status (it finalizes failed runs before
-      // rethrowing). The run exists, so read its verdict below rather than
-      // treating this as an infrastructure failure.
-      logger.warn(
-        "[github-checks] eval run threw; reading its terminal state",
-        {
-          triggerId: args.claimed.triggerId,
-          runId: prepared.runId,
-          error: error instanceof Error ? error.message : String(error),
+      // `runEvalSuiteWithAiSdk` finalizes a failed run itself before rethrowing,
+      // so USUALLY the terminal write already happened and we can just read the
+      // verdict. But a throw from OUTSIDE its own try leaves the run
+      // non-terminal, and reading that gives `result: undefined` → a bogus
+      // `evals_failed` on the PR with a run left running forever. Mirror the
+      // detached /api/v1 path: check terminality, and finalize defensively when
+      // the runner did not.
+      logger.warn("[github-checks] eval run threw; checking its run state", {
+        triggerId: args.claimed.triggerId,
+        runId: prepared.runId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      const terminal = await isRunTerminal(client, prepared.runId);
+      if (!terminal) {
+        if (!prepared.recorder) {
+          // Nothing can finalize the run, so do not invent a verdict from it.
+          throw error;
         }
-      );
+        await prepared.recorder
+          .finalize({
+            status: "failed",
+            notes:
+              error instanceof Error
+                ? error.message.slice(0, 500)
+                : String(error).slice(0, 500),
+          })
+          .catch((finalizeError: unknown) => {
+            logger.error(
+              "[github-checks] failed to finalize a non-terminal eval run",
+              finalizeError,
+              { triggerId: args.claimed.triggerId, runId: prepared.runId }
+            );
+          });
+      }
     }
 
-    const client = createConvexClient(args.bearer);
     const run = (await client.query("testSuites:getTestSuiteRun" as any, {
       runId: prepared.runId,
-    })) as { result?: string; summary?: CheckSummary } | null;
+    })) as { status?: string; result?: string; summary?: CheckSummary } | null;
+
+    // A run that is somehow STILL not terminal has no verdict to report. Raising
+    // here lands it as `infra_error` (neutral) rather than a false failure — this
+    // is our problem, not the PR's.
+    if (!TERMINAL_RUN_STATUSES.has(String(run?.status))) {
+      throw new Error(
+        `eval run ${prepared.runId} never reached a terminal status (last: ${
+          run?.status ?? "unknown"
+        })`
+      );
+    }
 
     return {
       runId: prepared.runId,

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -660,6 +660,54 @@ async function runCompleted(
  * the suite's stored binding is never consulted — which is also why this suite
  * must never be launched from the UI.
  */
+/**
+ * Whether this run's frozen environment names a DIFFERENT check's server.
+ *
+ * The dedicated suite is shared, and `refreshSnapshot: true` rewrites its stored
+ * environment before the run-start mutation freezes it — two mutations, no
+ * atomicity. Two checks running at once (two workers, or two replicas of one) can
+ * therefore interleave as: A rewrites → B rewrites → A starts and freezes B's
+ * server. A would then evaluate the wrong PR's server, or fail when B deletes it,
+ * and either way report a verdict about somebody else's code.
+ *
+ * This does not fix that race — it detects the case it can prove. Every check names
+ * its server `gh-check-<triggerId>`, so:
+ *
+ *   - the snapshot mentions OUR trigger → ours, proceed;
+ *   - it mentions some other check's trigger and not ours → stolen, and the check
+ *     is abandoned as neutral rather than reporting a verdict from it;
+ *   - it mentions no `gh-check-` server at all → nothing is proven. The snapshot's
+ *     shape is not this module's contract to rely on, so an unrecognised one must
+ *     not fail every check. Proceed.
+ *
+ * Best effort by design: a query that fails proves nothing either, and must not
+ * turn into a verdict.
+ */
+export async function snapshotBelongsToAnotherCheck(
+  client: ReturnType<typeof createConvexClient>,
+  runId: string,
+  triggerId: string
+): Promise<boolean> {
+  let snapshot: unknown;
+  try {
+    const run = (await client.query("testSuites:getTestSuiteRun" as any, {
+      runId,
+    })) as { configSnapshot?: { environment?: unknown } } | null;
+    snapshot = run?.configSnapshot?.environment;
+  } catch {
+    return false;
+  }
+  if (snapshot === undefined || snapshot === null) return false;
+  // Serialized rather than walked: the snapshot carries servers, bindings and
+  // display copies in shapes owned by the backend, and a name match anywhere in it
+  // is the signal — the ids are unique per ephemeral server.
+  const named = [
+    ...JSON.stringify(snapshot).matchAll(/gh-check-([A-Za-z0-9_-]+)/g),
+  ].map((match) => match[1]);
+  if (named.length === 0) return false;
+  return !named.includes(triggerId);
+}
+
 async function defaultRunEvalSuite(args: {
   claimed: ClaimedGithubCheck;
   bearer: string;
@@ -711,6 +759,25 @@ async function defaultRunEvalSuite(args: {
     });
 
     const client = createConvexClient(args.bearer);
+
+    // The suite is SHARED by every check, and rewriting its environment then
+    // starting the run are two separate mutations. Another check's rewrite can
+    // land in between, so this run's frozen snapshot can name ITS ephemeral
+    // server instead of ours. Verified before anything is evaluated, because a
+    // verdict from a run that tested a different PR's server is worse than no
+    // verdict at all. See `snapshotBelongsToAnotherCheck` for what is provable.
+    if (
+      await snapshotBelongsToAnotherCheck(
+        client,
+        prepared.runId,
+        args.claimed.triggerId
+      )
+    ) {
+      throw new CheckStepError(
+        "infra_error",
+        "another check's server was snapshotted onto this run"
+      );
+    }
 
     try {
       await prepared.execute();

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -889,7 +889,17 @@ export async function executeClaimedCheck(
       .catch(async (error: unknown) => {
         // A failure here may be the PR's server dying mid-run rather than an
         // outage of ours, and the difference decides who gets the red X.
-        throw await attributeEvalFailure(error, runningBox, recipe.port);
+        const attributed = await attributeEvalFailure(
+          error,
+          runningBox,
+          recipe.port
+        );
+        // The diagnostic above talks to the box, so it takes real time — long
+        // enough for the lease to be taken away while it runs. Re-checked here so
+        // a check somebody else has already concluded is abandoned rather than
+        // reported on, which is what every other step boundary does.
+        assertLeaseHeld();
+        throw attributed;
       });
 
     const outcome = outcomeForRunResult(run.result);

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -511,7 +511,6 @@ async function serverStillResponding(
     // predicate is shaped to avoid.
     return Number(answered[1]) < 500;
   }
-  if (stdout.includes(HTTP_ANSWERED_MARKER)) return true;
   // Refused, or accepted the connection and then said nothing at all. Either way
   // the server is not serving, and it is the PR's process.
   if (

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -674,7 +674,7 @@ async function runCompleted(
  * must never be launched from the UI.
  */
 /**
- * Whether this run's frozen environment names a DIFFERENT check's server.
+ * Which check's server this run's frozen environment names.
  *
  * The dedicated suite is shared, and `refreshSnapshot: true` rewrites its stored
  * environment before the run-start mutation freezes it — two mutations, no
@@ -686,21 +686,22 @@ async function runCompleted(
  * This does not fix that race — it detects the case it can prove. Every check names
  * its server `gh-check-<triggerId>`, so:
  *
- *   - the snapshot mentions OUR trigger → ours, proceed;
- *   - it mentions some other check's trigger and not ours → stolen, and the check
+ *   - the snapshot mentions OUR trigger → `ours`;
+ *   - it mentions some other check's trigger and not ours → `stolen`, and the check
  *     is abandoned as neutral rather than reporting a verdict from it;
- *   - it mentions no `gh-check-` server at all → nothing is proven. The snapshot's
- *     shape is not this module's contract to rely on, so an unrecognised one must
- *     not fail every check. Proceed.
- *
- * Best effort by design: a query that fails proves nothing either, and must not
- * turn into a verdict.
+ *   - it mentions no `gh-check-` server at all → `ours`. Nothing is proven, and the
+ *     snapshot's shape is the backend's contract rather than this module's, so an
+ *     unrecognised one must not fail every check;
+ *   - the query itself fails → `unverifiable`, which the caller also treats as
+ *     neutral. Being unable to look is different from looking and finding nothing:
+ *     it removes the only guard against publishing a verdict about another PR's
+ *     server, and a failed read of ours is ours to own.
  */
-export async function snapshotBelongsToAnotherCheck(
+export async function verifyRunSnapshot(
   client: ReturnType<typeof createConvexClient>,
   runId: string,
   triggerId: string
-): Promise<boolean> {
+): Promise<"ours" | "stolen" | "unverifiable"> {
   let snapshot: unknown;
   try {
     const run = (await client.query("testSuites:getTestSuiteRun" as any, {
@@ -708,17 +709,23 @@ export async function snapshotBelongsToAnotherCheck(
     })) as { configSnapshot?: { environment?: unknown } } | null;
     snapshot = run?.configSnapshot?.environment;
   } catch {
-    return false;
+    // We could not LOOK. During a race that is the one check standing between a
+    // wrong-PR verdict and publishing it, so it fails closed — and a Convex read
+    // of ours failing is our problem to own, which is what neutral means here.
+    return "unverifiable";
   }
-  if (snapshot === undefined || snapshot === null) return false;
+  if (snapshot === undefined || snapshot === null) return "ours";
   // Serialized rather than walked: the snapshot carries servers, bindings and
   // display copies in shapes owned by the backend, and a name match anywhere in it
   // is the signal — the ids are unique per ephemeral server.
   const named = [
     ...JSON.stringify(snapshot).matchAll(/gh-check-([A-Za-z0-9_-]+)/g),
   ].map((match) => match[1]);
-  if (named.length === 0) return false;
-  return !named.includes(triggerId);
+  // A shape we do not recognise is NOT the same as being unable to look. Failing
+  // closed on it would break every check the first time the backend's snapshot
+  // shape changed, which is a self-inflicted outage rather than a safeguard.
+  if (named.length === 0) return "ours";
+  return named.includes(triggerId) ? "ours" : "stolen";
 }
 
 async function defaultRunEvalSuite(args: {
@@ -778,17 +785,18 @@ async function defaultRunEvalSuite(args: {
     // land in between, so this run's frozen snapshot can name ITS ephemeral
     // server instead of ours. Verified before anything is evaluated, because a
     // verdict from a run that tested a different PR's server is worse than no
-    // verdict at all. See `snapshotBelongsToAnotherCheck` for what is provable.
-    if (
-      await snapshotBelongsToAnotherCheck(
-        client,
-        prepared.runId,
-        args.claimed.triggerId
-      )
-    ) {
+    // verdict at all. See `verifyRunSnapshot` for what is provable.
+    const ownership = await verifyRunSnapshot(
+      client,
+      prepared.runId,
+      args.claimed.triggerId
+    );
+    if (ownership !== "ours") {
       throw new CheckStepError(
         "infra_error",
-        "another check's server was snapshotted onto this run"
+        ownership === "stolen"
+          ? "another check's server was snapshotted onto this run"
+          : "could not verify which server this run was bound to"
       );
     }
 

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -796,11 +796,31 @@ async function defaultRunEvalSuite(args: {
         ownership === "stolen"
           ? "another check's server was snapshotted onto this run"
           : "could not verify which server this run was bound to";
-      // The run row already exists — `prepareEvalRun` created it — and this throw
-      // bypasses the catch around `execute()` where the non-terminal finalize
-      // lives. Left alone it would sit in `running` forever, and every raced check
-      // would leave another one behind. Best effort: failing to tidy up must not
-      // replace the reason we are bailing out.
+      // The run row already exists — `prepareEvalRun` created it, along with a
+      // pending iteration row per attempt — and this throw bypasses the catch
+      // around `execute()` where the cleanup lives. Left alone the run sits in
+      // `running` with every iteration `pending`, and each raced check strands
+      // another set. Mirrors `prepareEvalRun`'s own setup-abort cleanup: fail the
+      // iterations first, then the run, both best effort, because failing to tidy
+      // up must not replace the reason we are bailing out.
+      await client
+        .mutation("testSuites:markSetupPendingIterationsFailed" as any, {
+          runId: prepared.runId,
+          error: reason,
+        })
+        .catch((cleanupError: unknown) => {
+          logger.warn(
+            "[github-checks] failed to fail pending iterations after an unowned run",
+            {
+              triggerId: args.claimed.triggerId,
+              runId: prepared.runId,
+              error:
+                cleanupError instanceof Error
+                  ? cleanupError.message
+                  : String(cleanupError),
+            }
+          );
+        });
       if (prepared.recorder) {
         await prepared.recorder
           .finalize({ status: "failed", notes: reason })
@@ -1192,6 +1212,19 @@ export function startGithubChecksWorker(options?: {
   if (!requiredEnv()) {
     logger.warn(
       "[github-checks] worker enabled but CONVEX_HTTP_URL / INSPECTOR_SERVICE_TOKEN missing; not starting"
+    );
+    return { stop: async () => {} };
+  }
+
+  // `CONVEX_URL` is a SEPARATE variable from `CONVEX_HTTP_URL` above, and it is
+  // read later and deeper: `createConvexClient` throws "CONVEX_URL is not set"
+  // when the ephemeral server is created, which is AFTER the box is provisioned
+  // and the PR is built. A deployment holding one but not the other would claim a
+  // trigger, spend ten minutes on it, and conclude `infra_error` — for the same
+  // reason as the sandbox gate below, checked here instead.
+  if (!process.env.CONVEX_URL) {
+    logger.warn(
+      "[github-checks] worker enabled but CONVEX_URL missing; not starting (queued checks stay claimable)"
     );
     return { stop: async () => {} };
   }

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -498,6 +498,19 @@ async function serverStillResponding(
     // The box did not answer at all. That is an E2B problem, which is ours.
     return null;
   }
+  const answered = new RegExp(`${HTTP_ANSWERED_MARKER} (\\d{3})`).exec(stdout);
+  if (answered) {
+    // A 5xx is the server failing on its own terms — it is running, it is not
+    // serving, and that is the PR's code either way.
+    //
+    // A 4xx deliberately does NOT blame it. This request is a simplified,
+    // legacy-shaped `initialize` with none of the modern `_meta` envelope headers
+    // the real client sends, so a modern-only server can reject it correctly while
+    // remaining perfectly drivable by the eval run. Reading that as the PR's fault
+    // would put a red X on a working server, which is the error this whole
+    // predicate is shaped to avoid.
+    return Number(answered[1]) < 500;
+  }
   if (stdout.includes(HTTP_ANSWERED_MARKER)) return true;
   // Refused, or accepted the connection and then said nothing at all. Either way
   // the server is not serving, and it is the PR's process.

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -1,0 +1,655 @@
+/**
+ * github-checks-worker.ts — polling executor for GitHub PR check runs.
+ *
+ * Same pull/claim architecture as `scheduled-evals-worker.ts`: the backend
+ * never calls the Inspector. A PR webhook lands a trigger row in Convex; this
+ * loop claims one at a time over the service-token-gated
+ * `/internal/v1/github-checks/*` routes, builds the PR's MCP server in a
+ * disposable sandbox, and drives the EXISTING `prepareEvalRun()` → `execute()`
+ * pipeline against it.
+ *
+ * The worker never talks to GitHub, and it holds no GitHub credential. It
+ * reports an OUTCOME; the control plane turns that into a check conclusion.
+ * That split is why a compromised worker cannot write to anyone's repo.
+ *
+ * Two invariants this file is responsible for, and they are the reason every
+ * exit path goes through `report()`:
+ *
+ *   1. A claimed trigger ALWAYS gets a verdict. An unreported claim sits until
+ *      the backend's heartbeat sweep fails it ~5 minutes later, which shows up
+ *      on someone's PR as a check that hung then went neutral.
+ *   2. The verdict distinguishes the PR's fault from ours. `build_failed` and
+ *      `server_unhealthy` are the PR's (→ check failure); `infra_error` is ours
+ *      (→ neutral). Getting that backwards puts a red X on a good PR, or hides
+ *      a real breakage.
+ *
+ * Gated by `GITHUB_CHECKS_WORKER_ENABLED === '1'`; the backend has its own
+ * `GITHUB_CHECKS_ENABLED` gate and 404s this whole surface when it is off.
+ */
+
+import { WEB_CALL_TIMEOUT_MS } from "../config.js";
+import { logger } from "../utils/logger";
+import { getConvexBearerForDelegation } from "../utils/v1-convex-token.js";
+import { createAuthorizedManager } from "../routes/web/auth.js";
+import { prepareEvalRun } from "../routes/shared/evals.js";
+import { createConvexClient } from "./evals/route-helpers.js";
+import { resolveCheckRecipe } from "./github-checks/recipes.js";
+import {
+  buildAndStart,
+  CheckStepError,
+  clampOutput,
+  cloneAndCheckout,
+  killCheckSandbox,
+  provisionCheckSandbox,
+  type CheckSandbox,
+} from "./github-checks/sandbox.js";
+
+const POLL_INTERVAL_MS = 15_000;
+const POLL_JITTER_MS = 5_000;
+/** Backoff after claim/transport errors so a broken backend isn't hammered. */
+const ERROR_BACKOFF_MS = 60_000;
+/** Per-request cap on service-route calls so a stalled Convex can't wedge the loop. */
+const SERVICE_ROUTE_TIMEOUT_MS = 15_000;
+/**
+ * Heartbeat cadence. The backend fails a claim whose heartbeat is >5 minutes
+ * stale, so 60s leaves room for ~5 consecutive misses before a healthy worker
+ * gets its check taken away mid-build.
+ */
+const HEARTBEAT_INTERVAL_MS = 60_000;
+
+const SERVICE_BASE = "/internal/v1/github-checks";
+
+/**
+ * The claim payload, HAND-MIRRORED from the backend's `ClaimedGithubCheck`
+ * (`convex/github/checkTriggers.ts`). The two repos share no types, so this
+ * shape IS the contract: adding a field is a two-repo change, and unknown
+ * fields on the wire are ignored rather than rejected.
+ */
+export type ClaimedGithubCheck = {
+  triggerId: string;
+  repoFullName: string;
+  prNumber: number;
+  headSha: string;
+  organizationId: string;
+  projectId: string;
+  createdByExternalId: string;
+  suiteId: string;
+};
+
+/**
+ * The verdict vocabulary, also hand-mirrored. The backend maps these to check
+ * conclusions (`convex/github/checkRuns.ts`); an unknown value is rejected by
+ * the complete route rather than defaulted, so a typo here fails loudly instead
+ * of mislabeling a PR.
+ */
+export type GithubCheckOutcome =
+  | "passed"
+  | "evals_failed"
+  | "build_failed"
+  | "server_unhealthy"
+  | "recipe_unresolvable"
+  | "unsupported_fork"
+  | "infra_error";
+
+export type CheckSummary = {
+  total: number;
+  passed: number;
+  failed: number;
+  passRate: number;
+};
+
+export type CheckReport = {
+  triggerId: string;
+  outcome: GithubCheckOutcome;
+  runId?: string;
+  summary?: CheckSummary;
+  detailsMarkdown?: string;
+  failureReason?: string;
+};
+
+export function isGithubChecksWorkerEnabled(): boolean {
+  return process.env.GITHUB_CHECKS_WORKER_ENABLED === "1";
+}
+
+function requiredEnv(): { convexUrl: string; serviceToken: string } | null {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!convexUrl || !serviceToken) return null;
+  return { convexUrl, serviceToken };
+}
+
+async function postServiceRoute(
+  path: string,
+  body: Record<string, unknown>
+): Promise<{ status: number; body: any }> {
+  const env = requiredEnv();
+  if (!env) {
+    throw new Error(
+      "github-checks worker requires CONVEX_HTTP_URL and INSPECTOR_SERVICE_TOKEN"
+    );
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    SERVICE_ROUTE_TIMEOUT_MS
+  );
+  let response: Response;
+  try {
+    response = await fetch(`${env.convexUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-inspector-service-token": env.serviceToken,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+  let parsed: any = null;
+  try {
+    parsed = await response.json();
+  } catch {
+    // Tolerated; status carries the signal.
+  }
+  return { status: response.status, body: parsed };
+}
+
+async function claimNext(
+  claimedBy: string
+): Promise<ClaimedGithubCheck | null | "disabled"> {
+  const { status, body } = await postServiceRoute(`${SERVICE_BASE}/claim`, {
+    claimedBy,
+  });
+  // 404 = GITHUB_CHECKS_ENABLED is off backend-side. Treat as "nothing to do"
+  // with a long backoff so flipping the flag needs no Inspector restart.
+  if (status === 404) return "disabled";
+  if (status !== 200 || !body?.ok) {
+    throw new Error(`claim failed (${status}): ${JSON.stringify(body)}`);
+  }
+  return (body.claimed as ClaimedGithubCheck | null) ?? null;
+}
+
+async function reportOutcome(report: CheckReport): Promise<void> {
+  try {
+    const { status, body } = await postServiceRoute(
+      `${SERVICE_BASE}/complete`,
+      report as unknown as Record<string, unknown>
+    );
+    if (status !== 200 || !body?.ok) {
+      logger.warn("[github-checks] completion rejected", {
+        triggerId: report.triggerId,
+        status,
+      });
+    }
+  } catch (error) {
+    // Best effort: an unreported claim is failed by the backend's heartbeat
+    // sweep, which concludes the check `infra_error` rather than leaving it
+    // running forever.
+    logger.warn("[github-checks] failed to report outcome", {
+      triggerId: report.triggerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function sendHeartbeat(
+  triggerId: string,
+  claimedBy: string
+): Promise<void> {
+  await postServiceRoute(`${SERVICE_BASE}/heartbeat`, { triggerId, claimedBy });
+}
+
+async function recordEphemeralServer(
+  triggerId: string,
+  serverId: string
+): Promise<void> {
+  await postServiceRoute(`${SERVICE_BASE}/ephemeral-server`, {
+    triggerId,
+    serverId,
+  });
+}
+
+/**
+ * Map a thrown error to an outcome.
+ *
+ * `CheckStepError` already carries its verdict (the sandbox module decided
+ * whether a failure was the PR's or ours), so it wins outright. Beyond that,
+ * only ONE marker is matched: the backend's canonical `billing_limit_reached`
+ * code, which is an MCPJam-side limit and must never show as the PR's failure.
+ * Everything else is `infra_error` — deliberately, because the alternative is
+ * guessing from a message, and a wrong guess means a red X on a good PR.
+ */
+export function classifyCheckFailure(error: unknown): {
+  outcome: GithubCheckOutcome;
+  failureReason: string;
+  detailsMarkdown?: string;
+} {
+  if (error instanceof CheckStepError) {
+    return {
+      outcome: error.outcome,
+      failureReason: error.message.slice(0, 200),
+      ...(error.detailsMarkdown
+        ? { detailsMarkdown: error.detailsMarkdown }
+        : {}),
+    };
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  if (/billing_limit_reached/i.test(message)) {
+    return {
+      outcome: "infra_error",
+      failureReason: "billing_limit_reached",
+    };
+  }
+  return { outcome: "infra_error", failureReason: message.slice(0, 200) };
+}
+
+/** Terminal run result → outcome. Only `passed` is a pass. */
+export function outcomeForRunResult(
+  result: string | null | undefined
+): GithubCheckOutcome {
+  return result === "passed" ? "passed" : "evals_failed";
+}
+
+/**
+ * Injectable collaborators. Every external effect the executor performs is one
+ * of these, so the failure-path tests drive real control flow (including the
+ * `finally` cleanup and the heartbeat lifecycle) without an E2B box, a Convex
+ * deployment, or an MCP server.
+ */
+export type CheckExecutionDeps = {
+  resolveRecipe: typeof resolveCheckRecipe;
+  provisionSandbox: typeof provisionCheckSandbox;
+  cloneAndCheckout: typeof cloneAndCheckout;
+  buildAndStart: typeof buildAndStart;
+  killSandbox: typeof killCheckSandbox;
+  getBearer: (externalId: string, organizationId: string) => Promise<string>;
+  createEphemeralServer: (args: {
+    bearer: string;
+    projectId: string;
+    name: string;
+    url: string;
+  }) => Promise<string>;
+  deleteEphemeralServer: (args: {
+    bearer: string;
+    serverId: string;
+  }) => Promise<void>;
+  recordServer: (triggerId: string, serverId: string) => Promise<void>;
+  runEvalSuite: (args: {
+    claimed: ClaimedGithubCheck;
+    bearer: string;
+    serverId: string;
+    serverName: string;
+  }) => Promise<{ runId: string; result?: string; summary?: CheckSummary }>;
+  report: (report: CheckReport) => Promise<void>;
+  heartbeat: (triggerId: string, claimedBy: string) => Promise<void>;
+  heartbeatIntervalMs: number;
+};
+
+async function defaultCreateEphemeralServer(args: {
+  bearer: string;
+  projectId: string;
+  name: string;
+  url: string;
+}): Promise<string> {
+  const client = createConvexClient(args.bearer);
+  const serverId = await client.mutation("servers:createServer" as any, {
+    projectId: args.projectId,
+    name: args.name,
+    enabled: true,
+    transportType: "http",
+    url: args.url,
+  });
+  return String(serverId);
+}
+
+async function defaultDeleteEphemeralServer(args: {
+  bearer: string;
+  serverId: string;
+}): Promise<void> {
+  const client = createConvexClient(args.bearer);
+  await client.mutation("servers:deleteServer" as any, {
+    serverId: args.serverId,
+  });
+}
+
+/**
+ * Run the dedicated suite against the just-built server.
+ *
+ * The `serverIds` override is what makes this work at all: the suite is a
+ * persisted `[github-checks] …` suite whose own saved server refs point at some
+ * previous check's (now deleted) ephemeral row. Overriding on every run means
+ * the suite's stored binding is never consulted — which is also why this suite
+ * must never be launched from the UI.
+ */
+async function defaultRunEvalSuite(args: {
+  claimed: ClaimedGithubCheck;
+  bearer: string;
+  serverId: string;
+  serverName: string;
+}): Promise<{ runId: string; result?: string; summary?: CheckSummary }> {
+  // Empty caller context = plain-JWT caller; the delegated JWT is the principal
+  // (same contract as the scheduled worker).
+  const authorized = await createAuthorizedManager(
+    {},
+    args.bearer,
+    args.claimed.projectId,
+    [args.serverId],
+    WEB_CALL_TIMEOUT_MS,
+    undefined,
+    undefined,
+    { serverNames: [args.serverName] }
+  );
+
+  try {
+    const prepared = await prepareEvalRun(authorized.manager, {
+      suiteId: args.claimed.suiteId,
+      projectId: args.claimed.projectId,
+      tests: [],
+      serverIds: [args.serverId],
+      serverNames: [args.serverName],
+      suiteRerun: true,
+      // `source: 'github_check'` would be a two-repo union change; 'api' is the
+      // closest existing value and keeps this to one repo (see plan follow-up).
+      source: "api",
+      convexAuthToken: args.bearer,
+      // A claim retry can never double-create a run.
+      idempotencyKey: args.claimed.triggerId,
+    });
+
+    try {
+      await prepared.execute();
+    } catch (error) {
+      // The runner owns terminal run status (it finalizes failed runs before
+      // rethrowing). The run exists, so read its verdict below rather than
+      // treating this as an infrastructure failure.
+      logger.warn(
+        "[github-checks] eval run threw; reading its terminal state",
+        {
+          triggerId: args.claimed.triggerId,
+          runId: prepared.runId,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
+    }
+
+    const client = createConvexClient(args.bearer);
+    const run = (await client.query("testSuites:getTestSuiteRun" as any, {
+      runId: prepared.runId,
+    })) as { result?: string; summary?: CheckSummary } | null;
+
+    return {
+      runId: prepared.runId,
+      ...(run?.result ? { result: run.result } : {}),
+      ...(run?.summary ? { summary: run.summary } : {}),
+    };
+  } finally {
+    await authorized.manager.disconnectAllServers().catch(() => {});
+  }
+}
+
+function defaultDeps(): CheckExecutionDeps {
+  return {
+    resolveRecipe: resolveCheckRecipe,
+    provisionSandbox: provisionCheckSandbox,
+    cloneAndCheckout,
+    buildAndStart,
+    killSandbox: killCheckSandbox,
+    getBearer: getConvexBearerForDelegation,
+    createEphemeralServer: defaultCreateEphemeralServer,
+    deleteEphemeralServer: defaultDeleteEphemeralServer,
+    recordServer: recordEphemeralServer,
+    runEvalSuite: defaultRunEvalSuite,
+    report: reportOutcome,
+    heartbeat: sendHeartbeat,
+    heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+  };
+}
+
+/**
+ * Execute one claimed check end to end. NEVER throws, and every exit path
+ * reports an outcome — see the invariants at the top of the file.
+ */
+export async function executeClaimedCheck(
+  claimed: ClaimedGithubCheck,
+  claimedBy: string,
+  overrides?: Partial<CheckExecutionDeps>
+): Promise<void> {
+  const deps: CheckExecutionDeps = { ...defaultDeps(), ...overrides };
+  const logContext = {
+    triggerId: claimed.triggerId,
+    repo: claimed.repoFullName,
+    pr: claimed.prNumber,
+    sha: claimed.headSha.slice(0, 8),
+  };
+
+  // The lease is refreshed for the WHOLE duration, including the eval run — a
+  // suite legitimately takes many minutes and must not look like a dead worker.
+  const heartbeat = setInterval(() => {
+    void deps.heartbeat(claimed.triggerId, claimedBy).catch((error) =>
+      logger.warn("[github-checks] heartbeat failed", {
+        ...logContext,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    );
+  }, deps.heartbeatIntervalMs);
+  // Don't hold the event loop open on shutdown.
+  (heartbeat as unknown as { unref?: () => void }).unref?.();
+
+  let sandbox: CheckSandbox | null = null;
+  let serverId: string | null = null;
+  let bearer: string | null = null;
+
+  // Reporting is the last thing that can fail, and it must not turn a delivered
+  // verdict into a thrown error — the poll loop would read that as a transport
+  // failure and back off, while the backend's heartbeat sweep would eventually
+  // conclude the check `infra_error` anyway.
+  const safeReport = async (report: CheckReport): Promise<void> => {
+    try {
+      await deps.report(report);
+    } catch (error) {
+      logger.warn("[github-checks] reporting the outcome failed", {
+        ...logContext,
+        outcome: report.outcome,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  try {
+    const recipe = deps.resolveRecipe(claimed.repoFullName);
+    if (!recipe) {
+      // Defensive: the backend allowlist and the recipe table are configured
+      // together today. Routine once the resolver ladder exists.
+      await safeReport({
+        triggerId: claimed.triggerId,
+        outcome: "recipe_unresolvable",
+        failureReason: `no run recipe for ${claimed.repoFullName}`,
+      });
+      return;
+    }
+
+    sandbox = await deps.provisionSandbox({
+      triggerId: claimed.triggerId,
+      repoFullName: claimed.repoFullName,
+      prNumber: claimed.prNumber,
+    });
+    await deps.cloneAndCheckout(sandbox, {
+      repoFullName: claimed.repoFullName,
+      prNumber: claimed.prNumber,
+      headSha: claimed.headSha,
+    });
+    // Builds, revokes egress, starts, and waits for `initialize` — in that
+    // order, which `buildAndStart` owns precisely so it can't be reordered here.
+    const started = await deps.buildAndStart(sandbox, recipe);
+
+    logger.info("[github-checks] PR server is reachable", {
+      ...logContext,
+      url: started.url,
+    });
+
+    bearer = await deps.getBearer(
+      claimed.createdByExternalId,
+      claimed.organizationId
+    );
+
+    const serverName = `gh-check-${claimed.triggerId}`;
+    serverId = await deps.createEphemeralServer({
+      bearer,
+      projectId: claimed.projectId,
+      name: serverName,
+      url: started.url,
+    });
+    // Tell the backend before running anything: if this worker dies mid-eval,
+    // recovery needs the pointer to soft-delete the row.
+    await deps.recordServer(claimed.triggerId, serverId).catch((error) =>
+      logger.warn("[github-checks] failed to record ephemeral server", {
+        ...logContext,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    );
+
+    const run = await deps.runEvalSuite({
+      claimed,
+      bearer,
+      serverId,
+      serverName,
+    });
+
+    const outcome = outcomeForRunResult(run.result);
+    await safeReport({
+      triggerId: claimed.triggerId,
+      outcome,
+      runId: run.runId,
+      ...(run.summary ? { summary: run.summary } : {}),
+      ...(outcome === "evals_failed"
+        ? { failureReason: `run result: ${run.result ?? "unknown"}` }
+        : {}),
+    });
+  } catch (error) {
+    const classified = classifyCheckFailure(error);
+    logger.error("[github-checks] check failed", error, {
+      ...logContext,
+      outcome: classified.outcome,
+    });
+    await safeReport({
+      triggerId: claimed.triggerId,
+      outcome: classified.outcome,
+      failureReason: classified.failureReason,
+      ...(classified.detailsMarkdown
+        ? { detailsMarkdown: clampOutput(rawOf(classified.detailsMarkdown)) }
+        : {}),
+    });
+  } finally {
+    clearInterval(heartbeat);
+    // Each step best-effort and independent: a failure to delete the server row
+    // must not skip killing the box (which costs money), and vice versa. The
+    // backend's recovery sweep and E2B's TTL are the backstops for both.
+    if (serverId && bearer) {
+      await deps.deleteEphemeralServer({ bearer, serverId }).catch((error) =>
+        logger.warn("[github-checks] ephemeral server cleanup failed", {
+          ...logContext,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      );
+    }
+    await deps.killSandbox(sandbox);
+  }
+}
+
+/**
+ * `CheckStepError.detailsMarkdown` is already clamped and fenced. Re-clamping a
+ * fenced block would double-fence it, so hand back the fence-free inner text
+ * when we recognize our own formatting and let `clampOutput` be idempotent.
+ */
+function rawOf(detailsMarkdown: string): string {
+  const fenced = /^(?:_[^\n]*_\n)?(`{3,})text\n([\s\S]*)\n\1$/.exec(
+    detailsMarkdown
+  );
+  return fenced ? fenced[2] : detailsMarkdown;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(done, ms);
+    function done() {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }
+    function onAbort() {
+      clearTimeout(timer);
+      done();
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export interface GithubChecksWorkerHandle {
+  /** Aborts polling and resolves once the loop (incl. an in-flight check) settles. */
+  stop: () => Promise<void>;
+}
+
+/**
+ * Start the polling loop. One check in flight per replica; the FLEET-wide cap is
+ * enforced backend-side in the claim mutation, because Railway may run several
+ * replicas and this loop knows nothing about its siblings.
+ */
+export function startGithubChecksWorker(options?: {
+  claimedBy?: string;
+  /** Test seams: override the claim/execute pair. */
+  claim?: typeof claimNext;
+  execute?: (claimed: ClaimedGithubCheck, claimedBy: string) => Promise<void>;
+}): GithubChecksWorkerHandle {
+  const abort = new AbortController();
+  const claimedBy =
+    options?.claimedBy ??
+    `inspector-gh-${process.env.RAILWAY_REPLICA_ID ?? process.pid}`;
+  const claim = options?.claim ?? claimNext;
+  const execute =
+    options?.execute ??
+    ((claimed: ClaimedGithubCheck, by: string) =>
+      executeClaimedCheck(claimed, by));
+
+  if (!requiredEnv()) {
+    logger.warn(
+      "[github-checks] worker enabled but CONVEX_HTTP_URL / INSPECTOR_SERVICE_TOKEN missing; not starting"
+    );
+    return { stop: async () => {} };
+  }
+
+  logger.info("[github-checks] worker started", { claimedBy });
+
+  const loop = (async () => {
+    while (!abort.signal.aborted) {
+      let waitMs =
+        POLL_INTERVAL_MS + Math.floor(Math.random() * POLL_JITTER_MS);
+      try {
+        const claimed = await claim(claimedBy);
+        if (claimed === "disabled") {
+          waitMs = ERROR_BACKOFF_MS;
+        } else if (claimed) {
+          await execute(claimed, claimedBy);
+          // Drain mode: another PR's check may be queued behind this one.
+          waitMs = 1_000;
+        }
+      } catch (error) {
+        logger.warn("[github-checks] poll failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        waitMs = ERROR_BACKOFF_MS;
+      }
+      await sleep(waitMs, abort.signal);
+    }
+    logger.info("[github-checks] worker stopped");
+  })();
+
+  return {
+    stop: async () => {
+      abort.abort();
+      // Bounded by the caller's shutdown force-exit timer; a check that outlasts
+      // it is recovered by the backend's heartbeat sweep.
+      await loop;
+    },
+  };
+}

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -336,7 +336,12 @@ export function effectiveRunResult(
   if (run.status === "completed") {
     const total = run.summary?.total ?? 0;
     if (total > 0) {
-      const passRatePercent = ((run.summary?.passed ?? 0) / total) * 100;
+      // ROUNDED, like the client's `computeRunEffectiveStats`. Rounding the same
+      // way is what keeps the check's verdict and the eval UI's badge from
+      // disagreeing on a fractional rate (2/3 is 67% to both, not 66.67% to one).
+      const passRatePercent = Math.round(
+        ((run.summary?.passed ?? 0) / total) * 100
+      );
       return passRatePercent >= (run.passCriteria?.minimumPassRate ?? 100)
         ? "passed"
         : "failed";

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -966,6 +966,12 @@ function rawOf(detailsMarkdown: string): string {
 }
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  // Checked BEFORE the listener goes on, because an `abort` that already fired
+  // never fires again: a listener added afterwards waits out the whole delay. The
+  // loop can reach here post-abort whenever `claim()` or `execute()` settles after
+  // `stop()`, and the delay may be the 60s backoff — long past the caller's
+  // shutdown deadline, which then force-exits an otherwise idle worker.
+  if (signal?.aborted) return Promise.resolve();
   return new Promise((resolve) => {
     const timer = setTimeout(done, ms);
     function done() {

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -432,7 +432,7 @@ const IN_BOX_RESPONSE_TIMEOUT_MS = 10_000;
  * only whether response headers come back at all — so this is deliberately a local
  * literal rather than a coupling to the health probe's negotiation constants.
  */
-const LIVENESS_PROBE_PROTOCOL_VERSION = "2025-06-18";
+const LIVENESS_PROBE_PROTOCOL_VERSION = "2025-11-25";
 
 /**
  * Whether the PR's server is still ANSWERING — asked from INSIDE the sandbox.
@@ -626,6 +626,20 @@ async function runTerminality(
   } catch {
     return "unknown";
   }
+}
+
+/**
+ * Whether a run's status means an eval verdict was actually reached.
+ *
+ * Only `completed` does. The runner writes it on its own success path; `timed_out`,
+ * `cancelled` and `failed` all mean the machinery stopped, and two of those arrive
+ * WITHOUT a throw — a lifecycle stop (iteration or whole-run timeout) is finalized
+ * and returned normally. Since `outcomeForRunResult` calls everything that is not
+ * `passed` a PR failure, letting one of those through is a red X on a PR whose
+ * assertions were never judged.
+ */
+export function runReachedAVerdict(status: string | undefined): boolean {
+  return status === "completed";
 }
 
 /**
@@ -838,12 +852,17 @@ async function defaultRunEvalSuite(args: {
       passCriteria?: { minimumPassRate?: number };
     } | null;
 
-    // A run that is somehow STILL not terminal has no verdict to report. Raising
-    // here lands it as `infra_error` (neutral) rather than a false failure — this
-    // is our problem, not the PR's.
-    if (!TERMINAL_RUN_STATUSES.has(String(run?.status))) {
+    // Only `completed` carries a verdict — the same rule `runCompleted` states for
+    // the throwing path, applied here too. The runner reaches THIS path without
+    // throwing for a lifecycle stop as well: an iteration or whole-run timeout is
+    // finalized `timed_out` and returned normally, and `cancelled` arrives the same
+    // way. `effectiveRunResult` would hand those straight to `outcomeForRunResult`,
+    // which calls everything that is not `passed` a PR failure — so a provider
+    // timeout or a cancelled run would put a red X on a PR whose assertions were
+    // never judged. Raising instead lands them as `infra_error` (neutral).
+    if (!runReachedAVerdict(run?.status)) {
       throw new Error(
-        `eval run ${prepared.runId} never reached a terminal status (last: ${
+        `eval run ${prepared.runId} did not complete (status: ${
           run?.status ?? "unknown"
         })`
       );

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -153,8 +153,15 @@ async function postServiceRoute(
       // A malformed body is tolerated — the status carries the signal. A body
       // read that hit the abort deadline is NOT: silently returning
       // `body: null` would make a timed-out call look like a successful one
-      // whose response merely lacked a body.
-      if (controller.signal.aborted) throw error;
+      // whose response merely lacked a body. Rethrown as a TIMEOUT, since the
+      // underlying error is a parse failure and would otherwise read in the
+      // logs (and in an `infra_error` detail) as a malformed-response bug.
+      if (controller.signal.aborted) {
+        throw new Error(
+          `service route ${path} timed out after ${SERVICE_ROUTE_TIMEOUT_MS}ms while reading the response body`,
+          { cause: error }
+        );
+      }
     }
     return { status: response.status, body: parsed };
   } finally {
@@ -309,7 +316,12 @@ export function outcomeForRunResult(
  * `client/src/components/evals/suite-runs-list.tsx`); this is the server-side
  * mirror, kept here because the worker must not import client code.
  *
- * `passRate` and `minimumPassRate` are both 0-100 (see the backend schema).
+ * The percentage is computed from `passed`/`total` and NOT read from
+ * `summary.passRate`. The stored field is a 0-1 FRACTION (`evals-runner.ts`
+ * writes `passed / total`) while `minimumPassRate` is a 0-100 PERCENTAGE, so
+ * comparing them directly fails every run: a perfect run stores `1`, which is
+ * below any threshold. The client recomputes from the counts for the same
+ * reason — it never reads the stored rate either.
  */
 export function effectiveRunResult(
   run: {
@@ -322,9 +334,10 @@ export function effectiveRunResult(
   if (!run) return undefined;
   if (run.result) return run.result;
   if (run.status === "completed") {
-    const passRate = run.summary?.passRate;
-    if (typeof passRate === "number") {
-      return passRate >= (run.passCriteria?.minimumPassRate ?? 100)
+    const total = run.summary?.total ?? 0;
+    if (total > 0) {
+      const passRatePercent = ((run.summary?.passed ?? 0) / total) * 100;
+      return passRatePercent >= (run.passCriteria?.minimumPassRate ?? 100)
         ? "passed"
         : "failed";
     }

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -39,6 +39,7 @@ import {
   CheckStepError,
   clampOutput,
   cloneAndCheckout,
+  isGithubChecksSandboxConfigured,
   killCheckSandbox,
   provisionCheckSandbox,
   type CheckSandbox,
@@ -228,10 +229,26 @@ async function sendHeartbeat(
     throw new Error(`heartbeat rejected (${status}): ${JSON.stringify(body)}`);
   }
   // The route answers 200 with `result.ok: false` when this worker no longer
-  // holds the claim (lease recovered, row superseded). Nothing to retry, but the
-  // lease is gone and that belongs in the logs beside the lost check.
+  // holds the claim (lease recovered, row superseded). That is DEFINITIVE, not a
+  // transient failure: the backend has already concluded this check and will
+  // reject the completion, so the work in flight is worthless.
   if (body.result && body.result.ok === false) {
-    throw new Error(`heartbeat not applied: ${body.result.error ?? "unknown"}`);
+    throw new LeaseLostError(String(body.result.error ?? "unknown"));
+  }
+}
+
+/**
+ * The backend no longer considers this worker the holder of the claim.
+ *
+ * Distinct from a transport failure on purpose: a failed REQUEST is worth
+ * retrying on the next beat, whereas a lost LEASE means the check has already
+ * been concluded by someone else and every further minute of building or
+ * evaluating is wasted — up to the sandbox's full lifetime.
+ */
+export class LeaseLostError extends Error {
+  constructor(readonly reason: string) {
+    super(`lease lost: ${reason}`);
+    this.name = "LeaseLostError";
   }
 }
 
@@ -660,18 +677,38 @@ export async function executeClaimedCheck(
     sha: claimed.headSha.slice(0, 8),
   };
 
+  // Set once the backend tells us the claim is no longer ours. Checked at each
+  // step boundary below: there is no point building or evaluating for a check
+  // somebody else has already concluded, and the completion would be rejected.
+  let leaseLost: LeaseLostError | null = null;
+
   // The lease is refreshed for the WHOLE duration, including the eval run — a
   // suite legitimately takes many minutes and must not look like a dead worker.
   const heartbeat = setInterval(() => {
-    void deps.heartbeat(claimed.triggerId, claimedBy).catch((error) =>
+    void deps.heartbeat(claimed.triggerId, claimedBy).catch((error) => {
+      if (error instanceof LeaseLostError) {
+        // Definitive. Stop beating and let the next step boundary bail out.
+        leaseLost = error;
+        clearInterval(heartbeat);
+        logger.warn("[github-checks] lease lost; abandoning this check", {
+          ...logContext,
+          reason: error.reason,
+        });
+        return;
+      }
       logger.warn("[github-checks] heartbeat failed", {
         ...logContext,
         error: error instanceof Error ? error.message : String(error),
-      })
-    );
+      });
+    });
   }, deps.heartbeatIntervalMs);
   // Don't hold the event loop open on shutdown.
   (heartbeat as unknown as { unref?: () => void }).unref?.();
+
+  /** Throw out of the pipeline if the claim stopped being ours. */
+  const assertLeaseHeld = () => {
+    if (leaseLost) throw leaseLost;
+  };
 
   let sandbox: CheckSandbox | null = null;
   let serverId: string | null = null;
@@ -711,11 +748,13 @@ export async function executeClaimedCheck(
       repoFullName: claimed.repoFullName,
       prNumber: claimed.prNumber,
     });
+    assertLeaseHeld();
     await deps.cloneAndCheckout(sandbox, {
       repoFullName: claimed.repoFullName,
       prNumber: claimed.prNumber,
       headSha: claimed.headSha,
     });
+    assertLeaseHeld();
     // Builds, revokes egress, starts, and waits for `initialize` — in that
     // order, which `buildAndStart` owns precisely so it can't be reordered here.
     const started = await deps.buildAndStart(sandbox, recipe);
@@ -746,6 +785,8 @@ export async function executeClaimedCheck(
       })
     );
 
+    // The last and most valuable boundary: the eval run is the twenty-minute part.
+    assertLeaseHeld();
     const run = await deps.runEvalSuite({
       claimed,
       bearer,
@@ -764,6 +805,16 @@ export async function executeClaimedCheck(
         : {}),
     });
   } catch (error) {
+    if (error instanceof LeaseLostError) {
+      // Nothing to report: the backend already concluded this check, which is why
+      // the lease was taken away. Reporting anyway would just be rejected. The
+      // `finally` below still tears the sandbox down.
+      logger.warn("[github-checks] abandoned a check whose lease was lost", {
+        ...logContext,
+        reason: error.reason,
+      });
+      return;
+    }
     const classified = classifyCheckFailure(error);
     logger.error("[github-checks] check failed", error, {
       ...logContext,
@@ -850,6 +901,17 @@ export function startGithubChecksWorker(options?: {
   if (!requiredEnv()) {
     logger.warn(
       "[github-checks] worker enabled but CONVEX_HTTP_URL / INSPECTOR_SERVICE_TOKEN missing; not starting"
+    );
+    return { stop: async () => {} };
+  }
+
+  // Claiming without a usable sandbox configuration is WORSE than not starting:
+  // every queued trigger would be claimed, fail to provision, and be concluded
+  // `infra_error` — permanently, since a verdict is final. Not polling leaves
+  // those checks queued until the deployment is fixed.
+  if (!isGithubChecksSandboxConfigured()) {
+    logger.warn(
+      "[github-checks] worker enabled but E2B_API_KEY / GITHUB_CHECKS_E2B_TEMPLATE_ID missing; not starting (queued checks stay claimable)"
     );
     return { stop: async () => {} };
   }

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -299,6 +299,46 @@ export function outcomeForRunResult(
 }
 
 /**
+ * The run's verdict, derived when the record does not carry one.
+ *
+ * The recorder finalizes a run with `status: "completed"` and a `summary` but
+ * does NOT always populate `result`. Reading `result` alone therefore turns a
+ * run that passed every test into `evals_failed` — a red X on a good PR, which
+ * is the exact failure mode the outcome taxonomy exists to prevent. The client
+ * has the same derivation (`computeEffectiveRunResult` in
+ * `client/src/components/evals/suite-runs-list.tsx`); this is the server-side
+ * mirror, kept here because the worker must not import client code.
+ *
+ * `passRate` and `minimumPassRate` are both 0-100 (see the backend schema).
+ */
+export function effectiveRunResult(
+  run: {
+    status?: string;
+    result?: string;
+    summary?: CheckSummary | null;
+    passCriteria?: { minimumPassRate?: number } | null;
+  } | null
+): string | undefined {
+  if (!run) return undefined;
+  if (run.result) return run.result;
+  if (run.status === "completed") {
+    const passRate = run.summary?.passRate;
+    if (typeof passRate === "number") {
+      return passRate >= (run.passCriteria?.minimumPassRate ?? 100)
+        ? "passed"
+        : "failed";
+    }
+    // Completed with no counts at all — nothing to derive from. Left undefined
+    // so the caller reports `evals_failed` rather than inventing a pass.
+    return undefined;
+  }
+  if (run.status === "cancelled") return "cancelled";
+  if (run.status === "timed_out") return "timed_out";
+  if (run.status === "failed") return "failed";
+  return undefined;
+}
+
+/**
  * Injectable collaborators. Every external effect the executor performs is one
  * of these, so the failure-path tests drive real control flow (including the
  * `finally` cleanup and the heartbeat lifecycle) without an E2B box, a Convex
@@ -372,20 +412,33 @@ const TERMINAL_RUN_STATUSES = new Set([
   "timed_out",
 ]);
 
-async function isRunTerminal(
+/**
+ * Whether the run already has a terminal record — with `unknown` kept distinct
+ * from `non_terminal`.
+ *
+ * That distinction is the point. `unknown` means the LOOKUP failed, not that the
+ * run is unfinished, and treating it as unfinished means finalizing the run
+ * `failed` on the strength of a transient Convex outage — overwriting a verdict
+ * that may well have been a pass. Callers must not write on `unknown`; leaving
+ * the run alone lands the check as `infra_error` (neutral), which is the honest
+ * answer when we cannot see the run.
+ */
+type RunTerminality = "terminal" | "non_terminal" | "unknown";
+
+async function runTerminality(
   client: { query: (name: any, args: any) => Promise<any> },
   runId: string
-): Promise<boolean> {
+): Promise<RunTerminality> {
   try {
     const run = (await client.query("testSuites:getTestSuiteRun" as any, {
       runId,
     })) as { status?: string } | null;
-    return TERMINAL_RUN_STATUSES.has(String(run?.status));
+    if (!run) return "unknown";
+    return TERMINAL_RUN_STATUSES.has(String(run.status))
+      ? "terminal"
+      : "non_terminal";
   } catch {
-    // Can't tell. Let the defensive finalize proceed — `recorder.finalize`
-    // tolerates an already-terminal run, so the worst case is a duplicate
-    // terminal write rather than a run stranded mid-flight.
-    return false;
+    return "unknown";
   }
 }
 
@@ -466,8 +519,16 @@ async function defaultRunEvalSuite(args: {
         error: error instanceof Error ? error.message : String(error),
       });
 
-      const terminal = await isRunTerminal(client, prepared.runId);
-      if (!terminal) {
+      const terminality = await runTerminality(client, prepared.runId);
+      if (terminality === "unknown") {
+        // We could not read the run. Writing `failed` here would be a guess that
+        // can overwrite a real verdict, so leave the record alone — the read
+        // below decides, and if that fails too the check lands neutral.
+        logger.warn(
+          "[github-checks] could not read the run's state; not finalizing it",
+          { triggerId: args.claimed.triggerId, runId: prepared.runId }
+        );
+      } else if (terminality === "non_terminal") {
         if (!prepared.recorder) {
           // Nothing can finalize the run, so do not invent a verdict from it.
           throw error;
@@ -492,7 +553,12 @@ async function defaultRunEvalSuite(args: {
 
     const run = (await client.query("testSuites:getTestSuiteRun" as any, {
       runId: prepared.runId,
-    })) as { status?: string; result?: string; summary?: CheckSummary } | null;
+    })) as {
+      status?: string;
+      result?: string;
+      summary?: CheckSummary;
+      passCriteria?: { minimumPassRate?: number };
+    } | null;
 
     // A run that is somehow STILL not terminal has no verdict to report. Raising
     // here lands it as `infra_error` (neutral) rather than a false failure — this
@@ -505,9 +571,10 @@ async function defaultRunEvalSuite(args: {
       );
     }
 
+    const result = effectiveRunResult(run);
     return {
       runId: prepared.runId,
-      ...(run?.result ? { result: run.result } : {}),
+      ...(result ? { result } : {}),
       ...(run?.summary ? { summary: run.summary } : {}),
     };
   } finally {

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -42,6 +42,7 @@ import {
   isGithubChecksSandboxConfigured,
   killCheckSandbox,
   provisionCheckSandbox,
+  waitForMcpInitialize,
   type CheckSandbox,
 } from "./github-checks/sandbox.js";
 
@@ -406,7 +407,75 @@ export type CheckExecutionDeps = {
   report: (report: CheckReport) => Promise<void>;
   heartbeat: (triggerId: string, claimedBy: string) => Promise<void>;
   heartbeatIntervalMs: number;
+  /** Re-probe used to attribute an eval failure; see `attributeEvalFailure`. */
+  probeServer: (url: string, opts: { timeoutMs: number }) => Promise<boolean>;
 };
+
+/**
+ * How long the post-failure re-probe gets. Short on purpose: this runs only after
+ * the eval already failed, and it is a diagnostic, not a retry. A server that
+ * needs longer than this to answer is not one the eval could have used either.
+ */
+const EVAL_FAILURE_PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * Decide whether an eval-phase failure belongs to the PR or to us.
+ *
+ * `runEvalSuite` throws an ordinary transport error for two very different
+ * situations: the PR's server died after passing the health probe, or something on
+ * OUR side broke (Convex, the provider, E2B). Both used to land on neutral
+ * `infra_error`, which lets a PR whose server crashes seconds after `initialize`
+ * escape the `server_unhealthy` it earned.
+ *
+ * Rather than pattern-matching error messages — fragile, and wrong the first time a
+ * provider rewords a timeout — this asks the box directly, and only reclassifies on
+ * POSITIVE evidence of the PR's fault:
+ *
+ *   1. is the sandbox still reachable? If not, the box is gone and this is ours;
+ *   2. does the PR's server still answer the handshake? If it does, the server is
+ *      alive and the failure came from somewhere else — ours.
+ *
+ * Only "box answers, server does not" is attributed to the PR. Every other result,
+ * including the discriminator itself failing, leaves the original error alone and
+ * therefore stays neutral. That ordering is deliberate: a false `server_unhealthy`
+ * puts a red X on an innocent PR, so ambiguity must never produce one.
+ */
+async function attributeEvalFailure(
+  error: unknown,
+  sandbox: CheckSandbox,
+  serverUrl: string,
+  deps: Pick<CheckExecutionDeps, "probeServer">
+): Promise<unknown> {
+  // Our own typed failures and the lease guard already know what they are.
+  if (error instanceof CheckStepError || error instanceof LeaseLostError) {
+    return error;
+  }
+  try {
+    // A trivial command: proves the box is still ours to talk to and nothing more.
+    await sandbox.commands.run("true", {
+      timeoutMs: EVAL_FAILURE_PROBE_TIMEOUT_MS,
+    });
+  } catch {
+    return error;
+  }
+  let stillAnswering: boolean;
+  try {
+    stillAnswering = await deps.probeServer(serverUrl, {
+      timeoutMs: EVAL_FAILURE_PROBE_TIMEOUT_MS,
+    });
+  } catch {
+    return error;
+  }
+  if (stillAnswering) return error;
+  const message = error instanceof Error ? error.message : String(error);
+  return new CheckStepError(
+    "server_unhealthy",
+    "the server stopped answering after it started",
+    clampOutput(
+      `The server answered the health probe, then stopped responding while the eval suite was running. The sandbox itself was still reachable when we checked.\n\n${message}`
+    )
+  );
+}
 
 async function defaultCreateEphemeralServer(args: {
   bearer: string;
@@ -657,6 +726,7 @@ function defaultDeps(): CheckExecutionDeps {
     report: reportOutcome,
     heartbeat: sendHeartbeat,
     heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
+    probeServer: (url, opts) => waitForMcpInitialize(url, opts),
   };
 }
 
@@ -787,12 +857,21 @@ export async function executeClaimedCheck(
 
     // The last and most valuable boundary: the eval run is the twenty-minute part.
     assertLeaseHeld();
-    const run = await deps.runEvalSuite({
-      claimed,
-      bearer,
-      serverId,
-      serverName,
-    });
+    // Captured because the failure path reads it from inside a closure, and
+    // `sandbox` is a reassignable nullable whose narrowing does not survive that.
+    const runningBox = sandbox;
+    const run = await deps
+      .runEvalSuite({
+        claimed,
+        bearer,
+        serverId,
+        serverName,
+      })
+      .catch(async (error: unknown) => {
+        // A failure here may be the PR's server dying mid-run rather than an
+        // outage of ours, and the difference decides who gets the red X.
+        throw await attributeEvalFailure(error, runningBox, started.url, deps);
+      });
 
     const outcome = outcomeForRunResult(run.result);
     await safeReport({

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -42,7 +42,6 @@ import {
   isGithubChecksSandboxConfigured,
   killCheckSandbox,
   provisionCheckSandbox,
-  waitForMcpInitialize,
   type CheckSandbox,
 } from "./github-checks/sandbox.js";
 
@@ -407,16 +406,61 @@ export type CheckExecutionDeps = {
   report: (report: CheckReport) => Promise<void>;
   heartbeat: (triggerId: string, claimedBy: string) => Promise<void>;
   heartbeatIntervalMs: number;
-  /** Re-probe used to attribute an eval failure; see `attributeEvalFailure`. */
-  probeServer: (url: string, opts: { timeoutMs: number }) => Promise<boolean>;
 };
 
 /**
- * How long the post-failure re-probe gets. Short on purpose: this runs only after
- * the eval already failed, and it is a diagnostic, not a retry. A server that
- * needs longer than this to answer is not one the eval could have used either.
+ * How long the post-failure liveness check gets. Short on purpose: it runs only
+ * after the eval already failed, and it is a diagnostic, not a retry.
  */
 const EVAL_FAILURE_PROBE_TIMEOUT_MS = 15_000;
+
+/** Sentinels the in-box liveness check prints. Matched exactly, never parsed. */
+const PORT_OPEN_MARKER = "MCPJAM_CHECK_PORT_OPEN";
+const PORT_CLOSED_MARKER = "MCPJAM_CHECK_PORT_CLOSED";
+
+/**
+ * Whether the PR's server is still listening — asked from INSIDE the sandbox.
+ *
+ * Deliberately not a fetch to the public URL. That path traverses E2B's ingress,
+ * DNS and TLS, and the health probe reports every one of those failures exactly the
+ * way it reports a dead server: `false`. Blaming the PR for an ingress outage of
+ * OURS would be a red X on an innocent PR, so the question goes over the command
+ * RPC, where a loopback connect can only be answered by the server process itself.
+ *
+ * Three-valued on purpose: `null` is "could not tell", which the caller must treat
+ * as neutral, because the command channel failing is itself our symptom. Node is
+ * the one interpreter the dedicated template is guaranteed to carry (node + git),
+ * so this is a node one-liner rather than `curl`, and it always exits 0 and answers
+ * through stdout — an exit code cannot distinguish "connection refused" from "the
+ * command never ran".
+ */
+async function serverStillListening(
+  sandbox: CheckSandbox,
+  port: number
+): Promise<boolean | null> {
+  const script =
+    `const s=require('net').connect(${port},'127.0.0.1');` +
+    `const done=(m)=>{console.log(m);s.destroy();};` +
+    `s.on('connect',()=>done('${PORT_OPEN_MARKER}'));` +
+    `s.on('error',()=>done('${PORT_CLOSED_MARKER}'));` +
+    `s.setTimeout(5000,()=>s.destroy());`;
+  let stdout = "";
+  try {
+    const result = (await sandbox.commands.run(
+      `node -e ${JSON.stringify(script)}`,
+      { timeoutMs: EVAL_FAILURE_PROBE_TIMEOUT_MS }
+    )) as { stdout?: unknown } | null;
+    stdout = typeof result?.stdout === "string" ? result.stdout : "";
+  } catch {
+    // The box did not answer at all. That is an E2B problem, which is ours.
+    return null;
+  }
+  if (stdout.includes(PORT_OPEN_MARKER)) return true;
+  if (stdout.includes(PORT_CLOSED_MARKER)) return false;
+  // Neither sentinel: the connect timed out, or node produced nothing. Not
+  // evidence of anything, so it must not become evidence against the PR.
+  return null;
+}
 
 /**
  * Decide whether an eval-phase failure belongs to the PR or to us.
@@ -428,51 +472,27 @@ const EVAL_FAILURE_PROBE_TIMEOUT_MS = 15_000;
  * escape the `server_unhealthy` it earned.
  *
  * Rather than pattern-matching error messages — fragile, and wrong the first time a
- * provider rewords a timeout — this asks the box directly, and only reclassifies on
- * POSITIVE evidence of the PR's fault:
- *
- *   1. is the sandbox still reachable? If not, the box is gone and this is ours;
- *   2. does the PR's server still answer the handshake? If it does, the server is
- *      alive and the failure came from somewhere else — ours.
- *
- * Only "box answers, server does not" is attributed to the PR. Every other result,
- * including the discriminator itself failing, leaves the original error alone and
- * therefore stays neutral. That ordering is deliberate: a false `server_unhealthy`
- * puts a red X on an innocent PR, so ambiguity must never produce one.
+ * provider rewords a timeout — this asks the box whether the server process is
+ * still listening, and reclassifies ONLY on a definite "no". A `null` verdict
+ * (command channel down, or no answer at all) and a "yes" both leave the original
+ * error alone, so they stay neutral. Ambiguity must never produce a red X.
  */
 async function attributeEvalFailure(
   error: unknown,
   sandbox: CheckSandbox,
-  serverUrl: string,
-  deps: Pick<CheckExecutionDeps, "probeServer">
+  port: number
 ): Promise<unknown> {
   // Our own typed failures and the lease guard already know what they are.
   if (error instanceof CheckStepError || error instanceof LeaseLostError) {
     return error;
   }
-  try {
-    // A trivial command: proves the box is still ours to talk to and nothing more.
-    await sandbox.commands.run("true", {
-      timeoutMs: EVAL_FAILURE_PROBE_TIMEOUT_MS,
-    });
-  } catch {
-    return error;
-  }
-  let stillAnswering: boolean;
-  try {
-    stillAnswering = await deps.probeServer(serverUrl, {
-      timeoutMs: EVAL_FAILURE_PROBE_TIMEOUT_MS,
-    });
-  } catch {
-    return error;
-  }
-  if (stillAnswering) return error;
+  if ((await serverStillListening(sandbox, port)) !== false) return error;
   const message = error instanceof Error ? error.message : String(error);
   return new CheckStepError(
     "server_unhealthy",
-    "the server stopped answering after it started",
+    "the server stopped listening after it started",
     clampOutput(
-      `The server answered the health probe, then stopped responding while the eval suite was running. The sandbox itself was still reachable when we checked.\n\n${message}`
+      `The server answered the health probe, then stopped listening on port ${port} while the eval suite was running. Checked from inside the sandbox, so this is the server process rather than the network path to it.\n\n${message}`
     )
   );
 }
@@ -726,7 +746,6 @@ function defaultDeps(): CheckExecutionDeps {
     report: reportOutcome,
     heartbeat: sendHeartbeat,
     heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
-    probeServer: (url, opts) => waitForMcpInitialize(url, opts),
   };
 }
 
@@ -870,7 +889,7 @@ export async function executeClaimedCheck(
       .catch(async (error: unknown) => {
         // A failure here may be the PR's server dying mid-run rather than an
         // outage of ours, and the difference decides who gets the red X.
-        throw await attributeEvalFailure(error, runningBox, started.url, deps);
+        throw await attributeEvalFailure(error, runningBox, recipe.port);
       });
 
     const outcome = outcomeForRunResult(run.result);

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -33,7 +33,10 @@ import { getConvexBearerForDelegation } from "../utils/v1-convex-token.js";
 import { createAuthorizedManager } from "../routes/web/auth.js";
 import { prepareEvalRun } from "../routes/shared/evals.js";
 import { createConvexClient } from "./evals/route-helpers.js";
-import { resolveCheckRecipe } from "./github-checks/recipes.js";
+import {
+  resolveCheckRecipe,
+  type CheckRecipe,
+} from "./github-checks/recipes.js";
 import {
   buildAndStart,
   CheckStepError,
@@ -415,17 +418,40 @@ export type CheckExecutionDeps = {
 const EVAL_FAILURE_PROBE_TIMEOUT_MS = 15_000;
 
 /** Sentinels the in-box liveness check prints. Matched exactly, never parsed. */
-const PORT_OPEN_MARKER = "MCPJAM_CHECK_PORT_OPEN";
+const HTTP_ANSWERED_MARKER = "MCPJAM_CHECK_HTTP_ANSWERED";
+const HTTP_SILENT_MARKER = "MCPJAM_CHECK_HTTP_SILENT";
 const PORT_CLOSED_MARKER = "MCPJAM_CHECK_PORT_CLOSED";
+/**
+ * How long the in-box request waits for response headers. Generous next to the
+ * milliseconds a healthy server took at startup, because the only thing a short
+ * budget buys here is a chance of blaming a merely slow server.
+ */
+const IN_BOX_RESPONSE_TIMEOUT_MS = 10_000;
+/**
+ * The version the liveness request names. Which revision it is does not matter —
+ * only whether response headers come back at all — so this is deliberately a local
+ * literal rather than a coupling to the health probe's negotiation constants.
+ */
+const LIVENESS_PROBE_PROTOCOL_VERSION = "2025-06-18";
 
 /**
- * Whether the PR's server is still listening — asked from INSIDE the sandbox.
+ * Whether the PR's server is still ANSWERING — asked from INSIDE the sandbox.
  *
  * Deliberately not a fetch to the public URL. That path traverses E2B's ingress,
  * DNS and TLS, and the health probe reports every one of those failures exactly the
  * way it reports a dead server: `false`. Blaming the PR for an ingress outage of
  * OURS would be a red X on an innocent PR, so the question goes over the command
- * RPC, where a loopback connect can only be answered by the server process itself.
+ * RPC, where a loopback request can only be answered by the server process itself.
+ *
+ * It sends a real HTTP request rather than merely opening a socket, because a bound
+ * listener proves very little: a server whose event loop is wedged, deadlocked or
+ * thrashing still accepts connections while answering nothing, and that is the PR's
+ * bug to own. What it does NOT do is validate the MCP answer. That would mean
+ * reimplementing media-type selection, SSE framing and JSON-RPC validation inside a
+ * shell one-liner — the semantics this module gets right in typed, tested code — and
+ * a simplified copy would drift from the client and reintroduce the very mismatch
+ * class it was meant to catch. So the question asked is "does it still answer HTTP
+ * at all", and a server that answers WRONGLY stays neutral.
  *
  * Three-valued on purpose: `null` is "could not tell", which the caller must treat
  * as neutral, because the command channel failing is itself our symptom. Node is
@@ -434,16 +460,33 @@ const PORT_CLOSED_MARKER = "MCPJAM_CHECK_PORT_CLOSED";
  * through stdout — an exit code cannot distinguish "connection refused" from "the
  * command never ran".
  */
-async function serverStillListening(
+async function serverStillResponding(
   sandbox: CheckSandbox,
-  port: number
+  recipe: CheckRecipe
 ): Promise<boolean | null> {
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: LIVENESS_PROBE_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: "mcpjam-github-checks-liveness", version: "1.0.0" },
+    },
+  });
   const script =
-    `const s=require('net').connect(${port},'127.0.0.1');` +
-    `const done=(m)=>{console.log(m);s.destroy();};` +
-    `s.on('connect',()=>done('${PORT_OPEN_MARKER}'));` +
-    `s.on('error',()=>done('${PORT_CLOSED_MARKER}'));` +
-    `s.setTimeout(5000,()=>s.destroy());`;
+    `const http=require('http');let said=false;` +
+    `const say=(m)=>{if(!said){said=true;console.log(m);}};` +
+    `const body=${JSON.stringify(body)};` +
+    `const req=http.request({host:'127.0.0.1',port:${recipe.port},` +
+    `path:${JSON.stringify(recipe.mcpPath)},method:'POST',headers:{` +
+    `'content-type':'application/json',` +
+    `'accept':'application/json, text/event-stream',` +
+    `'content-length':Buffer.byteLength(body)}},` +
+    `(res)=>{say('${HTTP_ANSWERED_MARKER} '+res.statusCode);res.destroy();});` +
+    `req.on('error',(e)=>say(e&&e.code==='ECONNREFUSED'?'${PORT_CLOSED_MARKER}':'err '+(e&&e.code)));` +
+    `req.setTimeout(${IN_BOX_RESPONSE_TIMEOUT_MS},()=>{say('${HTTP_SILENT_MARKER}');req.destroy();});` +
+    `req.end(body);`;
   let stdout = "";
   try {
     const result = (await sandbox.commands.run(
@@ -455,10 +498,17 @@ async function serverStillListening(
     // The box did not answer at all. That is an E2B problem, which is ours.
     return null;
   }
-  if (stdout.includes(PORT_OPEN_MARKER)) return true;
-  if (stdout.includes(PORT_CLOSED_MARKER)) return false;
-  // Neither sentinel: the connect timed out, or node produced nothing. Not
-  // evidence of anything, so it must not become evidence against the PR.
+  if (stdout.includes(HTTP_ANSWERED_MARKER)) return true;
+  // Refused, or accepted the connection and then said nothing at all. Either way
+  // the server is not serving, and it is the PR's process.
+  if (
+    stdout.includes(PORT_CLOSED_MARKER) ||
+    stdout.includes(HTTP_SILENT_MARKER)
+  ) {
+    return false;
+  }
+  // Some other socket error, or no output at all: not evidence of anything, so it
+  // must not become evidence against the PR.
   return null;
 }
 
@@ -480,19 +530,19 @@ async function serverStillListening(
 async function attributeEvalFailure(
   error: unknown,
   sandbox: CheckSandbox,
-  port: number
+  recipe: CheckRecipe
 ): Promise<unknown> {
   // Our own typed failures and the lease guard already know what they are.
   if (error instanceof CheckStepError || error instanceof LeaseLostError) {
     return error;
   }
-  if ((await serverStillListening(sandbox, port)) !== false) return error;
+  if ((await serverStillResponding(sandbox, recipe)) !== false) return error;
   const message = error instanceof Error ? error.message : String(error);
   return new CheckStepError(
     "server_unhealthy",
-    "the server stopped listening after it started",
+    "the server stopped answering after it started",
     clampOutput(
-      `The server answered the health probe, then stopped listening on port ${port} while the eval suite was running. Checked from inside the sandbox, so this is the server process rather than the network path to it.\n\n${message}`
+      `The server answered the health probe, then stopped answering on port ${recipe.port} while the eval suite was running — it either refused the connection or accepted it and sent nothing back. Checked from inside the sandbox, so this is the server process and not the network path to it.\n\n${message}`
     )
   );
 }
@@ -892,7 +942,7 @@ export async function executeClaimedCheck(
         const attributed = await attributeEvalFailure(
           error,
           runningBox,
-          recipe.port
+          recipe
         );
         // The diagnostic above talks to the box, so it takes real time — long
         // enough for the lease to be taken away while it runs. Re-checked here so

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -149,8 +149,12 @@ async function postServiceRoute(
     let parsed: any = null;
     try {
       parsed = await response.json();
-    } catch {
-      // Tolerated; status carries the signal.
+    } catch (error) {
+      // A malformed body is tolerated — the status carries the signal. A body
+      // read that hit the abort deadline is NOT: silently returning
+      // `body: null` would make a timed-out call look like a successful one
+      // whose response merely lacked a body.
+      if (controller.signal.aborted) throw error;
     }
     return { status: response.status, body: parsed };
   } finally {
@@ -227,14 +231,30 @@ async function sendHeartbeat(
 /** Test seam: the heartbeat's response validation is the whole point of it. */
 export const sendHeartbeatForTests = sendHeartbeat;
 
+/**
+ * Register the ephemeral `servers` row, and THROW if the backend refused.
+ *
+ * Same reasoning as the heartbeat: a discarded status makes a rejected
+ * registration look successful, and the consequence is specific — recovery loses
+ * the pointer it needs to soft-delete the row, so a worker that dies mid-check
+ * leaks a live server row that nothing reaps. The caller keeps going (the PR
+ * still deserves its verdict) but the failure lands in the logs.
+ */
 async function recordEphemeralServer(
   triggerId: string,
   serverId: string
 ): Promise<void> {
-  await postServiceRoute(`${SERVICE_BASE}/ephemeral-server`, {
-    triggerId,
-    serverId,
-  });
+  const { status, body } = await postServiceRoute(
+    `${SERVICE_BASE}/ephemeral-server`,
+    { triggerId, serverId }
+  );
+  if (status !== 200 || !body?.ok) {
+    throw new Error(
+      `ephemeral-server registration rejected (${status}): ${JSON.stringify(
+        body
+      )}`
+    );
+  }
 }
 
 /**
@@ -405,6 +425,21 @@ async function defaultRunEvalSuite(args: {
       serverIds: [args.serverId],
       serverNames: [args.serverName],
       suiteRerun: true,
+      // REQUIRED, not incidental. `serverIds` is honored by the manager and by
+      // cap math, but it is NOT forwarded to the run-start mutation — the run's
+      // `configSnapshot.environment` comes from the suite's PERSISTED
+      // environment, and `suiteRerun: true` alone suppresses updating it
+      // (`authorEvalSuite`: `shouldUpdateSnapshot = !suiteRerun ||
+      // refreshSnapshot`). Without this flag the snapshot keeps naming the
+      // previous check's ephemeral server, which no longer exists, and the
+      // runner fails against a dead reference instead of testing the PR.
+      //
+      // This is the "suite binding rewrite" the design already called out as
+      // expected: the dedicated suite's stored server ref is rewritten every
+      // run. Harmless because we always override `serverIds` too — and the
+      // reason this suite is named `[github-checks] …` and must never be
+      // launched from the UI.
+      refreshSnapshot: true,
       // `source: 'github_check'` would be a two-repo union change; 'api' is the
       // closest existing value and keeps this to one repo (see plan follow-up).
       source: "api",

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -792,12 +792,27 @@ async function defaultRunEvalSuite(args: {
       args.claimed.triggerId
     );
     if (ownership !== "ours") {
-      throw new CheckStepError(
-        "infra_error",
+      const reason =
         ownership === "stolen"
           ? "another check's server was snapshotted onto this run"
-          : "could not verify which server this run was bound to"
-      );
+          : "could not verify which server this run was bound to";
+      // The run row already exists — `prepareEvalRun` created it — and this throw
+      // bypasses the catch around `execute()` where the non-terminal finalize
+      // lives. Left alone it would sit in `running` forever, and every raced check
+      // would leave another one behind. Best effort: failing to tidy up must not
+      // replace the reason we are bailing out.
+      if (prepared.recorder) {
+        await prepared.recorder
+          .finalize({ status: "failed", notes: reason })
+          .catch((finalizeError: unknown) => {
+            logger.error(
+              "[github-checks] failed to finalize an unowned eval run",
+              finalizeError,
+              { triggerId: args.claimed.triggerId, runId: prepared.runId }
+            );
+          });
+      }
+      throw new CheckStepError("infra_error", reason);
     }
 
     try {
@@ -1057,6 +1072,12 @@ export async function executeClaimedCheck(
         assertLeaseHeld();
         throw attributed;
       });
+
+    // The eval is the widest window in this flow — twenty minutes — so the lease
+    // can be taken away while it runs and still resolve normally. The failure path
+    // re-checks; this one has to as well, or a check the backend already concluded
+    // gets a verdict reported over the top of it.
+    assertLeaseHeld();
 
     const outcome = outcomeForRunResult(run.result);
     await safeReport({

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -461,6 +461,28 @@ async function runTerminality(
 }
 
 /**
+ * Did the runner FINISH the run, as opposed to abandoning it?
+ *
+ * `status: 'completed'` is written only on the runner's own success path, so it
+ * is the one status that means a verdict was actually reached. Everything else
+ * (`failed`, `timed_out`, `cancelled`) after a throw means the machinery gave
+ * up, which is ours to own — neutral, not the PR's failure.
+ */
+async function runCompleted(
+  client: { query: (name: any, args: any) => Promise<any> },
+  runId: string
+): Promise<boolean> {
+  try {
+    const run = (await client.query("testSuites:getTestSuiteRun" as any, {
+      runId,
+    })) as { status?: string } | null;
+    return run?.status === "completed";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Run the dedicated suite against the just-built server.
  *
  * The `serverIds` override is what makes this work at all: the suite is a
@@ -524,13 +546,19 @@ async function defaultRunEvalSuite(args: {
     try {
       await prepared.execute();
     } catch (error) {
-      // `runEvalSuiteWithAiSdk` finalizes a failed run itself before rethrowing,
-      // so USUALLY the terminal write already happened and we can just read the
-      // verdict. But a throw from OUTSIDE its own try leaves the run
-      // non-terminal, and reading that gives `result: undefined` → a bogus
-      // `evals_failed` on the PR with a run left running forever. Mirror the
-      // detached /api/v1 path: check terminality, and finalize defensively when
-      // the runner did not.
+      // A throw from `execute()` is NOT an eval verdict, and must not be read as
+      // one. `runEvalSuiteWithAiSdk` finalizes a normal run — pass or fail —
+      // with `status: 'completed'` and a summary; its outer catch writes
+      // `status: 'failed'` for any UNEXPECTED exception (Convex unreachable, tool
+      // discovery blew up, the transport died) before rethrowing. So a `failed`
+      // status here says "the machinery broke", not "the PR's assertions
+      // failed" — deriving `evals_failed` from it is a red X on a PR that was
+      // never actually judged.
+      //
+      // Two jobs then: make sure the run does not sit non-terminal forever, and
+      // let the original error propagate so it classifies as `infra_error`
+      // (neutral). The one exception is a run the runner DID finish
+      // (`completed`), where a late throw cannot invalidate a delivered verdict.
       logger.warn("[github-checks] eval run threw; checking its run state", {
         triggerId: args.claimed.triggerId,
         runId: prepared.runId,
@@ -538,19 +566,7 @@ async function defaultRunEvalSuite(args: {
       });
 
       const terminality = await runTerminality(client, prepared.runId);
-      if (terminality === "unknown") {
-        // We could not read the run. Writing `failed` here would be a guess that
-        // can overwrite a real verdict, so leave the record alone — the read
-        // below decides, and if that fails too the check lands neutral.
-        logger.warn(
-          "[github-checks] could not read the run's state; not finalizing it",
-          { triggerId: args.claimed.triggerId, runId: prepared.runId }
-        );
-      } else if (terminality === "non_terminal") {
-        if (!prepared.recorder) {
-          // Nothing can finalize the run, so do not invent a verdict from it.
-          throw error;
-        }
+      if (terminality === "non_terminal" && prepared.recorder) {
         await prepared.recorder
           .finalize({
             status: "failed",
@@ -566,6 +582,15 @@ async function defaultRunEvalSuite(args: {
               { triggerId: args.claimed.triggerId, runId: prepared.runId }
             );
           });
+      }
+
+      // `unknown` (we could not read the run) also lands here: not being able to
+      // see the run is not evidence the PR failed.
+      if (
+        terminality !== "terminal" ||
+        !(await runCompleted(client, prepared.runId))
+      ) {
+        throw error;
       }
     }
 

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -177,10 +177,10 @@ describe("buildAndStart", () => {
     expect(box.events.some((e) => e.startsWith("network:"))).toBe(false);
   });
 
-  it("reports server_unhealthy with the server’s stderr tail when initialize never lands", async () => {
-    // The started process complains on stderr while the probe keeps failing.
+  it("reports server_unhealthy with the server’s log tail when initialize never lands", async () => {
+    // The started process complains in its log while the probe keeps failing.
     const box = fakeSandbox({
-      stderrOnSpawn: ["Error: listen EADDRINUSE 127.0.0.1:3001"],
+      stdout: { "tail -c": "Error: listen EADDRINUSE 127.0.0.1:3001" },
     });
     const fetchImpl = vi.fn(async () => {
       throw new Error("ECONNREFUSED");
@@ -296,9 +296,14 @@ describe("buildAndStart", () => {
     expect((error as CheckStepError).outcome).toBe("infra_error");
   });
 
-  it("keeps only the tail of a firehose stderr", async () => {
+  it("bounds a firehose of server output INSIDE the box, and clamps what arrives", async () => {
+    // E2B's CommandHandle buffers every chunk it receives into an internal
+    // string, from the moment the handle exists and regardless of callbacks. A PR
+    // server that logs for twenty minutes would grow this process's heap without
+    // limit, so nothing is streamed: output goes to a file and only a bounded
+    // tail is ever fetched.
     const box = fakeSandbox({
-      stderrOnSpawn: ["x".repeat(50_000), "THE-LAST-LINE"],
+      stdout: { "tail -c": `${"x".repeat(50_000)}THE-LAST-LINE` },
     });
     const error = (await buildAndStart(box.sandbox, RECIPE, {
       fetchImpl: vi.fn(async () => {
@@ -307,6 +312,17 @@ describe("buildAndStart", () => {
       healthTimeoutMs: 30,
       healthIntervalMs: 1,
     }).catch((e) => e)) as CheckStepError;
+
+    // The spawn streams nothing back and redirects to a file…
+    const spawn = box.calls.find((call) => call.opts?.background === true);
+    expect(spawn?.command).toContain("> /tmp/mcp-server.log 2>&1");
+    expect(spawn?.opts?.onStderr).toBeUndefined();
+    expect(spawn?.opts?.onStdout).toBeUndefined();
+    // …and the truncation is done by the sandbox, not after the fact.
+    expect(
+      box.calls.some((call) => call.command.includes("tail -c 8000"))
+    ).toBe(true);
+    // Whatever still comes back is clamped before it can reach a check body.
     expect(error.detailsMarkdown).toContain("THE-LAST-LINE");
     expect(error.detailsMarkdown!.length).toBeLessThan(
       OUTPUT_CLAMP_CHARS + 200

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -689,6 +689,46 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("does not accept a correct result served with the wrong content type", async () => {
+    // The eval run's transport rejects anything that is not `application/json`
+    // or `text/event-stream` before it parses the body at all. A server that
+    // answers perfectly as `text/plain` therefore cannot be driven, and calling
+    // it healthy here hands its failure to us as a neutral `infra_error` instead
+    // of the `server_unhealthy` the PR earned.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT }),
+          { status: 200, headers: { "content-type": "text/plain" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a media type that carries parameters", async () => {
+    // `application/json; charset=utf-8` is the same essence, and the transport
+    // compares essences — so this must not be turned away.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json; charset=utf-8" },
+          }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
   it("does not accept a discover result offering only legacy versions", async () => {
     // `server/discover` is the MODERN arm. A result naming only 2025-era
     // revisions says nothing about it: for such a server the client falls back to

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -152,10 +152,20 @@ function okInitialize(): Response {
  * parseable document. All ASCII, so characters and bytes agree.
  */
 function cappedDocument(): string {
-  const answer = { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT, pad: "" };
+  // The padding goes INSIDE `result`, where the result schema is loose. At the top
+  // level it would be a fourth key on a strict arm — an envelope the transport
+  // rejects, and one the probe therefore rejects too.
+  const answer = {
+    jsonrpc: "2.0",
+    id: 1,
+    result: { ...INITIALIZE_RESULT, pad: "" },
+  };
   const padding = PROBE_MAX_RESPONSE_BYTES - JSON.stringify(answer).length;
   if (padding <= 0) throw new Error("initialize fixture exceeds the probe cap");
-  const document = JSON.stringify({ ...answer, pad: "a".repeat(padding) });
+  const document = JSON.stringify({
+    ...answer,
+    result: { ...answer.result, pad: "a".repeat(padding) },
+  });
   if (document.length !== PROBE_MAX_RESPONSE_BYTES) {
     throw new Error(`padded to ${document.length}, not the cap`);
   }
@@ -985,6 +995,56 @@ describe("waitForMcpInitialize", () => {
     expect(
       await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
     ).toBe(true);
+  });
+
+  it("does not accept an envelope mixing result with error", async () => {
+    // The result-response arm is `{ jsonrpc, id, result }` and it is strict, so an
+    // envelope carrying `error` as well matches no arm of the union and the
+    // transport throws on it. The result inside is irrelevant — the client never
+    // gets to look at it.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: INITIALIZE_RESULT,
+            error: { code: -32603, message: "also broken" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept an envelope carrying an extra top-level key", async () => {
+    // Same rule, less obvious case: `.strict()` rejects any unknown key, not just a
+    // conflicting discriminator.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: INITIALIZE_RESULT,
+            method: "initialize",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
   });
 
   it("accepts an answer delivered in a JSON batch", async () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -711,6 +711,50 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("accepts an SSE frame separated by bare CRs, after a BOM", async () => {
+    // LF, CRLF and bare CR are all legal separators and a leading BOM is stripped
+    // — the transport's parser accepts all of it, so a server it can drive must
+    // not read as unhealthy here.
+    const frame = `﻿event: message\rdata: ${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: INITIALIZE_RESULT,
+    })}\r\r`;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(frame, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        })
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("does not accept a capability the client's schema types as an object", async () => {
+    // `tools: true` fails the client's capabilities schema, so the eval run cannot
+    // drive this server — that is the PR's fault, not ours.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { ...INITIALIZE_RESULT, capabilities: { tools: true } },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
   it("accepts a media type that carries parameters", async () => {
     // `application/json; charset=utf-8` is the same essence, and the transport
     // compares essences — so this must not be turned away.
@@ -722,6 +766,29 @@ describe("waitForMcpInitialize", () => {
             status: 200,
             headers: { "content-type": "application/json; charset=utf-8" },
           }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("accepts an unknown capability of any shape", async () => {
+    // The client's schema passes unknown keys through, so an extension advertised
+    // as a bare string is still a server the eval run can drive. Rejecting it
+    // would be stricter than the client — a false server_unhealthy.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              ...INITIALIZE_RESULT,
+              capabilities: { tools: {}, "com.example/thing": "on" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
         )
     ) as unknown as typeof fetch;
     expect(

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -916,6 +916,43 @@ describe("waitForMcpInitialize", () => {
     ).toBe(true);
   });
 
+  it("does not accept a correct result acknowledged with 202", async () => {
+    // 202 is an acknowledgement: the transport drains the body, discards it, and
+    // returns before any result processing. So this answer never reaches the
+    // client's `initialize`, and calling the server healthy would hand its failure
+    // to us as a neutral `infra_error`.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT }),
+          { status: 202, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a result served with a 2xx other than 200", async () => {
+    // Only 202 is special-cased by the transport; every other 2xx is processed by
+    // content type. Narrowing to 200 would be stricter than the client, which is
+    // how a working PR earns a false `server_unhealthy`.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
   it("does not accept a correct result served with the wrong content type", async () => {
     // The eval run's transport rejects anything that is not `application/json`
     // or `text/event-stream` before it parses the body at all. A server that

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -105,12 +105,30 @@ function fakeSandbox(options?: {
   } as const;
 }
 
+/**
+ * A COMPLETE initialize result. The probe mirrors the real client, which
+ * validates the JSON-RPC envelope and `InitializeResultSchema` — so a fixture
+ * missing `capabilities` or `serverInfo` is not a server the eval run could
+ * have used either.
+ */
+const INITIALIZE_RESULT = {
+  protocolVersion: "2025-06-18",
+  capabilities: {},
+  serverInfo: { name: "fixture", version: "1.0.0" },
+} as const;
+
+const SSE_INITIALIZE_FRAME = `event: message\ndata: ${JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  result: INITIALIZE_RESULT,
+})}\n\n`;
+
 function okInitialize(): Response {
   return new Response(
     JSON.stringify({
       jsonrpc: "2.0",
       id: 1,
-      result: { protocolVersion: "2025-06-18", capabilities: {} },
+      result: INITIALIZE_RESULT,
     }),
     { status: 200, headers: { "content-type": "application/json" } }
   );
@@ -432,7 +450,7 @@ describe("waitForMcpInitialize", () => {
     const fetchImpl = vi.fn(
       async () =>
         new Response(
-          'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}\n\n',
+          SSE_INITIALIZE_FRAME,
           { status: 200, headers: { "content-type": "text/event-stream" } }
         )
     ) as unknown as typeof fetch;
@@ -455,7 +473,7 @@ describe("waitForMcpInitialize", () => {
             start(controller) {
               controller.enqueue(
                 new TextEncoder().encode(
-                  'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}\n\n'
+                  SSE_INITIALIZE_FRAME
                 )
               );
               // …and then nothing. No close(): the stream stays open, exactly
@@ -485,7 +503,7 @@ describe("waitForMcpInitialize", () => {
 
   it("decides from a frame that arrives split across chunks", async () => {
     const payload =
-      'data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}\n\n';
+      SSE_INITIALIZE_FRAME.replace("event: message\n", "");
     const cut = 40;
     const fetchImpl = vi.fn(
       async () =>
@@ -608,6 +626,53 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("does not accept an initialize result missing required fields", async () => {
+    // `InitializeResultSchema` requires `capabilities` and `serverInfo`. A
+    // result carrying only a good `protocolVersion` passes this probe but fails
+    // the client's own validation moments later — the same false neutral.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { protocolVersion: "2025-06-18" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept an answer to a different request as healthy", async () => {
+    // Someone else's response, or a server echoing a wrong id, is not proof our
+    // handshake completed — the client correlates by id and so does this.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 99,
+            result: INITIALIZE_RESULT,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
   it("does not accept a JSON-RPC error response as healthy", async () => {
     const fetchImpl = vi.fn(
       async () =>
@@ -668,6 +733,7 @@ describe("waitForMcpInitialize", () => {
             id: 1,
             result: {
               protocolVersion: "2025-06-18",
+              capabilities: {},
               serverInfo: { name: "reads data: urls", version: "1" },
             },
           }),

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -330,6 +330,105 @@ describe("waitForMcpInitialize", () => {
     ).toBe(true);
   });
 
+  it("accepts an initialize result on a stream the server never closes", async () => {
+    // THE realistic shape: a streamable-HTTP server answers `initialize` on an
+    // SSE stream and then holds it open for server-initiated messages. Reading
+    // the body with `response.text()` waits for the stream to END, so it never
+    // resolves — every attempt aborts and a perfectly healthy server reads as
+    // `server_unhealthy`.
+    let cancelled = false;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                new TextEncoder().encode(
+                  'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}\n\n'
+                )
+              );
+              // …and then nothing. No close(): the stream stays open, exactly
+              // like a real session.
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5_000,
+      })
+    ).toBe(true);
+    // One attempt, and the socket is released rather than leaked.
+    expect(
+      (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls
+    ).toHaveLength(1);
+    expect(cancelled).toBe(true);
+  });
+
+  it("decides from a frame that arrives split across chunks", async () => {
+    const payload =
+      'data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}\n\n';
+    const cut = 40;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              const encoder = new TextEncoder();
+              // A partial frame is not a verdict: it just fails to parse and the
+              // read continues.
+              controller.enqueue(encoder.encode(payload.slice(0, cut)));
+              controller.enqueue(encoder.encode(payload.slice(cut)));
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5_000,
+      })
+    ).toBe(true);
+  });
+
+  it("gives up on a stream that never carries an initialize result", async () => {
+    // Untrusted code streaming its own logs at us. Bounded by the deadline, not
+    // by how long it is willing to talk.
+    const fetchImpl = vi.fn(
+      async (_url: string, init?: { signal?: AbortSignal }) =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (init?.signal?.aborted) {
+                controller.close();
+                return;
+              }
+              controller.enqueue(new TextEncoder().encode("noise\n"));
+            },
+          }),
+          { status: 200 }
+        )
+    ) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        fetchImpl,
+        timeoutMs: 60,
+        intervalMs: 10,
+      })
+    ).toBe(false);
+  });
+
   it("keeps polling through connection refusals and succeeds once the server boots", async () => {
     let call = 0;
     const fetchImpl = vi.fn(async () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -916,6 +916,74 @@ describe("waitForMcpInitialize", () => {
     ).toBe(true);
   });
 
+  it("accepts an answer delivered in a JSON batch", async () => {
+    // Under `application/json` the transport unwraps an array and dispatches each
+    // element, so a batched answer is one the eval run receives. Rejecting it would
+    // be a false `server_unhealthy` on a server the client drives fine.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    // Bounded: this must be accepted on the first attempt, so a regression fails in
+    // a second instead of spinning out the full health window.
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 1_000,
+      })
+    ).toBe(true);
+  });
+
+  it("does not accept a JSON batch whose sibling is not a message", async () => {
+    // The transport maps the whole array through its message schema, so one
+    // malformed element throws and takes our answer with it. The batch is unusable.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+            { not: "a jsonrpc message" },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept a batch inside an SSE event", async () => {
+    // Batching is a JSON-body affordance. The transport's SSE path parses one
+    // message per event, so an array in `data:` fails its schema and is dropped —
+    // the client's `initialize` goes unanswered.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          `data: ${JSON.stringify([
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+          ])}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
   it("does not accept a correct result acknowledged with 202", async () => {
     // 202 is an acknowledgement: the transport drains the body, discards it, and
     // returns before any result processing. So this answer never reaches the

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -738,6 +738,59 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("does not accept an initialize result naming the modern protocol version", async () => {
+    // The legacy handshake accepts only `legacyProtocolVersions(...)` — everything
+    // before 2026-07-28 — and throws otherwise, and the eval run's unpinned
+    // connection uses the SDK's built-in list. So a server answering `initialize`
+    // with a modern revision is one the client refuses; accepting it here would let
+    // that server's failure reach us as a neutral `infra_error`. The modern revision
+    // is legitimate on the discover arm, which is tested separately.
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const parsed = JSON.parse(String(init.body)) as { method: string };
+      if (parsed.method === "initialize") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { ...INITIALIZE_RESULT, protocolVersion: "2026-07-28" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+      // No modern era either, so the verdict rests on the initialize answer.
+      return new Response("{}", {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts an initialize result naming the newest legacy version", async () => {
+    // The boundary just below the modern era must still be accepted: it is in the
+    // SDK's built-in list, so the client speaks it.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { ...INITIALIZE_RESULT, protocolVersion: "2025-11-25" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
   it("does not accept a discover result whose nested capability flags are mistyped", async () => {
     // `ServerCapabilitiesSchema` types `tools.listChanged` as a boolean, and the
     // client runs that schema over the discover result. `{ listChanged: "yes" }` is

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -244,6 +244,30 @@ describe("buildAndStart", () => {
     expect((error as CheckStepError).outcome).toBe("infra_error");
   });
 
+  it("still says infra_error when an E2B outage surfaces AFTER the deadline", async () => {
+    // The other direction: a spent clock must not turn an outage into the PR's
+    // failure just because it arrived late. E2B's own description of the failure
+    // closes the door the clock opened.
+    const box = fakeSandbox({
+      throwOn: (command) =>
+        command.includes("npm run build")
+          ? Object.assign(
+              new Error(
+                "connection error: This error is likely due to exceeding 'requestTimeoutMs'."
+              ),
+              { name: "TimeoutError" }
+            )
+          : undefined,
+    });
+
+    const error = await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+      buildTimeoutMs: 0,
+    }).catch((e) => e as CheckStepError);
+
+    expect((error as CheckStepError).outcome).toBe("infra_error");
+  });
+
   it("gives the PR's server a timeout covering the sandbox lifetime", async () => {
     // E2B's `timeoutMs` defaults to 60 SECONDS and applies to background
     // commands too, so an unset value kills the server (and its stderr stream)

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -755,6 +755,100 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("does not accept an SSE-framed result declared as application/json", async () => {
+    // The transport switches on the declared type, and for `application/json` it
+    // calls `response.json()` — which throws on `event: …\ndata: …` framing. So
+    // this server cannot be driven, however well-formed the JSON inside the frame
+    // is, and reading the frame anyway would call it healthy on the strength of
+    // something the client never gets to see.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(SSE_INITIALIZE_FRAME, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept a bare JSON result declared as text/event-stream", async () => {
+    // The mirror case: under `text/event-stream` the transport runs its
+    // EventSource parser, and a body with no `data:` line carries no events — the
+    // client's `initialize` would go unanswered until it timed out.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT }),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept a JSON body that continues past its first document", async () => {
+    // `response.json()` rejects trailing content, so a second document (or junk)
+    // after the first makes the whole body unparseable for the client. Deciding as
+    // soon as a valid prefix landed would pass a server the eval run cannot use.
+    const answer = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: INITIALIZE_RESULT,
+    });
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(`${answer}\n${answer}\n`, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a JSON body that arrives in several chunks", async () => {
+    // The flip side of withholding a JSON decision until the body ends: a body
+    // split across writes must still be accepted once the last one lands.
+    const answer = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: INITIALIZE_RESULT,
+    });
+    const split = Math.floor(answer.length / 2);
+    const fetchImpl = vi.fn(async () => {
+      const encoder = new TextEncoder();
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(answer.slice(0, split)));
+            controller.enqueue(encoder.encode(answer.slice(split)));
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
   it("accepts a media type that carries parameters", async () => {
     // `application/json; charset=utf-8` is the same essence, and the transport
     // compares essences — so this must not be turned away.

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -969,6 +969,51 @@ describe("waitForMcpInitialize", () => {
     ).toBe(true);
   });
 
+  it("does not accept an answer carried by a named non-message event", async () => {
+    // The transport dispatches an event's data only when the event is unnamed or
+    // named `message` — `event: ping` is dropped before its data is ever parsed.
+    // So the eval run's `initialize` would go unanswered here, and reading the
+    // payload anyway would call this server healthy off bytes the client discards.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          `event: ping\ndata: ${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: INITIALIZE_RESULT,
+          })}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a real answer that follows a named non-message event", async () => {
+    // The name belongs to its own event and must not leak into the next one: a
+    // server that emits `event: ping` before answering is perfectly usable, so the
+    // filter must not turn the answer behind it into a false `server_unhealthy`.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          `event: ping\ndata: {"noise":true}\n\ndata: ${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: INITIALIZE_RESULT,
+          })}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
   it("does not decide on a multi-field event before its terminator arrives", async () => {
     // The first `data:` field parses on its own, but the event is not over: the
     // second field makes the joined payload something else entirely. Deciding at

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -7,6 +7,7 @@ import {
   cloneAndCheckout,
   lockDownEgress,
   OUTPUT_CLAMP_CHARS,
+  PROBE_MAX_RESPONSE_BYTES,
   waitForMcpInitialize,
   type CheckSandbox,
 } from "../sandbox";
@@ -1199,10 +1200,12 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
-  it("accepts a final event the server terminated by closing the stream", async () => {
-    // Withholding an unterminated event must not mean withholding it forever. A
-    // server that writes the frame and then closes without a trailing blank line
-    // has still said everything it is going to say, so the tail gets parsed.
+  it("does not accept a final event the server left unterminated", async () => {
+    // Closing the body does NOT terminate the event. `EventSourceParserStream` is a
+    // `TransformStream` with no `flush`, so a pending event with no blank line after
+    // it is dropped on close rather than delivered — the client's `initialize` never
+    // gets an answer. Parsing the tail here anyway would call such a server healthy
+    // off a message the eval run never receives.
     const fetchImpl = vi.fn(
       async () =>
         new Response(
@@ -1221,8 +1224,53 @@ describe("waitForMcpInitialize", () => {
     ) as unknown as typeof fetch;
 
     expect(
-      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
-    ).toBe(true);
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept a capped JSON body that parses as a prefix", async () => {
+    // A body whose first `PROBE_MAX_RESPONSE_BYTES` happen to be a complete JSON
+    // document, followed by more content. We stop reading at the cap; the client
+    // does not — `response.json()` reads to EOF and rejects the trailing bytes. So
+    // the cap must not stand in for the body ending, or the probe passes a server
+    // the eval run cannot parse.
+    const answer = {
+      jsonrpc: "2.0",
+      id: 1,
+      result: INITIALIZE_RESULT,
+      pad: "",
+    };
+    const padding = PROBE_MAX_RESPONSE_BYTES - JSON.stringify(answer).length;
+    expect(padding).toBeGreaterThan(0);
+    const document = JSON.stringify({ ...answer, pad: "a".repeat(padding) });
+    expect(document.length).toBe(PROBE_MAX_RESPONSE_BYTES);
+
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                new TextEncoder().encode(`${document}{"trailing":"junk"}`)
+              );
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
   });
 
   it("does not accept a serverInfo without a name and version", async () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -202,7 +202,7 @@ describe("buildAndStart", () => {
     const box = fakeSandbox({
       throwOn: (command) =>
         command.includes("npm run build")
-          ? Object.assign(new Error("command timed out"), {
+          ? Object.assign(new Error("deadline exceeded"), {
               name: "TimeoutError",
             })
           : undefined,
@@ -210,6 +210,8 @@ describe("buildAndStart", () => {
 
     const error = await buildAndStart(box.sandbox, RECIPE, {
       fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+      // Zero deadline: whatever happens, the elapsed time has reached it.
+      buildTimeoutMs: 0,
     }).catch((e) => e as CheckStepError);
 
     expect((error as CheckStepError).outcome).toBe("build_failed");
@@ -217,14 +219,17 @@ describe("buildAndStart", () => {
     expect(box.events.some((e) => e.startsWith("spawn:"))).toBe(false);
   });
 
-  it("keeps a transport failure that merely looks like a timeout as infra_error", async () => {
-    // E2B's own handshake timeout carries the same error name. That one is the
-    // sandbox failing, and calling it `build_failed` puts a red X on a good PR.
+  it("keeps an E2B failure that merely looks like a timeout as infra_error", async () => {
+    // E2B raises `TimeoutError` for Unavailable and Canceled RPCs too, not only
+    // for a command deadline. Trusting the error's name would report an E2B
+    // outage during `npm ci` as the PR's broken build — a red X on a good PR.
     const box = fakeSandbox({
       throwOn: (command) =>
         command.includes("npm run build")
           ? Object.assign(
-              new Error("Request handshake timed out after 30000ms"),
+              new Error(
+                "sandbox is unavailable: This error is likely due to sandbox timeout."
+              ),
               { name: "TimeoutError" }
             )
           : undefined,
@@ -232,6 +237,8 @@ describe("buildAndStart", () => {
 
     const error = await buildAndStart(box.sandbox, RECIPE, {
       fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+      // A deadline the failure cannot plausibly have reached.
+      buildTimeoutMs: 10 * 60_000,
     }).catch((e) => e as CheckStepError);
 
     expect((error as CheckStepError).outcome).toBe("infra_error");

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -107,6 +107,17 @@ function fakeSandbox(options?: {
 }
 
 /**
+ * Undo the outer `bash -lc '<script>'` quoting so a test can assert on the script
+ * itself rather than on its escaped form. Nested quoting is correct but unreadable:
+ * an inner `'...'` arrives as `'\''...'\''`.
+ */
+function scriptOf(command: string): string {
+  const match = /^bash -lc '([\s\S]*)'$/.exec(command);
+  if (!match) throw new Error(`not a quoted bash -lc command: ${command}`);
+  return match[1].replace(/'\\''/g, "'");
+}
+
+/**
  * A COMPLETE initialize result. The probe mirrors the real client, which
  * validates the JSON-RPC envelope and `InitializeResultSchema` — so a fixture
  * missing `capabilities` or `serverInfo` is not a server the eval run could
@@ -280,14 +291,21 @@ describe("buildAndStart", () => {
     );
     expect(buildCall).toBeDefined();
     // Redirected to a file, with a watchdog bounding that file too.
-    expect(buildCall!.command).toContain("/tmp/mcp-build.log");
-    expect(buildCall!.command).toContain("wc -c");
+    const script = scriptOf(buildCall!.command);
+    expect(script).toContain("/tmp/mcp-build.log");
+    expect(script).toContain("wc -c");
+    // The WHOLE recipe is redirected, not just its last command. A redirection
+    // binds to one simple command, so `npm ci && npm run build >> log` would leave
+    // `npm ci` — most of the output — streaming into the accumulating handle.
+    expect(script).toContain(
+      `bash -lc '${RECIPE.build}' >> /tmp/mcp-build.log 2>&1`
+    );
     // No stream callbacks: supplying one is what makes the handle buffer eagerly.
     expect(buildCall!.opts?.onStdout).toBeUndefined();
     expect(buildCall!.opts?.onStderr).toBeUndefined();
     // And the build's exit status still has to survive the redirection, or a
     // broken build would read as a passing one.
-    expect(buildCall!.command).toContain("exit $MCPJAM_STATUS");
+    expect(script).toContain("exit $MCPJAM_STATUS");
   });
 
   it("attributes a build that runs out its deadline to the PR, not to us", async () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -1116,6 +1116,93 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("does not accept a batch whose sibling has an invalid request id", async () => {
+    // `null` is not a `RequestIdSchema` value, and the notification arm is strict
+    // with no `id` at all — so this sibling matches neither arm, the transport's
+    // `.map` throws, and the batch (our answer with it) is discarded.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+            { jsonrpc: "2.0", method: "ping", id: null },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept a batch whose error sibling has an invalid id", async () => {
+    // The error arm's `id` is optional, but a PRESENT one still has to be an id.
+    // Same class as the request case, on the arm the finding did not name.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+            { jsonrpc: "2.0", id: null, error: { code: -1, message: "x" } },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept a batch whose sibling has non-object params", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+            { jsonrpc: "2.0", method: "ping", params: "nope" },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a batch alongside a well-formed request sibling", async () => {
+    // The other direction: a server-initiated request with a real id and object
+    // params is a legal arm, so the batch parses and our answer is delivered.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { jsonrpc: "2.0", id: 7, method: "roots/list", params: {} },
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 1_000,
+      })
+    ).toBe(true);
+  });
+
   it("accepts a batch alongside a notification and an error response", async () => {
     // The other direction: these siblings are all legal arms of the union — a
     // notification with no id, and an error response — so the batch parses and our

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildAndStart,
+  CHECK_SANDBOX_TIMEOUT_MS,
   CheckStepError,
   clampOutput,
   cloneAndCheckout,
@@ -192,6 +193,65 @@ describe("buildAndStart", () => {
     }).catch((e) => e as CheckStepError);
     expect((error as CheckStepError).outcome).toBe("server_unhealthy");
     expect((error as CheckStepError).detailsMarkdown).toContain("EADDRINUSE");
+  });
+
+  it("attributes a build that runs out its deadline to the PR, not to us", async () => {
+    // E2B reports a command deadline as a TimeoutError with no exit code, which
+    // lands in the transport branch and concludes `neutral` — letting a hanging
+    // (or deliberately hanging) build dodge a red check.
+    const box = fakeSandbox({
+      throwOn: (command) =>
+        command.includes("npm run build")
+          ? Object.assign(new Error("command timed out"), {
+              name: "TimeoutError",
+            })
+          : undefined,
+    });
+
+    const error = await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    }).catch((e) => e as CheckStepError);
+
+    expect((error as CheckStepError).outcome).toBe("build_failed");
+    // And still no server, and no egress change.
+    expect(box.events.some((e) => e.startsWith("spawn:"))).toBe(false);
+  });
+
+  it("keeps a transport failure that merely looks like a timeout as infra_error", async () => {
+    // E2B's own handshake timeout carries the same error name. That one is the
+    // sandbox failing, and calling it `build_failed` puts a red X on a good PR.
+    const box = fakeSandbox({
+      throwOn: (command) =>
+        command.includes("npm run build")
+          ? Object.assign(
+              new Error("Request handshake timed out after 30000ms"),
+              { name: "TimeoutError" }
+            )
+          : undefined,
+    });
+
+    const error = await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    }).catch((e) => e as CheckStepError);
+
+    expect((error as CheckStepError).outcome).toBe("infra_error");
+  });
+
+  it("gives the PR's server a timeout covering the sandbox lifetime", async () => {
+    // E2B's `timeoutMs` defaults to 60 SECONDS and applies to background
+    // commands too, so an unset value kills the server (and its stderr stream)
+    // about a minute in — mid-suite, as a false failure.
+    const box = fakeSandbox();
+    await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    });
+
+    const spawn = box.calls.find((call) => call.opts?.background === true);
+    expect(spawn).toBeDefined();
+    expect(spawn?.opts?.timeoutMs).toBe(CHECK_SANDBOX_TIMEOUT_MS);
+    // Not 0: E2B forwards it to connect-rpc, which treats <= 0 as an expired
+    // deadline and would abort the spawn instantly.
+    expect(spawn?.opts?.timeoutMs).toBeGreaterThan(0);
   });
 
   it("treats a sandbox that cannot run commands at all as infra_error", async () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -1,0 +1,463 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAndStart,
+  CheckStepError,
+  clampOutput,
+  cloneAndCheckout,
+  lockDownEgress,
+  OUTPUT_CLAMP_CHARS,
+  waitForMcpInitialize,
+  type CheckSandbox,
+} from "../sandbox";
+import { listRecipeRepos, resolveCheckRecipe } from "../recipes";
+
+// Everything this module runs is untrusted PR code, so the tests are written
+// around the two properties that make that safe rather than around happy-path
+// plumbing:
+//
+//   1. egress is revoked BEFORE the PR's server process starts, and a failed
+//      revoke aborts instead of degrading to "start it anyway";
+//   2. failures are attributed correctly — a broken build is the PR's
+//      (`build_failed`), an unreachable E2B is ours (`infra_error`) — because
+//      the attribution is what decides whether someone gets a red X.
+
+const RECIPE = {
+  build: "npm ci && npm run build",
+  start: "npm start",
+  port: 3001,
+  mcpPath: "/mcp",
+};
+
+type Call = { command: string; opts?: Record<string, unknown> };
+
+/**
+ * Fake sandbox recording an ordered log of everything that happened, so
+ * ordering assertions are about the real sequence and not a mocked promise.
+ */
+function fakeSandbox(options?: {
+  exitCodes?: Record<string, number>;
+  stdout?: Record<string, string>;
+  stderr?: Record<string, string>;
+  throwOn?: (command: string) => unknown;
+  networkFails?: boolean;
+  /** Emitted on the background command's stderr the moment it is spawned. */
+  stderrOnSpawn?: string[];
+}) {
+  const events: string[] = [];
+  const calls: Call[] = [];
+  let stderrSink: ((data: string) => void) | undefined;
+
+  const matchKey = (command: string, table?: Record<string, unknown>) => {
+    if (!table) return undefined;
+    return Object.keys(table).find((key) => command.includes(key));
+  };
+
+  const sandbox: CheckSandbox = {
+    sandboxId: "sb_test",
+    getHost: (port: number) => `${port}-sb_test.e2b.app`,
+    commands: {
+      run: async (command, opts) => {
+        calls.push({ command, opts });
+        events.push(opts?.background ? `spawn:${command}` : `run:${command}`);
+
+        const thrown = options?.throwOn?.(command);
+        if (thrown) throw thrown;
+
+        if (opts?.background) {
+          stderrSink = opts.onStderr;
+          for (const chunk of options?.stderrOnSpawn ?? []) {
+            stderrSink?.(chunk);
+          }
+          return { pid: 1234 };
+        }
+
+        const exitKey = matchKey(command, options?.exitCodes);
+        const exitCode = exitKey ? options!.exitCodes![exitKey] : 0;
+        const outKey = matchKey(command, options?.stdout);
+        const errKey = matchKey(command, options?.stderr);
+        const result = {
+          exitCode,
+          stdout: outKey ? options!.stdout![outKey] : "",
+          stderr: errKey ? options!.stderr![errKey] : "",
+        };
+        if (exitCode !== 0) {
+          // E2B throws on non-zero exit, carrying the streams on the error.
+          throw Object.assign(new Error("command exited non-zero"), result);
+        }
+        return result;
+      },
+    },
+    updateNetwork: async (network) => {
+      events.push(`network:${JSON.stringify(network)}`);
+      if (options?.networkFails) throw new Error("e2b network 502");
+    },
+    kill: async () => {
+      events.push("kill");
+    },
+  };
+
+  return {
+    sandbox,
+    events,
+    calls,
+    emitStderr: (chunk: string) => stderrSink?.(chunk),
+  } as const;
+}
+
+function okInitialize(): Response {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { protocolVersion: "2025-06-18", capabilities: {} },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+describe("buildAndStart", () => {
+  it("locks down egress AFTER the build and BEFORE the server starts", async () => {
+    const box = fakeSandbox();
+    const fetchImpl = vi.fn(async () =>
+      okInitialize()
+    ) as unknown as typeof fetch;
+
+    const started = await buildAndStart(box.sandbox, RECIPE, { fetchImpl });
+
+    const buildIndex = box.events.findIndex((e) => e.includes("npm run build"));
+    const networkIndex = box.events.findIndex((e) => e.startsWith("network:"));
+    const spawnIndex = box.events.findIndex((e) => e.startsWith("spawn:"));
+
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+    expect(networkIndex).toBeGreaterThan(buildIndex);
+    expect(spawnIndex).toBeGreaterThan(networkIndex);
+    // Egress off, inbound untouched.
+    expect(box.events[networkIndex]).toBe(
+      'network:{"allowInternetAccess":false}'
+    );
+    expect(started.url).toBe("https://3001-sb_test.e2b.app/mcp");
+  });
+
+  it("never starts the PR’s server if the egress lockdown fails", async () => {
+    const box = fakeSandbox({ networkFails: true });
+    const fetchImpl = vi.fn(async () =>
+      okInitialize()
+    ) as unknown as typeof fetch;
+
+    await expect(
+      buildAndStart(box.sandbox, RECIPE, { fetchImpl })
+    ).rejects.toMatchObject({
+      name: "CheckStepError",
+      outcome: "infra_error",
+    });
+
+    // The load-bearing assertion: no background process was ever spawned.
+    expect(box.events.some((e) => e.startsWith("spawn:"))).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("attributes a non-zero build to the PR, with a clamped log tail", async () => {
+    const box = fakeSandbox({
+      exitCodes: { "npm run build": 1 },
+      stderr: { "npm run build": "npm ERR! missing script: build" },
+    });
+
+    const error = await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    }).catch((e) => e as CheckStepError);
+
+    expect(error).toBeInstanceOf(CheckStepError);
+    expect((error as CheckStepError).outcome).toBe("build_failed");
+    expect((error as CheckStepError).detailsMarkdown).toContain(
+      "missing script: build"
+    );
+    // A failed build means no server and no egress change to make.
+    expect(box.events.some((e) => e.startsWith("spawn:"))).toBe(false);
+    expect(box.events.some((e) => e.startsWith("network:"))).toBe(false);
+  });
+
+  it("reports server_unhealthy with the server’s stderr tail when initialize never lands", async () => {
+    // The started process complains on stderr while the probe keeps failing.
+    const box = fakeSandbox({
+      stderrOnSpawn: ["Error: listen EADDRINUSE 127.0.0.1:3001"],
+    });
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    const error = await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl,
+      healthTimeoutMs: 30,
+      healthIntervalMs: 1,
+    }).catch((e) => e as CheckStepError);
+    expect((error as CheckStepError).outcome).toBe("server_unhealthy");
+    expect((error as CheckStepError).detailsMarkdown).toContain("EADDRINUSE");
+  });
+
+  it("treats a sandbox that cannot run commands at all as infra_error", async () => {
+    const box = fakeSandbox({
+      throwOn: (command) =>
+        command.includes("npm") ? new Error("sandbox is gone") : undefined,
+    });
+    const error = await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    }).catch((e) => e as CheckStepError);
+    expect((error as CheckStepError).outcome).toBe("infra_error");
+  });
+
+  it("keeps only the tail of a firehose stderr", async () => {
+    const box = fakeSandbox({
+      stderrOnSpawn: ["x".repeat(50_000), "THE-LAST-LINE"],
+    });
+    const error = (await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => {
+        throw new Error("refused");
+      }) as unknown as typeof fetch,
+      healthTimeoutMs: 30,
+      healthIntervalMs: 1,
+    }).catch((e) => e)) as CheckStepError;
+    expect(error.detailsMarkdown).toContain("THE-LAST-LINE");
+    expect(error.detailsMarkdown!.length).toBeLessThan(
+      OUTPUT_CLAMP_CHARS + 200
+    );
+  });
+});
+
+describe("cloneAndCheckout", () => {
+  it("clones anonymously from the PR ref and asserts the resolved sha", async () => {
+    const headSha = "a".repeat(40);
+    const box = fakeSandbox({ stdout: { "rev-parse HEAD": `${headSha}\n` } });
+
+    await cloneAndCheckout(box.sandbox, {
+      repoFullName: "mcpjam/mcp-check-fixture",
+      prNumber: 7,
+      headSha,
+    });
+
+    const cloneCall = box.calls[0].command;
+    expect(cloneCall).toContain(
+      "https://github.com/mcpjam/mcp-check-fixture.git"
+    );
+    expect(cloneCall).toContain("pull/7/head");
+    expect(cloneCall).toContain("git checkout --detach");
+    expect(cloneCall).toContain(headSha);
+    // No credential of any kind reaches the box.
+    expect(cloneCall).not.toMatch(/x-access-token|ghs_|@github\.com/);
+    expect(box.calls[0].opts?.envs).toBeUndefined();
+  });
+
+  it("fails loudly when the checked-out sha is not the one we were told about", async () => {
+    // A force-push landed between the webhook and the clone: building the wrong
+    // tree and reporting it against the old sha would be a silent lie.
+    const box = fakeSandbox({
+      stdout: { "rev-parse HEAD": `${"b".repeat(40)}\n` },
+    });
+    await expect(
+      cloneAndCheckout(box.sandbox, {
+        repoFullName: "mcpjam/mcp-check-fixture",
+        prNumber: 7,
+        headSha: "a".repeat(40),
+      })
+    ).rejects.toMatchObject({ outcome: "infra_error" });
+  });
+
+  it("treats a failed clone of a public repo as our problem, not the PR’s", async () => {
+    const box = fakeSandbox({ exitCodes: { "git clone": 128 } });
+    const error = await cloneAndCheckout(box.sandbox, {
+      repoFullName: "mcpjam/mcp-check-fixture",
+      prNumber: 7,
+      headSha: "a".repeat(40),
+    }).catch((e) => e as CheckStepError);
+    expect((error as CheckStepError).outcome).toBe("infra_error");
+  });
+
+  it("quotes the sha and repo so neither can inject shell", async () => {
+    const box = fakeSandbox({
+      stdout: { "rev-parse HEAD": "deadbeef\n" },
+    });
+    await cloneAndCheckout(box.sandbox, {
+      repoFullName: "owner/repo; rm -rf /",
+      prNumber: 1,
+      headSha: "deadbeef",
+    }).catch(() => {});
+    // The whole script is a single quoted argument to `bash -lc`, and the
+    // injected text stays inside nested quotes.
+    expect(box.calls[0].command.startsWith("bash -lc '")).toBe(true);
+    expect(box.calls[0].command).not.toMatch(/;\s*rm -rf \/\s*'?\s*&&/);
+  });
+});
+
+describe("lockDownEgress", () => {
+  it("disables outbound while leaving the inbound host bridge alone", async () => {
+    const box = fakeSandbox();
+    await lockDownEgress(box.sandbox);
+    expect(box.events).toEqual(['network:{"allowInternetAccess":false}']);
+  });
+
+  it("surfaces a failure as infra_error so the caller can abort", async () => {
+    const box = fakeSandbox({ networkFails: true });
+    await expect(lockDownEgress(box.sandbox)).rejects.toMatchObject({
+      outcome: "infra_error",
+    });
+  });
+});
+
+describe("waitForMcpInitialize", () => {
+  const seams = {
+    intervalMs: 1,
+    sleep: async () => {},
+  };
+
+  it("accepts a JSON initialize result", async () => {
+    const fetchImpl = vi.fn(async () =>
+      okInitialize()
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("accepts an SSE-framed initialize result (streamable HTTP servers send either)", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}\n\n',
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("keeps polling through connection refusals and succeeds once the server boots", async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call += 1;
+      if (call < 3) throw new Error("ECONNREFUSED");
+      return okInitialize();
+    }) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 10_000,
+      })
+    ).toBe(true);
+    expect(call).toBe(3);
+  });
+
+  it("sends a real JSON-RPC initialize, not a bare GET", async () => {
+    const fetchImpl = vi.fn(async () =>
+      okInitialize()
+    ) as unknown as typeof fetch;
+    await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl });
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toMatchObject({ method: "initialize" });
+    expect(init.headers.accept).toContain("text/event-stream");
+  });
+
+  it("does not accept an HTTP 200 that isn’t an initialize result", async () => {
+    // A framework serving its own index page before the MCP route is mounted.
+    const fetchImpl = vi.fn(
+      async () => new Response("<html>ok</html>", { status: 200 })
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept a JSON-RPC error response as healthy", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            error: { code: -32600, message: "nope" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("gives up at the deadline", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("refused");
+    }) as unknown as typeof fetch;
+    let clock = 0;
+    const result = await waitForMcpInitialize("https://box/mcp", {
+      fetchImpl,
+      timeoutMs: 100,
+      intervalMs: 25,
+      now: () => clock,
+      sleep: async (ms) => {
+        clock += ms;
+      },
+    });
+    expect(result).toBe(false);
+    // Bounded: it stops once another interval would overshoot the deadline.
+    expect(
+      (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.length
+    ).toBeLessThanOrEqual(5);
+  });
+});
+
+describe("clampOutput", () => {
+  it("fences with a longer run so a log containing a fence cannot break out", () => {
+    const clamped = clampOutput("before\n```\n# heading\n```\nafter");
+    expect(clamped.startsWith("````text\n")).toBe(true);
+    expect(clamped.endsWith("\n````")).toBe(true);
+  });
+
+  it("strips ANSI escapes and NULs, keeps tabs and newlines", () => {
+    const clamped = clampOutput("a\u001b[31mred\u001b[0m\u0000\tb\nc");
+    expect(clamped).toContain("\tb");
+    expect(clamped).not.toContain("\u001b");
+    expect(clamped).not.toContain("\u0000");
+  });
+
+  it("keeps the tail and says so", () => {
+    const clamped = clampOutput(`${"x".repeat(OUTPUT_CLAMP_CHARS + 100)}TAIL`);
+    expect(clamped).toContain("TAIL");
+    expect(clamped).toContain("Showing the last");
+  });
+
+  it("returns empty rather than an empty code block", () => {
+    expect(clampOutput("")).toBe("");
+    expect(clampOutput(undefined)).toBe("");
+    expect(clampOutput("  \n ")).toBe("");
+  });
+});
+
+describe("recipes", () => {
+  it("resolves the fixture repo case-insensitively", () => {
+    expect(resolveCheckRecipe("MCPJam/MCP-Check-Fixture")).toMatchObject({
+      port: 3001,
+      mcpPath: "/mcp",
+    });
+  });
+
+  it("returns null for anything else — the worker maps that to recipe_unresolvable", () => {
+    expect(resolveCheckRecipe("someone/unknown-server")).toBeNull();
+    expect(resolveCheckRecipe("")).toBeNull();
+  });
+
+  it("only the fixture repo is wired up in the skeleton", () => {
+    expect(listRecipeRepos()).toEqual(["mcpjam/mcp-check-fixture"]);
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -784,6 +784,31 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("offers the same legacy version the eval client offers", async () => {
+    // `_legacyHandshake` sends `legacyVersions[0]`, and an unpinned connection
+    // leaves that list to the SDK's built-in `SUPPORTED_PROTOCOL_VERSIONS`, whose
+    // first entry is the latest legacy revision. Proposing an older one would probe
+    // a handshake the eval never performs: a server whose `2025-06-18` path works
+    // while its latest path is broken would pass here and fail the eval, arriving as
+    // a neutral `infra_error` instead of the PR's `server_unhealthy`.
+    const offered: unknown[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const parsed = JSON.parse(String(init.body)) as {
+        method: string;
+        params?: { protocolVersion?: unknown };
+      };
+      if (parsed.method === "initialize") {
+        offered.push(parsed.params?.protocolVersion);
+      }
+      return okInitialize();
+    }) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+    expect(offered).toEqual(["2025-11-25"]);
+  });
+
   it("does not accept an initialize result naming the modern protocol version", async () => {
     // The legacy handshake accepts only `legacyProtocolVersions(...)` — everything
     // before 2026-07-28 — and throws otherwise, and the eval run's unpinned

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -227,7 +227,9 @@ describe("buildAndStart", () => {
   it("attributes a non-zero build to the PR, with a clamped log tail", async () => {
     const box = fakeSandbox({
       exitCodes: { "npm run build": 1 },
-      stderr: { "npm run build": "npm ERR! missing script: build" },
+      // The build's own output never crosses into this process — it is redirected
+      // to a file in the box, and only a bounded `tail -c` of it is fetched.
+      stdout: { "tail -c": "npm ERR! missing script: build" },
     });
 
     const error = await buildAndStart(box.sandbox, RECIPE, {
@@ -260,6 +262,32 @@ describe("buildAndStart", () => {
     }).catch((e) => e as CheckStepError);
     expect((error as CheckStepError).outcome).toBe("server_unhealthy");
     expect((error as CheckStepError).detailsMarkdown).toContain("EADDRINUSE");
+  });
+
+  it("keeps the BUILD's output inside the box, never streaming it to us", async () => {
+    // The same hazard the start path already guards: E2B's command handle
+    // accumulates every chunk it receives into an internal string, so a build
+    // script that prints for its whole ten-minute window would grow THIS process's
+    // heap without limit — and the build is PR-controlled code. The output must be
+    // redirected in the box and only a bounded tail fetched.
+    const box = fakeSandbox();
+    await buildAndStart(box.sandbox, RECIPE, {
+      fetchImpl: vi.fn(async () => okInitialize()) as unknown as typeof fetch,
+    });
+
+    const buildCall = box.calls.find((call) =>
+      call.command.includes("npm run build")
+    );
+    expect(buildCall).toBeDefined();
+    // Redirected to a file, with a watchdog bounding that file too.
+    expect(buildCall!.command).toContain("/tmp/mcp-build.log");
+    expect(buildCall!.command).toContain("wc -c");
+    // No stream callbacks: supplying one is what makes the handle buffer eagerly.
+    expect(buildCall!.opts?.onStdout).toBeUndefined();
+    expect(buildCall!.opts?.onStderr).toBeUndefined();
+    // And the build's exit status still has to survive the redirection, or a
+    // broken build would read as a passing one.
+    expect(buildCall!.command).toContain("exit $MCPJAM_STATUS");
   });
 
   it("attributes a build that runs out its deadline to the PR, not to us", async () => {
@@ -960,6 +988,53 @@ describe("waitForMcpInitialize", () => {
         timeoutMs: 5,
       })
     ).toBe(false);
+  });
+
+  it("does not accept a batch whose sibling matches no message arm", async () => {
+    // `{"jsonrpc":"2.0"}` is not a request, a notification, a result or an error, so
+    // the transport's schema throws on it and the whole batch — our answer with it —
+    // is discarded. `jsonrpc: "2.0"` alone is not enough to call a sibling valid.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+            { jsonrpc: "2.0" },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a batch alongside a notification and an error response", async () => {
+    // The other direction: these siblings are all legal arms of the union — a
+    // notification with no id, and an error response — so the batch parses and our
+    // answer is delivered. Rejecting them would be a false `server_unhealthy`.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify([
+            { jsonrpc: "2.0", method: "notifications/message" },
+            { jsonrpc: "2.0", id: 9, error: { code: -32601, message: "nope" } },
+            { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 1_000,
+      })
+    ).toBe(true);
   });
 
   it("does not accept a batch inside an SSE event", async () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -689,6 +689,57 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("does not accept a discover result offering only legacy versions", async () => {
+    // `server/discover` is the MODERN arm. A result naming only 2025-era
+    // revisions says nothing about it: for such a server the client falls back to
+    // `initialize`, and whether THAT works is what the legacy probe answers. So an
+    // endpoint that answers discover with legacy-only versions while rejecting
+    // `initialize` is not a server the eval run can drive, and must not read as
+    // healthy off the arm that never proved it.
+    let clock = 0;
+    const seen: string[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const parsed = JSON.parse(String(init.body)) as { method: string };
+      seen.push(parsed.method);
+      if (parsed.method === "initialize") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            error: { code: -32600, message: "legacy era rejected" },
+          }),
+          { status: 400, headers: { "content-type": "application/json" } }
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          result: {
+            supportedVersions: ["2025-06-18", "2025-11-25"],
+            capabilities: {},
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        fetchImpl,
+        timeoutMs: 100,
+        intervalMs: 10,
+        now: () => clock,
+        sleep: async () => {
+          clock += 10;
+        },
+      })
+    ).toBe(false);
+    // The modern arm really did run — this is a rejection, not a probe that never
+    // got its turn.
+    expect(seen).toContain("server/discover");
+  });
+
   it("joins an event's data fields before parsing them", async () => {
     // SSE concatenates consecutive `data:` fields within one event. A server that
     // spreads one JSON-RPC message across several is legal; parsing each line
@@ -712,6 +763,76 @@ describe("waitForMcpInitialize", () => {
           headers: { "content-type": "text/event-stream" },
         })
     ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("does not decide on a multi-field event before its terminator arrives", async () => {
+    // The first `data:` field parses on its own, but the event is not over: the
+    // second field makes the joined payload something else entirely. Deciding at
+    // the chunk boundary would accept an answer the server never finished sending.
+    // Held instead until the blank line, at which point the whole event is judged
+    // — and this one is not valid JSON, so the verdict is "not healthy".
+    const chunks = [
+      `event: message\ndata: ${JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: INITIALIZE_RESULT,
+      })}\n`,
+      `data: "and the rest of the message"\n\n`,
+    ];
+    let clock = 0;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              const encoder = new TextEncoder();
+              for (const chunk of chunks) {
+                controller.enqueue(encoder.encode(chunk));
+              }
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        fetchImpl,
+        timeoutMs: 100,
+        intervalMs: 10,
+        now: () => clock,
+        sleep: async () => {
+          clock += 10;
+        },
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a final event the server terminated by closing the stream", async () => {
+    // Withholding an unterminated event must not mean withholding it forever. A
+    // server that writes the frame and then closes without a trailing blank line
+    // has still said everything it is going to say, so the tail gets parsed.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                new TextEncoder().encode(
+                  SSE_INITIALIZE_FRAME.replace(/\n+$/, "\n")
+                )
+              );
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+
     expect(
       await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
     ).toBe(true);

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -136,6 +136,22 @@ function okInitialize(): Response {
 }
 
 /**
+ * A complete, valid initialize answer padded to measure EXACTLY
+ * `PROBE_MAX_RESPONSE_BYTES`, so the probe's byte cap lands on the last byte of a
+ * parseable document. All ASCII, so characters and bytes agree.
+ */
+function cappedDocument(): string {
+  const answer = { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT, pad: "" };
+  const padding = PROBE_MAX_RESPONSE_BYTES - JSON.stringify(answer).length;
+  if (padding <= 0) throw new Error("initialize fixture exceeds the probe cap");
+  const document = JSON.stringify({ ...answer, pad: "a".repeat(padding) });
+  if (document.length !== PROBE_MAX_RESPONSE_BYTES) {
+    throw new Error(`padded to ${document.length}, not the cap`);
+  }
+  return document;
+}
+
+/**
  * A server that has no `initialize` and answers `server/discover` with the given
  * capabilities — the modern arm in isolation, so a capability-shape verdict is not
  * masked by the legacy arm accepting the same server.
@@ -1232,30 +1248,130 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("accepts an answer whose event name a colonless event line cleared", async () => {
+    // A line with no colon is that field with an empty value, and `event` with an
+    // empty value CLEARS the type — so this event is unnamed and the transport
+    // dispatches it as `message`. Skipping the colonless line would keep `ping` and
+    // discard an answer the client does receive: a false `server_unhealthy`.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          `event: ping\nevent\ndata: ${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: INITIALIZE_RESULT,
+          })}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("accepts an answer whose event carries id, retry and comment lines", async () => {
+    // None of these fields carry data and none of them end the event, so the
+    // payload must survive them intact. An unknown field is reported to an
+    // `onError` the transport never passes, so it is ignored too.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          [
+            ": keep-alive comment",
+            "id: 7",
+            "retry: 1000",
+            "x-unknown: whatever",
+            `data: ${JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              result: INITIALIZE_RESULT,
+            })}`,
+            "",
+            "",
+          ].join("\n"),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("accepts a JSON body that measures exactly the byte cap", async () => {
+    // The boundary is a working server: the whole document arrived, and the body
+    // ended there. Only the read after the cap can prove it ended, since `done`
+    // never rides along with the last chunk — and refusing to take that read would
+    // put a false `server_unhealthy` on a PR whose answer merely happens to be
+    // 64 KiB long.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(cappedDocument()));
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+
+    // Bounded deliberately: this must be accepted on the first attempt, so if it
+    // ever regresses the test fails in a second rather than spinning out the full
+    // two-minute health window.
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 1_000,
+      })
+    ).toBe(true);
+  });
+
+  it("does not accept a cap-sized JSON body that keeps going in a later write", async () => {
+    // Same first chunk as above, so the cap is reached with nothing dropped — but
+    // the body has not ended, and the read that follows says so. This is the case
+    // the extra read has to get right: `response.json()` would reject the trailing
+    // content.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              const encoder = new TextEncoder();
+              controller.enqueue(encoder.encode(cappedDocument()));
+              controller.enqueue(encoder.encode('{"trailing":"junk"}'));
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
   it("does not accept a capped JSON body that parses as a prefix", async () => {
     // A body whose first `PROBE_MAX_RESPONSE_BYTES` happen to be a complete JSON
     // document, followed by more content. We stop reading at the cap; the client
     // does not — `response.json()` reads to EOF and rejects the trailing bytes. So
     // the cap must not stand in for the body ending, or the probe passes a server
     // the eval run cannot parse.
-    const answer = {
-      jsonrpc: "2.0",
-      id: 1,
-      result: INITIALIZE_RESULT,
-      pad: "",
-    };
-    const padding = PROBE_MAX_RESPONSE_BYTES - JSON.stringify(answer).length;
-    expect(padding).toBeGreaterThan(0);
-    const document = JSON.stringify({ ...answer, pad: "a".repeat(padding) });
-    expect(document.length).toBe(PROBE_MAX_RESPONSE_BYTES);
-
     const fetchImpl = vi.fn(
       async () =>
         new Response(
           new ReadableStream<Uint8Array>({
             start(controller) {
               controller.enqueue(
-                new TextEncoder().encode(`${document}{"trailing":"junk"}`)
+                new TextEncoder().encode(
+                  `${cappedDocument()}{"trailing":"junk"}`
+                )
               );
               controller.close();
             },

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -823,6 +823,22 @@ describe("waitForMcpInitialize", () => {
     }
   });
 
+  it("accepts a discover result advertising tasks in any shape", async () => {
+    // `ServerCapabilities2026Schema` — the schema the rev2026 codec validates a
+    // discover result with — defines seven members and `tasks` is not one of them.
+    // So `tasks` is an unknown member, stripped rather than rejected, and the client
+    // negotiates the modern era regardless of its shape. Validating it against the
+    // 2025 schema's `tasks` shape turned working servers into `server_unhealthy`.
+    for (const tasks of [true, { list: true }, "on"]) {
+      expect(
+        await waitForMcpInitialize("https://box/mcp", {
+          ...seams,
+          fetchImpl: discoverCapabilitiesFetch({ tools: {}, tasks }),
+        })
+      ).toBe(true);
+    }
+  });
+
   it("accepts a discover result whose nested capabilities are all well typed", async () => {
     // The other direction, and the one that would hurt: every typed member here is
     // the type the schema asks for, and the unknown extension member is an object,

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -134,6 +134,38 @@ function okInitialize(): Response {
   );
 }
 
+/**
+ * A server that has no `initialize` and answers `server/discover` with the given
+ * capabilities — the modern arm in isolation, so a capability-shape verdict is not
+ * masked by the legacy arm accepting the same server.
+ */
+function discoverCapabilitiesFetch(
+  capabilities: unknown,
+  instructions?: unknown
+): typeof fetch {
+  return vi.fn(async (_url: string, init: RequestInit) => {
+    const parsed = JSON.parse(String(init.body)) as { method: string };
+    if (parsed.method === "initialize") {
+      return new Response("{}", {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        result: {
+          supportedVersions: ["2026-07-28"],
+          capabilities,
+          ...(instructions === undefined ? {} : { instructions }),
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    );
+  }) as unknown as typeof fetch;
+}
+
 describe("buildAndStart", () => {
   it("locks down egress AFTER the build and BEFORE the server starts", async () => {
     const box = fakeSandbox();
@@ -687,6 +719,115 @@ describe("waitForMcpInitialize", () => {
         timeoutMs: 5,
       })
     ).toBe(false);
+  });
+
+  it("does not accept a discover result whose nested capability flags are mistyped", async () => {
+    // `ServerCapabilitiesSchema` types `tools.listChanged` as a boolean, and the
+    // client runs that schema over the discover result. `{ listChanged: "yes" }` is
+    // an object at the top level and a violation one level down, so the client
+    // classifies this result `legacy` and declines the modern era — which is the
+    // only thing this arm is asked about.
+    const fetchImpl = discoverCapabilitiesFetch({
+      tools: { listChanged: "yes" },
+    });
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept a discover result whose extensions are not a map of objects", async () => {
+    // `extensions` is a record of name → object, so a bare `true` fails the schema,
+    // as does a member that is not an object.
+    for (const extensions of [true, { "com.example/thing": "on" }]) {
+      expect(
+        await waitForMcpInitialize("https://box/mcp", {
+          ...seams,
+          fetchImpl: discoverCapabilitiesFetch({ extensions }),
+          timeoutMs: 5,
+        })
+      ).toBe(false);
+    }
+  });
+
+  it("accepts a discover result whose nested capabilities are all well typed", async () => {
+    // The other direction, and the one that would hurt: every typed member here is
+    // the type the schema asks for, and the unknown extension member is an object,
+    // so the client drives this server in the modern era. Rejecting it would be a
+    // false `server_unhealthy` on a working PR.
+    const fetchImpl = discoverCapabilitiesFetch(
+      {
+        tools: { listChanged: true },
+        prompts: {},
+        resources: { subscribe: true, listChanged: false },
+        logging: {},
+        experimental: { "com.example/lab": {} },
+        extensions: { "com.example/thing": { enabled: true } },
+        tasks: { list: {}, requests: { tools: { call: {} } } },
+      },
+      "how to drive me"
+    );
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("does not accept a discover result whose instructions are not a string", async () => {
+    const fetchImpl = discoverCapabilitiesFetch({ tools: {} }, 42);
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("does not accept an answer whose event type carries trailing whitespace", async () => {
+    // The parser strips ONE optional space after the colon and keeps the rest, so
+    // this event's type is `"message "` — which is not `"message"`, so the transport
+    // drops it. Trimming the value here would normalise it and accept an answer the
+    // eval run never receives.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          `event: message \ndata: ${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: INITIALIZE_RESULT,
+          })}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a data field written with no space after the colon", async () => {
+    // `data:{...}` is legal and the space is optional, so the single-space rule must
+    // not eat the payload's first character.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          `data:${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: INITIALIZE_RESULT,
+          })}\n\n`,
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
   });
 
   it("does not accept a correct result served with the wrong content type", async () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -395,6 +395,56 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("bounds each attempt so a server that accepts and never answers cannot hang the check", async () => {
+    // Untrusted PR code that takes the socket and goes silent. Without a
+    // per-attempt bound this await never returns and the check occupies the
+    // worker's only in-flight slot until the sandbox TTL.
+    const fetchImpl = vi.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new Error("aborted"))
+          );
+        })
+    ) as unknown as typeof fetch;
+
+    const started = Date.now();
+    const result = await waitForMcpInitialize("https://box/mcp", {
+      fetchImpl,
+      timeoutMs: 150,
+      intervalMs: 10,
+    });
+    expect(result).toBe(false);
+    // Bounded by the health deadline, not by the server's patience.
+    expect(Date.now() - started).toBeLessThan(3_000);
+    expect(
+      (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].signal
+    ).toBeDefined();
+  });
+
+  it('does not misread a JSON body that merely contains "data:" as an SSE frame', async () => {
+    // A serverInfo name, instructions blob, or tool description can contain
+    // "data:" — classifying the whole body as SSE yielded zero payloads and a
+    // false server_unhealthy.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              protocolVersion: "2025-06-18",
+              serverInfo: { name: "reads data: urls", version: "1" },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
   it("gives up at the deadline", async () => {
     const fetchImpl = vi.fn(async () => {
       throw new Error("refused");

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -997,6 +997,52 @@ describe("waitForMcpInitialize", () => {
     ).toBe(true);
   });
 
+  it("does not accept a result whose _meta is not an object", async () => {
+    // `ResultSchema` types `_meta` as an optional OBJECT, so `_meta: true` fails the
+    // envelope parse before any handshake logic runs — the client never looks at the
+    // rest of the result, however valid it is.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { ...INITIALIZE_RESULT, _meta: true },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a result carrying a well-formed _meta", async () => {
+    // The other direction: `_meta` is loose, so any object passes — including the
+    // server-info key the spec suggests putting there.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              ...INITIALIZE_RESULT,
+              _meta: { "io.modelcontextprotocol/serverInfo": { name: "x" } },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
   it("does not accept an envelope mixing result with error", async () => {
     // The result-response arm is `{ jsonrpc, id, result }` and it is strict, so an
     // envelope carrying `error` as well matches no arm of the union and the

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -449,10 +449,10 @@ describe("waitForMcpInitialize", () => {
   it("accepts an SSE-framed initialize result (streamable HTTP servers send either)", async () => {
     const fetchImpl = vi.fn(
       async () =>
-        new Response(
-          SSE_INITIALIZE_FRAME,
-          { status: 200, headers: { "content-type": "text/event-stream" } }
-        )
+        new Response(SSE_INITIALIZE_FRAME, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        })
     ) as unknown as typeof fetch;
     expect(
       await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
@@ -472,9 +472,7 @@ describe("waitForMcpInitialize", () => {
           new ReadableStream<Uint8Array>({
             start(controller) {
               controller.enqueue(
-                new TextEncoder().encode(
-                  SSE_INITIALIZE_FRAME
-                )
+                new TextEncoder().encode(SSE_INITIALIZE_FRAME)
               );
               // …and then nothing. No close(): the stream stays open, exactly
               // like a real session.
@@ -502,8 +500,7 @@ describe("waitForMcpInitialize", () => {
   });
 
   it("decides from a frame that arrives split across chunks", async () => {
-    const payload =
-      SSE_INITIALIZE_FRAME.replace("event: message\n", "");
+    const payload = SSE_INITIALIZE_FRAME.replace("event: message\n", "");
     const cut = 40;
     const fetchImpl = vi.fn(
       async () =>
@@ -613,6 +610,125 @@ describe("waitForMcpInitialize", () => {
             jsonrpc: "2.0",
             id: 1,
             result: { protocolVersion: "bogus-9999" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("accepts a modern-only server through server/discover", async () => {
+    // A 2026-07-28 endpoint (the official handler with `legacy: "reject"`) has no
+    // `initialize` at all. The eval run negotiates eras automatically, so this is
+    // a server it can drive — calling it `server_unhealthy` would put a red X on
+    // a good PR. Probing alternates eras, so the discover attempt follows the
+    // rejected legacy one.
+    const seen: string[] = [];
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const parsed = JSON.parse(String(init.body)) as { method: string };
+      seen.push(parsed.method);
+      if (parsed.method === "initialize") {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            error: { code: -32600, message: "legacy era rejected" },
+          }),
+          { status: 400, headers: { "content-type": "application/json" } }
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          result: {
+            supportedVersions: ["2026-07-28"],
+            capabilities: { tools: {} },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+    expect(seen).toEqual(["initialize", "server/discover"]);
+  });
+
+  it("does not accept a discover result offering no version we speak", async () => {
+    const fetchImpl = vi.fn(async (_url: string, init: RequestInit) => {
+      const parsed = JSON.parse(String(init.body)) as { method: string };
+      if (parsed.method === "initialize") {
+        return new Response("{}", {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          result: { supportedVersions: ["3099-01-01"], capabilities: {} },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
+  it("joins an event's data fields before parsing them", async () => {
+    // SSE concatenates consecutive `data:` fields within one event. A server that
+    // spreads one JSON-RPC message across several is legal; parsing each line
+    // alone made every fragment fail and reported a false server_unhealthy.
+    // Fields are joined with a newline, per spec — which is exactly what a
+    // pretty-printed payload needs, since a newline is JSON whitespace between
+    // tokens. (A server splitting mid-token would be sending malformed SSE.)
+    const pretty = JSON.stringify(
+      { jsonrpc: "2.0", id: 1, result: INITIALIZE_RESULT },
+      null,
+      2
+    );
+    const frame = pretty
+      .split("\n")
+      .map((line) => `data: ${line}`)
+      .join("\n");
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(`event: message\n${frame}\n\n`, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        })
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", { ...seams, fetchImpl })
+    ).toBe(true);
+  });
+
+  it("does not accept a serverInfo without a name and version", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              serverInfo: {},
+            },
           }),
           { status: 200, headers: { "content-type": "application/json" } }
         )

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -584,6 +584,30 @@ describe("waitForMcpInitialize", () => {
     ).toBe(false);
   });
 
+  it("does not accept an unsupported protocol version as healthy", async () => {
+    // Present is not the same as usable: the real client rejects a version it
+    // does not support, which would surface as `infra_error` (neutral) from the
+    // eval run instead of the `server_unhealthy` the PR earned.
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { protocolVersion: "bogus-9999" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    ) as unknown as typeof fetch;
+    expect(
+      await waitForMcpInitialize("https://box/mcp", {
+        ...seams,
+        fetchImpl,
+        timeoutMs: 5,
+      })
+    ).toBe(false);
+  });
+
   it("does not accept a JSON-RPC error response as healthy", async () => {
     const fetchImpl = vi.fn(
       async () =>

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -313,11 +313,15 @@ describe("buildAndStart", () => {
       healthIntervalMs: 1,
     }).catch((e) => e)) as CheckStepError;
 
-    // The spawn streams nothing back and redirects to a file…
+    // The spawn streams nothing back and appends to a file…
     const spawn = box.calls.find((call) => call.opts?.background === true);
-    expect(spawn?.command).toContain("> /tmp/mcp-server.log 2>&1");
+    expect(spawn?.command).toContain(">> /tmp/mcp-server.log 2>&1");
     expect(spawn?.opts?.onStderr).toBeUndefined();
     expect(spawn?.opts?.onStdout).toBeUndefined();
+    // …with a watchdog so the file cannot fill the sandbox's disk either, which
+    // would take down the very server being evaluated.
+    expect(spawn?.command).toContain("wc -c < /tmp/mcp-server.log");
+    expect(spawn?.command).toContain("4194304");
     // …and the truncation is done by the sandbox, not after the fact.
     expect(
       box.calls.some((call) => call.command.includes("tail -c 8000"))

--- a/mcpjam-inspector/server/services/github-checks/recipes.ts
+++ b/mcpjam-inspector/server/services/github-checks/recipes.ts
@@ -1,0 +1,57 @@
+/**
+ * Run recipes: how to turn a PR checkout into a reachable MCP server.
+ *
+ * This is the ONE hardcoded piece of the GitHub-checks walking skeleton, and it
+ * is hardcoded on purpose. The unsolved problem in "test an arbitrary MCP
+ * server's PR" is not the testing — eval suites and the runner already exist —
+ * it is knowing how to build and start the server. The eventual answer is a
+ * resolution ladder (declared config → repo metadata → detection → agentic
+ * fallback). Everything AROUND that ladder is production plumbing, so it is
+ * built first against a single controlled fixture repo, and the ladder later
+ * replaces `RECIPES` without touching anything else.
+ *
+ * A repo with no recipe resolves to `recipe_unresolvable` (a NEUTRAL check —
+ * "we couldn't figure this out", never a failure attributed to the PR). In the
+ * skeleton that state is unreachable through the webhook, since the repo
+ * allowlist and this table are configured together; the worker still handles it
+ * defensively, because the resolver era makes it routine.
+ */
+
+export type CheckRecipe = {
+  /** Run to completion before the server starts. Non-zero exit = `build_failed`. */
+  build: string;
+  /** Long-running; spawned in the background and expected to bind `port`. */
+  start: string;
+  /**
+   * The port the started server listens on INSIDE the sandbox. It must bind
+   * `0.0.0.0`, not `127.0.0.1` — the sandbox host bridge only forwards to
+   * ports bound on all interfaces, so a loopback-only server is invisible and
+   * shows up as `server_unhealthy`.
+   */
+  port: number;
+  /** Path the streamable-HTTP MCP endpoint is served on. */
+  mcpPath: string;
+};
+
+/**
+ * Keyed by lowercased `owner/repo`, matching the backend's allowlist
+ * normalization (GitHub repo names are case-insensitive).
+ */
+const RECIPES: Record<string, CheckRecipe> = {
+  "mcpjam/mcp-check-fixture": {
+    build: "npm ci && npm run build",
+    start: "npm start",
+    port: 3001,
+    mcpPath: "/mcp",
+  },
+};
+
+export function resolveCheckRecipe(repoFullName: string): CheckRecipe | null {
+  if (typeof repoFullName !== "string") return null;
+  return RECIPES[repoFullName.trim().toLowerCase()] ?? null;
+}
+
+/** Exposed for tests and for an operator sanity-checking a deployment. */
+export function listRecipeRepos(): string[] {
+  return Object.keys(RECIPES);
+}

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -570,7 +570,11 @@ async function probeResponseIsHealthy(response: Response): Promise<boolean> {
     while (text.length < PROBE_MAX_RESPONSE_CHARS) {
       const { done, value } = await reader.read();
       if (value && value.byteLength > 0) {
-        text += decoder.decode(value, { stream: true });
+        // Decode only what fits in the remaining budget. Decoding the whole
+        // chunk first would let one large write blow past the cap — the bound
+        // has to be applied to the bytes, not checked after the fact.
+        const remaining = PROBE_MAX_RESPONSE_CHARS - text.length;
+        text += decoder.decode(value.subarray(0, remaining), { stream: true });
         // Checked per chunk: a frame can arrive split, and a partial JSON just
         // fails to parse and waits for the rest.
         if (looksLikeInitializeResult(text)) return true;

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -802,7 +802,8 @@ async function probeResponseIsHealthy(
   // `Unexpected content type` before it ever looks at the body. Accepting a
   // well-formed result served as `text/plain` would call that server healthy and
   // then hand its failure to us as neutral `infra_error`, when it is the PR's.
-  if (!hasTransportMediaType(response)) return false;
+  const mode = transportPayloadMode(response);
+  if (mode === null) return false;
 
   const body = (response as { body?: unknown }).body as
     | ReadableStream<Uint8Array>
@@ -812,7 +813,7 @@ async function probeResponseIsHealthy(
     // No streaming body available (a buffered runtime, or a test stub): the
     // payload is already in hand, so reading it cannot block — and nothing more
     // is coming, so an unterminated last event is all we will ever get.
-    return carriesAcceptedAnswer(await response.text(), accepts, true);
+    return carriesAcceptedAnswer(await response.text(), accepts, true, mode);
   }
 
   const reader = body.getReader();
@@ -836,16 +837,16 @@ async function probeResponseIsHealthy(
         // Checked per chunk: a frame can arrive split, and a partial JSON just
         // fails to parse and waits for the rest. Mid-stream, so an event whose
         // terminating blank line has not arrived yet is held, not parsed.
-        if (carriesAcceptedAnswer(text, accepts, false)) return true;
+        if (carriesAcceptedAnswer(text, accepts, false, mode)) return true;
       }
       if (done) {
         text += decoder.decode();
-        return carriesAcceptedAnswer(text, accepts, true);
+        return carriesAcceptedAnswer(text, accepts, true, mode);
       }
     }
     // Out of byte budget. Nothing further will be read, so this is the last look:
     // parse whatever the truncated tail holds rather than discarding it.
-    return carriesAcceptedAnswer(text, accepts, true);
+    return carriesAcceptedAnswer(text, accepts, true, mode);
   } finally {
     // We are done with this response either way — a healthy server is still
     // holding the stream open, so drop it rather than leaking the socket.
@@ -854,16 +855,29 @@ async function probeResponseIsHealthy(
 }
 
 /**
- * Whether the response declares a media type the streamable-HTTP transport can
- * consume. Compared on the essence only — parameters (`; charset=utf-8`) are
- * legal and the transport ignores them too. A missing header is a rejection: the
- * transport has nothing to match and fails the same way.
+ * How the streamable-HTTP transport would read this response's body, or `null`
+ * if it would refuse to read it at all.
+ *
+ * The transport does not sniff the body: it switches on the declared media type,
+ * handing `text/event-stream` to its EventSource parser and `application/json`
+ * to `response.json()`. So the header decides which framing is in force, and the
+ * OTHER framing is not a fallback — an SSE-framed body under `application/json`
+ * makes `response.json()` throw, and a bare JSON body under `text/event-stream`
+ * yields no events at all, leaving the client's `initialize` unanswered until it
+ * times out. Either way that server is unusable, and accepting it here would
+ * turn the PR's fault into our neutral `infra_error`.
+ *
+ * Compared on the essence only — parameters (`; charset=utf-8`) are legal and
+ * the transport ignores them too. A missing header is a rejection: the transport
+ * has nothing to match and fails the same way.
  */
-function hasTransportMediaType(response: Response): boolean {
+function transportPayloadMode(response: Response): "json" | "sse" | null {
   const header = response.headers?.get?.("content-type");
-  if (typeof header !== "string") return false;
+  if (typeof header !== "string") return null;
   const essence = header.split(";", 1)[0].trim().toLowerCase();
-  return essence === "application/json" || essence === "text/event-stream";
+  if (essence === "application/json") return "json";
+  if (essence === "text/event-stream") return "sse";
+  return null;
 }
 
 /**
@@ -875,9 +889,10 @@ function hasTransportMediaType(response: Response): boolean {
 function carriesAcceptedAnswer(
   text: string,
   accepts: (parsed: unknown) => boolean,
-  streamEnded: boolean
+  streamEnded: boolean,
+  mode: "json" | "sse"
 ): boolean {
-  for (const payload of ssePayloads(text, streamEnded)) {
+  for (const payload of candidatePayloads(text, streamEnded, mode)) {
     try {
       if (accepts(JSON.parse(payload))) return true;
     } catch {
@@ -888,13 +903,44 @@ function carriesAcceptedAnswer(
 }
 
 /**
- * The candidate JSON payloads in a probe response body.
+ * The candidate JSON payloads in the body, framed the way its declared media
+ * type says to frame them.
+ */
+function candidatePayloads(
+  text: string,
+  streamEnded: boolean,
+  mode: "json" | "sse"
+): string[] {
+  return mode === "sse"
+    ? ssePayloads(text, streamEnded)
+    : jsonPayloads(text, streamEnded);
+}
+
+/**
+ * The one candidate payload in an `application/json` body: the whole body.
  *
- * SSE framing is detected by a line that STARTS with `data:`, not by the
- * substring appearing anywhere: a single-line JSON body can legitimately contain
- * "data:" inside a string (a serverInfo name, an instructions blob, a tool
- * description), and treating that as SSE yielded zero payloads and a false
- * `server_unhealthy`.
+ * Withheld until the body is complete, because `response.json()` is what the
+ * transport calls and that needs the whole thing. Deciding early would also let
+ * a server whose body is one valid JSON document followed by more content (a
+ * second document, trailing junk) be accepted at the instant the first document
+ * lands — and `response.json()` rejects exactly that, so the client would fail
+ * where the probe passed.
+ */
+function jsonPayloads(text: string, streamEnded: boolean): string[] {
+  if (!streamEnded) return [];
+  const document = text.trim();
+  return document ? [document] : [];
+}
+
+/**
+ * The candidate JSON payloads in a `text/event-stream` body: the data of each
+ * complete event.
+ *
+ * A payload comes only from a line that STARTS with `data:` — a body under this
+ * media type that carries no such line carries no events, and the transport's
+ * EventSource parser would surface nothing to the client no matter how valid the
+ * JSON in it looks. (Which is also why "data:" appearing INSIDE a JSON string —
+ * a serverInfo name, an instructions blob, a tool description — is not a frame.)
  *
  * Within one event, consecutive `data:` fields are JOINED with newlines, per SSE
  * semantics. A server that spreads one JSON-RPC message across several fields is
@@ -912,7 +958,6 @@ function carriesAcceptedAnswer(
 function ssePayloads(text: string, streamEnded: boolean): string[] {
   const payloads: string[] = [];
   let current: string[] = [];
-  let sawFrame = false;
   const flush = () => {
     if (current.length > 0) {
       payloads.push(current.join("\n"));
@@ -938,7 +983,6 @@ function ssePayloads(text: string, streamEnded: boolean): string[] {
   for (let index = 0; index < lineCount; index += 1) {
     const line = segments[index];
     if (line.startsWith("data:")) {
-      sawFrame = true;
       current.push(line.slice("data:".length).trim());
       continue;
     }
@@ -947,12 +991,6 @@ function ssePayloads(text: string, streamEnded: boolean): string[] {
     if (line === "") flush();
   }
   if (streamEnded) flush();
-
-  if (!sawFrame) {
-    // Not SSE at all: a plain JSON body. Mid-stream it may be half-written, which
-    // just fails to parse — no framing to get wrong, so hand it over either way.
-    return text ? [text] : [];
-  }
   return payloads.filter((payload) => payload.length > 0);
 }
 

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -255,13 +255,17 @@ async function runForeground(
      * exit code, which would otherwise land in the transport branch below and
      * conclude `neutral`, letting a hanging build dodge a red check.
      *
-     * Decided by ELAPSED TIME against the deadline we set, and by nothing else.
-     * The error's identity cannot be used: E2B raises `TimeoutError` for
-     * `Code.Unavailable` and `Code.Canceled` as well as `DeadlineExceeded`, so
-     * matching on the name would report an E2B outage during `npm ci` as the
-     * PR's broken build — a red X on a good PR, the one failure this taxonomy
-     * exists to prevent. Elapsed time is exact here, since the deadline is what
-     * fires the abort.
+     * Two conditions, and both must hold: the clock we set is genuinely spent,
+     * AND the error does not identify itself as a transport failure.
+     *
+     * Neither alone is enough, in opposite directions. The error's NAME cannot
+     * decide it, because E2B raises `TimeoutError` for `Code.Unavailable` and
+     * `Code.Canceled` too — an E2B outage during `npm ci` would become the PR's
+     * broken build. Elapsed time cannot decide it alone either, because an
+     * outage that happens to surface after the deadline would be attributed the
+     * same way. So the clock opens the door and E2B's own description of the
+     * failure can still close it, which biases every uncertain case toward
+     * `infra_error` (neutral) rather than a red X on a good PR.
      */
     timeoutOutcome: CheckStepOutcome;
   }
@@ -286,7 +290,10 @@ async function runForeground(
         stderr: exit.stderr ?? "",
       };
     }
-    if (Date.now() - startedAt >= opts.timeoutMs) {
+    if (
+      Date.now() - startedAt >= opts.timeoutMs &&
+      !looksLikeSandboxTransportFailure(error)
+    ) {
       throw new CheckStepError(
         opts.timeoutOutcome,
         `command exceeded its ${Math.round(opts.timeoutMs / 1000)}s deadline`,
@@ -299,6 +306,20 @@ async function runForeground(
       `sandbox command failed: ${errorMessage(error)}`
     );
   }
+}
+
+/**
+ * Does the error say the SANDBOX failed, rather than the command overrunning?
+ *
+ * E2B funnels three distinct RPC conditions into one `TimeoutError`, and only
+ * `DeadlineExceeded` is the command's own deadline. The other two describe
+ * themselves unmistakably — the sandbox being unavailable, or the per-request
+ * timeout — and those are ours, not the PR's.
+ */
+function looksLikeSandboxTransportFailure(error: unknown): boolean {
+  return /requestTimeoutMs|sandbox timeout|handshake|unavailable|canceled|cancelled/i.test(
+    errorMessage(error)
+  );
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -647,7 +647,14 @@ function buildCommandScript(buildCommand: string): string {
       ` if [ "$(wc -c < ${BUILD_LOG_PATH} 2>/dev/null || echo 0)" -gt ${SERVER_LOG_MAX_BYTES} ];` +
       ` then : > ${BUILD_LOG_PATH}; fi; done ) &`,
     `MCPJAM_WATCHDOG=$!`,
-    `${buildCommand} >> ${BUILD_LOG_PATH} 2>&1`,
+    // The recipe runs in its OWN shell, and the redirection is applied to that
+    // shell rather than to the recipe text. A redirection binds to one simple
+    // command, so `npm ci && npm run build >> log` would send only `npm run
+    // build`'s output to the file and let `npm ci` stream into the accumulating
+    // handle — which is most of a build's output, and the whole point of the
+    // redirection. Wrapping also keeps the recipe's shell state (`cd`, `exit`,
+    // `set -e`) from reaching this script's watchdog cleanup.
+    `bash -lc ${shellQuote(buildCommand)} >> ${BUILD_LOG_PATH} 2>&1`,
     `MCPJAM_STATUS=$?`,
     `kill $MCPJAM_WATCHDOG 2>/dev/null || :`,
     `exit $MCPJAM_STATUS`,

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -162,6 +162,21 @@ const HEALTH_PROBE_ACCEPTED_VERSIONS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The subset of the above the MODERN negotiation arm can speak.
+ *
+ * A `server/discover` result is only evidence of a usable server if the versions
+ * it offers overlap THIS set. A discover answer naming nothing but legacy
+ * revisions asserts nothing about the modern arm — the client would fall back to
+ * `initialize` for such a server, and whether that fallback works is exactly what
+ * the legacy probe is for. Accepting it here would let a half-broken endpoint
+ * (answers discover, cannot actually serve a modern session) read as healthy off
+ * the arm that never proved it.
+ */
+const MODERN_PROBE_ACCEPTED_VERSIONS: ReadonlySet<string> = new Set([
+  MODERN_PROBE_PROTOCOL_VERSION,
+]);
+
+/**
  * Make untrusted PR output safe to put in a GitHub check body.
  *
  * Mirrors the backend's `clampCheckOutput` (the two repos share no code). Three
@@ -788,8 +803,9 @@ async function probeResponseIsHealthy(
     | undefined;
   if (!body || typeof body.getReader !== "function") {
     // No streaming body available (a buffered runtime, or a test stub): the
-    // payload is already in hand, so reading it cannot block.
-    return carriesAcceptedAnswer(await response.text(), accepts);
+    // payload is already in hand, so reading it cannot block — and nothing more
+    // is coming, so an unterminated last event is all we will ever get.
+    return carriesAcceptedAnswer(await response.text(), accepts, true);
   }
 
   const reader = body.getReader();
@@ -811,15 +827,18 @@ async function probeResponseIsHealthy(
         remainingBytes -= consumed;
         text += decoder.decode(value.subarray(0, consumed), { stream: true });
         // Checked per chunk: a frame can arrive split, and a partial JSON just
-        // fails to parse and waits for the rest.
-        if (carriesAcceptedAnswer(text, accepts)) return true;
+        // fails to parse and waits for the rest. Mid-stream, so an event whose
+        // terminating blank line has not arrived yet is held, not parsed.
+        if (carriesAcceptedAnswer(text, accepts, false)) return true;
       }
       if (done) {
         text += decoder.decode();
-        return carriesAcceptedAnswer(text, accepts);
+        return carriesAcceptedAnswer(text, accepts, true);
       }
     }
-    return carriesAcceptedAnswer(text, accepts);
+    // Out of byte budget. Nothing further will be read, so this is the last look:
+    // parse whatever the truncated tail holds rather than discarding it.
+    return carriesAcceptedAnswer(text, accepts, true);
   } finally {
     // We are done with this response either way — a healthy server is still
     // holding the stream open, so drop it rather than leaking the socket.
@@ -835,9 +854,10 @@ async function probeResponseIsHealthy(
  */
 function carriesAcceptedAnswer(
   text: string,
-  accepts: (parsed: unknown) => boolean
+  accepts: (parsed: unknown) => boolean,
+  streamEnded: boolean
 ): boolean {
-  for (const payload of ssePayloads(text)) {
+  for (const payload of ssePayloads(text, streamEnded)) {
     try {
       if (accepts(JSON.parse(payload))) return true;
     } catch {
@@ -859,8 +879,17 @@ function carriesAcceptedAnswer(
  * Within one event, consecutive `data:` fields are JOINED with newlines, per SSE
  * semantics. A server that spreads one JSON-RPC message across several fields is
  * legal, and parsing each line on its own made every fragment fail to parse.
+ *
+ * `streamEnded` says whether more bytes can still arrive. While the stream is
+ * live, an event whose terminating blank line has not been seen yet is INCOMPLETE
+ * and is withheld: a multi-field event read at a chunk boundary would otherwise be
+ * handed to `JSON.parse` a field short. That mostly just fails to parse, but a
+ * server whose first field happens to be a complete JSON object followed by more
+ * fields would be accepted off a truncated read. The unfinished event stays in
+ * `text`, so the next chunk simply re-parses it whole. Once the stream is over
+ * (or we stop reading), the tail is all there is, so parse it.
  */
-function ssePayloads(text: string): string[] {
+function ssePayloads(text: string, streamEnded: boolean): string[] {
   const payloads: string[] = [];
   let current: string[] = [];
   let sawFrame = false;
@@ -871,8 +900,17 @@ function ssePayloads(text: string): string[] {
     }
   };
 
-  for (const rawLine of text.split(/\n/)) {
-    const line = rawLine.replace(/\r$/, "");
+  const segments = text.split("\n");
+  // The final segment is whatever follows the last newline, so mid-stream it is a
+  // PARTIAL line, not a line. Treating it as one is subtly wrong in both
+  // directions: a half-written `data:` field would be parsed a character short,
+  // and — the case that actually bites — the empty tail left by a trailing "\n"
+  // would read as the event's blank-line terminator, flushing an event the server
+  // has not finished. A real terminator ("\n\n") shows up as an empty segment with
+  // another segment after it.
+  const lineCount = streamEnded ? segments.length : segments.length - 1;
+  for (let index = 0; index < lineCount; index += 1) {
+    const line = segments[index].replace(/\r$/, "");
     if (line.startsWith("data:")) {
       sawFrame = true;
       current.push(line.slice("data:".length).trim());
@@ -882,9 +920,13 @@ function ssePayloads(text: string): string[] {
     // carries no data but does not split it either.
     if (line === "") flush();
   }
-  flush();
+  if (streamEnded) flush();
 
-  if (!sawFrame) return text ? [text] : [];
+  if (!sawFrame) {
+    // Not SSE at all: a plain JSON body. Mid-stream it may be half-written, which
+    // just fails to parse — no framing to get wrong, so hand it over either way.
+    return text ? [text] : [];
+  }
   return payloads.filter((payload) => payload.length > 0);
 }
 
@@ -928,8 +970,9 @@ function isUsableInitializeResponse(parsed: unknown): boolean {
  *
  *   - the envelope and our id;
  *   - `supportedVersions`, a non-empty list of strings, with at least one the
- *     client can actually speak — an endpoint offering nothing in common is no
- *     more usable than a legacy server naming an unsupported version;
+ *     MODERN arm can actually speak — an endpoint offering nothing in common is
+ *     no more usable than a legacy server naming an unsupported version, and one
+ *     offering only legacy revisions is a question for the legacy probe;
  *   - `capabilities`, an object.
  *
  * Server identity lives in `_meta` here and is a SHOULD, not a member of the
@@ -947,7 +990,7 @@ function isUsableDiscoverResponse(parsed: unknown): boolean {
     (version): version is string => typeof version === "string"
   );
   if (offered.length !== discover.supportedVersions.length) return false;
-  if (!offered.some((version) => HEALTH_PROBE_ACCEPTED_VERSIONS.has(version))) {
+  if (!offered.some((version) => MODERN_PROBE_ACCEPTED_VERSIONS.has(version))) {
     return false;
   }
   return isPlainObject(discover.capabilities);

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -26,6 +26,7 @@
  */
 
 import { Sandbox } from "e2b";
+import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "../../utils/logger.js";
 import type { CheckRecipe } from "./recipes.js";
 
@@ -723,7 +724,8 @@ async function probeResponseIsHealthy(response: Response): Promise<boolean> {
 }
 
 /**
- * A successful `initialize` carries a `result` with a `protocolVersion`. An
+ * A successful `initialize` carries a `result` with a SUPPORTED
+ * `protocolVersion`. An
  * error response is still a live MCP server, but not a usable one — the eval
  * run's own handshake would fail the same way, so treat it as not-yet-healthy
  * and keep polling until the deadline.
@@ -746,7 +748,16 @@ function looksLikeInitializeResult(text: string): boolean {
       const parsed = JSON.parse(payload) as {
         result?: { protocolVersion?: unknown };
       };
-      if (parsed?.result && "protocolVersion" in (parsed.result ?? {})) {
+      // The version has to be one the real client will ACCEPT, not merely
+      // present. A server answering `protocolVersion: "bogus"` looks healthy
+      // here, and then the eval run's own handshake rejects it — surfacing as
+      // `infra_error` (neutral) and letting a broken PR server dodge the
+      // `server_unhealthy` it earned.
+      const version = parsed?.result?.protocolVersion;
+      if (
+        typeof version === "string" &&
+        SUPPORTED_PROTOCOL_VERSIONS.includes(version)
+      ) {
         return true;
       }
     } catch {

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -122,12 +122,21 @@ const SERVER_LOG_MAX_BYTES = 4 * 1024 * 1024;
 const SERVER_LOG_CHECK_SECONDS = 30;
 
 /**
- * The protocol version we offer in the health probe. Deliberately a plain
- * constant rather than the connect-form list: this probe only has to prove a
- * server is up and speaking MCP, and a server that negotiates down still
- * answers.
+ * The protocol version the legacy probe OFFERS, which is the one the eval run's
+ * client offers: `_legacyHandshake` sends `legacyVersions[0]`, and an unpinned
+ * connection leaves that list to the SDK's built-in `SUPPORTED_PROTOCOL_VERSIONS`,
+ * whose first entry is the latest legacy revision.
+ *
+ * Offering something older would probe a handshake the eval never performs. A
+ * server whose `2025-06-18` path works while its latest path is broken would pass
+ * here and then fail the eval, and that failure would reach us as a neutral
+ * `infra_error` instead of the PR's `server_unhealthy`.
+ *
+ * This is only what we PROPOSE. `LEGACY_PROBE_ACCEPTED_VERSIONS` is what we accept
+ * back, and it stays wide, because a server that negotiates down is one the client
+ * accepts too.
  */
-const HEALTH_PROBE_PROTOCOL_VERSION = "2025-06-18";
+const HEALTH_PROBE_PROTOCOL_VERSION = "2025-11-25";
 
 /** The version the modern-era probe self-describes with. */
 const MODERN_PROBE_PROTOCOL_VERSION = "2026-07-28";

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -95,6 +95,12 @@ export const HEALTH_INTERVAL_MS = 2_000;
  * point is that an unresponsive one cannot outlive the overall window.
  */
 export const PROBE_ATTEMPT_TIMEOUT_MS = 10_000;
+/**
+ * Cap on how much of a probe response we read before deciding. The answer we are
+ * looking for is the first frame; anything past this is a server streaming at us,
+ * not a handshake.
+ */
+export const PROBE_MAX_RESPONSE_CHARS = 64 * 1024;
 /** Where the PR is checked out inside the box. */
 export const CHECKOUT_DIR = "/home/user/repo";
 
@@ -508,15 +514,17 @@ export async function waitForMcpInitialize(
         // bounded too.
         signal: abort.signal,
       });
-      if (response.ok) {
-        const text = await response.text();
-        if (looksLikeInitializeResult(text)) return true;
+      if (response.ok && (await probeResponseIsHealthy(response))) {
+        return true;
       }
     } catch {
       // Connection refused, DNS not ready, or our own abort — all expected
       // while it boots, all "not healthy yet".
     } finally {
       clearTimeout(abortTimer);
+      // Tear the request down unconditionally. A streamable-HTTP server holds the
+      // response stream open after answering, and we have our answer.
+      abort.abort();
     }
     if (now() + intervalMs > deadline) break;
     await pause(intervalMs);
@@ -526,6 +534,58 @@ export async function waitForMcpInitialize(
     attempts,
   });
   return false;
+}
+
+/**
+ * Decide from the probe response WITHOUT waiting for the body to end.
+ *
+ * `response.text()` cannot be used here. A streamable-HTTP MCP server answers
+ * `initialize` on an SSE stream and then KEEPS THAT STREAM OPEN — that is the
+ * whole point of the transport. `text()` only resolves when the body ends, so it
+ * would never resolve against a healthy server: every attempt would hit its
+ * abort timer and the check would report `server_unhealthy` for a server that
+ * answered correctly in milliseconds. (The fixture happens to close after each
+ * response, which is exactly why this could pass its tests and still fail on a
+ * real server.)
+ *
+ * So read incrementally and return the moment the accumulated text carries an
+ * initialize result, then cancel the stream. `PROBE_MAX_RESPONSE_CHARS` bounds
+ * a server that streams unrelated output at us forever.
+ */
+async function probeResponseIsHealthy(response: Response): Promise<boolean> {
+  const body = (response as { body?: unknown }).body as
+    | ReadableStream<Uint8Array>
+    | null
+    | undefined;
+  if (!body || typeof body.getReader !== "function") {
+    // No streaming body available (a buffered runtime, or a test stub): the
+    // payload is already in hand, so reading it cannot block.
+    return looksLikeInitializeResult(await response.text());
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  try {
+    while (text.length < PROBE_MAX_RESPONSE_CHARS) {
+      const { done, value } = await reader.read();
+      if (value && value.byteLength > 0) {
+        text += decoder.decode(value, { stream: true });
+        // Checked per chunk: a frame can arrive split, and a partial JSON just
+        // fails to parse and waits for the rest.
+        if (looksLikeInitializeResult(text)) return true;
+      }
+      if (done) {
+        text += decoder.decode();
+        return looksLikeInitializeResult(text);
+      }
+    }
+    return looksLikeInitializeResult(text);
+  } finally {
+    // We are done with this response either way — a healthy server is still
+    // holding the stream open, so drop it rather than leaking the socket.
+    void reader.cancel().catch(() => {});
+  }
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -113,6 +113,10 @@ const STDERR_TAIL_CHARS = 8_000;
 
 /** Where the PR's server writes stdout+stderr, inside the box. */
 const SERVER_LOG_PATH = "/tmp/mcp-server.log";
+/** Cap on that file. A watchdog truncates it; see `startCommandScript`. */
+const SERVER_LOG_MAX_BYTES = 4 * 1024 * 1024;
+/** How often the watchdog checks the log's size. */
+const SERVER_LOG_CHECK_SECONDS = 30;
 
 /**
  * The protocol version we offer in the health probe. Deliberately a plain
@@ -478,7 +482,7 @@ export async function buildAndStart(
     // heap without limit, which no client-side ring buffer can prevent. Nothing
     // is streamed now; the tail is fetched, bounded, only if we need it.
     await sandbox.commands.run(
-      `bash -lc ${shellQuote(`${recipe.start} > ${SERVER_LOG_PATH} 2>&1`)}`,
+      `bash -lc ${shellQuote(startCommandScript(recipe.start))}`,
       {
         cwd: CHECKOUT_DIR,
         background: true,
@@ -517,6 +521,34 @@ export async function buildAndStart(
 }
 
 /**
+ * The PR's start command, wrapped so its output is bounded on BOTH sides.
+ *
+ * Redirecting to a file keeps untrusted output out of this process's heap (see
+ * the spawn site), but a file alone is just the same denial-of-service moved to
+ * the sandbox's disk: a server that logs continuously fills it, and `ENOSPC` can
+ * take down the very server we are evaluating — turning a chatty PR into a
+ * failing one. So a watchdog truncates the log whenever it grows past the cap.
+ *
+ * Details that matter:
+ *   - APPEND (`>>`), not truncate (`>`). With `>` the writer keeps its offset
+ *     across a truncation, leaving a sparse hole whose tail reads as NUL padding;
+ *     `O_APPEND` restarts cleanly at zero and keeps `tail -c` meaningful.
+ *   - `exec` for the server, so it replaces the shell and kill/signal semantics
+ *     stay those of the process itself.
+ *   - the watchdog is a child of that shell and needs no cleanup: it dies with
+ *     the sandbox, and if it dies early the only consequence is an unbounded log.
+ */
+function startCommandScript(startCommand: string): string {
+  return [
+    `: > ${SERVER_LOG_PATH}`,
+    `( while :; do sleep ${SERVER_LOG_CHECK_SECONDS};` +
+      ` if [ "$(wc -c < ${SERVER_LOG_PATH} 2>/dev/null || echo 0)" -gt ${SERVER_LOG_MAX_BYTES} ];` +
+      ` then : > ${SERVER_LOG_PATH}; fi; done ) &`,
+    `exec ${startCommand} >> ${SERVER_LOG_PATH} 2>&1`,
+  ].join("\n");
+}
+
+/**
  * Fetch a bounded tail of the PR server's log, from inside the box.
  *
  * `tail -c` does the truncation in the sandbox, so untrusted output is bounded
@@ -527,7 +559,9 @@ export async function buildAndStart(
 async function readLogTail(sandbox: CheckSandbox): Promise<string> {
   try {
     const result = (await sandbox.commands.run(
-      `bash -lc ${shellQuote(`tail -c ${STDERR_TAIL_CHARS} ${SERVER_LOG_PATH} 2>/dev/null || true`)}`,
+      `bash -lc ${shellQuote(
+        `tail -c ${STDERR_TAIL_CHARS} ${SERVER_LOG_PATH} 2>/dev/null || true`
+      )}`,
       { timeoutMs: 30_000 }
     )) as { stdout?: string } | undefined;
     return result?.stdout ?? "";

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -936,6 +936,9 @@ function jsonPayloads(text: string, streamEnded: boolean): string[] {
  * The candidate JSON payloads in a `text/event-stream` body: the data of each
  * complete event.
  *
+ * Only events the transport would actually dispatch count: unnamed or named
+ * `message` (see `flush`), and carrying data.
+ *
  * A payload comes only from a line that STARTS with `data:` — a body under this
  * media type that carries no such line carries no events, and the transport's
  * EventSource parser would surface nothing to the client no matter how valid the
@@ -958,11 +961,20 @@ function jsonPayloads(text: string, streamEnded: boolean): string[] {
 function ssePayloads(text: string, streamEnded: boolean): string[] {
   const payloads: string[] = [];
   let current: string[] = [];
+  let eventName = "";
   const flush = () => {
-    if (current.length > 0) {
+    // The transport dispatches an event's data only when the event is UNNAMED or
+    // named `message`; anything else (`event: ping`, `event: error`, a server's
+    // own progress channel) is dropped before it reaches the JSON parser. So a
+    // handshake answer smuggled inside a named event never arrives, the eval
+    // run's `initialize` goes unanswered, and reading it here would hand the PR's
+    // fault to us as a neutral `infra_error`. An empty `event:` value counts as
+    // unnamed, which is also how the spec dispatches it.
+    if (current.length > 0 && (eventName === "" || eventName === "message")) {
       payloads.push(current.join("\n"));
-      current = [];
     }
+    current = [];
+    eventName = "";
   };
 
   // LF, CRLF and bare CR are all legal SSE line separators, and a leading BOM is
@@ -986,7 +998,12 @@ function ssePayloads(text: string, streamEnded: boolean): string[] {
       current.push(line.slice("data:".length).trim());
       continue;
     }
-    // A blank line ends the event. Any other field (`event:`, `id:`, a comment)
+    if (line.startsWith("event:")) {
+      // Last one wins within an event, per the spec.
+      eventName = line.slice("event:".length).trim();
+      continue;
+    }
+    // A blank line ends the event. Any other field (`id:`, `retry:`, a comment)
     // carries no data but does not split it either.
     if (line === "") flush();
   }

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -703,7 +703,7 @@ export async function waitForMcpInitialize(
         signal: abort.signal,
       });
       if (
-        response.ok &&
+        transportProcessesBody(response) &&
         (await probeResponseIsHealthy(response, era.accepts))
       ) {
         return true;
@@ -882,6 +882,24 @@ async function probeResponseIsHealthy(
     // holding the stream open, so drop it rather than leaking the socket.
     void reader.cancel().catch(() => {});
   }
+}
+
+/**
+ * Whether the transport would read this response's body as an answer to the
+ * request at all — as opposed to discarding it.
+ *
+ * `ok` is not the test. HTTP 202 is an ACKNOWLEDGEMENT: the transport drains the
+ * body, throws it away, and returns before any result processing, so a handshake
+ * result served with 202 never reaches the client and its `initialize` goes
+ * unanswered. Accepting one here would call that server healthy and then hand its
+ * failure to us as a neutral `infra_error`.
+ *
+ * Only 202 is excluded, not "everything but 200": the transport processes any other
+ * 2xx by content type, so rejecting a 201 or 203 that carries a real answer would
+ * be stricter than the client and risk a false `server_unhealthy`.
+ */
+function transportProcessesBody(response: Response): boolean {
+  return response.ok && response.status !== 202;
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -823,6 +823,10 @@ async function probeResponseIsHealthy(
   // UTF-16 units, so budgeting by it would let non-ASCII output read more of the
   // wire than the cap allows — the slice below is in bytes either way.
   let remainingBytes = PROBE_MAX_RESPONSE_BYTES;
+  // Set when the cap cut a chunk we had already been handed, which proves the body
+  // is longer than what we kept. Without it, dropping those bytes and then reading
+  // EOF would look exactly like a body that ended at the cap.
+  let droppedBytes = false;
   try {
     while (remainingBytes > 0) {
       const { done, value } = await reader.read();
@@ -832,6 +836,7 @@ async function probeResponseIsHealthy(
         // cut in half here is held by the decoder (`stream: true`) and completed
         // by the next chunk, or dropped if the budget runs out first.
         const consumed = Math.min(value.byteLength, remainingBytes);
+        if (consumed < value.byteLength) droppedBytes = true;
         remainingBytes -= consumed;
         text += decoder.decode(value.subarray(0, consumed), { stream: true });
         // Checked per chunk: an SSE event completes the moment its blank line
@@ -843,10 +848,24 @@ async function probeResponseIsHealthy(
         return carriesAcceptedAnswer(text, accepts, true, mode);
       }
     }
-    // Out of byte budget — which is NOT the body ending. We stop reading; the eval
-    // run's client does not, so a JSON body must not be judged on this prefix even
-    // if the prefix happens to parse. Whatever the cap cut off is the client's
-    // problem to hit, not ours to guess at.
+    // Out of byte budget. Reaching the cap is NOT the body ending — we stop
+    // reading, the client does not — so a JSON prefix must not be judged as a whole
+    // document just because it happens to parse.
+    //
+    // But a body measuring EXACTLY the cap has ended, and nothing so far can say
+    // so: `done` never rides along with the last chunk, it takes one more read. A
+    // complete answer that lands on the boundary is a working server, so refusing to
+    // look would be a false `server_unhealthy` — the error worth avoiding. So take
+    // that read, unless the cap already cut a chunk short (then the body is provably
+    // longer and EOF here would be EOF of bytes we discarded). SSE never needs any
+    // of this: an event is complete at its blank line, whatever the body does next.
+    if (mode === "json" && !droppedBytes) {
+      const { done } = await reader.read();
+      if (done) {
+        text += decoder.decode();
+        return carriesAcceptedAnswer(text, accepts, true, mode);
+      }
+    }
     return carriesAcceptedAnswer(text, accepts, false, mode);
   } finally {
     // We are done with this response either way — a healthy server is still
@@ -943,11 +962,12 @@ function jsonPayloads(text: string, bodyComplete: boolean): string[] {
  * Only events the transport would actually dispatch count: unnamed or named
  * `message` (see `flush`), and carrying data.
  *
- * A payload comes only from a line that STARTS with `data:` — a body under this
- * media type that carries no such line carries no events, and the transport's
- * EventSource parser would surface nothing to the client no matter how valid the
- * JSON in it looks. (Which is also why "data:" appearing INSIDE a JSON string —
- * a serverInfo name, an instructions blob, a tool description — is not a frame.)
+ * A payload comes only from a `data` FIELD — a body under this media type that
+ * carries no such field carries no events, and the transport's EventSource parser
+ * would surface nothing to the client no matter how valid the JSON in it looks.
+ * (Which is also why "data:" appearing INSIDE a JSON string — a serverInfo name,
+ * an instructions blob, a tool description — is not a field: field names are read
+ * from the start of a line, never matched as a substring.)
  *
  * Within one event, consecutive `data:` fields are JOINED with newlines, per SSE
  * semantics. A server that spreads one JSON-RPC message across several fields is
@@ -999,36 +1019,57 @@ function ssePayloads(text: string): string[] {
   const lineCount = segments.length - 1;
   for (let index = 0; index < lineCount; index += 1) {
     const line = segments[index];
-    if (line.startsWith("data:")) {
-      current.push(sseFieldValue(line, "data:"));
+    // A blank line ends the event, and is the ONLY thing that does. Checked first
+    // because the parser reaches its dispatch before it ever looks at fields.
+    if (line === "") {
+      flush();
       continue;
     }
-    if (line.startsWith("event:")) {
+    const [field, value] = sseField(line);
+    if (field === "data") {
+      current.push(value);
+      continue;
+    }
+    if (field === "event") {
       // Last one wins within an event, per the spec.
-      eventName = sseFieldValue(line, "event:");
+      eventName = value;
       continue;
     }
-    // A blank line ends the event. Any other field (`id:`, `retry:`, a comment)
-    // carries no data but does not split it either.
-    if (line === "") flush();
+    // `id`, `retry`, a comment, an unknown field: carries no data, and does not
+    // split the event either. (Unknown fields are reported to an `onError` the
+    // transport does not pass, so they are ignored rather than fatal.)
   }
   return payloads.filter((payload) => payload.length > 0);
 }
 
 /**
- * The value of an SSE field line, stripped exactly the way the transport's parser
- * strips it: ONE optional space after the colon, and nothing else.
+ * One SSE line split into field name and value, by the transport's parser's rules.
  *
- * Trimming instead is wrong in a way that matters for `event:`. The parser keeps
- * the rest of the whitespace, so `event: message ` is the event type `"message "`,
- * which is not `"message"` and is therefore dropped — while a trim would normalise
- * it to `message` and let the probe accept an answer the eval run never receives.
- * For `data:` the difference is invisible to `JSON.parse`, but a payload assembled
- * from several fields is joined verbatim, so the same rule keeps that text intact.
+ * The name runs to the first colon and the value is what follows, minus ONE
+ * optional space — not trimmed. That matters for `event:`: the parser keeps the
+ * rest of the whitespace, so `event: message ` is the event type `"message "`,
+ * which is not `"message"` and is therefore dropped. A trim would normalise it and
+ * accept an answer the eval run never receives. For `data:` the difference is
+ * invisible to `JSON.parse`, but fields are joined verbatim, so the same rule keeps
+ * a multi-field payload's text intact.
+ *
+ * A line with NO colon is that field with an EMPTY value, not a line to skip. So a
+ * bare `event` CLEARS the event type (`eventType = value || void 0` in the parser)
+ * and the next dispatch is an unnamed `message` — it does not inherit the name from
+ * an earlier `event:` line. Skipping the line kept the stale name and discarded an
+ * answer the client does receive, which is a false `server_unhealthy`.
+ *
+ * A leading colon makes the name empty, which is how comments fall through to being
+ * ignored.
  */
-function sseFieldValue(line: string, field: string): string {
-  const value = line.slice(field.length);
-  return value.startsWith(" ") ? value.slice(1) : value;
+function sseField(line: string): [string, string] {
+  const separator = line.indexOf(":");
+  if (separator === -1) return [line, ""];
+  const value = line.slice(separator + 1);
+  return [
+    line.slice(0, separator),
+    value.startsWith(" ") ? value.slice(1) : value,
+  ];
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -1160,7 +1160,8 @@ function isUsableCapabilities(value: unknown): boolean {
  *     MODERN arm can actually speak — an endpoint offering nothing in common is
  *     no more usable than a legacy server naming an unsupported version, and one
  *     offering only legacy revisions is a question for the legacy probe;
- *   - `capabilities` and `instructions` as the discover result schema types them.
+ *   - `capabilities` and `instructions` as the MODERN discover result schema types
+ *     them, which is not the same schema the legacy arm's era uses.
  *
  * Unlike the legacy arm, this one has a schema to mirror and mirrors it. The client
  * runs the discover result through `codecForVersion(...).validateResult`, and a
@@ -1209,20 +1210,34 @@ const CAPABILITY_BOOLEAN_FLAGS: ReadonlyArray<
 ];
 
 /**
- * Whether `capabilities` would survive `ServerCapabilitiesSchema`, the schema the
- * client validates a `server/discover` result with.
+ * Whether `capabilities` would survive the schema the client validates a
+ * `server/discover` result with.
  *
- * Mirrored field by field rather than shape-only, because the schema types the
- * nesting: `tools: { listChanged: "yes" }` and `extensions: true` are both objects
- * at the top level and both rejected a level down. A probe that stops at "is it an
- * object" reports the modern arm healthy for a server the client declines to drive
- * there.
+ * That schema is `ServerCapabilities2026Schema`, reached through
+ * `codecForVersion(MODERN_WIRE_REVISION).validateResult("server/discover", …)` —
+ * the rev2026 codec. NOT the `ServerCapabilitiesSchema` that the 2025 codec uses
+ * for `initialize`. The two are close but not identical, and the difference is
+ * load-bearing: the 2026 schema is built from the SEVEN shared members below and
+ * omits `tasks` entirely, so a modern server advertising `tasks` in any shape at
+ * all has it stripped as an unknown member and negotiates fine. Validating it here
+ * rejected servers the client drives — a false `server_unhealthy`.
+ *
+ * Mirrored field by field rather than shape-only, because the schema does type the
+ * nesting of the members it defines: `tools: { listChanged: "yes" }` and
+ * `extensions: true` are both objects at the top level and both rejected a level
+ * down. A probe that stops at "is it an object" reports the modern arm healthy for
+ * a server the client declines to drive there.
  *
  * Unknown keys stay welcome, at every level the schema leaves open: the capability
  * objects are non-strict, so extra members are ignored rather than fatal, and
  * capabilities is explicitly "not a closed set". Only the members it gives a type
  * are checked. `JSONObject`-typed fields need only be objects — anything that came
  * off the wire as JSON already satisfies the value type.
+ *
+ * The result's own `ttlMs` and `cacheScope` are not checked either: the modern
+ * schema declares them with `.catch(…)`, so a malformed value is replaced with a
+ * default and can never fail validation. Checking them would be strictly stricter
+ * than the client.
  */
 function matchesServerCapabilitiesSchema(value: unknown): boolean {
   if (!isPlainObject(value)) return false;
@@ -1254,33 +1269,10 @@ function matchesServerCapabilitiesSchema(value: unknown): boolean {
     if (!flagsAreBooleans) return false;
   }
 
-  return matchesTasksCapabilitySchema(capabilities.tasks);
-}
-
-/**
- * The `tasks` capability, whose schema nests two levels deeper
- * (`requests.tools.call`) and types every level as an object.
- */
-function matchesTasksCapabilitySchema(value: unknown): boolean {
-  if (value === undefined) return true;
-  if (!isPlainObject(value)) return false;
-  const tasks = value as Record<string, unknown>;
-
-  for (const field of ["list", "cancel"] as const) {
-    const capability = tasks[field];
-    if (capability !== undefined && !isPlainObject(capability)) return false;
-  }
-
-  const requests = tasks.requests;
-  if (requests === undefined) return true;
-  if (!isPlainObject(requests)) return false;
-
-  const tools = (requests as Record<string, unknown>).tools;
-  if (tools === undefined) return true;
-  if (!isPlainObject(tools)) return false;
-
-  const call = (tools as Record<string, unknown>).call;
-  return call === undefined || isPlainObject(call);
+  // `tasks` is deliberately NOT checked. The modern schema does not define it, so
+  // it is an unknown member like any other and is stripped, not rejected — see the
+  // note above about which schema is actually in force here.
+  return true;
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -797,6 +797,13 @@ async function probeResponseIsHealthy(
   response: Response,
   accepts: (parsed: unknown) => boolean
 ): Promise<boolean> {
+  // Same gate the eval run's transport applies: a streamable-HTTP response must
+  // be `application/json` or `text/event-stream`, or the transport throws
+  // `Unexpected content type` before it ever looks at the body. Accepting a
+  // well-formed result served as `text/plain` would call that server healthy and
+  // then hand its failure to us as neutral `infra_error`, when it is the PR's.
+  if (!hasTransportMediaType(response)) return false;
+
   const body = (response as { body?: unknown }).body as
     | ReadableStream<Uint8Array>
     | null
@@ -844,6 +851,19 @@ async function probeResponseIsHealthy(
     // holding the stream open, so drop it rather than leaking the socket.
     void reader.cancel().catch(() => {});
   }
+}
+
+/**
+ * Whether the response declares a media type the streamable-HTTP transport can
+ * consume. Compared on the essence only — parameters (`; charset=utf-8`) are
+ * legal and the transport ignores them too. A missing header is a rejection: the
+ * transport has nothing to match and fails the same way.
+ */
+function hasTransportMediaType(response: Response): boolean {
+  const header = response.headers?.get?.("content-type");
+  if (typeof header !== "string") return false;
+  const essence = header.split(";", 1)[0].trim().toLowerCase();
+  return essence === "application/json" || essence === "text/event-stream";
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -1,0 +1,561 @@
+/**
+ * Turning a PR into a reachable MCP server, inside a disposable E2B sandbox.
+ *
+ * The security shape of this module is the whole point, so it is stated up
+ * front. Everything it runs is UNTRUSTED code from a pull request:
+ *
+ *   - the sandbox holds ZERO credentials. The clone is anonymous (public repo,
+ *     no token), and nothing about MCPJam's own environment is passed in;
+ *   - it runs a DEDICATED minimal template (`GITHUB_CHECKS_E2B_TEMPLATE_ID`:
+ *     node + git, nothing else), never the shared computer template;
+ *   - outbound network is DISABLED after the build and BEFORE the PR's server
+ *     starts. The build needs egress (`npm ci`); the server does not, and the
+ *     server is the part that runs for twenty minutes while an eval suite pokes
+ *     at it. If the lockdown fails we treat it as `infra_error` and never start
+ *     the server — an open-egress box running PR code is not an acceptable
+ *     degraded mode;
+ *   - inbound eval traffic still arrives through `getHost(port)`, which is why
+ *     the box is created with `allowPublicTraffic: true`. That is a one-way
+ *     door: we can reach in, the box cannot reach out.
+ *
+ * Failure attribution matters as much as failure detection. A build that exits
+ * non-zero is the PR's problem (`build_failed`); a server that never answers
+ * `initialize` is the PR's problem (`server_unhealthy`); E2B being unavailable
+ * is OUR problem (`infra_error`). `CheckStepError` carries that verdict so the
+ * worker never has to guess from an error message.
+ */
+
+import { Sandbox } from "e2b";
+import { logger } from "../../utils/logger.js";
+import type { CheckRecipe } from "./recipes.js";
+
+/** Outcomes this module can produce. A subset of the worker's full taxonomy. */
+export type CheckStepOutcome =
+  | "build_failed"
+  | "server_unhealthy"
+  | "infra_error";
+
+/**
+ * A step failure that already knows how the PR's check should conclude.
+ * `detailsMarkdown` is clamped, fenced, review-safe output (never raw).
+ */
+export class CheckStepError extends Error {
+  constructor(
+    readonly outcome: CheckStepOutcome,
+    message: string,
+    readonly detailsMarkdown?: string
+  ) {
+    super(message);
+    this.name = "CheckStepError";
+  }
+}
+
+/**
+ * Structural view of the sandbox this module needs. Narrow on purpose: the unit
+ * tests drive the whole build/start/health sequence through a fake, and a fake
+ * of four methods stays honest where a fake of the entire E2B surface would not.
+ */
+export interface CheckSandbox {
+  readonly sandboxId: string;
+  getHost(port: number): string;
+  commands: {
+    run(
+      command: string,
+      opts?: {
+        cwd?: string;
+        timeoutMs?: number;
+        background?: boolean;
+        envs?: Record<string, string>;
+        onStdout?: (data: string) => void;
+        onStderr?: (data: string) => void;
+      }
+    ): Promise<unknown>;
+  };
+  updateNetwork(network: {
+    allowInternetAccess?: boolean;
+    denyOut?: string[];
+  }): Promise<void>;
+  kill(): Promise<void>;
+}
+
+/**
+ * Worst case for one check: provision ~2m + clone/build ~10m + health ~2m +
+ * eval ~20m + overhead. 45 minutes with `onTimeout: "kill"` is the orphan
+ * backstop — if this process dies, E2B reaps the box on its own.
+ */
+export const CHECK_SANDBOX_TIMEOUT_MS = 45 * 60_000;
+/** Build is a foreground command; E2B's own default (~60s) is far too short. */
+export const BUILD_TIMEOUT_MS = 10 * 60_000;
+export const CLONE_TIMEOUT_MS = 5 * 60_000;
+export const HEALTH_TIMEOUT_MS = 2 * 60_000;
+export const HEALTH_INTERVAL_MS = 2_000;
+/** Where the PR is checked out inside the box. */
+export const CHECKOUT_DIR = "/home/user/repo";
+
+/** Cap on clamped untrusted output, in characters. */
+export const OUTPUT_CLAMP_CHARS = 4_000;
+
+/** How much stderr we keep from the started server, for a health failure. */
+const STDERR_TAIL_CHARS = 8_000;
+
+/**
+ * The protocol version we offer in the health probe. Deliberately a plain
+ * constant rather than the connect-form list: this probe only has to prove a
+ * server is up and speaking MCP, and a server that negotiates down still
+ * answers.
+ */
+const HEALTH_PROBE_PROTOCOL_VERSION = "2025-06-18";
+
+/**
+ * Make untrusted PR output safe to put in a GitHub check body.
+ *
+ * Mirrors the backend's `clampCheckOutput` (the two repos share no code). Three
+ * things: drop control characters, keep only the tail and say so, and fence with
+ * a backtick run longer than any inside the text — a build log containing ```
+ * must not be able to break out of the block and inject markdown into our
+ * message.
+ */
+export function clampOutput(text: string | null | undefined): string {
+  if (typeof text !== "string" || text.trim().length === 0) return "";
+
+  // CR is itself a control char, so normalize line endings first.
+  const normalized = stripControlCharacters(
+    text.replace(/\r\n?/g, "\n")
+  ).trimEnd();
+  if (normalized.length === 0) return "";
+
+  const truncated = normalized.length > OUTPUT_CLAMP_CHARS;
+  const body = truncated
+    ? normalized.slice(normalized.length - OUTPUT_CLAMP_CHARS)
+    : normalized;
+
+  const longestBacktickRun = Math.max(
+    0,
+    ...Array.from(body.matchAll(/`+/g), (match) => match[0].length)
+  );
+  const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
+
+  return [
+    truncated ? `_Showing the last ${OUTPUT_CLAMP_CHARS} characters._` : "",
+    `${fence}text`,
+    body,
+    fence,
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+function stripControlCharacters(text: string): string {
+  let out = "";
+  for (const char of text) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code === 0x09 || code === 0x0a) {
+      out += char;
+      continue;
+    }
+    if (code < 0x20 || code === 0x7f || (code >= 0x80 && code <= 0x9f))
+      continue;
+    out += char;
+  }
+  return out;
+}
+
+export function isGithubChecksSandboxConfigured(): boolean {
+  return Boolean(
+    process.env.E2B_API_KEY?.trim() &&
+      process.env.GITHUB_CHECKS_E2B_TEMPLATE_ID?.trim()
+  );
+}
+
+/**
+ * Create the box.
+ *
+ * The dedicated template is REQUIRED, with no fallback to the computer
+ * template: that image carries a browser, a desktop, and the tooling a
+ * Project Computer needs, none of which a PR's build should have access to.
+ * A missing template id is a deployment error, not something to paper over.
+ *
+ * `provisionEvalSandbox` (the eval-run path) cannot be reused here: it resolves
+ * its image from a run's frozen snapshot, and the run does not exist until the
+ * server this box builds is reachable — chicken and egg.
+ */
+export async function provisionCheckSandbox(args: {
+  triggerId: string;
+  repoFullName: string;
+  prNumber: number;
+}): Promise<CheckSandbox> {
+  const apiKey = process.env.E2B_API_KEY?.trim();
+  const templateId = process.env.GITHUB_CHECKS_E2B_TEMPLATE_ID?.trim();
+  if (!apiKey || !templateId) {
+    throw new CheckStepError(
+      "infra_error",
+      "github-checks sandbox requires E2B_API_KEY and GITHUB_CHECKS_E2B_TEMPLATE_ID"
+    );
+  }
+
+  try {
+    const sandbox = await Sandbox.create(templateId, {
+      apiKey,
+      timeoutMs: CHECK_SANDBOX_TIMEOUT_MS,
+      // If this process dies mid-check, E2B kills the box rather than paying to
+      // keep a snapshot of someone's PR build around.
+      lifecycle: { onTimeout: "kill" },
+      // Inbound only — the eval run reaches the server through `getHost`.
+      // Egress is revoked separately, after the build.
+      network: { allowPublicTraffic: true },
+      metadata: {
+        purpose: "github-checks",
+        triggerId: args.triggerId,
+        repoFullName: args.repoFullName,
+        prNumber: String(args.prNumber),
+      },
+    });
+    logger.info("[github-checks] sandbox provisioned", {
+      sandboxId: sandbox.sandboxId,
+      triggerId: args.triggerId,
+    });
+    return sandbox as unknown as CheckSandbox;
+  } catch (error) {
+    throw new CheckStepError(
+      "infra_error",
+      `sandbox provision failed: ${errorMessage(error)}`
+    );
+  }
+}
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+/**
+ * Foreground command, normalized. E2B throws on a non-zero exit; every caller
+ * here wants the exit code and the streams, so translate the throw back into a
+ * result and let the caller decide what a failure MEANS.
+ */
+async function runForeground(
+  sandbox: CheckSandbox,
+  command: string,
+  opts: { cwd?: string; timeoutMs: number }
+): Promise<RunResult> {
+  try {
+    const result = (await sandbox.commands.run(command, {
+      cwd: opts.cwd,
+      timeoutMs: opts.timeoutMs,
+    })) as Partial<RunResult> | undefined;
+    return {
+      exitCode: result?.exitCode ?? 0,
+      stdout: result?.stdout ?? "",
+      stderr: result?.stderr ?? "",
+    };
+  } catch (error) {
+    const exit = error as Partial<RunResult> & { exitCode?: number };
+    if (typeof exit?.exitCode === "number") {
+      return {
+        exitCode: exit.exitCode,
+        stdout: exit.stdout ?? "",
+        stderr: exit.stderr ?? "",
+      };
+    }
+    // Not a command failure — the sandbox itself is unreachable.
+    throw new CheckStepError(
+      "infra_error",
+      `sandbox command failed: ${errorMessage(error)}`
+    );
+  }
+}
+
+/**
+ * Clone the PR head, anonymously.
+ *
+ * `refs/pull/<n>/head` rather than the branch name: the branch may have been
+ * renamed or deleted since the webhook fired, and the PR ref is stable. The
+ * detached checkout is then ASSERTED to be exactly `headSha`. That assert is
+ * load-bearing — a force-push between the webhook and the clone would otherwise
+ * have us build a different tree and report the verdict against the sha in the
+ * check, i.e. quietly lie about what was tested.
+ *
+ * No credentials: the repo is public, so the clone is anonymous. This is what
+ * lets the box hold nothing worth stealing.
+ */
+export async function cloneAndCheckout(
+  sandbox: CheckSandbox,
+  args: { repoFullName: string; prNumber: number; headSha: string }
+): Promise<void> {
+  const cloneUrl = `https://github.com/${args.repoFullName}.git`;
+  const script = [
+    `set -e`,
+    `rm -rf ${CHECKOUT_DIR}`,
+    // Shallow, but deep enough that a PR ref's own history resolves.
+    `git clone --depth 50 ${shellQuote(cloneUrl)} ${CHECKOUT_DIR}`,
+    `cd ${CHECKOUT_DIR}`,
+    `git fetch --depth 50 origin ${shellQuote(`pull/${args.prNumber}/head`)}`,
+    `git checkout --detach ${shellQuote(args.headSha)}`,
+  ].join(" && ");
+
+  const result = await runForeground(
+    sandbox,
+    `bash -lc ${shellQuote(script)}`,
+    {
+      timeoutMs: CLONE_TIMEOUT_MS,
+    }
+  );
+  if (result.exitCode !== 0) {
+    // A public repo we were just told about should always clone. If it doesn't,
+    // that is our problem (or GitHub's), not the PR author's.
+    throw new CheckStepError(
+      "infra_error",
+      `clone/checkout failed (exit ${result.exitCode})`,
+      clampOutput(`${result.stdout}\n${result.stderr}`)
+    );
+  }
+
+  const head = await runForeground(
+    sandbox,
+    `git -C ${CHECKOUT_DIR} rev-parse HEAD`,
+    {
+      timeoutMs: 60_000,
+    }
+  );
+  const checkedOut = head.stdout.trim();
+  if (checkedOut !== args.headSha) {
+    throw new CheckStepError(
+      "infra_error",
+      `checkout drifted: expected ${args.headSha}, got ${
+        checkedOut || "nothing"
+      }`
+    );
+  }
+}
+
+/**
+ * Revoke outbound network.
+ *
+ * Called between the build and the start, and its ordering is a security
+ * property, not an optimization: `npm ci` needs the registry, the PR's server
+ * does not, and the server is the long-lived process an attacker would use. A
+ * failure here is `infra_error` and ABORTS — the caller must never fall back to
+ * starting the server with egress still open.
+ */
+export async function lockDownEgress(sandbox: CheckSandbox): Promise<void> {
+  try {
+    // Equivalent to `denyOut: ['0.0.0.0/0']`; inbound (`allowPublicTraffic`) is
+    // untouched, so the eval run can still reach the server.
+    await sandbox.updateNetwork({ allowInternetAccess: false });
+    logger.info("[github-checks] egress locked down", {
+      sandboxId: sandbox.sandboxId,
+    });
+  } catch (error) {
+    throw new CheckStepError(
+      "infra_error",
+      `failed to disable sandbox egress before starting PR code: ${errorMessage(
+        error
+      )}`
+    );
+  }
+}
+
+export type StartedServer = {
+  /** Public https URL of the MCP endpoint, via the sandbox host bridge. */
+  url: string;
+  /** Most recent server stderr, for a health failure message. */
+  readStderrTail: () => string;
+};
+
+/**
+ * Build, lock down egress, start, and wait for the server to speak MCP.
+ *
+ * The step ORDER is the contract this function exists to guarantee, so it is
+ * one function rather than three the caller sequences:
+ *
+ *   1. build (egress available)
+ *   2. lock down egress            ← must land before any PR process is long-lived
+ *   3. start the server
+ *   4. poll `initialize` until it answers
+ */
+export async function buildAndStart(
+  sandbox: CheckSandbox,
+  recipe: CheckRecipe,
+  options?: {
+    fetchImpl?: typeof fetch;
+    healthTimeoutMs?: number;
+    healthIntervalMs?: number;
+  }
+): Promise<StartedServer> {
+  const build = await runForeground(
+    sandbox,
+    `bash -lc ${shellQuote(recipe.build)}`,
+    {
+      cwd: CHECKOUT_DIR,
+      timeoutMs: BUILD_TIMEOUT_MS,
+    }
+  );
+  if (build.exitCode !== 0) {
+    // The PR's own build broke. This is a check FAILURE, attributed to the PR —
+    // not an infrastructure error, and not something to retry.
+    throw new CheckStepError(
+      "build_failed",
+      `build command exited ${build.exitCode}`,
+      clampOutput(`${build.stdout}\n${build.stderr}`)
+    );
+  }
+
+  await lockDownEgress(sandbox);
+
+  let stderrTail = "";
+  const appendStderr = (chunk: string) => {
+    stderrTail = `${stderrTail}${chunk}`.slice(-STDERR_TAIL_CHARS);
+  };
+
+  try {
+    await sandbox.commands.run(`bash -lc ${shellQuote(recipe.start)}`, {
+      cwd: CHECKOUT_DIR,
+      background: true,
+      onStderr: appendStderr,
+    });
+  } catch (error) {
+    throw new CheckStepError(
+      "infra_error",
+      `failed to spawn the start command: ${errorMessage(error)}`
+    );
+  }
+
+  const url = `https://${sandbox.getHost(recipe.port)}${recipe.mcpPath}`;
+  const healthy = await waitForMcpInitialize(url, {
+    timeoutMs: options?.healthTimeoutMs ?? HEALTH_TIMEOUT_MS,
+    intervalMs: options?.healthIntervalMs ?? HEALTH_INTERVAL_MS,
+    fetchImpl: options?.fetchImpl,
+  });
+  if (!healthy) {
+    throw new CheckStepError(
+      "server_unhealthy",
+      `server never completed MCP initialize on port ${recipe.port}${recipe.mcpPath}`,
+      clampOutput(stderrTail)
+    );
+  }
+
+  return { url, readStderrTail: () => stderrTail };
+}
+
+/**
+ * Poll the server with a real JSON-RPC `initialize` until it answers.
+ *
+ * A TCP connect or an HTTP 200 on `/` would be a weaker signal: a framework
+ * often serves before its MCP transport is mounted, and the eval run's very
+ * first act is an `initialize`. Probing with the actual handshake means "healthy"
+ * means the same thing here and there.
+ *
+ * Accepts either a JSON body or an SSE frame — streamable-HTTP servers legally
+ * answer with either.
+ */
+export async function waitForMcpInitialize(
+  url: string,
+  options?: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    fetchImpl?: typeof fetch;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+  }
+): Promise<boolean> {
+  const timeoutMs = options?.timeoutMs ?? HEALTH_TIMEOUT_MS;
+  const intervalMs = options?.intervalMs ?? HEALTH_INTERVAL_MS;
+  const doFetch = options?.fetchImpl ?? fetch;
+  const now = options?.now ?? (() => Date.now());
+  const pause = options?.sleep ?? ((ms: number) => sleep(ms));
+
+  const deadline = now() + timeoutMs;
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: HEALTH_PROBE_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: "mcpjam-github-checks-probe", version: "1.0.0" },
+    },
+  });
+
+  let attempts = 0;
+  while (now() <= deadline) {
+    attempts += 1;
+    try {
+      const response = await doFetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body,
+      });
+      if (response.ok) {
+        const text = await response.text();
+        if (looksLikeInitializeResult(text)) return true;
+      }
+    } catch {
+      // Connection refused / DNS not ready yet — expected while it boots.
+    }
+    if (now() + intervalMs > deadline) break;
+    await pause(intervalMs);
+  }
+  logger.warn("[github-checks] server never completed MCP initialize", {
+    url,
+    attempts,
+  });
+  return false;
+}
+
+/**
+ * A successful `initialize` carries a `result` with a `protocolVersion`. An
+ * error response is still a live MCP server, but not a usable one — the eval
+ * run's own handshake would fail the same way, so treat it as not-yet-healthy
+ * and keep polling until the deadline.
+ */
+function looksLikeInitializeResult(text: string): boolean {
+  const payloads = text.includes("data:")
+    ? text
+        .split(/\n/)
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice("data:".length).trim())
+    : [text];
+
+  for (const payload of payloads) {
+    if (!payload) continue;
+    try {
+      const parsed = JSON.parse(payload) as {
+        result?: { protocolVersion?: unknown };
+      };
+      if (parsed?.result && "protocolVersion" in (parsed.result ?? {})) {
+        return true;
+      }
+    } catch {
+      // Not JSON (a proxy's HTML error page, a partial frame) — keep looking.
+    }
+  }
+  return false;
+}
+
+/** Best-effort teardown. E2B's TTL + `onTimeout: "kill"` is the real backstop. */
+export async function killCheckSandbox(
+  sandbox: CheckSandbox | null
+): Promise<void> {
+  if (!sandbox) return;
+  try {
+    await sandbox.kill();
+  } catch (error) {
+    logger.warn("[github-checks] sandbox kill failed (E2B TTL will reap it)", {
+      sandboxId: sandbox.sandboxId,
+      error: errorMessage(error),
+    });
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Single-quote for `bash -lc`, so a repo name or sha can never inject. */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message.slice(0, 300) : String(error);
+}

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -89,6 +89,12 @@ export const BUILD_TIMEOUT_MS = 10 * 60_000;
 export const CLONE_TIMEOUT_MS = 5 * 60_000;
 export const HEALTH_TIMEOUT_MS = 2 * 60_000;
 export const HEALTH_INTERVAL_MS = 2_000;
+/**
+ * Per-attempt cap on the health probe, clamped to the remaining deadline. A
+ * healthy server answers `initialize` in milliseconds, so 10s is generous; the
+ * point is that an unresponsive one cannot outlive the overall window.
+ */
+export const PROBE_ATTEMPT_TIMEOUT_MS = 10_000;
 /** Where the PR is checked out inside the box. */
 export const CHECKOUT_DIR = "/home/user/repo";
 
@@ -476,6 +482,19 @@ export async function waitForMcpInitialize(
   let attempts = 0;
   while (now() <= deadline) {
     attempts += 1;
+    // Bound EACH attempt, not just the loop. A PR's server that accepts the
+    // socket and then never answers — or answers with an endless stream — would
+    // otherwise park this await indefinitely: the deadline is only consulted
+    // between attempts, so an unbounded request means the check occupies the
+    // worker's single in-flight slot until the 45-minute sandbox TTU instead of
+    // concluding `server_unhealthy` in two minutes. Untrusted code is exactly
+    // the code that does this.
+    const attemptBudgetMs = Math.max(
+      1,
+      Math.min(PROBE_ATTEMPT_TIMEOUT_MS, deadline - now())
+    );
+    const abort = new AbortController();
+    const abortTimer = setTimeout(() => abort.abort(), attemptBudgetMs);
     try {
       const response = await doFetch(url, {
         method: "POST",
@@ -484,13 +503,20 @@ export async function waitForMcpInitialize(
           accept: "application/json, text/event-stream",
         },
         body,
+        // The same signal covers the body read below: aborting it errors the
+        // response stream, so a server that sends headers and then stalls is
+        // bounded too.
+        signal: abort.signal,
       });
       if (response.ok) {
         const text = await response.text();
         if (looksLikeInitializeResult(text)) return true;
       }
     } catch {
-      // Connection refused / DNS not ready yet — expected while it boots.
+      // Connection refused, DNS not ready, or our own abort — all expected
+      // while it boots, all "not healthy yet".
+    } finally {
+      clearTimeout(abortTimer);
     }
     if (now() + intervalMs > deadline) break;
     await pause(intervalMs);
@@ -509,12 +535,16 @@ export async function waitForMcpInitialize(
  * and keep polling until the deadline.
  */
 function looksLikeInitializeResult(text: string): boolean {
-  const payloads = text.includes("data:")
-    ? text
-        .split(/\n/)
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice("data:".length).trim())
-    : [text];
+  // SSE framing is detected by a line that STARTS with `data:`, not by the
+  // substring appearing anywhere. A single-line JSON body can legitimately
+  // contain "data:" inside a string (a serverInfo name, an instructions blob, a
+  // tool description); treating that as SSE yielded zero payloads and a false
+  // `server_unhealthy`.
+  const frames = text
+    .split(/\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trim());
+  const payloads = frames.length > 0 ? frames : [text];
 
   for (const payload of payloads) {
     if (!payload) continue;

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -126,8 +126,18 @@ const SERVER_LOG_CHECK_SECONDS = 30;
  */
 const HEALTH_PROBE_PROTOCOL_VERSION = "2025-06-18";
 
-/** The id the probe sends, and therefore the id a real answer must carry. */
-const HEALTH_PROBE_REQUEST_ID = 1;
+/** The version the modern-era probe self-describes with. */
+const MODERN_PROBE_PROTOCOL_VERSION = "2026-07-28";
+
+/** The ids the probes send, and therefore the ids a real answer must carry. */
+const LEGACY_PROBE_REQUEST_ID = 1;
+const MODERN_PROBE_REQUEST_ID = 2;
+
+/** Who the probe says it is, in both eras. */
+const PROBE_CLIENT_INFO = {
+  name: "mcpjam-github-checks-probe",
+  version: "1.0.0",
+} as const;
 
 /**
  * Versions the probe will accept back from the PR's server.
@@ -596,15 +606,22 @@ async function readLogTail(sandbox: CheckSandbox): Promise<string> {
 }
 
 /**
- * Poll the server with a real JSON-RPC `initialize` until it answers.
+ * Poll the server until it answers a real MCP request.
  *
  * A TCP connect or an HTTP 200 on `/` would be a weaker signal: a framework
  * often serves before its MCP transport is mounted, and the eval run's very
- * first act is an `initialize`. Probing with the actual handshake means "healthy"
- * means the same thing here and there.
+ * first act is a real request. Probing with the real thing means "healthy" means
+ * the same thing here and there.
  *
- * Accepts either a JSON body or an SSE frame — streamable-HTTP servers legally
- * answer with either.
+ * BOTH eras are probed, alternating one per attempt: the legacy `initialize`
+ * handshake and the modern `server/discover`. The eval run connects with
+ * automatic era negotiation, so a modern-only endpoint (the official handler with
+ * `legacy: "reject"`, say) is one it can drive perfectly well — probing legacy
+ * alone would call that server `server_unhealthy` and put a red X on a good PR.
+ * Either answer proves the same thing this probe is asking.
+ *
+ * Accepts a JSON body or an SSE frame for either — streamable-HTTP servers
+ * legally answer with either.
  */
 export async function waitForMcpInitialize(
   url: string,
@@ -623,16 +640,9 @@ export async function waitForMcpInitialize(
   const pause = options?.sleep ?? ((ms: number) => sleep(ms));
 
   const deadline = now() + timeoutMs;
-  const body = JSON.stringify({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {
-      protocolVersion: HEALTH_PROBE_PROTOCOL_VERSION,
-      capabilities: {},
-      clientInfo: { name: "mcpjam-github-checks-probe", version: "1.0.0" },
-    },
-  });
+  // Legacy first: nearly every server speaks it, so the common case answers on
+  // the very first attempt. A modern-only endpoint answers on the second.
+  const eras = [legacyInitializeProbe(), modernDiscoverProbe()];
 
   let attempts = 0;
   while (now() <= deadline) {
@@ -648,41 +658,108 @@ export async function waitForMcpInitialize(
       1,
       Math.min(PROBE_ATTEMPT_TIMEOUT_MS, deadline - now())
     );
+    // One era per attempt, ALTERNATING — not both inside one attempt. A server
+    // that accepts a POST and then holds the response open answers the first
+    // era's request by never finishing it, so that era would eat the whole
+    // budget every time and the other would never get a turn: a legacy-only
+    // server would read as `server_unhealthy` because its probe never ran. Over
+    // a two-minute window each era still gets tens of attempts.
+    const era = eras[(attempts - 1) % eras.length];
     const abort = new AbortController();
     const abortTimer = setTimeout(() => abort.abort(), attemptBudgetMs);
     try {
       const response = await doFetch(url, {
         method: "POST",
-        headers: {
-          "content-type": "application/json",
-          accept: "application/json, text/event-stream",
-        },
-        body,
+        headers: era.headers,
+        body: era.body,
         // The same signal covers the body read below: aborting it errors the
         // response stream, so a server that sends headers and then stalls is
         // bounded too.
         signal: abort.signal,
       });
-      if (response.ok && (await probeResponseIsHealthy(response))) {
+      if (
+        response.ok &&
+        (await probeResponseIsHealthy(response, era.accepts))
+      ) {
         return true;
       }
     } catch {
-      // Connection refused, DNS not ready, or our own abort — all expected
-      // while it boots, all "not healthy yet".
+      // Connection refused, DNS not ready, this era rejected outright, or our
+      // own abort — all "not healthy yet, try the other era next poll".
     } finally {
       clearTimeout(abortTimer);
-      // Tear the request down unconditionally. A streamable-HTTP server holds the
-      // response stream open after answering, and we have our answer.
+      // Tear the requests down unconditionally. A streamable-HTTP server holds
+      // the response stream open after answering, and we have our answer.
       abort.abort();
     }
     if (now() + intervalMs > deadline) break;
     await pause(intervalMs);
   }
-  logger.warn("[github-checks] server never completed MCP initialize", {
+  logger.warn("[github-checks] server never answered an MCP request", {
     url,
     attempts,
   });
   return false;
+}
+
+/** One era's probe: what to send, and what counts as an answer. */
+interface EraProbe {
+  headers: Record<string, string>;
+  body: string;
+  accepts: (parsed: unknown) => boolean;
+}
+
+/**
+ * The legacy (2025-era) handshake: `initialize`, negotiated in the body.
+ */
+function legacyInitializeProbe(): EraProbe {
+  return {
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: LEGACY_PROBE_REQUEST_ID,
+      method: "initialize",
+      params: {
+        protocolVersion: HEALTH_PROBE_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: PROBE_CLIENT_INFO,
+      },
+    }),
+    accepts: isUsableInitializeResponse,
+  };
+}
+
+/**
+ * The modern (2026-07-28) era has no handshake: every request self-describes
+ * through a `_meta` envelope, and `server/discover` is its one universally
+ * available request — the same liveness probe the manager itself uses.
+ */
+function modernDiscoverProbe(): EraProbe {
+  return {
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      "mcp-protocol-version": MODERN_PROBE_PROTOCOL_VERSION,
+      "mcp-method": "server/discover",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: MODERN_PROBE_REQUEST_ID,
+      method: "server/discover",
+      params: {
+        _meta: {
+          "io.modelcontextprotocol/protocolVersion":
+            MODERN_PROBE_PROTOCOL_VERSION,
+          "io.modelcontextprotocol/clientCapabilities": {},
+          "io.modelcontextprotocol/clientInfo": PROBE_CLIENT_INFO,
+        },
+      },
+    }),
+    accepts: isUsableDiscoverResponse,
+  };
 }
 
 /**
@@ -701,7 +778,10 @@ export async function waitForMcpInitialize(
  * initialize result, then cancel the stream. `PROBE_MAX_RESPONSE_BYTES` bounds
  * a server that streams unrelated output at us forever.
  */
-async function probeResponseIsHealthy(response: Response): Promise<boolean> {
+async function probeResponseIsHealthy(
+  response: Response,
+  accepts: (parsed: unknown) => boolean
+): Promise<boolean> {
   const body = (response as { body?: unknown }).body as
     | ReadableStream<Uint8Array>
     | null
@@ -709,7 +789,7 @@ async function probeResponseIsHealthy(response: Response): Promise<boolean> {
   if (!body || typeof body.getReader !== "function") {
     // No streaming body available (a buffered runtime, or a test stub): the
     // payload is already in hand, so reading it cannot block.
-    return looksLikeInitializeResult(await response.text());
+    return carriesAcceptedAnswer(await response.text(), accepts);
   }
 
   const reader = body.getReader();
@@ -732,14 +812,14 @@ async function probeResponseIsHealthy(response: Response): Promise<boolean> {
         text += decoder.decode(value.subarray(0, consumed), { stream: true });
         // Checked per chunk: a frame can arrive split, and a partial JSON just
         // fails to parse and waits for the rest.
-        if (looksLikeInitializeResult(text)) return true;
+        if (carriesAcceptedAnswer(text, accepts)) return true;
       }
       if (done) {
         text += decoder.decode();
-        return looksLikeInitializeResult(text);
+        return carriesAcceptedAnswer(text, accepts);
       }
     }
-    return looksLikeInitializeResult(text);
+    return carriesAcceptedAnswer(text, accepts);
   } finally {
     // We are done with this response either way — a healthy server is still
     // holding the stream open, so drop it rather than leaking the socket.
@@ -748,32 +828,64 @@ async function probeResponseIsHealthy(response: Response): Promise<boolean> {
 }
 
 /**
- * A usable `initialize` answer is one the REAL client would also accept. An
- * error response is still a live MCP server, but not a usable one — the eval
- * run's own handshake would fail the same way, so treat it as not-yet-healthy
- * and keep polling until the deadline.
+ * Whether the text read so far carries an answer this era accepts. An error
+ * response is still a live MCP server, but not a usable one — the eval run's own
+ * connection would fail the same way, so treat it as not-yet-healthy and keep
+ * polling until the deadline.
  */
-function looksLikeInitializeResult(text: string): boolean {
-  // SSE framing is detected by a line that STARTS with `data:`, not by the
-  // substring appearing anywhere. A single-line JSON body can legitimately
-  // contain "data:" inside a string (a serverInfo name, an instructions blob, a
-  // tool description); treating that as SSE yielded zero payloads and a false
-  // `server_unhealthy`.
-  const frames = text
-    .split(/\n/)
-    .filter((line) => line.startsWith("data:"))
-    .map((line) => line.slice("data:".length).trim());
-  const payloads = frames.length > 0 ? frames : [text];
-
-  for (const payload of payloads) {
-    if (!payload) continue;
+function carriesAcceptedAnswer(
+  text: string,
+  accepts: (parsed: unknown) => boolean
+): boolean {
+  for (const payload of ssePayloads(text)) {
     try {
-      if (isUsableInitializeResponse(JSON.parse(payload))) return true;
+      if (accepts(JSON.parse(payload))) return true;
     } catch {
       // Not JSON (a proxy's HTML error page, a partial frame) — keep looking.
     }
   }
   return false;
+}
+
+/**
+ * The candidate JSON payloads in a probe response body.
+ *
+ * SSE framing is detected by a line that STARTS with `data:`, not by the
+ * substring appearing anywhere: a single-line JSON body can legitimately contain
+ * "data:" inside a string (a serverInfo name, an instructions blob, a tool
+ * description), and treating that as SSE yielded zero payloads and a false
+ * `server_unhealthy`.
+ *
+ * Within one event, consecutive `data:` fields are JOINED with newlines, per SSE
+ * semantics. A server that spreads one JSON-RPC message across several fields is
+ * legal, and parsing each line on its own made every fragment fail to parse.
+ */
+function ssePayloads(text: string): string[] {
+  const payloads: string[] = [];
+  let current: string[] = [];
+  let sawFrame = false;
+  const flush = () => {
+    if (current.length > 0) {
+      payloads.push(current.join("\n"));
+      current = [];
+    }
+  };
+
+  for (const rawLine of text.split(/\n/)) {
+    const line = rawLine.replace(/\r$/, "");
+    if (line.startsWith("data:")) {
+      sawFrame = true;
+      current.push(line.slice("data:".length).trim());
+      continue;
+    }
+    // A blank line ends the event. Any other field (`event:`, `id:`, a comment)
+    // carries no data but does not split it either.
+    if (line === "") flush();
+  }
+  flush();
+
+  if (!sawFrame) return text ? [text] : [];
+  return payloads.filter((payload) => payload.length > 0);
 }
 
 /**
@@ -793,32 +905,82 @@ function looksLikeInitializeResult(text: string): boolean {
  *   - `capabilities` and `serverInfo`, both required by `InitializeResultSchema`.
  */
 function isUsableInitializeResponse(parsed: unknown): boolean {
-  if (typeof parsed !== "object" || parsed === null) return false;
-  const message = parsed as {
-    jsonrpc?: unknown;
-    id?: unknown;
-    result?: unknown;
-  };
-  if (message.jsonrpc !== "2.0") return false;
-  if (message.id !== HEALTH_PROBE_REQUEST_ID) return false;
-  if (typeof message.result !== "object" || message.result === null) {
-    return false;
-  }
-  const result = message.result as {
+  const result = jsonRpcResultFor(parsed, LEGACY_PROBE_REQUEST_ID);
+  if (!result) return false;
+  const initialize = result as {
     protocolVersion?: unknown;
     capabilities?: unknown;
     serverInfo?: unknown;
   };
   if (
-    typeof result.protocolVersion !== "string" ||
-    !HEALTH_PROBE_ACCEPTED_VERSIONS.has(result.protocolVersion)
+    typeof initialize.protocolVersion !== "string" ||
+    !HEALTH_PROBE_ACCEPTED_VERSIONS.has(initialize.protocolVersion)
   ) {
     return false;
   }
-  if (typeof result.capabilities !== "object" || result.capabilities === null) {
+  if (!isPlainObject(initialize.capabilities)) return false;
+  return isServerIdentity(initialize.serverInfo);
+}
+
+/**
+ * Whether one parsed payload is a `server/discover` answer the eval run's client
+ * would accept. The modern era's equivalent of the checks above:
+ *
+ *   - the envelope and our id;
+ *   - `supportedVersions`, a non-empty list of strings, with at least one the
+ *     client can actually speak — an endpoint offering nothing in common is no
+ *     more usable than a legacy server naming an unsupported version;
+ *   - `capabilities`, an object.
+ *
+ * Server identity lives in `_meta` here and is a SHOULD, not a member of the
+ * result, so its absence is not a defect and is not required.
+ */
+function isUsableDiscoverResponse(parsed: unknown): boolean {
+  const result = jsonRpcResultFor(parsed, MODERN_PROBE_REQUEST_ID);
+  if (!result) return false;
+  const discover = result as {
+    supportedVersions?: unknown;
+    capabilities?: unknown;
+  };
+  if (!Array.isArray(discover.supportedVersions)) return false;
+  const offered = discover.supportedVersions.filter(
+    (version): version is string => typeof version === "string"
+  );
+  if (offered.length !== discover.supportedVersions.length) return false;
+  if (!offered.some((version) => HEALTH_PROBE_ACCEPTED_VERSIONS.has(version))) {
     return false;
   }
-  return typeof result.serverInfo === "object" && result.serverInfo !== null;
+  return isPlainObject(discover.capabilities);
+}
+
+/**
+ * The `result` of a JSON-RPC response to OUR request, or null. Rejects an error
+ * response, a notification, and an answer bearing someone else's id.
+ */
+function jsonRpcResultFor(parsed: unknown, expectedId: number): object | null {
+  if (!isPlainObject(parsed)) return null;
+  const message = parsed as {
+    jsonrpc?: unknown;
+    id?: unknown;
+    result?: unknown;
+  };
+  if (message.jsonrpc !== "2.0") return null;
+  if (message.id !== expectedId) return null;
+  return isPlainObject(message.result) ? (message.result as object) : null;
+}
+
+/** An object, and not an array — `typeof [] === "object"` alone is too loose. */
+function isPlainObject(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** `{ name, version }`, both strings — what the client's schema requires. */
+function isServerIdentity(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  const identity = value as { name?: unknown; version?: unknown };
+  return (
+    typeof identity.name === "string" && typeof identity.version === "string"
+  );
 }
 
 /** Best-effort teardown. E2B's TTL + `onTimeout: "kill"` is the real backstop. */

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -942,12 +942,51 @@ function carriesAcceptedAnswer(
 ): boolean {
   for (const payload of candidatePayloads(text, bodyComplete, mode)) {
     try {
-      if (accepts(JSON.parse(payload))) return true;
+      const parsed = JSON.parse(payload);
+      // A BATCH, and only under `application/json`: the transport unwraps a JSON
+      // array there and dispatches each element. Its SSE path parses one message
+      // per event and would reject an array outright, so the asymmetry is the
+      // client's, not an oversight here.
+      if (mode === "json" && Array.isArray(parsed)) {
+        if (batchCarriesAcceptedAnswer(parsed, accepts)) return true;
+        continue;
+      }
+      if (accepts(parsed)) return true;
     } catch {
       // Not JSON (a proxy's HTML error page, a partial frame) — keep looking.
     }
   }
   return false;
+}
+
+/**
+ * Whether a batched `application/json` body carries our answer.
+ *
+ * The transport maps the array through its message schema — `data.map((msg) =>
+ * JSONRPCMessageSchema.parse(msg))` — so ONE malformed element throws and takes the
+ * whole batch with it, our answer included. Hence the two conditions: every element
+ * has to look like a JSON-RPC message, and one of them has to be the answer. An
+ * empty array satisfies neither, and dispatches nothing.
+ *
+ * The per-element test is `jsonrpc: "2.0"` on an object, which every arm of that
+ * schema's union requires. It is not the full union, so a sibling that is an object
+ * with the right `jsonrpc` and nothing else passes here and would throw for the
+ * client. That leaves this a shade LOOSER than the transport, which is the side to
+ * err on: the cost is a broken server reaching us as a neutral `infra_error`, where
+ * being stricter would risk a red X on a PR the eval run can drive.
+ */
+function batchCarriesAcceptedAnswer(
+  batch: unknown[],
+  accepts: (parsed: unknown) => boolean
+): boolean {
+  if (batch.length === 0) return false;
+  const everyElementIsAMessage = batch.every(
+    (message) =>
+      isPlainObject(message) &&
+      (message as { jsonrpc?: unknown }).jsonrpc === "2.0"
+  );
+  if (!everyElementIsAMessage) return false;
+  return batch.some((message) => accepts(message));
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -111,6 +111,9 @@ export const OUTPUT_CLAMP_CHARS = 4_000;
 /** How much of the started server's log we keep, for a health failure. */
 const STDERR_TAIL_CHARS = 8_000;
 
+/** Where the PR's BUILD writes stdout+stderr, inside the box. */
+const BUILD_LOG_PATH = "/tmp/mcp-build.log";
+
 /** Where the PR's server writes stdout+stderr, inside the box. */
 const SERVER_LOG_PATH = "/tmp/mcp-server.log";
 /** Cap on that file. A watchdog truncates it; see `startCommandScript`. */
@@ -512,22 +515,36 @@ export async function buildAndStart(
     healthIntervalMs?: number;
   }
 ): Promise<StartedServer> {
-  const build = await runForeground(
-    sandbox,
-    `bash -lc ${shellQuote(recipe.build)}`,
-    {
-      cwd: CHECKOUT_DIR,
-      timeoutMs: options?.buildTimeoutMs ?? BUILD_TIMEOUT_MS,
-      timeoutOutcome: "build_failed",
+  let build: RunResult;
+  try {
+    build = await runForeground(
+      sandbox,
+      `bash -lc ${shellQuote(buildCommandScript(recipe.build))}`,
+      {
+        cwd: CHECKOUT_DIR,
+        timeoutMs: options?.buildTimeoutMs ?? BUILD_TIMEOUT_MS,
+        timeoutOutcome: "build_failed",
+      }
+    );
+  } catch (error) {
+    // A build that ran out its own deadline. Its output is in the box's log, not
+    // on the error, so the tail is fetched here rather than left empty.
+    if (error instanceof CheckStepError && error.outcome === "build_failed") {
+      throw new CheckStepError(
+        error.outcome,
+        error.message,
+        clampOutput(await readLogTail(sandbox, BUILD_LOG_PATH)) || undefined
+      );
     }
-  );
+    throw error;
+  }
   if (build.exitCode !== 0) {
     // The PR's own build broke. This is a check FAILURE, attributed to the PR —
     // not an infrastructure error, and not something to retry.
     throw new CheckStepError(
       "build_failed",
       `build command exited ${build.exitCode}`,
-      clampOutput(`${build.stdout}\n${build.stderr}`)
+      clampOutput(await readLogTail(sandbox, BUILD_LOG_PATH))
     );
   }
 
@@ -609,6 +626,35 @@ function startCommandScript(startCommand: string): string {
 }
 
 /**
+ * The build, with its output bounded INSIDE the box.
+ *
+ * Same hazard as the start path, and for the same reason: E2B's `CommandHandle`
+ * accumulates every chunk it receives into an internal string, so a build script
+ * that prints continuously for its ten-minute window grows THIS process's heap
+ * without limit — and the build is PR-controlled code, so "it would not do that"
+ * is not an assumption available here. Redirecting to a file keeps the output in
+ * the sandbox, a watchdog keeps the FILE bounded so a runaway build cannot fill
+ * the disk either, and only a bounded tail is ever fetched.
+ *
+ * The exit status has to survive all that, because it is what distinguishes a
+ * broken build from a working one: the status is captured immediately, the
+ * watchdog is stopped, and the captured status is what the script exits with.
+ */
+function buildCommandScript(buildCommand: string): string {
+  return [
+    `: > ${BUILD_LOG_PATH}`,
+    `( while :; do sleep ${SERVER_LOG_CHECK_SECONDS};` +
+      ` if [ "$(wc -c < ${BUILD_LOG_PATH} 2>/dev/null || echo 0)" -gt ${SERVER_LOG_MAX_BYTES} ];` +
+      ` then : > ${BUILD_LOG_PATH}; fi; done ) &`,
+    `MCPJAM_WATCHDOG=$!`,
+    `${buildCommand} >> ${BUILD_LOG_PATH} 2>&1`,
+    `MCPJAM_STATUS=$?`,
+    `kill $MCPJAM_WATCHDOG 2>/dev/null || :`,
+    `exit $MCPJAM_STATUS`,
+  ].join("\n");
+}
+
+/**
  * Fetch a bounded tail of the PR server's log, from inside the box.
  *
  * `tail -c` does the truncation in the sandbox, so untrusted output is bounded
@@ -616,11 +662,14 @@ function startCommandScript(startCommand: string): string {
  * runs to enrich a failure message, and failing to read a log must not change
  * the verdict.
  */
-async function readLogTail(sandbox: CheckSandbox): Promise<string> {
+async function readLogTail(
+  sandbox: CheckSandbox,
+  logPath: string = SERVER_LOG_PATH
+): Promise<string> {
   try {
     const result = (await sandbox.commands.run(
       `bash -lc ${shellQuote(
-        `tail -c ${STDERR_TAIL_CHARS} ${SERVER_LOG_PATH} 2>/dev/null || true`
+        `tail -c ${STDERR_TAIL_CHARS} ${logPath} 2>/dev/null || true`
       )}`,
       { timeoutMs: 30_000 }
     )) as { stdout?: string } | undefined;
@@ -968,25 +1017,62 @@ function carriesAcceptedAnswer(
  * has to look like a JSON-RPC message, and one of them has to be the answer. An
  * empty array satisfies neither, and dispatches nothing.
  *
- * The per-element test is `jsonrpc: "2.0"` on an object, which every arm of that
- * schema's union requires. It is not the full union, so a sibling that is an object
- * with the right `jsonrpc` and nothing else passes here and would throw for the
- * client. That leaves this a shade LOOSER than the transport, which is the side to
- * err on: the cost is a broken server reaching us as a neutral `infra_error`, where
- * being stricter would risk a red X on a PR the eval run can drive.
+ * The per-element test discriminates the four arms of that union, because
+ * `jsonrpc: "2.0"` alone does not: `{"jsonrpc":"2.0"}` matches none of them and
+ * throws for the client, so a batch carrying one is unusable however good its
+ * siblings are.
+ *
+ * What is NOT modelled is `.strict()`. Every arm rejects unknown top-level keys,
+ * and reproducing that means hand-copying each arm's exact key set. Fidelity there
+ * is not reachable anyway — the schema is not exported from
+ * `@modelcontextprotocol/client`, and `@modelcontextprotocol/core` is a transitive
+ * dependency this module has no business importing — so what remains is a shade
+ * LOOSER than the transport. That is the side to err on: the cost is a broken
+ * server reaching us as a neutral `infra_error`, where being stricter would risk a
+ * red X on a PR the eval run can drive.
  */
 function batchCarriesAcceptedAnswer(
   batch: unknown[],
   accepts: (parsed: unknown) => boolean
 ): boolean {
   if (batch.length === 0) return false;
-  const everyElementIsAMessage = batch.every(
-    (message) =>
-      isPlainObject(message) &&
-      (message as { jsonrpc?: unknown }).jsonrpc === "2.0"
-  );
-  if (!everyElementIsAMessage) return false;
+  if (!batch.every(isJsonRpcMessageShaped)) return false;
   return batch.some((message) => accepts(message));
+}
+
+/**
+ * Whether one value matches an arm of the JSON-RPC message union: a result
+ * response, an error response, or a request/notification.
+ *
+ * `id` is not required of a method-bearing message, because a notification
+ * legitimately has none — requiring it would reject valid traffic.
+ */
+function isJsonRpcMessageShaped(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  const message = value as {
+    jsonrpc?: unknown;
+    id?: unknown;
+    method?: unknown;
+    result?: unknown;
+    error?: unknown;
+  };
+  if (message.jsonrpc !== "2.0") return false;
+  const hasId =
+    typeof message.id === "string" ||
+    (typeof message.id === "number" && Number.isInteger(message.id));
+  if (message.result !== undefined) {
+    return isPlainObject(message.result) && hasId;
+  }
+  if (message.error !== undefined) {
+    if (!isPlainObject(message.error)) return false;
+    const error = message.error as { code?: unknown; message?: unknown };
+    return (
+      typeof error.code === "number" &&
+      Number.isInteger(error.code) &&
+      typeof error.message === "string"
+    );
+  }
+  return typeof message.method === "string";
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -254,6 +254,14 @@ async function runForeground(
      * hangs is the PR's (`build_failed`) — E2B reports that as a timeout with no
      * exit code, which would otherwise land in the transport branch below and
      * conclude `neutral`, letting a hanging build dodge a red check.
+     *
+     * Decided by ELAPSED TIME against the deadline we set, and by nothing else.
+     * The error's identity cannot be used: E2B raises `TimeoutError` for
+     * `Code.Unavailable` and `Code.Canceled` as well as `DeadlineExceeded`, so
+     * matching on the name would report an E2B outage during `npm ci` as the
+     * PR's broken build — a red X on a good PR, the one failure this taxonomy
+     * exists to prevent. Elapsed time is exact here, since the deadline is what
+     * fires the abort.
      */
     timeoutOutcome: CheckStepOutcome;
   }
@@ -278,7 +286,7 @@ async function runForeground(
         stderr: exit.stderr ?? "",
       };
     }
-    if (hitCommandDeadline(error, startedAt, opts.timeoutMs)) {
+    if (Date.now() - startedAt >= opts.timeoutMs) {
       throw new CheckStepError(
         opts.timeoutOutcome,
         `command exceeded its ${Math.round(opts.timeoutMs / 1000)}s deadline`,
@@ -291,29 +299,6 @@ async function runForeground(
       `sandbox command failed: ${errorMessage(error)}`
     );
   }
-}
-
-/**
- * Did the command run out its own clock, as opposed to the sandbox failing?
- *
- * Two independent signals, because getting this wrong in either direction is
- * costly: calling an infra failure a build failure puts a red X on a good PR,
- * and calling a hung build an infra failure lets it pass as neutral.
- *
- *   - elapsed time reached the deadline we ourselves set. Objective, and it does
- *     not depend on how the error is shaped;
- *   - the error identifies itself as a timeout. E2B's own handshake timeout also
- *     uses that name, so it is excluded by message — that one is transport.
- */
-function hitCommandDeadline(
-  error: unknown,
-  startedAt: number,
-  timeoutMs: number
-): boolean {
-  if (Date.now() - startedAt >= timeoutMs) return true;
-  const name = (error as { name?: unknown } | null)?.name;
-  if (name !== "TimeoutError") return false;
-  return !/handshake/i.test(errorMessage(error));
 }
 
 /**
@@ -434,6 +419,7 @@ export async function buildAndStart(
   recipe: CheckRecipe,
   options?: {
     fetchImpl?: typeof fetch;
+    buildTimeoutMs?: number;
     healthTimeoutMs?: number;
     healthIntervalMs?: number;
   }
@@ -443,7 +429,7 @@ export async function buildAndStart(
     `bash -lc ${shellQuote(recipe.build)}`,
     {
       cwd: CHECKOUT_DIR,
-      timeoutMs: BUILD_TIMEOUT_MS,
+      timeoutMs: options?.buildTimeoutMs ?? BUILD_TIMEOUT_MS,
       timeoutOutcome: "build_failed",
     }
   );

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -1083,7 +1083,7 @@ function isJsonRpcMessageShaped(value: unknown): boolean {
 
   if (message.result !== undefined) {
     return (
-      within(RESULT_RESPONSE_KEYS) && idIsValid && isPlainObject(message.result)
+      within(RESULT_RESPONSE_KEYS) && idIsValid && isResultShaped(message.result)
     );
   }
   if (message.error !== undefined) {
@@ -1468,7 +1468,7 @@ function jsonRpcResultFor(parsed: unknown, expectedId: number): object | null {
   };
   if (message.jsonrpc !== "2.0") return null;
   if (message.id !== expectedId) return null;
-  if (!isPlainObject(message.result)) return null;
+  if (!isResultShaped(message.result)) return null;
   // The result-response arm is `{ jsonrpc, id, result }` and it is STRICT, so a
   // fourth key means the envelope matches no arm of the union and the transport
   // throws on it — `result` alongside `error` or `method` most obviously, but any
@@ -1478,6 +1478,20 @@ function jsonRpcResultFor(parsed: unknown, expectedId: number): object | null {
   return RESULT_RESPONSE_KEYS.length === Object.keys(message).length
     ? (message.result as object)
     : null;
+}
+
+/**
+ * Whether a `result` payload satisfies the envelope's result schema.
+ *
+ * `ResultSchema` is a loose object with an OPTIONAL `_meta` that must itself be an
+ * object, so `_meta: true` fails the envelope parse before any handshake logic
+ * runs — the client never looks at the rest of the result. Everything else inside
+ * passes through, which is why this checks `_meta` and nothing more.
+ */
+function isResultShaped(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  const meta = (value as { _meta?: unknown })._meta;
+  return meta === undefined || isPlainObject(meta);
 }
 
 /** Every key the strict result-response arm allows, and it requires all three. */

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -920,17 +920,23 @@ function ssePayloads(text: string, streamEnded: boolean): string[] {
     }
   };
 
-  const segments = text.split("\n");
-  // The final segment is whatever follows the last newline, so mid-stream it is a
-  // PARTIAL line, not a line. Treating it as one is subtly wrong in both
+  // LF, CRLF and bare CR are all legal SSE line separators, and a leading BOM is
+  // stripped before parsing — that is what the transport's EventSource parser
+  // does, so a server it can drive must not be turned away here. Splitting on LF
+  // alone left a CR-separated frame unrecognised and the probe timed out.
+  const segments = text.replace(/^﻿/, "").split(/\r\n|\r|\n/);
+  // The final segment is whatever follows the last separator, so mid-stream it is
+  // a PARTIAL line, not a line. Treating it as one is subtly wrong in both
   // directions: a half-written `data:` field would be parsed a character short,
-  // and — the case that actually bites — the empty tail left by a trailing "\n"
-  // would read as the event's blank-line terminator, flushing an event the server
-  // has not finished. A real terminator ("\n\n") shows up as an empty segment with
-  // another segment after it.
+  // and — the case that actually bites — the empty tail left by a trailing
+  // separator would read as the event's blank-line terminator, flushing an event
+  // the server has not finished. A real terminator shows up as an empty segment
+  // with another segment after it. (A CRLF split across chunk boundaries is safe
+  // because the whole accumulated text is re-split on every read, never appended
+  // to a previous parse.)
   const lineCount = streamEnded ? segments.length : segments.length - 1;
   for (let index = 0; index < lineCount; index += 1) {
-    const line = segments[index].replace(/\r$/, "");
+    const line = segments[index];
     if (line.startsWith("data:")) {
       sawFrame = true;
       current.push(line.slice("data:".length).trim());
@@ -980,8 +986,37 @@ function isUsableInitializeResponse(parsed: unknown): boolean {
   ) {
     return false;
   }
-  if (!isPlainObject(initialize.capabilities)) return false;
+  if (!isUsableCapabilities(initialize.capabilities)) return false;
   return isServerIdentity(initialize.serverInfo);
+}
+
+/**
+ * The capability fields the client's schema gives a shape to. Every one it types
+ * is an object, so `tools: true` is a schema violation the client will reject.
+ *
+ * Deliberately a closed list rather than "every value must be an object": the
+ * client's capabilities schema passes unknown keys through untouched, so a server
+ * advertising some extension as a bare string is still one the eval run can
+ * drive. Rejecting it here would be stricter than the client — a false
+ * `server_unhealthy` on a working PR, which is the failure this whole predicate
+ * exists to avoid.
+ */
+const TYPED_CAPABILITY_FIELDS = [
+  "tools",
+  "prompts",
+  "resources",
+  "logging",
+  "completions",
+  "experimental",
+] as const;
+
+function isUsableCapabilities(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  const capabilities = value as Record<string, unknown>;
+  return TYPED_CAPABILITY_FIELDS.every(
+    (field) =>
+      capabilities[field] === undefined || isPlainObject(capabilities[field])
+  );
 }
 
 /**
@@ -993,7 +1028,7 @@ function isUsableInitializeResponse(parsed: unknown): boolean {
  *     MODERN arm can actually speak — an endpoint offering nothing in common is
  *     no more usable than a legacy server naming an unsupported version, and one
  *     offering only legacy revisions is a question for the legacy probe;
- *   - `capabilities`, an object.
+ *   - `capabilities`, an object whose typed fields are objects.
  *
  * Server identity lives in `_meta` here and is a SHOULD, not a member of the
  * result, so its absence is not a defect and is not required.
@@ -1013,7 +1048,7 @@ function isUsableDiscoverResponse(parsed: unknown): boolean {
   if (!offered.some((version) => MODERN_PROBE_ACCEPTED_VERSIONS.has(version))) {
     return false;
   }
-  return isPlainObject(discover.capabilities);
+  return isUsableCapabilities(discover.capabilities);
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -1038,14 +1038,13 @@ function carriesAcceptedAnswer(
  * throws for the client, so a batch carrying one is unusable however good its
  * siblings are.
  *
- * What is NOT modelled is `.strict()`. Every arm rejects unknown top-level keys,
- * and reproducing that means hand-copying each arm's exact key set. Fidelity there
- * is not reachable anyway — the schema is not exported from
- * `@modelcontextprotocol/client`, and `@modelcontextprotocol/core` is a transitive
- * dependency this module has no business importing — so what remains is a shade
- * LOOSER than the transport. That is the side to err on: the cost is a broken
- * server reaching us as a neutral `infra_error`, where being stricter would risk a
- * red X on a PR the eval run can drive.
+ * `.strict()` is modelled too: each arm's key set is small and fixed, so a sibling
+ * carrying an extra key — `result` next to `error` being the obvious one — matches
+ * no arm and throws for the client. Hand-copied out of necessity, since the schema
+ * is not exported from `@modelcontextprotocol/client` and
+ * `@modelcontextprotocol/core` is a transitive dependency this module has no
+ * business importing; the risk of that copy drifting is real but bounded, and the
+ * alternative was staying knowingly looser than the transport.
  */
 function batchCarriesAcceptedAnswer(
   batch: unknown[],
@@ -1073,11 +1072,22 @@ function isJsonRpcMessageShaped(value: unknown): boolean {
     error?: unknown;
   };
   if (message.jsonrpc !== "2.0") return false;
+  const keys = Object.keys(message);
   const hasId =
     typeof message.id === "string" ||
     (typeof message.id === "number" && Number.isInteger(message.id));
+  // Every arm is STRICT, so an arm matches only if the key set is within what it
+  // allows. That is what makes `result` next to `error` a violation rather than a
+  // curiosity, and it is why each branch below checks the keys and not just the
+  // presence of its discriminator.
+  const within = (allowed: readonly string[]) =>
+    keys.every((key) => allowed.includes(key));
   if (message.result !== undefined) {
-    return isPlainObject(message.result) && hasId;
+    return (
+      isPlainObject(message.result) &&
+      hasId &&
+      within(["jsonrpc", "id", "result"])
+    );
   }
   if (message.error !== undefined) {
     if (!isPlainObject(message.error)) return false;
@@ -1085,10 +1095,15 @@ function isJsonRpcMessageShaped(value: unknown): boolean {
     return (
       typeof error.code === "number" &&
       Number.isInteger(error.code) &&
-      typeof error.message === "string"
+      typeof error.message === "string" &&
+      within(["jsonrpc", "id", "error"])
     );
   }
-  return typeof message.method === "string";
+  // Request and notification differ only by `id`, and both allow `params`.
+  return (
+    typeof message.method === "string" &&
+    within(["jsonrpc", "id", "method", "params"])
+  );
 }
 
 /**
@@ -1447,8 +1462,20 @@ function jsonRpcResultFor(parsed: unknown, expectedId: number): object | null {
   };
   if (message.jsonrpc !== "2.0") return null;
   if (message.id !== expectedId) return null;
-  return isPlainObject(message.result) ? (message.result as object) : null;
+  if (!isPlainObject(message.result)) return null;
+  // The result-response arm is `{ jsonrpc, id, result }` and it is STRICT, so a
+  // fourth key means the envelope matches no arm of the union and the transport
+  // throws on it — `result` alongside `error` or `method` most obviously, but any
+  // extra key does it. An envelope the client cannot parse is not an answer,
+  // however good the result inside it looks, and accepting one would hand the PR's
+  // fault to us as a neutral `infra_error`.
+  return RESULT_RESPONSE_KEYS.length === Object.keys(message).length
+    ? (message.result as object)
+    : null;
 }
+
+/** Every key the strict result-response arm allows, and it requires all three. */
+const RESULT_RESPONSE_KEYS = ["jsonrpc", "id", "result"] as const;
 
 /** An object, and not an array — `typeof [] === "object"` alone is too loose. */
 function isPlainObject(value: unknown): boolean {

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -1064,45 +1064,51 @@ function batchCarriesAcceptedAnswer(
  */
 function isJsonRpcMessageShaped(value: unknown): boolean {
   if (!isPlainObject(value)) return false;
-  const message = value as {
-    jsonrpc?: unknown;
-    id?: unknown;
-    method?: unknown;
-    result?: unknown;
-    error?: unknown;
-  };
+  const message = value as Record<string, unknown>;
   if (message.jsonrpc !== "2.0") return false;
   const keys = Object.keys(message);
-  const hasId =
-    typeof message.id === "string" ||
-    (typeof message.id === "number" && Number.isInteger(message.id));
-  // Every arm is STRICT, so an arm matches only if the key set is within what it
+  // Every arm is STRICT, so an arm matches only when the key set is within what it
   // allows. That is what makes `result` next to `error` a violation rather than a
-  // curiosity, and it is why each branch below checks the keys and not just the
-  // presence of its discriminator.
+  // curiosity, and why each branch checks keys and not just its discriminator.
   const within = (allowed: readonly string[]) =>
     keys.every((key) => allowed.includes(key));
+  // `RequestIdSchema` is `string | int` — `null` is not an id, and neither is a
+  // fractional number.
+  const idIsValid =
+    typeof message.id === "string" ||
+    (typeof message.id === "number" && Number.isInteger(message.id));
+  // `params` is a LOOSE object where it appears, so being an object is all of it.
+  const paramsAreShaped =
+    message.params === undefined || isPlainObject(message.params);
+
   if (message.result !== undefined) {
     return (
-      isPlainObject(message.result) &&
-      hasId &&
-      within(["jsonrpc", "id", "result"])
+      within(RESULT_RESPONSE_KEYS) && idIsValid && isPlainObject(message.result)
     );
   }
   if (message.error !== undefined) {
+    if (!within(["jsonrpc", "id", "error"])) return false;
+    // `id` is OPTIONAL on this arm, but a present one still has to be an id.
+    if (message.id !== undefined && !idIsValid) return false;
     if (!isPlainObject(message.error)) return false;
     const error = message.error as { code?: unknown; message?: unknown };
     return (
       typeof error.code === "number" &&
       Number.isInteger(error.code) &&
-      typeof error.message === "string" &&
-      within(["jsonrpc", "id", "error"])
+      typeof error.message === "string"
     );
   }
-  // Request and notification differ only by `id`, and both allow `params`.
+  if (typeof message.method !== "string") return false;
+  // Request when it carries an id, notification when it does not. The notification
+  // arm is strict and has no `id` at all, so a message with an INVALID id matches
+  // neither arm — it is not a notification with a stray key, and not a request.
+  if (message.id === undefined) {
+    return within(["jsonrpc", "method", "params"]) && paramsAreShaped;
+  }
   return (
-    typeof message.method === "string" &&
-    within(["jsonrpc", "id", "method", "params"])
+    within(["jsonrpc", "id", "method", "params"]) &&
+    idIsValid &&
+    paramsAreShaped
   );
 }
 

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -26,7 +26,6 @@
  */
 
 import { Sandbox } from "e2b";
-import { SUPPORTED_PROTOCOL_VERSIONS } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "../../utils/logger.js";
 import type { CheckRecipe } from "./recipes.js";
 
@@ -126,6 +125,31 @@ const SERVER_LOG_CHECK_SECONDS = 30;
  * answers.
  */
 const HEALTH_PROBE_PROTOCOL_VERSION = "2025-06-18";
+
+/** The id the probe sends, and therefore the id a real answer must carry. */
+const HEALTH_PROBE_REQUEST_ID = 1;
+
+/**
+ * Versions the probe will accept back from the PR's server.
+ *
+ * Hand-listed rather than imported: `check:mcp-v1-runtime-imports` forbids
+ * reaching into the upstream v1 protocol SDK from inspector server code, and
+ * `MCP_PROTOCOL_VERSIONS` in our own SDK is the narrower set a connection can be
+ * PINNED to — it omits the legacy wire versions the client still accepts.
+ *
+ * The list must stay at least as permissive as the real client. A version this
+ * probe rejects but the client would have accepted turns a working PR server
+ * into a false `server_unhealthy`, which is worse than the neutral it replaces.
+ * So: upstream's supported list, plus the newest revision our SDK knows.
+ */
+const HEALTH_PROBE_ACCEPTED_VERSIONS: ReadonlySet<string> = new Set([
+  "2024-10-07",
+  "2024-11-05",
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+  "2026-07-28",
+]);
 
 /**
  * Make untrusted PR output safe to put in a GitHub check body.
@@ -724,8 +748,7 @@ async function probeResponseIsHealthy(response: Response): Promise<boolean> {
 }
 
 /**
- * A successful `initialize` carries a `result` with a SUPPORTED
- * `protocolVersion`. An
+ * A usable `initialize` answer is one the REAL client would also accept. An
  * error response is still a live MCP server, but not a usable one — the eval
  * run's own handshake would fail the same way, so treat it as not-yet-healthy
  * and keep polling until the deadline.
@@ -745,26 +768,57 @@ function looksLikeInitializeResult(text: string): boolean {
   for (const payload of payloads) {
     if (!payload) continue;
     try {
-      const parsed = JSON.parse(payload) as {
-        result?: { protocolVersion?: unknown };
-      };
-      // The version has to be one the real client will ACCEPT, not merely
-      // present. A server answering `protocolVersion: "bogus"` looks healthy
-      // here, and then the eval run's own handshake rejects it — surfacing as
-      // `infra_error` (neutral) and letting a broken PR server dodge the
-      // `server_unhealthy` it earned.
-      const version = parsed?.result?.protocolVersion;
-      if (
-        typeof version === "string" &&
-        SUPPORTED_PROTOCOL_VERSIONS.includes(version)
-      ) {
-        return true;
-      }
+      if (isUsableInitializeResponse(JSON.parse(payload))) return true;
     } catch {
       // Not JSON (a proxy's HTML error page, a partial frame) — keep looking.
     }
   }
   return false;
+}
+
+/**
+ * Whether one parsed payload is an `initialize` answer the eval run's client
+ * would accept.
+ *
+ * Every condition here is one the real client checks a moment later. Accepting
+ * something looser buys nothing: the client rejects it, that rejection escapes
+ * the eval path, and the worker reports neutral `infra_error` — so a broken PR
+ * server dodges the `server_unhealthy` it earned and the failure lands on us
+ * instead of on the PR. So mirror the client:
+ *
+ *   - the JSON-RPC envelope (`jsonrpc: "2.0"`, and the id we actually sent, so a
+ *     stray notification or an answer to someone else's request is not ours);
+ *   - a `result`, not an `error`;
+ *   - `protocolVersion` the client can speak;
+ *   - `capabilities` and `serverInfo`, both required by `InitializeResultSchema`.
+ */
+function isUsableInitializeResponse(parsed: unknown): boolean {
+  if (typeof parsed !== "object" || parsed === null) return false;
+  const message = parsed as {
+    jsonrpc?: unknown;
+    id?: unknown;
+    result?: unknown;
+  };
+  if (message.jsonrpc !== "2.0") return false;
+  if (message.id !== HEALTH_PROBE_REQUEST_ID) return false;
+  if (typeof message.result !== "object" || message.result === null) {
+    return false;
+  }
+  const result = message.result as {
+    protocolVersion?: unknown;
+    capabilities?: unknown;
+    serverInfo?: unknown;
+  };
+  if (
+    typeof result.protocolVersion !== "string" ||
+    !HEALTH_PROBE_ACCEPTED_VERSIONS.has(result.protocolVersion)
+  ) {
+    return false;
+  }
+  if (typeof result.capabilities !== "object" || result.capabilities === null) {
+    return false;
+  }
+  return typeof result.serverInfo === "object" && result.serverInfo !== null;
 }
 
 /** Best-effort teardown. E2B's TTL + `onTimeout: "kill"` is the real backstop. */

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -108,8 +108,11 @@ export const CHECKOUT_DIR = "/home/user/repo";
 /** Cap on clamped untrusted output, in characters. */
 export const OUTPUT_CLAMP_CHARS = 4_000;
 
-/** How much stderr we keep from the started server, for a health failure. */
+/** How much of the started server's log we keep, for a health failure. */
 const STDERR_TAIL_CHARS = 8_000;
+
+/** Where the PR's server writes stdout+stderr, inside the box. */
+const SERVER_LOG_PATH = "/tmp/mcp-server.log";
 
 /**
  * The protocol version we offer in the health probe. Deliberately a plain
@@ -420,8 +423,8 @@ export async function lockDownEgress(sandbox: CheckSandbox): Promise<void> {
 export type StartedServer = {
   /** Public https URL of the MCP endpoint, via the sandbox host bridge. */
   url: string;
-  /** Most recent server stderr, for a health failure message. */
-  readStderrTail: () => string;
+  /** Bounded tail of the server's own log, for a health failure message. */
+  readStderrTail: () => Promise<string>;
 };
 
 /**
@@ -466,25 +469,28 @@ export async function buildAndStart(
 
   await lockDownEgress(sandbox);
 
-  let stderrTail = "";
-  const appendStderr = (chunk: string) => {
-    stderrTail = `${stderrTail}${chunk}`.slice(-STDERR_TAIL_CHARS);
-  };
-
   try {
-    await sandbox.commands.run(`bash -lc ${shellQuote(recipe.start)}`, {
-      cwd: CHECKOUT_DIR,
-      background: true,
-      // REQUIRED. `timeoutMs` defaults to 60 SECONDS and applies to background
-      // commands too, so without this the PR's server — and the stderr stream
-      // this reads for the health-failure message — dies about a minute after it
-      // starts, in the middle of a suite that legitimately runs for twenty. The
-      // box's own TTL is the real bound, so use it. (Not `0`: E2B forwards the
-      // value to connect-rpc, which treats <= 0 as an already-expired deadline
-      // and would abort the spawn instantly.)
-      timeoutMs: CHECK_SANDBOX_TIMEOUT_MS,
-      onStderr: appendStderr,
-    });
+    // Output goes to a FILE IN THE BOX, not to a stream callback. E2B's
+    // `CommandHandle` appends every chunk it receives to an internal string —
+    // it does that whether or not `onStderr` is supplied, and it starts doing it
+    // the moment the handle is constructed. A PR server that logs continuously
+    // for the twenty minutes an eval takes would therefore grow THIS process's
+    // heap without limit, which no client-side ring buffer can prevent. Nothing
+    // is streamed now; the tail is fetched, bounded, only if we need it.
+    await sandbox.commands.run(
+      `bash -lc ${shellQuote(`${recipe.start} > ${SERVER_LOG_PATH} 2>&1`)}`,
+      {
+        cwd: CHECKOUT_DIR,
+        background: true,
+        // REQUIRED. `timeoutMs` defaults to 60 SECONDS and applies to background
+        // commands too, so without this the PR's server dies about a minute
+        // after it starts, in the middle of a suite that legitimately runs for
+        // twenty. The box's own TTL is the real bound, so use it. (Not `0`: E2B
+        // forwards the value to connect-rpc, which treats <= 0 as an
+        // already-expired deadline and would abort the spawn instantly.)
+        timeoutMs: CHECK_SANDBOX_TIMEOUT_MS,
+      }
+    );
   } catch (error) {
     throw new CheckStepError(
       "infra_error",
@@ -492,6 +498,7 @@ export async function buildAndStart(
     );
   }
 
+  const readServerLogTail = () => readLogTail(sandbox);
   const url = `https://${sandbox.getHost(recipe.port)}${recipe.mcpPath}`;
   const healthy = await waitForMcpInitialize(url, {
     timeoutMs: options?.healthTimeoutMs ?? HEALTH_TIMEOUT_MS,
@@ -502,11 +509,31 @@ export async function buildAndStart(
     throw new CheckStepError(
       "server_unhealthy",
       `server never completed MCP initialize on port ${recipe.port}${recipe.mcpPath}`,
-      clampOutput(stderrTail)
+      clampOutput(await readServerLogTail())
     );
   }
 
-  return { url, readStderrTail: () => stderrTail };
+  return { url, readStderrTail: readServerLogTail };
+}
+
+/**
+ * Fetch a bounded tail of the PR server's log, from inside the box.
+ *
+ * `tail -c` does the truncation in the sandbox, so untrusted output is bounded
+ * BEFORE it crosses into this process. Best effort by design: this only ever
+ * runs to enrich a failure message, and failing to read a log must not change
+ * the verdict.
+ */
+async function readLogTail(sandbox: CheckSandbox): Promise<string> {
+  try {
+    const result = (await sandbox.commands.run(
+      `bash -lc ${shellQuote(`tail -c ${STDERR_TAIL_CHARS} ${SERVER_LOG_PATH} 2>/dev/null || true`)}`,
+      { timeoutMs: 30_000 }
+    )) as { stdout?: string } | undefined;
+    return result?.stdout ?? "";
+  } catch {
+    return "";
+  }
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -995,12 +995,12 @@ function ssePayloads(text: string, streamEnded: boolean): string[] {
   for (let index = 0; index < lineCount; index += 1) {
     const line = segments[index];
     if (line.startsWith("data:")) {
-      current.push(line.slice("data:".length).trim());
+      current.push(sseFieldValue(line, "data:"));
       continue;
     }
     if (line.startsWith("event:")) {
       // Last one wins within an event, per the spec.
-      eventName = line.slice("event:".length).trim();
+      eventName = sseFieldValue(line, "event:");
       continue;
     }
     // A blank line ends the event. Any other field (`id:`, `retry:`, a comment)
@@ -1009,6 +1009,22 @@ function ssePayloads(text: string, streamEnded: boolean): string[] {
   }
   if (streamEnded) flush();
   return payloads.filter((payload) => payload.length > 0);
+}
+
+/**
+ * The value of an SSE field line, stripped exactly the way the transport's parser
+ * strips it: ONE optional space after the colon, and nothing else.
+ *
+ * Trimming instead is wrong in a way that matters for `event:`. The parser keeps
+ * the rest of the whitespace, so `event: message ` is the event type `"message "`,
+ * which is not `"message"` and is therefore dropped — while a trim would normalise
+ * it to `message` and let the probe accept an answer the eval run never receives.
+ * For `data:` the difference is invisible to `JSON.parse`, but a payload assembled
+ * from several fields is joined verbatim, so the same rule keeps that text intact.
+ */
+function sseFieldValue(line: string, field: string): string {
+  const value = line.slice(field.length);
+  return value.startsWith(" ") ? value.slice(1) : value;
 }
 
 /**
@@ -1046,15 +1062,20 @@ function isUsableInitializeResponse(parsed: unknown): boolean {
 }
 
 /**
- * The capability fields the client's schema gives a shape to. Every one it types
- * is an object, so `tools: true` is a schema violation the client will reject.
+ * The capability fields typed as objects by the shape a server is expected to send.
  *
- * Deliberately a closed list rather than "every value must be an object": the
- * client's capabilities schema passes unknown keys through untouched, so a server
- * advertising some extension as a bare string is still one the eval run can
- * drive. Rejecting it here would be stricter than the client — a false
- * `server_unhealthy` on a working PR, which is the failure this whole predicate
- * exists to avoid.
+ * This is the LEGACY arm's check, and it is deliberately shallow. `_legacyHandshake`
+ * assigns `result.capabilities` straight through without running a schema over it
+ * — the JSON-RPC envelope validates `result` as a loose object and stops there — so
+ * nothing below is forced by the client on this path. Nested field types are
+ * mirrored only on the discover arm, where the client really does run
+ * `ServerCapabilitiesSchema`.
+ *
+ * A closed list rather than "every value must be an object": the capabilities shape
+ * passes unknown keys through untouched, so a server advertising some extension as
+ * a bare string is still one the eval run can drive. Rejecting it here would be
+ * stricter than the client — a false `server_unhealthy` on a working PR, which is
+ * the failure this whole predicate exists to avoid.
  */
 const TYPED_CAPABILITY_FIELDS = [
   "tools",
@@ -1083,7 +1104,14 @@ function isUsableCapabilities(value: unknown): boolean {
  *     MODERN arm can actually speak — an endpoint offering nothing in common is
  *     no more usable than a legacy server naming an unsupported version, and one
  *     offering only legacy revisions is a question for the legacy probe;
- *   - `capabilities`, an object whose typed fields are objects.
+ *   - `capabilities` and `instructions` as the discover result schema types them.
+ *
+ * Unlike the legacy arm, this one has a schema to mirror and mirrors it. The client
+ * runs the discover result through `codecForVersion(...).validateResult`, and a
+ * result that FAILS is classified `legacy` — the connection falls back to
+ * `initialize` rather than erroring. So a payload rejected here is not necessarily
+ * a dead server; it is a server the client will not drive in the modern era, which
+ * is precisely what this arm is asked about. The legacy arm answers the rest.
  *
  * Server identity lives in `_meta` here and is a SHOULD, not a member of the
  * result, so its absence is not a defect and is not required.
@@ -1094,6 +1122,7 @@ function isUsableDiscoverResponse(parsed: unknown): boolean {
   const discover = result as {
     supportedVersions?: unknown;
     capabilities?: unknown;
+    instructions?: unknown;
   };
   if (!Array.isArray(discover.supportedVersions)) return false;
   const offered = discover.supportedVersions.filter(
@@ -1103,7 +1132,99 @@ function isUsableDiscoverResponse(parsed: unknown): boolean {
   if (!offered.some((version) => MODERN_PROBE_ACCEPTED_VERSIONS.has(version))) {
     return false;
   }
-  return isUsableCapabilities(discover.capabilities);
+  if (
+    discover.instructions !== undefined &&
+    typeof discover.instructions !== "string"
+  ) {
+    return false;
+  }
+  return matchesServerCapabilitiesSchema(discover.capabilities);
+}
+
+/**
+ * The capability fields whose nested flags the schema types as booleans.
+ */
+const CAPABILITY_BOOLEAN_FLAGS: ReadonlyArray<
+  readonly [string, readonly string[]]
+> = [
+  ["tools", ["listChanged"]],
+  ["prompts", ["listChanged"]],
+  ["resources", ["subscribe", "listChanged"]],
+];
+
+/**
+ * Whether `capabilities` would survive `ServerCapabilitiesSchema`, the schema the
+ * client validates a `server/discover` result with.
+ *
+ * Mirrored field by field rather than shape-only, because the schema types the
+ * nesting: `tools: { listChanged: "yes" }` and `extensions: true` are both objects
+ * at the top level and both rejected a level down. A probe that stops at "is it an
+ * object" reports the modern arm healthy for a server the client declines to drive
+ * there.
+ *
+ * Unknown keys stay welcome, at every level the schema leaves open: the capability
+ * objects are non-strict, so extra members are ignored rather than fatal, and
+ * capabilities is explicitly "not a closed set". Only the members it gives a type
+ * are checked. `JSONObject`-typed fields need only be objects — anything that came
+ * off the wire as JSON already satisfies the value type.
+ */
+function matchesServerCapabilitiesSchema(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  const capabilities = value as Record<string, unknown>;
+
+  for (const field of ["logging", "completions"] as const) {
+    const capability = capabilities[field];
+    if (capability !== undefined && !isPlainObject(capability)) return false;
+  }
+
+  // Name-keyed maps of objects, not free-form values.
+  for (const field of ["experimental", "extensions"] as const) {
+    const record = capabilities[field];
+    if (record === undefined) continue;
+    if (!isPlainObject(record)) return false;
+    const entries = Object.values(record as Record<string, unknown>);
+    if (!entries.every((entry) => isPlainObject(entry))) return false;
+  }
+
+  for (const [field, flags] of CAPABILITY_BOOLEAN_FLAGS) {
+    const capability = capabilities[field];
+    if (capability === undefined) continue;
+    if (!isPlainObject(capability)) return false;
+    const flagged = capability as Record<string, unknown>;
+    const flagsAreBooleans = flags.every(
+      (flag) =>
+        flagged[flag] === undefined || typeof flagged[flag] === "boolean"
+    );
+    if (!flagsAreBooleans) return false;
+  }
+
+  return matchesTasksCapabilitySchema(capabilities.tasks);
+}
+
+/**
+ * The `tasks` capability, whose schema nests two levels deeper
+ * (`requests.tools.call`) and types every level as an object.
+ */
+function matchesTasksCapabilitySchema(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!isPlainObject(value)) return false;
+  const tasks = value as Record<string, unknown>;
+
+  for (const field of ["list", "cancel"] as const) {
+    const capability = tasks[field];
+    if (capability !== undefined && !isPlainObject(capability)) return false;
+  }
+
+  const requests = tasks.requests;
+  if (requests === undefined) return true;
+  if (!isPlainObject(requests)) return false;
+
+  const tools = (requests as Record<string, unknown>).tools;
+  if (tools === undefined) return true;
+  if (!isPlainObject(tools)) return false;
+
+  const call = (tools as Record<string, unknown>).call;
+  return call === undefined || isPlainObject(call);
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -834,9 +834,8 @@ async function probeResponseIsHealthy(
         const consumed = Math.min(value.byteLength, remainingBytes);
         remainingBytes -= consumed;
         text += decoder.decode(value.subarray(0, consumed), { stream: true });
-        // Checked per chunk: a frame can arrive split, and a partial JSON just
-        // fails to parse and waits for the rest. Mid-stream, so an event whose
-        // terminating blank line has not arrived yet is held, not parsed.
+        // Checked per chunk: an SSE event completes the moment its blank line
+        // arrives, so waiting for the body to end would hang on a healthy server.
         if (carriesAcceptedAnswer(text, accepts, false, mode)) return true;
       }
       if (done) {
@@ -844,9 +843,11 @@ async function probeResponseIsHealthy(
         return carriesAcceptedAnswer(text, accepts, true, mode);
       }
     }
-    // Out of byte budget. Nothing further will be read, so this is the last look:
-    // parse whatever the truncated tail holds rather than discarding it.
-    return carriesAcceptedAnswer(text, accepts, true, mode);
+    // Out of byte budget — which is NOT the body ending. We stop reading; the eval
+    // run's client does not, so a JSON body must not be judged on this prefix even
+    // if the prefix happens to parse. Whatever the cap cut off is the client's
+    // problem to hit, not ours to guess at.
+    return carriesAcceptedAnswer(text, accepts, false, mode);
   } finally {
     // We are done with this response either way — a healthy server is still
     // holding the stream open, so drop it rather than leaking the socket.
@@ -889,10 +890,10 @@ function transportPayloadMode(response: Response): "json" | "sse" | null {
 function carriesAcceptedAnswer(
   text: string,
   accepts: (parsed: unknown) => boolean,
-  streamEnded: boolean,
+  bodyComplete: boolean,
   mode: "json" | "sse"
 ): boolean {
-  for (const payload of candidatePayloads(text, streamEnded, mode)) {
+  for (const payload of candidatePayloads(text, bodyComplete, mode)) {
     try {
       if (accepts(JSON.parse(payload))) return true;
     } catch {
@@ -905,15 +906,17 @@ function carriesAcceptedAnswer(
 /**
  * The candidate JSON payloads in the body, framed the way its declared media
  * type says to frame them.
+ *
+ * `bodyComplete` says the body ENDED — not merely that we stopped reading it. Only
+ * the JSON side cares: SSE payloads are complete events, and an event is complete
+ * when its blank line arrives, whatever the body does afterwards.
  */
 function candidatePayloads(
   text: string,
-  streamEnded: boolean,
+  bodyComplete: boolean,
   mode: "json" | "sse"
 ): string[] {
-  return mode === "sse"
-    ? ssePayloads(text, streamEnded)
-    : jsonPayloads(text, streamEnded);
+  return mode === "sse" ? ssePayloads(text) : jsonPayloads(text, bodyComplete);
 }
 
 /**
@@ -924,10 +927,11 @@ function candidatePayloads(
  * a server whose body is one valid JSON document followed by more content (a
  * second document, trailing junk) be accepted at the instant the first document
  * lands — and `response.json()` rejects exactly that, so the client would fail
- * where the probe passed.
+ * where the probe passed. That includes the byte cap: a prefix that parses is
+ * still a prefix, and the client reads past where we stopped.
  */
-function jsonPayloads(text: string, streamEnded: boolean): string[] {
-  if (!streamEnded) return [];
+function jsonPayloads(text: string, bodyComplete: boolean): string[] {
+  if (!bodyComplete) return [];
   const document = text.trim();
   return document ? [document] : [];
 }
@@ -949,16 +953,17 @@ function jsonPayloads(text: string, streamEnded: boolean): string[] {
  * semantics. A server that spreads one JSON-RPC message across several fields is
  * legal, and parsing each line on its own made every fragment fail to parse.
  *
- * `streamEnded` says whether more bytes can still arrive. While the stream is
- * live, an event whose terminating blank line has not been seen yet is INCOMPLETE
- * and is withheld: a multi-field event read at a chunk boundary would otherwise be
- * handed to `JSON.parse` a field short. That mostly just fails to parse, but a
- * server whose first field happens to be a complete JSON object followed by more
- * fields would be accepted off a truncated read. The unfinished event stays in
- * `text`, so the next chunk simply re-parses it whole. Once the stream is over
- * (or we stop reading), the tail is all there is, so parse it.
+ * An event is dispatched on its terminating BLANK LINE and at no other moment.
+ * Nothing here depends on whether the body has ended, because nothing in the
+ * transport does: `EventSourceParserStream` is a `TransformStream` with no `flush`,
+ * so a pending event with no blank line after it is dropped when the stream closes
+ * rather than delivered. An unterminated tail is therefore never a payload — not
+ * mid-stream, not at EOF, not when the byte cap stops us. Withholding it also keeps
+ * a multi-field event from being handed to `JSON.parse` a field short, which mostly
+ * just fails to parse but would otherwise accept a server whose first field happens
+ * to be a complete JSON object followed by more fields.
  */
-function ssePayloads(text: string, streamEnded: boolean): string[] {
+function ssePayloads(text: string): string[] {
   const payloads: string[] = [];
   let current: string[] = [];
   let eventName = "";
@@ -982,16 +987,16 @@ function ssePayloads(text: string, streamEnded: boolean): string[] {
   // does, so a server it can drive must not be turned away here. Splitting on LF
   // alone left a CR-separated frame unrecognised and the probe timed out.
   const segments = text.replace(/^﻿/, "").split(/\r\n|\r|\n/);
-  // The final segment is whatever follows the last separator, so mid-stream it is
-  // a PARTIAL line, not a line. Treating it as one is subtly wrong in both
-  // directions: a half-written `data:` field would be parsed a character short,
-  // and — the case that actually bites — the empty tail left by a trailing
-  // separator would read as the event's blank-line terminator, flushing an event
-  // the server has not finished. A real terminator shows up as an empty segment
-  // with another segment after it. (A CRLF split across chunk boundaries is safe
-  // because the whole accumulated text is re-split on every read, never appended
-  // to a previous parse.)
-  const lineCount = streamEnded ? segments.length : segments.length - 1;
+  // The final segment is whatever follows the last separator, so it is a PARTIAL
+  // line, not a line — a half-written `data:` field, or the empty tail left by a
+  // trailing separator. Neither is a line the parser has seen, and treating the
+  // empty tail as a line would read it as a blank-line terminator and dispatch an
+  // event the server has not finished. A REAL terminator shows up as an empty
+  // segment with another segment after it, so a properly terminated event is always
+  // inside this bound. (A CRLF split across chunk boundaries is safe because the
+  // whole accumulated text is re-split on every read, never appended to a previous
+  // parse.)
+  const lineCount = segments.length - 1;
   for (let index = 0; index < lineCount; index += 1) {
     const line = segments[index];
     if (line.startsWith("data:")) {
@@ -1007,7 +1012,6 @@ function ssePayloads(text: string, streamEnded: boolean): string[] {
     // carries no data but does not split it either.
     if (line === "") flush();
   }
-  if (streamEnded) flush();
   return payloads.filter((payload) => payload.length > 0);
 }
 

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -96,11 +96,12 @@ export const HEALTH_INTERVAL_MS = 2_000;
  */
 export const PROBE_ATTEMPT_TIMEOUT_MS = 10_000;
 /**
- * Cap on how much of a probe response we read before deciding. The answer we are
- * looking for is the first frame; anything past this is a server streaming at us,
- * not a handshake.
+ * Cap on how much of a probe response we read before deciding, in BYTES off the
+ * wire — the unit the budget is actually spent in, so multi-byte output cannot
+ * buy more of it than ASCII does. The answer we are looking for is the first
+ * frame; anything past this is a server streaming at us, not a handshake.
  */
-export const PROBE_MAX_RESPONSE_CHARS = 64 * 1024;
+export const PROBE_MAX_RESPONSE_BYTES = 64 * 1024;
 /** Where the PR is checked out inside the box. */
 export const CHECKOUT_DIR = "/home/user/repo";
 
@@ -245,8 +246,19 @@ type RunResult = { exitCode: number; stdout: string; stderr: string };
 async function runForeground(
   sandbox: CheckSandbox,
   command: string,
-  opts: { cwd?: string; timeoutMs: number }
+  opts: {
+    cwd?: string;
+    timeoutMs: number;
+    /**
+     * Whose fault it is when the command hits ITS OWN deadline. A build that
+     * hangs is the PR's (`build_failed`) — E2B reports that as a timeout with no
+     * exit code, which would otherwise land in the transport branch below and
+     * conclude `neutral`, letting a hanging build dodge a red check.
+     */
+    timeoutOutcome: CheckStepOutcome;
+  }
 ): Promise<RunResult> {
+  const startedAt = Date.now();
   try {
     const result = (await sandbox.commands.run(command, {
       cwd: opts.cwd,
@@ -266,12 +278,42 @@ async function runForeground(
         stderr: exit.stderr ?? "",
       };
     }
+    if (hitCommandDeadline(error, startedAt, opts.timeoutMs)) {
+      throw new CheckStepError(
+        opts.timeoutOutcome,
+        `command exceeded its ${Math.round(opts.timeoutMs / 1000)}s deadline`,
+        clampOutput(`${exit.stdout ?? ""}\n${exit.stderr ?? ""}`) || undefined
+      );
+    }
     // Not a command failure — the sandbox itself is unreachable.
     throw new CheckStepError(
       "infra_error",
       `sandbox command failed: ${errorMessage(error)}`
     );
   }
+}
+
+/**
+ * Did the command run out its own clock, as opposed to the sandbox failing?
+ *
+ * Two independent signals, because getting this wrong in either direction is
+ * costly: calling an infra failure a build failure puts a red X on a good PR,
+ * and calling a hung build an infra failure lets it pass as neutral.
+ *
+ *   - elapsed time reached the deadline we ourselves set. Objective, and it does
+ *     not depend on how the error is shaped;
+ *   - the error identifies itself as a timeout. E2B's own handshake timeout also
+ *     uses that name, so it is excluded by message — that one is transport.
+ */
+function hitCommandDeadline(
+  error: unknown,
+  startedAt: number,
+  timeoutMs: number
+): boolean {
+  if (Date.now() - startedAt >= timeoutMs) return true;
+  const name = (error as { name?: unknown } | null)?.name;
+  if (name !== "TimeoutError") return false;
+  return !/handshake/i.test(errorMessage(error));
 }
 
 /**
@@ -307,6 +349,9 @@ export async function cloneAndCheckout(
     `bash -lc ${shellQuote(script)}`,
     {
       timeoutMs: CLONE_TIMEOUT_MS,
+      // A public repo we were just told about should clone promptly; a stall is
+      // ours or GitHub's, matching how a non-zero clone exit is attributed.
+      timeoutOutcome: "infra_error",
     }
   );
   if (result.exitCode !== 0) {
@@ -324,6 +369,8 @@ export async function cloneAndCheckout(
     `git -C ${CHECKOUT_DIR} rev-parse HEAD`,
     {
       timeoutMs: 60_000,
+      // `rev-parse` on a fresh clone is instant; a stall is the sandbox, not the PR.
+      timeoutOutcome: "infra_error",
     }
   );
   const checkedOut = head.stdout.trim();
@@ -397,6 +444,7 @@ export async function buildAndStart(
     {
       cwd: CHECKOUT_DIR,
       timeoutMs: BUILD_TIMEOUT_MS,
+      timeoutOutcome: "build_failed",
     }
   );
   if (build.exitCode !== 0) {
@@ -420,6 +468,14 @@ export async function buildAndStart(
     await sandbox.commands.run(`bash -lc ${shellQuote(recipe.start)}`, {
       cwd: CHECKOUT_DIR,
       background: true,
+      // REQUIRED. `timeoutMs` defaults to 60 SECONDS and applies to background
+      // commands too, so without this the PR's server — and the stderr stream
+      // this reads for the health-failure message — dies about a minute after it
+      // starts, in the middle of a suite that legitimately runs for twenty. The
+      // box's own TTL is the real bound, so use it. (Not `0`: E2B forwards the
+      // value to connect-rpc, which treats <= 0 as an already-expired deadline
+      // and would abort the spawn instantly.)
+      timeoutMs: CHECK_SANDBOX_TIMEOUT_MS,
       onStderr: appendStderr,
     });
   } catch (error) {
@@ -549,7 +605,7 @@ export async function waitForMcpInitialize(
  * real server.)
  *
  * So read incrementally and return the moment the accumulated text carries an
- * initialize result, then cancel the stream. `PROBE_MAX_RESPONSE_CHARS` bounds
+ * initialize result, then cancel the stream. `PROBE_MAX_RESPONSE_BYTES` bounds
  * a server that streams unrelated output at us forever.
  */
 async function probeResponseIsHealthy(response: Response): Promise<boolean> {
@@ -566,15 +622,21 @@ async function probeResponseIsHealthy(response: Response): Promise<boolean> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let text = "";
+  // Spent in bytes, tracked separately from `text.length`. Decoded length is in
+  // UTF-16 units, so budgeting by it would let non-ASCII output read more of the
+  // wire than the cap allows — the slice below is in bytes either way.
+  let remainingBytes = PROBE_MAX_RESPONSE_BYTES;
   try {
-    while (text.length < PROBE_MAX_RESPONSE_CHARS) {
+    while (remainingBytes > 0) {
       const { done, value } = await reader.read();
       if (value && value.byteLength > 0) {
-        // Decode only what fits in the remaining budget. Decoding the whole
-        // chunk first would let one large write blow past the cap — the bound
-        // has to be applied to the bytes, not checked after the fact.
-        const remaining = PROBE_MAX_RESPONSE_CHARS - text.length;
-        text += decoder.decode(value.subarray(0, remaining), { stream: true });
+        // Decode only what fits. Decoding the whole chunk and checking after the
+        // fact would let one large write blow straight past the cap. A sequence
+        // cut in half here is held by the decoder (`stream: true`) and completed
+        // by the next chunk, or dropped if the budget runs out first.
+        const consumed = Math.min(value.byteLength, remainingBytes);
+        remainingBytes -= consumed;
+        text += decoder.decode(value.subarray(0, consumed), { stream: true });
         // Checked per chunk: a frame can arrive split, and a partial JSON just
         // fails to parse and waits for the rest.
         if (looksLikeInitializeResult(text)) return true;

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -140,29 +140,39 @@ const PROBE_CLIENT_INFO = {
 } as const;
 
 /**
- * Versions the probe will accept back from the PR's server.
+ * Versions the LEGACY `initialize` arm will accept back from the PR's server.
+ *
+ * Exactly the upstream SDK's built-in legacy list, and the modern revision is
+ * deliberately NOT in it. `_legacyHandshake` accepts only
+ * `legacyProtocolVersions(supportedProtocolVersions)` — everything before
+ * 2026-07-28 — and throws on anything else, and the eval run's unpinned
+ * connection passes no list of its own, so that built-in set is the one in force.
+ * Upstream keeps the two lists apart for this exact reason: "adding a revision
+ * here can never leak a modern version string into a 2025-era handshake". A server
+ * answering `initialize` with `2026-07-28` is one the client refuses, so accepting
+ * it here would hand the PR's fault to us as a neutral `infra_error`. The modern
+ * revision is reachable through `server/discover`, which is the arm that tests it.
  *
  * Hand-listed rather than imported: `check:mcp-v1-runtime-imports` forbids
  * reaching into the upstream v1 protocol SDK from inspector server code, and
  * `MCP_PROTOCOL_VERSIONS` in our own SDK is the narrower set a connection can be
  * PINNED to — it omits the legacy wire versions the client still accepts.
  *
- * The list must stay at least as permissive as the real client. A version this
- * probe rejects but the client would have accepted turns a working PR server
- * into a false `server_unhealthy`, which is worse than the neutral it replaces.
- * So: upstream's supported list, plus the newest revision our SDK knows.
+ * The list must stay exactly as permissive as the real client. Rejecting a version
+ * it accepts is a false `server_unhealthy` on a working PR; accepting one it
+ * rejects lets a broken PR dodge the blame.
  */
-const HEALTH_PROBE_ACCEPTED_VERSIONS: ReadonlySet<string> = new Set([
+const LEGACY_PROBE_ACCEPTED_VERSIONS: ReadonlySet<string> = new Set([
   "2024-10-07",
   "2024-11-05",
   "2025-03-26",
   "2025-06-18",
   "2025-11-25",
-  "2026-07-28",
 ]);
 
 /**
- * The subset of the above the MODERN negotiation arm can speak.
+ * Versions the MODERN `server/discover` arm can speak — the other side of that
+ * same split.
  *
  * A `server/discover` result is only evidence of a usable server if the versions
  * it offers overlap THIS set. A discover answer naming nothing but legacy
@@ -1085,7 +1095,8 @@ function sseField(line: string): [string, string] {
  *   - the JSON-RPC envelope (`jsonrpc: "2.0"`, and the id we actually sent, so a
  *     stray notification or an answer to someone else's request is not ours);
  *   - a `result`, not an `error`;
- *   - `protocolVersion` the client can speak;
+ *   - `protocolVersion` the client can speak IN THIS ERA — a modern revision here
+ *     is refused by the legacy handshake, so it is not usable evidence;
  *   - `capabilities` and `serverInfo`, both required by `InitializeResultSchema`.
  */
 function isUsableInitializeResponse(parsed: unknown): boolean {
@@ -1098,7 +1109,7 @@ function isUsableInitializeResponse(parsed: unknown): boolean {
   };
   if (
     typeof initialize.protocolVersion !== "string" ||
-    !HEALTH_PROBE_ACCEPTED_VERSIONS.has(initialize.protocolVersion)
+    !LEGACY_PROBE_ACCEPTED_VERSIONS.has(initialize.protocolVersion)
   ) {
     return false;
   }

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/.gitignore
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/README.md
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/README.md
@@ -13,14 +13,16 @@ the ops step is "copy and push" rather than "write from scratch".
 ```bash
 cp -R test-servers/mcp-check-fixture /tmp/mcp-check-fixture
 cd /tmp/mcp-check-fixture
-npm install          # generates package-lock.json — REQUIRED, see below
 git init && git add -A && git commit -m "mcp-check-fixture: minimal MCP server"
 gh repo create mcpjam/mcp-check-fixture --public --source=. --push
 ```
 
-`npm install` before the first commit is not optional: the run recipe uses
-`npm ci`, which fails without a committed `package-lock.json`. A check on a repo
-missing the lockfile reports `build_failed` — correctly, but confusingly.
+`package-lock.json` is committed here on purpose, and must stay committed in the
+published repo: the run recipe uses `npm ci`, which fails outright without one.
+A repo missing its lockfile reports `build_failed` — correctly, but confusingly.
+`@types/node` is likewise a real devDependency, not an assumption about the
+build environment: `tsconfig.json` declares `"types": ["node"]`, and this package
+is standalone with no workspace to hoist it from.
 
 ## The two things that must not be "cleaned up"
 

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/README.md
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/README.md
@@ -1,0 +1,76 @@
+# mcp-check-fixture
+
+The MCP server MCPJam's GitHub PR checks are validated against. This directory is
+the **seed** for the standalone public repository `mcpjam/mcp-check-fixture` —
+the only repo the walking-skeleton check pipeline is wired to
+(`server/services/github-checks/recipes.ts`).
+
+It lives here so it is reviewed alongside the pipeline that depends on it, and so
+the ops step is "copy and push" rather than "write from scratch".
+
+## Publishing it
+
+```bash
+cp -R test-servers/mcp-check-fixture /tmp/mcp-check-fixture
+cd /tmp/mcp-check-fixture
+npm install          # generates package-lock.json — REQUIRED, see below
+git init && git add -A && git commit -m "mcp-check-fixture: minimal MCP server"
+gh repo create mcpjam/mcp-check-fixture --public --source=. --push
+```
+
+`npm install` before the first commit is not optional: the run recipe uses
+`npm ci`, which fails without a committed `package-lock.json`. A check on a repo
+missing the lockfile reports `build_failed` — correctly, but confusingly.
+
+## The two things that must not be "cleaned up"
+
+**It binds `0.0.0.0`, not `127.0.0.1`.** E2B's host bridge only forwards to ports
+bound on all interfaces. A loopback-only server is invisible from outside the
+sandbox and the check reports `server_unhealthy` with a stderr tail that may not
+mention the bind address at all.
+
+**It answers `initialize` on `/mcp` immediately.** That handshake _is_ the health
+probe — the worker polls it until it succeeds. Anything that delays it (a
+warm-up, a lazily mounted route) reads as an unhealthy server.
+
+## Run recipe
+
+The recipe hardcoded in the Inspector for this repo:
+
+| field     | value                     |
+| --------- | ------------------------- |
+| `build`   | `npm ci && npm run build` |
+| `start`   | `npm start`               |
+| `port`    | `3001`                    |
+| `mcpPath` | `/mcp`                    |
+
+Changing any of those means changing `recipes.ts` in the same breath.
+
+## Tools
+
+Three, all deterministic and side-effect-free — the eval suite's job is to prove
+the pipeline works, not to be an interesting test:
+
+- `echo({ text })` → the same text
+- `add({ a, b })` → the sum
+- `server_info()` → `{"name":"mcp-check-fixture","version":"1.0.0"}`
+
+## Locally
+
+```bash
+npm install && npm run build && npm start
+curl -s localhost:3001/mcp -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
+```
+
+## Exercising the check's failure modes
+
+Each of these is a one-line change, and each should produce a specific check
+conclusion — useful for verifying the pipeline end to end:
+
+| Change                                | Expected outcome   | Check conclusion |
+| ------------------------------------- | ------------------ | ---------------- |
+| break a tool's return value           | `evals_failed`     | failure          |
+| introduce a type error                | `build_failed`     | failure          |
+| `throw` at the top of `server.ts`     | `server_unhealthy` | failure          |
+| bind `127.0.0.1` instead of `0.0.0.0` | `server_unhealthy` | failure          |

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/package-lock.json
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "mcp-check-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-check-fixture",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/package.json
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mcp-check-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Minimal streamable-HTTP MCP server used as the fixture for MCPJam's GitHub PR checks.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0"
+  }
+}

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/package.json
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/server.js"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.6.0"
   }
 }

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -1,0 +1,287 @@
+/**
+ * The MCP server the GitHub PR-check walking skeleton tests against.
+ *
+ * This file is the seed for the public repo `mcpjam/mcp-check-fixture` (see the
+ * README next to it). It exists so the check pipeline can be exercised
+ * end-to-end against something we control: a deliberately boring,
+ * deterministic, dependency-free streamable-HTTP MCP server.
+ *
+ * Two properties are load-bearing for the check pipeline and must not be
+ * "cleaned up":
+ *
+ *   1. It binds 0.0.0.0, not 127.0.0.1. E2B's host bridge only forwards to
+ *      ports bound on all interfaces, so a loopback-only server is invisible
+ *      from outside the sandbox and the check reports `server_unhealthy`.
+ *   2. It answers `initialize` immediately on `/mcp`. That handshake IS the
+ *      health probe — the worker polls it until it succeeds, so anything that
+ *      delays it (a warm-up, a lazy route mount) shows up as an unhealthy
+ *      server.
+ *
+ * The tools are intentionally trivial and side-effect-free: the eval suite's job
+ * here is to prove the pipeline works, not to be an interesting test.
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+
+const PORT = Number(process.env.PORT ?? 3001);
+/** All interfaces — see property (1) in the file comment. */
+const HOST = "0.0.0.0";
+const MCP_PATH = "/mcp";
+const PROTOCOL_VERSION = "2025-06-18";
+/** Bound on the request body; nothing here needs a large one. */
+const MAX_BODY_BYTES = 256 * 1024;
+
+type JsonRpcRequest = {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: Record<string, unknown>;
+};
+
+const TOOLS = [
+  {
+    name: "echo",
+    description: "Return the text you pass in, unchanged.",
+    inputSchema: {
+      type: "object",
+      properties: { text: { type: "string", description: "Text to echo." } },
+      required: ["text"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "add",
+    description: "Add two numbers and return the sum.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        a: { type: "number", description: "First addend." },
+        b: { type: "number", description: "Second addend." },
+      },
+      required: ["a", "b"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "server_info",
+    description:
+      "Return this fixture server's name and version. Takes no arguments.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+function textResult(text: string) {
+  return { content: [{ type: "text", text }] };
+}
+
+function callTool(
+  name: string,
+  args: Record<string, unknown>
+): { result?: unknown; error?: { code: number; message: string } } {
+  switch (name) {
+    case "echo": {
+      const text = args?.text;
+      if (typeof text !== "string") {
+        return { error: { code: -32602, message: "`text` must be a string" } };
+      }
+      return { result: textResult(text) };
+    }
+    case "add": {
+      const { a, b } = args ?? {};
+      if (typeof a !== "number" || typeof b !== "number") {
+        return {
+          error: { code: -32602, message: "`a` and `b` must be numbers" },
+        };
+      }
+      return { result: textResult(String(a + b)) };
+    }
+    case "server_info":
+      return {
+        result: textResult(
+          JSON.stringify({ name: "mcp-check-fixture", version: "1.0.0" })
+        ),
+      };
+    default:
+      return { error: { code: -32601, message: `Unknown tool: ${name}` } };
+  }
+}
+
+function handleRpc(request: JsonRpcRequest): {
+  status: number;
+  body?: unknown;
+} {
+  switch (request.method) {
+    case "initialize":
+      return {
+        status: 200,
+        body: {
+          jsonrpc: "2.0",
+          id: request.id ?? null,
+          result: {
+            protocolVersion: PROTOCOL_VERSION,
+            capabilities: { tools: {} },
+            serverInfo: { name: "mcp-check-fixture", version: "1.0.0" },
+          },
+        },
+      };
+    // Notifications carry no id and get no body — 202 per the transport.
+    case "notifications/initialized":
+      return { status: 202 };
+    case "ping":
+      return {
+        status: 200,
+        body: { jsonrpc: "2.0", id: request.id ?? null, result: {} },
+      };
+    case "tools/list":
+      return {
+        status: 200,
+        body: {
+          jsonrpc: "2.0",
+          id: request.id ?? null,
+          result: { tools: TOOLS },
+        },
+      };
+    case "tools/call": {
+      const name = String(request.params?.name ?? "");
+      const args = (request.params?.arguments ?? {}) as Record<string, unknown>;
+      const outcome = callTool(name, args);
+      return {
+        status: 200,
+        body: {
+          jsonrpc: "2.0",
+          id: request.id ?? null,
+          ...(outcome.error
+            ? { error: outcome.error }
+            : { result: outcome.result }),
+        },
+      };
+    }
+    default:
+      return {
+        status: 200,
+        body: {
+          jsonrpc: "2.0",
+          id: request.id ?? null,
+          error: {
+            code: -32601,
+            message: `Method not found: ${request.method ?? "(none)"}`,
+          },
+        },
+      };
+  }
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error("Payload too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(
+    req.url ?? "/",
+    `http://${req.headers.host ?? "localhost"}`
+  );
+
+  // A plain liveness endpoint, for humans. The CHECK's health probe is the MCP
+  // `initialize` on /mcp, not this.
+  if (req.method === "GET" && url.pathname === "/healthz") {
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  if (url.pathname !== MCP_PATH) {
+    sendJson(res, 404, { error: "Not found" });
+    return;
+  }
+  if (req.method !== "POST") {
+    // No server-initiated stream in this fixture.
+    res.writeHead(405, { allow: "POST" }).end();
+    return;
+  }
+
+  let raw: string;
+  try {
+    raw = await readBody(req);
+  } catch {
+    sendJson(res, 413, { error: "Payload too large" });
+    return;
+  }
+
+  let parsed: JsonRpcRequest | JsonRpcRequest[];
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    sendJson(res, 400, {
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32700, message: "Parse error" },
+    });
+    return;
+  }
+
+  // Batches are legal on the wire; answer them so a client that sends one
+  // doesn't look like a broken server.
+  if (Array.isArray(parsed)) {
+    const bodies = parsed
+      .map((entry) => handleRpc(entry))
+      .filter((entry) => entry.body !== undefined)
+      .map((entry) => entry.body);
+    if (bodies.length === 0) {
+      res.writeHead(202).end();
+      return;
+    }
+    sendJson(res, 200, bodies);
+    return;
+  }
+
+  const { status, body } = handleRpc(parsed);
+  if (body === undefined) {
+    res.writeHead(status).end();
+    return;
+  }
+  sendJson(res, status, body);
+});
+
+server.listen(PORT, HOST, () => {
+  // Log the bind address explicitly: "127.0.0.1" here is the single most likely
+  // cause of a `server_unhealthy` check, so make it visible in the check logs.
+  console.log(
+    `mcp-check-fixture listening on http://${HOST}:${PORT}${MCP_PATH}`
+  );
+});
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => {
+    server.close(() => process.exit(0));
+  });
+}

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -350,6 +350,12 @@ const server = createServer(async (req, res) => {
 server.listen(PORT, HOST, () => {
   // Log the bind address explicitly: "127.0.0.1" here is the single most likely
   // cause of a `server_unhealthy` check, so make it visible in the check logs.
+  //
+  // `console.log` on purpose, and the one place in this tree where the repo's
+  // logging rule does not apply: this file is the seed for a SEPARATE public
+  // repo and must stay dependency-free (its whole recipe is `npm ci && npm run
+  // build` with nothing but typescript + @types/node). Importing the inspector's
+  // logger would not even resolve once the file is copied out.
   console.log(
     `mcp-check-fixture listening on http://${HOST}:${PORT}${MCP_PATH}`
   );

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -114,13 +114,37 @@ function callTool(
   }
 }
 
+/**
+ * A well-formed JSON-RPC 2.0 request object.
+ *
+ * `jsonrpc` and the id's TYPE are checked, not just `method`: this fixture is
+ * the control for the check pipeline, so it has to be strict about the wire
+ * format. A client sending `{"method":"initialize"}` with no `jsonrpc`, or an
+ * id that is an object, is malformed and gets `-32600` — accepting it here
+ * would let the pipeline pass against a server that is more permissive than the
+ * spec.
+ */
 function isRpcRequest(value: unknown): value is JsonRpcRequest {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    !Array.isArray(value) &&
-    typeof (value as JsonRpcRequest).method === "string"
-  );
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as JsonRpcRequest & { id?: unknown };
+  if (candidate.jsonrpc !== "2.0") return false;
+  if (typeof candidate.method !== "string") return false;
+  return isValidRpcId(candidate.id);
+}
+
+/**
+ * A legal id: a string, an integer-valued number, or ABSENT (a notification).
+ *
+ * `null` is rejected. JSON-RPC 2.0 discourages it and MCP forbids it outright,
+ * and "absent" is the thing that means notification — a client sending an
+ * explicit `null` has a bug this fixture should surface rather than absorb.
+ */
+function isValidRpcId(id: unknown): boolean {
+  if (id === undefined) return true;
+  if (typeof id === "string") return true;
+  return typeof id === "number" && Number.isInteger(id);
 }
 
 function invalidRequest(value: unknown): { status: number; body?: unknown } {
@@ -285,6 +309,14 @@ const server = createServer(async (req, res) => {
   // Batches are legal on the wire; answer them so a client that sends one
   // doesn't look like a broken server.
   if (Array.isArray(parsed)) {
+    // An EMPTY batch is itself an invalid request per JSON-RPC 2.0 — not a batch
+    // of zero notifications. Answering 202 there would tell a client its
+    // malformed payload was accepted.
+    if (parsed.length === 0) {
+      const { status, body } = invalidRequest(null);
+      sendJson(res, status, body);
+      return;
+    }
     const bodies = parsed
       .map((entry) =>
         isRpcRequest(entry) ? handleRpc(entry) : invalidRequest(entry)

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -114,6 +114,30 @@ function callTool(
   }
 }
 
+function isRpcRequest(value: unknown): value is JsonRpcRequest {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as JsonRpcRequest).method === "string"
+  );
+}
+
+function invalidRequest(value: unknown): { status: number; body?: unknown } {
+  const id =
+    typeof value === "object" && value !== null
+      ? (value as JsonRpcRequest).id ?? null
+      : null;
+  return {
+    status: 400,
+    body: {
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32600, message: "Invalid Request" },
+    },
+  };
+}
+
 function handleRpc(request: JsonRpcRequest): {
   status: number;
   body?: unknown;
@@ -253,7 +277,9 @@ const server = createServer(async (req, res) => {
   // doesn't look like a broken server.
   if (Array.isArray(parsed)) {
     const bodies = parsed
-      .map((entry) => handleRpc(entry))
+      .map((entry) =>
+        isRpcRequest(entry) ? handleRpc(entry) : invalidRequest(entry)
+      )
       .filter((entry) => entry.body !== undefined)
       .map((entry) => entry.body);
     if (bodies.length === 0) {
@@ -264,7 +290,12 @@ const server = createServer(async (req, res) => {
     return;
   }
 
-  const { status, body } = handleRpc(parsed);
+  // `JSON.parse` happily yields `null`, a number, or a string — none of which
+  // have a `.method`. Dispatching those threw inside the request handler and
+  // left the client hanging instead of getting a JSON-RPC error.
+  const { status, body } = isRpcRequest(parsed)
+    ? handleRpc(parsed)
+    : invalidRequest(parsed);
   if (body === undefined) {
     res.writeHead(status).end();
     return;

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -124,9 +124,18 @@ function isRpcRequest(value: unknown): value is JsonRpcRequest {
 }
 
 function invalidRequest(value: unknown): { status: number; body?: unknown } {
-  const id =
+  // Echo the id only when it is a legal JSON-RPC id. A malformed request can
+  // carry anything here (an object, NaN), and reflecting that produces a
+  // response a strict client will itself reject — `null` is what the spec asks
+  // for when the id cannot be determined.
+  const candidate =
     typeof value === "object" && value !== null
-      ? (value as JsonRpcRequest).id ?? null
+      ? (value as { id?: unknown }).id
+      : null;
+  const id =
+    typeof candidate === "string" ||
+    (typeof candidate === "number" && Number.isFinite(candidate))
+      ? candidate
       : null;
   return {
     status: 400,

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -115,14 +115,15 @@ function callTool(
 }
 
 /**
- * A well-formed JSON-RPC 2.0 request object.
+ * A well-formed MCP message: a request WITH an id, or a notification WITHOUT
+ * one.
  *
- * `jsonrpc` and the id's TYPE are checked, not just `method`: this fixture is
- * the control for the check pipeline, so it has to be strict about the wire
- * format. A client sending `{"method":"initialize"}` with no `jsonrpc`, or an
- * id that is an object, is malformed and gets `-32600` — accepting it here
- * would let the pipeline pass against a server that is more permissive than the
- * spec.
+ * The whole envelope is checked, not just `method`, because this fixture is the
+ * control for the check pipeline: if it accepts sloppier input than the spec
+ * allows, a PR whose server is equally sloppy passes its check. MCP is stricter
+ * than bare JSON-RPC 2.0 here — a request MUST carry a string or integer id
+ * (never `null`), and a notification MUST NOT carry one at all, since any
+ * message with an `id` field is by definition a request.
  */
 function isRpcRequest(value: unknown): value is JsonRpcRequest {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -131,18 +132,20 @@ function isRpcRequest(value: unknown): value is JsonRpcRequest {
   const candidate = value as JsonRpcRequest & { id?: unknown };
   if (candidate.jsonrpc !== "2.0") return false;
   if (typeof candidate.method !== "string") return false;
+
+  if (isNotificationMethod(candidate.method)) {
+    return !("id" in candidate);
+  }
   return isValidRpcId(candidate.id);
 }
 
-/**
- * A legal id: a string, an integer-valued number, or ABSENT (a notification).
- *
- * `null` is rejected. JSON-RPC 2.0 discourages it and MCP forbids it outright,
- * and "absent" is the thing that means notification — a client sending an
- * explicit `null` has a bug this fixture should surface rather than absorb.
- */
+/** Notifications are exactly the `notifications/*` methods. */
+function isNotificationMethod(method: string): boolean {
+  return method.startsWith("notifications/");
+}
+
+/** A legal request id: a string, or an integer-valued number. Never `null`. */
 function isValidRpcId(id: unknown): boolean {
-  if (id === undefined) return true;
   if (typeof id === "string") return true;
   return typeof id === "number" && Number.isInteger(id);
 }

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -349,15 +349,17 @@ const server = createServer(async (req, res) => {
 
 server.listen(PORT, HOST, () => {
   // Log the bind address explicitly: "127.0.0.1" here is the single most likely
-  // cause of a `server_unhealthy` check, so make it visible in the check logs.
+  // cause of a `server_unhealthy` check, so make it visible in the check logs. A
+  // failed health check reports the tail of this server's log, and "listening
+  // on ..." is how you tell "never started" from "started and never answered".
   //
-  // `console.log` on purpose, and the one place in this tree where the repo's
-  // logging rule does not apply: this file is the seed for a SEPARATE public
-  // repo and must stay dependency-free (its whole recipe is `npm ci && npm run
-  // build` with nothing but typescript + @types/node). Importing the inspector's
-  // logger would not even resolve once the file is copied out.
-  console.log(
-    `mcp-check-fixture listening on http://${HOST}:${PORT}${MCP_PATH}`
+  // Written straight to stdout: `console.log` is prohibited repository-wide, and
+  // the inspector's logger cannot be imported here because this file is the seed
+  // for a SEPARATE public repo and must stay dependency-free — its whole recipe is
+  // `npm ci && npm run build` over nothing but typescript + @types/node, so that
+  // import would not resolve once the file is copied out.
+  process.stdout.write(
+    `mcp-check-fixture listening on http://${HOST}:${PORT}${MCP_PATH}\n`
   );
 });
 

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/tsconfig.json
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "declaration": false,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Inspector half of the GitHub App that tests MCP-server PRs: claim a PR trigger, build its MCP server in a disposable sandbox, run the dedicated eval suite against it, report an outcome. Control plane (webhook, queue, check-run writes) is MCPJam/mcpjam-backend#817, whose `docs/github-pr-checks.md` is the runbook for both halves.

### What lands

| Commit | Content |
|---|---|
| `fb1b832` | `server/services/github-checks/` — `recipes.ts` (the one hardcoded piece) and `sandbox.ts` (provision, clone, build, egress lockdown, health probe, `clampOutput`). |
| `890320b` | `github-checks-worker.ts` + `server/index.ts` wiring. |
| `fe8d9b6` | `test-servers/mcp-check-fixture/` — the fixture MCP server the pipeline is validated against. |

### The security shape, since that's the point

Everything this code runs is untrusted code from a pull request.

- **Zero credentials in the sandbox.** Anonymous clone of a public repo, no token, nothing about MCPJam's environment passed in. A test asserts the clone command contains no credential material and no `envs`.
- **A dedicated minimal template is required**, with no fallback to the computer image — that one carries a browser, a desktop, and Project Computer tooling a PR's build has no business reaching. A missing `GITHUB_CHECKS_E2B_TEMPLATE_ID` is a deployment error, not something to paper over.
- **Outbound network is revoked between the build and the start.** `npm ci` needs the registry; the PR's server does not, and the server is the process that runs for twenty minutes while an eval suite pokes at it. A failed revoke is `infra_error` and **aborts** — there's a test that no background process is ever spawned on that path. Inbound eval traffic still arrives via `getHost(port)`, so it's a one-way door.
- **The worker holds no GitHub credential and has no code path to one.** It reports an outcome; the control plane maps that to a conclusion. A compromised worker cannot write to anyone's repo.
- Build logs and server stderr are clamped, control-stripped, and fenced with a backtick run longer than any inside them before they can reach check-run markdown.

### Two details that are easy to get wrong

**The checkout sha is asserted.** The clone fetches `refs/pull/<n>/head` (branches get renamed) and then asserts `rev-parse HEAD === headSha`. Without that assert, a force-push between the webhook and the clone has us build a different tree and report the verdict against the sha shown in the check — quietly lying about what was tested.

**Health is a real JSON-RPC `initialize`**, not a TCP connect or a 200 on `/`. Frameworks routinely serve before their MCP transport is mounted, and the eval run's first act is an `initialize`, so probing with the actual handshake makes "healthy" mean the same thing in both places. JSON and SSE framing both count; a JSON-RPC *error* does not.

### Failure attribution

`CheckStepError` carries the verdict, so the worker never re-derives one from a message:

| Failure | Outcome | Whose fault |
|---|---|---|
| build exits non-zero | `build_failed` | the PR's |
| server never answers `initialize` | `server_unhealthy` | the PR's |
| E2B unavailable, clone of a public repo fails, egress lockdown fails, delegation fails | `infra_error` | ours |
| `billing_limit_reached` | `infra_error` | ours |
| anything unrecognized | `infra_error` | assumed ours |

That last row is deliberate. Guessing from an error message and guessing wrong means a red X on a good pull request, so an unrecognized failure is always ours.

### Worker invariants

A claimed trigger **always** gets exactly one reported outcome, on every path, and the sandbox is always torn down. An unreported claim shows up on someone's PR as a check that hangs for five minutes and then goes neutral. Reporting itself is failure-safe: a throw there would otherwise escape into the poll loop, which would read it as a transport error and back off 60s.

Cleanup steps are independent — a failure to soft-delete the ephemeral `servers` row must not skip killing the sandbox (which costs money), and vice versa. The ephemeral server id is reported to the backend *before* the eval run starts, so a worker that dies mid-run leaves recovery a pointer to reap.

### Cross-repo contract (hand-mirrored — please diff against the backend PR)

```ts
export type ClaimedGithubCheck = {
  triggerId: string;
  repoFullName: string;
  prNumber: number;
  headSha: string;
  organizationId: string;
  projectId: string;
  createdByExternalId: string;
  suiteId: string;
};

export type GithubCheckOutcome =
  | "passed" | "evals_failed" | "build_failed" | "server_unhealthy"
  | "recipe_unresolvable" | "unsupported_fork" | "infra_error";
```

Reported to `POST /internal/v1/github-checks/complete` as `{triggerId, outcome, runId?, summary?, detailsMarkdown?, failureReason?}`; heartbeat every 60s to `/heartbeat`; the created server row to `/ephemeral-server`. The repos share no types, so these shapes *are* the contract; unknown wire fields are ignored rather than rejected.

### Eval targeting

A real ephemeral `servers` row plus a `serverIds` override to `prepareEvalRun` — the path the scheduled worker already exercises; there is no inline-config injection point (`resolveServerIdsOrThrow`). The `*.e2b.app` URL passes `isUnsafeHostedOutboundHost`.

Consequence worth knowing: `authorEvalSuite` re-persists server refs each run, so the dedicated suite ends up pointing at the previous check's soft-deleted server. Harmless only because the worker always overrides `serverIds` — hence the `[github-checks] …` naming convention and "never run it from the UI".

`source: 'api'` rather than a new `'github_check'` value; that would be a two-repo schema change, deliberately deferred.

### Testing

52 new tests. `sandbox.test.ts` drives the whole build/start/health sequence through a fake that records an ordered event log, so the ordering assertions are about the real sequence rather than a mocked promise. `github-checks-worker.test.ts` drives `executeClaimedCheck` through injected collaborators, so every failure path exercises real control flow including the `finally` cleanup and the heartbeat lifecycle.

One test caught a real bug during development: `executeClaimedCheck` promises never to throw, but a failing reporter propagated out of the catch block. Fixed in `890320b`.

Pre-existing repo-wide `tsc` errors are unchanged (407 → 406 locally, and the one that went away was a generated bundle, not a type). New files contribute none.

### Not done here (needs console access)

Publishing `mcpjam/mcp-check-fixture` (seed + instructions are in `test-servers/mcp-check-fixture/README.md` — `npm install` and commit the lockfile before the first PR, the recipe uses `npm ci`), building the E2B template, and setting the env. `GITHUB_CHECKS_WORKER_ENABLED` defaults off, so merging this starts nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWoUGQoUMLn3SkFp9SieuY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Runs untrusted PR code in sandboxes and maps failures to GitHub-visible check conclusions; mis-attribution or lease/snapshot bugs directly affect PR authors, and long-running checks interact with deploy shutdown timing.
> 
> **Overview**
> Adds an env-gated **GitHub PR checks worker** (`GITHUB_CHECKS_WORKER_ENABLED`) that polls Convex service routes, claims one trigger at a time, and runs the full flow: resolve a build recipe → provision an E2B sandbox → clone/checkout → build with **egress locked before start** → health-probe via real MCP `initialize` → ephemeral `servers` row → existing `prepareEvalRun` / eval pipeline → **exactly one** reported outcome (`passed`, `evals_failed`, `build_failed`, `server_unhealthy`, `recipe_unresolvable`, `infra_error`).
> 
> The worker deliberately **never touches GitHub**; it only reports outcomes so attribution stays correct (**PR faults** vs **neutral `infra_error`**), including post-eval **in-sandbox liveness** (loopback, not public URL), lease loss abandonment, billing markers, and guards so non-`completed` runs and stolen suite snapshots do not produce false red Xs.
> 
> **`server/index.ts`** starts/stops the worker alongside scheduled evals and tightens shutdown: arm the force-exit timer before long `stop()` awaits, clear orphan polling before worker shutdown, and await both workers in the guarded path.
> 
> Supporting pieces include **`github-checks/recipes.ts`** (fixture repo recipe table for now) and large **`sandbox`** + **worker** test suites covering ordering, cleanup, heartbeats, and probe strictness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59fa2061f91e23ccbc9341fc2e5bed5da576f42f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub PR checks worker that builds a PR’s MCP server in an E2B sandbox, runs the eval suite, and reports one outcome per claim. Tightens JSON‑RPC result checks, guards snapshots, re-checks the lease after successful evals, and improves run cleanup to prevent orphaned rows.

- **Bug Fixes**
  - Build logs: run the whole recipe under `bash -lc` with file redirection and the watchdog so all output stays in-box and the exit status is preserved.
  - Snapshot guard: if the eval run’s environment snapshot names another check’s ephemeral server, abandon and go neutral; if the snapshot read fails, fail closed and go neutral instead of proceeding.
  - Legacy probe offer: send the client’s latest legacy revision (`2025-11-25`) so servers that only work on older revisions no longer pass the probe and are classified `server_unhealthy`.
  - Run and lease handling: require a `completed` run before deriving a result; `timed_out`/`cancelled` land neutral (`infra_error`); re-check the lease after both failed and successful evals and abandon without reporting if lost; finalize any created run as `failed` before exiting to avoid orphaned `running` rows; when aborting unowned runs, also mark setup‑pending iterations `failed` to avoid stranding them.
  - Startup gating: refuse to start the worker without `CONVEX_URL` to avoid claiming checks that will later fail `infra_error`.
  - JSON-RPC probe strictness: fully validate all four message arms (result/error/request/notification) with exact key sets, id type rules, object-shaped `params`, and an object-shaped optional `_meta` on results; validate batch siblings per arm to mirror the client and prevent false neutrals.

<sup>Written for commit 59fa2061f91e23ccbc9341fc2e5bed5da576f42f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

