### PR TITLE
Move Skills into Connect as a fourth tab

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -874,6 +874,8 @@ export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
             navigate(buildHostsPath(previewedHostId));
           } else if (next === "computer") {
             navigate(routePaths.computer);
+          } else if (next === "skills") {
+            navigate(routePaths.skills);
           }
         }}
         rightSlot={
@@ -954,6 +956,8 @@ export function ComputerRoute() {
             navigate(routePaths.hostCompare);
           } else if (next === "host" && previewedHostId) {
             navigate(buildHostsPath(previewedHostId));
+          } else if (next === "skills") {
+            navigate(routePaths.skills);
           }
         }}
       />
@@ -1282,9 +1286,18 @@ export function PromptsRoute() {
 }
 
 export function SkillsRoute() {
-  const { convexProjectId } = useAppRouteContext();
+  const { convexProjectId, isAuthenticated, isGuestProjectActor } =
+    useAppRouteContext();
+  const [previewedHostId] = usePreviewedHostId(convexProjectId);
+  const navigate = useAppNavigate();
   const computersEnabled = useComputersEnabledState();
   const skillsEnabled = useSkillsEnabledState();
+
+  // Skills is a Connect view (Servers | Client | Computer | Skills), so it
+  // renders the same chrome as its peers. Anonymous guests are provisioned
+  // Convex actors (`isAuthenticated === true`), so member-ness — not raw auth —
+  // decides whether there are peer tabs to switch to (mirrors ComputerRoute).
+  const isSignedInMember = isAuthenticated && !isGuestProjectActor;
 
   // Hosted skills are a project-MEMBERSHIP resource (authored in Convex,
   // available even without a Computer) but gated behind the `skills-enabled`
@@ -1310,11 +1323,44 @@ export function SkillsRoute() {
     }
   }
 
-  return (
+  const skillsView = (
     <SkillsTab
       projectId={convexProjectId}
       computersEnabled={computersEnabled === true}
     />
+  );
+
+  // Signed-out (and hosted-guest) users have no peer Connect tabs to switch
+  // to, so render bare — same posture as ComputerRoute.
+  if (!isSignedInMember) {
+    return skillsView;
+  }
+
+  return (
+    <motion.div
+      key="skills"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={SNAPPY_RAIL}
+      className="flex h-full min-h-0 flex-col"
+    >
+      <ConnectViewHeader
+        value="skills"
+        previewedHostId={previewedHostId}
+        onChange={(next) => {
+          if (next === "servers") {
+            navigate(routePaths.servers);
+          } else if (next === "compare") {
+            navigate(routePaths.hostCompare);
+          } else if (next === "host" && previewedHostId) {
+            navigate(buildHostsPath(previewedHostId));
+          } else if (next === "computer") {
+            navigate(routePaths.computer);
+          }
+        }}
+      />
+      <div className="min-h-0 flex-1">{skillsView}</div>
+    </motion.div>
   );
 }
 

