### PR TITLE
feat(github-checks): recipe resolver R2 — rung-2 detection + pinned corpus harness

### DIFF
--- a/mcpjam-inspector/scripts/resolver-corpus.manifest.json
+++ b/mcpjam-inspector/scripts/resolver-corpus.manifest.json
@@ -1,0 +1,226 @@
+{
+  "generatedAt": "2026-08-02",
+  "note": "Pinned corpus for scripts/resolver-corpus.ts. Every entry came from `gh api repos/{repo}/commits/HEAD`.",
+  "repos": [
+    {
+      "repo": "ChromeDevTools/chrome-devtools-mcp",
+      "sha": "c5ebf9e2023ec37c77d2ee355a345249ac91d192"
+    },
+    {
+      "repo": "microsoft/playwright-mcp",
+      "sha": "55679f5f3d4b4f3e2534ec0ce2fc5683ba2eaf3f"
+    },
+    {
+      "repo": "github/github-mcp-server",
+      "sha": "3778a41476e31a072430cfee7c5d31c5f72def60"
+    },
+    {
+      "repo": "firecrawl/firecrawl-mcp-server",
+      "sha": "41c257161d6b29a849fb66e097d5e5beccefdf2a"
+    },
+    {
+      "repo": "exa-labs/exa-mcp-server",
+      "sha": "a664592b5dd7c5598b70158c771dcc5c2a4fb2c1"
+    },
+    {
+      "repo": "makenotion/notion-mcp-server",
+      "sha": "1d38420769c8a1fe2d583ff1e7d2d108d4eb0b30"
+    },
+    {
+      "repo": "GLips/Figma-Context-MCP",
+      "sha": "c083d65c7e002923e7cb98f4e3bdafb105e90f6d"
+    },
+    {
+      "repo": "modelcontextprotocol/servers",
+      "sha": "76d64c822f5125032f89eb71dbdb94e42b434821"
+    },
+    {
+      "repo": "PostHog/mcp",
+      "sha": "13aaf2c6e5317e01e61d3af24e7b0744f527ed3e"
+    },
+    {
+      "repo": "cloudflare/mcp-server-cloudflare",
+      "sha": "70ff690553722f731849ede6ba9ce98958395a23"
+    },
+    {
+      "repo": "browserbase/mcp-server-browserbase",
+      "sha": "3e6f53461949037d5e65dd425da3ceb1263f11d6"
+    },
+    {
+      "repo": "apify/apify-mcp-server",
+      "sha": "1e5fd7c84a777ad271a4d7296ebce6458e17ee92"
+    },
+    {
+      "repo": "Flux159/mcp-server-kubernetes",
+      "sha": "f35b6c4db7ba0788edc111ca3c44111fcbf44413"
+    },
+    {
+      "repo": "Softeria/ms-365-mcp-server",
+      "sha": "66ca5177b9c7e484cc357042fd64a0ac08d5f800"
+    },
+    {
+      "repo": "bitwarden/mcp-server",
+      "sha": "70a23d3c90e1a19fa6884ff00ef33a908e99d823"
+    },
+    {
+      "repo": "arabold/docs-mcp-server",
+      "sha": "dfb49478f8853c2807885cba5aa957496048c9ff"
+    },
+    {
+      "repo": "antvis/mcp-server-chart",
+      "sha": "33178096abfa58f245b456f5bacb18bc37f5cbaf"
+    },
+    {
+      "repo": "Jpisnice/shadcn-ui-mcp-server",
+      "sha": "45d615f0950b49e7618b129fab8d637ebf44f3da"
+    },
+    {
+      "repo": "elastic/mcp-server-elasticsearch",
+      "sha": "9e64b842f22269eb214793e1a4885128dc4a8fd8"
+    },
+    {
+      "repo": "brave/brave-search-mcp-server",
+      "sha": "930f6b3af474108b9da91912e79a75395e24f1b8"
+    },
+    {
+      "repo": "sooperset/mcp-atlassian",
+      "sha": "ec543512fe6ac1b09dd77f6f5b36f0a3ae24366a"
+    },
+    {
+      "repo": "haris-musa/excel-mcp-server",
+      "sha": "f51340ecd5778952405044b203d3a2d4c8a46833"
+    },
+    {
+      "repo": "blazickjp/arxiv-mcp-server",
+      "sha": "8f79e8853c1104630a647889abb430fab539130e"
+    },
+    {
+      "repo": "designcomputer/mysql_mcp_server",
+      "sha": "d88c510f603413d1abad9c5cce2bd542d705e27c"
+    },
+    {
+      "repo": "datalayer/jupyter-mcp-server",
+      "sha": "eb90952dcad732a497cff92ce92672a19cf38ae3"
+    },
+    {
+      "repo": "alpacahq/alpaca-mcp-server",
+      "sha": "65848422bb996f5b74a12d3b5869c015295fd181"
+    },
+    {
+      "repo": "financial-datasets/mcp-server",
+      "sha": "08e7a3dbb949d3d99bbd6d6f3a22e5f02973ec58"
+    },
+    {
+      "repo": "GongRzhe/Office-Word-MCP-Server",
+      "sha": "a3bbbb6d6167e68cf855d73ef7dc6cd8cfbfedba"
+    },
+    {
+      "repo": "GongRzhe/Office-PowerPoint-MCP-Server",
+      "sha": "3631ba2ec0c24504476f78bf74d329c9be11caaa"
+    },
+    {
+      "repo": "ahujasid/blender-mcp",
+      "sha": "e3ece087adecce4242d4dc3e4db28c33010b51c4"
+    },
+    {
+      "repo": "awslabs/mcp",
+      "sha": "5175229f22823f3a5e220acc07d2ee0d06bde14f"
+    },
+    {
+      "repo": "Snowflake-Labs/mcp",
+      "sha": "662cb486395d79ab1ad0b3538f933fe6a686ce7c"
+    },
+    {
+      "repo": "MariaDB/mcp",
+      "sha": "3c533f636c1a0c7459992256cde2f3ee70362bc2"
+    },
+    {
+      "repo": "keboola/mcp-server",
+      "sha": "5260b35d7c307ee3caa318b378426b542e7cbd85"
+    },
+    {
+      "repo": "QuantConnect/mcp-server",
+      "sha": "1f0fa4e4f465bae4cffb2d69eb4701ad1ddff20c"
+    },
+    {
+      "repo": "hashicorp/terraform-mcp-server",
+      "sha": "f4c77fac8a0ee767eab3bd6dff2c5628f3d578cf"
+    },
+    {
+      "repo": "containers/kubernetes-mcp-server",
+      "sha": "af2fe585c2807ea3e3179ccef3d9d820565b803d"
+    },
+    {
+      "repo": "korotovsky/slack-mcp-server",
+      "sha": "b88c0de3f706f4f07337c9eda7133c736d1c9524"
+    },
+    {
+      "repo": "grafana/mcp-grafana",
+      "sha": "14fc39f83b620fe2732e1804fd344b562f8b43ef"
+    },
+    {
+      "repo": "stickerdaniel/linkedin-mcp-server",
+      "sha": "57a0e92b9a9625cb1cc0ce63dafbd786e3dd07b1"
+    },
+    {
+      "repo": "lharries/whatsapp-mcp",
+      "sha": "7d6a06dcdce1f01dfb24f60e1030d5efba9f3b88"
+    },
+    {
+      "repo": "zcaceres/markdownify-mcp",
+      "sha": "024f97cea9a94cd842c445eea4503c442c79bd71"
+    },
+    {
+      "repo": "benborla/mcp-server-mysql",
+      "sha": "b9c714e182422b9f18437242b80cf003adf1c7ea"
+    },
+    {
+      "repo": "e2b-dev/mcp-server",
+      "sha": "dba87432cacaa7a5af1326d72e37e2d770628a0b"
+    },
+    {
+      "repo": "GongRzhe/Gmail-MCP-Server",
+      "sha": "a890d19189bbc1325b8728fab830fc278cfd8804"
+    },
+    {
+      "repo": "getsentry/XcodeBuildMCP",
+      "sha": "e6ef59b49b44012c824f0a0de261c96142e37390"
+    },
+    {
+      "repo": "LaurieWired/GhidraMCP",
+      "sha": "27f316f80139e2d5dec882519a1bdf4aa46ac04c"
+    },
+    {
+      "repo": "CoplayDev/unity-mcp",
+      "sha": "84dfa7639c88a10f49f46556477dc267fd84feea"
+    },
+    {
+      "repo": "upstash/context7",
+      "sha": "594a73133e14631af8c915a1b4f2c8039c964fe1"
+    },
+    {
+      "repo": "googleapis/mcp-toolbox",
+      "sha": "801d5899665c120200d64bac45172741a785ae5d"
+    },
+    {
+      "repo": "directus/mcp",
+      "sha": "472ce5b8dd3ddda45dba2a494cc024467a601ff4"
+    },
+    {
+      "repo": "gleanwork/mcp-server",
+      "sha": "2cc472396bf642bc377f7546adc7bec7a3bbc090"
+    },
+    {
+      "repo": "UI5/mcp-server",
+      "sha": "b29f3deac107ceb655ab48685787481f533c713b"
+    },
+    {
+      "repo": "browserstack/mcp-server",
+      "sha": "7029c27dc1039cd9e2d0beee5e2aed6dc016f656"
+    },
+    {
+      "repo": "hyperbrowserai/mcp",
+      "sha": "7492e83cf1825b3cf9725bfa25c5086df702599a"
+    }
+  ]
+}

--- a/mcpjam-inspector/scripts/resolver-corpus.ts
+++ b/mcpjam-inspector/scripts/resolver-corpus.ts
@@ -44,9 +44,11 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  listRepoFiles,
   RecipeResolutionError,
   resolveRecipeLadder,
   type DetectionInputs,
+  type OwnershipProof,
   type ResolvedRecipe,
 } from "../server/services/github-checks/resolver";
 
@@ -63,7 +65,19 @@ type Row = {
   sha: string;
   category: Category;
   /** Present for `resolved`. */
-  candidates?: { build: string; start: string; port: number; mcpPath: string }[];
+  candidates?: {
+    build: string;
+    start: string;
+    port: number;
+    mcpPath: string;
+    ownershipProof: OwnershipProof;
+  }[];
+  /**
+   * Present for `resolved`: the BEST candidate's proof. This is the number that
+   * says how much of recall A3's runtime ownership check is carrying — an
+   * 'unverified' row resolved on a plausibility argument, not on evidence.
+   */
+  ownershipProof?: OwnershipProof;
   evidence?: string[];
   /** Present for `detector_miss` / `unsupported_transport`. */
   reasons?: string[];
@@ -114,46 +128,6 @@ function cloneAt(repo: string, sha: string, dir: string): void {
   run(["remote", "add", "origin", `https://github.com/${repo}.git`]);
   run(["fetch", "--quiet", "--depth", "1", "origin", sha]);
   run(["checkout", "--quiet", "FETCH_HEAD"]);
-}
-
-/**
- * Cap on the file listing handed to detection. Detection uses it for exact
- * lookups of a handful of entry paths, so a monorepo with 400k tracked files
- * would cost megabytes of strings to answer four questions. Truncation is SAFE
- * in the suppress direction: a missing listing entry can only cause a candidate
- * to be suppressed, never accepted.
- */
-const MAX_REPO_FILES = 20_000;
-
-/**
- * The checkout's tracked files, for detection's rule C (entry points must be
- * provably checkout code). `git ls-files` rather than a directory walk: the
- * clone is already a git repo, it is one process instead of a recursive stat
- * storm, and it excludes .git/ and anything gitignored for free.
- *
- * A3 populates the same field from the sandbox, where the checkout is likewise
- * on disk; the shape (POSIX-relative paths, no leading `./`) is what
- * `DetectionInputs.repoFiles` documents.
- */
-function listRepoFiles(dir: string): string[] {
-  try {
-    return execFileSync("git", ["ls-files", "-z"], {
-      cwd: dir,
-      stdio: "pipe",
-      timeout: 60_000,
-      maxBuffer: 32 * 1024 * 1024,
-    })
-      .toString("utf8")
-      .split("\0")
-      .filter((path) => path.length > 0)
-      .slice(0, MAX_REPO_FILES);
-  } catch {
-    // No listing is a valid input: detection falls back to its conservative
-    // path (syntactic checks for node, suppression for python). Reporting a
-    // detector_miss caused by our own git failure is the honest outcome — it
-    // biases recall DOWN, which is the safe direction for this number.
-    return [];
-  }
 }
 
 function readInputs(dir: string): DetectionInputs {
@@ -305,7 +279,9 @@ function classify(repo: string, sha: string, dir: string): Row {
         start: c.start,
         port: c.port,
         mcpPath: c.mcpPath,
+        ownershipProof: c.ownershipProof,
       })),
+      ownershipProof: candidates[0].ownershipProof,
       evidence: candidates[0].evidence,
       signals,
     };
@@ -396,6 +372,20 @@ function report(rows: Row[]): void {
   );
   console.log(
     "  (upper bound — no build, no probe; build_miss/probe_miss land in A3's e2e)",
+  );
+
+  // The other number this harness now owes: static analysis cannot establish
+  // that a build OUTPUT is checkout-derived, so those candidates ship marked
+  // 'unverified' and A3's runtime ownership check is what actually settles
+  // them. This split is how much load that check carries.
+  const resolvedRows = rows.filter((r) => r.category === "resolved");
+  const verified = resolvedRows.filter((r) => r.ownershipProof === "verified").length;
+  const unverified = resolvedRows.length - verified;
+  console.log(
+    `\nOWNERSHIP PROOF among resolved: verified ${verified}, unverified ${unverified}` +
+      (resolvedRows.length === 0
+        ? ""
+        : ` (${((unverified / resolvedRows.length) * 100).toFixed(1)}% need A3's runtime check)`),
   );
 
   if (miss > 0) {

--- a/mcpjam-inspector/scripts/resolver-corpus.ts
+++ b/mcpjam-inspector/scripts/resolver-corpus.ts
@@ -1,0 +1,322 @@
+/**
+ * Dev-only corpus harness for the recipe resolver's detection rung (R2).
+ *
+ * NOT IN CI, on purpose: it clones ~55 third-party repos over the network, so
+ * it is a decision instrument an engineer runs by hand, not a gate. Run it:
+ *
+ *   npx tsx scripts/resolver-corpus.ts               # from mcpjam-inspector/
+ *   npx tsx scripts/resolver-corpus.ts --json out.json
+ *   npx tsx scripts/resolver-corpus.ts --limit 10 --keep
+ *
+ * THE QUESTION IT ANSWERS is not "what fraction of MCP repos can we run" —
+ * that number is dominated by stdio-only servers, which detection is not
+ * supposed to fix (a stdio bridge is a separate, out-of-scope feature). It is
+ * RECALL OVER HTTP-CAPABLE REPOS:
+ *
+ *   recall = resolved / (resolved + detector_miss)
+ *
+ * Poor recall means the heuristics are the bottleneck and the agentic rung
+ * (R5) deserves priority. Good recall means the bottleneck is transport, and
+ * R5 would be optimizing the wrong end.
+ *
+ * WHAT IT CANNOT KNOW: it never builds and never probes. `resolved` therefore
+ * means "we produced a candidate that runs the checkout over HTTP", not "that
+ * candidate works". The `build_miss` (candidate built wrong) and `probe_miss`
+ * (built but never spoke MCP) buckets exist in the taxonomy and are reported
+ * as deferred — only A3's sandbox e2e can populate them. Read `resolved` as an
+ * UPPER BOUND on real recall.
+ *
+ * The manifest is pinned by sha (resolver-corpus.manifest.json) so a re-run
+ * after a detector change measures the detector, not GitHub's default branch.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  RecipeResolutionError,
+  resolveRecipeLadder,
+  type DetectionInputs,
+  type ResolvedRecipe,
+} from "../server/services/github-checks/resolver";
+
+type ManifestEntry = { repo: string; sha: string };
+
+type Category =
+  | "resolved"
+  | "unsupported_transport"
+  | "detector_miss"
+  | "infra_error";
+
+type Row = {
+  repo: string;
+  sha: string;
+  category: Category;
+  /** Present for `resolved`. */
+  candidates?: { build: string; start: string; port: number; mcpPath: string }[];
+  evidence?: string[];
+  /** Present for `detector_miss` / `unsupported_transport`. */
+  reasons?: string[];
+  signals: string[];
+};
+
+const MANIFEST = join(import.meta.dirname, "resolver-corpus.manifest.json");
+
+// Mirrors the in-sandbox byte cap R4 will read with (`head -c`): reading a
+// 200MB lockfile into this process would be a self-inflicted outage.
+const READ_CAP_BYTES = 512 * 1024;
+
+function arg(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+const hasFlag = (name: string) => process.argv.includes(`--${name}`);
+
+function readCapped(dir: string, relative: string): string | null {
+  const path = join(dir, relative);
+  if (!existsSync(path)) return null;
+  try {
+    const buffer = readFileSync(path);
+    return buffer.subarray(0, READ_CAP_BYTES).toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Shallow-clone at the pinned sha. `--depth 1` on a bare init + fetch is the
+ * only way to fetch ONE commit by sha: `git clone --depth 1` can only take a
+ * ref, and cloning full history for 55 repos is minutes of pointless IO.
+ */
+function cloneAt(repo: string, sha: string, dir: string): void {
+  const run = (args: string[]) =>
+    execFileSync("git", args, { cwd: dir, stdio: "pipe", timeout: 180_000 });
+  run(["init", "--quiet"]);
+  run(["remote", "add", "origin", `https://github.com/${repo}.git`]);
+  run(["fetch", "--quiet", "--depth", "1", "origin", sha]);
+  run(["checkout", "--quiet", "FETCH_HEAD"]);
+}
+
+function readInputs(dir: string): DetectionInputs {
+  return {
+    packageJson: readCapped(dir, "package.json"),
+    packageLockJson: readCapped(dir, "package-lock.json"),
+    pnpmLockYaml: readCapped(dir, "pnpm-lock.yaml"),
+    yarnLock: readCapped(dir, "yarn.lock"),
+    pyprojectToml: readCapped(dir, "pyproject.toml"),
+    uvLock: readCapped(dir, "uv.lock"),
+    serverJson: readCapped(dir, "server.json"),
+    readme: readCapped(dir, "README.md") ?? readCapped(dir, "readme.md"),
+  };
+}
+
+/**
+ * Does this repo appear to serve MCP over HTTP at all?
+ *
+ * This is the classifier that separates "we failed" from "not our problem", so
+ * it is deliberately GENEROUS toward HTTP: over-counting HTTP repos makes
+ * recall look WORSE than it is, which is the safe direction for a number that
+ * decides whether to invest in R5.
+ *
+ * These are corpus-report signals only — nothing here feeds the detector.
+ */
+function httpSignals(files: DetectionInputs, dir: string): string[] {
+  const signals: string[] = [];
+  const haystack = [
+    files.readme ?? "",
+    files.serverJson ?? "",
+    files.packageJson ?? "",
+    files.pyprojectToml ?? "",
+    // A source scan is worth one grep: many servers document only the stdio
+    // config in the README while shipping an HTTP mode behind a flag.
+    grepSources(dir),
+  ].join("\n");
+
+  if (/streamable[-_ ]?http/i.test(haystack)) signals.push("streamable-http");
+  if (/StreamableHTTPServerTransport|streamable_http_app|http_app\(|SSEServerTransport/.test(haystack)) {
+    signals.push("http-transport-api");
+  }
+  if (/--(port|http|transport[= ]http)/.test(haystack)) signals.push("http-cli-flag");
+  if (/\bexpress\(\)|createServer\(|FastAPI\(|uvicorn|starlette/i.test(haystack)) {
+    signals.push("http-framework");
+  }
+  if (/https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?\/[a-z]/i.test(haystack)) {
+    signals.push("localhost-url");
+  }
+  return signals;
+}
+
+function grepSources(dir: string): string {
+  try {
+    return execFileSync(
+      "grep",
+      [
+        "-rIl",
+        "--include=*.ts",
+        "--include=*.js",
+        "--include=*.py",
+        "--include=*.go",
+        "-e",
+        "StreamableHTTP",
+        "-e",
+        "streamable_http",
+        "-e",
+        "streamable-http",
+        "-e",
+        "SSEServerTransport",
+        ".",
+      ],
+      { cwd: dir, stdio: "pipe", timeout: 60_000, maxBuffer: 4 * 1024 * 1024 },
+    ).toString("utf8");
+  } catch {
+    // grep exits 1 when nothing matched — that is a normal answer, not an error.
+    return "";
+  }
+}
+
+function classify(repo: string, sha: string, dir: string): Row {
+  const files = readInputs(dir);
+  const signals = httpSignals(files, dir);
+
+  let candidates: ResolvedRecipe[] = [];
+  let reasons: string[] = [];
+  try {
+    const resolution = resolveRecipeLadder({
+      repoFullName: repo,
+      // The corpus measures DETECTION. Third-party repos have no mcpjam.yaml
+      // and no operator override, so the ladder always reaches rung 2; passing
+      // null keeps that explicit rather than accidental.
+      mcpjamYaml: null,
+      detection: files,
+    });
+    candidates =
+      resolution.kind === "candidates" ? resolution.candidates : [resolution.recipe];
+  } catch (err) {
+    if (!(err instanceof RecipeResolutionError)) throw err;
+    reasons = (err.detailsMarkdown ?? "")
+      .split("\n")
+      .filter((line) => line.startsWith("- "))
+      .map((line) => line.slice(2));
+  }
+
+  if (candidates.length > 0) {
+    return {
+      repo,
+      sha,
+      category: "resolved",
+      candidates: candidates.map((c) => ({
+        build: c.build,
+        start: c.start,
+        port: c.port,
+        mcpPath: c.mcpPath,
+      })),
+      evidence: candidates[0].evidence,
+      signals,
+    };
+  }
+
+  return {
+    repo,
+    sha,
+    // No candidate AND no sign of an HTTP server: a stdio-only repo is out of
+    // scope by design (the stdio bridge is a separate feature), so counting it
+    // as a detector failure would understate recall and mis-prioritize R5.
+    category: signals.length > 0 ? "detector_miss" : "unsupported_transport",
+    reasons,
+    signals,
+  };
+}
+
+async function main() {
+  const manifest = JSON.parse(readFileSync(MANIFEST, "utf8")) as {
+    repos: ManifestEntry[];
+  };
+  const limit = Number(arg("limit") ?? manifest.repos.length);
+  const entries = manifest.repos.slice(0, limit);
+  const keep = hasFlag("keep");
+
+  const rows: Row[] = [];
+  for (const [index, entry] of entries.entries()) {
+    const label = `[${index + 1}/${entries.length}] ${entry.repo}`;
+    const dir = mkdtempSync(join(tmpdir(), "resolver-corpus-"));
+    try {
+      cloneAt(entry.repo, entry.sha, dir);
+      const row = classify(entry.repo, entry.sha, dir);
+      rows.push(row);
+      console.error(`${label}: ${row.category}`);
+    } catch (err) {
+      // Clone/read trouble is OUR infrastructure failing, never a detector
+      // verdict — the same separation A3 enforces between resolver misses and
+      // sandbox infra errors.
+      rows.push({
+        repo: entry.repo,
+        sha: entry.sha,
+        category: "infra_error",
+        reasons: [err instanceof Error ? err.message.slice(0, 200) : String(err)],
+        signals: [],
+      });
+      console.error(`${label}: infra_error`);
+    } finally {
+      if (!keep) rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  report(rows);
+
+  const out = arg("json");
+  if (out) {
+    writeFileSync(out, `${JSON.stringify({ rows }, null, 2)}\n`);
+    console.log(`\nper-repo detail written to ${out}`);
+  }
+}
+
+function report(rows: Row[]): void {
+  const counts = new Map<Category, number>();
+  for (const row of rows) counts.set(row.category, (counts.get(row.category) ?? 0) + 1);
+
+  const total = rows.length;
+  const order: Category[] = [
+    "resolved",
+    "unsupported_transport",
+    "detector_miss",
+    "infra_error",
+  ];
+  console.log(`\n${"category".padEnd(24)}${"n".padStart(5)}${"share".padStart(9)}`);
+  console.log("-".repeat(38));
+  for (const category of order) {
+    const n = counts.get(category) ?? 0;
+    console.log(
+      `${category.padEnd(24)}${String(n).padStart(5)}${`${((n / total) * 100).toFixed(1)}%`.padStart(9)}`,
+    );
+  }
+  console.log(`${"build_miss (deferred)".padEnd(24)}${"—".padStart(5)}${"—".padStart(9)}`);
+  console.log(`${"probe_miss (deferred)".padEnd(24)}${"—".padStart(5)}${"—".padStart(9)}`);
+  console.log("-".repeat(38));
+  console.log(`${"total".padEnd(24)}${String(total).padStart(5)}`);
+
+  const resolved = counts.get("resolved") ?? 0;
+  const miss = counts.get("detector_miss") ?? 0;
+  const httpCapable = resolved + miss;
+  console.log(
+    `\nRECALL over HTTP-capable repos: ${resolved}/${httpCapable} = ` +
+      (httpCapable === 0 ? "n/a" : `${((resolved / httpCapable) * 100).toFixed(1)}%`),
+  );
+  console.log(
+    "  (upper bound — no build, no probe; build_miss/probe_miss land in A3's e2e)",
+  );
+
+  if (miss > 0) {
+    console.log("\ndetector_miss detail:");
+    for (const row of rows.filter((r) => r.category === "detector_miss")) {
+      console.log(`  ${row.repo}`);
+      for (const reason of row.reasons ?? []) console.log(`    - ${reason}`);
+      if ((row.reasons ?? []).length === 0) console.log("    - no supported ecosystem files");
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcpjam-inspector/scripts/resolver-corpus.ts
+++ b/mcpjam-inspector/scripts/resolver-corpus.ts
@@ -31,7 +31,16 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -76,11 +85,20 @@ const hasFlag = (name: string) => process.argv.includes(`--${name}`);
 function readCapped(dir: string, relative: string): string | null {
   const path = join(dir, relative);
   if (!existsSync(path)) return null;
+  // openSync + readSync into a fixed buffer, NOT readFileSync().subarray():
+  // the latter materializes the whole file first, so a 200MB lockfile would be
+  // fully resident before the cap ever applied — which is the outage this cap
+  // exists to prevent. This is `head -c`, the same thing R4 does in-sandbox.
+  let fd: number | undefined;
   try {
-    const buffer = readFileSync(path);
-    return buffer.subarray(0, READ_CAP_BYTES).toString("utf8");
+    fd = openSync(path, "r");
+    const buffer = Buffer.allocUnsafe(READ_CAP_BYTES);
+    const bytes = readSync(fd, buffer, 0, READ_CAP_BYTES, 0);
+    return buffer.subarray(0, bytes).toString("utf8");
   } catch {
     return null;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
   }
 }
 
@@ -147,12 +165,23 @@ function httpSignals(files: DetectionInputs, dir: string): string[] {
   return signals;
 }
 
+/** Bound on the grep haystack: signal regexes need text, not a whole codebase. */
+const GREP_MAX_BYTES = 1024 * 1024;
+
 function grepSources(dir: string): string {
+  // `-h`, never `-l`: `-l` prints FILE NAMES, and the signal regexes in
+  // httpSignals() would then run over a list of paths, so source-only HTTP
+  // evidence contributed nothing and HTTP-capable repos were misfiled as
+  // `unsupported_transport`. `-h` prints the matching LINES without the
+  // filename prefix, which is what those regexes need — `-o` would trim the
+  // match down to the `-e` token and hide longer forms like
+  // `StreamableHTTPServerTransport`. Output is bounded twice: maxBuffer here,
+  // and GREP_MAX_BYTES on the way out.
   try {
     return execFileSync(
       "grep",
       [
-        "-rIl",
+        "-rIh",
         "--include=*.ts",
         "--include=*.js",
         "--include=*.py",
@@ -168,9 +197,15 @@ function grepSources(dir: string): string {
         ".",
       ],
       { cwd: dir, stdio: "pipe", timeout: 60_000, maxBuffer: 4 * 1024 * 1024 },
-    ).toString("utf8");
+    )
+      .subarray(0, GREP_MAX_BYTES)
+      .toString("utf8");
   } catch {
-    // grep exits 1 when nothing matched — that is a normal answer, not an error.
+    // grep exits 1 when nothing matched — that is a normal answer, not an
+    // error. maxBuffer overflow lands here too; an oversized match set is
+    // already an HTTP signal we will have caught from the README in practice,
+    // and treating it as "no signal" biases toward `detector_miss`, the
+    // pessimistic direction for recall.
     return "";
   }
 }
@@ -200,6 +235,25 @@ function classify(repo: string, sha: string, dir: string): Row {
       .map((line) => line.slice(2));
   }
 
+  // TRANSPORT IS CHECKED FIRST, even when detection produced a candidate. A
+  // stdio-only repo with a package.json and a start script yields a perfectly
+  // good candidate — for a server this harness cannot probe over HTTP. Calling
+  // that `resolved` would put an out-of-scope repo in the recall NUMERATOR
+  // while the same repo lands outside the denominator whenever detection
+  // misses, inflating the one number this harness exists to produce.
+  if (signals.length === 0) {
+    return {
+      repo,
+      sha,
+      category: "unsupported_transport",
+      reasons:
+        candidates.length > 0
+          ? ["candidate detected, but no HTTP transport evidence in the repo"]
+          : reasons,
+      signals,
+    };
+  }
+
   if (candidates.length > 0) {
     return {
       repo,
@@ -216,23 +270,21 @@ function classify(repo: string, sha: string, dir: string): Row {
     };
   }
 
-  return {
-    repo,
-    sha,
-    // No candidate AND no sign of an HTTP server: a stdio-only repo is out of
-    // scope by design (the stdio bridge is a separate feature), so counting it
-    // as a detector failure would understate recall and mis-prioritize R5.
-    category: signals.length > 0 ? "detector_miss" : "unsupported_transport",
-    reasons,
-    signals,
-  };
+  // HTTP evidence present but no candidate: this one is ours to fix.
+  return { repo, sha, category: "detector_miss", reasons, signals };
 }
 
 async function main() {
   const manifest = JSON.parse(readFileSync(MANIFEST, "utf8")) as {
     repos: ManifestEntry[];
   };
-  const limit = Number(arg("limit") ?? manifest.repos.length);
+  // `--limit` last on the command line makes arg() undefined, and Number(
+  // undefined) is NaN — slice(0, NaN) is empty, and report() would then divide
+  // by zero and print NaN% for every category. Anything not a positive integer
+  // means "no limit".
+  const requested = Number(arg("limit"));
+  const limit =
+    Number.isInteger(requested) && requested > 0 ? requested : manifest.repos.length;
   const entries = manifest.repos.slice(0, limit);
   const keep = hasFlag("keep");
 
@@ -286,9 +338,8 @@ function report(rows: Row[]): void {
   console.log("-".repeat(38));
   for (const category of order) {
     const n = counts.get(category) ?? 0;
-    console.log(
-      `${category.padEnd(24)}${String(n).padStart(5)}${`${((n / total) * 100).toFixed(1)}%`.padStart(9)}`,
-    );
+    const share = total === 0 ? "n/a" : `${((n / total) * 100).toFixed(1)}%`;
+    console.log(`${category.padEnd(24)}${String(n).padStart(5)}${share.padStart(9)}`);
   }
   console.log(`${"build_miss (deferred)".padEnd(24)}${"—".padStart(5)}${"—".padStart(9)}`);
   console.log(`${"probe_miss (deferred)".padEnd(24)}${"—".padStart(5)}${"—".padStart(9)}`);

--- a/mcpjam-inspector/scripts/resolver-corpus.ts
+++ b/mcpjam-inspector/scripts/resolver-corpus.ts
@@ -116,8 +116,49 @@ function cloneAt(repo: string, sha: string, dir: string): void {
   run(["checkout", "--quiet", "FETCH_HEAD"]);
 }
 
+/**
+ * Cap on the file listing handed to detection. Detection uses it for exact
+ * lookups of a handful of entry paths, so a monorepo with 400k tracked files
+ * would cost megabytes of strings to answer four questions. Truncation is SAFE
+ * in the suppress direction: a missing listing entry can only cause a candidate
+ * to be suppressed, never accepted.
+ */
+const MAX_REPO_FILES = 20_000;
+
+/**
+ * The checkout's tracked files, for detection's rule C (entry points must be
+ * provably checkout code). `git ls-files` rather than a directory walk: the
+ * clone is already a git repo, it is one process instead of a recursive stat
+ * storm, and it excludes .git/ and anything gitignored for free.
+ *
+ * A3 populates the same field from the sandbox, where the checkout is likewise
+ * on disk; the shape (POSIX-relative paths, no leading `./`) is what
+ * `DetectionInputs.repoFiles` documents.
+ */
+function listRepoFiles(dir: string): string[] {
+  try {
+    return execFileSync("git", ["ls-files", "-z"], {
+      cwd: dir,
+      stdio: "pipe",
+      timeout: 60_000,
+      maxBuffer: 32 * 1024 * 1024,
+    })
+      .toString("utf8")
+      .split("\0")
+      .filter((path) => path.length > 0)
+      .slice(0, MAX_REPO_FILES);
+  } catch {
+    // No listing is a valid input: detection falls back to its conservative
+    // path (syntactic checks for node, suppression for python). Reporting a
+    // detector_miss caused by our own git failure is the honest outcome — it
+    // biases recall DOWN, which is the safe direction for this number.
+    return [];
+  }
+}
+
 function readInputs(dir: string): DetectionInputs {
   return {
+    repoFiles: listRepoFiles(dir),
     packageJson: readCapped(dir, "package.json"),
     packageLockJson: readCapped(dir, "package-lock.json"),
     pnpmLockYaml: readCapped(dir, "pnpm-lock.yaml"),

--- a/mcpjam-inspector/scripts/resolver-corpus.ts
+++ b/mcpjam-inspector/scripts/resolver-corpus.ts
@@ -180,8 +180,56 @@ function httpSignals(files: DetectionInputs, dir: string): string[] {
   return signals;
 }
 
-/** Bound on the grep haystack: signal regexes need text, not a whole codebase. */
-const GREP_MAX_BYTES = 1024 * 1024;
+/**
+ * Bound on the grep haystack: signal regexes need text, not a whole codebase.
+ *
+ * Raised with SOURCE_SIGNAL_ANCHORS. Truncation is BLIND to which signal a line
+ * carries, so a cap that the broadened anchor set can actually reach would drop
+ * `streamable` lines that happen to sort after a wall of `localhost` ones — a
+ * silent, file-order-dependent loss of exactly the evidence this scan exists to
+ * find. 8MB is comfortably past the total source size of every repo in the
+ * pinned manifest, so in practice nothing is truncated at all.
+ */
+const GREP_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Coarse anchors for EVERY signal `httpSignals()` classifies on, not just the
+ * transport-specific ones.
+ *
+ * This list is a PREFILTER, and the correspondence to `httpSignals()` is the
+ * whole point: grep decides which LINES the classifier gets to see, so any
+ * classifier pattern with no anchor here is a pattern that can only ever fire
+ * on README/manifest text. That is how `express()`, `FastAPI()`,
+ * `createServer()`, localhost URLs and the HTTP CLI flags were invisible in
+ * source — and a repo whose only HTTP evidence is source-level was then filed
+ * `unsupported_transport`, dropping OUT of the recall denominator and making
+ * recall look better than it is.
+ *
+ * Anchors are deliberately shorter and looser than the classifier regexes
+ * (`express` for `\bexpress\(\)`, `localhost` for the full URL form): grep only
+ * has to deliver the line, and `httpSignals()` still makes the actual call. In
+ * BRE, `(` and `)` are literal, so these are read as written.
+ */
+const SOURCE_SIGNAL_ANCHORS = [
+  // streamable-http, in every spelling httpSignals accepts
+  "streamable",
+  // http-transport-api
+  "SSEServerTransport",
+  "http_app",
+  // http-cli-flag
+  "--port",
+  "--http",
+  "--transport",
+  // http-framework
+  "express",
+  "createServer",
+  "FastAPI",
+  "uvicorn",
+  "starlette",
+  // localhost-url
+  "localhost",
+  "127.0.0.1",
+];
 
 function grepSources(dir: string): string {
   // `-h`, never `-l`: `-l` prints FILE NAMES, and the signal regexes in
@@ -190,28 +238,32 @@ function grepSources(dir: string): string {
   // `unsupported_transport`. `-h` prints the matching LINES without the
   // filename prefix, which is what those regexes need — `-o` would trim the
   // match down to the `-e` token and hide longer forms like
-  // `StreamableHTTPServerTransport`. Output is bounded twice: maxBuffer here,
-  // and GREP_MAX_BYTES on the way out.
+  // `StreamableHTTPServerTransport`. `-i` because several classifier regexes
+  // are case-insensitive and grep here only decides candidacy. Output is
+  // bounded twice: maxBuffer here, and GREP_MAX_BYTES on the way out.
   try {
     return execFileSync(
       "grep",
       [
-        "-rIh",
+        "-rIhi",
         "--include=*.ts",
         "--include=*.js",
         "--include=*.py",
         "--include=*.go",
-        "-e",
-        "StreamableHTTP",
-        "-e",
-        "streamable_http",
-        "-e",
-        "streamable-http",
-        "-e",
-        "SSEServerTransport",
+        ...SOURCE_SIGNAL_ANCHORS.flatMap((anchor) => ["-e", anchor]),
         ".",
       ],
-      { cwd: dir, stdio: "pipe", timeout: 60_000, maxBuffer: 4 * 1024 * 1024 },
+      {
+        cwd: dir,
+        stdio: "pipe",
+        timeout: 60_000,
+        // Raised with the anchor list: `localhost` and `--port` match far more
+        // lines than `StreamableHTTP` did, and an execFileSync maxBuffer
+        // overflow THROWS — which the catch below would turn into "no signal
+        // at all", silently undoing this fix on exactly the repos with the most
+        // HTTP evidence. GREP_MAX_BYTES still bounds what the classifier reads.
+        maxBuffer: 64 * 1024 * 1024,
+      },
     )
       .subarray(0, GREP_MAX_BYTES)
       .toString("utf8");

--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -562,13 +562,13 @@ describe("rule C round 2 — evidence that only LOOKED like proof", () => {
     expect(discarded.join(" ")).toContain("names no verifiable checkout file");
   });
 
-  it("suppresses an INDIRECTION such as `npm run dev`, and says so distinctly", () => {
+  it("RESOLVES an indirection such as `npm run dev` instead of discarding it", () => {
     // Real corpus case (exa-labs/exa-mcp-server): `"start": "npm run dev"`.
-    // The body that actually runs is a different script we never analysed, so
-    // nothing is proven — and the reason has to name the indirection rather
-    // than claim the entry file is missing, because the corpus report is read
-    // to decide what to fix next.
-    const { candidates, discarded } = detectCandidatesWithReasons(
+    // Round 2 discarded every indirection wholesale, which lost this repo.
+    // Round 3 follows the reference and applies the full rule set to what it
+    // lands on — `tsx src/cli.ts`, a regular file in the listing — so the
+    // candidate is emitted and PROVEN.
+    const { candidates } = detectCandidatesWithReasons(
       inputs({
         packageJson: JSON.stringify({
           scripts: { start: "npm run dev", dev: "tsx src/cli.ts" },
@@ -577,8 +577,9 @@ describe("rule C round 2 — evidence that only LOOKED like proof", () => {
         repoFiles: tracked("package.json", "src/cli.ts"),
       }),
     );
-    expect(candidates).toEqual([]);
-    expect(discarded.join(" ")).toContain("names no verifiable checkout file");
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].start).toBe("npm start");
+    expect(candidates[0].ownershipProof).toBe("verified");
   });
 
   it("keeps existing behavior for a bare-word start when there is NO listing", () => {
@@ -671,6 +672,380 @@ describe("rule C round 2 — evidence that only LOOKED like proof", () => {
         "  build: npm ci\n  start: npm start\n  port: 3001\n  path: /mcp\n",
     });
     expect(declared.ownershipProof).toBe("verified");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round 3: `scripts.start` is not the only thing `npm start` runs.
+//
+// Two ways past rules A/B/C that never touched `scripts.start` at all:
+// LIFECYCLE HOOKS (npm runs prestart before start) and SCRIPT INDIRECTION
+// (`"start": "npm run serve"`). Round 2 read neither. The fix is not a bigger
+// blocklist of spellings — it is to RESOLVE the reference and re-apply the
+// rules, so that provable indirections are ACCEPTED (recall recovery) and
+// unprovable ones are suppressed with their own legible reason.
+// ---------------------------------------------------------------------------
+describe("round 3 — lifecycle hooks", () => {
+  const listing = tracked("package.json", "dist/index.js");
+
+  it("suppresses a prestart that launches a published package", () => {
+    // The whole finding in one fixture: `scripts.start` is impeccable, and
+    // `npm start` still runs `npx @acme/server` first.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { prestart: "npx @acme/server", start: "node dist/index.js" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("scripts.prestart");
+    expect(discarded.join(" ")).toContain("published package or remote URL");
+  });
+
+  it("suppresses a poststart that launches a published package", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "node dist/index.js", poststart: "npx @acme/server" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("scripts.poststart");
+  });
+
+  it("suppresses a prestart that reaches a launcher through indirection", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            prestart: "npm run gen",
+            gen: "npx @acme/codegen",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("script indirection, level 1");
+  });
+
+  it("ACCEPTS an ordinary build-tool prestart — rule C does not apply to hooks", () => {
+    // `"prestart": "tsc"` is a bare word, which rule C would suppress. A hook
+    // must EXIT before the probe connects, so it cannot be the server, and
+    // suppressing build tools here would cost recall for no safety.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { prestart: "tsc", start: "node dist/index.js" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].ownershipProof).toBe("verified");
+    expect(candidates[0].evidence).toContain(
+      "start lifecycle hooks verified against the same rules",
+    );
+  });
+
+  it("suppresses a prestart that backgrounds or chains (rule A still applies)", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { prestart: "node vendor.js &", start: "node dist/index.js" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("cannot be established");
+  });
+
+  it("suppresses an install hook that fetches AND detaches", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { postinstall: "npx @acme/server &", start: "node dist/index.js" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("install lifecycle hook");
+  });
+
+  it("keeps ordinary install hooks — a FOREGROUND fetch cannot go falsely green", () => {
+    // `npx playwright install` in a postinstall is everywhere. It either exits
+    // or hangs the build; neither outcome is a green check on published code.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            postinstall: "npx playwright install",
+            prepare: "husky install",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+  });
+
+  it("suppresses a prebuild that fetches a remote artifact", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            prebuild: "npx @acme/dist-bundle",
+            build: "tsc",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("build lifecycle hook");
+  });
+
+  it("out-of-scope hooks do not run for anything we emit, so they are ignored", () => {
+    // `prepublishOnly` / `prepack` / `pretest` never fire for `npm ci`,
+    // `npm run build` or `npm start`. Suppressing on them would be theatre.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            prepublishOnly: "npx @acme/publisher",
+            prepack: "npx @acme/packer",
+            pretest: "npx @acme/server &",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+  });
+});
+
+describe("round 3 — recursive script-reference resolution", () => {
+  it("suppresses `start -> serve` when serve launches a published package", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "npm run serve", serve: "npx @acme/server" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("script indirection, level 1");
+    expect(discarded.join(" ")).toContain("published package or remote URL");
+  });
+
+  it("ACCEPTS `start -> serve` when serve runs a listed checkout file", () => {
+    // The recall recovery. The recipe stays `npm start` — the recursion is a
+    // VERIFICATION mechanism, not a rewriting one: emitting the resolved leaf
+    // would skip `prestart` and drop npm's PATH/env, which is exactly what a
+    // `tsx`/`ts-node` leaf depends on.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            build: "tsc",
+            start: "npm run serve",
+            serve: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      build: "npm ci && npm run build",
+      start: "npm start",
+      ownershipProof: "verified",
+    });
+  });
+
+  it("marks the resolved leaf unverified when only a build step could produce it", () => {
+    // Same shape, but `dist/index.js` is not in the listing — accepted on the
+    // build-output plausibility argument, and labelled so A3 settles it.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            build: "tsc",
+            start: "npm run serve",
+            serve: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "src/index.ts"),
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].ownershipProof).toBe("unverified");
+  });
+
+  it.each([
+    ["pnpm run serve", "pnpmLockYaml"],
+    ["pnpm serve", "pnpmLockYaml"],
+    ["yarn run serve", "yarnLock"],
+    ["yarn serve", "yarnLock"],
+  ] as const)("follows `%s` too, not just `npm run X`", (body, lockKey) => {
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: body, serve: "npx @acme/server" },
+        }),
+        [lockKey]: "lock\n",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    // The leaf is a launcher, so every spelling of the hand-off must reach it.
+    expect(candidates).toEqual([]);
+  });
+
+  it("follows every script named by npm-run-all / run-s", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "run-s prep serve",
+            prep: "node scripts/prep.js",
+            serve: "npx @acme/server",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "scripts/prep.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("published package or remote URL");
+  });
+
+  it("suppresses a reference to a script that is not defined", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "npm run serve" } }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("is not defined");
+  });
+
+  it("suppresses a runner whose target cannot be determined statically", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "npm run" } }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("cannot be determined statically");
+  });
+
+  it("suppresses a chain deeper than the cap (4 hops)", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "npm run a",
+            a: "npm run b",
+            b: "npm run c",
+            c: "npm run d",
+            d: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain(
+      "maximum resolvable script-indirection depth",
+    );
+  });
+
+  it("resolves a chain AT the cap (3 hops)", () => {
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "npm run a",
+            a: "npm run b",
+            b: "npm run c",
+            c: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].ownershipProof).toBe("verified");
+  });
+
+  it("terminates on a cycle instead of hanging", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "npm run a", a: "npm run b", b: "npm run a" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("cycle");
+  });
+
+  it("treats `npm start` inside scripts.start as the self-cycle it is", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "npm start" } }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("cycle");
+  });
+
+  it("never puts a script NAME into a discard reason (evidence hygiene)", () => {
+    // Reasons are rendered into GitHub check output, so they stay constant
+    // strings plus validated integers — script names are PR content.
+    const { discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "npm run pwned-script-name" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json"),
+      }),
+    );
+    expect(discarded.join(" ")).not.toContain("pwned-script-name");
   });
 });
 

