### PR TITLE
fix: give RPC log events stable ids so replayed/re-ingested rows don't duplicate

### DIFF
--- a/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.hosted.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.hosted.test.ts
@@ -8,7 +8,110 @@ vi.mock("@/lib/session-token", () => ({
   addTokenToUrl: vi.fn((url: string) => url),
 }));
 
-import { subscribeToRpcStream, useTrafficLogStore } from "../traffic-log-store";
+import {
+  ingestHostedHttpLogs,
+  ingestHostedRpcLogs,
+  subscribeToRpcStream,
+  useTrafficLogStore,
+} from "../traffic-log-store";
+import type {
+  HostedHttpLogEvent,
+  HostedRpcLogEvent,
+} from "@/shared/hosted-rpc-log";
+
+function hostedFrame(
+  id: string | undefined,
+  jsonRpcId: number
+): HostedRpcLogEvent {
+  return {
+    ...(id ? { id } : {}),
+    serverId: "srv-1",
+    serverName: "stateless",
+    direction: "send",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: { jsonrpc: "2.0", id: jsonRpcId, method: "tools/call" },
+  };
+}
+
+function hostedExchange(
+  id: string | undefined,
+  ray: string
+): HostedHttpLogEvent {
+  return {
+    ...(id ? { id } : {}),
+    serverId: "srv-1",
+    serverName: "stateless",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    exchange: {
+      serverId: "srv-1",
+      request: {
+        method: "POST",
+        url: "https://stateless.mcpjam.com/mcp",
+        headers: {},
+      },
+      response: { status: 200, statusText: "OK", headers: { "cf-ray": ray } },
+      durationMs: 22,
+    },
+  };
+}
+
+describe("traffic-log-store hosted ingest", () => {
+  beforeEach(() => {
+    useTrafficLogStore.getState().clear();
+  });
+
+  // Hosted twin of the local SSE replay regression: a collector can deliver the
+  // same captured event as a stream part AND again in the response envelope
+  // (a mid-turn stream-write failure drops the writer and falls back to the
+  // envelope, which still carries what already streamed).
+  it("re-ingesting the same batch keeps one row per event", () => {
+    const frames = [hostedFrame("rpc:h:1", 14), hostedFrame("rpc:h:3", 14)];
+    const exchanges = [hostedExchange("rpc:h:2", "a2504a801d1e99a0")];
+
+    ingestHostedRpcLogs(frames);
+    ingestHostedHttpLogs(exchanges);
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(3);
+
+    // Envelope delivery repeats the already-streamed events.
+    ingestHostedRpcLogs(frames);
+    ingestHostedHttpLogs(exchanges);
+
+    const items = useTrafficLogStore.getState().mcpServerItems;
+    expect(items).toHaveLength(3);
+    expect(new Set(items.map((item) => item.id)).size).toBe(3);
+  });
+
+  // The key is the PHYSICAL event, never the method: a multi-round MRTR flow
+  // sends several real `tools/call`s for one user action, and a retry repeats
+  // even the JSON-RPC id. Every one of them has to keep its own row.
+  it("keeps distinct physical exchanges as separate rows", () => {
+    ingestHostedRpcLogs([
+      hostedFrame("rpc:h:1", 14),
+      hostedFrame("rpc:h:2", 14), // retry: same method AND same JSON-RPC id
+      hostedFrame("rpc:h:3", 15), // next MRTR round
+    ]);
+    ingestHostedHttpLogs([
+      hostedExchange("rpc:h:4", "ray-a"),
+      hostedExchange("rpc:h:5", "ray-b"),
+    ]);
+
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(5);
+  });
+
+  it("appends events from a producer that sends no id", () => {
+    // Version skew must degrade to today's behavior, never drop rows.
+    ingestHostedRpcLogs([
+      hostedFrame(undefined, 14),
+      hostedFrame(undefined, 14),
+    ]);
+    ingestHostedHttpLogs([
+      hostedExchange(undefined, "ray-a"),
+      hostedExchange(undefined, "ray-a"),
+    ]);
+
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(4);
+  });
+});
 
 describe("traffic-log-store hosted mode", () => {
   beforeEach(() => {

--- a/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.hosted.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.hosted.test.ts
@@ -20,11 +20,11 @@ import type {
 } from "@/shared/hosted-rpc-log";
 
 function hostedFrame(
-  id: string | undefined,
+  eventId: string | undefined,
   jsonRpcId: number
 ): HostedRpcLogEvent {
   return {
-    ...(id ? { id } : {}),
+    ...(eventId ? { eventId } : {}),
     serverId: "srv-1",
     serverName: "stateless",
     direction: "send",
@@ -34,11 +34,11 @@ function hostedFrame(
 }
 
 function hostedExchange(
-  id: string | undefined,
+  eventId: string | undefined,
   ray: string
 ): HostedHttpLogEvent {
   return {
-    ...(id ? { id } : {}),
+    ...(eventId ? { eventId } : {}),
     serverId: "srv-1",
     serverName: "stateless",
     timestamp: "2026-08-02T00:00:00.000Z",
@@ -98,7 +98,7 @@ describe("traffic-log-store hosted ingest", () => {
     expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(5);
   });
 
-  it("appends events from a producer that sends no id", () => {
+  it("appends events from a producer that sends no eventId", () => {
     // Version skew must degrade to today's behavior, never drop rows.
     ingestHostedRpcLogs([
       hostedFrame(undefined, 14),

--- a/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
@@ -38,10 +38,10 @@ async function loadStore() {
   return import("../traffic-log-store");
 }
 
-function rpcFrame(id: string, jsonRpcId: number) {
+function rpcFrame(eventId: string, jsonRpcId: number) {
   return {
     type: "rpc",
-    id,
+    eventId,
     serverId: "srv-1",
     direction: "send",
     timestamp: "2026-08-02T00:00:00.000Z",
@@ -49,10 +49,10 @@ function rpcFrame(id: string, jsonRpcId: number) {
   };
 }
 
-function httpExchange(id: string, ray: string) {
+function httpExchange(eventId: string, ray: string) {
   return {
     type: "http",
-    id,
+    eventId,
     serverId: "srv-1",
     timestamp: "2026-08-02T00:00:00.000Z",
     exchange: {
@@ -84,7 +84,7 @@ describe("traffic-log-store rpc stream (local mode)", () => {
 
   // Regression: the SSE route seeds each new connection from the replay buffer,
   // so a panel remount re-delivers events the store already holds. Keyed on the
-  // bus-assigned id, a re-delivery updates its row instead of appending a copy.
+  // bus-assigned eventId, a re-delivery updates its row instead of appending one.
   it("does not duplicate a replayed event that was already ingested", async () => {
     const { subscribeToRpcStream, useTrafficLogStore } = await loadStore();
     useTrafficLogStore.getState().clear();
@@ -132,13 +132,13 @@ describe("traffic-log-store rpc stream (local mode)", () => {
     expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(5);
   });
 
-  it("still records events from a server that sends no id", async () => {
+  it("still records events from a server that sends no eventId", async () => {
     const { subscribeToRpcStream, useTrafficLogStore } = await loadStore();
     useTrafficLogStore.getState().clear();
 
     const unsubscribe = subscribeToRpcStream();
     const source = FakeEventSource.last!;
-    const { id: _omitted, ...withoutId } = rpcFrame("rpc:abc:1", 14);
+    const { eventId: _omitted, ...withoutId } = rpcFrame("rpc:abc:1", 14);
     source.emit(withoutId);
     source.emit(withoutId);
     unsubscribe();

--- a/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: false,
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  addTokenToUrl: vi.fn((url: string) => url),
+}));
+
+/**
+ * Minimal EventSource stand-in. `emit` plays a `data:` frame the same way the
+ * Logs SSE route does, so the store's `onmessage` runs for real.
+ */
+class FakeEventSource {
+  static last: FakeEventSource | null = null;
+  onmessage: ((evt: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public readonly url: string) {
+    FakeEventSource.last = this;
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  emit(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+}
+
+const originalEventSource = globalThis.EventSource;
+
+async function loadStore() {
+  vi.resetModules();
+  return import("../traffic-log-store");
+}
+
+function rpcFrame(id: string, jsonRpcId: number) {
+  return {
+    type: "rpc",
+    id,
+    serverId: "srv-1",
+    direction: "send",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    message: { jsonrpc: "2.0", id: jsonRpcId, method: "tools/call" },
+  };
+}
+
+function httpExchange(id: string, ray: string) {
+  return {
+    type: "http",
+    id,
+    serverId: "srv-1",
+    timestamp: "2026-08-02T00:00:00.000Z",
+    exchange: {
+      serverId: "srv-1",
+      request: {
+        method: "POST",
+        url: "https://stateless.mcpjam.com/mcp",
+        headers: {},
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: { "cf-ray": ray },
+      },
+      durationMs: 22,
+    },
+  };
+}
+
+describe("traffic-log-store rpc stream (local mode)", () => {
+  beforeEach(() => {
+    Object.assign(globalThis, { EventSource: FakeEventSource });
+    FakeEventSource.last = null;
+  });
+
+  afterEach(() => {
+    Object.assign(globalThis, { EventSource: originalEventSource });
+  });
+
+  // Regression: the SSE route seeds each new connection from the replay buffer,
+  // so a panel remount re-delivers events the store already holds. Keyed on the
+  // bus-assigned id, a re-delivery updates its row instead of appending a copy.
+  it("does not duplicate a replayed event that was already ingested", async () => {
+    const { subscribeToRpcStream, useTrafficLogStore } = await loadStore();
+    useTrafficLogStore.getState().clear();
+
+    const unsubscribe = subscribeToRpcStream();
+    const source = FakeEventSource.last!;
+    source.emit(rpcFrame("rpc:abc:1", 14));
+    source.emit(httpExchange("rpc:abc:2", "a2504a801d1e99a0"));
+    source.emit(rpcFrame("rpc:abc:3", 14));
+    unsubscribe();
+
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(3);
+
+    // Panel remounts: a fresh connection replays the same tail.
+    const unsubscribe2 = subscribeToRpcStream();
+    const replaySource = FakeEventSource.last!;
+    expect(replaySource).not.toBe(source);
+    replaySource.emit(rpcFrame("rpc:abc:1", 14));
+    replaySource.emit(httpExchange("rpc:abc:2", "a2504a801d1e99a0"));
+    replaySource.emit(rpcFrame("rpc:abc:3", 14));
+    unsubscribe2();
+
+    const items = useTrafficLogStore.getState().mcpServerItems;
+    expect(items).toHaveLength(3);
+    expect(new Set(items.map((item) => item.id)).size).toBe(3);
+  });
+
+  // The dedup key must be the physical event, never the method: a multi-round
+  // MRTR flow (or a retry) sends several real `tools/call`s for one user action
+  // and every one of them has to stay visible.
+  it("keeps distinct physical exchanges as separate rows", async () => {
+    const { subscribeToRpcStream, useTrafficLogStore } = await loadStore();
+    useTrafficLogStore.getState().clear();
+
+    const unsubscribe = subscribeToRpcStream();
+    const source = FakeEventSource.last!;
+    // Three genuine `tools/call` sends, distinct JSON-RPC ids and cf-rays.
+    source.emit(rpcFrame("rpc:abc:1", 14));
+    source.emit(rpcFrame("rpc:abc:2", 15));
+    source.emit(rpcFrame("rpc:abc:3", 16));
+    source.emit(httpExchange("rpc:abc:4", "ray-a"));
+    source.emit(httpExchange("rpc:abc:5", "ray-b"));
+    unsubscribe();
+
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(5);
+  });
+
+  it("still records events from a server that sends no id", async () => {
+    const { subscribeToRpcStream, useTrafficLogStore } = await loadStore();
+    useTrafficLogStore.getState().clear();
+
+    const unsubscribe = subscribeToRpcStream();
+    const source = FakeEventSource.last!;
+    const { id: _omitted, ...withoutId } = rpcFrame("rpc:abc:1", 14);
+    source.emit(withoutId);
+    source.emit(withoutId);
+    unsubscribe();
+
+    // No identity to dedup on — both are kept rather than silently dropped.
+    expect(useTrafficLogStore.getState().mcpServerItems).toHaveLength(2);
+  });
+});

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -107,6 +107,16 @@ export const useTrafficLogStore = create<TrafficLogState>((set) => ({
       ...item,
       id: item.id ?? `${item.timestamp}-${Math.random().toString(36).slice(2)}`,
     };
+    // Keyed upsert, LAST WRITE WINS. Two deliveries that share an id are
+    // expected to be BYTE-IDENTICAL — today they always are, because every
+    // path that can deliver twice (the Logs SSE replay window, a hosted
+    // collector streaming an event and then repeating it in the envelope)
+    // re-sends the same buffered object. That is an invariant of the
+    // producers, not something enforced here: if some future delivery ever
+    // enriches an event on the second pass (say the envelope copy carries
+    // `pluginOrigin` and the streamed copy did not), the later one silently
+    // overwrites the earlier with no signal. Enrich at CAPTURE, or give the
+    // enriched event its own id.
     set((state) => ({
       mcpServerItems: state.mcpServerItems.some(
         (existing) => existing.id === newItem.id,
@@ -121,21 +131,23 @@ export const useTrafficLogStore = create<TrafficLogState>((set) => ({
 }));
 
 /**
- * The producer-stamped id of a hosted log event, when it sent one.
+ * The producer-stamped `eventId` of a hosted log event, when it sent one.
  *
- * Passing it into `addMcpServerLog` makes hosted ingestion idempotent for the
- * same reason the local SSE path needs it: one captured event can reach the
- * browser twice. A `HostedRpcLogCollector` streams events as `data-rpc-log` /
- * `data-http-log` parts, but a stream write that fails mid-turn drops the
- * writer and falls back to envelope delivery — and the envelope carries the
- * ALREADY-STREAMED events too. Keyed on the producer's id, the second delivery
- * updates its row instead of appending a copy.
+ * Feeding it to `addMcpServerLog` as that row's `id` makes hosted ingestion
+ * idempotent for the same reason the local SSE path needs it: one captured
+ * event can reach the browser twice. A `HostedRpcLogCollector` streams events
+ * as `data-rpc-log` / `data-http-log` parts, but a stream write that fails
+ * mid-turn drops the writer and falls back to envelope delivery — and the
+ * envelope carries the ALREADY-STREAMED events too. Keyed on the producer's
+ * `eventId`, the second delivery updates its row instead of appending a copy.
  *
  * `undefined` for a producer that predates the field: those events append,
  * exactly as they always did, so version skew degrades instead of losing rows.
  */
-function hostedEventId(log: { id?: string }): string | undefined {
-  return typeof log.id === "string" && log.id.length > 0 ? log.id : undefined;
+function hostedEventId(log: { eventId?: string }): string | undefined {
+  return typeof log.eventId === "string" && log.eventId.length > 0
+    ? log.eventId
+    : undefined;
 }
 
 export function ingestHostedRpcLogs(logs: HostedRpcLogEvent[]): void {
@@ -284,7 +296,7 @@ export function subscribeToRpcStream(): () => void {
       try {
         const data = JSON.parse(evt.data) as {
           type?: string;
-          id?: string;
+          eventId?: string;
           serverId?: string;
           direction?: string;
           message?: unknown;
@@ -293,7 +305,7 @@ export function subscribeToRpcStream(): () => void {
         };
         if (!data) return;
 
-        // The bus-assigned event id. Carrying it into the store turns
+        // The bus-assigned `eventId`, used as this row's store key. That turns
         // `addMcpServerLog` into an idempotent keyed upsert for this channel:
         // the stream seeds every new connection with the tail of the replay
         // buffer (`?replay=N`), so a panel remount / EventSource reconnect
@@ -301,8 +313,8 @@ export function subscribeToRpcStream(): () => void {
         // published event, so retries and multi-round MRTR flows — distinct
         // frames that merely share a method — still get their own rows.
         const eventId =
-          typeof data.id === "string" && data.id.length > 0
-            ? data.id
+          typeof data.eventId === "string" && data.eventId.length > 0
+            ? data.eventId
             : undefined;
 
         if (data.type === "http") {

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -262,6 +262,7 @@ export function subscribeToRpcStream(): () => void {
       try {
         const data = JSON.parse(evt.data) as {
           type?: string;
+          id?: string;
           serverId?: string;
           direction?: string;
           message?: unknown;
@@ -270,10 +271,23 @@ export function subscribeToRpcStream(): () => void {
         };
         if (!data) return;
 
+        // The bus-assigned event id. Carrying it into the store turns
+        // `addMcpServerLog` into an idempotent keyed upsert for this channel:
+        // the stream seeds every new connection with the tail of the replay
+        // buffer (`?replay=N`), so a panel remount / EventSource reconnect
+        // re-delivers events the store already holds. One id per PHYSICAL
+        // published event, so retries and multi-round MRTR flows — distinct
+        // frames that merely share a method — still get their own rows.
+        const eventId =
+          typeof data.id === "string" && data.id.length > 0
+            ? data.id
+            : undefined;
+
         if (data.type === "http") {
           if (!data.exchange) return;
           const exchange = data.exchange;
           useTrafficLogStore.getState().addMcpServerLog({
+            ...(eventId ? { id: eventId } : {}),
             serverId:
               typeof data.serverId === "string" ? data.serverId : "unknown",
             direction: "HTTP",
@@ -289,6 +303,7 @@ export function subscribeToRpcStream(): () => void {
 
         const { serverId, direction, message, timestamp } = data;
         useTrafficLogStore.getState().addMcpServerLog({
+          ...(eventId ? { id: eventId } : {}),
           serverId: typeof serverId === "string" ? serverId : "unknown",
           direction:
             typeof direction === "string" ? direction.toUpperCase() : "",

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -120,6 +120,24 @@ export const useTrafficLogStore = create<TrafficLogState>((set) => ({
   clear: () => set({ items: [], mcpServerItems: [] }),
 }));
 
+/**
+ * The producer-stamped id of a hosted log event, when it sent one.
+ *
+ * Passing it into `addMcpServerLog` makes hosted ingestion idempotent for the
+ * same reason the local SSE path needs it: one captured event can reach the
+ * browser twice. A `HostedRpcLogCollector` streams events as `data-rpc-log` /
+ * `data-http-log` parts, but a stream write that fails mid-turn drops the
+ * writer and falls back to envelope delivery — and the envelope carries the
+ * ALREADY-STREAMED events too. Keyed on the producer's id, the second delivery
+ * updates its row instead of appending a copy.
+ *
+ * `undefined` for a producer that predates the field: those events append,
+ * exactly as they always did, so version skew degrades instead of losing rows.
+ */
+function hostedEventId(log: { id?: string }): string | undefined {
+  return typeof log.id === "string" && log.id.length > 0 ? log.id : undefined;
+}
+
 export function ingestHostedRpcLogs(logs: HostedRpcLogEvent[]): void {
   if (!Array.isArray(logs) || logs.length === 0) {
     return;
@@ -127,7 +145,9 @@ export function ingestHostedRpcLogs(logs: HostedRpcLogEvent[]): void {
 
   const store = useTrafficLogStore.getState();
   logs.forEach((log) => {
+    const id = hostedEventId(log);
     store.addMcpServerLog({
+      ...(id ? { id } : {}),
       serverId: log.serverId,
       serverName: log.serverName,
       direction: log.direction.toUpperCase(),
@@ -154,7 +174,9 @@ export function ingestHostedHttpLogs(logs: HostedHttpLogEvent[]): void {
 
   const store = useTrafficLogStore.getState();
   logs.forEach((log) => {
+    const id = hostedEventId(log);
     store.addMcpServerLog({
+      ...(id ? { id } : {}),
       serverId: log.serverId,
       serverName: log.serverName,
       direction: "HTTP",

--- a/mcpjam-inspector/server/routes/mcp/__tests__/rpc-stream-event-id.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/rpc-stream-event-id.test.ts
@@ -1,0 +1,193 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+import servers from "../servers";
+import { rpcLogBus } from "../../../services/rpc-log-bus";
+
+/**
+ * The wire contract of the Logs SSE: every frame carries the bus-assigned
+ * `eventId`.
+ *
+ * This is the ONLY link that carries identity from the bus to the browser, and
+ * it is carried implicitly — the route spreads the whole event into the frame
+ * (`send({ type, ...evt })`). A refactor that made `send` pick fields
+ * explicitly would drop `eventId` and silently reintroduce duplicate rows in
+ * the Logs panel, with every store-level test still green. So these drive the
+ * REAL route and parse the REAL serialized `data:` frames rather than
+ * hand-building the wire object.
+ *
+ * Both `send` call sites are covered, because they are separate lines: the
+ * replay-buffer seeding inside `start()`, and the live `rpcLogBus.subscribe`
+ * listener.
+ */
+
+function streamApp(serverIds: string[]) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    // What the real server's middleware injects (server/index.ts). Only
+    // `listServers` is reached by the /rpc/stream handler.
+    (c as unknown as { mcpClientManager: unknown }).mcpClientManager = {
+      listServers: () => serverIds,
+    };
+    await next();
+  });
+  app.route("/", servers);
+  return app;
+}
+
+/** Parse `count` SSE `data:` frames off the live response body, then hang up. */
+async function readFrames(
+  response: Response,
+  count: number
+): Promise<Array<Record<string, any>>> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  const frames: Array<Record<string, any>> = [];
+  let buffered = "";
+
+  try {
+    while (frames.length < count) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffered += decoder.decode(value, { stream: true });
+      let boundary = buffered.indexOf("\n\n");
+      while (boundary !== -1) {
+        const chunk = buffered.slice(0, boundary);
+        buffered = buffered.slice(boundary + 2);
+        // Keepalive comments (`: keepalive ...`) are not frames.
+        if (chunk.startsWith("data: ")) {
+          frames.push(JSON.parse(chunk.slice("data: ".length)));
+        }
+        boundary = buffered.indexOf("\n\n");
+      }
+    }
+  } finally {
+    await reader.cancel();
+  }
+
+  return frames;
+}
+
+function frame(serverId: string, jsonRpcId: number) {
+  return {
+    serverId,
+    direction: "send" as const,
+    timestamp: new Date().toISOString(),
+    message: { jsonrpc: "2.0", id: jsonRpcId, method: "tools/call" },
+  };
+}
+
+function exchange(serverId: string) {
+  return {
+    kind: "http" as const,
+    serverId,
+    timestamp: new Date().toISOString(),
+    exchange: {
+      serverId,
+      request: {
+        method: "POST",
+        url: "https://stateless.mcpjam.com/mcp",
+        headers: { "mcp-method": "tools/call" },
+      },
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: { "cf-ray": "a2504a801d1e99a0" },
+      },
+      durationMs: 22,
+    },
+  };
+}
+
+describe("GET /rpc/stream carries eventId onto the wire", () => {
+  it("stamps replayed frames (the ?replay= seeding path)", async () => {
+    const serverId = `replay-wire-${crypto.randomUUID()}`;
+    // Published BEFORE the stream opens, so these can only reach the client
+    // through the replay-buffer `send` inside `start()`.
+    rpcLogBus.publish(frame(serverId, 14));
+    rpcLogBus.publish(exchange(serverId));
+
+    const response = await streamApp([serverId]).request(
+      "/rpc/stream?replay=2"
+    );
+    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+
+    const frames = await readFrames(response, 2);
+    expect(frames.map((f) => f.type)).toEqual(["rpc", "http"]);
+
+    // The bus is the source of truth for what the ids should be.
+    const expectedIds = rpcLogBus
+      .getBuffer([serverId], -1)
+      .map((event) => event.eventId);
+    expect(expectedIds).toHaveLength(2);
+    expect(frames.map((f) => f.eventId)).toEqual(expectedIds);
+    for (const f of frames) {
+      expect(typeof f.eventId).toBe("string");
+      expect(f.eventId.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("stamps live frames (the subscribe path)", async () => {
+    const serverId = `live-wire-${crypto.randomUUID()}`;
+
+    // replay=0 so nothing can be seeded — every frame below arrives through
+    // the live subscription's own `send`.
+    const response = await streamApp([serverId]).request(
+      "/rpc/stream?replay=0"
+    );
+
+    rpcLogBus.publish(frame(serverId, 14));
+    rpcLogBus.publish(exchange(serverId));
+
+    const frames = await readFrames(response, 2);
+    expect(frames.map((f) => f.type)).toEqual(["rpc", "http"]);
+
+    const expectedIds = rpcLogBus
+      .getBuffer([serverId], -1)
+      .map((event) => event.eventId);
+    expect(frames.map((f) => f.eventId)).toEqual(expectedIds);
+    for (const f of frames) {
+      expect(typeof f.eventId).toBe("string");
+      expect(f.eventId.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("gives a replayed frame the SAME eventId it had when it was live", async () => {
+    // The whole point: a client that saw the live frame and then reconnects
+    // must recognize the replayed copy as the same event.
+    const serverId = `same-id-${crypto.randomUUID()}`;
+
+    const live = streamApp([serverId]);
+    const liveResponse = await live.request("/rpc/stream?replay=0");
+    rpcLogBus.publish(frame(serverId, 14));
+    const [liveFrame] = await readFrames(liveResponse, 1);
+
+    // Reconnect: a fresh stream seeds from the replay buffer.
+    const replayResponse = await streamApp([serverId]).request(
+      "/rpc/stream?replay=1"
+    );
+    const [replayedFrame] = await readFrames(replayResponse, 1);
+
+    expect(typeof liveFrame.eventId).toBe("string");
+    expect(liveFrame.eventId.length).toBeGreaterThan(0);
+    expect(replayedFrame.eventId).toBe(liveFrame.eventId);
+    // ...and it is genuinely the same event, not just an equal id.
+    expect(replayedFrame.message).toEqual(liveFrame.message);
+  });
+
+  it("gives two identical-looking frames different eventIds on the wire", async () => {
+    const serverId = `distinct-wire-${crypto.randomUUID()}`;
+    const response = await streamApp([serverId]).request(
+      "/rpc/stream?replay=0"
+    );
+
+    // Same method, same JSON-RPC id — a retry, or two rounds of one MRTR flow.
+    // These must stay two rows in the panel.
+    rpcLogBus.publish(frame(serverId, 14));
+    rpcLogBus.publish(frame(serverId, 14));
+
+    const frames = await readFrames(response, 2);
+    expect(frames).toHaveLength(2);
+    expect(frames[0].eventId).not.toBe(frames[1].eventId);
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/servers.ts
+++ b/mcpjam-inspector/server/routes/mcp/servers.ts
@@ -256,9 +256,14 @@ servers.get("/rpc/stream", async (c) => {
 
       // Replay recent messages for all known servers.
       //
-      // Every event carries the bus-assigned `id`, and the browser store keys
-      // on it — so a client that already holds a replayed event updates that
-      // row instead of appending a second copy of it.
+      // Every event carries the bus-assigned `eventId`, and the browser store
+      // keys rows on it — so a client that already holds a replayed event
+      // updates that row instead of appending a second copy of it.
+      //
+      // The spread below is what puts `eventId` on the wire. Keep it a spread:
+      // picking fields explicitly here would drop the identity and silently
+      // reintroduce duplicate rows in the Logs panel. Guarded by
+      // `__tests__/rpc-stream-event-id.test.ts`, which parses these frames.
       try {
         const recent = rpcLogBus.getBuffer(
           serverIds,
@@ -269,7 +274,9 @@ servers.get("/rpc/stream", async (c) => {
         }
       } catch {}
 
-      // Subscribe to live events for all known servers
+      // Subscribe to live events for all known servers. Same spread, same
+      // reason as the replay loop above — this is the second of the two places
+      // `eventId` reaches the wire.
       const unsubscribe = rpcLogBus.subscribe(
         serverIds,
         (evt: DeliveredRpcLogEvent) => {

--- a/mcpjam-inspector/server/routes/mcp/servers.ts
+++ b/mcpjam-inspector/server/routes/mcp/servers.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import "../../types/hono"; // Type extensions
-import { rpcLogBus, type RpcLogEvent } from "../../services/rpc-log-bus";
+import {
+  rpcLogBus,
+  type DeliveredRpcLogEvent,
+} from "../../services/rpc-log-bus";
 import { logger } from "../../utils/logger";
 import {
   executeLocalServerConnect,
@@ -251,7 +254,11 @@ servers.get("/rpc/stream", async (c) => {
         } catch {}
       };
 
-      // Replay recent messages for all known servers
+      // Replay recent messages for all known servers.
+      //
+      // Every event carries the bus-assigned `id`, and the browser store keys
+      // on it — so a client that already holds a replayed event updates that
+      // row instead of appending a second copy of it.
       try {
         const recent = rpcLogBus.getBuffer(
           serverIds,
@@ -263,9 +270,12 @@ servers.get("/rpc/stream", async (c) => {
       } catch {}
 
       // Subscribe to live events for all known servers
-      const unsubscribe = rpcLogBus.subscribe(serverIds, (evt: RpcLogEvent) => {
-        send({ type: evt.kind === "http" ? "http" : "rpc", ...evt });
-      });
+      const unsubscribe = rpcLogBus.subscribe(
+        serverIds,
+        (evt: DeliveredRpcLogEvent) => {
+          send({ type: evt.kind === "http" ? "http" : "rpc", ...evt });
+        }
+      );
 
       // Keepalive comments
       const keepalive = setInterval(() => {

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-http-logs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-http-logs.test.ts
@@ -117,14 +117,14 @@ describe("HostedRpcLogCollector HTTP channel", () => {
  * same event may be delivered twice (streamed as a part AND repeated in the
  * envelope when a mid-turn stream write fails and drops the writer).
  */
-describe("HostedRpcLogCollector event ids", () => {
+describe("HostedRpcLogCollector eventIds", () => {
   it("stamps every captured event, and the stream and the envelope agree", () => {
     const collector = createHostedRpcLogCollector({});
-    const written: Array<{ data: { id?: string } }> = [];
+    const written: Array<{ data: { eventId?: string } }> = [];
 
     collector.attachStreamWriter({
       write: (chunk) =>
-        written.push(chunk as unknown as { data: { id?: string } }),
+        written.push(chunk as unknown as { data: { eventId?: string } }),
     });
     collector.rpcLogger({
       direction: "send",
@@ -140,8 +140,8 @@ describe("HostedRpcLogCollector event ids", () => {
 
     const envelope = collector.buildEnvelope();
     const envelopeIds = [
-      ...(envelope._rpcLogs ?? []).map((log) => log.id),
-      ...(envelope._httpLogs ?? []).map((log) => log.id),
+      ...(envelope._rpcLogs ?? []).map((log) => log.eventId),
+      ...(envelope._httpLogs ?? []).map((log) => log.eventId),
     ];
     expect(envelopeIds).toHaveLength(3);
     expect(
@@ -152,11 +152,11 @@ describe("HostedRpcLogCollector event ids", () => {
     // The envelope repeats what already streamed (the documented fallback when
     // a stream write fails mid-turn). Identical ids are what lets the browser
     // fold those repeats onto the rows it already has.
-    const streamedIds = written.map((chunk) => chunk.data.id);
+    const streamedIds = written.map((chunk) => chunk.data.eventId);
     expect(new Set(streamedIds)).toEqual(new Set(envelopeIds));
   });
 
-  it("gives identical-looking frames distinct ids (retries and MRTR rounds stay separate)", () => {
+  it("gives identical-looking frames distinct eventIds (retries and MRTR rounds stay separate)", () => {
     const collector = createHostedRpcLogCollector({});
     // Same method, same JSON-RPC id, same payload — a retry, or two rounds of
     // one MRTR flow. These are separate physical events and must not collapse.
@@ -172,20 +172,20 @@ describe("HostedRpcLogCollector event ids", () => {
 
     const envelope = collector.buildEnvelope();
     const ids = [
-      ...(envelope._rpcLogs ?? []).map((log) => log.id),
-      ...(envelope._httpLogs ?? []).map((log) => log.id),
+      ...(envelope._rpcLogs ?? []).map((log) => log.eventId),
+      ...(envelope._httpLogs ?? []).map((log) => log.eventId),
     ];
     expect(new Set(ids).size).toBe(4);
   });
 
-  it("does not reuse ids across collectors (concurrent turns)", () => {
+  it("does not reuse eventIds across collectors (concurrent turns)", () => {
     const a = createHostedRpcLogCollector({});
     const b = createHostedRpcLogCollector({});
     a.httpLogger(exchange("srv-1"));
     b.httpLogger(exchange("srv-1"));
 
-    expect(a.buildEnvelope()._httpLogs?.[0]?.id).not.toBe(
-      b.buildEnvelope()._httpLogs?.[0]?.id
+    expect(a.buildEnvelope()._httpLogs?.[0]?.eventId).not.toBe(
+      b.buildEnvelope()._httpLogs?.[0]?.eventId
     );
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/hosted-http-logs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/hosted-http-logs.test.ts
@@ -111,6 +111,85 @@ describe("HostedRpcLogCollector HTTP channel", () => {
   });
 });
 
+/**
+ * Identity of hosted log events. The browser store keys rows on it, so the
+ * collector must stamp every captured event exactly once, at capture — the
+ * same event may be delivered twice (streamed as a part AND repeated in the
+ * envelope when a mid-turn stream write fails and drops the writer).
+ */
+describe("HostedRpcLogCollector event ids", () => {
+  it("stamps every captured event, and the stream and the envelope agree", () => {
+    const collector = createHostedRpcLogCollector({});
+    const written: Array<{ data: { id?: string } }> = [];
+
+    collector.attachStreamWriter({
+      write: (chunk) =>
+        written.push(chunk as unknown as { data: { id?: string } }),
+    });
+    collector.rpcLogger({
+      direction: "send",
+      message: { jsonrpc: "2.0", id: 14, method: "tools/call" },
+      serverId: "srv-1",
+    });
+    collector.httpLogger(exchange("srv-1"));
+    collector.rpcLogger({
+      direction: "receive",
+      message: { jsonrpc: "2.0", id: 14, result: {} },
+      serverId: "srv-1",
+    });
+
+    const envelope = collector.buildEnvelope();
+    const envelopeIds = [
+      ...(envelope._rpcLogs ?? []).map((log) => log.id),
+      ...(envelope._httpLogs ?? []).map((log) => log.id),
+    ];
+    expect(envelopeIds).toHaveLength(3);
+    expect(
+      envelopeIds.every((id) => typeof id === "string" && id.length > 0)
+    ).toBe(true);
+    expect(new Set(envelopeIds).size).toBe(3);
+
+    // The envelope repeats what already streamed (the documented fallback when
+    // a stream write fails mid-turn). Identical ids are what lets the browser
+    // fold those repeats onto the rows it already has.
+    const streamedIds = written.map((chunk) => chunk.data.id);
+    expect(new Set(streamedIds)).toEqual(new Set(envelopeIds));
+  });
+
+  it("gives identical-looking frames distinct ids (retries and MRTR rounds stay separate)", () => {
+    const collector = createHostedRpcLogCollector({});
+    // Same method, same JSON-RPC id, same payload — a retry, or two rounds of
+    // one MRTR flow. These are separate physical events and must not collapse.
+    const frame = {
+      direction: "send" as const,
+      message: { jsonrpc: "2.0", id: 14, method: "tools/call" },
+      serverId: "srv-1",
+    };
+    collector.rpcLogger(frame);
+    collector.rpcLogger(frame);
+    collector.httpLogger(exchange("srv-1"));
+    collector.httpLogger(exchange("srv-1"));
+
+    const envelope = collector.buildEnvelope();
+    const ids = [
+      ...(envelope._rpcLogs ?? []).map((log) => log.id),
+      ...(envelope._httpLogs ?? []).map((log) => log.id),
+    ];
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  it("does not reuse ids across collectors (concurrent turns)", () => {
+    const a = createHostedRpcLogCollector({});
+    const b = createHostedRpcLogCollector({});
+    a.httpLogger(exchange("srv-1"));
+    b.httpLogger(exchange("srv-1"));
+
+    expect(a.buildEnvelope()._httpLogs?.[0]?.id).not.toBe(
+      b.buildEnvelope()._httpLogs?.[0]?.id
+    );
+  });
+});
+
 describe("bridgeHarnessRpcLogsToCollector", () => {
   it("bridges both kinds off the bus", () => {
     const collector = createHostedRpcLogCollector({});

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -153,7 +153,7 @@ export class HostedRpcLogCollector {
       // `flushBufferedLogs`, which drops the writer and falls back to envelope
       // delivery mid-turn) carries the SAME id both times, and the browser
       // store keys them onto one row instead of two.
-      id: nextRpcLogEventId(),
+      eventId: nextRpcLogEventId(),
       serverId,
       serverName: normalizeServerName(serverId, this.serverNamesById),
       direction,
@@ -178,7 +178,7 @@ export class HostedRpcLogCollector {
     this.httpLogs.push({
       // Same discipline as `rpcLogger`: identity belongs to the captured
       // exchange, not to whichever delivery happens to carry it.
-      id: nextRpcLogEventId(),
+      eventId: nextRpcLogEventId(),
       serverId: exchange.serverId,
       serverName: normalizeServerName(exchange.serverId, this.serverNamesById),
       timestamp: new Date().toISOString(),

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -7,6 +7,7 @@ import {
   readCrossInstanceRpcLogs,
 } from "../../utils/harness/harness-rpc-log-sink.js";
 import { consumeCrossInstanceHarnessScopeStepUpMessage } from "../../utils/harness/harness-scope-step-up.js";
+import { nextRpcLogEventId } from "../../services/rpc-log-event-id.js";
 import type {
   HostedHttpLogEvent,
   HostedHttpLogsEnvelope,
@@ -146,6 +147,13 @@ export class HostedRpcLogCollector {
   readonly rpcLogger: RpcLogger = ({ direction, message, serverId }) => {
     const pluginOrigin = this.pluginOriginByServerId[serverId];
     const event: HostedRpcLogEvent = {
+      // Stamped once, HERE, at CAPTURE — not at delivery. Both deliveries read
+      // the same buffered event, so a frame that is streamed as a
+      // `data-rpc-log` part and then repeated in the response envelope (see
+      // `flushBufferedLogs`, which drops the writer and falls back to envelope
+      // delivery mid-turn) carries the SAME id both times, and the browser
+      // store keys them onto one row instead of two.
+      id: nextRpcLogEventId(),
       serverId,
       serverName: normalizeServerName(serverId, this.serverNamesById),
       direction,
@@ -168,6 +176,9 @@ export class HostedRpcLogCollector {
   readonly httpLogger: HttpExchangeLogger = (exchange) => {
     const pluginOrigin = this.pluginOriginByServerId[exchange.serverId];
     this.httpLogs.push({
+      // Same discipline as `rpcLogger`: identity belongs to the captured
+      // exchange, not to whichever delivery happens to carry it.
+      id: nextRpcLogEventId(),
       serverId: exchange.serverId,
       serverName: normalizeServerName(exchange.serverId, this.serverNamesById),
       timestamp: new Date().toISOString(),

--- a/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
@@ -92,11 +92,11 @@ describe("rpcLogBus", () => {
 
   // Regression: the Logs SSE seeds every new connection from the replay buffer,
   // so a panel remount / EventSource reconnect re-delivers recent events. The
-  // browser store keys on this id to recognize a re-delivery; without a stable
-  // id per published event those replays render as duplicate rows.
-  it("stamps every published event with a stable id that survives replay", () => {
+  // browser store keys rows on this `eventId` to recognize a re-delivery;
+  // without a stable id per published event those replays render as duplicates.
+  it("stamps every published event with a stable eventId that survives replay", () => {
     const serverId = `id-test-${crypto.randomUUID()}`;
-    const live: Array<{ id: string }> = [];
+    const live: Array<{ eventId: string }> = [];
     const stop = rpcLogBus.subscribe([serverId], (e) => live.push(e));
     try {
       rpcLogBus.publish(event(serverId, 14));
@@ -119,22 +119,22 @@ describe("rpcLogBus", () => {
       stop();
     }
 
-    expect(live.map((e) => e.id)).toEqual([
+    expect(live.map((e) => e.eventId)).toEqual([
       expect.any(String),
       expect.any(String),
     ]);
     // Distinct per PUBLISHED event — never per method or per JSON-RPC id.
-    expect(new Set(live.map((e) => e.id)).size).toBe(2);
+    expect(new Set(live.map((e) => e.eventId)).size).toBe(2);
 
     // A reconnect replays the tail; the ids must match the ones already
     // delivered so the client can recognize them.
     const replayed = rpcLogBus.getBuffer([serverId], 2);
-    expect(replayed.map((e) => e.id)).toEqual(live.map((e) => e.id));
+    expect(replayed.map((e) => e.eventId)).toEqual(live.map((e) => e.eventId));
   });
 
-  it("gives two identical-looking frames distinct ids (retries stay separate rows)", () => {
+  it("gives two identical-looking frames distinct eventIds (retries stay separate rows)", () => {
     const serverId = `retry-test-${crypto.randomUUID()}`;
-    const seen: Array<{ id: string }> = [];
+    const seen: Array<{ eventId: string }> = [];
     const stop = rpcLogBus.subscribe([serverId], (e) => seen.push(e));
     try {
       // Same method, same JSON-RPC id, same payload — two real sends.
@@ -143,6 +143,6 @@ describe("rpcLogBus", () => {
     } finally {
       stop();
     }
-    expect(new Set(seen.map((e) => e.id)).size).toBe(2);
+    expect(new Set(seen.map((e) => e.eventId)).size).toBe(2);
   });
 });

--- a/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/rpc-log-bus.test.ts
@@ -89,4 +89,60 @@ describe("rpcLogBus", () => {
     expect(seen.filter(isRpcMessageLogEvent)).toHaveLength(1);
     expect(idOf(seen[1])).toBeUndefined();
   });
+
+  // Regression: the Logs SSE seeds every new connection from the replay buffer,
+  // so a panel remount / EventSource reconnect re-delivers recent events. The
+  // browser store keys on this id to recognize a re-delivery; without a stable
+  // id per published event those replays render as duplicate rows.
+  it("stamps every published event with a stable id that survives replay", () => {
+    const serverId = `id-test-${crypto.randomUUID()}`;
+    const live: Array<{ id: string }> = [];
+    const stop = rpcLogBus.subscribe([serverId], (e) => live.push(e));
+    try {
+      rpcLogBus.publish(event(serverId, 14));
+      rpcLogBus.publish({
+        kind: "http",
+        serverId,
+        timestamp: new Date().toISOString(),
+        exchange: {
+          serverId,
+          request: {
+            method: "POST",
+            url: "https://example.test/mcp",
+            headers: {},
+          },
+          response: { status: 200, statusText: "OK", headers: {} },
+          durationMs: 22,
+        },
+      });
+    } finally {
+      stop();
+    }
+
+    expect(live.map((e) => e.id)).toEqual([
+      expect.any(String),
+      expect.any(String),
+    ]);
+    // Distinct per PUBLISHED event — never per method or per JSON-RPC id.
+    expect(new Set(live.map((e) => e.id)).size).toBe(2);
+
+    // A reconnect replays the tail; the ids must match the ones already
+    // delivered so the client can recognize them.
+    const replayed = rpcLogBus.getBuffer([serverId], 2);
+    expect(replayed.map((e) => e.id)).toEqual(live.map((e) => e.id));
+  });
+
+  it("gives two identical-looking frames distinct ids (retries stay separate rows)", () => {
+    const serverId = `retry-test-${crypto.randomUUID()}`;
+    const seen: Array<{ id: string }> = [];
+    const stop = rpcLogBus.subscribe([serverId], (e) => seen.push(e));
+    try {
+      // Same method, same JSON-RPC id, same payload — two real sends.
+      rpcLogBus.publish(event(serverId, 14));
+      rpcLogBus.publish(event(serverId, 14));
+    } finally {
+      stop();
+    }
+    expect(new Set(seen.map((e) => e.id)).size).toBe(2);
+  });
 });

--- a/mcpjam-inspector/server/services/rpc-log-bus.ts
+++ b/mcpjam-inspector/server/services/rpc-log-bus.ts
@@ -5,6 +5,8 @@ import { logger } from "../utils/logger";
 /** A JSON-RPC frame. `kind` is optional so existing publishers are unchanged. */
 export type RpcMessageLogEvent = {
   kind?: "rpc";
+  /** Stamped by {@link RpcLogBus.publish} — publishers never set it. */
+  id?: string;
   serverId: string;
   direction: "send" | "receive";
   timestamp: string; // ISO
@@ -23,12 +25,29 @@ export type RpcMessageLogEvent = {
  */
 export type HttpExchangeBusEvent = {
   kind: "http";
+  /** Stamped by {@link RpcLogBus.publish} — publishers never set it. */
+  id?: string;
   serverId: string;
   timestamp: string; // ISO
   exchange: HttpExchangeLogEvent;
 };
 
 export type RpcLogEvent = RpcMessageLogEvent | HttpExchangeBusEvent;
+
+/**
+ * What subscribers and the replay buffer actually carry: the published event
+ * plus the bus-assigned `id`.
+ *
+ * The id is what makes the Logs SSE re-deliverable without duplicating rows.
+ * The stream seeds every new connection with the tail of the replay buffer
+ * (`?replay=N`), so any RE-subscribe — the panel unmounting and remounting, a
+ * dropped EventSource, a second tab — hands the browser events it may already
+ * hold. Without a stable identity the client cannot tell a re-delivery from a
+ * genuinely new frame and appends it again. One id per PUBLISHED event (not per
+ * method, not per JSON-RPC id) means retries and multi-round MRTR flows still
+ * each get their own row.
+ */
+export type DeliveredRpcLogEvent = RpcLogEvent & { id: string };
 
 export function isRpcMessageLogEvent(
   event: RpcLogEvent,
@@ -44,24 +63,37 @@ const MAX_BUFFERED_EVENTS_PER_SERVER = 500;
 
 class RpcLogBus {
   private readonly emitter = new EventEmitter();
-  private readonly bufferByServer = new Map<string, RpcLogEvent[]>();
+  private readonly bufferByServer = new Map<string, DeliveredRpcLogEvent[]>();
+  /**
+   * Per-process nonce + counter. The nonce keeps ids from repeating across a
+   * server restart, which would otherwise let a reconnecting browser mistake a
+   * brand-new frame for one it already rendered.
+   */
+  private readonly idNonce = Math.random().toString(36).slice(2, 10);
+  private idCounter = 0;
+
+  private nextId(): string {
+    this.idCounter += 1;
+    return `rpc:${this.idNonce}:${this.idCounter}`;
+  }
 
   publish(event: RpcLogEvent): void {
-    const buffer = this.bufferByServer.get(event.serverId) ?? [];
-    buffer.push(event);
+    const stamped = { ...event, id: this.nextId() } as DeliveredRpcLogEvent;
+    const buffer = this.bufferByServer.get(stamped.serverId) ?? [];
+    buffer.push(stamped);
     if (buffer.length > MAX_BUFFERED_EVENTS_PER_SERVER) {
       buffer.splice(0, buffer.length - MAX_BUFFERED_EVENTS_PER_SERVER);
     }
-    this.bufferByServer.set(event.serverId, buffer);
-    this.emitter.emit("event", event);
+    this.bufferByServer.set(stamped.serverId, buffer);
+    this.emitter.emit("event", stamped);
   }
 
   subscribe(
     serverIds: string[],
-    listener: (event: RpcLogEvent) => void,
+    listener: (event: DeliveredRpcLogEvent) => void,
   ): () => void {
     const filter = new Set(serverIds);
-    const handler = (event: RpcLogEvent) => {
+    const handler = (event: DeliveredRpcLogEvent) => {
       if (filter.size === 0 || filter.has(event.serverId)) {
         // Isolate subscribers: EventEmitter.emit re-throws synchronously, so
         // an unguarded listener would propagate into the PRODUCER — turning a
@@ -81,9 +113,9 @@ class RpcLogBus {
     return () => this.emitter.off("event", handler);
   }
 
-  getBuffer(serverIds: string[], limit: number): RpcLogEvent[] {
+  getBuffer(serverIds: string[], limit: number): DeliveredRpcLogEvent[] {
     const filter = new Set(serverIds);
-    const all: RpcLogEvent[] = [];
+    const all: DeliveredRpcLogEvent[] = [];
     for (const [serverId, buf] of this.bufferByServer.entries()) {
       if (filter.size > 0 && !filter.has(serverId)) continue;
       all.push(...buf);

--- a/mcpjam-inspector/server/services/rpc-log-bus.ts
+++ b/mcpjam-inspector/server/services/rpc-log-bus.ts
@@ -7,7 +7,7 @@ import { nextRpcLogEventId } from "./rpc-log-event-id";
 export type RpcMessageLogEvent = {
   kind?: "rpc";
   /** Stamped by {@link RpcLogBus.publish} — publishers never set it. */
-  id?: string;
+  eventId?: string;
   serverId: string;
   direction: "send" | "receive";
   timestamp: string; // ISO
@@ -27,7 +27,7 @@ export type RpcMessageLogEvent = {
 export type HttpExchangeBusEvent = {
   kind: "http";
   /** Stamped by {@link RpcLogBus.publish} — publishers never set it. */
-  id?: string;
+  eventId?: string;
   serverId: string;
   timestamp: string; // ISO
   exchange: HttpExchangeLogEvent;
@@ -37,10 +37,13 @@ export type RpcLogEvent = RpcMessageLogEvent | HttpExchangeBusEvent;
 
 /**
  * What subscribers and the replay buffer actually carry: the published event
- * plus the bus-assigned `id` (see `nextRpcLogEventId`).
+ * plus the bus-assigned `eventId` (see `nextRpcLogEventId`).
  *
- * The id is what makes the Logs SSE re-deliverable without duplicating rows.
- * The stream seeds every new connection with the tail of the replay buffer
+ * `eventId`, not `id`: a JSON-RPC frame already has an `id` of its own inside
+ * `message`, and the two mean entirely different things.
+ *
+ * It is what makes the Logs SSE re-deliverable without duplicating rows. The
+ * stream seeds every new connection with the tail of the replay buffer
  * (`?replay=N`), so any RE-subscribe — the panel unmounting and remounting, a
  * dropped EventSource, a second tab — hands the browser events it may already
  * hold. Without a stable identity the client cannot tell a re-delivery from a
@@ -48,7 +51,23 @@ export type RpcLogEvent = RpcMessageLogEvent | HttpExchangeBusEvent;
  * method, not per JSON-RPC id) means retries and multi-round MRTR flows still
  * each get their own row.
  */
-export type DeliveredRpcLogEvent = RpcLogEvent & { id: string };
+export type DeliveredRpcLogEvent = RpcLogEvent & { eventId: string };
+
+/**
+ * Attach the delivery identity to a published event.
+ *
+ * Generic rather than a cast: identity is established on exactly this line, so
+ * it is the last place to switch the type checker off. `E extends RpcLogEvent`
+ * also preserves the concrete member of the union — a frame stays a frame, an
+ * exchange stays an exchange — which a plain `RpcLogEvent` return type would
+ * collapse.
+ */
+function stampEventId<E extends RpcLogEvent>(
+  event: E,
+  eventId: string,
+): E & { eventId: string } {
+  return { ...event, eventId };
+}
 
 export function isRpcMessageLogEvent(
   event: RpcLogEvent,
@@ -67,10 +86,7 @@ class RpcLogBus {
   private readonly bufferByServer = new Map<string, DeliveredRpcLogEvent[]>();
 
   publish(event: RpcLogEvent): void {
-    const stamped = {
-      ...event,
-      id: nextRpcLogEventId(),
-    } as DeliveredRpcLogEvent;
+    const stamped = stampEventId(event, nextRpcLogEventId());
     const buffer = this.bufferByServer.get(stamped.serverId) ?? [];
     buffer.push(stamped);
     if (buffer.length > MAX_BUFFERED_EVENTS_PER_SERVER) {

--- a/mcpjam-inspector/server/services/rpc-log-bus.ts
+++ b/mcpjam-inspector/server/services/rpc-log-bus.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import type { HttpExchangeLogEvent } from "@mcpjam/sdk";
 import { logger } from "../utils/logger";
+import { nextRpcLogEventId } from "./rpc-log-event-id";
 
 /** A JSON-RPC frame. `kind` is optional so existing publishers are unchanged. */
 export type RpcMessageLogEvent = {
@@ -36,7 +37,7 @@ export type RpcLogEvent = RpcMessageLogEvent | HttpExchangeBusEvent;
 
 /**
  * What subscribers and the replay buffer actually carry: the published event
- * plus the bus-assigned `id`.
+ * plus the bus-assigned `id` (see `nextRpcLogEventId`).
  *
  * The id is what makes the Logs SSE re-deliverable without duplicating rows.
  * The stream seeds every new connection with the tail of the replay buffer
@@ -64,21 +65,12 @@ const MAX_BUFFERED_EVENTS_PER_SERVER = 500;
 class RpcLogBus {
   private readonly emitter = new EventEmitter();
   private readonly bufferByServer = new Map<string, DeliveredRpcLogEvent[]>();
-  /**
-   * Per-process nonce + counter. The nonce keeps ids from repeating across a
-   * server restart, which would otherwise let a reconnecting browser mistake a
-   * brand-new frame for one it already rendered.
-   */
-  private readonly idNonce = Math.random().toString(36).slice(2, 10);
-  private idCounter = 0;
-
-  private nextId(): string {
-    this.idCounter += 1;
-    return `rpc:${this.idNonce}:${this.idCounter}`;
-  }
 
   publish(event: RpcLogEvent): void {
-    const stamped = { ...event, id: this.nextId() } as DeliveredRpcLogEvent;
+    const stamped = {
+      ...event,
+      id: nextRpcLogEventId(),
+    } as DeliveredRpcLogEvent;
     const buffer = this.bufferByServer.get(stamped.serverId) ?? [];
     buffer.push(stamped);
     if (buffer.length > MAX_BUFFERED_EVENTS_PER_SERVER) {

--- a/mcpjam-inspector/server/services/rpc-log-event-id.ts
+++ b/mcpjam-inspector/server/services/rpc-log-event-id.ts
@@ -1,0 +1,30 @@
+/**
+ * The identity every traffic-log event carries to the browser.
+ *
+ * ONE id per PHYSICAL published event — never per method, never per JSON-RPC
+ * id. The browser's traffic-log store keys rows on it, so anything that can
+ * hand the same event over twice becomes idempotent, while two genuinely
+ * distinct frames that merely look alike (a retry, each round of a multi-round
+ * MRTR flow) still get a row each.
+ *
+ * Both delivery paths mint from here rather than each rolling its own scheme:
+ *  - local mode: `RpcLogBus.publish` stamps every event, because the Logs SSE
+ *    seeds each new connection from the replay buffer (`?replay=N`) and any
+ *    re-subscribe therefore re-delivers the tail;
+ *  - hosted mode: `HostedRpcLogCollector` stamps every event it buffers,
+ *    because a collector can deliver the same event over the `data-rpc-log` /
+ *    `data-http-log` stream AND again in the response envelope — a stream
+ *    write that fails mid-turn drops the writer and falls back to envelope
+ *    delivery, which carries the ALREADY-STREAMED events too.
+ *
+ * The nonce is per PROCESS, so ids never repeat across a restart (a
+ * reconnecting browser must not mistake a brand-new frame for one it already
+ * rendered) and two hosted instances serving the same session cannot collide.
+ */
+const EVENT_ID_NONCE = Math.random().toString(36).slice(2, 10);
+let eventIdCounter = 0;
+
+export function nextRpcLogEventId(): string {
+  eventIdCounter += 1;
+  return `rpc:${EVENT_ID_NONCE}:${eventIdCounter}`;
+}

--- a/mcpjam-inspector/shared/hosted-rpc-log.ts
+++ b/mcpjam-inspector/shared/hosted-rpc-log.ts
@@ -15,7 +15,26 @@ export interface HostedRpcLogPluginOrigin {
   bundleHash: string | null;
 }
 
+/**
+ * Identity of ONE physically-captured event, stamped by the producing
+ * `HostedRpcLogCollector` (`nextRpcLogEventId`). The browser's traffic-log
+ * store keys rows on it, so an event delivered twice — streamed as a
+ * `data-*-log` part AND repeated in the response envelope after a stream write
+ * failed, or a response body read more than once — updates its row instead of
+ * appending a copy.
+ *
+ * Per physical event, never per method and never per JSON-RPC id: a retry and
+ * each round of a multi-round MRTR flow are separate events and keep separate
+ * rows.
+ *
+ * OPTIONAL on purpose, like every other addition to this cross-repo shape. A
+ * backend that predates it emits none and the client falls back to appending —
+ * version skew degrades to today's behavior rather than dropping rows.
+ */
+export type HostedLogEventId = string;
+
 export interface HostedRpcLogEvent {
+  id?: HostedLogEventId;
   serverId: string;
   serverName: string;
   direction: "send" | "receive";
@@ -91,6 +110,8 @@ export function isHostedRpcLogDataPart(
  * rather than staying header-blind.
  */
 export interface HostedHttpLogEvent {
+  /** See {@link HostedLogEventId}. Optional for the same skew reason. */
+  id?: HostedLogEventId;
   serverId: string;
   serverName: string;
   timestamp: string;

--- a/mcpjam-inspector/shared/hosted-rpc-log.ts
+++ b/mcpjam-inspector/shared/hosted-rpc-log.ts
@@ -27,6 +27,12 @@ export interface HostedRpcLogPluginOrigin {
  * each round of a multi-round MRTR flow are separate events and keep separate
  * rows.
  *
+ * Named `eventId`, NOT `id`, for two reasons. A JSON-RPC frame already carries
+ * an `id` of its own inside `message` and the two mean entirely different
+ * things — a reader seeing `id` next to `message.id` has to guess. And this is
+ * a cross-repo shape the backend consumes too, so claiming the most generic
+ * field name here would collide the day that side wants an `id` of its own.
+ *
  * OPTIONAL on purpose, like every other addition to this cross-repo shape. A
  * backend that predates it emits none and the client falls back to appending —
  * version skew degrades to today's behavior rather than dropping rows.
@@ -34,7 +40,7 @@ export interface HostedRpcLogPluginOrigin {
 export type HostedLogEventId = string;
 
 export interface HostedRpcLogEvent {
-  id?: HostedLogEventId;
+  eventId?: HostedLogEventId;
   serverId: string;
   serverName: string;
   direction: "send" | "receive";
@@ -111,7 +117,7 @@ export function isHostedRpcLogDataPart(
  */
 export interface HostedHttpLogEvent {
   /** See {@link HostedLogEventId}. Optional for the same skew reason. */
-  id?: HostedLogEventId;
+  eventId?: HostedLogEventId;
   serverId: string;
   serverName: string;
   timestamp: string;


### PR DESCRIPTION
## Symptom

Single JSON-RPC exchanges rendered as multiple identical rows in the traffic log panel. Captured against `stateless.mcpjam.com/mcp` on protocol `2026-07-28`: one `tools/call` for `run-task` produced two byte-identical `SEND` entries, two byte-identical `HTTP` entries, and two `RECEIVE` entries — all sharing the same Cloudflare ray id `a2504a801d1e99a0` and the same JSON-RPC `id: 14`. One cf-ray and one JSON-RPC id proves this was a single physical request; the duplication was purely client-side.

The duplication was *selective* — `tasks/get` ids 15–17 and `subscriptions/listen` in the same session appeared once each.

## Root cause

Not a doubled emitter and not a React effect running twice.

The local Logs SSE route seeds every new connection with the tail of the in-process replay buffer (`replay=3`). Nothing in that delivery carried an identity: the bus stored bare `{serverId, direction, timestamp, message}` objects and the browser store minted a **random** id per received event. So any re-subscribe re-ingested the tail as brand-new rows.

`subscribeToRpcStream` is refcounted — when the last `LoggerView` unmounts the `EventSource` is closed and nulled, and the next mount reopens with `replay=3` again. `onerror` does the same. The store is a singleton that survives those remounts, so replayed events landed on top of copies it already held.

This explains every detail: duplicates were byte-identical *including* cf-ray and `durationMs` because they were literally the same buffered object replayed; and it was selective because one exchange emits exactly ~3 bus events (send frame, HTTP exchange, receive frame), which is exactly the replay depth — only events inside that window at reconnect time were affected.

## Fix

Give every published event a stable identity — `eventId` on the wire — and let the store's already-existing id-keyed upsert do its job.

- `server/services/rpc-log-event-id.ts` (new) — `nextRpcLogEventId()`: process nonce + counter, `rpc:<nonce>:<n>`. The nonce prevents id reuse across a restart.
- `server/services/rpc-log-bus.ts` — `publish()` stamps `eventId` via a generic `stampEventId` helper (type-checked, no cast, and it preserves the concrete union member); buffer and subscribers carry it.
- `server/routes/mcp/servers.ts` — the SSE route spreads the event onto the wire, so `eventId` reaches the browser unchanged.
- `client/src/stores/traffic-log-store.ts` — the SSE handler passes `data.eventId` into `addMcpServerLog`, whose existing id-keyed branch **updates** the row instead of appending.

The wire field is deliberately **`eventId`, not `id`** — it travels next to the JSON-RPC `message.id`, and `shared/hosted-rpc-log.ts` is a cross-repo shape where claiming the generic `id` name would collide if the backend ever adds its own. The browser store's own pre-existing row key (`McpServerRpcItem.id`) is a separate concept and is unchanged; `eventId` feeds into it.

### Why replay was kept

Replay is the only recovery for events missed while an `EventSource` was down. Removing it would trade duplicates for silent loss. Keying the delivery is the emission-level fix and it also covers reconnects and multiple tabs.

## Hosted mode

Extended to the hosted delivery path using the **same** id scheme (the minter was extracted precisely so hosted reuses it rather than inventing a second mechanism).

- `shared/hosted-rpc-log.ts` — `eventId?:` added to `HostedRpcLogEvent` / `HostedHttpLogEvent`. Optional deliberately: the type guards check required fields only, so events from an older backend still validate and still append. No deploy ordering constraint, no dropped rows.
- `server/routes/web/hosted-rpc-logs.ts` — `HostedRpcLogCollector` stamps the id **at capture**, not at delivery, so both deliveries read the same buffered event.
- `client/src/stores/traffic-log-store.ts` — `ingestHostedRpcLogs` / `ingestHostedHttpLogs` pass `eventId` into the same keyed upsert.

This closes a **real** latent duplication, not just a defensive gap: `flushBufferedLogs` drops the writer when a stream write throws and falls back to envelope delivery, and `buildEnvelope()` returns *all* buffered logs — including those already streamed as `data-rpc-log` / `data-http-log` parts. Before this change, a mid-turn stream failure duplicated every event streamed up to that point. Now the streamed part and the envelope copy carry the same id and fold onto one row.

## Known limit of the test coverage

The route test stops at the serialized SSE frame; the browser's real `EventSource` + `JSON.parse` are not exercised end to end, and the client tests pick up from an already-parsed object. The two suites therefore meet at a hand-agreed field name rather than a shared type — a client-side-only typo (reading `data.eventID`) would be caught by the client tests, but nothing structurally binds the two halves. Standing up a live listening server for one field name was more harness than this warrants; both sides now assert on it explicitly, and both `send` sites carry a comment naming the guarding test.

## Explicit non-goal: collapsing legitimately-distinct rows

The id is minted **per physical published event** — never per method, never per JSON-RPC id. Multi-round MRTR flows and retries send several real requests for one user action and must still each get their own row. Tests assert this directly, including a retry that reuses a JSON-RPC id and a second MRTR round.

## Verification

- `npm run typecheck:client` → clean.
- `npx tsc --noEmit -p server/tsconfig.json` → 90 errors, **exactly matching the unmodified baseline** (stash-and-compare), none in any touched file. All pre-existing on `main`.
- `npx vitest run` → 1037 files passed, 2 skipped; **11685 tests passed**, 6 skipped.
- Both regression tests confirmed to **fail without the fix** (stashing only `traffic-log-store.ts`): local `expect(items).toHaveLength(3)` fails, hosted `re-ingesting the same batch keeps one row per event` fails.
- No lint script exists in this package, so lint was not run. `shared/hosted-rpc-log.ts` reports a prettier warning that is pre-existing on the baseline.

### Tests added

- `server/routes/mcp/__tests__/rpc-stream-event-id.test.ts` — mounts the **real** router and parses the **real** serialized SSE `data:` frames, so the `send({ type, ...evt })` spread executes for real rather than being fabricated. Covers both `send` call sites separately (replay seeding with `?replay=2`, live subscribe with `?replay=0`), that a replayed frame keeps the `eventId` it had when live, and that identical-looking frames get distinct ones. Confirmed to fail on the refactor it exists to guard: rewriting the spread to explicit fields fails all 4.
- `server/services/__tests__/rpc-log-bus.test.ts` — ids stamped, survive replay identically, identical-looking frames get distinct ids.
- `client/src/stores/__tests__/traffic-log-store.rpc-stream.test.ts` — fake `EventSource` drives the real handler: a remount replaying 3 events leaves 3 rows; 5 distinct exchanges stay 5; id-less events append.
- `server/routes/web/__tests__/hosted-http-logs.test.ts` — streamed ids and envelope ids are the same set (the fallback overlap); concurrent collectors never reuse an id.
- `client/src/stores/__tests__/traffic-log-store.hosted.test.ts` — mirrors the local trio for hosted ingest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
