### PR TITLE
feat(playground): show environment servers as active in the composer's server menu

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -1532,6 +1532,32 @@ describe("ChatInput", () => {
       expect(onResetEnvironmentServers).toHaveBeenCalled();
     });
 
+    it("locks the toggles and reset while a turn is streaming", () => {
+      const onEnvironmentServerToggle = vi.fn();
+      render(
+        <ChatInput
+          {...defaultProps}
+          isLoading={true}
+          environmentServers={environmentServers}
+          onEnvironmentServerToggle={onEnvironmentServerToggle}
+          environmentServersOverridden={true}
+          onResetEnvironmentServers={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      // Same guard the header section applied before these controls moved
+      // here: the in-flight turn keeps its resolved set, so a mid-stream
+      // flip would change NEXT turn while appearing to change this one.
+      expect(screen.getByRole("switch", { name: "Include bart" })).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: "Reset to environment" })
+      ).toBeDisabled();
+      fireEvent.click(screen.getByRole("switch", { name: "Include bart" }));
+      expect(onEnvironmentServerToggle).not.toHaveBeenCalled();
+    });
+
     it("shows no server section at all for an environment with zero servers", () => {
       render(
         <ChatInput

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -1500,6 +1500,38 @@ describe("ChatInput", () => {
       expect(onDisconnectServer).not.toHaveBeenCalled();
     });
 
+    it("shows Modified + reset only while a per-turn override exists", () => {
+      const onResetEnvironmentServers = vi.fn();
+      const { rerender } = render(
+        <ChatInput
+          {...defaultProps}
+          environmentServers={environmentServers}
+          onEnvironmentServerToggle={vi.fn()}
+          environmentServersOverridden={false}
+          onResetEnvironmentServers={onResetEnvironmentServers}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+      expect(screen.queryByText("Modified")).not.toBeInTheDocument();
+
+      rerender(
+        <ChatInput
+          {...defaultProps}
+          environmentServers={environmentServers}
+          onEnvironmentServerToggle={vi.fn()}
+          environmentServersOverridden={true}
+          onResetEnvironmentServers={onResetEnvironmentServers}
+        />
+      );
+
+      expect(screen.getByText("Modified")).toBeInTheDocument();
+      fireEvent.click(
+        screen.getByRole("button", { name: "Reset to environment" })
+      );
+      expect(onResetEnvironmentServers).toHaveBeenCalled();
+    });
+
     it("shows no server section at all for an environment with zero servers", () => {
       render(
         <ChatInput

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -27,6 +27,12 @@ vi.mock("@/lib/session-token", () => ({
   authFetch: vi.fn(),
 }));
 
+// Passing `onAddServer` mounts the real AddServerModal, which requires an
+// AuthKitProvider; the popover behavior under test doesn't need its internals.
+vi.mock("@/components/connection/AddServerModal", () => ({
+  AddServerModal: () => null,
+}));
+
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: (selector: (state: { themeMode: "light" }) => unknown) =>
     selector({ themeMode: "light" }),
@@ -1420,6 +1426,95 @@ describe("ChatInput", () => {
 
       expect(onReconnectServer).toHaveBeenCalledWith("downSrv");
       expect(onServerToggle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("environment servers (environment mode)", () => {
+    const environmentServers = [
+      { serverId: "srv_a", name: "bart", enabled: true, source: "host_or_group" },
+      { serverId: "srv_b", name: "excalidraw", enabled: true, source: "plugin" },
+      { serverId: "srv_c", name: "stateless", enabled: false, source: null },
+    ];
+
+    it("replaces the ad-hoc connection rows with the environment's servers", () => {
+      // Ad-hoc props are ALSO passed, as a caller bug would: the environment
+      // section must win outright — no Connect, no Add server.
+      render(
+        <ChatInput
+          {...defaultProps}
+          environmentServers={environmentServers}
+          onEnvironmentServerToggle={vi.fn()}
+          allServerConfigs={
+            {
+              adhoc: {
+                name: "adhoc",
+                config: { url: "http://localhost/x" },
+                connectionStatus: "disconnected",
+              },
+            } as any
+          }
+          onDisconnectServer={vi.fn()}
+          onReconnectServer={vi.fn()}
+          onAddServer={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      expect(screen.getByText("Environment servers")).toBeInTheDocument();
+      expect(
+        screen.getByText("Connected automatically on every message.")
+      ).toBeInTheDocument();
+      expect(screen.getByText("bart")).toBeInTheDocument();
+      expect(screen.getByText("excalidraw")).toBeInTheDocument();
+      expect(screen.getByText("stateless")).toBeInTheDocument();
+      expect(screen.queryByText("adhoc")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Connect" })
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("Add server")).not.toBeInTheDocument();
+    });
+
+    it("toggling a row reports the per-turn override, not a disconnect", () => {
+      const onEnvironmentServerToggle = vi.fn();
+      const onDisconnectServer = vi.fn();
+      render(
+        <ChatInput
+          {...defaultProps}
+          environmentServers={environmentServers}
+          onEnvironmentServerToggle={onEnvironmentServerToggle}
+          onDisconnectServer={onDisconnectServer}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      fireEvent.click(screen.getByRole("switch", { name: "Include bart" }));
+      expect(onEnvironmentServerToggle).toHaveBeenCalledWith("srv_a", false);
+
+      fireEvent.click(
+        screen.getByRole("switch", { name: "Include stateless" })
+      );
+      expect(onEnvironmentServerToggle).toHaveBeenCalledWith("srv_c", true);
+
+      expect(onDisconnectServer).not.toHaveBeenCalled();
+    });
+
+    it("shows no server section at all for an environment with zero servers", () => {
+      render(
+        <ChatInput
+          {...defaultProps}
+          environmentServers={[]}
+          onEnvironmentServerToggle={vi.fn()}
+          onAddServer={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      expect(screen.queryByText("Environment servers")).not.toBeInTheDocument();
+      expect(screen.queryByText("Servers")).not.toBeInTheDocument();
+      expect(screen.queryByText("Add server")).not.toBeInTheDocument();
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -1574,5 +1574,31 @@ describe("ChatInput", () => {
       expect(screen.queryByText("Servers")).not.toBeInTheDocument();
       expect(screen.queryByText("Add server")).not.toBeInTheDocument();
     });
+
+    it("keeps Modified + reset visible when an overridden environment resolves to zero servers", () => {
+      // An override survives live edits of the environment, so an environment
+      // edited down to zero servers can still carry one — and a retained id
+      // can still run if it's an authorized project server. The section must
+      // stay so the override is visible and resettable.
+      const onResetEnvironmentServers = vi.fn();
+      render(
+        <ChatInput
+          {...defaultProps}
+          environmentServers={[]}
+          onEnvironmentServerToggle={vi.fn()}
+          environmentServersOverridden={true}
+          onResetEnvironmentServers={onResetEnvironmentServers}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      expect(screen.getByText("Environment servers")).toBeInTheDocument();
+      expect(screen.getByText("Modified")).toBeInTheDocument();
+      fireEvent.click(
+        screen.getByRole("button", { name: "Reset to environment" })
+      );
+      expect(onResetEnvironmentServers).toHaveBeenCalled();
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -367,6 +367,14 @@ interface ChatInputProps {
     source?: string | null;
   }>;
   onEnvironmentServerToggle?: (serverId: string, enabled: boolean) => void;
+  /**
+   * True when the toggles above hold a per-turn override (some server was
+   * turned off/on for this session). Renders the Modified marker + reset —
+   * this menu is the ONLY surface for the override now, so the honesty
+   * affordance lives here too.
+   */
+  environmentServersOverridden?: boolean;
+  onResetEnvironmentServers?: () => void;
 }
 
 export function ChatInput({
@@ -428,6 +436,8 @@ export function ChatInput({
   onAttachChatboxServer,
   environmentServers,
   onEnvironmentServerToggle,
+  environmentServersOverridden = false,
+  onResetEnvironmentServers,
 }: ChatInputProps) {
   // Cloud skill source for the `/` picker: in hosted mode, list/load skills
   // from the project's Convex/Computer source (Playground carries projectId via
@@ -1518,6 +1528,22 @@ export function ChatInput({
                             <p className="px-2 pb-1.5 text-[11px] text-muted-foreground">
                               Connected automatically on every message.
                             </p>
+                            {environmentServersOverridden && (
+                              <div className="flex items-center gap-1.5 px-2 pb-1.5">
+                                <span className="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+                                  Modified
+                                </span>
+                                {onResetEnvironmentServers && (
+                                  <button
+                                    type="button"
+                                    onClick={onResetEnvironmentServers}
+                                    className="text-[11px] text-primary underline-offset-4 hover:underline"
+                                  >
+                                    Reset to environment
+                                  </button>
+                                )}
+                              </div>
+                            )}
                             <div className="max-h-48 overflow-y-auto">
                               {environmentServers.map((server) => (
                                 <div

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -1537,7 +1537,9 @@ export function ChatInput({
                                   <button
                                     type="button"
                                     onClick={onResetEnvironmentServers}
-                                    className="text-[11px] text-primary underline-offset-4 hover:underline"
+                                    // Same mid-turn lock as the toggles below.
+                                    disabled={isLoading}
+                                    className="text-[11px] text-primary underline-offset-4 hover:underline disabled:opacity-60"
                                   >
                                     Reset to environment
                                   </button>
@@ -1583,6 +1585,14 @@ export function ChatInput({
                                           next === true
                                         )
                                       }
+                                      // Locked while a turn is in flight —
+                                      // the same guard the header section
+                                      // applied before these controls moved:
+                                      // the running turn keeps its resolved
+                                      // set, so a mid-stream flip would only
+                                      // change NEXT turn while looking like
+                                      // it changed this one.
+                                      disabled={isLoading}
                                       aria-label={`Include ${server.name}`}
                                     />
                                   </div>

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -531,9 +531,18 @@ export function ChatInput({
   // Environment mode replaces the ad-hoc section outright — presence of the
   // prop (not its length) is the mode switch, so an environment that resolves
   // to zero servers shows no dead "Add server"/Connect controls either.
+  //
+  // `environmentServersOverridden` keeps the section even at zero servers: an
+  // override survives live edits of the environment (by design), so an
+  // environment edited down to zero servers can still carry a live override —
+  // a retained id can still run if it's an authorized project server. Hiding
+  // the section then would hide the Modified marker AND the only way to reset.
   const isEnvironmentServerMode = environmentServers !== undefined;
+  const environmentSectionVisible =
+    isEnvironmentServerMode &&
+    (environmentServers.length > 0 || environmentServersOverridden);
   const hasServerOptions = isEnvironmentServerMode
-    ? environmentServers.length > 0
+    ? environmentSectionVisible
     : Boolean(onAddServer || hasServerRows);
   const showHostStyleSelectorControl =
     showHostStyleSelector &&
@@ -1715,7 +1724,7 @@ export function ChatInput({
                       className={cn(
                         "px-1 pb-1",
                         (isEnvironmentServerMode
-                          ? environmentServers.length > 0
+                          ? environmentSectionVisible
                           : allServerConfigs &&
                             Object.keys(allServerConfigs).length > 0) &&
                           "border-t border-border mt-1 pt-1"

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -352,6 +352,21 @@ interface ChatInputProps {
     useOAuth: boolean;
   }>;
   onAttachChatboxServer?: (serverId: string) => void;
+  /**
+   * Environment mode (Project Environments): the environment's resolved
+   * servers, id-first from the preview. When present (even empty) this
+   * REPLACES the ad-hoc rows above in the "+" menu — environment servers are
+   * connected by the backend on every turn, so there is no browser connection
+   * to manage and a "Connect" button would be a dead control. The toggle is
+   * the per-turn narrowing override, not a connect/disconnect.
+   */
+  environmentServers?: Array<{
+    serverId: string;
+    name: string;
+    enabled: boolean;
+    source?: string | null;
+  }>;
+  onEnvironmentServerToggle?: (serverId: string, enabled: boolean) => void;
 }
 
 export function ChatInput({
@@ -411,6 +426,8 @@ export function ChatInput({
   voiceInputAuthHeaders,
   chatboxAttachableServers,
   onAttachChatboxServer,
+  environmentServers,
+  onEnvironmentServerToggle,
 }: ChatInputProps) {
   // Cloud skill source for the `/` picker: in hosted mode, list/load skills
   // from the project's Convex/Computer source (Playground carries projectId via
@@ -501,7 +518,13 @@ export function ChatInput({
       onDisconnectServer &&
       Object.keys(allServerConfigs).length > 0
   );
-  const hasServerOptions = Boolean(onAddServer || hasServerRows);
+  // Environment mode replaces the ad-hoc section outright — presence of the
+  // prop (not its length) is the mode switch, so an environment that resolves
+  // to zero servers shows no dead "Add server"/Connect controls either.
+  const isEnvironmentServerMode = environmentServers !== undefined;
+  const hasServerOptions = isEnvironmentServerMode
+    ? environmentServers.length > 0
+    : Boolean(onAddServer || hasServerRows);
   const showHostStyleSelectorControl =
     showHostStyleSelector &&
     Boolean(selectorHostStyle) &&
@@ -1486,9 +1509,64 @@ export function ChatInput({
                     {hasServerOptions && (
                       <div className="px-1 pt-1 pb-0">
                         <p className="px-2 py-1.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-                          Servers
+                          {isEnvironmentServerMode
+                            ? "Environment servers"
+                            : "Servers"}
                         </p>
-                        {allServerConfigs &&
+                        {isEnvironmentServerMode && (
+                          <>
+                            <p className="px-2 pb-1.5 text-[11px] text-muted-foreground">
+                              Connected automatically on every message.
+                            </p>
+                            <div className="max-h-48 overflow-y-auto">
+                              {environmentServers.map((server) => (
+                                <div
+                                  key={server.serverId}
+                                  className="flex items-center justify-between gap-2 rounded-md px-2 py-2 hover:bg-muted/60"
+                                >
+                                  <div className="flex items-center gap-2 min-w-0">
+                                    <div
+                                      className={cn(
+                                        "w-2 h-2 rounded-full shrink-0",
+                                        server.enabled
+                                          ? "bg-green-500 dark:bg-green-400"
+                                          : "bg-muted-foreground"
+                                      )}
+                                    />
+                                    <span
+                                      className={cn(
+                                        "text-sm font-medium truncate",
+                                        !server.enabled &&
+                                          "text-muted-foreground"
+                                      )}
+                                    >
+                                      {server.name}
+                                    </span>
+                                    {server.source === "plugin" && (
+                                      <span className="text-[10px] text-muted-foreground shrink-0 uppercase">
+                                        plugin
+                                      </span>
+                                    )}
+                                  </div>
+                                  <div className="flex items-center shrink-0">
+                                    <Switch
+                                      checked={server.enabled}
+                                      onCheckedChange={(next) =>
+                                        onEnvironmentServerToggle?.(
+                                          server.serverId,
+                                          next === true
+                                        )
+                                      }
+                                      aria-label={`Include ${server.name}`}
+                                    />
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </>
+                        )}
+                        {!isEnvironmentServerMode &&
+                          allServerConfigs &&
                           onDisconnectServer &&
                           Object.keys(allServerConfigs).length > 0 && (
                             <div className="max-h-48 overflow-y-auto">
@@ -1581,7 +1659,7 @@ export function ChatInput({
                                 })}
                             </div>
                           )}
-                        {onAddServer && (
+                        {!isEnvironmentServerMode && onAddServer && (
                           <button
                             type="button"
                             className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/60 cursor-pointer"
@@ -1600,8 +1678,10 @@ export function ChatInput({
                     <div
                       className={cn(
                         "px-1 pb-1",
-                        allServerConfigs &&
-                          Object.keys(allServerConfigs).length > 0 &&
+                        (isEnvironmentServerMode
+                          ? environmentServers.length > 0
+                          : allServerConfigs &&
+                            Object.keys(allServerConfigs).length > 0) &&
                           "border-t border-border mt-1 pt-1"
                       )}
                     >

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useRef } from "react";
-import { AlertTriangle, Loader2, RotateCcw, X } from "lucide-react";
-import { Checkbox } from "@mcpjam/design-system/checkbox";
-import { Label } from "@mcpjam/design-system/label";
+import { AlertTriangle, Loader2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { track } from "@/lib/analytics";
 import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
@@ -45,12 +43,8 @@ export function PlaygroundEnvironmentSection({
     preview,
     isPreviewLoading,
     previewError,
-    hasExplicitOverride,
-    servers,
     selectEnvironment,
     clearEnvironment,
-    resetServersToEnvironment,
-    setServerEnabled,
     plugins,
     hasExplicitPluginOverride,
     resetPluginsToEnvironment,
@@ -155,44 +149,13 @@ export function PlaygroundEnvironmentSection({
 
       {isEnvironmentMode && preview ? (
         <div className="flex min-w-0 flex-col gap-1">
-          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
-            <span className="font-medium text-foreground">
-              Environment: {preview.environment.name}
-            </span>
-            <span className="font-mono">
-              rev {preview.environment.revision}
-            </span>
-            <span>·</span>
-            <span data-testid="playground-environment-host">
-              {preview.host.hostName ?? preview.host.hostId}
-            </span>
-            <span>·</span>
-            <span data-testid="playground-environment-counts">
-              {pluralize(preview.capabilities.serverCount, "server")} ·{" "}
-              {pluralize(preview.capabilities.skillCount, "skill")} ·{" "}
-              {pluralize(preview.capabilities.pluginCount, "plugin")}
-            </span>
-            {hasExplicitOverride ? (
-              <span
-                className="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400"
-                data-testid="playground-environment-modified-badge"
-              >
-                Modified
-              </span>
-            ) : null}
-            {hasExplicitOverride ? (
-              <button
-                type="button"
-                onClick={resetServersToEnvironment}
-                disabled={disabled}
-                className="inline-flex items-center gap-1 rounded px-1 text-[11px] text-primary underline-offset-4 hover:underline disabled:opacity-60"
-                data-testid="playground-environment-reset"
-              >
-                <RotateCcw className="size-3" aria-hidden />
-                Reset to environment
-              </button>
-            ) : null}
-          </div>
+          {/* No summary line and no server chips here anymore: the composer's
+              "+" menu owns the environment server rows and their per-turn
+              toggles (including the Modified/reset affordance), and the Tools
+              rail lists the resolved tools. Repeating them in the header only
+              duplicated state three ways. What REMAINS here is what no other
+              surface says: warnings about the resolved bundle, and the plugin
+              chips with their preflight probe. */}
 
           {/* Skills exist but this client's harness has no skill channel, so
               they would NOT be delivered. Said out loud rather than shown as a
@@ -225,44 +188,6 @@ export function PlaygroundEnvironmentSection({
             onTogglePlugin={setPluginVersionEnabled}
             onResetPlugins={resetPluginsToEnvironment}
           />
-
-          {servers.length > 0 ? (
-            <div
-              // One scrolling row instead of an unbounded wrap: an environment
-              // can resolve to a dozen servers (host picks + plugin-contributed
-              // ones), and stacking them would push the chat surface down the
-              // page on every render of the header.
-              className="flex max-w-full flex-nowrap items-center gap-1.5 overflow-x-auto pb-0.5"
-              data-testid="playground-environment-servers"
-            >
-              {servers.map((server) => (
-                <Label
-                  key={server.serverId}
-                  className={cn(
-                    "flex shrink-0 cursor-pointer items-center gap-1 rounded-full border border-border/60 px-1.5 py-0.5 text-[11px] font-normal",
-                    server.enabled ? "bg-muted/40" : "opacity-55",
-                    disabled && "cursor-not-allowed opacity-60"
-                  )}
-                  data-testid={`playground-environment-server-${server.serverId}`}
-                >
-                  <Checkbox
-                    checked={server.enabled}
-                    onCheckedChange={(next) =>
-                      setServerEnabled(server.serverId, next === true)
-                    }
-                    disabled={disabled}
-                    aria-label={server.name}
-                  />
-                  <span className="max-w-[160px] truncate">{server.name}</span>
-                  {server.source === "plugin" ? (
-                    <span className="rounded-full bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
-                      plugin
-                    </span>
-                  ) : null}
-                </Label>
-              ))}
-            </div>
-          ) : null}
         </div>
       ) : null}
     </div>

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundEnvironmentSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundEnvironmentSection.test.tsx
@@ -146,91 +146,29 @@ describe("PlaygroundEnvironmentSection", () => {
   });
 
 
-  it("names the environment, its revision, its client and its counts", () => {
+  it("renders no summary line and no server chips — the composer menu and Tools rail own those", () => {
     render(
       <PlaygroundEnvironmentSection
         projectId="proj_1"
         environment={environmentState()}
       />
     );
-    expect(screen.getByText("Environment: Staging")).toBeTruthy();
-    expect(screen.getByText("rev 3")).toBeTruthy();
-    expect(screen.getByTestId("playground-environment-host").textContent).toBe(
-      "Codex"
-    );
+    // The picker still names the selected environment; the header no longer
+    // repeats the resolved bundle (rev/host/counts) or the server chips —
+    // the composer's "+" menu holds the server rows + per-turn toggles
+    // (including Modified/reset) and the Tools rail lists the tools.
+    expect(screen.queryByText("Environment: Staging")).toBeNull();
+    expect(screen.queryByText("rev 3")).toBeNull();
+    expect(screen.queryByTestId("playground-environment-host")).toBeNull();
+    expect(screen.queryByTestId("playground-environment-counts")).toBeNull();
+    expect(screen.queryByTestId("playground-environment-servers")).toBeNull();
     expect(
-      screen.getByTestId("playground-environment-counts").textContent
-    ).toContain("2 servers");
-    expect(
-      screen.getByTestId("playground-environment-counts").textContent
-    ).toContain("4 skills");
-    expect(
-      screen.getByTestId("playground-environment-counts").textContent
-    ).toContain("1 plugin");
-    // Singular, not "1 plugins" — three counts render through the same helper.
-    expect(
-      screen.getByTestId("playground-environment-counts").textContent
-    ).not.toContain("1 plugins");
-  });
-
-  it("stays within a bounded width no matter how many servers resolve", () => {
-    // The header slot that renders this section is `shrink-0`, so an unbounded
-    // section pushes the Clear control and the header's trailing controls out
-    // of reach. The cap lives here (self-contained) and the server chips scroll
-    // inside it instead of wrapping the chat surface down the page.
-    const servers = Array.from({ length: 12 }, (_, index) => ({
-      serverId: `srv_${index}`,
-      name: `Server number ${index}`,
-      source: "host_or_group" as const,
-      enabled: true,
-    }));
-    render(
-      <PlaygroundEnvironmentSection
-        projectId="proj_1"
-        environment={environmentState({ servers })}
-      />
-    );
-
-    const section = screen.getByTestId("playground-environment-section");
-    expect(section.className).toContain("max-w-[26rem]");
-    const serverRow = screen.getByTestId("playground-environment-servers");
-    expect(serverRow.className).toContain("overflow-x-auto");
-    expect(serverRow.className).toContain("flex-nowrap");
-    expect(serverRow.className).not.toContain("flex-wrap");
-    // Every chip is still reachable — clamped, not truncated away.
-    expect(serverRow.children.length).toBe(12);
-  });
-
-  it("shows no modified badge and no reset until an override exists", () => {
-    render(
-      <PlaygroundEnvironmentSection
-        projectId="proj_1"
-        environment={environmentState()}
-      />
-    );
+      screen.queryByTestId("playground-environment-server-srv_plugin")
+    ).toBeNull();
     expect(
       screen.queryByTestId("playground-environment-modified-badge")
     ).toBeNull();
     expect(screen.queryByTestId("playground-environment-reset")).toBeNull();
-  });
-
-  it("shows a modified badge and a reset action once the user overrides", () => {
-    const resetServersToEnvironment = vi.fn();
-    render(
-      <PlaygroundEnvironmentSection
-        projectId="proj_1"
-        environment={environmentState({
-          hasExplicitOverride: true,
-          serverOverrideIds: ["srv_plugin"],
-          resetServersToEnvironment,
-        })}
-      />
-    );
-    expect(
-      screen.getByTestId("playground-environment-modified-badge")
-    ).toBeTruthy();
-    fireEvent.click(screen.getByTestId("playground-environment-reset"));
-    expect(resetServersToEnvironment).toHaveBeenCalled();
   });
 
   it("says out loud when the client cannot consume this environment's skills", () => {
@@ -267,20 +205,6 @@ describe("PlaygroundEnvironmentSection", () => {
     expect(
       screen.queryByTestId("playground-environment-skill-limitation")
     ).toBeNull();
-  });
-
-  it("renders environment servers id-first, marking plugin-owned ones", () => {
-    render(
-      <PlaygroundEnvironmentSection
-        projectId="proj_1"
-        environment={environmentState()}
-      />
-    );
-    // Keyed and testid'd by serverId, not by name — plugin servers have no
-    // entry in the browser's name-keyed project-server catalog.
-    expect(
-      screen.getByTestId("playground-environment-server-srv_plugin").textContent
-    ).toContain("plugin");
   });
 
   it("emits client_selected from the project_environments location", () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -3728,6 +3728,10 @@ export function PlaygroundMain({
       ? {
           environmentServers: playgroundEnvironment.servers,
           onEnvironmentServerToggle: playgroundEnvironment.setServerEnabled,
+          environmentServersOverridden:
+            playgroundEnvironment.hasExplicitOverride,
+          onResetEnvironmentServers:
+            playgroundEnvironment.resetServersToEnvironment,
         }
       : {
           allServerConfigs: playgroundServerSelectorProps?.serverConfigs,

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -3718,11 +3718,24 @@ export function PlaygroundMain({
     pulseSubmit: composer.sendButtonOnboardingPulse,
     minimalMode: showPostConnectGuide,
     moveCaretToEndTrigger: composer.moveCaretToEndTrigger,
-    allServerConfigs: playgroundServerSelectorProps?.serverConfigs,
-    onServerToggle: handlePlaygroundServerToggle,
-    onReconnectServer: playgroundServerSelectorProps?.onReconnect,
-    onDisconnectServer: playgroundServerSelectorProps?.onDisconnect,
-    onAddServer: playgroundServerSelectorProps?.onConnect,
+    // ENVIRONMENT MODE swaps the "+" menu's server section wholesale: the
+    // backend connects the environment's servers on every turn, so the
+    // browser-connection rows (Connect/Retry, Add server) would all be dead
+    // controls against the wrong system. The rows shown instead come from the
+    // preview and their toggle is the SAME per-turn narrowing override as the
+    // header chips (`setServerEnabled`), so the two surfaces cannot disagree.
+    ...(isEnvironmentMode
+      ? {
+          environmentServers: playgroundEnvironment.servers,
+          onEnvironmentServerToggle: playgroundEnvironment.setServerEnabled,
+        }
+      : {
+          allServerConfigs: playgroundServerSelectorProps?.serverConfigs,
+          onServerToggle: handlePlaygroundServerToggle,
+          onReconnectServer: playgroundServerSelectorProps?.onReconnect,
+          onDisconnectServer: playgroundServerSelectorProps?.onDisconnect,
+          onAddServer: playgroundServerSelectorProps?.onConnect,
+        }),
     voiceInputContext: convexProjectId
       ? {
           projectId: convexProjectId,


### PR DESCRIPTION
## Why

In environment mode the browser never connects to the environment's servers — the backend opens ephemeral connections per turn. But the composer's "+" menu still rendered the browser's ad-hoc connection list: dead "Connect" buttons and an "Add server" row that have no effect on environment turns. The playground read as "nothing is connected" while tools visibly executed in chat, which is especially confusing when switching between environments.

## What

- `ChatInput` gains an optional `environmentServers` prop. When present it replaces the ad-hoc server rows outright: environment servers render with an active indicator and "Connected automatically on every message" copy, plugin-contributed servers keep their badge, and `Add server`/`Connect`/`Retry` are withdrawn (they target the browser connection system, which environment turns bypass).
- The row toggle is wired to the SAME per-turn narrowing override as the header chips (`setServerEnabled` from `usePlaygroundEnvironment`) — it is not a connect/disconnect, so the two surfaces can never disagree.
- `PlaygroundMain` passes the environment preview's servers when `isEnvironmentMode`, and the ad-hoc props otherwise. Chatboxes and other `ChatInput` callers are untouched (`environmentServers` stays undefined).
- An environment resolving to zero servers shows no server section at all rather than dead controls.

## Tests

- 3 new `ChatInput` tests: environment rows replace ad-hoc rows even when ad-hoc props are also passed; toggling reports the per-turn override (never a disconnect); zero-server environments render no section. `AddServerModal` mocked (it requires AuthKit).
- Full `ChatInput` suite 56/56, `PlaygroundMain`/`PlaygroundEnvironmentSection` suites 112/112, client typecheck clean for changed files.

## Not in this PR

Populating the left Tools rail with the environment's tools (needs a server-side one-shot list-tools read) — scoped as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground UI and prop wiring only; override behavior reuses existing environment hooks with added tests and streaming guards.
> 
> **Overview**
> In **project environment mode**, the composer **"+" menu** now shows **Environment servers** (active indicators, auto-connect copy, plugin badges) instead of browser **Connect / Add server** rows, which do not apply when the backend connects servers each turn.
> 
> **`ChatInput`** adds optional `environmentServers` and related callbacks; defining `environmentServers` (including `[]`) switches the menu. Toggles call the same **per-turn narrowing override** as before (`setServerEnabled`), with **Modified** / **Reset to environment** in the menu. Toggles and reset are **disabled while a turn is streaming**. Empty environments hide the server block unless an override remains (so reset stays available).
> 
> **`PlaygroundMain`** passes environment preview servers in environment mode and ad-hoc server props otherwise.
> 
> **`PlaygroundEnvironmentSection`** drops the header summary (rev, host, counts) and server chips so server control lives only in the composer menu (and Tools rail for tools); warnings and plugin selector stay in the header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63f72b30a5369fc1dcfdcdf0acb361ed23326522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows environment servers as active in the composer’s “+” menu when an environment is selected, moving per‑turn server overrides into the menu and removing the header summary/chips. Toggles/reset are locked mid‑stream, and Modified/reset stays visible even if the environment temporarily resolves to zero servers.

- **New Features**
  - `ChatInput` adds `environmentServers`, `onEnvironmentServerToggle`, `environmentServersOverridden`, and `onResetEnvironmentServers`; when provided (even `[]`), they replace ad‑hoc rows.
  - Environment rows show a green indicator, “Connected automatically on every message.” copy, keep plugin badges, and use `setServerEnabled` for per‑turn narrowing; the server section hides when zero servers unless an override exists.
  - `PlaygroundMain` wires environment servers, toggle handler, override state, and reset in environment mode; the header summary line and server chips are removed, and the menu now owns toggles plus the Modified/reset affordance.

- **Bug Fixes**
  - Disable environment server switches and “Reset to environment” while a turn is streaming.
  - Keep Modified/reset visible when an overridden environment resolves to zero servers.

<sup>Written for commit 63f72b30a5369fc1dcfdcdf0acb361ed23326522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

