### PR TITLE
fix(swarms): remove the MCPJAM_SWARM_EPHEMERAL_BASH flag

### DIFF
--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.integration.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.integration.test.ts
@@ -246,7 +246,8 @@ describe("swarm runner — real core integration", () => {
     expect(terminal.chatSessionId).toBe("synth_run-1_host-1_0");
   });
 
-  it("harness host: SUPPLIES a harnessMcpProxy + threads swarm continuity identity into the turn, and rides the swarm-chat resume-state commit into the transcript persist", async () => {
+  // eslint-disable-next-line vitest/no-disabled-tests -- un-skipped by Phase 6 (ephemeral harness)
+  it.skip("harness host: SUPPLIES a harnessMcpProxy + threads swarm continuity identity into the turn, and rides the swarm-chat resume-state commit into the transcript persist", async () => {
     // A harness turn returns a §3 resume-state commit as its 3rd
     // onConversationComplete arg; runAssistantTurn surfaces it on the result.
     // For swarm it carries ownerType "swarm-chat" (the backend derives the
@@ -271,6 +272,14 @@ describe("swarm runner — real core integration", () => {
       harnessSessionCommit: swarmCommit,
     }));
 
+    // NOTE (B-isolation, flag removal): with `MCPJAM_SWARM_EPHEMERAL_BASH` gone,
+    // ephemeral sandboxes are always on and harness targets FAIL CLOSED — they
+    // never reach the harness turn, so every assertion below is unreachable.
+    // Skipped rather than rewritten to assert refusal: that refusal is already
+    // covered in `swarm-runner.sandbox.test.ts`, and these assertions are the
+    // only coverage of the harness proxy plane, the swarm continuity identity,
+    // and the resume-state commit riding /ingest-chat. Phase 6 (ephemeral
+    // harness) must UN-SKIP this, not delete it.
     const opts = baseOpts();
     await startJourneyRun({
       ...opts,

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.sandbox.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.sandbox.test.ts
@@ -252,7 +252,6 @@ function terminalReports(): Array<Record<string, unknown>> {
 
 beforeEach(() => {
   vi.stubEnv("CONVEX_HTTP_URL", "https://convex.site");
-  vi.stubEnv("MCPJAM_SWARM_EPHEMERAL_BASH", "true");
   let seq = 0;
   provisionJourneySandboxMock.mockReset().mockImplementation(async () => {
     seq += 1;
@@ -544,7 +543,7 @@ describe("swarm runner — targets that want no sandbox", () => {
     expect(terminalReports()[0]).toMatchObject({ status: "succeeded" });
   });
 
-  it("FAILS the attempt when the flag is on but the data plane is unconfigured", async () => {
+  it("FAILS the attempt when the data plane is unconfigured", async () => {
     // A target that asked for a reproducible shell must not run without one
     // just because this server can't provision. That is the degraded-but-green
     // outcome the whole design refuses — and it is the same shape as the
@@ -571,12 +570,6 @@ describe("swarm runner — targets that want no sandbox", () => {
     expect(terminalReports()[0]).toMatchObject({ status: "succeeded" });
   });
 
-  it("does nothing at all when the flag is off", async () => {
-    vi.stubEnv("MCPJAM_SWARM_EPHEMERAL_BASH", "");
-    await startJourneyRun(baseOpts());
-    expect(provisionJourneySandboxMock).not.toHaveBeenCalled();
-    expect(resolverContexts()[0]!.sandboxBinding).toBeUndefined();
-  });
 });
 
 describe("swarm runner — harness targets fail closed (F4)", () => {
@@ -593,7 +586,7 @@ describe("swarm runner — harness targets fail closed (F4)", () => {
     expect(String(terminals[0]!.errorMessage)).toMatch(/harness/i);
   });
 
-  it("stays blocked when the flag is on but the data plane is UNCONFIGURED", async () => {
+  it("stays blocked when the data plane is UNCONFIGURED", async () => {
     // The refusal is gated on the FLAG ALONE, never on provision capability.
     // Tying it to availability would mean a broken or unconfigured sandbox
     // service silently re-enables the contamination path: no box to isolate
@@ -616,11 +609,4 @@ describe("swarm runner — harness targets fail closed (F4)", () => {
     expect(releaseSandboxMock).not.toHaveBeenCalled();
   });
 
-  it("leaves harness targets alone when the flag is off", async () => {
-    vi.stubEnv("MCPJAM_SWARM_EPHEMERAL_BASH", "");
-    await startJourneyRun(baseOpts({ harness: "claude-code" }));
-    // Flag off ⇒ today's behaviour, unchanged. The session proceeds through the
-    // normal path (which is still contaminated — that is what the flag fixes).
-    expect(terminalReports()[0]!.status).not.toBe("failed");
-  });
 });

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -19,7 +19,6 @@ import {
 import { createBrowserArtifactOutbox } from "../browser-artifact-outbox.js";
 import {
   canProvisionSwarmSandboxes,
-  isSwarmEphemeralBashEnabled,
   provisionAttemptSandbox,
   releaseAttemptSandbox,
   sandboxIntentFor,
@@ -367,7 +366,6 @@ async function runJourneyFanOut(
   // FAIL, not quietly run without it. Collapsing the two into one boolean is
   // what let an unavailable service turn into a silently degraded green run —
   // the same shape as the harness gate below.
-  const ephemeralRegime = isSwarmEphemeralBashEnabled();
   const ephemeralSandboxes = canProvisionSwarmSandboxes();
 
   // --- Run one target's sessions SEQUENTIALLY ------------------------------
@@ -383,15 +381,15 @@ async function runJourneyFanOut(
     // across every session in the run while the bash path looked isolated —
     // exactly the contamination this work exists to remove, wearing a fix.
     // Refuse it, loudly. Ephemeral harness binding is its own phase.
-    // Gated on the FLAG ALONE, deliberately — not on `ephemeralSandboxes`,
-    // which also requires the data plane to be configured. Tying the refusal to
-    // provision CAPABILITY would mean an unconfigured or briefly broken sandbox
-    // service silently re-enables the very contamination path this rule exists
-    // to close: flag on + data plane down ⇒ harness runs on the launcher's
-    // shared computer again. Availability must never widen what is allowed.
-    const harnessBlockedReason =
-      isSwarmEphemeralBashEnabled() && target.harness
-        ? "This target runs the " +
+    // UNCONDITIONAL on the harness, deliberately — in particular NOT gated on
+    // `ephemeralSandboxes`, which also requires the data plane to be
+    // configured. Tying the refusal to provision CAPABILITY would mean an
+    // unconfigured or briefly broken sandbox service silently re-enables the
+    // very contamination path this rule exists to close (data plane down ⇒
+    // harness runs on the launcher's shared computer again). Availability must
+    // never widen what is allowed.
+    const harnessBlockedReason = target.harness
+      ? "This target runs the " +
           target.harness +
           " harness, which does not yet support per-session disposable " +
           "sandboxes: it would share the launcher's project computer with " +
@@ -530,7 +528,7 @@ async function runJourneyFanOut(
         // `harnessBlockedReason` guarantees the shared core refuses this session
         // before any tool runs, so provisioning would boot a paid box purely to
         // release it unused — once per configured session.
-        if (ephemeralRegime && !harnessBlockedReason) {
+        if (!harnessBlockedReason) {
           const intent = sandboxIntentFor(target);
           if (intent.kind === "skip" && intent.reason) {
             // The target ASKED for a shell and the environment can't give it

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-sandbox.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-sandbox.ts
@@ -21,16 +21,6 @@ import type { TrustedSandboxBinding } from "../../utils/built-in-tools/registry.
 import { BASH_TOOL_NAME } from "../../utils/built-in-tools/bash.js";
 
 /**
- * Feature flag. Default OFF — swarm bash is currently suppressed entirely, so
- * the worst outcome of a bug behind this flag is "still no bash", the status
- * quo. Flip it on once the mechanism has soaked.
- */
-export function isSwarmEphemeralBashEnabled(): boolean {
-  const raw = process.env.MCPJAM_SWARM_EPHEMERAL_BASH?.trim().toLowerCase();
-  return raw === "1" || raw === "true" || raw === "yes";
-}
-
-/**
  * Does this target want a shell at all? Mirrors the backend's `wantsBash` gate
  * exactly — if the two disagree, we either provision a box nothing uses (paid,
  * silent) or ask for one the backend refused to pin (a spurious attempt
@@ -273,5 +263,5 @@ export async function releaseAttemptSandbox(
  * the same check `evals-runner.ts` makes before its own sandbox path.
  */
 export function canProvisionSwarmSandboxes(): boolean {
-  return isSwarmEphemeralBashEnabled() && isComputersDataPlaneConfigured();
+  return isComputersDataPlaneConfigured();
 }


### PR DESCRIPTION
Removes `MCPJAM_SWARM_EPHEMERAL_BASH`. Nobody is running with it on, and an env var is the wrong shape for this knob: flipping needs a redeploy, it's per-process so replicas can drift, it's invisible in the product, and "off" can't be distinguished from "unset". Ephemeral per-attempt sandboxes are now simply how swarm bash works.

## ⚠️ Do not merge before Phase 6 (ephemeral harness)

**This takes harness-in-swarms away.** Until now the flag defaulted off, so a harness-bearing swarm target ran normally — on the launcher's shared personal computer, contaminated but working. With the flag gone it is refused, because `runHarnessTurn` bypasses `resolveHostTools` entirely and the egress broker leases on an `Id<'projectComputers'>` that an ephemeral sandbox row doesn't have.

Merging this before Phase 6 lands converts a *latent* regression (opt-in only, nobody opted in) into a *live* one for anyone using a harness in a swarm. Phase 6 is in flight; merge that first, or merge these together.

If harness-in-swarms has no users, merge whenever — the rest of the change is safe on its own.

## Two properties preserved deliberately

- **The refusal is not gated on availability.** The harness block is now unconditional on `target.harness`, specifically *not* gated on `canProvisionSwarmSandboxes`. Tying a refusal to provisioning capability would mean an unconfigured or briefly-broken data plane silently re-enables the contamination path the rule exists to close. Availability must never widen what is allowed.
- **Want-a-shell-and-can't-get-one still fails.** It does not degrade to a bash-less green run. `canProvisionSwarmSandboxes` now reports only whether the data plane is configured — which is what it was always actually asking.

## On the skipped test

`swarm-runner.integration.test.ts`'s harness case is **skipped, not rewritten**. Its assertions are the only coverage of the harness proxy plane, the swarm continuity identity, and the resume-state commit riding `/ingest-chat`; the refusal itself is already covered in `swarm-runner.sandbox.test.ts`. Rewriting it to assert refusal would have deleted real coverage and duplicated existing coverage. **Phase 6 must un-skip it** — there's a comment in the file saying so.

## Verification

142 passed / 1 skipped across the touched suites; `npm run typecheck:client` clean. Real exit codes captured (not a piped `$?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Behavior change for harness-in-swarms (now always failed) and always-on ephemeral bash gating; merge timing relative to Phase 6 matters for anyone using harness targets.
> 
> **Overview**
> Removes the **`MCPJAM_SWARM_EPHEMERAL_BASH`** env flag and **`isSwarmEphemeralBashEnabled()`**. Per-attempt disposable sandboxes for swarm bash are now always in effect when the computers data plane is configured; **`canProvisionSwarmSandboxes()`** only checks **`isComputersDataPlaneConfigured()`**.
> 
> **Harness targets** are refused whenever **`target.harness`** is set (not gated on sandbox availability), so an unconfigured data plane cannot silently allow harness runs on the launcher's shared computer again. Sandbox provisioning runs for non-harness targets without a separate "ephemeral regime" switch.
> 
> Tests drop flag-on/off cases; the integration harness case is **`it.skip`** until Phase 6 (ephemeral harness), with a note that refusal is already covered in sandbox tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6382325b04f05c3230ec0565851c433db42b6fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `MCPJAM_SWARM_EPHEMERAL_BASH` flag; swarm bash now always uses per-attempt ephemeral sandboxes. Harness targets in swarms now fail closed until Phase 6 (ephemeral harness).

- **Migration**
  - Do not merge before Phase 6 unless no users run harness-in-swarms.
  - Harness refusal is unconditional on `target.harness` and not gated by `canProvisionSwarmSandboxes`.
  - Targets that request a shell still fail if the data plane is unconfigured; no bash-less green runs.
  - `canProvisionSwarmSandboxes` now checks only data plane configuration.
  - Tests: the harness integration test is skipped and must be un-skipped in Phase 6.

<sup>Written for commit f6382325b04f05c3230ec0565851c433db42b6fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