--- a/mcpjam-inspector/client/src/__tests__/SkillsRoute.flag-hydration.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/SkillsRoute.flag-hydration.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { routePaths } from "../lib/app-navigation";
+
+// Controls the tri-state PostHog flag the route guard reads. `undefined`
+// models the pre-hydration window; the regression is that the guard must NOT
+// redirect during it (only on an explicit `false`).
+let flagState: boolean | undefined = undefined;
+
+const { mockRouteContext, mockNavigate } = vi.hoisted(() => ({
+  mockRouteContext: {
+    convexProjectId: "project-1" as string | null,
+    isAuthenticated: true,
+    isGuestProjectActor: false,
+  },
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock("../hooks/useSkillsEnabled", () => ({
+  SKILLS_FEATURE_FLAG: "skills-enabled",
+  useSkillsEnabledState: () => flagState,
+  useSkillsEnabled: () => flagState === true,
+}));
+
+// Skills renders the local/cloud toggle off the computers flag; irrelevant here.
+vi.mock("../hooks/useComputersEnabled", () => ({
+  COMPUTERS_FEATURE_FLAG: "computers-enabled",
+  useComputersEnabledState: () => true,
+  useComputersEnabled: () => true,
+}));
+
+// The route guard only applies the flag under HOSTED_MODE.
+vi.mock("../lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/config")>();
+  return { ...actual, HOSTED_MODE: true };
+});
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router")>();
+  return {
+    ...actual,
+    useOutletContext: () => mockRouteContext,
+    // Sentinel so a redirect is observable without a real router.
+    Navigate: ({ to }: { to: string }) => (
+      <div data-testid="navigate" data-to={to} />
+    ),
+  };
+});
+
+vi.mock("../components/SkillsTab", () => ({
+  SkillsTab: () => <div data-testid="skills-view" />,
+}));
+
+vi.mock("../components/hosts/ConnectViewHeader", () => ({
+  ConnectViewHeader: () => <div data-testid="connect-header" />,
+}));
+
+vi.mock("../hooks/use-previewed-client-id", () => ({
+  usePreviewedHostId: () => [null],
+}));
+
+vi.mock("../lib/app-navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/app-navigation")>();
+  return { ...actual, useAppNavigate: () => mockNavigate };
+});
+
+// App.tsx's import graph pulls in the CodeMirror JSON editor; stub it (and the
+// CodeMirror packages it imports) so the route module loads under jsdom. Mirror
+// of ComputerRoute.flag-hydration.test.tsx.
+vi.mock("../components/ui/json-editor/codemirror-json-editor", () => ({
+  CodemirrorJsonEditor: () => null,
+}));
+vi.mock("@codemirror/lang-json", () => ({ json: () => ({}) }));
+vi.mock("@codemirror/view", () => ({
+  EditorView: class {},
+  lineNumbers: () => ({}),
+  highlightActiveLine: () => ({}),
+  highlightSpecialChars: () => ({}),
+  keymap: () => ({}),
+}));
+vi.mock("@codemirror/state", () => ({ EditorState: { create: vi.fn() } }));
+vi.mock("@codemirror/commands", () => ({
+  defaultKeymap: [],
+  history: () => ({}),
+  historyKeymap: [],
+}));
+vi.mock("@codemirror/language", () => ({
+  bracketMatching: () => ({}),
+  foldGutter: () => ({}),
+  indentOnInput: () => ({}),
+  syntaxHighlighting: () => ({}),
+  defaultHighlightStyle: {},
+}));
+vi.mock("@codemirror/lint", () => ({
+  linter: () => ({}),
+  lintGutter: () => ({}),
+}));
+
+import { SkillsRoute } from "../App";
+
+beforeEach(() => {
+  mockRouteContext.convexProjectId = "project-1";
+  mockRouteContext.isAuthenticated = true;
+  mockRouteContext.isGuestProjectActor = false;
+});
+
+afterEach(() => {
+  flagState = undefined;
+  vi.clearAllMocks();
+});
+
+describe("SkillsRoute — flag hydration + Connect chrome", () => {
+  it("does not redirect while the flag is still loading (undefined)", () => {
+    flagState = undefined;
+    render(<SkillsRoute />);
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    // Nothing renders yet either — it waits for the flag to settle.
+    expect(screen.queryByTestId("skills-view")).not.toBeInTheDocument();
+  });
+
+  it("does not redirect across an undefined -> true transition", () => {
+    flagState = undefined;
+    const { rerender } = render(<SkillsRoute />);
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+
+    // PostHog resolves the flag to enabled.
+    flagState = true;
+    rerender(<SkillsRoute />);
+
+    expect(screen.queryByTestId("navigate")).not.toBeInTheDocument();
+    expect(screen.getByTestId("skills-view")).toBeInTheDocument();
+    expect(screen.getByTestId("connect-header")).toBeInTheDocument();
+  });
+
+  it("redirects to servers only on an explicit false", () => {
+    flagState = false;
+    render(<SkillsRoute />);
+    const nav = screen.getByTestId("navigate");
+    expect(nav).toBeInTheDocument();
+    expect(nav).toHaveAttribute("data-to", routePaths.servers);
+    expect(screen.queryByTestId("skills-view")).not.toBeInTheDocument();
+  });
+
+  it("renders the bare view without Connect chrome for a guest actor", () => {
+    flagState = true;
+    mockRouteContext.isGuestProjectActor = true;
+    render(<SkillsRoute />);
+    expect(screen.getByTestId("skills-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("connect-header")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -483,6 +483,8 @@ export function HostsTab({
                         navigate(buildHostComparePath());
                       } else if (next === "computer") {
                         navigate(routePaths.computer);
+                      } else if (next === "skills") {
+                        navigate(routePaths.skills);
                       }
                     }}
                     rightSlot={

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -4,9 +4,8 @@ import {
   filterByFeatureFlags,
   getEvalsSubnavItems,
   getHostedNavigationSections,
-  resolveHostedSkillsNav,
+  navigationSections,
 } from "../mcp-sidebar";
-import { HOSTED_LOCAL_ONLY_TOOLTIP } from "@/lib/hosted-ui";
 
 const FakeIcon = () => null;
 
@@ -301,11 +300,13 @@ describe("applyBillingGateNavState", () => {
 });
 
 describe("getHostedNavigationSections", () => {
-  it("keeps hosted-blocked local tabs visible as disabled hosted-only items", () => {
+  it("drops hosted-blocked tabs and keeps hosted-capable ones", () => {
     const result = getHostedNavigationSections([
       {
         id: "others",
         items: [
+          // Skills is deliberately NOT sidebar-allowed in hosted mode — it is
+          // reached through the Connect tab switcher — so it is dropped here.
           { title: "Skills", url: "#skills", icon: FakeIcon },
           { title: "Tasks", url: "#tasks", icon: FakeIcon },
           {
@@ -328,15 +329,7 @@ describe("getHostedNavigationSections", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].items).toEqual([
-      {
-        title: "Skills",
-        url: "#skills",
-        icon: FakeIcon,
-        disabled: true,
-        disabledTooltip: HOSTED_LOCAL_ONLY_TOOLTIP,
-      },
-      // Tasks are hosted-capable (reconnect-per-poll routes), so the item is
-      // enabled rather than a disabled local-only stub.
+      // Tasks are hosted-capable (reconnect-per-poll routes), so the item stays.
       { title: "Tasks", url: "#tasks", icon: FakeIcon },
       {
         title: "Testing",
@@ -412,31 +405,21 @@ describe("getHostedNavigationSections", () => {
   });
 });
 
-describe("resolveHostedSkillsNav (skills-enabled gate)", () => {
-  const hostedSections = () =>
-    getHostedNavigationSections([
-      {
-        id: "others",
-        items: [
-          { title: "Skills", url: "#skills", icon: FakeIcon },
-          { title: "Tools", url: "#tools", icon: FakeIcon },
-        ],
-      },
-    ]);
+describe("Skills is no longer a sidebar item", () => {
+  // Skills moved into Connect as a fourth tab (Servers | Client | Computer |
+  // Skills); the sidebar has no Skills entry in either mode, and the hosted
+  // filter must not resurrect one.
+  it("has no /skills item in any section, local or hosted", () => {
+    const skillsItems = (sections: typeof navigationSections) =>
+      sections.flatMap((section) =>
+        section.items.filter(
+          (item) => item.url.replace(/^[#/]+/, "") === "skills"
+        )
+      );
 
-  it("enables the Skills item when the flag is on", () => {
-    const result = resolveHostedSkillsNav(hostedSections(), true);
-    const skills = result[0].items.find((i) => i.title === "Skills");
-    expect(skills).toBeDefined();
-    expect(skills?.disabled).toBe(false);
-    expect(skills?.disabledTooltip).toBeUndefined();
-  });
-
-  it("drops the Skills item entirely when the flag is off", () => {
-    const result = resolveHostedSkillsNav(hostedSections(), false);
-    expect(result[0].items.find((i) => i.title === "Skills")).toBeUndefined();
-    // Sibling items are untouched.
-    expect(result[0].items.find((i) => i.title === "Tools")).toBeDefined();
+    const hosted = getHostedNavigationSections(navigationSections);
+    expect(skillsItems(navigationSections)).toEqual([]);
+    expect(skillsItems(hosted)).toEqual([]);
   });
 });
 

--- a/mcpjam-inspector/client/src/components/hosts/ConnectViewHeader.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/ConnectViewHeader.tsx
@@ -1,8 +1,16 @@
 import type { ReactNode } from "react";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useSkillsEnabled } from "@/hooks/useSkillsEnabled";
+import { HOSTED_MODE } from "@/lib/config";
+import { track } from "@/lib/analytics";
 
-export type ConnectViewValue = "servers" | "host" | "compare" | "computer";
+export type ConnectViewValue =
+  | "servers"
+  | "host"
+  | "compare"
+  | "computer"
+  | "skills";
 
 interface ConnectViewHeaderProps {
   value: ConnectViewValue;
@@ -27,6 +35,22 @@ export function ConnectViewHeader({
   // The Computer tab only appears for users the `computers-enabled` flag is
   // rolled out to (also keeps it hidden pre-launch).
   const computersEnabled = useComputersEnabled();
+  // Skills is gated by `skills-enabled` in HOSTED mode only — local-mode
+  // filesystem skills never read the flag (see `useSkillsEnabled`), so the tab
+  // stays visible in the local app / Electron exactly as it was as a sidebar
+  // item. Hook is called unconditionally; only its use is mode-dependent.
+  const skillsEnabled = useSkillsEnabled();
+  const showSkillsTab = !HOSTED_MODE || skillsEnabled;
+
+  const handleChange = (next: ConnectViewValue) => {
+    // Connect tab switching had no tracking of its own; Skills moving here
+    // from the sidebar would otherwise drop the `sidebar_nav_clicked` signal
+    // for skills entries. One wrapper covers every route that renders this
+    // header.
+    track("connect_view_selected", { from: value, to: next });
+    onChange(next);
+  };
+
   return (
     <div
       className="@container relative shrink-0 border-b border-border/40 px-4 py-2.5 md:px-8"
@@ -42,7 +66,7 @@ export function ConnectViewHeader({
           <ViewModeSelector
             value={value}
             ariaLabel="Connect view"
-            onChange={onChange}
+            onChange={handleChange}
             options={[
               { value: "servers", label: "Servers" },
               {
@@ -54,6 +78,12 @@ export function ConnectViewHeader({
               // (see HostSectionTabs) rather than a peer primary tab.
               ...(computersEnabled
                 ? ([{ value: "computer", label: "Computer" }] as const)
+                : []),
+              // Skills is execution-context config like the tabs above it, so
+              // it lives here rather than in the sidebar. Hidden in hosted mode
+              // until `skills-enabled` is rolled out; always shown locally.
+              ...(showSkillsTab
+                ? ([{ value: "skills", label: "Skills" }] as const)
                 : []),
             ]}
           />

--- a/mcpjam-inspector/client/src/components/hosts/ConnectViewHeader.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/ConnectViewHeader.tsx
@@ -47,7 +47,11 @@ export function ConnectViewHeader({
     // from the sidebar would otherwise drop the `sidebar_nav_clicked` signal
     // for skills entries. One wrapper covers every route that renders this
     // header.
-    track("connect_view_selected", { from: value, to: next });
+    try {
+      track("connect_view_selected", { from: value, to: next });
+    } catch {
+      // swallow — a posthog throw must never block navigation
+    }
     onChange(next);
   };
 

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/ConnectViewHeader.computer.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/ConnectViewHeader.computer.test.tsx
@@ -6,6 +6,14 @@ vi.mock("@/hooks/useComputersEnabled", () => ({
   useComputersEnabled: () => flagEnabled,
 }));
 
+// The header also reads the skills flag and tracks tab switches; neither is
+// under test here (see ConnectViewHeader.skills.test.tsx), so keep PostHog out
+// of it.
+vi.mock("@/hooks/useSkillsEnabled", () => ({
+  useSkillsEnabled: () => false,
+}));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
 import { ConnectViewHeader } from "../ConnectViewHeader";
 
 afterEach(() => {

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/ConnectViewHeader.skills.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/ConnectViewHeader.skills.test.tsx
@@ -1,0 +1,97 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Skills is gated by `skills-enabled` in HOSTED mode only: local-mode
+// filesystem skills never read the flag, so the tab must stay visible in the
+// local app even with the flag off (unlike Computer, which is flagged in both).
+let hostedMode = false;
+let skillsFlag = false;
+let computersFlag = false;
+
+vi.mock("@/hooks/useComputersEnabled", () => ({
+  useComputersEnabled: () => computersFlag,
+}));
+
+vi.mock("@/hooks/useSkillsEnabled", () => ({
+  useSkillsEnabled: () => skillsFlag,
+}));
+
+vi.mock("@/lib/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/config")>();
+  return {
+    ...actual,
+    get HOSTED_MODE() {
+      return hostedMode;
+    },
+  };
+});
+
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { track } from "@/lib/analytics";
+import { ConnectViewHeader } from "../ConnectViewHeader";
+
+const renderHeader = (onChange = () => {}) =>
+  render(
+    <ConnectViewHeader
+      value="servers"
+      previewedHostId={null}
+      onChange={onChange}
+    />
+  );
+
+const tabLabels = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll('nav[aria-label="Connect view"] button')
+  ).map((button) => button.textContent);
+
+beforeEach(() => {
+  hostedMode = false;
+  skillsFlag = false;
+  computersFlag = false;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ConnectViewHeader — Skills tab gating", () => {
+  it("hides the Skills tab in hosted mode when the flag is off", () => {
+    hostedMode = true;
+    const { queryByText, getByText } = renderHeader();
+    expect(getByText("Servers")).toBeTruthy();
+    expect(queryByText("Skills")).toBeNull();
+  });
+
+  it("shows the Skills tab in hosted mode when the flag is on, after Computer", () => {
+    hostedMode = true;
+    skillsFlag = true;
+    computersFlag = true;
+    const { container, getByText } = renderHeader();
+    expect(getByText("Skills")).toBeTruthy();
+    expect(tabLabels(container)).toEqual([
+      "Servers",
+      "Client",
+      "Computer",
+      "Skills",
+    ]);
+  });
+
+  it("shows the Skills tab in local mode even with the flag off", () => {
+    hostedMode = false;
+    skillsFlag = false;
+    const { getByText } = renderHeader();
+    expect(getByText("Skills")).toBeTruthy();
+  });
+
+  it("tracks connect_view_selected and calls onChange when Skills is clicked", () => {
+    const onChange = vi.fn();
+    const { getByText } = renderHeader(onChange);
+    getByText("Skills").click();
+    expect(track).toHaveBeenCalledWith("connect_view_selected", {
+      from: "servers",
+      to: "skills",
+    });
+    expect(onChange).toHaveBeenCalledWith("skills");
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -41,6 +41,8 @@ import { parseHostVerifyTabParam } from "../host-verify-deep-link";
 import { buildRedesignedHostCanvas } from "./canvas/canvasBuilder";
 import { HostFocusPanel } from "./focus/HostFocusPanel";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useSkillsEnabled } from "@/hooks/useSkillsEnabled";
+import { HOSTED_MODE } from "@/lib/config";
 import { useComputerStatus } from "@/hooks/useProjectComputer";
 import { useBuiltInToolCatalog } from "@/hooks/useBuiltInToolCatalog";
 import {
@@ -79,6 +81,10 @@ export function HostBuilderViewRedesigned({
   });
   const { servers } = useProjectServers({ projectId, isAuthenticated });
   const computersEnabled = useComputersEnabled();
+  // Mirrors ConnectViewHeader's gating: Skills is flagged in hosted mode only,
+  // local filesystem skills are ungated.
+  const skillsEnabled = useSkillsEnabled();
+  const showSkillsTab = !HOSTED_MODE || skillsEnabled;
   // Project Computers canvas inputs. Both queries resolve to `undefined`
   // until their backend functions are deployed and stay cheap when the
   // feature flag is off (the islands they feed aren't emitted then).
@@ -470,6 +476,7 @@ export function HostBuilderViewRedesigned({
               value="host"
               ariaLabel="Connect view"
               onChange={(next) => {
+                track("connect_view_selected", { from: "host", to: next });
                 if (next === "servers") {
                   // Skip `onBack()` (which would push `/hosts` first via
                   // the parent's handleSelectHost) and just navigate.
@@ -478,6 +485,8 @@ export function HostBuilderViewRedesigned({
                   navigate("/servers");
                 } else if (next === "computer") {
                   navigate("/computer");
+                } else if (next === "skills") {
+                  navigate("/skills");
                 }
               }}
               options={[
@@ -487,6 +496,9 @@ export function HostBuilderViewRedesigned({
                 // this primary nav — keep it out so it isn't duplicated.
                 ...(computersEnabled
                   ? [{ value: "computer", label: "Computer" }]
+                  : []),
+                ...(showSkillsTab
+                  ? [{ value: "skills", label: "Skills" }]
                   : []),
               ]}
             />

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -476,7 +476,11 @@ export function HostBuilderViewRedesigned({
               value="host"
               ariaLabel="Connect view"
               onChange={(next) => {
-                track("connect_view_selected", { from: "host", to: next });
+                try {
+                  track("connect_view_selected", { from: "host", to: next });
+                } catch {
+                  // swallow — a posthog throw must never block navigation
+                }
                 if (next === "servers") {
                   // Skip `onBack()` (which would push `/hosts` first via
                   // the parent's handleSelectHost) and just navigate.

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -11,7 +11,6 @@ import {
   Boxes,
   Workflow,
   ListTodo,
-  SquareSlash,
   MessageCircleQuestionIcon,
   GraduationCap,
   Network,
@@ -71,7 +70,6 @@ import {
   navigateApp,
   useAppNavigate,
 } from "@/lib/app-navigation";
-import { HOSTED_LOCAL_ONLY_TOOLTIP } from "@/lib/hosted-ui";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
 import {
@@ -167,8 +165,10 @@ export function applyBillingGateNavState(
   }));
 }
 
-// Define sections with their respective items
-const navigationSections: NavSection[] = [
+// Define sections with their respective items.
+// Exported so tests can assert against the real nav data (e.g. that Skills is
+// not a sidebar item — it lives in the Connect tab switcher).
+export const navigationSections: NavSection[] = [
   {
     id: "connection",
     items: [
@@ -183,7 +183,7 @@ const navigationSections: NavSection[] = [
         url: "/servers",
         icon: MCPIcon,
         featureFlag: "hosts-enabled",
-        matchTabs: ["clients", "host-compare", "computer"],
+        matchTabs: ["clients", "host-compare", "computer", "skills"],
       },
       {
         title: "Servers",
@@ -239,11 +239,9 @@ const navigationSections: NavSection[] = [
   {
     id: "others",
     items: [
-      {
-        title: "Skills",
-        url: "/skills",
-        icon: SquareSlash,
-      },
+      // Skills is not a sidebar item: it's execution-context config, so it
+      // lives as a Connect tab (Servers | Client | Computer | Skills) and is
+      // reached through that switcher.
       {
         title: "Learning",
         url: "/learning",
@@ -371,17 +369,6 @@ export function getHostedNavigationSections(
           return [item];
         }
 
-        if (normalizedTab === "skills") {
-          return [
-            {
-              ...item,
-              disabled: true,
-              disabledTooltip: HOSTED_LOCAL_ONLY_TOOLTIP,
-              hiddenByFlag: undefined,
-            },
-          ];
-        }
-
         return [];
       }),
     }))
@@ -390,35 +377,6 @@ export function getHostedNavigationSections(
 
 const hostedNavigationSections =
   getHostedNavigationSections(navigationSections);
-
-/**
- * Resolve the hosted Skills nav item against the `skills-enabled` PostHog flag.
- * `getHostedNavigationSections` runs at module load (no hooks) and marks Skills
- * disabled by default. Hosted skills are a **project-membership** resource
- * (authored in Convex, available even without a Computer), but are gated behind
- * the flag until QA completes:
- *   - flag on  ⇒ flip the item to enabled (access is still enforced server-side);
- *   - flag off ⇒ drop the item entirely, rather than leave it grayed with the
- *     "local only" tooltip, which would misrepresent why it's unavailable.
- */
-export function resolveHostedSkillsNav(
-  sections: NavSection[],
-  enabled: boolean
-): NavSection[] {
-  return sections
-    .map((section) => ({
-      ...section,
-      items: section.items.flatMap((item) => {
-        const isSkills =
-          normalizeHostedHashTab(item.url.replace(/^[#/]+/, "")) === "skills";
-        if (!isSkills) return [item];
-        return enabled
-          ? [{ ...item, disabled: false, disabledTooltip: undefined }]
-          : [];
-      }),
-    }))
-    .filter((section) => section.items.length > 0);
-}
 
 interface MCPSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onNavigate?: (section: string) => void;
@@ -611,9 +569,6 @@ export function MCPSidebar({
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
   const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
-  // Hosted Cloud Skills nav is gated until QA completes; fail-closed (absent /
-  // loading flag ⇒ hidden). See `useSkillsEnabled`.
-  const skillsEnabled = useFeatureFlagEnabled("skills-enabled");
   const projectEnvironmentsEnabled = useFeatureFlagEnabled(
     "project-environments-enabled"
   );
@@ -707,9 +662,7 @@ export function MCPSidebar({
   );
   const hubNavHash = "#servers";
   const visibleNavigationSections = filterByFeatureFlags(
-    HOSTED_MODE
-      ? resolveHostedSkillsNav(hostedNavigationSections, skillsEnabled === true)
-      : navigationSections,
+    HOSTED_MODE ? hostedNavigationSections : navigationSections,
     featureFlags
   );
 

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/nav-main.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/nav-main.test.tsx
@@ -53,8 +53,11 @@ describe("NavMain", () => {
       <NavMain
         items={[
           {
-            title: "Skills",
-            url: "#skills",
+            // Any nav item whose url maps to a learn-more entry with a preview
+            // video works here; Playground is one (Skills used to be, before it
+            // moved out of the sidebar into the Connect tab switcher).
+            title: "Playground",
+            url: "#playground",
             icon: FakeIcon,
             disabled: true,
             disabledTooltip: HOSTED_LOCAL_ONLY_TOOLTIP,
@@ -66,7 +69,7 @@ describe("NavMain", () => {
     );
 
     // Should show learn-more hover card with disabled message
-    expect(screen.getByTestId("learn-more-skills")).toBeInTheDocument();
+    expect(screen.getByTestId("learn-more-playground")).toBeInTheDocument();
     expect(screen.getByTestId("disabled-message")).toHaveTextContent(
       HOSTED_LOCAL_ONLY_TOOLTIP
     );
@@ -75,7 +78,7 @@ describe("NavMain", () => {
       screen.queryByTitle(HOSTED_LOCAL_ONLY_TOOLTIP)
     ).not.toBeInTheDocument();
 
-    const button = screen.getByRole("button", { name: "Skills" });
+    const button = screen.getByRole("button", { name: "Playground" });
     expect(button).toHaveAttribute("aria-disabled", "true");
 
     fireEvent.click(button);

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -44,10 +44,10 @@ export const HOSTED_HASH_ALLOWED_TABS = [
   "computer",
   // Cloud Skills are a project-membership resource (Convex-backed, usable in
   // the Playground without a Computer) but gated behind the `skills-enabled`
-  // PostHog flag until QA completes. Kept OUT of the sidebar-allowed list so the
-  // nav item is disabled-by-default; `resolveHostedSkillsNav` (mcp-sidebar)
-  // enables it only when the flag is on, and the route guard (`SkillsRoute`)
-  // redirects direct navigation when the flag is off.
+  // PostHog flag until QA completes. Reached via the Connect tab switcher, not
+  // a standalone sidebar item, so it needs the hash allow-list only — the tab
+  // itself is hidden while the flag is off (`useSkillsEnabled`) and the route
+  // guard (`SkillsRoute`) redirects direct navigation.
   "skills",
 ] as const;
 

--- a/mcpjam-inspector/client/src/lib/learn-more-content.ts
+++ b/mcpjam-inspector/client/src/lib/learn-more-content.ts
@@ -48,18 +48,9 @@ export const learnMoreContent: Record<string, LearnMoreEntry> = {
       "A local development environment for ChatGPT apps and MCP apps. Emulate widgets, test across devices, themes, and client styles, debug CSP, and chat with your server — no ngrok or paid subscription needed.",
     docsUrl: "https://docs.mcpjam.com/inspector/playground",
   },
-  skills: {
-    title: "Skills",
-    videoUrl: "https://www.youtube.com/embed/kUdPwm6GJe8",
-    videoThumbnail:
-      "https://outstanding-fennec-304.convex.cloud/api/storage/8b3243cc-a853-4839-b5e4-f7690d5e982c",
-    previewVideoUrl:
-      "https://outstanding-fennec-304.convex.cloud/api/storage/673acc12-a14d-4ea7-878c-855185264e70",
-    description: "View, add, and manage your skills.",
-    expandedDescription:
-      "View your installed skills, upload new ones, and manage them all in one place. MCPJam discovers skills from your .claude/, .mcpjam/, and .agents/ directories automatically. Use them in the Playground or Chat — skills load based on your prompt, or inject one directly with the / command.",
-    docsUrl: "https://docs.mcpjam.com/inspector/skills",
-  },
+  // No `skills` entry: learn-more cards are keyed off sidebar nav item URLs
+  // (see nav-main.tsx) and Skills is now a Connect tab, not a sidebar item, so
+  // the card had no host left to render in.
   "oauth-flow": {
     title: "OAuth Debugger",
     videoUrl: "https://www.youtube.com/embed/tQSEnr4T5Qc",

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -96,6 +96,10 @@ export const ANALYTICS_EVENTS = {
   connect_host_overlay_quick_added: { source: "client" },
   connect_host_overlay_saved_as_new: { source: "client" },
   connect_host_overlay_swapped: { source: "client" },
+  // Connect's primary tab switcher (Servers | Client | Computer | Skills).
+  // Skills moved out of the sidebar into this switcher, so this replaces the
+  // `sidebar_nav_clicked` signal for skills entries.
+  connect_view_selected: { source: "client" },
   connecting_server: { source: "client" },
   connection_switch_toggled: { source: "client" },
   copy_agent_brief_clicked: { source: "client" },


### PR DESCRIPTION
## What

Skills was a standalone sidebar page, orphaned between Evaluate and Learning. With the environments push (environments pin the sandbox image, skills get pinned into environments), skills are execution-context config — the same family as Servers / Client / Computer. This moves Skills into the Connect surface as a fourth tab (**Servers | Client | Computer | Skills**) and removes the sidebar item.

The `/skills` route path is unchanged, so there are no redirects and no changes to `app-routes.ts` / `shared/app-surfaces.ts`.

## Flag semantics (unchanged, just relocated)

- **Hosted**: tab visibility via `useSkillsEnabled()` (boolean, fail-closed while hydrating — same pop-in behavior as the Computer tab). `SkillsRoute` keeps its existing tri-state guard: `false` → `Navigate` to `/servers`; `undefined` → render null, so a cold `/skills` load doesn't flash-redirect a flagged-in user mid-hydration.
- **Local / Electron**: Skills stays ungated, matching today — local FS skills never read the flag (per `useSkillsEnabled.ts`). Tab shows when `!HOSTED_MODE || skillsEnabled`. This intentionally differs from Computer (flagged in both modes): "keep skills flagged" means preserving the hosted gate, not adding a new local one.

## Changes

- **`ConnectViewHeader.tsx`** — `"skills"` added to `ConnectViewValue`; `useSkillsEnabled()` + `showSkillsTab` gate the new option, appended after Computer. `onChange` is wrapped to fire `connect_view_selected`.
- **Connect `onChange` switches** — `skills` branch added to `HostCompareRoute`, `ComputerRoute` (App.tsx) and the servers view (`HostsTab.tsx`). The `next === "host"` special case in HostsTab (which uses `onSelectHost` to avoid a duplicate history entry) is untouched.
- **`HostBuilderViewRedesigned.tsx`** — the host canvas draws its own header row with a duplicated selector; it gets the same gating, the Skills option, and `navigate("/skills")` (literal paths, matching that file's style).
- **`SkillsRoute`** — now renders the Connect chrome, copying `ComputerRoute`: flag guard first, then `usePreviewedHostId` + `isSignedInMember`; non-members get the bare `<SkillsTab />`, members get `motion.div` + `ConnectViewHeader value="skills"` with the view in a `min-h-0 flex-1` container.
- **Sidebar** — Skills nav item deleted; Connect's `matchTabs` gains `"skills"` so it highlights on `/skills`. The now-dead hosted-skills plumbing is removed: `resolveHostedSkillsNav`, the disabled-stub branch in `getHostedNavigationSections`, the `skills-enabled` flag read, and the `SquareSlash` / `HOSTED_LOCAL_ONLY_TOOLTIP` imports it needed. `navigationSections` is now exported so tests can assert against the real nav data.
- **`hosted-tab-policy.ts`** — no behavior change (skills stays hash-allowed, not sidebar-allowed); the rationale comment now mirrors Computer's ("reached via the Connect tab switcher").
- **`learn-more-content.ts`** — the Skills card was keyed off the sidebar item URL (`nav-main.tsx`), so it lost its host; entry deleted.
- **Analytics** — registered `connect_view_selected` (source: client) in `shared/analytics-events.ts` and fire `track("connect_view_selected", { from, to })` from `ConnectViewHeader` (one site covers all three route headers) and the `HostBuilderViewRedesigned` inline selector. Sidebar clicks to Skills used to ride on the generic `sidebar_nav_clicked`; Connect tab switching had no tracking, so without this the skills-entry signal would silently disappear. Uses the registered `track()`, so the analytics ratchet stays green.

No changes to: the chat-input skills popover, `mcp-skills-api`, `ProjectEnvironmentSkillsPicker`, server-side skill code, `shared/skill-types.ts`, `shared/app-surfaces.ts`, `app-routes.ts`.

## Tests

- **New** `ConnectViewHeader.skills.test.tsx` — hosted+flag off → no Skills tab; hosted+flag on → visible and ordered after Computer; local+flag off → still visible; clicking Skills fires `connect_view_selected` and calls `onChange`. (`ConnectViewHeader.computer.test.tsx` gains mocks for the header's new deps so PostHog stays out of it.)
- **New** `SkillsRoute.flag-hydration.test.tsx` — modeled on `ComputerRoute.flag-hydration.test.tsx`: `undefined` → no redirect and nothing rendered; `undefined → true` → no redirect, view + header render; `false` → `Navigate` to `routePaths.servers`; guest actor → bare view without header.
- **Updated** `mcp-sidebar-feature-flags.test.ts` — `resolveHostedSkillsNav` tests removed with the helper; the `getHostedNavigationSections` case no longer expects a disabled Skills stub; new assertion that no section contains a `/skills` item in either mode.
- **Updated** `nav-main.test.tsx` — its "disabled item with learn-more content" fixture used Skills, which no longer has a learn-more entry; switched to Playground (equivalent: an item whose URL maps to an entry with a preview video).
- Full client vitest suite green (6824 passed / 6 skipped), plus `shared` (451 passed) and `npm run typecheck:client`.

## Risks / notes

- **Signed-out local users lose the visible Skills entry point.** They render the bare view with no Connect header, so `/skills` becomes URL-only for them. This matches how Computer already behaves, but it's the one genuine UX regression in this change.
- `hosts-enabled` is hardcoded to `isAuthenticated` (not a PostHog flag), so "skills-enabled on but Connect hidden" can't occur for authenticated users.
- Hosted guests (`isGuestProjectActor`) get the bare SkillsTab without chrome — same posture as Computer.
- No `indicatorId` change was needed: the header selector uses `"Connect view"` and SkillsTab's internal Local/Cloud selector uses `"skills-source"`, so their sliding indicators already animate independently.

## Manual verification not run here

This sandbox has no browser session against a running dev server, so the visual/UX pass is untested: tab ordering and pill animation in the real app, browser-Back behavior from `/skills`, the host-canvas inline selector, hosted flag-off/flag-on behavior, and `connect_view_selected` arriving in PostHog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPv45r1Kng74ULybboCDa3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly navigation and UI chrome; hosted skills gating and route guards are preserved with added tests. Signed-out local users lose a visible Skills entry unless they use `/skills` directly.
> 
> **Overview**
> **Skills** is no longer a sidebar destination; it becomes a fourth **Connect** tab (**Servers | Client | Computer | Skills**) while **`/skills`** stays the same route.
> 
> **Connect chrome** — `ConnectViewHeader` adds a **Skills** option (hosted: `skills-enabled`; local: always on), wires **`/skills`** navigation from Compare, Computer, Servers hub, and the host builder’s inline selector, and emits **`connect_view_selected`** on tab changes. **`SkillsRoute`** mirrors **`ComputerRoute`**: hosted tri-state flag guard, **`ConnectViewHeader`** for signed-in members, bare **`SkillsTab`** for guests/non-members.
> 
> **Sidebar / hosted nav** — Removes the Skills item, **`resolveHostedSkillsNav`**, and the hosted “disabled local-only” Skills stub; **Connect**’s **`matchTabs`** includes **`skills`**. Skills learn-more content is dropped because sidebar URLs no longer drive it.
> 
> **Tests** — New coverage for Skills tab gating, route flag hydration, and Connect chrome; sidebar tests assert no **`/skills`** nav entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15877cc23e15d4a199c4f5083596eaa0812d6f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Skills into Connect as a fourth tab and removes the sidebar item. Keeps the `/skills` route and hosted gating; adds tab-switch analytics and wraps analytics in try/catch so navigation never blocks.

- **New Features**
  - Added a Skills tab to Connect, gated by `skills-enabled` in hosted; always visible in local/Electron. Ordered after Computer.
  - Fired `connect_view_selected` on all Connect tab changes (header + host builder inline selector), wrapped in try/catch.
  - `SkillsRoute` now renders Connect chrome for signed-in members; keeps the tri-state flag guard and redirects to `/servers` only when the flag is false.
  - Updated Connect switches in Host Compare, Computer, Servers hub, and Host Builder to navigate to `/skills`; sidebar Skills item removed and Connect `matchTabs` now highlights on `/skills`. `navigationSections` exported for tests; Skills learn-more card removed.

- **Migration**
  - Signed-out local users no longer see a Skills entry point; use the `/skills` URL.

<sup>Written for commit 15877cc23e15d4a199c4f5083596eaa0812d6f71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

