### PR TITLE
feat(environments): gate the editor's Skills section behind skills-enabled

### DIFF
--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
@@ -7,6 +7,7 @@ import { HostPicker } from "@/components/hosts/HostPicker";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
 import { EnvironmentBuildBadge } from "@/components/computer/EnvironmentBuildBadge";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useSkillsEnabled } from "@/hooks/useSkillsEnabled";
 import { useSandboxImages } from "@/hooks/useSandboxImages";
 import { convexErrMessage } from "@/lib/convex-error";
 import {
@@ -88,16 +89,18 @@ export function ProjectEnvironmentEditor({
   const updateEnvironment = useUpdateProjectEnvironment();
   // Double gate: the editor already sits behind `project-environments-enabled`
   // (the route); the sandbox-image section additionally requires
-  // `computers-enabled` (fail-closed) — mirroring how the eval suite settings
-  // gate their adjacent "Computer environment" row.
+  // `computers-enabled` and the skills section `skills-enabled` (both
+  // fail-closed) — so environments can launch before hosted skills/computers.
   //
-  // This flag is load-bearing for the WRITE path, not just visibility: while the
-  // picker is hidden the pin must be treated as if it weren't part of this form
-  // at all — excluded from `dirty` and omitted from both payloads — so a
-  // flag-off save can never set or clear a pin configured through the API/CLI.
-  // Draft divergence alone is NOT a sufficient guard, because the flag can flip
-  // false after an edit and leave a diverged value behind a vanished control.
+  // These flags are load-bearing for the WRITE path, not just visibility: while
+  // a picker is hidden its field must be treated as if it weren't part of this
+  // form at all — excluded from `dirty` and omitted from both payloads — so a
+  // flag-off save can never set or clear a value configured through the
+  // API/CLI. Draft divergence alone is NOT a sufficient guard, because a flag
+  // can flip false after an edit and leave a diverged value behind a vanished
+  // control.
   const computersEnabled = useComputersEnabled();
+  const skillsEnabled = useSkillsEnabled();
   const sandboxImages = useSandboxImages(computersEnabled ? projectId : null);
 
   const [draft, setDraft] = useState<EnvironmentDraft>(() =>
@@ -130,13 +133,15 @@ export function ProjectEnvironmentEditor({
       trimmedDescription !== (environment.description ?? "") ||
       draft.hostId !== environment.hostId ||
       draft.serverAttachmentId !== (environment.serverAttachmentId ?? null) ||
-      !sameSkillSelection(
-        draft.skillSelection,
-        environment.skillSelection ?? null
-      ) ||
-      // Only counts while the picker is rendered — otherwise a flag flip would
-      // leave Save enabled for a field the payload deliberately omits, i.e. a
-      // "Saved." that changes nothing but bumps the revision.
+      // Flag-gated fields only count while their picker is rendered —
+      // otherwise a flag flip would leave Save enabled for a field the
+      // payload deliberately omits, i.e. a "Saved." that changes nothing but
+      // bumps the revision.
+      (skillsEnabled &&
+        !sameSkillSelection(
+          draft.skillSelection,
+          environment.skillSelection ?? null
+        )) ||
       (computersEnabled &&
         draft.computerEnvironmentId !==
           (environment.computerEnvironmentId ?? null))
@@ -144,7 +149,7 @@ export function ProjectEnvironmentEditor({
       trimmedDescription.length > 0 ||
       draft.hostId !== null ||
       draft.serverAttachmentId !== null ||
-      draft.skillSelection !== null ||
+      (skillsEnabled && draft.skillSelection !== null) ||
       (computersEnabled && draft.computerEnvironmentId !== null);
 
   // Reactivity observed someone else's edit while this draft diverged.
@@ -208,13 +213,13 @@ export function ProjectEnvironmentEditor({
           ...(draft.serverAttachmentId
             ? { serverAttachmentId: draft.serverAttachmentId }
             : {}),
-          ...(draft.skillSelection
+          // Gated on the LIVE flags, not just the draft: PostHog can flip
+          // `skills-enabled` / `computers-enabled` false after the user made a
+          // pick, which unmounts the picker but leaves the draft value —
+          // shipping it then would contradict the fail-closed contract.
+          ...(skillsEnabled && draft.skillSelection
             ? { skillSelection: draft.skillSelection }
             : {}),
-          // Gated on the LIVE flag, not just the draft: PostHog can flip
-          // `computers-enabled` false after the user picked an image, which
-          // unmounts the picker but leaves the draft value — shipping it then
-          // would contradict the fail-closed contract.
           ...(computersEnabled && draft.computerEnvironmentId
             ? { computerEnvironmentId: draft.computerEnvironmentId }
             : {}),
@@ -240,19 +245,20 @@ export function ProjectEnvironmentEditor({
         (environment.serverAttachmentId ?? null)
           ? { serverAttachmentId: draft.serverAttachmentId }
           : {}),
-        ...(!sameSkillSelection(
+        // Flag-gated fields are included only when CHANGED **and** their
+        // picker is currently rendered. Draft divergence alone is not enough:
+        // if the flag flips false after an edit the picker unmounts while the
+        // diverged draft value survives, and a "flag-off" save would then set
+        // or clear the value — exactly what the fail-closed contract promises
+        // it cannot do. Gating on the live flag makes a hidden picker always
+        // omit the field (tri-state: omitted = unchanged, null = clear).
+        ...(skillsEnabled &&
+        !sameSkillSelection(
           draft.skillSelection,
           environment.skillSelection ?? null
         )
           ? { skillSelection: draft.skillSelection }
           : {}),
-        // Included only when CHANGED **and** the picker is currently rendered.
-        // Draft divergence alone is not enough: if the flag flips false after
-        // an edit the picker unmounts while the diverged draft value survives,
-        // and a "flag-off" save would then set or clear the pin — exactly what
-        // the fail-closed contract promises it cannot do. Gating on the live
-        // flag makes a hidden picker always omit the field (tri-state:
-        // omitted = unchanged, null = clear).
         ...(computersEnabled &&
         draft.computerEnvironmentId !==
           (environment.computerEnvironmentId ?? null)
@@ -339,8 +345,10 @@ export function ProjectEnvironmentEditor({
           disabled={readOnly}
         />
         <p className="text-[11px] text-muted-foreground">
-          Every environment runs on exactly one client. The client&apos;s own
-          skills always apply on top of this environment&apos;s selection.
+          Every environment runs on exactly one client.
+          {skillsEnabled
+            ? " The client's own skills always apply on top of this environment's selection."
+            : ""}
         </p>
       </div>
 
@@ -376,17 +384,19 @@ export function ProjectEnvironmentEditor({
         </div>
       </div>
 
-      <div className="space-y-1.5">
-        <Label className="text-xs">Skills</Label>
-        <ProjectEnvironmentSkillsPicker
-          projectId={projectId}
-          value={draft.skillSelection}
-          onChange={(skillSelection) =>
-            setDraft((d) => ({ ...d, skillSelection }))
-          }
-          disabled={readOnly}
-        />
-      </div>
+      {skillsEnabled ? (
+        <div className="space-y-1.5">
+          <Label className="text-xs">Skills</Label>
+          <ProjectEnvironmentSkillsPicker
+            projectId={projectId}
+            value={draft.skillSelection}
+            onChange={(skillSelection) =>
+              setDraft((d) => ({ ...d, skillSelection }))
+            }
+            disabled={readOnly}
+          />
+        </div>
+      ) : null}
 
       {computersEnabled ? (
         <div className="space-y-1.5">

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.initial-draft.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.initial-draft.test.tsx
@@ -21,6 +21,9 @@ vi.mock("@/hooks/useProjectEnvironments", () => ({
 vi.mock("@/hooks/useComputersEnabled", () => ({
   useComputersEnabled: () => false,
 }));
+vi.mock("@/hooks/useSkillsEnabled", () => ({
+  useSkillsEnabled: () => true,
+}));
 vi.mock("@/hooks/useSandboxImages", () => ({
   useSandboxImages: () => undefined,
 }));

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.sandbox-image.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.sandbox-image.test.tsx
@@ -32,6 +32,9 @@ vi.mock("@/hooks/useProjectEnvironments", () => ({
 vi.mock("@/hooks/useComputersEnabled", () => ({
   useComputersEnabled: () => mockComputersEnabled.value,
 }));
+vi.mock("@/hooks/useSkillsEnabled", () => ({
+  useSkillsEnabled: () => true,
+}));
 vi.mock("@/hooks/useSandboxImages", () => ({
   useSandboxImages: (projectId: string | null) =>
     projectId ? mockSandboxImages.value : undefined,

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.skills-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environment-editor.skills-gate.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * ProjectEnvironmentEditor — the "Skills" section behind `skills-enabled`.
+ *
+ * Environments can launch before hosted Cloud Skills, so the skills section
+ * mirrors the sandbox-image fail-closed contract: flag off ⇒ the picker never
+ * renders, AND a save of an environment that already carries a
+ * `skillSelection` (set via API/CLI) must OMIT the field from the update
+ * payload entirely — sending `null` would silently clear the pins. Also
+ * covers the flag flipping false AFTER an edit (the diverged draft value must
+ * not ship) and the flag-on attach/clear wire shapes.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreateEnvironment, mockUpdateEnvironment, mockSkillsEnabled } =
+  vi.hoisted(() => ({
+    mockCreateEnvironment: vi.fn(),
+    mockUpdateEnvironment: vi.fn(),
+    mockSkillsEnabled: { value: true },
+  }));
+
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useCreateProjectEnvironment: () => mockCreateEnvironment,
+  useUpdateProjectEnvironment: () => mockUpdateEnvironment,
+  isRevisionConflictError: () => false,
+}));
+vi.mock("@/hooks/useSkillsEnabled", () => ({
+  useSkillsEnabled: () => mockSkillsEnabled.value,
+}));
+vi.mock("@/hooks/useComputersEnabled", () => ({
+  useComputersEnabled: () => false,
+}));
+vi.mock("@/hooks/useSandboxImages", () => ({
+  useSandboxImages: () => undefined,
+}));
+// Sibling sections are not under test — render inert placeholders. The skills
+// picker mock exposes attach/clear buttons so tests can drive `onChange`.
+vi.mock("@/components/hosts/HostPicker", () => ({
+  HostPicker: ({
+    onChange,
+  }: {
+    onChange: (hostId: string | null) => void;
+  }) => (
+    <button type="button" onClick={() => onChange("host-1")}>
+      pick-host
+    </button>
+  ),
+}));
+vi.mock("@/components/hosts/ServerGroupPicker", () => ({
+  ServerGroupPicker: () => <div data-testid="server-group-picker" />,
+}));
+vi.mock("../ProjectEnvironmentSkillsPicker", () => ({
+  ProjectEnvironmentSkillsPicker: ({
+    onChange,
+  }: {
+    onChange: (
+      next: { mode: "explicit"; skillIds: string[] } | null
+    ) => void;
+  }) => (
+    <div data-testid="skills-picker">
+      <button
+        type="button"
+        onClick={() => onChange({ mode: "explicit", skillIds: ["sk-1"] })}
+      >
+        pick-skill
+      </button>
+      <button type="button" onClick={() => onChange(null)}>
+        clear-skills
+      </button>
+    </div>
+  ),
+}));
+vi.mock("@/components/computer/EnvironmentBuildBadge", () => ({
+  EnvironmentBuildBadge: () => null,
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+vi.mock("@/lib/convex-error", () => ({
+  convexErrMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+import { ProjectEnvironmentEditor } from "../ProjectEnvironmentEditor";
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+
+const PINNED = { mode: "explicit" as const, skillIds: ["sk-1", "sk-2"] };
+
+function envRow(
+  overrides: Partial<ProjectEnvironmentView> = {}
+): ProjectEnvironmentView {
+  return {
+    environmentId: "env-1",
+    projectId: "proj-1",
+    name: "Staging",
+    hostId: "host-1",
+    revision: 3,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSkillsEnabled.value = true;
+  mockCreateEnvironment.mockResolvedValue(envRow({ name: "created" }));
+  mockUpdateEnvironment.mockResolvedValue(envRow({ revision: 4 }));
+});
+
+function renderEditor(environment: ProjectEnvironmentView | null) {
+  return render(
+    <ProjectEnvironmentEditor
+      projectId="proj-1"
+      environment={environment}
+      canManage
+    />
+  );
+}
+
+describe("flag gating + the omission contract", () => {
+  it("hides the skills section when skills-enabled is off", () => {
+    mockSkillsEnabled.value = false;
+    renderEditor(envRow());
+    expect(screen.queryByTestId("skills-picker")).not.toBeInTheDocument();
+    expect(screen.queryByText("Skills")).not.toBeInTheDocument();
+  });
+
+  it("flag-off save of a pinned env OMITS skillSelection (pins survive)", async () => {
+    mockSkillsEnabled.value = false;
+    renderEditor(envRow({ skillSelection: PINNED }));
+
+    // Name-only edit, then save.
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    const args = mockUpdateEnvironment.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(args.name).toBe("Renamed");
+    // Omitted entirely — not null, not the old value.
+    expect("skillSelection" in args).toBe(false);
+  });
+
+  it("flag-on untouched selection is also omitted on an unrelated edit", async () => {
+    renderEditor(envRow({ skillSelection: PINNED }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    expect(
+      "skillSelection" in
+        (mockUpdateEnvironment.mock.calls[0]![0] as Record<string, unknown>)
+    ).toBe(false);
+  });
+});
+
+describe("flag flips false AFTER an edit", () => {
+  it("omits the selection when the flag turns off between editing and saving", async () => {
+    const { rerender } = renderEditor(envRow({ skillSelection: PINNED }));
+    // Admin clears the pins while the picker is visible…
+    fireEvent.click(screen.getByRole("button", { name: "clear-skills" }));
+    // …then PostHog re-evaluates the flag to false and the picker unmounts.
+    mockSkillsEnabled.value = false;
+    rerender(
+      <ProjectEnvironmentEditor
+        projectId="proj-1"
+        environment={envRow({ skillSelection: PINNED })}
+        canManage
+      />
+    );
+    expect(screen.queryByTestId("skills-picker")).not.toBeInTheDocument();
+
+    // The diverged draft value must NOT ship: a hidden picker always omits.
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    const args = mockUpdateEnvironment.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(args.name).toBe("Renamed");
+    expect("skillSelection" in args).toBe(false);
+  });
+
+  it("create also omits picked skills once the flag turns off", async () => {
+    const { rerender } = renderEditor(null);
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "New env" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "pick-host" }));
+    fireEvent.click(screen.getByRole("button", { name: "pick-skill" }));
+
+    mockSkillsEnabled.value = false;
+    rerender(
+      <ProjectEnvironmentEditor
+        projectId="proj-1"
+        environment={null}
+        canManage
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(mockCreateEnvironment).toHaveBeenCalled());
+    expect(
+      "skillSelection" in
+        (mockCreateEnvironment.mock.calls[0]![0] as Record<string, unknown>)
+    ).toBe(false);
+  });
+});
+
+describe("wire shapes (flag on)", () => {
+  it("attach sends the selection on update", async () => {
+    renderEditor(envRow());
+    fireEvent.click(screen.getByRole("button", { name: "pick-skill" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    expect(mockUpdateEnvironment.mock.calls[0]![0]).toMatchObject({
+      expectedRevision: 3,
+      skillSelection: { mode: "explicit", skillIds: ["sk-1"] },
+    });
+  });
+
+  it("clear sends null on update", async () => {
+    renderEditor(envRow({ skillSelection: PINNED }));
+    fireEvent.click(screen.getByRole("button", { name: "clear-skills" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockUpdateEnvironment).toHaveBeenCalled());
+    expect(
+      (mockUpdateEnvironment.mock.calls[0]![0] as Record<string, unknown>)
+        .skillSelection
+    ).toBeNull();
+  });
+
+  it("create includes the selection only when picked", async () => {
+    renderEditor(null);
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "New env" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "pick-host" }));
+    fireEvent.click(screen.getByRole("button", { name: "pick-skill" }));
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    await waitFor(() => expect(mockCreateEnvironment).toHaveBeenCalled());
+    expect(mockCreateEnvironment.mock.calls[0]![0]).toMatchObject({
+      projectId: "proj-1",
+      hostId: "host-1",
+      skillSelection: { mode: "explicit", skillIds: ["sk-1"] },
+    });
+  });
+});


### PR DESCRIPTION
## Why

Environments release ahead of hosted Cloud Skills. The environment editor's Skills picker rendered unconditionally, so flipping `project-environments-enabled` would have exposed a Skills multi-select backed by the unlaunched hosted-skills API (`listSkills({kind:'cloud'})`) to every user.

## What

- The Skills section now sits behind the existing `skills-enabled` flag (fail-closed), mirroring the sandbox-image section's `computers-enabled` gate in the same file.
- The gate is load-bearing on the **write path**, not just visibility: while the picker is hidden, `skillSelection` is excluded from `dirty` and omitted from both create and update payloads — a flag-off save can never set or clear pins configured via the API/CLI, including when the flag flips false *after* an edit (the diverged draft value must not ship).
- The Client help-text sentence about skills stacking is hidden while the flag is off.
- New test file `project-environment-editor.skills-gate.test.tsx` mirrors the sandbox-image gate suite: hidden section, omission contract on flag-off saves, flag-flip-after-edit for both update and create, and flag-on attach/clear/create wire shapes. Existing editor tests now mock `useSkillsEnabled` (the editor newly imports it).

Not touched: the public v1 API/CLI still accept `skillSelection` regardless of client flags (by design), and the `ConnectEnvironmentsStrip` skill-pin count chip stays — it's honest row data and flag-off users can't create pins once the editor is gated.

## Tests

21 tests pass across the three editor test files; no typecheck errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and client-side payload gating only; environment skill pins set via API/CLI are preserved when the flag is off, with no backend contract changes in this diff.
> 
> **Overview**
> The project environment editor’s **Skills** block is now behind the `skills-enabled` feature flag, using the same fail-closed pattern as the sandbox image section’s `computers-enabled` gate.
> 
> When the flag is off, the skills picker and related client help text are hidden. **`skillSelection` is also kept off the write path**: it does not affect dirty state and is omitted from create/update payloads unless the flag is on, so saves cannot set, clear, or overwrite API/CLI pins—including if the flag turns off after the user edited skills while the draft still holds those changes.
> 
> Tests add `project-environment-editor.skills-gate.test.tsx` for visibility, omission on flag-off saves, post-edit flag flips, and attach/clear/create payloads; existing editor tests mock `useSkillsEnabled`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435f1a21be79e828f11952d8a5c62d5adbee630f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->