### PR TITLE
fix(elicitation): stop stripping url mode from modern local connections

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/elicitation-local-modes.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/elicitation-local-modes.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { narrowElicitationToLocalSupport } from "../elicitation.js";
+import {
+  initElicitationCallback,
+  narrowElicitationToLocalSupport,
+} from "../elicitation.js";
 
 /**
  * The local SSE bridge is form-only. These lock "advertise = enforce" on that
@@ -115,5 +118,78 @@ describe("narrowElicitationToLocalSupport", () => {
         caps,
       );
     });
+  });
+});
+
+/**
+ * The connect-time narrowing keeps `url` for any connection that CAN land
+ * modern, which includes the unpinned auto-negotiating one. When such a
+ * connection lands legacy instead, this bridge is the fulfiller — and the SDK
+ * will pass a url request through, because we advertised url. Refuse it rather
+ * than render a form the user cannot complete.
+ */
+describe("initElicitationCallback — url mode on the legacy bridge", () => {
+  function captureCallback() {
+    let callback: any;
+    const manager = {
+      setElicitationCallback: (cb: any) => {
+        callback = cb;
+      },
+      getPendingElicitations: () => new Map(),
+    } as any;
+    initElicitationCallback(manager);
+    return callback;
+  }
+
+  it("rejects a url-mode request instead of broadcasting a form", async () => {
+    const callback = captureCallback();
+    await expect(
+      callback({
+        requestId: "r1",
+        serverId: "srv",
+        message: "Open the dashboard",
+        mode: "url",
+        url: "https://example.com/dash",
+      }),
+    ).rejects.toThrow(/URL-mode elicitation is not supported/);
+  });
+
+  it("does not fabricate a user decision", async () => {
+    // Resolving {action:"decline"} would tell the server the user declined.
+    // No user was ever asked.
+    const callback = captureCallback();
+    const result = await callback({
+      requestId: "r2",
+      message: "m",
+      mode: "url",
+      url: "https://example.com",
+    }).catch((err: Error) => err);
+    expect(result).toBeInstanceOf(Error);
+  });
+
+  it("leaves form mode on the normal path", async () => {
+    const callback = captureCallback();
+    // Form requests return a pending promise (resolved later by the SSE
+    // response route), so assert it stays unsettled rather than rejecting.
+    const settled = await Promise.race([
+      callback({ requestId: "r3", message: "m", schema: {} }).then(
+        () => "settled",
+        () => "rejected",
+      ),
+      Promise.resolve("pending"),
+    ]);
+    expect(settled).toBe("pending");
+  });
+
+  it("treats an absent mode as form (pre-2025-11-25 back-compat)", async () => {
+    const callback = captureCallback();
+    const settled = await Promise.race([
+      callback({ requestId: "r4", message: "m" }).then(
+        () => "settled",
+        () => "rejected",
+      ),
+      Promise.resolve("pending"),
+    ]);
+    expect(settled).toBe("pending");
   });
 });

--- a/mcpjam-inspector/server/routes/mcp/__tests__/elicitation-local-modes.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/elicitation-local-modes.test.ts
@@ -65,4 +65,55 @@ describe("narrowElicitationToLocalSupport", () => {
     narrowElicitationToLocalSupport(caps);
     expect(caps).toEqual({ elicitation: { form: {}, url: {} } });
   });
