### PR TITLE
fix(swarms): discard-safe scope reset, bounded frame retention, base64 guard (#3595 follow-up)

### DIFF
--- a/mcpjam-inspector/client/src/components/swarms/run-sessions-context.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/run-sessions-context.tsx
@@ -234,9 +234,18 @@ export function RunSessionsProvider({
   // and a pin carried across would both show the wrong session and keep
   // auto-follow from ever starting on the new one. Reset on the run identity.
   const scopeKey = `${runId}::${initialTargetKey ?? ""}::${initialThreadId ?? ""}`;
-  const appliedScopeRef = useRef(scopeKey);
-  if (appliedScopeRef.current !== scopeKey) {
-    appliedScopeRef.current = scopeKey;
+  // The guard is STATE, not a ref, and that distinction is the whole point.
+  // React may start a render and throw it away (concurrent rendering, a
+  // suspended sibling). A ref written during such a render keeps its new value
+  // even though nothing committed — so the guard would read as "already
+  // handled" while `setMatrixSelection(null)` never landed, leaving the new run
+  // showing the previous run's session with auto-follow permanently asleep.
+  // State is discarded with the render it belongs to, so the next attempt
+  // re-enters this block and redoes the reset; the ref writes inside are
+  // idempotent, which makes repeating them free.
+  const [appliedScope, setAppliedScope] = useState(scopeKey);
+  if (appliedScope !== scopeKey) {
+    setAppliedScope(scopeKey);
     appliedInitialThreadRef.current = false;
     appliedInitialTargetRef.current = false;
     // Render-phase reset (not an effect) so the very first render of the new run

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-stream-hub.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-stream-hub.test.ts
@@ -160,6 +160,45 @@ describe("JourneyRunStreamHub", () => {
     expect(seen).toEqual([1]);
   });
 
+  it("bounds retained frames and evicts the least recently updated session", () => {
+    // Retention is per session and outlives each session's completion (that is
+    // what gives a post-run joiner a picture), so the map grows with a run's
+    // session COUNT. Bound it, and evict by recency rather than by which session
+    // happened to start first.
+    const hub = new JourneyRunStreamHub();
+    const frameFor = (session: string, sequence: number) =>
+      event({
+        type: "browser_frame",
+        chatSessionId: session,
+        frame: {
+          sequence,
+          promptIndex: 0,
+          toolCallId: `tc-${session}`,
+          stepIndex: 0,
+          action: "left_click",
+          ts: sequence,
+        },
+      } as Partial<SwarmStreamEvent> & Pick<SwarmStreamEvent, "type">);
+
+    // 64 sessions fill the cap exactly.
+    for (let i = 0; i < 64; i++) hub.emit(frameFor(`s-${i}`, 1));
+    // Touch the oldest so recency, not insertion order, decides who is dropped.
+    hub.emit(frameFor("s-0", 2));
+    // One more session pushes past the cap.
+    hub.emit(frameFor("s-64", 1));
+
+    const replayed: string[] = [];
+    hub.subscribe((e) => {
+      if (e.type === "browser_frame") replayed.push(e.chatSessionId);
+    });
+
+    expect(replayed).toHaveLength(64);
+    // s-1 was the least recently updated, so it went; the re-touched s-0 stayed.
+    expect(replayed).not.toContain("s-1");
+    expect(replayed).toContain("s-0");
+    expect(replayed).toContain("s-64");
+  });
+
   it("subscriber errors do not break emit", () => {
     const hub = new JourneyRunStreamHub();
     hub.subscribe(() => {

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-stream-hub.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-stream-hub.ts
@@ -2,6 +2,14 @@ import type { SwarmStreamEvent } from "../../../shared/swarm-stream-events.js";
 
 const RING_BUFFER_SIZE = 200;
 
+/**
+ * How many sessions may hold a retained live frame at once. Frames are kept per
+ * session so a late joiner sees a picture even for a session that already
+ * finished, so this bounds the run's total retained bytes
+ * (~48 KiB x this) rather than throwing away that behavior.
+ */
+const MAX_RETAINED_FRAME_SESSIONS = 64;
+
 export type SwarmStreamListener = (event: SwarmStreamEvent) => void;
 
 /**
@@ -29,7 +37,25 @@ export class JourneyRunStreamHub {
   emit(event: SwarmStreamEvent): void {
     if (event.type === "browser_frame") {
       if (event.chatSessionId) {
+        // Delete-then-set so the Map's insertion order is true recency: `set`
+        // on an existing key keeps its ORIGINAL position, which would make the
+        // eviction below drop whichever session merely started first rather
+        // than the one that has gone quietest.
+        this.latestFrames.delete(event.chatSessionId);
         this.latestFrames.set(event.chatSessionId, event);
+        // Retention is per SESSION and deliberately outlives each session's
+        // completion — `subscribe` replays these first precisely so a joiner
+        // arriving after a session ended still gets a picture. That means the
+        // map grows with the run's session count, not its click count, so a
+        // large fan-out (hosts x sessions-per-host) is the only way it gets
+        // big: at 48 KiB a frame, a thousand sessions would be ~48 MB held for
+        // the life of the run. Cap it and drop the least-recently-updated
+        // session, which is the one whose picture is most likely already stale.
+        while (this.latestFrames.size > MAX_RETAINED_FRAME_SESSIONS) {
+          const oldest = this.latestFrames.keys().next();
+          if (oldest.done) break;
+          this.latestFrames.delete(oldest.value);
+        }
       }
       this.fanout(event);
       return;

--- a/mcpjam-inspector/shared/__tests__/browser-live-frame.test.ts
+++ b/mcpjam-inspector/shared/__tests__/browser-live-frame.test.ts
@@ -120,6 +120,26 @@ describe("isLiveBrowserFrame", () => {
     ).toBe(true);
   });
 
+  it("rejects a thumbnail that is not base64", () => {
+    // Defence in depth: React escapes the attribute and the media type beside it
+    // is allowlisted, so this can't inject — but a malformed payload should fail
+    // at the boundary rather than become a `data:` URI that can only 404.
+    for (const bad of [
+      '"><img src=x onerror=alert(1)>',
+      "not base64!",
+      "AAAA AAAA",
+      "AA=AAA",
+    ]) {
+      expect(isLiveBrowserFrame(frame({ thumbnailBase64: bad }))).toBe(false);
+    }
+  });
+
+  it("accepts correctly padded base64", () => {
+    for (const good of ["AAAA", "AAA=", "AA==", "AAAAAAA=", ""]) {
+      expect(isLiveBrowserFrame(frame({ thumbnailBase64: good }))).toBe(true);
+    }
+  });
+
   it("rejects a non-string thumbnail", () => {
     expect(isLiveBrowserFrame(frame({ thumbnailBase64: 42 }))).toBe(false);
   });

--- a/mcpjam-inspector/shared/browser-live-frame.ts
+++ b/mcpjam-inspector/shared/browser-live-frame.ts
@@ -20,6 +20,14 @@
 /** Hard cap on a live frame's decoded thumbnail bytes. */
 export const LIVE_FRAME_MAX_BYTES = 48 * 1024;
 
+/**
+ * Standard base64: 4-char groups, optionally ending in a padded group. Anchored,
+ * so a payload with embedded markup or whitespace fails rather than being handed
+ * to a `data:` URI. Empty is allowed through here and treated as "no thumbnail"
+ * by the size check below it.
+ */
+const BASE64_RE = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
 export type LiveBrowserFrame = {
   /** Monotonic per session. A consumer drops anything not greater than what it has. */
   sequence: number;
@@ -76,6 +84,12 @@ export function isLiveBrowserFrame(value: unknown): value is LiveBrowserFrame {
 
   if (frame.thumbnailBase64 !== undefined) {
     if (typeof frame.thumbnailBase64 !== "string") return false;
+    // Charset-check the payload. React escapes the attribute this ends up in and
+    // the media type beside it is allowlisted, so a junk value renders a broken
+    // image rather than injecting anything — this is defence in depth, and it
+    // fails a malformed frame at the boundary instead of shipping a `data:` URI
+    // that can only ever 404 in the viewer.
+    if (!BASE64_RE.test(frame.thumbnailBase64)) return false;
     // Enforce the byte bound at the READ boundary too, not only at emit. A
     // frame arrives from another process; trusting its size would let a buggy or
     // hostile runner defeat the cap on whoever renders it. base64 inflates 4/3.


### PR DESCRIPTION
Follow-up to #3595, from its review. Three fixes; one is a real correctness bug, two are hardening.

## The run-scope reset guard is state, not a ref

React may start a render and throw it away (concurrent rendering, a suspended sibling). A ref written during such a render keeps its new value even though nothing committed — so the guard read as *"already handled"* while `setMatrixSelection(null)` never landed.

Symptom: open run A, then run B, and B shows A's selected session — with auto-follow permanently asleep, because the same block is what clears `pinnedManually`.

State is discarded along with the render it belongs to, so the next attempt re-enters the block and redoes the reset. The ref writes inside it are idempotent, which is what makes repeating them free.

## Retained live frames are bounded

Frames are kept per session and deliberately outlive each session's completion — `subscribe` replays them *before* the ring buffer precisely so a joiner arriving after a session ended still gets a picture. So the map grows with a run's session **count**, not its click count, and a large fan-out (hosts × sessions-per-host) was the one way it got big: at ~48 KiB a frame, a thousand sessions is ~48 MB held for the life of the run.

Now capped at 64 sessions, evicting the least-recently-updated. The eviction deletes-then-sets on each frame because `Map.set` on an existing key keeps its *original* position — without that, eviction would drop whichever session merely started first rather than the one that has gone quietest.

**Deliberately not** evicting on `session_complete`, which was the first instinct in review: that would delete exactly the picture the frames-replayed-first ordering exists to preserve.

## Live-frame thumbnails are charset-checked

`thumbnailBase64` was bounded by length but never validated, and it is interpolated into a `data:` URI downstream. React escapes that attribute and the media type beside it is already allowlisted, so this was **not** injectable — this is defence in depth, and it fails a malformed frame at the boundary rather than rendering a URI that can only 404.

## Not included

The index-based React keys flagged in review. Both lists are derived from a single selected step and never reorder, so index keys are correct there; changing them would be churn rather than a fix.

## Verification

- 33 passing across the three touched suites (4 new: base64 accept/reject pairs, and recency-based frame eviction)
- `npm run build:inspector` clean; `npm run typecheck:client` clean
- Root `npm run typecheck` fails in the **`@mcpjam/mcp`** workspace on a duplicate `@modelcontextprotocol/sdk` resolution (`mcp/src/server.ts`, two copies via `node_modules/agents/`). That is an artifact of symlinked `node_modules` in a worktree and a file this PR does not touch — the build, which is the CI gate, passes.

**Still outstanding from the Tranche A review (not code):** the manual end-to-end pass on a live deployment — the live pane, the Replay tab on a real run, and the "Video unavailable — screenshots preserved" degradation have only ever been exercised by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The scope-reset change fixes user-visible run navigation correctness; stream hub and frame validation touch live swarm viewing paths but are bounded and covered by new tests.
> 
> **Overview**
> Fixes a **React concurrent-rendering bug** when switching between journey runs in `RunSessionsProvider`: the run-scope guard moves from a ref to **state** so a discarded render cannot skip `setMatrixSelection(null)` and `setPinnedManually(false)`, which previously left the new run showing the old session with auto-follow stuck off.
> 
> **`JourneyRunStreamHub`** now caps retained live browser frames at **64 sessions**, evicting the **least recently updated** session (delete-then-set on each frame so `Map` order reflects recency). Tests cover eviction behavior.
> 
> **`isLiveBrowserFrame`** adds a **base64 charset check** on `thumbnailBase64` before it is used in `data:` URIs, with new accept/reject unit tests—defense in depth, not a reported injection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea06fc64f2d89761b1a48ffa457335b7b9159ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stale session selection when switching runs, bound retained live-frame memory, and validate thumbnail data. Improves correctness and keeps memory under control for high fan-out runs.

- **Bug Fixes**
  - Reset run scope with state (not a ref) so switching runs clears selection and re-enables auto-follow even if a render is discarded.
  - Cap retained `browser_frame` thumbnails to 64 sessions and evict the least recently updated; use delete-then-set to keep true recency, and retain frames past `session_complete` for late joiners.
  - Validate `thumbnailBase64` with a strict base64 check (and existing size cap) to reject malformed values before building `data:` URIs.

<sup>Written for commit 3ea06fc64f2d89761b1a48ffa457335b7b9159ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