--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -7,6 +7,7 @@ import {
   resolveRecipe,
   resolveRecipeLadder,
   type DetectionInputs,
+  type RepoFileEntry,
 } from "../resolver";
 import { listRecipeRepos } from "../recipes";
 
@@ -44,6 +45,13 @@ const EMPTY: DetectionInputs = {
 function inputs(overrides: Partial<DetectionInputs>): DetectionInputs {
   return { ...EMPTY, ...overrides };
 }
+
+// Listing entries. The KIND is the load-bearing half of `repoFiles` — a
+// path-only listing cannot tell a regular `server.js` from a symlink into
+// `node_modules/`, which is why the contract carries a type per entry.
+const tracked = (...paths: string[]): RepoFileEntry[] =>
+  paths.map((path) => ({ path, kind: "file" as const }));
+const symlinked = (path: string): RepoFileEntry => ({ path, kind: "symlink" });
 
 const PKG = JSON.stringify({
   name: "acme-mcp-server",
@@ -392,7 +400,7 @@ describe("inverted policy — rule C: entry points verified against the checkout
       inputs({
         packageJson: PKG_NO_BUILD,
         packageLockJson: "{}",
-        repoFiles: ["package.json", "server/main.js"],
+        repoFiles: tracked("package.json", "server/main.js"),
       }),
     );
     expect(candidate.start).toBe("npm start");
@@ -403,25 +411,39 @@ describe("inverted policy — rule C: entry points verified against the checkout
       inputs({
         packageJson: PKG_NO_BUILD,
         packageLockJson: "{}",
-        repoFiles: ["package.json", "README.md"],
+        repoFiles: tracked("package.json", "README.md"),
       }),
     );
     expect(candidates).toEqual([]);
-    expect(discarded.join(" ")).toContain("not in the checkout");
+    expect(discarded.join(" ")).toContain("not proven to be checkout code");
   });
 
-  it("accepts a build OUTPUT that no listing can contain, when a build produces it", () => {
+  it("accepts a build OUTPUT that no listing can contain, but only as UNVERIFIED", () => {
     // `node dist/index.js` after `npm run build` is the most common shape in
     // the ecosystem, and `dist/` is by definition not committed. Requiring it
     // in the listing would suppress nearly every node repo for no safety gain.
+    // But the build script does NOT prove the output is checkout-derived, so
+    // the candidate is emitted carrying the debt rather than a false claim.
     const [candidate] = detectCandidates(
       inputs({
         packageJson: PKG,
         packageLockJson: "{}",
-        repoFiles: ["package.json", "src/index.ts"],
+        repoFiles: tracked("package.json", "src/index.ts"),
       }),
     );
     expect(candidate.start).toBe("npm start");
+    expect(candidate.ownershipProof).toBe("unverified");
+  });
+
+  it("marks an entry point PRESENT in the listing as verified", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: PKG_NO_BUILD,
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "server/main.js"),
+      }),
+    );
+    expect(candidate.ownershipProof).toBe("verified");
   });
 
   it("applies the same rule to a bin entry", () => {
@@ -429,17 +451,17 @@ describe("inverted policy — rule C: entry points verified against the checkout
       inputs({
         packageJson: JSON.stringify({ bin: { acme: "dist/cli.js" } }),
         packageLockJson: "{}",
-        repoFiles: ["package.json"],
+        repoFiles: tracked("package.json"),
       }),
     );
     expect(absent.candidates).toEqual([]);
-    expect(absent.discarded.join(" ")).toContain("not in the checkout");
+    expect(absent.discarded.join(" ")).toContain("not proven to be checkout code");
 
     const present = detectCandidates(
       inputs({
         packageJson: JSON.stringify({ bin: { acme: "cli.js" } }),
         packageLockJson: "{}",
-        repoFiles: ["package.json", "cli.js"],
+        repoFiles: tracked("package.json", "cli.js"),
       }),
     );
     expect(present[0].start).toBe("node ./cli.js");
@@ -447,11 +469,208 @@ describe("inverted policy — rule C: entry points verified against the checkout
 
   it("falls back to the strict syntactic rules when no listing is supplied", () => {
     // No listing is a normal input (production callers have none until A3).
-    // Node keeps working off the path rules; it does not become unusable.
+    // Node keeps working off the path rules; it does not become unusable — but
+    // nothing was verified against anything, so it says so.
     const [candidate] = detectCandidates(
       inputs({ packageJson: PKG_NO_BUILD, packageLockJson: "{}" }),
     );
     expect(candidate.start).toBe("npm start");
+    expect(candidate.ownershipProof).toBe("unverified");
+  });
+});
+
+// The second review round on the allowlist itself. Each case below is a way
+// rule C accepted on evidence that never established ownership; the fix is
+// either a suppression or an honest 'unverified' label, never more string
+// analysis of the same strings.
+describe("rule C round 2 — evidence that only LOOKED like proof", () => {
+  it("a build script alone does not make an absent entry VERIFIED", () => {
+    // The reported case: `"build": "mkdir -p dist && cp
+    // node_modules/acme/server.js dist/index.js"` copies PUBLISHED code into
+    // `dist/index.js`. Nothing static can distinguish that build body from
+    // `tsc`, so the output is never labelled verified on its account.
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            build: "mkdir -p dist && cp node_modules/acme/server.js dist/index.js",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "src/index.ts"),
+      }),
+    );
+    expect(candidate.ownershipProof).toBe("unverified");
+  });
+
+  it("suppresses an entry point the listing has as a SYMLINK", () => {
+    // `server.js -> node_modules/acme/server.js` appears in `git ls-files` as
+    // the harmless string "server.js". We do not chase the target and reason
+    // about it: unresolvable provenance is a miss, and a miss is recoverable.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "node server.js" } }),
+        packageLockJson: "{}",
+        repoFiles: [...tracked("package.json"), symlinked("server.js")],
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("not proven to be checkout code");
+  });
+
+  it("a symlinked entry is suppressed even when a build step exists", () => {
+    // The build-output leniency must not rescue a path the listing has already
+    // answered for. Present-but-not-a-regular-file is a NO, not a fall-through.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { build: "tsc", start: "node dist/index.js" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: [...tracked("package.json"), symlinked("dist/index.js")],
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  it("suppresses a symlinked python entry module", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        pyprojectToml:
+          '[project]\nname = "acme-mcp"\n\n[project.scripts]\nacme = "acme.server:main"\n',
+        uvLock: "version = 1\n",
+        repoFiles: [...tracked("pyproject.toml"), symlinked("acme/server.py")],
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("dependency module");
+  });
+
+  it("suppresses a BARE-WORD start command when a listing is available", () => {
+    // `start-server` resolves out of node_modules/.bin. It carries no script
+    // extension, so it extracted zero entry paths and rule C never fired on it
+    // — the node twin of the python `[project.scripts]` finding.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "start-server" } }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "src/index.ts"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("names no verifiable checkout file");
+  });
+
+  it("suppresses an INDIRECTION such as `npm run dev`, and says so distinctly", () => {
+    // Real corpus case (exa-labs/exa-mcp-server): `"start": "npm run dev"`.
+    // The body that actually runs is a different script we never analysed, so
+    // nothing is proven — and the reason has to name the indirection rather
+    // than claim the entry file is missing, because the corpus report is read
+    // to decide what to fix next.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "npm run dev", dev: "tsx src/cli.ts" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "src/cli.ts"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("names no verifiable checkout file");
+  });
+
+  it("keeps existing behavior for a bare-word start when there is NO listing", () => {
+    // Without a listing there is nothing to check against, so the candidate is
+    // still emitted — labelled unverified, which is what A3 gates on.
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "start-server" } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidate.start).toBe("npm start");
+    expect(candidate.ownershipProof).toBe("unverified");
+  });
+
+  it.each([
+    ["node .", tracked("package.json", "index.js")],
+    ["node ./", tracked("package.json", "index.js")],
+    ["node --enable-source-maps .", tracked("package.json", "index.js")],
+    ["node bin/cli", tracked("package.json", "bin/cli")],
+  ])("still accepts the extensionless-but-local start %s", (start, repoFiles) => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start } }),
+        packageLockJson: "{}",
+        repoFiles,
+      }),
+    );
+    expect(candidate?.start).toBe("npm start");
+    expect(candidate?.ownershipProof).toBe("verified");
+  });
+
+  it.each([
+    ["POSIX absolute", "node /etc/foo.js"],
+    ["windows drive, forward slashes", "node C:/x.js"],
+    ["windows drive, backslashes", "node C:\\x.js"],
+    ["drive-relative", "node C:x.js"],
+  ])("rejects an absolute entry path (%s)", (_label, start) => {
+    // `escapesCheckout` only ever matched `node_modules/` and `../`, and the
+    // build-output branch never checked relativity at all — so the docblock's
+    // "a relative path can only resolve inside the checkout" was load-bearing
+    // for a property nothing enforced.
+    for (const repoFiles of [undefined, tracked("package.json", "src/index.ts")]) {
+      const { candidates } = detectCandidatesWithReasons(
+        inputs({
+          packageJson: JSON.stringify({ scripts: { build: "tsc", start } }),
+          packageLockJson: "{}",
+          repoFiles,
+        }),
+      );
+      expect(candidates).toEqual([]);
+    }
+  });
+
+  it("rejects an absolute bin path", () => {
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          bin: { acme: "/opt/acme/cli.js" },
+          scripts: { build: "tsc" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  it("treats an entry with an unclassifiable kind as unproven, not as a file", () => {
+    // A submodule (gitlink) is someone else's commit. "We cannot classify it"
+    // must never read as "regular file".
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "node vendor/server.js" } }),
+        packageLockJson: "{}",
+        repoFiles: [
+          ...tracked("package.json"),
+          { path: "vendor/server.js", kind: "other" },
+        ],
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  it("authoritative rungs are always verified", () => {
+    const declared = resolveRecipe({
+      repoFullName: "acme/mcp",
+      mcpjamYaml:
+        "version: 1\nchecks:\n  transport: streamable-http\n" +
+        "  build: npm ci\n  start: npm start\n  port: 3001\n  path: /mcp\n",
+    });
+    expect(declared.ownershipProof).toBe("verified");
   });
 });
 
