### PR TITLE
fix(github-checks): correct bind-address claims (loopback works through the bridge)

### DIFF
--- a/mcpjam-inspector/server/services/github-checks/recipes.ts
+++ b/mcpjam-inspector/server/services/github-checks/recipes.ts
@@ -23,10 +23,11 @@ export type CheckRecipe = {
   /** Long-running; spawned in the background and expected to bind `port`. */
   start: string;
   /**
-   * The port the started server listens on INSIDE the sandbox. It must bind
-   * `0.0.0.0`, not `127.0.0.1` — the sandbox host bridge only forwards to
-   * ports bound on all interfaces, so a loopback-only server is invisible and
-   * shows up as `server_unhealthy`.
+   * The port the started server listens on INSIDE the sandbox. The bind
+   * address does not matter: the E2B host bridge proxies from inside the box,
+   * so loopback-bound servers are reachable too (e2e-verified 2026-08-02 —
+   * scenario C bound `127.0.0.1` and passed). What DOES surface as
+   * `server_unhealthy` is listening on a different port than declared here.
    */
   port: number;
   /** Path the streamable-HTTP MCP endpoint is served on. */

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/README.md
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/README.md
@@ -26,10 +26,10 @@ is standalone with no workspace to hoist it from.
 
 ## The two things that must not be "cleaned up"
 
-**It binds `0.0.0.0`, not `127.0.0.1`.** E2B's host bridge only forwards to ports
-bound on all interfaces. A loopback-only server is invisible from outside the
-sandbox and the check reports `server_unhealthy` with a stderr tail that may not
-mention the bind address at all.
+**It listens on the port the recipe declares (3001 / `$PORT`).** The bind
+address is not load-bearing — E2B's bridge proxies from inside the sandbox and
+reaches loopback-bound servers too (e2e-verified: a `127.0.0.1` bind passed the
+check). Listening on any *other port* is what reports `server_unhealthy`.
 
 **It answers `initialize` on `/mcp` immediately.** That handshake _is_ the health
 probe — the worker polls it until it succeeds. Anything that delays it (a
@@ -75,4 +75,4 @@ conclusion — useful for verifying the pipeline end to end:
 | break a tool's return value           | `evals_failed`     | failure          |
 | introduce a type error                | `build_failed`     | failure          |
 | `throw` at the top of `server.ts`     | `server_unhealthy` | failure          |
-| bind `127.0.0.1` instead of `0.0.0.0` | `server_unhealthy` | failure          |
+| listen on a port other than 3001      | `server_unhealthy` | failure          |

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/README.md
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/README.md
@@ -26,7 +26,8 @@ is standalone with no workspace to hoist it from.
 
 ## The two things that must not be "cleaned up"
 
-**It listens on the port the recipe declares (3001 / `$PORT`).** The bind
+**It listens on port 3001 — the port the check recipe declares.** (The `$PORT`
+env fallback exists for local runs only; the check worker sets no override.) The bind
 address is not load-bearing — E2B's bridge proxies from inside the sandbox and
 reaches loopback-bound servers too (e2e-verified: a `127.0.0.1` bind passed the
 check). Listening on any *other port* is what reports `server_unhealthy`.

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -9,9 +9,11 @@
  * Two properties are load-bearing for the check pipeline and must not be
  * "cleaned up":
  *
- *   1. It binds 0.0.0.0, not 127.0.0.1. E2B's host bridge only forwards to
- *      ports bound on all interfaces, so a loopback-only server is invisible
- *      from outside the sandbox and the check reports `server_unhealthy`.
+ *   1. It listens on the exact port the check recipe declares (3001, or
+ *      $PORT). The bind address is NOT load-bearing — E2B's bridge proxies
+ *      from inside the box and reaches loopback-bound servers too
+ *      (e2e-verified) — but the PORT is: listening anywhere else reports
+ *      `server_unhealthy`.
  *   2. It answers `initialize` immediately on `/mcp`. That handshake IS the
  *      health probe — the worker polls it until it succeeds, so anything that
  *      delays it (a warm-up, a lazy route mount) shows up as an unhealthy
@@ -28,7 +30,8 @@ import {
 } from "node:http";
 
 const PORT = Number(process.env.PORT ?? 3001);
-/** All interfaces — see property (1) in the file comment. */
+/** All interfaces. Not required by the bridge (see property 1) — kept because
+ *  it is the least surprising default for a fixture people copy from. */
 const HOST = "0.0.0.0";
 const MCP_PATH = "/mcp";
 const PROTOCOL_VERSION = "2025-06-18";
@@ -348,10 +351,11 @@ const server = createServer(async (req, res) => {
 });
 
 server.listen(PORT, HOST, () => {
-  // Log the bind address explicitly: "127.0.0.1" here is the single most likely
-  // cause of a `server_unhealthy` check, so make it visible in the check logs. A
-  // failed health check reports the tail of this server's log, and "listening
-  // on ..." is how you tell "never started" from "started and never answered".
+  // Log the LISTEN ADDRESS explicitly — the port is what matters (a port other
+  // than the recipe's is the likely `server_unhealthy` cause; the bind address
+  // is not, the bridge reaches loopback too). A failed health check reports the
+  // tail of this log, and "listening on ..." is how you tell "never started"
+  // from "started and never answered".
   //
   // Written straight to stdout: `console.log` is prohibited repository-wide, and
   // the inspector's logger cannot be imported here because this file is the seed

--- a/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
+++ b/mcpjam-inspector/test-servers/mcp-check-fixture/src/server.ts
@@ -9,8 +9,10 @@
  * Two properties are load-bearing for the check pipeline and must not be
  * "cleaned up":
  *
- *   1. It listens on the exact port the check recipe declares (3001, or
- *      $PORT). The bind address is NOT load-bearing — E2B's bridge proxies
+ *   1. It listens on 3001, the exact port the check recipe declares ($PORT is
+ *      a local-run convenience only; the check worker sets no override, so
+ *      relying on it in CI would probe a port nobody listens on).
+ *      The bind address is NOT load-bearing — E2B's bridge proxies
  *      from inside the box and reaches loopback-bound servers too
  *      (e2e-verified) — but the PORT is: listening anywhere else reports
  *      `server_unhealthy`.


### PR DESCRIPTION
E2E scenario C (fixture PR #4) bound the server to 127.0.0.1 and the check passed 2/2 — E2B's bridge proxies from inside the sandbox, so loopback binding was never a failure mode. Comment/README-only change correcting recipes.ts, the fixture server, and its README; the load-bearing requirement is listening on the recipe's PORT. Backend check-output copy counterpart: MCPJam/mcpjam-backend#837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and README updates only; no check worker or server runtime behavior changes in this diff.
> 
> **Overview**
> **Corrects GitHub check documentation** so it matches E2B sandbox behavior: loopback (`127.0.0.1`) is reachable through the host bridge, and **`server_unhealthy` is tied to listening on a port other than `CheckRecipe.port`**, not to binding only on `0.0.0.0`.
> 
> Updates the `CheckRecipe.port` JSDoc in `recipes.ts`, the mcp-check-fixture README (including the failure-mode table: wrong port instead of loopback bind), and comments/logging notes in `server.ts`. **`$PORT` is documented as local-only**; the check worker probes the recipe port with no override. The fixture still defaults to `0.0.0.0` for copy-paste clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cceaad89f0180746f7e213e7538685d645638251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected GitHub checks guidance: loopback binding is allowed; the check only requires listening on the recipe-declared port. Clarifies that `$PORT` is for local runs only; the worker always probes `recipe.port`.

- **Bug Fixes**
  - Updated `CheckRecipe.port` docs in `recipes.ts`: bridge reaches loopback; wrong port → `server_unhealthy`.
  - Revised fixture README to stress listening on port 3001 (the recipe port) and note `$PORT` is local-only and not used by the worker; updated the failure-mode table accordingly.
  - Updated fixture server comments/logs to highlight port correctness; kept `0.0.0.0` default for copy-paste clarity.

<sup>Written for commit cceaad89f0180746f7e213e7538685d645638251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

