### PR TITLE
fix(environments): allow the environments tab in hosted mode

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
@@ -89,6 +89,14 @@ describe("hosted-tab-policy", () => {
     expect(isHostedHashTabBlocked("xaa-flow")).toBe(false);
   });
 
+  it("allows environments in hosted navigation (visibility stays flag-gated)", () => {
+    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("environments");
+    expect(HOSTED_HASH_ALLOWED_TABS).toContain("environments");
+    expect(isHostedSidebarTabAllowed("environments")).toBe(true);
+    expect(isHostedHashTabAllowed("environments")).toBe(true);
+    expect(isHostedHashTabBlocked("environments")).toBe(false);
+  });
+
   it("allows learning in hosted navigation", () => {
     expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("learning");
     expect(HOSTED_HASH_ALLOWED_TABS).toContain("learning");

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -18,6 +18,11 @@ export const HOSTED_SIDEBAR_ALLOWED_TABS = [
   "client-config",
   "evals",
   "ci-evals",
+  // Project Environments are Convex-backed and hosted-first; the sidebar item
+  // and route are additionally gated behind `project-environments-enabled`
+  // (PostHog), so this entry only makes the tab REACHABLE — visibility still
+  // comes from the flag.
+  "environments",
   "tools",
   "resources",
   "prompts",


### PR DESCRIPTION
## Why

Hosted smoke-testing for the environments launch hit **"environments is not available in hosted mode"** with a redirect to /servers. `App.tsx` bounces any tab missing from `HOSTED_SIDEBAR_ALLOWED_TABS` / `HOSTED_HASH_ALLOWED_TABS` (`client/src/lib/hosted-tab-policy.ts`), and `environments` was never added — an independent gate the `project-environments-enabled` PostHog flag doesn't control. The tranche PRs were verified flag-on in **local** mode, where the allowlist doesn't apply.

## What

- Add `environments` to `HOSTED_SIDEBAR_ALLOWED_TABS` (flows into the hash allowlist). The entry only makes the tab **reachable** — visibility remains gated by the PostHog flag (flag-gated sidebar item + route guard, both fail-closed).
- Test asserting environments is allowed in hosted sidebar + hash navigation and not blocked.

The `project-environments` surface manifest already exists with nav segment `environments` and is not `hostedBlocked`, so the surface-coverage invariants pass unchanged (`showInAtlas: false` stays — the static atlas can't read the flag).

## Tests

37 tests pass across hosted-tab-policy, app-surface-coverage, and ui-actions.hosted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small allowlist change with tests; feature exposure in hosted mode remains controlled by the existing PostHog flag and route guards.
> 
> **Overview**
> **Fixes hosted smoke tests** that hit *"environments is not available in hosted mode"* and a redirect to `/servers`. Hosted `App.tsx` only permits tabs listed in `HOSTED_SIDEBAR_ALLOWED_TABS` / `HOSTED_HASH_ALLOWED_TABS`; `environments` was missing even when `project-environments-enabled` was on.
> 
> Adds **`environments`** to `HOSTED_SIDEBAR_ALLOWED_TABS` in `hosted-tab-policy.ts` (and thus the hash allowlist). This only makes the tab **reachable** in hosted mode—sidebar visibility and route access stay behind the PostHog flag. A unit test mirrors other hosted-nav tabs and asserts the tab is allowed, not blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4510d4f4e00bb1ae405252675b42318796e3e1d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the Environments tab in hosted mode so flagged users can access it without being redirected. Visibility remains gated by the `project-environments-enabled` flag.

- **Bug Fixes**
  - Added `environments` to `HOSTED_SIDEBAR_ALLOWED_TABS` (and hash allowlist) so the route is reachable; sidebar item and route stay flag-gated.
  - Added tests to confirm `environments` is allowed in hosted sidebar and hash navigation, and not blocked.

<sup>Written for commit 4510d4f4e00bb1ae405252675b42318796e3e1d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

