### PR TITLE
Rewind button

### DIFF
--- a/.changeset/inspector-release-31.md
+++ b/.changeset/inspector-release-31.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Release the latest Inspector updates.

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -1788,6 +1788,43 @@ export function ChatTabV2({
     sendMessage({ text, metadata: outgoingSenderMetadata });
   }, [sendMessage, outgoingSenderMetadata]);
 
+  // Rewind to a past user message and re-run the turn from edited text. The
+  // `messageId` makes the AI SDK truncate everything after that message and
+  // replace it in place, so this continues the same session rather than
+  // forking a new one.
+  const handleEditUserMessage = useCallback(
+    async (message: UIMessage, text: string) => {
+      if (sendBlocked) return;
+      const threadReady = await ensureThreadReadyForSend();
+      if (!threadReady) return;
+      // Editing revises the prompt text; the original attachments ride along.
+      const files = (message.parts ?? []).filter(
+        (part): part is Extract<UIMessage["parts"][number], { type: "file" }> =>
+          part.type === "file"
+      );
+      track("edit_message", {
+        location: "chat_tab",
+        model_id: selectedModel?.id ?? null,
+        model_name: selectedModel?.name ?? null,
+        model_provider: selectedModel?.provider ?? null,
+      });
+      lastSentUserMessageRef.current = text;
+      sendMessage({
+        text,
+        files: files.length > 0 ? files : undefined,
+        messageId: message.id,
+        metadata: outgoingSenderMetadata,
+      });
+    },
+    [
+      sendBlocked,
+      ensureThreadReadyForSend,
+      sendMessage,
+      outgoingSenderMetadata,
+      selectedModel,
+    ]
+  );
+
   const isConcurrencyThrottle =
     errorMessage?.code === "user_rate_limit" &&
     errorMessage?.limitKind === "concurrency";
@@ -2604,6 +2641,10 @@ export function ChatTabV2({
                                 }
                               : undefined
                           }
+                          onEditUserMessage={
+                            isMultiModelMode ? undefined : handleEditUserMessage
+                          }
+                          editDisabled={sendBlocked}
                           showSenderAvatars={showSenderAvatars}
                           resolveSenderAvatar={resolveSenderAvatar}
                         />

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/MessageView.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/MessageView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { MessageView } from "../thread/message-view";
 import type { UIMessage } from "@ai-sdk/react";
@@ -71,7 +71,7 @@ describe("MessageView", () => {
     render(
       <PreferencesStoreProvider themeMode="light" themePreset="default">
         {ui}
-      </PreferencesStoreProvider>,
+      </PreferencesStoreProvider>
     );
 
   describe("user messages", () => {
@@ -97,7 +97,7 @@ describe("MessageView", () => {
       expect(screen.getByTestId("part-text")).toBeInTheDocument();
       expect(screen.getByTestId("part-text")).toHaveAttribute(
         "data-role",
-        "user",
+        "user"
       );
     });
 
@@ -131,16 +131,14 @@ describe("MessageView", () => {
           {...defaultProps}
           message={message}
           renderUserMessageActions={renderActions}
-        />,
+        />
       );
 
       expect(renderActions).toHaveBeenCalledTimes(1);
       expect(renderActions).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "msg-row-test" }),
+        expect.objectContaining({ id: "msg-row-test" })
       );
-      expect(
-        screen.getByTestId("save-as-test-case-stub"),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("save-as-test-case-stub")).toBeInTheDocument();
     });
 
     it("does not render the actions slot when no renderer is provided", () => {
@@ -150,7 +148,7 @@ describe("MessageView", () => {
       });
       renderMessageView(<MessageView {...defaultProps} message={message} />);
       expect(
-        screen.queryByTestId("save-as-test-case-stub"),
+        screen.queryByTestId("save-as-test-case-stub")
       ).not.toBeInTheDocument();
     });
 