+
+  describe("urlCapable — the MRTR bridge fulfils this connection", () => {
+    it("keeps a declared url", () => {
+      // The MRTR bridge completes url rounds through UrlElicitationConsent, so
+      // pruning url here is what made every modern url-mode tool fail with
+      // -32021 before the server could ever ask.
+      expect(
+        narrowElicitationToLocalSupport(
+          { roots: {}, elicitation: { form: {}, url: {} } },
+          { urlCapable: true },
+        ),
+      ).toEqual({ roots: {}, elicitation: { form: {}, url: {} } });
+    });
+
+    it("keeps a url-only declaration instead of dropping the capability", () => {
+      expect(
+        narrowElicitationToLocalSupport(
+          { elicitation: { url: {} } },
+          { urlCapable: true },
+        ),
+      ).toEqual({ elicitation: { url: {} } });
+    });
+
+    it("never INVENTS url — a form-only declaration stays form-only", () => {
+      // The flag widens what may SURVIVE narrowing; it is not an advertisement
+      // in its own right. A host profile that declares form-only (emulating a
+      // host that has no url support) must go on the wire unchanged.
+      expect(
+        narrowElicitationToLocalSupport(
+          { elicitation: { form: {} } },
+          { urlCapable: true },
+        ),
+      ).toEqual({ elicitation: { form: {} } });
+    });
+
+    it("still prunes unknown modes", () => {
+      expect(
+        narrowElicitationToLocalSupport(
+          { elicitation: { form: {}, url: {}, telepathy: {} } },
+          { urlCapable: true },
+        ),
+      ).toEqual({ elicitation: { form: {}, url: {} } });
+    });
+
+    it("leaves bare {} untouched (form-only by the back-compat rule)", () => {
+      const caps = { elicitation: {} };
+      expect(narrowElicitationToLocalSupport(caps, { urlCapable: true })).toBe(
+        caps,
+      );
+    });
+  });
 });

--- a/mcpjam-inspector/server/routes/mcp/elicitation.ts
+++ b/mcpjam-inspector/server/routes/mcp/elicitation.ts
@@ -35,31 +35,51 @@ const registeredManagers = new WeakSet<MCPClientManager>();
  * no one has hit the elicitation routes yet.
  */
 /**
- * Elicitation modes the LOCAL bridge can actually complete.
+ * Elicitation modes the LOCAL bridges can actually complete.
  *
- * This SSE flow is form-only: it broadcasts `{requestId, message, schema}` and
- * resolves with form content. URL mode needs the URL to reach a consent dialog
- * and returns no content — neither of which this pipeline carries. (Hosted
- * chat has its own bridge, `routes/web/hosted-elicitation.ts`, which does both.)
+ * TWO bridges fulfil this one capability, split by era, and only one of them
+ * carries url:
+ *
+ * - **Legacy (2025-11-25 and earlier)** — elicitation arrives as an inbound
+ *   `elicitation/create` handled by the SSE flow in this module, which is
+ *   form-only: it broadcasts `{requestId, message, schema}` and resolves with
+ *   form content. The SDK's elicitation callback does not even surface `mode`
+ *   or `url`, so a url request would reach the user as a form with nothing to
+ *   fill in and no way to finish.
+ * - **Modern (2026-07-28)** — elicitation arrives exclusively inside an
+ *   `input_required` result, handled by the MRTR bridge (`routes/mcp/mrtr.ts`
+ *   → `MrtrElicitationHost`), which completes BOTH modes: form rounds through
+ *   `ElicitationDialog`, url rounds through `UrlElicitationConsent`.
+ *
+ * (Hosted chat has its own bridge, `routes/web/hosted-elicitation.ts`, which
+ * does both on either era and never comes through here.)
  */
