### PR TITLE
Show a pre-run credit estimate before launching evals and swarms

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
@@ -28,6 +28,7 @@ import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
 import type { EvalCase, EvalSuite } from "./types";
 import { getEffectiveSuiteServers } from "./helpers";
 import { isModelFree } from "@/shared/steps";
+import { QuickCaseRunCostEstimateHint } from "./run-cost-estimate-hint";
 import {
   formatCaseTitleForSidebar,
   getEvalCaseSidebarGroupKey,
@@ -72,6 +73,11 @@ interface TestCaseListSidebarProps {
   hideRunInsightsRow?: boolean;
   /** Overrides nav row label below the header (playground uses e.g. "Runs"). */
   insightsNavLabel?: string;
+  /**
+   * Iteration override the Run control will send (quick-run state), forwarded to
+   * the credit estimate so it prices the run this button actually launches.
+   */
+  quickRunIterationOverride?: number;
 }
 
 export function TestCaseListSidebar({
@@ -105,6 +111,7 @@ export function TestCaseListSidebar({
   hideRunAction = false,
   hideRunInsightsRow = false,
   insightsNavLabel = RUN_INSIGHTS_SIDEBAR_LABEL,
+  quickRunIterationOverride,
 }: TestCaseListSidebarProps) {
   const selectedTestCase = useMemo(
     () => testCases.find((testCase) => testCase._id === selectedTestId) ?? null,
@@ -113,6 +120,9 @@ export function TestCaseListSidebar({
   // Effective list = legacy `environment.servers` merged with any host
   // attachments' `resolvedServerNames`. Without the merge, sidebar Run
   // buttons stay disabled on attachment-only suites.
+  // Environment suites route single-case runs to "Run all", so this control
+  // never spends for them — and an estimate beside a non-running control lies.
+  const isEnvironmentSuite = (suite?.environmentIds?.length ?? 0) > 0;
   const suiteServers = suite ? getEffectiveSuiteServers(suite) : [];
   const hasConfiguredSuiteServers = suiteServers.length > 0;
   const missingServers = suiteServers.filter(
@@ -224,6 +234,20 @@ export function TestCaseListSidebar({
                               : "Run selected case"}
               </TooltipContent>
             </Tooltip>
+          ) : null}
+          {!hideRunAction ? (
+            // Suppressed wherever the Run control won't actually run: an
+            // environment suite (quick-run routes to Run all), a case with no
+            // models, a render check, or no selection at all.
+            <QuickCaseRunCostEstimateHint
+              suiteId={suiteId}
+              caseId={selectedTestCase?._id ?? null}
+              models={selectedTestCase?.models ?? []}
+              {...(quickRunIterationOverride !== undefined
+                ? { runs: quickRunIterationOverride }
+                : {})}
+              suppressed={!canRunSelectedCase || isEnvironmentSuite}
+            />
           ) : null}
           <Tooltip>
             <TooltipTrigger asChild>

--- a/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
@@ -28,6 +28,7 @@ import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
 import type { EvalCase, EvalSuite } from "./types";
 import { getEffectiveSuiteServers } from "./helpers";
 import { isModelFree } from "@/shared/steps";
+import { getDefaultTestCaseModelValue } from "./single-test-case-runner";
 import { QuickCaseRunCostEstimateHint } from "./run-cost-estimate-hint";
 import {
   formatCaseTitleForSidebar,
@@ -261,7 +262,9 @@ export function TestCaseListSidebar({
               suppressed={
                 !canRunSelectedCase ||
                 isEnvironmentSuite ||
-                runnableSelectedCaseModels.length === 0
+                runnableSelectedCaseModels.length === 0 ||
+                // Same index-0 default-model guard `handleRunTestCase` applies.
+                !getDefaultTestCaseModelValue(selectedTestCase)
               }
             />
           ) : null}

--- a/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
@@ -131,6 +131,18 @@ export function TestCaseListSidebar({
   const selectedCaseIsProbe = selectedTestCase
     ? isModelFree(selectedTestCase.steps)
     : false;
+  // The models quick-run will REALLY execute — entries missing a provider or
+  // model dropped, the rest deduped, matching `getConfiguredTestCaseModelValues`
+  // in `use-eval-handlers` and `runnableCaseModels` in `test-cases-overview`. A
+  // case whose entries are all malformed has `models.length > 0` yet still
+  // toasts "Add a model first", so the estimate must key off this list.
+  const runnableSelectedCaseModels = Array.from(
+    new Map(
+      (selectedTestCase?.models ?? [])
+        .filter((m) => Boolean(m?.provider) && Boolean(m?.model))
+        .map((m) => [`${m.provider}/${m.model}`, m] as const),
+    ).values(),
+  );
   const canRunSelectedCase =
     Boolean(selectedTestCase) &&
     !selectedCaseIsProbe &&
@@ -242,11 +254,15 @@ export function TestCaseListSidebar({
             <QuickCaseRunCostEstimateHint
               suiteId={suiteId}
               caseId={selectedTestCase?._id ?? null}
-              models={selectedTestCase?.models ?? []}
+              models={runnableSelectedCaseModels}
               {...(quickRunIterationOverride !== undefined
                 ? { runs: quickRunIterationOverride }
                 : {})}
-              suppressed={!canRunSelectedCase || isEnvironmentSuite}
+              suppressed={
+                !canRunSelectedCase ||
+                isEnvironmentSuite ||
+                runnableSelectedCaseModels.length === 0
+              }
             />
           ) : null}
           <Tooltip>

--- a/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/TestCaseListSidebar.tsx
@@ -28,7 +28,10 @@ import { buildEvalsPath, navigateApp } from "@/lib/app-navigation";
 import type { EvalCase, EvalSuite } from "./types";
 import { getEffectiveSuiteServers } from "./helpers";
 import { isModelFree } from "@/shared/steps";
-import { getDefaultTestCaseModelValue } from "./single-test-case-runner";
+import {
+  getDefaultTestCaseModelValue,
+  getRunnableCaseModels,
+} from "./single-test-case-runner";
 import { QuickCaseRunCostEstimateHint } from "./run-cost-estimate-hint";
 import {
   formatCaseTitleForSidebar,
@@ -132,18 +135,9 @@ export function TestCaseListSidebar({
   const selectedCaseIsProbe = selectedTestCase
     ? isModelFree(selectedTestCase.steps)
     : false;
-  // The models quick-run will REALLY execute — entries missing a provider or
-  // model dropped, the rest deduped, matching `getConfiguredTestCaseModelValues`
-  // in `use-eval-handlers` and `runnableCaseModels` in `test-cases-overview`. A
-  // case whose entries are all malformed has `models.length > 0` yet still
-  // toasts "Add a model first", so the estimate must key off this list.
-  const runnableSelectedCaseModels = Array.from(
-    new Map(
-      (selectedTestCase?.models ?? [])
-        .filter((m) => Boolean(m?.provider) && Boolean(m?.model))
-        .map((m) => [`${m.provider}/${m.model}`, m] as const),
-    ).values(),
-  );
+  // The models quick-run will REALLY execute. A case whose entries are all
+  // malformed has `models.length > 0` yet still toasts "Add a model first".
+  const runnableSelectedCaseModels = getRunnableCaseModels(selectedTestCase);
   const canRunSelectedCase =
     Boolean(selectedTestCase) &&
     !selectedCaseIsProbe &&

--- a/mcpjam-inspector/client/src/components/evals/__tests__/count-suite-run-plans.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/count-suite-run-plans.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { buildSuiteRunPlans, countSuiteRunPlans } from "../helpers";
+
+/**
+ * CONTRACT: `countSuiteRunPlans` is what the pre-run credit estimate sends to
+ * the backend as `planCount`, so it MUST equal `buildSuiteRunPlans(...).length`
+ * for every suite shape. A count that silently lags a new fan-out axis would
+ * understate every estimate — exactly the "confidently low number" this feature
+ * must never display.
+ */
+
+const hostAttachment = (namedHostId: string, servers: string[]) => ({
+  namedHostId,
+  enabledOptionalServerIds: [],
+  hostName: `host-${namedHostId}`,
+  resolvedServerNames: servers,
+});
+
+const shapes: Array<{
+  name: string;
+  suite: Parameters<typeof buildSuiteRunPlans>[0];
+  environments?: Parameters<typeof buildSuiteRunPlans>[1];
+  fallbackServerIds?: string[];
+}> = [
+  {
+    name: "environment axis (wins over hosts)",
+    suite: {
+      environment: { servers: ["flat-1"] },
+      hostAttachments: [hostAttachment("h1", ["srv-a"])],
+      environmentIds: ["env-1", "env-2", "env-3"],
+    },
+    environments: [
+      { environmentId: "env-1", name: "Alpha" },
+      { environmentId: "env-2", name: "Beta" },
+    ],
+    fallbackServerIds: ["flat-1"],
+  },
+  {
+    name: "environment axis with no environments list supplied",
+    suite: { environmentIds: ["env-x"] },
+  },
+  {
+    name: "host axis (multiple attachments)",
+    suite: {
+      environment: { servers: ["flat-1"] },
+      hostAttachments: [
+        hostAttachment("h1", ["srv-a"]),
+        hostAttachment("h2", ["srv-b"]),
+      ],
+    },
+    fallbackServerIds: ["flat-1"],
+  },
+  {
+    name: "host axis (single attachment)",
+    suite: { hostAttachments: [hostAttachment("h1", ["srv-a"])] },
+  },
+  {
+    name: "flat default plan (no environments, no attachments)",
+    suite: { environment: { servers: ["flat-1", "flat-2"] } },
+    fallbackServerIds: ["flat-1", "flat-2"],
+  },
+  {
+    name: "empty suite (still one default plan)",
+    suite: {},
+  },
+  {
+    name: "empty environmentIds array falls back to the host axis",
+    suite: {
+      environmentIds: [],
+      hostAttachments: [
+        hostAttachment("h1", ["srv-a"]),
+        hostAttachment("h2", ["srv-b"]),
+      ],
+    },
+  },
+];
+
+describe("countSuiteRunPlans", () => {
+  for (const shape of shapes) {
+    it(`matches buildSuiteRunPlans().length — ${shape.name}`, () => {
+      expect(
+        countSuiteRunPlans(
+          shape.suite,
+          shape.environments,
+          shape.fallbackServerIds,
+        ),
+      ).toBe(
+        buildSuiteRunPlans(
+          shape.suite,
+          shape.environments,
+          shape.fallbackServerIds,
+        ).length,
+      );
+    });
+  }
+
+  it("never returns zero — a suite always launches at least one plan", () => {
+    for (const shape of shapes) {
+      expect(
+        countSuiteRunPlans(
+          shape.suite,
+          shape.environments,
+          shape.fallbackServerIds,
+        ),
+      ).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("counts environments without needing the environments list", () => {
+    // The estimate only needs the COUNT, and the environments list contributes
+    // display names only — so a caller that has not loaded it still sends the
+    // right fan-out width.
+    expect(countSuiteRunPlans({ environmentIds: ["a", "b", "c"] })).toBe(3);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/count-suite-run-plans.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/count-suite-run-plans.test.ts
@@ -16,14 +16,23 @@ const hostAttachment = (namedHostId: string, servers: string[]) => ({
   resolvedServerNames: servers,
 });
 
+/**
+ * Each shape pins its ABSOLUTE expected width as well as parity. Parity alone is
+ * near-tautological while `countSuiteRunPlans` delegates to
+ * `buildSuiteRunPlans(...).length` — it catches a future divergence between the
+ * two, but not a shared fan-out bug inside `buildSuiteRunPlans` that would move
+ * both numbers together and quietly change every estimate.
+ */
 const shapes: Array<{
   name: string;
   suite: Parameters<typeof buildSuiteRunPlans>[0];
   environments?: Parameters<typeof buildSuiteRunPlans>[1];
   fallbackServerIds?: string[];
+  expected: number;
 }> = [
   {
     name: "environment axis (wins over hosts)",
+    expected: 3,
     suite: {
       environment: { servers: ["flat-1"] },
       hostAttachments: [hostAttachment("h1", ["srv-a"])],
@@ -37,10 +46,12 @@ const shapes: Array<{
   },
   {
     name: "environment axis with no environments list supplied",
+    expected: 1,
     suite: { environmentIds: ["env-x"] },
   },
   {
     name: "host axis (multiple attachments)",
+    expected: 2,
     suite: {
       environment: { servers: ["flat-1"] },
       hostAttachments: [
@@ -52,19 +63,23 @@ const shapes: Array<{
   },
   {
     name: "host axis (single attachment)",
+    expected: 1,
     suite: { hostAttachments: [hostAttachment("h1", ["srv-a"])] },
   },
   {
     name: "flat default plan (no environments, no attachments)",
+    expected: 1,
     suite: { environment: { servers: ["flat-1", "flat-2"] } },
     fallbackServerIds: ["flat-1", "flat-2"],
   },
   {
     name: "empty suite (still one default plan)",
+    expected: 1,
     suite: {},
   },
   {
     name: "empty environmentIds array falls back to the host axis",
+    expected: 2,
     suite: {
       environmentIds: [],
       hostAttachments: [
@@ -91,6 +106,15 @@ describe("countSuiteRunPlans", () => {
           shape.fallbackServerIds,
         ).length,
       );
+      // ...and pin the absolute width, so a shared fan-out change in
+      // `buildSuiteRunPlans` can't move both sides together unnoticed.
+      expect(
+        countSuiteRunPlans(
+          shape.suite,
+          shape.environments,
+          shape.fallbackServerIds,
+        ),
+      ).toBe(shape.expected);
     });
   }
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-cost-estimate-placement.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-cost-estimate-placement.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -53,11 +53,13 @@ const noModelsCase = {
   models: [],
 } as any;
 
+// Keeps a NON-EMPTY model list on purpose: with `models: []` this case would be
+// suppressed by the generic no-models branch and the model-free step would never
+// be the thing under test. The only difference from `promptCase` is the step kind.
 const renderCheckCase = {
   ...promptCase,
   _id: "case-render",
   title: "Render check",
-  models: [],
   query: "",
   steps: [
     {
@@ -132,6 +134,10 @@ describe("per-case credit estimate placement", () => {
   });
 
   it("renders no hint for a model-free render check", () => {
+    // `renderCheckCase` carries models, so the ONLY reason it is suppressed is
+    // its model-free steps — i.e. this exercises the render-check branch rather
+    // than falling through the no-models one.
+    expect(renderCheckCase.models.length).toBeGreaterThan(0);
     renderOverview([renderCheckCase]);
     expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
   });
@@ -142,6 +148,48 @@ describe("per-case credit estimate placement", () => {
       environmentIds: ["env-1"],
     });
     expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+  });
+
+  it("renders no hint when every model entry is malformed", () => {
+    // `models.length > 0` but nothing runnable: quick-run drops entries missing
+    // a provider or model and then toasts "Add a model first", so the estimate
+    // must key off the runnable list rather than the raw one.
+    renderOverview([
+      {
+        ...promptCase,
+        _id: "case-malformed",
+        models: [
+          { model: "", provider: "openai" },
+          { model: "gpt-5-mini", provider: "" },
+        ],
+      } as any,
+    ]);
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+  });
+
+  it("prices only the runnable, deduped models", async () => {
+    renderOverview([
+      {
+        ...promptCase,
+        _id: "case-dupes",
+        models: [
+          { model: "gpt-5-mini", provider: "openai" },
+          { model: "gpt-5-mini", provider: "openai" },
+          { model: "", provider: "openai" },
+        ],
+      } as any,
+    ]);
+    const hint = screen.getByTestId("run-cost-estimate-hint");
+    expect(hint).toBeInTheDocument();
+    // The estimate only fetches on open, so drive the tooltip and inspect args.
+    hint.focus();
+    await waitFor(() => expect(queryCalls.length).toBeGreaterThan(0));
+    const call = queryCalls.find(
+      (c) => c.name === RUN_COST_ESTIMATE_QUERIES.quickCase,
+    );
+    expect((call?.args as { models: unknown[] }).models).toEqual([
+      { model: "gpt-5-mini", provider: "openai" },
+    ]);
   });
 
   it("renders no hint when the suite has no servers attached", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-cost-estimate-placement.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-cost-estimate-placement.test.tsx
@@ -144,6 +144,27 @@ describe("per-case credit estimate placement", () => {
     expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
   });
 
+  it("renders no hint when the suite has no servers attached", () => {
+    // Quick-run toasts "Attach a client to this suite before running it." and
+    // returns — the same permanent refusal as the other suppressed cases, and
+    // the condition `TestCaseListSidebar` already gates on.
+    renderOverview([promptCase], {
+      ...baseSuite,
+      environment: { servers: [] },
+    });
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+  });
+
+  it("still renders the hint when servers are merely disconnected", () => {
+    // That state resolves by connecting — the row's tooltip says "Connect and
+    // run." — so the estimate is exactly right for the run that follows and
+    // must NOT be suppressed.
+    renderOverview([promptCase], baseSuite, {
+      connectedServerNames: new Set<string>(),
+    });
+    expect(screen.getAllByTestId("run-cost-estimate-hint")).toHaveLength(1);
+  });
+
   it("renders no hint when the Run control itself is not offered", () => {
     render(
       <TestCasesOverview

--- a/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-cost-estimate-placement.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-cost-estimate-placement.test.tsx
@@ -167,6 +167,23 @@ describe("per-case credit estimate placement", () => {
     expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
   });
 
+  it("renders no hint when the FIRST model entry is malformed", () => {
+    // `handleRunTestCase`'s default-model check reads `models[0]` specifically,
+    // so a malformed first entry with a valid second one still toasts "Add a
+    // model first" — a non-empty runnable list is not sufficient.
+    renderOverview([
+      {
+        ...promptCase,
+        _id: "case-bad-first",
+        models: [
+          { model: "", provider: "openai" },
+          { model: "gpt-5-mini", provider: "openai" },
+        ],
+      } as any,
+    ]);
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+  });
+
   it("prices only the runnable, deduped models", async () => {
     renderOverview([
       {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-cost-estimate-placement.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/quick-run-cost-estimate-placement.test.tsx
@@ -1,0 +1,169 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * CONTRACT: the per-case credit estimate must appear beside a quick-run control
+ * ONLY where that control will actually launch a run. Quick-run refuses to run
+ * (toast-and-return) for environment suites, cases with no models, and model-free
+ * render checks — an estimate next to a control that never spends is worse than
+ * no estimate at all.
+ *
+ * Also asserts the flag gate at the placement level: with the flag off, the
+ * rows render no hint and no estimate query is dispatched.
+ */
+
+const queryCalls: Array<{ name: string; args: unknown }> = [];
+
+vi.mock("convex/react", () => ({
+  useConvex: () => ({
+    query: (name: string, args: unknown) => {
+      queryCalls.push({ name, args });
+      return Promise.resolve(undefined);
+    },
+  }),
+  useQuery: () => undefined,
+  usePaginatedQuery: () => ({ results: [], status: "Exhausted" }),
+  useMutation: () => vi.fn(),
+}));
+
+let flagEnabled: boolean | undefined = true;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => flagEnabled,
+}));
+
+import { TestCasesOverview } from "../test-cases-overview";
+import { RUN_COST_ESTIMATE_QUERIES } from "@/hooks/use-run-cost-estimate";
+
+const promptCase = {
+  _id: "case-prompt",
+  testSuiteId: "suite-1",
+  createdBy: "user-1",
+  title: "Prompt case",
+  query: "Do the thing",
+  models: [{ model: "gpt-5-mini", provider: "openai" }],
+  runs: 1,
+  expectedToolCalls: [],
+  steps: [{ id: "s1", kind: "prompt", prompt: "Do the thing" }],
+} as any;
+
+const noModelsCase = {
+  ...promptCase,
+  _id: "case-no-models",
+  title: "No models",
+  models: [],
+} as any;
+
+const renderCheckCase = {
+  ...promptCase,
+  _id: "case-render",
+  title: "Render check",
+  models: [],
+  query: "",
+  steps: [
+    {
+      id: "s1",
+      kind: "toolCall",
+      serverName: "srv",
+      toolName: "render",
+      arguments: {},
+    },
+  ],
+} as any;
+
+const baseSuite = {
+  _id: "suite-1",
+  name: "Suite",
+  environment: { servers: ["asana"] },
+} as any;
+
+function renderOverview(
+  cases: any[],
+  suite: any = baseSuite,
+  extra: Record<string, unknown> = {},
+) {
+  return render(
+    <TestCasesOverview
+      suite={suite}
+      cases={cases}
+      allIterations={[]}
+      runsViewMode={"cases" as any}
+      onViewModeChange={vi.fn()}
+      onTestCaseClick={vi.fn()}
+      runTrendData={[]}
+      modelStats={[]}
+      runsLoading={false}
+      onRunTestCase={vi.fn()}
+      connectedServerNames={new Set(["asana"])}
+      {...extra}
+    />,
+  );
+}
+
+beforeEach(() => {
+  queryCalls.length = 0;
+  flagEnabled = true;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("per-case credit estimate placement", () => {
+  it("renders one hint for a runnable prompt case", () => {
+    renderOverview([promptCase]);
+    expect(screen.getAllByTestId("run-cost-estimate-hint")).toHaveLength(1);
+  });
+
+  it("renders no hint when the flag is off, and dispatches no query", async () => {
+    flagEnabled = false;
+    renderOverview([promptCase]);
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+    await Promise.resolve();
+    expect(
+      queryCalls.filter(
+        (call) => call.name === RUN_COST_ESTIMATE_QUERIES.quickCase,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("renders no hint for a case with no models (quick-run toasts instead)", () => {
+    renderOverview([noModelsCase]);
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+  });
+
+  it("renders no hint for a model-free render check", () => {
+    renderOverview([renderCheckCase]);
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+  });
+
+  it("renders no hint on an environment suite (quick-run routes to Run all)", () => {
+    renderOverview([promptCase], {
+      ...baseSuite,
+      environmentIds: ["env-1"],
+    });
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+  });
+
+  it("renders no hint when the Run control itself is not offered", () => {
+    render(
+      <TestCasesOverview
+        suite={baseSuite}
+        cases={[promptCase]}
+        allIterations={[]}
+        runsViewMode={"cases" as any}
+        onViewModeChange={vi.fn()}
+        onTestCaseClick={vi.fn()}
+        runTrendData={[]}
+        modelStats={[]}
+        runsLoading={false}
+        connectedServerNames={new Set(["asana"])}
+      />,
+    );
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+  });
+
+  it("shows a hint per runnable case and skips the unrunnable ones", () => {
+    renderOverview([promptCase, noModelsCase, renderCheckCase]);
+    expect(screen.getAllByTestId("run-cost-estimate-hint")).toHaveLength(1);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -150,6 +150,29 @@ export function buildSuiteRunPlans(
   return buildSuiteHostRunPlans(suite, fallbackServerIds);
 }
 
+/**
+ * Number of plans `buildSuiteRunPlans` would produce for this suite, without
+ * materializing them. Used by the pre-run credit estimate to tell the backend
+ * how wide the Run-all fan-out is (environments, then hosts, then the single
+ * default plan).
+ *
+ * Kept immediately beside `buildSuiteRunPlans` and covered by a parity test
+ * against `buildSuiteRunPlans(...).length`: if the plan shape ever gains another
+ * axis, a count that silently lags would understate every estimate.
+ */
+export function countSuiteRunPlans(
+  suite: {
+    environment?: { servers?: string[] } | undefined;
+    hostAttachments?: EvalSuite["hostAttachments"];
+    serverAttachment?: EvalSuite["serverAttachment"];
+    environmentIds?: string[];
+  },
+  environments?: Array<{ environmentId: string; name: string }>,
+  fallbackServerIds?: string[],
+): number {
+  return buildSuiteRunPlans(suite, environments, fallbackServerIds).length;
+}
+
 export function getSelectedSuiteHostRunPlan(
   suite: {
     environment?: { servers?: string[] } | undefined;

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -151,10 +151,10 @@ export function buildSuiteRunPlans(
 }
 
 /**
- * Number of plans `buildSuiteRunPlans` would produce for this suite, without
- * materializing them. Used by the pre-run credit estimate to tell the backend
- * how wide the Run-all fan-out is (environments, then hosts, then the single
- * default plan).
+ * Number of plans `buildSuiteRunPlans` produces for this suite — it delegates and
+ * reads `.length`, so parity holds by construction. Used by the pre-run credit
+ * estimate to tell the backend how wide the Run-all fan-out is (environments,
+ * then hosts, then the single default plan).
  *
  * Kept immediately beside `buildSuiteRunPlans` and covered by a parity test
  * against `buildSuiteRunPlans(...).length`: if the plan shape ever gains another

--- a/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
@@ -276,11 +276,16 @@ function SuiteEstimateFetcher({
  */
 export function JourneyRunCostEstimateHint({
   journeyId,
+  configKey,
   label = "Estimated credit cost of the next run",
   className,
   side = "top",
   align = "center",
-}: { journeyId: string | null | undefined } & HintChromeProps) {
+}: {
+  journeyId: string | null | undefined;
+  /** See `useJourneyRunCostEstimate` — re-fetches an open tooltip on a config edit. */
+  configKey?: string;
+} & HintChromeProps) {
   const flagEnabled = useCreditEstimateEnabled();
   if (!flagEnabled || !journeyId) {
     return null;
@@ -288,6 +293,7 @@ export function JourneyRunCostEstimateHint({
   return (
     <JourneyEstimateFetcher
       journeyId={journeyId}
+      configKey={configKey}
       label={label}
       className={className}
       side={side}
@@ -298,12 +304,17 @@ export function JourneyRunCostEstimateHint({
 
 function JourneyEstimateFetcher({
   journeyId,
+  configKey,
   label,
   className,
   side,
   align,
-}: { journeyId: string } & HintChromeProps) {
-  const state = useJourneyRunCostEstimate({ enabled: true, journeyId });
+}: { journeyId: string; configKey?: string } & HintChromeProps) {
+  const state = useJourneyRunCostEstimate({
+    enabled: true,
+    journeyId,
+    configKey,
+  });
   return (
     <RunCostEstimateHint
       state={state}

--- a/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
@@ -56,10 +56,11 @@ export function RunCostEstimateHint({
           aria-label={label}
           data-testid="run-cost-estimate-hint"
           onClick={(e) => {
-            // The trigger is decorative; a click must never submit a
-            // surrounding form or bubble into a row/card click handler that
-            // would navigate away or start the run.
-            e.preventDefault();
+            // Stop the click reaching a surrounding row/card handler that would
+            // navigate away or start the run. Deliberately NOT
+            // `preventDefault()` — that suppresses Radix's activation-close, so
+            // a keyboard or touch activation would open the tooltip and be
+            // unable to close it. `type="button"` already blocks form submits.
             e.stopPropagation();
           }}
           className={cn(

--- a/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useCreditEstimateEnabled } from "@/hooks/useCreditEstimateEnabled";
 import {
+  formatCredits,
   formatRunCostEstimate,
   useJourneyRunCostEstimate,
   useQuickCaseRunCostEstimate,
@@ -88,15 +89,12 @@ export function RunCostEstimateHint({
                   className="flex justify-between gap-3"
                 >
                   <span className="truncate">
-                    {line.label} × {line.units.toLocaleString()}
+                    {line.label} × {formatCredits(line.units)}
                   </span>
                   <span className="shrink-0 tabular-nums">
                     {line.credits === null
                       ? "unpriced"
-                      : `~${Math.max(
-                          0,
-                          Math.round(line.credits),
-                        ).toLocaleString()}`}
+                      : `~${formatCredits(line.credits)}`}
                   </span>
                 </li>
               ))}

--- a/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
@@ -1,0 +1,318 @@
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+
+import { cn } from "@/lib/utils";
+import { useCreditEstimateEnabled } from "@/hooks/useCreditEstimateEnabled";
+import {
+  formatRunCostEstimate,
+  useJourneyRunCostEstimate,
+  useQuickCaseRunCostEstimate,
+  useSuiteRunCostEstimate,
+  type QuickCaseEstimateModel,
+  type RunCostEstimateState,
+} from "@/hooks/use-run-cost-estimate";
+
+/**
+ * Info icon whose tooltip shows what the run about to be launched is estimated
+ * to cost. Purely presentational — the caller owns the flag gate and passes the
+ * fetch state, and the estimate is fetched only while the tooltip is open (see
+ * `use-run-cost-estimate`).
+ *
+ * Styled after `InfoHint` (`global-gates-info.tsx`) so it reads as the same kind
+ * of affordance as the other inline hints.
+ *
+ * The number is never a promise: copy always says "Estimated" / "At least"
+ * / "Rough estimate", and this control NEVER gates or disables the run.
+ */
+export function RunCostEstimateHint({
+  state,
+  label = "Estimated credit cost",
+  className,
+  side = "bottom",
+  align = "center",
+}: {
+  state: RunCostEstimateState;
+  label?: string;
+  className?: string;
+  side?: "top" | "bottom" | "left" | "right";
+  align?: "start" | "center" | "end";
+}) {
+  const summary = formatRunCostEstimate(state);
+  const detailLines =
+    state.status === "ready" && state.estimate
+      ? state.estimate.lines.filter((line) => line.units > 0)
+      : [];
+
+  return (
+    <Tooltip open={state.open} onOpenChange={state.setOpen}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          data-testid="run-cost-estimate-hint"
+          onClick={(e) => {
+            // The trigger is decorative; a click must never submit a
+            // surrounding form or bubble into a row/card click handler that
+            // would navigate away or start the run.
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          className={cn(
+            "rounded-full p-0.5 text-muted-foreground outline-none transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring",
+            className,
+          )}
+        >
+          <Info className="size-3" aria-hidden />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent
+        variant="muted"
+        side={side}
+        align={align}
+        className="max-w-[20rem] px-2.5 py-2"
+      >
+        <div className="space-y-1 text-xs leading-snug">
+          <p className="font-medium">{summary}</p>
+          {detailLines.length > 0 ? (
+            <ul className="space-y-0.5 text-muted-foreground">
+              {/* Labels are display strings and CAN repeat (two environments
+                  can share a name, and every unresolved target renders the same
+                  placeholder), so the index is part of the key. */}
+              {detailLines.map((line, index) => (
+                <li
+                  key={`${index}:${line.label}`}
+                  className="flex justify-between gap-3"
+                >
+                  <span className="truncate">
+                    {line.label} × {line.units.toLocaleString()}
+                  </span>
+                  <span className="shrink-0 tabular-nums">
+                    {line.credits === null
+                      ? "unpriced"
+                      : `~${Math.max(
+                          0,
+                          Math.round(line.credits),
+                        ).toLocaleString()}`}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {state.status === "ready" && state.estimate?.truncated ? (
+            <p className="text-muted-foreground">
+              Some history was capped, so this is a partial picture.
+            </p>
+          ) : null}
+          <p className="text-muted-foreground">
+            1 credit = $0.01. Your free daily allowance and any BYOK keys change
+            what is actually deducted.
+          </p>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+type HintChromeProps = {
+  label?: string;
+  className?: string;
+  side?: "top" | "bottom" | "left" | "right";
+  align?: "start" | "center" | "end";
+};
+
+type QuickCaseEstimateArgs = {
+  suiteId: string | null | undefined;
+  caseId?: string | null;
+  models: readonly QuickCaseEstimateModel[];
+  runs?: number;
+  draft?: { promptChars: number; stepCount: number };
+};
+
+/**
+ * Quick-run / draft-run variant: owns the flag gate and the fetch so it can be
+ * dropped beside a per-case Run control inside a list (where a hook can't be
+ * called from the row callback).
+ *
+ * `suppressed` is how a caller says "this control will NOT actually run" — an
+ * environment suite (quick-run toasts and returns), a case with no models ("Add
+ * a model first"), or a model-free render check. An estimate beside a control
+ * that never spends is worse than no estimate, so nothing renders and no query
+ * fires in those cases.
+ *
+ * The FETCH hook lives in a child component that is only mounted once the gate
+ * passes. That is deliberate: with the flag off this component touches no Convex
+ * client at all, which is what "flag off ⇒ no render, no query" has to mean for
+ * a surface that renders one of these per row.
+ */
+export function QuickCaseRunCostEstimateHint({
+  suppressed = false,
+  label = "Estimated credit cost of this run",
+  className,
+  side = "left",
+  align = "center",
+  ...args
+}: QuickCaseEstimateArgs & HintChromeProps & { suppressed?: boolean }) {
+  const flagEnabled = useCreditEstimateEnabled();
+  if (!flagEnabled || suppressed || !args.suiteId) {
+    return null;
+  }
+  return (
+    <QuickCaseEstimateFetcher
+      {...args}
+      label={label}
+      className={className}
+      side={side}
+      align={align}
+    />
+  );
+}
+
+function QuickCaseEstimateFetcher({
+  suiteId,
+  caseId,
+  models,
+  runs,
+  draft,
+  label,
+  className,
+  side,
+  align,
+}: QuickCaseEstimateArgs & HintChromeProps) {
+  const state = useQuickCaseRunCostEstimate({
+    enabled: true,
+    suiteId,
+    caseId: caseId ?? null,
+    models,
+    ...(runs !== undefined ? { runs } : {}),
+    ...(draft ? { draft } : {}),
+  });
+  return (
+    <RunCostEstimateHint
+      state={state}
+      label={label}
+      className={className}
+      side={side}
+      align={align}
+    />
+  );
+}
+
+/**
+ * Suite "Run all" variant. Same gate-then-mount shape as the quick-case one so a
+ * flagged-off suite header never constructs an estimate subscription.
+ */
+export function SuiteRunCostEstimateHint({
+  suiteId,
+  caseIds,
+  iterationOverride,
+  planCount,
+  label = "Estimated credit cost of running this suite",
+  className,
+  side = "bottom",
+  align = "center",
+}: {
+  suiteId: string | null | undefined;
+  caseIds?: readonly string[];
+  iterationOverride?: number;
+  planCount?: number;
+} & HintChromeProps) {
+  const flagEnabled = useCreditEstimateEnabled();
+  if (!flagEnabled || !suiteId) {
+    return null;
+  }
+  return (
+    <SuiteEstimateFetcher
+      suiteId={suiteId}
+      caseIds={caseIds}
+      iterationOverride={iterationOverride}
+      planCount={planCount}
+      label={label}
+      className={className}
+      side={side}
+      align={align}
+    />
+  );
+}
+
+function SuiteEstimateFetcher({
+  suiteId,
+  caseIds,
+  iterationOverride,
+  planCount,
+  label,
+  className,
+  side,
+  align,
+}: {
+  suiteId: string;
+  caseIds?: readonly string[];
+  iterationOverride?: number;
+  planCount?: number;
+} & HintChromeProps) {
+  const state = useSuiteRunCostEstimate({
+    enabled: true,
+    suiteId,
+    ...(caseIds ? { caseIds } : {}),
+    ...(iterationOverride !== undefined ? { iterationOverride } : {}),
+    ...(planCount !== undefined ? { planCount } : {}),
+  });
+  return (
+    <RunCostEstimateHint
+      state={state}
+      label={label}
+      className={className}
+      side={side}
+      align={align}
+    />
+  );
+}
+
+/**
+ * Swarm journey-card variant. The gate-then-mount split matters most here: the
+ * Journeys list renders one card per journey, so a flagged-off list must not
+ * spin up N estimate state machines.
+ */
+export function JourneyRunCostEstimateHint({
+  journeyId,
+  label = "Estimated credit cost of the next run",
+  className,
+  side = "top",
+  align = "center",
+}: { journeyId: string | null | undefined } & HintChromeProps) {
+  const flagEnabled = useCreditEstimateEnabled();
+  if (!flagEnabled || !journeyId) {
+    return null;
+  }
+  return (
+    <JourneyEstimateFetcher
+      journeyId={journeyId}
+      label={label}
+      className={className}
+      side={side}
+      align={align}
+    />
+  );
+}
+
+function JourneyEstimateFetcher({
+  journeyId,
+  label,
+  className,
+  side,
+  align,
+}: { journeyId: string } & HintChromeProps) {
+  const state = useJourneyRunCostEstimate({ enabled: true, journeyId });
+  return (
+    <RunCostEstimateHint
+      state={state}
+      label={label}
+      className={className}
+      side={side}
+      align={align}
+    />
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-cost-estimate-hint.tsx
@@ -208,6 +208,7 @@ export function SuiteRunCostEstimateHint({
   caseIds,
   iterationOverride,
   planCount,
+  suppressed = false,
   label = "Estimated credit cost of running this suite",
   className,
   side = "bottom",
@@ -217,9 +218,11 @@ export function SuiteRunCostEstimateHint({
   caseIds?: readonly string[];
   iterationOverride?: number;
   planCount?: number;
+  /** Set when Run all cannot launch at all (no cases, no servers configured). */
+  suppressed?: boolean;
 } & HintChromeProps) {
   const flagEnabled = useCreditEstimateEnabled();
-  if (!flagEnabled || !suiteId) {
+  if (!flagEnabled || suppressed || !suiteId) {
     return null;
   }
   return (

--- a/mcpjam-inspector/client/src/components/evals/single-test-case-runner.ts
+++ b/mcpjam-inspector/client/src/components/evals/single-test-case-runner.ts
@@ -89,6 +89,35 @@ export interface TestCaseModelOption {
 const TEST_CASE_MODEL_SELECTION_STORAGE_PREFIX =
   "eval-test-case-model-selection";
 
+/**
+ * The models a quick run will ACTUALLY execute: entries missing a provider or a
+ * model dropped, the rest deduped on `provider/model`.
+ *
+ * One definition, three consumers — `getConfiguredTestCaseModelValues` (which
+ * drives `handleRunTestCase`) plus the per-case and editor credit estimates. A
+ * second copy would let a future filter or dedupe-key change diverge silently
+ * from what the estimates price, which is exactly the mispricing this feature
+ * has to avoid.
+ */
+export function getRunnableCaseModels(
+  testCase: Pick<EvalCase, "models"> | null | undefined,
+): Array<{ model: string; provider: string }> {
+  const byValue = new Map<string, { model: string; provider: string }>();
+  for (const modelConfig of testCase?.models ?? []) {
+    if (!modelConfig?.provider || !modelConfig.model) {
+      continue;
+    }
+    const value = `${modelConfig.provider}/${modelConfig.model}`;
+    if (!byValue.has(value)) {
+      byValue.set(value, {
+        model: modelConfig.model,
+        provider: modelConfig.provider,
+      });
+    }
+  }
+  return Array.from(byValue.values());
+}
+
 export function getDefaultTestCaseModelValue(
   testCase: Pick<EvalCase, "models"> | null | undefined,
 ): string | null {

--- a/mcpjam-inspector/client/src/components/evals/suite-dashboard.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-dashboard.tsx
@@ -82,6 +82,8 @@ export interface SuiteDashboardProps {
    * environment-backed run. Falls back to attachment names alone when omitted.
    */
   hostNamesById?: Map<string, string | null>;
+  /** Forwarded to the per-case credit estimate (quick-run iteration override). */
+  quickRunIterationOverride?: number;
 }
 
 /**
@@ -119,6 +121,7 @@ export function SuiteDashboard({
   runDetailPane,
   onExitRun,
   hostNamesById: hostNamesByIdProp,
+  quickRunIterationOverride,
 }: SuiteDashboardProps) {
   const hasRuns = runs.length > 0;
   const attachmentHostNames = useMemo(
@@ -159,6 +162,7 @@ export function SuiteDashboard({
       onOpenLastRun={onOpenLastRun}
       onDeleteTestCasesBatch={onDeleteTestCasesBatch}
       onRunTestCase={onRunTestCase}
+      quickRunIterationOverride={quickRunIterationOverride}
       runningTestCaseId={runningTestCaseId}
       blockTestCaseRuns={blockTestCaseRuns}
       runTestCaseDisabledReason={runTestCaseDisabledReason}

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -635,6 +635,12 @@ export function SuiteHeader(props: SuiteHeaderProps) {
               <SuiteRunCostEstimateHint
                 suiteId={suite._id}
                 planCount={countSuiteRunPlans(suite)}
+                // Structural blockers only: with no cases there is nothing to
+                // price, and with no servers configured Run all can never
+                // launch. The transient blockers (a rerun/replay in flight, a
+                // case running, an entitlement block) keep the estimate — it
+                // stays accurate for the run that follows.
+                suppressed={testCaseCount === 0 || !hasServersConfigured}
                 {...(iterationOverride !== undefined
                   ? { iterationOverride }
                   : {})}

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -462,17 +462,25 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     hideRunActions && showTestCaseCtas
       ? (() => {
           const testCaseCount = testCases?.length ?? 0;
+          // Environment suites launch through the server's authoritative
+          // resolution — `handleRerunSuite` skips the local server gate for
+          // them (`!isEnvironmentSuite && suiteServers.length === 0`), so the
+          // browser never needs to know their closed server set. Requiring
+          // local servers here made Run all unclickable for an env-only suite.
+          const isEnvironmentSuite = (suite.environmentIds?.length ?? 0) > 0;
+          const runAllNeedsLocalServers =
+            !isEnvironmentSuite && !hasServersConfigured;
           const isRunAllDisabled = Boolean(
             isRerunning ||
               replayingRunId != null ||
               runningTestCaseId != null ||
               evalRunsDisabledReason ||
               testCaseCount === 0 ||
-              !hasServersConfigured
+              runAllNeedsLocalServers
           );
           const runAllDisabledReasonTooltip = evalRunsDisabledReason
             ? evalRunsDisabledReason
-            : !hasServersConfigured
+            : runAllNeedsLocalServers
             ? "Configure suite servers before running the full suite."
             : testCaseCount === 0
             ? "Add a test case first."
@@ -640,7 +648,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                 // launch. The transient blockers (a rerun/replay in flight, a
                 // case running, an entitlement block) keep the estimate — it
                 // stays accurate for the run that follows.
-                suppressed={testCaseCount === 0 || !hasServersConfigured}
+                suppressed={testCaseCount === 0 || runAllNeedsLocalServers}
                 {...(iterationOverride !== undefined
                   ? { iterationOverride }
                   : {})}

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -489,8 +489,15 @@ export function SuiteHeader(props: SuiteHeaderProps) {
             : runningTestCaseId != null
             ? "Finish the in-progress test case run first."
             : null;
+          // `missingServers` compares the LOCAL server list against connected
+          // ones. An environment suite launches against the server-side resolved
+          // set instead, so a disconnected legacy entry says nothing about
+          // whether its run can proceed — and now that env suites are runnable,
+          // showing "Connect and run." for them would be actively misleading.
           const runAllConnectionHint =
-            missingServers.length > 0 ? "Connect and run." : null;
+            !isEnvironmentSuite && missingServers.length > 0
+              ? "Connect and run."
+              : null;
           const hasRunOverride =
             (runMatchOptionsOverride &&
               Object.keys(runMatchOptionsOverride).length > 0) ||

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -60,6 +60,8 @@ import { getSuiteReplayEligibility } from "./replay-eligibility";
 import { RunDetailPlaygroundActions } from "./run-detail-playground-actions";
 import { cn } from "@/lib/utils";
 import { SuiteOverviewClientBar } from "./suite-overview-client-bar";
+import { countSuiteRunPlans } from "./helpers";
+import { SuiteRunCostEstimateHint } from "./run-cost-estimate-hint";
 import type { HostAttachmentDraft } from "./client-attachments-editor";
 import type { HostListItem } from "@/hooks/useClients";
 import type { SuiteOverviewView } from "@/lib/eval-route-types";
@@ -592,8 +594,8 @@ export function SuiteHeader(props: SuiteHeaderProps) {
               </Popover>
             </div>
           );
-          if (isRunAllDisabled && runAllDisabledReasonTooltip) {
-            return (
+          const runAllControl =
+            isRunAllDisabled && runAllDisabledReasonTooltip ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="inline-flex">{runAllButton}</span>
@@ -606,10 +608,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                   {runAllDisabledReasonTooltip}
                 </TooltipContent>
               </Tooltip>
-            );
-          }
-          if (!isRunAllDisabled && runAllConnectionHint) {
-            return (
+            ) : !isRunAllDisabled && runAllConnectionHint ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="inline-flex">{runAllButton}</span>
@@ -622,9 +621,26 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                   {runAllConnectionHint}
                 </TooltipContent>
               </Tooltip>
+            ) : (
+              runAllButton
             );
-          }
-          return runAllButton;
+          // The estimate rides BESIDE the CTA (never inside its disabled
+          // tooltip trigger) so it stays readable whether or not Run all is
+          // currently runnable, and it never gates the run. `countSuiteRunPlans`
+          // is the same fan-out width `buildSuiteRunPlans` produces; the hint
+          // renders nothing — and fetches nothing — when the flag is off.
+          return (
+            <span className="inline-flex items-center gap-1.5">
+              {runAllControl}
+              <SuiteRunCostEstimateHint
+                suiteId={suite._id}
+                planCount={countSuiteRunPlans(suite)}
+                {...(iterationOverride !== undefined
+                  ? { iterationOverride }
+                  : {})}
+              />
+            </span>
+          );
         })()
       : null;
 

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -830,6 +830,7 @@ export function SuiteIterationsView({
       onRunClick={handleRunClick}
       onDirectDeleteRun={onDirectDeleteRun}
       onRunTestCase={onRunTestCaseWithOverride}
+      quickRunIterationOverride={iterationOverride}
       runningTestCaseId={runningTestCaseId}
       blockTestCaseRuns={Boolean(
         rerunningSuiteId || replayingRunId || evalRunsDisabledReason
@@ -1212,6 +1213,7 @@ export function SuiteIterationsView({
                       }
                       onDeleteTestCasesBatch={onDeleteTestCasesBatch}
                       onRunTestCase={onRunTestCaseWithOverride}
+                      quickRunIterationOverride={iterationOverride}
                       runningTestCaseId={runningTestCaseId}
                       blockTestCaseRuns={Boolean(
                         rerunningSuiteId ||

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -188,13 +188,13 @@ export function TestCasesOverview({
   const isByHostView = canShowByHost && runsViewMode === "runs";
   const liveCases = useQuery(
     "testSuites:listTestCases" as any,
-    { suiteId: suite._id } as any
+    { suiteId: suite._id } as any,
   ) as EvalCase[] | undefined;
   const [hydratedIterations, setHydratedIterations] = useState<EvalIteration[]>(
-    []
+    [],
   );
   const [selectedCaseIds, setSelectedCaseIds] = useState<Set<string>>(
-    new Set()
+    new Set(),
   );
   const [showBatchDeleteModal, setShowBatchDeleteModal] = useState(false);
   const [isBatchDeleting, setIsBatchDeleting] = useState(false);
@@ -224,7 +224,7 @@ export function TestCasesOverview({
     }
 
     const liveCaseById = new Map(
-      liveCases.map((testCase) => [testCase._id, testCase] as const)
+      liveCases.map((testCase) => [testCase._id, testCase] as const),
     );
     const mergedCases = cases.map((testCase) => ({
       ...testCase,
@@ -260,7 +260,7 @@ export function TestCasesOverview({
       setSelectedCaseIds(new Set());
       setShowBatchDeleteModal(false);
       toast.success(
-        `Deleted ${ids.length} test case${ids.length === 1 ? "" : "s"}`
+        `Deleted ${ids.length} test case${ids.length === 1 ? "" : "s"}`,
       );
     } catch (error) {
       console.error("Failed to delete test cases:", error);
@@ -272,14 +272,14 @@ export function TestCasesOverview({
 
   useEffect(() => {
     const localIterationIds = new Set(
-      allIterations.map((iteration) => iteration._id)
+      allIterations.map((iteration) => iteration._id),
     );
     const localCaseIds = new Set(
       allIterations
         .map((iteration) => iteration.testCaseId)
         .filter(
-          (testCaseId): testCaseId is string => typeof testCaseId === "string"
-        )
+          (testCaseId): testCaseId is string => typeof testCaseId === "string",
+        ),
     );
     const casesNeedingHydration = effectiveCases.filter((testCase) => {
       const missingSavedIteration =
@@ -302,7 +302,7 @@ export function TestCasesOverview({
           try {
             const iterations = (await convex.query(
               "testSuites:listTestIterations" as any,
-              { testCaseId: testCase._id } as any
+              { testCaseId: testCase._id } as any,
             )) as EvalIteration[] | undefined;
 
             if (Array.isArray(iterations) && iterations.length > 0) {
@@ -311,7 +311,7 @@ export function TestCasesOverview({
           } catch (error) {
             console.error(
               "Failed to hydrate test case iterations from listTestIterations:",
-              error
+              error,
             );
           }
 
@@ -322,17 +322,17 @@ export function TestCasesOverview({
           try {
             const iteration = (await convex.query(
               "testSuites:getTestIteration" as any,
-              { iterationId: testCase.lastMessageRun } as any
+              { iterationId: testCase.lastMessageRun } as any,
             )) as EvalIteration | null;
             return iteration ? [iteration] : [];
           } catch (error) {
             console.error(
               "Failed to hydrate saved iteration from getTestIteration:",
-              error
+              error,
             );
             return [];
           }
-        })
+        }),
       );
 
       if (cancelled) {
@@ -367,7 +367,7 @@ export function TestCasesOverview({
   const testCaseStats = useMemo(() => {
     return effectiveCases.map((testCase) => {
       const caseIterations = effectiveIterations.filter(
-        (iter) => iter.testCaseId === testCase._id
+        (iter) => iter.testCaseId === testCase._id,
       );
       let lastRunIteration: EvalIteration | null = null;
       for (const iter of caseIterations) {
@@ -418,7 +418,7 @@ export function TestCasesOverview({
     connectedServerNames == null
       ? []
       : suiteServers.filter(
-          (serverName) => !connectedServerNames.has(serverName)
+          (serverName) => !connectedServerNames.has(serverName),
         );
   const showPersistentBatchHeader =
     batchDelete && hideViewModeSelect && testCaseStats.length > 0;
@@ -493,7 +493,7 @@ export function TestCasesOverview({
           <div
             className={cn(
               "shrink-0 flex items-center justify-between gap-3 border-b",
-              isByHostView ? "bg-muted/60 px-4 py-2.5" : "px-4 py-2"
+              isByHostView ? "bg-muted/60 px-4 py-2.5" : "px-4 py-2",
             )}
           >
             <div className="min-w-0">
@@ -530,7 +530,7 @@ export function TestCasesOverview({
                         "px-2 py-0.5 text-xs rounded transition-colors",
                         runsViewMode === value
                           ? "bg-background text-foreground shadow-sm font-medium"
-                          : "text-muted-foreground hover:text-foreground"
+                          : "text-muted-foreground hover:text-foreground",
                       )}
                     >
                       {label}
@@ -679,10 +679,7 @@ export function TestCasesOverview({
                             className="h-11 gap-2 px-6 text-sm"
                             onClick={onCreateTestCase}
                           >
-                            <Plus
-                              className="h-4 w-4 shrink-0"
-                              aria-hidden
-                            />
+                            <Plus className="h-4 w-4 shrink-0" aria-hidden />
                             New case
                           </Button>
                         ) : null}
@@ -702,7 +699,8 @@ export function TestCasesOverview({
                   const cellsWithData = clientColumns
                     .map((col) => byHost?.get(col.hostId))
                     .filter(
-                      (c): c is NonNullable<typeof c> => !!c && c.totalCount > 0,
+                      (c): c is NonNullable<typeof c> =>
+                        !!c && c.totalCount > 0,
                     );
                   const passFlags = cellsWithData.map(
                     (c) => c.passCount >= c.totalCount,
@@ -712,8 +710,8 @@ export function TestCasesOverview({
                       ? passFlags.every(Boolean)
                         ? null
                         : passFlags.some(Boolean)
-                          ? "diverge"
-                          : "allfail"
+                        ? "diverge"
+                        : "allfail"
                       : null;
                   const clientRail = showClientRail ? (
                     <div className="grid shrink-0" style={clientRailStyle}>
@@ -736,7 +734,7 @@ export function TestCasesOverview({
                     connectedServerNames == null
                       ? []
                       : suiteServers.filter(
-                          (serverName) => !connectedServerNames.has(serverName)
+                          (serverName) => !connectedServerNames.has(serverName),
                         );
                   const hasModels = Boolean(testCase.models?.length);
                   // Render checks have no quick-run path (suite/schedule only);
@@ -799,7 +797,7 @@ export function TestCasesOverview({
                       className={cn(
                         ITERATION_RESULT_BADGE_BASE,
                         "tracking-wider",
-                        EVAL_FAILED_BADGE_CLASS
+                        EVAL_FAILED_BADGE_CLASS,
                       )}
                       aria-label="Failed"
                     >
@@ -824,7 +822,7 @@ export function TestCasesOverview({
                     "Never run"
                   );
                   const lastRunOpenable = Boolean(
-                    onOpenLastRun && lastRunIteration?._id
+                    onOpenLastRun && lastRunIteration?._id,
                   );
                   const lastRunAriaLabel =
                     lastRunIteration && lastRunOpenable
@@ -923,11 +921,18 @@ export function TestCasesOverview({
                     </span>
                   );
 
-                  // Quick-run estimate. Hidden wherever the control won't
-                  // actually run: environment suites route to Run all, an empty
-                  // model list toasts "Add a model first", and render checks run
-                  // only with the full suite. Also hidden when the Run control
-                  // itself isn't offered.
+                  // Quick-run estimate. Hidden wherever quick-run REFUSES by
+                  // design: environment suites route to Run all, an empty model
+                  // list toasts "Add a model first", render checks run only with
+                  // the full suite, and a suite with no servers attached toasts
+                  // "Attach a client to this suite". Also hidden when the Run
+                  // control isn't offered. Matches `canRunSelectedCase` in
+                  // `TestCaseListSidebar` so the two surfaces agree.
+                  //
+                  // Deliberately NOT suppressed on merely-disconnected servers
+                  // (`serverGateBlocked`): that state resolves by connecting —
+                  // the row's own tooltip says "Connect and run." — and the
+                  // estimate is exactly right for the run that follows.
                   const quickRunEstimateHint = (
                     <QuickCaseRunCostEstimateHint
                       suiteId={suite._id}
@@ -941,7 +946,8 @@ export function TestCasesOverview({
                         !onRunTestCase ||
                         isEnvironmentSuite ||
                         isProbeCase ||
-                        !hasModels
+                        !hasModels ||
+                        !hasConfiguredSuiteServers
                       }
                     />
                   );

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -31,6 +31,7 @@ import { computeIterationResult } from "./pass-criteria";
 import { formatRelativeTime, getEffectiveSuiteServers } from "./helpers";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
 import { isModelFree } from "@/shared/steps";
+import { QuickCaseRunCostEstimateHint } from "./run-cost-estimate-hint";
 import type { SuiteOverviewView } from "@/lib/eval-route-types";
 import {
   caseListCardClassName,
@@ -56,6 +57,12 @@ interface TestCasesOverviewProps {
     environment?: { servers?: string[] };
     /** Host attachments drive the "By host" matrix; absent on minimal callers. */
     hostAttachments?: EvalSuite["hostAttachments"];
+    /**
+     * Attached project environments. Present ⇒ single-case quick-run routes to
+     * "Run all" instead of running, which suppresses the per-case credit
+     * estimate (an estimate beside a control that won't run misleads).
+     */
+    environmentIds?: string[];
   };
   cases: EvalCase[];
   allIterations: EvalIteration[];
@@ -133,6 +140,12 @@ interface TestCasesOverviewProps {
    * the parent (project host list) so this component stays queryless.
    */
   hostNamesById?: Map<string, string | null>;
+  /**
+   * Iteration override the per-case Run control will send (quick-run state).
+   * Forwarded to the credit estimate so the number matches the run the button
+   * will actually launch.
+   */
+  quickRunIterationOverride?: number;
 }
 
 export function TestCasesOverview({
@@ -161,10 +174,15 @@ export function TestCasesOverview({
   isGeneratingTestCases = false,
   onCreateTestCase,
   hostNamesById,
+  quickRunIterationOverride,
 }: TestCasesOverviewProps) {
   const convex = useConvex();
   // A one-host matrix is pointless, so the cross-host view is only offered when
   // the suite has >=2 host attachments. Same source useCrossHostData reads.
+  // Environment suites route single-case runs to "Run all" (the quick-run path
+  // can't resolve an environment's closed server set), so their per-case Run
+  // controls never spend — no estimate belongs beside them.
+  const isEnvironmentSuite = (suite.environmentIds?.length ?? 0) > 0;
   const hostAttachmentCount = suite.hostAttachments?.length ?? 0;
   const canShowByHost = hostAttachmentCount >= 2;
   const isByHostView = canShowByHost && runsViewMode === "runs";
@@ -905,6 +923,29 @@ export function TestCasesOverview({
                     </span>
                   );
 
+                  // Quick-run estimate. Hidden wherever the control won't
+                  // actually run: environment suites route to Run all, an empty
+                  // model list toasts "Add a model first", and render checks run
+                  // only with the full suite. Also hidden when the Run control
+                  // itself isn't offered.
+                  const quickRunEstimateHint = (
+                    <QuickCaseRunCostEstimateHint
+                      suiteId={suite._id}
+                      caseId={testCase._id}
+                      models={testCase.models ?? []}
+                      {...(quickRunIterationOverride !== undefined
+                        ? { runs: quickRunIterationOverride }
+                        : {})}
+                      suppressed={
+                        !showRunColumn ||
+                        !onRunTestCase ||
+                        isEnvironmentSuite ||
+                        isProbeCase ||
+                        !hasModels
+                      }
+                    />
+                  );
+
                   const runControl =
                     showRunColumn && onRunTestCase ? (
                       isProbeCase ? (
@@ -1002,6 +1043,7 @@ export function TestCasesOverview({
                         </div>
                         {caseRowClickTarget}
                         {clientRail}
+                        {quickRunEstimateHint}
                         {runControl}
                         {deleteControl}
                       </div>
@@ -1020,6 +1062,7 @@ export function TestCasesOverview({
                     >
                       {caseRowClickTarget}
                       {clientRail}
+                      {quickRunEstimateHint}
                       {runControl}
                       {deleteControl}
                     </div>

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -31,7 +31,10 @@ import { computeIterationResult } from "./pass-criteria";
 import { formatRelativeTime, getEffectiveSuiteServers } from "./helpers";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
 import { isModelFree } from "@/shared/steps";
-import { getDefaultTestCaseModelValue } from "./single-test-case-runner";
+import {
+  getDefaultTestCaseModelValue,
+  getRunnableCaseModels,
+} from "./single-test-case-runner";
 import { QuickCaseRunCostEstimateHint } from "./run-cost-estimate-hint";
 import type { SuiteOverviewView } from "@/lib/eval-route-types";
 import {
@@ -740,19 +743,11 @@ export function TestCasesOverview({
                           (serverName) => !connectedServerNames.has(serverName)
                         );
                   const hasModels = Boolean(testCase.models?.length);
-                  // The models quick-run will REALLY execute: entries missing a
-                  // provider or model are skipped and the rest deduped, exactly
-                  // as `getConfiguredTestCaseModelValues` does in
-                  // `use-eval-handlers`. A case whose only entries are malformed
-                  // has `hasModels === true` but still toasts "Add a model
-                  // first", so the estimate keys off this list, not the raw one.
-                  const runnableCaseModels = Array.from(
-                    new Map(
-                      (testCase.models ?? [])
-                        .filter((m) => Boolean(m?.provider) && Boolean(m?.model))
-                        .map((m) => [`${m.provider}/${m.model}`, m] as const)
-                    ).values()
-                  );
+                  // The models quick-run will REALLY execute. A case whose only
+                  // entries are malformed has `hasModels === true` but still
+                  // toasts "Add a model first", so the estimate keys off this
+                  // list, not the raw one.
+                  const runnableCaseModels = getRunnableCaseModels(testCase);
                   // Render checks have no quick-run path (suite/schedule only);
                   // keep the gate explicit rather than riding on their empty
                   // models. Detect both legacy widget_probe and new unified

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -188,13 +188,13 @@ export function TestCasesOverview({
   const isByHostView = canShowByHost && runsViewMode === "runs";
   const liveCases = useQuery(
     "testSuites:listTestCases" as any,
-    { suiteId: suite._id } as any,
+    { suiteId: suite._id } as any
   ) as EvalCase[] | undefined;
   const [hydratedIterations, setHydratedIterations] = useState<EvalIteration[]>(
-    [],
+    []
   );
   const [selectedCaseIds, setSelectedCaseIds] = useState<Set<string>>(
-    new Set(),
+    new Set()
   );
   const [showBatchDeleteModal, setShowBatchDeleteModal] = useState(false);
   const [isBatchDeleting, setIsBatchDeleting] = useState(false);
@@ -224,7 +224,7 @@ export function TestCasesOverview({
     }
 
     const liveCaseById = new Map(
-      liveCases.map((testCase) => [testCase._id, testCase] as const),
+      liveCases.map((testCase) => [testCase._id, testCase] as const)
     );
     const mergedCases = cases.map((testCase) => ({
       ...testCase,
@@ -260,7 +260,7 @@ export function TestCasesOverview({
       setSelectedCaseIds(new Set());
       setShowBatchDeleteModal(false);
       toast.success(
-        `Deleted ${ids.length} test case${ids.length === 1 ? "" : "s"}`,
+        `Deleted ${ids.length} test case${ids.length === 1 ? "" : "s"}`
       );
     } catch (error) {
       console.error("Failed to delete test cases:", error);
@@ -272,14 +272,14 @@ export function TestCasesOverview({
 
   useEffect(() => {
     const localIterationIds = new Set(
-      allIterations.map((iteration) => iteration._id),
+      allIterations.map((iteration) => iteration._id)
     );
     const localCaseIds = new Set(
       allIterations
         .map((iteration) => iteration.testCaseId)
         .filter(
-          (testCaseId): testCaseId is string => typeof testCaseId === "string",
-        ),
+          (testCaseId): testCaseId is string => typeof testCaseId === "string"
+        )
     );
     const casesNeedingHydration = effectiveCases.filter((testCase) => {
       const missingSavedIteration =
@@ -302,7 +302,7 @@ export function TestCasesOverview({
           try {
             const iterations = (await convex.query(
               "testSuites:listTestIterations" as any,
-              { testCaseId: testCase._id } as any,
+              { testCaseId: testCase._id } as any
             )) as EvalIteration[] | undefined;
 
             if (Array.isArray(iterations) && iterations.length > 0) {
@@ -311,7 +311,7 @@ export function TestCasesOverview({
           } catch (error) {
             console.error(
               "Failed to hydrate test case iterations from listTestIterations:",
-              error,
+              error
             );
           }
 
@@ -322,17 +322,17 @@ export function TestCasesOverview({
           try {
             const iteration = (await convex.query(
               "testSuites:getTestIteration" as any,
-              { iterationId: testCase.lastMessageRun } as any,
+              { iterationId: testCase.lastMessageRun } as any
             )) as EvalIteration | null;
             return iteration ? [iteration] : [];
           } catch (error) {
             console.error(
               "Failed to hydrate saved iteration from getTestIteration:",
-              error,
+              error
             );
             return [];
           }
-        }),
+        })
       );
 
       if (cancelled) {
@@ -367,7 +367,7 @@ export function TestCasesOverview({
   const testCaseStats = useMemo(() => {
     return effectiveCases.map((testCase) => {
       const caseIterations = effectiveIterations.filter(
-        (iter) => iter.testCaseId === testCase._id,
+        (iter) => iter.testCaseId === testCase._id
       );
       let lastRunIteration: EvalIteration | null = null;
       for (const iter of caseIterations) {
@@ -418,7 +418,7 @@ export function TestCasesOverview({
     connectedServerNames == null
       ? []
       : suiteServers.filter(
-          (serverName) => !connectedServerNames.has(serverName),
+          (serverName) => !connectedServerNames.has(serverName)
         );
   const showPersistentBatchHeader =
     batchDelete && hideViewModeSelect && testCaseStats.length > 0;
@@ -493,7 +493,7 @@ export function TestCasesOverview({
           <div
             className={cn(
               "shrink-0 flex items-center justify-between gap-3 border-b",
-              isByHostView ? "bg-muted/60 px-4 py-2.5" : "px-4 py-2",
+              isByHostView ? "bg-muted/60 px-4 py-2.5" : "px-4 py-2"
             )}
           >
             <div className="min-w-0">
@@ -530,7 +530,7 @@ export function TestCasesOverview({
                         "px-2 py-0.5 text-xs rounded transition-colors",
                         runsViewMode === value
                           ? "bg-background text-foreground shadow-sm font-medium"
-                          : "text-muted-foreground hover:text-foreground",
+                          : "text-muted-foreground hover:text-foreground"
                       )}
                     >
                       {label}
@@ -679,7 +679,10 @@ export function TestCasesOverview({
                             className="h-11 gap-2 px-6 text-sm"
                             onClick={onCreateTestCase}
                           >
-                            <Plus className="h-4 w-4 shrink-0" aria-hidden />
+                            <Plus
+                              className="h-4 w-4 shrink-0"
+                              aria-hidden
+                            />
                             New case
                           </Button>
                         ) : null}
@@ -699,8 +702,7 @@ export function TestCasesOverview({
                   const cellsWithData = clientColumns
                     .map((col) => byHost?.get(col.hostId))
                     .filter(
-                      (c): c is NonNullable<typeof c> =>
-                        !!c && c.totalCount > 0,
+                      (c): c is NonNullable<typeof c> => !!c && c.totalCount > 0,
                     );
                   const passFlags = cellsWithData.map(
                     (c) => c.passCount >= c.totalCount,
@@ -710,8 +712,8 @@ export function TestCasesOverview({
                       ? passFlags.every(Boolean)
                         ? null
                         : passFlags.some(Boolean)
-                        ? "diverge"
-                        : "allfail"
+                          ? "diverge"
+                          : "allfail"
                       : null;
                   const clientRail = showClientRail ? (
                     <div className="grid shrink-0" style={clientRailStyle}>
@@ -734,9 +736,22 @@ export function TestCasesOverview({
                     connectedServerNames == null
                       ? []
                       : suiteServers.filter(
-                          (serverName) => !connectedServerNames.has(serverName),
+                          (serverName) => !connectedServerNames.has(serverName)
                         );
                   const hasModels = Boolean(testCase.models?.length);
+                  // The models quick-run will REALLY execute: entries missing a
+                  // provider or model are skipped and the rest deduped, exactly
+                  // as `getConfiguredTestCaseModelValues` does in
+                  // `use-eval-handlers`. A case whose only entries are malformed
+                  // has `hasModels === true` but still toasts "Add a model
+                  // first", so the estimate keys off this list, not the raw one.
+                  const runnableCaseModels = Array.from(
+                    new Map(
+                      (testCase.models ?? [])
+                        .filter((m) => Boolean(m?.provider) && Boolean(m?.model))
+                        .map((m) => [`${m.provider}/${m.model}`, m] as const)
+                    ).values()
+                  );
                   // Render checks have no quick-run path (suite/schedule only);
                   // keep the gate explicit rather than riding on their empty
                   // models. Detect both legacy widget_probe and new unified
@@ -797,7 +812,7 @@ export function TestCasesOverview({
                       className={cn(
                         ITERATION_RESULT_BADGE_BASE,
                         "tracking-wider",
-                        EVAL_FAILED_BADGE_CLASS,
+                        EVAL_FAILED_BADGE_CLASS
                       )}
                       aria-label="Failed"
                     >
@@ -822,7 +837,7 @@ export function TestCasesOverview({
                     "Never run"
                   );
                   const lastRunOpenable = Boolean(
-                    onOpenLastRun && lastRunIteration?._id,
+                    onOpenLastRun && lastRunIteration?._id
                   );
                   const lastRunAriaLabel =
                     lastRunIteration && lastRunOpenable
@@ -937,7 +952,7 @@ export function TestCasesOverview({
                     <QuickCaseRunCostEstimateHint
                       suiteId={suite._id}
                       caseId={testCase._id}
-                      models={testCase.models ?? []}
+                      models={runnableCaseModels}
                       {...(quickRunIterationOverride !== undefined
                         ? { runs: quickRunIterationOverride }
                         : {})}
@@ -946,7 +961,7 @@ export function TestCasesOverview({
                         !onRunTestCase ||
                         isEnvironmentSuite ||
                         isProbeCase ||
-                        !hasModels ||
+                        runnableCaseModels.length === 0 ||
                         !hasConfiguredSuiteServers
                       }
                     />

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -31,6 +31,7 @@ import { computeIterationResult } from "./pass-criteria";
 import { formatRelativeTime, getEffectiveSuiteServers } from "./helpers";
 import type { EvalCase, EvalIteration, EvalSuite, EvalSuiteRun } from "./types";
 import { isModelFree } from "@/shared/steps";
+import { getDefaultTestCaseModelValue } from "./single-test-case-runner";
 import { QuickCaseRunCostEstimateHint } from "./run-cost-estimate-hint";
 import type { SuiteOverviewView } from "@/lib/eval-route-types";
 import {
@@ -962,6 +963,13 @@ export function TestCasesOverview({
                         isEnvironmentSuite ||
                         isProbeCase ||
                         runnableCaseModels.length === 0 ||
+                        // `handleRunTestCase` requires BOTH a non-empty runnable
+                        // list AND a well-formed `models[0]` — its default-model
+                        // check reads index 0 specifically, so a malformed first
+                        // entry with a valid second one still toasts "Add a model
+                        // first". Reuse that exact predicate rather than
+                        // re-deriving it.
+                        !getDefaultTestCaseModelValue(testCase) ||
                         !hasConfiguredSuiteServers
                       }
                     />

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -3049,10 +3049,19 @@ export function TestTemplateEditor({
                   models={draftRunEstimateModels}
                   runs={iterationOverride}
                   draft={draftRunEstimateHeuristic}
+                  // Mirrors `runPrimaryDisabled` for its STRUCTURAL blockers —
+                  // unsaved draft, render check, no model, no suite servers,
+                  // invalid steps — each of which means this Run can't launch
+                  // as configured. `isRunningCompare` is deliberately excluded:
+                  // that's transient, and the estimate stays accurate for the
+                  // next run (same line drawn for the per-case controls, which
+                  // keep the hint while servers are merely disconnected).
                   suppressed={
                     isDraft ||
                     casePinnedOnly ||
-                    draftRunEstimateModels.length === 0
+                    draftRunEstimateModels.length === 0 ||
+                    !canRun ||
+                    !arePromptTurnsValid
                   }
                   side="top"
                 />

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -127,6 +127,7 @@ import {
   getEffectiveSuiteServers,
   getSelectedSuiteHostRunPlan,
 } from "./helpers";
+import { QuickCaseRunCostEstimateHint } from "./run-cost-estimate-hint";
 import { useHost } from "@/hooks/useClients";
 import { useHarnessBuiltinToolCatalog } from "@/hooks/useHarnessBuiltinTools";
 import { mergeSystemToolsIntoAvailableTools } from "./harness-system-tools";
@@ -1344,6 +1345,31 @@ export function TestTemplateEditor({
     arePredicatesValid,
     editForm,
   ]);
+
+  // Pre-run credit estimate for the editor's Run / Run compare button. Priced
+  // against the models the button will ACTUALLY execute (`selectedModelValues`,
+  // which can differ from the saved case's configured list) and against the
+  // in-editor draft's size, so it tracks unsaved prompt edits.
+  const draftRunEstimateModels = useMemo(
+    () =>
+      selectedModelValues.map((modelValue) => {
+        const { provider, model } = parseModelValue(modelValue);
+        return { provider, model };
+      }),
+    [selectedModelValues],
+  );
+  const draftRunEstimateHeuristic = useMemo(() => {
+    const steps = editForm?.steps ?? [];
+    let promptChars = 0;
+    let stepCount = 0;
+    for (const step of steps) {
+      if (step.kind === "prompt") {
+        promptChars += step.prompt?.length ?? 0;
+        stepCount += 1;
+      }
+    }
+    return { promptChars, stepCount: Math.max(1, stepCount) };
+  }, [editForm?.steps]);
 
   const runPrimaryDisabled =
     isDraft ||
@@ -3013,6 +3039,23 @@ export function TestTemplateEditor({
                     ) : null}
                   </span>
                 )}
+                {/* Draft-run estimate: priced against the models the button will
+                    execute and the CURRENT (possibly unsaved) prompt size.
+                    Suppressed when the Run control can't run — an unsaved draft,
+                    a render check, or no model selected. */}
+                <QuickCaseRunCostEstimateHint
+                  suiteId={suiteId}
+                  caseId={draftKind ? null : (currentTestCase?._id ?? null)}
+                  models={draftRunEstimateModels}
+                  runs={iterationOverride}
+                  draft={draftRunEstimateHeuristic}
+                  suppressed={
+                    isDraft ||
+                    casePinnedOnly ||
+                    draftRunEstimateModels.length === 0
+                  }
+                  side="top"
+                />
               </div>
             </div>
           </div>

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1350,12 +1350,22 @@ export function TestTemplateEditor({
   // against the models the button will ACTUALLY execute (`selectedModelValues`,
   // which can differ from the saved case's configured list) and against the
   // in-editor draft's size, so it tracks unsaved prompt edits.
+  // Filtered and deduped like the per-case surfaces: the run path drops
+  // unparseable values (`filter(Boolean)` / `buildSelectedCompareModels`), so
+  // the estimate must price exactly the same set.
   const draftRunEstimateModels = useMemo(
     () =>
-      selectedModelValues.map((modelValue) => {
-        const { provider, model } = parseModelValue(modelValue);
-        return { provider, model };
-      }),
+      Array.from(
+        new Map(
+          selectedModelValues
+            .map((modelValue) => parseModelValue(modelValue))
+            .filter((parsed) => Boolean(parsed.provider) && Boolean(parsed.model))
+            .map(
+              (parsed) =>
+                [`${parsed.provider}/${parsed.model}`, parsed] as const,
+            ),
+        ).values(),
+      ),
     [selectedModelValues],
   );
   const draftRunEstimateHeuristic = useMemo(() => {
@@ -3061,6 +3071,11 @@ export function TestTemplateEditor({
                     casePinnedOnly ||
                     draftRunEstimateModels.length === 0 ||
                     !canRun ||
+                    // `canRun` lets a DIRECT GUEST through with zero servers,
+                    // but `handleRunCompare` still rejects with "No MCP servers
+                    // are configured for this suite." — so gate on the server
+                    // list itself, not just `canRun`.
+                    !hasConfiguredSuiteServers ||
                     !arePromptTurnsValid
                   }
                   side="top"

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -43,6 +43,7 @@ import { generateAndPersistEvalTests } from "@/lib/evals/generate-and-persist-te
 import { useConvexAccessToken } from "@/hooks/use-convex-access-token";
 import {
   getDefaultTestCaseModelValue,
+  getRunnableCaseModels,
   prepareSingleTestCaseRun,
 } from "./single-test-case-runner";
 import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
@@ -62,17 +63,11 @@ import {
 function getConfiguredTestCaseModelValues(
   testCase: Pick<EvalCase, "models">
 ): string[] {
-  const modelValues = new Set<string>();
-
-  for (const modelConfig of testCase.models ?? []) {
-    if (!modelConfig?.provider || !modelConfig.model) {
-      continue;
-    }
-
-    modelValues.add(`${modelConfig.provider}/${modelConfig.model}`);
-  }
-
-  return Array.from(modelValues);
+  // Derived from the shared helper so the run path and the credit estimates
+  // can never disagree about which models are runnable.
+  return getRunnableCaseModels(testCase).map(
+    (modelConfig) => `${modelConfig.provider}/${modelConfig.model}`
+  );
 }
 
 export function hasUnavailableServers(result: EnsureServersReadyResult) {

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -112,7 +112,7 @@ export function journeyTargetColumns(
   hosts: JourneyListHost[],
   latestRun?: JourneyRun | null,
   environments?: ProjectEnvironmentView[],
-  environmentsEnabled = true
+  environmentsEnabled = true,
 ): SwarmTargetColumn[] {
   // `nameOf` returns undefined for a host no longer in the project so
   // `buildSwarmRunTargets` can fall back to the RUN SNAPSHOT's own hostName
@@ -142,10 +142,10 @@ export function journeyTargetColumns(
  * pre-3A historical rows and fresh legacy rows key identically). */
 export function journeyHostOutcome(
   run: JourneyRun,
-  targetKey: string
+  targetKey: string,
 ): JourneyCellOutcome {
   const entry = run.hostSummaries.find(
-    (h) => summaryTargetKey(h) === targetKey
+    (h) => summaryTargetKey(h) === targetKey,
   );
   if (!entry || entry.total === 0) {
     return run.status === "running" ? "running" : "none";
@@ -182,7 +182,7 @@ export function JourneyList({
   isAuthenticated: boolean;
   projectId: string;
   onLaunch: (
-    journeyId: string
+    journeyId: string,
   ) => Promise<
     { status: "launched"; runId?: string } | { status: "already_launching" }
   >;
@@ -192,7 +192,7 @@ export function JourneyList({
   onOpenRun: (
     journey: JourneyListJourney,
     run: JourneyRun,
-    targetKey: string | null
+    targetKey: string | null,
   ) => void;
   onCloseRun: () => void;
   /** Live project environments (flag-gated; undefined when the flag is off). */
@@ -242,7 +242,7 @@ function JourneyBlock({
   hosts: JourneyListHost[];
   serverAttachments: ServerAttachment[];
   onLaunch: (
-    journeyId: string
+    journeyId: string,
   ) => Promise<
     { status: "launched"; runId?: string } | { status: "already_launching" }
   >;
@@ -252,7 +252,7 @@ function JourneyBlock({
   onOpenRun: (
     journey: JourneyListJourney,
     run: JourneyRun,
-    targetKey: string | null
+    targetKey: string | null,
   ) => void;
   onCloseRun: () => void;
   environments?: ProjectEnvironmentView[];
@@ -261,11 +261,11 @@ function JourneyBlock({
   const { results: runs } = usePaginatedQuery(
     SWARM_QUERIES.listJourneyRuns as any,
     { journeyRefId: journey._id } as any,
-    { initialNumItems: DEFAULT_PAGE_SIZE }
+    { initialNumItems: DEFAULT_PAGE_SIZE },
   );
   const rollup = useQuery(
     SWARM_QUERIES.journeyRollup as any,
-    { journeyRefId: journey._id } as any
+    { journeyRefId: journey._id } as any,
   ) as JourneyRollup | undefined;
 
   const [launching, setLaunching] = useState(false);
@@ -284,15 +284,24 @@ function JourneyBlock({
         hosts,
         latestRun,
         environments,
-        environmentsEnabled
+        environmentsEnabled,
       ),
-    [journey, hosts, latestRun, environments, environmentsEnabled]
+    [journey, hosts, latestRun, environments, environmentsEnabled],
   );
   const serverGroupName = journey.serverAttachmentId
     ? serverAttachments.find((a) => a._id === journey.serverAttachmentId)
         ?.name ?? null
     : null;
   const configHint = `${journey.config.sessionsPerHost}/host · ${journey.config.maxTurns} turns`;
+  // Cost-relevant journey config, so an edit re-prices an already-open estimate
+  // instead of leaving a pre-edit number on screen. Host-level model changes are
+  // resolved server-side and aren't visible here.
+  const estimateConfigKey = [
+    (journey.environmentIds ?? []).join(","),
+    journey.hostIds.join(","),
+    journey.config.sessionsPerHost,
+    journey.config.maxTurns,
+  ].join("|");
 
   // Deep-link restore: open the linked run in the detail panel. Runs once.
   const appliedInitialRunRef = useRef(false);
@@ -332,7 +341,7 @@ function JourneyBlock({
     <div
       className={cn(
         "rounded-lg border px-3 py-2.5",
-        selection ? "border-primary/50" : "border-border/60"
+        selection ? "border-primary/50" : "border-border/60",
       )}
     >
       <div className="flex items-start justify-between gap-3">
@@ -364,7 +373,7 @@ function JourneyBlock({
             <span
               className={cn(
                 "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
-                runStatusChipClass(latestRun.status)
+                runStatusChipClass(latestRun.status),
               )}
             >
               {latestRun.status.replace(/_/g, " ")}
@@ -405,7 +414,10 @@ function JourneyBlock({
             tooltip open — the list renders one card per journey, so a live
             subscription per card would re-read every journey's usage history.
             Renders (and fetches) nothing when the flag is off. */}
-        <JourneyRunCostEstimateHint journeyId={journey._id} />
+        <JourneyRunCostEstimateHint
+          journeyId={journey._id}
+          configKey={estimateConfigKey}
+        />
       </div>
 
       {launchError ? (
@@ -450,11 +462,11 @@ function JourneyBlock({
             }))
             .filter(
               (
-                p
+                p,
               ): p is {
                 run: JourneyRun;
                 outcome: Exclude<JourneyCellOutcome, "none">;
-              } => p.outcome !== "none"
+              } => p.outcome !== "none",
             )
             .slice(-MAX_TREND_SEGMENTS);
           const cellSelected =
@@ -468,7 +480,7 @@ function JourneyBlock({
                 "flex min-h-[4rem] w-full flex-col items-start justify-center gap-1 rounded-md border px-2.5 py-2 text-left transition-colors",
                 cellSelected
                   ? "border-primary bg-primary/5"
-                  : "border-border/50 bg-background/60"
+                  : "border-border/50 bg-background/60",
               )}
             >
               <button
@@ -497,7 +509,7 @@ function JourneyBlock({
                   <span
                     className={cn(
                       "text-[11px] font-semibold tabular-nums",
-                      meta?.text ?? "text-muted-foreground"
+                      meta?.text ?? "text-muted-foreground",
                     )}
                   >
                     {summary
@@ -516,20 +528,20 @@ function JourneyBlock({
                       key={run._id}
                       type="button"
                       aria-label={`Open run ${run.status} (${runSummaryLine(
-                        run
+                        run,
                       )}) on ${col.label}`}
                       title={`${runNumberLabel(
                         runCount,
-                        typedRuns.indexOf(run)
+                        typedRuns.indexOf(run),
                       )} · ${run.status.replace(/_/g, " ")} · ${runSummaryLine(
-                        run
+                        run,
                       )} · ${formatJourneyRelativeTime(run.createdAt)}`}
                       onClick={() => openRun(run, col.key)}
                       className={cn(
                         "min-w-[4px] flex-1 rounded-[2px] outline-none transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:ring-ring",
                         SEGMENT_CLASS[segOutcome],
                         selection?.runId === run._id &&
-                          "ring-1 ring-primary ring-offset-1 ring-offset-background"
+                          "ring-1 ring-primary ring-offset-1 ring-offset-background",
                       )}
                     />
                   ))}
@@ -581,7 +593,7 @@ function JourneyEnvironmentsEditor({
 
   const current = useMemo(
     () => journey.environmentIds ?? [],
-    [journey.environmentIds]
+    [journey.environmentIds],
   );
   // Seed ONLY on the closed→open transition. `journey` is a live Convex
   // subscription, so `current` gets a new identity whenever anything on the
@@ -602,12 +614,12 @@ function JourneyEnvironmentsEditor({
   // user can remove it (a saved journey can't target a retired environment).
   const liveEnvironments = useMemo(
     () => environments.filter((e) => !e.archivedAt),
-    [environments]
+    [environments],
   );
   const orphanDraftIds = useMemo(
     () =>
       draft.filter((id) => !environments.some((e) => e.environmentId === id)),
-    [draft, environments]
+    [draft, environments],
   );
 
   const toggle = (environmentId: string) =>
@@ -616,7 +628,7 @@ function JourneyEnvironmentsEditor({
         ? prev.filter((id) => id !== environmentId)
         : prev.length >= MAX_ENVIRONMENTS_PER_JOURNEY
         ? prev
-        : [...prev, environmentId]
+        : [...prev, environmentId],
     );
 
   const dirty =
@@ -626,7 +638,7 @@ function JourneyEnvironmentsEditor({
     const payload = buildEnvJourneyPayload(draft, environments);
     if (!payload) {
       toast.error(
-        "Pick at least one environment that resolves to a valid client."
+        "Pick at least one environment that resolves to a valid client.",
       );
       return;
     }
@@ -641,7 +653,7 @@ function JourneyEnvironmentsEditor({
       setOpen(false);
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Failed to update environments"
+        e instanceof Error ? e.message : "Failed to update environments",
       );
     } finally {
       setSaving(false);
@@ -653,7 +665,7 @@ function JourneyEnvironmentsEditor({
     if (!payload) {
       toast.error(
         "Can't switch to clients: none of this journey's environments " +
-          "resolves to a valid client. Select clients manually instead."
+          "resolves to a valid client. Select clients manually instead.",
       );
       return;
     }
@@ -661,7 +673,7 @@ function JourneyEnvironmentsEditor({
       !window.confirm(
         "Switch this journey back to clients? Environment server-group " +
           "overrides and environment skills stop applying; future runs use " +
-          "those clients' own defaults."
+          "those clients' own defaults.",
       )
     ) {
       return;
@@ -677,7 +689,7 @@ function JourneyEnvironmentsEditor({
       setOpen(false);
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Failed to update environments"
+        e instanceof Error ? e.message : "Failed to update environments",
       );
     } finally {
       setSaving(false);
@@ -738,13 +750,13 @@ function JourneyEnvironmentsEditor({
                       "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
                       "hover:bg-accent hover:text-accent-foreground",
                       selected && "bg-accent/50",
-                      disabled && "cursor-not-allowed opacity-50"
+                      disabled && "cursor-not-allowed opacity-50",
                     )}
                   >
                     <Check
                       className={cn(
                         "size-3.5 shrink-0",
-                        selected ? "opacity-100" : "opacity-0"
+                        selected ? "opacity-100" : "opacity-0",
                       )}
                     />
                     <span className="min-w-0 flex-1 truncate">
@@ -768,7 +780,7 @@ function JourneyEnvironmentsEditor({
                   onClick={() => toggle(id)}
                   className={cn(
                     "flex w-full items-center gap-2 rounded bg-accent/50 py-1.5 pl-2 pr-2 text-left text-sm",
-                    "hover:bg-accent hover:text-accent-foreground"
+                    "hover:bg-accent hover:text-accent-foreground",
                   )}
                 >
                   <Check className="size-3.5 shrink-0 opacity-100" />

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -301,20 +301,25 @@ function JourneyBlock({
   // Cost-relevant journey config, so an edit re-prices an already-open estimate
   // instead of leaving a pre-edit number on screen. Host-level model changes are
   // resolved server-side and aren't visible here.
-  const estimateConfigKey = [
-    (journey.environmentIds ?? []).join(","),
-    journey.hostIds.join(","),
-    journey.config.sessionsPerHost,
-    journey.config.maxTurns,
-    // Whether the judge auto-runs adds or removes a whole line, so it belongs
-    // in the signature as much as the target list does — and when it IS on, its
-    // model sets the line's price, so a model swap has to invalidate too. When
-    // it's off there is no judge line, so the model is irrelevant to the key.
+  // Structured serialization rather than a delimiter join: the judge model is
+  // configurable text, so a hand-rolled key would not be collision-free.
+  //
+  // Whether the judge auto-runs adds or removes a whole line, so it belongs in
+  // the signature as much as the target list does — and when it IS on, its model
+  // sets the line's price, so a model swap has to invalidate too. When it's off
+  // there is no judge line, so the model is irrelevant to the key.
+  const estimateJudgeKey =
     journey.judgeConfig?.goalCompletion?.enabled !== false &&
     journey.judgeConfig?.goalCompletion?.autoRun === true
-      ? `judge:on:${journey.judgeConfig?.goalCompletion?.judgeModel ?? "default"}`
-      : "judge:off"
-  ].join("|");
+      ? ["on", journey.judgeConfig?.goalCompletion?.judgeModel ?? "default"]
+      : ["off"];
+  const estimateConfigKey = JSON.stringify([
+    journey.environmentIds ?? [],
+    journey.hostIds,
+    journey.config.sessionsPerHost,
+    journey.config.maxTurns,
+    estimateJudgeKey
+  ]);
 
   // Deep-link restore: open the linked run in the detail panel. Runs once.
   const appliedInitialRunRef = useRef(false);

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -307,12 +307,13 @@ function JourneyBlock({
     journey.config.sessionsPerHost,
     journey.config.maxTurns,
     // Whether the judge auto-runs adds or removes a whole line, so it belongs
-    // in the signature as much as the target list does.
-    journey.judgeConfig?.goalCompletion?.enabled === false
-      ? "judge:off"
-      : journey.judgeConfig?.goalCompletion?.autoRun === true
-        ? "judge:on"
-        : "judge:off"
+    // in the signature as much as the target list does — and when it IS on, its
+    // model sets the line's price, so a model swap has to invalidate too. When
+    // it's off there is no judge line, so the model is irrelevant to the key.
+    journey.judgeConfig?.goalCompletion?.enabled !== false &&
+    journey.judgeConfig?.goalCompletion?.autoRun === true
+      ? `judge:on:${journey.judgeConfig?.goalCompletion?.judgeModel ?? "default"}`
+      : "judge:off"
   ].join("|");
 
   // Deep-link restore: open the linked run in the detail panel. Runs once.

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -14,6 +14,7 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import { cn } from "@/lib/utils";
 import { toast } from "@/lib/toast";
+import { JourneyRunCostEstimateHint } from "@/components/evals/run-cost-estimate-hint";
 import {
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
@@ -400,6 +401,11 @@ function JourneyBlock({
             <p className="text-xs leading-snug">{configHint}</p>
           </TooltipContent>
         </Tooltip>
+        {/* Pre-run credit estimate for this journey's next run. Lazy-fetched on
+            tooltip open — the list renders one card per journey, so a live
+            subscription per card would re-read every journey's usage history.
+            Renders (and fetches) nothing when the flag is off. */}
+        <JourneyRunCostEstimateHint journeyId={journey._id} />
       </div>
 
       {launchError ? (

--- a/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-list.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from "@/lib/utils";
 import { toast } from "@/lib/toast";
 import { JourneyRunCostEstimateHint } from "@/components/evals/run-cost-estimate-hint";
+import type { GoalJudgeConfig } from "@/components/shared/session-quality/judge-config";
 import {
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
@@ -57,6 +58,10 @@ export type JourneyListJourney = {
    * legacy `hostIds` are kept as inactive compat data. */
   environmentIds?: string[] | null;
   config: { sessionsPerHost: number; maxTurns: number };
+  /** Per-journey judge config. Already on the wire from `listJourneysByPersona`;
+   * declared here because `autoRun` decides whether the pre-run credit estimate
+   * carries a judge line at all. */
+  judgeConfig?: GoalJudgeConfig;
 };
 export type JourneyListHost = { hostId: string; name: string };
 type ServerAttachment = { _id: string; name: string };
@@ -112,7 +117,7 @@ export function journeyTargetColumns(
   hosts: JourneyListHost[],
   latestRun?: JourneyRun | null,
   environments?: ProjectEnvironmentView[],
-  environmentsEnabled = true,
+  environmentsEnabled = true
 ): SwarmTargetColumn[] {
   // `nameOf` returns undefined for a host no longer in the project so
   // `buildSwarmRunTargets` can fall back to the RUN SNAPSHOT's own hostName
@@ -142,10 +147,10 @@ export function journeyTargetColumns(
  * pre-3A historical rows and fresh legacy rows key identically). */
 export function journeyHostOutcome(
   run: JourneyRun,
-  targetKey: string,
+  targetKey: string
 ): JourneyCellOutcome {
   const entry = run.hostSummaries.find(
-    (h) => summaryTargetKey(h) === targetKey,
+    (h) => summaryTargetKey(h) === targetKey
   );
   if (!entry || entry.total === 0) {
     return run.status === "running" ? "running" : "none";
@@ -182,7 +187,7 @@ export function JourneyList({
   isAuthenticated: boolean;
   projectId: string;
   onLaunch: (
-    journeyId: string,
+    journeyId: string
   ) => Promise<
     { status: "launched"; runId?: string } | { status: "already_launching" }
   >;
@@ -192,7 +197,7 @@ export function JourneyList({
   onOpenRun: (
     journey: JourneyListJourney,
     run: JourneyRun,
-    targetKey: string | null,
+    targetKey: string | null
   ) => void;
   onCloseRun: () => void;
   /** Live project environments (flag-gated; undefined when the flag is off). */
@@ -242,7 +247,7 @@ function JourneyBlock({
   hosts: JourneyListHost[];
   serverAttachments: ServerAttachment[];
   onLaunch: (
-    journeyId: string,
+    journeyId: string
   ) => Promise<
     { status: "launched"; runId?: string } | { status: "already_launching" }
   >;
@@ -252,7 +257,7 @@ function JourneyBlock({
   onOpenRun: (
     journey: JourneyListJourney,
     run: JourneyRun,
-    targetKey: string | null,
+    targetKey: string | null
   ) => void;
   onCloseRun: () => void;
   environments?: ProjectEnvironmentView[];
@@ -261,11 +266,11 @@ function JourneyBlock({
   const { results: runs } = usePaginatedQuery(
     SWARM_QUERIES.listJourneyRuns as any,
     { journeyRefId: journey._id } as any,
-    { initialNumItems: DEFAULT_PAGE_SIZE },
+    { initialNumItems: DEFAULT_PAGE_SIZE }
   );
   const rollup = useQuery(
     SWARM_QUERIES.journeyRollup as any,
-    { journeyRefId: journey._id } as any,
+    { journeyRefId: journey._id } as any
   ) as JourneyRollup | undefined;
 
   const [launching, setLaunching] = useState(false);
@@ -284,9 +289,9 @@ function JourneyBlock({
         hosts,
         latestRun,
         environments,
-        environmentsEnabled,
+        environmentsEnabled
       ),
-    [journey, hosts, latestRun, environments, environmentsEnabled],
+    [journey, hosts, latestRun, environments, environmentsEnabled]
   );
   const serverGroupName = journey.serverAttachmentId
     ? serverAttachments.find((a) => a._id === journey.serverAttachmentId)
@@ -301,6 +306,13 @@ function JourneyBlock({
     journey.hostIds.join(","),
     journey.config.sessionsPerHost,
     journey.config.maxTurns,
+    // Whether the judge auto-runs adds or removes a whole line, so it belongs
+    // in the signature as much as the target list does.
+    journey.judgeConfig?.goalCompletion?.enabled === false
+      ? "judge:off"
+      : journey.judgeConfig?.goalCompletion?.autoRun === true
+        ? "judge:on"
+        : "judge:off"
   ].join("|");
 
   // Deep-link restore: open the linked run in the detail panel. Runs once.
@@ -341,7 +353,7 @@ function JourneyBlock({
     <div
       className={cn(
         "rounded-lg border px-3 py-2.5",
-        selection ? "border-primary/50" : "border-border/60",
+        selection ? "border-primary/50" : "border-border/60"
       )}
     >
       <div className="flex items-start justify-between gap-3">
@@ -373,7 +385,7 @@ function JourneyBlock({
             <span
               className={cn(
                 "rounded-full px-1.5 py-px text-[10px] font-medium capitalize",
-                runStatusChipClass(latestRun.status),
+                runStatusChipClass(latestRun.status)
               )}
             >
               {latestRun.status.replace(/_/g, " ")}
@@ -462,11 +474,11 @@ function JourneyBlock({
             }))
             .filter(
               (
-                p,
+                p
               ): p is {
                 run: JourneyRun;
                 outcome: Exclude<JourneyCellOutcome, "none">;
-              } => p.outcome !== "none",
+              } => p.outcome !== "none"
             )
             .slice(-MAX_TREND_SEGMENTS);
           const cellSelected =
@@ -480,7 +492,7 @@ function JourneyBlock({
                 "flex min-h-[4rem] w-full flex-col items-start justify-center gap-1 rounded-md border px-2.5 py-2 text-left transition-colors",
                 cellSelected
                   ? "border-primary bg-primary/5"
-                  : "border-border/50 bg-background/60",
+                  : "border-border/50 bg-background/60"
               )}
             >
               <button
@@ -509,7 +521,7 @@ function JourneyBlock({
                   <span
                     className={cn(
                       "text-[11px] font-semibold tabular-nums",
-                      meta?.text ?? "text-muted-foreground",
+                      meta?.text ?? "text-muted-foreground"
                     )}
                   >
                     {summary
@@ -528,20 +540,20 @@ function JourneyBlock({
                       key={run._id}
                       type="button"
                       aria-label={`Open run ${run.status} (${runSummaryLine(
-                        run,
+                        run
                       )}) on ${col.label}`}
                       title={`${runNumberLabel(
                         runCount,
-                        typedRuns.indexOf(run),
+                        typedRuns.indexOf(run)
                       )} · ${run.status.replace(/_/g, " ")} · ${runSummaryLine(
-                        run,
+                        run
                       )} · ${formatJourneyRelativeTime(run.createdAt)}`}
                       onClick={() => openRun(run, col.key)}
                       className={cn(
                         "min-w-[4px] flex-1 rounded-[2px] outline-none transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:ring-ring",
                         SEGMENT_CLASS[segOutcome],
                         selection?.runId === run._id &&
-                          "ring-1 ring-primary ring-offset-1 ring-offset-background",
+                          "ring-1 ring-primary ring-offset-1 ring-offset-background"
                       )}
                     />
                   ))}
@@ -593,7 +605,7 @@ function JourneyEnvironmentsEditor({
 
   const current = useMemo(
     () => journey.environmentIds ?? [],
-    [journey.environmentIds],
+    [journey.environmentIds]
   );
   // Seed ONLY on the closed→open transition. `journey` is a live Convex
   // subscription, so `current` gets a new identity whenever anything on the
@@ -614,12 +626,12 @@ function JourneyEnvironmentsEditor({
   // user can remove it (a saved journey can't target a retired environment).
   const liveEnvironments = useMemo(
     () => environments.filter((e) => !e.archivedAt),
-    [environments],
+    [environments]
   );
   const orphanDraftIds = useMemo(
     () =>
       draft.filter((id) => !environments.some((e) => e.environmentId === id)),
-    [draft, environments],
+    [draft, environments]
   );
 
   const toggle = (environmentId: string) =>
@@ -628,7 +640,7 @@ function JourneyEnvironmentsEditor({
         ? prev.filter((id) => id !== environmentId)
         : prev.length >= MAX_ENVIRONMENTS_PER_JOURNEY
         ? prev
-        : [...prev, environmentId],
+        : [...prev, environmentId]
     );
 
   const dirty =
@@ -638,7 +650,7 @@ function JourneyEnvironmentsEditor({
     const payload = buildEnvJourneyPayload(draft, environments);
     if (!payload) {
       toast.error(
-        "Pick at least one environment that resolves to a valid client.",
+        "Pick at least one environment that resolves to a valid client."
       );
       return;
     }
@@ -653,7 +665,7 @@ function JourneyEnvironmentsEditor({
       setOpen(false);
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Failed to update environments",
+        e instanceof Error ? e.message : "Failed to update environments"
       );
     } finally {
       setSaving(false);
@@ -665,7 +677,7 @@ function JourneyEnvironmentsEditor({
     if (!payload) {
       toast.error(
         "Can't switch to clients: none of this journey's environments " +
-          "resolves to a valid client. Select clients manually instead.",
+          "resolves to a valid client. Select clients manually instead."
       );
       return;
     }
@@ -673,7 +685,7 @@ function JourneyEnvironmentsEditor({
       !window.confirm(
         "Switch this journey back to clients? Environment server-group " +
           "overrides and environment skills stop applying; future runs use " +
-          "those clients' own defaults.",
+          "those clients' own defaults."
       )
     ) {
       return;
@@ -689,7 +701,7 @@ function JourneyEnvironmentsEditor({
       setOpen(false);
     } catch (e) {
       toast.error(
-        e instanceof Error ? e.message : "Failed to update environments",
+        e instanceof Error ? e.message : "Failed to update environments"
       );
     } finally {
       setSaving(false);
@@ -750,13 +762,13 @@ function JourneyEnvironmentsEditor({
                       "flex w-full items-center gap-2 rounded py-1.5 pl-2 pr-2 text-left text-sm",
                       "hover:bg-accent hover:text-accent-foreground",
                       selected && "bg-accent/50",
-                      disabled && "cursor-not-allowed opacity-50",
+                      disabled && "cursor-not-allowed opacity-50"
                     )}
                   >
                     <Check
                       className={cn(
                         "size-3.5 shrink-0",
-                        selected ? "opacity-100" : "opacity-0",
+                        selected ? "opacity-100" : "opacity-0"
                       )}
                     />
                     <span className="min-w-0 flex-1 truncate">
@@ -780,7 +792,7 @@ function JourneyEnvironmentsEditor({
                   onClick={() => toggle(id)}
                   className={cn(
                     "flex w-full items-center gap-2 rounded bg-accent/50 py-1.5 pl-2 pr-2 text-left text-sm",
-                    "hover:bg-accent hover:text-accent-foreground",
+                    "hover:bg-accent hover:text-accent-foreground"
                   )}
                 >
                   <Check className="size-3.5 shrink-0 opacity-100" />

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
@@ -35,6 +35,7 @@ vi.mock("posthog-js/react", () => ({
 
 import {
   RUN_COST_ESTIMATE_QUERIES,
+  formatCredits,
   formatRunCostEstimate,
   useJourneyRunCostEstimate,
   useQuickCaseRunCostEstimate,
@@ -395,6 +396,17 @@ describe("formatRunCostEstimate — copy matrix", () => {
         estimate: null,
       }),
     ).toBe("Estimate unavailable");
+  });
+
+  it("never renders a nonzero cost as ~0 credits", () => {
+    // Backend credits are integers by construction, so this is a guard rather
+    // than a live case: the one direction this display must not fail in is low.
+    expect(formatCredits(0.4)).toBe("1");
+    expect(formatCredits(0)).toBe("0");
+    expect(formatCredits(-5)).toBe("0");
+    // Identity on the integers that actually arrive.
+    expect(formatCredits(42)).toBe("42");
+    expect(formatCredits(12_345)).toBe("12,345");
   });
 
   it("formats large totals with thousands separators", () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
@@ -372,10 +372,11 @@ function SuiteProbe({
   return <span data-testid="status">{state.status}</span>;
 }
 
-function JourneyProbe() {
+function JourneyProbe({ configKey }: { configKey?: string } = {}) {
   const state = useJourneyRunCostEstimate({
     enabled: true,
     journeyId: "journey-1",
+    configKey,
   });
   useEffect(() => {
     state.setOpen(true);
@@ -407,6 +408,28 @@ describe("surface-specific query dispatch", () => {
     rerender(<SuiteProbe planCount={4} />);
     await waitFor(() => expect(queryCalls).toHaveLength(2));
     expect((queryCalls[1].args as { planCount: number }).planCount).toBe(4);
+  });
+
+  it("re-fetches an open journey estimate when the journey config changes", async () => {
+    // The query only takes `journeyId` and resolves targets server-side, so the
+    // config signature is the only thing that can invalidate an open tooltip
+    // after someone edits the journey's targets / sessions / turns.
+    const { rerender } = render(<JourneyProbe configKey="env-1|2|3" />);
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+    expect(queryCalls[0].args).toEqual({ journeyId: "journey-1" });
+
+    rerender(<JourneyProbe configKey="env-1,env-2|2|3" />);
+    await waitFor(() => expect(queryCalls).toHaveLength(2));
+    // The args are unchanged by design — the signature only drives the refetch.
+    expect(queryCalls[1].args).toEqual({ journeyId: "journey-1" });
+  });
+
+  it("does not re-fetch when the journey config signature is unchanged", async () => {
+    const { rerender } = render(<JourneyProbe configKey="env-1|2|3" />);
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+    rerender(<JourneyProbe configKey="env-1|2|3" />);
+    await Promise.resolve();
+    expect(queryCalls).toHaveLength(1);
   });
 
   it("sends the journey estimate under the registered Swarms query name", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
@@ -352,7 +352,7 @@ describe("formatRunCostEstimate — copy matrix", () => {
             lowerBoundCredits: 30,
           }),
         }),
-      ).toBe("At least ~30 credits — some models unpriced");
+      ).toBe("At least ~30 credits — part of this run is unpriced");
     }
   });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
@@ -247,6 +247,28 @@ describe("useQuickCaseRunCostEstimate — fetch on open", () => {
     );
   });
 
+  it("re-fetches for two model lists that a delimiter key would collide", async () => {
+    // `model` can itself contain "/" (canonical ids live there), so a
+    // `provider/model` join would render both of these as "a/b,c/d" — leaving
+    // the tooltip on the previous estimate after a real model change.
+    const { rerender } = render(
+      <EstimateProbe models={[{ provider: "a", model: "b,c/d" }]} open />,
+    );
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+
+    rerender(
+      <EstimateProbe
+        models={[
+          { provider: "a", model: "b" },
+          { provider: "c", model: "d" },
+        ]}
+        open
+      />,
+    );
+    await waitFor(() => expect(queryCalls).toHaveLength(2));
+    expect((queryCalls[1].args as { models: unknown[] }).models).toHaveLength(2);
+  });
+
   it("discards a stale response when the args changed mid-flight", async () => {
     // First request resolves LAST and with a different number — if request-id
     // tagging were missing, it would paint over the newer answer.

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -214,7 +214,13 @@ describe("useQuickCaseRunCostEstimate — fetch on open", () => {
       expect(screen.getByTestId("credits").textContent).toBe("7"),
     );
     resolvers[0](estimate({ credits: 999, lowerBoundCredits: 999 }));
-    await Promise.resolve();
+    // Flush to the end of the macrotask queue, not just one microtask: if the
+    // request-id guard regressed, the stale write needs a real chance to commit
+    // before we can claim it didn't happen. (A `waitFor` on "7" would be no
+    // stronger — it passes on its first poll and never sees a later overwrite.)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
     expect(screen.getByTestId("credits").textContent).toBe("7");
   });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
@@ -41,7 +41,11 @@ import {
   useSuiteRunCostEstimate,
   type RunCostEstimate,
 } from "../use-run-cost-estimate";
-import { QuickCaseRunCostEstimateHint } from "@/components/evals/run-cost-estimate-hint";
+import {
+  JourneyRunCostEstimateHint,
+  QuickCaseRunCostEstimateHint,
+  SuiteRunCostEstimateHint,
+} from "@/components/evals/run-cost-estimate-hint";
 
 function estimate(overrides: Partial<RunCostEstimate> = {}): RunCostEstimate {
   return {
@@ -124,6 +128,57 @@ describe("QuickCaseRunCostEstimateHint — flag gate", () => {
       />,
     );
     expect(screen.getByTestId("run-cost-estimate-hint")).toBeInTheDocument();
+    await Promise.resolve();
+    expect(queryCalls).toHaveLength(0);
+  });
+});
+
+describe("suite + journey wrappers — flag gate", () => {
+  // Same gate-then-mount structure as the quick-case wrapper: the flag is
+  // checked BEFORE the fetch hook is mounted, so a flagged-off surface
+  // constructs no state machine at all. That matters most for journeys, where
+  // the list renders one of these per card.
+  const cases = [
+    {
+      name: "SuiteRunCostEstimateHint",
+      render: () => <SuiteRunCostEstimateHint suiteId="suite-1" planCount={2} />,
+    },
+    {
+      name: "JourneyRunCostEstimateHint",
+      render: () => <JourneyRunCostEstimateHint journeyId="journey-1" />,
+    },
+  ];
+
+  for (const surface of cases) {
+    it(`${surface.name} renders nothing and dispatches no query when the flag is off`, async () => {
+      flagEnabled = false;
+      render(surface.render());
+      expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+      await Promise.resolve();
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    it(`${surface.name} treats an unresolved flag as off`, async () => {
+      flagEnabled = undefined;
+      render(surface.render());
+      expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+      await Promise.resolve();
+      expect(queryCalls).toHaveLength(0);
+    });
+
+    it(`${surface.name} renders the trigger but fetches nothing until opened`, async () => {
+      render(surface.render());
+      expect(screen.getByTestId("run-cost-estimate-hint")).toBeInTheDocument();
+      await Promise.resolve();
+      expect(queryCalls).toHaveLength(0);
+    });
+  }
+
+  it("suppresses the suite hint when Run all cannot launch", async () => {
+    render(
+      <SuiteRunCostEstimateHint suiteId="suite-1" planCount={2} suppressed />,
+    );
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
     await Promise.resolve();
     expect(queryCalls).toHaveLength(0);
   });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
@@ -1,0 +1,412 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * CONTRACT for the pre-run credit estimate's client half:
+ *
+ *  1. Flag off ⇒ the hint does not render AND no Convex query is dispatched.
+ *     The backend queries are read-only, so this gate exists to control rollout
+ *     and read volume — but a hidden hint that still fetches would defeat that.
+ *  2. The fetch happens on tooltip OPEN, not on mount, and re-fetches when the
+ *     arguments change while open. A stale/out-of-order response must never
+ *     paint over a newer one.
+ *  3. The tooltip copy is a function of BOTH coverage and confidence, and a
+ *     query rejection (e.g. TOO_MANY_MODELS) reads "Estimate unavailable".
+ */
+
+const queryCalls: Array<{ name: string; args: unknown }> = [];
+let queryImpl: (name: string, args: unknown) => Promise<unknown> = async () =>
+  undefined;
+
+vi.mock("convex/react", () => ({
+  useConvex: () => ({
+    query: (name: string, args: unknown) => {
+      queryCalls.push({ name, args });
+      return queryImpl(name, args);
+    },
+  }),
+}));
+
+let flagEnabled: boolean | undefined = true;
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: () => flagEnabled,
+}));
+
+import {
+  RUN_COST_ESTIMATE_QUERIES,
+  formatRunCostEstimate,
+  useJourneyRunCostEstimate,
+  useQuickCaseRunCostEstimate,
+  useSuiteRunCostEstimate,
+  type RunCostEstimate,
+} from "../use-run-cost-estimate";
+import { QuickCaseRunCostEstimateHint } from "@/components/evals/run-cost-estimate-hint";
+
+function estimate(overrides: Partial<RunCostEstimate> = {}): RunCostEstimate {
+  return {
+    credits: 42,
+    lowerBoundCredits: 42,
+    usd: 0.42,
+    coverage: "full",
+    confidence: "partial",
+    sampleCount: 3,
+    truncated: false,
+    lines: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  queryCalls.length = 0;
+  flagEnabled = true;
+  queryImpl = async () => estimate();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const MODELS = [{ model: "gpt-5-mini", provider: "openai" }];
+
+describe("QuickCaseRunCostEstimateHint — flag gate", () => {
+  it("renders nothing and dispatches no query when the flag is off", async () => {
+    flagEnabled = false;
+    render(
+      <QuickCaseRunCostEstimateHint
+        suiteId="suite-1"
+        caseId="case-1"
+        models={MODELS}
+      />,
+    );
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+    // Give any stray effect a chance to fire before asserting the absence.
+    await Promise.resolve();
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("treats an unresolved flag as off (fail-closed)", async () => {
+    flagEnabled = undefined;
+    render(
+      <QuickCaseRunCostEstimateHint
+        suiteId="suite-1"
+        caseId="case-1"
+        models={MODELS}
+      />,
+    );
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+    await Promise.resolve();
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("renders nothing and dispatches no query when suppressed", async () => {
+    // `suppressed` is how a caller says "this control won't actually run"
+    // (env suite / no models / render check).
+    render(
+      <QuickCaseRunCostEstimateHint
+        suiteId="suite-1"
+        caseId="case-1"
+        models={[]}
+        suppressed
+      />,
+    );
+    expect(screen.queryByTestId("run-cost-estimate-hint")).toBeNull();
+    await Promise.resolve();
+    expect(queryCalls).toHaveLength(0);
+  });
+
+  it("renders the trigger but fetches nothing until the tooltip opens", async () => {
+    render(
+      <QuickCaseRunCostEstimateHint
+        suiteId="suite-1"
+        caseId="case-1"
+        models={MODELS}
+      />,
+    );
+    expect(screen.getByTestId("run-cost-estimate-hint")).toBeInTheDocument();
+    await Promise.resolve();
+    expect(queryCalls).toHaveLength(0);
+  });
+});
+
+/** Harness that drives `setOpen` / arg changes directly — the tooltip's own
+ * pointer interactions are Radix's business, the state machine is ours. */
+function EstimateProbe({
+  models,
+  open,
+}: {
+  models: Array<{ model: string; provider: string }>;
+  open: boolean;
+}) {
+  const state = useQuickCaseRunCostEstimate({
+    enabled: true,
+    suiteId: "suite-1",
+    caseId: "case-1",
+    models,
+  });
+  // Mirror the tooltip's open/close into the hook.
+  useEffect(() => {
+    state.setOpen(open);
+  }, [open, state.setOpen]);
+  return (
+    <div>
+      <span data-testid="status">{state.status}</span>
+      <span data-testid="copy">{formatRunCostEstimate(state)}</span>
+      <span data-testid="credits">{state.estimate?.credits ?? ""}</span>
+    </div>
+  );
+}
+
+describe("useQuickCaseRunCostEstimate — fetch on open", () => {
+  it("dispatches the quick-case query with the models the run will use", async () => {
+    const { rerender } = render(<EstimateProbe models={MODELS} open={false} />);
+    expect(queryCalls).toHaveLength(0);
+
+    rerender(<EstimateProbe models={MODELS} open />);
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+    expect(queryCalls[0].name).toBe(RUN_COST_ESTIMATE_QUERIES.quickCase);
+    expect(queryCalls[0].args).toEqual({
+      suiteId: "suite-1",
+      caseId: "case-1",
+      models: MODELS,
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("ready"),
+    );
+  });
+
+  it("re-fetches when the args change while open", async () => {
+    const { rerender } = render(<EstimateProbe models={MODELS} open />);
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+
+    rerender(
+      <EstimateProbe
+        models={[...MODELS, { model: "gpt-5", provider: "openai" }]}
+        open
+      />,
+    );
+    await waitFor(() => expect(queryCalls).toHaveLength(2));
+    expect((queryCalls[1].args as { models: unknown[] }).models).toHaveLength(
+      2,
+    );
+  });
+
+  it("discards a stale response when the args changed mid-flight", async () => {
+    // First request resolves LAST and with a different number — if request-id
+    // tagging were missing, it would paint over the newer answer.
+    const resolvers: Array<(value: RunCostEstimate) => void> = [];
+    queryImpl = () =>
+      new Promise<RunCostEstimate>((resolve) => {
+        resolvers.push(resolve);
+      });
+
+    const { rerender } = render(<EstimateProbe models={MODELS} open />);
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+
+    rerender(
+      <EstimateProbe models={[{ model: "gpt-5", provider: "openai" }]} open />,
+    );
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+
+    // Newer request answers first, then the stale one.
+    resolvers[1](estimate({ credits: 7, lowerBoundCredits: 7 }));
+    await waitFor(() =>
+      expect(screen.getByTestId("credits").textContent).toBe("7"),
+    );
+    resolvers[0](estimate({ credits: 999, lowerBoundCredits: 999 }));
+    await Promise.resolve();
+    expect(screen.getByTestId("credits").textContent).toBe("7");
+  });
+
+  it("clears the painted estimate when the tooltip closes", async () => {
+    const { rerender } = render(<EstimateProbe models={MODELS} open />);
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("ready"),
+    );
+    rerender(<EstimateProbe models={MODELS} open={false} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("status").textContent).toBe("idle"),
+    );
+    expect(screen.getByTestId("credits").textContent).toBe("");
+  });
+
+  it("surfaces a rejected query as an error state", async () => {
+    queryImpl = async () => {
+      throw new Error(
+        'ConvexError: {"code":"TOO_MANY_MODELS","message":"Cost estimation supports at most 10 distinct models (received 11)."}',
+      );
+    };
+    render(<EstimateProbe models={MODELS} open />);
+    await waitFor(() =>
+      expect(screen.getByTestId("copy").textContent).toBe(
+        "Estimate unavailable",
+      ),
+    );
+  });
+});
+
+describe("formatRunCostEstimate — copy matrix", () => {
+  it("full + historical", () => {
+    expect(
+      formatRunCostEstimate({
+        status: "ready",
+        error: null,
+        estimate: estimate({ confidence: "historical" }),
+      }),
+    ).toBe("Estimated: ~42 credits — based on your recent runs");
+  });
+
+  it("full + partial (the normal eval case)", () => {
+    expect(
+      formatRunCostEstimate({
+        status: "ready",
+        error: null,
+        estimate: estimate({ confidence: "partial" }),
+      }),
+    ).toBe("Estimated: ~42 credits — partly based on recent runs");
+  });
+
+  it("full + heuristic (cold start)", () => {
+    expect(
+      formatRunCostEstimate({
+        status: "ready",
+        error: null,
+        estimate: estimate({ confidence: "heuristic" }),
+      }),
+    ).toBe("Rough estimate: ~42 credits — improves after first run");
+  });
+
+  it("partial coverage is phrased as a floor regardless of confidence", () => {
+    for (const confidence of ["historical", "partial", "heuristic"] as const) {
+      expect(
+        formatRunCostEstimate({
+          status: "ready",
+          error: null,
+          estimate: estimate({
+            coverage: "partial",
+            confidence,
+            credits: null,
+            usd: null,
+            lowerBoundCredits: 30,
+          }),
+        }),
+      ).toBe("At least ~30 credits — some models unpriced");
+    }
+  });
+
+  it("no coverage says so explicitly", () => {
+    expect(
+      formatRunCostEstimate({
+        status: "ready",
+        error: null,
+        estimate: estimate({
+          coverage: "none",
+          confidence: "unavailable",
+          credits: null,
+          usd: null,
+          lowerBoundCredits: 0,
+        }),
+      }),
+    ).toBe("Estimate unavailable for these models");
+  });
+
+  it("loading and error states", () => {
+    expect(
+      formatRunCostEstimate({
+        status: "loading",
+        error: null,
+        estimate: null,
+      }),
+    ).toBe("Estimating…");
+    expect(
+      formatRunCostEstimate({
+        status: "error",
+        error: "boom",
+        estimate: null,
+      }),
+    ).toBe("Estimate unavailable");
+  });
+
+  it("formats large totals with thousands separators", () => {
+    expect(
+      formatRunCostEstimate({
+        status: "ready",
+        error: null,
+        estimate: estimate({
+          confidence: "historical",
+          credits: 12_345,
+          lowerBoundCredits: 12_345,
+        }),
+      }),
+    ).toBe("Estimated: ~12,345 credits — based on your recent runs");
+  });
+});
+
+/** Suite + journey surfaces share the same state machine; assert each dispatches
+ * its own query name with the args the backend expects. */
+function SuiteProbe({
+  planCount,
+  iterationOverride,
+}: {
+  planCount: number;
+  iterationOverride?: number;
+}) {
+  const state = useSuiteRunCostEstimate({
+    enabled: true,
+    suiteId: "suite-1",
+    planCount,
+    ...(iterationOverride !== undefined ? { iterationOverride } : {}),
+  });
+  useEffect(() => {
+    state.setOpen(true);
+  }, [state.setOpen]);
+  return <span data-testid="status">{state.status}</span>;
+}
+
+function JourneyProbe() {
+  const state = useJourneyRunCostEstimate({
+    enabled: true,
+    journeyId: "journey-1",
+  });
+  useEffect(() => {
+    state.setOpen(true);
+  }, [state.setOpen]);
+  return <span data-testid="status">{state.status}</span>;
+}
+
+describe("surface-specific query dispatch", () => {
+  it("sends the suite fan-out width as planCount", async () => {
+    render(<SuiteProbe planCount={3} />);
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+    expect(queryCalls[0].name).toBe(RUN_COST_ESTIMATE_QUERIES.suite);
+    expect(queryCalls[0].args).toEqual({ suiteId: "suite-1", planCount: 3 });
+  });
+
+  it("forwards the iteration override so the estimate matches the launch", async () => {
+    render(<SuiteProbe planCount={1} iterationOverride={5} />);
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+    expect(queryCalls[0].args).toEqual({
+      suiteId: "suite-1",
+      planCount: 1,
+      iterationOverride: 5,
+    });
+  });
+
+  it("re-fetches when the plan count changes (host/env attach edits)", async () => {
+    const { rerender } = render(<SuiteProbe planCount={1} />);
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+    rerender(<SuiteProbe planCount={4} />);
+    await waitFor(() => expect(queryCalls).toHaveLength(2));
+    expect((queryCalls[1].args as { planCount: number }).planCount).toBe(4);
+  });
+
+  it("sends the journey estimate under the registered Swarms query name", async () => {
+    render(<JourneyProbe />);
+    await waitFor(() => expect(queryCalls).toHaveLength(1));
+    expect(queryCalls[0].name).toBe("journeyRuns:estimateJourneyRunCredits");
+    expect(RUN_COST_ESTIMATE_QUERIES.journey).toBe(
+      "journeyRuns:estimateJourneyRunCredits",
+    );
+    expect(queryCalls[0].args).toEqual({ journeyId: "journey-1" });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-run-cost-estimate.test.tsx
@@ -310,6 +310,15 @@ describe("formatRunCostEstimate — copy matrix", () => {
     ).toBe("Estimate unavailable for these models");
   });
 
+  it("idle reads as pending, not unavailable", () => {
+    // `idle` is the frame between the tooltip opening and the fetch effect
+    // committing `loading`. It must not flash "Estimate unavailable" and then
+    // retract it.
+    expect(
+      formatRunCostEstimate({ status: "idle", error: null, estimate: null }),
+    ).toBe("Estimating…");
+  });
+
   it("loading and error states", () => {
     expect(
       formatRunCostEstimate({

--- a/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
+++ b/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
@@ -99,8 +99,6 @@ function useFetchOnOpenEstimate({
   // Monotonic request id. Only the newest in-flight request may write state, so
   // a slow earlier response cannot overwrite a newer one.
   const requestIdRef = useRef(0);
-  const argsRef = useRef(args);
-  argsRef.current = args;
 
   const active = enabled && open && args !== null;
 
@@ -123,9 +121,14 @@ function useFetchOnOpenEstimate({
 
     void (async () => {
       try {
+        // `args` is closed over from the render that SCHEDULED this effect, so
+        // it is always a committed value. (A ref synced during render would not
+        // be: an abandoned concurrent render can advance it without committing.)
+        // It is memoized on the same inputs as `argsKey`, so the args and the
+        // key that triggered this fetch always agree.
         const result = (await convex.query(
           queryName as any,
-          argsRef.current as any,
+          args as any,
         )) as RunCostEstimate | undefined;
         if (requestId !== requestIdRef.current) return;
         setEstimate(result ?? null);
@@ -247,7 +250,8 @@ export function useJourneyRunCostEstimate({
    * signature into the request key makes a config edit re-fetch in place.
    *
    * This covers journey-level edits only. A change to a HOST's model is resolved
-   * server-side and isn't visible here, so that still needs a reopen.
+   * server-side and isn't visible on the journey DTO, so that still needs a
+   * reopen.
    */
   configKey?: string;
 }): RunCostEstimateState {

--- a/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
+++ b/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
@@ -306,8 +306,18 @@ export function formatRunCostEstimate(
   }
 }
 
-/** Locale-pinned so the separator matches the surrounding English copy — and so
- * the number doesn't change shape with the runtime locale. */
+/**
+ * Locale-pinned so the separator matches the surrounding English copy — and so
+ * the number doesn't change shape with the runtime locale.
+ *
+ * Rounds UP, not to nearest. Every `credits` value the backend emits is already
+ * an integer by construction (`evalUnitCredits` is a max of integers, swarm
+ * components sum `calculateCreditCost`, judge and computer lines are `ceil`,
+ * each times an integer unit count), so this is identity today. It rounds up
+ * anyway because the one direction this display must never fail in is low: were
+ * a fractional credit ever to reach here, `Math.round` would render a real
+ * 0.4-credit cost as "~0 credits".
+ */
 export function formatCredits(credits: number): string {
-  return Math.max(0, Math.round(credits)).toLocaleString("en-US");
+  return Math.max(0, Math.ceil(credits)).toLocaleString("en-US");
 }

--- a/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
+++ b/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
@@ -1,0 +1,291 @@
+import { useConvex } from "convex/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { SWARM_QUERIES } from "@/lib/swarm-api";
+
+/**
+ * Fetch hooks for the pre-run credit estimate.
+ *
+ * Deliberately NOT a reactive `useQuery` subscription. The suite estimate reads
+ * up to a few thousand iteration docs, and a live subscription would re-execute
+ * every time a run writes an iteration — i.e. exactly while the user is looking
+ * at a running suite. These hooks fetch ONCE when the tooltip opens, re-fetch
+ * when the arguments change while it is still open, and drop the subscription
+ * entirely when it closes.
+ *
+ * Out-of-order responses are discarded by request id: rapidly opening, changing
+ * models, and re-opening must never paint a stale estimate over a newer one.
+ */
+
+export type RunCostEstimateConfidence =
+  | "historical"
+  | "partial"
+  | "heuristic"
+  | "unavailable";
+
+export type RunCostEstimateCoverage = "full" | "partial" | "none";
+
+export interface RunCostEstimateLine {
+  label: string;
+  units: number;
+  usdPerUnit: number | null;
+  creditsPerUnit: number | null;
+  usd: number | null;
+  credits: number | null;
+  confidence: RunCostEstimateConfidence;
+  sampleCount: number;
+}
+
+export interface RunCostEstimate {
+  credits: number | null;
+  lowerBoundCredits: number;
+  usd: number | null;
+  coverage: RunCostEstimateCoverage;
+  confidence: RunCostEstimateConfidence;
+  sampleCount: number;
+  truncated: boolean;
+  lines: RunCostEstimateLine[];
+}
+
+export type RunCostEstimateStatus = "idle" | "loading" | "ready" | "error";
+
+export interface RunCostEstimateState {
+  status: RunCostEstimateStatus;
+  estimate: RunCostEstimate | null;
+  /** Set when the query rejected — the hint renders "Estimate unavailable". */
+  error: string | null;
+  /** Call when the tooltip opens (`true`) or closes (`false`). */
+  setOpen: (open: boolean) => void;
+  open: boolean;
+}
+
+/** Convex query names the estimate hooks call (string-keyed, like SWARM_QUERIES). */
+export const RUN_COST_ESTIMATE_QUERIES = {
+  suite: "testSuites:estimateSuiteRunCredits",
+  quickCase: "testSuites:estimateQuickCaseRunCredits",
+  // Single spelling for the swarm surface, shared with the rest of the Swarms
+  // string-keyed query registry.
+  journey: SWARM_QUERIES.estimateJourneyRunCredits,
+} as const;
+
+/**
+ * One fetch-on-open state machine, shared by all three surfaces.
+ *
+ * `enabled` folds in the PostHog flag AND any surface-specific reason to stay
+ * silent (an env suite's quick-run control, a model-free case, a missing id).
+ * When it is false nothing is fetched and no Convex call is made at all.
+ *
+ * `argsKey` must change exactly when `args` semantically changes — it is the
+ * re-fetch trigger and the memo key, so it may not be derived from an object
+ * identity that churns each render.
+ */
+function useFetchOnOpenEstimate({
+  enabled,
+  queryName,
+  args,
+  argsKey,
+}: {
+  enabled: boolean;
+  queryName: string;
+  args: Record<string, unknown> | null;
+  argsKey: string;
+}): RunCostEstimateState {
+  const convex = useConvex();
+  const [open, setOpen] = useState(false);
+  const [status, setStatus] = useState<RunCostEstimateStatus>("idle");
+  const [estimate, setEstimate] = useState<RunCostEstimate | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Monotonic request id. Only the newest in-flight request may write state, so
+  // a slow earlier response cannot overwrite a newer one.
+  const requestIdRef = useRef(0);
+  const argsRef = useRef(args);
+  argsRef.current = args;
+
+  const active = enabled && open && args !== null;
+
+  useEffect(() => {
+    if (!active) {
+      // Closing (or being disabled) invalidates any in-flight request as well as
+      // the painted value — reopening always re-fetches rather than flashing a
+      // stale number.
+      requestIdRef.current += 1;
+      setStatus("idle");
+      setEstimate(null);
+      setError(null);
+      return;
+    }
+
+    requestIdRef.current += 1;
+    const requestId = requestIdRef.current;
+    setStatus("loading");
+    setError(null);
+
+    void (async () => {
+      try {
+        const result = (await convex.query(
+          queryName as any,
+          argsRef.current as any,
+        )) as RunCostEstimate | undefined;
+        if (requestId !== requestIdRef.current) return;
+        setEstimate(result ?? null);
+        setStatus(result ? "ready" : "error");
+      } catch (err) {
+        if (requestId !== requestIdRef.current) return;
+        setEstimate(null);
+        setError(err instanceof Error ? err.message : String(err));
+        setStatus("error");
+      }
+    })();
+    // `useConvex()` may return a new object each render; the client is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, queryName, argsKey]);
+
+  return { status, estimate, error, open, setOpen };
+}
+
+export function useSuiteRunCostEstimate({
+  enabled,
+  suiteId,
+  caseIds,
+  iterationOverride,
+  planCount,
+}: {
+  enabled: boolean;
+  suiteId: string | null | undefined;
+  caseIds?: readonly string[];
+  iterationOverride?: number;
+  planCount?: number;
+}): RunCostEstimateState {
+  const caseIdsKey = caseIds ? [...caseIds].join(",") : "";
+  const args = useMemo(
+    () =>
+      suiteId
+        ? {
+            suiteId,
+            ...(caseIds && caseIds.length > 0 ? { caseIds: [...caseIds] } : {}),
+            ...(iterationOverride !== undefined ? { iterationOverride } : {}),
+            ...(planCount !== undefined ? { planCount } : {}),
+          }
+        : null,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [suiteId, caseIdsKey, iterationOverride, planCount],
+  );
+  return useFetchOnOpenEstimate({
+    enabled: enabled && Boolean(suiteId),
+    queryName: RUN_COST_ESTIMATE_QUERIES.suite,
+    args,
+    argsKey: `${suiteId ?? ""}|${caseIdsKey}|${iterationOverride ?? ""}|${
+      planCount ?? ""
+    }`,
+  });
+}
+
+export interface QuickCaseEstimateModel {
+  model: string;
+  provider: string;
+}
+
+export function useQuickCaseRunCostEstimate({
+  enabled,
+  suiteId,
+  caseId,
+  models,
+  runs,
+  draft,
+}: {
+  enabled: boolean;
+  suiteId: string | null | undefined;
+  caseId?: string | null;
+  models: readonly QuickCaseEstimateModel[];
+  runs?: number;
+  draft?: { promptChars: number; stepCount: number };
+}): RunCostEstimateState {
+  const modelsKey = models
+    .map((entry) => `${entry.provider}/${entry.model}`)
+    .join(",");
+  const draftKey = draft ? `${draft.promptChars}:${draft.stepCount}` : "";
+  const args = useMemo(
+    () =>
+      suiteId
+        ? {
+            suiteId,
+            ...(caseId ? { caseId } : {}),
+            models: models.map((entry) => ({
+              model: entry.model,
+              provider: entry.provider,
+            })),
+            ...(runs !== undefined ? { runs } : {}),
+            ...(draft ? { draft } : {}),
+          }
+        : null,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [suiteId, caseId, modelsKey, runs, draftKey],
+  );
+  return useFetchOnOpenEstimate({
+    enabled: enabled && Boolean(suiteId),
+    queryName: RUN_COST_ESTIMATE_QUERIES.quickCase,
+    args,
+    argsKey: `${suiteId ?? ""}|${caseId ?? ""}|${modelsKey}|${
+      runs ?? ""
+    }|${draftKey}`,
+  });
+}
+
+export function useJourneyRunCostEstimate({
+  enabled,
+  journeyId,
+}: {
+  enabled: boolean;
+  journeyId: string | null | undefined;
+}): RunCostEstimateState {
+  const args = useMemo(() => (journeyId ? { journeyId } : null), [journeyId]);
+  return useFetchOnOpenEstimate({
+    enabled: enabled && Boolean(journeyId),
+    queryName: RUN_COST_ESTIMATE_QUERIES.journey,
+    args,
+    argsKey: journeyId ?? "",
+  });
+}
+
+/**
+ * Tooltip copy, keyed on BOTH coverage and confidence.
+ *
+ * The two dimensions answer different questions and neither subsumes the other:
+ * coverage says whether every line could be priced at all, confidence says how
+ * much the priced part is grounded in this user's own history. A partial-coverage
+ * estimate is always phrased as a floor ("At least"), because its total is
+ * genuinely incomplete.
+ */
+export function formatRunCostEstimate(
+  state: Pick<RunCostEstimateState, "status" | "estimate" | "error">,
+): string {
+  if (state.status === "loading") {
+    return "Estimating…";
+  }
+  if (state.status === "error" || !state.estimate) {
+    return "Estimate unavailable";
+  }
+  const { coverage, confidence, credits, lowerBoundCredits } = state.estimate;
+  if (coverage === "none") {
+    return "Estimate unavailable for these models";
+  }
+  if (coverage === "partial") {
+    return `At least ~${formatCredits(
+      lowerBoundCredits,
+    )} credits — some models unpriced`;
+  }
+  const total = formatCredits(credits ?? lowerBoundCredits);
+  switch (confidence) {
+    case "historical":
+      return `Estimated: ~${total} credits — based on your recent runs`;
+    case "partial":
+      return `Estimated: ~${total} credits — partly based on recent runs`;
+    default:
+      return `Rough estimate: ~${total} credits — improves after first run`;
+  }
+}
+
+function formatCredits(credits: number): string {
+  return Math.max(0, Math.round(credits)).toLocaleString();
+}

--- a/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
+++ b/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
@@ -160,7 +160,8 @@ export function useSuiteRunCostEstimate({
   iterationOverride?: number;
   planCount?: number;
 }): RunCostEstimateState {
-  const caseIdsKey = caseIds ? [...caseIds].join(",") : "";
+  // Structured for the same reason as `modelsKey` below.
+  const caseIdsKey = caseIds ? JSON.stringify([...caseIds]) : "";
   const args = useMemo(
     () =>
       suiteId
@@ -204,10 +205,16 @@ export function useQuickCaseRunCostEstimate({
   runs?: number;
   draft?: { promptChars: number; stepCount: number };
 }): RunCostEstimateState {
-  const modelsKey = models
-    .map((entry) => `${entry.provider}/${entry.model}`)
-    .join(",");
-  const draftKey = draft ? `${draft.promptChars}:${draft.stepCount}` : "";
+  // Structured serialization, not a delimiter join: `model` can itself contain
+  // a "/" (canonical ids like `openai/gpt-5-mini` are stored there), so a
+  // hand-rolled key is not injective and two different model lists could share
+  // one — leaving an open tooltip showing the previous estimate.
+  const modelsKey = JSON.stringify(
+    models.map((entry) => [entry.provider, entry.model]),
+  );
+  const draftKey = draft
+    ? JSON.stringify([draft.promptChars, draft.stepCount])
+    : "";
   const args = useMemo(
     () =>
       suiteId

--- a/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
+++ b/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
@@ -260,7 +260,11 @@ export function useJourneyRunCostEstimate({
 export function formatRunCostEstimate(
   state: Pick<RunCostEstimateState, "status" | "estimate" | "error">,
 ): string {
-  if (state.status === "loading") {
+  // `idle` is the frame between the tooltip opening and the fetch effect
+  // committing `loading`. Falling through to "Estimate unavailable" there would
+  // flash alarming copy that immediately retracts itself, so idle reads as
+  // pending too.
+  if (state.status === "loading" || state.status === "idle") {
     return "Estimating…";
   }
   if (state.status === "error" || !state.estimate) {
@@ -286,6 +290,8 @@ export function formatRunCostEstimate(
   }
 }
 
-function formatCredits(credits: number): string {
-  return Math.max(0, Math.round(credits)).toLocaleString();
+/** Locale-pinned so the separator matches the surrounding English copy — and so
+ * the number doesn't change shape with the runtime locale. */
+export function formatCredits(credits: number): string {
+  return Math.max(0, Math.round(credits)).toLocaleString("en-US");
 }

--- a/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
+++ b/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
@@ -291,9 +291,12 @@ export function formatRunCostEstimate(
     return "Estimate unavailable for these models";
   }
   if (coverage === "partial") {
+    // Phrased as a floor, and deliberately not model-specific: an unpriced line
+    // can also be an un-estimated slice of the run's fan-out, not just a model
+    // whose price is unknown.
     return `At least ~${formatCredits(
       lowerBoundCredits,
-    )} credits — some models unpriced`;
+    )} credits — part of this run is unpriced`;
   }
   const total = formatCredits(credits ?? lowerBoundCredits);
   switch (confidence) {

--- a/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
+++ b/mcpjam-inspector/client/src/hooks/use-run-cost-estimate.ts
@@ -235,16 +235,28 @@ export function useQuickCaseRunCostEstimate({
 export function useJourneyRunCostEstimate({
   enabled,
   journeyId,
+  configKey,
 }: {
   enabled: boolean;
   journeyId: string | null | undefined;
+  /**
+   * Signature of the journey's cost-relevant config (targets, sessions, turns,
+   * judge autoRun). The query itself only takes `journeyId` and resolves
+   * everything else server-side, so without this the estimate would keep showing
+   * a pre-edit number for as long as the tooltip stayed open. Folding the
+   * signature into the request key makes a config edit re-fetch in place.
+   *
+   * This covers journey-level edits only. A change to a HOST's model is resolved
+   * server-side and isn't visible here, so that still needs a reopen.
+   */
+  configKey?: string;
 }): RunCostEstimateState {
   const args = useMemo(() => (journeyId ? { journeyId } : null), [journeyId]);
   return useFetchOnOpenEstimate({
     enabled: enabled && Boolean(journeyId),
     queryName: RUN_COST_ESTIMATE_QUERIES.journey,
     args,
-    argsKey: journeyId ?? "",
+    argsKey: `${journeyId ?? ""}|${configKey ?? ""}`,
   });
 }
 

--- a/mcpjam-inspector/client/src/hooks/useCreditEstimateEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditEstimateEnabled.ts
@@ -1,0 +1,18 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+/**
+ * PostHog rollout gate for the pre-run credit estimate hint (the info icon
+ * beside "Run all", the per-case quick-run controls, the template editor's
+ * draft-run button, and swarm journey cards).
+ *
+ * Fail-closed: `useFeatureFlagEnabled` returns `undefined` both while flags load
+ * AND when the flag does not exist, and both are treated as "not enabled"
+ * (`=== true`). Flag off means the hint does not render AND the estimate query
+ * never fires — the backend queries are read-only and fully authorized, so the
+ * gate exists purely to control rollout and query volume, not access.
+ */
+export const CREDIT_ESTIMATE_FEATURE_FLAG = "credit-estimate-enabled";
+
+export function useCreditEstimateEnabled(): boolean {
+  return useFeatureFlagEnabled(CREDIT_ESTIMATE_FEATURE_FLAG) === true;
+}

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -33,6 +33,11 @@ export const SWARM_QUERIES = {
   listRunningPersonaRefIds: "journeyRuns:listRunningPersonaRefIds",
   /** Project environments picker (env-based journeys — flag-gated UI). */
   listEnvironments: "projectEnvironments:listEnvironments",
+  /**
+   * Pre-run credit estimate for the next run of a journey (flag-gated UI,
+   * fetched lazily on tooltip open — never as a live subscription).
+   */
+  estimateJourneyRunCredits: "journeyRuns:estimateJourneyRunCredits",
 } as const;
 
 // ── Convex action names (string-keyed calls) ────────────────────────────────


### PR DESCRIPTION
Inspector half of the pre-run credit estimate. Adds a flag-gated info icon whose tooltip says what the run about to be launched is estimated to cost. Backend queries: MCPJam/mcpjam-backend#823 — this PR is inert until those ship and the PostHog flag is on.

## Why

Before launching an eval run or a swarm journey, there's no way to see what it will cost. Gateway pricing is already cached per model and historical usage is already persisted, so the number is derivable — it just wasn't surfaced.

## Surfaces (all flag-gated)

| Where | What it prices |
|---|---|
| Suite header "Run all" | The full fan-out: every case × its models × iterations × run plans |
| Per-case Run button (cases overview + case sidebar) | That case's configured models, one host, quick-run iteration override |
| Template editor Run / Run compare | The editor's **selected** models and the **current, possibly unsaved** prompt |
| Swarm journey card | The journey's next run across its live targets |

## Files

- **`useCreditEstimateEnabled`** — PostHog gate `credit-estimate-enabled`, fail-closed (`=== true`) exactly like `useSkillsEnabled`, so an unresolved flag reads as off.

- **`use-run-cost-estimate`** — one fetch-on-tooltip-open state machine behind `useSuiteRunCostEstimate` / `useQuickCaseRunCostEstimate` / `useJourneyRunCostEstimate`, plus `formatRunCostEstimate` for the copy.

  Deliberately **not** a reactive `useQuery`. The suite estimate reads up to a few thousand iteration docs, and a live subscription would re-execute on every iteration write — i.e. exactly while the user is watching a run in flight. Instead: fetch once on open, re-fetch when the args change while open, drop everything on close. Responses are tagged with a monotonic request id, so rapidly opening → changing models → reopening can never paint a slow earlier answer over a newer one.

- **`run-cost-estimate-hint`** — the presentational hint (styled after `InfoHint`, lucide `Info`, `TooltipContent variant="muted"`) plus one gated wrapper per surface. The flag is checked **before** the fetch hook is mounted, in a parent/child split: with the flag off these components construct no Convex client reference and no state machine at all. That matters for the journey list and the cases table, which render one of these per row.

- **`countSuiteRunPlans`** (`helpers.ts`) — the fan-out width the suite estimate sends as `planCount`. It lives immediately beside `buildSuiteRunPlans` and is covered by a parity test against `buildSuiteRunPlans(...).length` across every suite shape: a count that silently lagged a new fan-out axis would understate every estimate.

- **`SWARM_QUERIES.estimateJourneyRunCredits`** — registered alongside the other string-keyed Swarms queries so there's one spelling; the hook imports it rather than repeating the literal.

## Copy

A function of **both** coverage and confidence, and never a promise of a debit:

- `full` + `historical` → "Estimated: ~42 credits — based on your recent runs"
- `full` + `partial` → "Estimated: ~42 credits — partly based on recent runs" *(the normal eval case — see the backend PR on why eval history is capped at `partial`)*
- `full` + `heuristic` → "Rough estimate: ~42 credits — improves after first run"
- `partial` coverage, any confidence → "At least ~30 credits — part of this run is unpriced" *(deliberately not model-specific: an unpriced line can also be an un-estimated slice of the run's fan-out)*
- `none` → "Estimate unavailable for these models"
- loading → "Estimating…"; a rejected query (e.g. `TOO_MANY_MODELS`) → "Estimate unavailable"

The tooltip also breaks out per-model / per-component lines, flags a truncated read, and states that 1 credit = $0.01 and that the free allowance and BYOK keys change the actual deduction. **The hint never gates or disables a run.**

## Where the hint is deliberately absent

Quick-run refuses to run — toast-and-return — in several cases, and an estimate beside a control that will never spend is worse than no estimate:

- **environment suites** — single-case quick-run routes to Run all instead
- **cases with no runnable models** — "Add a model first". Keyed off the *runnable* list (`getRunnableCaseModels`) **and** `getDefaultTestCaseModelValue`, because `handleRunTestCase`'s default-model check reads `models[0]` specifically: a malformed first entry with a valid second one still refuses, so a non-empty runnable list is not sufficient.
- **model-free render checks** — those run with the full suite or on a schedule
- **suites with no servers attached** — "Attach a client to this suite before running it."

The line is *structural refusal* vs *transient blocker*. Suppressed only when the control can never launch as configured. Kept when the state resolves on its own or by one user action — servers merely disconnected ("Connect and run."), a run already in flight, or the eval-iteration quota being spent (which names its own reset time). In all of those the number stays correct for the run that follows, and suppressing would make the icon flicker as the quota/connection queries resolve.

Same reasoning in the template editor: suppressed for an unsaved draft, a render check, or no model selected.

Note the draft hint intentionally follows `selectedModelValues` and the live `editForm.steps`, not the saved case's configured list — that's what the Run / Run compare button will actually execute, and the estimate should move as the prompt is edited.

## Tests

- **`count-suite-run-plans.test.ts`** — parity with `buildSuiteRunPlans().length` across env / host / flat / empty shapes, never zero, and counting environments without needing the environments list loaded.
- **`use-run-cost-estimate.test.tsx`** — flag off (and unresolved flag) ⇒ no render *and* no Convex call, verified by spying on the client; renders the trigger but fetches nothing until open; re-fetches on arg change; the out-of-order race (older request resolves last with a different number and must be discarded); clears on close; a rejected query surfaces as an error; the full copy matrix incl. `full`+`partial` and partial-coverage-with-any-confidence; per-surface query names and args.
- **`quick-run-cost-estimate-placement.test.tsx`** — the suppression matrix rendered through `TestCasesOverview`: one hint for a runnable case, none for no-models / render-check / env-suite / no-Run-control, and none when the flag is off.

Full suite: 11,481 passed, 0 failures. `tsc --noEmit -p client/tsconfig.typecheck.json` clean.

Existing files get near-additive diffs (324 insertions, 22 deletions across 11 files). The 22 deletions are two refactors, not behaviour rewrites: the `Run all` CTA's three `return`s become one `runAllControl` expression so the estimate can sit beside it rather than inside its disabled-state tooltip trigger, and `getConfiguredTestCaseModelValues` now derives from the shared `getRunnableCaseModels` so the run handler and the estimate cannot disagree about which models will execute.

## Rollout

Flag off by default; enable for marcelo@mcpjam.com, then widen. Worth checking manually: a suite with history shows "partly based on recent runs" while a never-run suite shows the rough-estimate copy; an unpriced/denied model shows the "at least" copy; an empty-models case shows an **unpriced** suite-default line and the "At least" copy (the backend deliberately does not price that fallback — see MCPJam/mcpjam-backend#823); the quick controls show no hint on env suites / empty-models / render checks; the draft hint tracks the editor's model selection and prompt size; the journey estimate includes computer time only for harness targets.

**Correction to an earlier version of this description:** it claimed the journey estimate re-prices on a *host model* change. It does not. `configKey` covers the journey's own cost-relevant config — targets, sessions/host, max turns, and whether the judge auto-runs plus its model — so editing any of those re-prices an already-open tooltip. A change to a HOST's model is resolved server-side and is not on the journey DTO the list renders (`JourneyListHost` is `{ hostId, name }`), so that one needs the tooltip reopened. Widening the DTO to carry per-host models purely to key a tooltip is not worth the swarms data-path change; the caveat is documented on `useJourneyRunCostEstimate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X9dwdn1vkTUPTYUGaysTr

---
_Generated by [Claude Code](https://claude.ai/code/session_019X9dwdn1vkTUPTYUGaysTr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only, flag-gated read paths with no run gating; depends on backend estimate queries being deployed for the feature to be visible.
> 
> **Overview**
> Introduces a **pre-run credit estimate** behind the `credit-estimate-enabled` PostHog flag: an info icon whose tooltip loads a one-shot Convex estimate when opened (not a live subscription), with copy that never blocks runs.
> 
> **Eval surfaces:** `SuiteRunCostEstimateHint` beside **Run all** (sends `planCount` from new `countSuiteRunPlans`); `QuickCaseRunCostEstimateHint` beside per-case quick-run, the case sidebar, and the template editor (models from shared `getRunnableCaseModels`, optional iteration override and draft heuristics). Hints are **suppressed** when quick-run cannot spend (environment suites, render checks, no servers/models, malformed default model, etc.).
> 
> **Swarms:** `JourneyRunCostEstimateHint` on journey cards with a `configKey` so open tooltips re-price after journey edits.
> 
> **Related UX fixes:** Run all is no longer blocked on missing local servers for environment-only suites; run handlers share runnable model deduping with estimates. Tests cover plan-count parity, hint placement, and fetch/flag/format behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9db20ca5ab476bfeb9fa6cd4df71614ba1b1a61c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a flag-gated pre-run credit estimate beside eval and swarm run controls. Estimates load on tooltip open, match exactly what each control would launch, and never block runs.

- **New Features**
  - Adds `use-run-cost-estimate` hooks and `run-cost-estimate-hint` wrappers gated by `useCreditEstimateEnabled` (`credit-estimate-enabled`).
  - Suite “Run all”: sends `planCount` via `countSuiteRunPlans`; now allowed on environment-only suites; hint suppresses only when there are no cases or (non-env suites) no servers.
  - Per-case quick-run + editor: prices runnable, deduped models via shared `getRunnableCaseModels`; editor also prices current draft size. Suppressed for environment suites, render checks, no suite servers, no runnable models, or a missing default first model.
  - Swarms: registers `SWARM_QUERIES.estimateJourneyRunCredits`; journey hints re-fetch when `configKey` changes (targets, sessions, turns, judge autoRun, judge model).

- **Bug Fixes**
  - Idle shows “Estimating…”, stale responses are discarded, and `formatCredits` uses en-US separators and rounds up.
  - Suite header gating fixed to unblock env-only suites; per-case hints align with launch behavior and suppress on structural refusals.
  - Tooltip trigger no longer traps activation-close; partial-coverage copy now says “part of this run is unpriced.”
  - Removed the “Connect and run.” tooltip on environment suites, which launch against server-resolved targets.
  - Structured request keys (models, case IDs, journey config) to avoid delimiter-collision and ensure open tooltips re-fetch correctly after edits.

<sup>Written for commit 9db20ca5ab476bfeb9fa6cd4df71614ba1b1a61c. Summary will update on new commits.</sup>

[[Review in cubic](https://www.cubic.dev/buttons/review-in-cubic-dark.svg)](https://cubic.dev/pr/MCPJam/inspector/pull/3605?utm_source=github)

<!-- End of auto-generated description by cubic. -->
