### PR TITLE
fix(servers): stop Reconnect forcing OAuth on tokenless Auto servers

### DIFF
--- a/.changeset/reconnect-tokenless-auto-server.md
+++ b/.changeset/reconnect-tokenless-auto-server.md
@@ -1,0 +1,27 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix the server card's **Reconnect** action forcing an OAuth flow on servers
+that have no OAuth at all.
+
+The kebab-menu Reconnect decided whether to force a full re-authorization from
+`server.useOAuth === true || server.oauthTokens != null`. That predicate dates
+back to when `useOAuth` meant "the user chose OAuth", but unauthenticated-first
+Auto (#3198) made it also true for Auto servers: an Auto server that connects
+*unauthenticated* still gets `useOAuth: true` stamped on it as a derived
+mirror. Auth defaults to Automatic in the add-server form, so this covers most
+plain HTTP servers.
+
+The result, for a server with no authorization server at all: Reconnect took
+the `forceOAuthFlow` branch, which clears stored OAuth data, deletes the
+connection, flips the card to "Authorizing in browser...", and starts an
+interactive OAuth flow that then fails. The on/off toggle was unaffected — it
+only ever *allows* OAuth, so it reached the orchestrator's Auto guard and
+connected normally.
+
+Reconnect now mirrors that same guard and skips the forced flow for a tokenless
+Auto server, so it plainly reconnects. Everything else is unchanged: explicit
+OAuth servers, and any server already holding tokens (including Auto ones that
+did authorize), still force a fresh flow, and a real 401 still escalates
+through the existing user-confirmed prompt.

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -674,9 +674,20 @@ export function ServerConnectionCard({
                         track("reconnect_server_clicked", {
                           location: "server_connection_card",
                         });
+                        // A tokenless Auto server carries `useOAuth: true` as
+                        // a derived mirror even when it connected
+                        // unauthenticated, so that flag alone can't force the
+                        // flow — it would redirect an open server into an
+                        // OAuth it has no authorization server for. Mirror the
+                        // orchestrator's Auto guard and let the normal
+                        // reconnect escalate on a real 401 instead.
+                        const isTokenlessAutoServer =
+                          server.authMethod === "auto" &&
+                          server.oauthTokens == null;
                         const shouldForceOAuth =
-                          server.useOAuth === true ||
-                          server.oauthTokens != null;
+                          !isTokenlessAutoServer &&
+                          (server.useOAuth === true ||
+                            server.oauthTokens != null);
                         void handleReconnect(
                           shouldForceOAuth
                             ? { forceOAuthFlow: true }

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -399,6 +399,90 @@ describe("ServerConnectionCard", () => {
     });
   });
 
+  describe("actions menu reconnect", () => {
+    const clickMenuReconnect = async (server: ServerWithName) => {
+      const onReconnect = vi.fn().mockResolvedValue(undefined);
+      render(
+        <ServerConnectionCard
+          server={server}
+          {...defaultProps}
+          onReconnect={onReconnect}
+        />
+      );
+
+      fireEvent.pointerDown(
+        screen.getByRole("button", {
+          name: `Open actions menu for ${server.name}`,
+        }),
+        { button: 0, ctrlKey: false }
+      );
+      fireEvent.click(await screen.findByText("Reconnect"));
+
+      return onReconnect;
+    };
+
+    // A tokenless Auto server carries `useOAuth: true` as a derived mirror
+    // once it connects, even though it never authorized. Forcing the flow
+    // here redirected open servers into an OAuth they have no authorization
+    // server for, and the reconnect failed on "Authorizing in browser...".
+    it("does not force OAuth for a tokenless auto server", async () => {
+      const onReconnect = await clickMenuReconnect(
+        createServer({
+          connectionStatus: "disconnected",
+          authMethod: "auto",
+          useOAuth: true,
+          config: { url: "https://example.com/mcp" } as any,
+        })
+      );
+
+      expect(onReconnect).toHaveBeenCalledWith("test-server", undefined);
+    });
+
+    it("forces OAuth for an auto server that already holds tokens", async () => {
+      const onReconnect = await clickMenuReconnect(
+        createServer({
+          connectionStatus: "disconnected",
+          authMethod: "auto",
+          useOAuth: true,
+          oauthTokens: { access_token: "token" } as any,
+          config: { url: "https://example.com/mcp" } as any,
+        })
+      );
+
+      expect(onReconnect).toHaveBeenCalledWith("test-server", {
+        forceOAuthFlow: true,
+      });
+    });
+
+    it("forces OAuth for an explicitly configured OAuth server", async () => {
+      const onReconnect = await clickMenuReconnect(
+        createServer({
+          connectionStatus: "disconnected",
+          authMethod: "oauth",
+          useOAuth: true,
+          config: { url: "https://example.com/mcp" } as any,
+        })
+      );
+
+      expect(onReconnect).toHaveBeenCalledWith("test-server", {
+        forceOAuthFlow: true,
+      });
+    });
+
+    it("does not force OAuth for a server saved without authentication", async () => {
+      const onReconnect = await clickMenuReconnect(
+        createServer({
+          connectionStatus: "disconnected",
+          authMethod: "none",
+          useOAuth: false,
+          config: { url: "https://example.com/mcp" } as any,
+        })
+      );
+
+      expect(onReconnect).toHaveBeenCalledWith("test-server", undefined);
+    });
+  });
+
   describe("error display", () => {
     it("shows error message when connection failed", () => {
       const server = createServer({


### PR DESCRIPTION
## The bug

Clicking **Reconnect** in a server card's kebab menu on a plain, no-auth server flips the card to "Authorizing in browser…", starts an OAuth flow against a server that has no authorization server, and fails. The on/off toggle on the same card reconnects the same server fine.

## Cause

The menu item chose whether to force a full re-authorization from:

```ts
const shouldForceOAuth =
  server.useOAuth === true || server.oauthTokens != null;
```

That predicate predates hosted mode and was correct when `useOAuth: true` meant "the user picked OAuth". Unauthenticated-first Auto (#3198) changed what the flag means: an Auto server that connects *unauthenticated* still gets `useOAuth: true` stamped on it as a derived mirror ([`use-server-state.ts`](https://github.com/MCPJam/inspector/blob/main/mcpjam-inspector/client/src/hooks/use-server-state.ts#L3173) — the adjacent toast already acknowledges "An Auto server may have connected without credentials"). Auth defaults to **Automatic** in the add-server form, so this is most plain HTTP servers.

So for a no-auth server: `useOAuth === true`, no tokens → `forceOAuthFlow: true` → the reconnect path takes the destructive branch that calls `clearOAuthData`, `deleteServer`, sets status to `oauth-flow` ("Authorizing in browser…"), and starts an interactive flow that fails.

#3198 added guards for exactly this in two places but missed this call site — the only one in the client that sets `forceOAuthFlow`:

- `ensureAuthorizedForReconnect` returns *ready* for a tokenless Auto server instead of redirecting
- `gateAutoEscalation` asks the user before escalating an Auto server on a real 401

The toggle works because it only ever *allows* OAuth (`allowInteractiveOAuthFlow`), never forces it, so it reaches both guards.

## Fix

Mirror the orchestrator's Auto guard at the call site:

```ts
const isTokenlessAutoServer =
  server.authMethod === "auto" && server.oauthTokens == null;
const shouldForceOAuth =
  !isTokenlessAutoServer &&
  (server.useOAuth === true || server.oauthTokens != null);
```

Behavior by server shape:

| Server | Before | After |
|---|---|---|
| Auto, no tokens | forced OAuth → fails | plain reconnect |
| Auto, has tokens | forced OAuth | forced OAuth |
| Explicit OAuth | forced OAuth | forced OAuth |
| Bearer / none | plain reconnect | plain reconnect |

Only the first row changes. A real 401 on that row still escalates to OAuth through the existing user-confirmed prompt, so nothing is lost for an Auto server that does turn out to need auth.

Keying on `authMethod` rather than loosening `useOAuth` is deliberate: the only path that stamps `useOAuth: true` without a real OAuth flow is the Auto path, and it always persists `authMethod: "auto"` alongside. Legacy rows with `authMethod` undefined keep today's behavior.

## Tests

Four cases added to `ServerConnectionCard.test.tsx`, one per row above. Verified they fail against the old predicate — reverting just the logic fails the tokenless-Auto case with `forceOAuthFlow: true` where `undefined` is expected, and the other three pass as regression guards.

`client/src/components/connection/__tests__` — 148 passed. `tsc --noEmit -p client/tsconfig.typecheck.json` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Reconnect action so tokenless Auto servers no longer trigger an OAuth flow; they now reconnect normally. This prevents the failing “Authorizing in browser…” path on servers with no auth server.

- Bug Fixes
  - Skip forced OAuth when `authMethod === "auto"` and `oauthTokens == null`; otherwise force when `useOAuth === true` or tokens exist.
  - Explicit OAuth and token-bearing servers still force OAuth; real 401s still prompt to escalate.
  - Added four tests covering tokenless Auto, tokened Auto, explicit OAuth, and no-auth servers.

<sup>Written for commit c752e811908d99fdc4270b3d9b68da5a0fe9bc23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