@@ -466,7 +685,7 @@ describe("inverted policy — python [project.scripts] ownership", () => {
       inputs({
         pyprojectToml: PY("fastmcp.cli:main"),
         uvLock: "version = 1\n",
-        repoFiles: ["pyproject.toml", "uv.lock", "acme/__init__.py"],
+        repoFiles: tracked("pyproject.toml", "uv.lock", "acme/__init__.py"),
       }),
     );
     expect(candidates).toEqual([]);
@@ -494,7 +713,7 @@ describe("inverted policy — python [project.scripts] ownership", () => {
       inputs({
         pyprojectToml: PY("acme.server:main"),
         uvLock: "version = 1\n",
-        repoFiles: ["pyproject.toml", path],
+        repoFiles: tracked("pyproject.toml", path),
       }),
     );
     expect(candidate.start).toBe("uv run acme");
@@ -506,7 +725,7 @@ describe("inverted policy — recall on legitimate repos is not tanked", () => {
   // The other half of the bargain. Being aggressively conservative is only
   // defensible if ordinary repos still resolve; these are the shapes the corpus
   // is made of.
-  const REAL_FILES = ["package.json", "src/index.ts", "README.md"];
+  const REAL_FILES = tracked("package.json", "src/index.ts", "README.md");
 
   it.each([
     ["npm", { packageLockJson: "{}" }, "npm ci && npm run build", "npm start"],
@@ -542,7 +761,7 @@ describe("inverted policy — recall on legitimate repos is not tanked", () => {
         pyprojectToml:
           '[project]\nname = "acme-mcp"\n\n[project.scripts]\nacme-mcp = "acme.server:main"\n',
         uvLock: "version = 1\n",
-        repoFiles: ["pyproject.toml", "uv.lock", "src/acme/server.py"],
+        repoFiles: tracked("pyproject.toml", "uv.lock", "src/acme/server.py"),
       }),
     );
     expect(candidate).toMatchObject({ build: "uv sync --frozen", start: "uv run acme-mcp" });
@@ -574,7 +793,7 @@ describe("detectCandidates — ecosystems outside v1", () => {
           '[project]\nname = "acme-mcp"\n\n[project.scripts]\nacme-mcp = "acme.server:main"\n',
         uvLock: "version = 1\n",
         // Required now: without a listing the target's OWNER is unknowable.
-        repoFiles: ["pyproject.toml", "uv.lock", "acme/server.py"],
+        repoFiles: tracked("pyproject.toml", "uv.lock", "acme/server.py"),
       }),
     );
     expect(candidate).toMatchObject({

--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -1529,6 +1529,25 @@ describe("round 3.2 — install-hook guard: assignments, indirection, inline cod
       expect(candidates).toEqual([]);
     });
 
+    it("suppresses a detached runtime carrying ANY option", () => {
+      // `--require` takes a value, so "first token without a leading dash" is
+      // the OPTION'S VALUE, not the entry — the real entry sits beside it and
+      // was never examined.
+      expect(
+        withScripts({
+          prepare:
+            "nohup node --require ./scripts/boot.js node_modules/acme/server.js &",
+        }).candidates,
+      ).toEqual([]);
+      // Even an option whose value is benign: we refuse to guess which token
+      // the runtime will treat as the entry.
+      expect(
+        withScripts({
+          prepare: "nohup node --enable-source-maps dist/index.js &",
+        }).candidates,
+      ).toEqual([]);
+    });
+
     it("suppresses a detached runtime pointed OUTSIDE the checkout", () => {
       expect(
         withScripts({ prepare: "nohup node /etc/evil.js &" }).candidates,

--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -1049,6 +1049,391 @@ describe("round 3 — recursive script-reference resolution", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// ROUND 3.1 — the four places round 3's own mechanism did not reach.
+//
+// Round 3 established the right move (RESOLVE the reference, re-apply the
+// rules) and then applied it in fewer places than npm applies lifecycle hooks:
+//
+//   1. `pre<name>`/`post<name>` fire for ARBITRARY script names, at every depth
+//      — not only for the root `start`;
+//   2. the BUILD lifecycle read hook bodies literally, so one `npm run` hop
+//      hid a fetch from rule B;
+//   3. `npm ci` also fires `preprepare`/`postprepare`, which were not listed;
+//   4. the install guard tested for a FETCH, but a bare dependency binary is
+//      already on PATH by then and needs no fetch to answer the probe.
+//
+// Plus one correctness bug the mechanism carried from the start: script names
+// were lowercased before a case-SENSITIVE package.json lookup.
+// ---------------------------------------------------------------------------
+describe("round 3.1 — nested pre/post hooks at every level of indirection", () => {
+  const listing = tracked("package.json", "dist/index.js");
+
+  it("suppresses a `preserve` that fetches and detaches behind `start -> serve`", () => {
+    // The finding in one fixture: `serve` is impeccable and passes ownership
+    // verification, and `npm run serve` still runs `preserve` first.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "npm run serve",
+            preserve: "nohup npx @acme/server >/dev/null 2>&1 &",
+            serve: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("script indirection, level 1");
+  });
+
+  it("suppresses a `postserve` that launches a published package", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "npm run serve",
+            serve: "node dist/index.js",
+            postserve: "npx @acme/server",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("published package or remote URL");
+  });
+
+  it("ACCEPTS a benign nested hook — `\"preserve\": \"tsc\"` is a build tool", () => {
+    // The other half of the bargain. A nested hook gets the same 'prepares'
+    // role the root hooks get: rules A + B, not rule C, because it must exit
+    // before the probe connects.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            build: "tsc",
+            start: "npm run serve",
+            preserve: "tsc",
+            serve: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      start: "npm start",
+      ownershipProof: "verified",
+    });
+  });
+
+  it("reaches a nested hook at depth 2", () => {
+    // `start -> a -> b`, with the launcher parked in `preb`. Nothing about the
+    // hazard is specific to the first hop.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "npm run a",
+            a: "npm run b",
+            preb: "nohup npx @acme/server &",
+            b: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("script indirection, level 2");
+  });
+
+  it("follows the hooks of EVERY script named by a multi-script runner", () => {
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "run-s prep serve",
+            prep: "node scripts/prep.js",
+            preserve: "npx @acme/server",
+            serve: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "scripts/prep.js", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  it("terminates on a cycle reached through a nested hook", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "npm run a",
+            prea: "npm run a",
+            a: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("cycle");
+  });
+});
+
+describe("round 3.1 — build indirection", () => {
+  const listing = tracked("package.json", "dist/index.js");
+
+  it("suppresses `build -> bundle` when bundle fetches a remote artifact", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            build: "npm run bundle",
+            bundle: "npx @acme/dist-bundle",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("refusing to build from the network");
+  });
+
+  it("suppresses a fetch parked in the referenced script's OWN pre hook", () => {
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            build: "npm run bundle",
+            prebundle: "npx @acme/dist-bundle",
+            bundle: "tsc",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  it("ACCEPTS benign build indirection", () => {
+    // Following references must not turn ordinary `"build": "npm run compile"`
+    // into a suppression — rule B is still the only rule applied here.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            build: "npm run compile",
+            compile: "tsc -p tsconfig.json",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].build).toBe("npm ci && npm run build");
+  });
+
+  it("leaves a CHAINED build alone — rule A does not apply to the build step", () => {
+    // `tsc && chmod +x dist/cli.js` is the most ordinary build in the
+    // ecosystem. An unresolvable reference in the build lifecycle is not a
+    // rejection; a build that misbehaves is `build_failed`, an honest red.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            build: "tsc && chmod +x dist/index.js",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+  });
+});
+
+describe("round 3.1 — the full npm install lifecycle", () => {
+  const listing = tracked("package.json", "dist/index.js");
+
+  it.each(["preprepare", "postprepare"])(
+    "inspects `%s`, which npm ci runs and the old list omitted",
+    (hook) => {
+      const { candidates, discarded } = detectCandidatesWithReasons(
+        inputs({
+          packageJson: JSON.stringify({
+            scripts: {
+              [hook]: "nohup npx @acme/server >/dev/null 2>&1 &",
+              start: "node dist/index.js",
+            },
+          }),
+          packageLockJson: "{}",
+          repoFiles: listing,
+        }),
+      );
+      expect(candidates).toEqual([]);
+      expect(discarded.join(" ")).toContain("install lifecycle hook");
+    },
+  );
+
+  it("suppresses a DETACHED bare dependency binary — no fetch required", () => {
+    // `acme-mcp-server` is already on PATH from node_modules/.bin by the time
+    // install hooks run, so nothing is fetched and the fetch-only guard waved
+    // it through. It can still be listening when the probe arrives.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            prepare: "nohup acme-mcp-server >/dev/null 2>&1 &",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("install lifecycle hook");
+  });
+
+  it("ACCEPTS a NON-detached bare binary — it must exit before the probe", () => {
+    // `husky`/`patch-package`/`prisma generate` are the ecosystem. A
+    // foreground binary cannot still be answering the port when start runs.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            prepare: "husky",
+            postinstall: "patch-package",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+  });
+
+  it("ACCEPTS a detached CHECKOUT script — the runtime's argument is ours", () => {
+    // `node scripts/watch.js &` backgrounds checkout code, which is not the
+    // published-code hazard this guard exists for. The redirection fragments
+    // (`2>&1`) must not be mistaken for command words either.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            postinstall: "node scripts/watch.js >/dev/null 2>&1 &",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js", "scripts/watch.js"),
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+  });
+
+  it("suppresses a detached explicit node_modules path", () => {
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            postinstall: "nohup ./node_modules/.bin/acme-server &",
+            start: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: listing,
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe("round 3.1 — script names are case-SENSITIVE", () => {
+  it("resolves a mixed-case script name instead of missing it", () => {
+    // `npm run Serve` runs `Serve`. Lowercasing the name made this a "script
+    // is not defined" suppression on a perfectly good repo.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "npm run Serve", Serve: "node dist/index.js" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].ownershipProof).toBe("verified");
+  });
+
+  it("resolves the RIGHT one of a lowercase-colliding pair", () => {
+    // Both spellings exist. `npm run Serve` must reach the launcher, not the
+    // innocuous `serve` that happens to share its lowercase form — the failure
+    // mode here is a false VERIFICATION, which is the dangerous direction.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "npm run Serve",
+            Serve: "npx @acme/server",
+            serve: "node dist/index.js",
+          },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("published package or remote URL");
+  });
+
+  it("keeps the RUNNER and VERB case-insensitive", () => {
+    // The filesystem and npm's command table resolve those; only the script
+    // KEY is case-sensitive.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "NPM RUN serve", serve: "npx @acme/server" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  it("follows mixed-case names through pnpm's bare-script spelling", () => {
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "pnpm Serve", Serve: "npx @acme/server" },
+        }),
+        pnpmLockYaml: "lock\n",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+});
+
 describe("inverted policy — python [project.scripts] ownership", () => {
   const PY = (target: string) =>
     `[project]\nname = "acme-mcp"\n\n[project.scripts]\nacme = "${target}"\n`;

--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -1367,6 +1367,208 @@ describe("round 3.1 — the full npm install lifecycle", () => {
   });
 });
 
+// Round 3.2. Three ways the install-hook guard could still be walked past,
+// each a way of hiding WHICH token is the command or WHAT it will run.
+describe("round 3.2 — install-hook guard: assignments, indirection, inline code", () => {
+  const listing = tracked("package.json", "dist/index.js");
+
+  /** A repo whose start command is honest, so only the hook is on trial. */
+  const withScripts = (scripts: Record<string, string>, files = listing) =>
+    detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "node dist/index.js", ...scripts },
+        }),
+        packageLockJson: "{}",
+        repoFiles: files,
+      }),
+    );
+
+  // --- environment assignments ------------------------------------------
+  describe("environment assignments do not hide the command", () => {
+    it("suppresses a PATH-valued assignment before a detached binary", () => {
+      // The reported bypass. `FOO=/opt/x` contains a slash, so the old
+      // "assignment means no slash" test read it as the COMMAND, found it did
+      // not escape the checkout, and returned before reaching `acme-server`.
+      const { candidates, discarded } = withScripts({
+        prepare: "FOO=/opt/x nohup acme-server &",
+      });
+      expect(candidates).toEqual([]);
+      expect(discarded.join(" ")).toContain("install lifecycle hook");
+    });
+
+    it("suppresses through SEVERAL leading assignments", () => {
+      const { candidates } = withScripts({
+        prepare: "A=1 B=/opt/x C=y-z nohup acme-server >/dev/null 2>&1 &",
+      });
+      expect(candidates).toEqual([]);
+    });
+
+    it("suppresses assignments introduced by `env`", () => {
+      const { candidates } = withScripts({
+        prepare: "env FOO=1 nohup acme-server &",
+      });
+      expect(candidates).toEqual([]);
+    });
+
+    it("ACCEPTS a benign assignment in front of checkout code", () => {
+      // The recall side: `NODE_ENV=production node dist/index.js &` is the
+      // repo backgrounding its OWN build, which is not the hazard.
+      const { candidates } = withScripts({
+        postinstall: "NODE_ENV=production node dist/index.js >/dev/null 2>&1 &",
+      });
+      expect(candidates).toHaveLength(1);
+    });
+  });
+
+  // --- script-reference indirection --------------------------------------
+  describe("install hooks follow script references", () => {
+    it("suppresses a launch hidden one hop behind `npm run`", () => {
+      const { candidates, discarded } = withScripts({
+        prepare: "npm run sneaky",
+        sneaky: "nohup acme-server &",
+      });
+      expect(candidates).toEqual([]);
+      expect(discarded.join(" ")).toContain("script reference");
+    });
+
+    it("suppresses a launch in the referenced script's OWN pre/post hook", () => {
+      for (const hook of ["presetup", "postsetup"]) {
+        const { candidates } = withScripts({
+          prepare: "npm run setup",
+          setup: "tsc",
+          [hook]: "nohup acme-server &",
+        });
+        expect(candidates).toEqual([]);
+      }
+    });
+
+    it("ACCEPTS benign install-hook indirection", () => {
+      const { candidates } = withScripts(
+        { prepare: "npm run guard", guard: "node scripts/check.js" },
+        tracked("package.json", "dist/index.js", "scripts/check.js"),
+      );
+      expect(candidates).toHaveLength(1);
+    });
+
+    it("terminates on a reference CYCLE instead of recursing forever", () => {
+      const { candidates } = withScripts({
+        prepare: "npm run a",
+        a: "npm run b",
+        b: "npm run a",
+      });
+      expect(candidates).toHaveLength(1);
+    });
+
+    it("follows to the depth cap, and stops there", () => {
+      // At the cap the launch is still caught…
+      const atCap = withScripts({
+        prepare: "npm run a",
+        a: "npm run b",
+        b: "npm run c",
+        c: "nohup acme-server &",
+      });
+      expect(atCap.candidates).toEqual([]);
+
+      // …and one hop further we STOP walking rather than claim a depth of
+      // reasoning we capped on purpose. Pinned as a known, bounded limit.
+      const pastCap = withScripts({
+        prepare: "npm run a",
+        a: "npm run b",
+        b: "npm run c",
+        c: "npm run d",
+        d: "nohup acme-server &",
+      });
+      expect(pastCap.candidates).toHaveLength(1);
+    });
+  });
+
+  // --- inline-code runtimes ----------------------------------------------
+  describe("detached local runtimes must be pointed at checkout code", () => {
+    // The inline snippets below are deliberately free of parentheses and
+    // semicolons. `shellSegments` splits on those, so `node -e
+    // "require('acme').serve()"` fragments into a segment whose first word is
+    // `acme` — which the bare-binary rule suppresses on its own, for a
+    // tokenizing reason that has nothing to do with `-e`. Written that way the
+    // test passes with the inline-flag rule REMOVED and proves nothing. An
+    // ESM-style snippet leaves one clean segment, so only the flag rule can
+    // suppress it.
+    it.each([
+      ["nohup node -e \"import 'acme/server'\" &", "-e"],
+      ["nohup node --eval \"import 'acme/server'\" &", "--eval"],
+      ['nohup node -p "process.env.PORT" &', "-p"],
+      ['nohup node --print "process.env.PORT" &', "--print"],
+      ["nohup node \"--eval=import 'acme/server'\" &", "--eval=CODE"],
+    ])("suppresses a detached %s inline program", (body) => {
+      const { candidates, discarded } = withScripts({ prepare: body });
+      expect(candidates).toEqual([]);
+      expect(discarded.join(" ")).toContain("install lifecycle hook");
+    });
+
+    it("suppresses python's inline-program flag `-c`", () => {
+      // `python` is an accepted runtime, and a package.json script can call it.
+      const { candidates } = withScripts({
+        prepare: 'nohup python -c "import acme.server" &',
+      });
+      expect(candidates).toEqual([]);
+    });
+
+    it("suppresses python's installed-module flag `-m`", () => {
+      // Not inline code, same hazard: `acme.server` is resolved from
+      // site-packages, so no checkout listing can ever own it.
+      const { candidates } = withScripts({
+        prepare: "nohup python3 -m acme.server &",
+      });
+      expect(candidates).toEqual([]);
+    });
+
+    it("suppresses a detached runtime with NO entry argument", () => {
+      const { candidates } = withScripts({
+        prepare: "nohup node >/dev/null 2>&1 &",
+      });
+      expect(candidates).toEqual([]);
+    });
+
+    it("suppresses a detached runtime pointed OUTSIDE the checkout", () => {
+      expect(
+        withScripts({ prepare: "nohup node /etc/evil.js &" }).candidates,
+      ).toEqual([]);
+      expect(
+        withScripts({ prepare: "nohup node ../evil.js &" }).candidates,
+      ).toEqual([]);
+    });
+
+    it("suppresses a detached runtime pointed at an ABSENT file", () => {
+      // No build script here, so nothing could have produced it — the same
+      // judgement `verifyEntryPath` makes for a start command.
+      const { candidates } = withScripts({
+        postinstall: "nohup node scripts/watch.js &",
+      });
+      expect(candidates).toEqual([]);
+    });
+
+    it("ACCEPTS a NON-detached `node -e` — it must exit before the probe", () => {
+      // Pinned deliberately: the guard is about DETACHMENT. A foreground
+      // `node -e` cannot still be listening when start runs, so inline code on
+      // its own is not the hazard and suppressing it would cost recall.
+      const { candidates } = withScripts({
+        prepare: "node -e \"require('acme').warmup()\"",
+      });
+      expect(candidates).toHaveLength(1);
+    });
+
+    it("ACCEPTS a detached CHECKOUT entry point — the round-3.1 regression", () => {
+      // `nohup node dist/index.js >/dev/null 2>&1 &` is the shape the previous
+      // commit's tokenizer fix protected: the redirection fragments must not be
+      // read as command words, and a tracked entry file is ours.
+      const { candidates } = withScripts({
+        postinstall: "nohup node dist/index.js >/dev/null 2>&1 &",
+      });
+      expect(candidates).toHaveLength(1);
+    });
+  });
+});
+
 describe("round 3.1 — script names are case-SENSITIVE", () => {
   it("resolves a mixed-case script name instead of missing it", () => {
     // `npm run Serve` runs `Serve`. Lowercasing the name made this a "script
@@ -1405,10 +1607,35 @@ describe("round 3.1 — script names are case-SENSITIVE", () => {
     expect(discarded.join(" ")).toContain("published package or remote URL");
   });
 
+  // The two tests below use a BENIGN referenced script on purpose. Pointing
+  // them at a launcher and asserting `[]` proves nothing: a case-WRONG lookup
+  // finds no script, discards for "not defined", and yields `[]` too — the
+  // assertion holds whether or not the casing rule works. With a benign target
+  // the two outcomes separate: a correct lookup resolves it and ACCEPTS, a
+  // wrong lookup misses it and suppresses. Each keeps its suppression half as
+  // a second case, so both directions stay covered.
+
   it("keeps the RUNNER and VERB case-insensitive", () => {
     // The filesystem and npm's command table resolve those; only the script
-    // KEY is case-sensitive.
+    // KEY is case-sensitive. If `NPM`/`RUN` were matched case-SENSITIVELY the
+    // hand-off would not be recognised at all, the literal body `NPM RUN
+    // serve` would be judged directly — no entry path, not a local runtime —
+    // and there would be no candidate.
     const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { start: "NPM RUN serve", serve: "node dist/index.js" },
+        }),
+        packageLockJson: "{}",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].ownershipProof).toBe("verified");
+
+    // …and the hand-off is really being FOLLOWED, not merely tolerated: the
+    // same shape with a launcher behind it still suppresses.
+    const hostile = detectCandidatesWithReasons(
       inputs({
         packageJson: JSON.stringify({
           scripts: { start: "NPM RUN serve", serve: "npx @acme/server" },
@@ -1417,20 +1644,45 @@ describe("round 3.1 — script names are case-SENSITIVE", () => {
         repoFiles: tracked("package.json", "dist/index.js"),
       }),
     );
-    expect(candidates).toEqual([]);
+    expect(hostile.candidates).toEqual([]);
   });
 
   it("follows mixed-case names through pnpm's bare-script spelling", () => {
+    // `pnpm Serve` runs `Serve`. There is deliberately NO lowercase `serve`
+    // here: a lookup that lowercases finds nothing and suppresses, so the
+    // accepted candidate is only reachable through the case-correct lookup.
     const { candidates } = detectCandidatesWithReasons(
       inputs({
         packageJson: JSON.stringify({
-          scripts: { start: "pnpm Serve", Serve: "npx @acme/server" },
+          scripts: { start: "pnpm Serve", Serve: "node dist/index.js" },
         }),
         pnpmLockYaml: "lock\n",
         repoFiles: tracked("package.json", "dist/index.js"),
       }),
     );
-    expect(candidates).toEqual([]);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].ownershipProof).toBe("verified");
+
+    // The colliding pair through the SAME pnpm path, which is the dangerous
+    // direction: a lowercasing lookup would resolve the innocuous `serve` and
+    // emit a candidate for a repo whose `Serve` launches a published package.
+    const colliding = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: {
+            start: "pnpm Serve",
+            Serve: "npx @acme/server",
+            serve: "node dist/index.js",
+          },
+        }),
+        pnpmLockYaml: "lock\n",
+        repoFiles: tracked("package.json", "dist/index.js"),
+      }),
+    );
+    expect(colliding.candidates).toEqual([]);
+    expect(colliding.discarded.join(" ")).toContain(
+      "published package or remote URL",
+    );
   });
 });
 

--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -21,6 +21,14 @@ import { listRecipeRepos } from "../recipes";
 //   3. evidence never carries untrusted file content (same rule as R1);
 //   4. the authoritative rungs are untouched — an invalid mcpjam.yaml still
 //      throws instead of quietly falling through to a guess.
