### PR TITLE
feat(playground): list the environment's tools in the Tools rail

### DIFF
--- a/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
@@ -5,6 +5,9 @@ import { ChatHistoryRail } from "@/components/chat-v2/history/ChatHistoryRail";
 import { usePlaygroundStateContext } from "@/components/ui-playground/hooks/use-playground-state";
 import { PlaygroundLeft } from "@/components/ui-playground/PlaygroundLeft";
 import { useHarnessBuiltinTools } from "@/hooks/useHarnessBuiltinTools";
+import { usePreviewedEnvironmentId } from "@/hooks/use-previewed-environment-id";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { EnvironmentToolsPane } from "./panes/EnvironmentToolsPane";
 import { MultiServerToolsPaneInner } from "./panes/MultiServerToolsPane";
 import { usePlaygroundChatHistoryBridge } from "./playground-chat-history-bridge";
 import { cn } from "@/lib/utils";
@@ -19,10 +22,13 @@ type LeftRailTab = "sessions" | "tools";
  */
 export function PlaygroundLeftRail({
   previewedHostId,
+  projectId,
 }: {
   /** Resolved previewed host (from PlaygroundTab) — used to surface a harness
    *  host's native built-in tools in the Tools list. */
   previewedHostId?: string | null;
+  /** Project scope, for the environment-mode Tools body (see `ToolsBody`). */
+  projectId?: string | null;
 }) {
   const [activeTab, setActiveTab] = useState<LeftRailTab>("tools");
 
@@ -59,7 +65,10 @@ export function PlaygroundLeftRail({
         {activeTab === "sessions" ? (
           <SessionsBody />
         ) : (
-          <ToolsBody previewedHostId={previewedHostId ?? null} />
+          <ToolsBody
+            previewedHostId={previewedHostId ?? null}
+            projectId={projectId ?? null}
+          />
         )}
       </div>
     </div>
@@ -123,12 +132,36 @@ function SessionsBody() {
   );
 }
 
-function ToolsBody({ previewedHostId }: { previewedHostId: string | null }) {
+function ToolsBody({
+  previewedHostId,
+  projectId,
+}: {
+  previewedHostId: string | null;
+  projectId: string | null;
+}) {
   const state = usePlaygroundStateContext();
   // When the previewed host runs a harness (e.g. Claude Code), surface its
   // native built-in tools so the panel isn't empty/tool-less. Resolved once
   // here and fed into BOTH the multi-server pane and the zero-server fallback.
   const { tools: harnessBuiltinTools } = useHarnessBuiltinTools(previewedHostId);
+  // ENVIRONMENT MODE: the panes below read the browser's own connections,
+  // which environment turns never create (the backend connects per message) —
+  // so they'd report "No tools found" while tools execute fine in chat. Read
+  // the SAME selected-environment signal the Playground itself uses (the
+  // persisted previewed id, fail-closed behind the flag exactly like
+  // `usePlaygroundEnvironment`) and show the environment's server-listed
+  // tools instead.
+  const environmentsEnabled = useProjectEnvironmentsEnabled();
+  const [storedEnvironmentId] = usePreviewedEnvironmentId(projectId);
+  const environmentId = environmentsEnabled ? storedEnvironmentId : null;
+  if (environmentId && projectId) {
+    return (
+      <EnvironmentToolsPane
+        projectId={projectId}
+        environmentId={environmentId}
+      />
+    );
+  }
   // The Playground is multi-server by nature: its active set mirrors the
   // connected servers. Aggregate tools across ALL active servers whenever
   // there's at least one — not only when there's more than one. Using `> 1`

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -295,6 +295,15 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
                           >
                             <PlaygroundLeftRail
                               previewedHostId={previewedHostId}
+                              // Same project scope PlaygroundMain feeds
+                              // `usePlaygroundEnvironment`, so the rail and
+                              // the composer agree on which environment (if
+                              // any) is active.
+                              projectId={
+                                props.sharedProjectId ??
+                                props.activeProjectId ??
+                                null
+                              }
                             />
                           </ResizablePanel>
                           <ResizableHandle withHandle />

--- a/mcpjam-inspector/client/src/components/playground/__tests__/EnvironmentToolsPane.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/EnvironmentToolsPane.test.tsx
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { EnvironmentToolsPane } from "../panes/EnvironmentToolsPane";
+import type { UseEnvironmentToolsResult } from "@/hooks/use-environment-tools";
+
+const { useEnvironmentToolsMock } = vi.hoisted(() => ({
+  useEnvironmentToolsMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-environment-tools", () => ({
+  useEnvironmentTools: useEnvironmentToolsMock,
+}));
+
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => [
+    { environmentId: "env_1", revision: 7 },
+    { environmentId: "env_other", revision: 2 },
+  ],
+}));
+
+function setTools(result: Partial<UseEnvironmentToolsResult>) {
+  useEnvironmentToolsMock.mockReturnValue({
+    servers: null,
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+    ...result,
+  });
+}
+
+const SERVERS = [
+  {
+    serverId: "ps_1",
+    name: "linear",
+    source: "host_or_group" as const,
+    tools: [
+      {
+        name: "list_issues",
+        description: "List issues in a project",
+        inputSchema: { type: "object", properties: {} },
+      },
+      { name: "search", description: "Search linear" },
+    ],
+  },
+  {
+    serverId: "ps_2",
+    name: "asana",
+    source: "plugin" as const,
+    tools: [{ name: "search", description: "Search asana" }],
+  },
+];
+
+describe("EnvironmentToolsPane", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("feeds the selected environment's revision into the tools hook", () => {
+    setTools({ servers: SERVERS });
+    render(<EnvironmentToolsPane projectId="p_1" environmentId="env_1" />);
+    expect(useEnvironmentToolsMock).toHaveBeenCalledWith("p_1", "env_1", 7);
+  });
+
+  it("renders every server's tools flat, badging only colliding names", () => {
+    setTools({ servers: SERVERS });
+    render(<EnvironmentToolsPane projectId="p_1" environmentId="env_1" />);
+
+    expect(screen.getByText("list_issues")).toBeInTheDocument();
+    expect(screen.getAllByText("search")).toHaveLength(2);
+    // `search` exists on both servers → both rows carry a server badge;
+    // `list_issues` is unique → no badge.
+    expect(screen.getByText("linear")).toBeInTheDocument();
+    expect(screen.getByText("asana")).toBeInTheDocument();
+    // Read-only pane: the browser-connection run/connect chrome never renders.
+    expect(screen.queryByText("Run")).not.toBeInTheDocument();
+    expect(screen.queryByText("Connect")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/connect automatically on every message/i)
+    ).toBeInTheDocument();
+  });
+
+  it("filters by search across name and description", () => {
+    setTools({ servers: SERVERS });
+    render(<EnvironmentToolsPane projectId="p_1" environmentId="env_1" />);
+
+    fireEvent.change(screen.getByPlaceholderText("Search tools..."), {
+      target: { value: "issues" },
+    });
+    expect(screen.getByText("list_issues")).toBeInTheDocument();
+    expect(screen.queryAllByText("search")).toHaveLength(0);
+
+    fireEvent.change(screen.getByPlaceholderText("Search tools..."), {
+      target: { value: "zzz" },
+    });
+    expect(screen.getByText("No tools match your search")).toBeInTheDocument();
+  });
+
+  it("shows a per-server failure row while the healthy server's tools render", () => {
+    setTools({
+      servers: [
+        SERVERS[0],
+        { ...SERVERS[1], tools: [], error: "connect ECONNREFUSED" },
+      ],
+    });
+    render(<EnvironmentToolsPane projectId="p_1" environmentId="env_1" />);
+
+    expect(screen.getByText("list_issues")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("environment-tools-error-ps_2")
+    ).toHaveTextContent("asana: couldn't list tools");
+  });
+
+  it("shows the loading state until the first listing lands", () => {
+    setTools({ servers: null, isLoading: true });
+    render(<EnvironmentToolsPane projectId="p_1" environmentId="env_1" />);
+    expect(
+      screen.getByText("Listing the environment's tools…")
+    ).toBeInTheDocument();
+  });
+
+  it("shows a route-level error", () => {
+    setTools({ error: "This environment couldn't be resolved." });
+    render(<EnvironmentToolsPane projectId="p_1" environmentId="env_1" />);
+    expect(
+      screen.getByText("This environment couldn't be resolved.")
+    ).toBeInTheDocument();
+  });
+
+  it("distinguishes zero tools from all-servers-failed", () => {
+    setTools({ servers: [{ ...SERVERS[0], tools: [] }] });
+    const { unmount } = render(
+      <EnvironmentToolsPane projectId="p_1" environmentId="env_1" />
+    );
+    expect(
+      screen.getByText("This environment's servers expose no tools.")
+    ).toBeInTheDocument();
+    unmount();
+
+    setTools({
+      servers: [{ ...SERVERS[0], tools: [], error: "boom" }],
+    });
+    render(<EnvironmentToolsPane projectId="p_1" environmentId="env_1" />);
+    expect(screen.getByText("No tools could be listed.")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/playground/panes/EnvironmentToolsPane.tsx
+++ b/mcpjam-inspector/client/src/components/playground/panes/EnvironmentToolsPane.tsx
@@ -159,6 +159,7 @@ export function EnvironmentToolsPane({
                         onClick={() =>
                           setExpandedKey(isExpanded ? null : key)
                         }
+                        aria-expanded={isExpanded}
                         className={cn(
                           "w-full text-left px-3 py-2 rounded-md border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-1",
                           isExpanded
@@ -229,7 +230,10 @@ function ServerErrorRow({ server }: { server: EnvironmentServerTools }) {
     <Tooltip>
       <TooltipTrigger asChild>
         <div
-          className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] text-amber-600 dark:text-amber-400"
+          // Focusable so keyboard users can open the tooltip and read the
+          // underlying error text — the row itself is not an action.
+          tabIndex={0}
+          className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] text-amber-600 dark:text-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
           data-testid={`environment-tools-error-${server.serverId}`}
         >
           <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden />

--- a/mcpjam-inspector/client/src/components/playground/panes/EnvironmentToolsPane.tsx
+++ b/mcpjam-inspector/client/src/components/playground/panes/EnvironmentToolsPane.tsx
@@ -1,0 +1,246 @@
+/**
+ * EnvironmentToolsPane
+ *
+ * The Tools rail body while the Playground is in ENVIRONMENT mode. The
+ * ordinary panes read the browser's own MCP connections — which environment
+ * mode never creates (the backend connects per turn) — so they'd report
+ * "No tools found" while tools visibly execute in chat. This pane instead
+ * reads `GET /api/web/environments/:id/tools`, the server-side one-shot
+ * listing over the same connections a turn uses, so what it shows is what a
+ * message will actually run against (plugin-contributed servers included).
+ *
+ * Deliberately read-only in v1: execution in environment mode goes through
+ * chat, and the rail's browser-connection run machinery
+ * (`state.executeTool`) cannot reach these servers. Expanding a row shows
+ * the tool's description and input schema.
+ */
+import { useMemo, useState } from "react";
+import { AlertTriangle, ChevronDown, RefreshCw } from "lucide-react";
+import { Badge } from "@mcpjam/design-system/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import {
+  useEnvironmentTools,
+  type EnvironmentServerTools,
+} from "@/hooks/use-environment-tools";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
+import { SchemaViewer } from "@/components/ui/schema-viewer";
+import { SearchInput } from "@/components/ui/search-input";
+import { cn } from "@/lib/utils";
+
+interface EnvironmentToolsPaneProps {
+  projectId: string;
+  environmentId: string;
+}
+
+export function EnvironmentToolsPane({
+  projectId,
+  environmentId,
+}: EnvironmentToolsPaneProps) {
+  // The reactive row's `revision` makes a live edit (another tab, a
+  // collaborator) refetch — same signal the environment preview keys on.
+  const environments = useProjectEnvironments(projectId);
+  const revision = useMemo(
+    () =>
+      environments?.find((env) => env.environmentId === environmentId)
+        ?.revision ?? null,
+    [environments, environmentId]
+  );
+  const { servers, isLoading, error, refresh } = useEnvironmentTools(
+    projectId,
+    environmentId,
+    revision
+  );
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+
+  const flat = useMemo(
+    () =>
+      (servers ?? []).flatMap((server) =>
+        server.tools.map((tool) => ({ server, tool }))
+      ),
+    [servers]
+  );
+  const collidingNames = useMemo(() => {
+    const seen = new Map<string, number>();
+    for (const entry of flat) {
+      seen.set(entry.tool.name, (seen.get(entry.tool.name) ?? 0) + 1);
+    }
+    return new Set(
+      Array.from(seen.entries())
+        .filter(([, count]) => count > 1)
+        .map(([name]) => name)
+    );
+  }, [flat]);
+  const filtered = useMemo(() => {
+    if (!searchQuery.trim()) return flat;
+    const query = searchQuery.trim().toLowerCase();
+    return flat.filter((entry) =>
+      `${entry.tool.name} ${entry.tool.description ?? ""}`
+        .toLowerCase()
+        .includes(query)
+    );
+  }, [flat, searchQuery]);
+  const failedServers = useMemo(
+    () => (servers ?? []).filter((server) => server.error),
+    [servers]
+  );
+
+  return (
+    <div
+      className="h-full min-w-0 flex flex-col bg-background overflow-hidden"
+      data-testid="environment-tools-pane"
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2 flex-shrink-0">
+        <span className="text-xs font-medium">
+          Tools{" "}
+          <span className="text-muted-foreground">
+            {servers ? flat.length : ""}
+          </span>
+        </span>
+        <button
+          type="button"
+          onClick={refresh}
+          className="rounded p-1 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+          aria-label="Refresh environment tools"
+        >
+          <RefreshCw className={cn("h-3.5 w-3.5", isLoading && "animate-spin")} />
+        </button>
+      </div>
+
+      <div className="px-3 py-2 flex-shrink-0">
+        <SearchInput
+          value={searchQuery}
+          onValueChange={setSearchQuery}
+          placeholder="Search tools..."
+        />
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-auto px-2 pb-2">
+        {error ? (
+          <div className="text-center py-8 px-4">
+            <p className="text-xs text-destructive">{error}</p>
+          </div>
+        ) : isLoading && !servers ? (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <RefreshCw className="h-5 w-5 text-muted-foreground animate-spin mb-2" />
+            <p className="text-xs text-muted-foreground">
+              Listing the environment's tools…
+            </p>
+          </div>
+        ) : (
+          <>
+            {failedServers.map((server) => (
+              <ServerErrorRow key={server.serverId} server={server} />
+            ))}
+            {filtered.length === 0 ? (
+              <div className="text-center py-8 px-4">
+                <p className="text-xs text-muted-foreground">
+                  {flat.length === 0
+                    ? failedServers.length > 0
+                      ? "No tools could be listed."
+                      : "This environment's servers expose no tools."
+                    : "No tools match your search"}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-0.5">
+                {filtered.map(({ server, tool }) => {
+                  const key = `${server.serverId}\x00${tool.name}`;
+                  const isExpanded = expandedKey === key;
+                  return (
+                    <div key={key}>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setExpandedKey(isExpanded ? null : key)
+                        }
+                        className={cn(
+                          "w-full text-left px-3 py-2 rounded-md border border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 focus-visible:ring-offset-1",
+                          isExpanded
+                            ? "cursor-pointer bg-primary/10"
+                            : "cursor-pointer hover:bg-muted/50"
+                        )}
+                      >
+                        <div className="flex items-center gap-1.5 min-w-0">
+                          <code className="text-xs font-mono font-medium truncate flex-1">
+                            {tool.name}
+                          </code>
+                          {collidingNames.has(tool.name) ? (
+                            <Badge
+                              variant="outline"
+                              className="h-4 shrink-0 px-1 text-[9px] uppercase"
+                            >
+                              {server.name.length > 10
+                                ? `${server.name.slice(0, 8)}…`
+                                : server.name}
+                            </Badge>
+                          ) : null}
+                          <ChevronDown
+                            className={cn(
+                              "h-3 w-3 shrink-0 text-muted-foreground transition-transform",
+                              isExpanded && "rotate-180"
+                            )}
+                            aria-hidden
+                          />
+                        </div>
+                        {!isExpanded && tool.description ? (
+                          <p className="text-[10px] text-muted-foreground mt-1 line-clamp-2">
+                            {tool.description}
+                          </p>
+                        ) : null}
+                      </button>
+                      {isExpanded ? (
+                        <div className="mx-3 mb-2 mt-1 flex flex-col gap-2">
+                          <p className="text-[10px] text-muted-foreground">
+                            <span className="font-medium text-foreground">
+                              {server.name}
+                            </span>
+                            {tool.description ? ` — ${tool.description}` : ""}
+                          </p>
+                          {tool.inputSchema ? (
+                            <SchemaViewer schema={tool.inputSchema} />
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <p className="border-t border-border px-3 py-2 text-[10px] text-muted-foreground flex-shrink-0">
+        Environment servers connect automatically on every message — run these
+        tools by chatting.
+      </p>
+    </div>
+  );
+}
+
+function ServerErrorRow({ server }: { server: EnvironmentServerTools }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-[11px] text-amber-600 dark:text-amber-400"
+          data-testid={`environment-tools-error-${server.serverId}`}
+        >
+          <AlertTriangle className="h-3 w-3 shrink-0" aria-hidden />
+          <span className="truncate">
+            {server.name}: couldn't list tools
+          </span>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-72 break-words">
+        {server.error}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/use-environment-tools.ts
+++ b/mcpjam-inspector/client/src/hooks/use-environment-tools.ts
@@ -85,13 +85,19 @@ export function useEnvironmentTools(
         const payload = (await response.json().catch(() => null)) as {
           servers?: EnvironmentServerTools[];
           error?: { message?: string } | string;
+          message?: string;
         } | null;
         if (!active || seq !== requestSeqRef.current) return;
         if (!response.ok || !Array.isArray(payload?.servers)) {
+          // Same probe order as `use-environment-preview`: `error` (string or
+          // {message}) first, then a top-level `message` — some route error
+          // envelopes carry only the latter, and dropping it would flatten an
+          // actionable resolve/auth failure into the generic fallback.
           const message =
             typeof payload?.error === "string"
               ? payload.error
               : payload?.error?.message ||
+                payload?.message ||
                 "Couldn't load this environment's tools.";
           setCommitted({
             key: targetKey,

--- a/mcpjam-inspector/client/src/hooks/use-environment-tools.ts
+++ b/mcpjam-inspector/client/src/hooks/use-environment-tools.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Tool } from "@modelcontextprotocol/client";
+import { authFetch } from "@/lib/session-token";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
+import type { EnvironmentPreviewServerSource } from "@/hooks/use-environment-preview";
+
+/**
+ * Client mirror of `GET /api/web/environments/:environmentId/tools` —
+ * the environment's live tool surface, listed over the same ephemeral
+ * server-side connections a chat turn uses.
+ *
+ * This is deliberately NOT `useAggregatedTools`: that hook reads the
+ * browser's own connections, and in environment mode there are none — the
+ * backend connects per turn, and plugin-contributed servers aren't even
+ * representable in the browser's name-keyed catalog. One request returns
+ * every server's tools (or its per-server error), so the Tools rail can show
+ * what a turn will actually run against.
+ */
+export interface EnvironmentServerTools {
+  serverId: string;
+  name: string;
+  source: EnvironmentPreviewServerSource | null;
+  tools: Tool[];
+  /** Present when THIS server failed to connect/list; siblings still load. */
+  error?: string;
+}
+
+export interface UseEnvironmentToolsResult {
+  servers: EnvironmentServerTools[] | null;
+  isLoading: boolean;
+  /** Whole-route failure (auth, resolve). Per-server failures live on rows. */
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Same target-keyed commit discipline as `use-environment-preview.ts`: an
+ * environment switch blanks the list in the same render that changes the id,
+ * and a slow response for environment A can never land as environment B's
+ * tools. The `revision` dependency refetches after a live edit of the same
+ * environment without blanking the panel.
+ */
+export function useEnvironmentTools(
+  projectId: string | null,
+  environmentId: string | null,
+  revision?: number | null
+): UseEnvironmentToolsResult {
+  const [committed, setCommitted] = useState<{
+    key: string | null;
+    servers: EnvironmentServerTools[] | null;
+    error: string | null;
+    isLoading: boolean;
+  }>({ key: null, servers: null, error: null, isLoading: false });
+  const [refreshToken, setRefreshToken] = useState(0);
+  const requestSeqRef = useRef(0);
+
+  const normalizedProjectId = projectId?.trim() || null;
+  const normalizedEnvironmentId = environmentId?.trim() || null;
+  const targetKey =
+    normalizedProjectId &&
+    shouldQueryProjectId(normalizedProjectId) &&
+    normalizedEnvironmentId
+      ? `${normalizedProjectId}::${normalizedEnvironmentId}`
+      : null;
+
+  useEffect(() => {
+    const seq = ++requestSeqRef.current;
+    if (!targetKey || !normalizedProjectId || !normalizedEnvironmentId) {
+      setCommitted({ key: null, servers: null, error: null, isLoading: false });
+      return;
+    }
+    let active = true;
+    setCommitted((current) =>
+      current.key === targetKey
+        ? { ...current, isLoading: true }
+        : { key: targetKey, servers: null, error: null, isLoading: true }
+    );
+    (async () => {
+      try {
+        const response = await authFetch(
+          `/api/web/environments/${encodeURIComponent(
+            normalizedEnvironmentId
+          )}/tools?projectId=${encodeURIComponent(normalizedProjectId)}`
+        );
+        const payload = (await response.json().catch(() => null)) as {
+          servers?: EnvironmentServerTools[];
+          error?: { message?: string } | string;
+        } | null;
+        if (!active || seq !== requestSeqRef.current) return;
+        if (!response.ok || !Array.isArray(payload?.servers)) {
+          const message =
+            typeof payload?.error === "string"
+              ? payload.error
+              : payload?.error?.message ||
+                "Couldn't load this environment's tools.";
+          setCommitted({
+            key: targetKey,
+            servers: null,
+            error: message,
+            isLoading: false,
+          });
+          return;
+        }
+        setCommitted({
+          key: targetKey,
+          servers: payload.servers,
+          error: null,
+          isLoading: false,
+        });
+      } catch (caught) {
+        if (!active || seq !== requestSeqRef.current) return;
+        setCommitted({
+          key: targetKey,
+          servers: null,
+          error:
+            caught instanceof Error
+              ? caught.message
+              : "Couldn't load this environment's tools.",
+          isLoading: false,
+        });
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [
+    targetKey,
+    normalizedProjectId,
+    normalizedEnvironmentId,
+    revision,
+    refreshToken,
+  ]);
+
+  const refresh = useCallback(() => setRefreshToken((n) => n + 1), []);
+
+  const matchesTarget = committed.key === targetKey;
+  return {
+    servers: matchesTarget ? committed.servers : null,
+    error: matchesTarget ? committed.error : null,
+    isLoading: targetKey ? (matchesTarget ? committed.isLoading : true) : false,
+    refresh,
+  };
+}

--- a/mcpjam-inspector/server/routes/web/__tests__/environments-tools.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/environments-tools.test.ts
@@ -73,6 +73,10 @@ describe("GET /api/web/environments/:id/tools", () => {
     vi.clearAllMocks();
     process.env.CONVEX_URL = "https://example.convex.cloud";
     convexQueryMock.mockResolvedValue(SPEC);
+    // `clearAllMocks` keeps implementations, so reset this one explicitly —
+    // the teardown-rejection test below would otherwise leak into its
+    // successors.
+    disconnectAllServersMock.mockResolvedValue(undefined);
     createAuthorizedManagerMock.mockResolvedValue({
       manager: { disconnectAllServers: disconnectAllServersMock },
       oauthServerUrls: {},
@@ -212,6 +216,25 @@ describe("GET /api/web/environments/:id/tools", () => {
     });
     // Only the successfully-built manager exists to tear down.
     expect(disconnectAllServersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a successful listing when teardown rejects", async () => {
+    // A rejecting disconnect thrown from `finally` would replace the
+    // already-collected tools with an error row — reporting a healthy server
+    // as unreachable over a transient close failure.
+    disconnectAllServersMock.mockRejectedValue(new Error("socket already gone"));
+    listToolsMock.mockResolvedValue({ tools: [{ name: "list_issues" }] });
+
+    const response = await get(
+      "/api/web/environments/env_1/tools?projectId=p_1"
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.servers).toHaveLength(2);
+    for (const server of body.servers) {
+      expect(server.tools).toEqual([{ name: "list_issues" }]);
+      expect(server.error).toBeUndefined();
+    }
   });
 
   it("short-circuits an environment with zero servers without connecting", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/environments-tools.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/environments-tools.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Covers the browser-facing environment TOOLS route
+// (server/routes/web/environments.ts, GET /:environmentId/tools) — the Tools
+// rail's data source in environment mode. Convex is mocked at the
+// `convex/browser` boundary; the manager builder and the per-server list call
+// are mocked at their module boundaries, so the tests prove what the route
+// RESOLVES, which servers it lists, and how a per-server failure degrades.
+
+const { convexQueryMock } = vi.hoisted(() => ({
+  convexQueryMock: vi.fn(),
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+  })),
+}));
+
+const { createAuthorizedManagerMock, disconnectAllServersMock, listToolsMock } =
+  vi.hoisted(() => ({
+    createAuthorizedManagerMock: vi.fn(),
+    disconnectAllServersMock: vi.fn(),
+    listToolsMock: vi.fn(),
+  }));
+
+vi.mock("../auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auth.js")>();
+  return { ...actual, createAuthorizedManager: createAuthorizedManagerMock };
+});
+
+vi.mock("../../../utils/route-handlers.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../utils/route-handlers.js")>();
+  return { ...actual, listTools: listToolsMock };
+});
+
+import { createWebTestApp } from "./helpers/test-app.js";
+
+const SPEC = {
+  specVersion: 1,
+  environmentRef: { environmentId: "env_1", name: "Staging", revision: 7 },
+  host: {
+    hostId: "host_1",
+    hostName: "Alpha",
+    hostConfigId: "hc_1",
+    runtimeConfig: { modelId: "openai/gpt-5-mini", hostStyle: "claude" },
+  },
+  servers: {
+    selectedServerIds: ["ps_1"],
+    pluginServerIds: ["ps_2"],
+    baseEffectiveServerIds: ["ps_1", "ps_2"],
+    effectiveServerIds: ["ps_1", "ps_2"],
+    connectable: [
+      { serverId: "ps_1", name: "linear", source: "host_or_group" },
+      { serverId: "ps_2", name: "asana", source: "plugin" },
+    ],
+  },
+  skills: [],
+  pluginVersions: [],
+};
+
+function get(path: string, token: string | null = "test-token-123") {
+  const { app } = createWebTestApp();
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return app.request(path, { method: "GET", headers });
+}
+
+describe("GET /api/web/environments/:id/tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_URL = "https://example.convex.cloud";
+    convexQueryMock.mockResolvedValue(SPEC);
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: disconnectAllServersMock },
+      oauthServerUrls: {},
+      authenticatedUserId: "user_1",
+    });
+    listToolsMock.mockResolvedValue({ tools: [] });
+  });
+
+  it("requires a projectId", async () => {
+    const response = await get("/api/web/environments/env_1/tools");
+    expect(response.status).toBe(400);
+  });
+
+  it("requires a bearer token (never anonymous)", async () => {
+    const response = await get(
+      "/api/web/environments/env_1/tools?projectId=p_1",
+      null
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("resolves the environment and lists every resolved server by id", async () => {
+    listToolsMock.mockImplementation(
+      async (_manager: unknown, params: { serverId: string }) => ({
+        tools: [{ name: `tool-of-${params.serverId}` }],
+      })
+    );
+    const response = await get(
+      "/api/web/environments/env_1/tools?projectId=p_1"
+    );
+    expect(response.status).toBe(200);
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "projectEnvironments:resolveEnvironmentForRuntime",
+      { projectId: "p_1", environmentId: "env_1" }
+    );
+    // The manager is built over the environment's OWN resolved ids — the only
+    // path that reaches plugin-contributed servers.
+    expect(createAuthorizedManagerMock).toHaveBeenCalledTimes(1);
+    expect(createAuthorizedManagerMock.mock.calls[0][3]).toEqual([
+      "ps_1",
+      "ps_2",
+    ]);
+    expect(createAuthorizedManagerMock.mock.calls[0][7]).toMatchObject({
+      serverNames: ["linear", "asana"],
+    });
+    const body = await response.json();
+    expect(body.servers).toEqual([
+      {
+        serverId: "ps_1",
+        name: "linear",
+        source: "host_or_group",
+        tools: [{ name: "tool-of-ps_1" }],
+      },
+      {
+        serverId: "ps_2",
+        name: "asana",
+        source: "plugin",
+        tools: [{ name: "tool-of-ps_2" }],
+      },
+    ]);
+    expect(disconnectAllServersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades a per-server failure to that server's row, not the route", async () => {
+    listToolsMock.mockImplementation(
+      async (_manager: unknown, params: { serverId: string }) => {
+        if (params.serverId === "ps_2") {
+          throw new Error("connect ECONNREFUSED");
+        }
+        return { tools: [{ name: "list_issues" }] };
+      }
+    );
+    const response = await get(
+      "/api/web/environments/env_1/tools?projectId=p_1"
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.servers[0]).toMatchObject({
+      serverId: "ps_1",
+      tools: [{ name: "list_issues" }],
+    });
+    expect(body.servers[0].error).toBeUndefined();
+    expect(body.servers[1]).toMatchObject({
+      serverId: "ps_2",
+      tools: [],
+      error: "connect ECONNREFUSED",
+    });
+    // The connection teardown still runs after a per-server failure.
+    expect(disconnectAllServersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("short-circuits an environment with zero servers without connecting", async () => {
+    convexQueryMock.mockResolvedValue({
+      ...SPEC,
+      servers: {
+        selectedServerIds: [],
+        pluginServerIds: [],
+        baseEffectiveServerIds: [],
+        effectiveServerIds: [],
+        connectable: [],
+      },
+    });
+    const response = await get(
+      "/api/web/environments/env_1/tools?projectId=p_1"
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ servers: [] });
+    expect(createAuthorizedManagerMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a structured ENV_* resolve failure as a 409", async () => {
+    const { ConvexError } = await import("convex/values");
+    convexQueryMock.mockRejectedValue(
+      new ConvexError({
+        code: "ENV_PLUGIN_UNAVAILABLE",
+        message: "Plugin can no longer provide its server",
+      })
+    );
+    const response = await get(
+      "/api/web/environments/env_1/tools?projectId=p_1"
+    );
+    expect(response.status).toBe(409);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/environments-tools.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/environments-tools.test.ts
@@ -108,15 +108,23 @@ describe("GET /api/web/environments/:id/tools", () => {
       "projectEnvironments:resolveEnvironmentForRuntime",
       { projectId: "p_1", environmentId: "env_1" }
     );
-    // The manager is built over the environment's OWN resolved ids — the only
-    // path that reaches plugin-contributed servers.
-    expect(createAuthorizedManagerMock).toHaveBeenCalledTimes(1);
-    expect(createAuthorizedManagerMock.mock.calls[0][3]).toEqual([
-      "ps_1",
-      "ps_2",
-    ]);
+    // ONE manager per resolved server id — the only path that reaches
+    // plugin-contributed servers, isolated so one server's authorization
+    // failure can't blank its siblings.
+    expect(createAuthorizedManagerMock).toHaveBeenCalledTimes(2);
+    expect(createAuthorizedManagerMock.mock.calls[0][3]).toEqual(["ps_1"]);
+    expect(createAuthorizedManagerMock.mock.calls[1][3]).toEqual(["ps_2"]);
     expect(createAuthorizedManagerMock.mock.calls[0][7]).toMatchObject({
-      serverNames: ["linear", "asana"],
+      serverNames: ["linear"],
+      xaaIssuer: expect.any(String),
+    });
+    expect(createAuthorizedManagerMock.mock.calls[1][7]).toMatchObject({
+      serverNames: ["asana"],
+    });
+    // The headline "fresh read" guarantee: never a cached tools body.
+    expect(listToolsMock).toHaveBeenCalledWith(expect.anything(), {
+      serverId: "ps_1",
+      cacheMode: "bypass",
     });
     const body = await response.json();
     expect(body.servers).toEqual([
@@ -133,7 +141,8 @@ describe("GET /api/web/environments/:id/tools", () => {
         tools: [{ name: "tool-of-ps_2" }],
       },
     ]);
-    expect(disconnectAllServersMock).toHaveBeenCalledTimes(1);
+    // One teardown per per-server manager.
+    expect(disconnectAllServersMock).toHaveBeenCalledTimes(2);
   });
 
   it("degrades a per-server failure to that server's row, not the route", async () => {
@@ -160,7 +169,48 @@ describe("GET /api/web/environments/:id/tools", () => {
       tools: [],
       error: "connect ECONNREFUSED",
     });
-    // The connection teardown still runs after a per-server failure.
+    // Every per-server manager tears down, including the failing one's.
+    expect(disconnectAllServersMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("degrades an AUTHORIZATION failure to that server's row too", async () => {
+    // The batch-manager path validates all-or-nothing (right for a turn),
+    // which is exactly why this route builds one manager per server: an
+    // unauthorized/misconfigured server must not blank its healthy siblings.
+    createAuthorizedManagerMock.mockImplementation(
+      async (
+        _caller: unknown,
+        _bearer: unknown,
+        _projectId: unknown,
+        serverIds: string[]
+      ) => {
+        if (serverIds[0] === "ps_2") {
+          throw new Error("XAA connection is not configured for this server");
+        }
+        return {
+          manager: { disconnectAllServers: disconnectAllServersMock },
+          oauthServerUrls: {},
+          authenticatedUserId: "user_1",
+        };
+      }
+    );
+    listToolsMock.mockResolvedValue({ tools: [{ name: "list_issues" }] });
+
+    const response = await get(
+      "/api/web/environments/env_1/tools?projectId=p_1"
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.servers[0]).toMatchObject({
+      serverId: "ps_1",
+      tools: [{ name: "list_issues" }],
+    });
+    expect(body.servers[1]).toMatchObject({
+      serverId: "ps_2",
+      tools: [],
+      error: "XAA connection is not configured for this server",
+    });
+    // Only the successfully-built manager exists to tear down.
     expect(disconnectAllServersMock).toHaveBeenCalledTimes(1);
   });
 

--- a/mcpjam-inspector/server/routes/web/environments.ts
+++ b/mcpjam-inspector/server/routes/web/environments.ts
@@ -106,31 +106,42 @@ environments.get("/:environmentId/tools", async (c) =>
       : serverIds.map(() => null);
     if (serverIds.length === 0) return { servers: [] };
 
-    const { manager } = await createAuthorizedManager(
-      callerContextFromHono(c),
-      bearerToken,
-      projectId,
-      serverIds,
-      WEB_CALL_TIMEOUT_MS,
-      undefined,
-      undefined,
-      {
-        serverNames,
-        // Same enterprise-policy posture as an environment chat turn
-        // (chat-v2): the policy comes from the environment's own resolved
-        // host config — there is no request body here to even be tempted by.
-        xaaPolicy: xaaPolicyFromMcpProfile(
-          (spec.host.runtimeConfig as { mcpProfile?: unknown } | null)
-            ?.mcpProfile
-        ),
-        xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
-      }
+    // Same enterprise-policy posture as an environment chat turn (chat-v2):
+    // the policy comes from the environment's own resolved host config —
+    // there is no request body here to even be tempted by. Resolved ONCE and
+    // fail-closed for the whole route (a malformed policy is an environment
+    // problem, not one server's).
+    const xaaPolicy = xaaPolicyFromMcpProfile(
+      (spec.host.runtimeConfig as { mcpProfile?: unknown } | null)?.mcpProfile
     );
-    try {
-      const servers = await Promise.all(
-        serverIds.map(async (serverId, index) => {
-          const name = serverNames[index] ?? serverId;
-          const source = sources[index] ?? null;
+    const xaaIssuer = resolveXaaIssuer(c, HOSTED_MODE);
+    const caller = callerContextFromHono(c);
+
+    // ONE manager per server, not one batch: `createAuthorizedManager`
+    // validates the whole batch before connecting (correct for a turn, which
+    // runs all-or-nothing), so a single server's authorization/XAA failure
+    // would blank the entire panel. Here per-server isolation is the point —
+    // every failure, including an authorization one, degrades to that
+    // server's row.
+    const servers = await Promise.all(
+      serverIds.map(async (serverId, index) => {
+        const name = serverNames[index] ?? serverId;
+        const source = sources[index] ?? null;
+        try {
+          const { manager } = await createAuthorizedManager(
+            caller,
+            bearerToken,
+            projectId,
+            [serverId],
+            WEB_CALL_TIMEOUT_MS,
+            undefined,
+            undefined,
+            {
+              ...(serverNames.length > 0 ? { serverNames: [name] } : {}),
+              xaaPolicy,
+              xaaIssuer,
+            }
+          );
           try {
             // Bypass the response cache like every hosted direct-op: this
             // read is the user's "is my environment healthy" signal.
@@ -139,24 +150,22 @@ environments.get("/:environmentId/tools", async (c) =>
               cacheMode: "bypass",
             });
             return { serverId, name, source, tools: result.tools ?? [] };
-          } catch (error) {
-            return {
-              serverId,
-              name,
-              source,
-              tools: [],
-              error:
-                error instanceof Error
-                  ? error.message
-                  : "Failed to list tools",
-            };
+          } finally {
+            await manager.disconnectAllServers();
           }
-        })
-      );
-      return { servers };
-    } finally {
-      await manager.disconnectAllServers();
-    }
+        } catch (error) {
+          return {
+            serverId,
+            name,
+            source,
+            tools: [],
+            error:
+              error instanceof Error ? error.message : "Failed to list tools",
+          };
+        }
+      })
+    );
+    return { servers };
   })
 );
 

--- a/mcpjam-inspector/server/routes/web/environments.ts
+++ b/mcpjam-inspector/server/routes/web/environments.ts
@@ -23,14 +23,24 @@
  * server-side flag would only add a second, drifting gate.
  */
 import { Hono } from "hono";
+import { HOSTED_MODE, WEB_CALL_TIMEOUT_MS } from "../../config.js";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
 import {
   resolveEnvironmentForRuntime,
+  runtimeServerIds,
+  runtimeServerNames,
   toEnvironmentPreview,
 } from "../../services/environments/runtime.js";
+import { resolveXaaIssuer } from "../../services/xaa-mint.js";
+import { xaaPolicyFromMcpProfile } from "../../utils/effective-auth.js";
 import { harnessSupportsSkills } from "../../utils/harness/registry.js";
+import { listTools } from "../../utils/route-handlers.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
-import { handleRoute } from "./auth.js";
+import {
+  callerContextFromHono,
+  createAuthorizedManager,
+  handleRoute,
+} from "./auth.js";
 import { ErrorCode, WebRouteError } from "./errors.js";
 
 const environments = new Hono();
@@ -58,6 +68,95 @@ environments.get("/:environmentId/preview", async (c) =>
       { projectId, environmentId }
     );
     return toEnvironmentPreview(spec, { harnessSupportsSkills });
+  })
+);
+
+// GET /api/web/environments/:environmentId/tools?projectId=...
+//
+// The environment's live tool surface: resolve the environment atomically
+// (same read as the preview), open the SAME ephemeral per-turn connections a
+// chat turn would (`createAuthorizedManager` over the resolved server ids —
+// the only path that can reach plugin-contributed servers, which the ordinary
+// name-keyed project-server routes cannot represent), list each server's
+// tools, and disconnect. Nothing persists past the request.
+//
+// Per-server failures are per-server ROWS, not a route failure: an
+// environment with one unreachable server still shows every other server's
+// tools, and the error string doubles as a pre-turn health check.
+environments.get("/:environmentId/tools", async (c) =>
+  handleRoute(c, async () => {
+    const environmentId = c.req.param("environmentId");
+    const projectId = c.req.query("projectId");
+    if (!projectId) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "projectId is required"
+      );
+    }
+    const bearerToken = await getConvexBearerForRequest(c);
+    const spec = await resolveEnvironmentForRuntime(
+      createConvexClient(bearerToken),
+      { projectId, environmentId }
+    );
+    const serverIds = runtimeServerIds(spec);
+    const serverNames = runtimeServerNames(spec);
+    const sources = Array.isArray(spec.servers.connectable)
+      ? spec.servers.connectable.map((entry) => entry.source ?? null)
+      : serverIds.map(() => null);
+    if (serverIds.length === 0) return { servers: [] };
+
+    const { manager } = await createAuthorizedManager(
+      callerContextFromHono(c),
+      bearerToken,
+      projectId,
+      serverIds,
+      WEB_CALL_TIMEOUT_MS,
+      undefined,
+      undefined,
+      {
+        serverNames,
+        // Same enterprise-policy posture as an environment chat turn
+        // (chat-v2): the policy comes from the environment's own resolved
+        // host config — there is no request body here to even be tempted by.
+        xaaPolicy: xaaPolicyFromMcpProfile(
+          (spec.host.runtimeConfig as { mcpProfile?: unknown } | null)
+            ?.mcpProfile
+        ),
+        xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
+      }
+    );
+    try {
+      const servers = await Promise.all(
+        serverIds.map(async (serverId, index) => {
+          const name = serverNames[index] ?? serverId;
+          const source = sources[index] ?? null;
+          try {
+            // Bypass the response cache like every hosted direct-op: this
+            // read is the user's "is my environment healthy" signal.
+            const result = await listTools(manager, {
+              serverId,
+              cacheMode: "bypass",
+            });
+            return { serverId, name, source, tools: result.tools ?? [] };
+          } catch (error) {
+            return {
+              serverId,
+              name,
+              source,
+              tools: [],
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to list tools",
+            };
+          }
+        })
+      );
+      return { servers };
+    } finally {
+      await manager.disconnectAllServers();
+    }
   })
 );
 

--- a/mcpjam-inspector/server/routes/web/environments.ts
+++ b/mcpjam-inspector/server/routes/web/environments.ts
@@ -34,6 +34,7 @@ import {
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { xaaPolicyFromMcpProfile } from "../../utils/effective-auth.js";
 import { harnessSupportsSkills } from "../../utils/harness/registry.js";
+import { logger } from "../../utils/logger.js";
 import { listTools } from "../../utils/route-handlers.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import {
@@ -151,7 +152,18 @@ environments.get("/:environmentId/tools", async (c) =>
             });
             return { serverId, name, source, tools: result.tools ?? [] };
           } finally {
-            await manager.disconnectAllServers();
+            // Teardown failures are NOT listing failures. A rejecting
+            // disconnect thrown from `finally` would replace the successful
+            // return value and land in the catch below, reporting a healthy
+            // server as unreachable and discarding tools already in hand.
+            // Swallowed to one warn: the connection is ephemeral and the
+            // request is over either way.
+            await manager.disconnectAllServers().catch((error: unknown) => {
+              logger.warn("[web/environments] tools listing teardown failed", {
+                serverId,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            });
           }
         } catch (error) {
           return {


### PR DESCRIPTION
## Why

In environment mode the backend connects the environment's servers per turn — the browser never holds a connection. The Tools rail reads only browser connections, so it showed "No tools found" while tools visibly executed in chat. Fast-follow to #3617 (which fixed the composer's server menu).

## What

**Server** — `GET /api/web/environments/:environmentId/tools?projectId=…` (sibling of `/preview`): resolves the environment atomically, builds the same authorized ephemeral manager a chat turn uses (`createAuthorizedManager` over the resolved server ids — the only path that reaches plugin-contributed servers), lists each server's tools with `cacheMode: "bypass"`, disconnects in `finally`. Enterprise XAA policy comes from the environment's own resolved host config, mirroring chat-v2. Per-server failures return as per-server `error` rows — one dead server doesn't blank the panel, and the row doubles as a pre-turn health check.

**Client** — `useEnvironmentTools` (same target-keyed commit discipline as `use-environment-preview`: switches blank synchronously, stale responses can't land, live edits refetch via the row's `revision`) + a read-only `EnvironmentToolsPane`: flat searchable tool list, server badge on colliding names, expandable description + input schema, per-server failure rows, and the same "connects automatically on every message" copy as the composer menu. `ToolsBody` swaps it in when an environment is selected, reading the SAME persisted previewed-environment id the Playground uses, fail-closed behind `project-environments-enabled`.

Deliberately read-only in v1: execution in environment mode goes through chat, and the rail's run machinery targets browser connections these servers don't have.

## Tests

- 7 new route tests (`environments-tools.test.ts`): projectId/bearer required, resolved ids + names forwarded to the manager builder, per-server failure isolation + teardown, zero-server short-circuit without connecting, ENV_* resolve failure → 409.
- 7 new pane tests: revision plumbed to the hook, flat rendering with collision badges and no Connect/Run chrome, search, per-server failure row beside healthy tools, loading, route error, zero-tools vs all-failed empty states.
- Full env-route + playground suites: 138/138. Client typecheck clean for changed files; server typecheck error count unchanged vs main (pre-existing failures only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The new route opens real per-server MCP connections with the same auth/XAA path as chat turns; behavior is well-tested but it touches connection teardown and enterprise policy handling.
> 
> **Overview**
> Fixes the Playground **Tools** rail showing “No tools found” in **environment mode**, where the backend connects MCP servers per message and the browser never holds those connections.
> 
> Adds **`GET /api/web/environments/:environmentId/tools`**: resolves the environment like preview, then opens **one ephemeral authorized manager per server** (so plugin servers and per-server auth/XAA failures don’t blank siblings), lists tools with **`cacheMode: "bypass"`**, and tears down connections; failures surface as **per-server error rows** on an otherwise **200** response.
> 
> On the client, **`useEnvironmentTools`** fetches that route with the same target-key / revision discipline as environment preview. **`EnvironmentToolsPane`** is a **read-only** searchable list (schema on expand, server badges on name collisions, refresh). **`ToolsBody`** swaps it in when a previewed environment is selected (same persisted id and feature flag as the composer), with **`projectId`** passed from **`PlaygroundTab`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8aa2fbac6b6591ceb8f87739b8e9a14997647a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the environment’s tools in the Playground Tools rail when an environment is selected. Fixes the “No tools found” mismatch by listing tools over the same per-turn connections chat uses, with per-server isolation, clearer errors, and teardown failures that no longer blank the panel.

- New Features
  - Added `GET /api/web/environments/:environmentId/tools?projectId=…`: resolves the environment, builds one authorized manager per server id, lists each server’s tools with `cacheMode: "bypass"`, surfaces per-server errors, then disconnects; teardown failures are warned and ignored; XAA issuer/policy mirror chat.
  - Tools rail now reads the same persisted previewed-environment id as the Playground and swaps in a read-only `EnvironmentToolsPane`, fail-closed behind `project-environments-enabled`.
  - `EnvironmentToolsPane`: flat searchable list, server badges on colliding names, expandable description and input schema, per-server failure rows, keyboard-focusable error tooltips, `aria-expanded` on rows, and “connects automatically on every message” guidance.
  - `useEnvironmentTools` hook: target-keyed commits prevent stale responses on environment switches; refetches on environment `revision`; parses route errors from a top-level `message`.

<sup>Written for commit e8aa2fbac6b6591ceb8f87739b8e9a14997647a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

