### PR TITLE
fix(desktop): declare the mcpjam:// scheme in the macOS bundle

### DIFF
--- a/mcpjam-inspector/forge.config.ts
+++ b/mcpjam-inspector/forge.config.ts
@@ -69,6 +69,18 @@ const config: ForgeConfig = {
     appBundleId: "com.mcpjam.inspector",
     appCategoryType: "public.app-category.developer-tools",
     executableName: "mcpjam-inspector",
+    // Writes CFBundleURLTypes into the macOS Info.plist so LaunchServices
+    // knows the bundle owns mcpjam://. The runtime
+    // app.setAsDefaultProtocolClient("mcpjam") call in src/main.ts is what
+    // registers the scheme on Windows/Linux, but macOS only honors schemes
+    // declared in the bundle — without this, the browser leg of desktop
+    // sign-in has nowhere to hand the OAuth callback back to.
+    protocols: [
+      {
+        name: "MCPJam Inspector",
+        schemes: ["mcpjam"],
+      },
+    ],
     icon: "assets/icon",
     extraResource: [
       resolve(__dirname, "dist", "client"),

--- a/mcpjam-inspector/forge.config.ts
+++ b/mcpjam-inspector/forge.config.ts
@@ -70,11 +70,13 @@ const config: ForgeConfig = {
     appCategoryType: "public.app-category.developer-tools",
     executableName: "mcpjam-inspector",
     // Writes CFBundleURLTypes into the macOS Info.plist so LaunchServices
-    // knows the bundle owns mcpjam://. The runtime
-    // app.setAsDefaultProtocolClient("mcpjam") call in src/main.ts is what
-    // registers the scheme on Windows/Linux, but macOS only honors schemes
-    // declared in the bundle — without this, the browser leg of desktop
-    // sign-in has nowhere to hand the OAuth callback back to.
+    // knows the bundle owns mcpjam://. macOS only routes a scheme to a
+    // bundle that declares it, and the plist can't be modified at runtime:
+    // the app.setAsDefaultProtocolClient("mcpjam") call in src/main.ts
+    // registers the scheme on Windows (via the registry), while Linux
+    // resolves the handler from the installed .desktop entry. Without this
+    // declaration the browser leg of desktop sign-in has nowhere to hand
+    // the OAuth callback back to.
     protocols: [
       {
         name: "MCPJam Inspector",


### PR DESCRIPTION
Desktop sign-in opens WorkOS in the system browser and depends on the browser navigating to mcpjam://oauth/callback to hand the code back to the app — the browser and Electron have separate cookie jars, so there is no other return path.

macOS only routes a scheme to a bundle that declares it in CFBundleURLTypes. The runtime app.setAsDefaultProtocolClient("mcpjam") call in src/main.ts covers Windows/Linux but is documented as unsupported on macOS, and its return value is discarded, so the failure is silent. Shipped builds carried no CFBundleURLTypes at all: the handoff only worked on machines that happened to hold a stale LaunchServices default-handler preference for com.mcpjam.inspector. Everywhere else the browser leg dead-ends and the app never signs in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers the `mcpjam://` deep link scheme in the macOS app bundle so the OAuth callback returns to the desktop app. Fixes silent sign-in failures on macOS where the browser leg dead-ended.

- **Bug Fixes**
  - Added `protocols` to the macOS target in `forge.config.ts` to write CFBundleURLTypes for the `mcpjam` scheme.
  - Clarified per-platform handling: macOS owns `mcpjam://oauth/callback`; Windows uses `app.setAsDefaultProtocolClient("mcpjam")`; Linux resolves via the installed `.desktop` entry (comment-only).

<sup>Written for commit de242eb92acb5a741fb4e4258fe07edb3ff39f7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

