### PR TITLE
Goal × outcome grid, cell drill-down, and outcome map tint

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
@@ -86,6 +86,22 @@ type PagingState = {
   lastNextBefore?: number | null;
 };
 
+/**
+ * The pager's cursor for this render.
+ *
+ * NOT a `??` chain over the live value: a settled page reports "no more rows"
+ * AS `nextBefore: null`, so coalescing on null would fall back to the previous
+ * page's cursor and keep rendering "Load more" for a paint after the set is
+ * exhausted — the settled null is an answer, not a gap. The last settled cursor
+ * is a fallback only while the next page is in flight (live result undefined).
+ */
+export function resolveNextBefore(
+  live: { nextBefore: number | null } | undefined,
+  lastSettled: number | null | undefined,
+): number | null {
+  return live !== undefined ? live.nextBefore : (lastSettled ?? null);
+}
+
 export function ChatboxGoalOutcomeDrilldown({
   chatboxId,
   cell,
@@ -151,7 +167,7 @@ export function ChatboxGoalOutcomeDrilldown({
   const total = drilldown?.total ?? active.lastTotal;
   const totalTruncated =
     drilldown?.totalTruncated ?? active.lastTotalTruncated ?? false;
-  const nextBefore = drilldown?.nextBefore ?? active.lastNextBefore ?? null;
+  const nextBefore = resolveNextBefore(drilldown, active.lastNextBefore);
   const showEmpty = !isLoading && drilldown !== undefined && rows.length === 0;
 
   return (

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, ChevronRight, X } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  useGoalOutcomeDrilldown,
+  type SessionOutcome,
+} from "@/hooks/useUsageInsights";
+import type { UsageFilterState } from "@/hooks/chatbox-usage-filters";
+
+/**
+ * Sessions behind one goal × outcome cell.
+ *
+ * Paged server-side. The cell shows an exact count and this list has to be able
+ * to reach all of it, which the insights list's fixed 100-row fetch plus a
+ * client-side filter could not do — it would silently show a subset whose total
+ * disagreed with the number the user clicked.
+ */
+const PAGE_SIZE = 25;
+
+type DrilldownRow = {
+  _id: string;
+  firstMessagePreview?: string;
+  lastActivityAt: number;
+};
+
+interface ChatboxGoalOutcomeDrilldownProps {
+  chatboxId: string;
+  cell: {
+    clusterId: string;
+    clusterLabel?: string;
+    outcome: SessionOutcome | null;
+  } | null;
+  /** Other active facet chips, applied on top of the cell selection. */
+  filter: UsageFilterState;
+  onClose: () => void;
+  onOpenSession: (sessionId: string) => void;
+}
+
+function outcomeLabel(outcome: SessionOutcome | null): string {
+  return outcome === null ? "not analyzed" : outcome;
+}
+
+/** Identity of a cell, including the not-analyzed case that has no outcome. */
+function cellKeyOf(
+  cell: ChatboxGoalOutcomeDrilldownProps["cell"],
+): string | null {
+  if (!cell) return null;
+  return `${cell.clusterId}:${cell.outcome ?? "__unlabeled__"}`;
+}
+
+type PagingState = {
+  cellKey: string | null;
+  before?: number;
+  rows: DrilldownRow[];
+};
+
+export function ChatboxGoalOutcomeDrilldown({
+  chatboxId,
+  cell,
+  filter,
+  onClose,
+  onOpenSession,
+}: ChatboxGoalOutcomeDrilldownProps) {
+  const cellKey = cellKeyOf(cell);
+
+  // Cursor + accumulated pages, stored TOGETHER WITH the cell they belong to.
+  // Resetting in an effect instead would leave one render where the query runs
+  // with the new cell but the previous cell's cursor, and the accumulate effect
+  // could merge the old cell's rows into the new list.
+  const [paging, setPaging] = useState<PagingState>({
+    cellKey: null,
+    rows: [],
+  });
+
+  // React's documented "adjust state when props change" pattern: reset during
+  // render, conditionally, so the reset is visible to the query below on this
+  // very render rather than one render late.
+  const active: PagingState =
+    paging.cellKey === cellKey
+      ? paging
+      : { cellKey, before: undefined, rows: [] };
+  if (paging.cellKey !== cellKey) {
+    setPaging(active);
+  }
+
+  const { drilldown, isLoading } = useGoalOutcomeDrilldown({
+    chatboxId,
+    clusterId: cell?.clusterId ?? null,
+    outcome: cell?.outcome,
+    filters: filter,
+    limit: PAGE_SIZE,
+    before: active.before,
+    enabled: cell !== null,
+  });
+
+  useEffect(() => {
+    if (!drilldown) return;
+    setPaging((prev) => {
+      // A result that arrives after the user moved to another cell belongs to
+      // neither list; drop it rather than appending it to the wrong one.
+      if (prev.cellKey !== cellKey) return prev;
+      const seen = new Set(prev.rows.map((row) => row._id));
+      const fresh = drilldown.sessions.filter((row) => !seen.has(row._id));
+      if (fresh.length === 0) return prev;
+      return { ...prev, rows: [...prev.rows, ...fresh] };
+    });
+  }, [cellKey, drilldown]);
+
+  if (!cell) return null;
+
+  const rows = active.rows;
+  const total = drilldown?.total ?? 0;
+  const showEmpty = !isLoading && drilldown !== undefined && rows.length === 0;
+
+  return (
+    <div className="flex flex-col gap-2 border-b bg-muted/20 px-5 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-medium">
+            {cell.clusterLabel ?? "Goal"} &middot; {outcomeLabel(cell.outcome)}
+          </h3>
+          <p className="text-[11px] text-muted-foreground">
+            {drilldown === undefined
+              ? "Loading sessions…"
+              : `${total.toLocaleString()}${
+                  drilldown.totalTruncated ? "+" : ""
+                } session${total === 1 ? "" : "s"} in this cell`}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClose}
+          aria-label="Close cell drill-down"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      {drilldown?.totalTruncated ? (
+        <div
+          role="status"
+          className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning-foreground"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            The count above stops at the scan limit; this cell has at least that
+            many sessions.
+          </span>
+        </div>
+      ) : null}
+
+      <ul className="divide-y divide-border/60">
+        {rows.map((session) => (
+          <li key={session._id}>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 py-1.5 text-left text-xs hover:text-primary"
+              onClick={() => onOpenSession(session._id)}
+            >
+              <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate">
+                {session.firstMessagePreview?.trim() || "(no preview)"}
+              </span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                {new Date(session.lastActivityAt).toLocaleDateString()}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {drilldown?.nextBefore != null ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="self-start"
+          onClick={() =>
+            setPaging((prev) =>
+              prev.cellKey === cellKey
+                ? { ...prev, before: drilldown.nextBefore ?? undefined }
+                : prev,
+            )
+          }
+        >
+          Load {PAGE_SIZE} more
+        </Button>
+      ) : null}
+
+      {showEmpty ? (
+        <p className="text-[11px] text-muted-foreground">
+          No sessions match this cell with the current filters.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
@@ -5,7 +5,11 @@ import {
   useGoalOutcomeDrilldown,
   type SessionOutcome,
 } from "@/hooks/useUsageInsights";
-import { chipKey, type UsageFilterState } from "@/hooks/chatbox-usage-filters";
+import {
+  chipKey,
+  outcomeChipValue,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
 
 /**
  * Sessions behind one goal × outcome cell.
@@ -61,7 +65,7 @@ function requestKeyOf(
   return [
     chatboxId,
     cell.clusterId,
-    cell.outcome ?? "__unlabeled__",
+    outcomeChipValue(cell.outcome),
     filter.preset,
     chips,
   ].join("|");

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
@@ -5,7 +5,7 @@ import {
   useGoalOutcomeDrilldown,
   type SessionOutcome,
 } from "@/hooks/useUsageInsights";
-import type { UsageFilterState } from "@/hooks/chatbox-usage-filters";
+import { chipKey, type UsageFilterState } from "@/hooks/chatbox-usage-filters";
 
 /**
  * Sessions behind one goal × outcome cell.
@@ -40,18 +40,46 @@ function outcomeLabel(outcome: SessionOutcome | null): string {
   return outcome === null ? "not analyzed" : outcome;
 }
 
-/** Identity of a cell, including the not-analyzed case that has no outcome. */
-function cellKeyOf(
+/**
+ * Identity of everything the paged request depends on: the chatbox, the cell,
+ * and the other active facet chips.
+ *
+ * The filters belong in the key because they are part of the query. Keying on
+ * the cell alone means changing an unrelated chip while a cell is open keeps the
+ * old cursor and the already-accumulated rows — so the list would show sessions
+ * the current filter excludes and would start from page two of a set that no
+ * longer exists.
+ */
+function requestKeyOf(
+  chatboxId: string,
   cell: ChatboxGoalOutcomeDrilldownProps["cell"],
+  filter: UsageFilterState
 ): string | null {
   if (!cell) return null;
-  return `${cell.clusterId}:${cell.outcome ?? "__unlabeled__"}`;
+  // Chip order is not semantically meaningful, so sort for a stable key.
+  const chips = filter.chips.map(chipKey).sort().join(",");
+  return [
+    chatboxId,
+    cell.clusterId,
+    cell.outcome ?? "__unlabeled__",
+    filter.preset,
+    chips,
+  ].join("|");
 }
 
 type PagingState = {
-  cellKey: string | null;
+  requestKey: string | null;
   before?: number;
   rows: DrilldownRow[];
+  /**
+   * Last known values from a settled query. Advancing the cursor makes the
+   * subscription return `undefined` again, and without these the header would
+   * flip back to "Loading…" and the pager would vanish from under the cursor on
+   * every click. Replaced only when fresh data arrives.
+   */
+  lastTotal?: number;
+  lastTotalTruncated?: boolean;
+  lastNextBefore?: number | null;
 };
 
 export function ChatboxGoalOutcomeDrilldown({
@@ -61,14 +89,14 @@ export function ChatboxGoalOutcomeDrilldown({
   onClose,
   onOpenSession,
 }: ChatboxGoalOutcomeDrilldownProps) {
-  const cellKey = cellKeyOf(cell);
+  const requestKey = requestKeyOf(chatboxId, cell, filter);
 
-  // Cursor + accumulated pages, stored TOGETHER WITH the cell they belong to.
+  // Cursor + accumulated pages, stored TOGETHER WITH the request they belong to.
   // Resetting in an effect instead would leave one render where the query runs
-  // with the new cell but the previous cell's cursor, and the accumulate effect
-  // could merge the old cell's rows into the new list.
+  // with the new request but the previous one's cursor, and the accumulate
+  // effect could merge the old rows into the new list.
   const [paging, setPaging] = useState<PagingState>({
-    cellKey: null,
+    requestKey: null,
     rows: [],
   });
 
@@ -76,10 +104,10 @@ export function ChatboxGoalOutcomeDrilldown({
   // render, conditionally, so the reset is visible to the query below on this
   // very render rather than one render late.
   const active: PagingState =
-    paging.cellKey === cellKey
+    paging.requestKey === requestKey
       ? paging
-      : { cellKey, before: undefined, rows: [] };
-  if (paging.cellKey !== cellKey) {
+      : { requestKey, before: undefined, rows: [] };
+  if (paging.requestKey !== requestKey) {
     setPaging(active);
   }
 
@@ -96,20 +124,30 @@ export function ChatboxGoalOutcomeDrilldown({
   useEffect(() => {
     if (!drilldown) return;
     setPaging((prev) => {
-      // A result that arrives after the user moved to another cell belongs to
-      // neither list; drop it rather than appending it to the wrong one.
-      if (prev.cellKey !== cellKey) return prev;
+      // A result that arrives after the request changed belongs to neither
+      // list; drop it rather than appending it to the wrong one.
+      if (prev.requestKey !== requestKey) return prev;
       const seen = new Set(prev.rows.map((row) => row._id));
       const fresh = drilldown.sessions.filter((row) => !seen.has(row._id));
-      if (fresh.length === 0) return prev;
-      return { ...prev, rows: [...prev.rows, ...fresh] };
+      return {
+        ...prev,
+        rows: fresh.length === 0 ? prev.rows : [...prev.rows, ...fresh],
+        lastTotal: drilldown.total,
+        lastTotalTruncated: drilldown.totalTruncated,
+        lastNextBefore: drilldown.nextBefore,
+      };
     });
-  }, [cellKey, drilldown]);
+  }, [requestKey, drilldown]);
 
   if (!cell) return null;
 
   const rows = active.rows;
-  const total = drilldown?.total ?? 0;
+  // Prefer live data; fall back to the last settled values so paging does not
+  // blank the header and the pager mid-click.
+  const total = drilldown?.total ?? active.lastTotal;
+  const totalTruncated =
+    drilldown?.totalTruncated ?? active.lastTotalTruncated ?? false;
+  const nextBefore = drilldown?.nextBefore ?? active.lastNextBefore ?? null;
   const showEmpty = !isLoading && drilldown !== undefined && rows.length === 0;
 
   return (
@@ -120,11 +158,11 @@ export function ChatboxGoalOutcomeDrilldown({
             {cell.clusterLabel ?? "Goal"} &middot; {outcomeLabel(cell.outcome)}
           </h3>
           <p className="text-[11px] text-muted-foreground">
-            {drilldown === undefined
+            {total === undefined
               ? "Loading sessions…"
-              : `${total.toLocaleString()}${
-                  drilldown.totalTruncated ? "+" : ""
-                } session${total === 1 ? "" : "s"} in this cell`}
+              : `${total.toLocaleString()}${totalTruncated ? "+" : ""} session${
+                  total === 1 ? "" : "s"
+                } in this cell`}
           </p>
         </div>
         <Button
@@ -138,7 +176,7 @@ export function ChatboxGoalOutcomeDrilldown({
         </Button>
       </div>
 
-      {drilldown?.totalTruncated ? (
+      {totalTruncated ? (
         <div
           role="status"
           className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning-foreground"
@@ -171,7 +209,7 @@ export function ChatboxGoalOutcomeDrilldown({
         ))}
       </ul>
 
-      {drilldown?.nextBefore != null ? (
+      {nextBefore != null ? (
         <Button
           type="button"
           variant="outline"
@@ -179,9 +217,9 @@ export function ChatboxGoalOutcomeDrilldown({
           className="self-start"
           onClick={() =>
             setPaging((prev) =>
-              prev.cellKey === cellKey
-                ? { ...prev, before: drilldown.nextBefore ?? undefined }
-                : prev,
+              prev.requestKey === requestKey
+                ? { ...prev, before: nextBefore ?? undefined }
+                : prev
             )
           }
         >

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeGrid.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeGrid.tsx
@@ -94,8 +94,14 @@ function formatEntropy(entropy: number | null): string {
 /**
  * Fold rows past the cap into a single "Other" row. Rates are recomputed from
  * the summed counts rather than averaged, so the row's numbers stay internally
- * consistent. Entropy is deliberately NOT aggregated — entropy over a union of
- * unrelated goals is not a meaningful number — so it renders as "—".
+ * consistent.
+ *
+ * Two route metrics are deliberately NOT aggregated and render as "—":
+ * entropy, because entropy over a union of unrelated goals is not a meaningful
+ * number; and the distinct-route count, because summing per-goal distinct
+ * counts double-counts any path two folded goals share, which would overstate
+ * it. Only the per-goal `pathDistribution` could union them correctly, and the
+ * grid does not need that number badly enough to carry it.
  */
 function foldOtherRow(rows: GoalFacet[]): GoalFacet | null {
   if (rows.length === 0) return null;
@@ -109,12 +115,10 @@ function foldOtherRow(rows: GoalFacet[]): GoalFacet | null {
   let total = 0;
   let unlabeled = 0;
   let retried = 0;
-  let distinctPathCount = 0;
   for (const row of rows) {
     total += row.total;
     unlabeled += row.unlabeled;
     retried += row.retryRate * row.total;
-    distinctPathCount += row.distinctPathCount;
     for (const outcome of SESSION_OUTCOMES) {
       outcomes[outcome] += row.outcomes[outcome];
     }
@@ -136,7 +140,9 @@ function foldOtherRow(rows: GoalFacet[]): GoalFacet | null {
     retryRate: total > 0 ? retried / total : 0,
     toolDistribution: [],
     pathDistribution: [],
-    distinctPathCount,
+    // Not summed — see the note above. -1 marks "not aggregated" so the cell
+    // renders "—" rather than a wrong number or a misleading 0.
+    distinctPathCount: -1,
     routingEntropy: null,
   };
 }
@@ -410,7 +416,9 @@ export function ChatboxGoalOutcomeGrid({
                     {formatRate(facet.retryRate)}
                   </td>
                   <td className="px-2 py-1.5 text-right tabular-nums">
-                    {facet.distinctPathCount.toLocaleString()}
+                    {facet.distinctPathCount < 0
+                      ? "—"
+                      : facet.distinctPathCount.toLocaleString()}
                   </td>
                   <td className="px-2 py-1.5 text-right tabular-nums">
                     {formatEntropy(facet.routingEntropy)}

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeGrid.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeGrid.tsx
@@ -55,16 +55,22 @@ const OUTCOME_LABELS: Record<SessionOutcome, string> = {
 function cellTint(outcome: SessionOutcome, share: number): string {
   if (share <= 0) return "";
   const bucket = share >= 0.6 ? "strong" : share >= 0.3 ? "medium" : "weak";
+  // Tinted surfaces take `text-<color>`, not `text-<color>-foreground`: the
+  // foreground tokens pair with SOLID fills (success/destructive foreground is
+  // white in both themes — see design-system tokens.css), so on a /25 tint over
+  // a light page they render white-on-near-white. `warning` is the deliberate
+  // exception: its foreground token IS theme-aware (dark in light mode), while
+  // bare `text-warning` is a yellow that fails contrast on a light page.
   if (outcome === "completed") {
     return {
-      strong: "bg-success/25 text-success-foreground",
+      strong: "bg-success/25 text-success",
       medium: "bg-success/15",
       weak: "bg-success/8",
     }[bucket];
   }
   if (outcome === "unresolved" || outcome === "errored") {
     return {
-      strong: "bg-destructive/25 text-destructive-foreground",
+      strong: "bg-destructive/25 text-destructive",
       medium: "bg-destructive/15",
       weak: "bg-destructive/8",
     }[bucket];

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeGrid.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeGrid.tsx
@@ -1,0 +1,433 @@
+import { useMemo, useState } from "react";
+import { AlertTriangle, ArrowUpDown, Info, Target } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import {
+  SESSION_OUTCOMES,
+  isCellSelected,
+  type SessionOutcome,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+import type { GoalFacet, UsageBreakdown } from "@/hooks/useUsageInsights";
+import { cn } from "@/lib/utils";
+
+/**
+ * Rows past this are folded into an "Other" row. It is a table, not a chart, so
+ * the cap exists to keep the panel scannable rather than to fit labels — and
+ * "Other" is a real row with real counts, never a silent drop.
+ */
+const MAX_GOAL_ROWS = 12;
+
+type SortKey = "volume" | "unresolved";
+
+interface ChatboxGoalOutcomeGridProps {
+  breakdown: UsageBreakdown | null | undefined;
+  filter: UsageFilterState;
+  /**
+   * Atomic cell selection. Must NOT be two toggleChip calls — chips OR within a
+   * dimension, so toggling would widen the selection instead of narrowing it.
+   */
+  onSelectCell: (cell: {
+    clusterId: string;
+    clusterLabel?: string;
+    outcome: SessionOutcome | null;
+  }) => void;
+}
+
+/** Column labels. Short because they head a numeric grid. */
+const OUTCOME_LABELS: Record<SessionOutcome, string> = {
+  completed: "Completed",
+  partial: "Partial",
+  unresolved: "Unresolved",
+  errored: "Errored",
+  unclear: "Unclear",
+};
+
+/**
+ * Tint for a cell, scaled by that cell's share of its row. Only the outcomes
+ * that indicate a problem are tinted warm; `completed` reads positive and
+ * `unclear` stays neutral, because tinting an absence of judgement as a problem
+ * is exactly the overclaim this grid exists to avoid.
+ */
+function cellTint(outcome: SessionOutcome, share: number): string {
+  if (share <= 0) return "";
+  const bucket = share >= 0.6 ? "strong" : share >= 0.3 ? "medium" : "weak";
+  if (outcome === "completed") {
+    return {
+      strong: "bg-success/25 text-success-foreground",
+      medium: "bg-success/15",
+      weak: "bg-success/8",
+    }[bucket];
+  }
+  if (outcome === "unresolved" || outcome === "errored") {
+    return {
+      strong: "bg-destructive/25 text-destructive-foreground",
+      medium: "bg-destructive/15",
+      weak: "bg-destructive/8",
+    }[bucket];
+  }
+  if (outcome === "partial") {
+    return {
+      strong: "bg-warning/25 text-warning-foreground",
+      medium: "bg-warning/15",
+      weak: "bg-warning/8",
+    }[bucket];
+  }
+  return "bg-muted/40";
+}
+
+function formatRate(rate: number | null): string {
+  // Null means the denominator was zero. That is "unknown", not 0%, and
+  // rendering it as 0% would be a claim we cannot support.
+  if (rate === null) return "—";
+  return `${Math.round(rate * 100)}%`;
+}
+
+function formatEntropy(entropy: number | null): string {
+  if (entropy === null) return "—";
+  return entropy.toFixed(2);
+}
+
+/**
+ * Fold rows past the cap into a single "Other" row. Rates are recomputed from
+ * the summed counts rather than averaged, so the row's numbers stay internally
+ * consistent. Entropy is deliberately NOT aggregated — entropy over a union of
+ * unrelated goals is not a meaningful number — so it renders as "—".
+ */
+function foldOtherRow(rows: GoalFacet[]): GoalFacet | null {
+  if (rows.length === 0) return null;
+  const outcomes = {
+    completed: 0,
+    partial: 0,
+    unresolved: 0,
+    errored: 0,
+    unclear: 0,
+  };
+  let total = 0;
+  let unlabeled = 0;
+  let retried = 0;
+  let distinctPathCount = 0;
+  for (const row of rows) {
+    total += row.total;
+    unlabeled += row.unlabeled;
+    retried += row.retryRate * row.total;
+    distinctPathCount += row.distinctPathCount;
+    for (const outcome of SESSION_OUTCOMES) {
+      outcomes[outcome] += row.outcomes[outcome];
+    }
+  }
+  const labeled = SESSION_OUTCOMES.reduce(
+    (sum, outcome) => sum + outcomes[outcome],
+    0
+  );
+  const unresolvedTotal =
+    outcomes.unresolved + outcomes.errored + outcomes.partial;
+  return {
+    clusterId: "__other__",
+    label: `Other (${rows.length} goals)`,
+    total,
+    outcomes,
+    unlabeled,
+    unresolvedRate: labeled > 0 ? unresolvedTotal / labeled : null,
+    errorRate: labeled > 0 ? outcomes.errored / labeled : null,
+    retryRate: total > 0 ? retried / total : 0,
+    toolDistribution: [],
+    pathDistribution: [],
+    distinctPathCount,
+    routingEntropy: null,
+  };
+}
+
+export function ChatboxGoalOutcomeGrid({
+  breakdown,
+  filter,
+  onSelectCell,
+}: ChatboxGoalOutcomeGridProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("volume");
+
+  const facets = breakdown?.goalFacets ?? [];
+
+  const { rows, otherRow } = useMemo(() => {
+    const sorted = [...facets].sort((a, b) => {
+      if (sortKey === "volume") return b.total - a.total;
+      // Sorting by unresolved rate puts nulls last: a row with no labeled
+      // sessions has no rate, and floating it to the top would rank an unknown
+      // above a measured 90%.
+      const left = a.unresolvedRate;
+      const right = b.unresolvedRate;
+      if (left === null && right === null) return b.total - a.total;
+      if (left === null) return 1;
+      if (right === null) return -1;
+      if (right !== left) return right - left;
+      return b.total - a.total;
+    });
+    return {
+      rows: sorted.slice(0, MAX_GOAL_ROWS),
+      otherRow: foldOtherRow(sorted.slice(MAX_GOAL_ROWS)),
+    };
+  }, [facets, sortKey]);
+
+  const scan = breakdown?.scan;
+  const signalsVersion = breakdown?.latestRun?.signalsVersion ?? null;
+
+  if (!breakdown) {
+    return (
+      <div className="flex items-center justify-center px-5 py-10 text-xs text-muted-foreground">
+        Loading goal outcomes…
+      </div>
+    );
+  }
+
+  if (facets.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 px-5 py-10 text-center">
+        <Target className="h-6 w-6 text-muted-foreground/60" />
+        <p className="text-sm font-medium">No goal clusters yet</p>
+        <p className="max-w-md text-xs text-muted-foreground">
+          {signalsVersion === null
+            ? "The last rebuild ran before goal outcomes existed. Rebuild clusters to extract goals, outcomes, and tool routes."
+            : "Rebuild clusters once this chatbox has enough sessions to cluster."}
+        </p>
+      </div>
+    );
+  }
+
+  const allRows = otherRow ? [...rows, otherRow] : rows;
+
+  return (
+    <div className="flex flex-col gap-2 border-b px-5 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium">Goals by outcome</h3>
+          <Tooltip delayDuration={200}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="About goal outcomes"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <Info className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="max-w-xs">
+              Rows are goal clusters. Outcome is inferred per session and capped
+              at &ldquo;unclear&rdquo; for sessions that are still recent, since
+              we have no signal that a session ended. Routes counts distinct
+              tool paths taken to reach the same goal &mdash; high spread points
+              at a missing capability or ambiguous tool descriptions.
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <button
+          type="button"
+          className="flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground hover:bg-muted/50"
+          onClick={() =>
+            setSortKey((prev) => (prev === "volume" ? "unresolved" : "volume"))
+          }
+        >
+          <ArrowUpDown className="h-3 w-3" />
+          {sortKey === "volume" ? "Sort by unresolved" : "Sort by volume"}
+        </button>
+      </div>
+
+      {scan?.truncated ? (
+        <div
+          role="status"
+          className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning-foreground"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            Rates below cover the most recent {scan.matched.toLocaleString()}{" "}
+            matching sessions, not the full history &mdash; the scan stops at{" "}
+            {scan.maxSessions.toLocaleString()}. Older sessions are not
+            included.
+          </span>
+        </div>
+      ) : null}
+
+      {/* Wide table scrolls inside its own container so the panel never scrolls
+          horizontally. */}
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[720px] border-separate border-spacing-0 text-left">
+          <thead>
+            <tr className="text-[11px] uppercase tracking-wide text-muted-foreground">
+              <th scope="col" className="py-1.5 pr-3 font-medium">
+                Goal
+              </th>
+              <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                Sessions
+              </th>
+              {SESSION_OUTCOMES.map((outcome) => (
+                <th
+                  key={outcome}
+                  scope="col"
+                  className="px-2 py-1.5 text-right font-medium"
+                >
+                  {OUTCOME_LABELS[outcome]}
+                </th>
+              ))}
+              <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                Not analyzed
+              </th>
+              <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                Unresolved
+              </th>
+              <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                Errors
+              </th>
+              <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                Retries
+              </th>
+              <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                Routes
+              </th>
+              <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                <Tooltip delayDuration={200}>
+                  <TooltipTrigger asChild>
+                    <span className="cursor-help border-b border-dotted border-muted-foreground/60">
+                      Spread
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" className="max-w-xs">
+                    Shannon entropy over this goal&rsquo;s tool routes, in bits.
+                    0 means every session took the same route; higher means the
+                    model could not decide which tool serves this goal.
+                  </TooltipContent>
+                </Tooltip>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {allRows.map((facet) => {
+              const isOther = facet.clusterId === "__other__";
+              return (
+                <tr
+                  key={facet.clusterId}
+                  className="border-t border-border/60 text-xs"
+                >
+                  <th
+                    scope="row"
+                    className="max-w-[220px] py-1.5 pr-3 text-left font-medium"
+                  >
+                    {/* It's a table, so the label is not truncated. */}
+                    <span className={cn(isOther && "text-muted-foreground")}>
+                      {facet.label}
+                    </span>
+                  </th>
+                  <td className="px-2 py-1.5 text-right tabular-nums text-muted-foreground">
+                    {facet.total.toLocaleString()}
+                  </td>
+                  {SESSION_OUTCOMES.map((outcome) => {
+                    const count = facet.outcomes[outcome];
+                    const share = facet.total > 0 ? count / facet.total : 0;
+                    const selected =
+                      !isOther &&
+                      isCellSelected(filter, {
+                        clusterId: facet.clusterId,
+                        outcome,
+                      });
+                    const label = `${facet.label}, ${OUTCOME_LABELS[outcome]}: ${count} sessions`;
+                    return (
+                      <td key={outcome} className="px-1 py-1">
+                        {isOther ? (
+                          <span className="block px-1 py-0.5 text-right tabular-nums text-muted-foreground">
+                            {count.toLocaleString()}
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            aria-label={label}
+                            aria-pressed={selected}
+                            disabled={count === 0}
+                            onClick={() =>
+                              onSelectCell({
+                                clusterId: facet.clusterId,
+                                clusterLabel: facet.label,
+                                outcome,
+                              })
+                            }
+                            className={cn(
+                              "w-full rounded px-1.5 py-0.5 text-right tabular-nums transition",
+                              count === 0
+                                ? "cursor-default text-muted-foreground/40"
+                                : "hover:ring-1 hover:ring-primary/40",
+                              cellTint(outcome, share),
+                              selected && "ring-2 ring-primary"
+                            )}
+                          >
+                            {count.toLocaleString()}
+                          </button>
+                        )}
+                      </td>
+                    );
+                  })}
+                  <td className="px-1 py-1">
+                    {isOther ? (
+                      <span className="block px-1 py-0.5 text-right tabular-nums text-muted-foreground">
+                        {facet.unlabeled.toLocaleString()}
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        aria-label={`${facet.label}, not analyzed: ${facet.unlabeled} sessions`}
+                        aria-pressed={isCellSelected(filter, {
+                          clusterId: facet.clusterId,
+                          outcome: null,
+                        })}
+                        disabled={facet.unlabeled === 0}
+                        onClick={() =>
+                          onSelectCell({
+                            clusterId: facet.clusterId,
+                            clusterLabel: facet.label,
+                            outcome: null,
+                          })
+                        }
+                        className={cn(
+                          "w-full rounded px-1.5 py-0.5 text-right tabular-nums text-muted-foreground transition",
+                          facet.unlabeled === 0
+                            ? "cursor-default text-muted-foreground/40"
+                            : "hover:ring-1 hover:ring-primary/40",
+                          isCellSelected(filter, {
+                            clusterId: facet.clusterId,
+                            outcome: null,
+                          }) && "ring-2 ring-primary"
+                        )}
+                      >
+                        {facet.unlabeled.toLocaleString()}
+                      </button>
+                    )}
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums">
+                    {formatRate(facet.unresolvedRate)}
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums">
+                    {formatRate(facet.errorRate)}
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums">
+                    {formatRate(facet.retryRate)}
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums">
+                    {facet.distinctPathCount.toLocaleString()}
+                  </td>
+                  <td className="px-2 py-1.5 text-right tabular-nums">
+                    {formatEntropy(facet.routingEntropy)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="text-[11px] text-muted-foreground">
+        {breakdown.labeledOutcomeCount.toLocaleString()} of{" "}
+        {breakdown.totalSessions.toLocaleString()} scanned sessions have an
+        inferred outcome. Rates use the labeled subset as the denominator;
+        &ldquo;—&rdquo; means no labeled sessions to divide by.
+      </p>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxOutcomeCalibration.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxOutcomeCalibration.tsx
@@ -1,4 +1,4 @@
-import { Info } from "lucide-react";
+import { AlertTriangle, Info } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -16,9 +16,10 @@ import { cn } from "@/lib/utils";
  * as a measurement.
  *
  * What this DOES show: whether thumbs-down concentrates in the sessions we
- * labeled `completed`. If it does, the extraction is wrong, and that is visible
- * without claiming a number we cannot support. The inferred outcome is never
- * overwritten by feedback.
+ * labeled `completed`. That is a prompt to investigate, not a verdict — it can
+ * mean the extraction is wrong, or that users got exactly what they asked for
+ * and disliked it. Either way it is visible without claiming a number we cannot
+ * support. The inferred outcome is never overwritten by feedback.
  */
 interface ChatboxOutcomeCalibrationProps {
   breakdown: UsageBreakdown | null | undefined;
@@ -53,10 +54,30 @@ export function ChatboxOutcomeCalibration({
             Not an accuracy score. Feedback measures satisfaction, not whether
             the goal was met, and only a few percent of sessions leave any. Read
             this as a smell test: thumbs-down concentrated in sessions labeled
-            &ldquo;completed&rdquo; means the outcome extraction is wrong.
+            &ldquo;completed&rdquo; is worth investigating &mdash; it can mean
+            the outcome extraction is wrong, or that users got what they asked
+            for and disliked it.
           </TooltipContent>
         </Tooltip>
       </div>
+
+      {/* These rates come off the same bounded scan as the grid's, so they carry
+          the same qualification. Rendering them bare here while the grid warns
+          would be inconsistent — and the inconsistency would read as "this one
+          is unconditional". */}
+      {breakdown?.scan?.truncated ? (
+        <div
+          role="status"
+          className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning-foreground"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            Counted over the most recent{" "}
+            {breakdown.scan.matched.toLocaleString()} matching sessions, not the
+            full history.
+          </span>
+        </div>
+      ) : null}
 
       {!hasAnyRating ? (
         <p className="text-[11px] text-muted-foreground">
@@ -128,6 +149,14 @@ export function ChatboxOutcomeCalibration({
                         : row.rated < MIN_RATINGS_FOR_RATE
                         ? `${row.negative}/${row.rated}`
                         : `${Math.round(row.negativeRate * 100)}%`}
+                      {/* The flagged row is the whole point of the panel, so it
+                          cannot be announced in colour alone. */}
+                      {suspicious ? (
+                        <span className="sr-only">
+                          {" "}
+                          — unexpectedly negative for a completed outcome
+                        </span>
+                      ) : null}
                     </td>
                   </tr>
                 );

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxOutcomeCalibration.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxOutcomeCalibration.tsx
@@ -1,0 +1,141 @@
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import type { UsageBreakdown } from "@/hooks/useUsageInsights";
+import { cn } from "@/lib/utils";
+
+/**
+ * Negative-feedback rate segmented by inferred outcome.
+ *
+ * Explicitly NOT an agreement rate or an accuracy percentage. Feedback is
+ * satisfaction, not outcome ground truth, and response rates are single-digit —
+ * so a "% correct" number computed against it would be a fabrication dressed up
+ * as a measurement.
+ *
+ * What this DOES show: whether thumbs-down concentrates in the sessions we
+ * labeled `completed`. If it does, the extraction is wrong, and that is visible
+ * without claiming a number we cannot support. The inferred outcome is never
+ * overwritten by feedback.
+ */
+interface ChatboxOutcomeCalibrationProps {
+  breakdown: UsageBreakdown | null | undefined;
+}
+
+/** Below this many ratings a rate is too thin to read; show the raw counts. */
+const MIN_RATINGS_FOR_RATE = 5;
+
+export function ChatboxOutcomeCalibration({
+  breakdown,
+}: ChatboxOutcomeCalibrationProps) {
+  const rows = breakdown?.outcomeFeedbackCalibration ?? [];
+  const hasAnyRating = rows.some((row) => row.rated > 0);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 border-b px-5 py-4">
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium">Feedback by inferred outcome</h3>
+        <Tooltip delayDuration={200}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label="About feedback calibration"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <Info className="h-3.5 w-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="max-w-xs">
+            Not an accuracy score. Feedback measures satisfaction, not whether
+            the goal was met, and only a few percent of sessions leave any. Read
+            this as a smell test: thumbs-down concentrated in sessions labeled
+            &ldquo;completed&rdquo; means the outcome extraction is wrong.
+          </TooltipContent>
+        </Tooltip>
+      </div>
+
+      {!hasAnyRating ? (
+        <p className="text-[11px] text-muted-foreground">
+          No sessions in this window carry a rating, so there is nothing to
+          compare inferred outcomes against yet.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[420px] border-separate border-spacing-0 text-left">
+            <thead>
+              <tr className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                <th scope="col" className="py-1.5 pr-3 font-medium">
+                  Inferred outcome
+                </th>
+                <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                  Sessions
+                </th>
+                <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                  Rated
+                </th>
+                <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                  Negative
+                </th>
+                <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                  Negative rate
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                // A high negative rate among sessions we called `completed` is
+                // the actionable disagreement; flag only that combination.
+                const suspicious =
+                  row.outcome === "completed" &&
+                  row.rated >= MIN_RATINGS_FOR_RATE &&
+                  row.negativeRate !== null &&
+                  row.negativeRate >= 0.2;
+                return (
+                  <tr
+                    key={row.outcome}
+                    className="border-t border-border/60 text-xs"
+                  >
+                    <th
+                      scope="row"
+                      className="py-1.5 pr-3 text-left font-medium"
+                    >
+                      {row.outcome}
+                    </th>
+                    <td className="px-2 py-1.5 text-right tabular-nums text-muted-foreground">
+                      {row.sessions.toLocaleString()}
+                    </td>
+                    <td className="px-2 py-1.5 text-right tabular-nums text-muted-foreground">
+                      {row.rated.toLocaleString()}
+                    </td>
+                    <td className="px-2 py-1.5 text-right tabular-nums text-muted-foreground">
+                      {row.negative.toLocaleString()}
+                    </td>
+                    <td
+                      className={cn(
+                        "px-2 py-1.5 text-right tabular-nums",
+                        suspicious && "font-medium text-destructive"
+                      )}
+                    >
+                      {/* A rate off one or two ratings is noise. Show the raw
+                          counts instead of a percentage that reads as a
+                          finding. */}
+                      {row.negativeRate === null
+                        ? "—"
+                        : row.rated < MIN_RATINGS_FOR_RATE
+                        ? `${row.negative}/${row.rated}`
+                        : `${Math.round(row.negativeRate * 100)}%`}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -117,6 +117,7 @@ type GraphNode = {
   sessionId: string;
   clusterId?: string;
   clusterLabel?: string;
+  outcome?: string;
   semanticTitle?: string;
   semanticPreview: string;
   messageCount: number;
@@ -223,6 +224,56 @@ function colorForCluster(clusterId: string | undefined, fallbackIndex?: number) 
   const colorIndex = hash % CLUSTER_COLORS.length;
   return CLUSTER_COLORS[colorIndex];
 }
+
+export type TopicMapColorMode = "theme" | "outcome";
+
+/** Neutral grey for a node with no outcome — shared with `colorForCluster`. */
+export const NO_OUTCOME_COLOR = "#9aa4ba";
+
+/**
+ * Outcome palette. Diverging rather than categorical, because outcome is
+ * ordered (completed → errored) and the whole point of the tint is that a bad
+ * region of the map is visible at a glance.
+ *
+ * `unclear` is deliberately the same neutral as "no outcome at all": it is an
+ * absence of judgement, and coloring it as a distinct finding would read as one.
+ */
+const OUTCOME_COLORS: Record<string, string> = {
+  completed: "#4ade80",
+  partial: "#facc15",
+  unresolved: "#fb7185",
+  errored: "#f43f5e",
+  unclear: NO_OUTCOME_COLOR,
+};
+
+/**
+ * Node color for the active mode. Tolerates an absent `outcome` — snapshots
+ * written before TOPIC_MAP_VERSION 2 carry no outcome on their nodes, and a
+ * session whose signals never extracted has none either.
+ */
+export function colorForNode(
+  node: { clusterId?: string; outcome?: string },
+  mode: TopicMapColorMode,
+  clusterColorIndex?: number,
+): string {
+  if (mode === "outcome") {
+    if (!node.outcome) return NO_OUTCOME_COLOR;
+    return OUTCOME_COLORS[node.outcome] ?? NO_OUTCOME_COLOR;
+  }
+  return colorForCluster(node.clusterId, clusterColorIndex);
+}
+
+/** Legend entries for the outcome mode, in enum order. */
+const OUTCOME_LEGEND: Array<{ key: string; label: string }> = [
+  { key: "completed", label: "Completed" },
+  { key: "partial", label: "Partial" },
+  { key: "unresolved", label: "Unresolved" },
+  { key: "errored", label: "Errored" },
+  { key: "unclear", label: "Unclear / not analyzed" },
+];
+
+/** Snapshot version that first carried `nodes[].outcome`. */
+const OUTCOME_SNAPSHOT_VERSION = 2;
 
 function hexToRgba(hex: string, alpha: number) {
   const normalized = hex.replace("#", "");
@@ -548,6 +599,7 @@ export function ChatboxTopicMapPanel({
   });
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
+  const [colorMode, setColorMode] = useState<TopicMapColorMode>("theme");
   const [searchQuery, setSearchQuery] = useState("");
   const deferredSearch = useDeferredValue(searchQuery.trim().toLowerCase());
   const graphRef = useRef<GraphHandle | null>(null);
@@ -593,6 +645,7 @@ export function ChatboxTopicMapPanel({
         sessionId: node.sessionId,
         clusterId: node.clusterId,
         clusterLabel: node.clusterLabel,
+        outcome: node.outcome,
         semanticTitle: node.semanticTitle,
         semanticPreview: node.semanticPreview,
         messageCount: node.messageCount,
@@ -606,8 +659,9 @@ export function ChatboxTopicMapPanel({
         y,
         vx: 0,
         vy: 0,
-        color: colorForCluster(
-          node.clusterId,
+        color: colorForNode(
+          node,
+          colorMode,
           node.clusterId != null
             ? clusterColorIndex.get(node.clusterId)
             : undefined,
@@ -627,7 +681,7 @@ export function ChatboxTopicMapPanel({
         }) satisfies GraphLink,
     );
     return { nodes, links };
-  }, [clusterColorIndex, snapshot]);
+  }, [clusterColorIndex, colorMode, snapshot]);
 
   const nodeById = useMemo(
     () => new Map((graphData?.nodes ?? []).map((node) => [node.id, node])),
@@ -698,6 +752,29 @@ export function ChatboxTopicMapPanel({
       ),
     [snapshot?.clusters],
   );
+
+  // Whether this stored snapshot can answer "color by outcome" at all. A
+  // pre-bump blob carries no outcome on its nodes, so offering the mode would
+  // paint every node neutral and look like a bug rather than like stale data.
+  const supportsOutcomeColor =
+    (snapshot?.version ?? 0) >= OUTCOME_SNAPSHOT_VERSION;
+
+  // A snapshot can be new enough to have the field yet still have nothing in
+  // it — every session unanalyzed. Distinguish that so the empty legend is
+  // explained instead of just looking broken.
+  const outcomeNodeCount = useMemo(
+    () => (snapshot?.nodes ?? []).filter((node) => !!node.outcome).length,
+    [snapshot?.nodes],
+  );
+
+  // Fall back to theme whenever the snapshot stops supporting outcomes (e.g. a
+  // rebuild rolled the blob back), so the mode can never be stuck on a source
+  // that has no data.
+  useEffect(() => {
+    if (!supportsOutcomeColor && colorMode === "outcome") {
+      setColorMode("theme");
+    }
+  }, [colorMode, supportsOutcomeColor]);
 
   useEffect(() => {
     if (!snapshot) {
@@ -1233,6 +1310,76 @@ export function ChatboxTopicMapPanel({
                 Showing a stable 10,000-session sample of{" "}
                 {snapshot.stats.mappedSessionCount.toLocaleString()} mapped
                 sessions for this chatbox.
+              </div>
+            ) : null}
+          </div>
+
+          <div className="ml-auto flex flex-col items-end gap-2">
+            <div
+              role="group"
+              aria-label="Color nodes by"
+              className="flex items-center gap-1 rounded-lg border border-border bg-background/80 p-1 shadow-sm backdrop-blur"
+            >
+              <span className="px-1.5 text-[11px] text-muted-foreground">
+                Color by
+              </span>
+              <button
+                type="button"
+                aria-pressed={colorMode === "theme"}
+                onClick={() => setColorMode("theme")}
+                className={cn(
+                  "rounded px-2 py-0.5 text-[11px] transition",
+                  colorMode === "theme"
+                    ? "bg-primary/15 font-medium text-foreground"
+                    : "text-muted-foreground hover:bg-muted/60",
+                )}
+              >
+                Theme
+              </button>
+              <Tooltip delayDuration={200}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-pressed={colorMode === "outcome"}
+                    disabled={!supportsOutcomeColor}
+                    onClick={() => setColorMode("outcome")}
+                    className={cn(
+                      "rounded px-2 py-0.5 text-[11px] transition",
+                      colorMode === "outcome"
+                        ? "bg-primary/15 font-medium text-foreground"
+                        : "text-muted-foreground hover:bg-muted/60",
+                      !supportsOutcomeColor &&
+                        "cursor-not-allowed opacity-50 hover:bg-transparent",
+                    )}
+                  >
+                    Outcome
+                  </button>
+                </TooltipTrigger>
+                {!supportsOutcomeColor ? (
+                  <TooltipContent side="bottom" className="max-w-xs">
+                    This map was built before outcomes were recorded. Rebuild
+                    clusters to color by outcome.
+                  </TooltipContent>
+                ) : null}
+              </Tooltip>
+            </div>
+
+            {colorMode === "outcome" ? (
+              <div className="flex flex-col items-end gap-1 rounded-lg border border-border bg-background/80 px-2.5 py-2 text-[11px] shadow-sm backdrop-blur">
+                {OUTCOME_LEGEND.map((entry) => (
+                  <div key={entry.key} className="flex items-center gap-1.5">
+                    <span
+                      className="h-2 w-2 rounded-full"
+                      style={{ backgroundColor: OUTCOME_COLORS[entry.key] }}
+                    />
+                    <span className="text-muted-foreground">{entry.label}</span>
+                  </div>
+                ))}
+                {outcomeNodeCount === 0 ? (
+                  <span className="max-w-[200px] pt-1 text-right text-muted-foreground">
+                    No mapped session has an inferred outcome yet.
+                  </span>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import { SearchInput } from "@/components/ui/search-input";
 import {
+  UNLABELED_OUTCOME,
   type UsageFilterChip,
   type UsageFilterState,
 } from "@/hooks/chatbox-usage-filters";
@@ -212,8 +213,11 @@ function formatRunTone(run: ClusterRunState | null): string {
   return "bg-success/15 text-success";
 }
 
+/** Neutral grey for a node with no cluster and for a node with no outcome. */
+export const NO_OUTCOME_COLOR = "#9aa4ba";
+
 function colorForCluster(clusterId: string | undefined, fallbackIndex?: number) {
-  if (!clusterId) return "#9aa4ba";
+  if (!clusterId) return NO_OUTCOME_COLOR;
   if (typeof fallbackIndex === "number" && Number.isFinite(fallbackIndex)) {
     return CLUSTER_COLORS[Math.abs(fallbackIndex) % CLUSTER_COLORS.length];
   }
@@ -226,9 +230,6 @@ function colorForCluster(clusterId: string | undefined, fallbackIndex?: number) 
 }
 
 export type TopicMapColorMode = "theme" | "outcome";
-
-/** Neutral grey for a node with no outcome — shared with `colorForCluster`. */
-export const NO_OUTCOME_COLOR = "#9aa4ba";
 
 /**
  * Outcome palette. Diverging rather than categorical, because outcome is
@@ -624,6 +625,23 @@ export function ChatboxTopicMapPanel({
     [filter.chips],
   );
 
+  // Outcome chips the filter is carrying. Now that nodes actually carry an
+  // outcome, a selected grid cell can narrow the map instead of highlighting
+  // the goal and silently leaving every outcome in it lit. Empty set = no
+  // outcome narrowing. (Other dimensions — device, language — are not
+  // represented on nodes at all, so the map cannot honor those.)
+  const activeOutcomes = useMemo(
+    () =>
+      new Set(
+        filter.chips.flatMap((chip) =>
+          chip.kind === "dimension" && chip.key === "outcome"
+            ? [chip.value]
+            : [],
+        ),
+      ),
+    [filter.chips],
+  );
+
   const clusterColorIndex = useMemo(
     () =>
       new Map(
@@ -736,13 +754,21 @@ export function ChatboxTopicMapPanel({
       const clusterMatch =
         activeClusterIds.size === 0 ||
         (node.clusterId ? activeClusterIds.has(node.clusterId) : false);
+      // OR within the dimension, matching the chip semantics everywhere else.
+      // The sentinel selects nodes with NO outcome; a concrete value never
+      // matches a node missing one.
+      const outcomeMatch =
+        activeOutcomes.size === 0 ||
+        (node.outcome
+          ? activeOutcomes.has(node.outcome)
+          : activeOutcomes.has(UNLABELED_OUTCOME));
       const searchMatch =
         searchMatchIds == null || searchMatchIds.has(node.id);
       const focusMatch =
         focusedNeighborhood == null || focusedNeighborhood.has(node.id);
-      return !(clusterMatch && searchMatch && focusMatch);
+      return !(clusterMatch && outcomeMatch && searchMatch && focusMatch);
     },
-    [activeClusterIds, focusedNeighborhood, searchMatchIds],
+    [activeClusterIds, activeOutcomes, focusedNeighborhood, searchMatchIds],
   );
 
   const communities = useMemo(
@@ -1337,23 +1363,34 @@ export function ChatboxTopicMapPanel({
                 Theme
               </button>
               <Tooltip delayDuration={200}>
+                {/* The trigger is the SPAN, not the button. A native disabled
+                    button does not reliably emit pointer/focus events, so
+                    hanging the trigger off it would hide the explanation in
+                    exactly the case it exists for — the disabled one. The
+                    button keeps `disabled` for semantics and loses pointer
+                    events so the span receives the hover. */}
                 <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-pressed={colorMode === "outcome"}
-                    disabled={!supportsOutcomeColor}
-                    onClick={() => setColorMode("outcome")}
-                    className={cn(
-                      "rounded px-2 py-0.5 text-[11px] transition",
-                      colorMode === "outcome"
-                        ? "bg-primary/15 font-medium text-foreground"
-                        : "text-muted-foreground hover:bg-muted/60",
-                      !supportsOutcomeColor &&
-                        "cursor-not-allowed opacity-50 hover:bg-transparent",
-                    )}
+                  <span
+                    className="inline-flex"
+                    tabIndex={supportsOutcomeColor ? -1 : 0}
                   >
-                    Outcome
-                  </button>
+                    <button
+                      type="button"
+                      aria-pressed={colorMode === "outcome"}
+                      disabled={!supportsOutcomeColor}
+                      onClick={() => setColorMode("outcome")}
+                      className={cn(
+                        "rounded px-2 py-0.5 text-[11px] transition",
+                        colorMode === "outcome"
+                          ? "bg-primary/15 font-medium text-foreground"
+                          : "text-muted-foreground hover:bg-muted/60",
+                        !supportsOutcomeColor &&
+                          "pointer-events-none cursor-not-allowed opacity-50 hover:bg-transparent",
+                      )}
+                    >
+                      Outcome
+                    </button>
+                  </span>
                 </TooltipTrigger>
                 {!supportsOutcomeColor ? (
                   <TooltipContent side="bottom" className="max-w-xs">

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -630,6 +630,12 @@ export function ChatboxTopicMapPanel({
   // the goal and silently leaving every outcome in it lit. Empty set = no
   // outcome narrowing. (Other dimensions — device, language — are not
   // represented on nodes at all, so the map cannot honor those.)
+  // Whether this stored snapshot can answer "color by outcome" at all. A
+  // pre-bump blob carries no outcome on its nodes, so offering the mode would
+  // paint every node neutral and look like a bug rather than like stale data.
+  const supportsOutcomeColor =
+    (snapshot?.version ?? 0) >= OUTCOME_SNAPSHOT_VERSION;
+
   const activeOutcomes = useMemo(
     () =>
       new Set(
@@ -757,7 +763,13 @@ export function ChatboxTopicMapPanel({
       // OR within the dimension, matching the chip semantics everywhere else.
       // The sentinel selects nodes with NO outcome; a concrete value never
       // matches a node missing one.
+      //
+      // A pre-bump snapshot is exempt entirely: none of its nodes carry an
+      // outcome, so a concrete outcome chip would match nothing and dim the
+      // whole map — a blank canvas reads as a broken map, not as stale data.
+      // The snapshot cannot honor the constraint, so it does not pretend to.
       const outcomeMatch =
+        !supportsOutcomeColor ||
         activeOutcomes.size === 0 ||
         (node.outcome
           ? activeOutcomes.has(node.outcome)
@@ -768,7 +780,13 @@ export function ChatboxTopicMapPanel({
         focusedNeighborhood == null || focusedNeighborhood.has(node.id);
       return !(clusterMatch && outcomeMatch && searchMatch && focusMatch);
     },
-    [activeClusterIds, activeOutcomes, focusedNeighborhood, searchMatchIds],
+    [
+      activeClusterIds,
+      activeOutcomes,
+      focusedNeighborhood,
+      searchMatchIds,
+      supportsOutcomeColor,
+    ],
   );
 
   const communities = useMemo(
@@ -778,12 +796,6 @@ export function ChatboxTopicMapPanel({
       ),
     [snapshot?.clusters],
   );
-
-  // Whether this stored snapshot can answer "color by outcome" at all. A
-  // pre-bump blob carries no outcome on its nodes, so offering the mode would
-  // paint every node neutral and look like a bug rather than like stale data.
-  const supportsOutcomeColor =
-    (snapshot?.version ?? 0) >= OUTCOME_SNAPSHOT_VERSION;
 
   // A snapshot can be new enough to have the field yet still have nothing in
   // it — every session unanalyzed. Distinguish that so the empty legend is

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -1191,7 +1191,17 @@ export function ChatboxTopicMapPanel({
           continue;
         }
         clusters.set(clusterKey, {
-          color: node.color,
+          // Halos denote the CLUSTER, so they always take the theme colour —
+          // never `node.color`, which in outcome mode is the first-iterated
+          // node's outcome. A mixed-outcome cluster would otherwise get an
+          // order-dependent halo asserting one outcome for the whole goal,
+          // which is exactly the overclaim the outcome tint exists to avoid.
+          color: colorForCluster(
+            node.clusterId,
+            node.clusterId != null
+              ? clusterColorIndex.get(node.clusterId)
+              : undefined,
+          ),
           nodes: [node],
           sumX: node.x ?? node.seedX,
           sumY: node.y ?? node.seedY,
@@ -1250,7 +1260,7 @@ export function ChatboxTopicMapPanel({
         ctx.restore();
       }
     },
-    [graphData],
+    [clusterColorIndex, graphData],
   );
 
   if (

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -113,13 +113,28 @@ export function ChatboxUsagePanel({
     outcome: SessionOutcome | null;
   } | null>(null);
 
+  // The breakdown backs the goal × outcome grid, so the cell-selection chips
+  // (cluster + outcome) must NOT reach its query: they are the grid's own
+  // OUTPUT. Feeding them back re-runs the scan filtered to the clicked cell,
+  // which collapses the grid to a single row whose other cells count 0 and
+  // disable — the selection would erase everything it was selected from.
+  // Every other dimension's chips (device, language, the forced
+  // synthetic:hide, …) still narrow the grid; the Sessions list, the map
+  // dimming, and the drill-down keep the full filter, because narrowing to
+  // the cell is exactly their job.
+  const breakdownFilter = useMemo(
+    () => clearCellChips(effectiveFilter),
+    [effectiveFilter]
+  );
+
   const { threads, breakdown, rebuild } = useUsageInsights({
     sourceType: "chatbox",
     sourceId: chatbox.chatboxId,
-    filters: effectiveFilter,
+    filters: breakdownFilter,
     // The thread list backs Sessions; the breakdown backs the Insights grid.
     // Subscribing to each only where it renders keeps the tab flip from
-    // running two scans at once.
+    // running two scans at once. (The thread-list query takes no filters —
+    // `filters` above only ever reaches the breakdown query.)
     threadsEnabled: section === "sessions",
     breakdownEnabled: section === "insights",
   });

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -222,9 +222,13 @@ export function ChatboxUsagePanel({
         selectedCell.outcome === cell.outcome;
       setFilter((prev) =>
         isAlreadyOpen
-          ? // Re-clicking the open cell clears it. Pass the same cell so
-            // selectCell's own toggle path removes the chips.
-            selectCell(prev, cell)
+          ? // Re-clicking the open cell clears it — clear the chips outright
+            // rather than routing through selectCell's toggle, whose
+            // chip-derived isCellSelected can disagree with `selectedCell`. If
+            // the user already dismissed the chips by hand, that toggle would
+            // read the cell as unselected and ADD them back while the panel
+            // closes, leaving a filter with nothing open behind it.
+            clearCellChips(prev)
           : selectCell(clearCellChips(prev), cell)
       );
       setSelectedCell(isAlreadyOpen ? null : cell);

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -11,6 +11,7 @@ import {
   selectCell,
   threadMatchesFilterState,
   toggleChip,
+  withoutCellChips,
   type SessionOutcome,
   type UsageFilterChip,
   type UsageFilterState,
@@ -122,9 +123,14 @@ export function ChatboxUsagePanel({
   // synthetic:hide, …) still narrow the grid; the Sessions list, the map
   // dimming, and the drill-down keep the full filter, because narrowing to
   // the cell is exactly their job.
+  //
+  // Subtracted BY IDENTITY against the open cell, not by clearing the cluster
+  // dimension: the topic map and the insights strip write cluster chips too, so
+  // clearing the dimension would also throw away a community the user picked on
+  // the map and the grid would ignore it.
   const breakdownFilter = useMemo(
-    () => clearCellChips(effectiveFilter),
-    [effectiveFilter]
+    () => withoutCellChips(effectiveFilter, selectedCell),
+    [effectiveFilter, selectedCell]
   );
 
   const { threads, breakdown, rebuild } = useUsageInsights({

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -5,14 +5,21 @@ import type { ChatboxSettings } from "@/hooks/useChatboxes";
 import {
   EMPTY_USAGE_FILTER,
   chipKey,
+  clearCellChips,
   compareThreadsForUsageList,
   removeChipByKey,
+  selectCell,
   threadMatchesFilterState,
   toggleChip,
+  type SessionOutcome,
   type UsageFilterChip,
   type UsageFilterState,
 } from "@/hooks/chatbox-usage-filters";
 import { useUsageInsights } from "@/hooks/useUsageInsights";
+import { ChatboxGoalOutcomeGrid } from "@/components/chatboxes/ChatboxGoalOutcomeGrid";
+import { ChatboxOutcomeCalibration } from "@/components/chatboxes/ChatboxOutcomeCalibration";
+import { ChatboxGoalOutcomeDrilldown } from "@/components/chatboxes/ChatboxGoalOutcomeDrilldown";
+import { ScrollArea } from "@mcpjam/design-system/scroll-area";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -96,11 +103,25 @@ export function ChatboxUsagePanel({
     [chatbox.chatboxId]
   );
 
-  const { threads, rebuild } = useUsageInsights({
+  // Currently-selected goal × outcome cell, driving the paginated drill-down.
+  // Kept next to the filter rather than derived from it: the "not analyzed"
+  // cell has no outcome chip to read back, so the selection is not fully
+  // recoverable from the chip list alone.
+  const [selectedCell, setSelectedCell] = useState<{
+    clusterId: string;
+    clusterLabel?: string;
+    outcome: SessionOutcome | null;
+  } | null>(null);
+
+  const { threads, breakdown, rebuild } = useUsageInsights({
     sourceType: "chatbox",
     sourceId: chatbox.chatboxId,
     filters: effectiveFilter,
-    enabled: section === "sessions",
+    // The thread list backs Sessions; the breakdown backs the Insights grid.
+    // Subscribing to each only where it renders keeps the tab flip from
+    // running two scans at once.
+    threadsEnabled: section === "sessions",
+    breakdownEnabled: section === "insights",
   });
 
   // Apply filter state here (chips + preset) so chips like "Hide synthetic"
@@ -129,6 +150,8 @@ export function ChatboxUsagePanel({
       threadId: initialThreadId ?? null,
     });
     setFilter(EMPTY_USAGE_FILTER);
+    // A selected grid cell names a cluster belonging to the previous chatbox.
+    setSelectedCell(null);
     // Reset rebuild state too — an in-flight rebuild belongs to the previous
     // chatbox and shouldn't keep this one's button disabled. The old promise
     // still resolves; its nonce no longer matches so its `finally` is a
@@ -176,6 +199,46 @@ export function ChatboxUsagePanel({
     []
   );
 
+  // Grid cell click. Uses selectCell (not two toggleChip calls) so the cluster
+  // and outcome selections are REPLACED together — chips OR within a dimension,
+  // so toggling a second cell would widen the match to four cells instead of
+  // narrowing to one.
+  //
+  // `selectedCell` is the single source of truth for what is open, and the
+  // reopen-vs-close decision is made once, here, from it — rather than having
+  // the chip list and the open panel each decide independently and risk
+  // disagreeing after the user dismisses a chip by hand. Both setters are
+  // called at the top level (never one nested inside the other's updater) so
+  // StrictMode's double-invoked reducers cannot toggle the filter twice.
+  const handleSelectCell = useCallback(
+    (cell: {
+      clusterId: string;
+      clusterLabel?: string;
+      outcome: SessionOutcome | null;
+    }) => {
+      const isAlreadyOpen =
+        selectedCell !== null &&
+        selectedCell.clusterId === cell.clusterId &&
+        selectedCell.outcome === cell.outcome;
+      setFilter((prev) =>
+        isAlreadyOpen
+          ? // Re-clicking the open cell clears it. Pass the same cell so
+            // selectCell's own toggle path removes the chips.
+            selectCell(prev, cell)
+          : selectCell(clearCellChips(prev), cell)
+      );
+      setSelectedCell(isAlreadyOpen ? null : cell);
+    },
+    [selectedCell]
+  );
+
+  const handleCloseCell = useCallback(() => {
+    // Dismissing the panel also drops the selection it represents, so the grid
+    // cannot keep a cell highlighted with nothing open behind it.
+    setFilter((prev) => clearCellChips(prev));
+    setSelectedCell(null);
+  }, []);
+
   // Topic-map dot click → open that session in the Sessions tab. Clear the
   // filter so an active cluster chip can't hide the target thread (the
   // snap-to-first effect would silently reselect another session).
@@ -183,6 +246,9 @@ export function ChatboxUsagePanel({
     (sessionId: string) => {
       setSelection({ chatboxId: chatbox.chatboxId, threadId: sessionId });
       setFilter(EMPTY_USAGE_FILTER);
+      // The cleared filter no longer encodes a cell, so the grid highlight and
+      // the drill-down panel have to go with it.
+      setSelectedCell(null);
       onOpenSession?.(sessionId);
     },
     [chatbox.chatboxId, onOpenSession]
@@ -223,15 +289,32 @@ export function ChatboxUsagePanel({
   if (section === "insights") {
     return (
       <div className="flex h-full min-h-0 flex-col overflow-hidden">
-        <ChatboxTopicMapPanel
-          chatboxId={chatbox.chatboxId}
-          filter={filter}
-          onToggleChip={handleToggleChip}
-          onClearChip={handleClearChip}
-          onRebuild={handleRebuild}
-          rebuildBusy={rebuildBusy}
-          onOpenSession={handleOpenSessionFromMap}
-        />
+        <ScrollArea className="max-h-[62%] shrink-0 border-b">
+          <ChatboxGoalOutcomeGrid
+            breakdown={breakdown}
+            filter={filter}
+            onSelectCell={handleSelectCell}
+          />
+          <ChatboxGoalOutcomeDrilldown
+            chatboxId={chatbox.chatboxId}
+            cell={selectedCell}
+            filter={effectiveFilter}
+            onClose={handleCloseCell}
+            onOpenSession={handleOpenSessionFromMap}
+          />
+          <ChatboxOutcomeCalibration breakdown={breakdown} />
+        </ScrollArea>
+        <div className="min-h-0 flex-1">
+          <ChatboxTopicMapPanel
+            chatboxId={chatbox.chatboxId}
+            filter={filter}
+            onToggleChip={handleToggleChip}
+            onClearChip={handleClearChip}
+            onRebuild={handleRebuild}
+            rebuildBusy={rebuildBusy}
+            onOpenSession={handleOpenSessionFromMap}
+          />
+        </div>
       </div>
     );
   }

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeDrilldown.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeDrilldown.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ChatboxGoalOutcomeDrilldown } from "../ChatboxGoalOutcomeDrilldown";
+import {
+  ChatboxGoalOutcomeDrilldown,
+  resolveNextBefore,
+} from "../ChatboxGoalOutcomeDrilldown";
 import { EMPTY_USAGE_FILTER, toggleChip } from "@/hooks/chatbox-usage-filters";
 
 const { mockUseGoalOutcomeDrilldown } = vi.hoisted(() => ({
@@ -384,5 +387,67 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
       />
     );
     expect(screen.getByText(/No sessions match/i)).toBeInTheDocument();
+  });
+
+  it("removes the pager as soon as the final page settles with no cursor", async () => {
+    // The settled `nextBefore: null` is an answer ("no more rows"), not a gap
+    // to coalesce over. Falling back to the previous page's cursor here keeps
+    // a dead "Load more" button on screen after the set is exhausted.
+    const user = userEvent.setup();
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "first")],
+        nextBefore: 555,
+        total: 2,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    const { rerender } = renderDrilldown(CELL_A);
+    await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
+
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s2", "second")],
+        nextBefore: null,
+        total: 2,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    rerender(
+      <ChatboxGoalOutcomeDrilldown
+        chatboxId="chatbox-1"
+        cell={CELL_A}
+        filter={EMPTY_USAGE_FILTER}
+        onClose={vi.fn()}
+        onOpenSession={vi.fn()}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /Load 25 more/ })
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("resolveNextBefore", () => {
+  // The DOM assertions above cannot pin the regression exactly: the buggy
+  // frame lives between render and the accumulate effect, and testing-library
+  // flushes effects before any assertion runs. The derivation is therefore a
+  // pure exported function, pinned here where the distinction IS observable.
+  it("honors a settled null instead of falling back to the stale cursor", () => {
+    expect(resolveNextBefore({ nextBefore: null }, 555)).toBeNull();
+  });
+
+  it("keeps the last settled cursor while the next page is in flight", () => {
+    expect(resolveNextBefore(undefined, 555)).toBe(555);
+  });
+
+  it("reports a live cursor as-is", () => {
+    expect(resolveNextBefore({ nextBefore: 123 }, 555)).toBe(123);
+  });
+
+  it("is null before anything has settled", () => {
+    expect(resolveNextBefore(undefined, undefined)).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeDrilldown.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeDrilldown.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatboxGoalOutcomeDrilldown } from "../ChatboxGoalOutcomeDrilldown";
+import { EMPTY_USAGE_FILTER } from "@/hooks/chatbox-usage-filters";
+
+const { mockUseGoalOutcomeDrilldown } = vi.hoisted(() => ({
+  mockUseGoalOutcomeDrilldown: vi.fn(),
+}));
+
+vi.mock("@/hooks/useUsageInsights", () => ({
+  useGoalOutcomeDrilldown: (...args: unknown[]) =>
+    mockUseGoalOutcomeDrilldown(...args),
+}));
+
+function session(id: string, preview: string) {
+  return {
+    _id: id,
+    firstMessagePreview: preview,
+    lastActivityAt: Date.UTC(2026, 4, 1),
+  };
+}
+
+const CELL_A = {
+  clusterId: "cluster-a",
+  clusterLabel: "Invoice lookup",
+  outcome: "unresolved" as const,
+};
+
+beforeEach(() => {
+  mockUseGoalOutcomeDrilldown.mockReset();
+});
+
+function renderDrilldown(
+  cell: typeof CELL_A | { clusterId: string; outcome: null } | null,
+  onOpenSession = vi.fn(),
+) {
+  return render(
+    <ChatboxGoalOutcomeDrilldown
+      chatboxId="chatbox-1"
+      cell={cell as never}
+      filter={EMPTY_USAGE_FILTER}
+      onClose={vi.fn()}
+      onOpenSession={onOpenSession}
+    />,
+  );
+}
+
+describe("ChatboxGoalOutcomeDrilldown", () => {
+  it("renders nothing when no cell is selected", () => {
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: undefined,
+      isLoading: false,
+    });
+    const { container } = renderDrilldown(null);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("reports the server-counted total, not the page length", () => {
+    // The grid cell said 62; the page has 2 rows. The header must agree with the
+    // grid, which is the entire reason the total is counted server-side.
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "first"), session("s2", "second")],
+        nextBefore: 123,
+        total: 62,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    renderDrilldown(CELL_A);
+    expect(screen.getByText("62 sessions in this cell")).toBeInTheDocument();
+  });
+
+  it("labels the not-analyzed cell distinctly", () => {
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: { sessions: [], nextBefore: null, total: 0, totalTruncated: false },
+      isLoading: false,
+    });
+    renderDrilldown({ clusterId: "cluster-a", outcome: null });
+    expect(screen.getByRole("heading")).toHaveTextContent("not analyzed");
+  });
+
+  it("passes outcome: null through for the not-analyzed cell", () => {
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: { sessions: [], nextBefore: null, total: 0, totalTruncated: false },
+      isLoading: false,
+    });
+    renderDrilldown({ clusterId: "cluster-a", outcome: null });
+    expect(mockUseGoalOutcomeDrilldown).toHaveBeenCalledWith(
+      expect.objectContaining({ clusterId: "cluster-a", outcome: null }),
+    );
+  });
+
+  it("warns when the cell total hit the scan limit", () => {
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "first")],
+        nextBefore: null,
+        total: 2000,
+        totalTruncated: true,
+      },
+      isLoading: false,
+    });
+    renderDrilldown(CELL_A);
+    expect(screen.getByText("2,000+ sessions in this cell")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/scan limit/i);
+  });
+
+  it("starts with no cursor and advances it on Load more", async () => {
+    const user = userEvent.setup();
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "first")],
+        nextBefore: 555,
+        total: 40,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    renderDrilldown(CELL_A);
+
+    expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
+      expect.objectContaining({ before: undefined }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
+    expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
+      expect.objectContaining({ before: 555 }),
+    );
+  });
+
+  it("resets the cursor when the selected cell changes", async () => {
+    const user = userEvent.setup();
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "cell A row")],
+        nextBefore: 555,
+        total: 40,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    const { rerender } = renderDrilldown(CELL_A);
+
+    await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
+    expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
+      expect.objectContaining({ before: 555 }),
+    );
+
+    // Switching cells must not carry the previous cell's cursor over — the
+    // second page of cell A is not the second page of cell B.
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s9", "cell B row")],
+        nextBefore: null,
+        total: 3,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    rerender(
+      <ChatboxGoalOutcomeDrilldown
+        chatboxId="chatbox-1"
+        cell={{
+          clusterId: "cluster-b",
+          clusterLabel: "Refunds",
+          outcome: "errored",
+        }}
+        filter={EMPTY_USAGE_FILTER}
+        onClose={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+
+    expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
+      expect.objectContaining({ clusterId: "cluster-b", before: undefined }),
+    );
+    // And the previous cell's rows must be gone, not merged in.
+    expect(screen.queryByText("cell A row")).not.toBeInTheDocument();
+    expect(screen.getByText("cell B row")).toBeInTheDocument();
+  });
+
+  it("accumulates pages without duplicating rows", async () => {
+    const user = userEvent.setup();
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "first")],
+        nextBefore: 555,
+        total: 40,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    const { rerender } = renderDrilldown(CELL_A);
+
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        // The server re-sends s1 (overlapping cursor); it must not double up.
+        sessions: [session("s1", "first"), session("s2", "second")],
+        nextBefore: null,
+        total: 40,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
+    rerender(
+      <ChatboxGoalOutcomeDrilldown
+        chatboxId="chatbox-1"
+        cell={CELL_A}
+        filter={EMPTY_USAGE_FILTER}
+        onClose={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText("first")).toHaveLength(1);
+    expect(screen.getByText("second")).toBeInTheDocument();
+  });
+
+  it("opens a session when its row is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenSession = vi.fn();
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "first")],
+        nextBefore: null,
+        total: 1,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    renderDrilldown(CELL_A, onOpenSession);
+
+    await user.click(screen.getByText("first"));
+    expect(onOpenSession).toHaveBeenCalledWith("s1");
+  });
+
+  it("says the cell is empty only once the query has answered", () => {
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: undefined,
+      isLoading: true,
+    });
+    const { rerender } = renderDrilldown(CELL_A);
+    expect(screen.queryByText(/No sessions match/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Loading sessions…")).toBeInTheDocument();
+
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: { sessions: [], nextBefore: null, total: 0, totalTruncated: false },
+      isLoading: false,
+    });
+    rerender(
+      <ChatboxGoalOutcomeDrilldown
+        chatboxId="chatbox-1"
+        cell={CELL_A}
+        filter={EMPTY_USAGE_FILTER}
+        onClose={vi.fn()}
+        onOpenSession={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/No sessions match/i)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeDrilldown.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeDrilldown.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatboxGoalOutcomeDrilldown } from "../ChatboxGoalOutcomeDrilldown";
-import { EMPTY_USAGE_FILTER } from "@/hooks/chatbox-usage-filters";
+import { EMPTY_USAGE_FILTER, toggleChip } from "@/hooks/chatbox-usage-filters";
 
 const { mockUseGoalOutcomeDrilldown } = vi.hoisted(() => ({
   mockUseGoalOutcomeDrilldown: vi.fn(),
@@ -33,7 +33,7 @@ beforeEach(() => {
 
 function renderDrilldown(
   cell: typeof CELL_A | { clusterId: string; outcome: null } | null,
-  onOpenSession = vi.fn(),
+  onOpenSession = vi.fn()
 ) {
   return render(
     <ChatboxGoalOutcomeDrilldown
@@ -42,7 +42,7 @@ function renderDrilldown(
       filter={EMPTY_USAGE_FILTER}
       onClose={vi.fn()}
       onOpenSession={onOpenSession}
-    />,
+    />
   );
 }
 
@@ -74,7 +74,12 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
 
   it("labels the not-analyzed cell distinctly", () => {
     mockUseGoalOutcomeDrilldown.mockReturnValue({
-      drilldown: { sessions: [], nextBefore: null, total: 0, totalTruncated: false },
+      drilldown: {
+        sessions: [],
+        nextBefore: null,
+        total: 0,
+        totalTruncated: false,
+      },
       isLoading: false,
     });
     renderDrilldown({ clusterId: "cluster-a", outcome: null });
@@ -83,12 +88,17 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
 
   it("passes outcome: null through for the not-analyzed cell", () => {
     mockUseGoalOutcomeDrilldown.mockReturnValue({
-      drilldown: { sessions: [], nextBefore: null, total: 0, totalTruncated: false },
+      drilldown: {
+        sessions: [],
+        nextBefore: null,
+        total: 0,
+        totalTruncated: false,
+      },
       isLoading: false,
     });
     renderDrilldown({ clusterId: "cluster-a", outcome: null });
     expect(mockUseGoalOutcomeDrilldown).toHaveBeenCalledWith(
-      expect.objectContaining({ clusterId: "cluster-a", outcome: null }),
+      expect.objectContaining({ clusterId: "cluster-a", outcome: null })
     );
   });
 
@@ -103,7 +113,9 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
       isLoading: false,
     });
     renderDrilldown(CELL_A);
-    expect(screen.getByText("2,000+ sessions in this cell")).toBeInTheDocument();
+    expect(
+      screen.getByText("2,000+ sessions in this cell")
+    ).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent(/scan limit/i);
   });
 
@@ -121,12 +133,12 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     renderDrilldown(CELL_A);
 
     expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
-      expect.objectContaining({ before: undefined }),
+      expect.objectContaining({ before: undefined })
     );
 
     await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
     expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
-      expect.objectContaining({ before: 555 }),
+      expect.objectContaining({ before: 555 })
     );
   });
 
@@ -145,7 +157,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
 
     await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
     expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
-      expect.objectContaining({ before: 555 }),
+      expect.objectContaining({ before: 555 })
     );
 
     // Switching cells must not carry the previous cell's cursor over — the
@@ -170,11 +182,11 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}
         onOpenSession={vi.fn()}
-      />,
+      />
     );
 
     expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
-      expect.objectContaining({ clusterId: "cluster-b", before: undefined }),
+      expect.objectContaining({ clusterId: "cluster-b", before: undefined })
     );
     // And the previous cell's rows must be gone, not merged in.
     expect(screen.queryByText("cell A row")).not.toBeInTheDocument();
@@ -212,7 +224,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}
         onOpenSession={vi.fn()}
-      />,
+      />
     );
 
     expect(screen.getAllByText("first")).toHaveLength(1);
@@ -237,6 +249,113 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     expect(onOpenSession).toHaveBeenCalledWith("s1");
   });
 
+  it("resets the cursor and rows when another facet chip changes", async () => {
+    // The filter is part of the query. Keeping the cursor and rows across a
+    // filter change would show sessions the new filter excludes and would start
+    // from page two of a set that no longer exists.
+    const user = userEvent.setup();
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "unfiltered row")],
+        nextBefore: 555,
+        total: 40,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    const { rerender } = render(
+      <ChatboxGoalOutcomeDrilldown
+        chatboxId="chatbox-1"
+        cell={CELL_A}
+        filter={EMPTY_USAGE_FILTER}
+        onClose={vi.fn()}
+        onOpenSession={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
+    expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
+      expect.objectContaining({ before: 555 })
+    );
+
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s9", "filtered row")],
+        nextBefore: null,
+        total: 2,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    rerender(
+      <ChatboxGoalOutcomeDrilldown
+        chatboxId="chatbox-1"
+        cell={CELL_A}
+        filter={toggleChip(EMPTY_USAGE_FILTER, {
+          kind: "dimension",
+          key: "deviceKind",
+          value: "mobile",
+        })}
+        onClose={vi.fn()}
+        onOpenSession={vi.fn()}
+      />
+    );
+
+    expect(mockUseGoalOutcomeDrilldown).toHaveBeenLastCalledWith(
+      expect.objectContaining({ before: undefined })
+    );
+    expect(screen.queryByText("unfiltered row")).not.toBeInTheDocument();
+    expect(screen.getByText("filtered row")).toBeInTheDocument();
+  });
+
+  it("keeps the count and the pager steady while the next page is in flight", async () => {
+    // Advancing the cursor makes the subscription return undefined again.
+    // Without carrying the last settled values, the header flips to "Loading…"
+    // and the button the user just clicked disappears from under the cursor.
+    const user = userEvent.setup();
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: {
+        sessions: [session("s1", "first")],
+        nextBefore: 555,
+        total: 40,
+        totalTruncated: false,
+      },
+      isLoading: false,
+    });
+    const { rerender } = render(
+      <ChatboxGoalOutcomeDrilldown
+        chatboxId="chatbox-1"
+        cell={CELL_A}
+        filter={EMPTY_USAGE_FILTER}
+        onClose={vi.fn()}
+        onOpenSession={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
+
+    // In-flight: the query has no answer for the new cursor yet.
+    mockUseGoalOutcomeDrilldown.mockReturnValue({
+      drilldown: undefined,
+      isLoading: true,
+    });
+    rerender(
+      <ChatboxGoalOutcomeDrilldown
+        chatboxId="chatbox-1"
+        cell={CELL_A}
+        filter={EMPTY_USAGE_FILTER}
+        onClose={vi.fn()}
+        onOpenSession={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("40 sessions in this cell")).toBeInTheDocument();
+    expect(screen.queryByText("Loading sessions…")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Load 25 more/ })
+    ).toBeInTheDocument();
+    // Already-loaded rows stay put too.
+    expect(screen.getByText("first")).toBeInTheDocument();
+  });
+
   it("says the cell is empty only once the query has answered", () => {
     mockUseGoalOutcomeDrilldown.mockReturnValue({
       drilldown: undefined,
@@ -247,7 +366,12 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     expect(screen.getByText("Loading sessions…")).toBeInTheDocument();
 
     mockUseGoalOutcomeDrilldown.mockReturnValue({
-      drilldown: { sessions: [], nextBefore: null, total: 0, totalTruncated: false },
+      drilldown: {
+        sessions: [],
+        nextBefore: null,
+        total: 0,
+        totalTruncated: false,
+      },
       isLoading: false,
     });
     rerender(
@@ -257,7 +381,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}
         onOpenSession={vi.fn()}
-      />,
+      />
     );
     expect(screen.getByText(/No sessions match/i)).toBeInTheDocument();
   });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeGrid.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeGrid.test.tsx
@@ -1,0 +1,352 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ChatboxGoalOutcomeGrid } from "../ChatboxGoalOutcomeGrid";
+import { EMPTY_USAGE_FILTER, selectCell } from "@/hooks/chatbox-usage-filters";
+import type { GoalFacet, UsageBreakdown } from "@/hooks/useUsageInsights";
+
+function facet(overrides: Partial<GoalFacet> = {}): GoalFacet {
+  return {
+    clusterId: "cluster-a",
+    label: "Invoice lookup",
+    total: 10,
+    outcomes: {
+      completed: 3,
+      partial: 0,
+      unresolved: 5,
+      errored: 2,
+      unclear: 0,
+    },
+    unlabeled: 0,
+    unresolvedRate: 0.7,
+    errorRate: 0.2,
+    retryRate: 0.4,
+    toolDistribution: [],
+    pathDistribution: [],
+    distinctPathCount: 4,
+    routingEntropy: 1.85,
+    ...overrides,
+  };
+}
+
+function breakdown(overrides: Partial<UsageBreakdown> = {}): UsageBreakdown {
+  return {
+    themes: [],
+    userBreakdown: [],
+    deviceBreakdown: [],
+    languageBreakdown: [],
+    modelBreakdown: [],
+    outcomeBreakdown: [],
+    frictionBreakdown: [],
+    behaviorTagBreakdown: [],
+    goalFacets: [facet()],
+    labeledOutcomeCount: 10,
+    outcomeFeedbackCalibration: [],
+    totalSessions: 10,
+    latestRun: null,
+    ...overrides,
+  };
+}
+
+describe("ChatboxGoalOutcomeGrid", () => {
+  it("renders the target reading: goal, volume, unresolved rate, route count", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown()}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+
+    const row = screen.getByRole("row", { name: /Invoice lookup/ });
+    expect(within(row).getByText("10")).toBeInTheDocument();
+    expect(within(row).getByText("70%")).toBeInTheDocument();
+    expect(within(row).getByText("20%")).toBeInTheDocument();
+    // Distinct tool routes for this one goal.
+    expect(within(row).getByText("4")).toBeInTheDocument();
+    expect(within(row).getByText("1.85")).toBeInTheDocument();
+  });
+
+  it("does not truncate the goal label", () => {
+    const long =
+      "Invoice lookup and reconciliation against outstanding purchase orders";
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({ goalFacets: [facet({ label: long })] })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(screen.getByText(long)).toBeInTheDocument();
+  });
+
+  it("renders an unknown rate as an em dash, never as 0%", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({
+          goalFacets: [
+            facet({
+              unresolvedRate: null,
+              errorRate: null,
+              routingEntropy: null,
+            }),
+          ],
+        })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    const row = screen.getByRole("row", { name: /Invoice lookup/ });
+    // Three unknowns: unresolved rate, error rate, entropy.
+    expect(within(row).getAllByText("—")).toHaveLength(3);
+    expect(within(row).queryByText("0%")).not.toBeInTheDocument();
+  });
+
+  it("shows the truncation notice so rates are not read as unconditional", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({
+          scan: {
+            scanned: 5000,
+            matched: 2000,
+            truncated: true,
+            maxSessions: 2000,
+            windowEndAt: 1,
+            windowStartAt: 0,
+          },
+        })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /most recent 2,000 matching sessions/i
+    );
+  });
+
+  it("omits the truncation notice when the scan was complete", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({
+          scan: {
+            scanned: 42,
+            matched: 42,
+            truncated: false,
+            maxSessions: 2000,
+            windowEndAt: 1,
+            windowStartAt: 0,
+          },
+        })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("reports the labeled denominator explicitly", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({ labeledOutcomeCount: 7, totalSessions: 10 })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByText(/7 of 10 scanned sessions have an inferred outcome/i)
+    ).toBeInTheDocument();
+  });
+
+  it("separates the not-analyzed column from the unclear column", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({
+          goalFacets: [
+            facet({
+              total: 6,
+              outcomes: {
+                completed: 0,
+                partial: 0,
+                unresolved: 0,
+                errored: 0,
+                unclear: 2,
+              },
+              unlabeled: 4,
+            }),
+          ],
+        })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    // Two distinct columns, because absence of a verdict is not the `unclear`
+    // verdict.
+    expect(
+      screen.getByRole("columnheader", { name: "Unclear" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Not analyzed" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Unclear: 2 sessions/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /not analyzed: 4 sessions/ })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onSelectCell with the clicked cell", async () => {
+    const user = userEvent.setup();
+    const onSelectCell = vi.fn();
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown()}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={onSelectCell}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Unresolved: 5 sessions/ })
+    );
+    expect(onSelectCell).toHaveBeenCalledWith({
+      clusterId: "cluster-a",
+      clusterLabel: "Invoice lookup",
+      outcome: "unresolved",
+    });
+  });
+
+  it("marks the selected cell pressed and leaves the others unpressed", () => {
+    const filter = selectCell(EMPTY_USAGE_FILTER, {
+      clusterId: "cluster-a",
+      outcome: "unresolved",
+    });
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown()}
+        filter={filter}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /Unresolved: 5 sessions/ })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: /Completed: 3 sessions/ })
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("disables empty cells so there is nothing to drill into", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown()}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /Partial: 0 sessions/ })
+    ).toBeDisabled();
+  });
+
+  it("sorts by unresolved rate on request, ranking unknown rates last", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({
+          goalFacets: [
+            facet({
+              clusterId: "big",
+              label: "Big volume",
+              total: 100,
+              unresolvedRate: 0.1,
+            }),
+            facet({
+              clusterId: "bad",
+              label: "Bad outcomes",
+              total: 10,
+              unresolvedRate: 0.9,
+            }),
+            facet({
+              clusterId: "unknown",
+              label: "No labels",
+              total: 50,
+              unresolvedRate: null,
+            }),
+          ],
+        })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+
+    // Default is volume.
+    let rowHeaders = screen
+      .getAllByRole("rowheader")
+      .map((el) => el.textContent);
+    expect(rowHeaders[0]).toBe("Big volume");
+
+    await user.click(
+      screen.getByRole("button", { name: /Sort by unresolved/ })
+    );
+    rowHeaders = screen.getAllByRole("rowheader").map((el) => el.textContent);
+    expect(rowHeaders[0]).toBe("Bad outcomes");
+    // An unknown rate must not outrank a measured one.
+    expect(rowHeaders[rowHeaders.length - 1]).toBe("No labels");
+  });
+
+  it("folds rows past the cap into a real Other row rather than dropping them", () => {
+    const many = Array.from({ length: 15 }, (_, i) =>
+      facet({
+        clusterId: `c${i}`,
+        label: `Goal ${i}`,
+        total: 100 - i,
+      })
+    );
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({ goalFacets: many })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(screen.getByText("Other (3 goals)")).toBeInTheDocument();
+  });
+
+  it("explains an empty grid on a run that predates the split", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({
+          goalFacets: [],
+          latestRun: {
+            _id: "run-1",
+            status: "done",
+            startedAt: 0,
+            finishedAt: 1,
+            sessionCount: 5,
+            clusterCount: 2,
+            errorMessage: null,
+            signalsVersion: null,
+            isStale: false,
+          },
+        })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByText(/ran before goal outcomes existed/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders a loading state rather than an empty grid while the breakdown is undefined", () => {
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={undefined}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Loading goal outcomes/i)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeGrid.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeGrid.test.tsx
@@ -257,6 +257,40 @@ describe("ChatboxGoalOutcomeGrid", () => {
     ).toHaveAttribute("aria-pressed", "false");
   });
 
+  it("colors strong tints with the tint text token, not the solid-fill foreground", () => {
+    // `--success-foreground`/`--destructive-foreground` are white in BOTH
+    // themes (they pair with solid fills), so on a /25 tint over a light page
+    // they render white-on-near-white. tokens.css's own guidance for tinted
+    // surfaces is `text-destructive`/`text-success`.
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({
+          goalFacets: [
+            facet({
+              total: 10,
+              outcomes: {
+                completed: 0,
+                partial: 0,
+                unresolved: 7, // share 0.7 → the "strong" tint bucket
+                errored: 0,
+                unclear: 3,
+              },
+            }),
+          ],
+        })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    const classes = screen
+      .getByRole("button", { name: /Unresolved: 7 sessions/ })
+      .className.split(/\s+/);
+    expect(classes).toContain("text-destructive");
+    // Substring-safe: "text-destructive" is a prefix of the wrong class, so
+    // assert on the exact class list rather than the class string.
+    expect(classes).not.toContain("text-destructive-foreground");
+  });
+
   it("disables empty cells so there is nothing to drill into", () => {
     render(
       <ChatboxGoalOutcomeGrid

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeGrid.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeGrid.test.tsx
@@ -313,6 +313,33 @@ describe("ChatboxGoalOutcomeGrid", () => {
     expect(screen.getByText("Other (3 goals)")).toBeInTheDocument();
   });
 
+  it("does not report a summed route count for the Other row", () => {
+    // Summing per-goal distinct-route counts double-counts any path two folded
+    // goals share, so it would overstate. Unknown beats wrong.
+    const many = Array.from({ length: 14 }, (_, i) =>
+      facet({
+        clusterId: `c${i}`,
+        label: `Goal ${i}`,
+        total: 100 - i,
+        // Every goal takes the same single route, so a correct union is 1 and a
+        // naive sum is 14.
+        distinctPathCount: 1,
+        routingEntropy: 0,
+      })
+    );
+    render(
+      <ChatboxGoalOutcomeGrid
+        breakdown={breakdown({ goalFacets: many })}
+        filter={EMPTY_USAGE_FILTER}
+        onSelectCell={vi.fn()}
+      />
+    );
+    const otherRow = screen.getByRole("row", { name: /Other \(2 goals\)/ });
+    expect(within(otherRow).queryByText("2")).not.toBeInTheDocument();
+    // Routes and Spread both read as unknown for the folded row.
+    expect(within(otherRow).getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
   it("explains an empty grid on a run that predates the split", () => {
     render(
       <ChatboxGoalOutcomeGrid

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeGrid.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeGrid.test.tsx
@@ -48,6 +48,27 @@ function breakdown(overrides: Partial<UsageBreakdown> = {}): UsageBreakdown {
   };
 }
 
+/**
+ * The `<td>` under a named column, located via the header row.
+ *
+ * Numeric cells are asserted through this rather than with a bare
+ * `getByText("4")` scoped to the row: a bare text query passes or fails on
+ * whether that string happens to appear in some *other* cell, which is a
+ * property of the fixture rather than of the column under test. Deriving the
+ * index from the headers also means adding or reordering a column cannot make
+ * an assertion silently start checking its neighbour.
+ */
+function cellForColumn(row: HTMLElement, columnName: string): HTMLElement {
+  const headers = screen
+    .getAllByRole("columnheader")
+    .map((header) => header.textContent?.trim());
+  const index = headers.indexOf(columnName);
+  expect(index, `no column named '${columnName}'`).toBeGreaterThanOrEqual(0);
+  // The first column is the row header (the goal label), not a <td>, so the
+  // Nth columnheader maps to the (N-1)th cell.
+  return within(row).getAllByRole("cell")[index - 1];
+}
+
 describe("ChatboxGoalOutcomeGrid", () => {
   it("renders the target reading: goal, volume, unresolved rate, route count", () => {
     render(
@@ -335,9 +356,10 @@ describe("ChatboxGoalOutcomeGrid", () => {
       />
     );
     const otherRow = screen.getByRole("row", { name: /Other \(2 goals\)/ });
-    expect(within(otherRow).queryByText("2")).not.toBeInTheDocument();
-    // Routes and Spread both read as unknown for the folded row.
-    expect(within(otherRow).getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    // Two folded goals each with 1 route: the naive sum is 2, the correct union
+    // is 1, and we claim neither — the fold cannot know which paths overlap.
+    expect(cellForColumn(otherRow, "Routes")).toHaveTextContent(/^—$/);
+    expect(cellForColumn(otherRow, "Spread")).toHaveTextContent(/^—$/);
   });
 
   it("explains an empty grid on a run that predates the split", () => {

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxOutcomeCalibration.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxOutcomeCalibration.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ChatboxOutcomeCalibration } from "../ChatboxOutcomeCalibration";
+import type {
+  OutcomeFeedbackCalibration,
+  UsageBreakdown,
+} from "@/hooks/useUsageInsights";
+
+function row(
+  overrides: Partial<OutcomeFeedbackCalibration> = {}
+): OutcomeFeedbackCalibration {
+  return {
+    outcome: "completed",
+    sessions: 0,
+    rated: 0,
+    negative: 0,
+    negativeRate: null,
+    ...overrides,
+  };
+}
+
+function breakdown(overrides: Partial<UsageBreakdown> = {}): UsageBreakdown {
+  return {
+    themes: [],
+    userBreakdown: [],
+    deviceBreakdown: [],
+    languageBreakdown: [],
+    modelBreakdown: [],
+    outcomeBreakdown: [],
+    frictionBreakdown: [],
+    behaviorTagBreakdown: [],
+    goalFacets: [],
+    labeledOutcomeCount: 0,
+    outcomeFeedbackCalibration: [],
+    totalSessions: 0,
+    latestRun: null,
+    ...overrides,
+  };
+}
+
+describe("ChatboxOutcomeCalibration", () => {
+  it("renders nothing when the server sent no calibration rows", () => {
+    const { container } = render(
+      <ChatboxOutcomeCalibration breakdown={breakdown()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("explains the absence rather than showing an empty table when nobody rated", () => {
+    render(
+      <ChatboxOutcomeCalibration
+        breakdown={breakdown({
+          outcomeFeedbackCalibration: [row({ sessions: 10 })],
+        })}
+      />
+    );
+    expect(screen.getByText(/nothing to compare/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders a percentage once the ratings are thick enough", () => {
+    render(
+      <ChatboxOutcomeCalibration
+        breakdown={breakdown({
+          outcomeFeedbackCalibration: [
+            row({ sessions: 20, rated: 10, negative: 4, negativeRate: 0.4 }),
+          ],
+        })}
+      />
+    );
+    expect(screen.getByText("40%")).toBeInTheDocument();
+  });
+
+  it("shows raw counts instead of a percentage on a thin sample", () => {
+    // 1/2 is 50%, but a "50% negative" reads as a finding when it is two
+    // ratings. Show the fraction so the sample size travels with the number.
+    render(
+      <ChatboxOutcomeCalibration
+        breakdown={breakdown({
+          outcomeFeedbackCalibration: [
+            row({ sessions: 9, rated: 2, negative: 1, negativeRate: 0.5 }),
+          ],
+        })}
+      />
+    );
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+    expect(screen.queryByText("50%")).not.toBeInTheDocument();
+  });
+
+  it("renders an unrated outcome as an em dash, never 0%", () => {
+    render(
+      <ChatboxOutcomeCalibration
+        breakdown={breakdown({
+          outcomeFeedbackCalibration: [
+            row({ outcome: "errored", sessions: 5, rated: 0 }),
+            row({ sessions: 5, rated: 5, negative: 0, negativeRate: 0 }),
+          ],
+        })}
+      />
+    );
+    const erroredRow = screen.getByRole("row", { name: /errored/ });
+    expect(within(erroredRow).getByText("—")).toBeInTheDocument();
+  });
+
+  it("announces the flagged row in text, not colour alone", () => {
+    // The one actionable signal in the panel must reach a screen reader.
+    render(
+      <ChatboxOutcomeCalibration
+        breakdown={breakdown({
+          outcomeFeedbackCalibration: [
+            row({ sessions: 20, rated: 10, negative: 5, negativeRate: 0.5 }),
+          ],
+        })}
+      />
+    );
+    expect(
+      screen.getByText(/unexpectedly negative for a completed outcome/i)
+    ).toBeInTheDocument();
+  });
+
+  it("does not flag a high negative rate on a non-completed outcome", () => {
+    // Negative feedback on an `errored` session is expected, not a signal that
+    // the extraction disagrees with users.
+    render(
+      <ChatboxOutcomeCalibration
+        breakdown={breakdown({
+          outcomeFeedbackCalibration: [
+            row({
+              outcome: "errored",
+              sessions: 20,
+              rated: 10,
+              negative: 9,
+              negativeRate: 0.9,
+            }),
+          ],
+        })}
+      />
+    );
+    expect(
+      screen.queryByText(/unexpectedly negative/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("qualifies its rates when the scan was truncated", () => {
+    // Same bounded scan as the grid, so the same qualification. Bare
+    // percentages here while the grid warns would read as unconditional.
+    render(
+      <ChatboxOutcomeCalibration
+        breakdown={breakdown({
+          outcomeFeedbackCalibration: [
+            row({ sessions: 20, rated: 10, negative: 1, negativeRate: 0.1 }),
+          ],
+          scan: {
+            scanned: 5000,
+            matched: 2000,
+            truncated: true,
+            maxSessions: 2000,
+            windowEndAt: 1,
+            windowStartAt: 0,
+          },
+        })}
+      />
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /most recent 2,000 matching sessions/i
+    );
+  });
+
+  it("does not qualify when the scan was complete", () => {
+    render(
+      <ChatboxOutcomeCalibration
+        breakdown={breakdown({
+          outcomeFeedbackCalibration: [
+            row({ sessions: 20, rated: 10, negative: 1, negativeRate: 0.1 }),
+          ],
+          scan: {
+            scanned: 20,
+            matched: 20,
+            truncated: false,
+            maxSessions: 2000,
+            windowEndAt: 1,
+            windowStartAt: 0,
+          },
+        })}
+      />
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -7,7 +7,11 @@ import {
   colorForNode,
   topicMapNodeHoverLabel,
 } from "../ChatboxTopicMapPanel";
-import type { UsageFilterState } from "@/hooks/chatbox-usage-filters";
+import {
+  EMPTY_USAGE_FILTER,
+  selectCell,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
 
 const { mockUseChatboxTopicMap } = vi.hoisted(() => ({
   mockUseChatboxTopicMap: vi.fn(),
@@ -22,7 +26,7 @@ vi.mock("react-force-graph-2d", async () => {
         onNodeClick?: (node: { id: string }) => void;
         onBackgroundClick?: () => void;
       },
-      ref,
+      ref
     ) {
       React.useImperativeHandle(ref, () => ({
         zoomToFit: vi.fn(),
@@ -209,7 +213,9 @@ function outcomeAwareHookValue() {
 
 beforeEach(() => {
   mockUseChatboxTopicMap.mockReset();
-  mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+  mockUseChatboxTopicMap.mockReturnValue(
+    createDefaultChatboxTopicMapHookValue()
+  );
 });
 
 describe("topicMapNodeHoverLabel", () => {
@@ -219,7 +225,7 @@ describe("topicMapNodeHoverLabel", () => {
         semanticTitle: "Password reset",
         semanticPreview: "User needs to reset a forgotten password.",
         sessionId: "session-a",
-      }),
+      })
     ).toBe("Password reset");
   });
 
@@ -229,7 +235,7 @@ describe("topicMapNodeHoverLabel", () => {
         semanticPreview:
           "The user requested a drawing of a dog, prompting the assistant to utilize a drawing tool.",
         sessionId: "session-a",
-      }),
+      })
     ).toBe("drawing");
   });
 
@@ -238,7 +244,7 @@ describe("topicMapNodeHoverLabel", () => {
       topicMapNodeHoverLabel({
         semanticPreview: "User needs: billing help, urgently.",
         sessionId: "session-a",
-      }),
+      })
     ).toBe("billing");
   });
 
@@ -255,7 +261,7 @@ describe("topicMapNodeHoverLabel", () => {
       sessionId: "session-cat",
     };
     expect(topicMapNodeHoverLabel(dogNode)).not.toBe(
-      topicMapNodeHoverLabel(catNode),
+      topicMapNodeHoverLabel(catNode)
     );
   });
 
@@ -264,7 +270,7 @@ describe("topicMapNodeHoverLabel", () => {
       topicMapNodeHoverLabel({
         semanticPreview: "   ",
         sessionId: "sess-xyz",
-      }),
+      })
     ).toBe("sess-xyz");
   });
 });
@@ -299,7 +305,9 @@ describe("ChatboxTopicMapPanel", () => {
       const { rerender } = render(<ChatboxTopicMapPanel {...panelProps} />);
       expect(observed).toHaveLength(0);
 
-      mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+      mockUseChatboxTopicMap.mockReturnValue(
+        createDefaultChatboxTopicMapHookValue()
+      );
       rerender(<ChatboxTopicMapPanel {...panelProps} />);
       expect(observed.length).toBeGreaterThan(0);
     } finally {
@@ -315,14 +323,14 @@ describe("ChatboxTopicMapPanel", () => {
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
 
     expect(screen.queryByText("Historical Topic Map")).not.toBeInTheDocument();
     expect(screen.queryByText("2 mapped sessions")).not.toBeInTheDocument();
     expect(screen.getByText("Password resets")).toBeInTheDocument();
     expect(
-      screen.getByText("Reset and account recovery questions."),
+      screen.getByText("Reset and account recovery questions.")
     ).toBeInTheDocument();
     expect(screen.getByText("Billing issues")).toBeInTheDocument();
     expect(screen.getByText("Invoice and refund help.")).toBeInTheDocument();
@@ -336,13 +344,13 @@ describe("ChatboxTopicMapPanel", () => {
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
 
     const fitView = screen.getByRole("button", { name: /fit view/i });
     const rebuild = screen.getByRole("button", { name: /rebuild clusters/i });
     expect(fitView.compareDocumentPosition(rebuild)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
+      Node.DOCUMENT_POSITION_FOLLOWING
     );
   });
 
@@ -375,7 +383,7 @@ describe("ChatboxTopicMapPanel", () => {
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
 
     expect(screen.getByText("Updating clusters")).toBeInTheDocument();
@@ -392,11 +400,13 @@ describe("ChatboxTopicMapPanel", () => {
         onToggleChip={onToggleChip}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
 
     await user.click(
-      screen.getByRole("button", { name: /Billing issues Invoice and refund help/i }),
+      screen.getByRole("button", {
+        name: /Billing issues Invoice and refund help/i,
+      })
     );
 
     expect(onToggleChip).toHaveBeenCalledWith({
@@ -414,13 +424,13 @@ describe("ChatboxTopicMapPanel", () => {
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
 
     const keywordChip = screen.getByText("password");
     expect(keywordChip.tagName).toBe("SPAN");
     expect(
-      screen.queryByRole("button", { name: "password" }),
+      screen.queryByRole("button", { name: "password" })
     ).not.toBeInTheDocument();
   });
 
@@ -430,12 +440,18 @@ describe("ChatboxTopicMapPanel", () => {
         chatboxId="chatbox-1"
         filter={{
           preset: "all",
-          chips: [{ kind: "cluster", clusterId: "cluster-a", label: "Password resets" }],
+          chips: [
+            {
+              kind: "cluster",
+              clusterId: "cluster-a",
+              label: "Password resets",
+            },
+          ],
         }}
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
 
     const clusterButton = screen.getByRole("button", {
@@ -456,17 +472,20 @@ describe("ChatboxTopicMapPanel", () => {
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
         onOpenSession={onOpenSession}
-      />,
+      />
     );
 
-    await user.click(screen.getByRole("button", { name: /graph node session-b/i }));
+    await user.click(
+      screen.getByRole("button", { name: /graph node session-b/i })
+    );
 
     expect(onOpenSession).toHaveBeenCalledWith("session-b");
     // Selection still tracks the click so the node reads as active when the
     // operator returns to the map.
-    expect(
-      screen.getByTestId("force-graph").parentElement,
-    ).toHaveAttribute("data-selected-session", "session-b");
+    expect(screen.getByTestId("force-graph").parentElement).toHaveAttribute(
+      "data-selected-session",
+      "session-b"
+    );
   });
 
   it("clears node selection when the graph background is clicked", async () => {
@@ -479,13 +498,15 @@ describe("ChatboxTopicMapPanel", () => {
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
 
     const graphHost = screen.getByTestId("force-graph").parentElement;
     expect(graphHost).toHaveAttribute("data-selected-session", "session-a");
 
-    await user.click(screen.getByRole("button", { name: /graph node session-b/i }));
+    await user.click(
+      screen.getByRole("button", { name: /graph node session-b/i })
+    );
     expect(graphHost).toHaveAttribute("data-selected-session", "session-b");
 
     await user.click(screen.getByTestId("force-graph-background"));
@@ -498,7 +519,7 @@ describe("colorForNode", () => {
     const themed = colorForNode(
       { clusterId: "cluster-a", outcome: "errored" },
       "theme",
-      0,
+      0
     );
     // Theme mode must ignore outcome entirely — colorForCluster's path is
     // unchanged by the outcome feature.
@@ -510,17 +531,21 @@ describe("colorForNode", () => {
     const completed = colorForNode(
       { clusterId: "cluster-a", outcome: "completed" },
       "outcome",
-      0,
+      0
     );
     const errored = colorForNode(
       { clusterId: "cluster-a", outcome: "errored" },
       "outcome",
-      0,
+      0
     );
     expect(completed).not.toBe(errored);
     // Same outcome in a different cluster is the same color: that is the point.
     expect(
-      colorForNode({ clusterId: "cluster-b", outcome: "completed" }, "outcome", 5),
+      colorForNode(
+        { clusterId: "cluster-b", outcome: "completed" },
+        "outcome",
+        5
+      )
     ).toBe(completed);
   });
 
@@ -528,13 +553,13 @@ describe("colorForNode", () => {
     // A node on a pre-bump snapshot, or a session whose signals never
     // extracted. Neither is a verdict, so neither may be painted as one.
     expect(colorForNode({ clusterId: "cluster-a" }, "outcome", 0)).toBe(
-      NO_OUTCOME_COLOR,
+      NO_OUTCOME_COLOR
     );
   });
 
   it("renders unclear with the same neutral as no outcome at all", () => {
     expect(
-      colorForNode({ clusterId: "cluster-a", outcome: "unclear" }, "outcome", 0),
+      colorForNode({ clusterId: "cluster-a", outcome: "unclear" }, "outcome", 0)
     ).toBe(NO_OUTCOME_COLOR);
   });
 
@@ -543,8 +568,8 @@ describe("colorForNode", () => {
       colorForNode(
         { clusterId: "cluster-a", outcome: "something-new" },
         "outcome",
-        0,
-      ),
+        0
+      )
     ).toBe(NO_OUTCOME_COLOR);
   });
 });
@@ -558,7 +583,7 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
   }
 
@@ -568,11 +593,11 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
 
     expect(screen.getByRole("button", { name: "Theme" })).toHaveAttribute(
       "aria-pressed",
-      "true",
+      "true"
     );
     expect(screen.getByRole("button", { name: "Outcome" })).toHaveAttribute(
       "aria-pressed",
-      "false",
+      "false"
     );
   });
 
@@ -586,7 +611,7 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
 
     expect(screen.getByRole("button", { name: "Outcome" })).toHaveAttribute(
       "aria-pressed",
-      "true",
+      "true"
     );
     expect(screen.getByText("Unresolved")).toBeInTheDocument();
     expect(screen.getByText("Unclear / not analyzed")).toBeInTheDocument();
@@ -595,14 +620,18 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
   it("disables outcome mode on a pre-bump snapshot instead of painting it neutral", () => {
     // version 1 blobs carry no `outcome` on their nodes. Offering the mode
     // would paint every node grey and read as a bug rather than stale data.
-    mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+    mockUseChatboxTopicMap.mockReturnValue(
+      createDefaultChatboxTopicMapHookValue()
+    );
     renderPanel();
 
     expect(screen.getByRole("button", { name: "Outcome" })).toBeDisabled();
   });
 
   it("still renders a pre-bump snapshot normally", () => {
-    mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+    mockUseChatboxTopicMap.mockReturnValue(
+      createDefaultChatboxTopicMapHookValue()
+    );
     renderPanel();
 
     expect(screen.getByText("Password resets")).toBeInTheDocument();
@@ -617,7 +646,7 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
       snapshot: {
         ...base.snapshot,
         nodes: base.snapshot.nodes.map(
-          ({ outcome: _outcome, ...node }) => node,
+          ({ outcome: _outcome, ...node }) => node
         ),
       },
     });
@@ -625,7 +654,7 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
 
     await user.click(screen.getByRole("button", { name: "Outcome" }));
     expect(
-      screen.getByText("No mapped session has an inferred outcome yet."),
+      screen.getByText("No mapped session has an inferred outcome yet.")
     ).toBeInTheDocument();
   });
 
@@ -637,10 +666,12 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
     await user.click(screen.getByRole("button", { name: "Outcome" }));
     expect(screen.getByRole("button", { name: "Outcome" })).toHaveAttribute(
       "aria-pressed",
-      "true",
+      "true"
     );
 
-    mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+    mockUseChatboxTopicMap.mockReturnValue(
+      createDefaultChatboxTopicMapHookValue()
+    );
     rerender(
       <ChatboxTopicMapPanel
         chatboxId="chatbox-1"
@@ -648,12 +679,73 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
-      />,
+      />
     );
 
     expect(screen.getByRole("button", { name: "Theme" })).toHaveAttribute(
       "aria-pressed",
-      "true",
+      "true"
     );
+  });
+});
+
+describe("ChatboxTopicMapPanel outcome narrowing", () => {
+  it("dims nodes outside the selected outcome, not just outside the goal", () => {
+    // Before this, clicking an outcome cell highlighted the goal and left every
+    // outcome inside it lit — the map disagreed with the grid about what was
+    // selected. Nodes now carry an outcome, so the map can honor the chip.
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    const { container } = render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={selectCell(EMPTY_USAGE_FILTER, {
+          clusterId: "cluster-a",
+          outcome: "unresolved",
+        })}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />
+    );
+    // session-a is cluster-a/completed, so the unresolved chip excludes it.
+    // Both nodes still render; dimming is a canvas concern, so assert via the
+    // exported colour helper that the two are distinguishable at all.
+    expect(container).toBeTruthy();
+    expect(
+      colorForNode({ clusterId: "cluster-a", outcome: "completed" }, "outcome")
+    ).not.toBe(
+      colorForNode({ clusterId: "cluster-a", outcome: "unresolved" }, "outcome")
+    );
+  });
+
+  it("treats the unlabeled sentinel as selecting nodes with no outcome", () => {
+    const base = outcomeAwareHookValue();
+    mockUseChatboxTopicMap.mockReturnValue({
+      ...base,
+      snapshot: {
+        ...base.snapshot,
+        nodes: [
+          base.snapshot.nodes[0],
+          // A node with no outcome at all.
+          (({ outcome: _o, ...rest }) => rest)(base.snapshot.nodes[1]),
+        ],
+      },
+    });
+    render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={selectCell(EMPTY_USAGE_FILTER, {
+          clusterId: "cluster-b",
+          outcome: null,
+        })}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />
+    );
+    // The unlabeled node is the one the sentinel selects; it still renders.
+    expect(
+      screen.getByRole("button", { name: /graph node session-b/i })
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -17,12 +17,60 @@ const { mockUseChatboxTopicMap } = vi.hoisted(() => ({
   mockUseChatboxTopicMap: vi.fn(),
 }));
 
+/**
+ * Minimal 2D-context stub that records every `globalAlpha` assignment.
+ *
+ * Dimming is a canvas concern — `drawNode` expresses it as
+ * `ctx.globalAlpha = dimmed ? 0.16 : 1` — so it is invisible to the DOM unless
+ * the mock actually runs the draw callback. Without this, a test can only assert
+ * that nodes render at all, which stays green even if filtering is deleted.
+ */
+function makeRecordingCtx() {
+  const alphas: number[] = [];
+  const noop = () => {};
+  const ctx = {
+    save: noop,
+    restore: noop,
+    beginPath: noop,
+    closePath: noop,
+    arc: noop,
+    arcTo: noop,
+    moveTo: noop,
+    lineTo: noop,
+    fill: noop,
+    stroke: noop,
+    fillRect: noop,
+    fillText: noop,
+    measureText: () => ({ width: 10 }),
+    createRadialGradient: () => ({ addColorStop: noop }),
+    globalCompositeOperation: "",
+    shadowColor: "",
+    shadowBlur: 0,
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 0,
+    font: "",
+    set globalAlpha(value: number) {
+      alphas.push(value);
+    },
+    get globalAlpha() {
+      return alphas[alphas.length - 1] ?? 1;
+    },
+  };
+  return { ctx, alphas };
+}
+
 vi.mock("react-force-graph-2d", async () => {
   const React = await import("react");
   return {
     default: React.forwardRef(function MockForceGraph2D(
       props: {
         graphData?: { nodes?: Array<{ id: string }> };
+        nodeCanvasObject?: (
+          node: unknown,
+          ctx: unknown,
+          globalScale: number
+        ) => void;
         onNodeClick?: (node: { id: string }) => void;
         onBackgroundClick?: () => void;
       },
@@ -40,20 +88,40 @@ vi.mock("react-force-graph-2d", async () => {
           >
             Graph background
           </button>
-          {(props.graphData?.nodes ?? []).map((node) => (
-            <button
-              key={node.id}
-              type="button"
-              onClick={() => props.onNodeClick?.(node)}
-            >
-              Graph node {node.id}
-            </button>
-          ))}
+          {(props.graphData?.nodes ?? []).map((node) => {
+            // Run the real draw callback against a recording context so each
+            // node's dimmed state becomes assertable from the DOM. The first
+            // globalAlpha write is the dim decision.
+            const { ctx, alphas } = makeRecordingCtx();
+            try {
+              props.nodeCanvasObject?.(node, ctx, 1);
+            } catch {
+              // A draw failure must not silently mask the other assertions.
+            }
+            return (
+              <button
+                key={node.id}
+                type="button"
+                data-node-alpha={String(alphas[0] ?? 1)}
+                onClick={() => props.onNodeClick?.(node)}
+              >
+                Graph node {node.id}
+              </button>
+            );
+          })}
         </div>
       );
     }),
   };
 });
+
+/** True when the mock recorded this node as drawn dimmed. */
+function isNodeDimmed(sessionId: string): boolean {
+  const node = screen.getByRole("button", {
+    name: new RegExp(`graph node ${sessionId}`, "i"),
+  });
+  return Number(node.getAttribute("data-node-alpha")) < 1;
+}
 
 vi.mock("@/hooks/useChatboxTopicMap", () => ({
   useChatboxTopicMap: (...args: unknown[]) => mockUseChatboxTopicMap(...args),
@@ -690,35 +758,54 @@ describe("ChatboxTopicMapPanel color-by mode", () => {
 });
 
 describe("ChatboxTopicMapPanel outcome narrowing", () => {
-  it("dims nodes outside the selected outcome, not just outside the goal", () => {
-    // Before this, clicking an outcome cell highlighted the goal and left every
-    // outcome inside it lit — the map disagreed with the grid about what was
-    // selected. Nodes now carry an outcome, so the map can honor the chip.
-    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
-    const { container } = render(
+  function renderWithFilter(filter: UsageFilterState) {
+    return render(
       <ChatboxTopicMapPanel
         chatboxId="chatbox-1"
-        filter={selectCell(EMPTY_USAGE_FILTER, {
-          clusterId: "cluster-a",
-          outcome: "unresolved",
-        })}
+        filter={filter}
         onToggleChip={vi.fn()}
         onClearChip={vi.fn()}
         onRebuild={vi.fn()}
       />
     );
-    // session-a is cluster-a/completed, so the unresolved chip excludes it.
-    // Both nodes still render; dimming is a canvas concern, so assert via the
-    // exported colour helper that the two are distinguishable at all.
-    expect(container).toBeTruthy();
-    expect(
-      colorForNode({ clusterId: "cluster-a", outcome: "completed" }, "outcome")
-    ).not.toBe(
-      colorForNode({ clusterId: "cluster-a", outcome: "unresolved" }, "outcome")
+  }
+
+  it("dims nodes outside the selected outcome, not just outside the goal", () => {
+    // session-a is cluster-a/completed; session-b is cluster-b/unresolved.
+    // Selecting cluster-a/unresolved must leave NOTHING lit in cluster-a —
+    // previously the goal chip lit every outcome inside it.
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    renderWithFilter(
+      selectCell(EMPTY_USAGE_FILTER, {
+        clusterId: "cluster-a",
+        outcome: "unresolved",
+      })
     );
+    expect(isNodeDimmed("session-a")).toBe(true);
+    expect(isNodeDimmed("session-b")).toBe(true);
   });
 
-  it("treats the unlabeled sentinel as selecting nodes with no outcome", () => {
+  it("leaves the matching node lit", () => {
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    renderWithFilter(
+      selectCell(EMPTY_USAGE_FILTER, {
+        clusterId: "cluster-a",
+        outcome: "completed",
+      })
+    );
+    expect(isNodeDimmed("session-a")).toBe(false);
+    // Different goal AND different outcome.
+    expect(isNodeDimmed("session-b")).toBe(true);
+  });
+
+  it("dims nothing when no cell is selected", () => {
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    renderWithFilter(EMPTY_USAGE_FILTER);
+    expect(isNodeDimmed("session-a")).toBe(false);
+    expect(isNodeDimmed("session-b")).toBe(false);
+  });
+
+  it("selects nodes with no outcome for the unlabeled sentinel", () => {
     const base = outcomeAwareHookValue();
     mockUseChatboxTopicMap.mockReturnValue({
       ...base,
@@ -726,26 +813,38 @@ describe("ChatboxTopicMapPanel outcome narrowing", () => {
         ...base.snapshot,
         nodes: [
           base.snapshot.nodes[0],
-          // A node with no outcome at all.
-          (({ outcome: _o, ...rest }) => rest)(base.snapshot.nodes[1]),
+          // session-b carries no outcome at all.
+          (({ outcome: _outcome, ...rest }) => rest)(base.snapshot.nodes[1]),
         ],
       },
     });
-    render(
-      <ChatboxTopicMapPanel
-        chatboxId="chatbox-1"
-        filter={selectCell(EMPTY_USAGE_FILTER, {
-          clusterId: "cluster-b",
-          outcome: null,
-        })}
-        onToggleChip={vi.fn()}
-        onClearChip={vi.fn()}
-        onRebuild={vi.fn()}
-      />
+    renderWithFilter(
+      selectCell(EMPTY_USAGE_FILTER, {
+        clusterId: "cluster-b",
+        outcome: null,
+      })
     );
-    // The unlabeled node is the one the sentinel selects; it still renders.
-    expect(
-      screen.getByRole("button", { name: /graph node session-b/i })
-    ).toBeInTheDocument();
+    // The unanalyzed node in the selected goal is the one that stays lit.
+    expect(isNodeDimmed("session-b")).toBe(false);
+    expect(isNodeDimmed("session-a")).toBe(true);
+  });
+
+  it("does not dim the whole map on a pre-bump snapshot", () => {
+    // A v1 snapshot has no outcome on any node, so a concrete outcome chip
+    // would match nothing and blank the canvas — which reads as a broken map
+    // rather than as stale data. The snapshot cannot honor the constraint, so
+    // it is exempt from it; the cluster chip still narrows.
+    mockUseChatboxTopicMap.mockReturnValue(
+      createDefaultChatboxTopicMapHookValue()
+    );
+    renderWithFilter(
+      selectCell(EMPTY_USAGE_FILTER, {
+        clusterId: "cluster-a",
+        outcome: "unresolved",
+      })
+    );
+    expect(isNodeDimmed("session-a")).toBe(false);
+    // The cluster constraint is still applied.
+    expect(isNodeDimmed("session-b")).toBe(true);
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -27,6 +27,7 @@ const { mockUseChatboxTopicMap } = vi.hoisted(() => ({
  */
 function makeRecordingCtx() {
   const alphas: number[] = [];
+  const gradientStops: string[] = [];
   const noop = () => {};
   const ctx = {
     save: noop,
@@ -42,7 +43,11 @@ function makeRecordingCtx() {
     fillRect: noop,
     fillText: noop,
     measureText: () => ({ width: 10 }),
-    createRadialGradient: () => ({ addColorStop: noop }),
+    createRadialGradient: () => ({
+      addColorStop: (_offset: number, color: string) => {
+        gradientStops.push(color);
+      },
+    }),
     globalCompositeOperation: "",
     shadowColor: "",
     shadowBlur: 0,
@@ -57,7 +62,7 @@ function makeRecordingCtx() {
       return alphas[alphas.length - 1] ?? 1;
     },
   };
-  return { ctx, alphas };
+  return { ctx, alphas, gradientStops };
 }
 
 vi.mock("react-force-graph-2d", async () => {
@@ -71,6 +76,7 @@ vi.mock("react-force-graph-2d", async () => {
           ctx: unknown,
           globalScale: number
         ) => void;
+        onRenderFramePre?: (ctx: unknown) => void;
         onNodeClick?: (node: { id: string }) => void;
         onBackgroundClick?: () => void;
       },
@@ -79,8 +85,19 @@ vi.mock("react-force-graph-2d", async () => {
       React.useImperativeHandle(ref, () => ({
         zoomToFit: vi.fn(),
       }));
+      // Halos are drawn in onRenderFramePre as radial gradients; record their
+      // colour stops so "what colour is this cluster's halo" is assertable.
+      const frame = makeRecordingCtx();
+      try {
+        props.onRenderFramePre?.(frame.ctx);
+      } catch {
+        // Ignore: halo drawing must not mask the node assertions.
+      }
       return (
-        <div data-testid="force-graph">
+        <div
+          data-testid="force-graph"
+          data-halo-colors={frame.gradientStops.join(",")}
+        >
           <button
             type="button"
             data-testid="force-graph-background"
@@ -114,6 +131,15 @@ vi.mock("react-force-graph-2d", async () => {
     }),
   };
 });
+
+/** Colours the halo gradients were painted with this render. */
+function haloColors(): string[] {
+  return (
+    screen.getByTestId("force-graph").getAttribute("data-halo-colors") ?? ""
+  )
+    .split(",")
+    .filter(Boolean);
+}
 
 /** True when the mock recorded this node as drawn dimmed. */
 function isNodeDimmed(sessionId: string): boolean {
@@ -846,5 +872,48 @@ describe("ChatboxTopicMapPanel outcome narrowing", () => {
     expect(isNodeDimmed("session-a")).toBe(false);
     // The cluster constraint is still applied.
     expect(isNodeDimmed("session-b")).toBe(true);
+  });
+});
+
+describe("ChatboxTopicMapPanel cluster halos", () => {
+  function renderPanel() {
+    return render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_USAGE_FILTER}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />
+    );
+  }
+
+  it("paints halos with the theme colour in both modes", async () => {
+    // A halo denotes the CLUSTER. Deriving it from a member node's colour means
+    // that in outcome mode a mixed-outcome cluster gets whichever outcome the
+    // first-iterated node had — an order-dependent halo asserting one outcome
+    // for the whole goal. Halos are therefore mode-independent.
+    const user = userEvent.setup();
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    renderPanel();
+
+    const themeHalos = haloColors();
+    expect(themeHalos.length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("button", { name: "Outcome" }));
+    expect(haloColors()).toEqual(themeHalos);
+  });
+
+  it("does not paint an outcome colour into a halo", () => {
+    // session-a is `completed`; its outcome colour must not reach the halo.
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    renderPanel();
+    const completedColor = colorForNode(
+      { clusterId: "cluster-a", outcome: "completed" },
+      "outcome"
+    );
+    for (const stop of haloColors()) {
+      expect(stop).not.toContain(completedColor.replace("#", ""));
+    }
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -3,6 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ChatboxTopicMapPanel,
+  NO_OUTCOME_COLOR,
+  colorForNode,
   topicMapNodeHoverLabel,
 } from "../ChatboxTopicMapPanel";
 import type { UsageFilterState } from "@/hooks/chatbox-usage-filters";
@@ -180,6 +182,28 @@ function createDefaultChatboxTopicMapHookValue() {
     snapshotError: null,
     isLoading: false,
     metadata: null,
+  };
+}
+
+/**
+ * A snapshot at the version that first carries `nodes[].outcome`. The default
+ * fixture stays at version 1 on purpose so the pre-bump regression path keeps
+ * being exercised.
+ */
+function outcomeAwareHookValue() {
+  const base = createDefaultChatboxTopicMapHookValue();
+  return {
+    ...base,
+    latestRun: { ...base.latestRun, topicMapVersion: 2, signalsVersion: 1 },
+    snapshotMetadata: { ...base.snapshotMetadata, topicMapVersion: 2 },
+    snapshot: {
+      ...base.snapshot,
+      version: 2,
+      nodes: [
+        { ...base.snapshot.nodes[0], outcome: "completed" as const },
+        { ...base.snapshot.nodes[1], outcome: "unresolved" as const },
+      ],
+    },
   };
 }
 
@@ -466,5 +490,170 @@ describe("ChatboxTopicMapPanel", () => {
 
     await user.click(screen.getByTestId("force-graph-background"));
     expect(graphHost).toHaveAttribute("data-selected-session", "");
+  });
+});
+
+describe("colorForNode", () => {
+  it("colors by cluster in theme mode", () => {
+    const themed = colorForNode(
+      { clusterId: "cluster-a", outcome: "errored" },
+      "theme",
+      0,
+    );
+    // Theme mode must ignore outcome entirely — colorForCluster's path is
+    // unchanged by the outcome feature.
+    expect(themed).not.toBe(NO_OUTCOME_COLOR);
+    expect(themed).toBe(colorForNode({ clusterId: "cluster-a" }, "theme", 0));
+  });
+
+  it("colors by outcome in outcome mode, ignoring the cluster", () => {
+    const completed = colorForNode(
+      { clusterId: "cluster-a", outcome: "completed" },
+      "outcome",
+      0,
+    );
+    const errored = colorForNode(
+      { clusterId: "cluster-a", outcome: "errored" },
+      "outcome",
+      0,
+    );
+    expect(completed).not.toBe(errored);
+    // Same outcome in a different cluster is the same color: that is the point.
+    expect(
+      colorForNode({ clusterId: "cluster-b", outcome: "completed" }, "outcome", 5),
+    ).toBe(completed);
+  });
+
+  it("renders an absent outcome as neutral rather than a bucket", () => {
+    // A node on a pre-bump snapshot, or a session whose signals never
+    // extracted. Neither is a verdict, so neither may be painted as one.
+    expect(colorForNode({ clusterId: "cluster-a" }, "outcome", 0)).toBe(
+      NO_OUTCOME_COLOR,
+    );
+  });
+
+  it("renders unclear with the same neutral as no outcome at all", () => {
+    expect(
+      colorForNode({ clusterId: "cluster-a", outcome: "unclear" }, "outcome", 0),
+    ).toBe(NO_OUTCOME_COLOR);
+  });
+
+  it("falls back to neutral for an unrecognized outcome value", () => {
+    expect(
+      colorForNode(
+        { clusterId: "cluster-a", outcome: "something-new" },
+        "outcome",
+        0,
+      ),
+    ).toBe(NO_OUTCOME_COLOR);
+  });
+});
+
+describe("ChatboxTopicMapPanel color-by mode", () => {
+  function renderPanel() {
+    return render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_FILTER}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />,
+    );
+  }
+
+  it("defaults to theme and offers an outcome toggle", () => {
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    renderPanel();
+
+    expect(screen.getByRole("button", { name: "Theme" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Outcome" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("shows the outcome legend once outcome mode is active", async () => {
+    const user = userEvent.setup();
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    renderPanel();
+
+    expect(screen.queryByText("Unresolved")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Outcome" }));
+
+    expect(screen.getByRole("button", { name: "Outcome" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByText("Unresolved")).toBeInTheDocument();
+    expect(screen.getByText("Unclear / not analyzed")).toBeInTheDocument();
+  });
+
+  it("disables outcome mode on a pre-bump snapshot instead of painting it neutral", () => {
+    // version 1 blobs carry no `outcome` on their nodes. Offering the mode
+    // would paint every node grey and read as a bug rather than stale data.
+    mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+    renderPanel();
+
+    expect(screen.getByRole("button", { name: "Outcome" })).toBeDisabled();
+  });
+
+  it("still renders a pre-bump snapshot normally", () => {
+    mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+    renderPanel();
+
+    expect(screen.getByText("Password resets")).toBeInTheDocument();
+    expect(screen.getByTestId("force-graph")).toBeInTheDocument();
+  });
+
+  it("explains an empty legend when no mapped session has an outcome", async () => {
+    const user = userEvent.setup();
+    const base = outcomeAwareHookValue();
+    mockUseChatboxTopicMap.mockReturnValue({
+      ...base,
+      snapshot: {
+        ...base.snapshot,
+        nodes: base.snapshot.nodes.map(
+          ({ outcome: _outcome, ...node }) => node,
+        ),
+      },
+    });
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Outcome" }));
+    expect(
+      screen.getByText("No mapped session has an inferred outcome yet."),
+    ).toBeInTheDocument();
+  });
+
+  it("reverts to theme if the snapshot stops supporting outcomes", async () => {
+    const user = userEvent.setup();
+    mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
+    const { rerender } = renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Outcome" }));
+    expect(screen.getByRole("button", { name: "Outcome" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+    rerender(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_FILTER}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Theme" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -96,7 +96,7 @@ vi.mock("react-force-graph-2d", async () => {
       return (
         <div
           data-testid="force-graph"
-          data-halo-colors={frame.gradientStops.join(",")}
+          data-halo-colors={frame.gradientStops.join("|")}
         >
           <button
             type="button"
@@ -135,10 +135,24 @@ vi.mock("react-force-graph-2d", async () => {
 /** Colours the halo gradients were painted with this render. */
 function haloColors(): string[] {
   return (
-    screen.getByTestId("force-graph").getAttribute("data-halo-colors") ?? ""
-  )
-    .split(",")
-    .filter(Boolean);
+    (screen.getByTestId("force-graph").getAttribute("data-halo-colors") ?? "")
+      // "|" and not "," — a colour string like "rgba(251, 113, 133, 0.08)" has
+      // commas in it, so splitting on those shreds each stop into fragments.
+      .split("|")
+      .filter(Boolean)
+  );
+}
+
+/**
+ * A hex colour as `hexToRgba` renders its channels: "#4ade80" -> "74, 222, 128".
+ * Halo gradients carry decimal rgba(), so hex substrings never match them.
+ */
+function rgbTriple(hex: string): string {
+  const value = hex.replace("#", "");
+  const red = Number.parseInt(value.slice(0, 2), 16);
+  const green = Number.parseInt(value.slice(2, 4), 16);
+  const blue = Number.parseInt(value.slice(4, 6), 16);
+  return `${red}, ${green}, ${blue}`;
 }
 
 /** True when the mock recorded this node as drawn dimmed. */
@@ -904,16 +918,35 @@ describe("ChatboxTopicMapPanel cluster halos", () => {
     expect(haloColors()).toEqual(themeHalos);
   });
 
-  it("does not paint an outcome colour into a halo", () => {
-    // session-a is `completed`; its outcome colour must not reach the halo.
+  it("does not paint an outcome colour into a halo", async () => {
+    // Two things this test has to get right to mean anything:
+    //  1. Compare decimal RGB triples, not hex. The gradient is built with
+    //     hexToRgba, which emits `rgba(74, 222, 128, …)`, so asserting against
+    //     the hex substring "4ade80" could never fail whatever colour was used.
+    //  2. Assert in OUTCOME mode. In theme mode a node's colour already IS the
+    //     cluster colour, so the bug this guards against cannot show up there.
+    const user = userEvent.setup();
     mockUseChatboxTopicMap.mockReturnValue(outcomeAwareHookValue());
     renderPanel();
-    const completedColor = colorForNode(
-      { clusterId: "cluster-a", outcome: "completed" },
-      "outcome"
+    await user.click(screen.getByRole("button", { name: "Outcome" }));
+
+    const outcomeRgb = rgbTriple(
+      colorForNode({ clusterId: "cluster-a", outcome: "completed" }, "outcome")
     );
-    for (const stop of haloColors()) {
-      expect(stop).not.toContain(completedColor.replace("#", ""));
+    const themeRgb = rgbTriple(
+      colorForNode({ clusterId: "cluster-a" }, "theme", 0)
+    );
+    // If these ever coincide the assertions below prove nothing, so say so
+    // loudly rather than passing for the wrong reason.
+    expect(outcomeRgb).not.toBe(themeRgb);
+
+    const stops = haloColors().filter((stop) => !stop.startsWith("rgba(0,0,0"));
+    expect(stops.length).toBeGreaterThan(0);
+    // The theme colour is present...
+    expect(stops.some((stop) => stop.includes(themeRgb))).toBe(true);
+    // ...and no outcome colour is.
+    for (const stop of stops) {
+      expect(stop).not.toContain(outcomeRgb);
     }
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxUsagePanel.cell-selection.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxUsagePanel.cell-selection.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * Panel-level wiring for goal × outcome cell selection.
+ *
+ * Pins the regression the per-component tests could not see: the breakdown
+ * query that RENDERS the grid must never receive the grid's own cell-selection
+ * chips. Those chips are the grid's output — feeding them back re-runs the
+ * scan filtered to the clicked cell, which collapses the grid to a single row
+ * whose other cells count 0 and disable. The drill-down and the session list
+ * are the opposite: narrowing to the cell is their entire job, so they must
+ * keep the full filter. Only a test that renders the panel (where the two
+ * filters diverge) can observe the difference, which is why this file exists
+ * alongside 50-odd green component tests that missed it.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatboxUsagePanel } from "../ChatboxUsagePanel";
+import {
+  chipKey,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+import type { GoalFacet, UsageBreakdown } from "@/hooks/useUsageInsights";
+
+const { mockUseUsageInsights, mockUseGoalOutcomeDrilldown } = vi.hoisted(
+  () => ({
+    mockUseUsageInsights: vi.fn(),
+    mockUseGoalOutcomeDrilldown: vi.fn(),
+  })
+);
+
+vi.mock("@/hooks/useUsageInsights", () => ({
+  useUsageInsights: (...args: unknown[]) => mockUseUsageInsights(...args),
+  useGoalOutcomeDrilldown: (...args: unknown[]) =>
+    mockUseGoalOutcomeDrilldown(...args),
+}));
+
+// The topic map pulls in react-force-graph-2d and owns no behavior under test
+// here; its chip-driven dimming is covered by its own test file.
+vi.mock("@/components/chatboxes/ChatboxTopicMapPanel", () => ({
+  ChatboxTopicMapPanel: () => null,
+}));
+
+// Sessions-tab components: imported by the panel but never rendered in the
+// insights section; stubbed to keep the module graph out of this test.
+vi.mock("@/components/connection/share-usage/ShareUsageThreadList", () => ({
+  ShareUsageThreadList: () => null,
+}));
+vi.mock("@/components/connection/share-usage/ShareUsageThreadDetail", () => ({
+  ShareUsageThreadDetail: () => null,
+}));
+
+function facet(overrides: Partial<GoalFacet> = {}): GoalFacet {
+  return {
+    clusterId: "cluster-a",
+    label: "Invoice lookup",
+    total: 10,
+    outcomes: {
+      completed: 3,
+      partial: 0,
+      unresolved: 5,
+      errored: 2,
+      unclear: 0,
+    },
+    unlabeled: 0,
+    unresolvedRate: 0.7,
+    errorRate: 0.2,
+    retryRate: 0.4,
+    toolDistribution: [],
+    pathDistribution: [],
+    distinctPathCount: 4,
+    routingEntropy: 1.85,
+    ...overrides,
+  };
+}
+
+function breakdown(): UsageBreakdown {
+  return {
+    themes: [],
+    userBreakdown: [],
+    deviceBreakdown: [],
+    languageBreakdown: [],
+    modelBreakdown: [],
+    outcomeBreakdown: [],
+    frictionBreakdown: [],
+    behaviorTagBreakdown: [],
+    goalFacets: [facet()],
+    labeledOutcomeCount: 10,
+    outcomeFeedbackCalibration: [],
+    totalSessions: 10,
+    latestRun: null,
+  };
+}
+
+/** Chip keys of the filter passed to the breakdown-backing hook, last render. */
+function lastBreakdownChipKeys(): string[] {
+  const call = mockUseUsageInsights.mock.calls.at(-1)?.[0] as {
+    filters: UsageFilterState;
+  };
+  return call.filters.chips.map(chipKey);
+}
+
+/** The drill-down hook's args as of the last render. */
+function lastDrilldownArgs(): {
+  clusterId: string | null;
+  outcome: unknown;
+  filters?: UsageFilterState;
+} {
+  return mockUseGoalOutcomeDrilldown.mock.calls.at(-1)?.[0];
+}
+
+function renderInsightsPanel() {
+  return render(
+    <ChatboxUsagePanel
+      chatbox={{ chatboxId: "chatbox-1" } as never}
+      section="insights"
+    />
+  );
+}
+
+beforeEach(() => {
+  mockUseUsageInsights.mockReset();
+  mockUseGoalOutcomeDrilldown.mockReset();
+  mockUseUsageInsights.mockReturnValue({
+    threads: undefined,
+    breakdown: breakdown(),
+    rebuild: vi.fn(),
+  });
+  mockUseGoalOutcomeDrilldown.mockReturnValue({
+    drilldown: { sessions: [], nextBefore: null, total: 5, totalTruncated: false },
+    isLoading: false,
+  });
+});
+
+describe("ChatboxUsagePanel cell selection", () => {
+  it("never feeds the cell-selection chips back into the breakdown query", async () => {
+    const user = userEvent.setup();
+    renderInsightsPanel();
+
+    await user.click(
+      screen.getByRole("button", { name: /Unresolved: 5 sessions/ })
+    );
+
+    const keys = lastBreakdownChipKeys();
+    // The grid's own selection must not filter the grid's input…
+    expect(keys).not.toContain("cluster:cluster-a");
+    expect(keys.some((key) => key.startsWith("outcome:"))).toBe(false);
+    // …while chips from other dimensions (here the forced synthetic:hide)
+    // still narrow it.
+    expect(keys).toContain("synthetic:hide");
+  });
+
+  it("gives the drill-down the full filter, cell chips included", async () => {
+    const user = userEvent.setup();
+    renderInsightsPanel();
+
+    await user.click(
+      screen.getByRole("button", { name: /Unresolved: 5 sessions/ })
+    );
+
+    const args = lastDrilldownArgs();
+    expect(args.clusterId).toBe("cluster-a");
+    expect(args.outcome).toBe("unresolved");
+    const keys = (args.filters?.chips ?? []).map(chipKey);
+    expect(keys).toContain("cluster:cluster-a");
+    expect(keys).toContain("outcome:unresolved");
+    expect(keys).toContain("synthetic:hide");
+  });
+
+  it("still highlights the selected cell even though the breakdown filter is stripped", async () => {
+    // The grid's highlight reads the UNstripped user filter; stripping must
+    // apply to the breakdown query alone.
+    const user = userEvent.setup();
+    renderInsightsPanel();
+
+    const cell = screen.getByRole("button", {
+      name: /Unresolved: 5 sessions/,
+    });
+    await user.click(cell);
+    expect(cell).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("strips the breakdown filter again for the not-analyzed cell's sentinel chip", async () => {
+    mockUseUsageInsights.mockReturnValue({
+      threads: undefined,
+      breakdown: {
+        ...breakdown(),
+        goalFacets: [facet({ unlabeled: 4 })],
+      },
+      rebuild: vi.fn(),
+    });
+    const user = userEvent.setup();
+    renderInsightsPanel();
+
+    await user.click(
+      screen.getByRole("button", { name: /not analyzed: 4 sessions/ })
+    );
+
+    const keys = lastBreakdownChipKeys();
+    expect(keys).not.toContain("cluster:cluster-a");
+    expect(keys.some((key) => key.startsWith("outcome:"))).toBe(false);
+    // And the drill-down still gets the null-outcome cell.
+    expect(lastDrilldownArgs().outcome).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxUsagePanel.cell-selection.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxUsagePanel.cell-selection.test.tsx
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatboxUsagePanel } from "../ChatboxUsagePanel";
 import {
   chipKey,
+  type UsageFilterChip,
   type UsageFilterState,
 } from "@/hooks/chatbox-usage-filters";
 import type { GoalFacet, UsageBreakdown } from "@/hooks/useUsageInsights";
@@ -35,9 +36,30 @@ vi.mock("@/hooks/useUsageInsights", () => ({
 }));
 
 // The topic map pulls in react-force-graph-2d and owns no behavior under test
-// here; its chip-driven dimming is covered by its own test file.
+// here; its chip-driven dimming is covered by its own test file. It is stubbed
+// down to the one thing this file needs: the `onToggleChip` callback the real
+// map fires when a community is clicked, which writes a CLUSTER chip — the same
+// dimension the grid's cell selection writes. That collision is what the
+// map-originated tests below exercise.
 vi.mock("@/components/chatboxes/ChatboxTopicMapPanel", () => ({
-  ChatboxTopicMapPanel: () => null,
+  ChatboxTopicMapPanel: ({
+    onToggleChip,
+  }: {
+    onToggleChip: (chip: UsageFilterChip) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onToggleChip({
+          kind: "cluster",
+          clusterId: "cluster-b",
+          label: "Refund status",
+        })
+      }
+    >
+      pick map community
+    </button>
+  ),
 }));
 
 // Sessions-tab components: imported by the panel but never rendered in the
@@ -200,5 +222,36 @@ describe("ChatboxUsagePanel cell selection", () => {
     expect(keys.some((key) => key.startsWith("outcome:"))).toBe(false);
     // And the drill-down still gets the null-outcome cell.
     expect(lastDrilldownArgs().outcome).toBeNull();
+  });
+
+  // The grid is not the only writer of cluster chips: the topic map writes one
+  // when a community is clicked, and the insights strip does too. Stripping the
+  // cluster DIMENSION to keep the grid from filtering itself therefore also
+  // discarded those, and picking a community silently stopped narrowing the
+  // grid. Only the open cell's own chips may be subtracted.
+  it("keeps a map-originated cluster chip in the breakdown query when no cell is open", async () => {
+    const user = userEvent.setup();
+    renderInsightsPanel();
+
+    await user.click(screen.getByRole("button", { name: "pick map community" }));
+
+    expect(lastBreakdownChipKeys()).toContain("cluster:cluster-b");
+  });
+
+  it("subtracts only the open cell's cluster chip, not a map community's", async () => {
+    const user = userEvent.setup();
+    renderInsightsPanel();
+
+    // Cell first: selecting one replaces any prior cluster narrowing, so a map
+    // chip added before this click would legitimately be gone.
+    await user.click(
+      screen.getByRole("button", { name: /Unresolved: 5 sessions/ })
+    );
+    await user.click(screen.getByRole("button", { name: "pick map community" }));
+
+    const keys = lastBreakdownChipKeys();
+    expect(keys).toContain("cluster:cluster-b");
+    expect(keys).not.toContain("cluster:cluster-a");
+    expect(keys.some((key) => key.startsWith("outcome:"))).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-cells.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-cells.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_USAGE_FILTER,
+  chipKey,
+  isCellSelected,
+  selectCell,
+  threadMatchesChip,
+  threadMatchesFilterState,
+  toggleChip,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+import type { SharedChatThread } from "@/hooks/useSharedChatThreads";
+
+function thread(overrides: Partial<SharedChatThread> = {}): SharedChatThread {
+  return {
+    _id: "s1",
+    sourceType: "chatbox",
+    chatSessionId: "cs1",
+    messageCount: 4,
+    startedAt: 0,
+    lastActivityAt: 0,
+    ...overrides,
+  } as SharedChatThread;
+}
+
+const CELL_A_UNRESOLVED = {
+  clusterId: "cluster-a",
+  clusterLabel: "Invoice lookup",
+  outcome: "unresolved" as const,
+};
+const CELL_B_ERRORED = {
+  clusterId: "cluster-b",
+  clusterLabel: "Refunds",
+  outcome: "errored" as const,
+};
+
+describe("selectCell", () => {
+  it("selects one cell as a cluster chip plus an outcome chip", () => {
+    const next = selectCell(EMPTY_USAGE_FILTER, CELL_A_UNRESOLVED);
+    expect(next.chips.map(chipKey).sort()).toEqual([
+      "cluster:cluster-a",
+      "outcome:unresolved",
+    ]);
+  });
+
+  it("NARROWS to exactly one cell when a second cell is clicked", () => {
+    // The reason this is not two toggleChip calls. Chips OR within a dimension,
+    // so toggling would leave two cluster chips and two outcome chips active —
+    // matching four cells instead of the one the user clicked.
+    const first = selectCell(EMPTY_USAGE_FILTER, CELL_A_UNRESOLVED);
+    const second = selectCell(first, CELL_B_ERRORED);
+
+    expect(second.chips.map(chipKey).sort()).toEqual([
+      "cluster:cluster-b",
+      "outcome:errored",
+    ]);
+    expect(isCellSelected(second, CELL_B_ERRORED)).toBe(true);
+    expect(isCellSelected(second, CELL_A_UNRESOLVED)).toBe(false);
+  });
+
+  it("widens rather than narrows if toggleChip is used instead — the bug this avoids", () => {
+    // Pinned as a contrast case: if a future refactor reaches for toggleChip
+    // here, this documents concretely what goes wrong.
+    let widened: UsageFilterState = EMPTY_USAGE_FILTER;
+    for (const cell of [CELL_A_UNRESOLVED, CELL_B_ERRORED]) {
+      widened = toggleChip(widened, {
+        kind: "cluster",
+        clusterId: cell.clusterId,
+      });
+      widened = toggleChip(widened, {
+        kind: "dimension",
+        key: "outcome",
+        value: cell.outcome,
+      });
+    }
+
+    // A session from cluster-a with the OTHER cell's outcome now matches,
+    // which is a cell the user never clicked.
+    const crossCell = thread({
+      themeClusterId: "cluster-a",
+      outcome: "errored",
+    });
+    expect(threadMatchesFilterState(crossCell, widened)).toBe(true);
+    // selectCell does not have that problem.
+    const narrowed = selectCell(
+      selectCell(EMPTY_USAGE_FILTER, CELL_A_UNRESOLVED),
+      CELL_B_ERRORED
+    );
+    expect(threadMatchesFilterState(crossCell, narrowed)).toBe(false);
+  });
+
+  it("clears the selection when the selected cell is clicked again", () => {
+    const selected = selectCell(EMPTY_USAGE_FILTER, CELL_A_UNRESOLVED);
+    const cleared = selectCell(selected, CELL_A_UNRESOLVED);
+    expect(cleared.chips).toEqual([]);
+    expect(isCellSelected(cleared, CELL_A_UNRESOLVED)).toBe(false);
+  });
+
+  it("preserves chips from other dimensions", () => {
+    const withSynthetic = toggleChip(EMPTY_USAGE_FILTER, {
+      kind: "dimension",
+      key: "synthetic",
+      value: "hide",
+    });
+    const next = selectCell(withSynthetic, CELL_A_UNRESOLVED);
+    expect(next.chips.map(chipKey)).toContain("synthetic:hide");
+    expect(next.chips.map(chipKey)).toContain("cluster:cluster-a");
+  });
+
+  it("preserves the preset", () => {
+    const next = selectCell(
+      { preset: "needs_review", chips: [] },
+      CELL_A_UNRESOLVED
+    );
+    expect(next.preset).toBe("needs_review");
+  });
+
+  it("represents the not-analyzed cell as a cluster chip with no outcome chip", () => {
+    // Absence cannot be expressed as an outcome chip — no value matches a
+    // missing field — so this cell carries only the cluster narrowing.
+    const next = selectCell(EMPTY_USAGE_FILTER, {
+      clusterId: "cluster-a",
+      outcome: null,
+    });
+    expect(next.chips.map(chipKey)).toEqual(["cluster:cluster-a"]);
+    expect(
+      isCellSelected(next, { clusterId: "cluster-a", outcome: null })
+    ).toBe(true);
+  });
+
+  it("does not confuse the not-analyzed cell with the unclear cell", () => {
+    const notAnalyzed = selectCell(EMPTY_USAGE_FILTER, {
+      clusterId: "cluster-a",
+      outcome: null,
+    });
+    expect(
+      isCellSelected(notAnalyzed, {
+        clusterId: "cluster-a",
+        outcome: "unclear",
+      })
+    ).toBe(false);
+
+    const unclear = selectCell(EMPTY_USAGE_FILTER, {
+      clusterId: "cluster-a",
+      outcome: "unclear",
+    });
+    expect(
+      isCellSelected(unclear, { clusterId: "cluster-a", outcome: null })
+    ).toBe(false);
+  });
+
+  it("switches from the not-analyzed cell to a concrete outcome cell cleanly", () => {
+    const notAnalyzed = selectCell(EMPTY_USAGE_FILTER, {
+      clusterId: "cluster-a",
+      outcome: null,
+    });
+    const concrete = selectCell(notAnalyzed, CELL_A_UNRESOLVED);
+    expect(concrete.chips.map(chipKey).sort()).toEqual([
+      "cluster:cluster-a",
+      "outcome:unresolved",
+    ]);
+  });
+});
+
+describe("isCellSelected", () => {
+  it("is false when two clusters are selected", () => {
+    const widened = toggleChip(
+      toggleChip(EMPTY_USAGE_FILTER, {
+        kind: "cluster",
+        clusterId: "cluster-a",
+      }),
+      { kind: "cluster", clusterId: "cluster-b" }
+    );
+    expect(
+      isCellSelected(widened, {
+        clusterId: "cluster-a",
+        outcome: null,
+      })
+    ).toBe(false);
+  });
+
+  it("is false for an empty filter", () => {
+    expect(isCellSelected(EMPTY_USAGE_FILTER, CELL_A_UNRESOLVED)).toBe(false);
+  });
+});
+
+describe("goal-facet chip matching", () => {
+  it("matches outcome by equality and never matches an absent one", () => {
+    expect(
+      threadMatchesChip(thread({ outcome: "unresolved" }), {
+        kind: "dimension",
+        key: "outcome",
+        value: "unresolved",
+      })
+    ).toBe(true);
+    // A thread with no recorded outcome is not in the `unclear` bucket.
+    expect(
+      threadMatchesChip(thread({}), {
+        kind: "dimension",
+        key: "outcome",
+        value: "unclear",
+      })
+    ).toBe(false);
+  });
+
+  it("matches behaviorTag by array-contains", () => {
+    const tagged = thread({ behaviorTags: ["retried", "errored_tool"] });
+    expect(
+      threadMatchesChip(tagged, {
+        kind: "dimension",
+        key: "behaviorTag",
+        value: "errored_tool",
+      })
+    ).toBe(true);
+    expect(
+      threadMatchesChip(tagged, {
+        kind: "dimension",
+        key: "behaviorTag",
+        value: "looping",
+      })
+    ).toBe(false);
+    expect(
+      threadMatchesChip(thread({}), {
+        kind: "dimension",
+        key: "behaviorTag",
+        value: "retried",
+      })
+    ).toBe(false);
+  });
+
+  it("matches friction and pathKey by equality", () => {
+    const t = thread({
+      friction: "missing_capability",
+      pathKey: "search→get",
+    });
+    expect(
+      threadMatchesChip(t, {
+        kind: "dimension",
+        key: "friction",
+        value: "missing_capability",
+      })
+    ).toBe(true);
+    expect(
+      threadMatchesChip(t, {
+        kind: "dimension",
+        key: "pathKey",
+        value: "search→get",
+      })
+    ).toBe(true);
+  });
+
+  it("ORs multiple behaviorTag chips within the dimension", () => {
+    const t = thread({ behaviorTags: ["looping"] });
+    expect(
+      threadMatchesFilterState(t, {
+        preset: "all",
+        chips: [
+          { kind: "dimension", key: "behaviorTag", value: "retried" },
+          { kind: "dimension", key: "behaviorTag", value: "looping" },
+        ],
+      })
+    ).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-cells.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-cells.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   EMPTY_USAGE_FILTER,
+  UNLABELED_OUTCOME,
   chipKey,
+  clearCellChips,
   isCellSelected,
   selectCell,
   threadMatchesChip,
@@ -115,17 +117,60 @@ describe("selectCell", () => {
     expect(next.preset).toBe("needs_review");
   });
 
-  it("represents the not-analyzed cell as a cluster chip with no outcome chip", () => {
-    // Absence cannot be expressed as an outcome chip — no value matches a
-    // missing field — so this cell carries only the cluster narrowing.
+  it("represents the not-analyzed cell with the unlabeled sentinel chip", () => {
+    // The cell has to be expressible as a chip. A cluster chip ALONE would be a
+    // wider filter — every outcome in that goal — so the drill-down and the
+    // session list would disagree about what the user selected.
     const next = selectCell(EMPTY_USAGE_FILTER, {
       clusterId: "cluster-a",
       outcome: null,
     });
-    expect(next.chips.map(chipKey)).toEqual(["cluster:cluster-a"]);
+    expect(next.chips.map(chipKey).sort()).toEqual([
+      "cluster:cluster-a",
+      `outcome:${UNLABELED_OUTCOME}`,
+    ]);
     expect(
       isCellSelected(next, { clusterId: "cluster-a", outcome: null })
     ).toBe(true);
+  });
+
+  it("narrows the session list to unanalyzed sessions for the not-analyzed cell", () => {
+    // The point of the sentinel: the same filter that drives the drill-down
+    // must also narrow the Sessions list and the map to the same rows.
+    const filter = selectCell(EMPTY_USAGE_FILTER, {
+      clusterId: "cluster-a",
+      outcome: null,
+    });
+    const unanalyzed = thread({ themeClusterId: "cluster-a" });
+    const analyzed = thread({
+      themeClusterId: "cluster-a",
+      outcome: "completed",
+    });
+    const unclear = thread({
+      themeClusterId: "cluster-a",
+      outcome: "unclear",
+    });
+    expect(threadMatchesFilterState(unanalyzed, filter)).toBe(true);
+    expect(threadMatchesFilterState(analyzed, filter)).toBe(false);
+    // `unclear` is a verdict, not an absence — it is a different cell.
+    expect(threadMatchesFilterState(unclear, filter)).toBe(false);
+  });
+
+  it("matches only absence for the sentinel, and only the value otherwise", () => {
+    expect(
+      threadMatchesChip(thread({}), {
+        kind: "dimension",
+        key: "outcome",
+        value: UNLABELED_OUTCOME,
+      })
+    ).toBe(true);
+    expect(
+      threadMatchesChip(thread({ outcome: "completed" }), {
+        kind: "dimension",
+        key: "outcome",
+        value: UNLABELED_OUTCOME,
+      })
+    ).toBe(false);
   });
 
   it("does not confuse the not-analyzed cell with the unclear cell", () => {
@@ -159,6 +204,35 @@ describe("selectCell", () => {
       "cluster:cluster-a",
       "outcome:unresolved",
     ]);
+  });
+});
+
+describe("clearCellChips", () => {
+  it("removes only the cluster and outcome chips", () => {
+    const filter = selectCell(
+      toggleChip(EMPTY_USAGE_FILTER, {
+        kind: "dimension",
+        key: "synthetic",
+        value: "hide",
+      }),
+      CELL_A_UNRESOLVED
+    );
+    const cleared = clearCellChips(filter);
+    expect(cleared.chips.map(chipKey)).toEqual(["synthetic:hide"]);
+  });
+
+  it("is what a re-click must use, so a hand-dismissed chip cannot come back", () => {
+    // The divergence case: chips already dismissed by hand while the panel is
+    // still open. Routing the close through selectCell's chip-derived toggle
+    // would read the cell as unselected and re-ADD the chips while the panel
+    // closes; clearCellChips cannot do that.
+    const openButChipless = clearCellChips(
+      selectCell(EMPTY_USAGE_FILTER, CELL_A_UNRESOLVED)
+    );
+    expect(clearCellChips(openButChipless).chips).toEqual([]);
+    expect(selectCell(openButChipless, CELL_A_UNRESOLVED).chips).toHaveLength(
+      2
+    );
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
+++ b/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
@@ -227,6 +227,40 @@ export function clearCellChips(filter: UsageFilterState): UsageFilterState {
  */
 export const UNLABELED_OUTCOME = "__unlabeled__";
 
+/**
+ * Drop only the chips that the *currently open* cell put there, by identity.
+ *
+ * `clearCellChips` cannot serve this purpose. It strips the cluster dimension
+ * wholesale, but the grid is not the only thing that writes cluster chips — the
+ * topic map (clicking a community) and the usage-insights strip do too. Using it
+ * to build the breakdown's own query therefore silently discarded a
+ * map-originated cluster filter, so selecting a community stopped narrowing the
+ * grid at all. Subtracting the open cell's two chips by value leaves every other
+ * cluster chip, whatever wrote it, intact.
+ *
+ * With `cell` null nothing is removed: no cell is open, so no chip in the filter
+ * is the grid's own output.
+ */
+export function withoutCellChips(
+  filter: UsageFilterState,
+  cell: { clusterId: string; outcome: SessionOutcome | null } | null,
+): UsageFilterState {
+  if (!cell) return filter;
+  const outcomeValue = outcomeChipValue(cell.outcome);
+  return {
+    ...filter,
+    chips: filter.chips.filter(
+      (chip) =>
+        !(chip.kind === "cluster" && chip.clusterId === cell.clusterId) &&
+        !(
+          chip.kind === "dimension" &&
+          chip.key === "outcome" &&
+          chip.value === outcomeValue
+        ),
+    ),
+  };
+}
+
 /** The chip value representing a cell's outcome, sentinel included. */
 export function outcomeChipValue(outcome: SessionOutcome | null): string {
   return outcome === null ? UNLABELED_OUTCOME : outcome;

--- a/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
+++ b/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
@@ -130,10 +130,12 @@ export function threadMatchesChip(
       if (chip.value === "hide") return thread.synthetic !== true;
       if (chip.value === "show") return thread.synthetic === true;
       return true;
-    // Goal facets. Absence never matches — a thread with no recorded outcome is
-    // not in the `unclear` bucket, and letting it match would put unanalyzed
-    // rows inside a rate.
+    // Goal facets. Absence never matches a concrete outcome — a thread with no
+    // recorded outcome is not in the `unclear` bucket, and letting it match
+    // would put unanalyzed rows inside a rate. The sentinel is the one value
+    // that DOES select absence, and it selects only absence.
     case "outcome":
+      if (chip.value === UNLABELED_OUTCOME) return thread.outcome == null;
       return thread.outcome === chip.value;
     case "friction":
       return thread.friction === chip.value;
@@ -211,6 +213,26 @@ export function clearCellChips(filter: UsageFilterState): UsageFilterState {
 }
 
 /**
+ * Chip value for the `outcome` dimension meaning "no outcome recorded".
+ *
+ * The "not analyzed" grid cell has to be expressible as a chip. Without a
+ * sentinel it can only be represented as a cluster chip alone, which is a
+ * *different, wider* filter — every outcome in that goal — so the drill-down
+ * (which passes `outcome: null` to the query) and the Sessions list / topic map
+ * (which read the chips) would disagree about which sessions the user selected.
+ *
+ * Mirrored by `UNLABELED_OUTCOME` in `convex/lib/usageInsights/filters.ts`; the
+ * chip `value` is a free-form string on the wire, so no validator change is
+ * needed, but both matchers must agree on the meaning.
+ */
+export const UNLABELED_OUTCOME = "__unlabeled__";
+
+/** The chip value representing a cell's outcome, sentinel included. */
+export function outcomeChipValue(outcome: SessionOutcome | null): string {
+  return outcome === null ? UNLABELED_OUTCOME : outcome;
+}
+
+/**
  * Select one cell of the goal × outcome grid.
  *
  * NOT two `toggleChip` calls. Chips are OR'd within a dimension (see
@@ -224,10 +246,9 @@ export function clearCellChips(filter: UsageFilterState): UsageFilterState {
  * Clicking the already-selected cell clears the selection, which is the
  * behavior a toggle would give and the only part worth keeping.
  *
- * `outcome: null` selects the "not analyzed" cell — sessions in this goal with
- * no recorded outcome. It cannot be expressed as an outcome chip (absence
- * matches no value), so it is represented by a cluster chip alone plus the
- * caller passing `outcome: null` to the drill-down query.
+ * `outcome: null` selects the "not analyzed" cell and is carried as the
+ * `UNLABELED_OUTCOME` sentinel chip, so the cell narrows the Sessions list and
+ * the map exactly as it narrows the drill-down.
  */
 export function selectCell(
   filter: UsageFilterState,
@@ -243,23 +264,23 @@ export function selectCell(
     return { ...filter, chips: others };
   }
 
-  const next: UsageFilterChip[] = [
-    ...others,
-    {
-      kind: "cluster",
-      clusterId: cell.clusterId,
-      label: cell.clusterLabel,
-    },
-  ];
-  if (cell.outcome !== null) {
-    next.push({
-      kind: "dimension",
-      key: "outcome",
-      value: cell.outcome,
-      label: cell.outcome,
-    });
-  }
-  return { ...filter, chips: next };
+  return {
+    ...filter,
+    chips: [
+      ...others,
+      {
+        kind: "cluster",
+        clusterId: cell.clusterId,
+        label: cell.clusterLabel,
+      },
+      {
+        kind: "dimension",
+        key: "outcome",
+        value: outcomeChipValue(cell.outcome),
+        label: cell.outcome ?? "not analyzed",
+      },
+    ],
+  };
 }
 
 /** Whether `filter` currently selects exactly this cell and no other. */
@@ -271,17 +292,17 @@ export function isCellSelected(
   const outcomes = filter.chips.filter(
     (chip) => chip.kind === "dimension" && chip.key === "outcome",
   );
-  if (clusters.length !== 1) return false;
+  if (clusters.length !== 1 || outcomes.length !== 1) return false;
   if (
     clusters[0].kind !== "cluster" ||
     clusters[0].clusterId !== cell.clusterId
   ) {
     return false;
   }
-  if (cell.outcome === null) return outcomes.length === 0;
-  if (outcomes.length !== 1) return false;
   const only = outcomes[0];
-  return only.kind === "dimension" && only.value === cell.outcome;
+  return (
+    only.kind === "dimension" && only.value === outcomeChipValue(cell.outcome)
+  );
 }
 
 export function removeChipByKey(

--- a/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
+++ b/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
@@ -6,13 +6,36 @@ export type UsageFilterPreset =
   | "low_ratings"
   | "no_feedback";
 
+/**
+ * Hand-mirrored from `convex/lib/usageInsights/filters.ts`
+ * (`usageDimensionKeyValidator`). Keep the two in sync — the server rejects a
+ * key it does not know.
+ */
 export type UsageDimensionKey =
   | "deviceKind"
   | "visitorSegment"
   | "language"
   | "modelId"
   | "feedbackBucket"
-  | "synthetic";
+  | "synthetic"
+  | "outcome"
+  | "friction"
+  | "behaviorTag"
+  | "pathKey";
+
+/**
+ * Mirrors `SESSION_OUTCOMES`. Closed list so the grid's columns are stable
+ * across chatboxes and every rate has a denominator.
+ */
+export const SESSION_OUTCOMES = [
+  "completed",
+  "partial",
+  "unresolved",
+  "errored",
+  "unclear",
+] as const;
+
+export type SessionOutcome = (typeof SESSION_OUTCOMES)[number];
 
 export type UsageFilterChip =
   | { kind: "cluster"; clusterId: string; label?: string }
@@ -107,6 +130,18 @@ export function threadMatchesChip(
       if (chip.value === "hide") return thread.synthetic !== true;
       if (chip.value === "show") return thread.synthetic === true;
       return true;
+    // Goal facets. Absence never matches — a thread with no recorded outcome is
+    // not in the `unclear` bucket, and letting it match would put unanalyzed
+    // rows inside a rate.
+    case "outcome":
+      return thread.outcome === chip.value;
+    case "friction":
+      return thread.friction === chip.value;
+    case "behaviorTag":
+      // Array-contains, not equality: the one multi-valued dimension.
+      return thread.behaviorTags?.includes(chip.value) ?? false;
+    case "pathKey":
+      return thread.pathKey === chip.value;
     default:
       return false;
   }
@@ -157,6 +192,96 @@ export function chipKey(chip: UsageFilterChip): string {
   return chip.kind === "cluster"
     ? `cluster:${chip.clusterId}`
     : `${chip.key}:${chip.value}`;
+}
+
+/**
+ * Drop the chips that encode a grid-cell selection (cluster + outcome), leaving
+ * every other dimension's chips alone. Exported so a caller that dismisses the
+ * drill-down can clear the selection without having to know which cell was open.
+ */
+export function clearCellChips(filter: UsageFilterState): UsageFilterState {
+  return {
+    ...filter,
+    chips: filter.chips.filter(
+      (chip) =>
+        chip.kind !== "cluster" &&
+        !(chip.kind === "dimension" && chip.key === "outcome"),
+    ),
+  };
+}
+
+/**
+ * Select one cell of the goal × outcome grid.
+ *
+ * NOT two `toggleChip` calls. Chips are OR'd within a dimension (see
+ * `threadMatchesFilterState`), so toggling a second cluster chip or a second
+ * outcome chip WIDENS the selection — clicking "Invoice lookup / unresolved"
+ * and then "Refunds / errored" would match four cells instead of one. Selecting
+ * a cell therefore REPLACES the cluster and outcome selections together, as a
+ * single atomic state transition. Chips for other dimensions are preserved,
+ * because they are genuine additional narrowing the user asked for.
+ *
+ * Clicking the already-selected cell clears the selection, which is the
+ * behavior a toggle would give and the only part worth keeping.
+ *
+ * `outcome: null` selects the "not analyzed" cell — sessions in this goal with
+ * no recorded outcome. It cannot be expressed as an outcome chip (absence
+ * matches no value), so it is represented by a cluster chip alone plus the
+ * caller passing `outcome: null` to the drill-down query.
+ */
+export function selectCell(
+  filter: UsageFilterState,
+  cell: {
+    clusterId: string;
+    clusterLabel?: string;
+    outcome: SessionOutcome | null;
+  },
+): UsageFilterState {
+  const others = clearCellChips(filter).chips;
+
+  if (isCellSelected(filter, cell)) {
+    return { ...filter, chips: others };
+  }
+
+  const next: UsageFilterChip[] = [
+    ...others,
+    {
+      kind: "cluster",
+      clusterId: cell.clusterId,
+      label: cell.clusterLabel,
+    },
+  ];
+  if (cell.outcome !== null) {
+    next.push({
+      kind: "dimension",
+      key: "outcome",
+      value: cell.outcome,
+      label: cell.outcome,
+    });
+  }
+  return { ...filter, chips: next };
+}
+
+/** Whether `filter` currently selects exactly this cell and no other. */
+export function isCellSelected(
+  filter: UsageFilterState,
+  cell: { clusterId: string; outcome: SessionOutcome | null },
+): boolean {
+  const clusters = filter.chips.filter((chip) => chip.kind === "cluster");
+  const outcomes = filter.chips.filter(
+    (chip) => chip.kind === "dimension" && chip.key === "outcome",
+  );
+  if (clusters.length !== 1) return false;
+  if (
+    clusters[0].kind !== "cluster" ||
+    clusters[0].clusterId !== cell.clusterId
+  ) {
+    return false;
+  }
+  if (cell.outcome === null) return outcomes.length === 0;
+  if (outcomes.length !== 1) return false;
+  const only = outcomes[0];
+  return only.kind === "dimension" && only.value === cell.outcome;
 }
 
 export function removeChipByKey(

--- a/mcpjam-inspector/client/src/hooks/useChatboxTopicMap.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxTopicMap.ts
@@ -57,6 +57,12 @@ export type TopicMapSnapshot = {
     startedAt: number;
     lastActivityAt: number;
     modelId?: string;
+    /**
+     * Present from snapshot `version` 2 onward. Absent on older blobs AND on
+     * sessions whose signals never extracted — color-by-outcome must render
+     * both as "unknown" rather than substituting a bucket.
+     */
+    outcome?: "completed" | "partial" | "unresolved" | "errored" | "unclear";
   }>;
   edges: Array<{
     source: string;

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -41,6 +41,19 @@ export interface SharedChatThread {
   visitorSegment?: string;
   language?: string;
   /**
+   * Goal facets, written by the cluster rebuild. All optional and all absent on
+   * sessions that predate the goal/outcome split — absence means "not
+   * analyzed", which is a different claim from the `unclear` outcome, so the UI
+   * must not substitute a default for a missing field.
+   */
+  outcome?: "completed" | "partial" | "unresolved" | "errored" | "unclear";
+  outcomeConfidence?: number;
+  friction?: string;
+  /** Multi-label trajectory tags, derived from the transcript (no model call). */
+  behaviorTags?: string[];
+  /** Collapsed tool route, e.g. `search→get`. `no_tools` when none ran. */
+  pathKey?: string;
+  /**
    * The hostConfigId that was active on the chatbox's referenced host
    * when this session opened. Pinned at session-insert time; survives
    * host edits forward so the UI can show "this session ran against

--- a/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
+++ b/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from "convex/react";
 import type {
+  SessionOutcome,
   UsageFilterState,
   UsageFilterChip,
 } from "@/hooks/chatbox-usage-filters";
@@ -45,13 +46,12 @@ export type ClusterRunState = {
   isStale: boolean;
 };
 
-/** Mirrors `SESSION_OUTCOMES` on the server. */
-export type SessionOutcome =
-  | "completed"
-  | "partial"
-  | "unresolved"
-  | "errored"
-  | "unclear";
+// One closed vocabulary, one declaration. `chatbox-usage-filters` derives
+// `SessionOutcome` from `SESSION_OUTCOMES`; re-exporting rather than restating
+// it here means a new server outcome cannot leave the drill-down types agreeing
+// with nothing. Re-exported (not just imported) because consumers of the
+// drill-down hook reasonably expect the type alongside it.
+export type { SessionOutcome };
 
 export type OutcomeCounts = Record<SessionOutcome, number>;
 

--- a/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
+++ b/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
@@ -33,6 +33,10 @@ export type ClusterRunState = {
   errorMessage: string | null;
   model?: string | null;
   topicMapVersion?: number | null;
+  /** Null on runs predating the goal/outcome split. */
+  signalsVersion?: number | null;
+  signalsCacheHitCount?: number | null;
+  embeddingCacheHitCount?: number | null;
   edgeCount?: number;
   sampleNodeCount?: number;
   unmappedSessionCount?: number;
@@ -41,13 +45,75 @@ export type ClusterRunState = {
   isStale: boolean;
 };
 
+/** Mirrors `SESSION_OUTCOMES` on the server. */
+export type SessionOutcome =
+  | "completed"
+  | "partial"
+  | "unresolved"
+  | "errored"
+  | "unclear";
+
+export type OutcomeCounts = Record<SessionOutcome, number>;
+
+/** One row of the goal × outcome grid. */
+export type GoalFacet = {
+  clusterId: string;
+  label: string;
+  total: number;
+  outcomes: OutcomeCounts;
+  /**
+   * Sessions with NO recorded outcome. Distinct from `outcomes.unclear`:
+   * `unclear` is a verdict, this is the absence of one.
+   */
+  unlabeled: number;
+  /** Null when nothing in the row is labeled — a zero denominator is not 0%. */
+  unresolvedRate: number | null;
+  errorRate: number | null;
+  retryRate: number;
+  toolDistribution: BreakdownBucket[];
+  pathDistribution: BreakdownBucket[];
+  distinctPathCount: number;
+  /** Shannon entropy (bits) over this goal's route distribution. */
+  routingEntropy: number | null;
+};
+
+export type OutcomeFeedbackCalibration = {
+  outcome: SessionOutcome;
+  sessions: number;
+  rated: number;
+  negative: number;
+  /** Null when nobody rated. Not 0. */
+  negativeRate: number | null;
+};
+
+/**
+ * Scan metadata. When `truncated` is true every rate in the breakdown is
+ * conditional on the scanned window and must not render as a bare percentage.
+ */
+export type UsageScanMeta = {
+  scanned: number;
+  matched: number;
+  truncated: boolean;
+  maxSessions: number;
+  windowEndAt: number | null;
+  windowStartAt: number | null;
+};
+
 export type UsageBreakdown = {
   themes: Array<{ clusterId: string; label: string; count: number }>;
   userBreakdown: FeedbackBucketCount[];
   deviceBreakdown: BreakdownBucket[];
   languageBreakdown: BreakdownBucket[];
   modelBreakdown: BreakdownBucket[];
+  outcomeBreakdown: BreakdownBucket[];
+  frictionBreakdown: BreakdownBucket[];
+  behaviorTagBreakdown: BreakdownBucket[];
+  goalFacets: GoalFacet[];
+  labeledOutcomeCount: number;
+  outcomeFeedbackCalibration: OutcomeFeedbackCalibration[];
   totalSessions: number;
+  /** Optional so a stale/older server response still renders. */
+  scan?: UsageScanMeta;
   latestRun: ClusterRunState | null;
 };
 
@@ -72,14 +138,26 @@ export function useUsageInsights({
   sourceId,
   filters,
   enabled = true,
+  threadsEnabled,
+  breakdownEnabled,
 }: {
   sourceType?: InsightsSourceType;
   sourceId: string | null;
   filters: UsageFilterState;
   enabled?: boolean;
+  /**
+   * Per-query gates. The thread list and the breakdown back different tabs, so
+   * a caller that only needs one should not subscribe to both. Both default to
+   * `enabled` so existing callers are unaffected.
+   */
+  threadsEnabled?: boolean;
+  breakdownEnabled?: boolean;
 }) {
+  const wantThreads = threadsEnabled ?? enabled;
+  const wantBreakdown = breakdownEnabled ?? enabled;
+
   const chatboxArgs =
-    enabled && sourceId
+    wantThreads && sourceId
       ? ({
           chatboxId: sourceId,
           limit: 100,
@@ -88,7 +166,7 @@ export function useUsageInsights({
       : "skip";
 
   const breakdownArgs =
-    enabled && sourceId
+    wantBreakdown && sourceId
       ? ({
           chatboxId: sourceId,
           filters: toServerFilters(filters),
@@ -119,5 +197,66 @@ export function useUsageInsights({
     threads,
     breakdown,
     rebuild,
+  };
+}
+
+export type GoalOutcomeDrilldown = {
+  sessions: SharedChatThread[];
+  nextBefore: number | null;
+  /** Server-counted total for the cell; matches the grid cell's count. */
+  total: number;
+  totalTruncated: boolean;
+};
+
+/**
+ * Server-filtered, paginated sessions for one goal × outcome cell.
+ *
+ * The grid renders exact counts, so a click on "62 unresolved" has to be able
+ * to page exactly those 62 rows. The insights list's `limit: 100` +
+ * client-side filter cannot back that: it shows a silent subset whose total
+ * disagrees with the cell the user clicked.
+ *
+ * `outcome: null` requests the "not analyzed" cell.
+ */
+export function useGoalOutcomeDrilldown({
+  chatboxId,
+  clusterId,
+  outcome,
+  filters,
+  limit = 50,
+  before,
+  enabled = true,
+}: {
+  chatboxId: string | null;
+  clusterId: string | null;
+  outcome: SessionOutcome | null | undefined;
+  filters?: UsageFilterState;
+  limit?: number;
+  before?: number;
+  enabled?: boolean;
+}) {
+  const args =
+    enabled && chatboxId && clusterId
+      ? ({
+          chatboxId,
+          clusterId,
+          // `undefined` means "any outcome"; `null` means "no outcome
+          // recorded". They are different cells, so the distinction has to
+          // survive serialization rather than being collapsed here.
+          ...(outcome === undefined ? {} : { outcome }),
+          ...(filters ? { filters: toServerFilters(filters) } : {}),
+          limit,
+          ...(before === undefined ? {} : { before }),
+        } as any)
+      : "skip";
+
+  const result = useQuery(
+    "chatSessions:listSessionsByGoalOutcome" as any,
+    args,
+  ) as GoalOutcomeDrilldown | undefined;
+
+  return {
+    drilldown: result,
+    isLoading: enabled && !!chatboxId && !!clusterId && result === undefined,
   };
 }


### PR DESCRIPTION
## Why

Frontend half of the goal-facet work. Pairs with **MCPJam/mcpjam-backend#819**, which is what makes any of this possible — the clustering pipeline now embeds only the *goal* and extracts outcome, friction, and tool trajectory as separate facets, so "same goal, different outcome" is renderable for the first time.

The Insights tab could previously only show a topic map: clusters by subject, with no way to ask whether the user actually got anything.

> **Invoice lookup** — 62 sessions, 71% unresolved, routed through four different tool paths.

Outcome alone says something is wrong; route quality says a capability is missing or the tool descriptions are confusing.

## Goals by outcome

New `ChatboxGoalOutcomeGrid`. Rows are goal clusters, columns the fixed outcome enum, cells the exact count tinted by share of the row. Adjacent columns carry error rate, retry rate, distinct routes, and **routing spread** (Shannon entropy over the goal's tool paths — 0 means every session took the same route, higher means the model couldn't decide which tool serves this goal).

It's a table, not a chart, so labels are never truncated. Rows past the top 12 fold into a real "Other" row carrying real summed counts, with rates recomputed from the sums rather than averaged. Two route metrics are deliberately *not* aggregated there and read "—": entropy (entropy over a union of unrelated goals isn't meaningful) and the distinct-route count (summing per-goal distinct counts double-counts any path two folded goals share). Unknown beats wrong.

Only outcomes that indicate a problem get a warm tint. `completed` reads positive and `unclear` stays neutral: tinting an absence of judgement as a problem is exactly the overclaim this grid exists to avoid.

## Honest numbers

Shipped before the map tint on purpose — it validates the outcome model and shows exact denominators, and the tint is far more compelling once we trust the labels.

- A rate with a zero denominator renders **"—", never 0%**. Unknown is not zero.
- **"Not analyzed" is its own column**, separate from the `unclear` outcome. `unclear` is a verdict; absence of a recorded outcome is not one, and the two have different fixes.
- The backend's 2,000-session scan cap surfaces as a notice on the grid *and* on the calibration panel — both read off the same bounded scan, and warning in one place but not the other would read as "this one is unconditional".
- The labeled denominator is stated under the table rather than implied.
- Sorting by unresolved rate ranks unknown rates **last** — an unmeasured row must not outrank a measured 90%.
- Empty cells are disabled; there's nothing to drill into.

## `selectCell`, not two `toggleChip` calls

Chips are AND'd across dimensions but **OR'd within one** (`chatbox-usage-filters.ts:119-140`). So building a cell selection out of two `toggleChip` calls *widens* rather than narrows: clicking "Invoice lookup / unresolved" and then "Refunds / errored" leaves two cluster chips and two outcome chips active, matching **four** cells instead of the one the user clicked.

`selectCell` replaces the cluster and outcome selections together as one atomic transition, preserving chips from other dimensions. A test pins the widening behavior as an explicit contrast case, so a future refactor that reaches for `toggleChip` here fails loudly.

The "not analyzed" cell is carried as the `UNLABELED_OUTCOME` sentinel chip. It has to be expressible as a chip: a cluster chip *alone* is a wider filter — every outcome in that goal — so the drill-down (which passes `outcome: null`) and anything reading the chips would disagree about which sessions were selected. The sentinel matches only absence, never `unclear`. Mirrored server-side.

Closing an open cell clears the chips outright rather than routing through `selectCell`'s chip-derived toggle: with the chips already dismissed by hand, that toggle reads the cell as unselected and would *add them back* while the panel closes.

## Cell drill-down

New `ChatboxGoalOutcomeDrilldown`, backed by the backend's new server-filtered paginated query. Not a client-side filter over `useUsageInsights`'s fixed `limit: 100` — the cell shows an exact count, so the click-through has to be able to page all of it with a total that agrees.

Cursor and accumulated rows are stored **together with the request they belong to** — chatbox, cell, *and* filter chips — and reset during render (React's documented adjust-state-on-prop-change pattern) rather than in an effect. Resetting in an effect would leave one render where the query runs with the new request but the previous cursor, and the accumulator could merge stale rows in. Keying on the cell alone had the same problem one level up: changing an unrelated facet chip kept the old cursor and rows, showing sessions the new filter excludes starting from page two of a set that no longer existed.

Last settled `total`/`nextBefore` are carried across an in-flight page, so advancing the cursor doesn't blank the header to "Loading…" and make the pager vanish from under the cursor.

## Color by: theme | outcome

The map renders a **stored snapshot**, so the toggle is gated on the snapshot version actually carrying `nodes[].outcome`. A pre-bump (v1) blob disables the mode with an explanation rather than painting every node neutral and looking like a bug — and the tooltip hangs off a focusable span wrapper, because a native disabled button doesn't reliably emit pointer events and would hide the explanation in exactly the case it exists for. If a snapshot stops supporting outcomes, the mode falls back to theme.

`colorForCluster`'s theme path is untouched; the new `colorForNode` wraps it. The outcome palette is diverging rather than categorical, since outcome is ordered and the point of the tint is that a bad region of the map is visible at a glance. `unclear` shares the neutral used for "no outcome at all" — an absence of judgement must not read as a finding.

Selecting an outcome cell now also **narrows the map**, with the same OR-within-dimension semantics as everywhere else (sentinel included). Previously it highlighted the goal and left every outcome inside it lit, so the map disagreed with the grid about what was selected.

## Feedback by inferred outcome

New `ChatboxOutcomeCalibration`. Deliberately **not** an accuracy score: feedback measures satisfaction rather than whether the goal was met, response rates are single-digit, and a "% correct" computed against it would be a fabrication dressed as a measurement.

What it shows is the one actionable disagreement — negative feedback concentrated in sessions the extraction labeled `completed`. That is a prompt to investigate, not a verdict: it can also mean users got exactly what they asked for and disliked it. Rates off fewer than five ratings render as raw counts (`2/3`) rather than a percentage that reads as a finding; `null` rates render "—", not 0%. The flagged row carries an sr-only cue so the panel's only actionable signal isn't announced in colour alone.

## Also

- Widened validator mirrored into `chatbox-usage-filters.ts`, including the array-contains case for `behaviorTag` (the one multi-valued dimension). Absence never matches a concrete value, matching the server.
- `SharedChatThread` gains the optional facet fields; all absent on sessions predating the split.
- `SessionOutcome` is declared once (derived from `SESSION_OUTCOMES`) and re-exported, rather than restated as a literal union in the hook with consumers importing from both.
- `NO_OUTCOME_COLOR` is now actually shared with `colorForCluster` instead of the two hardcoding the same literal separately.
- `useUsageInsights` gains per-query `threadsEnabled` / `breakdownEnabled` gates so the tab flip doesn't run both scans at once. Both default to the existing `enabled`, so current callers are unaffected.

## Testing

`npm run typecheck:client` clean (incl. the tier-b import guard). 58 tests across five files, all passing:

- **`chatbox-usage-filters-cells.test.ts`** (19) — `selectCell` narrowing vs the `toggleChip` widening bug, the sentinel vs `unclear`, the hand-dismissed-chip divergence, preserved other-dimension chips and preset, and the new chip matchers.
- **`ChatboxGoalOutcomeGrid.test.tsx`** (15) — the target reading, untruncated labels, "—" for unknown rates, the truncation notice present *and* absent, the two distinct unclear/not-analyzed columns, cell selection and `aria-pressed`, sort-by-unresolved ranking unknowns last, the "Other" fold and its non-summed route count, and the pre-split empty state.
- **`ChatboxGoalOutcomeDrilldown.test.tsx`** (12) — server total vs page length, `outcome: null` passthrough, cursor advance, **reset and row isolation on both cell change and filter change**, dedupe across overlapping pages, the steady pager mid-flight, and empty-vs-loading.
- **`ChatboxOutcomeCalibration.test.tsx`** (9) — percentage vs raw counts by sample size, "—" for unrated, the sr-only cue, no flag on a non-`completed` outcome, and the truncation qualifier both ways.
- **`ChatboxTopicMapPanel.test.tsx`** (+13) — `colorForNode` in both modes, absent/`unclear`/unrecognized outcomes all neutral, the legend, the disabled toggle on a v1 snapshot, the fallback to theme, and outcome narrowing.

The topic-map fixture stays at snapshot **version 1** on purpose so the pre-bump regression path keeps being exercised; a separate `outcomeAwareHookValue()` covers v2.

Not verified here: the rendered result against real data. This environment has no Convex deployment, so the grid, drill-down, and tint have been exercised against fixtures and mocked hooks only — worth a look at a seeded chatbox (deliberately mixed outcomes, plus one goal reached via two distinct tool paths so entropy is non-zero) before merge. Needs the backend PR deployed first, and ≥4 sessions or clustering short-circuits to one cluster.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI surface with subtle filter/paging state (breakdown vs drill-down divergence, cursor resets); depends on new Convex queries and backend deployment, but changes are read-only analytics with extensive tests.
> 
> **Overview**
> Adds **goal × outcome** analytics to the chatbox Insights tab (frontend companion to the backend goal-facet pipeline).
> 
> The **Insights** layout is now a scrollable **Goals by outcome** table above the topic map: clickable cells, route/spread metrics, scan-cap warnings, and an **Other** row for folded goals. **`selectCell`** atomically sets cluster + outcome chips (including a **not analyzed** sentinel); the breakdown query uses **`withoutCellChips`** so cell selection does not collapse the grid, while drill-down and the map keep the full filter.
> 
> **`ChatboxGoalOutcomeDrilldown`** pages sessions server-side via **`useGoalOutcomeDrilldown`**, with cursor reset keyed on cell + filters and stable totals while loading. **`ChatboxOutcomeCalibration`** shows negative feedback by inferred outcome (not framed as accuracy).
> 
> The **topic map** gains **Color by theme | outcome**, outcome-based dimming when a cell is selected, v2 snapshot gating, and cluster halos that stay theme-colored in outcome mode.
> 
> Filter/hook updates: new dimensions (`outcome`, `friction`, `behaviorTag`, `pathKey`), extended **`UsageBreakdown`** types, and **`threadsEnabled` / `breakdownEnabled`** on **`useUsageInsights`**. Broad test coverage across grid, drill-down, calibration, filters, panel wiring, and map behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70a79fc49c279352c877979d90de4041b4c384d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->