### PR TITLE
feat(api): headless agent turn endpoint (POST /api/v1/projects/:projectId/agent)

### DIFF
--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -3373,7 +3373,7 @@
           "Agent"
         ],
         "summary": "Run one headless agent turn",
-        "description": "Runs ONE assistant turn over the supplied message history and responds synchronously with the final assistant text, the operations it invoked, and references to any resources it created (currently eval suites).\n\nThe caller owns conversation state: resend the full history each turn. The model is pinned server-side (hosted catalog) and billed to the project. Tools available to the turn are read operations plus atomic `create_eval_suite`; run/cancel and generation operations are deliberately excluded — starting a run stays an explicit caller action via `POST /eval-runs`.\n\nEvery tool invocation is hard-clamped to the path `projectId`. Turns are capped at 4 concurrent per organization (`429 RATE_LIMITED`) and ~90s wall clock (`504 TIMEOUT`). Guest callers are denied. Requires a hosted MCPJam deployment (`422 FEATURE_NOT_SUPPORTED` otherwise).",
+        "description": "Runs ONE assistant turn over the supplied message history and responds synchronously with the final assistant text, the operations it invoked, and references to any resources it created (currently eval suites).\n\nThe caller owns conversation state: resend the full history each turn. The model is pinned server-side (hosted catalog) and billed to the project. Tools available to the turn are read operations plus atomic `create_eval_suite`; run/cancel and generation operations are deliberately excluded — starting a run stays an explicit caller action via `POST /eval-runs`.\n\nEvery tool invocation is hard-clamped to the path `projectId`. Turns are capped at 4 concurrent per organization (`429 RATE_LIMITED`) and ~90s wall clock (`504 TIMEOUT`). Guest callers are denied. Requires a hosted MCPJam deployment (`422 FEATURE_NOT_SUPPORTED` otherwise).\n\nWhen a turn fails or times out AFTER a create operation already persisted a resource, the error body's `details.createdResources` carries the created references — check it before retrying, or a retry will create duplicates.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3445,6 +3445,9 @@
           },
           "504": {
             "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
           }
         }
       }

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -3373,7 +3373,7 @@
           "Agent"
         ],
         "summary": "Run one headless agent turn",
-        "description": "Runs ONE assistant turn over the supplied message history and responds synchronously with the final assistant text, the operations it invoked, and references to any resources it created (currently eval suites).\n\nThe caller owns conversation state: resend the full history each turn. The model is pinned server-side (hosted catalog) and billed to the project. Tools available to the turn are read operations plus atomic `create_eval_suite`; run/cancel and generation operations are deliberately excluded — starting a run stays an explicit caller action via `POST /eval-runs`.\n\nEvery tool invocation is hard-clamped to the path `projectId`. Turns are capped at 4 concurrent per organization (`429 RATE_LIMITED`) and ~90s wall clock (`504 TIMEOUT`). Guest callers are denied. Requires a hosted MCPJam deployment (`422 FEATURE_NOT_SUPPORTED` otherwise).\n\nWhen a turn fails or times out AFTER a create operation already persisted a resource, the error body's `details.createdResources` carries the created references — check it before retrying, or a retry will create duplicates.",
+        "description": "Runs ONE assistant turn over the supplied message history and responds synchronously with the final assistant text, the operations it invoked, and references to any resources it created (currently eval suites).\n\nThe caller owns conversation state: resend the full history each turn. The model is pinned server-side (hosted catalog) and billed to the project. Tools available to the turn are read operations plus atomic `create_eval_suite`; run/cancel and generation operations are deliberately excluded — starting a run stays an explicit caller action via `POST /eval-runs`.\n\nEvery tool invocation is hard-clamped to the path `projectId`. Turns are capped at 4 concurrent per organization (`429 RATE_LIMITED`; enforced per server instance) and ~90s wall clock (`504 TIMEOUT`). Guest callers are denied. Requires a hosted MCPJam deployment (`422 FEATURE_NOT_SUPPORTED` otherwise).\n\nWhen a turn fails or times out AFTER a create operation already persisted a resource, the error body's `details.createdResources` carries the created references — check it before retrying, or a retry will create duplicates.\n\n**Retry policy:** this operation is NOT idempotent — a turn may persist resources (eval suites) even when the response is lost, and there is no idempotency key yet. Do not blind-retry: deduplicate on your own trigger identity (e.g. the Slack event id) and, when a retry is unavoidable, first list suites to check whether the previous attempt already created one.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -6516,7 +6516,7 @@
             "type": "array",
             "minItems": 1,
             "maxItems": 50,
-            "description": "The conversation so far, oldest first. The caller owns state and resends the full history each turn.",
+            "description": "The conversation so far, oldest first. The caller owns state and resends the full history each turn. Each message content is capped at 8,000 characters AND 8,192 UTF-8 bytes; the whole history is additionally capped at 98,304 UTF-8 bytes (96 KB).",
             "items": {
               "type": "object",
               "required": [
@@ -6534,7 +6534,8 @@
                 "content": {
                   "type": "string",
                   "minLength": 1,
-                  "maxLength": 8000
+                  "maxLength": 8000,
+                  "description": "Plain text. Max 8,000 characters and 8,192 UTF-8 bytes."
                 }
               }
             }

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "MCPJam API",
     "version": "1.0.0-preview",
-    "description": "Programmatic access to MCP servers saved in your MCPJam projects \u2014 live diagnostics (validate, inspect, export) and operations: call tools, render prompts, run eval suites asynchronously and poll their results, and import OAuth tokens.\n\n**The API is in preview**: the surface may change while we finish the design. Error `code` values are stable; error `message` strings are not. Write clients that ignore unknown response fields.",
+    "description": "Programmatic access to MCP servers saved in your MCPJam projects — live diagnostics (validate, inspect, export) and operations: call tools, render prompts, run eval suites asynchronously and poll their results, and import OAuth tokens.\n\n**The API is in preview**: the surface may change while we finish the design. Error `code` values are stable; error `message` strings are not. Write clients that ignore unknown response fields.",
     "contact": {
       "name": "MCPJam",
       "url": "https://github.com/MCPJam/inspector/issues"
@@ -68,6 +68,10 @@
     {
       "name": "Tunnels",
       "description": "Relay tunnels that expose local MCP servers through a public URL, registered as first-class project servers (the `mcpjam tunnel` CLI flow)."
+    },
+    {
+      "name": "Agent",
+      "description": "Headless agent turns over the public API: send a message history, the server runs one assistant turn with project-scoped workspace tools (eval reads + suite creation) on a pinned hosted model, and returns the reply plus created-resource references."
     }
   ],
   "paths": {
@@ -78,7 +82,7 @@
           "Catalog"
         ],
         "summary": "Get the host-compat catalog",
-        "description": "The versioned host-compatibility catalog backing `mcpjam compat` verdicts. Public and unauthenticated: static host facts and creation config with no project or user scope. Always returns a catalog \u2014 `source` is `live` when the backend publish was reachable and `bundled` when serving the SDK's built-in fallback.",
+        "description": "The versioned host-compatibility catalog backing `mcpjam compat` verdicts. Public and unauthenticated: static host facts and creation config with no project or user scope. Always returns a catalog — `source` is `live` when the backend publish was reachable and `bundled` when serving the SDK's built-in fallback.",
         "security": [],
         "responses": {
           "200": {
@@ -200,7 +204,7 @@
           "Harness"
         ],
         "summary": "List a harness's native built-in tools",
-        "description": "The native tools an agent harness (e.g. `claude-code`) runs INSIDE its sandbox \u2014 Bash, Read, Edit, Glob, Grep, WebSearch, and the like. Display-only: these execute via the harness's own agent loop and are NOT callable through MCPJam. Static published-package metadata; no project scope.",
+        "description": "The native tools an agent harness (e.g. `claude-code`) runs INSIDE its sandbox — Bash, Read, Edit, Glob, Grep, WebSearch, and the like. Display-only: these execute via the harness's own agent loop and are NOT callable through MCPJam. Static published-package metadata; no project scope.",
         "parameters": [
           {
             "name": "harnessId",
@@ -284,7 +288,7 @@
           "Sandbox images"
         ],
         "summary": "List a project's sandbox images",
-        "description": "The custom Computer images (digest-pinned Dockerfiles built into immutable images) saved in the project \u2014 your own personal drafts plus the project-shared ones.",
+        "description": "The custom Computer images (digest-pinned Dockerfiles built into immutable images) saved in the project — your own personal drafts plus the project-shared ones.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -497,7 +501,7 @@
           "Sandbox images"
         ],
         "summary": "Delete a sandbox image",
-        "description": "Permanently delete a sandbox image. Computers booted from it fall back to the base image. Deleting a project-shared image requires project admin. Bodyless \u2014 any field is rejected. Guest callers are denied (a write).",
+        "description": "Permanently delete a sandbox image. Computers booted from it fall back to the base image. Deleting a project-shared image requires project admin. Bodyless — any field is rejected. Guest callers are denied (a write).",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -596,7 +600,7 @@
           "Sandbox images"
         ],
         "summary": "Build a sandbox image",
-        "description": "Trigger a build of the sandbox image's image and respond `202`. The build runs asynchronously \u2014 poll the builds list for status. Bodyless. Guest callers are denied (a write).",
+        "description": "Trigger a build of the sandbox image's image and respond `202`. The build runs asynchronously — poll the builds list for status. Bodyless. Guest callers are denied (a write).",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -809,7 +813,7 @@
           "Hosts"
         ],
         "summary": "List a project's hosts",
-        "description": "The hosts saved in the project \u2014 the named model + capability profiles you attach to chats and eval suites. Returns the `id`s the host detail/update/delete routes take.",
+        "description": "The hosts saved in the project — the named model + capability profiles you attach to chats and eval suites. Returns the `id`s the host detail/update/delete routes take.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1147,7 +1151,7 @@
           "Server diagnostics"
         ],
         "summary": "Run the doctor",
-        "description": "Runs the full doctor workflow \u2014 probe \u2192 connect \u2192 initialize \u2192 capabilities \u2192 primitives \u2014 and returns a step-by-step report. The richest signal for \"is this server healthy, and why not.\"",
+        "description": "Runs the full doctor workflow — probe → connect → initialize → capabilities → primitives — and returns a step-by-step report. The richest signal for \"is this server healthy, and why not.\"",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1532,7 +1536,7 @@
           "Export"
         ],
         "summary": "Export a server snapshot",
-        "description": "Lists tools, resources, and prompts in one call and returns a single JSON snapshot \u2014 handy for diffing a server's surface over time in CI.",
+        "description": "Lists tools, resources, and prompts in one call and returns a single JSON snapshot — handy for diffing a server's surface over time in CI.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1589,7 +1593,7 @@
           "Execution"
         ],
         "summary": "Call a tool",
-        "description": "Executes a tool on the server and returns the MCP `CallToolResult` directly. Tool-level failures (`isError: true` in the result) are **successful calls** \u2014 the server answered; only transport/auth errors use the error envelope.",
+        "description": "Executes a tool on the server and returns the MCP `CallToolResult` directly. Tool-level failures (`isError: true` in the result) are **successful calls** — the server answered; only transport/auth errors use the error envelope.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1942,7 +1946,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "description": "Page size, 1\u2013200. Defaults to 50.",
+            "description": "Page size, 1–200. Defaults to 50.",
             "schema": {
               "type": "integer",
               "minimum": 1,
@@ -1996,7 +2000,7 @@
           "Eval runs"
         ],
         "summary": "Get an iteration trace",
-        "description": "Full trace envelope for one iteration: conversation messages, expected-vs-actual tool call analysis, and spans. The shape is rich and may evolve \u2014 treat it as an open document. Returns `404` with `details.reason: \"TRACE_NOT_AVAILABLE\"` when the iteration finished without a stored trace.",
+        "description": "Full trace envelope for one iteration: conversation messages, expected-vs-actual tool call analysis, and spans. The shape is rich and may evolve — treat it as an open document. Returns `404` with `details.reason: \"TRACE_NOT_AVAILABLE\"` when the iteration finished without a stored trace.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2046,7 +2050,7 @@
           "Eval runs"
         ],
         "summary": "Get an iteration's step results",
-        "description": "One row per authored test step, in order, with `status` (`ok`/`fail`/`skipped`/`pending`), a `reason`, and any `evidence` (screenshots, replay-video offset, widget tool calls). The fastest way to see which step failed and why. Unlike `/trace`, a missing trace is not a `404` \u2014 step verdicts still return, just without evidence.",
+        "description": "One row per authored test step, in order, with `status` (`ok`/`fail`/`skipped`/`pending`), a `reason`, and any `evidence` (screenshots, replay-video offset, widget tool calls). The fastest way to see which step failed and why. Unlike `/trace`, a missing trace is not a `404` — step verdicts still return, just without evidence.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2214,7 +2218,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "description": "Maximum runs to return, 1\u2013100. Defaults to 25.",
+            "description": "Maximum runs to return, 1–100. Defaults to 25.",
             "schema": {
               "type": "integer",
               "minimum": 1,
@@ -2259,7 +2263,7 @@
           "OAuth"
         ],
         "summary": "Import OAuth tokens",
