### PR TITLE
feat(billing): update pricing table copy for 3x eval iteration quotas

### DIFF
--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -72,11 +72,11 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
     expect(evalIterations?.label).toBe("Eval iterations");
     expect(evalIterations?.free).toEqual({
       kind: "text",
-      text: "25 / day",
+      text: "75 / day",
     });
     expect(evalIterations?.team).toEqual({
       kind: "text",
-      text: "5,000 / mo",
+      text: "15,000 / mo",
       emphasize: true,
     });
     expect(evalIterations?.enterprise).toEqual({

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -56,8 +56,8 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
     rows: [
       {
         label: "Eval iterations",
-        free: t("25 / day"),
-        team: t("5,000 / mo", true),
+        free: t("75 / day"),
+        team: t("15,000 / mo", true),
         enterprise: t("Custom", true),
       },
       {


### PR DESCRIPTION
Free 25→75/day, Team 5,000→15,000/seat/mo. Enforcement values change in mcpjam-backend (feat/3x-eval-iteration-quotas); this is display copy only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing strings and test assertions only; no billing enforcement or runtime behavior in this PR.
> 
> **Overview**
> Updates the organization **compare plans** marketing table so **Eval iterations** reflects the new 3× quotas: **Free** **75 / day** (was 25 / day) and **Team** **15,000 / mo** (was 5,000 / mo). Enterprise remains **Custom**.
> 
> The matching unit test expectations in `compare-plan-marketing.test.ts` are updated so they stay aligned with `COMPARE_PLAN_MARKETING_SECTIONS`. This is **display copy only**; actual quota enforcement is handled elsewhere (backend).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb3172c369d6f0b42d3d4660913dd42640dc5c46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update pricing table copy to reflect the new 3x eval iteration quotas.
Free now shows 75/day; Team shows 15,000/mo. This is display-only; enforcement is handled in `mcpjam-backend` (feat/3x-eval-iteration-quotas).

<sup>Written for commit bb3172c369d6f0b42d3d4660913dd42640dc5c46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

