### PR TITLE
feat(tracing): hosted HTTP-header delivery + headers inline on JSON-RPC frames

### DIFF
--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/lib/oauth/oauth-debugger-navigation";
 import { cn } from "@/lib/utils";
 import { HttpExchangeDetails } from "@/components/tracing/HttpExchangeDetails";
+import { InlineFrameHeaders } from "@/components/tracing/InlineFrameHeaders";
 import type { HttpExchangeLogEvent } from "@mcpjam/sdk/browser";
 
 type TrafficSource = "mcp-server" | "mcp-apps" | "oauth" | "http";
@@ -992,15 +993,34 @@ export function LoggerView({
                             exchange={it.payload as HttpExchangeLogEvent}
                           />
                         ) : (
-                          <JsonEditor
-                            height="100%"
-                            value={normalizePayload(it.payload) as object}
-                            readOnly
-                            showToolbar={false}
-                            collapsible
-                            defaultExpandDepth={2}
-                            collapseStringsAfterLength={100}
-                          />
+                          <div className="space-y-2">
+                            <JsonEditor
+                              height="100%"
+                              value={normalizePayload(it.payload) as object}
+                              readOnly
+                              showToolbar={false}
+                              collapsible
+                              defaultExpandDepth={2}
+                              collapseStringsAfterLength={100}
+                            />
+                            {/*
+                              The headers this frame rode in, when they can be
+                              correlated confidently. Collapsed by default: the
+                              body is what a reader opened the row for, and on
+                              every era before 2026-07-28 the headers carry
+                              nothing they need. Absent entirely when nothing
+                              matched — see `findExchangeForFrame`.
+                            */}
+                            {/*
+                              Correlated against `allItems`, never
+                              `filteredItems`: with the funnel on "Server" the
+                              exchanges are filtered OUT of the list, and
+                              searching the filtered view would make the
+                              headers vanish under exactly the filter a reader
+                              picks to look at frames.
+                            */}
+                            <InlineFrameHeaders frame={it} items={allItems} />
+                          </div>
                         )}
                       </div>
                     </div>

--- a/mcpjam-inspector/client/src/components/tracing/InlineFrameHeaders.tsx
+++ b/mcpjam-inspector/client/src/components/tracing/InlineFrameHeaders.tsx
@@ -14,7 +14,7 @@
  * carry nothing a reader needs.
  */
 
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -39,6 +39,23 @@ function isFailure(status: McpHeaderAssessment["status"]): boolean {
   );
 }
 
+/**
+ * True when a row carries a verdict at all.
+ *
+ * Before `2026-07-28` nothing is mirrored, so `evaluateMcpHeaders` returns
+ * every present header as `unchecked` — a legacy exchange's `Mcp-Session-Id`
+ * or `Last-Event-ID` produces rows with no cross-check behind them. Those
+ * headers are real, debuggable state (a missing session id or a failed resume
+ * is often the bug), which is why capture keeps them for every era and the
+ * dedicated HTTP row renders them in full. What they are not is a reason for
+ * an INLINE disclosure: this affordance exists to surface a cross-check the
+ * body cannot show, and on a legacy frame there is none to surface. Legacy
+ * support is not reduced here — the same bytes stay one filter away.
+ */
+function isDecided(status: McpHeaderAssessment["status"]): boolean {
+  return status !== "unchecked";
+}
+
 /** The collapsed row's own words: the count, or the first thing that is wrong. */
 function summarize(exchange: HttpExchangeLogEvent, rows: McpHeaderAssessment[]) {
   const broken = rows.filter((row) => isFailure(row.status));
@@ -54,7 +71,13 @@ function summarize(exchange: HttpExchangeLogEvent, rows: McpHeaderAssessment[]) 
   const status = exchange.response?.status;
   return {
     text: rows.length === 1 ? "1 MCP header" : `${rows.length} MCP headers`,
-    failed: status !== undefined && status >= 400,
+    // `error` is set when the fetch itself rejected — DNS, TLS, an abort — and
+    // that case has NO response, so a status-only test reads a dead connection
+    // as healthy. It is the one failure the reader cannot infer from the body
+    // either, since no reply ever came back to log.
+    failed:
+      exchange.error !== undefined ||
+      (status !== undefined && status >= 400),
   };
 }
 
