### PR TITLE
fix(design-system): stop long unbroken textarea values widening dialogs

### DIFF
--- a/.changeset/textarea-dialog-blowout.md
+++ b/.changeset/textarea-dialog-blowout.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix the OAuth Debugger's "Configure Server to Test" dialog blowing out horizontally when Scopes held a long unbroken value. The shared design-system `Textarea` uses `field-sizing: content`, so an unbreakable value set its min-content width and dragged every `w-full` field and the footer past the dialog edge; `wrap-anywhere` makes the value wrap and the field grow vertically instead.

--- a/design-system/src/components/textarea.tsx
+++ b/design-system/src/components/textarea.tsx
@@ -7,7 +7,10 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        // wrap-anywhere caps the field-sizing-content min-content width: without
+        // it a long unbroken value widens the textarea past its container and
+        // drags every w-full sibling in the dialog along with it.
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/30 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base wrap-anywhere shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Problem
In the OAuth Debugger's "Configure Server to Test" dialog, pasting a long value with no spaces into **Scopes** pushed every input and the footer buttons past the modal's right edge.

## Cause
The shared design-system `Textarea` uses `field-sizing: content`, so an unbreakable value sets its min-content width; `DialogContent` is a grid, so the form and every `w-full` sibling expand with it.

## Fix
Add `wrap-anywhere` + `min-w-0` to the shared `Textarea`: long values wrap and the field grows vertically. Covers every `Textarea`; single-line `Input`s were never affected. Changeset: patch for `@mcpjam/inspector`.

Verified with a headless repro (form width 3721px -> 526px inside the 576px dialog) and `OAuthProfileModal` unit tests (9/9).

## Screenshots
<img width="1948" height="1578" alt="image" src="https://github.com/user-attachments/assets/fc47fc88-ae91-4a8e-b043-79cde8c34d44" />

### After
<img width="668" height="912" alt="image" src="https://github.com/user-attachments/assets/ae6bd47b-fa78-4bee-a5a9-3bc635acd23d" />
---
## Summary by cubic
Fixed dialogs widening when a textarea contains a long unbroken value (e.g., OAuth Debugger “Configure Server to Test” Scopes). Updated the shared `Textarea` to wrap long strings and cap min-content width by adding `wrap-anywhere` and `min-w-0` (patch for `@mcpjam/inspector`).

<sup>Written for commit d55bd4e2538ec64e023b24f999a0e04d4e61d727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

