### PR TITLE
fix(api): agent turns fail to author suites — opaque validation error + discovery step-waste

### DIFF
--- a/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
@@ -119,6 +119,27 @@ function turnRequest(
 
 const OK_BODY = { messages: [{ role: "user", content: "hello" }] };
 
+// Schema-valid create input (the adapter pre-validates against the op's
+// real schema before executing).
+const VALID_CREATE_INPUT = {
+  name: "smoke",
+  servers: ["srv"],
+  model: "anthropic/claude-haiku-4.5",
+  cases: [
+    {
+      title: "t1",
+      steps: [
+        { id: "s1", kind: "prompt", prompt: "hello" },
+        {
+          id: "s2",
+          kind: "assert",
+          assertion: { type: "toolCalledAtLeastOnce", toolName: "echo" },
+        },
+      ],
+    },
+  ],
+};
+
 function okTurnResult(overrides: Record<string, unknown> = {}) {
   return {
     messages: [],
@@ -319,7 +340,7 @@ describe("POST /api/v1/projects/:projectId/agent", () => {
     // the suite is persisted, so the 500 must still reference it.
     runUnifiedAssistantTurnMock.mockImplementation(async (opts: any) => {
       await opts.tools[createEvalSuiteOperation.name].execute(
-        { name: "smoke", servers: ["srv"], model: "m", cases: [] },
+        VALID_CREATE_INPUT,
         {}
       );
       return okTurnResult({ turnTrace: undefined });
@@ -423,6 +444,23 @@ describe("agent tool surface", () => {
     executeSpy.mockRestore();
   });
 
+  it("returns field-addressed validation errors (not a bare 'Invalid input')", async () => {
+    const tools = buildAgentApiToolSet({
+      client: {} as PlatformApiClient,
+      projectId: "p1",
+      created: [],
+    });
+    const tool = tools[createEvalSuiteOperation.name]! as {
+      execute: (input: unknown, ctx: unknown) => Promise<unknown>;
+    };
+    // Missing model + cases entirely — the model must learn WHICH fields.
+    const result = (await tool.execute({ name: "x" }, {})) as {
+      error?: string;
+    };
+    expect(result.error).toContain("fix these fields");
+    expect(result.error).toMatch(/model|cases|servers/);
+  });
+
   it("advertises `project` as optional even when the op requires it", () => {
     const tools = buildAgentApiToolSet({
       client: {} as PlatformApiClient,
@@ -477,7 +515,7 @@ describe("agent tool surface", () => {
       execute: (input: unknown, ctx: unknown) => Promise<unknown>;
     };
     const result = (await tool.execute(
-      { name: "smoke", servers: ["srv"], model: "m", cases: [] },
+      VALID_CREATE_INPUT,
       {}
     )) as Record<string, unknown>;
     expect(created).toEqual([

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -184,11 +184,29 @@ export function buildAgentApiToolSet(opts: {
         if (requested && requested !== opts.projectId) {
           return { error: PROJECT_SCOPE_ERROR };
         }
+        // Pre-validate against the op's REAL schema and return a
+        // field-addressed error: downstream validation (the v1 route's
+        // parseWithSchema) flattens zod failures to a bare "Invalid input",
+        // which gives the model nothing to correct — it wanders off to docs
+        // and burns the step budget instead of fixing the field.
+        const clamped = { ...input, project: opts.projectId };
+        const parsed = (
+          operation.inputSchema as z.ZodType<Record<string, unknown>>
+        ).safeParse(clamped);
+        if (!parsed.success) {
+          const issues = parsed.error.issues
+            .slice(0, 5)
+            .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+            .join("; ");
+          return {
+            error: `Invalid input for ${operation.name} — fix these fields and retry: ${issues}`,
+          };
+        }
         try {
-          const result = await operation.execute(
-            { ...input, project: opts.projectId },
-            { client: opts.client, signal: abortSignal }
-          );
+          const result = await operation.execute(parsed.data, {
+            client: opts.client,
+            signal: abortSignal,
+          });
           if (operation.name === createEvalSuiteOperation.name) {
             const suite = (result as { suite?: { id?: string; name?: string } })
               ?.suite;
@@ -257,6 +275,7 @@ const AGENT_API_SYSTEM_PROMPT = [
   `- When creating a suite, set the suite \`model\` explicitly to \`${DEFAULT_SUITE_MODEL}\` unless the user asks for a different model.`,
   "- You CANNOT run suites, and must not claim to. After creating a suite, tell the user it's ready to run and report its id — the surface you're hosted in offers the run action separately.",
   "- Always report the ids of anything you created.",
+  "- Tool input schemas are AUTHORITATIVE. Never consult docs to learn a tool's argument shape — the schema you were given is the truth. If a tool returns a validation error naming fields, correct exactly those fields and retry the same call.",
   "- Consult the MCPJam docs tools (when available) for product questions instead of answering from memory.",
   "- Keep replies concise and concrete. If the request is ambiguous, ask instead of inventing.",
 ].join("\n");
@@ -274,7 +293,7 @@ const MAX_MESSAGE_BYTES = 8_192;
  * smaller envelope since every byte is resent each turn and billed.
  */
 const MAX_TOTAL_MESSAGE_BYTES = 98_304; // 96 KB
-const MAX_STEPS = 12;
+const MAX_STEPS = 16;
 const TURN_WALL_CLOCK_MS = 90_000;
 /** In-process per-org concurrent-turn cap (same shape as evals' run cap). */
 const MAX_CONCURRENT_TURNS_PER_ORG = 4;
@@ -501,6 +520,9 @@ agent.post("/projects/:projectId/agent", async (c) => {
       systemPrompt: AGENT_API_SYSTEM_PROMPT,
       builtInTools,
       skillsSource: { kind: "none" },
+      // The toolset is small and fixed — discovery meta-tools would only
+      // add search/load indirection steps and hide the op schemas.
+      progressiveToolDiscovery: { enabled: false },
     });
 
     const chatSessionId = randomUUID();


### PR DESCRIPTION
First live dogfood turn of the Slack bot exposed two compounding failures in `POST /projects/:id/agent` (#3629):

1. **`create_eval_suite` failed with a bare `{"error":"Invalid input"}`** — `parseWithSchema` surfaces only the first zod issue's message, and zod v4's default message is literally "Invalid input" with no field path. The model had nothing to correct, so it wandered off to the docs server and burned its remaining steps (observed: 13 tool calls, 144k input tokens, no suite created). The tool adapter now pre-validates against the op's real schema and returns **field-addressed errors** (`cases.0.steps.1.assertion.type: …`) the model can act on in one retry; the system prompt states tool schemas are authoritative and forbids consulting docs for schemas.
2. **Progressive discovery meta-tools were pure waste here** — search/load indirection cost 3–4 steps per turn and hid the op schemas behind a load step, for a toolset of ~8 fixed operations. Disabled for this endpoint.

Also raises `maxSteps` 12 → 16 so a validation-error retry fits comfortably.

Tests: +1 (field-addressed validation error); the create-fixture inputs upgraded to schema-valid shapes (the pre-validation now correctly rejects the old `cases: []` shortcut). 22/22 agent tests green.

Follow-up worth considering separately: `parseWithSchema` dropping the issue path affects every v1 route's 400s, not just this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the v1 agent route and tool adapter; improves model-facing errors without changing auth or eval execution paths.
> 
> **Overview**
> Fixes agent turns failing to create eval suites when `create_eval_suite` rejected input with an unhelpful **"Invalid input"** message. The agent tool adapter now **pre-validates** each platform op with its real Zod schema (after project clamp) and returns **field-path errors** the model can fix in one retry, instead of relying on downstream v1 validation that drops paths.
> 
> **Turn efficiency:** `progressiveToolDiscovery` is turned **off** for this endpoint so the small fixed op set is exposed directly without search/load meta-tools. **`MAX_STEPS`** goes **12 → 16** to leave room for a validation retry.
> 
> **Prompt:** adds a rule that tool input schemas are authoritative—retry on named fields, don’t use docs for argument shapes.
> 
> **Tests:** `VALID_CREATE_INPUT` fixture for schema-valid creates; new test for field-addressed validation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4897a53881e1bcad61b52805de70d7b27a4ae2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes agent turns on `POST /projects/:projectId/agent` that failed to create eval suites due to opaque validation errors, and removes wasted discovery steps. Returns clear, field-scoped schema errors and slightly expands the step budget to allow a quick retry.

- **Bug Fixes**
  - Pre-validate tool input against the operation’s schema and return field-addressed errors (e.g., `cases.0.steps.1.assertion.type`) instead of a bare "Invalid input"; system prompt now makes schemas authoritative and instructs correcting named fields before retrying.
  - Disable progressive tool discovery for this endpoint to avoid search/load indirection and keep op schemas visible.
  - Raise `MAX_STEPS` from 12 to 16 to accommodate a validation-retry.
  - Tests: add a validation-error test; update create-suite fixtures to schema-valid inputs.

<sup>Written for commit c4897a53881e1bcad61b52805de70d7b27a4ae2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

