### PR TITLE
feat(agent): ui_ask_user — inline clarifying questions for the in-app agent

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -7,7 +7,7 @@ import { ToolPart } from "./parts/tool-part";
 import { AskUserPart } from "./parts/ask-user-part";
 import {
   ASK_USER_TOOL_NAME,
-  useAskUserToolIsOurs,
+  useAskUserCallIsOurs,
 } from "@/lib/webmcp/ask-user-store";
 import {
   ReasoningPart,
@@ -205,9 +205,12 @@ export function PartSwitch({
   // sibling <WidgetReplay>; the existing sendToolInput/sendToolResult path then
   // re-renders the live iframe with no reload. Sentinel-wrapped so "edited to
   // null" stays distinct from pristine (null = pristine).
-  // Unconditional (hook rules): whether `ui_ask_user` in this transcript is
-  // ours to render as a question card. See the ownership gate below.
-  const askUserToolIsOurs = useAskUserToolIsOurs();
+  // Unconditional (hook rules): whether THIS call is a question we asked.
+  // Per call, not per page — see the ownership gate below.
+  const askUserCallIsOurs = useAskUserCallIsOurs(
+    toolInfoFromPart?.toolCallId,
+    toolInfoFromPart?.output ?? toolInfoFromPart?.rawOutput,
+  );
   const [isEditing, setIsEditing] = useState(false);
   const [editedInput, setEditedInput] = useState<{ value: unknown } | null>(
     null
@@ -284,12 +287,12 @@ export function PartSwitch({
     // widget / inline-edit / approval branch below, none of which apply to a
     // question that touches no server and never gates (it is read-only).
     //
-    // Gated on OWNERSHIP, not the name: the executor dispatches on registry
-    // membership precisely so a genuine MCP server tool named `ui_*` runs
-    // untouched, and a renderer keyed on the string alone would still hijack
-    // it — painting a clarification card over a real server call in a chat
-    // where our catalog was never registered.
-    if (toolInfo.toolName === ASK_USER_TOOL_NAME && askUserToolIsOurs) {
+    // Gated on PER-CALL provenance, not the name and not page-global state:
+    // a connected MCP server may legitimately expose `ui_ask_user`, and the
+    // `ui_*` catalog is registered app-wide on ordinary routes, so "is the
+    // tool registered" would be true almost everywhere and would claim that
+    // server's call in a regular chat. See `useAskUserCallIsOurs`.
+    if (toolInfo.toolName === ASK_USER_TOOL_NAME && askUserCallIsOurs) {
       return (
         <AskUserPart
           toolCallId={toolInfo.toolCallId}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -5,7 +5,10 @@ import type { ContentBlock } from "@modelcontextprotocol/client";
 
 import { ToolPart } from "./parts/tool-part";
 import { AskUserPart } from "./parts/ask-user-part";
-import { ASK_USER_TOOL_NAME } from "@/lib/webmcp/ask-user-store";
+import {
+  ASK_USER_TOOL_NAME,
+  useAskUserToolIsOurs,
+} from "@/lib/webmcp/ask-user-store";
 import {
   ReasoningPart,
   type ReasoningDisplayMode,
@@ -202,6 +205,9 @@ export function PartSwitch({
   // sibling <WidgetReplay>; the existing sendToolInput/sendToolResult path then
   // re-renders the live iframe with no reload. Sentinel-wrapped so "edited to
   // null" stays distinct from pristine (null = pristine).
+  // Unconditional (hook rules): whether `ui_ask_user` in this transcript is
+  // ours to render as a question card. See the ownership gate below.
+  const askUserToolIsOurs = useAskUserToolIsOurs();
   const [isEditing, setIsEditing] = useState(false);
   const [editedInput, setEditedInput] = useState<{ value: unknown } | null>(
     null
@@ -277,7 +283,13 @@ export function PartSwitch({
     // whole point is that the user answers it inline. Handled before every
     // widget / inline-edit / approval branch below, none of which apply to a
     // question that touches no server and never gates (it is read-only).
-    if (toolInfo.toolName === ASK_USER_TOOL_NAME) {
+    //
+    // Gated on OWNERSHIP, not the name: the executor dispatches on registry
+    // membership precisely so a genuine MCP server tool named `ui_*` runs
+    // untouched, and a renderer keyed on the string alone would still hijack
+    // it — painting a clarification card over a real server call in a chat
+    // where our catalog was never registered.
+    if (toolInfo.toolName === ASK_USER_TOOL_NAME && askUserToolIsOurs) {
       return (
         <AskUserPart
           toolCallId={toolInfo.toolCallId}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -4,6 +4,8 @@ import { UIMessage } from "@ai-sdk/react";
 import type { ContentBlock } from "@modelcontextprotocol/client";
 
 import { ToolPart } from "./parts/tool-part";
+import { AskUserPart } from "./parts/ask-user-part";
+import { ASK_USER_TOOL_NAME } from "@/lib/webmcp/ask-user-store";
 import {
   ReasoningPart,
   type ReasoningDisplayMode,
@@ -270,6 +272,26 @@ export function PartSwitch({
   if (isToolPart(part) || isDynamicTool(part)) {
     const toolPart = part as ToolUIPart<UITools> | DynamicToolUIPart;
     const toolInfo = toolInfoFromPart ?? getToolInfo(toolPart);
+
+    // The agent's clarifying question renders as a card, not a tool row: the
+    // whole point is that the user answers it inline. Handled before every
+    // widget / inline-edit / approval branch below, none of which apply to a
+    // question that touches no server and never gates (it is read-only).
+    if (toolInfo.toolName === ASK_USER_TOOL_NAME) {
+      return (
+        <AskUserPart
+          toolCallId={toolInfo.toolCallId}
+          input={toolInfo.input}
+          output={toolInfo.output ?? toolInfo.rawOutput}
+          hasOutput={
+            typeof toolInfo.toolState === "string" &&
+            toolInfo.toolState.startsWith("output-")
+          }
+          interactive={interactive}
+        />
+      );
+    }
+
     const approvalId = toolPart.approval?.id;
     const approvalProps =
       interactive && approvalId

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/ask-user-part.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/ask-user-part.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * The three states of the clarifying-question card, and the one rule that
+ * matters most: the free-text escape hatch is always there, so a closed set
+ * of model-authored choices can never trap a user whose intent isn't listed.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { AskUserPart } from "../ask-user-part";
+import {
+  registerAskUserQuestion,
+  __resetAskUserStoreForTests,
+} from "@/lib/webmcp/ask-user-store";
+
+const OPTIONS = [
+  { label: "Connect to a local MCP server", value: "local" },
+  { label: "Connect to a remote MCP server", value: "remote" },
+];
+
+const INPUT = { question: "What are you trying to do?", options: OPTIONS };
+
+/** A settled tool output, shaped exactly as `okResult` produces it. */
+function output(data: Record<string, unknown>) {
+  return {
+    content: [{ type: "text", text: JSON.stringify({ ok: true, data }) }],
+  };
+}
+
+describe("AskUserPart", () => {
+  beforeEach(() => {
+    __resetAskUserStoreForTests();
+  });
+
+  it("renders the parked question with an always-present escape hatch", async () => {
+    const answer = registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "What are you trying to do?",
+      options: OPTIONS,
+    });
+    render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={undefined}
+        hasOutput={false}
+      />,
+    );
+
+    expect(screen.getByText("What are you trying to do?")).toBeInTheDocument();
+    expect(
+      screen.getByText("Connect to a local MCP server"),
+    ).toBeInTheDocument();
+    // The model is told NOT to author an "other" option because this row is
+    // guaranteed by the renderer instead.
+    await userEvent.click(screen.getByText("Something else"));
+    await userEvent.type(
+      screen.getByLabelText("Answer in your own words"),
+      "neither, I want to debug OAuth",
+    );
+    await userEvent.click(screen.getByText("Send"));
+
+    await expect(answer).resolves.toEqual({
+      kind: "freeText",
+      text: "neither, I want to debug OAuth",
+    });
+  });
+
+  it("resolves with the chosen option's value", async () => {
+    const answer = registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "What are you trying to do?",
+      options: OPTIONS,
+    });
+    render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={undefined}
+        hasOutput={false}
+      />,
+    );
+    await userEvent.click(screen.getByText("Connect to a remote MCP server"));
+    await expect(answer).resolves.toEqual({
+      kind: "selected",
+      value: "remote",
+      label: "Connect to a remote MCP server",
+    });
+  });
+
+  it("shows the recorded choice once the part has an output", () => {
+    render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={output({
+          kind: "selected",
+          value: "remote",
+          label: "Connect to a remote MCP server",
+        })}
+        hasOutput
+      />,
+    );
+    expect(screen.getByTestId("ask-user-answer")).toHaveTextContent(
+      "Connect to a remote MCP server",
+    );
+    // Settled: no live buttons to re-answer a question the turn moved past.
+    expect(screen.queryByText("Something else")).not.toBeInTheDocument();
+  });
+
+  it("renders a dismissal as 'no answer', not as a failure", () => {
+    render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={output({ kind: "dismissed" })}
+        hasOutput
+      />,
+    );
+    expect(screen.getByTestId("ask-user-answer")).toHaveTextContent(
+      "No answer",
+    );
+  });
+
+  it("degrades to 'answered' when the output can't be parsed", () => {
+    // Never throw inside a thread render over a payload shape we didn't
+    // expect — a transcript from an older build, say.
+    render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={{ content: [{ type: "text", text: "not json" }] }}
+        hasOutput
+      />,
+    );
+    expect(screen.getByTestId("ask-user-answer")).toHaveTextContent("Answered");
+  });
+
+  it("marks the question expired when nothing is parked and no output exists", () => {
+    // The post-reload case: the paused turn died with the previous page, so
+    // clickable options would be a lie.
+    render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={undefined}
+        hasOutput={false}
+      />,
+    );
+    expect(screen.getByTestId("ask-user-card")).toHaveTextContent(
+      "This question expired",
+    );
+    expect(screen.queryByText("Something else")).not.toBeInTheDocument();
+  });
+
+  it("is read-only on a non-interactive render", () => {
+    registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "What are you trying to do?",
+      options: OPTIONS,
+    });
+    render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={undefined}
+        hasOutput={false}
+        interactive={false}
+      />,
+    );
+    // Eval replays and shared transcripts must never let a viewer answer a
+    // question on someone else's behalf.
+    expect(screen.queryByText("Something else")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/ask-user-part.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/ask-user-part.test.tsx
@@ -155,7 +155,7 @@ describe("AskUserPart", () => {
     expect(screen.queryByText("Something else")).not.toBeInTheDocument();
   });
 
-  it("is read-only on a non-interactive render", () => {
+  it("shows a parked question read-only rather than expired", () => {
     registerAskUserQuestion({
       toolCallId: "call-1",
       question: "What are you trying to do?",
@@ -170,8 +170,72 @@ describe("AskUserPart", () => {
         interactive={false}
       />,
     );
-    // Eval replays and shared transcripts must never let a viewer answer a
-    // question on someone else's behalf.
+    // Eval replays and shared transcripts must never let a viewer answer on
+    // someone else's behalf...
     expect(screen.queryByText("Something else")).not.toBeInTheDocument();
+    // ...but the question is LIVE, so calling it expired would be false, and
+    // dropping the options would lose what was actually asked.
+    expect(screen.getByTestId("ask-user-readonly")).toBeInTheDocument();
+    expect(
+      screen.getByText("Connect to a local MCP server"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/expired/i)).not.toBeInTheDocument();
+  });
+
+  it("never flashes 'expired' between the click and the tool result", async () => {
+    // The store drops the pending entry the instant the promise settles, which
+    // is one or more renders BEFORE `addToolOutput` produces the part's
+    // output. Without the answered latch, that gap paints the expiry copy over
+    // a question the user just successfully answered.
+    registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "What are you trying to do?",
+      options: OPTIONS,
+    });
+    render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={undefined}
+        hasOutput={false}
+      />,
+    );
+    await userEvent.click(screen.getByText("Connect to a remote MCP server"));
+
+    expect(screen.queryByText(/expired/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("ask-user-resolving")).toBeInTheDocument();
+  });
+
+  it("a settled output supersedes the local resolving state", async () => {
+    registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "What are you trying to do?",
+      options: OPTIONS,
+    });
+    const { rerender } = render(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={undefined}
+        hasOutput={false}
+      />,
+    );
+    await userEvent.click(screen.getByText("Connect to a remote MCP server"));
+    rerender(
+      <AskUserPart
+        toolCallId="call-1"
+        input={INPUT}
+        output={output({
+          kind: "selected",
+          value: "remote",
+          label: "Connect to a remote MCP server",
+        })}
+        hasOutput
+      />,
+    );
+    expect(screen.queryByTestId("ask-user-resolving")).not.toBeInTheDocument();
+    expect(screen.getByTestId("ask-user-answer")).toHaveTextContent(
+      "Connect to a remote MCP server",
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/ask-user-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/ask-user-part.tsx
@@ -7,13 +7,24 @@
  * route would take the question with it; a card that reads a module-scoped
  * store simply re-renders wherever the conversation lands.
  *
- * Three states, and the source of truth differs per state:
- *   pending  — the store has a parked question; the card is interactive.
- *   answered — the tool part carries an output; read the answer back from it
- *              so a reloaded transcript shows what was chosen.
- *   expired  — neither. Only reachable after a reload (the paused turn died
- *              with the previous page; the server never persisted it), so the
- *              card states that plainly instead of offering dead buttons.
+ * States, and the source of truth for each. "Expired" is the dangerous one:
+ * it is the fall-through, so anything not positively identified would inherit
+ * copy that is actively wrong. Every other state is therefore recognised
+ * explicitly, and expiry is reserved for the single case that earns it.
+ *
+ *   pending   — a parked question, on an interactive surface. Clickable.
+ *   read-only — a parked question on a NON-interactive surface (eval replay,
+ *               a shared transcript). The question is live, just not this
+ *               viewer's to answer; showing it as expired would be a lie.
+ *   resolving — answered locally, output not back yet. The store clears the
+ *               entry the instant the promise settles, which is one or more
+ *               renders BEFORE `addToolOutput` lands — without a latch the
+ *               card flashes "expired" between the click and the result.
+ *   answered  — the part carries an output; read the outcome back from it so
+ *               a reloaded transcript shows what was chosen.
+ *   expired   — no parked question, no output, nothing answered here. Only
+ *               reachable after a reload: the paused turn died with the
+ *               previous page and the server never persisted it.
  */
 import { useCallback, useMemo, useState } from "react";
 import { Check, HelpCircle } from "lucide-react";
@@ -21,44 +32,19 @@ import { Check, HelpCircle } from "lucide-react";
 import { cn } from "@/lib/chat-utils";
 import {
   answerAskUserQuestion,
+  readAskUserAnswerFromOutput,
   useAskUserPendingQuestion,
+  type AskUserAnswer,
   type AskUserOption,
 } from "@/lib/webmcp/ask-user-store";
 
 /**
- * The answer as recorded in the transcript. Mirrors what the tool returned
- * (`okResult` wraps it as `{ok, data}` inside a text content block), read
- * defensively: a shape we don't recognize degrades to the neutral "answered"
- * row rather than throwing inside a thread render.
+ * The answer as recorded in the transcript. Decoded by the store so the
+ * auto-resume gate and this card can never disagree about what a settled
+ * payload means. A shape we don't recognise degrades to the neutral
+ * "Answered" row rather than throwing inside a thread render.
  */
-interface RecordedAnswer {
-  kind: "selected" | "freeText" | "dismissed";
-  label?: string;
-}
-
-function readRecordedAnswer(output: unknown): RecordedAnswer | null {
-  const content = (output as { content?: unknown } | null)?.content;
-  if (!Array.isArray(content)) return null;
-  const first = content[0] as { type?: unknown; text?: unknown } | undefined;
-  if (first?.type !== "text" || typeof first.text !== "string") return null;
-  try {
-    const parsed = JSON.parse(first.text) as {
-      data?: { kind?: unknown; label?: unknown };
-    };
-    const kind = parsed?.data?.kind;
-    if (kind !== "selected" && kind !== "freeText" && kind !== "dismissed") {
-      return null;
-    }
-    return {
-      kind,
-      ...(typeof parsed.data?.label === "string"
-        ? { label: parsed.data.label }
-        : {}),
-    };
-  } catch {
-    return null;
-  }
-}
+type RecordedAnswer = { kind: AskUserAnswer["kind"]; label?: string };
 
 /** The question text, read off the tool part's input for the settled states. */
 function readQuestionText(input: unknown): string | null {
@@ -97,10 +83,17 @@ function PendingCard({
   toolCallId,
   question,
   options,
+  onAnswered,
 }: {
   toolCallId: string;
   question: string;
   options: AskUserOption[];
+  /**
+   * Fired when THIS card resolved the question. The parent latches it: the
+   * store drops the pending entry on settle, which can re-render us before
+   * `addToolOutput` lands, and without the latch that gap paints "expired".
+   */
+  onAnswered: () => void;
 }) {
   const [freeText, setFreeText] = useState("");
   const [showFreeText, setShowFreeText] = useState(false);
@@ -108,21 +101,28 @@ function PendingCard({
   const choose = useCallback(
     (option: AskUserOption) => {
       // The store's settle() is one-shot, so a double-click resolves once —
-      // no local "submitting" flag needed to keep the turn honest.
-      answerAskUserQuestion(toolCallId, {
+      // no local "submitting" flag needed to keep the turn honest. Latch only
+      // on the call that actually won, so a losing double-click can't claim a
+      // resolution that wasn't its own.
+      const settled = answerAskUserQuestion(toolCallId, {
         kind: "selected",
         value: option.value,
         label: option.label,
       });
+      if (settled) onAnswered();
     },
-    [toolCallId],
+    [onAnswered, toolCallId],
   );
 
   const submitFreeText = useCallback(() => {
     const trimmed = freeText.trim();
     if (!trimmed) return;
-    answerAskUserQuestion(toolCallId, { kind: "freeText", text: trimmed });
-  }, [freeText, toolCallId]);
+    const settled = answerAskUserQuestion(toolCallId, {
+      kind: "freeText",
+      text: trimmed,
+    });
+    if (settled) onAnswered();
+  }, [freeText, onAnswered, toolCallId]);
 
   return (
     <CardShell question={question}>
@@ -222,6 +222,41 @@ function SettledCard({
   );
 }
 
+/**
+ * A parked question the viewer may not answer (eval replay, a shared
+ * transcript). Shows the real choices, greyed and inert — the question is
+ * live, so calling it expired would be false, and hiding the options would
+ * lose the context of what was actually asked.
+ */
+function ReadOnlyParkedCard({
+  question,
+  options,
+}: {
+  question: string;
+  options: AskUserOption[];
+}) {
+  return (
+    <CardShell question={question}>
+      <div className="flex flex-col gap-1" data-testid="ask-user-readonly">
+        {options.map((option, index) => (
+          <div
+            key={option.value}
+            className="flex items-center gap-2.5 px-2 py-1.5 text-[13px] text-muted-foreground"
+          >
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-foreground/10 text-[11px] tabular-nums text-muted-foreground">
+              {index + 1}
+            </span>
+            {option.label}
+          </div>
+        ))}
+        <div className="px-2 pt-1 text-[12px] text-muted-foreground/70">
+          Waiting for an answer.
+        </div>
+      </div>
+    </CardShell>
+  );
+}
+
 export function AskUserPart({
   toolCallId,
   input,
@@ -244,28 +279,56 @@ export function AskUserPart({
 }) {
   const pending = useAskUserPendingQuestion(toolCallId);
   const questionText = readQuestionText(input);
+  // Latched, never cleared: it only records "this card resolved the question",
+  // which stays true. It bridges the window between settle() dropping the
+  // pending entry and `addToolOutput` producing the part's output.
+  const [answeredHere, setAnsweredHere] = useState(false);
+  const handleAnswered = useCallback(() => setAnsweredHere(true), []);
 
-  if (pending && interactive && !hasOutput && toolCallId) {
+  // Terminal output wins over every local guess — it is the transcript.
+  if (hasOutput) {
     return (
+      <SettledCard
+        question={questionText}
+        answer={readAskUserAnswerFromOutput(output)}
+      />
+    );
+  }
+
+  if (pending && toolCallId) {
+    return interactive ? (
       <PendingCard
         toolCallId={toolCallId}
+        question={pending.question}
+        options={pending.options}
+        onAnswered={handleAnswered}
+      />
+    ) : (
+      <ReadOnlyParkedCard
         question={pending.question}
         options={pending.options}
       />
     );
   }
 
-  if (hasOutput) {
+  // Answered here, output still in flight: the store has already forgotten the
+  // question but the result has not landed. Not expired — resolving.
+  if (answeredHere) {
     return (
-      <SettledCard
-        question={questionText}
-        answer={readRecordedAnswer(output)}
-      />
+      <CardShell question={questionText}>
+        <div
+          className="px-2 text-[13px] text-muted-foreground"
+          data-testid="ask-user-resolving"
+        >
+          Sending your answer…
+        </div>
+      </CardShell>
     );
   }
 
-  // Nothing parked and no output: this transcript was hydrated after a reload
-  // that killed the paused turn. Say so rather than render dead buttons.
+  // Nothing parked, nothing answered here, no output: this transcript was
+  // hydrated after a reload that killed the paused turn. Say so rather than
+  // render dead buttons.
   return (
     <CardShell question={questionText}>
       <div className="px-2 text-[13px] text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/ask-user-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/ask-user-part.tsx
@@ -1,0 +1,276 @@
+/**
+ * Renders a `ui_ask_user` tool part as an inline clarifying-question card.
+ *
+ * INLINE, not a modal, for the same reason the agent's `Chat` instance lives
+ * outside React: the surface painting this card can be replaced mid-question
+ * (Home takeover → side panel on a navigation handoff). A modal owned by a
+ * route would take the question with it; a card that reads a module-scoped
+ * store simply re-renders wherever the conversation lands.
+ *
+ * Three states, and the source of truth differs per state:
+ *   pending  — the store has a parked question; the card is interactive.
+ *   answered — the tool part carries an output; read the answer back from it
+ *              so a reloaded transcript shows what was chosen.
+ *   expired  — neither. Only reachable after a reload (the paused turn died
+ *              with the previous page; the server never persisted it), so the
+ *              card states that plainly instead of offering dead buttons.
+ */
+import { useCallback, useMemo, useState } from "react";
+import { Check, HelpCircle } from "lucide-react";
+
+import { cn } from "@/lib/chat-utils";
+import {
+  answerAskUserQuestion,
+  useAskUserPendingQuestion,
+  type AskUserOption,
+} from "@/lib/webmcp/ask-user-store";
+
+/**
+ * The answer as recorded in the transcript. Mirrors what the tool returned
+ * (`okResult` wraps it as `{ok, data}` inside a text content block), read
+ * defensively: a shape we don't recognize degrades to the neutral "answered"
+ * row rather than throwing inside a thread render.
+ */
+interface RecordedAnswer {
+  kind: "selected" | "freeText" | "dismissed";
+  label?: string;
+}
+
+function readRecordedAnswer(output: unknown): RecordedAnswer | null {
+  const content = (output as { content?: unknown } | null)?.content;
+  if (!Array.isArray(content)) return null;
+  const first = content[0] as { type?: unknown; text?: unknown } | undefined;
+  if (first?.type !== "text" || typeof first.text !== "string") return null;
+  try {
+    const parsed = JSON.parse(first.text) as {
+      data?: { kind?: unknown; label?: unknown };
+    };
+    const kind = parsed?.data?.kind;
+    if (kind !== "selected" && kind !== "freeText" && kind !== "dismissed") {
+      return null;
+    }
+    return {
+      kind,
+      ...(typeof parsed.data?.label === "string"
+        ? { label: parsed.data.label }
+        : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** The question text, read off the tool part's input for the settled states. */
+function readQuestionText(input: unknown): string | null {
+  const question = (input as { question?: unknown } | null)?.question;
+  return typeof question === "string" && question.trim().length > 0
+    ? question
+    : null;
+}
+
+function CardShell({
+  question,
+  children,
+}: {
+  question: string | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-lg border border-border/60 bg-muted/20 p-3"
+      data-testid="ask-user-card"
+    >
+      {question ? (
+        <div className="flex items-start gap-2">
+          <HelpCircle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="text-[13px] font-medium text-foreground">
+            {question}
+          </span>
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+function PendingCard({
+  toolCallId,
+  question,
+  options,
+}: {
+  toolCallId: string;
+  question: string;
+  options: AskUserOption[];
+}) {
+  const [freeText, setFreeText] = useState("");
+  const [showFreeText, setShowFreeText] = useState(false);
+
+  const choose = useCallback(
+    (option: AskUserOption) => {
+      // The store's settle() is one-shot, so a double-click resolves once —
+      // no local "submitting" flag needed to keep the turn honest.
+      answerAskUserQuestion(toolCallId, {
+        kind: "selected",
+        value: option.value,
+        label: option.label,
+      });
+    },
+    [toolCallId],
+  );
+
+  const submitFreeText = useCallback(() => {
+    const trimmed = freeText.trim();
+    if (!trimmed) return;
+    answerAskUserQuestion(toolCallId, { kind: "freeText", text: trimmed });
+  }, [freeText, toolCallId]);
+
+  return (
+    <CardShell question={question}>
+      <div className="flex flex-col gap-1">
+        {options.map((option, index) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => choose(option)}
+            className="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-[13px] text-foreground transition-colors hover:bg-foreground/5 cursor-pointer"
+          >
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-foreground/10 text-[11px] tabular-nums text-muted-foreground">
+              {index + 1}
+            </span>
+            {option.label}
+          </button>
+        ))}
+
+        {/*
+          The escape hatch is never optional: a closed set of choices would let
+          the agent force one of its own guesses on a user whose actual intent
+          isn't on the list. The tool description tells the model not to add
+          its own "Something else" — this row IS that option, always present.
+        */}
+        {showFreeText ? (
+          <div className="flex items-center gap-2 px-2 py-1.5">
+            <input
+              autoFocus
+              value={freeText}
+              onChange={(event) => setFreeText(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  submitFreeText();
+                }
+              }}
+              placeholder="Tell the assistant what you meant…"
+              aria-label="Answer in your own words"
+              className="min-w-0 flex-1 rounded-md border border-border/60 bg-background px-2 py-1 text-[13px] outline-none focus:border-primary/60"
+            />
+            <button
+              type="button"
+              onClick={submitFreeText}
+              disabled={freeText.trim().length === 0}
+              className="inline-flex shrink-0 items-center gap-1 rounded-full bg-primary px-3 py-1 text-[12px] font-semibold text-primary-foreground transition hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+            >
+              Send
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setShowFreeText(true)}
+            className="flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-[13px] text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground cursor-pointer"
+          >
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-foreground/10 text-[11px] tabular-nums text-muted-foreground">
+              {options.length + 1}
+            </span>
+            Something else
+          </button>
+        )}
+      </div>
+    </CardShell>
+  );
+}
+
+function SettledCard({
+  question,
+  answer,
+}: {
+  question: string | null;
+  answer: RecordedAnswer | null;
+}) {
+  const text = useMemo(() => {
+    if (!answer) return "Answered";
+    if (answer.kind === "selected") return answer.label ?? "Answered";
+    if (answer.kind === "freeText") return "Answered in their own words";
+    return "No answer — the assistant continued on its best interpretation";
+  }, [answer]);
+  const muted = !answer || answer.kind !== "selected";
+
+  return (
+    <CardShell question={question}>
+      <div
+        className={cn(
+          "flex items-center gap-2 px-2 text-[13px]",
+          muted ? "text-muted-foreground" : "text-foreground",
+        )}
+        data-testid="ask-user-answer"
+      >
+        {answer?.kind === "dismissed" ? null : (
+          <Check className="h-3.5 w-3.5 shrink-0 text-success" />
+        )}
+        {text}
+      </div>
+    </CardShell>
+  );
+}
+
+export function AskUserPart({
+  toolCallId,
+  input,
+  output,
+  hasOutput,
+  interactive = true,
+}: {
+  toolCallId: string | undefined;
+  input: unknown;
+  output: unknown;
+  /**
+   * Whether the tool part reached a terminal output state. Passed explicitly
+   * rather than inferred from `output` being truthy: the distinction between
+   * "no answer yet" and "answered" decides whether the card is interactive,
+   * and an output that failed to parse must still count as settled.
+   */
+  hasOutput: boolean;
+  /** False on read-only renders (eval replay, shared transcripts). */
+  interactive?: boolean;
+}) {
+  const pending = useAskUserPendingQuestion(toolCallId);
+  const questionText = readQuestionText(input);
+
+  if (pending && interactive && !hasOutput && toolCallId) {
+    return (
+      <PendingCard
+        toolCallId={toolCallId}
+        question={pending.question}
+        options={pending.options}
+      />
+    );
+  }
+
+  if (hasOutput) {
+    return (
+      <SettledCard
+        question={questionText}
+        answer={readRecordedAnswer(output)}
+      />
+    );
+  }
+
+  // Nothing parked and no output: this transcript was hydrated after a reload
+  // that killed the paused turn. Say so rather than render dead buttons.
+  return (
+    <CardShell question={questionText}>
+      <div className="px-2 text-[13px] text-muted-foreground">
+        This question expired — send a new message to continue.
+      </div>
+    </CardShell>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/ask-user-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/ask-user-part.tsx
@@ -34,6 +34,7 @@ import {
   answerAskUserQuestion,
   readAskUserAnswerFromOutput,
   useAskUserPendingQuestion,
+  wasAnsweredHere,
   type AskUserAnswer,
   type AskUserOption,
 } from "@/lib/webmcp/ask-user-store";
@@ -200,7 +201,9 @@ function SettledCard({
     if (!answer) return "Answered";
     if (answer.kind === "selected") return answer.label ?? "Answered";
     if (answer.kind === "freeText") return "Answered in their own words";
-    return "No answer — the assistant continued on its best interpretation";
+    // NOT "continued on its best interpretation" — the turn is suppressed on
+    // a dismissal, so the assistant does not answer the abandoned request.
+    return "No answer — the assistant stopped here";
   }, [answer]);
   const muted = !answer || answer.kind !== "selected";
 
@@ -279,11 +282,15 @@ export function AskUserPart({
 }) {
   const pending = useAskUserPendingQuestion(toolCallId);
   const questionText = readQuestionText(input);
-  // Latched, never cleared: it only records "this card resolved the question",
-  // which stays true. It bridges the window between settle() dropping the
-  // pending entry and `addToolOutput` producing the part's output.
-  const [answeredHere, setAnsweredHere] = useState(false);
-  const handleAnswered = useCallback(() => setAnsweredHere(true), []);
+  // Bridges the window between settle() dropping the pending entry and
+  // `addToolOutput` producing the part's output. Read from the STORE rather
+  // than local state because part-switch keys ownership off the same set —
+  // a local latch could say "resolving" while the parent said "not ours".
+  // `answeredTick` only forces the re-render; the store holds the truth.
+  const [answeredTick, setAnsweredTick] = useState(0);
+  const handleAnswered = useCallback(() => setAnsweredTick((n) => n + 1), []);
+  void answeredTick;
+  const answeredLocally = wasAnsweredHere(toolCallId);
 
   // Terminal output wins over every local guess — it is the transcript.
   if (hasOutput) {
@@ -313,7 +320,7 @@ export function AskUserPart({
 
   // Answered here, output still in flight: the store has already forgotten the
   // question but the result has not landed. Not expired — resolving.
-  if (answeredHere) {
+  if (answeredLocally) {
     return (
       <CardShell question={questionText}>
         <div

--- a/mcpjam-inspector/client/src/hooks/__tests__/ask-user-sdk-canary.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/ask-user-sdk-canary.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * SDK canary for `ui_ask_user` — runs against the REAL `ai` / `@ai-sdk/react`
+ * packages (scripted transport, no HTTP). Sibling of
+ * `webmcp-approval-sdk-ordering.test.tsx`.
+ *
+ * Two SDK behaviors that the ask-user design DEPENDS on, neither of which is
+ * documented, both of which an `ai` upgrade could silently flip. They were
+ * established by measurement (an earlier comment in `agent-chat-instances.ts`
+ * asserted the OPPOSITE of #1 and was wrong), so they are pinned here rather
+ * than believed:
+ *
+ *   1. While a client-fulfilled tool call is parked — `onToolCall` awaited,
+ *      no output yet — `chat.status` stays `"streaming"`, NOT `"ready"`.
+ *      The agent's instance eviction has to special-case parked sessions
+ *      because of this; if the SDK ever reaches `ready` here, that
+ *      special-casing becomes dead weight and this test says so.
+ *
+ *   2. Supplying a DISMISSED ask-user result does NOT resume the turn. The
+ *      result must still be recorded (a dangling tool call is an invalid
+ *      message history for Anthropic and OpenAI), but abandonment is not a
+ *      prompt — a user who pressed Stop must not get an answer to the
+ *      question they walked away from. `shouldAutoResumeTurn` enforces this;
+ *      the canary proves the enforcement reaches the real SDK loop.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { Chat } from "@ai-sdk/react";
+import type { UIMessage } from "@ai-sdk/react";
+import type { ChatTransport, UIMessageChunk } from "ai";
+import { shouldAutoResumeTurn } from "@/lib/chat-auto-resume";
+import {
+  __resetUiToolExecutorForTests,
+  handleUiToolCall,
+} from "@/lib/webmcp/ui-tool-executor";
+import {
+  useUiToolsRegistry,
+  type UiToolDefinition,
+} from "@/lib/webmcp/ui-tools-registry";
+import { ASK_USER_TOOL_NAME } from "@/lib/webmcp/ask-user-store";
+
+const TOOL_CALL_ID = "tc-ask-canary";
+
+function chunkStream(chunks: UIMessageChunk[]): ReadableStream<UIMessageChunk> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+/** The model asks a clarifying question; the server pauses for the browser. */
+const ASK_TURN: UIMessageChunk[] = [
+  { type: "start" },
+  { type: "start-step" },
+  {
+    type: "tool-input-available",
+    toolCallId: TOOL_CALL_ID,
+    toolName: ASK_USER_TOOL_NAME,
+    input: { question: "Which one?", options: [] },
+    dynamic: true,
+  },
+  { type: "finish-step" },
+  { type: "finish" },
+] as UIMessageChunk[];
+
+const TEXT_TURN: UIMessageChunk[] = [
+  { type: "start" },
+  { type: "start-step" },
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: "ok." },
+  { type: "text-end", id: "t1" },
+  { type: "finish-step" },
+  { type: "finish" },
+] as UIMessageChunk[];
+
+const settleMacrotasks = (ms = 80) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Parks `execute` until the returned release fn supplies `answer`. */
+function setupParkedAsk(answerPayload: unknown) {
+  __resetUiToolExecutorForTests();
+  useUiToolsRegistry.setState({ tools: new Map(), shippedNames: new Set() });
+
+  let release: (() => void) | null = null;
+  const def: UiToolDefinition = {
+    name: ASK_USER_TOOL_NAME,
+    description: "Ask the user",
+    readOnly: true,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+    execute: vi.fn(
+      () =>
+        new Promise((resolve) => {
+          release = () =>
+            resolve({
+              content: [
+                { type: "text", text: JSON.stringify(answerPayload) },
+              ],
+            });
+        }),
+    ),
+  };
+  useUiToolsRegistry.getState().registerUiTool(def);
+
+  const requests: string[] = [];
+  const transport: ChatTransport<UIMessage> = {
+    sendMessages: async () => {
+      requests.push("request");
+      return chunkStream(requests.length === 1 ? ASK_TURN : TEXT_TURN);
+    },
+    reconnectToStream: async () => null,
+  };
+
+  const chat = new Chat<UIMessage>({
+    id: `ask-canary-${requests.length}`,
+    transport,
+    onToolCall: async ({ toolCall }) => {
+      await handleUiToolCall({
+        toolName: (toolCall as { toolName: string }).toolName,
+        toolCallId: (toolCall as { toolCallId: string }).toolCallId,
+        input: (toolCall as { input: unknown }).input,
+        addToolOutput: (output) => chat.addToolOutput(output),
+        telemetryScope: "ask-canary",
+      });
+    },
+    sendAutomaticallyWhen: shouldAutoResumeTurn,
+  });
+
+  return { chat, requests, release: () => release?.() };
+}
+
+describe("ui_ask_user — SDK canary (real ai package)", () => {
+  it("PIN #1: a parked question keeps the chat 'streaming', never 'ready'", async () => {
+    const { chat } = setupParkedAsk({ ok: true, data: { kind: "selected" } });
+
+    void chat.sendMessage({ parts: [{ type: "text", text: "hi" }] });
+    await settleMacrotasks();
+
+    // If this ever reads "ready", `evictIdleInstances` no longer needs its
+    // parked-session special case — and the comment there is stale.
+    expect(chat.status).toBe("streaming");
+  });
+
+  it("PIN #2: a DISMISSED answer is recorded but does NOT resume the turn", async () => {
+    const { chat, requests, release } = setupParkedAsk({
+      ok: true,
+      data: { kind: "dismissed" },
+    });
+
+    void chat.sendMessage({ parts: [{ type: "text", text: "hi" }] });
+    await settleMacrotasks();
+    expect(requests).toHaveLength(1);
+
+    release();
+    await settleMacrotasks(150);
+
+    // Recorded: the tool part is terminal, so the message history stays valid
+    // for the next request (a dangling tool call would 400 both providers).
+    // `dynamic: true` on the chunk means the part is a `dynamic-tool`, so
+    // match on the call id rather than the type prefix.
+    const toolPart = chat.messages
+      .at(-1)
+      ?.parts.find(
+        (p) => (p as { toolCallId?: string }).toolCallId === TOOL_CALL_ID,
+      ) as { state?: string } | undefined;
+    expect(toolPart?.state).toBe("output-available");
+
+    // NOT generated from: no second request, so the model never answers the
+    // question the user walked away from.
+    expect(requests).toHaveLength(1);
+  });
+
+  it("an ANSWERED question still resumes the turn", async () => {
+    // The counterweight to PIN #2 — the suppression must be specific to
+    // dismissal, or answering a question would strand the turn instead.
+    const { chat, requests, release } = setupParkedAsk({
+      ok: true,
+      data: { kind: "selected", value: "local", label: "Local" },
+    });
+
+    void chat.sendMessage({ parts: [{ type: "text", text: "hi" }] });
+    await settleMacrotasks();
+    release();
+    await settleMacrotasks(150);
+
+    expect(requests).toHaveLength(2);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/ask-user-sdk-canary.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/ask-user-sdk-canary.test.tsx
@@ -36,7 +36,13 @@ import {
   useUiToolsRegistry,
   type UiToolDefinition,
 } from "@/lib/webmcp/ui-tools-registry";
-import { ASK_USER_TOOL_NAME } from "@/lib/webmcp/ask-user-store";
+import {
+  ASK_USER_TOOL_NAME,
+  dismissAskUserQuestions,
+  registerAskUserQuestion,
+  __resetAskUserStoreForTests,
+} from "@/lib/webmcp/ask-user-store";
+import { waitForTerminalToolParts } from "@/lib/webmcp/wait-for-tool-output";
 
 const TOOL_CALL_ID = "tc-ask-canary";
 
@@ -173,6 +179,90 @@ describe("ui_ask_user — SDK canary (real ai package)", () => {
     // NOT generated from: no second request, so the model never answers the
     // question the user walked away from.
     expect(requests).toHaveLength(1);
+  });
+
+  it("PIN #3: the message after a dismissal carries no unresolved tool call", async () => {
+    // Settling only resolves the parked promise — `execute` returns on a later
+    // microtask and the executor writes the output after that. Sending
+    // synchronously snapshots the assistant message with the tool part still
+    // `input-available`: a tool call with no result, which both Anthropic and
+    // OpenAI reject. `submit()` therefore waits for the terminal part first,
+    // and this pins that the wait is actually sufficient against the real SDK.
+    __resetAskUserStoreForTests();
+    __resetUiToolExecutorForTests();
+    useUiToolsRegistry.setState({ tools: new Map(), shippedNames: new Set() });
+
+    const def: UiToolDefinition = {
+      name: ASK_USER_TOOL_NAME,
+      description: "Ask the user",
+      readOnly: true,
+      execute: async (_args, ctx) => {
+        const answer = await registerAskUserQuestion({
+          toolCallId: ctx!.toolCallId,
+          question: "Which one?",
+          options: [
+            { label: "Local", value: "local" },
+            { label: "Remote", value: "remote" },
+          ],
+          scope: "pin3",
+        });
+        return {
+          content: [
+            { type: "text", text: JSON.stringify({ ok: true, data: answer }) },
+          ],
+        };
+      },
+    };
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    const requestToolStates: string[][] = [];
+    let turn = 0;
+    const transport: ChatTransport<UIMessage> = {
+      sendMessages: async (options) => {
+        requestToolStates.push(
+          (options.messages as UIMessage[]).flatMap((m) =>
+            m.parts
+              .filter((part) => (part as { toolCallId?: string }).toolCallId)
+              .map((part) => String((part as { state?: string }).state)),
+          ),
+        );
+        turn += 1;
+        return chunkStream(turn === 1 ? ASK_TURN : TEXT_TURN);
+      },
+      reconnectToStream: async () => null,
+    };
+
+    const chat = new Chat<UIMessage>({
+      id: "ask-canary-pin3",
+      transport,
+      onToolCall: async ({ toolCall }) => {
+        await handleUiToolCall({
+          toolName: (toolCall as { toolName: string }).toolName,
+          toolCallId: (toolCall as { toolCallId: string }).toolCallId,
+          input: (toolCall as { input: unknown }).input,
+          addToolOutput: (output) => chat.addToolOutput(output),
+          telemetryScope: "pin3",
+        });
+      },
+      sendAutomaticallyWhen: shouldAutoResumeTurn,
+    });
+
+    void chat.sendMessage({ parts: [{ type: "text", text: "hi" }] });
+    await settleMacrotasks();
+
+    // Exactly what `submit()` does: dismiss, WAIT for the output, then send.
+    const dismissed = dismissAskUserQuestions("new_message", { scope: "pin3" });
+    expect(dismissed).toHaveLength(1);
+    await waitForTerminalToolParts(() => chat.messages, dismissed);
+    void chat.sendMessage({ parts: [{ type: "text", text: "new topic" }] });
+    await settleMacrotasks(150);
+
+    expect(requestToolStates).toHaveLength(2);
+    // Every tool part in the follow-up request is terminal. Without the wait
+    // this array contains "input-available" and the provider 400s.
+    for (const state of requestToolStates[1]!) {
+      expect(state).toMatch(/^output-/);
+    }
   });
 
   it("an ANSWERED question still resumes the turn", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-mcpjam-agent-session.uitools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-mcpjam-agent-session.uitools.test.tsx
@@ -482,12 +482,15 @@ describe("useMcpjamAgentSession — WebMCP UI tools", () => {
       await waitFor(() => expect(mockState.lastChatInit).not.toBeNull());
       const answer = parkQuestion("call-1", SESSION_ID);
 
-      result.current.submit("actually, show me the evals");
+      // `submit` is async now: it must not send until the dismissal's tool
+      // output exists, or the request carries a tool call with no result.
+      const sent = result.current.submit("actually, show me the evals");
 
       await expect(answer).resolves.toEqual({
         kind: "dismissed",
         reason: "new_message",
       });
+      await sent;
       // The new message is the next thing the user wanted to say — NOT the
       // answer to a question the model can no longer see in context.
       expect(mockState.sendMessage.mock.calls[0][0].parts[1]).toEqual({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-mcpjam-agent-session.uitools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-mcpjam-agent-session.uitools.test.tsx
@@ -103,6 +103,11 @@ import {
 import { getChatHistoryDetail } from "@/lib/apis/web/chat-history-api";
 import { transcriptToUIMessages } from "@/lib/transcript-to-ui-messages";
 import { UI_CONTEXT_PART_TYPE } from "@/shared/ui-context";
+import {
+  registerAskUserQuestion,
+  useAskUserStore,
+  __resetAskUserStoreForTests,
+} from "@/lib/webmcp/ask-user-store";
 
 const SESSION_ID = "agent-session-1";
 
@@ -129,6 +134,7 @@ describe("useMcpjamAgentSession — WebMCP UI tools", () => {
     mockState.lastUseChatOptions = null;
     mockState.lastTransportOptions = null;
     __resetAgentChatInstancesForTests();
+    __resetAskUserStoreForTests();
     useUiToolsRegistry.setState({
       tools: new Map(),
       shippedNames: new Set(),
@@ -196,7 +202,12 @@ describe("useMcpjamAgentSession — WebMCP UI tools", () => {
       },
     });
 
-    expect(def.execute).toHaveBeenCalledWith({ target: "playground" });
+    // The context carries this session's id, which is what lets a parked
+    // `ui_ask_user` be cancelled per conversation.
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "playground" },
+      { toolCallId: "tc-1", scope: SESSION_ID }
+    );
     expect(mockState.addToolOutput).toHaveBeenCalledWith({
       tool: "ui_navigate",
       toolCallId: "tc-1",
@@ -448,6 +459,68 @@ describe("useMcpjamAgentSession — WebMCP UI tools", () => {
         type: "text",
         text: "padded",
       });
+    });
+  });
+
+  describe("pending clarifying questions", () => {
+    // A parked `ui_ask_user` promise IS the turn: `execute` is awaiting it and
+    // the server stream stays paused until it settles. Every way the user
+    // abandons the question has to resolve it, or the turn hangs for good.
+    const parkQuestion = (toolCallId: string, scope: string) =>
+      registerAskUserQuestion({
+        toolCallId,
+        question: "What are you trying to do?",
+        options: [
+          { label: "Local", value: "local" },
+          { label: "Remote", value: "remote" },
+        ],
+        scope,
+      });
+
+    it("settles the question when the user types instead of answering", async () => {
+      const { result } = render();
+      await waitFor(() => expect(mockState.lastChatInit).not.toBeNull());
+      const answer = parkQuestion("call-1", SESSION_ID);
+
+      result.current.submit("actually, show me the evals");
+
+      await expect(answer).resolves.toEqual({
+        kind: "dismissed",
+        reason: "new_message",
+      });
+      // The new message is the next thing the user wanted to say — NOT the
+      // answer to a question the model can no longer see in context.
+      expect(mockState.sendMessage.mock.calls[0][0].parts[1]).toEqual({
+        type: "text",
+        text: "actually, show me the evals",
+      });
+    });
+
+    it("settles the question when generation is stopped", async () => {
+      const { result } = render();
+      await waitFor(() => expect(mockState.lastChatInit).not.toBeNull());
+      const answer = parkQuestion("call-1", SESSION_ID);
+
+      result.current.stop();
+
+      await expect(answer).resolves.toEqual({
+        kind: "dismissed",
+        reason: "stopped",
+      });
+      expect(mockState.stop).toHaveBeenCalled();
+    });
+
+    it("leaves another session's question alone", async () => {
+      const { result } = render();
+      await waitFor(() => expect(mockState.lastChatInit).not.toBeNull());
+      parkQuestion("call-mine", SESSION_ID);
+      parkQuestion("call-theirs", "other-session");
+
+      result.current.stop();
+
+      // A background turn in a second session keeps streaming on its own
+      // instance; stopping this one must not cancel its question.
+      expect(useAskUserStore.getState().pending.has("call-theirs")).toBe(true);
     });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/webmcp-approval-sdk-ordering.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/webmcp-approval-sdk-ordering.test.tsx
@@ -198,7 +198,10 @@ describe("WebMCP approval — SDK ordering canary (real ai package)", () => {
     );
     await waitFor(() => chat.status === "ready", "resume turn to settle");
 
-    expect(def.execute).toHaveBeenCalledWith({ target: "servers" });
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "servers" },
+      expect.objectContaining({ toolCallId: "tc-canary-1" })
+    );
     expect(addToolApprovalResponse).not.toHaveBeenCalled();
     const part = findToolPart(chat);
     expect(part.state).toBe("output-available");

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -22,6 +22,7 @@ import {
 } from "@/lib/mcpjam-agent/agent-chat-instances";
 import { fulfillOrphanedDeferredUiToolCalls } from "@/lib/webmcp/ui-tool-approval";
 import { dismissAskUserQuestions } from "@/lib/webmcp/ask-user-store";
+import { waitForTerminalToolParts } from "@/lib/webmcp/wait-for-tool-output";
 import { buildUiContextPart } from "@/lib/webmcp/ui-context-snapshot";
 import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
 import {
@@ -165,8 +166,13 @@ export interface UseMcpjamAgentSessionResult {
   messages: UIMessage[];
   status: ReturnType<typeof useChat>["status"];
   error: ReturnType<typeof useChat>["error"];
-  /** Send the next user message. */
-  submit: (text: string) => void;
+  /**
+   * Send the next user message. Async because a pending clarifying question
+   * has to be settled — and its tool output actually written — before the
+   * next request can carry a valid message history. Callers may ignore the
+   * promise; it is exposed so tests can await the full sequence.
+   */
+  submit: (text: string) => Promise<void>;
   /** Stop in-flight generation. */
   stop: ReturnType<typeof useChat>["stop"];
   /** Resolved active model — exposed for headers / debugging. */
@@ -485,17 +491,27 @@ export function useMcpjamAgentSession(
   ]);
 
   const submit = useCallback(
-    (text: string) => {
+    async (text: string) => {
       const trimmed = text.trim();
       if (!trimmed) return;
       // Typing instead of answering IS an answer to the clarifying question:
-      // the user moved on. Settle it first — the parked `execute` is holding
-      // this session's turn open, and the new message can't be delivered
-      // until that turn resolves. The message is NOT fed in as the answer:
-      // it's the next thing the user wanted to say, and the model should read
-      // it as such rather than as a reply to a question it can no longer see
-      // in context.
-      dismissAskUserQuestions("new_message", { scope: chatSessionId });
+      // the user moved on. The message is NOT fed in as the answer — it's the
+      // next thing they wanted to say, and the model should read it as such
+      // rather than as a reply to a question it can no longer see in context.
+      //
+      // AWAIT the resulting tool output before sending. Settling only
+      // resolves the parked promise; `execute` returns on a later microtask
+      // and the executor writes the output after that. Sending synchronously
+      // snapshots the assistant message with the tool part still
+      // `input-available` — a tool call with no result, which is an invalid
+      // message history for both Anthropic and OpenAI, so the request fails
+      // validation and the late output lands on a superseded turn.
+      const dismissed = dismissAskUserQuestions("new_message", {
+        scope: chatSessionId,
+      });
+      if (dismissed.length > 0) {
+        await waitForTerminalToolParts(() => chat.messages, dismissed);
+      }
       // A fresh session minted by this submit has no persisted transcript —
       // mark it seeded so late hydration can never overwrite the live turn.
       if (!providedSessionId) {
@@ -535,7 +551,7 @@ export function useMcpjamAgentSession(
         parts: [buildUiContextPart(), { type: "text", text: trimmed }],
       });
     },
-    [chatSessionId, config, providedSessionId, sendMessage, surface]
+    [chat, chatSessionId, config, providedSessionId, sendMessage, surface]
   );
 
   // Stopping generation abandons the turn a parked question belongs to, so

--- a/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-mcpjam-agent-session.ts
@@ -21,6 +21,7 @@ import {
   claimAgentTurnCompletion,
 } from "@/lib/mcpjam-agent/agent-chat-instances";
 import { fulfillOrphanedDeferredUiToolCalls } from "@/lib/webmcp/ui-tool-approval";
+import { dismissAskUserQuestions } from "@/lib/webmcp/ask-user-store";
 import { buildUiContextPart } from "@/lib/webmcp/ui-context-snapshot";
 import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
 import {
@@ -487,6 +488,14 @@ export function useMcpjamAgentSession(
     (text: string) => {
       const trimmed = text.trim();
       if (!trimmed) return;
+      // Typing instead of answering IS an answer to the clarifying question:
+      // the user moved on. Settle it first — the parked `execute` is holding
+      // this session's turn open, and the new message can't be delivered
+      // until that turn resolves. The message is NOT fed in as the answer:
+      // it's the next thing the user wanted to say, and the model should read
+      // it as such rather than as a reply to a question it can no longer see
+      // in context.
+      dismissAskUserQuestions("new_message", { scope: chatSessionId });
       // A fresh session minted by this submit has no persisted transcript —
       // mark it seeded so late hydration can never overwrite the live turn.
       if (!providedSessionId) {
@@ -529,13 +538,22 @@ export function useMcpjamAgentSession(
     [chatSessionId, config, providedSessionId, sendMessage, surface]
   );
 
+  // Stopping generation abandons the turn a parked question belongs to, so
+  // the question has to settle with it — otherwise `execute` keeps awaiting a
+  // promise on a stream nobody will resume, and the card stays clickable for
+  // a turn that is already gone.
+  const stopWithPendingQuestions = useCallback(() => {
+    dismissAskUserQuestions("stopped", { scope: chatSessionId });
+    return stop();
+  }, [chatSessionId, stop]);
+
   return {
     chatSessionId,
     messages,
     status,
     error,
     submit,
-    stop,
+    stop: stopWithPendingQuestions,
     model: resolvedModel,
     hydrating,
     requireToolApproval,

--- a/mcpjam-inspector/client/src/lib/chat-auto-resume.ts
+++ b/mcpjam-inspector/client/src/lib/chat-auto-resume.ts
@@ -20,6 +20,10 @@ import {
   lastAssistantMessageIsCompleteWithApprovalResponses,
   lastAssistantMessageIsCompleteWithToolCalls,
 } from "ai";
+import {
+  ASK_USER_TOOL_NAME,
+  readAskUserAnswerFromOutput,
+} from "./webmcp/ask-user-store";
 
 /**
  * True while any tool call in the last assistant message's current step is
@@ -63,15 +67,66 @@ export function lastStepHasPendingApproval({
 }
 
 /**
+ * True when the last step settled a `ui_ask_user` call as DISMISSED — the user
+ * pressed Stop, typed something else, or walked away.
+ *
+ * Abandonment is not a prompt. The dismissal still has to be RECORDED (a
+ * `tool_use` with no result is an invalid message history for both Anthropic
+ * and OpenAI, so the next request would fail), but resuming on it makes the
+ * model answer the very question the user just walked away from — a reply
+ * streaming in after Stop. Recording a result and generating from it are
+ * separate steps; only the second is unsolicited.
+ *
+ * Read from the recorded output rather than in-memory state so it survives a
+ * reload and needs no bookkeeping to clean up. It cannot stall the turn: once
+ * the user sends anything, the last assistant message is a different one and
+ * this is false again.
+ *
+ * Scoped like the SDK's own predicates — parts after the last `step-start`.
+ */
+export function lastStepDismissedAskUser({
+  messages,
+}: {
+  messages: UIMessage[];
+}): boolean {
+  const message = messages[messages.length - 1];
+  if (!message || message.role !== "assistant") return false;
+  const parts = message.parts;
+  let lastStepStartIndex = -1;
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i]?.type === "step-start") lastStepStartIndex = i;
+  }
+  return parts.slice(lastStepStartIndex + 1).some((part) => {
+    // BOTH part shapes: the server registers `ui_*` as dynamic tools, so the
+    // streamed part is `dynamic-tool` carrying `toolName` — matching only the
+    // static `tool-<name>` type would silently never fire in production
+    // (which is exactly what the SDK canary caught).
+    const candidate = part as {
+      type?: string;
+      toolName?: string;
+      output?: unknown;
+    };
+    const isAskUser =
+      candidate.type === `tool-${ASK_USER_TOOL_NAME}` ||
+      (candidate.type === "dynamic-tool" &&
+        candidate.toolName === ASK_USER_TOOL_NAME);
+    if (!isAskUser) return false;
+    return readAskUserAnswerFromOutput(candidate.output)?.kind === "dismissed";
+  });
+}
+
+/**
  * `sendAutomaticallyWhen` for the client-driven agent loop: resume the turn
  * once the last step's tool calls settle or its approvals are answered, but
  * NEVER while an approval pill is still pending (BUG-4 — see
- * `lastStepHasPendingApproval`).
+ * `lastStepHasPendingApproval`), and never off an abandoned clarifying
+ * question (see `lastStepDismissedAskUser`).
  */
 export function shouldAutoResumeTurn(options: {
   messages: UIMessage[];
 }): boolean {
   if (lastStepHasPendingApproval(options)) return false;
+  if (lastStepDismissedAskUser(options)) return false;
   if (lastAssistantMessageIsCompleteWithToolCalls(options)) return true;
   return lastAssistantMessageIsCompleteWithApprovalResponses(options);
 }

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
@@ -249,7 +249,10 @@ describe("agent-chat-instances", () => {
 
       entry.handleToolApprovalResponse({ id: "appr-appr", approved: true });
       await new Promise((r) => setTimeout(r, 0));
-      expect(def.execute).toHaveBeenCalledWith({ target: "servers" });
+      expect(def.execute).toHaveBeenCalledWith(
+        { target: "servers" },
+        expect.objectContaining({ toolCallId: "tc-appr" })
+      );
       expect((entry.chat as any).addToolOutput).toHaveBeenCalledWith(
         expect.objectContaining({ toolCallId: "tc-appr" })
       );

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/__tests__/agent-chat-instances.test.ts
@@ -64,6 +64,11 @@ import {
 } from "../tour-session-prompt";
 import { __resetUiToolExecutorForTests } from "@/lib/webmcp/ui-tool-executor";
 import {
+  registerAskUserQuestion,
+  useAskUserStore,
+  __resetAskUserStoreForTests,
+} from "@/lib/webmcp/ask-user-store";
+import {
   AGENT_PANEL_STORAGE_KEY,
   useAgentPanelStore,
 } from "@/stores/agent-panel/agent-panel-store";
@@ -94,6 +99,7 @@ describe("agent-chat-instances", () => {
     mockState.lastTransportOptions = null;
     __resetAgentChatInstancesForTests();
     __resetUiToolExecutorForTests();
+    __resetAskUserStoreForTests();
     __resetTourSystemPromptsForTests();
     window.localStorage.removeItem(AGENT_PANEL_STORAGE_KEY);
     useAgentPanelStore.setState({
@@ -162,6 +168,56 @@ describe("agent-chat-instances", () => {
     expect(getOrCreateAgentChat("attached")).toBe(pinnedAttached);
     // idle-1 was the oldest evictable entry; a fresh call re-creates it.
     expect(getOrCreateAgentChat("idle-1").chat).not.toBe(originalIdle1);
+  });
+
+  it("evicts a detached session parked on a question, and settles it", async () => {
+    // A parked question reports `status: "streaming"` (the SDK awaits
+    // `onToolCall`), so the plain idle check would pin the slot forever: the
+    // promise leaks, the turn strands, and `instances` grows past the cap for
+    // as long as the user never comes back. Pinned by the ask-user SDK canary.
+    const parkedEntry = getOrCreateAgentChat("parked");
+    (parkedEntry.chat as any).status = "streaming";
+    const answer = registerAskUserQuestion({
+      toolCallId: "tc-parked",
+      question: "Which one?",
+      options: [
+        { label: "Local", value: "local" },
+        { label: "Remote", value: "remote" },
+      ],
+      scope: "parked",
+    });
+
+    for (const id of ["idle-a", "idle-b", "idle-c", "idle-d"]) {
+      getOrCreateAgentChat(id);
+    }
+
+    await expect(answer).resolves.toEqual({
+      kind: "dismissed",
+      reason: "session_evicted",
+    });
+    expect(useAskUserStore.getState().pending.has("tc-parked")).toBe(false);
+  });
+
+  it("keeps a parked session that a surface is still rendering", async () => {
+    // The guard that makes the above safe is attachment, not status: while a
+    // thread is painting the card, the question is answerable and must live.
+    const parkedEntry = getOrCreateAgentChat("parked-visible");
+    (parkedEntry.chat as any).status = "streaming";
+    parkedEntry.config.attachedSurfaces.add("side-panel");
+    registerAskUserQuestion({
+      toolCallId: "tc-visible",
+      question: "Which one?",
+      options: [
+        { label: "Local", value: "local" },
+        { label: "Remote", value: "remote" },
+      ],
+      scope: "parked-visible",
+    });
+
+    for (const id of ["x1", "x2", "x3", "x4"]) getOrCreateAgentChat(id);
+
+    expect(getOrCreateAgentChat("parked-visible")).toBe(parkedEntry);
+    expect(useAskUserStore.getState().pending.has("tc-visible")).toBe(true);
   });
 
   it("never evicts the just-created instance, even when all others are pinned", () => {

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -24,6 +24,7 @@ import { authFetch } from "@/lib/session-token";
 import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
 import { handleUiToolCall } from "@/lib/webmcp/ui-tool-executor";
 import { createUiAwareApprovalResponseHandler } from "@/lib/webmcp/ui-tool-approval";
+import { dismissAskUserQuestions } from "@/lib/webmcp/ask-user-store";
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
 import { readTourSystemPrompt } from "./tour-session-prompt";
 import type { ModelDefinition } from "@/shared/types";
@@ -168,6 +169,15 @@ function evictIdleInstances(excludeKey: string): void {
     const status = entry.chat.status;
     const idle = status === "ready" || status === "error";
     if (idle && entry.config.attachedSurfaces.size === 0) {
+      // Nothing will render this session's thread again, so a question parked
+      // against it can never be answered — settle it rather than leak the
+      // promise (and the `execute` awaiting it) for the page's lifetime.
+      // Safe because eviction requires zero attached surfaces: no thread is
+      // painting the card, so this can't cancel a question the user can see.
+      // (A parked question does NOT keep the instance busy — the SDK reaches
+      // `ready` while the client-fulfilled call is outstanding — so the idle
+      // check alone would not have protected it.)
+      dismissAskUserQuestions("session_evicted", { scope: key });
       instances.delete(key);
     }
   }

--- a/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-agent/agent-chat-instances.ts
@@ -24,7 +24,10 @@ import { authFetch } from "@/lib/session-token";
 import { useUiToolsRegistry } from "@/lib/webmcp/ui-tools-registry";
 import { handleUiToolCall } from "@/lib/webmcp/ui-tool-executor";
 import { createUiAwareApprovalResponseHandler } from "@/lib/webmcp/ui-tool-approval";
-import { dismissAskUserQuestions } from "@/lib/webmcp/ask-user-store";
+import {
+  dismissAskUserQuestions,
+  hasPendingAskUserQuestions,
+} from "@/lib/webmcp/ask-user-store";
 import { useAgentPanelStore } from "@/stores/agent-panel/agent-panel-store";
 import { readTourSystemPrompt } from "./tour-session-prompt";
 import type { ModelDefinition } from "@/shared/types";
@@ -43,6 +46,10 @@ const ROUTE_BOUND_SURFACES = new Set(["home"]);
  * have a surface attached, so a long-running background turn always finishes
  * (and therefore persists server-side) even if the user opens several other
  * sessions meanwhile.
+ *
+ * One exception, see `evictIdleInstances`: a session parked on an unanswered
+ * clarifying question reads as `"streaming"` but is making no progress, so
+ * "streaming" alone would let it pin a slot forever.
  */
 const MAX_INSTANCES = 4;
 
@@ -167,16 +174,19 @@ function evictIdleInstances(excludeKey: string): void {
     // getOrCreateAgentChat mint a second instance for the same session.
     if (key === excludeKey) continue;
     const status = entry.chat.status;
-    const idle = status === "ready" || status === "error";
+    // A session parked on an unanswered clarifying question reports
+    // `"streaming"`, NOT `"ready"`: the SDK awaits `onToolCall`, and our
+    // `execute` is sitting on the card's promise (pinned by the ask-user SDK
+    // canary). It is nonetheless making no progress and nothing is rendering
+    // it, so treating it as busy would leak the promise, strand the turn, and
+    // let `instances` grow past the cap for as long as the user never returns.
+    const parkedOnQuestion = hasPendingAskUserQuestions(key);
+    const idle = status === "ready" || status === "error" || parkedOnQuestion;
     if (idle && entry.config.attachedSurfaces.size === 0) {
-      // Nothing will render this session's thread again, so a question parked
-      // against it can never be answered — settle it rather than leak the
-      // promise (and the `execute` awaiting it) for the page's lifetime.
-      // Safe because eviction requires zero attached surfaces: no thread is
-      // painting the card, so this can't cancel a question the user can see.
-      // (A parked question does NOT keep the instance busy — the SDK reaches
-      // `ready` while the client-fulfilled call is outstanding — so the idle
-      // check alone would not have protected it.)
+      // Settle before dropping the entry: nothing will render this session's
+      // thread again, so the question can never be answered. Safe because
+      // eviction requires zero attached surfaces — no thread is painting the
+      // card, so this cannot cancel a question the user can see.
       dismissAskUserQuestions("session_evicted", { scope: key });
       instances.delete(key);
     }

--- a/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
+++ b/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
@@ -85,6 +85,22 @@ tool that PREFILLS a form for the user to review and submit —
 whose full input the model can plausibly get right and the user can see
 happen.
 
+### Ask instead of guessing (but rarely)
+
+`ui_ask_user` (core group) parks the turn on an inline multiple-choice card
+and resumes it with the user's answer. A tool handler that discovers
+ambiguity should NOT call it — return an error naming what is missing and let
+the model decide whether asking is worth an interruption.
+
+Two rules keep it from becoming noise. It is READ-ONLY, so it never gates —
+do not "improve" it with an approval pill. And it is never a substitute for
+one: asking "shall I delete this?" on a question card is not an approval,
+because the destructive tool that follows is a separate call carrying its own
+annotations.
+
+The free-text escape hatch is supplied by the renderer and is not optional. A
+prompt or tool that has the model author its own "Other" option is a bug.
+
 ### Names
 
 `UI_TOOL_NAME_REGEX`: `ui_[a-z0-9][a-z0-9_]*`, max 64 chars. Distinguish

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ask-user-store.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ask-user-store.test.ts
@@ -1,0 +1,299 @@
+/**
+ * `ui_ask_user`: the parked-promise lifecycle and the tool's argument
+ * contract.
+ *
+ * The invariant under test throughout: EVERY path settles. An unresolved
+ * question means an `execute` that never returns, which means a paused
+ * server stream that never resumes — the worst failure this feature can
+ * have, and the one that is invisible until a user is staring at a spinner.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { trackMock } = vi.hoisted(() => ({ trackMock: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ track: trackMock }));
+
+// The core group imports the inspector command bus for its other tools.
+vi.mock("@/lib/inspector-command-handlers", () => ({
+  executeInspectorCommand: vi.fn(),
+  hasInspectorCommandHandler: vi.fn().mockReturnValue(true),
+}));
+
+import {
+  ASK_USER_TOOL_NAME,
+  answerAskUserQuestion,
+  dismissAskUserQuestions,
+  registerAskUserQuestion,
+  useAskUserStore,
+  __resetAskUserStoreForTests,
+} from "../ask-user-store";
+import { buildCoreUiTools } from "../groups/core";
+import type { UiToolResult } from "../ui-tools-registry";
+
+function askUserTool() {
+  const tool = buildCoreUiTools().find((t) => t.name === ASK_USER_TOOL_NAME);
+  if (!tool) throw new Error("core group is missing ui_ask_user");
+  return tool;
+}
+
+/** The `{ok, data}` payload the tool packs into its text content block. */
+function readPayload(result: UiToolResult): Record<string, unknown> {
+  return JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+}
+
+/** Let the microtask that resolves a parked promise run. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const OPTIONS = [
+  { label: "Connect to a local MCP server", value: "local" },
+  { label: "Connect to a remote MCP server", value: "remote" },
+];
+
+describe("ask-user store", () => {
+  beforeEach(() => {
+    __resetAskUserStoreForTests();
+    trackMock.mockClear();
+  });
+
+  it("parks a question and resolves it with the chosen option", async () => {
+    const pending = registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "What are you trying to do?",
+      options: OPTIONS,
+    });
+    expect(useAskUserStore.getState().pending.get("call-1")?.question).toBe(
+      "What are you trying to do?",
+    );
+
+    answerAskUserQuestion("call-1", {
+      kind: "selected",
+      value: "remote",
+      label: "Connect to a remote MCP server",
+    });
+
+    await expect(pending).resolves.toEqual({
+      kind: "selected",
+      value: "remote",
+      label: "Connect to a remote MCP server",
+    });
+    // Cleared on settle, so a re-render can't paint a stale interactive card.
+    expect(useAskUserStore.getState().pending.has("call-1")).toBe(false);
+  });
+
+  it("resolves exactly once — a second answer is a no-op", async () => {
+    const pending = registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "Which one?",
+      options: OPTIONS,
+    });
+    expect(
+      answerAskUserQuestion("call-1", {
+        kind: "selected",
+        value: "local",
+        label: "Local",
+      }),
+    ).toBe(true);
+    // A double-click, or a dismissal racing the click.
+    expect(
+      answerAskUserQuestion("call-1", {
+        kind: "freeText",
+        text: "actually something else",
+      }),
+    ).toBe(false);
+    expect(dismissAskUserQuestions("stopped")).toBe(0);
+
+    await expect(pending).resolves.toMatchObject({ value: "local" });
+  });
+
+  it("dismisses only the scoped session's questions", async () => {
+    const mine = registerAskUserQuestion({
+      toolCallId: "call-mine",
+      question: "Mine?",
+      options: OPTIONS,
+      scope: "session-a",
+    });
+    registerAskUserQuestion({
+      toolCallId: "call-theirs",
+      question: "Theirs?",
+      options: OPTIONS,
+      scope: "session-b",
+    });
+
+    expect(dismissAskUserQuestions("new_message", { scope: "session-a" })).toBe(
+      1,
+    );
+    await expect(mine).resolves.toEqual({
+      kind: "dismissed",
+      reason: "new_message",
+    });
+    // A background turn in another session keeps its question.
+    expect(useAskUserStore.getState().pending.has("call-theirs")).toBe(true);
+  });
+
+  it("emits outcome telemetry without the question, options, or answer text", async () => {
+    const pending = registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "Which server did you mean?",
+      options: OPTIONS,
+    });
+    answerAskUserQuestion("call-1", {
+      kind: "freeText",
+      text: "the one I set up yesterday at acme.internal",
+    });
+    await pending;
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    const [event, props] = trackMock.mock.calls[0]!;
+    expect(event).toBe("agent_ask_user_resolved");
+    expect(props).toMatchObject({ outcome: "freeText", option_count: 2 });
+    expect(typeof props.time_to_answer_ms).toBe("number");
+    // HARD RULE: names, counts, durations — never the user's or the model's
+    // words. The answer above is the kind of thing that would leak.
+    const serialized = JSON.stringify(props);
+    expect(serialized).not.toContain("acme.internal");
+    expect(serialized).not.toContain("Which server");
+    expect(serialized).not.toContain("Connect to a");
+  });
+
+  it("a throwing analytics client still settles the question", async () => {
+    trackMock.mockImplementationOnce(() => {
+      throw new Error("analytics is down");
+    });
+    const pending = registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "Which one?",
+      options: OPTIONS,
+    });
+    answerAskUserQuestion("call-1", {
+      kind: "selected",
+      value: "local",
+      label: "Local",
+    });
+    await expect(pending).resolves.toMatchObject({ kind: "selected" });
+  });
+});
+
+describe("ui_ask_user tool", () => {
+  beforeEach(() => {
+    __resetAskUserStoreForTests();
+    trackMock.mockClear();
+  });
+
+  it("parks on the tool-call id and returns the answer to the model", async () => {
+    const result = askUserTool().execute(
+      { question: "What are you trying to do?", options: OPTIONS },
+      { toolCallId: "call-1", scope: "session-a" },
+    );
+    await flush();
+
+    const parked = useAskUserStore.getState().pending.get("call-1");
+    expect(parked?.scope).toBe("session-a");
+    expect(parked?.options).toEqual(OPTIONS);
+
+    answerAskUserQuestion("call-1", {
+      kind: "selected",
+      value: "remote",
+      label: "Connect to a remote MCP server",
+    });
+
+    const payload = readPayload(await result);
+    expect(payload).toEqual({
+      ok: true,
+      data: {
+        kind: "selected",
+        value: "remote",
+        label: "Connect to a remote MCP server",
+      },
+    });
+  });
+
+  it("reports a dismissal as a normal result, not an error", async () => {
+    const result = askUserTool().execute(
+      { question: "Which one?", options: OPTIONS },
+      { toolCallId: "call-1", scope: "session-a" },
+    );
+    await flush();
+    dismissAskUserQuestions("new_message", { scope: "session-a" });
+
+    const settled = await result;
+    // isError would invite the model to retry the question — the single
+    // response that is certainly wrong when the user has moved on.
+    expect(settled.isError).toBeUndefined();
+    const payload = readPayload(settled) as { data: { kind: string } };
+    expect(payload.data.kind).toBe("dismissed");
+    expect(settled.content[0]!.text).toContain("Do not ask again");
+  });
+
+  it("fails fast when no tool-call id is available", async () => {
+    // Nothing could ever resolve this call, so it must error instead of
+    // parking a promise that hangs the stream forever.
+    const result = await askUserTool().execute({
+      question: "Which one?",
+      options: OPTIONS,
+    });
+    expect(result.isError).toBe(true);
+    expect(useAskUserStore.getState().pending.size).toBe(0);
+  });
+
+  it.each([
+    ["a missing question", { options: OPTIONS }],
+    ["a blank question", { question: "   ", options: OPTIONS }],
+    ["an over-long question", { question: "x".repeat(301), options: OPTIONS }],
+    ["no options", { question: "Which one?" }],
+    ["one option", { question: "Which one?", options: [OPTIONS[0]] }],
+    [
+      "options that collapse to one after dedupe",
+      {
+        question: "Which one?",
+        options: [
+          { label: "Local", value: "same" },
+          { label: "Remote", value: "same" },
+        ],
+      },
+    ],
+    [
+      "more than four options",
+      {
+        question: "Which one?",
+        options: ["a", "b", "c", "d", "e"].map((v) => ({ label: v, value: v })),
+      },
+    ],
+  ])("rejects %s without parking", async (_name, args) => {
+    const result = await askUserTool().execute(
+      args as Record<string, unknown>,
+      {
+        toolCallId: "call-1",
+      },
+    );
+    expect(result.isError).toBe(true);
+    expect(useAskUserStore.getState().pending.size).toBe(0);
+  });
+
+  it("accepts bare strings as options and defaults value to the label", async () => {
+    void askUserTool().execute(
+      { question: "Which one?", options: ["Local", { label: "Remote" }] },
+      { toolCallId: "call-1" },
+    );
+    await flush();
+    expect(useAskUserStore.getState().pending.get("call-1")?.options).toEqual([
+      { label: "Local", value: "Local" },
+      { label: "Remote", value: "Remote" },
+    ]);
+  });
+
+  it("truncates an over-long label but keeps the full value", async () => {
+    const longLabel = "L".repeat(120);
+    void askUserTool().execute(
+      {
+        question: "Which one?",
+        options: [{ label: longLabel, value: "local" }, { label: "Remote" }],
+      },
+      { toolCallId: "call-1" },
+    );
+    await flush();
+    const [first] = useAskUserStore.getState().pending.get("call-1")!.options;
+    expect(first!.label).toHaveLength(80);
+    expect(first!.label.endsWith("…")).toBe(true);
+    // The value is what comes back to the model — it must not be mangled.
+    expect(first!.value).toBe("local");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ask-user-store.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ask-user-store.test.ts
@@ -18,11 +18,13 @@ vi.mock("@/lib/inspector-command-handlers", () => ({
   hasInspectorCommandHandler: vi.fn().mockReturnValue(true),
 }));
 
+import { renderHook } from "@testing-library/react";
 import {
   ASK_USER_TOOL_NAME,
   answerAskUserQuestion,
   dismissAskUserQuestions,
   registerAskUserQuestion,
+  useAskUserCallIsOurs,
   useAskUserStore,
   __resetAskUserStoreForTests,
 } from "../ask-user-store";
@@ -99,7 +101,7 @@ describe("ask-user store", () => {
         text: "actually something else",
       }),
     ).toBe(false);
-    expect(dismissAskUserQuestions("stopped")).toBe(0);
+    expect(dismissAskUserQuestions("stopped")).toEqual([]);
 
     await expect(pending).resolves.toMatchObject({ value: "local" });
   });
@@ -118,9 +120,11 @@ describe("ask-user store", () => {
       scope: "session-b",
     });
 
-    expect(dismissAskUserQuestions("new_message", { scope: "session-a" })).toBe(
-      1,
-    );
+    // Returns the settled ids, not a count: the caller must wait for those
+    // specific tool outputs before it can send another request.
+    expect(
+      dismissAskUserQuestions("new_message", { scope: "session-a" }),
+    ).toEqual(["call-mine"]);
     await expect(mine).resolves.toEqual({
       kind: "dismissed",
       reason: "new_message",
@@ -313,8 +317,12 @@ describe("ui_ask_user tool", () => {
     expect(result.isError).toBe(true);
   });
 
-  it("bounds the answer token the model gets back", async () => {
-    void askUserTool().execute(
+  it("rejects an over-long answer token rather than rewriting it", async () => {
+    // Truncating would hand the model a token answering a different option
+    // than the one offered, and two values differing only past the cut would
+    // collapse into a false duplicate. Labels are the opposite case — display
+    // text, where an ellipsis beats an error.
+    const result = await askUserTool().execute(
       {
         question: "Which one?",
         options: [
@@ -324,11 +332,9 @@ describe("ui_ask_user tool", () => {
       },
       { toolCallId: "call-1" },
     );
-    await flush();
-    const [first] = useAskUserStore.getState().pending.get("call-1")!.options;
-    // The schema calls it a short token; labels were already capped, and an
-    // uncapped value would ride the whole way back into the transcript.
-    expect(first!.value).toHaveLength(120);
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("answer token");
+    expect(useAskUserStore.getState().pending.size).toBe(0);
   });
 
   it("truncates an over-long label but keeps the full value", async () => {
@@ -346,5 +352,67 @@ describe("ui_ask_user tool", () => {
     expect(first!.label.endsWith("…")).toBe(true);
     // The value is what comes back to the model — it must not be mangled.
     expect(first!.value).toBe("local");
+  });
+});
+
+describe("useAskUserCallIsOurs — per-call provenance", () => {
+  beforeEach(() => {
+    __resetAskUserStoreForTests();
+  });
+
+  const ours = (toolCallId: string | undefined, output: unknown) =>
+    renderHook(() => useAskUserCallIsOurs(toolCallId, output)).result.current;
+
+  it("claims a question parked here", () => {
+    registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "Which one?",
+      options: OPTIONS,
+    });
+    expect(ours("call-1", undefined)).toBe(true);
+  });
+
+  it("claims a call we answered whose output has not landed yet", () => {
+    registerAskUserQuestion({
+      toolCallId: "call-1",
+      question: "Which one?",
+      options: OPTIONS,
+    });
+    answerAskUserQuestion("call-1", {
+      kind: "selected",
+      value: "local",
+      label: "Local",
+    });
+    // Pending is already gone; without this the card would flip to a plain
+    // tool row mid-answer and the parent gate would disown its own question.
+    expect(useAskUserStore.getState().pending.has("call-1")).toBe(false);
+    expect(ours("call-1", undefined)).toBe(true);
+  });
+
+  it("claims a hydrated call whose recorded output decodes as ours", () => {
+    const output = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ ok: true, data: { kind: "selected" } }),
+        },
+      ],
+    };
+    expect(ours("call-reloaded", output)).toBe(true);
+  });
+
+  it("does NOT claim a real MCP server tool that happens to share the name", () => {
+    // The executor deliberately lets a genuine `ui_*` server tool run, so the
+    // renderer must not paint a clarification card over its result. Nothing
+    // is parked, we answered nothing, and the payload is the server's own.
+    const serverOutput = {
+      content: [{ type: "text", text: '{"temperature": 21}' }],
+    };
+    expect(ours("call-foreign", serverOutput)).toBe(false);
+    expect(ours("call-foreign", undefined)).toBe(false);
+  });
+
+  it("does not claim anything without a tool-call id", () => {
+    expect(ours(undefined, undefined)).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ask-user-store.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ask-user-store.test.ts
@@ -220,7 +220,7 @@ describe("ui_ask_user tool", () => {
     expect(settled.isError).toBeUndefined();
     const payload = readPayload(settled) as { data: { kind: string } };
     expect(payload.data.kind).toBe("dismissed");
-    expect(settled.content[0]!.text).toContain("Do not ask again");
+    expect(settled.content[0]!.text).toContain("Do not ask this again");
   });
 
   it("fails fast when no tool-call id is available", async () => {
@@ -278,6 +278,57 @@ describe("ui_ask_user tool", () => {
       { label: "Local", value: "Local" },
       { label: "Remote", value: "Remote" },
     ]);
+  });
+
+  it("collapses options that render as the same button", async () => {
+    // Distinct values, identical labels: two buttons the user cannot tell
+    // apart is not a choice, exactly as two identical values aren't.
+    const result = await askUserTool().execute(
+      {
+        question: "Which one?",
+        options: [
+          { label: "Local", value: "a" },
+          { label: "Local", value: "b" },
+        ],
+      },
+      { toolCallId: "call-1" },
+    );
+    expect(result.isError).toBe(true);
+    expect(useAskUserStore.getState().pending.size).toBe(0);
+  });
+
+  it("compares labels AFTER truncation, since that is what is painted", async () => {
+    const shared = "L".repeat(100);
+    const result = await askUserTool().execute(
+      {
+        question: "Which one?",
+        options: [
+          { label: `${shared}-one`, value: "a" },
+          { label: `${shared}-two`, value: "b" },
+        ],
+      },
+      { toolCallId: "call-1" },
+    );
+    // Both truncate to the same 80 chars — one button, so not a question.
+    expect(result.isError).toBe(true);
+  });
+
+  it("bounds the answer token the model gets back", async () => {
+    void askUserTool().execute(
+      {
+        question: "Which one?",
+        options: [
+          { label: "Local", value: "v".repeat(500) },
+          { label: "Remote", value: "remote" },
+        ],
+      },
+      { toolCallId: "call-1" },
+    );
+    await flush();
+    const [first] = useAskUserStore.getState().pending.get("call-1")!.options;
+    // The schema calls it a short token; labels were already capped, and an
+    // uncapped value would ride the whole way back into the transcript.
+    expect(first!.value).toHaveLength(120);
   });
 
   it("truncates an over-long label but keeps the full value", async () => {

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-approval.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-approval.test.ts
@@ -78,7 +78,10 @@ describe("createUiAwareApprovalResponseHandler", () => {
     handler({ id: "appr-1", approved: true });
     await flushMicrotasks();
 
-    expect(def.execute).toHaveBeenCalledWith({ target: "servers" });
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "servers" },
+      expect.objectContaining({ toolCallId: expect.any(String) })
+    );
     expect(addToolOutput).toHaveBeenCalledWith(
       expect.objectContaining({ tool: "ui_navigate", toolCallId: "tc-1" })
     );
@@ -195,7 +198,10 @@ describe("fulfillOrphanedDeferredUiToolCalls", () => {
     });
     await flushMicrotasks();
 
-    expect(def.execute).toHaveBeenCalledWith({ target: "servers" });
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "servers" },
+      expect.objectContaining({ toolCallId: expect.any(String) })
+    );
     expect(addToolOutput).toHaveBeenCalled();
   });
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-approval.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-approval.test.ts
@@ -80,7 +80,7 @@ describe("createUiAwareApprovalResponseHandler", () => {
 
     expect(def.execute).toHaveBeenCalledWith(
       { target: "servers" },
-      expect.objectContaining({ toolCallId: expect.any(String) })
+      { toolCallId: "tc-1" }
     );
     expect(addToolOutput).toHaveBeenCalledWith(
       expect.objectContaining({ tool: "ui_navigate", toolCallId: "tc-1" })

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
@@ -47,7 +47,7 @@ describe("handleUiToolCall", () => {
     expect(handled).toBe(true);
     expect(def.execute).toHaveBeenCalledWith(
       { target: "playground" },
-      expect.objectContaining({ toolCallId: expect.any(String) })
+      { toolCallId: "tc-1" }
     );
     expect(addToolOutput).toHaveBeenCalledWith({
       tool: "ui_navigate",
@@ -185,7 +185,7 @@ describe("handleUiToolCall", () => {
     expect(def.execute).toHaveBeenCalledTimes(1);
     expect(def.execute).toHaveBeenCalledWith(
       { target: "servers" },
-      expect.objectContaining({ toolCallId: expect.any(String) })
+      { toolCallId: "tc-appr" }
     );
     expect(addToolOutput).toHaveBeenCalledTimes(1);
     expect(listDeferredUiToolCalls()).toEqual([]);
@@ -207,7 +207,7 @@ describe("handleUiToolCall", () => {
 
     expect(def.execute).toHaveBeenCalledWith(
       { target: "evals" },
-      expect.objectContaining({ toolCallId: expect.any(String) })
+      { toolCallId: "tc-reload" }
     );
     expect(addToolOutput).toHaveBeenCalledWith(
       expect.objectContaining({ toolCallId: "tc-reload" })
@@ -307,7 +307,7 @@ describe("handleUiToolCall", () => {
     });
     expect(def.execute).toHaveBeenCalledWith(
       {},
-      expect.objectContaining({ toolCallId: expect.any(String) })
+      { toolCallId: "tc-1" }
     );
   });
 

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tool-executor.test.ts
@@ -45,12 +45,36 @@ describe("handleUiToolCall", () => {
     });
 
     expect(handled).toBe(true);
-    expect(def.execute).toHaveBeenCalledWith({ target: "playground" });
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "playground" },
+      expect.objectContaining({ toolCallId: expect.any(String) })
+    );
     expect(addToolOutput).toHaveBeenCalledWith({
       tool: "ui_navigate",
       toolCallId: "tc-1",
       output: { content: [{ type: "text", text: "navigated" }] },
     });
+  });
+
+  it("hands execute the call's identity and session scope", async () => {
+    // Tools that park on user input (`ui_ask_user`) key their pending state
+    // on the tool-call id and cancel per conversation — neither is derivable
+    // from the arguments, so both have to arrive through the context.
+    const def = makeTool();
+    useUiToolsRegistry.getState().registerUiTool(def);
+
+    await handleUiToolCall({
+      toolName: "ui_navigate",
+      toolCallId: "tc-scoped",
+      input: { target: "playground" },
+      addToolOutput: vi.fn(),
+      telemetryScope: "session-a",
+    });
+
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "playground" },
+      { toolCallId: "tc-scoped", scope: "session-a" }
+    );
   });
 
   it("defers mutating tools when requireToolApproval is on (no execute, no output)", async () => {
@@ -159,7 +183,10 @@ describe("handleUiToolCall", () => {
     await fulfillApprovedUiToolCall({ toolCallId: "tc-appr", addToolOutput });
 
     expect(def.execute).toHaveBeenCalledTimes(1);
-    expect(def.execute).toHaveBeenCalledWith({ target: "servers" });
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "servers" },
+      expect.objectContaining({ toolCallId: expect.any(String) })
+    );
     expect(addToolOutput).toHaveBeenCalledTimes(1);
     expect(listDeferredUiToolCalls()).toEqual([]);
   });
@@ -178,7 +205,10 @@ describe("handleUiToolCall", () => {
       addToolOutput,
     });
 
-    expect(def.execute).toHaveBeenCalledWith({ target: "evals" });
+    expect(def.execute).toHaveBeenCalledWith(
+      { target: "evals" },
+      expect.objectContaining({ toolCallId: expect.any(String) })
+    );
     expect(addToolOutput).toHaveBeenCalledWith(
       expect.objectContaining({ toolCallId: "tc-reload" })
     );
@@ -275,7 +305,10 @@ describe("handleUiToolCall", () => {
       input: "garbage",
       addToolOutput: vi.fn(),
     });
-    expect(def.execute).toHaveBeenCalledWith({});
+    expect(def.execute).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ toolCallId: expect.any(String) })
+    );
   });
 
   it("converts execute throws into isError outputs", async () => {

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/ui-tools-catalog.test.ts
@@ -47,8 +47,13 @@ describe("buildUiToolsCatalog", () => {
     // the always-on playground catalog rather than forming a mount-scoped group
     // because the playground manifest is kind:"global" — update this exact list
     // consciously, never as a silent side effect.
+    //
+    // 16 → 17: `ui_ask_user` joins the CORE group. Global rather than
+    // surface-scoped because a clarifying question has to be available
+    // wherever the agent is, like navigation.
     expect(catalog.map((t) => t.name).sort()).toEqual([
       "ui_add_server",
+      "ui_ask_user",
       "ui_connect_server",
       "ui_disconnect_server",
       "ui_execute_tool",
@@ -72,6 +77,9 @@ describe("buildUiToolsCatalog", () => {
       expect(typeof tool.execute).toBe("function");
     }
     expect(getTool("ui_snapshot_app").readOnly).toBe(true);
+    // Asking a question changes nothing, so it must never gate — a
+    // confirmation click to permit a click.
+    expect(getTool("ui_ask_user").readOnly).toBe(true);
   });
 
   it("every tool annotates readOnly/destructive/openWorld explicitly", () => {

--- a/mcpjam-inspector/client/src/lib/webmcp/__tests__/wait-for-tool-output.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/__tests__/wait-for-tool-output.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The wait that keeps a dismissal from shipping an unresolved tool call.
+ * Its failure mode matters as much as its success one: blocking the user's
+ * message forever would be worse than the invalid history it prevents.
+ */
+import { describe, expect, it } from "vitest";
+
+import { waitForTerminalToolParts } from "../wait-for-tool-output";
+
+const part = (toolCallId: string, state: string) => ({
+  parts: [{ toolCallId, state }],
+});
+
+describe("waitForTerminalToolParts", () => {
+  it("returns immediately when there is nothing to wait for", async () => {
+    await expect(waitForTerminalToolParts(() => [], [])).resolves.toBe(true);
+  });
+
+  it("resolves as soon as the output lands", async () => {
+    // A thunk, not a captured array: the SDK swaps the messages array on every
+    // update, so a snapshot reference would never observe the transition.
+    let messages = [part("tc-1", "input-available")];
+    setTimeout(() => {
+      messages = [part("tc-1", "output-available")];
+    }, 20);
+
+    await expect(
+      waitForTerminalToolParts(() => messages, ["tc-1"], { timeoutMs: 500 }),
+    ).resolves.toBe(true);
+  });
+
+  it("accepts any terminal output state, not just output-available", async () => {
+    const messages = [part("tc-1", "output-error")];
+    await expect(
+      waitForTerminalToolParts(() => messages, ["tc-1"], { timeoutMs: 100 }),
+    ).resolves.toBe(true);
+  });
+
+  it("waits for EVERY id, not just the first", async () => {
+    const messages = [part("tc-1", "output-available"), part("tc-2", "input-available")];
+    await expect(
+      waitForTerminalToolParts(() => messages, ["tc-1", "tc-2"], {
+        timeoutMs: 60,
+        pollMs: 5,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("gives up rather than blocking the user's message forever", async () => {
+    // A stuck output is a bug; a permanently wedged composer is a worse one.
+    const messages = [part("tc-1", "input-available")];
+    await expect(
+      waitForTerminalToolParts(() => messages, ["tc-1"], {
+        timeoutMs: 60,
+        pollMs: 5,
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/webmcp/ask-user-store.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ask-user-store.ts
@@ -17,15 +17,27 @@
  * exposes scoped dismissal for the ways a question stops being answerable
  * (the user sends a new message, stops generation, the session is evicted).
  * A dismissal is a NORMAL answer, not an error: the tool returns "the user
- * didn't answer, proceed on your best interpretation".
+ * didn't answer".
+ *
+ * RECORDED, BUT NEVER GENERATED FROM. A dismissal must still write a tool
+ * result — a dangling `tool_use` with no result is an invalid message history
+ * for both Anthropic and OpenAI, so the next request would fail. It must NOT
+ * resume the turn: abandonment is not a prompt, and a user who pressed Stop
+ * or changed the subject should never get an answer to the question they
+ * walked away from. `shouldAutoResumeTurn` enforces that by reading the
+ * recorded outcome back out (see `readAskUserAnswerFromOutput`). The model
+ * sees the unanswered question as context on the user's NEXT message, which
+ * is where it belongs.
  *
  * Reload is the one case with no in-memory entry to settle: the page is new,
  * the paused turn died with the old one, and the server only persists turns
- * that complete. A hydrated part with no pending entry therefore renders as
- * expired rather than waiting on a promise nobody holds.
+ * that complete. A hydrated part with no pending entry AND no output is
+ * therefore genuinely expired — but that is the ONLY state the card may call
+ * expired (see `ask-user-part.tsx`).
  */
 import { create } from "zustand";
 import { track } from "@/lib/analytics";
+import { useUiToolsRegistry } from "./ui-tools-registry";
 
 /**
  * The tool name, shared by the catalog entry and the thread renderer so the
@@ -194,6 +206,75 @@ export function useAskUserPendingQuestion(
 ): AskUserQuestion | null {
   return useAskUserStore((state) =>
     toolCallId ? (state.pending.get(toolCallId) ?? null) : null,
+  );
+}
+
+/**
+ * Whether any question is parked for a session. The agent's instance eviction
+ * needs this because a parked call does NOT look idle: `onToolCall` is awaited
+ * by the SDK, so `chat.status` stays `"streaming"` for as long as the question
+ * is unanswered (pinned by the ask-user SDK canary). Without this, a detached
+ * session's question could never be reached by the idle sweep.
+ */
+export function hasPendingAskUserQuestions(scope: string): boolean {
+  for (const question of useAskUserStore.getState().pending.values()) {
+    if (question.scope === scope) return true;
+  }
+  return false;
+}
+
+/**
+ * The answer recorded in a settled tool part's output, or null when the output
+ * isn't one of ours / can't be read. Single source of truth for decoding the
+ * `okResult`-wrapped payload: the thread card reads it to paint the outcome,
+ * and the auto-resume gate reads it to recognise a dismissal.
+ *
+ * Defensive by construction — a shape we don't recognise returns null rather
+ * than throwing inside a render or a stream predicate.
+ */
+export function readAskUserAnswerFromOutput(
+  output: unknown,
+): { kind: AskUserAnswer["kind"]; label?: string } | null {
+  const content = (output as { content?: unknown } | null)?.content;
+  if (!Array.isArray(content)) return null;
+  const first = content[0] as { type?: unknown; text?: unknown } | undefined;
+  if (first?.type !== "text" || typeof first.text !== "string") return null;
+  try {
+    const parsed = JSON.parse(first.text) as {
+      data?: { kind?: unknown; label?: unknown };
+    };
+    const kind = parsed?.data?.kind;
+    if (kind !== "selected" && kind !== "freeText" && kind !== "dismissed") {
+      return null;
+    }
+    return {
+      kind,
+      ...(typeof parsed.data?.label === "string"
+        ? { label: parsed.data.label }
+        : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether `ui_ask_user` in this transcript is OURS.
+ *
+ * The thread renderer must not claim a tool part by name alone: the executor
+ * deliberately dispatches on registry membership so a genuine MCP server tool
+ * named `ui_*` runs untouched, and a renderer keyed on the string would still
+ * hijack it — painting a clarification card over a real server call in a
+ * regular chat. Mirroring the executor's gate keeps the two consistent.
+ *
+ * `wasShipped` is part of the gate because a hydrated transcript renders
+ * before any new snapshot is drained, and an answered card must still paint.
+ */
+export function useAskUserToolIsOurs(): boolean {
+  return useUiToolsRegistry(
+    (state) =>
+      state.tools.has(ASK_USER_TOOL_NAME) ||
+      state.shippedNames.has(ASK_USER_TOOL_NAME),
   );
 }
 

--- a/mcpjam-inspector/client/src/lib/webmcp/ask-user-store.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ask-user-store.ts
@@ -1,0 +1,208 @@
+/**
+ * Pending `ui_ask_user` questions — the agent's clarify-before-acting seam.
+ *
+ * `ui_ask_user` is a UI tool whose "execution" is waiting for a click: the
+ * executor calls `execute()`, which parks here on a promise, and the card
+ * rendered for the tool part resolves it. The stream stays paused until then,
+ * exactly as it does for any other client-fulfilled call.
+ *
+ * WHY THE PARKED STATE LIVES OUTSIDE REACT (module scope, like
+ * `agent-chat-instances.ts`): the surface rendering the card can unmount
+ * mid-question — the Home takeover dies on navigation, and the side panel
+ * adopts the conversation. A promise owned by a component would be lost with
+ * it, stranding the paused turn forever. Module scope means the question
+ * outlives whichever surface happens to be painting it.
+ *
+ * EVERY PATH MUST SETTLE. An unresolved entry is a hung turn, so the store
+ * exposes scoped dismissal for the ways a question stops being answerable
+ * (the user sends a new message, stops generation, the session is evicted).
+ * A dismissal is a NORMAL answer, not an error: the tool returns "the user
+ * didn't answer, proceed on your best interpretation".
+ *
+ * Reload is the one case with no in-memory entry to settle: the page is new,
+ * the paused turn died with the old one, and the server only persists turns
+ * that complete. A hydrated part with no pending entry therefore renders as
+ * expired rather than waiting on a promise nobody holds.
+ */
+import { create } from "zustand";
+import { track } from "@/lib/analytics";
+
+/**
+ * The tool name, shared by the catalog entry and the thread renderer so the
+ * card can never be wired to a name the tool doesn't register under.
+ */
+export const ASK_USER_TOOL_NAME = "ui_ask_user";
+
+export interface AskUserOption {
+  /** Shown to the user. */
+  label: string;
+  /** Returned to the model. Unique within a question. */
+  value: string;
+}
+
+export interface AskUserQuestion {
+  toolCallId: string;
+  question: string;
+  options: AskUserOption[];
+  /**
+   * The asking session's chatSessionId. Scopes dismissal so stopping one
+   * conversation can't cancel a question parked in another (a background
+   * turn in a second session keeps streaming on its own instance).
+   */
+  scope?: string;
+}
+
+export type AskUserDismissReason =
+  | "new_message"
+  | "stopped"
+  | "session_evicted";
+
+export type AskUserAnswer =
+  | { kind: "selected"; value: string; label: string }
+  | { kind: "freeText"; text: string }
+  | { kind: "dismissed"; reason: AskUserDismissReason };
+
+interface ParkedCall {
+  resolve: (answer: AskUserAnswer) => void;
+  startedAt: number;
+  optionCount: number;
+}
+
+/**
+ * Resolvers, kept OUT of the zustand state: they're functions, they must not
+ * participate in render equality, and nothing should be able to reach them
+ * through a component subscription. The store below mirrors only what the
+ * card needs to paint.
+ */
+const parked = new Map<string, ParkedCall>();
+
+interface AskUserState {
+  /** Questions awaiting an answer, keyed by toolCallId. */
+  pending: Map<string, AskUserQuestion>;
+}
+
+export const useAskUserStore = create<AskUserState>(() => ({
+  pending: new Map(),
+}));
+
+/**
+ * Observation-only, and never text: the question, the option labels, and any
+ * free-text answer are the user's own words and stay in the transcript. Only
+ * the outcome shape, the option count, and timing are emitted — enough to
+ * tune the ask-threshold (high `freeText` share means the options are wrong;
+ * high `dismissed` means the agent is over-asking) and nothing more.
+ */
+function emitResolved(answer: AskUserAnswer, call: ParkedCall): void {
+  try {
+    track("agent_ask_user_resolved", {
+      location: "mcpjam_agent",
+      outcome: answer.kind,
+      option_count: call.optionCount,
+      time_to_answer_ms: Date.now() - call.startedAt,
+      ...(answer.kind === "dismissed" ? { dismiss_reason: answer.reason } : {}),
+    });
+  } catch {
+    // Telemetry must never break tool fulfillment — a lost result hangs the
+    // stream, which is strictly worse than a lost event.
+  }
+}
+
+/**
+ * Resolve a parked call exactly once. Returns false when the id isn't parked
+ * (already settled, or never ours), which is what makes double-click on an
+ * option and a racing dismissal safe.
+ */
+function settle(toolCallId: string, answer: AskUserAnswer): boolean {
+  const call = parked.get(toolCallId);
+  if (!call) return false;
+  parked.delete(toolCallId);
+  useAskUserStore.setState((state) => {
+    if (!state.pending.has(toolCallId)) return state;
+    const pending = new Map(state.pending);
+    pending.delete(toolCallId);
+    return { pending };
+  });
+  emitResolved(answer, call);
+  call.resolve(answer);
+  return true;
+}
+
+/**
+ * Park a question and return the promise the tool's `execute()` awaits.
+ * Never rejects: the tool layer treats a rejection as a failed call, and a
+ * question the user simply didn't answer isn't a failure.
+ */
+export function registerAskUserQuestion(
+  question: AskUserQuestion,
+): Promise<AskUserAnswer> {
+  // A re-registered id would orphan the first promise (its awaiting
+  // `execute` never returns → the turn hangs). The executor's settled/
+  // in-flight guard makes this unreachable today; settling the old one keeps
+  // it unreachable if that guard ever changes.
+  if (parked.has(question.toolCallId)) {
+    settle(question.toolCallId, {
+      kind: "dismissed",
+      reason: "session_evicted",
+    });
+  }
+  return new Promise<AskUserAnswer>((resolve) => {
+    parked.set(question.toolCallId, {
+      resolve,
+      startedAt: Date.now(),
+      optionCount: question.options.length,
+    });
+    useAskUserStore.setState((state) => {
+      const pending = new Map(state.pending);
+      pending.set(question.toolCallId, question);
+      return { pending };
+    });
+  });
+}
+
+/** Answer a pending question. No-op (false) if it already settled. */
+export function answerAskUserQuestion(
+  toolCallId: string,
+  answer: Exclude<AskUserAnswer, { kind: "dismissed" }>,
+): boolean {
+  return settle(toolCallId, answer);
+}
+
+/**
+ * Settle every question that can no longer be answered. Pass `scope` (a
+ * chatSessionId) to limit the sweep to one conversation; omit it only for
+ * teardown paths that really do mean "all of them".
+ *
+ * Returns how many were settled, so callers can assert the seam in tests.
+ */
+export function dismissAskUserQuestions(
+  reason: AskUserDismissReason,
+  opts?: { scope?: string },
+): number {
+  let dismissed = 0;
+  for (const [toolCallId, question] of [
+    ...useAskUserStore.getState().pending,
+  ]) {
+    if (opts?.scope !== undefined && question.scope !== opts.scope) continue;
+    if (settle(toolCallId, { kind: "dismissed", reason })) dismissed += 1;
+  }
+  return dismissed;
+}
+
+/** The pending question for a tool part, or null once it has been answered. */
+export function useAskUserPendingQuestion(
+  toolCallId: string | undefined,
+): AskUserQuestion | null {
+  return useAskUserStore((state) =>
+    toolCallId ? (state.pending.get(toolCallId) ?? null) : null,
+  );
+}
+
+export function __resetAskUserStoreForTests(): void {
+  // Settle rather than drop: a test that leaves a promise dangling would
+  // otherwise leak an un-awaited `execute` into the next test.
+  for (const toolCallId of [...parked.keys()]) {
+    settle(toolCallId, { kind: "dismissed", reason: "session_evicted" });
+  }
+  parked.clear();
+  useAskUserStore.setState({ pending: new Map() });
+}

--- a/mcpjam-inspector/client/src/lib/webmcp/ask-user-store.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ask-user-store.ts
@@ -37,7 +37,6 @@
  */
 import { create } from "zustand";
 import { track } from "@/lib/analytics";
-import { useUiToolsRegistry } from "./ui-tools-registry";
 
 /**
  * The tool name, shared by the catalog entry and the thread renderer so the
@@ -87,6 +86,18 @@ interface ParkedCall {
  * card needs to paint.
  */
 const parked = new Map<string, ParkedCall>();
+
+/**
+ * Calls THIS page answered, kept after they settle.
+ *
+ * Two jobs, both about the window between `settle()` and the tool output
+ * landing: it proves the call is ours when `pending` has already dropped it
+ * (provenance), and it tells the card to show "sending" instead of "expired"
+ * (state). Bounded and page-lifetime — one short id per question the user
+ * actually answered, which is a human-scale number.
+ */
+const answeredHere = new Set<string>();
+const ANSWERED_HERE_LIMIT = 64;
 
 interface AskUserState {
   /** Questions awaiting an answer, keyed by toolCallId. */
@@ -176,7 +187,15 @@ export function answerAskUserQuestion(
   toolCallId: string,
   answer: Exclude<AskUserAnswer, { kind: "dismissed" }>,
 ): boolean {
-  return settle(toolCallId, answer);
+  const settled = settle(toolCallId, answer);
+  if (settled) {
+    if (answeredHere.size >= ANSWERED_HERE_LIMIT) {
+      const oldest = answeredHere.values().next().value;
+      if (oldest !== undefined) answeredHere.delete(oldest);
+    }
+    answeredHere.add(toolCallId);
+  }
+  return settled;
 }
 
 /**
@@ -184,18 +203,25 @@ export function answerAskUserQuestion(
  * chatSessionId) to limit the sweep to one conversation; omit it only for
  * teardown paths that really do mean "all of them".
  *
- * Returns how many were settled, so callers can assert the seam in tests.
+ * Returns the settled tool-call ids, NOT a count: resolving the promise is
+ * only the start: the parked `execute` returns on a later microtask and the
+ * executor writes the tool output after that. A caller about to send another
+ * request has to WAIT for those outputs (an unresolved tool call is an
+ * invalid message history for both Anthropic and OpenAI), and it needs the
+ * ids to know what to wait for.
  */
 export function dismissAskUserQuestions(
   reason: AskUserDismissReason,
   opts?: { scope?: string },
-): number {
-  let dismissed = 0;
+): string[] {
+  const dismissed: string[] = [];
   for (const [toolCallId, question] of [
     ...useAskUserStore.getState().pending,
   ]) {
     if (opts?.scope !== undefined && question.scope !== opts.scope) continue;
-    if (settle(toolCallId, { kind: "dismissed", reason })) dismissed += 1;
+    if (settle(toolCallId, { kind: "dismissed", reason })) {
+      dismissed.push(toolCallId);
+    }
   }
   return dismissed;
 }
@@ -259,23 +285,38 @@ export function readAskUserAnswerFromOutput(
 }
 
 /**
- * Whether `ui_ask_user` in this transcript is OURS.
+ * Whether THIS `ui_ask_user` call is one we asked — per call, never per page.
  *
- * The thread renderer must not claim a tool part by name alone: the executor
- * deliberately dispatches on registry membership so a genuine MCP server tool
- * named `ui_*` runs untouched, and a renderer keyed on the string would still
- * hijack it — painting a clarification card over a real server call in a
- * regular chat. Mirroring the executor's gate keeps the two consistent.
+ * The name alone can't decide it: a connected MCP server may legitimately
+ * expose a tool called `ui_ask_user`, and the executor deliberately lets such
+ * a tool run untouched. Nor can page-global registry state: the `ui_*`
+ * catalog is registered app-wide on ordinary inspector routes, so "is the
+ * tool registered" is true almost everywhere and would claim a real server
+ * call in a regular chat. `shippedNames` is worse still — page-lifetime and
+ * never evicted, so one agent turn would poison every later transcript.
  *
- * `wasShipped` is part of the gate because a hydrated transcript renders
- * before any new snapshot is drained, and an answered card must still paint.
+ * Provenance instead, in three forms, each of which only WE can produce:
+ *   - the question is parked here (we are asking it right now),
+ *   - we answered it on this page and the output is still in flight,
+ *   - the recorded output decodes as one of our payloads (hydrated history).
+ * Anything else is somebody else's tool call and renders as one.
  */
-export function useAskUserToolIsOurs(): boolean {
-  return useUiToolsRegistry(
-    (state) =>
-      state.tools.has(ASK_USER_TOOL_NAME) ||
-      state.shippedNames.has(ASK_USER_TOOL_NAME),
+export function useAskUserCallIsOurs(
+  toolCallId: string | undefined,
+  output: unknown,
+): boolean {
+  const parkedHere = useAskUserStore((state) =>
+    toolCallId ? state.pending.has(toolCallId) : false,
   );
+  if (!toolCallId) return false;
+  if (parkedHere) return true;
+  if (answeredHere.has(toolCallId)) return true;
+  return readAskUserAnswerFromOutput(output) !== null;
+}
+
+/** True while a locally-answered call's output has not landed yet. */
+export function wasAnsweredHere(toolCallId: string | undefined): boolean {
+  return toolCallId ? answeredHere.has(toolCallId) : false;
 }
 
 export function __resetAskUserStoreForTests(): void {
@@ -285,5 +326,6 @@ export function __resetAskUserStoreForTests(): void {
     settle(toolCallId, { kind: "dismissed", reason: "session_evicted" });
   }
   parked.clear();
+  answeredHere.clear();
   useAskUserStore.setState({ pending: new Map() });
 }

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/core.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/core.ts
@@ -52,6 +52,12 @@ const DISPLAY_MODES: InspectorAppDisplayMode[] = [
 // a wall of text into the conversation.
 const MAX_QUESTION_CHARS = 300;
 const MAX_OPTION_LABEL_CHARS = 80;
+// The answer token echoed back to the model. Bounded for the same reason the
+// label is: it is model-supplied, it lands in the transcript, and the schema
+// describes it as short. Downstream serialization is already budgeted
+// (`okResult`), so this is about keeping the contract honest rather than
+// preventing a hang.
+const MAX_OPTION_VALUE_CHARS = 120;
 const MIN_ASK_OPTIONS = 2;
 const MAX_ASK_OPTIONS = 4;
 
@@ -62,8 +68,13 @@ const MAX_ASK_OPTIONS = 4;
  * value — a cheap, lossless reading of the most likely schema slip), strict
  * about COUNT: fewer than two choices isn't a question, and more than four
  * is a contract violation the model should fix rather than have silently
- * truncated behind its back. Duplicate values collapse, because the value is
- * what comes back to the model and two identical answers are indistinguishable.
+ * truncated behind its back.
+ *
+ * Duplicates collapse on BOTH fields, for two different reasons that both
+ * amount to "that isn't a choice": two identical values are indistinguishable
+ * to the model, and two identical labels are indistinguishable to the user.
+ * Labels are compared AFTER truncation, since that is what actually gets
+ * painted — two long labels differing only past the cut render as one button.
  */
 function parseAskUserOptions(
   raw: unknown,
@@ -82,6 +93,7 @@ function parseAskUserOptions(
   }
   const options: AskUserOption[] = [];
   const seenValues = new Set<string>();
+  const seenLabels = new Set<string>();
   for (const entry of raw) {
     let label: string | undefined;
     let value: string | undefined;
@@ -96,15 +108,18 @@ function parseAskUserOptions(
       value = asOptionalString(record.value) ?? label;
     }
     if (!label || !value) continue;
+    if (value.length > MAX_OPTION_VALUE_CHARS) {
+      value = value.slice(0, MAX_OPTION_VALUE_CHARS);
+    }
+    const displayLabel =
+      label.length > MAX_OPTION_LABEL_CHARS
+        ? `${label.slice(0, MAX_OPTION_LABEL_CHARS - 1)}…`
+        : label;
     if (seenValues.has(value)) continue;
+    if (seenLabels.has(displayLabel)) continue;
     seenValues.add(value);
-    options.push({
-      label:
-        label.length > MAX_OPTION_LABEL_CHARS
-          ? `${label.slice(0, MAX_OPTION_LABEL_CHARS - 1)}…`
-          : label,
-      value,
-    });
+    seenLabels.add(displayLabel);
+    options.push({ label: displayLabel, value });
   }
   if (options.length < MIN_ASK_OPTIONS) {
     return {
@@ -360,10 +375,15 @@ export function buildCoreUiTools(): UiToolDefinition[] {
         // A dismissal is a normal outcome, NOT an error: the user moved on,
         // which is information. Returning isError would invite the model to
         // retry the question — the one response that's certainly wrong.
+        //
+        // The note tells the model to STOP, not to press on. The turn is not
+        // resumed off a dismissal (`shouldAutoResumeTurn`), so this text is
+        // read on the user's NEXT message — where "continue with your best
+        // interpretation" would mean answering the request they abandoned.
         if (answer.kind === "dismissed") {
           return okResult({
             kind: "dismissed",
-            note: "The user did not answer. Do not ask again — continue with your single best interpretation and state the assumption you made.",
+            note: "The user did not answer and moved on. Do not ask this again, and do not answer the original request from a guess — respond to whatever they say next.",
           });
         }
         return okResult(answer);

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/core.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/core.ts
@@ -108,8 +108,16 @@ function parseAskUserOptions(
       value = asOptionalString(record.value) ?? label;
     }
     if (!label || !value) continue;
+    // REJECT rather than truncate. The value is the token handed back to the
+    // model, so trimming it invents a different answer than the one offered —
+    // and two values differing only past the cut would collapse into a false
+    // duplicate. The label is the opposite case: it is display text, where a
+    // clean ellipsis is better than an error.
     if (value.length > MAX_OPTION_VALUE_CHARS) {
-      value = value.slice(0, MAX_OPTION_VALUE_CHARS);
+      return {
+        ok: false,
+        error: `'options[].value' must be ${MAX_OPTION_VALUE_CHARS} characters or fewer — it is an answer token, not prose.`,
+      };
     }
     const displayLabel =
       label.length > MAX_OPTION_LABEL_CHARS

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/core.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/core.ts
@@ -1,8 +1,8 @@
 /**
  * Core app-wide UI tools: navigation, server focus, emulated app context,
- * and the whole-app snapshot. Registered globally (never surface-scoped) —
- * they are how the agent moves BETWEEN surfaces, so they must exist on all
- * of them.
+ * the whole-app snapshot, and the clarifying question. Registered globally
+ * (never surface-scoped) — they are how the agent moves BETWEEN surfaces, so
+ * they must exist on all of them.
  */
 
 import type {
@@ -23,7 +23,13 @@ import {
   ensurePlaygroundOpen,
   errorResult,
   fromActionResult,
+  okResult,
 } from "./shared";
+import {
+  ASK_USER_TOOL_NAME,
+  registerAskUserQuestion,
+  type AskUserOption,
+} from "../ask-user-store";
 
 const DEVICE_TYPES: InspectorAppDeviceType[] = [
   "fill",
@@ -37,6 +43,77 @@ const DISPLAY_MODES: InspectorAppDisplayMode[] = [
   "pip",
   "fullscreen",
 ];
+
+// --- ui_ask_user argument bounds ---------------------------------------
+//
+// The question and its labels are rendered verbatim in the user's thread, so
+// they're bounded here rather than trusted. Both caps are generous for a real
+// clarifying question and small enough that a runaway generation can't paint
+// a wall of text into the conversation.
+const MAX_QUESTION_CHARS = 300;
+const MAX_OPTION_LABEL_CHARS = 80;
+const MIN_ASK_OPTIONS = 2;
+const MAX_ASK_OPTIONS = 4;
+
+/**
+ * Normalize the model's `options` into distinct, renderable choices.
+ *
+ * Tolerant about SHAPE (a bare string is accepted as its own label and
+ * value — a cheap, lossless reading of the most likely schema slip), strict
+ * about COUNT: fewer than two choices isn't a question, and more than four
+ * is a contract violation the model should fix rather than have silently
+ * truncated behind its back. Duplicate values collapse, because the value is
+ * what comes back to the model and two identical answers are indistinguishable.
+ */
+function parseAskUserOptions(
+  raw: unknown,
+): { ok: true; options: AskUserOption[] } | { ok: false; error: string } {
+  if (!Array.isArray(raw)) {
+    return {
+      ok: false,
+      error: `'options' must be an array of ${MIN_ASK_OPTIONS}-${MAX_ASK_OPTIONS} choices.`,
+    };
+  }
+  if (raw.length > MAX_ASK_OPTIONS) {
+    return {
+      ok: false,
+      error: `'options' must contain at most ${MAX_ASK_OPTIONS} choices (got ${raw.length}). Ask a narrower question.`,
+    };
+  }
+  const options: AskUserOption[] = [];
+  const seenValues = new Set<string>();
+  for (const entry of raw) {
+    let label: string | undefined;
+    let value: string | undefined;
+    if (typeof entry === "string") {
+      label = asOptionalString(entry);
+      value = label;
+    } else if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+      const record = entry as Record<string, unknown>;
+      label = asOptionalString(record.label);
+      // `value` is optional: the label is a fine answer token when the model
+      // doesn't supply a separate one.
+      value = asOptionalString(record.value) ?? label;
+    }
+    if (!label || !value) continue;
+    if (seenValues.has(value)) continue;
+    seenValues.add(value);
+    options.push({
+      label:
+        label.length > MAX_OPTION_LABEL_CHARS
+          ? `${label.slice(0, MAX_OPTION_LABEL_CHARS - 1)}…`
+          : label,
+      value,
+    });
+  }
+  if (options.length < MIN_ASK_OPTIONS) {
+    return {
+      ok: false,
+      error: `'options' must contain at least ${MIN_ASK_OPTIONS} distinct choices, each with a non-empty label.`,
+    };
+  }
+  return { ok: true, options };
+}
 
 export function buildCoreUiTools(): UiToolDefinition[] {
   return [
@@ -184,9 +261,9 @@ export function buildCoreUiTools(): UiToolDefinition[] {
         additionalProperties: false,
       },
       readOnly: true,
-      // The only read-only tool in the catalog: never gates, in either
-      // approval mode. That exemption is only sound because it observes
-      // whatever is already open and never mounts a surface to read it.
+      // Read-only: never gates, in either approval mode. That exemption is
+      // only sound because it observes whatever is already open and never
+      // mounts a surface to read it.
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -200,6 +277,96 @@ export function buildCoreUiTools(): UiToolDefinition[] {
           payload: surface ? { surface: surface as never } : {},
         });
         return fromActionResult(commandResponseToActionResult(response));
+      },
+    },
+    {
+      name: ASK_USER_TOOL_NAME,
+      description:
+        "Ask the user one short multiple-choice question and wait for their answer. Use ONLY when the request is genuinely ambiguous AND the readings lead to materially different actions; if one reading dominates, act on it and say what you assumed. Never ask what ui_snapshot_app or the message's UI context already answers. Read (docs, snapshots) before asking so the choices are good; never change anything before asking. The user can always answer in their own words instead of choosing.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          question: {
+            type: "string",
+            description:
+              "The single question to ask, in plain language. Max 300 characters.",
+          },
+          options: {
+            type: "array",
+            minItems: MIN_ASK_OPTIONS,
+            maxItems: MAX_ASK_OPTIONS,
+            items: {
+              type: "object",
+              properties: {
+                label: {
+                  type: "string",
+                  description:
+                    "What the user sees. Phrase it as their goal ('Connect to a local MCP server'), not an internal noun.",
+                },
+                value: {
+                  type: "string",
+                  description:
+                    "Short token returned to you when this is chosen. Defaults to the label.",
+                },
+              },
+              required: ["label"],
+              additionalProperties: false,
+            },
+            description:
+              "2-4 mutually exclusive choices. A free-text answer is always offered — do not add an 'Other'/'Something else' option yourself.",
+          },
+        },
+        required: ["question", "options"],
+        additionalProperties: false,
+      },
+      // Asking changes nothing. Read-only means it never gates behind the
+      // approval pill — a confirmation click on a question would be a click
+      // to permit a click.
+      readOnly: true,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        // NOT idempotent: each call paints a new card and demands the user's
+        // attention. A native agent retrying freely would nag.
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+      execute: async (args, ctx) => {
+        // The card resolves the parked promise by tool-call id, so a call
+        // that arrived without one can never be answered — fail it now
+        // rather than hang the stream.
+        const toolCallId = ctx?.toolCallId;
+        if (!toolCallId) {
+          return errorResult("ui_ask_user is unavailable in this context.");
+        }
+        const question = asOptionalString(args.question);
+        if (!question)
+          return errorResult("Missing required 'question' string.");
+        if (question.length > MAX_QUESTION_CHARS) {
+          return errorResult(
+            `'question' must be ${MAX_QUESTION_CHARS} characters or fewer.`,
+          );
+        }
+        const parsed = parseAskUserOptions(args.options);
+        if (!parsed.ok) return errorResult(parsed.error);
+
+        const answer = await registerAskUserQuestion({
+          toolCallId,
+          question,
+          options: parsed.options,
+          ...(ctx?.scope !== undefined ? { scope: ctx.scope } : {}),
+        });
+
+        // A dismissal is a normal outcome, NOT an error: the user moved on,
+        // which is information. Returning isError would invite the model to
+        // retry the question — the one response that's certainly wrong.
+        if (answer.kind === "dismissed") {
+          return okResult({
+            kind: "dismissed",
+            note: "The user did not answer. Do not ask again — continue with your single best interpretation and state the assumption you made.",
+          });
+        }
+        return okResult(answer);
       },
     },
   ];

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tool-executor.ts
@@ -377,7 +377,7 @@ async function executeResolvedUiTool(
   def: UiToolDefinition,
   opts: Pick<
     HandleUiToolCallOptions,
-    "toolName" | "toolCallId" | "input" | "addToolOutput"
+    "toolName" | "toolCallId" | "input" | "addToolOutput" | "telemetryScope"
   >,
   approval: UiToolCallApproval,
 ): Promise<void> {
@@ -391,7 +391,15 @@ async function executeResolvedUiTool(
       input && typeof input === "object" && !Array.isArray(input)
         ? (input as Record<string, unknown>)
         : {};
-    output = await def.execute(args);
+    // Identity of the call, not just its arguments: tools that park on user
+    // input (`ui_ask_user`) key their pending state on the tool-call id, and
+    // scope cancellation to the asking conversation.
+    output = await def.execute(args, {
+      toolCallId,
+      ...(opts.telemetryScope !== undefined
+        ? { scope: opts.telemetryScope }
+        : {}),
+    });
   } catch (error) {
     threw = true;
     output = {
@@ -522,7 +530,13 @@ export async function handleUiToolCall(
 
   await executeResolvedUiTool(
     def,
-    { toolName, toolCallId, input, addToolOutput },
+    {
+      toolName,
+      toolCallId,
+      input,
+      addToolOutput,
+      telemetryScope: opts.telemetryScope,
+    },
     "not_required",
   );
   return true;
@@ -595,7 +609,13 @@ export async function fulfillApprovedUiToolCall(opts: {
 
   await executeResolvedUiTool(
     def,
-    { toolName, toolCallId, input, addToolOutput },
+    {
+      toolName,
+      toolCallId,
+      input,
+      addToolOutput,
+      telemetryScope: opts.telemetryScope ?? stashed?.telemetryScope,
+    },
     "approved",
   );
 }

--- a/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/ui-tools-registry.ts
@@ -31,6 +31,27 @@ export interface UiToolResult {
   isError?: boolean;
 }
 
+/**
+ * Per-call context handed to `execute`, for the few tools that need to know
+ * WHICH call they are rather than just their arguments.
+ *
+ * Optional on the signature so the catalog's ordinary tools — and the tests
+ * that invoke them directly — keep working with a single argument. Only the
+ * executor supplies it.
+ */
+export interface UiToolExecuteContext {
+  /**
+   * The streamed tool-call id. Required by tools that park on user input
+   * (`ui_ask_user`): it's the key the rendered card resolves against.
+   */
+  toolCallId: string;
+  /**
+   * The caller's chatSessionId. Lets a parked tool be cancelled per
+   * conversation instead of globally.
+   */
+  scope?: string;
+}
+
 export interface UiToolDefinition {
   /** Model-facing tool name. Must match `UI_TOOL_NAME_REGEX` (`ui_*`). */
   name: string;
@@ -59,7 +80,10 @@ export interface UiToolDefinition {
    * it to the server.
    */
   mayNavigate?: boolean;
-  execute: (args: Record<string, unknown>) => Promise<UiToolResult>;
+  execute: (
+    args: Record<string, unknown>,
+    ctx?: UiToolExecuteContext,
+  ) => Promise<UiToolResult>;
 }
 
 // Server-mirrored limits for the chat POST snapshot (same as app tools).

--- a/mcpjam-inspector/client/src/lib/webmcp/wait-for-tool-output.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/wait-for-tool-output.ts
@@ -1,0 +1,69 @@
+/**
+ * Wait for client-fulfilled tool calls to reach a terminal output state.
+ *
+ * WHY THIS EXISTS: settling a parked UI tool (a dismissed `ui_ask_user`) only
+ * resolves the promise `execute` is sitting on. `execute` then returns on a
+ * later microtask, and the executor writes `addToolOutput` after that. Any
+ * caller that starts a NEW request in between snapshots the assistant message
+ * with the tool part still `input-available` — a tool call carrying no result,
+ * which both Anthropic and OpenAI reject as an invalid message history.
+ *
+ * Polls rather than subscribing because the authoritative state lives in the
+ * SDK's own message array, which offers no per-part completion hook. The wait
+ * is bounded and NON-fatal on timeout: a stuck output is a bug, but blocking
+ * the user's message forever would be a worse one, so we give up and let the
+ * send proceed.
+ */
+
+/** Terminal = any `output-*` state (available, error, denied). */
+function isTerminalState(state: unknown): boolean {
+  return typeof state === "string" && state.startsWith("output-");
+}
+
+interface MessageLike {
+  parts?: unknown[];
+}
+
+/**
+ * Resolve once every id in `toolCallIds` has a terminal part — or once
+ * `timeoutMs` elapses.
+ *
+ * `getMessages` is a thunk, not an array: the SDK replaces the messages array
+ * on every update, so a captured reference would never show the output land.
+ *
+ * Returns true when everything settled, false on timeout — callers may use it
+ * for telemetry, but must not treat false as a reason to drop the send.
+ */
+export async function waitForTerminalToolParts(
+  getMessages: () => MessageLike[],
+  toolCallIds: string[],
+  { timeoutMs = 2000, pollMs = 10 }: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<boolean> {
+  if (toolCallIds.length === 0) return true;
+  const wanted = new Set(toolCallIds);
+  const deadline = Date.now() + timeoutMs;
+
+  const allTerminal = () => {
+    const seen = new Set<string>();
+    for (const message of getMessages()) {
+      if (!Array.isArray(message.parts)) continue;
+      for (const part of message.parts) {
+        const candidate = part as { toolCallId?: string; state?: unknown };
+        if (!candidate.toolCallId || !wanted.has(candidate.toolCallId)) continue;
+        if (isTerminalState(candidate.state)) seen.add(candidate.toolCallId);
+      }
+    }
+    return seen.size === wanted.size;
+  };
+
+  // Check before waiting: the output can already be there (a re-emitted call
+  // the executor settled synchronously), and an unconditional sleep would add
+  // latency to every send.
+  if (allTerminal()) return true;
+
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    if (allTerminal()) return true;
+  }
+  return false;
+}

--- a/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
+++ b/mcpjam-inspector/server/routes/web/mcpjam-agent.ts
@@ -122,6 +122,12 @@ const AGENT_IDENTITY_PROMPT = [
   "When the user asks a QUESTION about the product — how something works, how to do something, what a feature can do — search the MCPJam documentation first and answer from what it says; the screen atlas below tells you where things live, not how they behave, so don't answer product behavior from it alone. Then, if you can carry the answer out in the app, offer to — and wait for a yes before acting.",
   "Use web search for questions beyond MCPJam itself. You have no other way to act — when something isn't reachable through a `ui_*` tool, say so plainly rather than inventing a tool or claiming you did it.",
   "When the user wants to add or try an MCP server but hasn't named one, ask which server they'd like to connect — never invent a placeholder server (there is no default \"weather\" server). If they just want a quick example to try, offer these real ones: `https://mcp.excalidraw.com/mcp` (streamable HTTP, no auth) or `https://mcp.mcpjam.com/mcp` (an OAuth example). Only add a server once you have a concrete name and URL from the user or from one of these examples.",
+  // Clarification policy. The `ui_ask_user` tool's own description carries
+  // the mechanics; this is the behavioural threshold, which belongs with the
+  // identity because over-asking is what makes an assistant feel worse, not
+  // better. Deliberately biased AGAINST asking: acting on the dominant
+  // reading and naming the assumption is recoverable, an interruption isn't.
+  "Prefer acting on the most likely reading over asking. Use `ui_ask_user` only when a request is genuinely ambiguous AND the readings would lead you to do materially different things — otherwise pick the strongest reading, do it, and say in one clause what you assumed. Never ask for something the UI context on the user's message or `ui_snapshot_app` already tells you (which screen they're on, which server is selected). Search the docs and read the app first, so that if you do ask, the choices are informed. Never change anything before asking.",
   "Keep replies short: lead with the answer in a few sentences, no filler, no restating the question. If the docs don't settle it, say you're not sure rather than guessing.",
   "",
   // The atlas: what screens exist and what they're for. Derived from the

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -257,6 +257,13 @@ export const ANALYTICS_EVENTS = {
   // ui_tool_call_started / ui_tool_call_completed: lifecycle of one ui_*
   //   client-fulfilled tool call (outcome, approval, structured error code,
   //   duplicate-call detection).
+  // agent_ask_user_resolved: one clarifying question settled (outcome:
+  //   selected | freeText | dismissed, option_count, time_to_answer_ms).
+  //   The ask-threshold tuning signal: a high freeText share means the
+  //   model's options are wrong; a high dismissed share means it is
+  //   over-asking. The question, its labels, and any free-text answer are
+  //   the user's own words and are NEVER emitted.
+  agent_ask_user_resolved: { source: "client" },
   agent_turn_completed: { source: "client" },
   ui_navigation_rejected: { source: "client" },
   ui_tool_call_completed: { source: "client" },

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -257,8 +257,10 @@ export const ANALYTICS_EVENTS = {
   // ui_tool_call_started / ui_tool_call_completed: lifecycle of one ui_*
   //   client-fulfilled tool call (outcome, approval, structured error code,
   //   duplicate-call detection).
-  // agent_ask_user_resolved: one clarifying question settled (outcome:
-  //   selected | freeText | dismissed, option_count, time_to_answer_ms).
+  // agent_ask_user_resolved: one clarifying question settled. Payload:
+  //   location, outcome (selected | freeText | dismissed), option_count,
+  //   time_to_answer_ms, and — on a dismissal only — dismiss_reason
+  //   (new_message | stopped | session_evicted).
   //   The ask-threshold tuning signal: a high freeText share means the
   //   model's options are wrong; a high dismissed share means it is
   //   over-asking. The question, its labels, and any free-text answer are


### PR DESCRIPTION
## What

Gives the MCPJam in-app agent a way to **ask instead of guess**. When a request is genuinely ambiguous, it renders a multiple-choice card inline in the thread; the user picks (or answers in their own words), and the same turn continues with the answer.

```
Could you clarify what you mean by "docs server"?
┌──────────────────────────────────────┐
│ What are you trying to do?           │
│  1  Connect to a local MCP server    │
│  2  Connect to a remote MCP server   │
│  3  Build/run an MCP server          │
│  4  Something else                   │
└──────────────────────────────────────┘
```

## How

It rides the existing client-fulfilled seam — the server registers it no-execute, the stream pauses, the browser resolves it through `addToolOutput`. **No new transport, no server-side state, no change to the paused-stream contract.** `ui_ask_user` is simply a UI tool whose "execution" is waiting for a click.

## Design decisions worth reviewing

**Core group, not a surface group.** A clarifying question has to be available wherever the agent is, like `ui_navigate`. Catalog goes 16 → 17.

**Read-only, so it never gates.** A confirmation pill on a question would be a click to permit a click. It is explicitly *not* a substitute for the pill either — asking "shall I delete this?" on a card is not an approval, because the destructive tool that follows is a separate call carrying its own annotations. Written into `ADDING_SURFACE_TOOLS.md` so nobody "improves" it later.

**The parked promise lives outside React**, for the same reason `agent-chat-instances.ts` hoists the `Chat`: the surface painting the card can be replaced mid-question by the Home → side-panel handoff, and a promise owned by a component would die with it.

**Every path settles.** This is the invariant the tests are built around. An unresolved question is an `execute` that never returns — a paused stream that never resumes, invisible until a user is staring at a spinner. So: new message, stop, and instance eviction all dismiss, **scoped by `chatSessionId`** so a background turn in another session is untouched. A reloaded transcript with nothing parked renders as *expired* rather than offering dead buttons.

**A dismissal is a normal result, not an error.** `isError` would invite the model to retry the question — the one response that's certainly wrong once the user has moved on. The payload tells it to continue on its best interpretation and state the assumption.

**The free-text escape hatch is the renderer's job, not the model's.** A closed set of model-authored choices could trap a user whose intent isn't listed, so "Something else" is always present and the tool description tells the model not to author its own.

## Also in this PR

- `execute` gains an optional context `{ toolCallId, scope }` — the call's identity, which isn't derivable from its arguments and is what the card resolves against. Optional, so existing tools and their direct-invocation tests are unchanged.
- A clarification **threshold** on `AGENT_IDENTITY_PROMPT` (still static — the cacheable prefix is unaffected), deliberately biased *against* asking. Over-asking is what makes an assistant feel worse; acting on the dominant reading and naming the assumption is recoverable, an interruption isn't.
- `agent_ask_user_resolved` telemetry: outcome / option_count / time_to_answer_ms. That's the tuning signal — high `freeText` share means the options are wrong, high `dismissed` means it's over-asking. The question, its labels, and any free-text answer are the user's own words and are **never** emitted (there's a test that greps the payload for them).

## Testing

Full suite green: **11,698 passed**, client typecheck clean.

New coverage: store lifecycle (settle-once under double-click, scoped dismissal, telemetry redaction, throwing-analytics still settles), the tool's argument contract (bounds, dedupe, bare-string options, no-toolCallId fails fast rather than hanging), all three card states, and the executor's context plumbing.

## Follow-ups (not here)

- Whether guided tours should suppress it — they're where users are most confused, so probably not, but the tour prompt shouldn't make it chatty.
- Whether the native-agent mirror should exclude it: a browser-native agent has its own clarify affordance, so exposing ours risks double-prompting.
- The Slack agent can reuse this contract with Block Kit buttons — the input shape (`question` + 2–4 `options` + always-on free text) was kept surface-agnostic for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the agent turn loop (auto-resume, async submit, message history validity) and shared chat instance eviction; mistakes could strand turns or send invalid histories to providers, though coverage is extensive.
> 
> **Overview**
> Adds **`ui_ask_user`** so the in-app agent can pause a turn on an **inline multiple-choice card** (with a fixed **“Something else”** free-text path) instead of guessing when ambiguity would change what it does.
> 
> The tool is a **read-only core UI tool** whose `execute` **parks on a module-scoped store** keyed by `toolCallId` and session `scope`; the thread renders **`AskUserPart`** when **`useAskUserCallIsOurs`** proves the call is ours (not a homonymous MCP server tool). **`submit`** and **`stop`** dismiss pending questions per session, **`waitForTerminalToolParts`** avoids sending with unresolved tool parts, and **`shouldAutoResumeTurn`** records dismissals but **does not auto-resume** on them. Detached sessions stuck on a question are **evictable** and dismissed as **`session_evicted`**.
> 
> Also extends **`UiToolDefinition.execute`** with optional **`{ toolCallId, scope }`**, updates the agent identity prompt toward **act-first / ask-rarely**, adds **`agent_ask_user_resolved`** telemetry (no question/answer text), and pins **`ai` SDK** behavior in new canaries and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9487520e90de3fe60ff962fc2cbef39dd5a6466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ui_ask_user`: an inline multiple-choice card that lets the in-app agent ask a clarifying question when a request is truly ambiguous, then continues the same turn with the user’s answer. Also fixes dismissal handling so the agent never resumes or sends the next message before the tool output lands.

- **New Features**
  - Renders a read-only question card with 2–4 options and an always-on “Something else”; shows only when our `ui_ask_user` is registered.
  - Runs as a CORE UI tool via the client-fulfilled seam (`addToolOutput`); all paths settle (new message, stop, or session eviction), scoped by `chatSessionId`. Card states: pending, read-only, resolving, answered, and true “expired” only after reloads.
  - Telemetry `agent_ask_user_resolved` (outcome, option_count, time_to_answer_ms; dismiss_reason on dismissals), with question/labels/free-text redacted. Prompt updated to prefer the dominant reading and ask only when ambiguity would change the action.

- **Bug Fixes**
  - `submit` is async and waits for dismissed ask-user calls to reach a terminal tool-part via `waitForTerminalToolParts` (bounded; avoids shipping an `input-available` tool call in the next request).
  - Suppresses auto-resume on a dismissed `ui_ask_user`; the result is still recorded for a valid history. Answered questions still resume.
  - Evicts detached sessions parked on a question and settles them; attached sessions stay.
  - Per-call provenance gate: the card renders only when the specific call is ours (parked/answered/output-decoded), so server tools named `ui_ask_user` aren’t hijacked.
  - Tightened input rules: dedupe by label and value (after truncation), labels are truncated for display, and over-long option values are rejected (not trimmed). Dismissal copy corrected to “the assistant stopped here.”
  - `UiToolDefinition.execute` accepts optional `{ toolCallId, scope }`; the executor supplies it so parked questions resolve/cancel per conversation. Added SDK canaries to pin behavior and tests for store lifecycle, card states, executor context, and the new wait.

<sup>Written for commit c9487520e90de3fe60ff962fc2cbef39dd5a6466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