-const LOCAL_SUPPORTED_ELICITATION_MODES = ["form"] as const;
+const LOCAL_FORM_ONLY_ELICITATION_MODES = ["form"] as const;
+const LOCAL_URL_CAPABLE_ELICITATION_MODES = ["form", "url"] as const;
 
 /**
- * Drop elicitation modes the local bridge can't complete before they reach the
- * wire.
+ * Drop elicitation modes the local bridge for this connection can't complete,
+ * before they reach the wire.
  *
- * Advertising `url` here would be a lie with teeth: the SDK would accept a
- * conforming url-mode request, this bridge would drop the `url`, and the user
- * would get a form with nothing to fill in and no way to finish the
- * interaction. Not advertising it means the SDK rejects such requests with
- * `-32602` and the server can fall back — which is the honest outcome until the
- * local pipeline carries URL mode end to end.
+ * Advertising `url` on a connection whose only fulfiller is the form-only SSE
+ * bridge would be a lie with teeth: the SDK would accept a conforming url-mode
+ * request, the bridge would drop the `url`, and the user would get a form they
+ * cannot complete. Not advertising it means the request is rejected and the
+ * server can fall back — the honest outcome.
+ *
+ * `urlCapable` is the caller's assertion that this connection's fulfiller is
+ * the MRTR bridge (see {@link LOCAL_URL_CAPABLE_ELICITATION_MODES}). It is a
+ * per-connection fact, not a global one, which is why it is a parameter:
+ * `local-server-resolver.ts` derives it from the transport and the protocol
+ * pins. Passing `true` never INVENTS the mode — it only stops pruning a `url`
+ * the host config actually declared.
  *
  * Only prunes; a config that never mentioned elicitation is returned untouched
  * so this can sit on the shared local path without inventing capabilities.
  */
 export function narrowElicitationToLocalSupport(
   capabilities: Record<string, unknown> | undefined,
+  options?: { urlCapable?: boolean },
 ): Record<string, unknown> | undefined {
   const elicitation = capabilities?.elicitation;
   if (
@@ -76,8 +96,12 @@ export function narrowElicitationToLocalSupport(
   // rewriting it would churn configs for no behavior change.
   if (Object.keys(declared).length === 0) return capabilities;
 
+  const supportedModes = options?.urlCapable
+    ? LOCAL_URL_CAPABLE_ELICITATION_MODES
+    : LOCAL_FORM_ONLY_ELICITATION_MODES;
+
   const narrowed: Record<string, unknown> = {};
-  for (const mode of LOCAL_SUPPORTED_ELICITATION_MODES) {
+  for (const mode of supportedModes) {
     if (declared[mode] !== undefined) narrowed[mode] = declared[mode];
   }
   // Everything was unsupported (e.g. `{url:{}}`): declaring `elicitation: {}`

--- a/mcpjam-inspector/server/routes/mcp/elicitation.ts
+++ b/mcpjam-inspector/server/routes/mcp/elicitation.ts
@@ -43,9 +43,11 @@ const registeredManagers = new WeakSet<MCPClientManager>();
  * - **Legacy (2025-11-25 and earlier)** — elicitation arrives as an inbound
  *   `elicitation/create` handled by the SSE flow in this module, which is
  *   form-only: it broadcasts `{requestId, message, schema}` and resolves with
- *   form content. The SDK's elicitation callback does not even surface `mode`
- *   or `url`, so a url request would reach the user as a form with nothing to
- *   fill in and no way to finish.
+ *   form content. It carries no url and its dialog has no consent surface, so
+ *   a url request would reach the user as a form with nothing to fill in and
+ *   no way to finish. (The SDK does hand `mode` and `url` to the callback —
+ *   see `initElicitationCallback`, which uses `mode` to refuse rather than to
+ *   fulfil.)
  * - **Modern (2026-07-28)** — elicitation arrives exclusively inside an
  *   `input_required` result, handled by the MRTR bridge (`routes/mcp/mrtr.ts`
  *   → `MrtrElicitationHost`), which completes BOTH modes: form rounds through
@@ -121,7 +123,32 @@ export function initElicitationCallback(manager: MCPClientManager): void {
 
   // Per MCP Tasks spec (2025-11-25), elicitations related to a task include relatedTaskId
   manager.setElicitationCallback(
-    ({ requestId, serverId, message, schema, relatedTaskId }) => {
+    ({ requestId, serverId, message, schema, relatedTaskId, mode }) => {
+      // BACKSTOP for the one case the connect-time narrowing cannot cover.
+      //
+      // `narrowElicitationToLocalSupport` keeps `elicitation.url` for any
+      // connection that *can* land modern, which includes the unpinned
+      // auto-negotiating one — and auto lands legacy against a legacy server.
+      // Capabilities are declared before the era is knowable, so such a
+      // connection advertises url and then gets fulfilled by THIS form-only
+      // bridge. The SDK's own mode gate (`assertElicitationModeDeclared`)
+      // checks the request against what was advertised, so it passes url
+      // through here: we said url was fine.
+      //
+      // Refusing is the honest answer. Resolving `{action:"decline"}` would
+      // fabricate a user decision that no user made; an error tells the server
+      // its request could not be handled, which is what a client that cannot
+      // render the consent surface owes it.
+      if (mode === "url") {
+        return Promise.reject(
+          new Error(
+            "URL-mode elicitation is not supported on this connection: it " +
+              "negotiated a pre-2026 protocol revision, whose inbound " +
+              "elicitation bridge is form-only. URL mode is available on " +
+              "2026-07-28 connections, where it is served over MRTR.",
+          ),
+        );
+      }
       return new Promise<ElicitResult>((resolve, reject) => {
         try {
           manager.getPendingElicitations().set(requestId, { resolve, reject });

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
@@ -1121,3 +1121,68 @@ describe("enterprise-managed authorization policy (xaaPolicy)", () => {
     });
   });
 });
+
+describe("toMCPServerConfig — elicitation url mode is era-gated", () => {
+  const CAPS = { elicitation: { form: {}, url: {} } };
+
+  it("keeps url on an unpinned HTTP connection (auto-negotiation can land modern)", () => {
+    // The common case: the default MCPJam client with Protocol version
+    // "Automatic". Pruning url here made every url-mode tool on a 2026 server
+    // fail with -32021 before the server could ask.
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {
+      clientCapabilities: CAPS,
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({
+      form: {},
+      url: {},
+    });
+  });
+
+  it("keeps url on a modern pin", () => {
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {
+      clientCapabilities: CAPS,
+      mcpProtocolVersion: "2026-07-28" as any,
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({
+      form: {},
+      url: {},
+    });
+  });
+
+  it("strips url on a legacy pin — the inbound SSE bridge is form-only", () => {
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {
+      clientCapabilities: CAPS,
+      mcpProtocolVersion: "2025-11-25" as any,
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({ form: {} });
+  });
+
+  it("strips url when the accept-list names no stateless version", () => {
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {
+      clientCapabilities: CAPS,
+      supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({ form: {} });
+  });
+
+  it("keeps url when the accept-list includes a stateless version", () => {
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {
+      clientCapabilities: CAPS,
+      supportedProtocolVersions: ["2026-07-28", "2025-11-25"],
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({
+      form: {},
+      url: {},
+    });
+  });
+
+  it("strips url on stdio — the modern era is HTTP-only", () => {
+    // The SDK factory throws StatelessRequiresHttpTransport for a stateless
+    // pin on stdio, so a stdio connection is always fulfilled by the legacy
+    // form-only bridge.
+    const config: any = toMCPServerConfig(stdioAuth, {
+      clientCapabilities: CAPS,
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({ form: {} });
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
@@ -1186,3 +1186,37 @@ describe("toMCPServerConfig — elicitation url mode is era-gated", () => {
     expect(config.clientCapabilities.elicitation).toEqual({ form: {} });
   });
 });
+
+describe("toMCPServerConfig — malformed protocol versions fail closed", () => {
+  const CAPS = { elicitation: { form: {}, url: {} } };
+
+  it("strips url when the accept-list holds only unrecognized versions", () => {
+    // `isStatelessProtocolVersion` is a DENY-list: unrecognized strings answer
+    // `true`. Without the membership check first, a typo would advertise url
+    // on a connection that lands legacy.
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {
+      clientCapabilities: CAPS,
+      supportedProtocolVersions: ["2025-11-52", "totally-bogus"],
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({ form: {} });
+  });
+
+  it("keeps url when a real stateless version sits beside a typo", () => {
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {
+      clientCapabilities: CAPS,
+      supportedProtocolVersions: ["2026-07-28", "2025-11-52"],
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({
+      form: {},
+      url: {},
+    });
+  });
+
+  it("strips url on an unrecognized pin", () => {
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth, {
+      clientCapabilities: CAPS,
+      mcpProtocolVersion: "2025-11-52" as any,
+    });
+    expect(config.clientCapabilities.elicitation).toEqual({ form: {} });
+  });
+});

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -8,6 +8,7 @@ import {
 import {
   describeError,
   isKnownProtocolVersion,
+  isStatelessProtocolVersion,
   isUnauthorized401,
   type McpProtocolVersion,
 } from "@mcpjam/sdk";
@@ -415,6 +416,43 @@ export function parseConnectionDefaults(
 }
 
 /**
+ * Can this connection land on the 2026-era (modern) protocol?
+ *
+ * Deliberately asks the NEGATIVE question — "is a modern landing ruled out?" —
+ * and defaults to `true`. That is the difference from the `isModernOnlyLocalConnection`
+ * predicate this supersedes (see `withLocalMrtrElicitationCapability` in
+ * `routes/mcp/mrtr.ts`): proving a connection *must* land modern is impossible
+ * for the common case, an unpinned auto-negotiated connection, where auto in
+ * fact lands modern against a modern server. Proving it *cannot* is decidable
+ * from the config alone, which is all this needs — the only cost of a `true`
+ * here is that a url the host config already declared stays declared.
+ *
+ * Ruled out by:
+ * - **stdio** — the SDK factory throws `StatelessRequiresHttpTransport`; the
+ *   modern era is HTTP-only, so a stdio connection is always legacy.
+ * - **a legacy protocol pin** — an explicit non-stateless `mcpProtocolVersion`.
+ * - **a legacy-only accept-list** — a `supportedProtocolVersions` naming no
+ *   stateless version, so negotiation cannot arrive at one.
+ */
+function canLandModernEra(
+  serverConfig: { transportType?: string },
+  options?: {
+    mcpProtocolVersion?: McpProtocolVersion;
+    supportedProtocolVersions?: string[];
+  }
+): boolean {
+  if (serverConfig.transportType !== "http") return false;
+  if (options?.mcpProtocolVersion) {
+    return isStatelessProtocolVersion(options.mcpProtocolVersion);
+  }
+  const acceptList = options?.supportedProtocolVersions;
+  if (acceptList && acceptList.length > 0) {
+    return acceptList.some((version) => isStatelessProtocolVersion(version));
+  }
+  return true;
+}
+
+/**
  * Build an `MCPServerConfig` (the SDK's union of stdio + http configs) from a
  * local authorize result. Distinct from hosted's `toHttpConfig` which strips
  * STDIO and rejects non-HTTPS — this is the unstripped local-mode equivalent.
@@ -502,11 +540,13 @@ export function toMCPServerConfig(
       resolveEffectiveAuthMethod(serverConfig, options?.xaaPolicy) === "xaa")
       ? withXaaExtensionCapability(baseClientCapabilities)
       : baseClientCapabilities;
-  // Advertise = enforce: the local elicitation bridge is form-only, so a config
-  // declaring `elicitation.url` (the host toggle can write it) must not put url
-  // on the wire — the SDK would accept the request and the bridge would drop
-  // the URL, leaving the user a form they cannot complete.
-  const clientCapabilities = narrowElicitationToLocalSupport(xaaMerged);
+  // Advertise = enforce, per era. The MODERN fulfiller (the MRTR bridge)
+  // completes url rounds; the LEGACY one (the inbound `elicitation/create` SSE
+  // bridge) is form-only. So `elicitation.url` — which the host toggle writes —
+  // may go on the wire only for a connection that can actually land modern.
+  const clientCapabilities = narrowElicitationToLocalSupport(xaaMerged, {
+    urlCapable: canLandModernEra(serverConfig, options),
+  });
 
   if (serverConfig.transportType === "stdio") {
     const stdio: any = {

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -433,6 +433,16 @@ export function parseConnectionDefaults(
  * - **a legacy protocol pin** — an explicit non-stateless `mcpProtocolVersion`.
  * - **a legacy-only accept-list** — a `supportedProtocolVersions` naming no
  *   stateless version, so negotiation cannot arrive at one.
+ *
+ * ## Why every version goes through `isKnownProtocolVersion` first
+ *
+ * `isStatelessProtocolVersion` is a DENY-list (`!STATEFUL.has(v)`), so it
+ * answers `true` for any unrecognized string — its own docblock says to call
+ * it only after the membership check. `supportedProtocolVersions` is taken
+ * verbatim from the host profile and validated for non-emptiness only, so a
+ * typo (`"2025-11-52"`) would otherwise classify as stateless and put `url` on
+ * a connection that lands legacy — inverting this predicate's fail-closed
+ * direction on exactly the malformed input where it matters most.
  */
 function canLandModernEra(
   serverConfig: { transportType?: string },
@@ -441,13 +451,16 @@ function canLandModernEra(
     supportedProtocolVersions?: string[];
   }
 ): boolean {
+  const isModernVersion = (version: string): boolean =>
+    isKnownProtocolVersion(version) && isStatelessProtocolVersion(version);
+
   if (serverConfig.transportType !== "http") return false;
   if (options?.mcpProtocolVersion) {
-    return isStatelessProtocolVersion(options.mcpProtocolVersion);
+    return isModernVersion(options.mcpProtocolVersion);
   }
   const acceptList = options?.supportedProtocolVersions;
   if (acceptList && acceptList.length > 0) {
-    return acceptList.some((version) => isStatelessProtocolVersion(version));
+    return acceptList.some(isModernVersion);
   }
   return true;
 }


### PR DESCRIPTION
## Symptom

Every URL-mode elicitation from a modern (2026-07-28) server fails in local mode before the server can ask. Reproduced against `stateless.mcpjam.com/mcp`, tool `open-dashboard`:

```
-32021 Missing required client capability
Cannot request input 'visit' (elicitation/create): the request's client
capabilities do not declare the required capability
```

The connection's Client settings had **Elicitation → URL mode** ticked, and the host config's `clientCapabilities` really did carry `elicitation: { form: {}, url: {} }`. The declaration was being dropped between the config and the wire.

## Root cause

`toMCPServerConfig` narrows the declared capabilities through `narrowElicitationToLocalSupport`, whose supported-mode list was the module constant `["form"]` — unconditionally, for every local connection. `{ form: {}, url: {} }` came out as `{ form: {} }`, and the server's mode-aware capability gate then correctly refused to embed a url-mode `elicitation/create`.

The form-only rationale was sound when written, but it describes only **one of the two** local fulfillers:

- **Legacy (2025-11-25 and earlier)** — elicitation arrives as an inbound `elicitation/create` served by the SSE bridge in `routes/mcp/elicitation.ts`. That one really is form-only: it broadcasts `{requestId, message, schema}`, and the SDK's elicitation callback does not even surface `mode` or `url`, so a url round would reach the user as a form they cannot complete.
- **Modern (2026-07-28)** — elicitation arrives exclusively inside an `input_required` result, served by the MRTR bridge, which completes **both** modes: form rounds through `ElicitationDialog`, url rounds through `UrlElicitationConsent` (`MrtrElicitationHost.tsx:184`).

So the guard was a legacy-bridge constraint applied to a pipeline that does not have it. The url half of MRTR was fully built — route (`mrtr.ts:115`), validation (`shared/mrtr-continuation.ts:248`), consent dialog — and unreachable in local mode for any server.

### Why the existing era seam didn't already cover this

`withLocalMrtrElicitationCapability` (`routes/mcp/mrtr.ts`) declares `{form, url}` for the modern era via the SDK's `eraCapabilities.modern` overlay, which is the right mechanism. But it early-returns when the config carries an exact `clientCapabilities` set, and the SDK ignores `eraCapabilities` for exact sets by the same rule. Every host-configured connection sets an exact set, so on the path that matters the overlay never applied. Widening the exact set inside the SDK is not the fix — that rule is what keeps host-compat profile emulation faithful.

## Fix

Make the narrowing per-connection rather than global. `narrowElicitationToLocalSupport` takes a `urlCapable` flag; the resolver derives it from the connection:

```ts
const clientCapabilities = narrowElicitationToLocalSupport(xaaMerged, {
  urlCapable: canLandModernEra(serverConfig, options),
});
```

`canLandModernEra` deliberately asks the **negative** question — "is a modern landing ruled out?" — and defaults to `true`. That is the difference from the `isModernOnlyLocalConnection` predicate this supersedes: proving a connection *must* land modern is impossible for the common case (an unpinned, auto-negotiating connection — where auto in fact lands modern against a modern server), which is why that predicate was removed. Proving it *cannot* is decidable from the config alone, and that is all this needs. Modern is ruled out by:

- **stdio** — the modern era is HTTP-only (`StatelessRequiresHttpTransport`), so a stdio connection is always served by the legacy bridge;
- **a legacy protocol pin** — an explicit non-stateless `mcpProtocolVersion`;
- **a legacy-only accept-list** — a `supportedProtocolVersions` naming no stateless version.

The only cost of a `true` is that a url the host config *already declared* stays declared.

Every version is checked with `isKnownProtocolVersion` before `isStatelessProtocolVersion`. The latter is a **deny-list** (`!STATEFUL.has(v)`) and answers `true` for anything unrecognized — its own docblock says to call it only after the membership check. `supportedProtocolVersions` is taken verbatim from the host profile and validated for non-emptiness only, so without the guard a typo like `"2025-11-52"` would classify as stateless and advertise url on a connection that lands legacy: fail-*open* on exactly the malformed input where the predicate matters most.

### Two properties this deliberately keeps

- **`urlCapable` never invents `url`.** It widens what may survive narrowing; it is not an advertisement in its own right. A form-only host profile stays form-only on a modern connection, so host-compat emulation (a Cursor / VS Code profile) is byte-identical to before.
- **Legacy still fails closed**, by two different mechanisms. A *pinned* legacy connection keeps getting `{ form: {} }` at connect time. An *unpinned* one cannot be decided at connect time at all — capabilities are declared before the era is knowable — so it advertises url and, if it then lands legacy, is refused at request time by the bridge itself (below). Actually carrying url on legacy still needs that bridge to gain a consent surface; it can reuse `UrlElicitationConsent`.

## The one case the connect-time gate cannot cover

`canLandModernEra` returns `true` for an unpinned connection, which is correct — auto-negotiation lands modern against a modern server. But against a *legacy* server the same connection lands legacy, having already advertised url. The SDK's inbound mode gate (`assertElicitationModeDeclared`) checks the request against **what was advertised**, so it passes url straight through to the form-only bridge: we told it url was fine.

So the callback in `routes/mcp/elicitation.ts` now refuses `mode === "url"` outright. Refusing with an error — rather than resolving `{ action: "decline" }` — is deliberate: declining would report a user decision that no user made. An error says the client could not handle the request, which is what a client with no consent surface owes the server.

This is the backstop, not the mechanism; the connect-time narrowing still does the work everywhere it can decide.

## Verification

- Manually confirmed end to end against `stateless.mcpjam.com` on `2026-07-28`: `open-dashboard` now reaches `UrlElicitationConsent`, the opened URL's `?session=` nonce matches the nonce echoed in round two's `structuredContent`, and the tool returns `URL elicitation outcome: accept`.
- `npx vitest run --project server server/routes/mcp server/utils` → 137 files, **1861 tests passed**.
- `npx tsc --noEmit -p server/tsconfig.json` → 90 errors, **exactly matching the unmodified baseline** (stash-and-compare); none in any touched file.
- **Every guard test was mutation-checked** — each new assertion was re-run against the code with its own guard disabled, and each failed. The three "keeps url" tests fail with the call site reverted; the two deny-list tests fail with the `isKnownProtocolVersion` check removed; the two url-refusal tests *time out at 30s* with the `mode === "url"` branch disabled, which is the unfinishable form the refusal exists to prevent, reproduced. The "strips url" tests pass either way by design — they pin behavior this PR intentionally leaves alone.

### Tests added

`server/routes/mcp/__tests__/elicitation-local-modes.test.ts` — url survives under `urlCapable`; a url-only declaration is no longer dropped wholesale; **a form-only declaration is not widened**; unknown modes are still pruned; bare `{}` still passes through untouched. Plus the legacy bridge: a url request rejects rather than broadcasting a form, no `{action}` is fabricated, and form mode (explicit or absent, the pre-2025-11-25 back-compat case) still returns a pending promise on the normal path.

`server/utils/__tests__/local-server-resolver.test.ts` — the era gate through the real `toMCPServerConfig`: url kept on an unpinned HTTP connection (the reported case) and on a modern pin or a stateless-bearing accept-list; url stripped on a legacy pin, on a legacy-only accept-list, and on stdio. Malformed input fails closed: an accept-list of only unrecognized versions strips url, an unrecognized pin strips url, and a real stateless version beside a typo still keeps it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