@@ -66,6 +89,10 @@ export function InlineFrameHeaders({
   items: CorrelatableLogItem[];
 }) {
   const [open, setOpen] = useState(false);
+  // Per-instance: the Logs list mounts one of these under every expanded
+  // frame, so a hard-coded id would repeat and point assistive tech at
+  // whichever panel happened to render first.
+  const panelId = useId();
   const exchange = useMemo(
     () => findExchangeForFrame(frame, items),
     [frame, items],
@@ -79,11 +106,11 @@ export function InlineFrameHeaders({
     [exchange],
   );
 
-  // Nothing correlated, or the exchange carries no MCP headers at all (a
-  // legacy-era exchange whose only headers are `content-type` and a session
-  // id). Either way there is nothing here a reader needs; the dedicated HTTP
-  // row still shows the raw exchange.
-  if (!exchange || mcpHeaders.length === 0) {
+  // Nothing correlated, or nothing that was cross-checked. The second case is
+  // every pre-2026 exchange (see `isDecided`) plus a modern one whose only
+  // `Mcp-*` header is a session id: rows exist, but none of them judge
+  // anything, so an inline disclosure would promise a verdict it does not have.
+  if (!exchange || !mcpHeaders.some((row) => isDecided(row.status))) {
     return null;
   }
 
@@ -96,6 +123,7 @@ export function InlineFrameHeaders({
         onClick={() => setOpen((prev) => !prev)}
         className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] text-muted-foreground hover:bg-muted/40"
         aria-expanded={open}
+        aria-controls={panelId}
       >
         <ChevronRight
           className={cn(
@@ -114,7 +142,7 @@ export function InlineFrameHeaders({
         </span>
       </button>
       {open && (
-        <div className="border-t border-border/60 p-2">
+        <div id={panelId} className="border-t border-border/60 p-2">
           <HttpExchangeDetails exchange={exchange} />
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/tracing/InlineFrameHeaders.tsx
+++ b/mcpjam-inspector/client/src/components/tracing/InlineFrameHeaders.tsx
@@ -1,0 +1,123 @@
+/**
+ * The HTTP headers a JSON-RPC frame rode in, shown under the frame itself.
+ *
+ * Why this exists on top of the HTTP source filter: from `2026-07-28` the
+ * mirrored `Mcp-*` headers are protocol state that is NOT in the body
+ * (SEP-2243), so a `-32020 HeaderMismatch` cannot be explained from the frame
+ * a reader is looking at. Making them switch source filters and re-find the
+ * matching exchange to answer "why did this call fail" is the wrong shape for
+ * the question. The dedicated HTTP rows stay — they are the place to read an
+ * exchange on its own terms, including ones that carry no single frame.
+ *
+ * Collapsed by default and absent when nothing correlates: the body is what
+ * the row was opened for, and on every era before `2026-07-28` these headers
+ * carry nothing a reader needs.
+ */
+
+import { useMemo, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  evaluateMcpHeaders,
+  type HttpExchangeLogEvent,
+  type McpHeaderAssessment,
+} from "@mcpjam/sdk/browser";
+import { HttpExchangeDetails } from "./HttpExchangeDetails";
+import {
+  findExchangeForFrame,
+  type CorrelatableLogItem,
+} from "./correlate-http-exchange";
+
+/**
+ * A header/body disagreement the server answers `-32020` to. Named on the
+ * COLLAPSED row, because the reader who needs it is precisely the one who would
+ * not think to open a headers section — the body they came to read looks fine.
+ */
+function isFailure(status: McpHeaderAssessment["status"]): boolean {
+  return (
+    status === "mismatch" || status === "missing" || status === "undecodable"
+  );
+}
+
+/** The collapsed row's own words: the count, or the first thing that is wrong. */
+function summarize(exchange: HttpExchangeLogEvent, rows: McpHeaderAssessment[]) {
+  const broken = rows.filter((row) => isFailure(row.status));
+  if (broken.length > 0) {
+    return {
+      text:
+        broken.length === 1
+          ? `${broken[0].name} disagrees with the body`
+          : `${broken.length} headers disagree with the body`,
+      failed: true,
+    };
+  }
+  const status = exchange.response?.status;
+  return {
+    text: rows.length === 1 ? "1 MCP header" : `${rows.length} MCP headers`,
+    failed: status !== undefined && status >= 400,
+  };
+}
+
+export function InlineFrameHeaders({
+  frame,
+  items,
+}: {
+  frame: CorrelatableLogItem;
+  items: CorrelatableLogItem[];
+}) {
+  const [open, setOpen] = useState(false);
+  const exchange = useMemo(
+    () => findExchangeForFrame(frame, items),
+    [frame, items],
+  );
+
+  const mcpHeaders = useMemo(
+    () =>
+      exchange
+        ? evaluateMcpHeaders(exchange.request.headers, exchange.bodyValues)
+        : [],
+    [exchange],
+  );
+
+  // Nothing correlated, or the exchange carries no MCP headers at all (a
+  // legacy-era exchange whose only headers are `content-type` and a session
+  // id). Either way there is nothing here a reader needs; the dedicated HTTP
+  // row still shows the raw exchange.
+  if (!exchange || mcpHeaders.length === 0) {
+    return null;
+  }
+
+  const { text, failed } = summarize(exchange, mcpHeaders);
+
+  return (
+    <div className="rounded-sm border border-border/60">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-[11px] text-muted-foreground hover:bg-muted/40"
+        aria-expanded={open}
+      >
+        <ChevronRight
+          className={cn(
+            "h-3 w-3 flex-shrink-0 transition-transform",
+            open && "rotate-90",
+          )}
+        />
+        <span className="font-medium">HTTP headers</span>
+        <span
+          className={cn(
+            "truncate font-mono",
+            failed && "text-red-600 dark:text-red-400",
+          )}
+        >
+          {text}
+        </span>
+      </button>
+      {open && (
+        <div className="border-t border-border/60 p-2">
+          <HttpExchangeDetails exchange={exchange} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/tracing/__tests__/InlineFrameHeaders.test.tsx
+++ b/mcpjam-inspector/client/src/components/tracing/__tests__/InlineFrameHeaders.test.tsx
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { InlineFrameHeaders } from "../InlineFrameHeaders";
+import type { CorrelatableLogItem } from "../correlate-http-exchange";
+
+/**
+ * The collapsed row is the whole point of the feature: a reader who opened a
+ * frame to read its body must be told, without opening anything else, that the
+ * headers it rode in disagree with that body. These assert what that row says.
+ */
+
+const FRAME: CorrelatableLogItem = {
+  id: "frame-1",
+  serverId: "srv-1",
+  direction: "SEND",
+  timestamp: "2026-07-29T12:00:00.000Z",
+  source: "mcp-server",
+  payload: {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "execute-sql",
+      arguments: { region: "west" },
+      _meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28" },
+    },
+  },
+};
+
+function httpItem(
+  headers: Record<string, string>,
+  status = 200,
+): CorrelatableLogItem {
+  return {
+    id: "http-1",
+    serverId: "srv-1",
+    direction: "HTTP",
+    timestamp: "2026-07-29T12:00:00.200Z",
+    source: "http",
+    payload: {
+      serverId: "srv-1",
+      request: { method: "POST", url: "https://example.com/mcp", headers },
+      response: { status, statusText: "", headers: {} },
+      durationMs: 7,
+      bodyValues: {
+        method: "tools/call",
+        name: "execute-sql",
+        protocolVersion: "2026-07-28",
+      },
+    },
+  };
+}
+
+const CONFORMING = {
+  "mcp-protocol-version": "2026-07-28",
+  "mcp-method": "tools/call",
+  "mcp-name": "execute-sql",
+};
+
+describe("InlineFrameHeaders", () => {
+  it("renders nothing when no exchange correlates", () => {
+    const { container } = render(
+      <InlineFrameHeaders frame={FRAME} items={[FRAME]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("summarizes a conforming exchange by count, collapsed", () => {
+    const http = httpItem(CONFORMING);
+    render(<InlineFrameHeaders frame={FRAME} items={[FRAME, http]} />);
+
+    expect(screen.getByText("3 MCP headers")).toBeTruthy();
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false");
+    // Collapsed means collapsed: the detail body is not rendered.
+    expect(screen.queryByText("Response headers")).toBeNull();
+  });
+
+  it("names the disagreeing header on the collapsed row", () => {
+    // `Mcp-Name` is REQUIRED on tools/call and the body says `execute-sql`.
+    // Dropping it is the `-32020` case, and the reader must see it without
+    // expanding anything.
+    const { "mcp-name": _dropped, ...withoutName } = CONFORMING;
+    render(
+      <InlineFrameHeaders
+        frame={FRAME}
+        items={[FRAME, httpItem(withoutName, 400)]}
+      />,
+    );
+
+    expect(screen.getByText("mcp-name disagrees with the body")).toBeTruthy();
+  });
+
+  it("counts multiple disagreements rather than naming one", () => {
+    render(
+      <InlineFrameHeaders
+        frame={FRAME}
+        items={[
+          FRAME,
+          httpItem({ "mcp-protocol-version": "2026-07-28" }, 400),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("2 headers disagree with the body"),
+    ).toBeTruthy();
+  });
+
+  it("stays out of the way on a legacy exchange with no MCP headers", () => {
+    const legacyFrame: CorrelatableLogItem = {
+      ...FRAME,
+      payload: { jsonrpc: "2.0", id: 1, method: "tools/call", params: {} },
+    };
+    const legacyHttp: CorrelatableLogItem = {
+      ...httpItem({}),
+      payload: {
+        serverId: "srv-1",
+        request: {
+          method: "POST",
+          url: "https://example.com/mcp",
+          headers: { "content-type": "application/json" },
+        },
+        response: { status: 200, statusText: "OK", headers: {} },
+        durationMs: 7,
+        bodyValues: { method: "tools/call" },
+      },
+    };
+
+    const { container } = render(
+      <InlineFrameHeaders frame={legacyFrame} items={[legacyFrame, legacyHttp]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/mcpjam-inspector/client/src/components/tracing/__tests__/InlineFrameHeaders.test.tsx
+++ b/mcpjam-inspector/client/src/components/tracing/__tests__/InlineFrameHeaders.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 
 import { InlineFrameHeaders } from "../InlineFrameHeaders";
 import type { CorrelatableLogItem } from "../correlate-http-exchange";
@@ -105,6 +105,78 @@ describe("InlineFrameHeaders", () => {
     expect(
       screen.getByText("2 headers disagree with the body"),
     ).toBeTruthy();
+  });
+
+  it("marks a transport failure that never got a response", () => {
+    // DNS / TLS / abort: `error` is set and there is NO response, so a
+    // status-only test reads a dead connection as healthy. The body cannot
+    // tell the reader either — no reply ever came back to log.
+    const http = httpItem(CONFORMING);
+    const payload = http.payload as { response?: unknown; error?: string };
+    payload.response = undefined;
+    payload.error = "fetch failed";
+
+    render(<InlineFrameHeaders frame={FRAME} items={[FRAME, http]} />);
+
+    expect(screen.getByText("3 MCP headers").className).toContain(
+      "text-red-600",
+    );
+  });
+
+  it("suppresses a legacy exchange whose headers carry no verdict", () => {
+    // 2025-era: nothing is mirrored, so `evaluateMcpHeaders` returns
+    // `Mcp-Session-Id` as `unchecked`. Rows exist but none judge anything, and
+    // an inline disclosure would promise a cross-check it does not have. The
+    // header is NOT lost — the dedicated HTTP row still renders it in full.
+    const legacyFrame: CorrelatableLogItem = {
+      ...FRAME,
+      payload: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "execute-sql" },
+      },
+    };
+    const legacyHttp: CorrelatableLogItem = {
+      ...httpItem({}),
+      payload: {
+        serverId: "srv-1",
+        request: {
+          method: "POST",
+          url: "https://example.com/mcp",
+          headers: {
+            "content-type": "application/json",
+            "mcp-session-id": "sess-42",
+          },
+        },
+        response: { status: 200, statusText: "OK", headers: {} },
+        durationMs: 7,
+        bodyValues: { method: "tools/call", name: "execute-sql" },
+      },
+    };
+
+    const { container } = render(
+      <InlineFrameHeaders
+        frame={legacyFrame}
+        items={[legacyFrame, legacyHttp]}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("associates the toggle with the panel it controls", () => {
+    render(
+      <InlineFrameHeaders frame={FRAME} items={[FRAME, httpItem(CONFORMING)]} />,
+    );
+
+    const button = screen.getByRole("button");
+    const panelId = button.getAttribute("aria-controls");
+    expect(panelId).toBeTruthy();
+    // Collapsed: the id is declared but the panel is not in the tree yet.
+    expect(document.getElementById(panelId!)).toBeNull();
+
+    act(() => button.click());
+    expect(document.getElementById(panelId!)).not.toBeNull();
   });
 
   it("stays out of the way on a legacy exchange with no MCP headers", () => {

--- a/mcpjam-inspector/client/src/components/tracing/__tests__/correlate-http-exchange.test.ts
+++ b/mcpjam-inspector/client/src/components/tracing/__tests__/correlate-http-exchange.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findExchangeForFrame,
+  frameIdentity,
+  type CorrelatableLogItem,
+} from "../correlate-http-exchange";
+
+/**
+ * Correlation is the only place this feature can produce a WRONG answer rather
+ * than no answer, so the negative cases carry as much weight as the positive
+ * one: pairing a frame with a different call's exchange would have a reader
+ * chase a mirrored-header verdict that belongs somewhere else.
+ */
+
+let seq = 0;
+
+function frame(
+  method: string,
+  at: string,
+  extra?: {
+    serverId?: string;
+    direction?: string;
+    params?: Record<string, unknown>;
+  },
+): CorrelatableLogItem {
+  seq += 1;
+  return {
+    id: `frame-${seq}`,
+    serverId: extra?.serverId ?? "srv-1",
+    direction: extra?.direction ?? "SEND",
+    timestamp: at,
+    source: "mcp-server",
+    payload: {
+      jsonrpc: "2.0",
+      id: seq,
+      method,
+      ...(extra?.params ? { params: extra.params } : {}),
+    },
+  };
+}
+
+function httpItem(
+  at: string,
+  bodyValues: { method?: string; name?: string } | undefined,
+  extra?: { serverId?: string; url?: string; status?: number },
+): CorrelatableLogItem {
+  seq += 1;
+  return {
+    id: `http-${seq}`,
+    serverId: extra?.serverId ?? "srv-1",
+    direction: "HTTP",
+    timestamp: at,
+    source: "http",
+    payload: {
+      serverId: extra?.serverId ?? "srv-1",
+      request: {
+        method: "POST",
+        url: extra?.url ?? "https://example.com/mcp",
+        headers: { "mcp-method": bodyValues?.method ?? "" },
+      },
+      response: {
+        status: extra?.status ?? 200,
+        statusText: "OK",
+        headers: {},
+      },
+      durationMs: 5,
+      ...(bodyValues ? { bodyValues } : {}),
+    },
+  };
+}
+
+describe("frameIdentity", () => {
+  it("reads the routing target from name, uri, or a routed taskId", () => {
+    expect(
+      frameIdentity({ method: "tools/call", params: { name: "echo" } }),
+    ).toEqual({ method: "tools/call", name: "echo" });
+    expect(
+      frameIdentity({ method: "resources/read", params: { uri: "demo://x" } }),
+    ).toEqual({ method: "resources/read", name: "demo://x" });
+    expect(
+      frameIdentity({ method: "tasks/get", params: { taskId: "t-1" } }),
+    ).toEqual({ method: "tasks/get", name: "t-1" });
+  });
+
+  it("ignores taskId on methods that do not route by it", () => {
+    // `tools/call` with a task opt-in carries a taskId that is NOT its
+    // `Mcp-Name` source; reading it here would make every task-augmented call
+    // look name-mismatched against its own exchange.
+    expect(
+      frameIdentity({
+        method: "tools/call",
+        params: { name: "run-task", taskId: "t-1" },
+      }),
+    ).toEqual({ method: "tools/call", name: "run-task" });
+  });
+
+  it("rejects payloads that are not a single request", () => {
+    expect(frameIdentity(undefined)).toBeUndefined();
+    expect(frameIdentity([{ method: "tools/call" }])).toBeUndefined();
+    expect(frameIdentity({ jsonrpc: "2.0", id: 1, result: {} })).toBeUndefined();
+  });
+});
+
+describe("findExchangeForFrame", () => {
+  it("pairs a frame with the exchange logged just after it", () => {
+    const f = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "execute-sql" },
+    });
+    const h = httpItem("2026-07-29T12:00:00.120Z", {
+      method: "tools/call",
+      name: "execute-sql",
+    });
+
+    expect(findExchangeForFrame(f, [f, h])?.request.url).toBe(
+      "https://example.com/mcp",
+    );
+  });
+
+  it("never pairs a response frame", () => {
+    const f = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      direction: "RECEIVE",
+      params: { name: "execute-sql" },
+    });
+    const h = httpItem("2026-07-29T12:00:00.120Z", {
+      method: "tools/call",
+      name: "execute-sql",
+    });
+
+    expect(findExchangeForFrame(f, [f, h])).toBeUndefined();
+  });
+
+  it("does not cross servers", () => {
+    const f = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "echo" },
+    });
+    const h = httpItem(
+      "2026-07-29T12:00:00.120Z",
+      { method: "tools/call", name: "echo" },
+      { serverId: "srv-2", url: "https://other.example.com/mcp" },
+    );
+
+    expect(findExchangeForFrame(f, [f, h])).toBeUndefined();
+  });
+
+  it("does not pair when the routing target disagrees", () => {
+    const f = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "echo" },
+    });
+    const h = httpItem("2026-07-29T12:00:00.120Z", {
+      method: "tools/call",
+      name: "execute-sql",
+    });
+
+    expect(findExchangeForFrame(f, [f, h])).toBeUndefined();
+  });
+
+  it("does not pair with an exchange that carries no single-request body", () => {
+    // A batched or non-JSON body: `bodyValues` is absent, so its headers
+    // describe no single frame.
+    const f = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "echo" },
+    });
+    const h = httpItem("2026-07-29T12:00:00.120Z", undefined);
+
+    expect(findExchangeForFrame(f, [f, h])).toBeUndefined();
+  });
+
+  it("does not reach backwards to an earlier call's exchange", () => {
+    const stale = httpItem("2026-07-29T11:59:00.000Z", {
+      method: "tools/call",
+      name: "echo",
+    });
+    const f = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "echo" },
+    });
+
+    // The only candidate predates the frame by a minute — the fetch resolves
+    // after the frame is logged, so this cannot be its exchange.
+    expect(findExchangeForFrame(f, [stale, f])).toBeUndefined();
+  });
+
+  it("pairs repeated identical calls by ordinal, in order", () => {
+    const first = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "echo" },
+    });
+    const second = frame("tools/call", "2026-07-29T12:00:01.000Z", {
+      params: { name: "echo" },
+    });
+    const firstExchange = httpItem(
+      "2026-07-29T12:00:00.500Z",
+      { method: "tools/call", name: "echo" },
+      { url: "https://example.com/first" },
+    );
+    const secondExchange = httpItem(
+      "2026-07-29T12:00:01.500Z",
+      { method: "tools/call", name: "echo" },
+      { url: "https://example.com/second" },
+    );
+
+    // Deliberately shuffled: the list is newest-first in the store, and order
+    // of arrival must not decide the pairing.
+    const items = [secondExchange, second, firstExchange, first];
+    expect(findExchangeForFrame(first, items)?.request.url).toBe(
+      "https://example.com/first",
+    );
+    expect(findExchangeForFrame(second, items)?.request.url).toBe(
+      "https://example.com/second",
+    );
+  });
+
+  it("leaves the second of two frames unpaired when only one exchange exists", () => {
+    // In-flight: the second call's fetch has not resolved yet. Showing the
+    // first call's headers under it would be the wrong answer, not a partial
+    // one.
+    const first = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "echo" },
+    });
+    const second = frame("tools/call", "2026-07-29T12:00:01.000Z", {
+      params: { name: "echo" },
+    });
+    const only = httpItem("2026-07-29T12:00:00.500Z", {
+      method: "tools/call",
+      name: "echo",
+    });
+
+    const items = [second, only, first];
+    expect(findExchangeForFrame(first, items)).toBeDefined();
+    expect(findExchangeForFrame(second, items)).toBeUndefined();
+  });
+
+  it("keeps distinct methods on the same server independent", () => {
+    const call = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "echo" },
+    });
+    const list = frame("tools/list", "2026-07-29T12:00:00.100Z");
+    const listExchange = httpItem(
+      "2026-07-29T12:00:00.200Z",
+      { method: "tools/list" },
+      { url: "https://example.com/list" },
+    );
+    const callExchange = httpItem(
+      "2026-07-29T12:00:00.300Z",
+      { method: "tools/call", name: "echo" },
+      { url: "https://example.com/call" },
+    );
+
+    const items = [callExchange, listExchange, list, call];
+    expect(findExchangeForFrame(call, items)?.request.url).toBe(
+      "https://example.com/call",
+    );
+    expect(findExchangeForFrame(list, items)?.request.url).toBe(
+      "https://example.com/list",
+    );
+  });
+
+  it("returns nothing for an http row itself", () => {
+    const h = httpItem("2026-07-29T12:00:00.000Z", { method: "tools/list" });
+    expect(findExchangeForFrame(h, [h])).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/components/tracing/__tests__/correlate-http-exchange.test.ts
+++ b/mcpjam-inspector/client/src/components/tracing/__tests__/correlate-http-exchange.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { TASK_ROUTED_METHODS } from "@mcpjam/sdk/browser";
+
 import {
   findExchangeForFrame,
   frameIdentity,
@@ -257,5 +259,66 @@ describe("findExchangeForFrame", () => {
   it("returns nothing for an http row itself", () => {
     const h = httpItem("2026-07-29T12:00:00.000Z", { method: "tools/list" });
     expect(findExchangeForFrame(h, [h])).toBeUndefined();
+  });
+
+  it("ignores rows from other traffic sources", () => {
+    // OAuth and Apps rows are already excluded by their direction strings, so
+    // this asserts the ALLOW-LIST rather than the symptom: correctness must
+    // not depend on a direction literal owned by another module.
+    const oauthish: CorrelatableLogItem = {
+      ...frame("tools/call", "2026-07-29T12:00:00.000Z", {
+        params: { name: "echo" },
+      }),
+      source: "oauth",
+    };
+    const h = httpItem("2026-07-29T12:00:00.100Z", {
+      method: "tools/call",
+      name: "echo",
+    });
+
+    expect(findExchangeForFrame(oauthish, [oauthish, h])).toBeUndefined();
+  });
+
+  it("does not let a foreign-source row shift a real frame's ordinal", () => {
+    // The sibling scan decides the ordinal. An Apps/OAuth row that looked like
+    // the same call would push this frame to index 1 and pair it with the
+    // NEXT exchange — the wrong-headers failure mode.
+    const foreign: CorrelatableLogItem = {
+      ...frame("tools/call", "2026-07-29T11:59:59.000Z", {
+        params: { name: "echo" },
+      }),
+      source: "mcp-apps",
+    };
+    const real = frame("tools/call", "2026-07-29T12:00:00.000Z", {
+      params: { name: "echo" },
+    });
+    const mine = httpItem(
+      "2026-07-29T12:00:00.500Z",
+      { method: "tools/call", name: "echo" },
+      { url: "https://example.com/mine" },
+    );
+
+    expect(findExchangeForFrame(real, [foreign, real, mine])?.request.url).toBe(
+      "https://example.com/mine",
+    );
+  });
+});
+
+describe("task routing reads the SDK's set, not a local copy", () => {
+  it("routes by taskId for exactly the methods the capture side does", () => {
+    // The capture side (`deriveMirroredBodyValues`) reads `params.taskId` for
+    // the SDK's `TASK_ROUTED_METHODS` and nothing else. This module imports
+    // that same set; iterating it here guards against anyone reintroducing a
+    // local literal, which `tsc` could not check against the original.
+    for (const method of TASK_ROUTED_METHODS) {
+      expect(frameIdentity({ method, params: { taskId: "t-1" } })).toEqual({
+        method,
+        name: "t-1",
+      });
+    }
+    // A `tasks/*` method NOT in the set must ignore taskId entirely.
+    expect(
+      frameIdentity({ method: "tasks/list", params: { taskId: "t-1" } }),
+    ).toEqual({ method: "tasks/list" });
   });
 });

--- a/mcpjam-inspector/client/src/components/tracing/correlate-http-exchange.ts
+++ b/mcpjam-inspector/client/src/components/tracing/correlate-http-exchange.ts
@@ -27,21 +27,18 @@
  * today. Absence is the honest answer.
  */
 
-import type { HttpExchangeLogEvent } from "@mcpjam/sdk/browser";
-
 /**
- * The `tasks/*` methods whose `Mcp-Name` comes from `params.taskId` rather than
- * `params.name`/`params.uri` (SEP-2663 routing headers). Mirrors the SDK's
- * `TASK_ROUTED_METHODS`, which is not exported from the browser entry; the
- * capture side reads `taskId` for exactly these, so the match side must too or
- * every task frame would look name-mismatched.
+ * `TASK_ROUTED_METHODS` is the SDK's own set — the SEP-2663 methods whose
+ * `Mcp-Name` comes from `params.taskId` rather than `params.name`/`params.uri`.
+ * Imported rather than restated: the CAPTURE side
+ * (`deriveMirroredBodyValues`) reads `taskId` for exactly these, so a local
+ * copy would be a literal list `tsc` cannot check against the original, and
+ * the tasks extension is versioned independently of core.
  */
-const TASK_ROUTED_METHODS = new Set([
-  "tasks/get",
-  "tasks/update",
-  "tasks/cancel",
-  "tasks/result",
-]);
+import {
+  TASK_ROUTED_METHODS,
+  type HttpExchangeLogEvent,
+} from "@mcpjam/sdk/browser";
 
 /** The minimum a log row must expose to take part in correlation. */
 export type CorrelatableLogItem = {
@@ -137,7 +134,12 @@ export function findExchangeForFrame(
   frame: CorrelatableLogItem,
   items: CorrelatableLogItem[]
 ): HttpExchangeLogEvent | undefined {
-  if (frame.source === "http" || !isOutgoing(frame)) {
+  // Allow-list the one source that carries MCP JSON-RPC frames rather than
+  // excluding `"http"`. OAuth (`direction: "OAUTH"`) and Apps
+  // (`"UI→HOST"`/`"HOST→UI"`) rows are already excluded by `isOutgoing`, but
+  // that makes correctness depend on a direction STRING in another module; an
+  // allow-list keeps it a property of this one.
+  if (frame.source !== "mcp-server" || !isOutgoing(frame)) {
     return undefined;
   }
   const identity = frameIdentity(frame.payload);
@@ -157,7 +159,10 @@ export function findExchangeForFrame(
   const siblings = items
     .filter((item) => {
       if (item.serverId !== frame.serverId) return false;
-      if (item.source === "http" || !isOutgoing(item)) return false;
+      // Same allow-list as the frame itself: the sibling set decides this
+      // frame's ordinal, so admitting a row the entry guard would reject
+      // would shift the index and pair it with the wrong exchange.
+      if (item.source !== "mcp-server" || !isOutgoing(item)) return false;
       const other = frameIdentity(item.payload);
       if (!other) return false;
       return other.method === identity.method && other.name === identity.name;

--- a/mcpjam-inspector/client/src/components/tracing/correlate-http-exchange.ts
+++ b/mcpjam-inspector/client/src/components/tracing/correlate-http-exchange.ts
@@ -1,0 +1,207 @@
+/**
+ * Pair a JSON-RPC frame in the Logs list with the HTTP exchange it rode in.
+ *
+ * The two are separate log entries on purpose — the transport hands over
+ * headers when the fetch resolves, which is after the `send` frame was logged
+ * and before the `receive` frames are parsed, so there is no moment at which a
+ * frame and its headers are both in hand (see `HttpExchangeBusEvent`). That
+ * makes correlation a RENDER-TIME concern, and this module is the whole of it.
+ *
+ * The bar is deliberately high: showing the wrong request's headers under a
+ * frame is worse than showing none, because the reader would then chase a
+ * mirrored-header verdict that belongs to a different call. So:
+ *
+ * - Only OUTGOING frames get headers. A response frame has no method to match
+ *   on, and one HTTP round trip can carry several of them.
+ * - The method must agree, and when both sides name a target (`params.name`,
+ *   `params.uri`, or a routed `params.taskId`) the names must agree too.
+ * - Repeats pair by ORDINAL: the nth `tools/call execute-sql` frame takes the
+ *   nth matching exchange. Two identical calls in flight at once cannot be
+ *   told apart by content, and ordinal pairing is at least stable and is what
+ *   a reader comparing the two lists by eye would do.
+ * - An exchange is never paired to a frame logged AFTER it. The fetch resolves
+ *   second, so `exchange.timestamp >= frame.timestamp` always holds for a real
+ *   pair.
+ *
+ * When nothing satisfies all of that, the frame renders exactly as it does
+ * today. Absence is the honest answer.
+ */
+
+import type { HttpExchangeLogEvent } from "@mcpjam/sdk/browser";
+
+/**
+ * The `tasks/*` methods whose `Mcp-Name` comes from `params.taskId` rather than
+ * `params.name`/`params.uri` (SEP-2663 routing headers). Mirrors the SDK's
+ * `TASK_ROUTED_METHODS`, which is not exported from the browser entry; the
+ * capture side reads `taskId` for exactly these, so the match side must too or
+ * every task frame would look name-mismatched.
+ */
+const TASK_ROUTED_METHODS = new Set([
+  "tasks/get",
+  "tasks/update",
+  "tasks/cancel",
+  "tasks/result",
+]);
+
+/** The minimum a log row must expose to take part in correlation. */
+export type CorrelatableLogItem = {
+  id: string;
+  serverId: string;
+  direction: string;
+  timestamp: string;
+  payload: unknown;
+  source: string;
+};
+
+type FrameIdentity = {
+  method: string;
+  /** `params.name` / `params.uri` / routed `params.taskId`, when present. */
+  name?: string;
+};
+
+/**
+ * The method and routing target a frame's body carries — the same two values
+ * the transport mirrors into `Mcp-Method` / `Mcp-Name`, read off the frame
+ * rather than off the headers so the comparison stays a cross-check.
+ */
+export function frameIdentity(payload: unknown): FrameIdentity | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined;
+  }
+
+  const { method, params } = payload as {
+    method?: unknown;
+    params?: {
+      name?: unknown;
+      uri?: unknown;
+      taskId?: unknown;
+    };
+  };
+  if (typeof method !== "string" || method.length === 0) {
+    return undefined;
+  }
+
+  const routedTaskId = TASK_ROUTED_METHODS.has(method)
+    ? params?.taskId
+    : undefined;
+  const name = params?.name ?? params?.uri ?? routedTaskId;
+  return {
+    method,
+    ...(typeof name === "string" ? { name } : {}),
+  };
+}
+
+function isOutgoing(item: CorrelatableLogItem): boolean {
+  return item.direction.toUpperCase() === "SEND";
+}
+
+function exchangeOf(item: CorrelatableLogItem): HttpExchangeLogEvent | undefined {
+  return item.source === "http"
+    ? (item.payload as HttpExchangeLogEvent)
+    : undefined;
+}
+
+/**
+ * True when an exchange's captured body values are consistent with a frame's.
+ *
+ * `bodyValues` is absent when the request body was not a single JSON-RPC
+ * request (a batch, or a non-JSON body), and in that case there is nothing to
+ * agree on — treated as NO match rather than a free pass, since a batch's
+ * headers describe no single frame.
+ */
+function agrees(
+  exchange: HttpExchangeLogEvent,
+  identity: FrameIdentity
+): boolean {
+  const values = exchange.bodyValues;
+  if (!values || values.method !== identity.method) {
+    return false;
+  }
+  // A name on only one side is not a disagreement: `deriveMirroredBodyValues`
+  // omits it for methods that carry no routing target.
+  if (
+    identity.name !== undefined &&
+    values.name !== undefined &&
+    values.name !== identity.name
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * The exchange belonging to `frame`, or `undefined` when nothing matches
+ * confidently. `items` is the full log list in any order.
+ */
+export function findExchangeForFrame(
+  frame: CorrelatableLogItem,
+  items: CorrelatableLogItem[]
+): HttpExchangeLogEvent | undefined {
+  if (frame.source === "http" || !isOutgoing(frame)) {
+    return undefined;
+  }
+  const identity = frameIdentity(frame.payload);
+  if (!identity) {
+    return undefined;
+  }
+
+  const frameAt = Date.parse(frame.timestamp);
+  if (Number.isNaN(frameAt)) {
+    return undefined;
+  }
+
+  // Ordinal position of this frame among identical ones on the same server:
+  // count the matching frames logged strictly before it. Ties on an identical
+  // timestamp break on `id` so the ordering is total and stable — two frames
+  // must not both claim ordinal 0 and render the same exchange.
+  const siblings = items
+    .filter((item) => {
+      if (item.serverId !== frame.serverId) return false;
+      if (item.source === "http" || !isOutgoing(item)) return false;
+      const other = frameIdentity(item.payload);
+      if (!other) return false;
+      return other.method === identity.method && other.name === identity.name;
+    })
+    .sort(
+      (a, b) =>
+        Date.parse(a.timestamp) - Date.parse(b.timestamp) ||
+        a.id.localeCompare(b.id)
+    );
+  const ordinal = siblings.findIndex((item) => item.id === frame.id);
+  if (ordinal < 0) {
+    return undefined;
+  }
+
+  // Ordinal is taken over ALL matching exchanges, not over a time-filtered
+  // subset: filtering first would shift the index whenever an earlier call's
+  // exchange fell outside the window, quietly pairing frame n with exchange
+  // n+1. The window is applied to the SELECTED match instead, below.
+  const candidates = items
+    .filter((item) => {
+      if (item.serverId !== frame.serverId) return false;
+      const exchange = exchangeOf(item);
+      return Boolean(exchange && agrees(exchange, identity));
+    })
+    .sort(
+      (a, b) =>
+        Date.parse(a.timestamp) - Date.parse(b.timestamp) ||
+        a.id.localeCompare(b.id)
+    );
+
+  const match = candidates[ordinal];
+  if (!match) {
+    return undefined;
+  }
+
+  // Plausibility check on the pair, not on the search. The fetch resolves
+  // after the frame was logged, so an exchange stamped meaningfully earlier is
+  // not this frame's — which is how a desync shows up if the store's
+  // oldest-first trim ever cut a frame away from its exchange (both share one
+  // capped list, so they normally age out together). A slow call can take
+  // minutes, so there is deliberately no upper bound. The 1s slack absorbs
+  // skew between the two capture points; hosted stamps both server-side.
+  if (Date.parse(match.timestamp) < frameAt - 1000) {
+    return undefined;
+  }
+  return exchangeOf(match);
+}

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -100,6 +100,7 @@ import {
 } from "@/components/evals/trace-viewer-adapter";
 import { useSharedChatWidgetCapture } from "@/hooks/useSharedChatWidgetCapture";
 import {
+  ingestHostedHttpLogs,
   ingestHostedRpcLogs,
   useTrafficLogStore,
 } from "@/stores/traffic-log-store";
@@ -131,7 +132,10 @@ import {
   buildLiveChatPreviewSpans,
   pickTranscriptForLiveTracePreview,
 } from "@/shared/live-chat-trace-preview";
-import { isHostedRpcLogDataPart } from "@/shared/hosted-rpc-log";
+import {
+  isHostedHttpLogDataPart,
+  isHostedRpcLogDataPart,
+} from "@/shared/hosted-rpc-log";
 import {
   HOSTED_ELICITATION_VERSION,
   isHostedElicitationDataPart,
@@ -1870,6 +1874,13 @@ export function useChatSession(
               operation: successfulOperation,
             });
           }
+        } else if (isHostedHttpLogDataPart(part)) {
+          // Headers only, and deliberately NOT run through the step-up
+          // reconciliation above: that correlates JSON-RPC ids, and an
+          // exchange carries no id (one HTTP round trip can wrap several
+          // frames). The `data-rpc-log` part for the same call is what clears
+          // the counter; this part exists purely to fill the Tracing view.
+          ingestHostedHttpLogs([part.data]);
         } else if (isHarnessSessionDataPart(part)) {
           // Cache the harness workdir so the Playground Shell can open a
           // terminal there. Keyed by project + host — and on an ENVIRONMENT

--- a/mcpjam-inspector/client/src/lib/apis/web/__tests__/base.http-logs.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/__tests__/base.http-logs.test.ts
@@ -177,4 +177,80 @@ describe("web/base hosted http logs", () => {
     await webPost("/api/web/tools/execute", {});
     expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(0);
   });
+
+  it("drops entries whose header values are not strings", async () => {
+    // Every consumer treats header values as strings — `decodeMcpHeaderValue`
+    // calls `startsWith` on each — so a number from a mis-serializing producer
+    // would throw while rendering the expanded row, turning one bad entry into
+    // a broken panel. An array passes `typeof === "object"` too, so it is
+    // rejected explicitly.
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        _httpLogs: [
+          {
+            serverId: "srv-1",
+            serverName: "stateless",
+            timestamp: "2026-07-29T12:00:00.000Z",
+            exchange: {
+              serverId: "srv-1",
+              request: {
+                method: "POST",
+                url: "https://example.com/mcp",
+                headers: { "content-length": 42 },
+              },
+              durationMs: 1,
+            },
+          },
+          {
+            serverId: "srv-1",
+            serverName: "stateless",
+            timestamp: "2026-07-29T12:00:01.000Z",
+            exchange: {
+              serverId: "srv-1",
+              request: {
+                method: "POST",
+                url: "https://example.com/mcp",
+                headers: ["not", "a", "record"],
+              },
+              durationMs: 1,
+            },
+          },
+        ],
+      }),
+    );
+
+    await webPost("/api/web/tools/execute", {});
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(0);
+  });
+
+  it("keeps an exchange that failed at the transport, with no response", async () => {
+    // The counterpart to the guard above: `response` is legitimately absent on
+    // a DNS/TLS/abort failure, and that is a row the reader especially needs.
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        _httpLogs: [
+          {
+            serverId: "srv-1",
+            serverName: "stateless",
+            timestamp: "2026-07-29T12:00:00.000Z",
+            exchange: {
+              serverId: "srv-1",
+              request: {
+                method: "POST",
+                url: "https://example.com/mcp",
+                headers: { "mcp-method": "tools/call" },
+              },
+              error: "fetch failed",
+              durationMs: 30,
+            },
+          },
+        ],
+      }),
+    );
+
+    await webPost("/api/web/tools/execute", {});
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(1);
+  });
 });

--- a/mcpjam-inspector/client/src/lib/apis/web/__tests__/base.http-logs.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/__tests__/base.http-logs.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFetchMock = vi.fn();
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: true,
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: (...args: unknown[]) => authFetchMock(...args),
+  addTokenToUrl: vi.fn((url: string) => url),
+}));
+
+import { webPost } from "../base";
+import { useTrafficLogStore } from "@/stores/traffic-log-store";
+
+/**
+ * The hosted `_httpLogs` envelope, from the wire to the store.
+ *
+ * These assert the ingested item matches what the LOCAL SSE path produces for
+ * the same exchange — `direction: "HTTP"`, `kind: "http"`, a `METHOD /path`
+ * label. The source funnel filters on `kind` and `HttpExchangeDetails` reads
+ * the payload, so a shape drift here shows up as hosted mode rendering the
+ * Tracing panel differently from local mode rather than as a test failure.
+ */
+
+const EXCHANGE = {
+  serverId: "srv-1",
+  request: {
+    method: "POST",
+    // Query string present on purpose: the row label must drop it (a query can
+    // carry a token, and the label feeds the Tracing agent snapshot).
+    url: "https://stateless.mcpjam.com/mcp?session=secret",
+    headers: {
+      "mcp-method": "tools/call",
+      "mcp-name": "execute-sql",
+      "mcp-protocol-version": "2026-07-28",
+    },
+  },
+  response: { status: 400, statusText: "Bad Request", headers: {} },
+  durationMs: 9,
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("web/base hosted http logs", () => {
+  beforeEach(() => {
+    authFetchMock.mockReset();
+    useTrafficLogStore.getState().clear();
+  });
+
+  it("strips and ingests an HTTP-only envelope", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        _httpLogs: [
+          {
+            serverId: "srv-1",
+            serverName: "stateless",
+            timestamp: "2026-07-29T12:00:00.000Z",
+            exchange: EXCHANGE,
+          },
+        ],
+      }),
+    );
+
+    // No `_rpcLogs` at all: the payload must still come back clean. The old
+    // strip helper bailed out when `_rpcLogs` was missing, which would have
+    // left `_httpLogs` on the typed result AND dropped the logs.
+    const result = await webPost<{ request: boolean }, { ok: boolean }>(
+      "/api/web/tools/execute",
+      { request: true },
+    );
+    expect(result).toEqual({ ok: true });
+
+    const items = useTrafficLogStore.getState().mcpServerItems;
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      serverId: "srv-1",
+      serverName: "stateless",
+      direction: "HTTP",
+      kind: "http",
+      method: "POST /mcp",
+      timestamp: "2026-07-29T12:00:00.000Z",
+    });
+    // The payload is the exchange itself — what HttpExchangeDetails renders.
+    expect(items[0].payload).toEqual(EXCHANGE);
+  });
+
+  it("ingests both kinds when a response carries both", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        _rpcLogs: [
+          {
+            serverId: "srv-1",
+            serverName: "stateless",
+            direction: "send",
+            timestamp: "2026-07-29T12:00:00.000Z",
+            message: { jsonrpc: "2.0", id: 1, method: "tools/call" },
+          },
+        ],
+        _httpLogs: [
+          {
+            serverId: "srv-1",
+            serverName: "stateless",
+            timestamp: "2026-07-29T12:00:01.000Z",
+            exchange: EXCHANGE,
+          },
+        ],
+      }),
+    );
+
+    await webPost("/api/web/tools/execute", {});
+
+    const kinds = useTrafficLogStore
+      .getState()
+      .mcpServerItems.map((item) => item.kind ?? "rpc");
+    expect(kinds.sort()).toEqual(["http", "rpc"]);
+  });
+
+  it("ingests HTTP logs from an error response too", async () => {
+    // The -32020 case: the request FAILED, and the header that explains why is
+    // only in the exchange. Dropping the envelope on the error path would lose
+    // exactly the evidence the panel exists to show.
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          code: "INTERNAL_ERROR",
+          message: "boom",
+          _httpLogs: [
+            {
+              serverId: "srv-1",
+              serverName: "stateless",
+              timestamp: "2026-07-29T12:00:00.000Z",
+              exchange: EXCHANGE,
+            },
+          ],
+        },
+        500,
+      ),
+    );
+
+    await expect(webPost("/api/web/tools/execute", {})).rejects.toMatchObject({
+      status: 500,
+      code: "INTERNAL_ERROR",
+    });
+
+    expect(useTrafficLogStore.getState().mcpServerItems).toEqual([
+      expect.objectContaining({ kind: "http", method: "POST /mcp" }),
+    ]);
+  });
+
+  it("drops malformed entries instead of rendering a broken row", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        _httpLogs: [
+          // No `exchange.request` — the renderer needs it for the label and
+          // every mirrored-header verdict.
+          {
+            serverId: "srv-1",
+            serverName: "stateless",
+            timestamp: "2026-07-29T12:00:00.000Z",
+            exchange: { serverId: "srv-1" },
+          },
+          { nonsense: true },
+        ],
+      }),
+    );
+
+    await webPost("/api/web/tools/execute", {});
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(0);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/web/base.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/base.ts
@@ -1,7 +1,10 @@
 import type { NormalizedError } from "@mcpjam/sdk/browser";
 import { authFetch } from "@/lib/session-token";
 import { stripHostedRpcLogs } from "./rpc-logs";