+//
+// The policy is an ALLOWLIST ("prove it runs the checkout"), not a blocklist
+// ("reject the launchers we thought of") — see detect.ts's docblock for why
+// three rounds of bypasses forced that inversion. The suites below are
+// organised around it: each of the three bypasses gets a named case AND the
+// class it represents, because pinning only the reported spelling would repeat
+// the mistake that made the inversion necessary. The last suite pins the other
+// half of the bargain: the inversion must not tank recall on ordinary repos.
 
 const EMPTY: DetectionInputs = {
   packageJson: null,
@@ -40,7 +48,9 @@ function inputs(overrides: Partial<DetectionInputs>): DetectionInputs {
 const PKG = JSON.stringify({
   name: "acme-mcp-server",
   scripts: { build: "tsc", start: "node dist/index.js" },
-  dependencies: { "@modelcontextprotocol/sdk": "^1.0.0" },
+  // Any package under the official scope is the MCP signal, not the one exact
+  // sdk name — `server-everything` exercises the same detection branch.
+  dependencies: { "@modelcontextprotocol/server-everything": "^1.0.0" },
 });
 
 describe("detectCandidates — package managers", () => {
@@ -282,6 +292,280 @@ describe("detectCandidates — the run-the-checkout invariant", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// The inversion: the three reported bypasses, and the CLASS each belongs to.
+// ---------------------------------------------------------------------------
+
+describe("inverted policy — rule B: fetching subcommand anywhere in the tokens", () => {
+  // FINDING 1: `npm --yes exec -- @acme/mcp-server`. An adjacency-based regex
+  // needs `npm` and `exec` to be neighbours; there is an unbounded supply of
+  // options to put between them, so the check is now token-based.
+  it.each([
+    ["npm --yes exec -- @acme/mcp-server", "the reported bypass"],
+    ["npm -y x @acme/mcp-server", "short option before the alias"],
+    ["npm exec @acme/mcp-server", "no option at all"],
+    ["npm --loglevel warn exec @acme/mcp-server", "an option that takes a value"],
+    ["npm --yes --silent --loglevel=warn exec -- @acme/mcp-server", "several options"],
+    ["npm exec --yes -- @acme/mcp-server", "option after the subcommand"],
+    ["pnpm --silent dlx @acme/mcp-server", "pnpm dlx with an option"],
+    ["yarn --cwd . dlx @acme/mcp-server", "yarn dlx with an option"],
+    ["bun --bun x @acme/mcp-server", "bun x with an option"],
+    ["pipx --quiet run acme-mcp", "pipx run with an option"],
+    ["uv run --from acme-mcp acme", "uv run --from, which fetches despite `run`"],
+    ["uv run --with acme-mcp acme", "uv run --with"],
+  ])("suppresses %s", (body) => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: body } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("published package or remote URL");
+  });
+
+  it("still allows the non-fetching runners it deliberately permits", () => {
+    // `pnpm exec` / `yarn run` / `bun run` / bare `uv run` execute what is
+    // already resolved into the project. Banning them would discard the
+    // ordinary `"build": "tsc"` shape for no safety gain.
+    for (const build of ["pnpm exec tsc", "yarn run compile", "bun run build.ts"]) {
+      const [candidate] = detectCandidates(
+        inputs({
+          packageJson: JSON.stringify({ scripts: { build, start: "node dist/i.js" } }),
+          pnpmLockYaml: "lockfileVersion: '9.0'\n",
+        }),
+      );
+      expect(candidate?.start).toBe("pnpm start");
+    }
+  });
+});
+
+describe("inverted policy — rule A: shell-computed commands are unprovable", () => {
+  // FINDING 2: `node "$(npm root)"/@acme/server/bin.js`. The entry path does
+  // not exist as a literal in the script — the shell builds it at runtime and
+  // it lands on an installed package. No path check can see it, so the class of
+  // "commands that compute themselves" is refused wholesale.
+  it.each([
+    ['node "$(npm root)"/@acme/server/bin.js', "the reported bypass"],
+    ["node `npm root`/@acme/server/bin.js", "backtick substitution"],
+    ["node ${NODE_MODULES}/@acme/server/bin.js", "parameter expansion"],
+    ["node $HOME/server/bin.js", "bare variable"],
+    ["node ~/server/bin.js", "home expansion"],
+    ["cat pkg | sh", "a pipe"],
+    ["true; node dist/index.js", "a chained command"],
+    ["node dist/index.js && node other.js", "an && chain"],
+    ["(cd packages/server && node dist/index.js)", "a subshell"],
+    ["node dist/*.js", "a glob"],
+    ["node dist/index.js > /dev/null", "a redirection"],
+    ["node dist/{a,b}.js", "brace expansion"],
+  ])("suppresses %s", (body) => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: body } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("cannot be established");
+  });
+
+  it("leaves the BUILD script free to chain and expand", () => {
+    // A misbehaving build yields `build_failed` — a red check with honest
+    // blame. Only an unanalysable START can produce a green on unknown code.
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { build: "rm -rf dist && tsc -p . > build.log", start: "node dist/i.js" },
+        }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidate.build).toBe("npm ci && npm run build");
+  });
+});
+
+describe("inverted policy — rule C: entry points verified against the checkout", () => {
+  const PKG_NO_BUILD = JSON.stringify({ scripts: { start: "node server/main.js" } });
+
+  it("accepts an entry point that is present in the checkout", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: PKG_NO_BUILD,
+        packageLockJson: "{}",
+        repoFiles: ["package.json", "server/main.js"],
+      }),
+    );
+    expect(candidate.start).toBe("npm start");
+  });
+
+  it("suppresses an entry point that is absent from the checkout", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: PKG_NO_BUILD,
+        packageLockJson: "{}",
+        repoFiles: ["package.json", "README.md"],
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("not in the checkout");
+  });
+
+  it("accepts a build OUTPUT that no listing can contain, when a build produces it", () => {
+    // `node dist/index.js` after `npm run build` is the most common shape in
+    // the ecosystem, and `dist/` is by definition not committed. Requiring it
+    // in the listing would suppress nearly every node repo for no safety gain.
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: PKG,
+        packageLockJson: "{}",
+        repoFiles: ["package.json", "src/index.ts"],
+      }),
+    );
+    expect(candidate.start).toBe("npm start");
+  });
+
+  it("applies the same rule to a bin entry", () => {
+    const absent = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ bin: { acme: "dist/cli.js" } }),
+        packageLockJson: "{}",
+        repoFiles: ["package.json"],
+      }),
+    );
+    expect(absent.candidates).toEqual([]);
+    expect(absent.discarded.join(" ")).toContain("not in the checkout");
+
+    const present = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({ bin: { acme: "cli.js" } }),
+        packageLockJson: "{}",
+        repoFiles: ["package.json", "cli.js"],
+      }),
+    );
+    expect(present[0].start).toBe("node ./cli.js");
+  });
+
+  it("falls back to the strict syntactic rules when no listing is supplied", () => {
+    // No listing is a normal input (production callers have none until A3).
+    // Node keeps working off the path rules; it does not become unusable.
+    const [candidate] = detectCandidates(
+      inputs({ packageJson: PKG_NO_BUILD, packageLockJson: "{}" }),
+    );
+    expect(candidate.start).toBe("npm start");
+  });
+});
+
+describe("inverted policy — python [project.scripts] ownership", () => {
+  const PY = (target: string) =>
+    `[project]\nname = "acme-mcp"\n\n[project.scripts]\nacme = "${target}"\n`;
+
+  // FINDING 3: `fastmcp.cli:main` has exactly the shape of a local entry point.
+  // `module:attr` is a syntax; ownership is a fact about the checkout.
+  it("suppresses a target that resolves to a DEPENDENCY module", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        pyprojectToml: PY("fastmcp.cli:main"),
+        uvLock: "version = 1\n",
+        repoFiles: ["pyproject.toml", "uv.lock", "acme/__init__.py"],
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("dependency module");
+  });
+
+  it("suppresses ALL python project scripts when there is no file listing", () => {
+    // Without the checkout we cannot tell `fastmcp.cli:main` from
+    // `acme.server:main`. A miss is recoverable; `uv run acme` starting fastmcp
+    // and greening is not.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({ pyprojectToml: PY("acme.server:main"), uvLock: "version = 1\n" }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("no file listing available");
+  });
+
+  it.each([
+    ["acme/server.py", "flat module"],
+    ["src/acme/server.py", "src layout"],
+    ["acme/server/__init__.py", "package"],
+    ["src/acme/server/__init__.py", "src-layout package"],
+  ])("accepts a target proven local by %s", (path) => {
+    const [candidate] = detectCandidates(
+      inputs({
+        pyprojectToml: PY("acme.server:main"),
+        uvLock: "version = 1\n",
+        repoFiles: ["pyproject.toml", path],
+      }),
+    );
+    expect(candidate.start).toBe("uv run acme");
+    expect(candidate.evidence.join(" ")).toContain("verified against the checkout");
+  });
+});
+
+describe("inverted policy — recall on legitimate repos is not tanked", () => {
+  // The other half of the bargain. Being aggressively conservative is only
+  // defensible if ordinary repos still resolve; these are the shapes the corpus
+  // is made of.
+  const REAL_FILES = ["package.json", "src/index.ts", "README.md"];
+
+  it.each([
+    ["npm", { packageLockJson: "{}" }, "npm ci && npm run build", "npm start"],
+    [
+      "pnpm",
+      { pnpmLockYaml: "lockfileVersion: '9.0'\n" },
+      "pnpm install --frozen-lockfile && pnpm run build",
+      "pnpm start",
+    ],
+    [
+      "yarn",
+      { yarnLock: "# yarn lockfile v1\n" },
+      "yarn install --frozen-lockfile && yarn run build",
+      "yarn start",
+    ],
+  ])("%s: an ordinary repo still resolves, with and without a listing", (
+    _pm,
+    lock,
+    build,
+    start,
+  ) => {
+    for (const repoFiles of [undefined, REAL_FILES]) {
+      const [candidate] = detectCandidates(
+        inputs({ packageJson: PKG, ...lock, repoFiles }),
+      );
+      expect(candidate).toMatchObject({ build, start });
+    }
+  });
+
+  it("uv: an ordinary python repo still resolves", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        pyprojectToml:
+          '[project]\nname = "acme-mcp"\n\n[project.scripts]\nacme-mcp = "acme.server:main"\n',
+        uvLock: "version = 1\n",
+        repoFiles: ["pyproject.toml", "uv.lock", "src/acme/server.py"],
+      }),
+    );
+    expect(candidate).toMatchObject({ build: "uv sync --frozen", start: "uv run acme-mcp" });
+  });
+
+  it.each([
+    "node dist/index.js",
+    "node ./dist/index.js",
+    "node build/server.js --port 3001",
+    "node .",
+    "node index.mjs",
+    "tsx src/server.ts",
+  ])("does not reject the ordinary start script %s", (body) => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { build: "tsc", start: body } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidate?.start).toBe("npm start");
+  });
+});
+
 describe("detectCandidates — ecosystems outside v1", () => {
   it("python with uv.lock yields a uv candidate", () => {
     const [candidate] = detectCandidates(
@@ -289,6 +573,8 @@ describe("detectCandidates — ecosystems outside v1", () => {
         pyprojectToml:
           '[project]\nname = "acme-mcp"\n\n[project.scripts]\nacme-mcp = "acme.server:main"\n',
         uvLock: "version = 1\n",
+        // Required now: without a listing the target's OWNER is unknowable.
+        repoFiles: ["pyproject.toml", "uv.lock", "acme/server.py"],
       }),
     );
     expect(candidate).toMatchObject({
@@ -431,8 +717,12 @@ describe("detectCandidates — evidence hygiene", () => {
       inputs({
         packageJson: JSON.stringify({
           name: hostile,
-          scripts: { build: `tsc # ${hostile}`, start: `node "${hostile}.js"` },
-          dependencies: { "@modelcontextprotocol/sdk": hostile },
+          // The start script is plain: a hostile one is SUPPRESSED now (rule A
+          // — `${…}` is shell expansion), which is pinned in its own case
+          // below. This case is about what reaches EVIDENCE when a candidate
+          // does survive, so it needs a surviving candidate.
+          scripts: { build: `tsc # ${hostile}`, start: "node dist/index.js" },
+          dependencies: { "@modelcontextprotocol/server-everything": hostile },
         }),
         packageLockJson: "{}",
         readme: `http://localhost:9000/${"a".repeat(10)} ${hostile}`,

--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -1,0 +1,415 @@
+import { describe, expect, it } from "vitest";
+import {
+  DETECTION_MAX_BYTES,
+  detectCandidates,
+  detectCandidatesWithReasons,
+  RecipeResolutionError,
+  resolveRecipe,
+  resolveRecipeLadder,
+  type DetectionInputs,
+} from "../resolver";
+import { listRecipeRepos } from "../recipes";
+
+// Detection is a HEURISTIC rung, so the tests pin the properties that make a
+// guess safe to act on rather than "does it guess right":
+//
+//   1. a candidate always RUNS THE CHECKOUT — anything that would launch a
+//      published package or fetch a remote URL is discarded, because a green
+//      check on someone else's artifact is worse than no check;
+//   2. only the v1 ecosystems produce candidates, and everything else says so
+//      by name (the corpus report counts those reasons);
+//   3. evidence never carries untrusted file content (same rule as R1);
+//   4. the authoritative rungs are untouched — an invalid mcpjam.yaml still
+//      throws instead of quietly falling through to a guess.
+
+const EMPTY: DetectionInputs = {
+  packageJson: null,
+  packageLockJson: null,
+  pnpmLockYaml: null,
+  yarnLock: null,
+  pyprojectToml: null,
+  uvLock: null,
+  serverJson: null,
+  readme: null,
+};
+
+function inputs(overrides: Partial<DetectionInputs>): DetectionInputs {
+  return { ...EMPTY, ...overrides };
+}
+
+const PKG = JSON.stringify({
+  name: "acme-mcp-server",
+  scripts: { build: "tsc", start: "node dist/index.js" },
+  dependencies: { "@modelcontextprotocol/sdk": "^1.0.0" },
+});
+
+describe("detectCandidates — package managers", () => {
+  it("npm: package-lock.json -> npm ci", () => {
+    const [candidate] = detectCandidates(
+      inputs({ packageJson: PKG, packageLockJson: "{}" }),
+    );
+    expect(candidate).toMatchObject({
+      build: "npm ci && npm run build",
+      start: "npm start",
+      port: 3001,
+      mcpPath: "/mcp",
+      rung: "detected",
+    });
+  });
+
+  it("pnpm: pnpm-lock.yaml -> frozen pnpm install", () => {
+    const [candidate] = detectCandidates(
+      inputs({ packageJson: PKG, pnpmLockYaml: "lockfileVersion: '9.0'\n" }),
+    );
+    expect(candidate.build).toBe("pnpm install --frozen-lockfile && pnpm run build");
+    expect(candidate.start).toBe("pnpm start");
+  });
+
+  it("yarn classic: yarn.lock -> frozen yarn install", () => {
+    const [candidate] = detectCandidates(
+      inputs({ packageJson: PKG, yarnLock: "# yarn lockfile v1\n" }),
+    );
+    expect(candidate.build).toBe("yarn install --frozen-lockfile && yarn run build");
+    expect(candidate.start).toBe("yarn start");
+  });
+
+  it("no lockfile still yields a candidate, using npm install and ranked below one", () => {
+    const noLock = detectCandidates(inputs({ packageJson: PKG }));
+    expect(noLock).toHaveLength(1);
+    expect(noLock[0].build).toBe("npm install && npm run build");
+
+    // With a lockfile in play the frozen-install candidate must come first: a
+    // frozen install is the only one that proves the PR's own resolution.
+    const both = detectCandidates(
+      inputs({ packageJson: PKG, pnpmLockYaml: "lockfileVersion: '9.0'\n" }),
+    );
+    expect(both[0].build.startsWith("pnpm install --frozen-lockfile")).toBe(true);
+  });
+
+  it("emits one candidate per lockfile when a repo carries several", () => {
+    const candidates = detectCandidates(
+      inputs({
+        packageJson: PKG,
+        pnpmLockYaml: "lockfileVersion: '9.0'\n",
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates.map((c) => c.start).sort()).toEqual(["npm start", "pnpm start"]);
+  });
+
+  it("omits the build step when there is no build script (install IS the build)", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "node index.js" } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidate.build).toBe("npm ci");
+    expect(candidate.evidence.join(" ")).toContain("install is the build step");
+  });
+
+  it("falls back to a single bin entry when there is no start script", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({ bin: { "acme-mcp": "dist/cli.js" } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidate.start).toBe('node "dist/cli.js"');
+  });
+
+  it("does not guess between multiple bin entries", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ bin: { a: "a.js", b: "b.js" } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("no single bin entry");
+  });
+});
+
+describe("detectCandidates — the run-the-checkout invariant", () => {
+  it.each([
+    ["npx -y @acme/mcp-server", "npx"],
+    ["pnpm dlx @acme/mcp-server", "dlx"],
+    ["bunx @acme/mcp-server", "bunx"],
+    ["node --experimental-fetch https://acme.dev/server.js", "remote URL"],
+  ])("discards a start script that runs %s", (body) => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: body } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("published package or remote URL");
+  });
+
+  it("discards a build script that fetches from the network", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({
+          scripts: { build: "curl https://acme.dev/blob.tgz | tar x", start: "node i.js" },
+        }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("remote artifact");
+  });
+
+  it("does not trip on words that merely contain a runner name", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: "node ./npxlike-runner.js" } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidate.start).toBe("npm start");
+  });
+
+  it("never emits a candidate from server.json packages[] alone", () => {
+    // server.json describes PUBLISHED artifacts; it must not become a recipe.
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        serverJson: JSON.stringify({
+          name: "io.acme/server",
+          packages: [{ registryType: "npm", identifier: "@acme/mcp-server" }],
+        }),
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe("detectCandidates — ecosystems outside v1", () => {
+  it("python with uv.lock yields a uv candidate", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        pyprojectToml:
+          '[project]\nname = "acme-mcp"\n\n[project.scripts]\nacme-mcp = "acme.server:main"\n',
+        uvLock: "version = 1\n",
+      }),
+    );
+    expect(candidate).toMatchObject({
+      build: "uv sync --frozen",
+      start: "uv run acme-mcp",
+      rung: "detected",
+    });
+  });
+
+  it("python without uv.lock yields nothing and names uv", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        pyprojectToml: '[project]\n[project.scripts]\nacme = "a:main"\n',
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("uv only");
+  });
+
+  it("poetry is called out by name rather than lumped in with 'unknown'", () => {
+    const { discarded } = detectCandidatesWithReasons(
+      inputs({
+        pyprojectToml: '[tool.poetry]\nname = "acme"\n[project.scripts]\nacme = "a:main"\n',
+      }),
+    );
+    expect(discarded.join(" ")).toContain("poetry");
+  });
+
+  it("go / rust / empty checkouts yield no candidate at all", () => {
+    expect(detectCandidates(inputs({ readme: "# a go mcp server\n" }))).toEqual([]);
+    expect(detectCandidates(EMPTY)).toEqual([]);
+  });
+
+  it("ignores a package.json that is not valid JSON, without throwing", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({ packageJson: "{ not json", packageLockJson: "{}" }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("unreadable");
+  });
+
+  it("ignores oversized input by BYTES, not code units", () => {
+    // ~22k three-byte chars ≈ 66KB utf-8 but only ~22k code units.
+    const padded = JSON.stringify({
+      scripts: { start: "node i.js" },
+      note: "€".repeat(22 * 1024),
+    });
+    expect(Buffer.byteLength(padded, "utf8")).toBeGreaterThan(DETECTION_MAX_BYTES);
+    expect(padded.length).toBeLessThan(DETECTION_MAX_BYTES);
+    expect(detectCandidates(inputs({ packageJson: padded, packageLockJson: "{}" }))).toEqual([]);
+  });
+});
+
+describe("detectCandidates — port/path hints", () => {
+  it("server.json remotes[] overrides port and path", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: PKG,
+        packageLockJson: "{}",
+        serverJson: JSON.stringify({
+          remotes: [{ type: "streamable-http", url: "http://localhost:8931/sse-mcp" }],
+        }),
+      }),
+    );
+    expect(candidate.port).toBe(8931);
+    expect(candidate.mcpPath).toBe("/sse-mcp");
+    // The command is untouched by the hint — that is the whole rule.
+    expect(candidate.start).toBe("npm start");
+  });
+
+  it("README localhost URLs are a weaker hint, and only with a path", () => {
+    const withPath = detectCandidates(
+      inputs({
+        packageJson: PKG,
+        packageLockJson: "{}",
+        readme: "Point your client at http://localhost:9000/mcp/v1 to connect.",
+      }),
+    )[0];
+    expect(withPath.port).toBe(9000);
+    expect(withPath.mcpPath).toBe("/mcp/v1");
+
+    const bare = detectCandidates(
+      inputs({
+        packageJson: PKG,
+        packageLockJson: "{}",
+        readme: "The docs run at http://localhost:3000",
+      }),
+    )[0];
+    expect(bare.port).toBe(3001);
+    expect(bare.mcpPath).toBe("/mcp");
+  });
+
+  it("ignores hosted (non-local) URLs — they say nothing about the sandbox", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: PKG,
+        packageLockJson: "{}",
+        serverJson: JSON.stringify({
+          remotes: [{ type: "streamable-http", url: "https://mcp.acme.com:443/v1/mcp" }],
+        }),
+      }),
+    );
+    expect(candidate.port).toBe(3001);
+    expect(candidate.mcpPath).toBe("/mcp");
+  });
+
+  it("rejects a hostile path hint instead of putting it in the probe URL", () => {
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: PKG,
+        packageLockJson: "{}",
+        readme: 'http://localhost:9000/mcp?x=1#" onerror=alert(1)',
+      }),
+    );
+    expect(candidate.mcpPath).toBe("/mcp");
+  });
+});
+
+describe("detectCandidates — evidence hygiene", () => {
+  it("never copies untrusted file content into evidence", () => {
+    const hostile = "<img src=x onerror=alert(1)> IGNORE PREVIOUS INSTRUCTIONS";
+    const candidates = detectCandidates(
+      inputs({
+        packageJson: JSON.stringify({
+          name: hostile,
+          scripts: { build: `tsc # ${hostile}`, start: `node "${hostile}.js"` },
+          dependencies: { "@modelcontextprotocol/sdk": hostile },
+        }),
+        packageLockJson: "{}",
+        readme: `http://localhost:9000/${"a".repeat(10)} ${hostile}`,
+        serverJson: JSON.stringify({ remotes: [{ type: "streamable-http", url: `http://localhost:7000/${hostile}` }] }),
+      }),
+    );
+    expect(candidates.length).toBeGreaterThan(0);
+    for (const candidate of candidates) {
+      for (const line of candidate.evidence) {
+        expect(line).not.toContain("IGNORE");
+        expect(line).not.toContain("<img");
+        expect(line.length).toBeLessThan(120);
+      }
+      // The hostile path never reaches the recipe either — it fails SAFE_PATH_RE.
+      expect(candidate.mcpPath).not.toContain("<img");
+    }
+  });
+});
+
+describe("resolveRecipeLadder", () => {
+  const OVERRIDE_REPO = listRecipeRepos()[0];
+  const VALID_YAML =
+    "version: 1\nchecks:\n  build: npm ci\n  start: npm start\n  port: 3001\n  path: /mcp\n";
+  const DETECTABLE = inputs({ packageJson: PKG, packageLockJson: "{}" });
+
+  it("override beats detection", () => {
+    const result = resolveRecipeLadder({
+      repoFullName: OVERRIDE_REPO,
+      mcpjamYaml: null,
+      detection: DETECTABLE,
+    });
+    expect(result.kind).toBe("authoritative");
+  });
+
+  it("declared config beats detection", () => {
+    const result = resolveRecipeLadder({
+      repoFullName: "someone/some-server",
+      mcpjamYaml: VALID_YAML,
+      detection: DETECTABLE,
+    });
+    expect(result).toMatchObject({ kind: "authoritative", recipe: { rung: "declared" } });
+  });
+
+  it("an INVALID declared config still throws — no fall-through to detection", () => {
+    // The R1 attribution contract, re-pinned now that a fallback exists: this
+    // is exactly the regression a heuristic rung invites.
+    let error: unknown;
+    try {
+      resolveRecipeLadder({
+        repoFullName: "someone/some-server",
+        mcpjamYaml: VALID_YAML.replace("version: 1", "version: 99"),
+        detection: DETECTABLE,
+      });
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeInstanceOf(RecipeResolutionError);
+    expect((error as RecipeResolutionError).reason).toBe("invalid_mcpjam_yaml");
+  });
+
+  it("returns detected candidates when nothing authoritative exists", () => {
+    const result = resolveRecipeLadder({
+      repoFullName: "someone/some-server",
+      mcpjamYaml: null,
+      detection: DETECTABLE,
+    });
+    expect(result.kind).toBe("candidates");
+    if (result.kind !== "candidates") throw new Error("unreachable");
+    expect(result.candidates[0].rung).toBe("detected");
+  });
+
+  it("nothing detectable -> no_recipe, with the discard reasons attached", () => {
+    let error: RecipeResolutionError | undefined;
+    try {
+      resolveRecipeLadder({
+        repoFullName: "someone/some-server",
+        mcpjamYaml: null,
+        detection: inputs({ pyprojectToml: "[project]\n" }),
+      });
+    } catch (err) {
+      error = err as RecipeResolutionError;
+    }
+    expect(error?.reason).toBe("no_recipe");
+    expect(error?.detailsMarkdown).toContain("uv only");
+  });
+
+  it("resolveRecipe keeps its R1 behavior (authoritative only, throws otherwise)", () => {
+    expect(
+      resolveRecipe({ repoFullName: "someone/some-server", mcpjamYaml: VALID_YAML }).rung,
+    ).toBe("declared");
+    expect(() =>
+      resolveRecipe({ repoFullName: "someone/some-server", mcpjamYaml: null }),
+    ).toThrowError(RecipeResolutionError);
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -115,7 +115,7 @@ describe("detectCandidates — package managers", () => {
         packageLockJson: "{}",
       }),
     );
-    expect(candidate.start).toBe('node "dist/cli.js"');
+    expect(candidate.start).toBe("node ./dist/cli.js");
   });
 
   it("does not guess between multiple bin entries", () => {
@@ -168,6 +168,104 @@ describe("detectCandidates — the run-the-checkout invariant", () => {
       }),
     );
     expect(candidate.start).toBe("npm start");
+  });
+
+  it.each([
+    ["npm exec -- @acme/mcp-server", "npm exec"],
+    ["npm x @acme/mcp-server", "npm x alias"],
+    ["yarn dlx @acme/mcp-server", "yarn dlx"],
+    ["bun x @acme/mcp-server", "bun x"],
+    ["uvx acme-mcp", "uvx"],
+    ["uv tool run acme-mcp", "uv tool run"],
+    ["pipx run acme-mcp", "pipx run"],
+  ])("discards the %s package launcher", (body) => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: body } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("published package or remote URL");
+  });
+
+  it.each([
+    ["NPX -y @acme/mcp-server", "uppercase"],
+    ["sh -c 'npx -y @acme/mcp-server'", "single-quoted"],
+    ['sh -c "npx -y @acme/mcp-server"', "double-quoted"],
+    ["./node_modules/.bin/npx @acme/mcp-server", "path-prefixed"],
+  ])("does not let %s slip past the runner guard", (body) => {
+    const { candidates } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: body } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  it.each([
+    ["node node_modules/@acme/server/bin.js", "an installed dependency"],
+    ["node ./node_modules/acme/dist/cli.js", "a ./-prefixed dependency path"],
+    ["node ../sibling/dist/index.js", "a path outside the checkout"],
+  ])("discards a start script that runs %s", (body) => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ scripts: { start: body } }),
+        packageLockJson: "{}",
+      }),
+    );
+    // A dependency is published code just as much as a registry fetch is: it
+    // would go green no matter what the PR broke.
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("installed dependency");
+  });
+
+  it.each([
+    ["node_modules/acme/bin.js", "dependency"],
+    ["../outside/bin.js", "traversal"],
+    ["/usr/local/bin/acme", "absolute"],
+  ])("suppresses the candidate when the %s bin path is not checkout source", (bin) => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ bin: { acme: bin } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("plain relative path");
+  });
+
+  it.each([
+    "dist/x$(id).js",
+    "dist/x`id`.js",
+    'dist/x";id;".js',
+    "dist/x$HOME.js",
+    "dist/x;rm -rf /.js",
+  ])("rejects a hostile bin path (%s) rather than quoting it", (bin) => {
+    // `start` runs under `bash -lc`, where double quotes still expand `$(…)`,
+    // backticks and `$VAR` — quoting is not escaping, so the only safe answer
+    // is to refuse the value.
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        packageJson: JSON.stringify({ bin: { acme: bin } }),
+        packageLockJson: "{}",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("plain relative path");
+  });
+
+  it("does not emit a python candidate whose entry point is not a local module", () => {
+    const { candidates, discarded } = detectCandidatesWithReasons(
+      inputs({
+        pyprojectToml:
+          '[project]\n[project.scripts]\nacme = "../vendor/thing.py"\n',
+        uvLock: "version = 1\n",
+      }),
+    );
+    expect(candidates).toEqual([]);
+    expect(discarded.join(" ")).toContain("local module reference");
   });
 
   it("never emits a candidate from server.json packages[] alone", () => {
@@ -281,6 +379,23 @@ describe("detectCandidates — port/path hints", () => {
     )[0];
     expect(bare.port).toBe(3001);
     expect(bare.mcpPath).toBe("/mcp");
+  });
+
+  it.each([
+    ["http://localhost/mcp", 80],
+    ["https://localhost/mcp", 443],
+  ])("infers the scheme-default port for %s", (url, port) => {
+    // `URL.port` is empty for a scheme-default port; falling back to 3001 here
+    // would probe a port the author never mentioned.
+    const [candidate] = detectCandidates(
+      inputs({
+        packageJson: PKG,
+        packageLockJson: "{}",
+        serverJson: JSON.stringify({ remotes: [{ type: "streamable-http", url }] }),
+      }),
+    );
+    expect(candidate.port).toBe(port);
+    expect(candidate.mcpPath).toBe("/mcp");
   });
 
   it("ignores hosted (non-local) URLs — they say nothing about the sandbox", () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/repoFiles.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/repoFiles.test.ts
@@ -1,0 +1,129 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  listRepoFiles,
+  MAX_REPO_FILES,
+  parseLsFilesEntries,
+} from "../resolver";
+
+// This listing is the ONLY evidence rule C has. If its parsing regresses, the
+// detector does not fail loudly — it quietly stops finding entry points, every
+// candidate drops to `ownershipProof: 'unverified'` or is suppressed, and
+// corpus recall moves for reasons nobody attributes to this function. Hence
+// coverage for the three ways it can silently produce a wrong listing:
+// NUL-delimited parsing, git failing, and the truncation cap.
+
+const dirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "repo-files-test-"));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (dirs.length > 0) {
+    rmSync(dirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+const record = (mode: string, path: string) => `${mode} 0000000000 0\t${path}`;
+
+describe("parseLsFilesEntries — NUL-delimited records", () => {
+  it("splits on NUL and reads the mode column into a kind", () => {
+    const stdout = [
+      record("100644", "package.json"),
+      record("100755", "bin/cli"),
+      record("120000", "server.js"),
+      record("160000", "vendor/sub"),
+      "",
+    ].join("\0");
+
+    expect(parseLsFilesEntries(stdout)).toEqual([
+      { path: "package.json", kind: "file" },
+      { path: "bin/cli", kind: "file" },
+      { path: "server.js", kind: "symlink" },
+      { path: "vendor/sub", kind: "other" },
+    ]);
+  });
+
+  it("keeps a path containing a NEWLINE intact", () => {
+    // The whole reason for `-z`: newlines are legal in git paths, and a
+    // line-oriented parser would split one path into two bogus entries — two
+    // lookups that silently miss.
+    const stdout = `${record("100644", "src/we\nird.js")}\0`;
+    expect(parseLsFilesEntries(stdout)).toEqual([
+      { path: "src/we\nird.js", kind: "file" },
+    ]);
+  });
+
+  it("keeps a path containing SPACES intact (the mode split is on the tab)", () => {
+    const stdout = `${record("100644", "my dir/my server.js")}\0`;
+    expect(parseLsFilesEntries(stdout)).toEqual([
+      { path: "my dir/my server.js", kind: "file" },
+    ]);
+  });
+
+  it("drops malformed records instead of guessing at them", () => {
+    const stdout = ["no-tab-here", record("100644", "ok.js"), "\t", ""].join(
+      "\0"
+    );
+    expect(parseLsFilesEntries(stdout)).toEqual([
+      { path: "ok.js", kind: "file" },
+    ]);
+  });
+
+  it("returns nothing for empty output", () => {
+    expect(parseLsFilesEntries("")).toEqual([]);
+  });
+
+  it("truncates at MAX_REPO_FILES", () => {
+    const stdout = Array.from({ length: MAX_REPO_FILES + 500 }, (_, i) =>
+      record("100644", `f${i}.js`)
+    ).join("\0");
+    const entries = parseLsFilesEntries(stdout);
+    expect(entries).toHaveLength(MAX_REPO_FILES);
+    // Truncation is safe in the SUPPRESS direction only if it keeps a prefix of
+    // real entries rather than corrupting the tail.
+    expect(entries[MAX_REPO_FILES - 1]).toEqual({
+      path: `f${MAX_REPO_FILES - 1}.js`,
+      kind: "file",
+    });
+  });
+});
+
+describe("listRepoFiles — against real git", () => {
+  it("reports a regular file as 'file' and a symlink as 'symlink'", () => {
+    // Run against real git rather than a mocked stdout: mode 120000 is the one
+    // fact this module exists to carry, and a fixture asserting our own guess
+    // about git's output would not catch git disagreeing with it.
+    const dir = tempDir();
+    execFileSync("git", ["init", "--quiet"], { cwd: dir, stdio: "pipe" });
+    writeFileSync(join(dir, "package.json"), "{}\n");
+    writeFileSync(join(dir, "real.js"), "//\n");
+    symlinkSync("node_modules/acme/server.js", join(dir, "linked.js"));
+    execFileSync("git", ["add", "-A"], { cwd: dir, stdio: "pipe" });
+
+    const entries = listRepoFiles(dir);
+    const byPath = new Map(entries.map((e) => [e.path, e.kind]));
+    expect(byPath.get("package.json")).toBe("file");
+    expect(byPath.get("real.js")).toBe("file");
+    expect(byPath.get("linked.js")).toBe("symlink");
+  });
+
+  it("returns an empty listing when the command fails", () => {
+    // Not a git repo -> `git ls-files` exits non-zero. An empty listing is a
+    // VALID input (detection reads it as "no listing" and marks what it emits
+    // unverified), so this must not throw into the caller.
+    expect(listRepoFiles(tempDir())).toEqual([]);
+  });
+
+  it("returns an empty listing when the directory does not exist", () => {
+    expect(listRepoFiles(join(tmpdir(), "definitely-not-here-0f8a2c"))).toEqual(
+      []
+    );
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolver.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolver.test.ts
@@ -49,6 +49,7 @@ describe("parseMcpjamYaml (declared rung)", () => {
       port: 3001,
       mcpPath: "/mcp",
       rung: "declared",
+      ownershipProof: "verified",
       evidence: ["mcpjam.yaml at repo root (version 1)"],
     });
   });

--- a/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
@@ -22,6 +22,59 @@
  * (`node node_modules/@acme/server/bin.js`) or reaches outside the checkout
  * (`../`) is published code too, and is discarded for the same reason.
  *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE POLICY IS AN ALLOWLIST, NOT A BLOCKLIST. THIS IS THE IMPORTANT PART.
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * This module used to enumerate KNOWN-BAD launcher spellings and let everything
+ * else through. That approach sprang a leak in three consecutive review rounds,
+ * each a different spelling of the same bypass:
+ *
+ *   1. `npm --yes exec -- @acme/mcp-server` — an option between `npm` and
+ *      `exec` walked past an adjacency-based regex;
+ *   2. `node "$(npm root)"/@acme/server/bin.js` — the entry path is computed by
+ *      the SHELL at runtime, so no literal-path check can ever see it;
+ *   3. `[project.scripts] acme = "fastmcp.cli:main"` — `module:attr` is a
+ *      SYNTAX, and syntax proves nothing about who owns the module; `uv run
+ *      acme` then starts the dependency.
+ *
+ * A blocklist cannot establish the invariant we actually need, because the
+ * invariant is a positive claim: THIS COMMAND DEMONSTRABLY RUNS CODE FROM THE
+ * PR CHECKOUT. Patching spellings only ever proves a command is not one of the
+ * launchers we happened to think of. So the policy is inverted: a heuristic
+ * candidate is emitted only when it is PROVABLY local, and SUPPRESSED whenever
+ * we cannot establish that — including when the reason we cannot is simply that
+ * we lack the evidence.
+ *
+ * The asymmetry is what licenses being this aggressive:
+ *
+ *   suppressed candidate  →  a resolver MISS. Neutral check, measurable in the
+ *                            corpus, and recoverable by the author in one file
+ *                            (`mcpjam.yaml`, the authoritative rung).
+ *   accepted-but-wrong    →  a SILENT FALSE GREEN on published code. Nobody
+ *                            finds out, and it is the exact failure this module
+ *                            exists to prevent.
+ *
+ * A miss costs recall. A false green costs the product its meaning. We buy the
+ * second with the first, deliberately, and the corpus harness reports the price.
+ *
+ * The three rules that implement the inversion:
+ *
+ *   A. UNPROVABLE BY CONSTRUCTION → REJECT. A start command containing shell
+ *      metacharacters ($, backtick, |, ;, &, <, >, globs, braces, subshells,
+ *      newlines) computes its own entry point at runtime. No static analysis
+ *      can see what it runs, so nothing about it can be proven, so it is never
+ *      emitted. This kills finding 2 and its whole class permanently, rather
+ *      than one spelling of it.
+ *   B. FETCHING SUBCOMMAND ANYWHERE IN THE TOKEN LIST → REJECT. Launcher
+ *      detection is TOKEN-based, not adjacency-based: `npm … exec` is a fetch
+ *      no matter how many options are interleaved. This kills finding 1 and
+ *      every option permutation of it.
+ *   C. ENTRY POINTS ARE VERIFIED AGAINST THE ACTUAL CHECKOUT when a file
+ *      listing is available (`DetectionInputs.repoFiles`). For python, that
+ *      verification is REQUIRED — without it, a `[project.scripts]` target is
+ *      suppressed outright, which is finding 3's answer.
+ *
  * v1 ECOSYSTEMS (deliberately short; everything else yields no candidate):
  *   - node: npm (package-lock.json), pnpm (pnpm-lock.yaml), yarn classic
  *     (yarn.lock), driven off package.json
@@ -54,6 +107,23 @@ export type DetectionInputs = {
   serverJson: string | null;
   /** README.md. HINTS ONLY. */
   readme: string | null;
+  /**
+   * OPTIONAL, and the evidence that turns rule C from a guess into a proof:
+   * relative paths (POSIX separators, no leading `./`) of files present in the
+   * checkout. This is a FILE LISTING, not file contents — it does not join the
+   * R3 recipe cache key the way the parsed fields above do, because it is
+   * derived from the same commit those are read at.
+   *
+   * When present, a candidate's entry point must be findable in it. When
+   * ABSENT, node falls back to the strict syntactic path rules (relative, no
+   * `node_modules`, no `../`, safe charset) and python `[project.scripts]`
+   * candidates are suppressed outright — see `detectPython`.
+   *
+   * Populated today by `scripts/resolver-corpus.ts` (it has the clone on disk).
+   * A3 populates it from the sandbox, where the checkout is likewise on disk;
+   * until then, production callers pass nothing and get the conservative path.
+   */
+  repoFiles?: string[];
 };
 
 /**
@@ -74,34 +144,148 @@ const DEFAULT_PORT = 3001;
 const DEFAULT_MCP_PATH = "/mcp";
 
 /**
- * PACKAGE LAUNCHERS: commands whose job is to fetch a published package and run
- * it. The list is enumerated deliberately rather than pattern-guessed, because
- * every entry is a decision about what "runs the checkout" means:
+ * RULE A — shell metacharacters that make a command UNPROVABLE.
  *
- *   npm    `npx`, `npm exec`, and its alias `npm x` — `npm exec` is documented
- *          as running "a local or REMOTE npm package", so `npm exec -- @acme/s`
- *          installs from the registry and runs published code.
- *   pnpm   `pnpm dlx`      (fetch-and-run; `pnpm exec` is NOT here — see below)
- *   yarn   `yarn dlx`
- *   bun    `bunx`, `bun x`
- *   python `uvx`, `uv tool run` (uvx's long form), `pipx run`
+ * `$` / backtick (command substitution, parameter expansion), `|` `;` `&`
+ * (chaining, so the thing that actually starts the server may be a token we
+ * never analysed), `<` `>` (redirection), `(` `)` (subshells), `{` `}` (brace
+ * expansion), `*` `?` `[` `]` (globbing), `~` (home expansion — a path OUT of
+ * the checkout), `\` (quote removal), and newlines.
  *
- * DELIBERATELY ABSENT: `pnpm exec`, `yarn run`, `bun run`, `uv run`. Those only
- * run something already resolved into the project (a build tool from
- * node_modules/.bin, a console script from `uv sync`), and banning them would
- * discard the overwhelmingly common `"build": "tsc"` shape for no safety gain.
- * A dependency used to BUILD the checkout is fine; a dependency used AS the
- * server is what `escapesCheckout` below rejects.
+ * `node "$(npm root)"/@acme/server/bin.js` is the motivating case: the entry
+ * path does not exist as a literal anywhere in the script, the shell builds it
+ * at runtime, and it lands on an INSTALLED PACKAGE. There is no literal-path
+ * check that can catch that — not because we wrote the wrong regex, but because
+ * the information is not in the text. So the answer is not a better path check,
+ * it is refusing to reason about shell-computed commands at all.
  *
- * Case-insensitive, and bounded by "not a path/identifier character" rather
- * than by whitespace, so quoted (`sh -c "npx -y pkg"`), uppercase (`NPX`) and
- * path-prefixed (`node_modules/.bin/npx`) forms all match, while `npxlike.js`
- * and `dist/npx.js` still do not.
+ * Applied to the START body only. `build` may chain and expand freely: a build
+ * that misbehaves yields `build_failed`, which is a red check with honest
+ * blame, whereas a start we cannot analyse yields a GREEN check on unknown
+ * code. Only the second one lies.
+ *
+ * Quotes (`'` `"`) are deliberately NOT here: quoting alone computes nothing,
+ * and the tokenizer below strips them, so `sh -c "npx pkg"` is still caught as
+ * the launcher it is.
  */
-const REMOTE_RUNNER_RE =
-  /(^|[^A-Za-z0-9_.\-])(npx|npm\s+(?:exec|x)|pnpm\s+dlx|yarn\s+dlx|bunx|bun\s+x|uvx|uv\s+tool\s+run|pipx\s+run)([^A-Za-z0-9_.\-]|$)/i;
+const UNPROVABLE_SHELL_RE = /[$`|;&<>(){}\[\]*?~\\\n\r]/;
+
+/**
+ * RULE B — PACKAGE LAUNCHERS: commands whose job is to fetch a published
+ * package and run it. Enumerated deliberately rather than pattern-guessed,
+ * because every entry is a decision about what "runs the checkout" means.
+ *
+ * Commands that fetch no matter what they are followed by:
+ *   `npx`, `pnpx`, `bunx`, `uvx`.
+ */
+const ALWAYS_FETCHING_COMMANDS: ReadonlySet<string> = new Set([
+  "npx",
+  "pnpx",
+  "bunx",
+  "uvx",
+]);
+
+/**
+ * Package managers that fetch only under a particular SUBCOMMAND. Each entry is
+ * re-verified here, with the reason it is (or is not) a fetcher:
+ *
+ *   npm   `exec`, `x` — npm documents `npm exec` as running "a local or REMOTE
+ *         npm package"; `npm x` is its alias. Both install from the registry.
+ *   pnpm  `dlx` — "fetch a package from the registry and run it". `pnpm exec`
+ *         is NOT a fetcher: pnpm splits the two verbs, and `exec` runs only
+ *         what is already in the project's node_modules/.bin.
+ *   yarn  `dlx` — berry's fetch-and-run. `yarn run` executes a package.json
+ *         script, no fetch.
+ *   bun   `x` — the long form of `bunx`. `bun run` executes a local script.
+ *   uv    `tool` (`uv tool run` is uvx's long form, `uv tool install` fetches),
+ *         and the `--from` / `--with` OPTIONS, which are the sharp edge here:
+ *         `uv run --from acme-mcp acme` runs the PUBLISHED package even though
+ *         the subcommand is the innocuous `uv run`. Bare `uv run <script>` is
+ *         not a fetcher — it runs a console script from the synced project env.
+ *   pipx  `run` (fetch-and-run), `install`.
+ *
+ * DELIBERATELY ABSENT, re-verified: `pnpm exec`, `yarn run`, `bun run`,
+ * `uv run`. Those only run something already resolved into the project, and
+ * banning them would discard the overwhelmingly common `"build": "tsc"` shape
+ * for no safety gain. A dependency used to BUILD the checkout is fine; a
+ * dependency used AS the server is what the other rules reject.
+ */
+const FETCHING_SUBCOMMANDS: Record<string, ReadonlySet<string>> = {
+  npm: new Set(["exec", "x"]),
+  pnpm: new Set(["dlx"]),
+  yarn: new Set(["dlx"]),
+  bun: new Set(["x"]),
+  uv: new Set(["tool", "--from", "--with"]),
+  pipx: new Set(["run", "install"]),
+};
+
 /** Any absolute URL in a command — `node https://…`, `curl … | sh`, etc. */
 const REMOTE_URL_RE = /\b[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Split a script body into command segments, then into tokens.
+ *
+ * Crude on purpose — this is not a shell parser and must never be mistaken for
+ * one. It exists so launcher detection can be TOKEN-based instead of
+ * adjacency-based, which is what finding 1 (`npm --yes exec -- pkg`) proved is
+ * necessary: any regex that requires `npm` and `exec` to be neighbours loses to
+ * an interleaved option, and there is an unbounded supply of options.
+ *
+ * Quotes are stripped rather than honoured, so `sh -c "npx pkg"` tokenizes to
+ * the launcher it will actually run. That over-tokenizes some inputs, which for
+ * a suppression rule is the safe direction.
+ */
+function shellSegments(body: string): string[][] {
+  return body
+    .split(/[\n\r;|&()]+/)
+    .map((segment) =>
+      segment
+        .split(/\s+/)
+        .map((token) => token.replace(/['"`]/g, ""))
+        .filter((token) => token.length > 0),
+    )
+    .filter((segment) => segment.length > 0);
+}
+
+/** Last path component, lowercased: `./node_modules/.bin/NPX` -> `npx`. */
+function commandName(token: string): string {
+  const parts = token.split("/");
+  return (parts[parts.length - 1] ?? "").toLowerCase();
+}
+
+/**
+ * True when any segment invokes a package manager with a fetching subcommand
+ * ANYWHERE in its token list, or a command that always fetches.
+ *
+ * "Anywhere before `--`" rather than "immediately after the manager" is the
+ * whole fix for finding 1: `npm --yes exec -- @acme/pkg`, `npm -y x pkg`,
+ * `npm --loglevel warn exec pkg` and every other permutation reduce to the same
+ * token set. The scan stops at `--` because tokens after it are arguments, not
+ * subcommands (`npm run build -- --dlx-ish-flag` is not a fetch).
+ *
+ * KNOWN OVER-REJECTION, accepted: a package.json script literally named `x` or
+ * `exec` makes `npm run x` look like `npm x`. That repo gets a resolver miss
+ * and can declare `mcpjam.yaml`. Under the inversion, an over-rejection is a
+ * cost we pay in recall; the alternative is reasoning about which position a
+ * token occupies, which is exactly the adjacency assumption that has now failed
+ * three times.
+ */
+function usesPackageLauncher(body: string): boolean {
+  for (const segment of shellSegments(body)) {
+    for (let i = 0; i < segment.length; i++) {
+      const name = commandName(segment[i]);
+      if (ALWAYS_FETCHING_COMMANDS.has(name)) return true;
+      const fetching = FETCHING_SUBCOMMANDS[name];
+      if (!fetching) continue;
+      for (let j = i + 1; j < segment.length; j++) {
+        const token = segment[j].toLowerCase();
+        if (token === "--") break;
+        if (fetching.has(token)) return true;
+      }
+    }
+  }
+  return false;
+}
 
 /**
  * Paths that are inside the tree but NOT checkout source: an installed
@@ -174,7 +358,15 @@ function asStringRecord(value: unknown): Record<string, string> {
  * is a published-package launcher wearing a local disguise.
  */
 function isRemoteInvocation(body: string): boolean {
-  return REMOTE_RUNNER_RE.test(body) || REMOTE_URL_RE.test(body);
+  return usesPackageLauncher(body) || REMOTE_URL_RE.test(body);
+}
+
+/**
+ * True when the command computes part of itself at runtime, so no static claim
+ * about what it runs can be made. See UNPROVABLE_SHELL_RE.
+ */
+function isUnprovableShell(body: string): boolean {
+  return UNPROVABLE_SHELL_RE.test(body);
 }
 
 /**
@@ -185,6 +377,92 @@ function isRemoteInvocation(body: string): boolean {
  */
 function escapesCheckout(body: string): boolean {
   return NODE_MODULES_RE.test(body) || PARENT_TRAVERSAL_RE.test(body);
+}
+
+// ---------------------------------------------------------------------------
+// Rule C: verify entry points against the actual checkout
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize the caller's listing into a lookup set. Leading `./` is stripped
+ * and separators are POSIX, so `./dist/cli.js` and `dist/cli.js` are the same
+ * file — a caller assembling this from `git ls-files` or a directory walk
+ * should not have to know which spelling we compare against.
+ */
+function checkoutFiles(repoFiles: string[] | undefined): Set<string> | null {
+  // An EMPTY listing means "we could not list the checkout", not "the checkout
+  // is empty" — no repo we can detect has zero files. Treating it as absent
+  // keeps the reasons honest (a caller whose `git ls-files` failed gets the
+  // no-listing reason, not "your entry point is a dependency").
+  if (!repoFiles || repoFiles.length === 0) return null;
+  const out = new Set<string>();
+  for (const entry of repoFiles) {
+    if (typeof entry !== "string" || entry === "") continue;
+    out.add(entry.replace(/\\/g, "/").replace(/^\.\//, ""));
+  }
+  return out;
+}
+
+/** Extensions that make a token an ENTRY POINT rather than an argument. */
+const SCRIPT_EXTENSION_RE = /\.(?:js|mjs|cjs|jsx|ts|mts|cts|tsx|py)$/i;
+
+/**
+ * The file paths a start command would execute. Options (`--port`) and bare
+ * words (`node`, a script name) are not entry points; a token with a script
+ * extension is.
+ *
+ * Only meaningful AFTER `isUnprovableShell` has passed: a command that builds
+ * its path at runtime has no such token, which is precisely why it is rejected
+ * before we get here rather than "found to have zero entry points".
+ */
+function entryPaths(body: string): string[] {
+  const out: string[] = [];
+  for (const segment of shellSegments(body)) {
+    for (const token of segment) {
+      if (token.startsWith("-")) continue;
+      if (SCRIPT_EXTENSION_RE.test(token)) out.push(token.replace(/^\.\//, ""));
+    }
+  }
+  return out;
+}
+
+/**
+ * Is this entry path established as checkout code?
+ *
+ * Present in the listing → yes, directly. Absent but the candidate has a BUILD
+ * step → also yes: `node dist/index.js` after `npm run build` is the single
+ * most common shape in the ecosystem, and `dist/` is a build OUTPUT — it is by
+ * definition not in the checkout, and it is by definition produced from the
+ * checkout. Requiring it to be committed would suppress nearly every node repo
+ * for no safety gain, since a relative path that no launcher and no shell
+ * expansion produced can only resolve inside the checkout.
+ *
+ * Absent AND no build step → suppressed. Nothing in the repo produces that
+ * file, so whatever the command finds at runtime is not this PR's code (and if
+ * it finds nothing, the check would fail and blame the author for our guess).
+ */
+function entryEstablished(
+  path: string,
+  files: Set<string>,
+  hasBuildStep: boolean,
+): boolean {
+  return files.has(path) || hasBuildStep;
+}
+
+/**
+ * Candidate on-disk locations for a python `module.path` — flat layout, src
+ * layout, module and package forms. `fastmcp.cli` is checkout code only if one
+ * of these is a real file in the checkout; if none is, the module belongs to a
+ * DEPENDENCY and `uv run <script>` would start it. That is finding 3.
+ */
+function pythonModuleFiles(module: string): string[] {
+  const relative = module.split(".").join("/");
+  return [
+    `${relative}.py`,
+    `${relative}/__init__.py`,
+    `src/${relative}.py`,
+    `src/${relative}/__init__.py`,
+  ];
 }
 
 // ---------------------------------------------------------------------------
@@ -364,13 +642,19 @@ function detectNode(
     ...asStringRecord(pkg.dependencies),
     ...asStringRecord(pkg.devDependencies),
   };
+  // Matched by SCOPE prefix rather than by the one exact package name: any
+  // dependency under the official scope (server-*, and whatever ships next) is
+  // at least as good an MCP signal as the sdk itself.
   const hasMcpSdk = Object.keys(deps).some(
     (name) =>
-      name === "@modelcontextprotocol/sdk" ||
+      name.startsWith("@modelcontextprotocol/") ||
       name === "@mcpjam/sdk" ||
       name === "fastmcp" ||
       name === "mcp-framework",
   );
+
+  const checkout = checkoutFiles(files.repoFiles);
+  const hasBuildStep = typeof scripts.build === "string" && scripts.build !== "";
 
   const out: Scored[] = [];
   for (const manager of managers) {
@@ -390,6 +674,15 @@ function detectNode(
         );
         continue;
       }
+      if (isUnprovableShell(scripts.start)) {
+        // Rule A. `node "$(npm root)"/@acme/server/bin.js` and every other
+        // shell-computed entry point lands here: we cannot see what it runs, so
+        // we cannot claim it runs the checkout, so we do not emit it.
+        discarded.push(
+          `${manager.pm}: scripts.start uses shell expansion or chaining, so what it runs cannot be established`,
+        );
+        continue;
+      }
       if (escapesCheckout(scripts.start)) {
         // Same verdict, nearer miss: `node node_modules/@acme/server/bin.js`
         // starts the installed dependency. Suppressing beats emitting — a
@@ -400,6 +693,19 @@ function detectNode(
         );
         continue;
       }
+      if (checkout) {
+        // Rule C. Every file the start command names must be checkout code or
+        // the output of the checkout's own build.
+        const unestablished = entryPaths(scripts.start).filter(
+          (path) => !entryEstablished(path, checkout, hasBuildStep),
+        );
+        if (unestablished.length > 0) {
+          discarded.push(
+            `${manager.pm}: scripts.start runs a file that is not in the checkout and no build step produces it`,
+          );
+          continue;
+        }
+      }
       start = cmd.start;
       evidence.push("start command from scripts.start");
       score += 10;
@@ -409,6 +715,14 @@ function detectNode(
         if (SAFE_RELATIVE_PATH_RE.test(bin) && !escapesCheckout(bin)) {
           // Validated (not merely quoted — see SAFE_RELATIVE_PATH_RE) plain
           // relative path inside the checkout, so it is safe to exec directly.
+          const binPath = bin.replace(/^\.\//, "");
+          if (checkout && !entryEstablished(binPath, checkout, hasBuildStep)) {
+            // Rule C, same reasoning as for scripts.start.
+            discarded.push(
+              `${manager.pm}: package.json bin is not in the checkout and no build step produces it`,
+            );
+            continue;
+          }
           start = `node ./${bin}`;
           evidence.push("start command from package.json bin entry");
           score += 6;
@@ -509,14 +823,14 @@ function pyprojectFacts(raw: string): {
 }
 
 /**
- * A `[project.scripts]` target we are willing to start: a dotted module path
- * and an attribute, e.g. `acme.server:main`. `uv sync` installs THIS project,
- * so a console script declared here and pointing at a plain module reference is
- * the checkout's own entry point. Anything else — a path, a traversal, a
- * dependency's module — we cannot establish as checkout source, so we suppress
- * rather than emit a candidate that might green on published code.
+ * SHAPE of a `[project.scripts]` target: a dotted module path and an attribute,
+ * e.g. `acme.server:main`. This is a NECESSARY condition and emphatically not a
+ * sufficient one — see `detectPython`. `fastmcp.cli:main` has exactly this
+ * shape and names a DEPENDENCY, which is finding 3: `module:attr` is a syntax,
+ * and no syntax can tell you who owns the module.
  */
-const PY_ENTRY_POINT_RE = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_.]*$/;
+const PY_ENTRY_POINT_RE =
+  /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_.]*$/;
 
 function detectPython(
   files: DetectionInputs,
@@ -563,6 +877,31 @@ function detectPython(
     return [];
   }
 
+  // Rule C, and for python it is MANDATORY rather than an extra check.
+  //
+  // `uv sync` installs this project AND its dependencies into one environment,
+  // and `[project.scripts]` may legally point at either. `fastmcp.cli:main`
+  // parses exactly like `acme.server:main`; the only difference is who owns the
+  // module, and that fact lives in the checkout, not in the pyproject. Without
+  // a file listing we have no way to tell them apart, so we suppress — a
+  // resolver miss instead of `uv run acme` quietly starting fastmcp and
+  // greening a check on a dependency's code.
+  const checkout = checkoutFiles(files.repoFiles);
+  if (!checkout) {
+    discarded.push(
+      "python: cannot verify the [project.scripts] target is checkout code (no file listing available)",
+    );
+    return [];
+  }
+  const module = facts.firstScriptTarget.split(":")[0];
+  const owned = pythonModuleFiles(module).some((path) => checkout.has(path));
+  if (!owned) {
+    discarded.push(
+      "python: the [project.scripts] target resolves to a dependency module, not to checkout source",
+    );
+    return [];
+  }
+
   return [
     {
       recipe: finish(
@@ -574,7 +913,11 @@ function detectPython(
           start: `uv run ${facts.firstScript}`,
         },
         hint,
-        ["pyproject.toml + uv.lock", "start command from [project.scripts]"],
+        [
+          "pyproject.toml + uv.lock",
+          "start command from [project.scripts]",
+          "entry module verified against the checkout file listing",
+        ],
       ),
       score: 25,
     },

--- a/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
@@ -1158,9 +1158,22 @@ function runtimeRunsForeignCode(
       if (inlineFlags.has(flag)) return true;
     }
   }
-  const entry = args.find(
-    (token) => !token.startsWith("-") && !REDIRECTION_RE.test(token),
-  );
+  // ANY option present ⇒ foreign, without trying to work out which token is
+  // the entry. Picking "the first token that does not start with `-`" is wrong
+  // the moment an option takes a VALUE: in
+  // `node --require ./scripts/boot.js node_modules/acme/server.js`
+  // that heuristic returns `./scripts/boot.js` — the option's value — verifies
+  // it as checkout code, and never looks at the real entry beside it.
+  //
+  // Getting this right means implementing the runtime's CLI grammar (which
+  // options take values, `--opt=v` vs `--opt v`, per runtime, per version).
+  // That is a parser whose bugs are false greens, so it is not worth writing:
+  // this branch only judges a runtime that was DETACHED inside an install
+  // hook, where the legitimate shape (`nohup node dist/index.js &`) needs no
+  // options at all. Conservative rejection costs a resolver miss the author
+  // can fix with mcpjam.yaml; the alternative costs a silent false green.
+  if (args.some((token) => token.startsWith("-"))) return true;
+  const entry = args.find((token) => !REDIRECTION_RE.test(token));
   if (entry === undefined) return true;
   // `node .` runs the checkout root through its own package.json `main`.
   if (entry === "." || entry === "./") return false;

--- a/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
@@ -17,7 +17,10 @@
  * would then report on code the PR never touched, which is worse than no check
  * at all (a silent false green on a broken PR). So anything that resolves to a
  * published package or a remote URL is DISCARDED, with the reason recorded, and
- * we would rather emit no candidate than a lying one.
+ * we would rather emit no candidate than a lying one. The same applies one step
+ * closer to home: a command that starts an INSTALLED DEPENDENCY
+ * (`node node_modules/@acme/server/bin.js`) or reaches outside the checkout
+ * (`../`) is published code too, and is discarded for the same reason.
  *
  * v1 ECOSYSTEMS (deliberately short; everything else yields no candidate):
  *   - node: npm (package-lock.json), pnpm (pnpm-lock.yaml), yarn classic
@@ -71,12 +74,44 @@ const DEFAULT_PORT = 3001;
 const DEFAULT_MCP_PATH = "/mcp";
 
 /**
- * Commands that fetch-and-run something instead of running the checkout.
- * Matched on word boundaries so `npx` in `my-npxtool` doesn't trip it.
+ * PACKAGE LAUNCHERS: commands whose job is to fetch a published package and run
+ * it. The list is enumerated deliberately rather than pattern-guessed, because
+ * every entry is a decision about what "runs the checkout" means:
+ *
+ *   npm    `npx`, `npm exec`, and its alias `npm x` — `npm exec` is documented
+ *          as running "a local or REMOTE npm package", so `npm exec -- @acme/s`
+ *          installs from the registry and runs published code.
+ *   pnpm   `pnpm dlx`      (fetch-and-run; `pnpm exec` is NOT here — see below)
+ *   yarn   `yarn dlx`
+ *   bun    `bunx`, `bun x`
+ *   python `uvx`, `uv tool run` (uvx's long form), `pipx run`
+ *
+ * DELIBERATELY ABSENT: `pnpm exec`, `yarn run`, `bun run`, `uv run`. Those only
+ * run something already resolved into the project (a build tool from
+ * node_modules/.bin, a console script from `uv sync`), and banning them would
+ * discard the overwhelmingly common `"build": "tsc"` shape for no safety gain.
+ * A dependency used to BUILD the checkout is fine; a dependency used AS the
+ * server is what `escapesCheckout` below rejects.
+ *
+ * Case-insensitive, and bounded by "not a path/identifier character" rather
+ * than by whitespace, so quoted (`sh -c "npx -y pkg"`), uppercase (`NPX`) and
+ * path-prefixed (`node_modules/.bin/npx`) forms all match, while `npxlike.js`
+ * and `dist/npx.js` still do not.
  */
-const REMOTE_RUNNER_RE = /(^|[\s;&|(])(npx|pnpm\s+dlx|yarn\s+dlx|bunx|uvx|pipx\s+run)([\s;&|)]|$)/;
+const REMOTE_RUNNER_RE =
+  /(^|[^A-Za-z0-9_.\-])(npx|npm\s+(?:exec|x)|pnpm\s+dlx|yarn\s+dlx|bunx|bun\s+x|uvx|uv\s+tool\s+run|pipx\s+run)([^A-Za-z0-9_.\-]|$)/i;
 /** Any absolute URL in a command — `node https://…`, `curl … | sh`, etc. */
 const REMOTE_URL_RE = /\b[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Paths that are inside the tree but NOT checkout source: an installed
+ * dependency (`node_modules/…`) or anything reached by climbing out of the
+ * checkout (`../`). `node dist/index.js` tests the PR; `node
+ * node_modules/@acme/server/bin.js` tests the published package the PR merely
+ * depends on, and goes green regardless of what the PR broke.
+ */
+const NODE_MODULES_RE = /(^|[^A-Za-z0-9_.\-])node_modules\//i;
+const PARENT_TRAVERSAL_RE = /(^|[^A-Za-z0-9_.\-])\.\.\//;
 
 /**
  * Paths reach the probe URL, so they are constrained rather than trusted.
@@ -84,6 +119,19 @@ const REMOTE_URL_RE = /\b[a-z][a-z0-9+.-]*:\/\//i;
  * short, absolute path is dropped and the default is kept.
  */
 const SAFE_PATH_RE = /^\/[A-Za-z0-9._~\-/]{0,64}$/;
+
+/**
+ * The relative-path counterpart of SAFE_PATH_RE, same character allowlist, used
+ * for a `bin` value that we splice into a shell command.
+ *
+ * This is VALIDATION, not escaping. `start` is run under `bash -lc`, where
+ * double quotes still expand `$(…)`, backticks and `$VAR` — so a bin of
+ * `dist/x$(id).js` would command-substitute no matter how it is quoted. The
+ * only honest options are "reject" or "spawn without a shell", and rejecting is
+ * the one that fits a heuristic rung: an author whose bin path needs shell
+ * metacharacters can write mcpjam.yaml instead.
+ */
+const SAFE_RELATIVE_PATH_RE = /^(?!\/)(?!.*\.\.)[A-Za-z0-9._~\-/]{1,128}$/;
 
 type NodePackageManager = "npm" | "pnpm" | "yarn";
 
@@ -129,6 +177,16 @@ function isRemoteInvocation(body: string): boolean {
   return REMOTE_RUNNER_RE.test(body) || REMOTE_URL_RE.test(body);
 }
 
+/**
+ * True when the command names something that is in the working tree but is not
+ * checkout source — an installed dependency, or a path above the checkout root.
+ * Same failure mode as `isRemoteInvocation`, one step closer to home: the
+ * command runs, the check goes green, and it proved nothing about the PR.
+ */
+function escapesCheckout(body: string): boolean {
+  return NODE_MODULES_RE.test(body) || PARENT_TRAVERSAL_RE.test(body);
+}
+
 // ---------------------------------------------------------------------------
 // Hints (port/path only — NEVER a command)
 // ---------------------------------------------------------------------------
@@ -158,7 +216,15 @@ function portFromUrl(url: string): { port?: number; path?: string } | null {
     parsed.hostname === "[::1]";
   if (!isLocal) return null;
 
-  const port = parsed.port ? Number(parsed.port) : undefined;
+  // `URL.port` is EMPTY for a scheme-default port, so `http://localhost/mcp`
+  // parses with no port at all. Falling through to DEFAULT_PORT there would
+  // probe 3001 on a repo that explicitly documented 80 — an author who wrote a
+  // scheme-default URL stated a port just as much as one who wrote `:8080`.
+  const port = parsed.port
+    ? Number(parsed.port)
+    : parsed.protocol === "https:"
+      ? 443
+      : 80;
   const path = parsed.pathname && parsed.pathname !== "/" ? parsed.pathname : undefined;
   const out: { port?: number; path?: string } = {};
   if (port !== undefined && Number.isInteger(port) && port >= 1 && port <= 65535) {
@@ -324,17 +390,34 @@ function detectNode(
         );
         continue;
       }
+      if (escapesCheckout(scripts.start)) {
+        // Same verdict, nearer miss: `node node_modules/@acme/server/bin.js`
+        // starts the installed dependency. Suppressing beats emitting — a
+        // missed candidate is a resolver miss we can measure, a false green is
+        // the failure this whole module exists to prevent.
+        discarded.push(
+          `${manager.pm}: scripts.start runs an installed dependency or a path outside the checkout`,
+        );
+        continue;
+      }
       start = cmd.start;
       evidence.push("start command from scripts.start");
       score += 10;
     } else {
       const bin = singleBinPath(pkg);
-      if (bin && !isRemoteInvocation(bin) && !bin.startsWith("/")) {
-        // Relative path inside the checkout: safe to exec directly. Quoted
-        // because package.json `bin` paths are author-controlled text.
-        start = `node ${JSON.stringify(bin)}`;
-        evidence.push("start command from package.json bin entry");
-        score += 6;
+      if (bin) {
+        if (SAFE_RELATIVE_PATH_RE.test(bin) && !escapesCheckout(bin)) {
+          // Validated (not merely quoted — see SAFE_RELATIVE_PATH_RE) plain
+          // relative path inside the checkout, so it is safe to exec directly.
+          start = `node ./${bin}`;
+          evidence.push("start command from package.json bin entry");
+          score += 6;
+        } else {
+          discarded.push(
+            `${manager.pm}: package.json bin is not a plain relative path inside the checkout`,
+          );
+          continue;
+        }
       }
     }
     if (!start) {
@@ -391,10 +474,12 @@ function detectNode(
  */
 function pyprojectFacts(raw: string): {
   firstScript: string | null;
+  firstScriptTarget: string | null;
   hasPoetry: boolean;
 } {
   let section = "";
   let firstScript: string | null = null;
+  let firstScriptTarget: string | null = null;
   let hasPoetry = false;
   for (const line of raw.split(/\r?\n/)) {
     const trimmed = line.trim();
@@ -408,12 +493,30 @@ function pyprojectFacts(raw: string): {
       continue;
     }
     if (section === "project.scripts" && firstScript === null) {
-      const entry = trimmed.match(/^["']?([A-Za-z0-9._-]+)["']?\s*=/);
-      if (entry) firstScript = entry[1];
+      // Both halves matter: the NAME becomes `uv run <name>`, and the TARGET is
+      // the only evidence available here that the name resolves to this
+      // project's own module rather than to a dependency's console script.
+      const entry = trimmed.match(
+        /^["']?([A-Za-z0-9._-]+)["']?\s*=\s*["']([^"']*)["']\s*$/,
+      );
+      if (entry) {
+        firstScript = entry[1];
+        firstScriptTarget = entry[2];
+      }
     }
   }
-  return { firstScript, hasPoetry };
+  return { firstScript, firstScriptTarget, hasPoetry };
 }
+
+/**
+ * A `[project.scripts]` target we are willing to start: a dotted module path
+ * and an attribute, e.g. `acme.server:main`. `uv sync` installs THIS project,
+ * so a console script declared here and pointing at a plain module reference is
+ * the checkout's own entry point. Anything else — a path, a traversal, a
+ * dependency's module — we cannot establish as checkout source, so we suppress
+ * rather than emit a candidate that might green on published code.
+ */
+const PY_ENTRY_POINT_RE = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*:[A-Za-z_][A-Za-z0-9_.]*$/;
 
 function detectPython(
   files: DetectionInputs,
@@ -442,6 +545,21 @@ function detectPython(
   }
   if (facts.firstScript === null) {
     discarded.push("python: no [project.scripts] entry to start");
+    return [];
+  }
+  // The name is spliced into `uv run <name>`; require it to look like a script
+  // name and not like a flag or an option value.
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(facts.firstScript)) {
+    discarded.push("python: [project.scripts] name is not a plain script name");
+    return [];
+  }
+  if (
+    facts.firstScriptTarget === null ||
+    !PY_ENTRY_POINT_RE.test(facts.firstScriptTarget)
+  ) {
+    discarded.push(
+      "python: [project.scripts] entry point is not a local module reference",
+    );
     return [];
   }
 

--- a/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
@@ -1,0 +1,526 @@
+/**
+ * Rung 2: detection — guess how to build and start the server from the SHAPE
+ * of the checkout.
+ *
+ * This rung is HEURISTIC (see types.ts): nobody promised us anything, so it
+ * never throws. It returns zero or more candidates, ordered best-first, and
+ * the orchestrator (R4) tries them one at a time — each in its own sandbox —
+ * until one builds and speaks MCP.
+ *
+ * THE ONE INVARIANT THAT MAKES THIS SAFE TO RUN:
+ *
+ *   A candidate must RUN THE CHECKOUT.
+ *
+ * A check exists to say whether THIS PULL REQUEST works. A command like
+ * `npx @acme/mcp-server` or `node https://…` looks like it starts the server
+ * and would even go green, but it starts the PUBLISHED artifact — the check
+ * would then report on code the PR never touched, which is worse than no check
+ * at all (a silent false green on a broken PR). So anything that resolves to a
+ * published package or a remote URL is DISCARDED, with the reason recorded, and
+ * we would rather emit no candidate than a lying one.
+ *
+ * v1 ECOSYSTEMS (deliberately short; everything else yields no candidate):
+ *   - node: npm (package-lock.json), pnpm (pnpm-lock.yaml), yarn classic
+ *     (yarn.lock), driven off package.json
+ *   - python: pyproject.toml + uv.lock (uv only)
+ * bun / poetry / pipenv / go / rust are out of scope for v1 — they are named
+ * in the discard reasons so the corpus report can count them honestly rather
+ * than burying them in one "unsupported" bucket.
+ *
+ * NO I/O: like mcpjamYaml.ts, this module is a pure function of already-read
+ * file contents. The worker does the (byte-capped, in-sandbox) reading.
+ */
+
+import type { CheckRecipe } from "../recipes";
+import type { ResolvedRecipe } from "./types";
+
+/**
+ * Contents of the files detection looks at; `null` means "file absent", which
+ * is itself a signal (a missing lockfile changes the install command). The
+ * field list is fixed and ordered because R3 hashes exactly these paths to key
+ * the recipe cache — adding one here is a cache-key change, not a local edit.
+ */
+export type DetectionInputs = {
+  packageJson: string | null;
+  packageLockJson: string | null;
+  pnpmLockYaml: string | null;
+  yarnLock: string | null;
+  pyprojectToml: string | null;
+  uvLock: string | null;
+  /** Registry manifest (modelcontextprotocol/registry). HINTS ONLY. */
+  serverJson: string | null;
+  /** README.md. HINTS ONLY. */
+  readme: string | null;
+};
+
+/**
+ * Defensive cap in BYTES for files we PARSE, mirroring
+ * MCPJAM_YAML_MAX_BYTES's approach (UTF-8 bytes, not code units — code units
+ * undercount multi-byte text and would admit inputs past the in-sandbox cap
+ * this bound exists to mirror). READMEs are routinely larger than a config
+ * file, so they get their own, larger cap.
+ *
+ * Oversize input is IGNORED, never fatal: this is a heuristic rung, and a
+ * 4MB generated README is not the author's fault.
+ */
+export const DETECTION_MAX_BYTES = 64 * 1024;
+export const DETECTION_README_MAX_BYTES = 256 * 1024;
+
+/** Defaults when nothing hints otherwise. Match the fixture recipe. */
+const DEFAULT_PORT = 3001;
+const DEFAULT_MCP_PATH = "/mcp";
+
+/**
+ * Commands that fetch-and-run something instead of running the checkout.
+ * Matched on word boundaries so `npx` in `my-npxtool` doesn't trip it.
+ */
+const REMOTE_RUNNER_RE = /(^|[\s;&|(])(npx|pnpm\s+dlx|yarn\s+dlx|bunx|uvx|pipx\s+run)([\s;&|)]|$)/;
+/** Any absolute URL in a command — `node https://…`, `curl … | sh`, etc. */
+const REMOTE_URL_RE = /\b[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Paths reach the probe URL, so they are constrained rather than trusted.
+ * README/server.json are untrusted PR content; a hint that isn't a plain,
+ * short, absolute path is dropped and the default is kept.
+ */
+const SAFE_PATH_RE = /^\/[A-Za-z0-9._~\-/]{0,64}$/;
+
+type NodePackageManager = "npm" | "pnpm" | "yarn";
+
+/** Per-candidate scoring inputs; higher total sorts first. */
+type Scored = { recipe: ResolvedRecipe; score: number };
+
+function withinCap(raw: string | null, cap: number): string | null {
+  if (raw === null) return null;
+  return Buffer.byteLength(raw, "utf8") > cap ? null : raw;
+}
+
+function parseJsonObject(raw: string | null): Record<string, unknown> | null {
+  if (raw === null) return null;
+  try {
+    const doc: unknown = JSON.parse(raw);
+    if (typeof doc !== "object" || doc === null || Array.isArray(doc)) {
+      return null;
+    }
+    return doc as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function asStringRecord(value: unknown): Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (typeof val === "string") out[key] = val;
+  }
+  return out;
+}
+
+/**
+ * True when running this script body would execute something OTHER than the
+ * checkout. Checked on the SCRIPT BODY, not on the command we emit: we emit
+ * `npm start`, but if `scripts.start` is `npx -y @acme/server` then `npm start`
+ * is a published-package launcher wearing a local disguise.
+ */
+function isRemoteInvocation(body: string): boolean {
+  return REMOTE_RUNNER_RE.test(body) || REMOTE_URL_RE.test(body);
+}
+
+// ---------------------------------------------------------------------------
+// Hints (port/path only — NEVER a command)
+// ---------------------------------------------------------------------------
+
+type Hint = {
+  port?: number;
+  path?: string;
+  /** Constant, content-free label for evidence. */
+  source: "server.json" | "README";
+};
+
+function portFromUrl(url: string): { port?: number; path?: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  // Only LOCAL urls are usable hints. A hint pointing at a hosted deployment
+  // (https://mcp.acme.com/v1) says nothing about which port the checkout binds
+  // inside our sandbox, and its path may not even be served by the local build.
+  const isLocal =
+    parsed.hostname === "localhost" ||
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "0.0.0.0" ||
+    parsed.hostname === "[::1]";
+  if (!isLocal) return null;
+
+  const port = parsed.port ? Number(parsed.port) : undefined;
+  const path = parsed.pathname && parsed.pathname !== "/" ? parsed.pathname : undefined;
+  const out: { port?: number; path?: string } = {};
+  if (port !== undefined && Number.isInteger(port) && port >= 1 && port <= 65535) {
+    out.port = port;
+  }
+  if (path !== undefined && SAFE_PATH_RE.test(path)) out.path = path;
+  return out.port === undefined && out.path === undefined ? null : out;
+}
+
+/**
+ * Registry manifest hint. The registry describes streamable-http servers with
+ * a `remotes[]` array; only that shape is read, and only for port/path. The
+ * `packages[]` array (which names PUBLISHED artifacts) is deliberately ignored
+ * — it is exactly the "run the published thing" trap this rung refuses.
+ */
+function hintFromServerJson(raw: string | null): Hint | null {
+  const doc = parseJsonObject(withinCap(raw, DETECTION_MAX_BYTES));
+  if (!doc) return null;
+  const remotes = doc.remotes;
+  if (!Array.isArray(remotes)) return null;
+  for (const remote of remotes) {
+    if (typeof remote !== "object" || remote === null) continue;
+    const entry = remote as Record<string, unknown>;
+    const type = typeof entry.type === "string" ? entry.type : "";
+    if (type !== "streamable-http" && type !== "http") continue;
+    if (typeof entry.url !== "string") continue;
+    const hint = portFromUrl(entry.url);
+    if (hint) return { ...hint, source: "server.json" };
+  }
+  return null;
+}
+
+/**
+ * README hint: the first localhost HTTP URL that looks like an MCP endpoint.
+ * READMEs are prose plus config blobs, so this is the weakest signal in the
+ * module — it only ever moves port/path, never the command.
+ */
+function hintFromReadme(raw: string | null): Hint | null {
+  const text = withinCap(raw, DETECTION_README_MAX_BYTES);
+  if (text === null) return null;
+  const matches = text.match(
+    /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(?::\d{1,5})?(?:\/[A-Za-z0-9._~\-/]*)?/g,
+  );
+  if (!matches) return null;
+  for (const match of matches) {
+    const hint = portFromUrl(match);
+    // Require a path segment: a bare `http://localhost:3000` in a README is
+    // usually the docs site or a web UI, not the MCP endpoint.
+    if (hint?.path) return { ...hint, source: "README" };
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Node
+// ---------------------------------------------------------------------------
+
+function nodeCommands(pm: NodePackageManager, hasLockfile: boolean) {
+  // Frozen installs are the point of a lockfile: they fail loudly if the PR
+  // forgot to update it, instead of quietly resolving different dependencies
+  // than the author tested against.
+  switch (pm) {
+    case "pnpm":
+      return {
+        install: "pnpm install --frozen-lockfile",
+        run: (script: string) => `pnpm run ${script}`,
+        start: "pnpm start",
+      };
+    case "yarn":
+      return {
+        install: "yarn install --frozen-lockfile",
+        run: (script: string) => `yarn run ${script}`,
+        start: "yarn start",
+      };
+    case "npm":
+      return {
+        install: hasLockfile ? "npm ci" : "npm install",
+        run: (script: string) => `npm run ${script}`,
+        start: "npm start",
+      };
+  }
+}
+
+/**
+ * Resolve `bin` to a single local entry path, or null. `bin` is either a
+ * string or a name→path map; a map with several entries is ambiguous (which
+ * one is the server?) and we do not guess.
+ */
+function singleBinPath(pkg: Record<string, unknown>): string | null {
+  const bin = pkg.bin;
+  if (typeof bin === "string") return bin;
+  if (typeof bin === "object" && bin !== null && !Array.isArray(bin)) {
+    const entries = Object.entries(bin).filter(
+      ([, value]) => typeof value === "string",
+    ) as [string, string][];
+    if (entries.length === 1) return entries[0][1];
+  }
+  return null;
+}
+
+function detectNode(
+  files: DetectionInputs,
+  hint: Hint | null,
+  discarded: string[],
+): Scored[] {
+  const pkg = parseJsonObject(withinCap(files.packageJson, DETECTION_MAX_BYTES));
+  if (!pkg) {
+    if (files.packageJson !== null) {
+      discarded.push("package.json present but unreadable (too large or not valid JSON)");
+    }
+    return [];
+  }
+
+  // Bun is a v1 non-goal and its lockfile is binary, so it is not even an
+  // input; a bun-only repo simply has no lockfile here and falls into the
+  // `npm install` fallback. That is acceptable (npm can usually install a bun
+  // project) and the corpus counts whether it actually works.
+  const managers: { pm: NodePackageManager; lock: boolean; why: string }[] = [];
+  if (files.pnpmLockYaml !== null) {
+    managers.push({ pm: "pnpm", lock: true, why: "pnpm-lock.yaml" });
+  }
+  if (files.yarnLock !== null) {
+    managers.push({ pm: "yarn", lock: true, why: "yarn.lock" });
+  }
+  if (files.packageLockJson !== null) {
+    managers.push({ pm: "npm", lock: true, why: "package-lock.json" });
+  }
+  if (managers.length === 0) {
+    // No lockfile at all: still worth a shot, but ranked below any lockfile
+    // candidate — `npm install` resolves whatever is current, so a green check
+    // proves less than a frozen install would.
+    managers.push({ pm: "npm", lock: false, why: "package.json (no lockfile)" });
+  }
+
+  const scripts = asStringRecord(pkg.scripts);
+  const deps = {
+    ...asStringRecord(pkg.dependencies),
+    ...asStringRecord(pkg.devDependencies),
+  };
+  const hasMcpSdk = Object.keys(deps).some(
+    (name) =>
+      name === "@modelcontextprotocol/sdk" ||
+      name === "@mcpjam/sdk" ||
+      name === "fastmcp" ||
+      name === "mcp-framework",
+  );
+
+  const out: Scored[] = [];
+  for (const manager of managers) {
+    const cmd = nodeCommands(manager.pm, manager.lock);
+    const evidence: string[] = [`package.json + ${manager.why}`];
+    let score = manager.lock ? 20 : 5;
+
+    // --- start command -----------------------------------------------------
+    let start: string | null = null;
+    if (scripts.start) {
+      if (isRemoteInvocation(scripts.start)) {
+        // The disguised-launcher case. Do not fall back to `bin` here: a repo
+        // whose own start script fetches the published package is telling us
+        // its checkout is not the thing under test.
+        discarded.push(
+          `${manager.pm}: scripts.start launches a published package or remote URL, not the checkout`,
+        );
+        continue;
+      }
+      start = cmd.start;
+      evidence.push("start command from scripts.start");
+      score += 10;
+    } else {
+      const bin = singleBinPath(pkg);
+      if (bin && !isRemoteInvocation(bin) && !bin.startsWith("/")) {
+        // Relative path inside the checkout: safe to exec directly. Quoted
+        // because package.json `bin` paths are author-controlled text.
+        start = `node ${JSON.stringify(bin)}`;
+        evidence.push("start command from package.json bin entry");
+        score += 6;
+      }
+    }
+    if (!start) {
+      discarded.push(
+        `${manager.pm}: package.json has no scripts.start and no single bin entry`,
+      );
+      continue;
+    }
+
+    // --- build command -----------------------------------------------------
+    // CheckRecipe.build is required, and for a node project the install IS the
+    // minimum build step — so a repo with no build script gets the install
+    // alone rather than a no-op like `true`. That keeps the recipe honest
+    // (a failing install is still `build_failed`, which is the right blame)
+    // and avoids a recipe that pretends to have built something.
+    let build = cmd.install;
+    if (scripts.build) {
+      if (isRemoteInvocation(scripts.build)) {
+        discarded.push(
+          `${manager.pm}: scripts.build fetches a remote artifact; refusing to build from the network`,
+        );
+        continue;
+      }
+      build = `${cmd.install} && ${cmd.run("build")}`;
+      evidence.push("build step from scripts.build");
+      score += 8;
+    } else {
+      evidence.push("no build script; install is the build step");
+    }
+
+    if (hasMcpSdk) {
+      evidence.push("declares an MCP server SDK dependency");
+      score += 15;
+    }
+
+    out.push({
+      recipe: finish({ build, start }, hint, evidence),
+      score,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Python (uv only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal, section-aware pyproject reader. A full TOML parser is not a
+ * dependency this module is worth adding: we need exactly two facts (does
+ * `[project.scripts]` exist, and what is its first entry name) and one
+ * negative signal (`[tool.poetry]`). Anything this misreads yields NO
+ * candidate, which is the safe direction for a heuristic.
+ */
+function pyprojectFacts(raw: string): {
+  firstScript: string | null;
+  hasPoetry: boolean;
+} {
+  let section = "";
+  let firstScript: string | null = null;
+  let hasPoetry = false;
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#") || trimmed === "") continue;
+    const header = trimmed.match(/^\[([^\]]+)\]$/);
+    if (header) {
+      section = header[1].trim();
+      if (section === "tool.poetry" || section.startsWith("tool.poetry.")) {
+        hasPoetry = true;
+      }
+      continue;
+    }
+    if (section === "project.scripts" && firstScript === null) {
+      const entry = trimmed.match(/^["']?([A-Za-z0-9._-]+)["']?\s*=/);
+      if (entry) firstScript = entry[1];
+    }
+  }
+  return { firstScript, hasPoetry };
+}
+
+function detectPython(
+  files: DetectionInputs,
+  hint: Hint | null,
+  discarded: string[],
+): Scored[] {
+  const raw = withinCap(files.pyprojectToml, DETECTION_MAX_BYTES);
+  if (raw === null) {
+    if (files.pyprojectToml !== null) {
+      discarded.push("pyproject.toml present but exceeds the read cap");
+    }
+    return [];
+  }
+
+  const facts = pyprojectFacts(raw);
+  if (files.uvLock === null) {
+    // v1 supports exactly one python toolchain. Naming the alternative is the
+    // point: the corpus report needs to distinguish "python we chose not to
+    // support yet" from "we couldn't tell what this repo is".
+    discarded.push(
+      facts.hasPoetry
+        ? "python: poetry project (v1 supports uv only)"
+        : "python: pyproject.toml without uv.lock (v1 supports uv only)",
+    );
+    return [];
+  }
+  if (facts.firstScript === null) {
+    discarded.push("python: no [project.scripts] entry to start");
+    return [];
+  }
+
+  return [
+    {
+      recipe: finish(
+        {
+          // `--frozen` for the same reason as the node frozen installs: the
+          // lockfile is the contract, and drifting from it silently would test
+          // dependencies the author never resolved.
+          build: "uv sync --frozen",
+          start: `uv run ${facts.firstScript}`,
+        },
+        hint,
+        ["pyproject.toml + uv.lock", "start command from [project.scripts]"],
+      ),
+      score: 25,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+
+function finish(
+  commands: { build: string; start: string },
+  hint: Hint | null,
+  evidence: string[],
+): ResolvedRecipe {
+  const recipe: CheckRecipe = {
+    build: commands.build,
+    start: commands.start,
+    port: hint?.port ?? DEFAULT_PORT,
+    mcpPath: hint?.path ?? DEFAULT_MCP_PATH,
+  };
+  const lines = [...evidence];
+  if (hint && (hint.port !== undefined || hint.path !== undefined)) {
+    // Names the SOURCE, never the value: `hint.path` is untrusted PR content
+    // and evidence is rendered into GitHub check output. The port is echoed
+    // because it is an integer we validated, and it is the one number an
+    // author debugging a `server_unhealthy` result actually needs.
+    const parts: string[] = [];
+    if (hint.port !== undefined) parts.push(`port ${recipe.port}`);
+    if (hint.path !== undefined) parts.push("path");
+    lines.push(`${parts.join(" and ")} from ${hint.source}`);
+  }
+  return { ...recipe, rung: "detected", evidence: lines };
+}
+
+/**
+ * Detect candidate recipes for a checkout, best-first.
+ *
+ * Returns `[]` when nothing is detectable — an empty array is a normal
+ * outcome, not an error (heuristic rung). Reasons for rejected candidates are
+ * not part of the recipe; use `detectCandidatesWithReasons` when you need them
+ * (the corpus harness does, and R4's `recipe_unresolvable` output will).
+ */
+export function detectCandidates(files: DetectionInputs): ResolvedRecipe[] {
+  return detectCandidatesWithReasons(files).candidates;
+}
+
+export function detectCandidatesWithReasons(files: DetectionInputs): {
+  candidates: ResolvedRecipe[];
+  /** Why plausible candidates were rejected. Constant strings only. */
+  discarded: string[];
+} {
+  const discarded: string[] = [];
+  // Hints are computed once and shared: they describe the SERVER, not the
+  // toolchain, so every candidate for this checkout gets the same port/path.
+  const hint = hintFromServerJson(files.serverJson) ?? hintFromReadme(files.readme);
+
+  const scored = [
+    ...detectNode(files, hint, discarded),
+    ...detectPython(files, hint, discarded),
+  ];
+
+  // Stable, best-first. `sort` is stable in modern V8, so equal scores keep
+  // detection order (node before python), which is deterministic — R3 caches
+  // these by evidence hash and a reshuffle would look like a cache miss.
+  scored.sort((a, b) => b.score - a.score);
+
+  return { candidates: scored.map((entry) => entry.recipe), discarded };
+}

--- a/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
@@ -106,6 +106,77 @@
  *      site, including the build-output one.
  *
  * ═══════════════════════════════════════════════════════════════════════════
+ * RULE C, ROUND 3: `scripts.start` IS NOT THE ONLY THING `npm start` RUNS
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * Rounds 1 and 2 both analysed the LITERAL BODY of `scripts.start` and assumed
+ * that was the whole of what the emitted command executes. It is not. npm (and
+ * pnpm/yarn/bun) resolve two further layers that the body never mentions:
+ *
+ *   1. LIFECYCLE HOOKS. `npm start` runs `prestart`, then `start`, then
+ *      `poststart`. A `prestart` of `npx @acme/server` launches a published
+ *      package while `scripts.start` sits there looking impeccable. Nothing in
+ *      round 2 ever read `prestart`.
+ *   2. SCRIPT INDIRECTION. `"start": "npm run serve"` runs `scripts.serve`,
+ *      which round 2 also never read. Round 2's answer was to DISCARD every
+ *      indirection wholesale — safe, but it cost real repos (exa-mcp-server's
+ *      `"start": "npm run dev"` was a corpus miss for exactly this reason), and
+ *      it only covered the plain `npm run X` spelling. `pnpm serve`,
+ *      `yarn serve`, `bun run serve` and `npm-run-all a b` are the same
+ *      indirection in different clothes.
+ *
+ * The prescription is the same inversion as before, applied one level deeper:
+ * do not blacklist the spellings of indirection, RESOLVE it and verify what it
+ * lands on. So a script reference is followed through the `scripts` map and the
+ * full rule set is applied to the resolved body, recursively, with a depth cap
+ * (MAX_SCRIPT_DEPTH) and cycle detection. Anything that cannot be resolved —
+ * an absent script, a computed script name, an unrecognised runner, a cycle,
+ * a chain deeper than the cap — is SUPPRESSED, with its own reason. That turns
+ * a blanket discard into "verify and accept when provable", which recovers
+ * legitimate repos without conceding anything to the unprovable ones.
+ *
+ * WHICH HOOKS ARE ACCOUNTED FOR, AND WHY THE OTHERS ARE NOT. The surface is
+ * decided by the two commands this module actually emits — `<pm> start` and
+ * `<install> [&& <pm> run build]` — and by which of them can put a process
+ * behind the PROBE, because that is the only way a false GREEN happens:
+ *
+ *   START LIFECYCLE — `prestart`, `start`, `poststart`.  FULLY IN SCOPE.
+ *     `start` gets rules A + B + escape + C, recursively: it is the process the
+ *     probe talks to, so its ownership is the invariant.
+ *     `prestart`/`poststart` get rules A + B, recursively, but NOT rule C and
+ *     not the escapes-checkout check. This is a deliberate line, not an
+ *     oversight: a hook must EXIT
+ *     before npm moves on, so it cannot be the process the probe connects to.
+ *     A `prestart` that foregrounds a published server hangs npm and the check
+ *     times out — a red result with honest blame, not a false green. A hook
+ *     that DETACHES one is the real hazard, and rule A already refuses `&`,
+ *     backgrounding and chaining in the start lifecycle. Applying rule C here
+ *     would instead suppress `"prestart": "tsc"` — a build tool, doing exactly
+ *     its job — and buy no safety for it.
+ *
+ *   BUILD LIFECYCLE — `prebuild`, `build`, `postbuild`.  RULE B ONLY.
+ *     This extends the check `build` already had to the hooks `npm run build`
+ *     drags along with it. Rules A and C are deliberately not applied: build
+ *     steps chain and expand freely by design (see UNPROVABLE_SHELL_RE), and a
+ *     build that misbehaves yields `build_failed`, which is honest.
+ *
+ *   INSTALL LIFECYCLE — `preinstall`, `install`, `postinstall`, `prepare`,
+ *     `prepublish`.  NARROW RULE: fetch AND detach.
+ *     These run for any `npm ci`/`npm install`, so we cannot avoid triggering
+ *     them and a broad rule here would suppress half the ecosystem
+ *     (`patch-package`, `husky`, `npx playwright install`). A FOREGROUND fetch
+ *     in an install hook cannot produce a false green — it either exits, or it
+ *     hangs and the build times out. The one shape that can is a hook that
+ *     fetches a published package AND backgrounds it, leaving a listener that
+ *     answers the probe before `start` ever binds. That conjunction, and only
+ *     that conjunction, suppresses the candidate.
+ *
+ *   OUT OF SCOPE BY CONSTRUCTION — `prepublishOnly`, `prepack`, `postpack`,
+ *     `pretest`/`test`/`posttest`, `preversion`, `publish`. None of them run
+ *     for `npm ci`, `npm install`, `npm run build` or `npm start`, so nothing
+ *     we emit can trigger them.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
  * WHAT REPLACES THE BUILD-SCRIPT INFERENCE: `ownershipProof`
  * ═══════════════════════════════════════════════════════════════════════════
  *
@@ -636,6 +707,289 @@ function verifyExtensionlessStart(
   return checkout.get(normalized) === "file" ? "verified" : "rejected";
 }
 
+// ---------------------------------------------------------------------------
+// Rule C, round 3: script indirection and lifecycle hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * How many levels of package.json script indirection we will follow.
+ *
+ * Counted in HOPS from the root script: `start -> serve` is one hop, and
+ * `start -> serve -> exec` is two, which is already deeper than anything in
+ * the corpus. Past the cap we SUPPRESS rather than keep walking, for the usual
+ * reason — an unbounded walk is an unbounded amount of reasoning we would then
+ * be claiming to have done.
+ */
+const MAX_SCRIPT_DEPTH = 3;
+
+/**
+ * Package managers that run a package.json script, and whether the `run` verb
+ * is mandatory.
+ *
+ *   'run-required' — npm and bun only reach a script through `run`
+ *                    (`npm run serve`, `npm run-script serve`, `bun run serve`)
+ *                    or through a LIFECYCLE verb (`npm start`, `npm test`).
+ *   'run-optional' — pnpm and yarn additionally accept the bare script name
+ *                    (`pnpm serve`, `yarn serve`).
+ *
+ * Note this is the same token set rule B already scans, read for a different
+ * question: rule B asks "does this FETCH", this asks "does this HAND OFF".
+ */
+const SCRIPT_RUNNERS: Record<string, "run-required" | "run-optional"> = {
+  npm: "run-required",
+  pnpm: "run-optional",
+  yarn: "run-optional",
+  bun: "run-required",
+};
+
+/** Verbs that reach a script without `run`. `npm start` IS `scripts.start`. */
+const LIFECYCLE_VERBS: ReadonlySet<string> = new Set([
+  "start",
+  "stop",
+  "restart",
+  "test",
+]);
+
+/**
+ * Runners whose ARGUMENTS are all script names: `npm-run-all build serve`,
+ * `run-s clean build`, `run-p a b`. Every named script is resolved and the
+ * weakest verdict wins. Glob forms (`run-s "build:*"`) never reach here — rule
+ * A rejects `*` before we get this far.
+ */
+const MULTI_SCRIPT_RUNNERS: ReadonlySet<string> = new Set([
+  "npm-run-all",
+  "npm-run-all2",
+  "run-s",
+  "run-p",
+]);
+
+/** A script name we are willing to look up: plain, no expansion, no options. */
+const SCRIPT_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9:._-]*$/;
+
+type ScriptReference =
+  /** Not a hand-off; analyse this body directly. */
+  | { kind: "none" }
+  /** A hand-off we cannot follow (computed name, missing argument). */
+  | { kind: "unresolvable" }
+  | { kind: "scripts"; names: string[] };
+
+/**
+ * Does this body hand off to other package.json scripts, and if so which?
+ *
+ * Called only AFTER rule A, so the body is a single segment: no chaining, no
+ * expansion, no subshells. That is what makes this analysable at all — the
+ * question "which script does this run" has a static answer precisely when the
+ * command is not computing itself.
+ */
+function scriptReference(body: string): ScriptReference {
+  const segments = shellSegments(body);
+  if (segments.length !== 1) return { kind: "unresolvable" };
+  const segment = segments[0];
+  const runner = commandName(segment[0]);
+
+  if (MULTI_SCRIPT_RUNNERS.has(runner)) {
+    const names = segment
+      .slice(1)
+      .filter((token) => !token.startsWith("-"))
+      .map((token) => token.toLowerCase());
+    if (names.length === 0) return { kind: "unresolvable" };
+    if (!names.every((name) => SCRIPT_NAME_RE.test(name))) {
+      return { kind: "unresolvable" };
+    }
+    return { kind: "scripts", names };
+  }
+
+  const style = SCRIPT_RUNNERS[runner];
+  if (!style) return { kind: "none" };
+
+  // Skip manager-level options (`npm --silent run serve`) and stop at `--`,
+  // after which everything is an argument to the script, not a verb.
+  const rest: string[] = [];
+  for (const token of segment.slice(1)) {
+    if (token === "--") break;
+    if (token.startsWith("-")) continue;
+    rest.push(token);
+  }
+  if (rest.length === 0) return { kind: "unresolvable" };
+
+  const verb = rest[0].toLowerCase();
+  if (verb === "run" || verb === "run-script") {
+    const name = rest[1];
+    if (name === undefined || !SCRIPT_NAME_RE.test(name)) {
+      return { kind: "unresolvable" };
+    }
+    return { kind: "scripts", names: [name.toLowerCase()] };
+  }
+  if (LIFECYCLE_VERBS.has(verb)) return { kind: "scripts", names: [verb] };
+  if (style === "run-optional" && SCRIPT_NAME_RE.test(rest[0])) {
+    // `pnpm serve`. If `serve` is not a script this resolves to nothing and the
+    // caller suppresses with the "not defined" reason — which is the right
+    // answer for `pnpm install` as a start command too.
+    return { kind: "scripts", names: [verb] };
+  }
+  // `npm ci`, `bun index.ts`, and anything else this manager does that is not
+  // a script hand-off. Not an indirection; fall through to the normal rules.
+  return { kind: "none" };
+}
+
+/**
+ * How strictly to judge a body in the START lifecycle.
+ *
+ *   'serves-probe' — this body (or something it hands off to) is the process
+ *                    the probe will talk to. Full rule set, ownership included.
+ *   'prepares'     — a hook that must EXIT before the probe ever connects, so
+ *                    it cannot be the server. Rules A, B and escape still
+ *                    apply (they are what stop it detaching a published one);
+ *                    rule C does not, because `"prestart": "tsc"` is a build
+ *                    tool doing its job, not a server.
+ */
+type ScriptRole = "serves-probe" | "prepares";
+
+type ScriptVerdict =
+  | { kind: "accepted"; proof: OwnershipProof }
+  | { kind: "rejected"; reason: string };
+
+type ScriptContext = {
+  scripts: Record<string, string>;
+  checkout: Checkout | null;
+  hasBuildStep: boolean;
+  role: ScriptRole;
+};
+
+/**
+ * Label for a discard reason. CONSTANT strings plus a validated integer — the
+ * script NAME is PR content and never reaches the reason text (same hygiene
+ * rule as `finish`'s hint line).
+ */
+function chainLabel(root: string, depth: number): string {
+  return depth === 0 ? root : `${root} (script indirection, level ${depth})`;
+}
+
+/**
+ * Apply the rule set to one script body, following any hand-off to other
+ * scripts. Returns the weakest verdict reachable from here.
+ *
+ * `seen` carries every script name already on this path, which is what makes
+ * `"a": "npm run b"` / `"b": "npm run a"` terminate with a reason instead of a
+ * stack overflow.
+ */
+function verifyScriptBody(
+  body: string,
+  root: string,
+  ctx: ScriptContext,
+  depth: number,
+  seen: ReadonlySet<string>,
+): ScriptVerdict {
+  const label = chainLabel(root, depth);
+  const reject = (reason: string): ScriptVerdict => ({
+    kind: "rejected",
+    reason: `${label} ${reason}`,
+  });
+
+  // Rule B — a fetching launcher or a remote URL, at any depth.
+  if (isRemoteInvocation(body)) {
+    return reject(
+      "launches a published package or remote URL, not the checkout",
+    );
+  }
+  // Rule A — shell-computed or chained, so unanalysable (and, for a hook, the
+  // rule that stops it backgrounding a server it fetched).
+  if (isUnprovableShell(body)) {
+    return reject(
+      "uses shell expansion or chaining, so what it runs cannot be established",
+    );
+  }
+  // Ownership of the PROCESS is a start-command question. A hook running
+  // `node node_modules/.bin/tsc` is a build tool doing its job; it exits, and
+  // the probe never meets it.
+  if (ctx.role === "serves-probe" && escapesCheckout(body)) {
+    return reject("runs an installed dependency or a path outside the checkout");
+  }
+
+  const reference = scriptReference(body);
+  if (reference.kind === "unresolvable") {
+    return reject(
+      "hands off to a script runner whose target cannot be determined statically",
+    );
+  }
+  if (reference.kind === "scripts") {
+    if (depth + 1 > MAX_SCRIPT_DEPTH) {
+      return reject(
+        `exceeds the maximum resolvable script-indirection depth (${MAX_SCRIPT_DEPTH})`,
+      );
+    }
+    let proof: OwnershipProof = "verified";
+    for (const name of reference.names) {
+      if (seen.has(name)) {
+        return reject("forms a cycle of package.json script references");
+      }
+      const next = ctx.scripts[name];
+      if (typeof next !== "string" || next === "") {
+        return reject("references a package.json script that is not defined");
+      }
+      const verdict = verifyScriptBody(
+        next,
+        root,
+        ctx,
+        depth + 1,
+        new Set([...seen, name]),
+      );
+      if (verdict.kind === "rejected") return verdict;
+      if (verdict.proof === "unverified") proof = "unverified";
+    }
+    return { kind: "accepted", proof };
+  }
+
+  // A hook has nothing left to prove: it exits before the probe connects.
+  if (ctx.role === "prepares") return { kind: "accepted", proof: "verified" };
+
+  // Rule C — ownership of what the probe will actually talk to.
+  const paths = entryPaths(body);
+  const entryVerdict =
+    paths.length > 0
+      ? weakest(
+          paths.map((path) =>
+            verifyEntryPath(path, ctx.checkout, ctx.hasBuildStep),
+          ),
+        )
+      : verifyExtensionlessStart(body, ctx.checkout);
+  if (entryVerdict === "rejected") {
+    return reject(
+      paths.length > 0
+        ? "runs a file that is not proven to be checkout code (absent from the listing, not a regular file, or not a checkout-relative path)"
+        : "names no verifiable checkout file — a bare command name resolved from node_modules/.bin",
+    );
+  }
+  return { kind: "accepted", proof: entryVerdict };
+}
+
+/**
+ * Commands that DETACH a process, so that it can outlive the script that
+ * started it and still be listening when the probe connects. `&&` is not a
+ * match: the first alternative requires the `&` to be neither preceded nor
+ * followed by another `&`.
+ */
+const BACKGROUNDING_RE =
+  /(?:^|[^&|])&(?!&)|\bnohup\b|\bsetsid\b|\bdisown\b|\bpm2\b|\bforever\b|\btmux\b/;
+
+/**
+ * INSTALL-lifecycle hooks: the narrow rule, see the module docblock. A hook
+ * that fetches in the FOREGROUND either exits or hangs the build — neither is
+ * a false green. A hook that fetches AND detaches can leave a published server
+ * listening on the probe port before `start` ever runs, and that is the one
+ * shape we refuse.
+ */
+const INSTALL_LIFECYCLE = [
+  "preinstall",
+  "install",
+  "postinstall",
+  "prepare",
+  "prepublish",
+] as const;
+
+/** BUILD-lifecycle hooks that `<pm> run build` drags along. */
+const BUILD_LIFECYCLE = ["prebuild", "build", "postbuild"] as const;
+
 /**
  * Candidate on-disk locations for a python `module.path` — flat layout, src
  * layout, module and package forms. `fastmcp.cli` is checkout code only if one
@@ -853,65 +1207,71 @@ function detectNode(
     // candidate, because A3's runtime check is per-candidate, not per-path.
     let proof: OwnershipProof = "verified";
 
+    // --- install lifecycle -------------------------------------------------
+    // `npm ci` / `npm install` runs preinstall/install/postinstall/prepare
+    // whatever we do. Only the fetch-AND-detach shape can produce a false
+    // green here (module docblock); a foreground fetch fails the build loudly.
+    const detaching = INSTALL_LIFECYCLE.find(
+      (hook) =>
+        typeof scripts[hook] === "string" &&
+        isRemoteInvocation(scripts[hook]) &&
+        BACKGROUNDING_RE.test(scripts[hook]),
+    );
+    if (detaching) {
+      discarded.push(
+        `${manager.pm}: an install lifecycle hook fetches a published package and backgrounds it, which could answer the probe instead of the checkout`,
+      );
+      continue;
+    }
+
     // --- start command -----------------------------------------------------
     let start: string | null = null;
     if (scripts.start) {
-      if (isRemoteInvocation(scripts.start)) {
-        // The disguised-launcher case. Do not fall back to `bin` here: a repo
-        // whose own start script fetches the published package is telling us
-        // its checkout is not the thing under test.
-        discarded.push(
-          `${manager.pm}: scripts.start launches a published package or remote URL, not the checkout`,
+      // What `<pm> start` ACTUALLY runs: prestart, then start, then poststart
+      // — each of which may hand off to further scripts. `scripts.start` alone
+      // was never the whole command, which is round 3's finding.
+      const ctx = { scripts, checkout, hasBuildStep };
+      const lifecycle: { hook: string; role: ScriptRole }[] = [
+        { hook: "prestart", role: "prepares" },
+        { hook: "start", role: "serves-probe" },
+        { hook: "poststart", role: "prepares" },
+      ];
+      let rejected: string | null = null;
+      for (const { hook, role } of lifecycle) {
+        const body = scripts[hook];
+        if (typeof body !== "string" || body === "") continue;
+        const verdict = verifyScriptBody(
+          body,
+          `scripts.${hook}`,
+          { ...ctx, role },
+          0,
+          new Set([hook]),
         );
+        if (verdict.kind === "rejected") {
+          rejected = verdict.reason;
+          break;
+        }
+        if (verdict.proof === "unverified") proof = "unverified";
+      }
+      if (rejected !== null) {
+        // Do not fall back to `bin` here: a repo whose own start lifecycle
+        // cannot be proven local is telling us its checkout is not the thing
+        // under test, and guessing a different entry point would be us
+        // overruling the author.
+        discarded.push(`${manager.pm}: ${rejected}`);
         continue;
       }
-      if (isUnprovableShell(scripts.start)) {
-        // Rule A. `node "$(npm root)"/@acme/server/bin.js` and every other
-        // shell-computed entry point lands here: we cannot see what it runs, so
-        // we cannot claim it runs the checkout, so we do not emit it.
-        discarded.push(
-          `${manager.pm}: scripts.start uses shell expansion or chaining, so what it runs cannot be established`,
-        );
-        continue;
-      }
-      if (escapesCheckout(scripts.start)) {
-        // Same verdict, nearer miss: `node node_modules/@acme/server/bin.js`
-        // starts the installed dependency. Suppressing beats emitting — a
-        // missed candidate is a resolver miss we can measure, a false green is
-        // the failure this whole module exists to prevent.
-        discarded.push(
-          `${manager.pm}: scripts.start runs an installed dependency or a path outside the checkout`,
-        );
-        continue;
-      }
-      // Rule C. Every file the start command names must be a regular file in
-      // the checkout, or a path the checkout's own build could have produced —
-      // and in the second case the candidate is marked 'unverified' rather than
-      // pretending the build script settled it.
-      const paths = entryPaths(scripts.start);
-      // Zero entry paths is not "nothing to check": `"start": "start-server"`
-      // names a dependency binary and used to walk straight past rule C. The
-      // two cases get DIFFERENT discard reasons because the corpus report is
-      // read to decide what to fix next, and "your entry file isn't in the
-      // checkout" and "your start script names no file at all" are different
-      // problems with different answers.
-      const verdict =
-        paths.length > 0
-          ? weakest(
-              paths.map((path) => verifyEntryPath(path, checkout, hasBuildStep)),
-            )
-          : verifyExtensionlessStart(scripts.start, checkout);
-      if (verdict === "rejected") {
-        discarded.push(
-          paths.length > 0
-            ? `${manager.pm}: scripts.start runs a file that is not proven to be checkout code (absent from the listing, not a regular file, or not a checkout-relative path)`
-            : `${manager.pm}: scripts.start names no verifiable checkout file — a bare command name resolved from node_modules/.bin, or an indirection such as \`${manager.pm} run <script>\``,
-        );
-        continue;
-      }
-      if (verdict === "unverified") proof = "unverified";
+      // The emitted command stays `<pm> start`, NOT the resolved leaf. The
+      // recursion above is a VERIFICATION mechanism, not a rewriting one:
+      // running `node dist/index.js` directly would skip `prestart` (often the
+      // build) and drop npm's environment, and `tsx src/cli.ts` outside `npm
+      // run` has no `node_modules/.bin` on PATH at all. We verified what
+      // `<pm> start` does; `<pm> start` is what we emit.
       start = cmd.start;
       evidence.push("start command from scripts.start");
+      if (scripts.prestart || scripts.poststart) {
+        evidence.push("start lifecycle hooks verified against the same rules");
+      }
       score += 10;
     } else {
       const bin = singleBinPath(pkg);
@@ -955,9 +1315,18 @@ function detectNode(
     // and avoids a recipe that pretends to have built something.
     let build = cmd.install;
     if (scripts.build) {
-      if (isRemoteInvocation(scripts.build)) {
+      // Rule B across the whole BUILD lifecycle, not just `build`: `npm run
+      // build` runs prebuild and postbuild too, and a `prebuild` of `npx
+      // @acme/dist-bundle` fetches the artifact just as effectively.
+      const fetching = BUILD_LIFECYCLE.find(
+        (hook) =>
+          typeof scripts[hook] === "string" && isRemoteInvocation(scripts[hook]),
+      );
+      if (fetching) {
         discarded.push(
-          `${manager.pm}: scripts.build fetches a remote artifact; refusing to build from the network`,
+          fetching === "build"
+            ? `${manager.pm}: scripts.build fetches a remote artifact; refusing to build from the network`
+            : `${manager.pm}: a build lifecycle hook fetches a remote artifact; refusing to build from the network`,
         );
         continue;
       }

--- a/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
@@ -1064,6 +1064,116 @@ const COMMAND_WRAPPERS: ReadonlySet<string> = new Set([
 const BARE_COMMAND_RE = /^[A-Za-z_@.][A-Za-z0-9_@.:+-]*$/;
 
 /**
+ * Shell ASSIGNMENT syntax: `NAME=` prefixing a command word.
+ *
+ * Matched STRUCTURALLY — on the name and the `=`, never on what the value
+ * looks like. The previous spelling also required the token to contain no `/`,
+ * on the theory that a slash means "path, therefore command". A path-valued
+ * assignment (`FOO=/opt/x nohup acme-server &`) is ordinary shell, so that
+ * token read as the COMMAND, `escapesCheckout("FOO=/opt/x")` said false, and
+ * the loop returned before ever reaching `acme-server`. Value shape is not a
+ * signal; position and syntax are.
+ */
+const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+/**
+ * Redirection fragments left behind by `shellSegments`, which is a tokenizer
+ * and not a shell: `node x.js >/dev/null 2>&1` yields `>/dev/null` and `2>`.
+ * They are neither options nor entry points, so the entry-argument search
+ * below must step over them rather than mistake one for the file being run.
+ */
+const REDIRECTION_RE = /^\d*[<>]/;
+
+/**
+ * Flags that make an accepted runtime execute code it was handed INLINE, or a
+ * module resolved out of the installed dependency tree, instead of a file from
+ * the checkout. `nohup node -e "require('acme').serve()" &` is a published
+ * server wearing a local runtime's name: the runtime is ours, the code is not,
+ * and the old rule waved through every `LOCAL_RUNTIMES` command on the
+ * strength of the runtime alone.
+ *
+ * Enumerated per runtime because the spellings differ:
+ *   node, nodejs  `-e` / `--eval` and `-p` / `--print` — node also accepts the
+ *                 `--eval=CODE` joined form, which is why the check compares
+ *                 the part before `=`.
+ *   tsx           the same set: tsx forwards node's CLI flags verbatim.
+ *   ts-node       the same set, as its own options.
+ *   python,       `-c` (inline program) and `-m` (run an INSTALLED module by
+ *   python3       dotted name — not inline code, but the identical hazard:
+ *                 the name is resolved from site-packages, never from a
+ *                 checkout path, so no listing lookup can ever own it).
+ *
+ * This list is a fast path, not the whole guard. A flag we did not enumerate
+ * still has to get past the entry-argument check, which requires the first
+ * non-flag token to be a path the checkout owns — so an unlisted code-injecting
+ * flag fails there instead of here.
+ */
+const NODE_INLINE_CODE_FLAGS: ReadonlySet<string> = new Set([
+  "-e",
+  "--eval",
+  "-p",
+  "--print",
+]);
+const PYTHON_INLINE_CODE_FLAGS: ReadonlySet<string> = new Set(["-c", "-m"]);
+const INLINE_CODE_FLAGS: Readonly<Record<string, ReadonlySet<string>>> = {
+  node: NODE_INLINE_CODE_FLAGS,
+  nodejs: NODE_INLINE_CODE_FLAGS,
+  tsx: NODE_INLINE_CODE_FLAGS,
+  "ts-node": NODE_INLINE_CODE_FLAGS,
+  python: PYTHON_INLINE_CODE_FLAGS,
+  python3: PYTHON_INLINE_CODE_FLAGS,
+};
+
+/** What the install-hook guard needs in order to judge an entry argument. */
+type InstallGuardContext = {
+  checkout: Checkout | null;
+  hasBuildStep: boolean;
+};
+
+/**
+ * A local runtime was found in command position of a DETACHED segment. Is the
+ * code it will run foreign?
+ *
+ * "The argument decides what runs, and the argument is checkout code" was the
+ * old assumption, and it is only true when there IS an argument and it names
+ * checkout code. Three ways it does not:
+ *
+ *   - an inline-code flag (see INLINE_CODE_FLAGS) — the argument is a program,
+ *     not a path, and `require('acme')` inside it serves a dependency;
+ *   - no argument at all (`nohup node &`) — nothing names checkout code;
+ *   - an argument the checkout does not own, which is exactly the judgement
+ *     `verifyEntryPath` already makes for start commands (absolute paths,
+ *     `../`, `node_modules/`, symlinks, and absent files without a build step).
+ */
+function runtimeRunsForeignCode(
+  runtime: string,
+  args: readonly string[],
+  ctx: InstallGuardContext,
+): boolean {
+  const inlineFlags = INLINE_CODE_FLAGS[runtime];
+  if (inlineFlags) {
+    for (const token of args) {
+      // `--eval=CODE` and `--eval CODE` are the same flag.
+      const flag = token.split("=")[0];
+      if (inlineFlags.has(flag)) return true;
+    }
+  }
+  const entry = args.find(
+    (token) => !token.startsWith("-") && !REDIRECTION_RE.test(token),
+  );
+  if (entry === undefined) return true;
+  // `node .` runs the checkout root through its own package.json `main`.
+  if (entry === "." || entry === "./") return false;
+  return (
+    verifyEntryPath(
+      entry.replace(/^\.\//, ""),
+      ctx.checkout,
+      ctx.hasBuildStep,
+    ) === "rejected"
+  );
+}
+
+/**
  * Does this body launch a binary that npm resolved from `node_modules/.bin`
  * (or an explicit path into `node_modules`), rather than checkout code?
  *
@@ -1074,25 +1184,43 @@ const BARE_COMMAND_RE = /^[A-Za-z_@.][A-Za-z0-9_@.:+-]*$/;
  * the validated start command ever binds, which is the same false green a
  * detached `npx` produces.
  *
- * Only the COMMAND position of each segment is examined. A local runtime
- * (`node dist/server.js`) is not a foreign launch: the argument decides what
- * runs, and that argument is checkout code the start rules already govern.
+ * Only the COMMAND position of each segment is examined, and reaching it means
+ * stepping over the things that PRECEDE a command: options, environment
+ * assignments, and wrappers. A local runtime found there is judged on what it
+ * was pointed at (`runtimeRunsForeignCode`), not accepted on its name.
  */
-function launchesInstalledBinary(body: string): boolean {
+function launchesInstalledBinary(
+  body: string,
+  ctx: InstallGuardContext,
+): boolean {
   for (const segment of shellSegments(body)) {
-    for (const token of segment) {
+    for (let i = 0; i < segment.length; i++) {
+      const token = segment[i];
       if (token.startsWith("-")) continue;
-      // `PORT=1 acme-server` — an assignment, not the command.
-      if (token.includes("=") && !token.includes("/")) continue;
+      // `FOO=1 BAR=/opt/x acme-server` — assignments prefix the command, and
+      // any number of them may. `env FOO=1 acme-server` reaches the same place
+      // via the `env` wrapper below.
+      if (ENV_ASSIGNMENT_RE.test(token)) continue;
       const name = commandName(token);
       if (COMMAND_WRAPPERS.has(name)) continue;
       if (token.includes("/")) {
         // A PATH, not a PATH lookup. Only one that leaves the checkout is
         // somebody else's code; a relative path inside it is the checkout's.
+        // A runtime named by an in-checkout path (`/usr/bin/node`) is still a
+        // runtime, and its argument still has to be ours.
+        if (LOCAL_RUNTIMES.has(name) && !escapesCheckout(token)) {
+          if (runtimeRunsForeignCode(name, segment.slice(i + 1), ctx)) {
+            return true;
+          }
+          break;
+        }
         return escapesCheckout(token);
       }
       if (!BARE_COMMAND_RE.test(token)) break;
-      if (LOCAL_RUNTIMES.has(name)) break;
+      if (LOCAL_RUNTIMES.has(name)) {
+        if (runtimeRunsForeignCode(name, segment.slice(i + 1), ctx)) return true;
+        break;
+      }
       return true;
     }
   }
@@ -1101,13 +1229,62 @@ function launchesInstalledBinary(body: string): boolean {
 
 /**
  * The install-hook shape that can produce a false green: DETACHED plus foreign.
- * Foreign is either a fetch (`npx @acme/server`) or a binary npm installed for
- * us (`acme-mcp-server`). A NON-detached foreign command stays acceptable — it
- * must exit before npm proceeds, so it cannot still be answering the probe.
+ * Foreign is either a fetch (`npx @acme/server`), a binary npm installed for us
+ * (`acme-mcp-server`), or a local runtime pointed at code we do not own
+ * (`node -e "…"`). A NON-detached foreign command stays acceptable — it must
+ * exit before npm proceeds, so it cannot still be answering the probe.
  */
-function detachesForeignProcess(body: string): boolean {
+function detachesForeignProcess(
+  body: string,
+  ctx: InstallGuardContext,
+): boolean {
   if (!BACKGROUNDING_RE.test(body)) return false;
-  return isRemoteInvocation(body) || launchesInstalledBinary(body);
+  return isRemoteInvocation(body) || launchesInstalledBinary(body, ctx);
+}
+
+/**
+ * `detachesForeignProcess` across the install lifecycle, FOLLOWING statically
+ * resolvable script references — the same recursion `buildFetchesRemotely`
+ * uses for rule B, for the same reason. `"prepare": "npm run sneaky"` with
+ * `"sneaky": "nohup acme-server &"` detaches exactly as effectively as writing
+ * the launch in `prepare` itself, and the literal-body check never saw it:
+ * reference-following was wired for the start and build lifecycles only.
+ *
+ * The referenced script's OWN `pre`/`post` hooks are followed too, because npm
+ * runs them; depth is capped at MAX_SCRIPT_DEPTH; `seen` terminates cycles.
+ *
+ * Returns the HOP COUNT at which the detached launch was found, or null. That
+ * number is the only thing distinguishing the two suppression reasons, and it
+ * is an integer we computed — no script name, and therefore no PR content,
+ * reaches the reason text.
+ */
+function installDetachesForeign(
+  body: string,
+  scripts: Record<string, string>,
+  ctx: InstallGuardContext,
+  depth: number,
+  seen: ReadonlySet<string>,
+): number | null {
+  if (detachesForeignProcess(body, ctx)) return depth;
+  if (depth + 1 > MAX_SCRIPT_DEPTH) return null;
+  const reference = scriptReference(body);
+  if (reference.kind !== "scripts") return null;
+  for (const name of reference.names) {
+    for (const hook of [`pre${name}`, name, `post${name}`]) {
+      if (seen.has(hook)) continue;
+      const next = scripts[hook];
+      if (typeof next !== "string" || next === "") continue;
+      const found = installDetachesForeign(
+        next,
+        scripts,
+        ctx,
+        depth + 1,
+        new Set([...seen, hook]),
+      );
+      if (found !== null) return found;
+    }
+  }
+  return null;
 }
 
 /** BUILD-lifecycle hooks that `<pm> run build` drags along. */
@@ -1373,14 +1550,28 @@ function detectNode(
     // prepare trio) whatever we do. Only the DETACH-something-foreign shape can
     // produce a false green here (module docblock); a foreground launch either
     // exits or fails the build loudly.
-    const detaching = INSTALL_LIFECYCLE.find(
-      (hook) =>
-        typeof scripts[hook] === "string" &&
-        detachesForeignProcess(scripts[hook]),
-    );
-    if (detaching) {
+    // Reference-following (`"prepare": "npm run sneaky"`) is part of the check,
+    // not an extra: one hop of indirection used to carry the launch straight
+    // past the guard.
+    const installGuard: InstallGuardContext = { checkout, hasBuildStep };
+    let detachedAt: number | null = null;
+    for (const hook of INSTALL_LIFECYCLE) {
+      const body = scripts[hook];
+      if (typeof body !== "string" || body === "") continue;
+      detachedAt = installDetachesForeign(
+        body,
+        scripts,
+        installGuard,
+        0,
+        new Set([hook]),
+      );
+      if (detachedAt !== null) break;
+    }
+    if (detachedAt !== null) {
       discarded.push(
-        `${manager.pm}: an install lifecycle hook backgrounds a published package or an installed dependency binary, which could answer the probe instead of the checkout`,
+        detachedAt === 0
+          ? `${manager.pm}: an install lifecycle hook backgrounds a published package or an installed dependency binary, which could answer the probe instead of the checkout`
+          : `${manager.pm}: an install lifecycle hook reaches a backgrounded published package or installed dependency binary through a package.json script reference (level ${detachedAt}), which could answer the probe instead of the checkout`,
       );
       continue;
     }

--- a/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
@@ -116,7 +116,9 @@
  *   1. LIFECYCLE HOOKS. `npm start` runs `prestart`, then `start`, then
  *      `poststart`. A `prestart` of `npx @acme/server` launches a published
  *      package while `scripts.start` sits there looking impeccable. Nothing in
- *      round 2 ever read `prestart`.
+ *      round 2 ever read `prestart`. And the hooks are not special to `start`:
+ *      npm fires `pre<name>`/`post<name>` for ARBITRARY script names, so they
+ *      exist at every level of indirection too (round 3.1's finding).
  *   2. SCRIPT INDIRECTION. `"start": "npm run serve"` runs `scripts.serve`,
  *      which round 2 also never read. Round 2's answer was to DISCARD every
  *      indirection wholesale — safe, but it cost real repos (exa-mcp-server's
@@ -140,7 +142,8 @@
  * `<install> [&& <pm> run build]` — and by which of them can put a process
  * behind the PROBE, because that is the only way a false GREEN happens:
  *
- *   START LIFECYCLE — `prestart`, `start`, `poststart`.  FULLY IN SCOPE.
+ *   START LIFECYCLE — `prestart`, `start`, `poststart`, AND the `pre`/`post`
+ *     hooks of every script reached from them.  FULLY IN SCOPE.
  *     `start` gets rules A + B + escape + C, recursively: it is the process the
  *     probe talks to, so its ownership is the invariant.
  *     `prestart`/`poststart` get rules A + B, recursively, but NOT rule C and
@@ -154,22 +157,29 @@
  *     would instead suppress `"prestart": "tsc"` — a build tool, doing exactly
  *     its job — and buy no safety for it.
  *
- *   BUILD LIFECYCLE — `prebuild`, `build`, `postbuild`.  RULE B ONLY.
+ *   BUILD LIFECYCLE — `prebuild`, `build`, `postbuild`, and the scripts they
+ *     REFERENCE.  RULE B ONLY.
  *     This extends the check `build` already had to the hooks `npm run build`
- *     drags along with it. Rules A and C are deliberately not applied: build
- *     steps chain and expand freely by design (see UNPROVABLE_SHELL_RE), and a
- *     build that misbehaves yields `build_failed`, which is honest.
+ *     drags along with it, and follows statically resolvable script references
+ *     so `"build": "npm run bundle"` cannot park the fetch one hop away. Rules
+ *     A and C are deliberately not applied, and an UNRESOLVABLE reference is
+ *     deliberately not a rejection: build steps chain and expand freely by
+ *     design (see UNPROVABLE_SHELL_RE), and a build that misbehaves yields
+ *     `build_failed`, which is honest.
  *
- *   INSTALL LIFECYCLE — `preinstall`, `install`, `postinstall`, `prepare`,
- *     `prepublish`.  NARROW RULE: fetch AND detach.
+ *   INSTALL LIFECYCLE — `preinstall`, `install`, `postinstall`, `prepublish`,
+ *     `preprepare`, `prepare`, `postprepare` (npm 11.x's documented order for
+ *     `install`/`ci`).  NARROW RULE: detach AND foreign.
  *     These run for any `npm ci`/`npm install`, so we cannot avoid triggering
  *     them and a broad rule here would suppress half the ecosystem
- *     (`patch-package`, `husky`, `npx playwright install`). A FOREGROUND fetch
+ *     (`patch-package`, `husky`, `npx playwright install`). A FOREGROUND launch
  *     in an install hook cannot produce a false green — it either exits, or it
- *     hangs and the build times out. The one shape that can is a hook that
- *     fetches a published package AND backgrounds it, leaving a listener that
- *     answers the probe before `start` ever binds. That conjunction, and only
- *     that conjunction, suppresses the candidate.
+ *     hangs and the build times out. The shapes that can are a hook that
+ *     BACKGROUNDS something foreign: either a fetch (`nohup npx @acme/server
+ *     &`) or a binary npm itself put on PATH from `node_modules/.bin`
+ *     (`nohup acme-mcp-server &` — no fetch at all, and just as capable of
+ *     answering the probe with published code). That conjunction, and only that
+ *     conjunction, suppresses the candidate.
  *
  *   OUT OF SCOPE BY CONSTRUCTION — `prepublishOnly`, `prepack`, `postpack`,
  *     `pretest`/`test`/`posttest`, `preversion`, `publish`. None of them run
@@ -780,6 +790,15 @@ type ScriptReference =
  * expansion, no subshells. That is what makes this analysable at all — the
  * question "which script does this run" has a static answer precisely when the
  * command is not computing itself.
+ *
+ * CASE. Runner names and verbs are matched case-INSENSITIVELY (`commandName`
+ * lowercases, and each verb is lowered before comparison) because those are
+ * resolved through the filesystem and npm's own command table. Script NAMES are
+ * returned with their ORIGINAL CASING, because `package.json` `scripts` keys are
+ * case-sensitive: `npm run Serve` runs `Serve` and nothing else. Lowering the
+ * name here made the lookup in `verifyScriptBody` either miss a legitimately
+ * mixed-case script (suppressing a good repo) or, worse, silently verify a
+ * DIFFERENT script that happened to be the lowercase spelling of the same word.
  */
 function scriptReference(body: string): ScriptReference {
   const segments = shellSegments(body);
@@ -790,8 +809,7 @@ function scriptReference(body: string): ScriptReference {
   if (MULTI_SCRIPT_RUNNERS.has(runner)) {
     const names = segment
       .slice(1)
-      .filter((token) => !token.startsWith("-"))
-      .map((token) => token.toLowerCase());
+      .filter((token) => !token.startsWith("-"));
     if (names.length === 0) return { kind: "unresolvable" };
     if (!names.every((name) => SCRIPT_NAME_RE.test(name))) {
       return { kind: "unresolvable" };
@@ -818,14 +836,18 @@ function scriptReference(body: string): ScriptReference {
     if (name === undefined || !SCRIPT_NAME_RE.test(name)) {
       return { kind: "unresolvable" };
     }
-    return { kind: "scripts", names: [name.toLowerCase()] };
+    return { kind: "scripts", names: [name] };
   }
+  // A lifecycle VERB is a fixed npm identifier, not a user-chosen script name:
+  // `npm Start` is not a command npm accepts, so the script it would reach is
+  // the canonical lowercase one.
   if (LIFECYCLE_VERBS.has(verb)) return { kind: "scripts", names: [verb] };
   if (style === "run-optional" && SCRIPT_NAME_RE.test(rest[0])) {
     // `pnpm serve`. If `serve` is not a script this resolves to nothing and the
     // caller suppresses with the "not defined" reason — which is the right
-    // answer for `pnpm install` as a start command too.
-    return { kind: "scripts", names: [verb] };
+    // answer for `pnpm install` as a start command too. Original casing, not
+    // `verb`: `pnpm Serve` runs `Serve`.
+    return { kind: "scripts", names: [rest[0]] };
   }
   // `npm ci`, `bun index.ts`, and anything else this manager does that is not
   // a script hand-off. Not an indirection; fall through to the normal rules.
@@ -927,6 +949,30 @@ function verifyScriptBody(
       if (typeof next !== "string" || next === "") {
         return reject("references a package.json script that is not defined");
       }
+      // npm's pre/post hooks are not a property of `start` — they fire for
+      // ARBITRARY script names, at every level of indirection. `npm run serve`
+      // runs `preserve`, then `serve`, then `postserve`, so a `preserve` of
+      // `nohup npx @acme/server &` would leave published code answering the
+      // probe while the tracked `serve` body passed inspection. The hooks get
+      // the same treatment the ROOT lifecycle's hooks get: rules A + B, role
+      // 'prepares' (they must exit before the probe connects, so rule C would
+      // suppress `"preserve": "tsc"` for no safety gain).
+      for (const hook of [`pre${name}`, `post${name}`]) {
+        const hookBody = ctx.scripts[hook];
+        if (typeof hookBody !== "string" || hookBody === "") continue;
+        if (seen.has(hook)) {
+          return reject("forms a cycle of package.json script references");
+        }
+        const hookVerdict = verifyScriptBody(
+          hookBody,
+          root,
+          { ...ctx, role: "prepares" },
+          depth + 1,
+          new Set([...seen, name, hook]),
+        );
+        if (hookVerdict.kind === "rejected") return hookVerdict;
+        if (hookVerdict.proof === "unverified") proof = "unverified";
+      }
       const verdict = verifyScriptBody(
         next,
         root,
@@ -974,21 +1020,136 @@ const BACKGROUNDING_RE =
 
 /**
  * INSTALL-lifecycle hooks: the narrow rule, see the module docblock. A hook
- * that fetches in the FOREGROUND either exits or hangs the build — neither is
- * a false green. A hook that fetches AND detaches can leave a published server
- * listening on the probe port before `start` ever runs, and that is the one
- * shape we refuse.
+ * that runs something foreign in the FOREGROUND either exits or hangs the
+ * build — neither is a false green. A hook that runs it AND detaches can leave
+ * a published server listening on the probe port before `start` ever runs, and
+ * that is the one shape we refuse.
+ *
+ * The list is npm's documented `install`/`ci` lifecycle order (npm 11.x):
+ * preinstall, install, postinstall, prepublish (deprecated but still fired),
+ * then the PREPARE trio — `preprepare`, `prepare`, `postprepare`. The trio's
+ * outer two were missing, so `"preprepare": "nohup npx @acme/server &"` was
+ * never inspected at all.
  */
 const INSTALL_LIFECYCLE = [
   "preinstall",
   "install",
   "postinstall",
-  "prepare",
   "prepublish",
+  "preprepare",
+  "prepare",
+  "postprepare",
 ] as const;
+
+/**
+ * Tokens that WRAP another command rather than being one. `nohup acme-server`
+ * is a launch of `acme-server`, not of `nohup`.
+ */
+const COMMAND_WRAPPERS: ReadonlySet<string> = new Set([
+  "nohup",
+  "setsid",
+  "disown",
+  "env",
+  "exec",
+  "time",
+]);
+
+/**
+ * A plain command WORD. Anchored to a letter/`_`/`@`/`.` first character on
+ * purpose: `shellSegments` is a crude tokenizer that splits on `&`, so
+ * `2>&1` leaves fragments like `2>` and `1` behind. Neither is a command, and
+ * treating them as one would suppress `"postinstall": "node x.js >/dev/null
+ * 2>&1 &"` — checkout code — for a typographic reason.
+ */
+const BARE_COMMAND_RE = /^[A-Za-z_@.][A-Za-z0-9_@.:+-]*$/;
+
+/**
+ * Does this body launch a binary that npm resolved from `node_modules/.bin`
+ * (or an explicit path into `node_modules`), rather than checkout code?
+ *
+ * This is the half of the install-hook guard that `isRemoteInvocation` cannot
+ * see. `"prepare": "nohup acme-mcp-server >/dev/null 2>&1 &"` fetches nothing —
+ * npm has ALREADY installed `acme-mcp-server` and put it on PATH by the time
+ * install hooks run — yet it leaves published dependency code listening before
+ * the validated start command ever binds, which is the same false green a
+ * detached `npx` produces.
+ *
+ * Only the COMMAND position of each segment is examined. A local runtime
+ * (`node dist/server.js`) is not a foreign launch: the argument decides what
+ * runs, and that argument is checkout code the start rules already govern.
+ */
+function launchesInstalledBinary(body: string): boolean {
+  for (const segment of shellSegments(body)) {
+    for (const token of segment) {
+      if (token.startsWith("-")) continue;
+      // `PORT=1 acme-server` — an assignment, not the command.
+      if (token.includes("=") && !token.includes("/")) continue;
+      const name = commandName(token);
+      if (COMMAND_WRAPPERS.has(name)) continue;
+      if (token.includes("/")) {
+        // A PATH, not a PATH lookup. Only one that leaves the checkout is
+        // somebody else's code; a relative path inside it is the checkout's.
+        return escapesCheckout(token);
+      }
+      if (!BARE_COMMAND_RE.test(token)) break;
+      if (LOCAL_RUNTIMES.has(name)) break;
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The install-hook shape that can produce a false green: DETACHED plus foreign.
+ * Foreign is either a fetch (`npx @acme/server`) or a binary npm installed for
+ * us (`acme-mcp-server`). A NON-detached foreign command stays acceptable — it
+ * must exit before npm proceeds, so it cannot still be answering the probe.
+ */
+function detachesForeignProcess(body: string): boolean {
+  if (!BACKGROUNDING_RE.test(body)) return false;
+  return isRemoteInvocation(body) || launchesInstalledBinary(body);
+}
 
 /** BUILD-lifecycle hooks that `<pm> run build` drags along. */
 const BUILD_LIFECYCLE = ["prebuild", "build", "postbuild"] as const;
+
+/**
+ * Rule B across the build lifecycle, FOLLOWING statically resolvable script
+ * references. `"build": "npm run bundle"` with `"bundle": "npx @acme/dist-
+ * bundle"` fetches the artifact just as effectively as writing the `npx` in
+ * `build` itself, and the literal-body check never saw it.
+ *
+ * Deliberately rule B ONLY, and deliberately silent on what it cannot resolve.
+ * Build steps chain and expand freely by design (`tsc && chmod +x dist/*.js`),
+ * so an unresolvable reference here is NOT a rejection the way it is in the
+ * start lifecycle — a build that misbehaves yields `build_failed`, which is an
+ * honest red. The referenced script's own pre/post hooks are followed too,
+ * for the same reason the start lifecycle follows them.
+ */
+function buildFetchesRemotely(
+  body: string,
+  scripts: Record<string, string>,
+  depth: number,
+  seen: ReadonlySet<string>,
+): boolean {
+  if (isRemoteInvocation(body)) return true;
+  if (depth + 1 > MAX_SCRIPT_DEPTH) return false;
+  const reference = scriptReference(body);
+  if (reference.kind !== "scripts") return false;
+  for (const name of reference.names) {
+    for (const hook of [`pre${name}`, name, `post${name}`]) {
+      if (seen.has(hook)) continue;
+      const next = scripts[hook];
+      if (typeof next !== "string" || next === "") continue;
+      if (
+        buildFetchesRemotely(next, scripts, depth + 1, new Set([...seen, hook]))
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 /**
  * Candidate on-disk locations for a python `module.path` — flat layout, src
@@ -1208,18 +1369,18 @@ function detectNode(
     let proof: OwnershipProof = "verified";
 
     // --- install lifecycle -------------------------------------------------
-    // `npm ci` / `npm install` runs preinstall/install/postinstall/prepare
-    // whatever we do. Only the fetch-AND-detach shape can produce a false
-    // green here (module docblock); a foreground fetch fails the build loudly.
+    // `npm ci` / `npm install` runs the whole install lifecycle (including the
+    // prepare trio) whatever we do. Only the DETACH-something-foreign shape can
+    // produce a false green here (module docblock); a foreground launch either
+    // exits or fails the build loudly.
     const detaching = INSTALL_LIFECYCLE.find(
       (hook) =>
         typeof scripts[hook] === "string" &&
-        isRemoteInvocation(scripts[hook]) &&
-        BACKGROUNDING_RE.test(scripts[hook]),
+        detachesForeignProcess(scripts[hook]),
     );
     if (detaching) {
       discarded.push(
-        `${manager.pm}: an install lifecycle hook fetches a published package and backgrounds it, which could answer the probe instead of the checkout`,
+        `${manager.pm}: an install lifecycle hook backgrounds a published package or an installed dependency binary, which could answer the probe instead of the checkout`,
       );
       continue;
     }
@@ -1317,10 +1478,13 @@ function detectNode(
     if (scripts.build) {
       // Rule B across the whole BUILD lifecycle, not just `build`: `npm run
       // build` runs prebuild and postbuild too, and a `prebuild` of `npx
-      // @acme/dist-bundle` fetches the artifact just as effectively.
+      // @acme/dist-bundle` fetches the artifact just as effectively. Script
+      // references are FOLLOWED (buildFetchesRemotely), so `"build": "npm run
+      // bundle"` cannot hide the fetch one hop away.
       const fetching = BUILD_LIFECYCLE.find(
         (hook) =>
-          typeof scripts[hook] === "string" && isRemoteInvocation(scripts[hook]),
+          typeof scripts[hook] === "string" &&
+          buildFetchesRemotely(scripts[hook], scripts, 0, new Set([hook])),
       );
       if (fetching) {
         discarded.push(

--- a/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/detect.ts
@@ -75,6 +75,60 @@
  *      verification is REQUIRED — without it, a `[project.scripts]` target is
  *      suppressed outright, which is finding 3's answer.
  *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * RULE C, ROUND 2: WHAT COUNTS AS EVIDENCE (and what only LOOKED like it)
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * The first cut of rule C accepted on evidence that does not actually establish
+ * ownership. Four more spellings of the same mistake, and the answer each got:
+ *
+ *   a. "A build script exists, so an absent `dist/index.js` must be built from
+ *      the checkout." It must not. `"build": "mkdir -p dist && cp
+ *      node_modules/acme/server.js dist/index.js"` copies PUBLISHED code into
+ *      that exact path. A build step runs arbitrary code, so its OUTPUT has no
+ *      statically knowable provenance. The inference is gone — see below for
+ *      what replaces it.
+ *   b. "The path is in `git ls-files`, so it is checkout source." `git ls-files`
+ *      yields PATHS, not file TYPES. A tracked `server.js` that is a SYMLINK to
+ *      `node_modules/acme/server.js` (or to `../outside`) appears in that
+ *      listing as an innocuous relative path, and node follows the link. So
+ *      `repoFiles` now carries a kind per entry, and a symlinked entry point is
+ *      SUPPRESSED — we do not chase the target and reason about it, because
+ *      unresolvable provenance is a miss, and a miss is recoverable.
+ *   c. "Every entry point is checked." Only tokens with a script EXTENSION were
+ *      ever extracted, so `"start": "start-server"` — a bare word resolved out
+ *      of `node_modules/.bin` — extracted ZERO entry paths and sailed past a
+ *      rule that never fired. That is the node twin of finding 3, and it is now
+ *      suppressed whenever a listing is available.
+ *   d. "A relative path can only resolve inside the checkout." True, but the
+ *      code never required the path to BE relative: `node /etc/foo.js` and
+ *      `node C:/x.js` passed. Relativity is now mandatory at every acceptance
+ *      site, including the build-output one.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHAT REPLACES THE BUILD-SCRIPT INFERENCE: `ownershipProof`
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * Dropping build outputs entirely would collapse recall — build outputs are by
+ * definition not committed, and `node dist/index.js` after `npm run build` is
+ * the single most common shape in the ecosystem. So they are still emitted, but
+ * they are no longer PRETENDING to be proven: every candidate carries
+ * `ownershipProof: 'verified' | 'unverified'` (see ./types.ts).
+ *
+ *   'verified'   — the entry point is a regular file in the checkout listing.
+ *   'unverified' — accepted but unproven: a relative, non-escaping path that no
+ *                  listing contains and a build step plausibly produces; or the
+ *                  degenerate case where no listing was supplied at all, so
+ *                  there was nothing to verify against.
+ *
+ * A3 REQUIREMENT (repeated in ./types.ts so it cannot be lost between PRs):
+ * when `ownershipProof === 'unverified'`, A3's `resolveAndStart` MUST run a
+ * RUNTIME ownership check in the sandbox after the server starts — resolve the
+ * listening process's main module (`/proc/<pid>` or equivalent), `realpath` it,
+ * and require it to live inside the checkout and outside `node_modules/`.
+ * That check has ground truth; no amount of string reasoning here does. This
+ * module's job is to say which candidates still owe it.
+ *
  * v1 ECOSYSTEMS (deliberately short; everything else yields no candidate):
  *   - node: npm (package-lock.json), pnpm (pnpm-lock.yaml), yarn classic
  *     (yarn.lock), driven off package.json
@@ -88,7 +142,27 @@
  */
 
 import type { CheckRecipe } from "../recipes";
-import type { ResolvedRecipe } from "./types";
+import type { OwnershipProof, ResolvedRecipe } from "./types";
+
+/**
+ * One entry of the checkout listing.
+ *
+ * The KIND is the load-bearing half, and it is why this is not `string[]` any
+ * more. `git ls-files` prints paths; a tracked `server.js` that is a symlink to
+ * `node_modules/acme/server.js` prints as `server.js` and looks exactly like
+ * checkout source. Node follows the link. So callers must say what each entry
+ * IS, and only `'file'` — a regular file — can prove ownership.
+ *
+ *   'file'    — regular file (git mode 100644 / 100755).
+ *   'symlink' — git mode 120000. SUPPRESSED as an entry point: we deliberately
+ *               do not resolve the target and reason about it, because a
+ *               symlink is precisely the case where the path text lies.
+ *   'other'   — submodule (160000), gitlink, or anything a caller cannot
+ *               classify. Treated like 'symlink': not proof of anything.
+ */
+export type RepoFileKind = "file" | "symlink" | "other";
+
+export type RepoFileEntry = { path: string; kind: RepoFileKind };
 
 /**
  * Contents of the files detection looks at; `null` means "file absent", which
@@ -109,21 +183,27 @@ export type DetectionInputs = {
   readme: string | null;
   /**
    * OPTIONAL, and the evidence that turns rule C from a guess into a proof:
-   * relative paths (POSIX separators, no leading `./`) of files present in the
-   * checkout. This is a FILE LISTING, not file contents — it does not join the
-   * R3 recipe cache key the way the parsed fields above do, because it is
-   * derived from the same commit those are read at.
+   * the checkout's files as relative paths (POSIX separators, no leading `./`)
+   * PAIRED WITH THEIR TYPE. This is a FILE LISTING, not file contents — it does
+   * not join the R3 recipe cache key the way the parsed fields above do,
+   * because it is derived from the same commit those are read at.
    *
-   * When present, a candidate's entry point must be findable in it. When
-   * ABSENT, node falls back to the strict syntactic path rules (relative, no
-   * `node_modules`, no `../`, safe charset) and python `[project.scripts]`
-   * candidates are suppressed outright — see `detectPython`.
+   * The type is not decoration. A path-only listing cannot distinguish a
+   * regular `server.js` from a symlink into `node_modules/`, and the second one
+   * runs published code while looking identical in the text. Only
+   * `kind: 'file'` proves ownership; anything else suppresses the candidate.
    *
-   * Populated today by `scripts/resolver-corpus.ts` (it has the clone on disk).
-   * A3 populates it from the sandbox, where the checkout is likewise on disk;
-   * until then, production callers pass nothing and get the conservative path.
+   * When ABSENT, node falls back to the strict syntactic path rules (relative,
+   * no `node_modules`, no `../`, safe charset) and marks the result
+   * `ownershipProof: 'unverified'`, and python `[project.scripts]` candidates
+   * are suppressed outright — see `detectPython`.
+   *
+   * Populated today by `scripts/resolver-corpus.ts` (it has the clone on disk,
+   * and reads modes out of `git ls-files -s`). A3 populates it from the
+   * sandbox, where the checkout is likewise on disk; until then, production
+   * callers pass nothing and get the conservative path.
    */
-  repoFiles?: string[];
+  repoFiles?: RepoFileEntry[];
 };
 
 /**
@@ -384,23 +464,54 @@ function escapesCheckout(body: string): boolean {
 // ---------------------------------------------------------------------------
 
 /**
- * Normalize the caller's listing into a lookup set. Leading `./` is stripped
- * and separators are POSIX, so `./dist/cli.js` and `dist/cli.js` are the same
- * file — a caller assembling this from `git ls-files` or a directory walk
- * should not have to know which spelling we compare against.
+ * Normalize the caller's listing into a path -> kind lookup. Leading `./` is
+ * stripped and separators are POSIX, so `./dist/cli.js` and `dist/cli.js` are
+ * the same file — a caller assembling this from `git ls-files` or a directory
+ * walk should not have to know which spelling we compare against.
+ *
+ * An entry with a missing or unrecognised `kind` is recorded as `'other'`, not
+ * as a file: an unclassifiable entry is exactly the case where we know least,
+ * and the whole point of carrying the kind is that "we don't know" must not
+ * read as "regular file".
  */
-function checkoutFiles(repoFiles: string[] | undefined): Set<string> | null {
+type Checkout = ReadonlyMap<string, RepoFileKind>;
+
+function checkoutFiles(
+  repoFiles: readonly RepoFileEntry[] | undefined,
+): Checkout | null {
   // An EMPTY listing means "we could not list the checkout", not "the checkout
   // is empty" — no repo we can detect has zero files. Treating it as absent
   // keeps the reasons honest (a caller whose `git ls-files` failed gets the
   // no-listing reason, not "your entry point is a dependency").
   if (!repoFiles || repoFiles.length === 0) return null;
-  const out = new Set<string>();
+  const out = new Map<string, RepoFileKind>();
   for (const entry of repoFiles) {
-    if (typeof entry !== "string" || entry === "") continue;
-    out.add(entry.replace(/\\/g, "/").replace(/^\.\//, ""));
+    if (typeof entry !== "object" || entry === null) continue;
+    const path = entry.path;
+    if (typeof path !== "string" || path === "") continue;
+    const kind: RepoFileKind =
+      entry.kind === "file" || entry.kind === "symlink" ? entry.kind : "other";
+    out.set(path.replace(/\\/g, "/").replace(/^\.\//, ""), kind);
   }
-  return out;
+  return out.size === 0 ? null : out;
+}
+
+/**
+ * Absolute paths, in every spelling that reaches a filesystem OUTSIDE the
+ * checkout: POSIX (`/etc/foo.js`), Windows drive-qualified (`C:/x.js`, and
+ * `C:x.js`, which is drive-relative, not checkout-relative), and UNC (`//host`,
+ * which the POSIX branch already covers).
+ *
+ * The docblock's central claim — "a relative path can only resolve inside the
+ * checkout" — is only true of paths that are actually relative, and nothing was
+ * enforcing that. This is that enforcement, and it applies at EVERY acceptance
+ * site, including the build-output one where an absent path used to be waved
+ * through on the strength of a build script existing.
+ */
+const ABSOLUTE_PATH_RE = /^(?:\/|[A-Za-z]:)/;
+
+function isCheckoutRelative(path: string): boolean {
+  return !ABSOLUTE_PATH_RE.test(path) && !escapesCheckout(path);
 }
 
 /** Extensions that make a token an ENTRY POINT rather than an argument. */
@@ -427,26 +538,102 @@ function entryPaths(body: string): string[] {
 }
 
 /**
- * Is this entry path established as checkout code?
+ * How well is this entry path established as checkout code?
  *
- * Present in the listing → yes, directly. Absent but the candidate has a BUILD
- * step → also yes: `node dist/index.js` after `npm run build` is the single
- * most common shape in the ecosystem, and `dist/` is a build OUTPUT — it is by
- * definition not in the checkout, and it is by definition produced from the
- * checkout. Requiring it to be committed would suppress nearly every node repo
- * for no safety gain, since a relative path that no launcher and no shell
- * expansion produced can only resolve inside the checkout.
+ *   'rejected'   — suppress the candidate entirely. Three ways to land here:
+ *                  the path is not checkout-relative (absolute, drive letter,
+ *                  `../`, `node_modules/`); the listing has it but NOT as a
+ *                  regular file (symlink or submodule — the path text lies
+ *                  about where it goes, and we refuse to chase it); or the
+ *                  listing does not have it and nothing could have produced it.
+ *   'verified'   — the listing has it as a regular file. This is the only
+ *                  branch that PROVES anything.
+ *   'unverified' — accepted on a plausibility argument, not on evidence:
+ *                  a relative path a build step could have produced (the
+ *                  `node dist/index.js` + `npm run build` shape), or the
+ *                  degenerate case of no listing at all.
  *
- * Absent AND no build step → suppressed. Nothing in the repo produces that
- * file, so whatever the command finds at runtime is not this PR's code (and if
- * it finds nothing, the check would fail and blame the author for our guess).
+ * Note what is NOT here any more: "some `scripts.build` exists, therefore the
+ * output is checkout-derived". A build script runs arbitrary code and can copy
+ * `node_modules/acme/server.js` into `dist/index.js`. That case now yields
+ * 'unverified', which is a promise that A3 will settle it at runtime, not a
+ * claim that we already did.
  */
-function entryEstablished(
+type EntryVerdict = "verified" | "unverified" | "rejected";
+
+function verifyEntryPath(
   path: string,
-  files: Set<string>,
+  checkout: Checkout | null,
   hasBuildStep: boolean,
-): boolean {
-  return files.has(path) || hasBuildStep;
+): EntryVerdict {
+  if (!isCheckoutRelative(path)) return "rejected";
+  if (!checkout) return "unverified";
+  const kind = checkout.get(path);
+  if (kind === "file") return "verified";
+  // Present but not a regular file: a symlink can point at a dependency or out
+  // of the checkout entirely, and a submodule is someone else's commit. Both
+  // are unresolvable provenance, which is a miss, and a miss is recoverable.
+  if (kind !== undefined) return "rejected";
+  return hasBuildStep ? "unverified" : "rejected";
+}
+
+/** Weakest verdict wins: one 'rejected' sinks the candidate. */
+function weakest(verdicts: readonly EntryVerdict[]): EntryVerdict {
+  if (verdicts.includes("rejected")) return "rejected";
+  return verdicts.includes("unverified") ? "unverified" : "verified";
+}
+
+/**
+ * Interpreters that run a script ARGUMENT rather than resolving a published
+ * binary by name. Deliberately short, and deliberately excludes `deno` and
+ * `bun`: both accept scheme-prefixed package specifiers (`deno run npm:acme`)
+ * that are launchers wearing a runtime's clothes.
+ */
+const LOCAL_RUNTIMES: ReadonlySet<string> = new Set([
+  "node",
+  "nodejs",
+  "tsx",
+  "ts-node",
+  "python",
+  "python3",
+]);
+
+/**
+ * Verdict for a start command that names NO script-extension entry path at all.
+ *
+ * This is the bare-word case: `"start": "start-server"` resolves out of
+ * `node_modules/.bin`, so `npm start` launches a DEPENDENCY's published code —
+ * and because it extracts zero entry paths, the old rule C simply never fired
+ * on it. It passed rules A and B and `escapesCheckout` and was emitted.
+ *
+ * With a listing available, a bare word cannot be proven to be checkout code,
+ * so it is SUPPRESSED. The two shapes that survive are the ones that do name
+ * the checkout: a local runtime pointed at `.` / `./` (which is the checkout
+ * root, resolved through its own package.json `main`), and a local runtime
+ * pointed at an extensionless path the listing has as a regular file
+ * (`node bin/cli`).
+ *
+ * WITHOUT a listing there is nothing to check against, so behavior is
+ * unchanged — the candidate is emitted and carries 'unverified', which is the
+ * honest label and the one A3 gates on.
+ */
+function verifyExtensionlessStart(
+  body: string,
+  checkout: Checkout | null,
+): EntryVerdict {
+  if (!checkout) return "unverified";
+  const segments = shellSegments(body);
+  // Rule A already rejected chaining, so a start body is one segment; anything
+  // else means we mis-tokenized, and mis-tokenized is not proven.
+  if (segments.length !== 1) return "rejected";
+  const [command, ...rest] = segments[0];
+  if (!LOCAL_RUNTIMES.has(commandName(command))) return "rejected";
+  const target = rest.find((token) => !token.startsWith("-"));
+  if (target === undefined) return "rejected";
+  if (target === "." || target === "./") return "verified";
+  const normalized = target.replace(/^\.\//, "");
+  if (!isCheckoutRelative(normalized)) return "rejected";
+  return checkout.get(normalized) === "file" ? "verified" : "rejected";
 }
 
 /**
@@ -661,6 +848,10 @@ function detectNode(
     const cmd = nodeCommands(manager.pm, manager.lock);
     const evidence: string[] = [`package.json + ${manager.why}`];
     let score = manager.lock ? 20 : 5;
+    // Starts optimistic and only ever weakens: any entry point accepted on a
+    // plausibility argument rather than on the listing downgrades the whole
+    // candidate, because A3's runtime check is per-candidate, not per-path.
+    let proof: OwnershipProof = "verified";
 
     // --- start command -----------------------------------------------------
     let start: string | null = null;
@@ -693,19 +884,32 @@ function detectNode(
         );
         continue;
       }
-      if (checkout) {
-        // Rule C. Every file the start command names must be checkout code or
-        // the output of the checkout's own build.
-        const unestablished = entryPaths(scripts.start).filter(
-          (path) => !entryEstablished(path, checkout, hasBuildStep),
+      // Rule C. Every file the start command names must be a regular file in
+      // the checkout, or a path the checkout's own build could have produced —
+      // and in the second case the candidate is marked 'unverified' rather than
+      // pretending the build script settled it.
+      const paths = entryPaths(scripts.start);
+      // Zero entry paths is not "nothing to check": `"start": "start-server"`
+      // names a dependency binary and used to walk straight past rule C. The
+      // two cases get DIFFERENT discard reasons because the corpus report is
+      // read to decide what to fix next, and "your entry file isn't in the
+      // checkout" and "your start script names no file at all" are different
+      // problems with different answers.
+      const verdict =
+        paths.length > 0
+          ? weakest(
+              paths.map((path) => verifyEntryPath(path, checkout, hasBuildStep)),
+            )
+          : verifyExtensionlessStart(scripts.start, checkout);
+      if (verdict === "rejected") {
+        discarded.push(
+          paths.length > 0
+            ? `${manager.pm}: scripts.start runs a file that is not proven to be checkout code (absent from the listing, not a regular file, or not a checkout-relative path)`
+            : `${manager.pm}: scripts.start names no verifiable checkout file — a bare command name resolved from node_modules/.bin, or an indirection such as \`${manager.pm} run <script>\``,
         );
-        if (unestablished.length > 0) {
-          discarded.push(
-            `${manager.pm}: scripts.start runs a file that is not in the checkout and no build step produces it`,
-          );
-          continue;
-        }
+        continue;
       }
+      if (verdict === "unverified") proof = "unverified";
       start = cmd.start;
       evidence.push("start command from scripts.start");
       score += 10;
@@ -716,13 +920,15 @@ function detectNode(
           // Validated (not merely quoted — see SAFE_RELATIVE_PATH_RE) plain
           // relative path inside the checkout, so it is safe to exec directly.
           const binPath = bin.replace(/^\.\//, "");
-          if (checkout && !entryEstablished(binPath, checkout, hasBuildStep)) {
+          const verdict = verifyEntryPath(binPath, checkout, hasBuildStep);
+          if (verdict === "rejected") {
             // Rule C, same reasoning as for scripts.start.
             discarded.push(
-              `${manager.pm}: package.json bin is not in the checkout and no build step produces it`,
+              `${manager.pm}: package.json bin is not proven to be checkout code (absent from the listing, not a regular file, or not a checkout-relative path)`,
             );
             continue;
           }
+          if (verdict === "unverified") proof = "unverified";
           start = `node ./${bin}`;
           evidence.push("start command from package.json bin entry");
           score += 6;
@@ -767,8 +973,14 @@ function detectNode(
       score += 15;
     }
 
+    evidence.push(
+      proof === "verified"
+        ? "entry point verified against the checkout file listing"
+        : "entry point NOT verified against the checkout; runtime ownership check required",
+    );
+
     out.push({
-      recipe: finish({ build, start }, hint, evidence),
+      recipe: finish({ build, start }, hint, evidence, proof),
       score,
     });
   }
@@ -894,7 +1106,12 @@ function detectPython(
     return [];
   }
   const module = facts.firstScriptTarget.split(":")[0];
-  const owned = pythonModuleFiles(module).some((path) => checkout.has(path));
+  // `=== "file"`, not "present": a `src/acme/server.py` that is a SYMLINK into
+  // a dependency's site-packages is the python spelling of the same lie, and
+  // the listing now carries enough to refuse it.
+  const owned = pythonModuleFiles(module).some(
+    (path) => checkout.get(path) === "file",
+  );
   if (!owned) {
     discarded.push(
       "python: the [project.scripts] target resolves to a dependency module, not to checkout source",
@@ -918,6 +1135,10 @@ function detectPython(
           "start command from [project.scripts]",
           "entry module verified against the checkout file listing",
         ],
+        // Python only ever emits when the module was found as a regular file in
+        // the listing — the no-listing and not-found paths both returned above
+        // — so this arm is proven by construction.
+        "verified",
       ),
       score: 25,
     },
@@ -930,6 +1151,7 @@ function finish(
   commands: { build: string; start: string },
   hint: Hint | null,
   evidence: string[],
+  ownershipProof: OwnershipProof,
 ): ResolvedRecipe {
   const recipe: CheckRecipe = {
     build: commands.build,
@@ -948,7 +1170,7 @@ function finish(
     if (hint.path !== undefined) parts.push("path");
     lines.push(`${parts.join(" and ")} from ${hint.source}`);
   }
-  return { ...recipe, rung: "detected", evidence: lines };
+  return { ...recipe, rung: "detected", ownershipProof, evidence: lines };
 }
 
 /**

--- a/mcpjam-inspector/server/services/github-checks/resolver/index.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/index.ts
@@ -33,11 +33,19 @@ export {
   DETECTION_MAX_BYTES,
   DETECTION_README_MAX_BYTES,
   type DetectionInputs,
+  type RepoFileEntry,
+  type RepoFileKind,
 } from "./detect";
+export {
+  listRepoFiles,
+  parseLsFilesEntries,
+  MAX_REPO_FILES,
+} from "./repoFiles";
 export { parseMcpjamYaml, MCPJAM_YAML_MAX_BYTES } from "./mcpjamYaml";
 export { resolveOverrideRecipe } from "./overrides";
 export {
   RecipeResolutionError,
+  type OwnershipProof,
   type RecipeRung,
   type ResolvedRecipe,
 } from "./types";
@@ -51,11 +59,17 @@ export type LadderInput = {
    * exactly what `resolveRecipe` does, so the two entry points stay one code
    * path instead of drifting.
    *
-   * Include `detection.repoFiles` (the checkout's file listing) whenever the
-   * caller has the checkout on disk: detection is strictly more permissive with
-   * it, because it can PROVE an entry point is checkout code instead of
-   * suppressing what it cannot establish. `scripts/resolver-corpus.ts`
-   * populates it from the clone; A3 populates it from the sandbox.
+   * Include `detection.repoFiles` (the checkout's file listing, WITH a kind per
+   * entry — see `RepoFileEntry`) whenever the caller has the checkout on disk.
+   * It is not simply a permissiveness dial: with a listing detection can PROVE
+   * an entry point is checkout code and mark the candidate
+   * `ownershipProof: 'verified'`, and it can also REFUSE things it would
+   * otherwise have to let through (a symlinked entry point, a bare-word start
+   * resolved from `node_modules/.bin`). Without one, node candidates fall back
+   * to syntactic rules and come out 'unverified', and python is suppressed
+   * outright. Use `listRepoFiles()` to build it — one shape, one command, for
+   * both callers. `scripts/resolver-corpus.ts` populates it from the clone; A3
+   * populates it from the sandbox.
    */
   detection?: DetectionInputs;
 };

--- a/mcpjam-inspector/server/services/github-checks/resolver/index.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/index.ts
@@ -50,6 +50,12 @@ export type LadderInput = {
    * Files for rung 2. Omit to run the authoritative rungs only — which is
    * exactly what `resolveRecipe` does, so the two entry points stay one code
    * path instead of drifting.
+   *
+   * Include `detection.repoFiles` (the checkout's file listing) whenever the
+   * caller has the checkout on disk: detection is strictly more permissive with
+   * it, because it can PROVE an entry point is checkout code instead of
+   * suppressing what it cannot establish. `scripts/resolver-corpus.ts`
+   * populates it from the clone; A3 populates it from the sandbox.
    */
   detection?: DetectionInputs;
 };

--- a/mcpjam-inspector/server/services/github-checks/resolver/index.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/index.ts
@@ -1,5 +1,5 @@
 /**
- * The recipe resolution ladder (R1: authoritative rungs only).
+ * The recipe resolution ladder (R1 authoritative rungs + R2 detection).
  *
  * Ships dark: nothing imports this from the worker yet. Wiring happens in R4,
  * after the backend learns to persist rung provenance (R3). Until then the
@@ -9,13 +9,31 @@
  *
  *   0. operator override  (authoritative) — present wins outright
  *   1. declared mcpjam.yaml (authoritative) — invalid FAILS, never falls through
- *   2+ detected / agentic (heuristic) — land in R2 / R5
+ *   2. detected (heuristic) — MULTIPLE candidates, verified one at a time
+ *   3+ agentic (heuristic) — lands in R5
+ *
+ * WHY THE RETURN SHAPE IS A UNION: rungs 0/1 produce a recipe that is already
+ * true — an operator or the author said so, and there is nothing to choose
+ * between. Rung 2 produces GUESSES, and a guess is only known good after it
+ * builds and answers MCP. Collapsing them to one `ResolvedRecipe` would force
+ * this module to pick a candidate on the caller's behalf, silently discarding
+ * the fallbacks R4 needs (it runs each candidate in a FRESH sandbox). So the
+ * ladder returns which KIND of answer it has, and the caller decides how much
+ * verification that answer still owes.
  */
 
 import { resolveOverrideRecipe } from "./overrides";
 import { parseMcpjamYaml } from "./mcpjamYaml";
+import { detectCandidatesWithReasons, type DetectionInputs } from "./detect";
 import { RecipeResolutionError, type ResolvedRecipe } from "./types";
 
+export {
+  detectCandidates,
+  detectCandidatesWithReasons,
+  DETECTION_MAX_BYTES,
+  DETECTION_README_MAX_BYTES,
+  type DetectionInputs,
+} from "./detect";
 export { parseMcpjamYaml, MCPJAM_YAML_MAX_BYTES } from "./mcpjamYaml";
 export { resolveOverrideRecipe } from "./overrides";
 export {
@@ -24,11 +42,29 @@ export {
   type ResolvedRecipe,
 } from "./types";
 
-export function resolveRecipe(input: {
+export type LadderInput = {
   repoFullName: string;
   /** Contents of mcpjam.yaml at the repo root, or null if the file is absent. */
   mcpjamYaml: string | null;
-}): ResolvedRecipe {
+  /**
+   * Files for rung 2. Omit to run the authoritative rungs only — which is
+   * exactly what `resolveRecipe` does, so the two entry points stay one code
+   * path instead of drifting.
+   */
+  detection?: DetectionInputs;
+};
+
+export type LadderResolution =
+  /** Rung 0/1: someone declared this. Run it; a failure is attributable. */
+  | { kind: "authoritative"; recipe: ResolvedRecipe }
+  /**
+   * Rung 2+: guesses, best-first and always non-empty (an empty detection
+   * result throws `no_recipe` instead). Each must be verified before it is
+   * believed, and R4 verifies each in its own sandbox.
+   */
+  | { kind: "candidates"; candidates: ResolvedRecipe[] };
+
+export function resolveRecipeLadder(input: LadderInput): LadderResolution {
   const override = resolveOverrideRecipe(input.repoFullName);
   if (override) {
     // An override outranks a declared config even when both exist; say so in
@@ -36,17 +72,55 @@ export function resolveRecipe(input: {
     if (input.mcpjamYaml !== null) {
       override.evidence.push("mcpjam.yaml present but outranked by override");
     }
-    return override;
+    return { kind: "authoritative", recipe: override };
   }
 
   // Authoritative rung: throws on an invalid file, by design (types.ts).
+  // Detection is NOT consulted on the way past — a broken mcpjam.yaml that
+  // fell through to a guess would run something the author never declared and
+  // then blame them for the result.
   const declared = parseMcpjamYaml(input.mcpjamYaml);
-  if (declared) return declared;
+  if (declared) return { kind: "authoritative", recipe: declared };
+
+  const detected = input.detection
+    ? detectCandidatesWithReasons(input.detection)
+    : { candidates: [], discarded: [] as string[] };
+  if (detected.candidates.length > 0) {
+    return { kind: "candidates", candidates: detected.candidates };
+  }
 
   // Maps to the existing `recipe_unresolvable` check outcome once the worker
   // adopts the ladder in R4 (a NEUTRAL check, never a failure blamed on the PR).
+  // The discard reasons are constant strings from detect.ts, safe to render.
   throw new RecipeResolutionError(
     "no_recipe",
-    `no recipe available for ${input.repoFullName}: no operator override and no mcpjam.yaml`,
+    `no recipe available for ${input.repoFullName}: no operator override, no mcpjam.yaml` +
+      (input.detection ? ", and nothing detectable" : ""),
+    detected.discarded.length > 0
+      ? `Detection considered and rejected:\n${detected.discarded
+          .map((reason) => `- ${reason}`)
+          .join("\n")}`
+      : undefined,
   );
+}
+
+/**
+ * Authoritative-only entry point, unchanged from R1 (same signature, same
+ * throws). Kept because a caller that only wants "is this configured?" should
+ * not have to destructure a union it can never observe the second arm of.
+ */
+export function resolveRecipe(input: {
+  repoFullName: string;
+  mcpjamYaml: string | null;
+}): ResolvedRecipe {
+  const resolution = resolveRecipeLadder(input);
+  // Unreachable: without `detection`, rung 2 produces nothing and the ladder
+  // throws `no_recipe` above. Asserted rather than assumed.
+  if (resolution.kind !== "authoritative") {
+    throw new RecipeResolutionError(
+      "no_recipe",
+      `no recipe available for ${input.repoFullName}: no operator override and no mcpjam.yaml`,
+    );
+  }
+  return resolution.recipe;
 }

--- a/mcpjam-inspector/server/services/github-checks/resolver/mcpjamYaml.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/mcpjamYaml.ts
@@ -172,6 +172,10 @@ export function parseMcpjamYaml(raw: string | null): ResolvedRecipe | null {
   return {
     ...recipe,
     rung: "declared",
+    // AUTHORITATIVE rung: the repo author declared this start command, so a
+    // wrong one is attributable to them and not a silent false green from our
+    // guessing. See `OwnershipProof` in ./types.ts.
+    ownershipProof: "verified",
     // Constant string on purpose: evidence must never carry file content.
     evidence: ["mcpjam.yaml at repo root (version 1)"],
   };

--- a/mcpjam-inspector/server/services/github-checks/resolver/overrides.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/overrides.ts
@@ -21,6 +21,10 @@ export function resolveOverrideRecipe(
   return {
     ...recipe,
     rung: "override",
+    // AUTHORITATIVE rung: an operator wrote this command down deliberately, so
+    // the declaration IS the ownership fact the ladder attributes to. There is
+    // nothing left for A3's runtime check to establish.
+    ownershipProof: "verified",
     // repoFullName is operator/allowlist-controlled, not PR content, so it is
     // safe to echo into evidence.
     evidence: [`operator override for ${repoFullName.trim().toLowerCase()}`],

--- a/mcpjam-inspector/server/services/github-checks/resolver/repoFiles.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/repoFiles.ts
@@ -1,0 +1,96 @@
+/**
+ * The checkout listing that rule C verifies entry points against.
+ *
+ * SEPARATE FROM detect.ts ON PURPOSE: detect.ts is a pure function of already-
+ * read file contents and does no I/O, which is what makes it trivially testable
+ * and safe to call from a cache-keying path. This module is the one place that
+ * shells out, so both callers that have a checkout on disk — the corpus harness
+ * (a clone in a tmpdir) and A3 (the checkout in the sandbox) — produce the
+ * SAME shape from the SAME command instead of two hand-rolled listings that
+ * drift.
+ *
+ * WHY `git ls-files -s` AND NOT `git ls-files`:
+ *
+ * Plain `git ls-files` prints PATHS. A tracked `server.js` that is a symlink to
+ * `node_modules/acme/server.js` prints as `server.js` — indistinguishable from
+ * checkout source in the text, and node follows the link at runtime. `-s`
+ * prints the MODE, and mode `120000` is git's symlink mode. That one column is
+ * the difference between proving an entry point is checkout code and merely
+ * observing that its name is unremarkable.
+ */
+
+import { execFileSync } from "node:child_process";
+import type { RepoFileEntry, RepoFileKind } from "./detect";
+
+/**
+ * Cap on the listing handed to detection. Detection uses it for exact lookups
+ * of a handful of entry paths, so a monorepo with 400k tracked files would cost
+ * megabytes of strings to answer four questions. Truncation is SAFE in the
+ * suppress direction: a missing entry can only cause a candidate to be
+ * suppressed or downgraded to 'unverified', never accepted.
+ */
+export const MAX_REPO_FILES = 20_000;
+
+/** git's file modes, as they appear in `git ls-files -s`. */
+const GIT_MODE_SYMLINK = "120000";
+const GIT_MODE_REGULAR = new Set(["100644", "100755"]);
+
+function kindForMode(mode: string): RepoFileKind {
+  if (GIT_MODE_REGULAR.has(mode)) return "file";
+  if (mode === GIT_MODE_SYMLINK) return "symlink";
+  // 160000 is a gitlink (submodule); anything else is a mode we do not know,
+  // and "we do not know" must never read as "regular file".
+  return "other";
+}
+
+/**
+ * Parse `git ls-files -s -z` output.
+ *
+ * Each record is `<mode> <sha> <stage>\t<path>`, NUL-terminated. NUL delimiting
+ * is not a nicety: newlines are legal in git paths, so a line-oriented parser
+ * would split one path into two entries — and a bogus half-path in the listing
+ * is a lookup that silently misses, i.e. a silent recall loss.
+ *
+ * Malformed records are DROPPED rather than guessed at, for the same reason.
+ */
+export function parseLsFilesEntries(stdout: string): RepoFileEntry[] {
+  const out: RepoFileEntry[] = [];
+  for (const record of stdout.split("\0")) {
+    if (record.length === 0) continue;
+    const tab = record.indexOf("\t");
+    if (tab === -1) continue;
+    const path = record.slice(tab + 1);
+    if (path.length === 0) continue;
+    const mode = record.slice(0, tab).split(" ")[0] ?? "";
+    out.push({ path, kind: kindForMode(mode) });
+    if (out.length >= MAX_REPO_FILES) break;
+  }
+  return out;
+}
+
+/**
+ * The checkout's tracked files with their types, for detection's rule C.
+ *
+ * `git ls-files` rather than a directory walk: the clone is already a git repo,
+ * it is one process instead of a recursive stat storm, and it excludes `.git/`
+ * and anything gitignored for free.
+ *
+ * Returns `[]` when git fails for any reason. That is a VALID input, not an
+ * error: detection reads an empty listing as "no listing", falls back to its
+ * conservative path, and marks what it does emit `ownershipProof: 'unverified'`
+ * so A3 still settles it at runtime. Biasing toward suppression on our own
+ * infrastructure failure is the safe direction.
+ */
+export function listRepoFiles(dir: string): RepoFileEntry[] {
+  try {
+    const stdout = execFileSync("git", ["ls-files", "-s", "-z"], {
+      cwd: dir,
+      stdio: "pipe",
+      timeout: 60_000,
+      maxBuffer: 64 * 1024 * 1024,
+    }).toString("utf8");
+    return parseLsFilesEntries(stdout);
+  } catch {
+    return [];
+  }
+}

--- a/mcpjam-inspector/server/services/github-checks/resolver/types.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/types.ts
@@ -37,8 +37,55 @@ import type { CheckRecipe } from "../recipes";
  */
 export type RecipeRung = "override" | "declared" | "detected" | "agentic";
 
+/**
+ * Whether the recipe's entry point is PROVEN to be checkout code.
+ *
+ * This exists because static analysis genuinely cannot settle the question in
+ * every case, and pretending otherwise is how the detection allowlist sprang a
+ * leak twice. A build script runs arbitrary code: `"build": "mkdir -p dist &&
+ * cp node_modules/acme/server.js dist/index.js"` produces a `dist/index.js`
+ * that is PUBLISHED code wearing a checkout-relative path. No amount of string
+ * reasoning about the build body can tell that apart from `tsc`. Only watching
+ * the process that actually ends up listening can.
+ *
+ * So the resolver stops guessing and starts LABELLING:
+ *
+ *   'verified'   — the entry point is a REGULAR FILE present in the checkout
+ *                  listing, or the rung is authoritative (an operator or the
+ *                  repo author declared it, and that declaration IS the truth
+ *                  the ladder attributes to). Nothing further is owed.
+ *   'unverified' — accepted, but its provenance was never established. Today
+ *                  that is exactly one case: a relative, non-escaping entry
+ *                  path that no listing contains and a build step plausibly
+ *                  produces (`node dist/index.js` + `npm run build`), plus the
+ *                  degenerate form of it — no listing was supplied at all, so
+ *                  there was nothing to check against.
+ *
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ A3 REQUIREMENT — DO NOT DROP THIS BETWEEN PRs.                          │
+ * │                                                                         │
+ * │ When `ownershipProof === 'unverified'`, A3's `resolveAndStart` MUST     │
+ * │ perform a RUNTIME ownership check inside the sandbox once the server    │
+ * │ is up, before the probe result is allowed to turn a check green:        │
+ * │                                                                         │
+ * │   1. resolve the LISTENING process's main module (e.g. `/proc/<pid>/`   │
+ * │      `cmdline` + `cwd`, or the equivalent for the sandbox runtime);     │
+ * │   2. `realpath` it (this is the step that defeats symlinks, which no    │
+ * │      path-string check can);                                            │
+ * │   3. require the result to live INSIDE the checkout directory and NOT   │
+ * │      inside any `node_modules/`.                                        │
+ * │                                                                         │
+ * │ Failing that check is a resolver MISS (neutral check), never a green.   │
+ * │ That check has ground truth. This field does not — it only says which   │
+ * │ candidates need it.                                                     │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ */
+export type OwnershipProof = "verified" | "unverified";
+
 export type ResolvedRecipe = CheckRecipe & {
   rung: RecipeRung;
+  /** See `OwnershipProof` — and the A3 REQUIREMENT recorded with it. */
+  ownershipProof: OwnershipProof;
   /**
    * Short human-readable strings surfaced in check output ("mcpjam.yaml at
    * repo root", "operator override for <repo>"). These MUST stay free of


### PR DESCRIPTION
## What this adds

**Rung 2 of the recipe ladder: detection.** `resolver/detect.ts` takes already-read checkout files (no I/O, exactly like `mcpjamYaml.ts`) and returns ordered, best-first candidate recipes.

The one invariant that makes a guess safe to run: **a candidate must RUN THE CHECKOUT.** A command like `npx @acme/mcp-server` looks like it starts the server and would even go green — but it starts the *published* artifact, so the check would report on code the PR never touched. That is a silent false green, worse than no check. Anything resolving to a published package (`npx` / `pnpm dlx` / `yarn dlx` / `bunx` / `uvx` / `pipx run`) or a remote URL is **discarded**, with the reason recorded. The check is on the script *body*, not on the command we emit: we emit `npm start`, but if `scripts.start` is `npx -y @acme/server` then `npm start` is a published-package launcher wearing a local disguise.

### v1 ecosystems (deliberately short)
| ecosystem | trigger | build | start |
|---|---|---|---|
| pnpm | `pnpm-lock.yaml` | `pnpm install --frozen-lockfile [&& pnpm run build]` | `pnpm start` |
| yarn classic | `yarn.lock` | `yarn install --frozen-lockfile [&& yarn run build]` | `yarn start` |
| npm | `package-lock.json` | `npm ci [&& npm run build]` | `npm start` |
| npm (no lockfile) | `package.json` alone | `npm install [&& npm run build]` | `npm start` |
| python | `pyproject.toml` **+** `uv.lock` | `uv sync --frozen` | `uv run <first [project.scripts]>` |

Everything else — bun, poetry, pipenv, go, rust — yields **no candidate**, and says so by name in the discard reason so the corpus report can count them instead of burying them in one "unsupported" blob. Start falls back to a single `bin` entry when there is no `scripts.start`; multiple bin entries are ambiguous and we don't guess.

**Build when there is no build script:** the candidate's build is the **install step alone**, not a no-op like `true`. For a node/python project the install genuinely *is* the minimum build step, a failing install is honestly `build_failed`, and a `true` build would be a recipe pretending to have built something.

**Hints, not recipes.** `server.json` `remotes[]` and README localhost URLs may move **port/path only**, never the command. `server.json`'s `packages[]` array (which names published artifacts) is ignored outright — it's exactly the trap above. Hosted URLs are ignored (a `https://mcp.acme.com/v1` says nothing about which port the checkout binds in our sandbox), and a path hint must match a plain-path allowlist before it can reach the probe URL.

**Evidence hygiene** (R1's rule, mirrored with a test that feeds hostile content through every input): evidence lines are constant strings plus validated integers. The hint line names the *source* ("port 8931 and path from server.json"), never the path value.

**Byte caps** via `Buffer.byteLength`, mirroring `MCPJAM_YAML_MAX_BYTES`: 64KB for parsed config files, 256KB for READMEs. Oversize input is *ignored*, never fatal — heuristic rung.

## Ladder return-shape decision

Added **`resolveRecipeLadder(input): { kind: "authoritative"; recipe } | { kind: "candidates"; candidates }`** and left `resolveRecipe` with its exact R1 signature and semantics (it now delegates, so there is one code path, not two that drift).

Why a union rather than one `ResolvedRecipe`: rungs 0/1 produce a recipe that is *already true* — an operator or the author said so. Rung 2 produces **guesses**, and a guess is only known good after it builds and answers MCP. Collapsing them would force the resolver to pick a candidate on the caller's behalf and silently discard the fallbacks A3 needs (it runs each candidate in a fresh sandbox).

**Authoritative semantics are unchanged, and re-pinned by a new test:** a present-but-invalid `mcpjam.yaml` still throws `invalid_mcpjam_yaml` and does **not** fall through to detection. That regression is exactly what adding a heuristic rung invites. When nothing resolves, `no_recipe` now carries the discard reasons in `detailsMarkdown` (constant strings, safe to render).

## Corpus results — real run, 55 sha-pinned repos

`scripts/resolver-corpus.ts` + `scripts/resolver-corpus.manifest.json` (dev-only, **not in CI** — it clones 55 third-party repos). Every manifest entry came from a real `gh api repos/{repo}/commits/HEAD`. Run: `npx tsx scripts/resolver-corpus.ts --json out.json`.

| category | n | share |
|---|---|---|
| `resolved` | 27 | 49.1% |
| `unsupported_transport` | 7 | 12.7% |
| `detector_miss` | 21 | 38.2% |
| `infra_error` | 0 | 0.0% |
| `build_miss` | — | deferred |
| `probe_miss` | — | deferred |
| **total** | **55** | |

### 🎯 Recall over HTTP-capable repos: **27/48 = 56.3%** (of which 14 verified / 13 unverified)

**This number CANNOT close the A4 priority gate, and should not be used to.** The harness never builds and never probes, so `resolved` means "we produced a candidate", not "that candidate works" — every figure here is an **upper bound**, and the true recall is lower by however many candidates fail at build or probe time. Only A3's sandbox e2e can populate `build_miss`/`probe_miss` and produce a number the gate can actually rest on. A4's dependency remains A3 regardless.

Revision history of this number, since it moved several times under review: 67.4% (invalid — stdio repos counted as resolved, and a `grep -l` bug hid source-only HTTP evidence) → 59.5% → 57.1% (allowlist inversion) → 54.8% (Rule C tightening) → 57.1% (Rule C round 3: script indirection is now RESOLVED and verified rather than discarded wholesale, which returns exa-labs/exa-mcp-server) → **56.3%** (round 3.1).

**Round 3.1's recall FELL because the DENOMINATOR grew, not because anything regressed.** The source scan now anchors every pattern `httpSignals()` classifies on, so repos whose only HTTP evidence was source-level stopped being filed `unsupported_transport` (13 → 7) and started being counted. The detector's verdict is byte-for-byte identical on all 55 repos — every one of the four false-green paths closed in round 3.1 cost exactly zero corpus recall. The six repos that moved:

| repo | was | now | why |
|---|---|---|---|
| `zcaceres/markdownify-mcp` | `unsupported_transport` | **`resolved`** | `http-framework` in source; was already resolvable, just uncounted |
| `UI5/mcp-server` | `unsupported_transport` | **`resolved`** | `localhost-url` in source (verified proof) |
| `browserstack/mcp-server` | `unsupported_transport` | **`resolved`** | `http-cli-flag` in source |
| `lharries/whatsapp-mcp` | `unsupported_transport` | `detector_miss` | `localhost-url` in source; Go/Python, no supported ecosystem files |
| `getsentry/XcodeBuildMCP` | `unsupported_transport` | `detector_miss` | `http-framework` in source; no `scripts.start`, no single `bin` |
| `CoplayDev/unity-mcp` | `unsupported_transport` | `detector_miss` | three HTTP signals in source; no supported ecosystem files |

Resolved by package manager (best candidate per repo): 13 npm, 9 uv, 5 pnpm (the corpus happened to contain no yarn-classic repo — that path is covered by unit test only).

`detector_miss` breakdown — every miss is legible, none is a mystery:

| reason | n | notes |
|---|---|---|
| no supported ecosystem files | 11 | Go (github-mcp-server, terraform-mcp-server, kubernetes-mcp-server, slack-mcp-server, mcp-grafana, mcp-toolbox, whatsapp-mcp), Java (GhidraMCP), C#/Python (unity-mcp), monorepos with no root manifest (awslabs/mcp, elastic) |
| no `scripts.start` and no single `bin` | 5 | monorepo roots (modelcontextprotocol/servers, PostHog/mcp, cloudflare, context7, XcodeBuildMCP) |
| python without `uv.lock` | 3 | pip/poetry projects — a named v1 non-goal |
| `scripts.start` uses shell expansion | 1 | chrome-devtools-mcp — rule A, unprovable by construction |
| start script launches a published package | 1 | antvis/mcp-server-chart — **correctly** refused |

## What the harness cannot measure

It **never builds and never probes.** So `resolved` means "we produced a candidate that runs the checkout over HTTP", not "that candidate works" — read 56.3% as an **upper bound**. The `build_miss` (candidate built wrong) and `probe_miss` (built but never spoke MCP) buckets are in the taxonomy and reported as `—`; only A3's sandbox e2e can populate them.

The HTTP/stdio classifier is deliberately **generous toward HTTP** (README + server.json + package manifests + a source grep anchoring **every** pattern the classifier scores on — transport APIs, `express()`/`FastAPI()`/`createServer()`/`uvicorn`, HTTP CLI flags and localhost URLs). Any classifier pattern missing an anchor in that grep is a pattern that can only ever fire on README text, which is how six source-only repos previously fell out of the denominator. Over-counting HTTP repos makes recall look *worse*, which is the safe direction for a number that decides investment. Clone/read failures are `infra_error`, never a detector verdict — the same separation A3 enforces between resolver misses and sandbox infra errors.

## Ships DARK

Nothing imports the ladder from the worker. `resolveCheckRecipe` is still what runs in production; **A3 wires `resolveAndStart()`**, after A2 teaches the backend to persist rung provenance.

## Tests

`npx vitest run server/services/github-checks/__tests__/` → **290 passed, exit 0** (detect 167, resolver 27, sandbox 87, repoFiles 9)
- new `detect.test.ts` (167 tests): each package manager, no-lockfile fallback + ranking, multiple lockfiles, install-is-the-build, bin fallback, ambiguous bin, npx/dlx/bunx/remote-URL discard, `npxlike-runner.js` false-positive guard, `server.json packages[]` never becomes a recipe, uv candidate, python-without-uv, poetry named, go/rust/empty, invalid JSON, byte-vs-code-unit cap, server.json + README hints, hosted-URL ignored, hostile path hint rejected, evidence hygiene under hostile content, ladder ordering, **invalid-yaml-still-throws regression**
- existing `resolver.test.ts` (27), `sandbox.test.ts` (87), `github-checks-worker.test.ts` (53) all unchanged and green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new heuristic layer that decides what runs in sandboxes; mistakes could cause false greens or missed checks, but it ships dark, rejects remote/published launchers aggressively, and is heavily unit-tested.
> 
> **Overview**
> Introduces **rung 2 (detection)** for GitHub check recipes: `detect.ts` infers build/start recipes from lockfiles, `package.json` / `pyproject.toml`, and optional `repoFiles` listings, returning **ordered candidates** that must **run the checkout** (not `npx`/registry/remote URLs). Policy is an **allowlist** with rules for unprovable shell, fetching subcommands, and entry-point verification; it also walks **lifecycle hooks** and **script indirection** (`npm run serve`, install/build hooks) with depth limits.
> 
> **`resolveRecipeLadder`** returns `{ kind: "authoritative" | "candidates" }` so callers can try multiple detected recipes in separate sandboxes; invalid `mcpjam.yaml` still **does not** fall through to detection. Recipes gain **`ownershipProof: verified | unverified`** (authoritative rungs always verified); unverified candidates expect a future **A3 runtime ownership check**.
> 
> Adds **`repoFiles.ts`** (`git ls-files -s` with symlink/submodule kinds), **`scripts/resolver-corpus.ts`** + pinned **manifest** (manual recall over ~55 HTTP-capable MCP repos, not CI), and large **`detect.test.ts`** / **`repoFiles.test.ts`** coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 145fb3c10d3ebebae0f43cfe3e09c8a8fe014b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds R2 detection that proposes best‑first recipes that must run the checkout, with ownership labeling and a pinned corpus harness. This update closes four install‑hook bypasses and keeps recall steady at 27/48 (56.3%).

- **Bug Fixes**
  - Install hooks: handle leading env assignments, and follow `npm run`/`pnpm`/`yarn`/`bun run` indirection during install (depth‑limited, cycle‑safe).
  - Inline runtimes in install hooks: treat detached runs as foreign, including `node -e/--eval/-p`, `python -c/-m`, and any invocation with options; detached checkout entries stay allowed; non‑detached inline runs stay allowed.
  - Tests/corpus: fix case‑sensitive script name lookups and add inline‑flag coverage; corpus unchanged — 27 resolved; HTTP recall 27/48 = 56.3% (14 verified, 13 unverified).

<sup>Written for commit 145fb3c10d3ebebae0f43cfe3e09c8a8fe014b1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