@@ -167,12 +165,140 @@ describe("MessageView", () => {
           {...defaultProps}
           message={message}
           renderUserMessageActions={renderActions}
-        />,
+        />
       );
       expect(renderActions).not.toHaveBeenCalled();
       expect(
-        screen.queryByTestId("save-as-test-case-stub"),
+        screen.queryByTestId("save-as-test-case-stub")
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("editing a past user message", () => {
+    const editableMessage = () =>
+      createMessage({
+        id: "msg-edit-test",
+        role: "user",
+        parts: [{ type: "text", text: "original prompt" }],
+      });
+
+    const editButton = () =>
+      screen.getByRole("button", { name: "Edit this message" });
+
+    it("renders the edit affordance only when a handler is provided", () => {
+      const message = editableMessage();
+      const { unmount } = renderMessageView(
+        <MessageView {...defaultProps} message={message} />
+      );
+      expect(
+        screen.queryByRole("button", { name: "Edit this message" })
+      ).not.toBeInTheDocument();
+      unmount();
+
+      renderMessageView(
+        <MessageView
+          {...defaultProps}
+          message={message}
+          onEditUserMessage={vi.fn()}
+        />
+      );
+      expect(editButton()).toBeInTheDocument();
+    });
+
+    it("does not render the edit affordance for assistant messages", () => {
+      const message = createMessage({
+        role: "assistant",
+        parts: [{ type: "text", text: "assistant reply" }],
+      });
+      renderMessageView(
+        <MessageView
+          {...defaultProps}
+          message={message}
+          onEditUserMessage={vi.fn()}
+        />
+      );
+      expect(
+        screen.queryByRole("button", { name: "Edit this message" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("swaps the bubble for a textarea seeded with the message text", () => {
+      renderMessageView(
+        <MessageView
+          {...defaultProps}
+          message={editableMessage()}
+          onEditUserMessage={vi.fn()}
+        />
+      );
+
+      fireEvent.click(editButton());
+
+      const textarea = screen.getByRole("textbox", { name: "Edit message" });
+      expect(textarea).toHaveValue("original prompt");
+      expect(
+        screen.queryByTestId("user-message-bubble")
+      ).not.toBeInTheDocument();
+    });
+
+    it("submits the edited text and closes the editor", () => {
+      const onEditUserMessage = vi.fn();
+      const message = editableMessage();
+      renderMessageView(
+        <MessageView
+          {...defaultProps}
+          message={message}
+          onEditUserMessage={onEditUserMessage}
+        />
+      );
+
+      fireEvent.click(editButton());
+      fireEvent.change(screen.getByRole("textbox", { name: "Edit message" }), {
+        target: { value: "revised prompt" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+      expect(onEditUserMessage).toHaveBeenCalledTimes(1);
+      expect(onEditUserMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "msg-edit-test" }),
+        "revised prompt"
+      );
+      expect(screen.getByTestId("user-message-bubble")).toBeInTheDocument();
+    });
+
+    it("cancels without submitting and restores the bubble", () => {
+      const onEditUserMessage = vi.fn();
+      renderMessageView(
+        <MessageView
+          {...defaultProps}
+          message={editableMessage()}
+          onEditUserMessage={onEditUserMessage}
+        />
+      );
+
+      fireEvent.click(editButton());
+      fireEvent.change(screen.getByRole("textbox", { name: "Edit message" }), {
+        target: { value: "discarded" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(onEditUserMessage).not.toHaveBeenCalled();
+      expect(screen.getByTestId("user-message-bubble")).toBeInTheDocument();
+    });
+
+    it("does not resend when the text is unchanged", () => {
+      const onEditUserMessage = vi.fn();
+      renderMessageView(
+        <MessageView
+          {...defaultProps}
+          message={editableMessage()}
+          onEditUserMessage={onEditUserMessage}
+        />
+      );
+
+      fireEvent.click(editButton());
+      fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+      expect(onEditUserMessage).not.toHaveBeenCalled();
     });
   });
 
@@ -186,7 +312,7 @@ describe("MessageView", () => {
       renderMessageView(<MessageView {...defaultProps} message={message} />);
 
       expect(
-        screen.queryByTestId("user-message-bubble"),
+        screen.queryByTestId("user-message-bubble")
       ).not.toBeInTheDocument();
       expect(screen.getByRole("article")).toBeInTheDocument();
     });
@@ -202,7 +328,7 @@ describe("MessageView", () => {
       expect(screen.getByTestId("part-text")).toBeInTheDocument();
       expect(screen.getByTestId("part-text")).toHaveAttribute(
         "data-role",
-        "assistant",
+        "assistant"
       );
     });
 
@@ -227,12 +353,12 @@ describe("MessageView", () => {
       renderMessageView(
         <ChatboxHostStyleProvider value="claude">
           <MessageView {...defaultProps} message={message} />
-        </ChatboxHostStyleProvider>,
+        </ChatboxHostStyleProvider>
       );
 
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
       expect(
-        screen.queryByLabelText("GPT-4 assistant"),
+        screen.queryByLabelText("GPT-4 assistant")
       ).not.toBeInTheDocument();
     });
   });
@@ -246,7 +372,7 @@ describe("MessageView", () => {
       });
 
       const { container } = renderMessageView(
-        <MessageView {...defaultProps} message={message} />,
+        <MessageView {...defaultProps} message={message} />
       );
 
       expect(container.firstChild).toBeNull();
@@ -260,7 +386,7 @@ describe("MessageView", () => {
       });
 
       const { container } = renderMessageView(
-        <MessageView {...defaultProps} message={message} />,
+        <MessageView {...defaultProps} message={message} />
       );
 
       expect(container.firstChild).toBeNull();
@@ -273,7 +399,7 @@ describe("MessageView", () => {
       });
 
       const { container } = renderMessageView(
-        <MessageView {...defaultProps} message={message} />,
+        <MessageView {...defaultProps} message={message} />
       );
 
       expect(container.firstChild).toBeNull();
@@ -328,7 +454,7 @@ describe("MessageView", () => {
           {...defaultProps}
           message={message}
           onSendFollowUp={onSendFollowUp}
-        />,
+        />
       );
 
       expect(screen.getByTestId("part-text")).toBeInTheDocument();
@@ -346,7 +472,7 @@ describe("MessageView", () => {
           {...defaultProps}
           message={message}
           onWidgetStateChange={onWidgetStateChange}
-        />,
+        />
       );
 
       expect(screen.getByTestId("part-text")).toBeInTheDocument();
@@ -365,7 +491,7 @@ describe("MessageView", () => {
           {...defaultProps}
           message={message}
           displayMode="fullscreen"
-        />,
+        />
       );
 
       expect(screen.getByTestId("part-text")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/edit-message-action.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/edit-message-action.tsx
@@ -1,0 +1,41 @@
+import { Pencil } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+
+type EditMessageActionProps = {
+  onClick: () => void;
+  disabled?: boolean;
+};
+
+/**
+ * Per-user-message action that swaps the bubble for an inline editor. Saving
+ * rewinds the thread to this message and re-runs the turn. Unlike
+ * `SaveAsTestCaseAction` this needs no auth or project — it works on any
+ * transcript, hosted or local.
+ */
+export function EditMessageAction({
+  onClick,
+  disabled = false,
+}: EditMessageActionProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex shrink-0">
+          <button
+            type="button"
+            aria-label="Edit this message"
+            disabled={disabled}
+            className="flex size-6 shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:bg-accent focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-50"
+            onClick={onClick}
+          >
+            <Pencil className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>Edit message</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -88,6 +88,13 @@ interface ThreadProps {
    */
   renderUserMessageActions?: TranscriptThreadProps["renderUserMessageActions"];
   /**
+   * Enables the per-user-message edit affordance. Saving rewinds the thread to
+   * that message and re-runs the turn from the edited text.
+   */
+  onEditUserMessage?: TranscriptThreadProps["onEditUserMessage"];
+  /** Blocks editing while a response is streaming. */
+  editDisabled?: TranscriptThreadProps["editDisabled"];
+  /**
    * Per-message sender attribution in shared sessions. Both must be supplied
    * for avatars to render; otherwise the transcript looks identical to today.
    */
@@ -165,6 +172,8 @@ export function Thread({
   contentClassName,
   getMessageWrapperProps,
   renderUserMessageActions,
+  onEditUserMessage,
+  editDisabled,
   showSenderAvatars,
   resolveSenderAvatar,
   recorder,
@@ -376,6 +385,8 @@ export function Thread({
           }
           getMessageWrapperProps={getMessageWrapperProps}
           renderUserMessageActions={renderUserMessageActions}
+          onEditUserMessage={onEditUserMessage}
+          editDisabled={editDisabled}
           showSenderAvatars={showSenderAvatars}
           resolveSenderAvatar={resolveSenderAvatar}
           recorder={recorder}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
@@ -1,8 +1,11 @@
-import { memo } from "react";
+import { memo, useLayoutEffect, useRef, useState } from "react";
 import { UIMessage } from "@ai-sdk/react";
 import { MessageCircle } from "lucide-react";
 import type { ContentBlock } from "@modelcontextprotocol/client";
 
+import { Button } from "@mcpjam/design-system/button";
+import { EditMessageAction } from "@/components/chat-v2/shared/edit-message-action";
+import { extractUserMessageText } from "@/components/chat-v2/shared/chat-helpers";
 import { UserMessageBubble } from "./user-message-bubble";
 import { PartSwitch } from "./part-switch";
 import type { RecorderProps } from "./recorder-types";
@@ -76,6 +79,15 @@ interface MessageViewProps {
    * sessionId + per-message id.
    */
   renderUserMessageActions?: (message: UIMessage) => React.ReactNode;
+  /**
+   * When provided, user messages gain a pencil action that swaps the bubble
+   * for an inline editor. Saving rewinds the thread to this message and
+   * re-runs the turn from the edited text. Omit it (compare mode, read-only
+   * transcripts) and no edit affordance renders.
+   */
+  onEditUserMessage?: (message: UIMessage, text: string) => void;
+  /** Blocks the edit affordance while a response is streaming. */
+  editDisabled?: boolean;
   /** Tier 3 recorder bundle, forwarded to the assistant tool PartSwitch. */
   recorder?: RecorderProps;
   /**
@@ -184,12 +196,153 @@ function areMessageViewPropsEqual(
     prev.claudeFooterMode === next.claudeFooterMode &&
     prev.mcpjamFooterActive === next.mcpjamFooterActive &&
     prev.renderUserMessageActions === next.renderUserMessageActions &&
+    prev.onEditUserMessage === next.onEditUserMessage &&
+    prev.editDisabled === next.editDisabled &&
     isSameSenderAvatar(prev.senderAvatar, next.senderAvatar) &&
     prev.showSenderAvatar === next.showSenderAvatar &&
     // Tier 3: arming/disarming recording flips the recorder bundle's identity;
     // without this the memo skips the re-render and recordMode never reaches
     // the widget (the recorder appears "unavailable").
     prev.recorder === next.recorder
+  );
+}
+
+/**
+ * The user-side transcript row. Owns the inline-edit state locally so the host
+ * only has to supply a submit handler — nothing about "which message is being
+ * edited" has to cross a component boundary. File attachments stay rendered
+ * above the editor, since editing revises the text and keeps the files.
+ */
+function UserMessageRow({
+  message,
+  files,
+  bubble,
+  actions,
+  onEditUserMessage,
+  editDisabled,
+  senderAvatar,
+  showSenderAvatar,
+}: {
+  message: UIMessage;
+  files: React.ReactNode;
+  bubble: React.ReactNode;
+  actions: React.ReactNode;
+  onEditUserMessage?: (message: UIMessage, text: string) => void;
+  editDisabled: boolean;
+  senderAvatar?: ProjectThreadOwnerAvatar;
+  showSenderAvatar: boolean;
+}) {
+  const originalText = extractUserMessageText(message);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(originalText);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Size the textarea to its content and drop the caret at the end on open,
+  // so a long prompt is fully visible and ready to append to.
+  useLayoutEffect(() => {
+    if (!editing) return;
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+  }, [editing]);
+
+  const startEditing = () => {
+    setDraft(originalText);
+    setEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setEditing(false);
+    setDraft(originalText);
+  };
+
+  const submitEdit = () => {
+    const next = draft.trim();
+    if (!next || next === originalText.trim()) {
+      cancelEditing();
+      return;
+    }
+    setEditing(false);
+    onEditUserMessage?.(message, next);
+  };
+
+  const showActionRow = Boolean(actions) || Boolean(onEditUserMessage);
+
+  return (
+    <div className="group/user-message flex w-full min-w-0 flex-col items-end gap-2">
+      {showSenderAvatar && senderAvatar ? (
+        <div className="flex max-w-[min(100%,48rem)] justify-end">
+          <SenderAvatar avatar={senderAvatar} />
+        </div>
+      ) : null}
+      {/* File attachments above the bubble */}
+      {files}
+      {editing ? (
+        <div className="flex w-full max-w-[min(100%,48rem)] flex-col gap-2">
+          <textarea
+            ref={textareaRef}
+            aria-label="Edit message"
+            value={draft}
+            rows={1}
+            onChange={(event) => {
+              setDraft(event.target.value);
+              const textarea = event.currentTarget;
+              textarea.style.height = "auto";
+              textarea.style.height = `${textarea.scrollHeight}px`;
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Escape") {
+                event.preventDefault();
+                cancelEditing();
+                return;
+              }
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                submitEdit();
+              }
+            }}
+            className="max-h-[50vh] w-full resize-none overflow-y-auto rounded-2xl border border-border bg-muted/40 px-4 py-3 text-sm text-foreground outline-none focus-visible:border-ring"
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={cancelEditing}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={submitEdit}
+              disabled={editDisabled}
+            >
+              Send
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          {/* Text and other parts inside the bubble */}
+          {bubble}
+          {showActionRow ? (
+            <div className="flex max-w-[min(100%,48rem)] justify-end gap-1 opacity-0 transition-opacity duration-150 group-hover/user-message:opacity-100 focus-within:opacity-100">
+              {onEditUserMessage ? (
+                <EditMessageAction
+                  onClick={startEditing}
+                  disabled={editDisabled}
+                />
+              ) : null}
+              {actions}
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
   );
 }
 
@@ -223,6 +376,8 @@ function MessageViewImpl({
   claudeFooterMode = "none",
   mcpjamFooterActive = false,
   renderUserMessageActions,
+  onEditUserMessage,
+  editDisabled = false,
   senderAvatar,
   showSenderAvatar = false,
   recorder,
@@ -253,89 +408,91 @@ function MessageViewImpl({
     const otherParts =
       message.parts?.filter((part) => part.type !== "file") ?? [];
 
+    const filesNode =
+      fileParts.length > 0 ? (
+        <div className="flex max-w-[min(100%,48rem)] flex-wrap justify-end gap-2">
+          {fileParts.map((part, i) => (
+            <PartSwitch
+              key={`file-${i}`}
+              part={part}
+              role={role}
+              chatSessionId={chatSessionId}
+              onSendFollowUp={onSendFollowUp}
+              toolsMetadata={toolsMetadata}
+              toolServerMap={toolServerMap}
+              onWidgetStateChange={onWidgetStateChange}
+              onModelContextUpdate={onModelContextUpdate}
+              onAppToolInvocationChange={onAppToolInvocationChange}
+              pipWidgetId={pipWidgetId}
+              fullscreenWidgetId={fullscreenWidgetId}
+              onRequestPip={onRequestPip}
+              onExitPip={onExitPip}
+              onRequestFullscreen={onRequestFullscreen}
+              onExitFullscreen={onExitFullscreen}
+              onRequestTeardown={onRequestTeardown}
+              tornDownWidgetIds={tornDownWidgetIds}
+              displayMode={displayMode}
+              onDisplayModeChange={onDisplayModeChange}
+              toolRenderOverrides={toolRenderOverrides}
+              showInlineEdit={showInlineEdit}
+              minimalMode={minimalMode}
+              interactive={interactive}
+              reasoningDisplayMode={reasoningDisplayMode}
+              mcpToolResultImageRendering={mcpToolResultImageRendering}
+            />
+          ))}
+        </div>
+      ) : null;
+
+    const bubbleNode =
+      otherParts.length > 0 || fileParts.length === 0 ? (
+        <UserMessageBubble>
+          {otherParts.map((part, i) => (
+            <PartSwitch
+              key={i}
+              part={part}
+              role={role}
+              chatSessionId={chatSessionId}
+              onSendFollowUp={onSendFollowUp}
+              toolsMetadata={toolsMetadata}
+              toolServerMap={toolServerMap}
+              onWidgetStateChange={onWidgetStateChange}
+              onModelContextUpdate={onModelContextUpdate}
+              onAppToolInvocationChange={onAppToolInvocationChange}
+              pipWidgetId={pipWidgetId}
+              fullscreenWidgetId={fullscreenWidgetId}
+              onRequestPip={onRequestPip}
+              onExitPip={onExitPip}
+              onRequestFullscreen={onRequestFullscreen}
+              onExitFullscreen={onExitFullscreen}
+              onRequestTeardown={onRequestTeardown}
+              tornDownWidgetIds={tornDownWidgetIds}
+              displayMode={displayMode}
+              onDisplayModeChange={onDisplayModeChange}
+              toolRenderOverrides={toolRenderOverrides}
+              showInlineEdit={showInlineEdit}
+              minimalMode={minimalMode}
+              interactive={interactive}
+              reasoningDisplayMode={reasoningDisplayMode}
+              mcpToolResultImageRendering={mcpToolResultImageRendering}
+            />
+          ))}
+        </UserMessageBubble>
+      ) : null;
+
     return (
-      <div className="group/user-message flex w-full min-w-0 flex-col items-end gap-2">
-        {showSenderAvatar && senderAvatar ? (
-          <div className="flex max-w-[min(100%,48rem)] justify-end">
-            <SenderAvatar avatar={senderAvatar} />
-          </div>
-        ) : null}
-        {/* File attachments above the bubble */}
-        {fileParts.length > 0 && (
-          <div className="flex max-w-[min(100%,48rem)] flex-wrap justify-end gap-2">
-            {fileParts.map((part, i) => (
-              <PartSwitch
-                key={`file-${i}`}
-                part={part}
-                role={role}
-                chatSessionId={chatSessionId}
-                onSendFollowUp={onSendFollowUp}
-                toolsMetadata={toolsMetadata}
-                toolServerMap={toolServerMap}
-                onWidgetStateChange={onWidgetStateChange}
-                onModelContextUpdate={onModelContextUpdate}
-                onAppToolInvocationChange={onAppToolInvocationChange}
-                pipWidgetId={pipWidgetId}
-                fullscreenWidgetId={fullscreenWidgetId}
-                onRequestPip={onRequestPip}
-                onExitPip={onExitPip}
-                onRequestFullscreen={onRequestFullscreen}
-                onExitFullscreen={onExitFullscreen}
-                onRequestTeardown={onRequestTeardown}
-                tornDownWidgetIds={tornDownWidgetIds}
-                displayMode={displayMode}
-                onDisplayModeChange={onDisplayModeChange}
-                toolRenderOverrides={toolRenderOverrides}
-                showInlineEdit={showInlineEdit}
-                minimalMode={minimalMode}
-                interactive={interactive}
-                reasoningDisplayMode={reasoningDisplayMode}
-                mcpToolResultImageRendering={mcpToolResultImageRendering}
-              />
-            ))}
-          </div>
-        )}
-        {/* Text and other parts inside the bubble */}
-        {(otherParts.length > 0 || fileParts.length === 0) && (
-          <UserMessageBubble>
-            {otherParts.map((part, i) => (
-              <PartSwitch
-                key={i}
-                part={part}
-                role={role}
-                chatSessionId={chatSessionId}
-                onSendFollowUp={onSendFollowUp}
-                toolsMetadata={toolsMetadata}
-                toolServerMap={toolServerMap}
-                onWidgetStateChange={onWidgetStateChange}
-                onModelContextUpdate={onModelContextUpdate}
-                onAppToolInvocationChange={onAppToolInvocationChange}
-                pipWidgetId={pipWidgetId}
-                fullscreenWidgetId={fullscreenWidgetId}
-                onRequestPip={onRequestPip}
-                onExitPip={onExitPip}
-                onRequestFullscreen={onRequestFullscreen}
-                onExitFullscreen={onExitFullscreen}
-                onRequestTeardown={onRequestTeardown}
-                tornDownWidgetIds={tornDownWidgetIds}
-                displayMode={displayMode}
-                onDisplayModeChange={onDisplayModeChange}
-                toolRenderOverrides={toolRenderOverrides}
-                showInlineEdit={showInlineEdit}
-                minimalMode={minimalMode}
-                interactive={interactive}
-                reasoningDisplayMode={reasoningDisplayMode}
-                mcpToolResultImageRendering={mcpToolResultImageRendering}
-              />
-            ))}
-          </UserMessageBubble>
-        )}
-        {renderUserMessageActions ? (
-          <div className="flex max-w-[min(100%,48rem)] justify-end gap-1 opacity-0 transition-opacity duration-150 group-hover/user-message:opacity-100 focus-within:opacity-100">
-            {renderUserMessageActions(message)}
-          </div>
-        ) : null}
-      </div>
+      <UserMessageRow
+        message={message}
+        files={filesNode}
+        bubble={bubbleNode}
+        actions={
+          renderUserMessageActions ? renderUserMessageActions(message) : null
+        }
+        onEditUserMessage={onEditUserMessage}
+        editDisabled={editDisabled}
+        senderAvatar={senderAvatar}
+        showSenderAvatar={showSenderAvatar}
+      />
     );
   }
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
@@ -262,6 +262,8 @@ export function TranscriptThread({
   lastRenderableMessageId = null,
   getMessageWrapperProps,
   renderUserMessageActions,
+  onEditUserMessage,
+  editDisabled,
   showSenderAvatars = false,
   resolveSenderAvatar,
   recorder,
@@ -575,6 +577,8 @@ export function TranscriptThread({
               claudeFooterMode={claudeFooterMode}
               mcpjamFooterActive={mcpjamFooterActive}
               renderUserMessageActions={renderUserMessageActions}
+              onEditUserMessage={onEditUserMessage}
+              editDisabled={editDisabled}
               senderAvatar={senderAvatar}
               showSenderAvatar={showSenderAvatarForMessage}
               recorder={recorder}

--- a/mcpjam-inspector/client/src/components/evals/eval-live-chat-panel.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-live-chat-panel.tsx
@@ -227,6 +227,7 @@ export function EvalLiveChatPanel({
                       hideWelcomeHero
                       hideCenterHeaderChrome
                       hideInlineEdit
+                      hideMessageEdit
                       suppressHistoryConflictToast
                       onMessagesChange={handleMessagesChange}
                       recorder={recorder}

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -339,6 +339,8 @@ interface PlaygroundMainProps {
   // View-mode controls
   disableChatInput?: boolean;
   hideInlineEdit?: boolean;
+  /** Suppresses the per-user-message edit/rewind affordance. */
+  hideMessageEdit?: boolean;
   disabledInputPlaceholder?: string;
   // Onboarding
   initialInput?: string;
@@ -492,6 +494,7 @@ export function PlaygroundMain({
   onTimeZoneChange: _onTimeZoneChange,
   disableChatInput = false,
   hideInlineEdit = false,
+  hideMessageEdit = false,
   disabledInputPlaceholder = "Input disabled in Views",
   initialInput,
   initialInputTypewriter = false,
@@ -3468,6 +3471,35 @@ export function PlaygroundMain({
     await performComposerSubmit();
   };
 
+  // Rewind to a past user message and re-run the turn from edited text. The
+  // `messageId` makes the AI SDK truncate everything after that message and
+  // replace it in place, so this continues the same session rather than
+  // forking a new one.
+  const handleEditUserMessage = useCallback(
+    async (message: UIMessage, text: string) => {
+      if (sendBlocked) return;
+      const serverReady = await ensureSelectedServerReadyForChat();
+      if (!serverReady) return;
+      // Editing revises the prompt text; the original attachments ride along.
+      const files = (message.parts ?? []).filter(
+        (part): part is Extract<UIMessage["parts"][number], { type: "file" }> =>
+          part.type === "file"
+      );
+      sendMessage({
+        text,
+        files: files.length > 0 ? files : undefined,
+        messageId: message.id,
+        metadata: outgoingSenderMetadata,
+      });
+    },
+    [
+      sendBlocked,
+      ensureSelectedServerReadyForChat,
+      sendMessage,
+      outgoingSenderMetadata,
+    ]
+  );
+
   // Eval Quick Run: re-run the case in the live preview. Two phases so the send
   // never races the reset's `setMessages`:
   //   1. On a new `runPreviewRequest` nonce, reset the thread and mark a pending
@@ -3940,6 +3972,12 @@ export function PlaygroundMain({
                       }
                     : undefined
                 }
+                onEditUserMessage={
+                  isCompareMode || hideMessageEdit
+                    ? undefined
+                    : handleEditUserMessage
+                }
+                editDisabled={sendBlocked}
                 showSenderAvatars={showSenderAvatars}
                 resolveSenderAvatar={resolveSenderAvatar}
                 recorder={recorderWithResolver}

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -376,6 +376,10 @@ export interface UseChatSessionReturn {
     metadata?: Record<string, unknown>;
     /** Ephemeral SEP-1865 widget context for the next model turn. */
     widgetModelContext?: WidgetModelContextEntry[];
+    /** Id of an existing user message to rewind to. The AI SDK truncates the
+     *  transcript to that message, replaces it with this content, and re-runs
+     *  the turn — an in-place edit that keeps the same `chatSessionId`. */
+    messageId?: string;
   }) => void;
   stop: () => void;
   status: "submitted" | "streaming" | "ready" | "error";
@@ -3158,8 +3162,9 @@ export function useChatSession(
       }>;
       metadata?: Record<string, unknown>;
       widgetModelContext?: WidgetModelContextEntry[];
+      messageId?: string;
     }) => {
-      const { text, files, metadata, widgetModelContext } = options;
+      const { text, files, metadata, widgetModelContext, messageId } = options;
       // SEP-2350 turn boundary: a new user turn spins up a fresh per-turn MCP
       // client (`web-chat-turn.ts` disconnects the prior one), and each new
       // client RESTARTS its numeric JSON-RPC ids from scratch. Any `tools/call`
@@ -3236,11 +3241,17 @@ export function useChatSession(
           }
         }
         try {
+          // `messageId` makes the AI SDK truncate the transcript to that
+          // message and replace it in place, rather than appending. It mutates
+          // the Chat store directly, so the wrapped `setMessages` (and with it
+          // `shouldForkChatSession`) never runs — an edit rewinds the current
+          // session instead of branching into a new one.
+          const rewind = messageId ? { messageId } : {};
           if (files && files.length > 0) {
             // AI SDK accepts FileUIPart[] with data URLs
-            baseSendMessage({ text, files, ...extra });
+            baseSendMessage({ text, files, ...extra, ...rewind });
           } else {
-            baseSendMessage({ text, ...extra });
+            baseSendMessage({ text, ...extra, ...rewind });
           }
         } catch (error) {
           pendingWidgetModelContextRef.current = undefined;

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -28,6 +28,7 @@ export const ANALYTICS_EVENTS = {
   // --- Chat (paired: client event + server twin) ---
   send_message: { source: "client" },
   send_message_server: { source: "server" },
+  edit_message: { source: "client" },
 
   // --- Tool execution (paired) ---
   execute_tool: { source: "client" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add inline edit for past user messages to rewind the thread and re-run the turn in the same session. This lets you quickly fix prompts without forking chat history.

- **New Features**
  - Hover pencil on user messages opens an inline editor. Enter sends, Shift+Enter adds a newline, Escape cancels. Unchanged text is a no-op.
  - Resend uses `messageId` to truncate to that message and replace it, preserving original file attachments. Editing is disabled while a response streams.
  - Available in Playground and Chat tabs; hidden in multi-model compare and in evals via the new `hideMessageEdit` prop.
  - `Thread`/`MessageView` accept `onEditUserMessage` and `editDisabled`. `use-chat-session` supports `messageId`. Added `edit_message` analytics event and tests.
  - Note: saved test cases and persisted traces anchored by promptIndex may reference content that changes after edits.

`@mcpjam/inspector`: patch release.

<sup>Written for commit e220b085a69ecc900d5f887bf34778135ef905b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

