### PR TITLE
fix(oauth-debugger): absent callback iss crashed the 2026-07-28 flow (null treated as mismatched issuer)

### DIFF
--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -678,7 +678,7 @@ export const OAuthFlowTab = ({
     const processOAuthCallback = (
       code: string,
       state: string | undefined,
-      iss?: string | undefined
+      iss?: string | null
     ) => {
       if (processedCodeRef.current === code) {
         return;
@@ -721,7 +721,10 @@ export const OAuthFlowTab = ({
         // 2R-iss / review F8: record the RFC 9207 `iss` so the machine's
         // authorization-response issuer step validates it (it reads
         // `state.authorizationResponseIss`) instead of leaving it unset.
-        authorizationResponseIss: iss,
+        // Absence is `undefined`, never `null`: the machine's presence check
+        // must route a missing `iss` to the "absent" rows, and flow state
+        // types the field as `string | undefined`.
+        authorizationResponseIss: iss ?? undefined,
         error: undefined,
       });
 
@@ -737,7 +740,14 @@ export const OAuthFlowTab = ({
       }
 
       if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
-        processOAuthCallback(event.data.code, event.data.state, event.data.iss);
+        // `event.data` is untyped: older callback pages (and any page reading
+        // URLSearchParams directly) send `iss: null` when the param is absent.
+        // Coalesce so the machine sees absence, not a null "present" value.
+        processOAuthCallback(
+          event.data.code,
+          event.data.state,
+          event.data.iss ?? undefined,
+        );
       }
     };
 
@@ -786,7 +796,7 @@ export const OAuthFlowTab = ({
           processOAuthCallback(
             event.data.code,
             event.data.state,
-            event.data.iss
+            event.data.iss ?? undefined
           );
         }
       };

--- a/mcpjam-inspector/client/src/components/oauth/OAuthDebugCallback.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthDebugCallback.tsx
@@ -59,8 +59,11 @@ export default function OAuthDebugCallback() {
         const callbackSearch = new URLSearchParams(window.location.search);
         const stateParam = callbackSearch.get("state");
         // 2R-iss: forward the RFC 9207 `iss` so the opener can validate it
-        // against the recorded issuer before redeeming the code.
-        const issParam = callbackSearch.get("iss");
+        // against the recorded issuer before redeeming the code. An absent
+        // param must travel as `undefined`, not the `null` URLSearchParams
+        // returns — the machine treats `iss: null` as a present-but-mismatched
+        // issuer and refuses the exchange.
+        const issParam = callbackSearch.get("iss") ?? undefined;
         const message = {
           type: "OAUTH_CALLBACK",
           code: callbackParams.code,

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthDebugCallback.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthDebugCallback.test.tsx
@@ -1,5 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildElectronDebugCallbackUrl } from "../OAuthDebugCallback";
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import OAuthDebugCallback, {
+  buildElectronDebugCallbackUrl,
+} from "../OAuthDebugCallback";
 
 describe("OAuthDebugCallback", () => {
   beforeEach(() => {
@@ -17,5 +20,61 @@ describe("OAuthDebugCallback", () => {
     expect(buildElectronDebugCallbackUrl()).toBe(
       "mcpjam://oauth/callback?flow=debug&code=test-code&state=test-state",
     );
+  });
+
+  describe("popup callback message", () => {
+    const postMessage = vi.fn();
+
+    beforeEach(() => {
+      window.name = "oauth_authorization_test";
+      Object.defineProperty(window, "opener", {
+        configurable: true,
+        value: { postMessage, closed: false },
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "opener", {
+        configurable: true,
+        value: null,
+      });
+      vi.restoreAllMocks();
+    });
+
+    // Regression for the 2026-07-28 debugger crash: `URLSearchParams.get`
+    // returns `null` for a missing param, and a null `iss` in the callback
+    // message made the SDK machine treat a conformant AS that omits `iss`
+    // (a SHOULD) as a present-but-mismatched issuer — crashing in
+    // `quoteUntrusted` before the code could be redeemed. Absence must
+    // travel as `undefined`.
+    it("sends iss as undefined (never null) when the callback has no iss param", async () => {
+      render(<OAuthDebugCallback />);
+
+      await waitFor(() => expect(postMessage).toHaveBeenCalled());
+      const message = postMessage.mock.calls[0][0];
+      expect(message).toMatchObject({
+        type: "OAUTH_CALLBACK",
+        code: "test-code",
+        state: "test-state",
+      });
+      expect(message.iss).toBeUndefined();
+      expect(message.iss).not.toBeNull();
+    });
+
+    it("forwards a present iss verbatim", async () => {
+      window.history.replaceState(
+        {},
+        "",
+        "/oauth/callback/debug?code=test-code&state=test-state&iss=" +
+          encodeURIComponent("https://auth.example.com"),
+      );
+
+      render(<OAuthDebugCallback />);
+
+      await waitFor(() => expect(postMessage).toHaveBeenCalled());
+      expect(postMessage.mock.calls[0][0].iss).toBe(
+        "https://auth.example.com",
+      );
+    });
   });
 });

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -609,10 +609,19 @@ function quoteUntrusted(value: string): string {
  * passes `false` to downgrade row 2 to a `warning` and let the flow continue.
  * Defaults to enforcing: an omitted flag must fail closed, and the value that
  * carries the era lives with the caller, not here.
+ *
+ * "Absent" means `undefined`, `null`, or the empty string. `null` is what a
+ * callback boundary produces when the param is missing (`URLSearchParams.get`),
+ * so it MUST land in rows 3/4, never in the present-`iss` comparison — treating
+ * it as present turns every spec-conformant AS that simply omits `iss` into a
+ * hard mismatch (and `quoteUntrusted(null)` crashes). An empty `iss=` is
+ * likewise treated as absent rather than compared: RFC 9207 gives the value
+ * issuer-URL syntax, so an empty one carries no issuer claim to validate — but
+ * it still fails closed via row 3 whenever the AS advertised iss support.
  */
 export function validateAuthorizationResponseIssuer(input: {
   recordedIssuer: string | undefined;
-  returnedIss: string | undefined;
+  returnedIss: string | null | undefined;
   issParameterSupported: boolean | undefined;
   enforcePresentIssMismatch?: boolean;
 }): AuthorizationResponseIssuerCheck {
@@ -623,7 +632,7 @@ export function validateAuthorizationResponseIssuer(input: {
     enforcePresentIssMismatch = true,
   } = input;
 
-  if (returnedIss !== undefined && returnedIss !== "") {
+  if (returnedIss != null && returnedIss !== "") {
     if (recordedIssuer !== undefined && returnedIss !== recordedIssuer) {
       const mismatch =
         "Authorization response `iss` does not match the issuer this flow " +

--- a/sdk/tests/oauth/debug-oauth-2026.test.ts
+++ b/sdk/tests/oauth/debug-oauth-2026.test.ts
@@ -282,6 +282,51 @@ describe("validateAuthorizationResponseIssuer (RFC 9207)", () => {
       }),
     ).toEqual({ ok: true });
   });
+
+  it("empty-string iss still fails closed when the AS advertised iss support", () => {
+    const result = validateAuthorizationResponseIssuer({
+      recordedIssuer: ISS,
+      returnedIss: "",
+      issParameterSupported: true,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  // Regression: `URLSearchParams.get("iss")` returns `null` when the param is
+  // absent. Treating that null as a PRESENT iss sent every conformant AS that
+  // omits `iss` (a SHOULD, not a MUST) into the mismatch branch, where
+  // `quoteUntrusted(null)` crashed with "Cannot read properties of null
+  // (reading 'replace')" before the code could be redeemed.
+  it("row 4: a null iss from URLSearchParams is absent, not a mismatch", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: null,
+        issParameterSupported: undefined,
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("row 3: a null iss still rejects when the AS advertised iss support", () => {
+    const result = validateAuthorizationResponseIssuer({
+      recordedIssuer: ISS,
+      returnedIss: null,
+      issParameterSupported: true,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/RFC 9207/);
+  });
+
+  it("null iss never crashes or warns on the non-enforcing (legacy) path", () => {
+    expect(
+      validateAuthorizationResponseIssuer({
+        recordedIssuer: ISS,
+        returnedIss: null,
+        issParameterSupported: false,
+        enforcePresentIssMismatch: false,
+      }),
+    ).toEqual({ ok: true });
+  });
 });
 
 describe("debug-oauth-2026-07-28 machine — 2M-a spec steps", () => {


### PR DESCRIPTION
## Bug

Running the OAuth debugger against Asana's MCP server (`https://mcp.asana.com/v2/mcp`) on protocol **2026-07-28** with a pre-registered client crashes at **Authorization Code Received** with:

```
TypeError: Cannot read properties of null (reading 'replace')
```

The flow never reaches the token endpoint. The error also gets misattributed onto the "Request Authorization Server Metadata" step in the guide, because the AS-metadata fetch is the last HTTP-history entry when the crash happens (display-only; tracked separately).

## Root cause

1. Asana's authorization callback does not include an `iss` parameter — conformant, since server inclusion of `iss` is a **SHOULD** in the draft.
2. `OAuthDebugCallback.tsx` reads it with `URLSearchParams.get("iss")`, which returns **`null`** when absent, and posts it raw. The popup `postMessage` and `BroadcastChannel` paths in `OAuthFlowTab.tsx` forwarded it uncoalesced (the Electron path already did `?? undefined`).
3. The SDK's `validateAuthorizationResponseIssuer` presence guard was `returnedIss !== undefined`, so `null` counted as **present** → present-but-mismatched branch → `quoteUntrusted(null)` → `null.replace(...)` → TypeError.

Beyond the crash, the semantics violated the draft's Authorization Response Validation table (a client **MUST**): absent `iss` + no `authorization_response_iss_parameter_supported` advertisement is row 4, **Proceed** — not a mismatch rejection.

## Fix

- **SDK** (`debug-oauth-2026-07-28.ts`): `returnedIss` now accepts `string | null | undefined`; presence guard is `!= null && !== ""` so `null` (and the documented empty-string lenience) routes to the absent rows. Row 3 (advertised + absent → reject) still fails closed, including for `null`/`""`.
- **Inspector**: `OAuthDebugCallback.tsx` posts `iss ?? undefined`; both `OAuthFlowTab.tsx` message paths coalesce; the single `authorizationResponseIss` write site coalesces defensively for any future caller.

## Version scope / blast radius

- Only the 2026-07-28 machine calls this validator; the 2025-era machines never read `authorizationResponseIss` — no legacy behavior change.
- The connect flow's `evaluateCallbackSecurity` (all eras) already coalesced its `callbackIss` before calling the shared validator, so the `!= null` guard is a no-op there — which is also why `/servers` connects fine while the debugger crashed.
- No wire output changes anywhere; this is callback validation only.

## Tests

- SDK: `null` → row 4 proceed (regression), `null`/`""` → row 3 reject when advertised, `null` never crashes on the non-enforcing legacy path (all four table rows still covered by existing tests).
- Inspector: `OAuthDebugCallback` popup message asserts `iss` is `undefined` (never `null`) when the param is absent, and forwarded verbatim when present.
- `tsc` clean for sdk; client tsc error set is byte-identical to main (pre-existing test-file errors only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow callback-boundary and validator semantics fix with regression tests; only affects 2026-07-28 issuer validation, not wire behavior.
> 
> **Overview**
> Fixes a **2026-07-28 OAuth debugger crash** when the authorization server omits RFC 9207 `iss` (allowed): `URLSearchParams.get("iss")` yields **`null`**, which was treated as a present issuer, hit the mismatch path, and threw in `quoteUntrusted(null)` before token exchange.
> 
> **SDK:** `validateAuthorizationResponseIssuer` treats **`null` like absent** (`!= null` guard), so conformant callbacks proceed (row 4) and advertised-but-missing `iss` still fails closed (row 3).
> 
> **Inspector:** `OAuthDebugCallback` and `OAuthFlowTab` **coalesce `iss` to `undefined`** on `postMessage`, `BroadcastChannel`, and flow state so the machine never sees `null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc729b169669e32588204f39d7f464dbee3cdb6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an OAuth debugger crash on protocol `2026-07-28` when the authorization callback omits `iss` by treating `null`/`""` as absent per RFC 9207. The flow now proceeds (or rejects only when `authorization_response_iss_parameter_supported` is advertised) and never crashes.

- **Bug Fixes**
  - SDK (`validateAuthorizationResponseIssuer`): accept `string | null | undefined`; treat `null`/`""` as absent; compare only when `iss` is present; prevents `quoteUntrusted(null)` crash and aligns with RFC 9207 rows 3/4.
  - Inspector: `OAuthDebugCallback.tsx` posts `iss ?? undefined`; `OAuthFlowTab.tsx` coalesces incoming `iss` to `undefined` across popup/BroadcastChannel and on state write.
  - Tests: add regressions for `null` and `""` handling, and ensure the popup sends `iss` as `undefined` when absent.
  - Scope: only affects the `2026-07-28` debugger machine; earlier flows unchanged.

<sup>Written for commit fc729b169669e32588204f39d7f464dbee3cdb6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

