### PR TITLE
feat(analytics): track which starter chip was clicked on every surface

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -2012,7 +2012,7 @@ export function ChatTabV2({
   };
 
   const handleStarterPrompt = async (prompt: string) => {
-    track("chat_starter_prompt_clicked", { location: "chat_tab" });
+    track("chat_starter_prompt_clicked", { prompt, location: "chat_tab" });
     if (composerDisabled || sendBlocked) {
       setInput(prompt);
       return;

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
@@ -383,10 +383,19 @@ describe("ChatTabV2 trace views", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
 
-      expect(track).toHaveBeenCalledWith("chat_starter_prompt_clicked", {
-        prompt: "Starter chip prompt",
-        location: "chat_tab",
-      });
+      // Filter by event name: mount fires other events (chat_tab_viewed), so
+      // a bare call count can't prove the click emitted exactly one.
+      const starterCalls = vi
+        .mocked(track)
+        .mock.calls.filter(
+          ([event]) => event === "chat_starter_prompt_clicked",
+        );
+      expect(starterCalls).toEqual([
+        [
+          "chat_starter_prompt_clicked",
+          { prompt: "Starter chip prompt", location: "chat_tab" },
+        ],
+      ]);
     });
   });
 

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
@@ -7,8 +7,9 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatTabV2 } from "../ChatTabV2";
+import { track } from "@/lib/analytics";
 
 vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
@@ -114,6 +115,12 @@ vi.mock("@/components/chat-v2/error", () => ({
   ),
 }));
 
