### PR TITLE
feat(github-checks): label check-triggered eval runs 'github_check' (H3)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -601,7 +601,7 @@ export type EvalSuiteRun = {
     | "run_timeout"
     | "iteration_timeout"
     | "stale_worker";
-  source?: "ui" | "sdk" | "api" | "schedule";
+  source?: "ui" | "sdk" | "api" | "schedule" | "github_check";
   replayedFromRunId?: string;
   /** Set when this run was created by the Auto fix suite replay step. */
   traceRepairJobId?: string;

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -363,9 +363,11 @@ type RunEvalsWithManagerRequest = RunEvalsRequest & {
   orgModelConfig?: ResolvedOrgModelConfig;
   /**
    * Run origin persisted on `testSuiteRun.source`; /api/v1 passes 'api',
-   * the scheduled-evals worker passes 'schedule'.
+   * the scheduled-evals worker passes 'schedule', and the GitHub-checks
+   * worker passes 'github_check'. Server-internal on purpose: it is NOT on
+   * `RunEvalsRequestSchema`, so API callers cannot spoof run provenance.
    */
-  source?: "ui" | "api" | "schedule";
+  source?: "ui" | "api" | "schedule" | "github_check";
   /**
    * Forwarded to `startTestSuiteRun.idempotencyKey`. The scheduled worker
    * passes its trigger id so claim retries can never double-create a run.

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker-source.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker-source.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The worker tests stub out `runEvalSuite`, so nothing there can see what the
+// REAL `defaultRunEvalSuite` hands to `prepareEvalRun`. The provenance label
+// (`source: 'github_check'`) lives exactly in that gap: a regression back to
+// 'api' would pass every existing test while silently mislabeling every check
+// run in the dashboard — and dropping it from the stale-run watchdog's source
+// gate on the backend. This file mocks the three integration boundaries and
+// asserts on the actual call.
+
+const prepareEvalRun = vi.fn();
+const createAuthorizedManager = vi.fn();
+const createConvexClient = vi.fn();
+
+vi.mock("../../routes/shared/evals.js", () => ({
+  prepareEvalRun: (...args: unknown[]) => prepareEvalRun(...args),
+}));
+vi.mock("../../routes/web/auth.js", () => ({
+  createAuthorizedManager: (...args: unknown[]) =>
+    createAuthorizedManager(...args),
+}));
+vi.mock("../evals/route-helpers.js", () => ({
+  createConvexClient: (...args: unknown[]) => createConvexClient(...args),
+}));
+
+import { defaultRunEvalSuiteForTests } from "../github-checks-worker";
+
+describe("defaultRunEvalSuite provenance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createAuthorizedManager.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    prepareEvalRun.mockResolvedValue({
+      runId: "run-1",
+      recorder: null,
+      execute: vi.fn().mockResolvedValue(undefined),
+    });
+    // First query: snapshot ownership check (null environment → 'ours');
+    // second: the terminal run read.
+    createConvexClient.mockReturnValue({
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ configSnapshot: { environment: null } })
+        .mockResolvedValue({
+          status: "completed",
+          result: "passed",
+          summary: { total: 2, passed: 2, failed: 0, passRate: 1 },
+        }),
+      mutation: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  it("passes source: 'github_check' (never 'api') to prepareEvalRun", async () => {
+    const run = defaultRunEvalSuiteForTests();
+    const result = await run({
+      claimed: {
+        triggerId: "trig-src",
+        repoFullName: "mcpjam/mcp-check-fixture",
+        prNumber: 1,
+        headSha: "a".repeat(40),
+        organizationId: "org-1",
+        projectId: "proj-1",
+        createdByExternalId: "user_x",
+        suiteId: "suite-1",
+      },
+      bearer: "bearer-token",
+      serverId: "srv-1",
+      serverName: "gh-check-trig-src",
+    });
+
+    expect(prepareEvalRun).toHaveBeenCalledTimes(1);
+    const request = prepareEvalRun.mock.calls[0][1] as Record<string, unknown>;
+    expect(request.source).toBe("github_check");
+    // The rest of the provenance-bearing contract, pinned alongside it:
+    expect(request.idempotencyKey).toBe("trig-src");
+    expect(request.suiteRerun).toBe(true);
+    expect(request.refreshSnapshot).toBe(true);
+    expect(result.result).toBe("passed");
+  });
+});

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -422,9 +422,10 @@ export const startSuiteRunWithRecorder = async ({
   /**
    * Run origin persisted on `testSuiteRun.source` for audit attribution.
    * Omitted means 'ui' (backend default); the public /api/v1 surface
-   * passes 'api'; the scheduled-evals worker passes 'schedule'.
+   * passes 'api'; the scheduled-evals worker passes 'schedule'; the
+   * GitHub-checks worker passes 'github_check'.
    */
-  source?: "ui" | "api" | "schedule";
+  source?: "ui" | "api" | "schedule" | "github_check";
   /**
    * Forwarded to `startTestSuiteRun.idempotencyKey` so retried triggers
    * (scheduled-run claim retries) can never double-create a run. Absent on

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -259,6 +259,14 @@ export class LeaseLostError extends Error {
 export const sendHeartbeatForTests = sendHeartbeat;
 
 /**
+ * Test seam for the real eval integration. The worker tests replace
+ * `runEvalSuite` with a stub, which means nothing asserts what
+ * `defaultRunEvalSuite` actually passes to `prepareEvalRun` — and the
+ * `source: 'github_check'` provenance label lives exactly there.
+ */
+export const defaultRunEvalSuiteForTests = () => defaultRunEvalSuite;
+
+/**
  * Register the ephemeral `servers` row, and THROW if the backend refused.
  *
  * Same reasoning as the heartbeat: a discarded status makes a rejected

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -770,9 +770,9 @@ async function defaultRunEvalSuite(args: {
       // reason this suite is named `[github-checks] …` and must never be
       // launched from the UI.
       refreshSnapshot: true,
-      // `source: 'github_check'` would be a two-repo union change; 'api' is the
-      // closest existing value and keeps this to one repo (see plan follow-up).
-      source: "api",
+      // Distinguishes check-triggered runs from real /api/v1 calls in run
+      // history and heartbeat accounting (backend union accepts this value).
+      source: "github_check",
       convexAuthToken: args.bearer,
       // A claim retry can never double-create a run.
       idempotencyKey: args.claimed.triggerId,


### PR DESCRIPTION
## Summary

Sender half of MCPJam/mcpjam-backend#833 (**merged/deployed**), which extended the Convex `testSuiteRun.source` union with `'github_check'` and added it to `EVAL_RUN_HEARTBEAT_SOURCES`. Receiver-first rollout is satisfied — the backend accepts the value before this PR sends it.

The GitHub-checks worker was labeling its eval runs `source: 'api'` as an explicit stopgap (the real value would have been a two-repo union change at the time). That union change has now shipped, so the worker labels its runs `'github_check'`, making check-triggered runs distinguishable from real `/api/v1` calls in run history and heartbeat accounting.

## Changes

- `server/services/github-checks-worker.ts`: `defaultRunEvalSuite` passes `source: 'github_check'` instead of `'api'`; stopgap comment replaced with the why.
- `server/routes/shared/evals.ts`: `'github_check'` added to the **internal** `RunEvalsWithManagerRequest` source union.
- `server/services/evals/recorder.ts`: same union on the recorder boundary type (the typed consumer downstream of the shared route helper).
- `client/src/components/evals/types.ts`: client `EvalSuiteRun.source` union mirrors the backend value. UI badge sites fall through by design (only `'schedule'` has a dedicated chip), so no rendering change.

## Public schema untouched (deliberate)

`source` is **not** on the public `RunEvalsRequestSchema` — it is set server-side per entry point so API callers cannot spoof run provenance. This PR keeps that boundary: only the internal request types gained the new value.

## Verification

- `vitest run server/services/__tests__/github-checks-worker.test.ts` — 53 passed
- `vitest run server/routes/shared/__tests__/evals.test.ts client/src/components/evals/__tests__/helpers-run-metric-source.test.ts` — 67 passed
- `tsc --noEmit -p server/tsconfig.json` — no errors in touched files (remaining errors pre-exist on main)
- `tsc --noEmit -p client/tsconfig.typecheck.json` — clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Provenance-only typing and worker labeling after the backend union already accepts `github_check`; no auth or public API behavior change.
> 
> **Overview**
> GitHub PR check eval runs are now persisted with **`source: 'github_check'`** instead of the temporary **`'api'`** label, so run history and heartbeat accounting can tell check-triggered runs apart from real `/api/v1` launches.
> 
> The **github-checks worker** passes that value through `prepareEvalRun`; **`'github_check'`** is added only on **internal** server types (`RunEvalsWithManagerRequest`, recorder) and the client **`EvalSuiteRun.source`** union. The **public** `RunEvalsRequestSchema` is unchanged so callers still cannot spoof provenance. A **`defaultRunEvalSuiteForTests`** seam and a focused unit test assert the worker never regresses to **`'api'`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96aa4a5b35fb8ccf345aabf102e7993e234858d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Label GitHub-check-triggered eval runs as `github_check` instead of `api` so they’re distinct from real `/api/v1` runs in history and heartbeat accounting. Adds `github_check` to internal server/client source unions only, keeps the public request schema and UI unchanged, and adds a test seam plus focused test to ensure `github_check` is passed to `prepareEvalRun`.

<sup>Written for commit 96aa4a5b35fb8ccf345aabf102e7993e234858d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