-import { ingestHostedRpcLogs } from "@/stores/traffic-log-store";
+import {
+  ingestHostedHttpLogs,
+  ingestHostedRpcLogs,
+} from "@/stores/traffic-log-store";
 
 export class WebApiError extends Error {
   code: string | null;
@@ -53,8 +56,13 @@ export async function webPost<TRequest, TResponse>(
     // ignored
   }
 
-  const { payload: sanitizedPayload, rpcLogs } = stripHostedRpcLogs(body);
+  const {
+    payload: sanitizedPayload,
+    rpcLogs,
+    httpLogs,
+  } = stripHostedRpcLogs(body);
   ingestHostedRpcLogs(rpcLogs);
+  ingestHostedHttpLogs(httpLogs);
 
   if (!response.ok) {
     const errBody = sanitizedPayload as Record<string, unknown> | null;

--- a/mcpjam-inspector/client/src/lib/apis/web/rpc-logs.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/rpc-logs.ts
@@ -1,8 +1,13 @@
 import {
+  isHostedHttpLogEvent,
   isHostedRpcLogEvent,
+  type HostedHttpLogEvent,
   type HostedRpcLogEvent,
 } from "@/shared/hosted-rpc-log";
-import { ingestHostedRpcLogs } from "@/stores/traffic-log-store";
+import {
+  ingestHostedHttpLogs,
+  ingestHostedRpcLogs,
+} from "@/stores/traffic-log-store";
 
 function extractEnvelopeLogs(value: unknown): HostedRpcLogEvent[] {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -17,31 +22,58 @@ function extractEnvelopeLogs(value: unknown): HostedRpcLogEvent[] {
   return candidate._rpcLogs.filter(isHostedRpcLogEvent);
 }
 
+function extractEnvelopeHttpLogs(value: unknown): HostedHttpLogEvent[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (!Array.isArray(candidate._httpLogs)) {
+    return [];
+  }
+
+  return candidate._httpLogs.filter(isHostedHttpLogEvent);
+}
+
 export function stripHostedRpcLogs<T>(payload: T): {
   payload: T;
   rpcLogs: HostedRpcLogEvent[];
+  httpLogs: HostedHttpLogEvent[];
 } {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    return { payload, rpcLogs: [] };
+    return { payload, rpcLogs: [], httpLogs: [] };
   }
 
   const candidate = payload as Record<string, unknown>;
-  if (!("_rpcLogs" in candidate)) {
-    return { payload, rpcLogs: [] };
+  // Either key alone is enough to do the work: a route that captured only
+  // headers (no JSON-RPC frame reached the logger) still sends `_httpLogs`,
+  // and returning early on a missing `_rpcLogs` would both drop those logs and
+  // leave the private key on the typed payload.
+  if (!("_rpcLogs" in candidate) && !("_httpLogs" in candidate)) {
+    return { payload, rpcLogs: [], httpLogs: [] };
   }
 
   const rpcLogs = Array.isArray(candidate._rpcLogs)
     ? candidate._rpcLogs.filter(isHostedRpcLogEvent)
     : [];
-  const { _rpcLogs: _discarded, ...rest } = candidate;
+  const httpLogs = Array.isArray(candidate._httpLogs)
+    ? candidate._httpLogs.filter(isHostedHttpLogEvent)
+    : [];
+  const {
+    _rpcLogs: _discarded,
+    _httpLogs: _httpDiscarded,
+    ...rest
+  } = candidate;
   return {
     payload: rest as T,
     rpcLogs,
+    httpLogs,
   };
 }
 
 function ingestHostedRpcLogsFromPayload(payload: unknown): void {
   ingestHostedRpcLogs(extractEnvelopeLogs(payload));
+  ingestHostedHttpLogs(extractEnvelopeHttpLogs(payload));
 }
 
 export async function ingestHostedRpcLogsFromResponse(

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -14,7 +14,10 @@
 import { create } from "zustand";
 import { addTokenToUrl } from "@/lib/session-token";
 import { HOSTED_MODE } from "@/lib/config";
-import type { HostedRpcLogEvent } from "@/shared/hosted-rpc-log";
+import type {
+  HostedHttpLogEvent,
+  HostedRpcLogEvent,
+} from "@/shared/hosted-rpc-log";
 import type {
   OAuthTrace,
   OAuthTraceSource,
@@ -131,6 +134,36 @@ export function ingestHostedRpcLogs(logs: HostedRpcLogEvent[]): void {
       method: extractMethod(log.message),
       timestamp: log.timestamp,
       payload: log.message,
+    });
+  });
+}
+
+/**
+ * Hosted-mode twin of the local SSE path's `kind: "http"` branch.
+ *
+ * Deliberately builds the SAME `McpServerRpcItem` shape that branch does —
+ * `direction: "HTTP"`, a `METHOD /path` label, the exchange as the payload —
+ * so the source funnel and `HttpExchangeDetails` need no hosted-specific
+ * casing. If the two ever diverge, the Tracing panel silently renders one mode
+ * differently from the other; keep them in step.
+ */
+export function ingestHostedHttpLogs(logs: HostedHttpLogEvent[]): void {
+  if (!Array.isArray(logs) || logs.length === 0) {
+    return;
+  }
+
+  const store = useTrafficLogStore.getState();
+  logs.forEach((log) => {
+    store.addMcpServerLog({
+      serverId: log.serverId,
+      serverName: log.serverName,
+      direction: "HTTP",
+      method: `${log.exchange.request.method} ${describeHttpTarget(
+        log.exchange.request.url,
+      )}`,
+      timestamp: log.timestamp,
+      payload: log.exchange,
+      kind: "http",
     });
   });
 }

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-http-logs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-http-logs.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import type { HttpExchangeLogEvent } from "@mcpjam/sdk";
+
+import {
+  attachHostedRpcLogs,
+  bridgeHarnessRpcLogsToCollector,
+  createHostedRpcLogCollector,
+} from "../hosted-rpc-logs";
+import { rpcLogBus } from "../../../services/rpc-log-bus";
+
+/**
+ * Hosted delivery of the headers-only HTTP channel.
+ *
+ * The regression these cover is the one the old bridge comment described as a
+ * deliberate gap: hosted mode captured exchanges and then dropped them, so the
+ * Tracing panel's HTTP filter was permanently empty in hosted mode while local
+ * mode showed the same traffic. The failure mode is silent — a `-32020
+ * HeaderMismatch` looks like an unexplained error because the disagreeing
+ * header is invisible — so assert delivery end to end rather than just the
+ * collector's internals.
+ */
+
+function exchange(
+  serverId: string,
+  overrides?: Partial<HttpExchangeLogEvent>
+): HttpExchangeLogEvent {
+  return {
+    serverId,
+    request: {
+      method: "POST",
+      url: "https://stateless.example.com/mcp?token=secret",
+      headers: {
+        "mcp-method": "tools/call",
+        "mcp-name": "execute-sql",
+        "mcp-protocol-version": "2026-07-28",
+      },
+    },
+    response: { status: 400, statusText: "Bad Request", headers: {} },
+    durationMs: 12,
+    ...overrides,
+  };
+}
+
+describe("HostedRpcLogCollector HTTP channel", () => {
+  it("carries exchanges in the envelope under their own key", () => {
+    const collector = createHostedRpcLogCollector({
+      serverId: "srv-1",
+      serverName: "stateless",
+    });
+
+    collector.httpLogger(exchange("srv-1"));
+
+    const envelope = collector.buildEnvelope();
+    expect(envelope._httpLogs).toHaveLength(1);
+    expect(envelope._httpLogs?.[0]).toMatchObject({
+      serverId: "srv-1",
+      serverName: "stateless",
+      exchange: { request: { headers: { "mcp-name": "execute-sql" } } },
+    });
+    // The RPC key stays absent rather than becoming an empty array: consumers
+    // branch on presence, and an empty `_rpcLogs` would read as "frames were
+    // captured and there were none".
+    expect(envelope._rpcLogs).toBeUndefined();
+  });
+
+  it("attaches an HTTP-only envelope to the response payload", () => {
+    const collector = createHostedRpcLogCollector({});
+    collector.httpLogger(exchange("srv-1"));
+
+    // `hasLogs()` gates this attach. Before the HTTP channel existed it
+    // counted JSON-RPC frames only, so a turn that captured headers and no
+    // frames — a connect that failed at the transport, a doctor probe — had its
+    // whole envelope dropped here.
+    const attached = attachHostedRpcLogs({ ok: true }, collector) as {
+      ok: boolean;
+      _httpLogs?: unknown[];
+    };
+    expect(attached.ok).toBe(true);
+    expect(attached._httpLogs).toHaveLength(1);
+  });
+
+  it("streams exchanges as their own part type, after buffering", () => {
+    const collector = createHostedRpcLogCollector({});
+    const written: Array<{ type: string }> = [];
+
+    // Logged BEFORE a writer exists — the buffered-then-flushed path.
+    collector.httpLogger(exchange("srv-1"));
+    collector.rpcLogger({
+      direction: "send",
+      message: { method: "tools/call" },
+      serverId: "srv-1",
+    });
+
+    collector.attachStreamWriter({
+      write: (chunk) => written.push(chunk as unknown as { type: string }),
+    });
+
+    expect(written.map((chunk) => chunk.type)).toEqual([
+      "data-rpc-log",
+      "data-http-log",
+    ]);
+
+    // And no re-delivery of what already streamed.
+    collector.httpLogger(exchange("srv-1"));
+    expect(written.map((chunk) => chunk.type)).toEqual([
+      "data-rpc-log",
+      "data-http-log",
+      "data-http-log",
+    ]);
+  });
+});
+
+describe("bridgeHarnessRpcLogsToCollector", () => {
+  it("bridges both kinds off the bus", () => {
+    const collector = createHostedRpcLogCollector({});
+    const stop = bridgeHarnessRpcLogsToCollector(["srv-1"], collector);
+
+    rpcLogBus.publish({
+      serverId: "srv-1",
+      direction: "send",
+      timestamp: "t",
+      message: { method: "tools/call" },
+    });
+    rpcLogBus.publish({
+      kind: "http",
+      serverId: "srv-1",
+      timestamp: "t",
+      exchange: exchange("srv-1"),
+    });
+    stop();
+
+    const envelope = collector.buildEnvelope();
+    expect(envelope._rpcLogs).toHaveLength(1);
+    expect(envelope._httpLogs).toHaveLength(1);
+  });
+
+  it("still scopes by server id", () => {
+    const collector = createHostedRpcLogCollector({});
+    const stop = bridgeHarnessRpcLogsToCollector(["srv-1"], collector);
+
+    rpcLogBus.publish({
+      kind: "http",
+      serverId: "srv-2",
+      timestamp: "t",
+      exchange: exchange("srv-2"),
+    });
+    stop();
+
+    expect(collector.buildEnvelope()._httpLogs).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -9,6 +9,7 @@ import {
 import type {
   ConfidentialCimdProvider,
   ElicitationCallback,
+  HttpExchangeLogger,
   HttpServerConfig,
   MrtrInputCollector,
   RpcLogger,
@@ -878,6 +879,14 @@ export async function createAuthorizedManager(
     chatboxId?: string;
     accessVersion?: number;
     rpcLogger?: RpcLogger;
+    /**
+     * Headers-only HTTP-exchange channel, a SEPARATE SDK channel from
+     * `rpcLogger`: from 2026-07-28 the mirrored `Mcp-*` headers a
+     * `-32020 HeaderMismatch` is about are not in the JSON-RPC body at all.
+     * Threaded wherever `rpcLogger` is so hosted Tracing sees the same wire
+     * local mode does.
+     */
+    httpLogger?: HttpExchangeLogger;
     serverNames?: string[];
     /**
      * mcpProfile.initialize.* pins. `clientInfo` and
@@ -996,6 +1005,7 @@ export async function createAuthorizedManager(
         {
           defaultTimeout: timeoutMs,
           rpcLogger: options?.rpcLogger,
+          httpLogger: options?.httpLogger,
           retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
           // Auto-negotiation outcome telemetry (always-on negotiation).
           negotiationOutcomeLogger: negotiationTelemetryLogger("hosted-direct"),
@@ -1405,6 +1415,7 @@ export async function createAuthorizedManager(
   const manager = new MCPClientManager(Object.fromEntries(configEntries), {
     defaultTimeout: timeoutMs,
     rpcLogger: options?.rpcLogger,
+    httpLogger: options?.httpLogger,
     retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
     // Auto-negotiation outcome telemetry (always-on negotiation).
     negotiationOutcomeLogger: negotiationTelemetryLogger("hosted-direct"),
@@ -1629,6 +1640,7 @@ export async function runEphemeralConnection<S extends z.ZodTypeAny, T>(
     timeoutMs?: number;
     guestUnsupportedMessage?: string;
     rpcLogger?: ReturnType<typeof createHostedRpcLogCollector>["rpcLogger"];
+    httpLogger?: ReturnType<typeof createHostedRpcLogCollector>["httpLogger"];
   }
 ): Promise<T> {
   const { manager, body } = await createManualHostedConnection(
@@ -1659,6 +1671,7 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
     timeoutMs?: number;
     guestUnsupportedMessage?: string;
     rpcLogger?: ReturnType<typeof createHostedRpcLogCollector>["rpcLogger"];
+    httpLogger?: ReturnType<typeof createHostedRpcLogCollector>["httpLogger"];
     /**
      * Per-server MRTR (`input_required`) collector factory (MCP 2026-07-28
      * §12.5). Threaded to `createAuthorizedManager` so a hosted DIRECT op
@@ -1763,6 +1776,7 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
       chatboxId,
       accessVersion,
       rpcLogger: options?.rpcLogger,
+      httpLogger: options?.httpLogger,
       serverNames,
       initializePins,
       mcpProtocolVersionsByServerId,
@@ -1864,6 +1878,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
         timeoutMs: options?.timeoutMs,
         guestUnsupportedMessage: options?.guestUnsupportedMessage,
         rpcLogger: rpcCollector?.rpcLogger,
+        httpLogger: rpcCollector?.httpLogger,
       }
     );
 

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -941,6 +941,7 @@ chatV2.post("/", async (c) => {
         chatboxId,
         accessVersion,
         rpcLogger: rpcCollector.rpcLogger,
+        httpLogger: rpcCollector.httpLogger,
         serverNames: effectiveServerNames,
         initializePins,
         mcpProtocolVersionsByServerId,

--- a/mcpjam-inspector/server/routes/web/harness-mcp.ts
+++ b/mcpjam-inspector/server/routes/web/harness-mcp.ts
@@ -232,6 +232,33 @@ async function handle(c: any) {
               message,
             });
           },
+          // The header half of the same traffic, onto the same bus. Without
+          // this a harness turn's Logs panel shows frames and no headers,
+          // which from 2026-07-28 is the half that explains a
+          // `-32020 HeaderMismatch`. Same observation-only contract as
+          // `rpcLogger`: guarded, and a failure can never reach the RPC.
+          //
+          // NOT enqueued to the Convex sink: that shape carries JSON-RPC
+          // frames only, so cross-instance harness turns still get frames
+          // without headers. Widening the sink is a backend change; this at
+          // least closes the same-instance case rather than leaving the bus
+          // branch unexercised.
+          httpLogger: (exchange) => {
+            try {
+              rpcLogBus.publish({
+                kind: "http",
+                serverId: exchange.serverId,
+                timestamp: new Date().toISOString(),
+                exchange,
+              });
+            } catch (error) {
+              logger.warn(
+                `[harness-mcp] http log publish failed serverId=${
+                  exchange.serverId
+                }: ${error instanceof Error ? error.message : error}`
+              );
+            }
+          },
         }
       ),
       (manager) =>

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -1,5 +1,5 @@
 import type { UIMessageChunk } from "ai";
-import type { RpcLogger } from "@mcpjam/sdk";
+import type { HttpExchangeLogger, RpcLogger } from "@mcpjam/sdk";
 import { isRpcMessageLogEvent, rpcLogBus } from "../../services/rpc-log-bus.js";
 import { logger } from "../../utils/logger.js";
 import {
@@ -8,6 +8,8 @@ import {
 } from "../../utils/harness/harness-rpc-log-sink.js";
 import { consumeCrossInstanceHarnessScopeStepUpMessage } from "../../utils/harness/harness-scope-step-up.js";
 import type {
+  HostedHttpLogEvent,
+  HostedHttpLogsEnvelope,
   HostedRpcLogEvent,
   HostedRpcLogPluginOrigin,
   HostedRpcLogsEnvelope,
@@ -33,6 +35,22 @@ function writeHostedRpcLogDataPart(
 ): void {
   writer.write({
     type: "data-rpc-log",
+    data: event,
+    transient: true,
+  } as unknown as UIMessageChunk);
+}
+
+/**
+ * The header half, on its own stream part. A client that predates
+ * `data-http-log` drops an unrecognized part, so this cannot break an older
+ * build the way a changed `data-rpc-log` payload would.
+ */
+function writeHostedHttpLogDataPart(
+  writer: HostedRpcChunkWriter,
+  event: HostedHttpLogEvent
+): void {
+  writer.write({
+    type: "data-http-log",
     data: event,
     transient: true,
   } as unknown as UIMessageChunk);
@@ -99,6 +117,14 @@ export class HostedRpcLogCollector {
   private readonly logs: HostedRpcLogEvent[] = [];
   private streamedCount = 0;
   private writer: HostedRpcChunkWriter | null = null;
+  /**
+   * HTTP exchanges (headers only), buffered separately from the JSON-RPC
+   * frames because they are a separate delivery shape — see
+   * `HostedHttpLogEvent`. Same lifecycle as `logs`: buffered until a writer
+   * attaches, then streamed, and always available for envelope delivery.
+   */
+  private readonly httpLogs: HostedHttpLogEvent[] = [];
+  private httpStreamedCount = 0;
 
   /**
    * INS-3 plugin provenance, keyed by server id. Set AFTER construction
@@ -132,12 +158,41 @@ export class HostedRpcLogCollector {
     this.flushBufferedLogs();
   };
 
+  /**
+   * The SDK's headers-only HTTP channel, wired wherever `rpcLogger` is.
+   *
+   * `serverId` comes off the exchange itself (the SDK stamps it in
+   * `wrapFetchForHttpLogging`) rather than from a closure, so one collector
+   * serves a multi-server turn exactly as `rpcLogger` does.
+   */
+  readonly httpLogger: HttpExchangeLogger = (exchange) => {
+    const pluginOrigin = this.pluginOriginByServerId[exchange.serverId];
+    this.httpLogs.push({
+      serverId: exchange.serverId,
+      serverName: normalizeServerName(exchange.serverId, this.serverNamesById),
+      timestamp: new Date().toISOString(),
+      exchange,
+      ...(pluginOrigin ? { pluginOrigin } : {}),
+    });
+    this.flushBufferedLogs();
+  };
+
+  /**
+   * True when the turn produced ANY log of either kind. Callers gate envelope
+   * attachment on this (`attachHostedRpcLogs`), so it must count HTTP
+   * exchanges too — a doctor run that only captured headers would otherwise
+   * have its envelope dropped on the floor.
+   */
   hasLogs(): boolean {
-    return this.logs.length > 0;
+    return this.logs.length > 0 || this.httpLogs.length > 0;
   }
 
   getLogs(): HostedRpcLogEvent[] {
     return this.logs.map((event) => ({ ...event }));
+  }
+
+  getHttpLogs(): HostedHttpLogEvent[] {
+    return this.httpLogs.map((event) => ({ ...event }));
   }
 
   attachStreamWriter(writer: HostedRpcChunkWriter): void {
@@ -145,8 +200,11 @@ export class HostedRpcLogCollector {
     this.flushBufferedLogs();
   }
 
-  buildEnvelope(): HostedRpcLogsEnvelope {
-    return this.hasLogs() ? { _rpcLogs: this.getLogs() } : {};
+  buildEnvelope(): HostedRpcLogsEnvelope & HostedHttpLogsEnvelope {
+    return {
+      ...(this.logs.length > 0 ? { _rpcLogs: this.getLogs() } : {}),
+      ...(this.httpLogs.length > 0 ? { _httpLogs: this.getHttpLogs() } : {}),
+    };
   }
 
   private flushBufferedLogs(): void {
@@ -161,6 +219,23 @@ export class HostedRpcLogCollector {
       } catch (error) {
         logger.warn(
           "Hosted RPC log stream write failed; falling back to envelope delivery",
+          { error }
+        );
+        this.writer = null;
+        return;
+      }
+    }
+
+    while (this.httpStreamedCount < this.httpLogs.length) {
+      try {
+        writeHostedHttpLogDataPart(
+          this.writer,
+          this.httpLogs[this.httpStreamedCount]
+        );
+        this.httpStreamedCount += 1;
+      } catch (error) {
+        logger.warn(
+          "Hosted HTTP log stream write failed; falling back to envelope delivery",
           { error }
         );
         this.writer = null;
@@ -208,11 +283,19 @@ export function bridgeHarnessRpcLogsToCollector(
   // a harness turn with no MCP servers has nothing to bridge.
   if (serverIds.length === 0) return () => {};
   return rpcLogBus.subscribe(serverIds, (event) => {
-    // HTTP-exchange events are local-Tracing only. The hosted delivery
-    // (`data-rpc-log` parts, the Convex sink, `isHostedRpcLogEvent`) is a
-    // closed JSON-RPC-frame shape defined across two repos; widening it is its
-    // own change, so hosted stays header-blind rather than half-wired.
-    if (!isRpcMessageLogEvent(event)) return;
+    // Both kinds bridge now: HTTP exchanges ride their own delivery shape
+    // (`data-http-log` parts / `_httpLogs`), so hosted reaches the same
+    // Tracing view local mode has instead of staying header-blind.
+    //
+    // Still NOT covered: the cross-instance Convex sink
+    // (`startCrossInstanceRpcLogPoll`) carries JSON-RPC frames only, so a
+    // harness-mcp request that lands on another instance contributes its
+    // frames but not its headers. That needs a matching backend change; the
+    // gap is per-instance and additive, never a wrong header.
+    if (!isRpcMessageLogEvent(event)) {
+      collector.httpLogger(event.exchange);
+      return;
+    }
     collector.rpcLogger({
       direction: event.direction,
       message: event.message,
@@ -300,7 +383,7 @@ export function startCrossInstanceRpcLogPoll(
 export function attachHostedRpcLogs<T>(
   payload: T,
   collector?: HostedRpcLogCollector
-): T | (T & HostedRpcLogsEnvelope) {
+): T | (T & HostedRpcLogsEnvelope & HostedHttpLogsEnvelope) {
   if (
     !collector?.hasLogs() ||
     !payload ||
@@ -313,5 +396,5 @@ export function attachHostedRpcLogs<T>(
   return {
     ...(payload as Record<string, unknown>),
     ...collector.buildEnvelope(),
-  } as T & HostedRpcLogsEnvelope;
+  } as T & HostedRpcLogsEnvelope & HostedHttpLogsEnvelope;
 }

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -236,6 +236,7 @@ mcpjamAgent.post("/", async (c) => {
       {
         defaultTimeout: WEB_STREAM_TIMEOUT_MS,
         rpcLogger: rpcCollector.rpcLogger,
+        httpLogger: rpcCollector.httpLogger,
         retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
       }
     );

--- a/mcpjam-inspector/server/routes/web/mrtr-direct.ts
+++ b/mcpjam-inspector/server/routes/web/mrtr-direct.ts
@@ -245,7 +245,12 @@ export async function runHostedDirectMrtrOperation<S extends z.ZodTypeAny, R>(
       ...(options?.guestUnsupportedMessage
         ? { guestUnsupportedMessage: options.guestUnsupportedMessage }
         : {}),
-      ...(rpcCollector ? { rpcLogger: rpcCollector.rpcLogger } : {}),
+      ...(rpcCollector
+        ? {
+            rpcLogger: rpcCollector.rpcLogger,
+            httpLogger: rpcCollector.httpLogger,
+          }
+        : {}),
       ...(mrtrInputCollectorForServer ? { mrtrInputCollectorForServer } : {}),
     });
     managerHolder.manager = manager;

--- a/mcpjam-inspector/shared/hosted-rpc-log.ts
+++ b/mcpjam-inspector/shared/hosted-rpc-log.ts
@@ -141,11 +141,24 @@ export function isHostedHttpLogEvent(
   }
 
   const req = request as Record<string, unknown>;
+  if (typeof req.method !== "string" || typeof req.url !== "string") {
+    return false;
+  }
+
+  // Header VALUES are checked, not just the container. Every consumer treats
+  // them as strings — `decodeMcpHeaderValue` calls `startsWith` on each — so a
+  // number or null slipped in by a mis-serializing producer would throw while
+  // rendering the expanded row, turning one malformed entry into a broken
+  // panel. An array passes `typeof === "object"` too, hence the explicit
+  // rejection.
+  const headers = req.headers;
   return (
-    typeof req.method === "string" &&
-    typeof req.url === "string" &&
-    Boolean(req.headers) &&
-    typeof req.headers === "object"
+    Boolean(headers) &&
+    typeof headers === "object" &&
+    !Array.isArray(headers) &&
+    Object.values(headers as Record<string, unknown>).every(
+      (value) => typeof value === "string",
+    )
   );
 }
 

--- a/mcpjam-inspector/shared/hosted-rpc-log.ts
+++ b/mcpjam-inspector/shared/hosted-rpc-log.ts
@@ -62,3 +62,102 @@ export function isHostedRpcLogDataPart(
     candidate.type === "data-rpc-log" && isHostedRpcLogEvent(candidate.data)
   );
 }
+
+/**
+ * One HTTP exchange (headers only) delivered over the hosted log path — the
+ * envelope the JSON-RPC frames rode in.
+ *
+ * A SIBLING of {@linkcode HostedRpcLogEvent}, deliberately not a widening of
+ * it. Three reasons, in order of how badly each would bite:
+ *
+ * 1. `message` and `direction` are REQUIRED on the RPC shape and both this
+ *    repo and the backend guard on them (`isHostedRpcLogEvent`). An exchange
+ *    has neither — it is one request/response pair, not a directional frame —
+ *    so making them optional would weaken the guard for every existing
+ *    producer to describe a shape none of them emit.
+ * 2. The two shapes arrive at different moments. The transport hands over
+ *    headers when the fetch resolves: after the `send` frame was logged and
+ *    before the `receive` frames are parsed out. There is no instant at which
+ *    a frame and its headers are both in hand (see `HttpExchangeBusEvent` in
+ *    `server/services/rpc-log-bus.ts`, which made the same call for the same
+ *    reason).
+ * 3. Additive is forward- and backward-compatible across the repo boundary. A
+ *    backend that has never heard of `_httpLogs` keeps producing valid
+ *    `_rpcLogs`; a client on an older build ignores an unknown envelope key
+ *    and an unknown stream part. Neither side has to deploy first.
+ *
+ * Local mode does not use this type — it streams `HttpExchangeBusEvent`
+ * straight over SSE. This exists so hosted mode reaches the same Tracing view
+ * rather than staying header-blind.
+ */
+export interface HostedHttpLogEvent {
+  serverId: string;
+  serverName: string;
+  timestamp: string;
+  /**
+   * Headers only, secrets redacted at capture (`wrapFetchForHttpLogging`).
+   * Bodies are never captured here — the request body is already in
+   * `_rpcLogs`, and reading the response body would consume the stream the
+   * transport is about to parse.
+   */
+  exchange: import("@mcpjam/sdk/browser").HttpExchangeLogEvent;
+  pluginOrigin?: HostedRpcLogPluginOrigin;
+}
+
+export interface HostedHttpLogsEnvelope {
+  _httpLogs?: HostedHttpLogEvent[];
+}
+
+export interface HostedHttpLogDataPart {
+  type: "data-http-log";
+  data: HostedHttpLogEvent;
+}
+
+export function isHostedHttpLogEvent(
+  value: unknown,
+): value is HostedHttpLogEvent {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.serverId !== "string" ||
+    typeof candidate.serverName !== "string" ||
+    typeof candidate.timestamp !== "string" ||
+    !candidate.exchange ||
+    typeof candidate.exchange !== "object"
+  ) {
+    return false;
+  }
+
+  // The request half is the only part the renderer cannot do without: a row
+  // label comes from `request.url` and every mirrored-header verdict is
+  // computed against `request.headers`. `response` is legitimately absent on a
+  // transport-level failure (DNS, TLS, abort), so it is NOT required here.
+  const request = (candidate.exchange as Record<string, unknown>).request;
+  if (!request || typeof request !== "object") {
+    return false;
+  }
+
+  const req = request as Record<string, unknown>;
+  return (
+    typeof req.method === "string" &&
+    typeof req.url === "string" &&
+    Boolean(req.headers) &&
+    typeof req.headers === "object"
+  );
+}
+
+export function isHostedHttpLogDataPart(
+  value: unknown,
+): value is HostedHttpLogDataPart {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.type === "data-http-log" && isHostedHttpLogEvent(candidate.data)
+  );
+}

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -379,6 +379,12 @@ export {
   MCP_HEADER_SENTINEL_PREFIX,
   MCP_HEADER_SENTINEL_SUFFIX,
   MCP_PARAM_HEADER_PREFIX,
+  // Exported for the renderer's frame↔exchange correlation, which must treat
+  // `params.taskId` as the `Mcp-Name` source for exactly the methods the
+  // CAPTURE side does. A copy in the client would be a literal list `tsc`
+  // cannot check against this one, and the tasks extension is versioned
+  // independently of core — the set moves on its own schedule.
+  TASK_ROUTED_METHODS,
   classifyMcpHeader,
   decodeMcpHeaderValue,
   evaluateMcpHeaders,


### PR DESCRIPTION
From `2026-07-28`, SEP-2243 mirrors routing and cross-check metadata into HTTP **headers**, so a `-32020 HeaderMismatch` cannot be explained from the JSON-RPC body — the body looks valid and the disagreeing header is invisible. Two gaps made that undebuggable. One commit each.

Found while testing an "everything" stateless server (`stateless.mcpjam.com/mcp`) against the local Inspector: an `execute-sql` call whose `region` argument declares `x-mcp-header` failed `-32020`, surfaced as "Unknown error", and the header view was unreachable.

## 1. Hosted mode never delivered HTTP exchanges — `1db4484116`

The Tracing panel's HTTP source filter was permanently empty in hosted mode. Capture already worked there (the hosted per-request managers wire `httpLogger` and publish `kind: "http"` to the bus exactly as local does); the delivery path dropped every exchange:

> HTTP-exchange events are local-Tracing only. … hosted stays header-blind rather than half-wired.

An honest call when the only delivery shape was a closed JSON-RPC-frame contract — and the wrong outcome now.

Delivered as a **sibling** shape, not a widening of `HostedRpcLogEvent`:

- `message`/`direction` are required on the RPC shape and both repos guard on them. An exchange has neither, so relaxing the guard would weaken it for every existing producer to describe a shape none emit.
- The two never coexist in time. Headers arrive when the fetch resolves — after the `send` frame was logged, before the `receive` frames are parsed. `HttpExchangeBusEvent` made the same call for the same reason.
- Additive crosses the repo boundary safely: a backend that has never heard of `_httpLogs` keeps producing valid `_rpcLogs`; an older client ignores an unknown envelope key and an unknown stream part. Neither side has to deploy first.

Store ingestion mirrors the local SSE `kind: "http"` branch field for field, so the funnel and `HttpExchangeDetails` needed no hosted-specific casing.

Two latent bugs fixed on the way:
- `hasLogs()` gates `attachHostedRpcLogs` and counted frames only — a turn that captured headers and no frames (a connect that died at the transport) had its whole envelope dropped.
- `stripHostedRpcLogs` early-returned on a missing `_rpcLogs`, which would both lose the HTTP logs and leak the private key onto the typed payload.

## 2. Headers were only reachable via a separate filter — `319d7cfb2c`

Answering "why did this call fail" cost a source-filter switch plus a manual re-find of the matching exchange. Now every outgoing frame carries a collapsed **HTTP headers** disclosure, and the collapsed row names the disagreement (`mcp-name disagrees with the body`) — the reader who needs it is exactly the one who would not think to open a headers section.

The dedicated HTTP rows stay; they are still the place to read an exchange on its own terms, including ones carrying no single frame.

Correlation is render-time by necessity, and `correlate-http-exchange.ts` is deliberately conservative — the wrong call's headers are worse than none, since the reader would chase a verdict belonging elsewhere:

- Outgoing frames only (a response has no method to match on; one round trip can carry several).
- Method must agree; when both sides name a routing target (`params.name` / `params.uri` / a routed `params.taskId`) the names must too. A `tools/call` with a task opt-in carries a taskId that is **not** its `Mcp-Name` source, so it is read only for the SEP-2663 routed methods.
- No `bodyValues` (batched / non-JSON body) never pairs: those headers describe no single frame.
- Repeats pair by ordinal taken over **all** matching exchanges, not a time-filtered subset — filtering first shifts the index whenever an earlier call's exchange falls outside the window, quietly pairing frame n with exchange n+1. The window is a plausibility check on the selected pair instead.
- Two frames, one resolved exchange: the second stays unpaired. In-flight is an honest "no answer".

Correlated against the **unfiltered** list — with the funnel on "Server" the exchanges are filtered out, and searching the filtered view would make headers vanish under exactly the filter a reader picks to see frames.

## Verification

- `typecheck:client` clean. Server `tsc` introduces no new errors (diffed against a stashed baseline; the remainder are pre-existing on `main`).
- 107 tests pass across the affected suites, **22 new**: collector/envelope/stream-part behavior, bus bridging and its server scoping, client strip+ingest (including the error-response and malformed-entry paths), 13 correlation cases, and 5 render assertions on the collapsed row.

## Deliberately out of scope

- **`Mcp-Param-*` still gets no verdict**, in either view. Param body values are not captured (`bodyValues` carries method/name/protocolVersion only), so an absent `Mcp-Param-Region` produces no row at all — the response status goes red and the specific header is not named. This is the header that motivated the investigation; fixing it means widening capture in the SDK and is its own change rather than something smuggled into a tracing PR.
- **Cross-instance hosted.** The Convex sink carries JSON-RPC frames only, so a `harness-mcp` request landing on another instance contributes frames but not headers. Needs a matching backend change. Additive, and can never show a *wrong* header.
- **`/doctor`.** `runServerDoctor` builds its own client with no `httpLogger` seam, so it stays body-only rather than half-wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted response/stream plumbing across many web routes and adds heuristic frame↔exchange pairing where a wrong match would mislead debugging; mitigated by conservative rules and heavy tests, with no auth or data-model changes.
> 
> **Overview**
> **Hosted tracing** now delivers headers-only HTTP exchanges the same way local mode does: `_httpLogs` on JSON API responses, `data-http-log` on chat streams, ingestion into `kind: "http"` rows, and `httpLogger` wired through hosted MCP managers (auth, chat, harness, agent, MRTR). Fixes **`hasLogs()`** so headers-only turns still attach an envelope, and **`stripHostedRpcLogs`** so HTTP logs are not dropped when `_rpcLogs` is missing.
> 
> **Logs UI** adds a collapsed **HTTP headers** block under expanded outgoing JSON-RPC rows (not dedicated HTTP rows). It correlates each frame to an exchange at render time via **`findExchangeForFrame`**, runs **`evaluateMcpHeaders`**, and surfaces disagreements on the collapsed row (e.g. `mcp-name disagrees with the body`). Correlation uses the **full** log list so headers still appear when the source filter is “Server” only. Legacy / unchecked headers stay hidden inline; dedicated HTTP rows are unchanged.
> 
> The SDK re-exports **`TASK_ROUTED_METHODS`** so frame↔exchange matching stays aligned with capture for task-routed methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc1a703bea0db745d94765da924a2dccfc94b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hosted delivery of headers-only HTTP exchanges and shows correlated HTTP headers inline under each outgoing JSON-RPC frame, making HeaderMismatch errors easy to debug.

- **New Features**
  - Hosted: deliver HTTP exchanges via `_httpLogs` and `data-http-log`; client ingests them into the same `kind: "http"` items used in local mode.
  - Trace UI: adds a collapsed “HTTP headers” section under outgoing frames that names the first disagreement (e.g., “mcp-name disagrees with the body”).
  - Safe correlation at render time: outgoing frames only; method/name must match; skip batched/non-JSON requests; pair repeats by ordinal; never pair to an earlier exchange; search against the unfiltered list.

- **Bug Fixes**
  - `hasLogs()` now counts HTTP exchanges so headers-only turns still attach an envelope.
  - `stripHostedRpcLogs()` no longer drops `_httpLogs` or leak the private key when `_rpcLogs` is absent.

<sup>Written for commit 319d7cfb2c7fc2e0c5950d31aee139077657656a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