+// Mutable so individual tests can render starter chips; kept empty by
+// default so layout tests don't churn on real starter copy.
+const mockStarterPrompts = vi.hoisted(
+  () => [] as Array<{ label: string; text: string }>,
+);
+
 vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {
   const actual =
     await importOriginal<
@@ -121,7 +128,7 @@ vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {
     >();
   return {
     ...actual,
-    STARTER_PROMPTS: [],
+    STARTER_PROMPTS: mockStarterPrompts,
     formatErrorMessage: (error: Error | null) =>
       error ? { message: error.message } : null,
     buildMcpPromptMessages: () => [],
@@ -357,6 +364,30 @@ describe("ChatTabV2 trace views", () => {
     rerender(<ChatTabV2 {...defaultProps} enableTraceViews={true} />);
 
     expect(screen.queryByTestId("trace-view-tabs")).not.toBeInTheDocument();
+  });
+
+  describe("starter prompt tracking", () => {
+    beforeEach(() => {
+      mockStarterPrompts.push({
+        label: "Starter chip",
+        text: "Starter chip prompt",
+      });
+    });
+
+    afterEach(() => {
+      mockStarterPrompts.length = 0;
+    });
+
+    it("tracks the chip click with the prompt and chat tab location", () => {
+      render(<ChatTabV2 {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
+
+      expect(track).toHaveBeenCalledWith("chat_starter_prompt_clicked", {
+        prompt: "Starter chip prompt",
+        location: "chat_tab",
+      });
+    });
   });
 
   it("sends a handoff's pendingUserMessage after the seeded conversation is applied", async () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -3378,6 +3378,10 @@ export function PlaygroundMain({
   // no broadcast consumer in single-model mode.
   const handleStarterPrompt = useCallback(
     (prompt: string) => {
+      track("chat_starter_prompt_clicked", {
+        prompt,
+        location: isCompareMode ? "playground_compare" : "playground_single",
+      });
       if (composerDisabled || sendBlocked) {
         composer.setInput(prompt);
         return;

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -8,6 +8,7 @@ import {
   within,
 } from "@testing-library/react";
 import { PlaygroundMain } from "../PlaygroundMain";
+import { track } from "@/lib/analytics";
 import { DEFAULT_CHAT_COMPOSER_PLACEHOLDER } from "@/components/chat-v2/shared/chat-helpers";
 import { useHostContextStore } from "@/stores/client-context-store";
 import { usePlaygroundChatHistoryBridgeStore } from "@/components/playground/playground-chat-history-bridge";
@@ -1411,6 +1412,28 @@ describe("PlaygroundMain", () => {
       ).not.toHaveLength(0);
     });
 
+    it("tracks the chip click with the compare location when multi-model is active", () => {
+      mockUseChatSession.availableModels = [
+        { id: "gpt-4", name: "GPT-4", provider: "openai" },
+        {
+          id: "claude-sonnet-4-5",
+          name: "Claude Sonnet 4.5",
+          provider: "anthropic",
+        },
+      ];
+      mockUseChatSession.selectedModelIds = ["gpt-4", "claude-sonnet-4-5"];
+      mockUseChatSession.multiModelEnabled = true;
+
+      render(<PlaygroundMain {...defaultProps} enableMultiModelChat={true} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
+
+      expect(track).toHaveBeenCalledWith("chat_starter_prompt_clicked", {
+        prompt: "Starter chip prompt",
+        location: "playground_compare",
+      });
+    });
+
     it("shows trace empty diagnostics and hides compare grid when Trace is selected before first message", () => {
       mockUseChatSession.availableModels = [
         {
@@ -1471,6 +1494,17 @@ describe("PlaygroundMain", () => {
         expect(mockUseChatSession.sendMessage).toHaveBeenCalledWith(
           expect.objectContaining({ text: "Starter chip prompt" }),
         );
+      });
+    });
+
+    it("tracks the chip click with the prompt and single-model location", () => {
+      render(<PlaygroundMain {...defaultProps} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
+
+      expect(track).toHaveBeenCalledWith("chat_starter_prompt_clicked", {
+        prompt: "Starter chip prompt",
+        location: "playground_single",
       });
     });
 

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -1428,10 +1428,17 @@ describe("PlaygroundMain", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
 
-      expect(track).toHaveBeenCalledWith("chat_starter_prompt_clicked", {
-        prompt: "Starter chip prompt",
-        location: "playground_compare",
-      });
+      const starterCalls = vi
+        .mocked(track)
+        .mock.calls.filter(
+          ([event]) => event === "chat_starter_prompt_clicked",
+        );
+      expect(starterCalls).toEqual([
+        [
+          "chat_starter_prompt_clicked",
+          { prompt: "Starter chip prompt", location: "playground_compare" },
+        ],
+      ]);
     });
 
     it("shows trace empty diagnostics and hides compare grid when Trace is selected before first message", () => {
@@ -1502,10 +1509,19 @@ describe("PlaygroundMain", () => {
 
       fireEvent.click(screen.getByRole("button", { name: "Starter chip" }));
 
-      expect(track).toHaveBeenCalledWith("chat_starter_prompt_clicked", {
-        prompt: "Starter chip prompt",
-        location: "playground_single",
-      });
+      // Filter by event name: the single-model click also fires
+      // app_builder_send_message, so a bare call count would be racy.
+      const starterCalls = vi
+        .mocked(track)
+        .mock.calls.filter(
+          ([event]) => event === "chat_starter_prompt_clicked",
+        );
+      expect(starterCalls).toEqual([
+        [
+          "chat_starter_prompt_clicked",
+          { prompt: "Starter chip prompt", location: "playground_single" },
+        ],
+      ]);
     });
 
     it("hides starter chips when the welcome hero is suppressed", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics-ratchet.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { readdirSync, readFileSync } from "fs";
-import { join, relative, resolve } from "path";
+import { join, relative, resolve, sep } from "path";
 import { fileURLToPath } from "url";
 
 /**
@@ -46,7 +46,8 @@ function sourceFiles(dir: string): string[] {
 describe("analytics ratchet", () => {
   const offenders = sourceFiles(CLIENT_SRC)
     .filter((file) => RAW_CAPTURE_PATTERN.test(readFileSync(file, "utf8")))
-    .map((file) => relative(CLIENT_SRC, file))
+    // Normalize Windows separators so allow/legacy lookups match on any OS.
+    .map((file) => relative(CLIENT_SRC, file).split(sep).join("/"))
     .filter((file) => !ALLOWED_FILES.has(file));
 
   it("no NEW files call posthog.capture directly — use lib/analytics.ts track()", () => {

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -68,6 +68,8 @@ export const ANALYTICS_EVENTS = {
   chat_cleared: { source: "client" },
   chat_model_selector_clicked: { source: "client" },
   chat_options_plus_clicked: { source: "client" },
+  // Every starter-chip surface fires this one event; props: prompt (chip
+  // text), location: chat_tab | playground_single | playground_compare.
   chat_starter_prompt_clicked: { source: "client" },
   chat_tab_viewed: { source: "client" },
   chat_voice_input_recording_canceled: { source: "client" },


### PR DESCRIPTION
## Problem
The starter prompt chips (follow-up to #3556, UER-90) have no per-button analytics. The Chat tab fires `chat_starter_prompt_clicked` without saying which chip was clicked, and the two Playground surfaces (single-model and compare) fire nothing.

## Changes
- `PlaygroundMain.handleStarterPrompt` now fires `chat_starter_prompt_clicked` with the chip text and `location: "playground_single" | "playground_compare"`, picked by `isCompareMode` at click time. It fires at the top of the handler, so a click counts even when the send is blocked and only stages the composer.
- ChatTabV2 adds the `prompt` property to its existing call (`location: "chat_tab"` unchanged).
- Reused the registered event instead of adding a new one, so every chip click lands on a single PostHog event split by `prompt` and `location`. With person identification already in place, each chip's clicks are attributed to identified users. Props documented in `shared/analytics-events.ts`.
- Fixed the analytics ratchet test on Windows: `relative()` returns backslash paths there, so `lib/analytics.ts` itself was flagged as a raw-capture offender. Separators are now normalized before the allowlist lookup.

## Testing
- New tests cover the chip click on all three surfaces (prompt + location asserted). The compare test was mutation-checked: hardcoding the location makes it fail.
- 130 tests green across the touched suites; typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track which starter chip was clicked across Chat and Playground by sending the chip prompt and surface location, meeting UER-90’s per-chip telemetry need. Also fixes the analytics ratchet test on Windows and tightens tests to ensure exactly one event per click.

- **New Features**
  - All starter chips send `chat_starter_prompt_clicked` with `prompt` and `location`.
  - Playground fires with `location` = `playground_single` or `playground_compare` (based on compare mode).
  - Chat tab adds `prompt`; `location` stays `chat_tab`.

- **Bug Fixes**
  - Normalize path separators in the analytics ratchet test to avoid false positives on Windows.
  - Tests assert exactly one `chat_starter_prompt_clicked` per click by filtering calls by event name.

<sup>Written for commit d58e9f93e74ebc264d10f0181a0428503d418f09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