-        "description": "Stores OAuth tokens you obtained yourself (e.g. via the SDK's `runOAuthLogin` \u2014 interactive loopback, headless, or client-credentials) for this server, scoped to your user, project, and server. Subsequent API calls against the server inject the stored access token automatically, and `401`s from the server trigger a server-side refresh \u2014 no further caller involvement.\n\nThis closes the loop after an `OAUTH_REQUIRED` error.",
+        "description": "Stores OAuth tokens you obtained yourself (e.g. via the SDK's `runOAuthLogin` — interactive loopback, headless, or client-credentials) for this server, scoped to your user, project, and server. Subsequent API calls against the server inject the stored access token automatically, and `401`s from the server trigger a server-side refresh — no further caller involvement.\n\nThis closes the loop after an `OAUTH_REQUIRED` error.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2281,8 +2285,8 @@
                   "clientId": "client_123"
                 },
                 "tokens": {
-                  "access_token": "at_\u2026",
-                  "refresh_token": "rt_\u2026",
+                  "access_token": "at_…",
+                  "refresh_token": "rt_…",
                   "expires_in": 3600
                 }
               }
@@ -2423,7 +2427,7 @@
           "Catalog"
         ],
         "summary": "List a project's servers",
-        "description": "The MCP servers saved in the project \u2014 the `serverId`s every other route takes. STDIO command/args/env and raw headers are never exposed.",
+        "description": "The MCP servers saved in the project — the `serverId`s every other route takes. STDIO command/args/env and raw headers are never exposed.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2468,7 +2472,7 @@
           "Catalog"
         ],
         "summary": "List a project's eval suites",
-        "description": "Eval suites in the project with latest-run summaries and pass-rate trends \u2014 the `suiteId`s the eval-run routes take.",
+        "description": "Eval suites in the project with latest-run summaries and pass-rate trends — the `suiteId`s the eval-run routes take.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2511,7 +2515,7 @@
           "Eval runs"
         ],
         "summary": "Create an eval suite (author-only, does not run)",
-        "description": "Creates a runnable eval suite \u2014 the suite record plus its test cases \u2014 and responds `201` **synchronously**, WITHOUT executing anything. Use this to author a suite, then run it later with `POST /eval-runs` (passing the returned `suiteId`).\n\nThis is distinct from `POST /eval-runs`, which creates a run and **detaches execution**, responding `202` with a `runId`. There is no concurrency cap here (no run is started).\n\nThe body uses an ergonomic authoring shape: a suite-level default `model` (and optional `provider`) applies to every test unless the test overrides it; `provider` is derived from a `provider/model` id when neither is supplied. Each test's case body is an ordered `steps` array (prompt / toolCall / interact / assert).\n\nGuest callers are denied (suite creation is a write).",
+        "description": "Creates a runnable eval suite — the suite record plus its test cases — and responds `201` **synchronously**, WITHOUT executing anything. Use this to author a suite, then run it later with `POST /eval-runs` (passing the returned `suiteId`).\n\nThis is distinct from `POST /eval-runs`, which creates a run and **detaches execution**, responding `202` with a `runId`. There is no concurrency cap here (no run is started).\n\nThe body uses an ergonomic authoring shape: a suite-level default `model` (and optional `provider`) applies to every test unless the test overrides it; `provider` is derived from a `provider/model` id when neither is supplied. Each test's case body is an ordered `steps` array (prompt / toolCall / interact / assert).\n\nGuest callers are denied (suite creation is a write).",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2628,7 +2632,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "description": "Page size, 1\u2013200. Defaults to 50.",
+            "description": "Page size, 1–200. Defaults to 50.",
             "schema": {
               "type": "integer",
               "minimum": 1,
@@ -2682,7 +2686,7 @@
           "Chatboxes"
         ],
         "summary": "List a project's chatboxes",
-        "description": "The chatboxes published from this project \u2014 name, access mode, attached servers, and share link. Read-only.",
+        "description": "The chatboxes published from this project — name, access mode, attached servers, and share link. Read-only.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2781,7 +2785,7 @@
           "Tunnels"
         ],
         "summary": "Create (or revive) a relay tunnel for a named project server",
-        "description": "Registers a server record named `name` if missing, mints a relay tunnel grant for it, and **persists the tunnel bearer URL (including the plaintext `?k=` secret) onto the server record's `url`** so evals and chatboxes can target the tunnel like any remote server. The plaintext persistence is a deliberate trade-off of the current tunnel MVP \u2014 the backend otherwise stores only a hash of the secret \u2014 mitigated by rotation: **every call rotates the secret, revokes the previous grant at the edge (disconnecting any live tunnel session for the server), and updates the stored URL**, so re-calling this route is also the rotation/recovery path.\n\nThe caller hosts the tunnel itself: connect a WebSocket to `relayWsUrl` (subprotocol `mcpjam-tunnel.v1`, `Authorization: Bearer <connectToken>`) and serve the relayed requests \u2014 this is what `mcpjam tunnel` does. When the host disconnects, the server record stays and calls to the public URL fail fast at the edge.",
+        "description": "Registers a server record named `name` if missing, mints a relay tunnel grant for it, and **persists the tunnel bearer URL (including the plaintext `?k=` secret) onto the server record's `url`** so evals and chatboxes can target the tunnel like any remote server. The plaintext persistence is a deliberate trade-off of the current tunnel MVP — the backend otherwise stores only a hash of the secret — mitigated by rotation: **every call rotates the secret, revokes the previous grant at the edge (disconnecting any live tunnel session for the server), and updates the stored URL**, so re-calling this route is also the rotation/recovery path.\n\nThe caller hosts the tunnel itself: connect a WebSocket to `relayWsUrl` (subprotocol `mcpjam-tunnel.v1`, `Authorization: Bearer <connectToken>`) and serve the relayed requests — this is what `mcpjam tunnel` does. When the host disconnects, the server record stays and calls to the public URL fail fast at the edge.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2813,8 +2817,8 @@
                   "name": "everything",
                   "existed": false,
                   "slug": "calm-otter",
-                  "url": "https://calm-otter.tunnels.mcpjam.com/api/mcp/adapter-http/srv_abc123?k=\u2026",
-                  "connectToken": "ct_\u2026",
+                  "url": "https://calm-otter.tunnels.mcpjam.com/api/mcp/adapter-http/srv_abc123?k=…",
+                  "connectToken": "ct_…",
                   "connectTokenExpiresAt": 1767225600000,
                   "relayWsUrl": "wss://tunnels.mcpjam.com/agent",
                   "secretVersion": 3
@@ -2853,7 +2857,7 @@
           "Tunnels"
         ],
         "summary": "Revoke a tunnel's live grant",
-        "description": "Revokes the grant at the control plane and edge: the public URL stops working immediately and any live tunnel session is disconnected. The server record \u2014 including its now-dead `url` \u2014 is intentionally left untouched, so the next create revives the tunnel with the same slug.",
+        "description": "Revokes the grant at the control plane and edge: the public URL stops working immediately and any live tunnel session is disconnected. The server record — including its now-dead `url` — is intentionally left untouched, so the next create revives the tunnel with the same slug.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2905,7 +2909,7 @@
           "Environments"
         ],
         "summary": "List a project's environments",
-        "description": "The project environments saved in the project. Archived environments are excluded unless `includeArchived=true` \u2014 you need that to find one to restore.",
+        "description": "The project environments saved in the project. Archived environments are excluded unless `includeArchived=true` — you need that to find one to restore.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3065,7 +3069,7 @@
           "Environments"
         ],
         "summary": "Update an environment",
-        "description": "Edit an environment. Only the fields you send change; send `null` for `serverAttachmentId`, `skillSelection`, or `pluginVersionIds` to clear them. Requires `expectedRevision` \u2014 the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
+        "description": "Edit an environment. Only the fields you send change; send `null` for `serverAttachmentId`, `skillSelection`, or `pluginVersionIds` to clear them. Requires `expectedRevision` — the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3129,7 +3133,7 @@
           "Environments"
         ],
         "summary": "Preview what an environment resolves to",
-        "description": "Resolve an environment to the exact execution inputs a run would use right now: the host's current config, the closed server set (including servers contributed by pinned plugin versions), and the resolved plugin versions. Returns 409 when the environment cannot currently produce a runnable configuration \u2014 for example a pinned plugin was disabled or deleted; `details.code` carries the specific reason (`ENV_PLUGIN_UNAVAILABLE`, `ENV_NO_SERVERS`, `ENV_HOST_MISSING`, \u2026).",
+        "description": "Resolve an environment to the exact execution inputs a run would use right now: the host's current config, the closed server set (including servers contributed by pinned plugin versions), and the resolved plugin versions. Returns 409 when the environment cannot currently produce a runnable configuration — for example a pinned plugin was disabled or deleted; `details.code` carries the specific reason (`ENV_PLUGIN_UNAVAILABLE`, `ENV_NO_SERVERS`, `ENV_HOST_MISSING`, …).",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3180,7 +3184,7 @@
           "Environments"
         ],
         "summary": "Archive an environment",
-        "description": "Archive an environment. It stops being selectable for runs and frees its name for a new one, but the row is kept and can be restored \u2014 this is why archive is a sub-action rather than a DELETE. Requires `expectedRevision` \u2014 the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
+        "description": "Archive an environment. It stops being selectable for runs and frees its name for a new one, but the row is kept and can be restored — this is why archive is a sub-action rather than a DELETE. Requires `expectedRevision` — the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3244,7 +3248,7 @@
           "Environments"
         ],
         "summary": "Restore an archived environment",
-        "description": "Restore an archived environment. Returns 409 if another live environment took its name in the meantime. Plugin pins whose version row no longer exists at all are dropped on the way back to live \u2014 compare the returned `pluginVersionIds` against what you archived to detect that. Requires `expectedRevision` \u2014 the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
+        "description": "Restore an archived environment. Returns 409 if another live environment took its name in the meantime. Plugin pins whose version row no longer exists at all are dropped on the way back to live — compare the returned `pluginVersionIds` against what you archived to detect that. Requires `expectedRevision` — the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3361,6 +3365,89 @@
           }
         }
       }
