### PR TITLE
feat(agent): connect the MCP spec docs server for protocol questions

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent-widget-content.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent-widget-content.test.ts
@@ -210,7 +210,10 @@ describe("POST /api/web/mcpjam-agent system prompt", () => {
       };
       // Degraded turn: no platform tools advertised, so no instructions
       // about them either.
-      expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs"]);
+      expect(args.prepare.selectedServerIds).toEqual([
+        "mcpjam-docs",
+        "mcp-spec",
+      ]);
       expect(args.prepare.systemPrompt).not.toContain("Workspace context");
     });
   });

--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
@@ -92,6 +92,17 @@ describe("web routes — mcpjam-agent is UI-only", () => {
     expect(spec.accessToken).toBeUndefined();
   });
 
+  it("drops the spec guidance when the spec server failed preflight", async () => {
+    // Same rule as the workspace-context section: never describe a tool the
+    // degraded turn doesn't advertise.
+    listToolsMock.mockImplementation(async (serverId?: unknown) => {
+      if (serverId === "mcp-spec") throw new Error("upstream unreachable");
+      return { tools: [] };
+    });
+    const args = await postAgentTurn();
+    expect(args.prepare.systemPrompt).not.toContain("MCP SPECIFICATION");
+  });
+
   it("declines the docs servers' submit_feedback write tool", async () => {
     // Both Mintlify docs servers ship it under the SAME unqualified name, and
     // `getToolsForAiSdk` flattens last-in-wins — so advertising it would both
@@ -195,6 +206,20 @@ describe("web routes — mcpjam-agent is UI-only", () => {
       // shapes that have to be reasoned about separately.
       await postAgentTurn();
       expect(Object.keys(managerConfigs[0])).toContain("mcp-spec");
+    });
+
+    it("keeps the spec-reading guidance alongside the connected spec server", async () => {
+      // The identity prompt goes (its "ui_* is your only way to act" claim is
+      // false here), but the spec guidance is a READ instruction and must
+      // track the server. Connecting the authoritative protocol source while
+      // deleting the instruction to read it is the one combination that has
+      // the feature's cost and none of its value.
+      const args = await postAgentTurn();
+      expect(args.prepare.systemPrompt).not.toContain("MCPJam in-app assistant");
+      expect(args.prepare.systemPrompt).toContain("MCP SPECIFICATION");
+      expect(args.prepare.systemPrompt).toContain(
+        "ALWAYS establish which version",
+      );
     });
 
     it("drops the UI-only identity prompt so the rollback isn't self-contradictory", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.ui-only.test.ts
@@ -60,6 +60,10 @@ describe("web routes — mcpjam-agent is UI-only", () => {
     managerConfigs.length = 0;
     delete process.env.MCPJAM_AGENT_PLATFORM_TOOLS;
     streamWebChatTurnMock.mockResolvedValue(new Response("ok", { status: 200 }));
+    // `clearAllMocks` clears calls but NOT implementations, so the degraded
+    // -preflight test below would otherwise leak its throwing stub into every
+    // later test in the file.
+    listToolsMock.mockImplementation(async () => ({ tools: [] }));
   });
 
   afterEach(() => {
@@ -71,10 +75,40 @@ describe("web routes — mcpjam-agent is UI-only", () => {
     // exactly what a surface whose premise is "you can watch me work" must
     // not do.
     await postAgentTurn();
-    expect(Object.keys(managerConfigs[0])).toEqual(["mcpjam-docs"]);
+    expect(Object.keys(managerConfigs[0])).toEqual(["mcpjam-docs", "mcp-spec"]);
   });
 
-  it("selects only the docs server", async () => {
+  it("selects both read-only knowledge servers", async () => {
+    const args = await postAgentTurn();
+    expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs", "mcp-spec"]);
+  });
+
+  it("connects the MCP spec docs server unauthenticated", async () => {
+    // It's a third party. Forwarding the caller's bearer would put an AuthKit
+    // token outside our trust boundary for what is a public docs search.
+    await postAgentTurn();
+    const spec = managerConfigs[0]!["mcp-spec"] as Record<string, unknown>;
+    expect(spec.url).toBe("https://modelcontextprotocol.io/mcp");
+    expect(spec.accessToken).toBeUndefined();
+  });
+
+  it("declines the docs servers' submit_feedback write tool", async () => {
+    // Both Mintlify docs servers ship it under the SAME unqualified name, and
+    // `getToolsForAiSdk` flattens last-in-wins — so advertising it would both
+    // let the agent post free text to a third party unattended AND silently
+    // route MCPJam docs feedback to the MCP project.
+    const args = await postAgentTurn();
+    expect(args.prepare.excludeMcpToolNames).toContain("submit_feedback");
+  });
+
+  it("degrades instead of failing when a knowledge server is down", async () => {
+    // `getToolsForAiSdk` fails the WHOLE turn when any SELECTED server errors
+    // at connect/list time, so an outage at modelcontextprotocol.io — which we
+    // do not operate — must not take the agent down with it.
+    listToolsMock.mockImplementation(async (serverId?: unknown) => {
+      if (serverId === "mcp-spec") throw new Error("upstream unreachable");
+      return { tools: [] };
+    });
     const args = await postAgentTurn();
     expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs"]);
   });
@@ -98,6 +132,22 @@ describe("web routes — mcpjam-agent is UI-only", () => {
     expect(args.prepare.systemPrompt).toContain("wait for a yes before acting");
     // Brevity + honesty rails for the same answer path.
     expect(args.prepare.systemPrompt).toContain("lead with the answer");
+  });
+
+  it("routes protocol questions to the spec server, version-first", async () => {
+    // The whole point of connecting modelcontextprotocol.io: priors degrade
+    // across exactly the version range this debugger targets, and the four
+    // recent specs are near-identical text, so answering without pinning a
+    // version is how you get a confidently wrong answer.
+    const args = await postAgentTurn();
+    expect(args.prepare.systemPrompt).toContain("MCP SPECIFICATION");
+    expect(args.prepare.systemPrompt).toContain("/specification/<version>");
+    expect(args.prepare.systemPrompt).toContain(
+      "ALWAYS establish which version",
+    );
+    expect(args.prepare.systemPrompt).toContain(
+      "Never generalize one version's behavior to another",
+    );
   });
 
   it("ships the app atlas so the model knows what screens exist", async () => {
@@ -138,6 +188,15 @@ describe("web routes — mcpjam-agent is UI-only", () => {
       process.env.MCPJAM_AGENT_PLATFORM_TOOLS = "1";
     });
 
+    it("still connects the knowledge servers — the switch governs acting, not reading", async () => {
+      // The kill-switch exists to restore the ACTION contract (platform tools
+      // back, UI-only prompt gone). Read-only docs are orthogonal to that
+      // question, so they stay in both modes rather than giving the config two
+      // shapes that have to be reasoned about separately.
+      await postAgentTurn();
+      expect(Object.keys(managerConfigs[0])).toContain("mcp-spec");
+    });
+
     it("drops the UI-only identity prompt so the rollback isn't self-contradictory", async () => {
       // "The ui_* tools are your only way to act" is false once the platform
       // tools are back. Shipping both would leave the model with opposite
@@ -156,10 +215,12 @@ describe("web routes — mcpjam-agent is UI-only", () => {
       const args = await postAgentTurn();
       expect(Object.keys(managerConfigs[0])).toEqual([
         "mcpjam-docs",
+        "mcp-spec",
         "mcpjam-platform",
       ]);
       expect(args.prepare.selectedServerIds).toEqual([
         "mcpjam-docs",
+        "mcp-spec",
         "mcpjam-platform",
       ]);
       expect(args.prepare.systemPrompt).toContain("Workspace context");

--- a/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.uitools.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/mcpjam-agent.uitools.test.ts
@@ -120,6 +120,6 @@ describe("web routes — mcpjam-agent uiTools boundary", () => {
     expect(args.prepare.appTools).toBeUndefined();
     // The docs server passes the preflight under the mock; the
     // client-supplied ids are still ignored.
-    expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs"]);
+    expect(args.prepare.selectedServerIds).toEqual(["mcpjam-docs", "mcp-spec"]);
   });
 });

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -5,14 +5,32 @@
  * UI through the client-fulfilled `ui_*` tools, so every action is visible
  * to the user in their own app. It KNOWS things via read-only sources:
  *   - the hosted docs server (`https://docs.mcpjam.com/mcp`, Mintlify) for
- *     documentation search, and
+ *     how MCPJam itself behaves,
+ *   - the MCP project's own docs server (`https://modelcontextprotocol.io/mcp`,
+ *     also Mintlify) for what the PROTOCOL says, and
  *   - the `web_search` built-in.
+ *
+ * Why a second docs server rather than protocol knowledge in the prompt (or
+ * a pinned skill): the spec is published per version — `/specification/`
+ * holds `2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25`, `2026-07-28`
+ * and `draft`, the exact range this debugger targets — and its server
+ * exposes a read-only filesystem (`ls`/`cat`/`rg` over the `.mdx` sources)
+ * alongside search. That makes retrieval ADDRESSED: the model must name a
+ * version to read one, so it cannot silently answer a 2026-07-28 question
+ * out of the 2025-03-26 text. Model priors degrade across exactly that range,
+ * which is where the wrong answers were coming from.
+ *
+ * Both docs servers also offer a `submit_feedback` WRITE tool, which this
+ * route declines — see `DECLINED_MCP_TOOL_NAMES`.
  *
  * It deliberately does NOT connect the MCPJam platform MCP worker for chat
  * turns any more: those tools mutate the user's workspace (projects,
  * servers, evals, chatboxes) server-side and invisibly, which is exactly
  * what this surface is meant not to do. `MCPJAM_AGENT_PLATFORM_TOOLS=1`
- * restores the old behavior wholesale (see `agentPlatformToolsEnabled`).
+ * restores the old ACTION contract wholesale (see
+ * `agentPlatformToolsEnabled`). It does not gate the knowledge sources: the
+ * kill-switch governs how the agent acts, not what it may read, so the docs
+ * servers are connected identically in both modes.
  *
  * The platform CONFIG and the `/widget-content` sub-route below stay: chat
  * sessions from before the cutover still contain platform widget parts, and
@@ -36,14 +54,13 @@
  * degrades the agent to docs + web_search.
  *
  * Differences vs `/api/web/chat-v2`:
- *   - The agent owns its own `MCPClientManager` hardcoded to the two
- *     servers. It does NOT go through `createAuthorizedManager`'s
- *     project-server resolution and does NOT register either server into
- *     any user's project.
+ *   - The agent owns its own `MCPClientManager` hardcoded to these servers.
+ *     It does NOT go through `createAuthorizedManager`'s project-server
+ *     resolution and does NOT register any of them into any user's project.
  *   - Persists as `sourceType: "direct"` with `hostConfig: null` — the
- *     synthetic `"mcpjam-docs"` / `"mcpjam-platform"` ids would fail
- *     backend `selectedServerIds` validation against the project's
- *     `servers` rows. The chat appears in the user's history alongside
+ *     synthetic `"mcpjam-docs"` / `"mcp-spec"` / `"mcpjam-platform"` ids
+ *     would fail backend `selectedServerIds` validation against the
+ *     project's `servers` rows. The chat appears in the user's history alongside
  *     other direct sessions; per-surface differentiation is client-side.
  *   - Ignores chatbox / appTools / selectedServerIds fields up front — this
  *     surface owns its MCP tool set. The one client-supplied tool snapshot it
@@ -91,6 +108,26 @@ import { getClientIp } from "../../utils/client-ip.js";
 
 const DOCS_SERVER_ID = "mcpjam-docs";
 const DEFAULT_DOCS_URL = "https://docs.mcpjam.com/mcp";
+const SPEC_SERVER_ID = "mcp-spec";
+const DEFAULT_SPEC_URL = "https://modelcontextprotocol.io/mcp";
+
+/**
+ * Both Mintlify docs servers ship a `submit_feedback` write tool alongside
+ * their read tools. This surface declines it for two independent reasons,
+ * either of which is sufficient:
+ *
+ *  1. It posts model-authored free text to a docs team — an outward-facing
+ *     action, taken unattended (the agent's approval preference defaults off)
+ *     and invisible in the app the user is watching. That is precisely the
+ *     class of tool this route dropped the platform worker to avoid.
+ *  2. Both servers expose the SAME unqualified name, and
+ *     `getToolsForAiSdk` flattens selected servers last-in-wins — so
+ *     advertising it would silently route MCPJam docs feedback to the MCP
+ *     project instead, with nothing at the call site to reveal it.
+ *
+ * Deleting it by name resolves both: neither server's copy survives.
+ */
+const DECLINED_MCP_TOOL_NAMES = ["submit_feedback"] as const;
 const PLATFORM_SERVER_ID = MCPJAM_PLATFORM_SERVER_ID;
 
 /**
@@ -120,7 +157,8 @@ const AGENT_IDENTITY_PROMPT = [
   "You are embedded in the MCPJam inspector, sitting next to the user's own screen. You act by DRIVING THAT UI with the `ui_*` tools: every action you take lands in the app the user is looking at, and they watch it happen.",
   "When the user asks you to DO something (or where something is), drive the UI and take them there — prefer showing over describing.",
   "When the user asks a QUESTION about the product — how something works, how to do something, what a feature can do — search the MCPJam documentation first and answer from what it says; the screen atlas below tells you where things live, not how they behave, so don't answer product behavior from it alone. Then, if you can carry the answer out in the app, offer to — and wait for a yes before acting.",
-  "Use web search for questions beyond MCPJam itself. You have no other way to act — when something isn't reachable through a `ui_*` tool, say so plainly rather than inventing a tool or claiming you did it.",
+  "When the question is about the MCP SPECIFICATION rather than about MCPJam — what the protocol requires, what a message or field means, what changed between versions — read the MCP docs server instead of answering from memory. Your training data is unreliable across the versions this app targets. The spec is published per version under `/specification/<version>` (`2024-11-05` through `2026-07-28`, plus `draft`), and you can list and read those files directly, so ALWAYS establish which version you're answering for — ask the user if they haven't said — and read that version's page. Never generalize one version's behavior to another; where they differ, say so and name the versions.",
+  "Use web search for questions beyond MCPJam and the protocol. You have no other way to act — when something isn't reachable through a `ui_*` tool, say so plainly rather than inventing a tool or claiming you did it.",
   "When the user wants to add or try an MCP server but hasn't named one, ask which server they'd like to connect — never invent a placeholder server (there is no default \"weather\" server). If they just want a quick example to try, offer these real ones: `https://mcp.excalidraw.com/mcp` (streamable HTTP, no auth) or `https://mcp.mcpjam.com/mcp` (an OAuth example). Only add a server once you have a concrete name and URL from the user or from one of these examples.",
   "Keep replies short: lead with the answer in a few sentences, no filler, no restating the question. If the docs don't settle it, say you're not sure rather than guessing.",
   "",
@@ -147,12 +185,30 @@ const MCP_APPS_CLIENT_CAPABILITIES = {
   },
 };
 
-function buildDocsConfig(): HttpServerConfig {
+/**
+ * Both knowledge servers are the same shape — an unauthenticated hosted
+ * Mintlify docs server — so they share one builder rather than drifting into
+ * two near-identical literals. No `accessToken`: neither is authenticated,
+ * and adding one would send the caller's bearer to a third party.
+ */
+function buildDocsServerConfig(url: string): HttpServerConfig {
   return {
-    url: process.env.MCPJAM_DOCS_MCP_URL ?? DEFAULT_DOCS_URL,
+    url,
     timeout: 30_000,
     clientCapabilities: MCP_APPS_CLIENT_CAPABILITIES,
   };
+}
+
+function buildDocsConfig(): HttpServerConfig {
+  return buildDocsServerConfig(
+    process.env.MCPJAM_DOCS_MCP_URL ?? DEFAULT_DOCS_URL
+  );
+}
+
+function buildSpecConfig(): HttpServerConfig {
+  return buildDocsServerConfig(
+    process.env.MCPJAM_SPEC_MCP_URL ?? DEFAULT_SPEC_URL
+  );
 }
 
 function buildPlatformConfig(bearerToken: string): HttpServerConfig {
@@ -229,6 +285,7 @@ mcpjamAgent.post("/", async (c) => {
     manager = new MCPClientManager(
       {
         [DOCS_SERVER_ID]: buildDocsConfig(),
+        [SPEC_SERVER_ID]: buildSpecConfig(),
         ...(platformToolsEnabled
           ? { [PLATFORM_SERVER_ID]: buildPlatformConfig(bearerToken) }
           : {}),
@@ -242,18 +299,19 @@ mcpjamAgent.post("/", async (c) => {
     );
 
     try {
-      // Preflight both servers in parallel: `getToolsForAiSdk` (inside
+      // Preflight every server in parallel: `getToolsForAiSdk` (inside
       // `prepareChatV2`) fails the WHOLE turn when any selected server
-      // errors at connect/list time, so either server's outage (or the
+      // errors at connect/list time, so ANY one server's outage (or the
       // platform worker rejecting local dev's untrusted issuer) would
-      // otherwise take down the entire agent. Select only the servers that
-      // responded; connections and tool metadata are cached on the manager,
-      // so the later prepare doesn't repeat the round trips. With both
-      // down, the turn still runs on web_search + the bare model.
+      // otherwise take down the entire agent. This matters more now that one
+      // of them is a third party we don't operate. Select only the servers
+      // that responded; connections and tool metadata are cached on the
+      // manager, so the later prepare doesn't repeat the round trips. With
+      // all down, the turn still runs on web_search + the bare model.
       const mcp = manager;
       const candidateServerIds = platformToolsEnabled
-        ? [DOCS_SERVER_ID, PLATFORM_SERVER_ID]
-        : [DOCS_SERVER_ID];
+        ? [DOCS_SERVER_ID, SPEC_SERVER_ID, PLATFORM_SERVER_ID]
+        : [DOCS_SERVER_ID, SPEC_SERVER_ID];
       const preflights = await Promise.allSettled(
         candidateServerIds.map((serverId) => mcp.listTools(serverId))
       );
@@ -338,6 +396,7 @@ mcpjamAgent.post("/", async (c) => {
           temperature: body.temperature,
           requireToolApproval: body.requireToolApproval,
           respectToolVisibility: body.respectToolVisibility,
+          excludeMcpToolNames: DECLINED_MCP_TOOL_NAMES,
           uiMessages: body.messages,
           uiTools: validatedUiTools,
           builtInTools,

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -157,7 +157,6 @@ const AGENT_IDENTITY_PROMPT = [
   "You are embedded in the MCPJam inspector, sitting next to the user's own screen. You act by DRIVING THAT UI with the `ui_*` tools: every action you take lands in the app the user is looking at, and they watch it happen.",
   "When the user asks you to DO something (or where something is), drive the UI and take them there — prefer showing over describing.",
   "When the user asks a QUESTION about the product — how something works, how to do something, what a feature can do — search the MCPJam documentation first and answer from what it says; the screen atlas below tells you where things live, not how they behave, so don't answer product behavior from it alone. Then, if you can carry the answer out in the app, offer to — and wait for a yes before acting.",
-  "When the question is about the MCP SPECIFICATION rather than about MCPJam — what the protocol requires, what a message or field means, what changed between versions — read the MCP docs server instead of answering from memory. Your training data is unreliable across the versions this app targets. The spec is published per version under `/specification/<version>` (`2024-11-05` through `2026-07-28`, plus `draft`), and you can list and read those files directly, so ALWAYS establish which version you're answering for — ask the user if they haven't said — and read that version's page. Never generalize one version's behavior to another; where they differ, say so and name the versions.",
   "Use web search for questions beyond MCPJam and the protocol. You have no other way to act — when something isn't reachable through a `ui_*` tool, say so plainly rather than inventing a tool or claiming you did it.",
   "When the user wants to add or try an MCP server but hasn't named one, ask which server they'd like to connect — never invent a placeholder server (there is no default \"weather\" server). If they just want a quick example to try, offer these real ones: `https://mcp.excalidraw.com/mcp` (streamable HTTP, no auth) or `https://mcp.mcpjam.com/mcp` (an OAuth example). Only add a server once you have a concrete name and URL from the user or from one of these examples.",
   "Keep replies short: lead with the answer in a few sentences, no filler, no restating the question. If the docs don't settle it, say you're not sure rather than guessing.",
@@ -172,6 +171,28 @@ const AGENT_IDENTITY_PROMPT = [
   // users an incomplete map of their own app. Still one value per build, so
   // the prefix stays cacheable.
   buildAppAtlas({ hosted: HOSTED_MODE }),
+].join("\n");
+
+/**
+ * How to use the spec docs server. Emitted separately from
+ * `AGENT_IDENTITY_PROMPT` for two reasons that pull the same way:
+ *
+ *  - The identity prompt is dropped under `MCPJAM_AGENT_PLATFORM_TOOLS=1`,
+ *    because its "the `ui_*` tools are your only way to act" claim is false
+ *    there. That is an ACTION statement. This is a READ statement, and the
+ *    kill-switch governs acting rather than reading — so if the spec server
+ *    is connected in that mode (it is), the guidance to actually use it has
+ *    to survive alongside it. Connecting the authoritative protocol source
+ *    and then deleting the instruction to read it is the worst of both.
+ *  - It is conditional on the server surviving preflight, matching the
+ *    existing rule that instructions must never reference tools a degraded
+ *    turn doesn't advertise (see `ambientContextPrompt`).
+ *
+ * Static text, so it costs the cacheable prefix nothing beyond its presence.
+ */
+const SPEC_DOCS_PROMPT = [
+  "## Answering MCP protocol questions",
+  "When the question is about the MCP SPECIFICATION rather than about MCPJam — what the protocol requires, what a message or field means, what changed between versions — read the MCP docs server instead of answering from memory. Your training data is unreliable across the versions this app targets. The spec is published per version under `/specification/<version>` (`2024-11-05` through `2026-07-28`, plus `draft`), and you can list and read those files directly, so ALWAYS establish which version you're answering for — ask the user if they haven't said — and read that version's page. Never generalize one version's behavior to another; where they differ, say so and name the versions.",
 ].join("\n");
 
 // Advertise the MCP UI extension so the platform worker registers its
@@ -361,6 +382,14 @@ mcpjamAgent.post("/", async (c) => {
               "explicitly asks about a different project.",
           ].join("\n")
         : undefined;
+      // Spec-docs guidance tracks the SERVER, not the kill-switch: it is a
+      // read instruction, and the switch governs acting. Gating it on the
+      // identity prompt instead would connect the authoritative protocol
+      // source in rollback mode and simultaneously delete the instruction to
+      // read it — the feature present, its whole purpose removed. Gated on
+      // preflight for the same reason `ambientContextPrompt` is: never
+      // describe a tool the degraded turn doesn't advertise.
+      const specToolsAvailable = selectedServerIds.includes(SPEC_SERVER_ID);
       // The identity prompt says the `ui_*` tools are the only way to act.
       // Under the kill-switch that becomes false — the platform tools are
       // back — and shipping both sections would hand the model directly
@@ -370,6 +399,7 @@ mcpjamAgent.post("/", async (c) => {
       const effectiveSystemPrompt = [
         body.systemPrompt,
         platformToolsEnabled ? undefined : AGENT_IDENTITY_PROMPT,
+        specToolsAvailable ? SPEC_DOCS_PROMPT : undefined,
         ambientContextPrompt,
       ]
         .filter((section): section is string => Boolean(section?.trim()))

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -283,6 +283,68 @@ describe("prepareChatV2", () => {
     });
   });
 
+  it("drops host-declined MCP tool names from the model tool set", async () => {
+    // `excludeMcpToolNames` is the HOST declining a tool the server is happy
+    // to offer — the mirror image of `respectToolVisibility`, which honors a
+    // policy the SERVER declares.
+    const manager = mockManager({
+      search_docs: { description: "read", _serverId: "srv" },
+      submit_feedback: { description: "write", _serverId: "srv" },
+    });
+
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["srv"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      excludeMcpToolNames: ["submit_feedback"],
+    });
+
+    expect(Object.keys(result.allTools)).toEqual(["search_docs"]);
+  });
+
+  it("declines a name across servers, not just the flatten winner", async () => {
+    // `getToolsForAiSdk` flattens every selected server into one name-keyed
+    // set, last-in wins. A name two servers both offer must not survive as
+    // whichever copy sorted last — that collision is why this option exists.
+    // The manager mock returns the ALREADY-flattened set, so the single
+    // `submit_feedback` here stands for whichever server's copy won.
+    const manager = mockManager({
+      search_docs: { description: "read", _serverId: "srv-a" },
+      submit_feedback: { description: "write", _serverId: "srv-b" },
+    });
+
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["srv-a", "srv-b"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      excludeMcpToolNames: ["submit_feedback"],
+    });
+
+    expect(Object.keys(result.allTools)).not.toContain("submit_feedback");
+  });
+
+  it("leaves the tool set untouched when nothing is declined", async () => {
+    // No default: a surface that omits the option gets every server tool.
+    const manager = mockManager({
+      search_docs: { description: "read", _serverId: "srv" },
+      submit_feedback: { description: "write", _serverId: "srv" },
+    });
+
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["srv"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+    });
+
+    expect(Object.keys(result.allTools).sort()).toEqual([
+      "search_docs",
+      "submit_feedback",
+    ]);
+  });
+
   it("filters selectedServers down to ids the manager has registered", async () => {
     const manager = mockManager({});
     manager.hasServer = vi.fn((id: string) => id === "live-server");

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -660,6 +660,24 @@ export interface PrepareChatV2Options {
    * Cursor template to mirror hosts that don't yet implement visibility.
    */
   respectToolVisibility?: boolean;
+  /**
+   * MCP tool names this surface refuses to advertise, whichever server offers
+   * them. Applied right after the visibility filter, so it only ever removes
+   * SERVER tools — skills, app tools and UI tools are merged later and are
+   * untouched.
+   *
+   * Distinct from `respectToolVisibility`, which honors a policy the SERVER
+   * declares. This is the HOST declining a tool the server is happy to offer,
+   * so it is a per-surface decision with deliberately no default: a surface
+   * that wants nothing filtered omits it.
+   *
+   * Names are unqualified because `getToolsForAiSdk` flattens every selected
+   * server into one name-keyed set (last-in wins on collision) — there is no
+   * per-server key to target at this layer, and a name colliding across
+   * servers is precisely the case you want removed wholesale rather than
+   * silently resolved in favor of whichever server sorted last.
+   */
+  excludeMcpToolNames?: readonly string[];
   /** Host/client policy for eligible MCP tool-result content/resources. */
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
   customProviders?: CustomProviderConfig[];
@@ -929,6 +947,7 @@ export async function prepareChatV2(
     temperature,
     requireToolApproval,
     respectToolVisibility,
+    excludeMcpToolNames,
     modelVisibleMcpToolResults,
     customProviders,
     appTools,
@@ -984,6 +1003,14 @@ export async function prepareChatV2(
   // lack of visibility filtering.
   if (respectToolVisibility !== false) {
     filterAppOnlyTools(mcpTools, mcpClientManager);
+  }
+  // Host-declined server tools (see `excludeMcpToolNames`). Deletes by name
+  // across the flattened set, so a name offered by two selected servers is
+  // removed for both rather than leaving whichever one won the flatten.
+  if (excludeMcpToolNames?.length) {
+    for (const name of excludeMcpToolNames) {
+      delete (mcpTools as Record<string, unknown>)[name];
+    }
   }
   // Skills source, in precedence order:
   //   0. skillsSource set ⇒ in-memory tools (`pinned` for eval runs,

--- a/mcpjam-inspector/server/utils/web-chat-turn.ts
+++ b/mcpjam-inspector/server/utils/web-chat-turn.ts
@@ -256,6 +256,11 @@ export interface WebChatTurnPrepareInputs {
   temperature?: number;
   requireToolApproval?: boolean;
   respectToolVisibility?: boolean;
+  /**
+   * MCP tool names this surface declines to advertise, whichever selected
+   * server offers them. See `PrepareChatV2Options.excludeMcpToolNames`.
+   */
+  excludeMcpToolNames?: readonly string[];
   modelVisibleMcpToolResults?: ModelVisibleMcpToolResults;
   customProviders?: CustomProviderConfig[];
   /** UI messages from the inbound request, converted to ModelMessages by helper. */
@@ -555,6 +560,9 @@ export async function streamWebChatTurn(
       temperature: prepare.temperature,
       requireToolApproval: prepare.requireToolApproval,
       respectToolVisibility: prepare.respectToolVisibility,
+      ...(prepare.excludeMcpToolNames
+        ? { excludeMcpToolNames: prepare.excludeMcpToolNames }
+        : {}),
       modelVisibleMcpToolResults: prepare.modelVisibleMcpToolResults,
       customProviders: prepare.customProviders,
       priorMessages: modelMessages,


### PR DESCRIPTION
## The gap

The in-app agent could search MCPJam's own docs (`docs.mcpjam.com/mcp`) and the web, but nothing gave it the **MCP protocol spec**. So "what does `toolCalledWith` match?" was answered from docs, and "does `tools/list` support cursor in 2025-11-25?" was answered from training data — which degrades across exactly the version range this debugger targets.

## Why a second docs server (and not a prompt dump or RAG)

`modelcontextprotocol.io/mcp` runs the **same Mintlify docs-server product** as ours: unauthenticated streamable HTTP, stateless, so it drops into the existing config builder unchanged. It exposes search plus a read-only virtual filesystem over the `.mdx` sources, and:

```
$ ls /specification
2024-11-05  2025-03-26  2025-06-18  2025-11-25  2026-07-28  draft
```

That makes retrieval **addressed, not similarity-based**: the model has to name a version to read one, so it cannot silently answer a 2026-07-28 question out of the 2025-03-26 text. Four near-identical spec versions are the worst possible case for embedding retrieval and the best case for path addressing — which is also why this beats a pinned in-repo spec skill (build-static, needs a deploy to correct) and a prompt dump (paid every turn by every user, including the ones asking where the Connect button is).

Verified live through our own SDK, with our client capabilities:

```
TOOLS: search_model_context_protocol, query_docs_filesystem_model_context_protocol, submit_feedback
```

## The `submit_feedback` problem

That third tool is a **write** (`readOnlyHint: false`, free-text `feedback` string), and **both** Mintlify docs servers ship it under the same unqualified name. Two independent problems, either sufficient on its own:

1. It posts model-authored free text to a docs team — outward-facing, taken unattended (the agent's approval preference defaults off), invisible in the app the user is watching. Exactly the class of action this route dropped the platform worker to avoid.
2. `getToolsForAiSdk` flattens selected servers **last-in-wins** on name collisions, so advertising it would have silently routed *MCPJam* docs feedback to the *MCP project* — with nothing at the call site to reveal it.

Fixed with a new `excludeMcpToolNames` option on `prepareChatV2` / `streamWebChatTurn`, applied right after the SEP-1865 visibility filter. It is the mirror image of `respectToolVisibility`: that honors a policy the **server** declares, this is the **host** declining a tool the server is happy to offer. No default — a surface that wants nothing filtered omits it. Deleting by name resolves the collision too: neither copy survives.

Note this write tool was already reachable via our own docs server before this PR; the collision is what's new, and the fix covers both.

## Other decisions

- **Preflight**: the spec server joins the existing `Promise.allSettled` degrade-per-server path. This matters more now — one of the two knowledge servers is a third party we don't operate, and `getToolsForAiSdk` fails the *whole* turn if any selected server errors at connect/list time. Covered by a new test.
- **Unauthenticated**: no `accessToken`, asserted in a test. Forwarding the caller's AuthKit bearer to a third party for a public docs search would be a leak.
- **Kill-switch scope**: `MCPJAM_AGENT_PLATFORM_TOOLS=1` restores the old *action* contract. It does not gate knowledge sources — the switch governs how the agent acts, not what it may read — so both docs servers connect in either mode, rather than giving the config two shapes. Docstring updated to say so, with a test.
- **Prompt**: one new section routing protocol questions to the spec server, version-first ("ALWAYS establish which version… never generalize one version's behavior to another"). Static, so the cacheable prefix stays byte-stable — the existing stability test still passes.
- `MCPJAM_SPEC_MCP_URL` overrides the URL, matching `MCPJAM_DOCS_MCP_URL`.

## Testing

- `vitest run --project server` — **303 files, 4068 tests, all passing** (both shared files are widely consumed, so the full project was run, not just the touched suites).
- New coverage: spec server connected + unauthenticated, both servers selected, per-server preflight degradation, `submit_feedback` declined, knowledge servers present under the kill-switch, version-first prompt rules, and three `excludeMcpToolNames` unit tests in `chat-v2-orchestration.test.ts` (declines, covers collisions, no-op when omitted).
- ESLint clean on the touched route (one pre-existing `logger.warn` warning, untouched).

## Follow-up (not in this PR)

The planned Slack app hits the same gap — its `/api/v1/.../agent` endpoint should connect these same two knowledge servers, and can reuse `excludeMcpToolNames` verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent MCP wiring, system prompts, and shared chat orchestration; behavior is well-tested but affects every agent turn and tool advertisement when both docs servers are selected.
> 
> **Overview**
> Adds a second read-only knowledge MCP server (`mcp-spec` → `https://modelcontextprotocol.io/mcp`) alongside MCPJam docs so the in-app agent can answer **protocol** questions from versioned spec sources instead of training data. Preflight now considers both servers and **degrades per server** (a spec outage drops only that server and its prompt section, not the whole turn).
> 
> Introduces **`excludeMcpToolNames`** on `prepareChatV2` / `streamWebChatTurn` so hosts can strip MCP tools by name after visibility filtering; the agent uses it to decline **`submit_feedback`** from both Mintlify docs servers (write tool + duplicate name collision when servers are flattened).
> 
> New **`SPEC_DOCS_PROMPT`** steers protocol Q&A to the spec server with version pinning; it stays enabled under `MCPJAM_AGENT_PLATFORM_TOOLS=1` (read path) but is omitted when spec preflight fails. Docs config is refactored through a shared unauthenticated `buildDocsServerConfig`; optional **`MCPJAM_SPEC_MCP_URL`** override matches the docs URL env pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d9d1a61f1e39d9691cac30df82cf4d6ea8c664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connect the MCP spec docs server so the agent can answer protocol questions by version instead of from memory. Add a host-side filter to drop `submit_feedback`, preflight each server to degrade instead of fail, and emit spec guidance with the server so it survives the kill-switch.

- **New Features**
  - Connect `https://modelcontextprotocol.io/mcp` as `mcp-spec` (unauthenticated).
  - Prompt: route protocol questions to the spec, version-first via `/specification/<version>`.
  - New `excludeMcpToolNames` to drop `submit_feedback` across servers; applied in `prepareChatV2` and `streamWebChatTurn`.
  - Preflight all selected servers and degrade per server; turns continue with `web_search` if a docs server is down.
  - Kill-switch `MCPJAM_AGENT_PLATFORM_TOOLS=1` restores actions only; docs servers stay connected. `MCPJAM_SPEC_MCP_URL` added to override the spec URL.

- **Bug Fixes**
  - Spec guidance is now gated on `mcp-spec` preflight and emitted independently of the identity prompt, so it remains active under `MCPJAM_AGENT_PLATFORM_TOOLS=1`.

<sup>Written for commit d1d9d1a61f1e39d9691cac30df82cf4d6ea8c664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

