### PR TITLE
Remove feature flags that reached 100% rollout

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1024,7 +1024,6 @@ export function ToolsRoute() {
 
 export function EvalsRoute() {
   const {
-    billingUiEnabled,
     activeTabBillingLocked,
     activeTabBillingFeature,
     convexProjectId,
@@ -1033,7 +1032,7 @@ export function EvalsRoute() {
     handleConnect,
   } = useAppRouteContext();
 
-  if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
+  if (activeTabBillingLocked && activeTabBillingFeature) {
     return <ActiveBillingUpsellGate />;
   }
 
@@ -1051,7 +1050,6 @@ export function CiEvalsRoute() {
   const {
     evaluateRunsFlagsLoaded,
     evaluateRunsEnabled,
-    billingUiEnabled,
     activeTabBillingLocked,
     activeTabBillingFeature,
     convexProjectId,
@@ -1071,7 +1069,7 @@ export function CiEvalsRoute() {
 
   if (evaluateRunsEnabled !== true) return null;
 
-  if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
+  if (activeTabBillingLocked && activeTabBillingFeature) {
     return <ActiveBillingUpsellGate />;
   }
 
@@ -1117,14 +1115,13 @@ export function CompatibilityRoute() {
 // billing feature + `sandboxes-enabled` flag.
 export function ChatboxesRoute() {
   const {
-    billingUiEnabled,
     activeTabBillingLocked,
     activeTabBillingFeature,
     convexProjectId,
     isAuthenticated,
   } = useAppRouteContext();
 
-  if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
+  if (activeTabBillingLocked && activeTabBillingFeature) {
     return <ActiveBillingUpsellGate />;
   }
 
@@ -1142,7 +1139,6 @@ export function SwarmsRoute() {
   // product surface, and re-mounts per project so selection state can't leak
   // across a project switch.
   const {
-    billingUiEnabled,
     activeTabBillingLocked,
     activeTabBillingFeature,
     convexProjectId,
@@ -1174,7 +1170,7 @@ export function SwarmsRoute() {
     identityLoading: isWorkOsLoading,
   });
 
-  if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
+  if (activeTabBillingLocked && activeTabBillingFeature) {
     return <ActiveBillingUpsellGate />;
   }
 
@@ -1474,7 +1470,6 @@ export function OAuthFlowRoute() {
 
 export function XAAFlowRoute() {
   const {
-    xaaEnabled,
     appState,
     displayServerConfigs,
     areServersHydrated,
@@ -1486,7 +1481,6 @@ export function XAAFlowRoute() {
     xaaServerModalNonce,
     xaaDebuggerHasHeaderServers,
   } = useAppRouteContext();
-  if (xaaEnabled !== true) return null;
 
   return (
     <ErrorBoundary
@@ -1711,15 +1705,11 @@ export default function App() {
   const [evaluateRunsFlagsLoaded, setEvaluateRunsFlagsLoaded] = useState(
     () => posthog.featureFlags?.hasLoadedFlags === true
   );
-  const billingEntitlementsUiEnabled = useFeatureFlagEnabled(
-    "billing-entitlements-ui"
-  );
   const learningEnabled = useFeatureFlagEnabled("mcpjam-learning");
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
   const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
-  const xaaEnabled = useFeatureFlagEnabled("xaa");
 
   // Per-tab "hide from this header" list for the OAuth / XAA debugger chip strip.
   // View-only (localStorage) — the x on a chip dismisses it from this header
@@ -1727,7 +1717,7 @@ export default function App() {
   const headerHiddenSurface: HeaderSurface | null =
     activeTab === "oauth-flow"
       ? "oauth"
-      : activeTab === "xaa-flow" && xaaEnabled === true
+      : activeTab === "xaa-flow"
       ? "xaa"
       : null;
   const { hidden: hiddenHeaderServers, hide: hideHeaderServer } =
@@ -2554,14 +2544,12 @@ export default function App() {
   } = useOrganizationBilling(isAuthenticated ? billingOrganizationId : null, {
     projectId: billingProjectId,
   });
-  const billingUiEnabled = billingEntitlementsUiEnabled === true;
   const navPremiumness =
     billingProjectId && projectPremiumness
       ? projectPremiumness
       : organizationPremiumness;
   const activeTabGate = getPremiumnessGateForTab(activeTab);
   const activeTabBillingLocked = isPremiumnessGateDeniedForShell({
-    billingUiEnabled,
     projectPremiumness,
     organizationPremiumness,
     hasProject: !!billingProjectId,
@@ -2573,7 +2561,6 @@ export default function App() {
     activeTabGate
   );
   const projectCreationGate = resolveBillingGateState({
-    billingUiEnabled,
     organizationId: billingOrganizationId,
     billingStatus: shellBillingStatus,
     premiumness: organizationPremiumness,
@@ -2587,7 +2574,7 @@ export default function App() {
     return denied;
   }, [navPremiumness]);
   const billingGateEnforcementActive =
-    billingUiEnabled && isBillingEnforcementActive(navPremiumness);
+    isBillingEnforcementActive(navPremiumness);
   const isGuestProjectActor = currentUser?.isAnonymous === true;
   const guestProjectLimitReached =
     isGuestProjectActor && Object.keys(projects).length >= 1;
@@ -2624,12 +2611,10 @@ export default function App() {
   const trialModalDismissed =
     trialModalDismissedForOrg === billingOrganizationId;
   const showTrialDecisionModal =
-    billingUiEnabled &&
     shellBillingStatus?.decisionRequired === true &&
     shellBillingStatus?.isOwner === true &&
     !trialModalDismissed;
   const showTrialDecisionNotice =
-    billingUiEnabled &&
     shellBillingStatus?.decisionRequired === true &&
     shellBillingStatus?.isOwner === false;
 
@@ -3306,10 +3291,6 @@ export default function App() {
     if (!isAuthenticated || isAuthLoading) return;
     if (isLoadingOrganizations) return;
 
-    if (billingEntitlementsUiEnabled === false) {
-      return;
-    }
-
     if (!pendingCheckoutIntent) {
       billingDeepLinkNavRef.current = false;
       return;
@@ -3344,7 +3325,6 @@ export default function App() {
   }, [
     activeOrganizationId,
     activeProject?.organizationId,
-    billingEntitlementsUiEnabled,
     consumeCheckoutIntent,
     isAuthLoading,
     isAuthenticated,
@@ -3404,13 +3384,7 @@ export default function App() {
       // Only bounce on an explicit `false`. While PostHog hydrates the flag is
       // `undefined`; redirecting then would strand a flagged-in user who
       // cold-loads /compatibility (the redirect fires before the flag
-      // resolves) — the "refresh sends me home" bug. Mirrors the xaa branch.
-      navigateToTarget(defaultHubRoute, { replace: true });
-    } else if (activeTab === "xaa-flow" && xaaEnabled === false) {
-      // Only bounce on an explicit `false`. While PostHog hydrates the flag is
-      // `undefined`; redirecting then would strand a flagged-in user who
-      // cold-loads /xaa-flow (the redirect fires before the flag resolves) —
-      // which is exactly the "refresh sends me home" bug. Mirrors ComputerRoute.
+      // resolves) — the "refresh sends me home" bug. Mirrors ComputerRoute.
       navigateToTarget(defaultHubRoute, { replace: true });
     }
   }, [
@@ -3421,7 +3395,6 @@ export default function App() {
     learningEnabled,
     evaluateRunsFlagsLoaded,
     evaluateRunsEnabled,
-    xaaEnabled,
     isAuthenticated,
     isAuthLoading,
     activeTab,
@@ -3592,7 +3565,6 @@ export default function App() {
   const checkoutIntentForBilling =
     useMemo((): CheckoutIntentWithOrganization | null => {
       if (
-        !billingUiEnabled ||
         activeTab !== "organizations" ||
         !routeOrganizationId ||
         routeOrganizationSection !== "billing" ||
@@ -3606,7 +3578,6 @@ export default function App() {
         organizationId: routeOrganizationId,
       };
     }, [
-      billingUiEnabled,
       activeTab,
       routeOrganizationId,
       routeOrganizationSection,
@@ -3713,7 +3684,6 @@ export default function App() {
   const shouldShowBillingHandoffOverlay =
     !isHostedChatRoute &&
     !isOAuthCallback &&
-    billingEntitlementsUiEnabled !== false &&
     pendingCheckoutIntent !== null;
 
   if (
@@ -3761,7 +3731,7 @@ export default function App() {
     activeTab === "conformance" ||
     activeTab === "compatibility" ||
     activeTab === "oauth-flow" ||
-    (activeTab === "xaa-flow" && xaaEnabled === true) ||
+    activeTab === "xaa-flow" ||
     activeTab === "chat";
 
   const oauthDebuggerHasHeaderServers = hasDebuggerHeaderServers({
@@ -3790,7 +3760,7 @@ export default function App() {
           // which strands the user on an error page when the client isn't
           // registered). Save without connecting, then select it as the target.
           onConnect:
-            activeTab === "xaa-flow" && xaaEnabled === true
+            activeTab === "xaa-flow"
               ? async (formData) => {
                   await saveServerConfigWithoutConnecting(formData);
                   const name = formData.name?.trim();
@@ -3804,7 +3774,7 @@ export default function App() {
           // the active debugger's modal so it matches the in-canvas "Configure"
           // button; other tabs fall back to the generic modal (prop omitted).
           onAddServerRequested:
-            activeTab === "xaa-flow" && xaaEnabled === true
+            activeTab === "xaa-flow"
               ? () => setXaaServerModalNonce((n) => n + 1)
               : activeTab === "oauth-flow"
               ? () => setOauthServerModalNonce((n) => n + 1)
@@ -3813,9 +3783,8 @@ export default function App() {
           onMultiServerToggle: toggleServerSelection,
           selectedMultipleServers: appState.selectedMultipleServers,
           showOnlyOAuthServers:
-            activeTab === "oauth-flow" ||
-            (activeTab === "xaa-flow" && xaaEnabled === true),
-          includeXaaServers: activeTab === "xaa-flow" && xaaEnabled === true,
+            activeTab === "oauth-flow" || activeTab === "xaa-flow",
+          includeXaaServers: activeTab === "xaa-flow",
           // Only the OAuth / XAA debugger headers get the "hide from this tab"
           // x button; other surfaces omit onHideServer so no x renders.
           hiddenServers: hiddenHeaderServers,
@@ -3827,8 +3796,7 @@ export default function App() {
           // target and it must not change without an explicit click. Other
           // tabs keep full auto-select (stale selections get replaced).
           autoSelectFilteredServer:
-            activeTab === "oauth-flow" ||
-            (activeTab === "xaa-flow" && xaaEnabled === true)
+            activeTab === "oauth-flow" || activeTab === "xaa-flow"
               ? "when-empty"
               : true,
           showOnlyServersWithViews: false,
@@ -3915,7 +3883,6 @@ export default function App() {
     appState,
     billingOrganizationId,
     billingProjectId,
-    billingUiEnabled,
     activeHost,
     activeHostId,
     checkoutIntentForBilling,
@@ -3977,7 +3944,6 @@ export default function App() {
     toggleServerSelection,
     upgradePlanForActiveTab,
     workOsUser,
-    xaaEnabled,
     oauthDebuggerHasHeaderServers,
     xaaDebuggerHasHeaderServers,
     xaaServerModalNonce,
@@ -4001,7 +3967,6 @@ export default function App() {
         onSwitchOrganization={handleSidebarSwitchOrganization}
         onSwitchActiveOrganization={handleSwitchActiveOrganization}
         onProjectShared={handleProjectShared}
-        billingUiEnabled={billingUiEnabled}
         billingGateDenied={sidebarGateDenied}
         billingGateEnforcementActive={billingGateEnforcementActive}
         isCreateProjectDisabled={isCreateProjectDisabled}

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -1401,7 +1401,7 @@ describe("App hosted OAuth callback handling", () => {
     clearChatboxSession();
     window.history.replaceState({}, "", "/organizations/org-3");
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      () => false
     );
     mockUseAppState.mockImplementation(() => ({
       ...createAppStateMock(),
@@ -1537,7 +1537,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/callback?code=oauth-code");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      () => false
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1593,7 +1593,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      () => false
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1671,7 +1671,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      () => false
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1729,7 +1729,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      () => false
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1781,7 +1781,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      () => false
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -1836,7 +1836,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/billing?plan=team&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "billing-entitlements-ui"
+      () => false
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "organizations:getMyOrganizations") {
@@ -2277,7 +2277,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/playground");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "playground-enabled"
+      () => false
     );
 
     render(<App />);
@@ -2307,7 +2307,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/playground");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "playground-enabled"
+      () => false
     );
 
     render(<App />);
@@ -2670,7 +2670,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/evals");
     mockHandleOAuthCallback.mockReset();
     mockUseFeatureFlagEnabled.mockImplementation(
-      (flag: string) => flag === "playground-enabled" || flag === "evaluate-ui"
+      () => false
     );
 
     render(<App />);
@@ -2696,7 +2696,7 @@ describe("App hosted OAuth callback handling", () => {
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
       flag === "evaluate-ci"
         ? evaluateRunsState.value
-        : flag === "playground-enabled"
+        : false
     );
 
     render(<App />);
@@ -2729,7 +2729,7 @@ describe("App hosted OAuth callback handling", () => {
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
       flag === "evaluate-ci"
         ? undefined
-        : flag === "playground-enabled" || flag === "evaluate-ui"
+        : false
     );
 
     render(<App />);
@@ -2758,7 +2758,7 @@ describe("App hosted OAuth callback handling", () => {
     mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
       flag === "evaluate-ci"
         ? undefined
-        : flag === "playground-enabled" || flag === "evaluate-ui"
+        : false
     );
 
     render(<App />);
@@ -2837,30 +2837,13 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.getByTestId("hosts-tab")).toBeInTheDocument();
   });
 
-  it("redirects xaa-flow to home when the xaa flag is disabled", async () => {
+  // The `xaa` rollout finished at 100% and the flag was removed, so /xaa-flow
+  // always renders instead of redirecting flag-off users home.
+  it("renders xaa-flow", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/xaa-flow");
     mockHandleOAuthCallback.mockReset();
-
-    render(<App />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("home-tab")).toBeInTheDocument();
-    });
-
-    expect(window.location.pathname).toBe("/home");
-    expect(screen.queryByTestId("xaa-flow-tab")).not.toBeInTheDocument();
-  });
-
-  it("renders xaa-flow when the xaa flag is enabled", async () => {
-    clearHostedOAuthPendingState();
-    clearChatboxSession();
-    window.history.replaceState({}, "", "/xaa-flow");
-    mockHandleOAuthCallback.mockReset();
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "xaa" ? true : false
-    );
 
     render(<App />);
 
@@ -2877,9 +2860,6 @@ describe("App hosted OAuth callback handling", () => {
     clearChatboxSession();
     window.history.replaceState({}, "", "/xaa-flow");
     mockHandleOAuthCallback.mockReset();
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "xaa" ? true : false
-    );
     const appStateMock = createAppStateMock();
     const currentProjectServers = {
       "current-project-xaa-oauth": {
@@ -3028,7 +3008,7 @@ describe("App hosted OAuth callback handling", () => {
     }));
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) =>
-        flag === "billing-entitlements-ui" || flag === "evaluate-ci"
+        flag === "evaluate-ci"
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "users:getCurrentUser") {

--- a/mcpjam-inspector/client/src/__tests__/ChatboxesRoute.billing.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/ChatboxesRoute.billing.test.tsx
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const { mockChatboxesTab, mockRouteContext } = vi.hoisted(() => ({
   mockChatboxesTab: vi.fn(() => <div>Chatboxes Tab</div>),
   mockRouteContext: {
-    billingUiEnabled: true,
     activeTabBillingLocked: false,
     activeTabBillingFeature: "chatboxes" as string | null,
     convexProjectId: "project-1" as string | null,
@@ -82,7 +81,6 @@ import { ChatboxesRoute } from "../App";
 describe("ChatboxesRoute billing gate", () => {
   beforeEach(() => {
     mockChatboxesTab.mockClear();
-    mockRouteContext.billingUiEnabled = true;
     mockRouteContext.activeTabBillingLocked = false;
     mockRouteContext.activeTabBillingFeature = "chatboxes";
     mockRouteContext.convexProjectId = "project-1";
@@ -139,15 +137,5 @@ describe("ChatboxesRoute billing gate", () => {
       projectId: "project-1",
       isAuthenticated: true,
     });
-  });
-
-  it("renders ChatboxesTab when billing UI is disabled", () => {
-    mockRouteContext.billingUiEnabled = false;
-    mockRouteContext.activeTabBillingLocked = true;
-
-    render(<ChatboxesRoute />);
-
-    expect(screen.getByText("Chatboxes Tab")).toBeInTheDocument();
-    expect(screen.queryByTestId("billing-upsell-gate")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/__tests__/SwarmsRoute.guest-gate.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/SwarmsRoute.guest-gate.test.tsx
@@ -22,7 +22,6 @@ const {
     })),
     mockUseViewerProjectRole: vi.fn(() => mockViewerRole),
     mockRouteContext: {
-      billingUiEnabled: true,
       activeTabBillingLocked: false,
       activeTabBillingFeature: "chatboxes" as string | null,
       convexProjectId: "project-1" as string | null,
@@ -98,7 +97,6 @@ describe("SwarmsRoute member-only gate", () => {
     mockUseAuth.mockClear();
     mockUseViewerProjectRole.mockClear();
     mockUseViewerProjectRole.mockImplementation(() => mockViewerRole);
-    mockRouteContext.billingUiEnabled = true;
     mockRouteContext.activeTabBillingLocked = false;
     mockRouteContext.activeTabBillingFeature = "chatboxes";
     mockRouteContext.convexProjectId = "project-1";

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import { useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { EditableText } from "@/components/ui/editable-text";
@@ -557,10 +556,6 @@ function OrganizationPage({
     enabled: isAuthenticated,
     includeSeatPaymentIntent: true,
   });
-  const billingEntitlementsUiEnabled = useFeatureFlagEnabled(
-    "billing-entitlements-ui"
-  );
-  const billingUiEnabled = billingEntitlementsUiEnabled === true;
   const activeSection: OrganizationRouteSection =
     section === "models"
       ? "models"
@@ -568,14 +563,11 @@ function OrganizationPage({
       ? "billing"
       : "overview";
   const memberInviteGate = resolveBillingGateState({
-    billingUiEnabled,
     organizationId: organization._id,
     billingStatus,
     premiumness: organizationPremiumness,
     gate: BILLING_GATES.memberInvites,
-    isLoading:
-      billingUiEnabled &&
-      (isLoadingBilling || isLoadingOrganizationPremiumness),
+    isLoading: isLoadingBilling || isLoadingOrganizationPremiumness,
   });
   const memberUpsellTeaser = getBillingUpsellTeaser({
     planCatalog,
@@ -872,8 +864,10 @@ function OrganizationPage({
   };
 
   const initial = organization.name.charAt(0).toUpperCase();
-  const auditLogLocked =
-    billingUiEnabled && isGateAccessDenied(organizationPremiumness, "auditLog");
+  const auditLogLocked = isGateAccessDenied(
+    organizationPremiumness,
+    "auditLog"
+  );
   const navigateToSection = (nextSection: OrganizationRouteSection) => {
     appNavigate(buildOrganizationPath(organization._id, nextSection));
   };
@@ -1169,11 +1163,9 @@ function OrganizationPage({
                     {organization.name}
                   </h1>
                 )}
-                {billingUiEnabled ? (
-                  <p className="text-sm text-muted-foreground">
-                    Organization settings
-                  </p>
-                ) : null}
+                <p className="text-sm text-muted-foreground">
+                  Organization settings
+                </p>
               </div>
             </div>
           </CardContent>
@@ -1233,7 +1225,7 @@ function OrganizationPage({
             {pendingSeatPaymentNotice}
             <OrganizationBillingSection
               organizationId={organization._id}
-              showPlanBilling={billingUiEnabled}
+              showPlanBilling
               showCredits
               billingStatus={billingStatus}
               organizationName={organization.name}
@@ -1250,57 +1242,55 @@ function OrganizationPage({
               checkoutIntent={checkoutIntent}
               onCheckoutIntentConsumed={onCheckoutIntentConsumed}
               currentPlanPanel={
-                billingUiEnabled ? (
-                  <Card className="border-border/60">
-                    <CardHeader className="pb-2">
-                      <CardTitle className="flex items-center gap-2 text-xl">
-                        <CreditCard className="size-4 text-muted-foreground" />
-                        Billing
-                      </CardTitle>
-                      <p className="text-sm text-muted-foreground">
-                        Review your current plan and subscription.
-                      </p>
-                    </CardHeader>
-                    <CardContent className="space-y-3 pt-0">
-                      {isLoadingBilling ? (
-                        <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
-                          Loading billing details...
-                        </div>
-                      ) : billingStatus && !billingStatus.billingConfigured ? (
-                        <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
-                          Billing is not configured in this environment.
-                        </div>
-                      ) : billingStatus ? (
-                        <>
-                          <OrganizationCurrentPlanPanel
-                            billingStatus={billingStatus}
-                            planCatalog={planCatalog}
-                            isLoadingPlanCatalog={isLoadingPlanCatalog}
-                            onChangeBillingInterval={
-                              handleChangeBillingInterval
-                            }
-                            onCancelScheduledBillingChange={
-                              scheduledBillingChangeCancellation
-                                ? handleOpenScheduledBillingChangeCancelDialog
-                                : undefined
-                            }
-                            cancelScheduledBillingChangeLabel={
-                              scheduledBillingChangeCancellation?.ctaLabel ??
-                              null
-                            }
-                            onManageBilling={handleManageBilling}
-                            isOpeningPortal={isOpeningPortal}
-                          />
-                          {!billingStatus.canManageBilling ? (
-                            <p className="min-w-0 text-sm font-medium text-primary">
-                              Only organization owners can manage billing.
-                            </p>
-                          ) : null}
-                        </>
-                      ) : null}
-                    </CardContent>
-                  </Card>
-                ) : null
+                <Card className="border-border/60">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="flex items-center gap-2 text-xl">
+                      <CreditCard className="size-4 text-muted-foreground" />
+                      Billing
+                    </CardTitle>
+                    <p className="text-sm text-muted-foreground">
+                      Review your current plan and subscription.
+                    </p>
+                  </CardHeader>
+                  <CardContent className="space-y-3 pt-0">
+                    {isLoadingBilling ? (
+                      <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
+                        Loading billing details...
+                      </div>
+                    ) : billingStatus && !billingStatus.billingConfigured ? (
+                      <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
+                        Billing is not configured in this environment.
+                      </div>
+                    ) : billingStatus ? (
+                      <>
+                        <OrganizationCurrentPlanPanel
+                          billingStatus={billingStatus}
+                          planCatalog={planCatalog}
+                          isLoadingPlanCatalog={isLoadingPlanCatalog}
+                          onChangeBillingInterval={
+                            handleChangeBillingInterval
+                          }
+                          onCancelScheduledBillingChange={
+                            scheduledBillingChangeCancellation
+                              ? handleOpenScheduledBillingChangeCancelDialog
+                              : undefined
+                          }
+                          cancelScheduledBillingChangeLabel={
+                            scheduledBillingChangeCancellation?.ctaLabel ??
+                            null
+                          }
+                          onManageBilling={handleManageBilling}
+                          isOpeningPortal={isOpeningPortal}
+                        />
+                        {!billingStatus.canManageBilling ? (
+                          <p className="min-w-0 text-sm font-medium text-primary">
+                            Only organization owners can manage billing.
+                          </p>
+                        ) : null}
+                      </>
+                    ) : null}
+                  </CardContent>
+                </Card>
               }
             />
             {billingError ? (
@@ -1477,8 +1467,7 @@ function OrganizationPage({
                 </p>
               </CardHeader>
               <CardContent className="space-y-3 pt-0">
-                {billingUiEnabled &&
-                (isLoadingEntitlements || isLoadingOrganizationPremiumness) ? (
+                {isLoadingEntitlements || isLoadingOrganizationPremiumness ? (
                   <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
                     Loading audit log access...
                   </div>
@@ -1495,11 +1484,9 @@ function OrganizationPage({
                           : " Ask an organization owner to upgrade to Enterprise."}
                       </p>
                     </div>
-                    {billingUiEnabled ? (
-                      <Button className="mt-3" onClick={handleViewBilling}>
-                        View billing options
-                      </Button>
-                    ) : null}
+                    <Button className="mt-3" onClick={handleViewBilling}>
+                      View billing options
+                    </Button>
                   </div>
                 ) : (
                   <OrganizationAuditLog

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -325,10 +325,7 @@ describe("OrganizationsTab billing", () => {
     removeMemberMock.mockResolvedValue(undefined);
 
     mockUseConvexAuth.mockReturnValue({ isAuthenticated: true });
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) => {
-      if (flag === "billing-entitlements-ui") return true;
-      return true;
-    });
+    mockUseFeatureFlagEnabled.mockImplementation(() => true);
     mockUseAuth.mockReturnValue({
       user: { email: "owner@example.com" },
       signIn: vi.fn(),
@@ -1820,8 +1817,9 @@ describe("OrganizationsTab billing", () => {
     ).toBeInTheDocument();
   });
 
-  it("skips the audit-log loading placeholder when the billing UI flag is off", () => {
-    mockUseFeatureFlagEnabled.mockReturnValue(false);
+  // `billing-entitlements-ui` reached 100% and was removed, so the audit-log
+  // placeholder now depends only on whether entitlements are still loading.
+  it("shows the audit-log loading placeholder while entitlements load", () => {
     mockUseOrganizationBilling.mockReturnValue(
       createBillingHookState({
         billingStatus: billingStatusFixture({
@@ -1834,6 +1832,32 @@ describe("OrganizationsTab billing", () => {
         }),
         isLoadingEntitlements: true,
         isLoadingOrganizationPremiumness: true,
+      })
+    );
+
+    render(<OrganizationsTab organizationId="org-1" />);
+
+    expect(
+      screen.getByText("Loading audit log access...")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("organization-audit-log")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the audit log once entitlements have loaded", () => {
+    mockUseOrganizationBilling.mockReturnValue(
+      createBillingHookState({
+        billingStatus: billingStatusFixture({
+          plan: "team",
+          effectivePlan: "team",
+          billingInterval: "monthly",
+          subscriptionStatus: "active",
+          hasCustomer: true,
+          stripePriceId: "price_123",
+        }),
+        isLoadingEntitlements: false,
+        isLoadingOrganizationPremiumness: false,
       })
     );
 

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -53,26 +53,34 @@ describe("filterByFeatureFlags", () => {
     expect(titles).toEqual(["Always Visible"]);
   });
 
-  it("hides XAA Debugger when the xaa flag is off", () => {
+  // The `xaa` rollout finished at 100% and the flag was removed, so the XAA
+  // Debugger now sits alongside the OAuth Debugger with no gate of its own.
+  it("keeps XAA Debugger visible with no flags set", () => {
+    const xaaItem = navigationSections
+      .flatMap((section) => section.items)
+      .find((item) => item.title === "XAA Debugger");
+
+    expect(xaaItem).toBeDefined();
+    expect(xaaItem?.featureFlag).toBeUndefined();
+    expect(xaaItem?.authVisibility).toBeUndefined();
+
     const result = filterByFeatureFlags(
       [
         {
           id: "others",
           items: [
             { title: "OAuth Debugger", url: "#oauth-flow", icon: FakeIcon },
-            {
-              title: "XAA Debugger",
-              url: "#xaa-flow",
-              icon: FakeIcon,
-              featureFlag: "xaa",
-            },
+            { title: "XAA Debugger", url: "#xaa-flow", icon: FakeIcon },
           ],
         },
       ],
-      { xaa: false },
+      {},
     );
 
-    expect(result[0].items.map((i) => i.title)).toEqual(["OAuth Debugger"]);
+    expect(result[0].items.map((i) => i.title)).toEqual([
+      "OAuth Debugger",
+      "XAA Debugger",
+    ]);
   });
 
   it("keeps Testing visible when unrelated flags are on", () => {
@@ -229,7 +237,6 @@ describe("filterByFeatureFlags", () => {
         },
       ],
       {
-        billingUiEnabled: true,
         gateDenied: { chatboxes: true },
         enforcementActive: true,
       },
@@ -256,7 +263,6 @@ describe("applyBillingGateNavState", () => {
         },
       ],
       {
-        billingUiEnabled: true,
         gateDenied: { evals: true },
         enforcementActive: false,
       },
@@ -286,7 +292,6 @@ describe("applyBillingGateNavState", () => {
         },
       ],
       {
-        billingUiEnabled: true,
         gateDenied: { evals: true },
         enforcementActive: true,
       },
@@ -423,11 +428,10 @@ describe("Skills is no longer a sidebar item", () => {
   });
 });
 
-// The sidebar uses `featureFlag` to keep "Connect" visible and `hiddenByFlag`
-// to swap "Servers" out. The "hosts-enabled" map entry is auth-driven (the
-// PostHog rollout finished and the flag was removed): signed-in users get
-// Connect, signed-out users keep the legacy Servers item.
-describe("filterByFeatureFlags (Connect/Servers swap)", () => {
+// The `hosts-enabled` and `home-page-enabled` rollouts finished at 100% and
+// both flags were removed. The Connect/Servers swap is purely auth-driven:
+// signed-in users get Connect, signed-out users keep the legacy Servers item.
+describe("filterByFeatureFlags (auth-driven visibility)", () => {
   const connectAndServers = () => [
     {
       id: "connection",
@@ -436,29 +440,34 @@ describe("filterByFeatureFlags (Connect/Servers swap)", () => {
           title: "Connect",
           url: "/servers",
           icon: FakeIcon,
-          featureFlag: "hosts-enabled",
+          authVisibility: "authed" as const,
         },
         {
           title: "Servers",
           url: "/servers",
           icon: FakeIcon,
-          hiddenByFlag: "hosts-enabled",
+          authVisibility: "guest" as const,
         },
       ],
     },
   ];
 
   it("shows Connect (and hides legacy Servers) when authenticated", () => {
-    const result = filterByFeatureFlags(connectAndServers(), {
-      "hosts-enabled": true,
-    });
+    const result = filterByFeatureFlags(connectAndServers(), {}, true);
     expect(result[0].items.map((i) => i.title)).toEqual(["Connect"]);
   });
 
   it("falls back to legacy Servers until the user signs in", () => {
-    const result = filterByFeatureFlags(connectAndServers(), {
-      "hosts-enabled": false,
-    });
+    const result = filterByFeatureFlags(connectAndServers(), {}, false);
     expect(result[0].items.map((i) => i.title)).toEqual(["Servers"]);
+  });
+
+  it("hides the Home item from signed-out users", () => {
+    const homeItem = navigationSections
+      .flatMap((section) => section.items)
+      .find((item) => item.title === "Home");
+
+    expect(homeItem?.authVisibility).toBe("authed");
+    expect(homeItem?.featureFlag).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -429,9 +429,11 @@ describe("Skills is no longer a sidebar item", () => {
 });
 
 // The `hosts-enabled` and `home-page-enabled` rollouts finished at 100% and
-// both flags were removed. The Connect/Servers swap is purely auth-driven:
-// signed-in users get Connect, signed-out users keep the legacy Servers item.
-describe("filterByFeatureFlags (auth-driven visibility)", () => {
+// both flags were removed. The Connect/Servers swap is driven by Convex
+// session presence, which is what those flag entries already keyed off.
+// Convex reports a session for hosted anonymous guests too, so "no session"
+// here means the pre-session window, not "has no WorkOS account".
+describe("filterByFeatureFlags (session-driven visibility)", () => {
   const connectAndServers = () => [
     {
       id: "connection",
@@ -452,17 +454,17 @@ describe("filterByFeatureFlags (auth-driven visibility)", () => {
     },
   ];
 
-  it("shows Connect (and hides legacy Servers) when authenticated", () => {
+  it("shows Connect (and hides legacy Servers) with a Convex session", () => {
     const result = filterByFeatureFlags(connectAndServers(), {}, true);
     expect(result[0].items.map((i) => i.title)).toEqual(["Connect"]);
   });
 
-  it("falls back to legacy Servers until the user signs in", () => {
+  it("falls back to legacy Servers before a Convex session exists", () => {
     const result = filterByFeatureFlags(connectAndServers(), {}, false);
     expect(result[0].items.map((i) => i.title)).toEqual(["Servers"]);
   });
 
-  it("hides the Home item from signed-out users", () => {
+  it("scopes the Home item to sessions", () => {
     const homeItem = navigationSections
       .flatMap((section) => section.items)
       .find((item) => item.title === "Home");

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
@@ -74,36 +74,6 @@ describe("AuthenticationSection", () => {
     expect(screen.getByText("Cross-App Access (XAA)")).toBeInTheDocument();
   });
 
-  it("renders the XAA settings for a server already configured with it", async () => {
-    render(
-      <AuthenticationSection
-        serverUrl="https://example.com/mcp"
-        authType="none"
-        onAuthTypeChange={vi.fn()}
-        showAuthSettings={false}
-        bearerToken=""
-        onBearerTokenChange={vi.fn()}
-        oauthScopesInput=""
-        onOauthScopesChange={vi.fn()}
-        oauthProtocolMode="2025-11-25"
-        onOauthProtocolModeChange={vi.fn()}
-        registrationMode="auto"
-        onOauthRegistrationModeChange={vi.fn()}
-        useCustomClientId={false}
-        onUseCustomClientIdChange={vi.fn()}
-        clientId=""
-        onClientIdChange={vi.fn()}
-        clientSecret=""
-        onClientSecretChange={vi.fn()}
-        clientIdError={null}
-        clientSecretError={null}
-      />
-    );
-
-    await userEvent.click(screen.getByRole("combobox"));
-    expect(screen.getByText("Cross-App Access (XAA)")).toBeInTheDocument();
-  });
-
   it("keeps the XAA settings visible for a server already using it", async () => {
     render(
       <AuthenticationSection

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
@@ -9,10 +9,8 @@ vi.mock("@/lib/apis/hosted-oauth-client-secret-api", () => ({
   fetchOAuthClientSecret: vi.fn(),
 }));
 
-let xaaFlagValue: boolean | undefined = undefined;
 vi.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: (flag: string) =>
-    flag === "xaa" ? xaaFlagValue : undefined,
+  useFeatureFlagEnabled: () => undefined,
 }));
 
 const fetchOAuthClientSecretMock = vi.mocked(fetchOAuthClientSecret);
@@ -44,45 +42,9 @@ const hostedSecretProps = {
 };
 
 describe("AuthenticationSection", () => {
-  beforeEach(() => {
-    xaaFlagValue = undefined;
-  });
-
-  it("hides the Cross-App Access (XAA) option when the xaa flag is off", async () => {
-    xaaFlagValue = false;
-    render(
-      <AuthenticationSection
-        serverUrl="https://example.com/mcp"
-        authType="none"
-        onAuthTypeChange={vi.fn()}
-        showAuthSettings={false}
-        bearerToken=""
-        onBearerTokenChange={vi.fn()}
-        oauthScopesInput=""
-        onOauthScopesChange={vi.fn()}
-        oauthProtocolMode="2025-11-25"
-        onOauthProtocolModeChange={vi.fn()}
-        registrationMode="auto"
-        onOauthRegistrationModeChange={vi.fn()}
-        useCustomClientId={false}
-        onUseCustomClientIdChange={vi.fn()}
-        clientId=""
-        onClientIdChange={vi.fn()}
-        clientSecret=""
-        onClientSecretChange={vi.fn()}
-        clientIdError={null}
-        clientSecretError={null}
-      />
-    );
-
-    await userEvent.click(screen.getByRole("combobox"));
-    expect(
-      screen.queryByText("Cross-App Access (XAA)")
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows the Cross-App Access (XAA) option when the xaa flag is enabled", async () => {
-    xaaFlagValue = true;
+  // The `xaa` rollout finished at 100% and the flag was removed, so the option
+  // is now offered to everyone rather than gated.
+  it("always offers the Cross-App Access (XAA) option", async () => {
     render(
       <AuthenticationSection
         serverUrl="https://example.com/mcp"
@@ -112,8 +74,37 @@ describe("AuthenticationSection", () => {
     expect(screen.getByText("Cross-App Access (XAA)")).toBeInTheDocument();
   });
 
-  it("keeps the Cross-App Access (XAA) option visible for a server already using it, even when the flag is off", async () => {
-    xaaFlagValue = false;
+  it("renders the XAA settings for a server already configured with it", async () => {
+    render(
+      <AuthenticationSection
+        serverUrl="https://example.com/mcp"
+        authType="none"
+        onAuthTypeChange={vi.fn()}
+        showAuthSettings={false}
+        bearerToken=""
+        onBearerTokenChange={vi.fn()}
+        oauthScopesInput=""
+        onOauthScopesChange={vi.fn()}
+        oauthProtocolMode="2025-11-25"
+        onOauthProtocolModeChange={vi.fn()}
+        registrationMode="auto"
+        onOauthRegistrationModeChange={vi.fn()}
+        useCustomClientId={false}
+        onUseCustomClientIdChange={vi.fn()}
+        clientId=""
+        onClientIdChange={vi.fn()}
+        clientSecret=""
+        onClientSecretChange={vi.fn()}
+        clientIdError={null}
+        clientSecretError={null}
+      />
+    );
+
+    await userEvent.click(screen.getByRole("combobox"));
+    expect(screen.getByText("Cross-App Access (XAA)")).toBeInTheDocument();
+  });
+
+  it("keeps the XAA settings visible for a server already using it", async () => {
     render(
       <AuthenticationSection
         serverUrl="https://example.com/mcp"
@@ -317,7 +308,6 @@ describe("AuthenticationSection", () => {
   };
 
   it("shows only labels in the menu — no option subtitles", async () => {
-    xaaFlagValue = true;
     render(<AuthenticationSection {...autoProps} />);
 
     const trigger = screen.getByRole("combobox");
@@ -338,26 +328,21 @@ describe("AuthenticationSection", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the Auto option visible for a server saved as auto, even when the flag is off", () => {
-    xaaFlagValue = false;
+  it("keeps the Auto option visible for a server saved as auto", () => {
     render(<AuthenticationSection {...autoProps} />);
 
     expect(screen.getByRole("combobox")).toHaveTextContent("Auto");
   });
 
-  it("offers Auto to everyone without XAA in the menu when the flag is off", async () => {
-    xaaFlagValue = false;
+  it("offers Auto alongside XAA in the menu", async () => {
     render(<AuthenticationSection {...autoProps} authType="none" />);
 
     await userEvent.click(screen.getByRole("combobox"));
     expect(screen.getByRole("option", { name: "Auto" })).toBeInTheDocument();
-    expect(
-      screen.queryByText("Cross-App Access (XAA)")
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("Cross-App Access (XAA)")).toBeInTheDocument();
   });
 
   it("explains Auto per-server: discover when XAA is not configured", () => {
-    xaaFlagValue = true;
     render(<AuthenticationSection {...autoProps} autoSelectsXaa={false} />);
 
     expect(
@@ -366,7 +351,6 @@ describe("AuthenticationSection", () => {
   });
 
   it("explains Auto per-server: XAA when configured", () => {
-    xaaFlagValue = true;
     render(<AuthenticationSection {...autoProps} autoSelectsXaa={true} />);
 
     expect(

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -17,11 +17,8 @@ vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({
     capture: mockCapture,
   }),
-  // ServerDetailModal calls `useFeatureFlagEnabled("stateless-mcp-enabled")`
-  // to gate the per-server protocol-version dropdown. Default `false` here
-  // so the existing test setup exercises the pre-flag UI shape; tests that
-  // need the dropdown enabled should override per-test via
-  // `vi.mocked(useFeatureFlagEnabled).mockReturnValue(true)`.
+  // ServerDetailModal itself reads no flags, but its subtree may. Default
+  // `false` so tests exercise the un-flagged UI shape.
   useFeatureFlagEnabled: (...args: unknown[]) =>
     mockUseFeatureFlagEnabled(...args),
 }));

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Switch } from "@mcpjam/design-system/switch";
@@ -219,13 +218,6 @@ export function AuthenticationSection({
   const [isReplacingSecret, setIsReplacingSecret] = useState(false);
   const [isBearerTokenVisible, setIsBearerTokenVisible] = useState(false);
 
-  const xaaFlagEnabled = useFeatureFlagEnabled("xaa");
-  // Keep the XAA option visible if a server is already configured with it,
-  // even when the flag is off, so the trigger doesn't render blank for it.
-  // Auto is un-gated: its discover behavior (no auth first, OAuth on 401) is
-  // for everyone — only the XAA leg and its mention stay behind the flag.
-  const showXaaOption = xaaFlagEnabled === true || authType === "xaa";
-
   const canRevealClientSecret =
     hasStoredClientSecret &&
     !clearClientSecret &&
@@ -408,9 +400,7 @@ export function AuthenticationSection({
               <SelectItem value="none">No Authentication</SelectItem>
               <SelectItem value="bearer">Bearer Token</SelectItem>
               <SelectItem value="oauth">OAuth</SelectItem>
-              {showXaaOption && (
-                <SelectItem value="xaa">Cross-App Access (XAA)</SelectItem>
-              )}
+              <SelectItem value="xaa">Cross-App Access (XAA)</SelectItem>
             </SelectContent>
           </Select>
           {authType === "auto" && (

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -585,16 +585,6 @@ export function ProtocolTab({
   const policyState = readXaaEnterprisePolicy(draft.mcpProfile);
   const policyOn = policyState.kind === "on";
   const policyInvalid = policyState.kind === "invalid";
-  // Gated on the same `xaa` flag as the per-server XAA auth option
-  // (AuthenticationSection's `showXaaOption`) — without it a flag-off user
-  // could turn the policy on, make every Auto server fail closed, and have
-  // no UI left to add the XAA registration that fixes them. Same escape
-  // hatch as that gate: an already-on (or malformed) stored policy always
-  // renders, so a host is never stranded with an invisible active policy
-  // it can't turn off.
-  const xaaFlagEnabled = useFeatureFlagEnabled("xaa");
-  const showPolicyToggle =
-    xaaFlagEnabled === true || policyState.kind !== "off";
   const setPolicyOn = (next: boolean) => {
     onDraftChange((prev) => {
       const profile = prev.mcpProfile as Record<string, unknown> | undefined;
@@ -688,7 +678,6 @@ export function ProtocolTab({
               : `Pinned to ${selectedDropdownValue} — the initialize handshake offers only this version. A server's own protocol override still wins.`}
           </p>
         )}
-        {showPolicyToggle && (
         <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
           <div className="min-w-0">
             <span className="text-[12px] font-medium">
@@ -715,7 +704,6 @@ export function ProtocolTab({
             aria-label="Enterprise-managed authorization"
           />
         </div>
-        )}
         {showTasksPolicy && (
         <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
           <div className="min-w-0">

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.enterprisePolicy.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.enterprisePolicy.test.tsx
@@ -1,11 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 
-// The policy toggle is gated on the `xaa` feature flag (same gate as the
-// per-server XAA auth option) — without it a flag-off user could enable the
-// policy and lose the UI needed to register the servers it breaks.
+// The `xaa` rollout finished at 100% and the flag was removed, so the policy
+// toggle is no longer gated. `mcp-tasks` is still flagged, hence the mock.
 const { featureFlagMock } = vi.hoisted(() => ({
-  featureFlagMock: vi.fn((flag: string) => flag === "xaa"),
+  featureFlagMock: vi.fn((_flag: string) => false),
 }));
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture: vi.fn() }),
@@ -122,36 +121,26 @@ describe("ProtocolTab — enterprise-managed authorization policy switch", () =>
     ).toBe(true);
   });
 
-  it("hides the toggle when the xaa flag is off (no policy on the host)", () => {
-    featureFlagMock.mockImplementation(() => false);
-    try {
-      renderTab(emptyHostConfigInputV2());
-      expect(
-        screen.queryByRole("switch", {
-          name: /enterprise-managed authorization/i,
-        })
-      ).toBeNull();
-    } finally {
-      featureFlagMock.mockImplementation((flag: string) => flag === "xaa");
-    }
+  it("shows the toggle on a host with no policy stored", () => {
+    renderTab(emptyHostConfigInputV2());
+    expect(
+      screen.getByRole("switch", {
+        name: /enterprise-managed authorization/i,
+      })
+    ).toHaveAttribute("aria-checked", "false");
   });
 
-  it("still shows the toggle with the flag off when a policy is already stored (never strand a host)", () => {
-    featureFlagMock.mockImplementation(() => false);
-    try {
-      const draft = emptyHostConfigInputV2();
-      draft.mcpProfile = {
-        profileVersion: 1,
-        extensions: { [XAA_ENTERPRISE_POLICY_EXTENSION]: { idp: "mcpjam" } },
-      };
-      renderTab(draft);
-      expect(
-        screen.getByRole("switch", {
-          name: /enterprise-managed authorization/i,
-        })
-      ).toHaveAttribute("aria-checked", "true");
-    } finally {
-      featureFlagMock.mockImplementation((flag: string) => flag === "xaa");
-    }
+  it("shows the toggle as on when a policy is already stored", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      extensions: { [XAA_ENTERPRISE_POLICY_EXTENSION]: { idp: "mcpjam" } },
+    };
+    renderTab(draft);
+    expect(
+      screen.getByRole("switch", {
+        name: /enterprise-managed authorization/i,
+      })
+    ).toHaveAttribute("aria-checked", "true");
   });
 });

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -91,7 +91,13 @@ interface NavItem {
   featureFlag?: string;
   /** Hide this item when the named feature flag is enabled */
   hiddenByFlag?: string;
-  /** Restrict this item to signed-in ("authed") or signed-out ("guest") users */
+  /**
+   * Restrict this item by Convex session presence. Note that Convex reports
+   * `isAuthenticated` for hosted *anonymous* sessions too (see the note at
+   * `App.tsx`'s SwarmsRoute), so "guest" here means "no Convex session yet" —
+   * not "no WorkOS account". That is the same signal the `hosts-enabled` /
+   * `home-page-enabled` flag entries used before those flags were removed.
+   */
   authVisibility?: "authed" | "guest";
   /** Extra tab ids that should also highlight this item as active */
   matchTabs?: string[];
@@ -107,15 +113,16 @@ interface NavSection {
 }
 
 /**
- * Filter navigation items based on active feature flags and auth state.
+ * Filter navigation items based on active feature flags and Convex session.
  * Items with `featureFlag` are shown only when that flag is enabled.
  * Items with `hiddenByFlag` are hidden when that flag is enabled.
- * Items with `authVisibility` are shown only to signed-in or signed-out users.
+ * Items with `authVisibility` are filtered by `hasConvexSession` — see the
+ * caveat on that field about hosted anonymous sessions.
  */
 export function filterByFeatureFlags(
   sections: NavSection[],
   flags: Record<string, boolean>,
-  isAuthenticated = false
+  hasConvexSession = false
 ): NavSection[] {
   return sections
     .map((section) => ({
@@ -123,8 +130,8 @@ export function filterByFeatureFlags(
       items: section.items.filter((item) => {
         if (item.featureFlag && !flags[item.featureFlag]) return false;
         if (item.hiddenByFlag && flags[item.hiddenByFlag]) return false;
-        if (item.authVisibility === "authed" && !isAuthenticated) return false;
-        if (item.authVisibility === "guest" && isAuthenticated) return false;
+        if (item.authVisibility === "authed" && !hasConvexSession) return false;
+        if (item.authVisibility === "guest" && hasConvexSession) return false;
         return true;
       }),
     }))

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -91,6 +91,8 @@ interface NavItem {
   featureFlag?: string;
   /** Hide this item when the named feature flag is enabled */
   hiddenByFlag?: string;
+  /** Restrict this item to signed-in ("authed") or signed-out ("guest") users */
+  authVisibility?: "authed" | "guest";
   /** Extra tab ids that should also highlight this item as active */
   matchTabs?: string[];
   /** Hide this item when billing enforcement is active and the org lacks this feature */
@@ -105,13 +107,15 @@ interface NavSection {
 }
 
 /**
- * Filter navigation items based on active feature flags.
+ * Filter navigation items based on active feature flags and auth state.
  * Items with `featureFlag` are shown only when that flag is enabled.
  * Items with `hiddenByFlag` are hidden when that flag is enabled.
+ * Items with `authVisibility` are shown only to signed-in or signed-out users.
  */
 export function filterByFeatureFlags(
   sections: NavSection[],
-  flags: Record<string, boolean>
+  flags: Record<string, boolean>,
+  isAuthenticated = false
 ): NavSection[] {
   return sections
     .map((section) => ({
@@ -119,6 +123,8 @@ export function filterByFeatureFlags(
       items: section.items.filter((item) => {
         if (item.featureFlag && !flags[item.featureFlag]) return false;
         if (item.hiddenByFlag && flags[item.hiddenByFlag]) return false;
+        if (item.authVisibility === "authed" && !isAuthenticated) return false;
+        if (item.authVisibility === "guest" && isAuthenticated) return false;
         return true;
       }),
     }))
@@ -135,14 +141,13 @@ export function filterByFeatureFlags(
 export function applyBillingGateNavState(
   sections: NavSection[],
   options: {
-    billingUiEnabled: boolean;
     /** When true, feature is denied by premiumness (locked). */
     gateDenied: Partial<Record<BillingFeatureName, boolean>>;
     enforcementActive: boolean;
   }
 ): NavSection[] {
-  const { billingUiEnabled, gateDenied, enforcementActive } = options;
-  if (!billingUiEnabled || !enforcementActive) {
+  const { gateDenied, enforcementActive } = options;
+  if (!enforcementActive) {
     return sections;
   }
 
@@ -176,20 +181,20 @@ export const navigationSections: NavSection[] = [
         title: "Home",
         url: "/home",
         icon: House,
-        featureFlag: "home-page-enabled",
+        authVisibility: "authed",
       },
       {
         title: "Connect",
         url: "/servers",
         icon: MCPIcon,
-        featureFlag: "hosts-enabled",
+        authVisibility: "authed",
         matchTabs: ["clients", "host-compare", "computer", "skills"],
       },
       {
         title: "Servers",
         url: "/servers",
         icon: MCPIcon,
-        hiddenByFlag: "hosts-enabled",
+        authVisibility: "guest",
       },
       {
         title: "Registry",
@@ -286,7 +291,6 @@ export const navigationSections: NavSection[] = [
         url: "/xaa-flow",
         icon: ShieldCheck,
         badge: "New",
-        featureFlag: "xaa",
       },
     ],
   },
@@ -398,7 +402,6 @@ interface MCPSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onProjectShared?: (sharedProjectId: string, sourceProjectId?: string) => void;
   billingGateDenied?: Partial<Record<BillingFeatureName, boolean>>;
   billingGateEnforcementActive?: boolean;
-  billingUiEnabled?: boolean;
   isCreateProjectDisabled?: boolean;
   createProjectDisabledReason?: string;
   onBeforeSignOut?: () => void | Promise<void>;
@@ -555,7 +558,6 @@ export function MCPSidebar({
   onProjectShared,
   billingGateDenied = {},
   billingGateEnforcementActive = false,
-  billingUiEnabled = false,
   isCreateProjectDisabled = false,
   createProjectDisabledReason,
   onBeforeSignOut,
@@ -565,7 +567,6 @@ export function MCPSidebar({
   const sandboxesEnabled = useFeatureFlagEnabled("sandboxes-enabled");
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
-  const xaaEnabled = useFeatureFlagEnabled("xaa");
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
   const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
@@ -611,12 +612,10 @@ export function MCPSidebar({
   const shouldShowInviteCta = isAuthenticated && !!user && !!activeProject;
   const trialBilling = useOrganizationBillingStatus(
     activeProject?.organizationId ?? null,
-    { enabled: billingUiEnabled && !!activeProject?.organizationId }
+    { enabled: !!activeProject?.organizationId }
   );
   const trialActive =
-    billingUiEnabled &&
-    trialBilling?.trialStatus === "active" &&
-    !!trialBilling.trialEndsAt;
+    trialBilling?.trialStatus === "active" && !!trialBilling.trialEndsAt;
   const handleTrialUpgradeClick = () => {
     if (!activeProject?.organizationId) return;
     appNavigate(`/organizations/${activeProject.organizationId}/billing`);
@@ -641,11 +640,6 @@ export function MCPSidebar({
       "registry-enabled": registryEnabled === true,
       "mcpjam-conformance": conformanceEnabled === true,
       "mcpjam-compatibility": compatibilityEnabled === true,
-      // Hosts/Connect and Home are fully rolled out; their nav visibility is
-      // purely auth-driven (signed-out users keep the legacy Servers item).
-      "hosts-enabled": isAuthenticated,
-      "home-page-enabled": isAuthenticated,
-      xaa: xaaEnabled === true,
       "project-environments-enabled":
         projectEnvironmentsEnabled === true && isAuthenticated,
     }),
@@ -655,7 +649,6 @@ export function MCPSidebar({
       registryEnabled,
       conformanceEnabled,
       compatibilityEnabled,
-      xaaEnabled,
       projectEnvironmentsEnabled,
       isAuthenticated,
     ]
@@ -663,7 +656,8 @@ export function MCPSidebar({
   const hubNavHash = "#servers";
   const visibleNavigationSections = filterByFeatureFlags(
     HOSTED_MODE ? hostedNavigationSections : navigationSections,
-    featureFlags
+    featureFlags,
+    isAuthenticated
   );
 
   // Signed-in users reach Settings/Support via the account menu; only

--- a/mcpjam-inspector/client/src/components/project/ShareProjectDialog.tsx
+++ b/mcpjam-inspector/client/src/components/project/ShareProjectDialog.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import { track } from "@/lib/analytics";
 import {
   Dialog,
@@ -231,8 +230,6 @@ export function ShareProjectDialog({
   });
 
   // Billing gate for member invites
-  const billingUiFlag = useFeatureFlagEnabled("billing-entitlements-ui");
-  const billingUiEnabled = billingUiFlag === true;
   const {
     billingStatus,
     organizationPremiumness,
@@ -241,14 +238,11 @@ export function ShareProjectDialog({
     isLoadingOrganizationPremiumness,
   } = useOrganizationBilling(selectedProject.organizationId ?? null);
   const memberInviteGate = resolveBillingGateState({
-    billingUiEnabled,
     organizationId: selectedProject.organizationId ?? null,
     billingStatus,
     premiumness: organizationPremiumness,
     gate: BILLING_GATES.memberInvites,
-    isLoading:
-      billingUiEnabled &&
-      (isLoadingBilling || isLoadingOrganizationPremiumness),
+    isLoading: isLoadingBilling || isLoadingOrganizationPremiumness,
   });
   const memberUpsellTeaser = getBillingUpsellTeaser({
     planCatalog,

--- a/mcpjam-inspector/client/src/components/project/__tests__/ShareProjectDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/project/__tests__/ShareProjectDialog.test.tsx
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ShareProjectDialog } from "../ShareProjectDialog";
 
 const mockCapture = vi.fn();
-let mockBillingUiFlag = false;
 const mockUseProjectMembers = vi.fn();
 const mockUseOrganizationBilling = vi.fn();
 const mockResolveBillingGateState = vi.fn();
@@ -20,8 +19,7 @@ vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({
     capture: mockCapture,
   }),
-  useFeatureFlagEnabled: (flag: string) =>
-    flag === "billing-entitlements-ui" ? mockBillingUiFlag : false,
+  useFeatureFlagEnabled: () => false,
 }));
 
 vi.mock("@/lib/analytics", () => ({
@@ -173,7 +171,6 @@ describe("ShareProjectDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.location.hash = "";
-    mockBillingUiFlag = false;
 
     mockCreateProject.mockResolvedValue("ws-created");
     mockInviteProjectMember.mockResolvedValue({
@@ -650,7 +647,6 @@ describe("ShareProjectDialog", () => {
   });
 
   it("shows the member limit upsell and re-enables Invite when the gate clears", () => {
-    mockBillingUiFlag = true;
     mockUseOrganizationBilling.mockReturnValue({
       billingStatus: {
         canManageBilling: true,

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -367,7 +367,6 @@ describe("getDisplayPriceCentsForPlan", () => {
 describe("isPremiumnessGateDeniedForShell", () => {
   it("prefers project premiumness when a project exists", () => {
     const denied = isPremiumnessGateDeniedForShell({
-      billingUiEnabled: true,
       hasProject: true,
       gateKey: "evals",
       projectPremiumness: premiumness({

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-gates.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-gates.test.ts
@@ -55,7 +55,6 @@ describe("resolveBillingGateState", () => {
 
   it("resolves denied feature gates with upgrade guidance", () => {
     const gate = resolveBillingGateState({
-      billingUiEnabled: true,
       organizationId: "org-1",
       billingStatus: {
         organizationId: "org-1",
@@ -109,7 +108,6 @@ describe("resolveBillingGateState", () => {
 
   it("formats limit gates through the shared resolver", () => {
     const gate = resolveBillingGateState({
-      billingUiEnabled: true,
       organizationId: "org-1",
       billingStatus: {
         organizationId: "org-1",
@@ -165,7 +163,6 @@ describe("resolveBillingGateState", () => {
 
   it("ignores denied decisions when enforcement is disabled", () => {
     const gate = resolveBillingGateState({
-      billingUiEnabled: true,
       organizationId: "org-1",
       premiumness: {
         plan: "free",

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -82,20 +82,14 @@ export function isGateAccessDenied(
  * organization premiumness applies.
  */
 export function isPremiumnessGateDeniedForShell(params: {
-  billingUiEnabled: boolean;
   projectPremiumness: PremiumnessState | undefined;
   organizationPremiumness: PremiumnessState | undefined;
   hasProject: boolean;
   gateKey: PremiumnessGateKey | null;
 }): boolean {
-  const {
-    billingUiEnabled,
-    projectPremiumness,
-    organizationPremiumness,
-    hasProject,
-    gateKey,
-  } = params;
-  if (!billingUiEnabled || !gateKey) {
+  const { projectPremiumness, organizationPremiumness, hasProject, gateKey } =
+    params;
+  if (!gateKey) {
     return false;
   }
   const premiumness =

--- a/mcpjam-inspector/client/src/lib/billing-gates.ts
+++ b/mcpjam-inspector/client/src/lib/billing-gates.ts
@@ -1,5 +1,4 @@
 import { useConvexAuth } from "convex/react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
 import {
   useOrganizationBilling,
   type BillingFeatureName,
@@ -57,7 +56,6 @@ export interface ResolvedBillingGate {
 }
 
 interface ResolveBillingGateStateParams {
-  billingUiEnabled: boolean;
   organizationId: string | null;
   billingStatus?: OrganizationBillingStatus;
   premiumness?: PremiumnessState;
@@ -69,7 +67,6 @@ export function resolveBillingGateState(
   params: ResolveBillingGateStateParams,
 ): ResolvedBillingGate {
   const {
-    billingUiEnabled,
     organizationId,
     billingStatus,
     premiumness,
@@ -84,9 +81,7 @@ export function resolveBillingGateState(
     "free";
   const canManageBilling = billingStatus?.canManageBilling ?? false;
   const isDenied =
-    billingUiEnabled &&
-    isBillingEnforcementActive(premiumness) &&
-    decision?.canAccess === false;
+    isBillingEnforcementActive(premiumness) && decision?.canAccess === false;
   const denialMessage =
     isDenied && decision?.kind === "limit"
       ? formatBillingLimitReachedMessage(
@@ -121,13 +116,7 @@ export function useProjectBillingGate({
   gate,
 }: UseProjectBillingGateParams): ResolvedBillingGate {
   const { isAuthenticated } = useConvexAuth();
-  const billingUiFlag = useFeatureFlagEnabled("billing-entitlements-ui");
-  const billingUiEnabled = billingUiFlag === true;
-  const shouldResolve =
-    isAuthenticated &&
-    billingUiFlag !== false &&
-    !!projectId &&
-    !!organizationId;
+  const shouldResolve = isAuthenticated && !!projectId && !!organizationId;
   const resolvedOrganizationId = shouldResolve ? organizationId : null;
   const {
     billingStatus,
@@ -145,13 +134,11 @@ export function useProjectBillingGate({
       : organizationPremiumness;
   const isLoadingGate =
     shouldResolve &&
-    (billingUiFlag === undefined ||
-      isLoadingBilling ||
+    (isLoadingBilling ||
       isLoadingProjectPremiumness ||
       isLoadingOrganizationPremiumness);
 
   return resolveBillingGateState({
-    billingUiEnabled,
     organizationId: resolvedOrganizationId,
     billingStatus,
     premiumness,

--- a/mcpjam-inspector/docs/analytics-flag-defaults.md
+++ b/mcpjam-inspector/docs/analytics-flag-defaults.md
@@ -30,43 +30,48 @@ Every gate resolves `undefined` → **hidden/off**. Two shapes:
 
 | Flag | Gates (representative) | Blocked-state default | Safe? |
 |------|------------------------|-----------------------|-------|
-| `billing-entitlements-ui` | `App.tsx:1321`, `OrganizationsTab.tsx:561`, `ShareProjectDialog.tsx:235` | Billing/entitlements UI hidden | ⚠️ see below |
 | `evaluate-ci` | `App.tsx`, `mcp-sidebar.tsx` | Evals-CI nav hidden | ✅ |
 | `mcpjam-learning` | `mcp-sidebar.tsx` | Learning nav hidden | ✅ |
 | `registry-enabled` | `mcp-sidebar.tsx` | Registry nav hidden | ✅ |
 | `mcpjam-conformance` / `mcpjam-compatibility` | `mcp-sidebar.tsx` | Nav hidden | ✅ |
-| `xaa` / `xaa-registration` | `mcp-sidebar.tsx`, XAA components | XAA surfaces hidden | ✅ |
 | `sandboxes-enabled` / `learn-more-enabled` | `mcp-sidebar.tsx` | Nav hidden | ✅ |
 | `skills-enabled` | `useSkillsEnabled(State)` | Skills hidden; route guard waits on tri-state | ✅ |
 | `computers-enabled` | `useComputersEnabled(State)` | Computers hidden; route guard waits on tri-state | ✅ |
 | `claude-code-host-enabled` / `codex-host-enabled` | host hooks | Host template hidden | ✅ |
 | `tool-quality-enabled` | `useToolQualityEnabled` | Quality badges hidden | ✅ |
 | `synthetic-monitors` | evals suite views | Monitors hidden | ✅ |
-| `stateless-mcp-enabled` | per-server protocol toggle | Opt-in stays off | ✅ |
 | `mcp-inspector-multi-host/model-enabled` | playground | Feature off | ✅ |
 
 For every beta/nav/opt-in feature, fail-closed is **correct**: a not-yet-GA
 surface briefly not showing is strictly better than flickering it on for a
 user who shouldn't have it.
 
-## The one to watch: `billing-entitlements-ui`
+## Removed: flags that reached 100%
 
-This gates billing/entitlements UI for **paying** orgs. Fail-closed means: if
-the flag hasn't resolved, a customer who has paid briefly doesn't see the
-billing surface they're entitled to. With the relay + bootstrap this window is
-now small (same-origin, no ad-block), so the residual risk is only the
-first-paint moment on a cold load.
+`billing-entitlements-ui` and `xaa` finished their rollouts at 100% for all
+users and have been removed from the code entirely, along with
+`home-page-enabled` and `hosts-enabled` (whose sidebar entries were already
+auth-driven rather than PostHog-driven — they now use the explicit
+`authVisibility` field on `NavItem`).
 
-**Recommendation:** leave it fail-closed (showing billing UI to a
-not-entitled org would be worse), but confirm the gate renders a neutral
-loading state — not an "upgrade" CTA — while the flag is `undefined`, so a
-paying customer never momentarily sees an upsell for something they already
-have. The tri-state pattern (`billingUiFlag === undefined` → skeleton, not
-CTA) is the fix if any gate currently shows the un-entitled variant during
-load.
+`stateless-mcp-enabled` is also at 100% in PostHog but had no gate left in the
+code — the per-server protocol toggle it once guarded is already un-flagged.
+Only a stale test comment referenced it, now corrected.
+
+Removing them also removes their first-paint flicker: the surfaces they gated
+now render immediately instead of waiting on `/flags`. That resolved the one
+case this audit had flagged as ⚠️ — `billing-entitlements-ui`, which gated
+billing UI for *paying* orgs and could briefly hide a surface a customer had
+already paid for. It also closes the opposite direction: a free-plan org no
+longer sees unlocked premium UI during the window before the gate resolved.
+
+Note for self-hosted builds: these features are now on unconditionally. Before
+removal, an install with no PostHog configured left every flag `undefined` and
+therefore hid them.
+
+These flag keys are safe to archive in PostHog; nothing reads them.
 
 ## Verdict
 
-Post-relay, the fail-closed defaults are safe. No gate needs to change its
-default. The only follow-up is the `billing-entitlements-ui` loading-state
-check above — a UX nicety, not a data-loss issue.
+Post-relay, the fail-closed defaults are safe for the flags that remain. No
+gate needs to change its default.


### PR DESCRIPTION
## Why

Audited every active flag in the PostHog MCPJam project (33 flags, none archived) against its release conditions. **12 are released to all users** — a condition group with no property filters at 100%. Their gates can never evaluate false, so the flag reads and their off-branches are dead code.

Of those 12, only **4 had a live gate** in this repo. The rest are listed below as safe to archive in PostHog.

## What changed

**`billing-entitlements-ui`** — removed `billingUiEnabled` everywhere it was threaded:
- `App.tsx` (shell billing gates, trial decision modal/notice, checkout deep-link effect, billing handoff overlay, route context)
- `OrganizationsTab.tsx`, `ShareProjectDialog.tsx`, `mcp-sidebar.tsx`
- Dropped the parameter from `resolveBillingGateState`, `isPremiumnessGateDeniedForShell`, and `applyBillingGateNavState`

**`xaa`** — removed the gates in:
- `App.tsx` — the `/xaa-flow` route guard and the header server-selector conditions
- `mcp-sidebar.tsx` — the XAA Debugger nav item
- `ProtocolTab.tsx` — the enterprise-managed authorization toggle
- `AuthenticationSection.tsx` — the Cross-App Access auth-method option

**`home-page-enabled` / `hosts-enabled`** — these were never PostHog-driven. The sidebar built a flag map that set both keys to `isAuthenticated`, so a flag key was standing in for an auth rule. Replaced with an explicit `authVisibility: "authed" | "guest"` field on `NavItem`; `filterByFeatureFlags` now takes `isAuthenticated`. Home and Connect are `authed`, legacy Servers is `guest` — same behavior, stated directly.

**Stale references cleaned up** — these flags are at 100% but already had no gate in code, only leftovers: `credit-topups-ui`, `evaluate-ui`, `playground-enabled`, `playground-sessions-enabled`, `playground-tab-enabled`, `shared-threads-enabled`, `team-credits-ui`, `stateless-mcp-enabled`. Removed test mocks returning values nothing reads, and corrected a `ServerDetailModal` comment describing a `stateless-mcp-enabled` gate the component no longer has.

`docs/analytics-flag-defaults.md` updated — the removed rows are gone and the audit's one ⚠️ item is resolved (see below).

## Behavior changes

Both are intended and match the finished rollouts, but worth a look:

1. **These surfaces no longer wait on `/flags` to paint.** Previously every gate resolved `undefined` → hidden during load. For `billing-entitlements-ui` this removes both directions of that flicker: a paying customer's billing surface was briefly hidden, and a free-plan org briefly saw unlocked premium UI before the gate resolved. Gate denial is now immediate. This is the follow-up the flag-defaults audit had flagged as the one case to watch.

2. **Self-hosted installs with no PostHog configured.** Every flag evaluated `undefined` there, so these features were hidden. They are now unconditionally on — which is what a 100% rollout means, but it is a visible change for those builds.

## Not changed

`mcpjam-backend` needs no changes — it has no feature-flag gating. Its only mention is a historical plan doc citing `playground-enabled` as a pattern example, left as a record.

## Follow-up in PostHog (no code impact)

Safe to archive now that nothing reads them: `credit-topups-ui`, `evaluate-ui`, `playground-enabled`, `playground-sessions-enabled`, `playground-tab-enabled`, `shared-threads-enabled`, `team-credits-ui`, `stateless-mcp-enabled`, `billing-entitlements-ui`, `xaa`, `home-page-enabled`, `hosts-enabled`.

Separately noticed while auditing, not addressed here: `mcpjam-learning` matches `icontains "@mcpjam"` (no TLD) and `registry-enabled` matches `icontains "mcpjam.com"` (no `@`) — both wider than the `@mcpjam.com` the other internal flags use.

## Testing

- `npm run typecheck:client` — clean
- Full inspector vitest suite — passing
- Updated the specs that asserted flag-off behavior, which is now unreachable: the XAA option/policy-toggle hidden states, the `/xaa-flow` redirect, the Connect/Servers swap (now auth-driven), and the audit-log placeholder skip (now purely entitlement-loading driven, with a companion test for the loaded state)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRd5pm8nMkLvQFr3561m6F)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide client surface area (billing gates, XAA routes/auth, sidebar) with behavior changes for self-hosted and immediate premium enforcement without flag-load grace; logic is mostly deletion but entitlement mistakes would affect all users.
> 
> **Overview**
> Removes **PostHog gates that reached 100% rollout** and the branches that could never run in production.
> 
> **Billing (`billing-entitlements-ui`)** — Drops `billingUiEnabled` from the app shell, org settings, share dialog, sidebar, and billing helpers (`resolveBillingGateState`, `isPremiumnessGateDeniedForShell`, `applyBillingGateNavState`). Premium upsells and enforcement now depend only on premiumness/enforcement state, not a separate UI flag. Checkout deep-link and billing handoff no longer bail when the flag was off.
> 
> **XAA (`xaa`)** — `/xaa-flow` always mounts (no redirect home). XAA Debugger nav, Cross-App Access in `AuthenticationSection`, and the host **enterprise-managed authorization** toggle in `ProtocolTab` are always available; header server-selector behavior no longer checks `xaaEnabled`.
> 
> **Sidebar auth** — `home-page-enabled` / `hosts-enabled` fake flag map entries are replaced with **`authVisibility: "authed" | "guest"`** on nav items; `filterByFeatureFlags` takes Convex session presence so Connect/Home vs legacy Servers behaves the same without PostHog.
> 
> **Docs & tests** — `analytics-flag-defaults.md` documents removed flags and the eliminated first-paint flicker. Tests drop flag-off scenarios (XAA redirect, billing UI bypass when flag off, etc.) and align mocks with unconditional behavior.
> 
> **Notable product effect:** gated UI no longer waits on `/flags`; self-hosted installs without PostHog now show these features by default instead of hiding them while flags stay `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8d19c81604f2ee02f14b435391fb4c2bb0fa5cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed fully rolled out feature flags and their dead code paths to simplify gating and remove flag-load flicker. XAA and billing UI are now always on, and the sidebar uses Convex session presence for Home/Connect/Servers visibility.

- **Refactors**
  - Removed `billing-entitlements-ui` and `xaa` gates: always render XAA Flow, XAA auth option, and enterprise policy toggle; dropped the `/xaa-flow` route guard and sidebar nav gate.
  - Replaced `home-page-enabled` and `hosts-enabled` with `authVisibility: "authed" | "guest"` on `NavItem`; `filterByFeatureFlags` now takes `hasConvexSession` (Convex may report hosted anonymous sessions as “authed”).
  - Dropped `billingUiEnabled` from `resolveBillingGateState`, `isPremiumnessGateDeniedForShell`, `applyBillingGateNavState`, and all call sites.
  - Cleaned up stale flag references/mocks, removed a duplicate test, and updated `docs/analytics-flag-defaults.md` to drop rows for removed flags and note the flicker fix.

- **Behavior Changes**
  - UI no longer waits on `/flags` to render; billing gates deny immediately, eliminating flicker.
  - Self-hosted without PostHog now sees these features enabled by default.

<sup>Written for commit f8d19c81604f2ee02f14b435391fb4c2bb0fa5cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