+    },
+    "/projects/{projectId}/agent": {
+      "post": {
+        "operationId": "runAgentTurn",
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Run one headless agent turn",
+        "description": "Runs ONE assistant turn over the supplied message history and responds synchronously with the final assistant text, the operations it invoked, and references to any resources it created (currently eval suites).\n\nThe caller owns conversation state: resend the full history each turn. The model is pinned server-side (hosted catalog) and billed to the project. Tools available to the turn are read operations plus atomic `create_eval_suite`; run/cancel and generation operations are deliberately excluded — starting a run stays an explicit caller action via `POST /eval-runs`.\n\nEvery tool invocation is hard-clamped to the path `projectId`. Turns are capped at 4 concurrent per organization (`429 RATE_LIMITED`) and ~90s wall clock (`504 TIMEOUT`). Guest callers are denied. Requires a hosted MCPJam deployment (`422 FEATURE_NOT_SUPPORTED` otherwise).",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/projectId"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTurnRequest"
+              },
+              "example": {
+                "messages": [
+                  {
+                    "role": "user",
+                    "content": "Create an eval suite for my weather server with one case that checks get_forecast is called for \"forecast for Paris\"."
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The completed turn.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTurnResponse"
+                },
+                "example": {
+                  "reply": "Created the suite \"weather smoke\" with 1 case. It is ready to run.",
+                  "toolCalls": [
+                    {
+                      "operation": "list_project_servers"
+                    },
+                    {
+                      "operation": "create_eval_suite"
+                    }
+                  ],
+                  "createdResources": [
+                    {
+                      "type": "eval_suite",
+                      "id": "ts_abc123",
+                      "name": "weather smoke",
+                      "url": "https://app.mcpjam.com/evals/suite/ts_abc123"
+                    }
+                  ],
+                  "usage": {
+                    "inputTokens": 2450,
+                    "outputTokens": 312
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/FeatureNotSupported"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "504": {
+            "$ref": "#/components/responses/Timeout"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -3368,7 +3455,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "MCPJam API key (`sk_\u2026`). Create one at [Settings \u2192 API keys](https://app.mcpjam.com/settings/api-keys). Guest sessions cannot use the API, and API keys cannot manage other API keys."
+        "description": "MCPJam API key (`sk_…`). Create one at [Settings → API keys](https://app.mcpjam.com/settings/api-keys). Guest sessions cannot use the API, and API keys cannot manage other API keys."
       }
     },
     "parameters": {
@@ -3514,7 +3601,7 @@
           },
           "message": {
             "type": "string",
-            "description": "Human-readable description. May change between releases \u2014 don't match on it."
+            "description": "Human-readable description. May change between releases — don't match on it."
           },
           "details": {
             "type": "object",
@@ -3550,7 +3637,7 @@
       },
       "DoctorReport": {
         "type": "object",
-        "description": "Step-by-step health report from the probe \u2192 connect \u2192 initialize \u2192 capabilities workflow.",
+        "description": "Step-by-step health report from the probe → connect → initialize → capabilities workflow.",
         "required": [
           "generatedAt",
           "status",
@@ -3935,7 +4022,7 @@
           },
           "isError": {
             "type": "boolean",
-            "description": "`true` when the **tool** reported a failure. The HTTP call still succeeds \u2014 the server answered."
+            "description": "`true` when the **tool** reported a failure. The HTTP call still succeeds — the server answered."
           }
         },
         "additionalProperties": true
@@ -4269,7 +4356,7 @@
       },
       "EvalRunCreateRequest": {
         "type": "object",
-        "description": "Three valid shapes: `suiteId` (rerun an existing suite, optionally upserting inline `tests` into it), `suiteName` + `tests` + `serverIds` (create a new suite and run it), or `suiteName` + `tests` + `environmentId` (create a new suite and run it against a project environment, which supplies the servers). Inline `tests` alone \u2014 without a `suiteId` or a `suiteName` \u2014 are rejected with `VALIDATION_ERROR`.",
+        "description": "Three valid shapes: `suiteId` (rerun an existing suite, optionally upserting inline `tests` into it), `suiteName` + `tests` + `serverIds` (create a new suite and run it), or `suiteName` + `tests` + `environmentId` (create a new suite and run it against a project environment, which supplies the servers). Inline `tests` alone — without a `suiteId` or a `suiteName` — are rejected with `VALIDATION_ERROR`.",
         "anyOf": [
           {
             "required": [
@@ -4324,14 +4411,14 @@
           "serverIds": {
             "type": "array",
             "minItems": 1,
-            "description": "Servers (by ID) the run connects to. Required when creating a new suite unless `environmentId` is given (the environment supplies the closed server set, and any `serverIds` sent alongside it are ignored); optional on reruns \u2014 when omitted, the run connects the suite's saved server selection (the set its snapshot references). A rerun of a suite with no saved selection is rejected with `VALIDATION_ERROR` (`details.reason: \"NO_SAVED_SERVER_SELECTION\"`).",
+            "description": "Servers (by ID) the run connects to. Required when creating a new suite unless `environmentId` is given (the environment supplies the closed server set, and any `serverIds` sent alongside it are ignored); optional on reruns — when omitted, the run connects the suite's saved server selection (the set its snapshot references). A rerun of a suite with no saved selection is rejected with `VALIDATION_ERROR` (`details.reason: \"NO_SAVED_SERVER_SELECTION\"`).",
             "items": {
               "type": "string"
             }
           },
           "modelApiKeys": {
             "type": "object",
-            "description": "Optional per-provider model API keys (e.g. `{ \"anthropic\": \"sk-ant-\u2026\" }`). Falls back to your organization's configured providers when omitted.",
+            "description": "Optional per-provider model API keys (e.g. `{ \"anthropic\": \"sk-ant-…\" }`). Falls back to your organization's configured providers when omitted.",
             "additionalProperties": {
               "type": "string"
             }
@@ -4355,7 +4442,7 @@
           },
           "environmentId": {
             "type": "string",
-            "description": "Run against a project environment. The environment supplies the closed server set (so `serverIds` is not required and is ignored if sent), and the run is pinned to the revision resolved at launch \u2014 if the environment changes in between, the run is rejected with 409 rather than executing against a different configuration."
+            "description": "Run against a project environment. The environment supplies the closed server set (so `serverIds` is not required and is ignored if sent), and the run is pinned to the revision resolved at launch — if the environment changes in between, the run is rejected with 409 rather than executing against a different configuration."
           }
         },
         "additionalProperties": true
@@ -4381,7 +4468,7 @@
           },
           "servers": {
             "type": "array",
-            "description": "The servers the run connects to \u2014 explicit or derived from the suite's saved selection. `name` is present when known (always, on the derived path).",
+            "description": "The servers the run connects to — explicit or derived from the suite's saved selection. `name` is present when known (always, on the derived path).",
             "items": {
               "type": "object",
               "required": [
@@ -4687,7 +4774,7 @@
           },
           "clientInformation": {
             "type": "object",
-            "description": "OAuth client used to obtain the tokens. Optional, but without it server-side refresh cannot run \u2014 always include it when you provide a `refresh_token`.",
+            "description": "OAuth client used to obtain the tokens. Optional, but without it server-side refresh cannot run — always include it when you provide a `refresh_token`.",
             "required": [
               "clientId"
             ],
@@ -5951,7 +6038,7 @@
       },
       "SandboxImageBuildStarted": {
         "type": "object",
-        "description": "A build was accepted (202). It runs in the background \u2014 poll the builds list for status.",
+        "description": "A build was accepted (202). It runs in the background — poll the builds list for status.",
         "required": [
           "id",
           "buildId",
@@ -6008,7 +6095,7 @@
       },
       "EnvironmentSkillSelection": {
         "type": "object",
-        "description": "An explicit pinned skill selection. Cannot be empty \u2014 clear the field instead (send `null` on update) to mean \"no pinned skills\".",
+        "description": "An explicit pinned skill selection. Cannot be empty — clear the field instead (send `null` on update) to mean \"no pinned skills\".",
         "required": [
           "mode",
           "skillIds"
@@ -6153,14 +6240,14 @@
           "sandboxImageId": {
             "type": "string",
             "minLength": 1,
-            "description": "Optional sandbox-image pin. Must be a project-shared image; personal drafts are rejected \u2014 promote them first.",
+            "description": "Optional sandbox-image pin. Must be a project-shared image; personal drafts are rejected — promote them first.",
             "pattern": ".*\\S.*"
           }
         }
       },
       "ProjectEnvironmentUpdateRequest": {
         "type": "object",
-        "description": "Only the fields you send change. `serverAttachmentId`, `skillSelection`, and `pluginVersionIds` are three-state: omit to leave unchanged, send `null` to CLEAR, send a value to set. An empty array is rejected \u2014 it is not a way to clear. Send at least one field besides `expectedRevision`. Unknown fields are rejected.",
+        "description": "Only the fields you send change. `serverAttachmentId`, `skillSelection`, and `pluginVersionIds` are three-state: omit to leave unchanged, send `null` to CLEAR, send a value to set. An empty array is rejected — it is not a way to clear. Send at least one field besides `expectedRevision`. Unknown fields are rejected.",
         "required": [
           "expectedRevision"
         ],
@@ -6233,7 +6320,7 @@
       },
       "ProjectEnvironmentResolved": {
         "type": "object",
-        "description": "What an environment resolves to right now \u2014 the same resolution an eval run performs.",
+        "description": "What an environment resolves to right now — the same resolution an eval run performs.",
         "required": [
           "environment",
           "hostId",
@@ -6273,7 +6360,7 @@
           },
           "hostConfigId": {
             "type": "string",
-            "description": "The host's config at resolve time \u2014 hosts rotate configs live, so this can change without the environment's `revision` changing."
+            "description": "The host's config at resolve time — hosts rotate configs live, so this can change without the environment's `revision` changing."
           },
           "serverAttachmentId": {
             "type": "string"
@@ -6296,7 +6383,7 @@
             "items": {
               "type": "string"
             },
-            "description": "`selectedServerIds` plus the servers contributed by pinned plugin versions \u2014 the set a run actually connects. Identical to `selectedServerIds` when no plugins are pinned."
+            "description": "`selectedServerIds` plus the servers contributed by pinned plugin versions — the set a run actually connects. Identical to `selectedServerIds` when no plugins are pinned."
           },
           "pluginVersions": {
             "type": "array",
@@ -6361,7 +6448,7 @@
       },
       "SandboxImageBlueprintValidateResult": {
         "type": "object",
-        "description": "Lint result. `ok: true` carries the resolved base digest; `ok: false` carries structured errors. Always returned with HTTP 200 \u2014 an invalid blueprint is a successful lint.",
+        "description": "Lint result. `ok: true` carries the resolved base digest; `ok: false` carries structured errors. Always returned with HTTP 200 — an invalid blueprint is a successful lint.",
         "required": [
           "ok"
         ],
@@ -6415,6 +6502,116 @@
             }
           }
         ]
+      },
+      "AgentTurnRequest": {
+        "type": "object",
+        "required": [
+          "messages"
+        ],
+        "properties": {
+          "messages": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 50,
+            "description": "The conversation so far, oldest first. The caller owns state and resends the full history each turn.",
+            "items": {
+              "type": "object",
+              "required": [
+                "role",
+                "content"
+              ],
+              "properties": {
+                "role": {
+                  "type": "string",
+                  "enum": [
+                    "user",
+                    "assistant"
+                  ]
+                },
+                "content": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 8000
+                }
+              }
+            }
+          }
+        }
+      },
+      "AgentTurnResponse": {
+        "type": "object",
+        "required": [
+          "reply",
+          "toolCalls",
+          "createdResources",
+          "usage"
+        ],
+        "properties": {
+          "reply": {
+            "type": "string",
+            "description": "The assistant's final text for this turn."
+          },
+          "toolCalls": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "operation"
+              ],
+              "properties": {
+                "operation": {
+                  "type": "string",
+                  "description": "Platform operation name invoked during the turn."
+                }
+              }
+            }
+          },
+          "createdResources": {
+            "type": "array",
+            "description": "Resources the turn created, with app deep links.",
+            "items": {
+              "type": "object",
+              "required": [
+                "type",
+                "id",
+                "url"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "eval_suite"
+                  ]
+                },
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          },
+          "usage": {
+            "type": "object",
+            "required": [
+              "inputTokens",
+              "outputTokens"
+            ],
+            "properties": {
+              "inputTokens": {
+                "type": "integer"
+              },
+              "outputTokens": {
+                "type": "integer"
+              }
+            }
+          }
+        }
       }
     },
     "responses": {
@@ -6447,7 +6644,7 @@
         }
       },
       "Unauthorized": {
-        "description": "Missing, invalid, revoked, or orphaned key (`UNAUTHORIZED`) \u2014 or the **target MCP server** needs an OAuth grant (`OAUTH_REQUIRED`), which is a property of the server, not your key.",
+        "description": "Missing, invalid, revoked, or orphaned key (`UNAUTHORIZED`) — or the **target MCP server** needs an OAuth grant (`OAUTH_REQUIRED`), which is a property of the server, not your key.",
         "content": {
           "application/json": {
             "schema": {
@@ -6565,7 +6762,7 @@
         }
       },
       "Conflict": {
-        "description": "The resource is not in a state that accepts this write \u2014 a stale `expectedRevision`, a duplicate name, or an environment that cannot currently be launched. The request was well-formed; re-read the resource and retry.",
+        "description": "The resource is not in a state that accepts this write — a stale `expectedRevision`, a duplicate name, or an environment that cannot currently be launched. The request was well-formed; re-read the resource and retry.",
         "content": {
           "application/json": {
             "schema": {

--- a/docs/reference/public-api.mdx
+++ b/docs/reference/public-api.mdx
@@ -274,6 +274,13 @@ plugin pins whose version no longer exists.
 | `POST .../eval-ingest/runs/finalize` | Finalize a chunked run (idempotent) |
 | `POST .../eval-ingest/artifacts/upload-url` | Mint an upload URL for eval artifacts (JUnit XML, Jest/Vitest JSON) |
 
+**Agent** (`/projects/{projectId}/agent`) — a headless assistant turn for
+building conversational surfaces (the MCPJam Slack app is the first consumer):
+
+| Endpoint | What it does |
+| --- | --- |
+| `POST .../agent` | Run ONE assistant turn over a `messages` history (`{role: "user"\|"assistant", content}` items, max 50 × 8 KB). The model is pinned server-side and billed to the project. The turn can read project servers/suites/runs and **create eval suites**; it can NOT start runs — kick those off yourself with `POST .../eval-runs`. Responds synchronously with `reply`, the `toolCalls` it made, `createdResources` (ids + app links), and token `usage`. Capped at 4 concurrent turns per organization and ~90 s wall clock; the caller owns conversation state and resends the full history each turn |
+
 **Chatboxes** (`/projects/{projectId}/chatboxes...`) — read-only:
 
 | Endpoint | What it does |

--- a/docs/reference/public-api.mdx
+++ b/docs/reference/public-api.mdx
@@ -279,7 +279,7 @@ building conversational surfaces (the MCPJam Slack app is the first consumer):
 
 | Endpoint | What it does |
 | --- | --- |
-| `POST .../agent` | Run ONE assistant turn over a `messages` history (`{role: "user"\|"assistant", content}` items, max 50 × 8 KB). The model is pinned server-side and billed to the project. The turn can read project servers/suites/runs and **create eval suites**; it can NOT start runs — kick those off yourself with `POST .../eval-runs`. Responds synchronously with `reply`, the `toolCalls` it made, `createdResources` (ids + app links), and token `usage`. Capped at 4 concurrent turns per organization and ~90 s wall clock; the caller owns conversation state and resends the full history each turn |
+| `POST .../agent` | Run ONE assistant turn over a `messages` history (`{role: "user"\|"assistant", content}` items, max 50 messages × 8 KB each, 96 KB total). The model is pinned server-side and billed to the project. The turn can read project servers/suites/runs and **create eval suites**; it can NOT start runs — kick those off yourself with `POST .../eval-runs`. Responds synchronously with `reply`, the `toolCalls` it made, `createdResources` (ids + app links), and token `usage`. Capped at 4 concurrent turns per organization and ~90 s wall clock. **Not idempotent — never blind-retry**: dedupe on your own trigger identity, and on an error response check `details.createdResources` (and, after a lost response, list suites) before retrying, or you'll create duplicates |
 
 **Chatboxes** (`/projects/{projectId}/chatboxes...`) — read-only:
 

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Covers the v1 agent-turn surface: auth/guest gating, schema limits, the
+// deployment guard, engine failure → code mapping, the per-org concurrency
+// cap, and the tool adapter's project clamp + created-resource collector.
+
+const {
+  validateGuestTokenMock,
+  getConvexBearerMock,
+  prepareChatV2Mock,
+  resolveTurnRuntimeMock,
+  runUnifiedAssistantTurnMock,
+  getSelfFetchMock,
+  isHostedCatalogModelMock,
+  managerListToolsMock,
+  managerDisconnectMock,
+} = vi.hoisted(() => {
+  process.env.DO_NOT_TRACK = "1"; // analytics no-op in tests
+  return {
+    validateGuestTokenMock: vi.fn(),
+    getConvexBearerMock: vi.fn(),
+    prepareChatV2Mock: vi.fn(),
+    resolveTurnRuntimeMock: vi.fn(),
+    runUnifiedAssistantTurnMock: vi.fn(),
+    getSelfFetchMock: vi.fn(),
+    isHostedCatalogModelMock: vi.fn(),
+    managerListToolsMock: vi.fn(),
+    managerDisconnectMock: vi.fn(),
+  };
+});
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+vi.mock("../../../utils/v1-convex-token.js", () => ({
+  getConvexBearerForRequest: getConvexBearerMock,
+}));
+
+vi.mock("../../../utils/chat-v2-orchestration.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/chat-v2-orchestration.js")
+  >("../../../utils/chat-v2-orchestration.js");
+  return { ...actual, prepareChatV2: prepareChatV2Mock };
+});
+
+vi.mock("../../../utils/resolve-turn-runtime.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../utils/resolve-turn-runtime.js")
+  >("../../../utils/resolve-turn-runtime.js");
+  return { ...actual, resolveTurnRuntime: resolveTurnRuntimeMock };
+});
+
+vi.mock("../../../utils/turn-execution.js", () => ({
+  runUnifiedAssistantTurn: runUnifiedAssistantTurnMock,
+}));
+
+vi.mock("../../../utils/self-app.js", () => ({
+  getSelfFetch: getSelfFetchMock,
+}));
+
+vi.mock("../../../services/hosted-model-catalog.js", () => ({
+  isHostedCatalogModel: isHostedCatalogModelMock,
+}));
+
+vi.mock("@mcpjam/sdk", async () => {
+  const actual =
+    await vi.importActual<typeof import("@mcpjam/sdk")>("@mcpjam/sdk");
+  return {
+    ...actual,
+    MCPClientManager: vi.fn().mockImplementation(() => ({
+      listTools: managerListToolsMock,
+      disconnectAllServers: managerDisconnectMock,
+      hasServer: () => false,
+      getToolsForAiSdk: async () => ({}),
+    })),
+  };
+});
+
+import v1Routes from "../index.js";
+import {
+  AGENT_API_OPERATIONS,
+  buildAgentApiToolSet,
+  type CreatedResource,
+} from "../agent.js";
+import { isMcpjamToolId } from "../../../utils/built-in-tools/mcpjam.js";
+import {
+  createEvalSuiteOperation,
+  listProjectServersOperation,
+  runEvalSuiteOperation,
+  generateEvalCasesOperation,
+  type PlatformApiClient,
+} from "@mcpjam/sdk/platform";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+function turnRequest(
+  app: Hono,
+  body: unknown,
+  token = "tok"
+): Promise<Response> {
+  return Promise.resolve(
+    app.request("/api/v1/projects/p1/agent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+const OK_BODY = { messages: [{ role: "user", content: "hello" }] };
+
+function okTurnResult(overrides: Record<string, unknown> = {}) {
+  return {
+    messages: [],
+    newMessages: [],
+    assistantMessages: [
+      { role: "assistant", content: [{ type: "text", text: "done" }] },
+    ],
+    toolCalls: [{ toolCallId: "t1", toolName: "list_eval_suites", input: {} }],
+    toolResults: [],
+    turnTrace: { turnId: "turn_1" },
+    usage: { inputTokens: 5, outputTokens: 2 },
+    aborted: false,
+    ...overrides,
+  };
+}
+
+describe("POST /api/v1/projects/:projectId/agent", () => {
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "http://convex.test";
+    process.env.INSPECTOR_SERVICE_TOKEN = "svc";
+    validateGuestTokenMock.mockResolvedValue({ valid: false });
+    getConvexBearerMock.mockResolvedValue("delegated-jwt");
+    getSelfFetchMock.mockReturnValue(async () => new Response("{}"));
+    isHostedCatalogModelMock.mockReturnValue(true);
+    managerListToolsMock.mockRejectedValue(new Error("docs down"));
+    managerDisconnectMock.mockResolvedValue(undefined);
+    prepareChatV2Mock.mockImplementation(async (opts: any) => ({
+      allTools: opts.builtInTools ?? {},
+      enhancedSystemPrompt: opts.systemPrompt,
+    }));
+    resolveTurnRuntimeMock.mockResolvedValue({
+      runtime: { kind: "hosted", endpointPath: "/stream" },
+      modelSource: "mcpjam",
+      finalizeUsage: async () => undefined,
+      classifyFailure: (message: string) =>
+        /rate.?limit|spend|\bquota\b|\bcap\b/i.test(message)
+          ? "rate_limited"
+          : "failed",
+    });
+    runUnifiedAssistantTurnMock.mockResolvedValue(okTurnResult());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requires a bearer token", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/v1/projects/p1/agent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(OK_BODY),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("denies guests (default-deny, no allowlist entry)", async () => {
+    validateGuestTokenMock.mockResolvedValue({
+      valid: true,
+      guestId: "guest_abc",
+    });
+    const res = await turnRequest(makeApp(), OK_BODY);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects an empty message list", async () => {
+    const res = await turnRequest(makeApp(), { messages: [] });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("rejects oversized messages", async () => {
+    const res = await turnRequest(makeApp(), {
+      messages: [{ role: "user", content: "x".repeat(8_001) }],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns FEATURE_NOT_SUPPORTED without hosted backend wiring", async () => {
+    delete process.env.CONVEX_HTTP_URL;
+    const res = await turnRequest(makeApp(), OK_BODY);
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("FEATURE_NOT_SUPPORTED");
+  });
+
+  it("runs a turn and returns reply + toolCalls + usage", async () => {
+    const res = await turnRequest(makeApp(), OK_BODY);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, any>;
+    expect(body.reply).toBe("done");
+    expect(body.toolCalls).toEqual([{ operation: "list_eval_suites" }]);
+    expect(body.usage).toEqual({ inputTokens: 5, outputTokens: 2 });
+    expect(body.createdResources).toEqual([]);
+    // Engine got the delegated JWT, never the caller's raw key.
+    const engineOpts = runUnifiedAssistantTurnMock.mock.calls[0]![0];
+    expect(engineOpts.authContext).toEqual({
+      kind: "user_bearer",
+      token: "Bearer delegated-jwt",
+    });
+    expect(engineOpts.projectId).toBe("p1");
+    expect(engineOpts.streamSink).toBe("none");
+    expect(engineOpts.approvalMode).toBe("auto-deny");
+  });
+
+  it("degrades when the docs server is down (turn still runs)", async () => {
+    const res = await turnRequest(makeApp(), OK_BODY);
+    expect(res.status).toBe(200);
+    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0];
+    expect(prepareOpts.selectedServers).toEqual([]);
+    expect(prepareOpts.skillsSource).toEqual({ kind: "none" });
+  });
+
+  it("maps engine spend-cap failures to RATE_LIMITED", async () => {
+    runUnifiedAssistantTurnMock.mockImplementation(async (opts: any) => {
+      opts.onEngineError?.({
+        message: "Daily spend cap exceeded",
+        httpStatus: 429,
+      });
+      return okTurnResult({ turnTrace: undefined });
+    });
+    const res = await turnRequest(makeApp(), OK_BODY);
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("RATE_LIMITED");
+  });
+
+  it("maps other engine failures to INTERNAL_ERROR", async () => {
+    runUnifiedAssistantTurnMock.mockResolvedValue(
+      okTurnResult({ turnTrace: undefined })
+    );
+    const res = await turnRequest(makeApp(), OK_BODY);
+    expect(res.status).toBe(500);
+  });
+
+  it("caps concurrent turns per organization", async () => {
+    const gate: Array<() => void> = [];
+    runUnifiedAssistantTurnMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          gate.push(() => resolve(okTurnResult()));
+        })
+    );
+    const app = makeApp();
+    const inflight = [1, 2, 3, 4].map(() => turnRequest(app, OK_BODY));
+    // Let the four turns reach the engine before the fifth arrives.
+    await vi.waitFor(() => {
+      expect(gate.length).toBe(4);
+    });
+    const fifth = await turnRequest(app, OK_BODY);
+    expect(fifth.status).toBe(429);
+    gate.forEach((release) => release());
+    const results = await Promise.all(inflight);
+    for (const res of results) expect(res.status).toBe(200);
+  });
+});
+
+describe("agent tool surface", () => {
+  it("keeps spend ops out of the op list and the in-app gate unchanged", () => {
+    const names = AGENT_API_OPERATIONS.map((op) => op.name);
+    expect(names).toContain(createEvalSuiteOperation.name);
+    expect(names).not.toContain(runEvalSuiteOperation.name);
+    expect(names).not.toContain(generateEvalCasesOperation.name);
+    expect(names).not.toContain("cancel_eval_run");
+    // The in-app built-in gate must NOT widen to the create op.
+    expect(isMcpjamToolId(createEvalSuiteOperation.name)).toBe(false);
+  });
+
+  it("clamps every operation to the route's project", async () => {
+    const executeSpy = vi
+      .spyOn(listProjectServersOperation, "execute")
+      .mockResolvedValue({ servers: [] } as never);
+    const created: CreatedResource[] = [];
+    const tools = buildAgentApiToolSet({
+      client: {} as PlatformApiClient,
+      projectId: "p1",
+      created,
+    });
+    const tool = tools[listProjectServersOperation.name]! as {
+      execute: (input: unknown, ctx: unknown) => Promise<unknown>;
+    };
+
+    // Explicit foreign project → rejected without touching the client.
+    const denied = await tool.execute({ project: "p2" }, {});
+    expect(denied).toMatchObject({ error: expect.stringContaining("scoped") });
+    expect(executeSpy).not.toHaveBeenCalled();
+
+    // Omitted project → clamped in.
+    await tool.execute({}, {});
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ project: "p1" }),
+      expect.anything()
+    );
+    executeSpy.mockRestore();
+  });
+
+  it("collects created suites from raw op results (pre-truncation)", async () => {
+    const bigDescription = "x".repeat(30_000); // would trip the model cap
+    const executeSpy = vi
+      .spyOn(createEvalSuiteOperation, "execute")
+      .mockResolvedValue({
+        project: { id: "p1" },
+        suite: { id: "ts_1", name: "smoke", description: bigDescription },
+        servers: [],
+      } as never);
+    const created: CreatedResource[] = [];
+    const tools = buildAgentApiToolSet({
+      client: {} as PlatformApiClient,
+      projectId: "p1",
+      created,
+    });
+    const tool = tools[createEvalSuiteOperation.name]! as {
+      execute: (input: unknown, ctx: unknown) => Promise<unknown>;
+    };
+    const result = (await tool.execute(
+      { name: "smoke", servers: ["srv"], model: "m", cases: [] },
+      {}
+    )) as Record<string, unknown>;
+    expect(created).toEqual([
+      {
+        type: "eval_suite",
+        id: "ts_1",
+        name: "smoke",
+        url: expect.stringContaining("/evals/suite/ts_1"),
+      },
+    ]);
+    // The model-facing result may be truncated; the collector must not be.
+    expect(result.truncated).toBe(true);
+    executeSpy.mockRestore();
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
@@ -87,6 +87,7 @@ import {
 import { isMcpjamToolId } from "../../../utils/built-in-tools/mcpjam.js";
 import {
   createEvalSuiteOperation,
+  getEvalRunOperation,
   listProjectServersOperation,
   runEvalSuiteOperation,
   generateEvalCasesOperation,
@@ -234,6 +235,69 @@ describe("POST /api/v1/projects/:projectId/agent", () => {
     expect(prepareOpts.skillsSource).toEqual({ kind: "none" });
   });
 
+  it("selects the docs server when the preflight succeeds", async () => {
+    managerListToolsMock.mockResolvedValue({ tools: [] });
+    const res = await turnRequest(makeApp(), OK_BODY);
+    expect(res.status).toBe(200);
+    const prepareOpts = prepareChatV2Mock.mock.calls[0]![0];
+    expect(prepareOpts.selectedServers).toEqual(["mcpjam-docs"]);
+  });
+
+  it("degrades when the docs preflight hangs (bounded, not stacked on the turn)", async () => {
+    // Never settles — the 5s preflight deadline must fire, not the 30s
+    // docs client timeout. Fake timers make that instant.
+    vi.useFakeTimers();
+    try {
+      managerListToolsMock.mockImplementation(() => new Promise(() => {}));
+      const pending = turnRequest(makeApp(), OK_BODY);
+      await vi.advanceTimersByTimeAsync(6_000);
+      const res = await pending;
+      expect(res.status).toBe(200);
+      const prepareOpts = prepareChatV2Mock.mock.calls[0]![0];
+      expect(prepareOpts.selectedServers).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("enforces the byte cap on multibyte content", async () => {
+    // 5,000 chars × 2 bytes = 10,000 bytes: passes the char cap, must
+    // still fail the byte cap.
+    const res = await turnRequest(makeApp(), {
+      messages: [{ role: "user", content: "é".repeat(5_000) }],
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("surfaces already-created resources on a failed turn", async () => {
+    const executeSpy = vi
+      .spyOn(createEvalSuiteOperation, "execute")
+      .mockResolvedValue({
+        project: { id: "p1" },
+        suite: { id: "ts_9", name: "smoke" },
+        servers: [],
+      } as never);
+    // The engine "runs" the create tool, then dies without a turn trace —
+    // the suite is persisted, so the 500 must still reference it.
+    runUnifiedAssistantTurnMock.mockImplementation(async (opts: any) => {
+      await opts.tools[createEvalSuiteOperation.name].execute(
+        { name: "smoke", servers: ["srv"], model: "m", cases: [] },
+        {}
+      );
+      return okTurnResult({ turnTrace: undefined });
+    });
+    try {
+      const res = await turnRequest(makeApp(), OK_BODY);
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as {
+        details?: { createdResources?: Array<{ id: string }> };
+      };
+      expect(body.details?.createdResources?.[0]?.id).toBe("ts_9");
+    } finally {
+      executeSpy.mockRestore();
+    }
+  });
+
   it("maps engine spend-cap failures to RATE_LIMITED", async () => {
     runUnifiedAssistantTurnMock.mockImplementation(async (opts: any) => {
       opts.onEngineError?.({
@@ -314,6 +378,41 @@ describe("agent tool surface", () => {
       expect.objectContaining({ project: "p1" }),
       expect.anything()
     );
+    executeSpy.mockRestore();
+  });
+
+  it("advertises `project` as optional even when the op requires it", () => {
+    const tools = buildAgentApiToolSet({
+      client: {} as PlatformApiClient,
+      projectId: "p1",
+      created: [],
+    });
+    const schema = (tools[getEvalRunOperation.name] as { inputSchema: any })
+      .inputSchema;
+    // The op's own schema REQUIRES project; the advertised one must not —
+    // the prompt tells the model to omit it and the clamp fills it in.
+    expect(schema.safeParse({ runId: "run_1" }).success).toBe(true);
+  });
+
+  it("strips otherProjects switching metadata from results", async () => {
+    const executeSpy = vi
+      .spyOn(listProjectServersOperation, "execute")
+      .mockResolvedValue({
+        project: { id: "p1", name: "P1" },
+        otherProjects: [{ id: "p2", name: "Secret Project" }],
+        servers: [],
+      } as never);
+    const tools = buildAgentApiToolSet({
+      client: {} as PlatformApiClient,
+      projectId: "p1",
+      created: [],
+    });
+    const tool = tools[listProjectServersOperation.name]! as {
+      execute: (input: unknown, ctx: unknown) => Promise<unknown>;
+    };
+    const result = (await tool.execute({}, {})) as Record<string, unknown>;
+    expect(result.otherProjects).toBeUndefined();
+    expect(result.servers).toEqual([]);
     executeSpy.mockRestore();
   });
 

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
@@ -260,6 +260,44 @@ describe("POST /api/v1/projects/:projectId/agent", () => {
     }
   });
 
+  it("enforces the aggregate history byte budget", async () => {
+    // 20 messages × 7,000 ASCII bytes = 140,000 bytes: every message passes
+    // the per-message caps, the total must still fail the 96 KB budget.
+    const res = await turnRequest(makeApp(), {
+      messages: Array.from({ length: 20 }, () => ({
+        role: "user",
+        content: "x".repeat(7_000),
+      })),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("aborts the turn when the caller disconnects", async () => {
+    let sawAbort = false;
+    runUnifiedAssistantTurnMock.mockImplementation(async (opts: any) => {
+      opts.abortSignal?.addEventListener("abort", () => {
+        sawAbort = true;
+      });
+      requestAbort.abort(); // caller hangs up mid-turn
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return okTurnResult();
+    });
+    const requestAbort = new AbortController();
+    const app = makeApp();
+    const res = await app.request("/api/v1/projects/p1/agent", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer tok",
+      },
+      body: JSON.stringify(OK_BODY),
+      signal: requestAbort.signal,
+    });
+    expect(sawAbort).toBe(true);
+    // The aborted branch responds TIMEOUT; nobody is listening anyway.
+    expect(res.status).toBe(504);
+  });
+
   it("enforces the byte cap on multibyte content", async () => {
     // 5,000 chars × 2 bytes = 10,000 bytes: passes the char cap, must
     // still fail the byte cap.
@@ -356,7 +394,11 @@ describe("agent tool surface", () => {
   it("clamps every operation to the route's project", async () => {
     const executeSpy = vi
       .spyOn(listProjectServersOperation, "execute")
-      .mockResolvedValue({ servers: [] } as never);
+      .mockResolvedValue({
+        project: { id: "p1", name: "P1" },
+        items: [],
+        otherProjects: [],
+      } as never);
     const created: CreatedResource[] = [];
     const tools = buildAgentApiToolSet({
       client: {} as PlatformApiClient,
@@ -400,7 +442,7 @@ describe("agent tool surface", () => {
       .mockResolvedValue({
         project: { id: "p1", name: "P1" },
         otherProjects: [{ id: "p2", name: "Secret Project" }],
-        servers: [],
+        items: [],
       } as never);
     const tools = buildAgentApiToolSet({
       client: {} as PlatformApiClient,
@@ -412,7 +454,7 @@ describe("agent tool surface", () => {
     };
     const result = (await tool.execute({}, {})) as Record<string, unknown>;
     expect(result.otherProjects).toBeUndefined();
-    expect(result.servers).toEqual([]);
+    expect(result.items).toEqual([]);
     executeSpy.mockRestore();
   });
 

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -1,0 +1,538 @@
+/**
+ * POST /api/v1/projects/:projectId/agent — headless agent turn over the
+ * public API.
+ *
+ * An external caller (first consumer: the MCPJam Slack bot) sends a plain
+ * message history; the server runs ONE assistant turn through the shared
+ * engine facade (`runUnifiedAssistantTurn`) with a curated set of platform
+ * operations as tools, and returns the final assistant text plus references
+ * to any resources the turn created. Synchronous JSON — the caller holds
+ * conversation state and resends history each turn.
+ *
+ * Surface decisions (see the Slack-app v1 plan):
+ *  - Tools are READ ops + atomic `create_eval_suite` ONLY. Run/cancel ops
+ *    (spend eval quota) and `generate_eval_cases` (spends org credits) are
+ *    excluded: `approvalMode: "auto-deny"` has no interactive fallback, so
+ *    an unattended turn must never spend on the model's own initiative.
+ *    Runs stay human-gated caller-side (the Slack "Run it" button posts to
+ *    POST /eval-runs directly).
+ *  - Every operation is HARD-CLAMPED to the route's `projectId`. The op
+ *    catalog's `project` selector allows cross-project roaming for other
+ *    surfaces; prompt instructions are not an authorization boundary, so
+ *    this adapter overwrites the input and rejects mismatching explicit
+ *    values. Org isolation stays enforced by Convex via the delegated JWT.
+ *  - The model is pinned server-side (hosted catalog), billed to the
+ *    caller's project through the hosted `/stream` rail.
+ *  - No chat-session persistence: the caller owns the transcript.
+ *  - No tasks seam (the /api/v1 surface refuses task opt-ins by type).
+ *
+ * Auth plumbing: the caller authenticates with a WorkOS API key (`sk_…`),
+ * but BOTH the engine's Convex `/stream` calls and the self-dispatched
+ * platform-op calls need a JWT — so the delegated org-scoped JWT minted by
+ * `getConvexBearerForRequest` is used for both. Routing the ops through the
+ * delegated JWT (not the raw `sk_` key) also keeps the agent's own tool
+ * calls out of the caller's per-key rate bucket.
+ */
+import { randomUUID } from "node:crypto";
+import { Hono } from "hono";
+import { z } from "zod";
+import { tool, type ToolSet } from "ai";
+import { MCPClientManager } from "@mcpjam/sdk";
+import {
+  PlatformApiClient,
+  createEvalSuiteOperation,
+  getEvalRunOperation,
+  getEvalSuiteOperation,
+  listEvalCasesOperation,
+  listEvalSuiteRunsOperation,
+  listEvalSuitesOperation,
+  listProjectServersOperation,
+  listServerToolsOperation,
+  type PlatformOperation,
+} from "@mcpjam/sdk/platform";
+import { MCPJAM_HOSTED_ORIGIN, WEB_STREAM_TIMEOUT_MS } from "../../config.js";
+import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
+import { parseWithSchema } from "../web/errors.js";
+import { getSelfFetch } from "../../utils/self-app.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
+import { resolveTurnRuntime } from "../../utils/resolve-turn-runtime.js";
+import { runUnifiedAssistantTurn } from "../../utils/turn-execution.js";
+import {
+  capForModel,
+  toToolError,
+} from "../../utils/built-in-tools/mcpjam.js";
+import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
+import type { ModelDefinition } from "@/shared/types";
+import { captureServerEvent } from "../../utils/analytics.js";
+import type { RequestLogContext } from "../../utils/log-events.js";
+import { logger } from "../../utils/logger.js";
+import { v1Error, v1Resource } from "./envelope.js";
+
+// ---------------------------------------------------------------------------
+// Tool surface
+// ---------------------------------------------------------------------------
+
+/**
+ * The public-agent op list: reads + atomic suite creation. Deliberately NOT
+ * derived from the in-app `WORKSPACE_OPERATIONS` set (and deliberately not
+ * added to it — `isMcpjamToolId` must keep returning false for
+ * `create_eval_suite`, or the in-app chat gate widens).
+ */
+export const AGENT_API_OPERATIONS: ReadonlyArray<
+  PlatformOperation<any, unknown>
+> = [
+  listProjectServersOperation,
+  listServerToolsOperation,
+  listEvalSuitesOperation,
+  getEvalSuiteOperation,
+  listEvalCasesOperation,
+  listEvalSuiteRunsOperation,
+  getEvalRunOperation,
+  createEvalSuiteOperation,
+];
+
+export type CreatedResource = {
+  type: "eval_suite";
+  id: string;
+  name?: string;
+  url: string;
+};
+
+function suiteUrl(suiteId: string): string {
+  return `${MCPJAM_HOSTED_ORIGIN}/evals/suite/${encodeURIComponent(suiteId)}`;
+}
+
+const PROJECT_SCOPE_ERROR =
+  "This agent surface is scoped to a single project; omit the `project` " +
+  "argument (it is filled in automatically).";
+
+/**
+ * Build the endpoint's ToolSet from the op list: one AI-SDK tool per
+ * operation, with (a) the project input clamped to the route's projectId and
+ * (b) successful create results collected into `created` BEFORE the
+ * model-facing cap can truncate them.
+ */
+export function buildAgentApiToolSet(opts: {
+  client: PlatformApiClient;
+  projectId: string;
+  created: CreatedResource[];
+}): ToolSet {
+  const tools: ToolSet = {};
+  for (const operation of AGENT_API_OPERATIONS) {
+    tools[operation.name] = tool({
+      description: `${operation.description} (Scoped to the current project automatically.)`,
+      inputSchema: operation.inputSchema,
+      execute: async (input: Record<string, unknown>, { abortSignal }) => {
+        if (abortSignal?.aborted) {
+          return { error: `${operation.title} was cancelled.` };
+        }
+        // HARD CLAMP: the route's project always wins. An explicit different
+        // selector is rejected rather than silently rewritten so the model
+        // learns the boundary instead of believing it roamed.
+        const requested =
+          typeof input.project === "string" ? input.project.trim() : "";
+        if (requested && requested !== opts.projectId) {
+          return { error: PROJECT_SCOPE_ERROR };
+        }
+        try {
+          const result = await operation.execute(
+            { ...input, project: opts.projectId },
+            { client: opts.client, signal: abortSignal }
+          );
+          if (operation.name === createEvalSuiteOperation.name) {
+            const suite = (result as { suite?: { id?: string; name?: string } })
+              ?.suite;
+            if (suite?.id) {
+              opts.created.push({
+                type: "eval_suite",
+                id: suite.id,
+                ...(suite.name ? { name: suite.name } : {}),
+                url: suiteUrl(suite.id),
+              });
+            }
+          }
+          return capForModel(result);
+        } catch (error) {
+          if (abortSignal?.aborted) {
+            return { error: `${operation.title} was cancelled.` };
+          }
+          return toToolError(error, `${operation.title} failed.`);
+        }
+      },
+    });
+  }
+  return tools;
+}
+
+// ---------------------------------------------------------------------------
+// Model + prompt (both static per build, on purpose)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pinned hosted model. There is no "hosted default" lookup in the catalog —
+ * this is an explicit product choice, validated against the live catalog per
+ * request so a catalog outage/self-hosted install fails loudly instead of
+ * mis-billing.
+ */
+const AGENT_API_MODEL: ModelDefinition = {
+  id: "anthropic/claude-sonnet-5",
+  name: "Claude Sonnet 5",
+  provider: "anthropic",
+  hosted: true,
+};
+
+/**
+ * Static per build — nothing volatile (no projectId, no timestamp) so the
+ * cacheable prompt prefix survives across a conversation's requests. The
+ * project boundary is enforced by the tool adapter, not the prompt, so the
+ * prompt only needs to SAY it, not carry the id.
+ */
+const AGENT_API_SYSTEM_PROMPT = [
+  "## You are the MCPJam agent",
+  "You help users work with their MCPJam project over an API surface (the first host is the MCPJam Slack app). Your specialty is turning conversations into eval suites: reading what the user wants tested, authoring test cases, and creating runnable suites with `create_eval_suite`.",
+  "",
+  "## Ground rules",
+  "- Every operation is automatically scoped to the caller's current project. Omit the `project` argument.",
+  "- NEVER invent server names or ids. Call `list_project_servers` first and use exactly what it returns. If no server matches what the user described, ask which server they mean — do not guess and do not fabricate placeholders.",
+  "- Before authoring tool-call assertions, check the server's real tool names with `list_server_tools`.",
+  "- Author cases as `steps` arrays; prefer a `prompt` step plus `toolCalledWith`-style assertions on the tools the conversation showed. Set `expectedOutput` when the user stated one.",
+  `- When creating a suite, set the suite \`model\` explicitly to \`${AGENT_API_MODEL.id}\` unless the user asks for a different model.`,
+  "- You CANNOT run suites, and must not claim to. After creating a suite, tell the user it's ready to run and report its id — the surface you're hosted in offers the run action separately.",
+  "- Always report the ids of anything you created.",
+  "- Consult the MCPJam docs tools (when available) for product questions instead of answering from memory.",
+  "- Keep replies concise and concrete. If the request is ambiguous, ask instead of inventing.",
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Request/response contract
+// ---------------------------------------------------------------------------
+
+const MAX_MESSAGES = 50;
+const MAX_MESSAGE_CHARS = 8_000;
+const MAX_STEPS = 12;
+const TURN_WALL_CLOCK_MS = 90_000;
+/** In-process per-org concurrent-turn cap (same shape as evals' run cap). */
+const MAX_CONCURRENT_TURNS_PER_ORG = 4;
+
+const agentTurnSchema = z.object({
+  messages: z
+    .array(
+      z.object({
+        role: z.enum(["user", "assistant"]),
+        content: z.string().min(1).max(MAX_MESSAGE_CHARS),
+      })
+    )
+    .min(1)
+    .max(MAX_MESSAGES),
+});
+
+const activeTurnsByOrg = new Map<string, number>();
+
+function acquireTurnSlot(key: string): boolean {
+  const active = activeTurnsByOrg.get(key) ?? 0;
+  if (active >= MAX_CONCURRENT_TURNS_PER_ORG) return false;
+  activeTurnsByOrg.set(key, active + 1);
+  return true;
+}
+
+function releaseTurnSlot(key: string): void {
+  const active = activeTurnsByOrg.get(key) ?? 0;
+  if (active <= 1) activeTurnsByOrg.delete(key);
+  else activeTurnsByOrg.set(key, active - 1);
+}
+
+// Docs MCP server: read-only product knowledge, same source as the in-app
+// agent. Preflighted below — an outage degrades the turn, never fails it.
+const DOCS_SERVER_ID = "mcpjam-docs";
+const DEFAULT_DOCS_URL = "https://docs.mcpjam.com/mcp";
+
+function extractAssistantText(
+  assistantMessages: Array<{ content: unknown }>
+): string {
+  const parts: string[] = [];
+  for (const message of assistantMessages) {
+    if (typeof message.content === "string") {
+      if (message.content) parts.push(message.content);
+      continue;
+    }
+    if (Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (
+          part &&
+          typeof part === "object" &&
+          (part as { type?: string }).type === "text" &&
+          typeof (part as { text?: unknown }).text === "string"
+        ) {
+          parts.push((part as { text: string }).text);
+        }
+      }
+    }
+  }
+  return parts.join("\n").trim();
+}
+
+const agent = new Hono();
+
+agent.post("/projects/:projectId/agent", async (c) => {
+  const projectId = c.req.param("projectId");
+
+  // Graceful degradation on OSS/self-hosted installs: the hosted engine and
+  // the delegated-token mint both require the backend wiring.
+  if (!process.env.CONVEX_HTTP_URL || !process.env.INSPECTOR_SERVICE_TOKEN) {
+    return v1Error(
+      c,
+      "FEATURE_NOT_SUPPORTED",
+      "The agent endpoint requires a hosted MCPJam deployment."
+    );
+  }
+
+  if (!isHostedCatalogModel(String(AGENT_API_MODEL.id), "anthropic")) {
+    return v1Error(
+      c,
+      "FEATURE_NOT_SUPPORTED",
+      "The agent endpoint's hosted model is unavailable on this deployment."
+    );
+  }
+
+  const body = parseWithSchema(
+    agentTurnSchema,
+    await c.req.json().catch(() => {
+      return {};
+    })
+  );
+
+  const orgKey =
+    c.get("mcpjamOrganizationId") ?? c.get("workosUserId") ?? "anonymous";
+  if (!acquireTurnSlot(orgKey)) {
+    return v1Error(
+      c,
+      "RATE_LIMITED",
+      `Too many concurrent agent turns for this organization (max ${MAX_CONCURRENT_TURNS_PER_ORG}).`
+    );
+  }
+
+  const startedAt = Date.now();
+  let manager: MCPClientManager | undefined;
+  const abortController = new AbortController();
+  const wallClock = setTimeout(
+    () => abortController.abort(),
+    TURN_WALL_CLOCK_MS
+  );
+
+  try {
+    // One delegated org-scoped JWT for both the engine's Convex calls and the
+    // self-dispatched platform-op calls (see module docblock).
+    const convexJwt = await getConvexBearerForRequest(c);
+    const authHeader = `Bearer ${convexJwt}`;
+
+    const selfFetch = getSelfFetch();
+    if (!selfFetch) {
+      return v1Error(
+        c,
+        "INTERNAL_ERROR",
+        "In-process /api/v1 dispatch is not registered."
+      );
+    }
+    const client = new PlatformApiClient({
+      baseUrl: "http://self.mcpjam.internal/api/v1",
+      getAuth: () => convexJwt,
+      fetch: async (input, init) => selfFetch(new Request(input, init)),
+    });
+
+    const created: CreatedResource[] = [];
+    const builtInTools = buildAgentApiToolSet({ client, projectId, created });
+
+    // Docs server with preflight-degrade: `getToolsForAiSdk` (inside
+    // `prepareChatV2`) fails the whole turn when a selected server errors at
+    // connect/list time, so a docs outage must deselect it, not 500 the turn.
+    manager = new MCPClientManager(
+      {
+        [DOCS_SERVER_ID]: {
+          url: process.env.MCPJAM_DOCS_MCP_URL ?? DEFAULT_DOCS_URL,
+          timeout: 30_000,
+        },
+      },
+      {
+        defaultTimeout: WEB_STREAM_TIMEOUT_MS,
+        retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
+      }
+    );
+    const [docsPreflight] = await Promise.allSettled([
+      manager.listTools(DOCS_SERVER_ID),
+    ]);
+    const selectedServers =
+      docsPreflight?.status === "fulfilled" ? [DOCS_SERVER_ID] : [];
+    if (docsPreflight?.status === "rejected") {
+      logger.warn("[v1/agent] docs MCP server unavailable; continuing", {
+        error:
+          docsPreflight.reason instanceof Error
+            ? docsPreflight.reason.message
+            : String(docsPreflight.reason),
+      });
+    }
+
+    const prepared = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers,
+      modelDefinition: AGENT_API_MODEL,
+      systemPrompt: AGENT_API_SYSTEM_PROMPT,
+      builtInTools,
+      skillsSource: { kind: "none" },
+    });
+
+    const chatSessionId = randomUUID();
+    const rt = await resolveTurnRuntime({
+      modelDefinition: AGENT_API_MODEL,
+      projectId,
+      authHeader,
+      sourceType: "direct",
+      chatSessionId,
+      tools: prepared.allTools,
+    });
+    if (rt.runtime.kind !== "hosted") {
+      // Unreachable for a pinned hosted-catalog model; guard so a resolver
+      // change can't silently route this endpoint onto a BYOK rail.
+      return v1Error(
+        c,
+        "INTERNAL_ERROR",
+        "Agent turn resolved to an unexpected runtime."
+      );
+    }
+
+    let lastEngineError:
+      | { message: string; code?: string; httpStatus?: number }
+      | undefined;
+
+    const result = await runUnifiedAssistantTurn({
+      runtime: rt.runtime,
+      streamSink: "none",
+      persistMode: "caller",
+      approvalMode: "auto-deny",
+      messages: body.messages,
+      modelDefinition: AGENT_API_MODEL,
+      systemPrompt: prepared.enhancedSystemPrompt,
+      tools: prepared.allTools,
+      mcpClientManager: manager,
+      authContext: { kind: "user_bearer", token: authHeader },
+      sourceType: "direct",
+      origin: "mcpjam_agent",
+      maxSteps: MAX_STEPS,
+      projectId,
+      chatSessionId,
+      abortSignal: abortController.signal,
+      ...(prepared.progressivePlan
+        ? { progressivePlan: prepared.progressivePlan }
+        : {}),
+      ...(prepared.discoveryState
+        ? { discoveryState: prepared.discoveryState }
+        : {}),
+      onEngineError: (event: {
+        message: string;
+        code?: string;
+        httpStatus?: number;
+      }) => {
+        lastEngineError = event;
+      },
+    });
+
+    if (abortController.signal.aborted) {
+      captureTurnEvent(c, {
+        startedAt,
+        outcome: "timeout",
+        toolCallCount: result.toolCalls.length,
+      });
+      return v1Error(
+        c,
+        "TIMEOUT",
+        `Agent turn exceeded the ${TURN_WALL_CLOCK_MS / 1000}s limit.`
+      );
+    }
+
+    // Hosted-engine failure contract: a missing turnTrace on a non-aborted
+    // turn means the engine failed; the structured cap/quota detail only
+    // arrives via onEngineError in streamSink:"none" mode.
+    if (!result.turnTrace) {
+      const message =
+        lastEngineError?.message ??
+        "Agent turn failed: the engine returned no turn trace.";
+      const rateLimited =
+        lastEngineError?.httpStatus === 429 ||
+        rt.classifyFailure(message) === "rate_limited";
+      captureTurnEvent(c, {
+        startedAt,
+        outcome: rateLimited ? "rate_limited" : "failed",
+        toolCallCount: result.toolCalls.length,
+      });
+      return v1Error(
+        c,
+        rateLimited ? "RATE_LIMITED" : "INTERNAL_ERROR",
+        message
+      );
+    }
+
+    const reply = extractAssistantText(result.assistantMessages);
+    captureTurnEvent(c, {
+      startedAt,
+      outcome: "ok",
+      toolCallCount: result.toolCalls.length,
+      opNames: result.toolCalls.map((call) => call.toolName),
+      createdCount: created.length,
+    });
+
+    return v1Resource(c, {
+      reply,
+      toolCalls: result.toolCalls.map((call) => ({
+        operation: call.toolName,
+      })),
+      createdResources: created,
+      usage: {
+        inputTokens: result.usage?.inputTokens ?? 0,
+        outputTokens: result.usage?.outputTokens ?? 0,
+      },
+    });
+  } finally {
+    clearTimeout(wallClock);
+    releaseTurnSlot(orgKey);
+    if (manager) {
+      void manager.disconnectAllServers().catch(() => undefined);
+    }
+  }
+});
+
+/**
+ * Server-authoritative telemetry (`agent_turn_completed` is client-only —
+ * this surface has no client). Names, booleans, counts, durations ONLY:
+ * tool args/outputs here are customer conversation content.
+ */
+function captureTurnEvent(
+  c: Parameters<typeof captureServerEvent>[0],
+  data: {
+    startedAt: number;
+    outcome: "ok" | "failed" | "rate_limited" | "timeout";
+    toolCallCount: number;
+    opNames?: string[];
+    createdCount?: number;
+  }
+): void {
+  // API-key callers never pass the Convex authorize exchange that normally
+  // fills `userExternalId`; the WorkOS user id from bearer auth IS the
+  // actorKey the analytics identity contract requires.
+  const ctx = c.var.requestLogContext as RequestLogContext | undefined;
+  const workosUserId = c.get("workosUserId");
+  if (ctx && !ctx.userExternalId && workosUserId) {
+    c.set("requestLogContext", { ...ctx, userExternalId: workosUserId });
+  }
+  captureServerEvent(c, "api_agent_turn_completed", {
+    surface: "api",
+    outcome: data.outcome,
+    duration_ms: Date.now() - data.startedAt,
+    tool_call_count: data.toolCallCount,
+    ...(data.opNames ? { op_names: data.opNames } : {}),
+    ...(data.createdCount !== undefined
+      ? { created_count: data.createdCount }
+      : {}),
+  });
+}
+
+export default agent;

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -9,6 +9,14 @@
  * to any resources the turn created. Synchronous JSON — the caller holds
  * conversation state and resends history each turn.
  *
+ * RETRY CONTRACT (v1): the operation is NOT idempotent and there is no
+ * idempotency key yet — a turn can persist suites even when the response
+ * is lost mid-flight. Callers must dedupe on their own trigger identity
+ * (the Slack app dedupes on channel+event ts) and never blind-retry;
+ * error responses carry `details.createdResources` for the partial-state
+ * case. Durable idempotency (a key honored through the mutation path)
+ * is the prerequisite for opening this beyond dogfood.
+ *
  * Surface decisions (see the Slack-app v1 plan):
  *  - Tools are READ ops + atomic `create_eval_suite` ONLY. Run/cancel ops
  *    (spend eval quota) and `generate_eval_cases` (spends org credits) are
@@ -224,6 +232,14 @@ const AGENT_API_MODEL: ModelDefinition = {
 };
 
 /**
+ * Default model for AUTHORED SUITES — deliberately not the agent's own
+ * model. Suites run every case × iteration on a schedule, so the default
+ * is the cheap eval workhorse (same one the public-API docs examples
+ * use); the user can always name a bigger model.
+ */
+const DEFAULT_SUITE_MODEL = "anthropic/claude-haiku-4.5";
+
+/**
  * Static per build — nothing volatile (no projectId, no timestamp) so the
  * cacheable prompt prefix survives across a conversation's requests. The
  * project boundary is enforced by the tool adapter, not the prompt, so the
@@ -238,7 +254,7 @@ const AGENT_API_SYSTEM_PROMPT = [
   "- NEVER invent server names or ids. Call `list_project_servers` first and use exactly what it returns. If no server matches what the user described, ask which server they mean — do not guess and do not fabricate placeholders.",
   "- Before authoring tool-call assertions, check the server's real tool names with `list_server_tools`.",
   "- Author cases as `steps` arrays; prefer a `prompt` step plus `toolCalledWith`-style assertions on the tools the conversation showed. Set `expectedOutput` when the user stated one.",
-  `- When creating a suite, set the suite \`model\` explicitly to \`${AGENT_API_MODEL.id}\` unless the user asks for a different model.`,
+  `- When creating a suite, set the suite \`model\` explicitly to \`${DEFAULT_SUITE_MODEL}\` unless the user asks for a different model.`,
   "- You CANNOT run suites, and must not claim to. After creating a suite, tell the user it's ready to run and report its id — the surface you're hosted in offers the run action separately.",
   "- Always report the ids of anything you created.",
   "- Consult the MCPJam docs tools (when available) for product questions instead of answering from memory.",
@@ -252,6 +268,12 @@ const AGENT_API_SYSTEM_PROMPT = [
 const MAX_MESSAGES = 50;
 const MAX_MESSAGE_CHARS = 8_000;
 const MAX_MESSAGE_BYTES = 8_192;
+/**
+ * Aggregate history budget: the per-message caps alone would admit
+ * ~400 KB (50 × 8 KB) per request; the whole history must fit a far
+ * smaller envelope since every byte is resent each turn and billed.
+ */
+const MAX_TOTAL_MESSAGE_BYTES = 98_304; // 96 KB
 const MAX_STEPS = 12;
 const TURN_WALL_CLOCK_MS = 90_000;
 /** In-process per-org concurrent-turn cap (same shape as evals' run cap). */
@@ -275,7 +297,17 @@ const agentTurnSchema = z.object({
       })
     )
     .min(1)
-    .max(MAX_MESSAGES),
+    .max(MAX_MESSAGES)
+    .refine(
+      (messages) =>
+        messages.reduce(
+          (total, message) => total + Buffer.byteLength(message.content, "utf8"),
+          0
+        ) <= MAX_TOTAL_MESSAGE_BYTES,
+      {
+        message: `Message history exceeds ${MAX_TOTAL_MESSAGE_BYTES} total bytes`,
+      }
+    ),
 });
 
 const activeTurnsByOrg = new Map<string, number>();
@@ -378,6 +410,15 @@ agent.post("/projects/:projectId/agent", async (c) => {
     () => abortController.abort(),
     TURN_WALL_CLOCK_MS
   );
+  // Caller disconnects (Slack gave up, network drop) must also stop the
+  // turn — an abandoned request should not keep consuming model capacity.
+  const requestSignal = c.req.raw.signal;
+  const onRequestAbort = () => abortController.abort();
+  if (requestSignal.aborted) {
+    abortController.abort();
+  } else {
+    requestSignal.addEventListener("abort", onRequestAbort, { once: true });
+  }
 
   try {
     // One delegated org-scoped JWT for both the engine's Convex calls and the
@@ -421,6 +462,10 @@ agent.post("/projects/:projectId/agent", async (c) => {
     // client's own 30 s connect timeout would otherwise stack ON TOP of
     // the 90 s budget. Race it against a short deadline + the turn signal;
     // any non-success degrades (no docs), never delays or fails the turn.
+    // The losing timer is disarmed once the race settles so a successful
+    // preflight can't later emit a false timeout warning.
+    let preflightDeadline: NodeJS.Timeout | undefined;
+    let onPreflightAbort: (() => void) | undefined;
     const docsAvailable = await Promise.race([
       manager.listTools(DOCS_SERVER_ID).then(
         () => true,
@@ -432,20 +477,21 @@ agent.post("/projects/:projectId/agent", async (c) => {
         }
       ),
       new Promise<boolean>((resolve) => {
-        const deadline = setTimeout(() => {
+        preflightDeadline = setTimeout(() => {
           logger.warn("[v1/agent] docs MCP preflight timed out; continuing");
           resolve(false);
         }, DOCS_PREFLIGHT_TIMEOUT_MS);
-        abortController.signal.addEventListener(
-          "abort",
-          () => {
-            clearTimeout(deadline);
-            resolve(false);
-          },
-          { once: true }
-        );
+        onPreflightAbort = () => resolve(false);
+        abortController.signal.addEventListener("abort", onPreflightAbort, {
+          once: true,
+        });
       }),
-    ]);
+    ]).finally(() => {
+      if (preflightDeadline !== undefined) clearTimeout(preflightDeadline);
+      if (onPreflightAbort) {
+        abortController.signal.removeEventListener("abort", onPreflightAbort);
+      }
+    });
     const selectedServers = docsAvailable ? [DOCS_SERVER_ID] : [];
 
     const prepared = await prepareChatV2({
@@ -577,13 +623,22 @@ agent.post("/projects/:projectId/agent", async (c) => {
     });
   } finally {
     clearTimeout(wallClock);
+    requestSignal.removeEventListener("abort", onRequestAbort);
     releaseTurnSlot(orgKey);
-    // Cleanup must never clobber the response — guard against a SYNC throw
-    // too (a bare call would escape the finally and discard a computed 200).
+    // Cleanup must never clobber or delay the response — guard against a
+    // SYNC throw too (a bare call would escape the finally and discard a
+    // computed 200). Detached rather than awaited, but observably so: a
+    // failed teardown is logged, never swallowed silently.
     try {
-      void manager?.disconnectAllServers().catch(() => undefined);
-    } catch {
-      // best-effort teardown
+      void manager?.disconnectAllServers().catch((error) => {
+        logger.warn("[v1/agent] MCP manager teardown failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    } catch (error) {
+      logger.warn("[v1/agent] MCP manager teardown threw synchronously", {
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
   }
 });

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -108,6 +108,45 @@ const PROJECT_SCOPE_ERROR =
   "argument (it is filled in automatically).";
 
 /**
+ * Some catalog ops (e.g. `get_eval_run`) REQUIRE `project` in their input
+ * schema — which would tell the model the field is mandatory while the
+ * system prompt says to omit it (the clamp fills it in). Advertise the
+ * field as optional instead, without touching the op's own schema.
+ * @param schema the operation's zod input schema
+ */
+function relaxProjectRequirement(schema: unknown): unknown {
+  const asObject = schema as z.ZodObject<z.ZodRawShape> | undefined;
+  if (!asObject?.shape?.project || typeof asObject.extend !== "function") {
+    return schema;
+  }
+  return asObject.extend({
+    project: z
+      .string()
+      .trim()
+      .optional()
+      .describe("Omit — automatically scoped to the current project."),
+  });
+}
+
+/**
+ * Project-scope hygiene: several listing ops return `otherProjects`
+ * (switching metadata for roaming surfaces). This surface is clamped to
+ * one project, so that list would disclose the org's other projects to
+ * the model and the caller — strip it.
+ * @param result a platform-op result
+ */
+function stripProjectSwitchingMetadata(result: unknown): unknown {
+  if (result && typeof result === "object" && "otherProjects" in result) {
+    const { otherProjects: _dropped, ...rest } = result as Record<
+      string,
+      unknown
+    >;
+    return rest;
+  }
+  return result;
+}
+
+/**
  * Build the endpoint's ToolSet from the op list: one AI-SDK tool per
  * operation, with (a) the project input clamped to the route's projectId and
  * (b) successful create results collected into `created` BEFORE the
@@ -122,7 +161,9 @@ export function buildAgentApiToolSet(opts: {
   for (const operation of AGENT_API_OPERATIONS) {
     tools[operation.name] = tool({
       description: `${operation.description} (Scoped to the current project automatically.)`,
-      inputSchema: operation.inputSchema,
+      inputSchema: relaxProjectRequirement(
+        operation.inputSchema
+      ) as typeof operation.inputSchema,
       execute: async (input: Record<string, unknown>, { abortSignal }) => {
         if (abortSignal?.aborted) {
           return { error: `${operation.title} was cancelled.` };
@@ -152,7 +193,7 @@ export function buildAgentApiToolSet(opts: {
               });
             }
           }
-          return capForModel(result);
+          return capForModel(stripProjectSwitchingMetadata(result));
         } catch (error) {
           if (abortSignal?.aborted) {
             return { error: `${operation.title} was cancelled.` };
@@ -210,6 +251,7 @@ const AGENT_API_SYSTEM_PROMPT = [
 
 const MAX_MESSAGES = 50;
 const MAX_MESSAGE_CHARS = 8_000;
+const MAX_MESSAGE_BYTES = 8_192;
 const MAX_STEPS = 12;
 const TURN_WALL_CLOCK_MS = 90_000;
 /** In-process per-org concurrent-turn cap (same shape as evals' run cap). */
@@ -220,7 +262,16 @@ const agentTurnSchema = z.object({
     .array(
       z.object({
         role: z.enum(["user", "assistant"]),
-        content: z.string().min(1).max(MAX_MESSAGE_CHARS),
+        content: z
+          .string()
+          .min(1)
+          .max(MAX_MESSAGE_CHARS)
+          // The quota is a spend cap, so enforce BYTES too — a char-only
+          // limit is 4x bypassable with multibyte text.
+          .refine(
+            (value) => Buffer.byteLength(value, "utf8") <= MAX_MESSAGE_BYTES,
+            { message: `Message exceeds ${MAX_MESSAGE_BYTES} bytes` }
+          ),
       })
     )
     .min(1)
@@ -246,6 +297,8 @@ function releaseTurnSlot(key: string): void {
 // agent. Preflighted below — an outage degrades the turn, never fails it.
 const DOCS_SERVER_ID = "mcpjam-docs";
 const DEFAULT_DOCS_URL = "https://docs.mcpjam.com/mcp";
+/** Docs are a nice-to-have — never let their preflight eat the turn budget. */
+const DOCS_PREFLIGHT_TIMEOUT_MS = 5_000;
 
 function extractAssistantText(
   assistantMessages: Array<{ content: unknown }>
@@ -302,8 +355,14 @@ agent.post("/projects/:projectId/agent", async (c) => {
     })
   );
 
+  // sk_ callers get their org id from bearer auth; JWT callers reach this
+  // route with neither var set (their bearer is validated at Convex), so
+  // fall back to a PROJECT-scoped bucket — a shared global bucket would let
+  // one tenant exhaust the endpoint for everyone.
   const orgKey =
-    c.get("mcpjamOrganizationId") ?? c.get("workosUserId") ?? "anonymous";
+    c.get("mcpjamOrganizationId") ??
+    c.get("workosUserId") ??
+    `project:${projectId}`;
   if (!acquireTurnSlot(orgKey)) {
     return v1Error(
       c,
@@ -358,19 +417,36 @@ agent.post("/projects/:projectId/agent", async (c) => {
         retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
       }
     );
-    const [docsPreflight] = await Promise.allSettled([
-      manager.listTools(DOCS_SERVER_ID),
+    // The preflight must stay inside the turn's wall clock: the docs
+    // client's own 30 s connect timeout would otherwise stack ON TOP of
+    // the 90 s budget. Race it against a short deadline + the turn signal;
+    // any non-success degrades (no docs), never delays or fails the turn.
+    const docsAvailable = await Promise.race([
+      manager.listTools(DOCS_SERVER_ID).then(
+        () => true,
+        (reason) => {
+          logger.warn("[v1/agent] docs MCP server unavailable; continuing", {
+            error: reason instanceof Error ? reason.message : String(reason),
+          });
+          return false;
+        }
+      ),
+      new Promise<boolean>((resolve) => {
+        const deadline = setTimeout(() => {
+          logger.warn("[v1/agent] docs MCP preflight timed out; continuing");
+          resolve(false);
+        }, DOCS_PREFLIGHT_TIMEOUT_MS);
+        abortController.signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(deadline);
+            resolve(false);
+          },
+          { once: true }
+        );
+      }),
     ]);
-    const selectedServers =
-      docsPreflight?.status === "fulfilled" ? [DOCS_SERVER_ID] : [];
-    if (docsPreflight?.status === "rejected") {
-      logger.warn("[v1/agent] docs MCP server unavailable; continuing", {
-        error:
-          docsPreflight.reason instanceof Error
-            ? docsPreflight.reason.message
-            : String(docsPreflight.reason),
-      });
-    }
+    const selectedServers = docsAvailable ? [DOCS_SERVER_ID] : [];
 
     const prepared = await prepareChatV2({
       mcpClientManager: manager,
@@ -436,6 +512,12 @@ agent.post("/projects/:projectId/agent", async (c) => {
       },
     });
 
+    // A failed/timed-out turn may still have PERSISTED suites (the create
+    // op completed before the failure). Surface them in the error details
+    // so a retrying caller doesn't double-create.
+    const errorDetails = () =>
+      created.length > 0 ? { createdResources: created } : undefined;
+
     if (abortController.signal.aborted) {
       captureTurnEvent(c, {
         startedAt,
@@ -445,7 +527,8 @@ agent.post("/projects/:projectId/agent", async (c) => {
       return v1Error(
         c,
         "TIMEOUT",
-        `Agent turn exceeded the ${TURN_WALL_CLOCK_MS / 1000}s limit.`
+        `Agent turn exceeded the ${TURN_WALL_CLOCK_MS / 1000}s limit.`,
+        errorDetails()
       );
     }
 
@@ -467,7 +550,8 @@ agent.post("/projects/:projectId/agent", async (c) => {
       return v1Error(
         c,
         rateLimited ? "RATE_LIMITED" : "INTERNAL_ERROR",
-        message
+        message,
+        errorDetails()
       );
     }
 
@@ -494,8 +578,12 @@ agent.post("/projects/:projectId/agent", async (c) => {
   } finally {
     clearTimeout(wallClock);
     releaseTurnSlot(orgKey);
-    if (manager) {
-      void manager.disconnectAllServers().catch(() => undefined);
+    // Cleanup must never clobber the response — guard against a SYNC throw
+    // too (a bare call would escape the finally and discard a computed 200).
+    try {
+      void manager?.disconnectAllServers().catch(() => undefined);
+    } catch {
+      // best-effort teardown
     }
   }
 });

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -24,6 +24,7 @@ import harness from "./harness.js";
 import environments from "./environments.js";
 import sandboxImages from "./images.js";
 import evalIngest from "./eval-ingest.js";
+import agent from "./agent.js";
 import oauth from "./oauth.js";
 import catalog from "./catalog.js";
 import hostCatalog from "./host-catalog.js";
@@ -154,6 +155,9 @@ v1.route("/", environments);
 // project-scoped caller.
 v1.route("/", sandboxImages);
 v1.route("/", evalIngest);
+// Headless agent turn (Slack bot terminal). Guest-DENIED by default (no
+// GUEST_ALLOWED_V1_RULES entry) — every turn spends hosted-model credits.
+v1.route("/", agent);
 v1.route("/", oauth);
 v1.route("/", catalog);
 v1.route("/", tunnels);

--- a/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
@@ -143,7 +143,7 @@ const MODEL_OUTPUT_CAP = 24_000;
  * JSON preview the model can still read names out of (same philosophy as
  * bash's stdout cap — never fail the turn over size).
  */
-function capForModel(value: unknown): unknown {
+export function capForModel(value: unknown): unknown {
   let json: string;
   try {
     json = JSON.stringify(value) ?? "null";
@@ -160,7 +160,7 @@ function capForModel(value: unknown): unknown {
 }
 
 /** Map a thrown error to the `{ error }` envelope, preferring its message. */
-function toToolError(error: unknown, fallback: string): { error: string } {
+export function toToolError(error: unknown, fallback: string): { error: string } {
   const message =
     error instanceof Error && error.message.trim() ? error.message : "";
   return { error: message || fallback };

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -37,6 +37,9 @@ export const ANALYTICS_EVENTS = {
   eval_suite_run_started: { source: "client" },
   eval_suite_run_started_server: { source: "server" },
 
+  // --- Public API agent surface (server-authoritative; no client twin) ---
+  api_agent_turn_completed: { source: "server" },
+
   // --- Skills (exemplar migrated area) ---
   skill_deleted: { source: "client" },
   skill_promoted: { source: "client" },


### PR DESCRIPTION
## What

A new public-API terminal for the shared agent engine: `POST /api/v1/projects/:projectId/agent` runs ONE assistant turn over a caller-supplied message history and returns the reply, invoked operations, created-resource references (with app deep links), and token usage. First consumer: the MCPJam Slack app (separate repo/PR) — Slack collects the thread, calls this endpoint, posts the reply.

## Design decisions (from the reviewed plan)

- **One engine, another terminal**: composes `prepareChatV2` → `resolveTurnRuntime` → `runUnifiedAssistantTurn` (`streamSink: "none"`, `persistMode: "caller"`, `approvalMode: "auto-deny"`), modeled on `drainAssistantTurn`. No forked engine logic.
- **Spend ops excluded**: the tool surface is platform-op reads + atomic `create_eval_suite`. `run_*`/`cancel_*`/`generate_eval_cases` are deliberately absent — auto-deny has no interactive fallback, so an unattended turn must not spend eval quota/credits. Runs stay an explicit caller action (`POST /eval-runs`).
- **Hard project clamp**: every op input is clamped to the route's `projectId`; an explicit foreign selector is rejected. The in-app `WORKSPACE_OPERATIONS` gate (`isMcpjamToolId`) is untouched — asserted by test.
- **Auth**: the delegated org-scoped Convex JWT (`getConvexBearerForRequest`) backs both the engine's `/stream` calls (JWT-only) and the self-dispatched platform-op calls (keeps agent tool calls out of the caller's per-key `sk_` rate bucket). Billing rides the path `projectId` on the hosted rail.
- **Static system prompt** (cacheable prefix), pinned hosted model (`anthropic/claude-sonnet-5`), docs MCP server with preflight-degrade, `skillsSource: none`, no tasks seam, no chat persistence.
- **Caps**: 4 concurrent turns/org → 429; 12 steps; 90 s wall clock → 504; 50 messages × 8 KB input limits. Engine cap/quota errors map to `RATE_LIMITED`; missing turnTrace → `INTERNAL_ERROR`; missing backend wiring (OSS installs) → `FEATURE_NOT_SUPPORTED`.
- `createdResources` are collected via an execution wrapper **before** the 24 KB model-facing cap can truncate ids.
- New server-authoritative telemetry event `api_agent_turn_completed` (names/counts/durations only — never args/outputs).

## Security notes

- Guest-denied by default (no `GUEST_ALLOWED_V1_RULES` entry).
- Project authorization enforced by Convex through the delegated token (no gateway membership scan); org isolation unchanged.
- The clamp means prompt injection in a Slack thread cannot roam the model to another project; worst case within-project is authoring (free) — never running — evals.

## Tests

13 new tests (`agent.test.ts`): auth/guest gating, schema limits, deployment guard, delegated-JWT plumbing, docs-degrade, spend-cap → 429 mapping, concurrency cap, project clamp, pre-truncation collector, op-list/gate assertions. Full v1 suite + built-in tools: 247 passed. `openapi-drift` green (new `Agent` tag + schemas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> New public surface spends hosted model credits, can create eval suites on non-idempotent turns, and relies on project clamping plus delegated JWT for authorization—mistakes in tool scope or retry guidance could cause duplicate resources or cross-tenant issues.
> 
> **Overview**
> Adds **`POST /api/v1/projects/:projectId/agent`**, a synchronous public API for one headless assistant turn over caller-owned `messages`, wired through the existing `prepareChatV2` → `resolveTurnRuntime` → `runUnifiedAssistantTurn` path (`streamSink: "none"`, `persistMode: "caller"`, `approvalMode: "auto-deny"`).
> 
> The route exposes a **curated platform-op tool set** (reads plus `create_eval_suite` only—no run/cancel/generate), **hard-clamps** every op to the path `projectId`, strips cross-project metadata, and returns `reply`, `toolCalls`, `createdResources` (with deep links), and `usage`. Auth uses a **delegated Convex JWT** for the engine and in-process v1 op calls; guests are denied; hosted-only with caps (4 concurrent turns/org, ~90s, message byte limits) and partial-state `details.createdResources` on failures.
> 
> Also documents the **Agent** tag in OpenAPI/`public-api.mdx`, exports `capForModel`/`toToolError` for reuse, adds `api_agent_turn_completed` analytics, and ships **`agent.test.ts`** coverage for gating, limits, concurrency, and the tool adapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d1ff5dff0137d0f259bb28fe59f7f202f9ce951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new headless agent endpoint `POST /api/v1/projects/:projectId/agent` that runs one assistant turn on a pinned hosted model and returns the reply, invoked operations, created-resource links, and token usage. First consumer is the MCPJam Slack app; preflight, limits, and retry guidance were tightened.

- **New Features**
  - One-turn agent over caller-supplied `messages`. Responds with `reply`, `toolCalls`, `createdResources`, and `usage`. Not idempotent — dedupe on trigger identity and check `details.createdResources` before retrying.
  - Tool surface: read-only platform ops plus `create_eval_suite`. Run/cancel and generation ops are excluded; `approvalMode: "auto-deny"`.
  - Project clamp: all op inputs are forced to the route `projectId`; foreign selectors are rejected. Tool schemas advertise `project` as optional; `otherProjects` metadata is stripped from results.
  - Auth: uses a delegated org-scoped Convex JWT for both engine and platform-op calls. Billing is per path `projectId`.
  - Model and prompt: pinned hosted model `anthropic/claude-sonnet-5`, static system prompt, docs MCP server with a 5s preflight raced against the turn’s abort signal (bounded, timer disarmed on settle). Authored suites default to `anthropic/claude-haiku-4.5`.
  - Limits and errors: 4 concurrent turns/org → 429 (JWT callers fall back to a project-scoped bucket), 12 steps, ~90s wall clock → 504. Input caps: 50 messages × 8 KB, 8192 bytes per message, and 96 KB total history. Engine cap/quota map to `RATE_LIMITED`; missing `turnTrace` → `INTERNAL_ERROR`; missing hosted wiring → `FEATURE_NOT_SUPPORTED`. Caller disconnects abort the turn. Failed/timed-out turns include `details.createdResources`.
  - Pre-truncation collector for `createdResources` (e.g., eval suites with app deep links).
  - New telemetry event `api_agent_turn_completed`. OpenAPI and `public-api.mdx` updated (Agent tag and schemas; documented `500` response; byte/concurrency caps). Tests: 21 cases for route, limits, clamp, preflight, disconnect abort, and created-on-failure behavior.

<sup>Written for commit 9d1ff5dff0137d0f259bb28fe59f7f202f9ce951. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

