### PR TITLE
feat(swarms): generate personas and journeys against environments

### DIFF
--- a/mcpjam-inspector/client/src/components/project-environments/environment-picker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/environment-picker.tsx
@@ -47,6 +47,7 @@ export function EnvironmentPicker({
   className,
   triggerTestId,
   triggerAriaLabel,
+  inModal = false,
 }: {
   projectId: string;
   /** Selected id(s). Single-select accepts `string | null`. */
@@ -64,6 +65,13 @@ export function EnvironmentPicker({
   /** Test hook + a11y label for the trigger, for callers that key on them. */
   triggerTestId?: string;
   triggerAriaLabel?: string;
+  /**
+   * Render the popover INLINE rather than in a portal, for callers that live
+   * inside a Radix Dialog. A portalled popover lands outside the dialog, where
+   * the modal overlay's `pointer-events: none` on the body swallows every
+   * click. Same escape hatch, same name, as `ServerGroupPicker`.
+   */
+  inModal?: boolean;
 }) {
   // Include archived so a still-attached archived row can surface and be
   // detached (see the doc block above).
@@ -168,7 +176,12 @@ export function EnvironmentPicker({
           )}
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-1" align="start" sideOffset={4}>
+      <PopoverContent
+        className="w-72 p-1"
+        align="start"
+        sideOffset={4}
+        portalled={!inModal}
+      >
         <div className="px-2 pb-1 pt-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
           {multi ? "Environments · run order" : "Environments"}
         </div>

--- a/mcpjam-inspector/client/src/components/swarms/GenerateSwarmDialog.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/GenerateSwarmDialog.tsx
@@ -5,12 +5,27 @@
  *   - `persona`  — generate one persona AND its journeys in a single click.
  *   - `journeys` — generate journeys for the already-selected persona.
  *
- * The dialog picks the grounding + targets (server group → the tool inventory
- * the prompt is grounded in; clients + journey count → what the created rows
- * target). Generation itself is a backend call; the rows are then created
- * through the ordinary `personas:createPersona` / `journeys:createJourney`
- * mutations so every existing validation applies and the results land as real,
- * editable rows. Running them stays a separate explicit click.
+ * The dialog picks the grounding + targets (a tool inventory the prompt is
+ * grounded in; targets + journey count → what the created rows run against).
+ * Generation itself is a backend call; the rows are then created through the
+ * ordinary `personas:createPersona` / `journeys:createJourney` mutations so
+ * every existing validation applies and the results land as real, editable
+ * rows. Running them stays a separate explicit click.
+ *
+ * TARGET MODE mirrors the new-journey form (`NewJourneyButton`): "environments"
+ * (Project Environments — the default whenever the flag is on and the project
+ * has at least one environment) or the legacy "clients" mode. Env submits send
+ * `environmentIds` + compat `hostIds` recomputed from those environments and
+ * OMIT `serverAttachmentId`, exactly like the manual form — see
+ * `journey-environments.ts` for that invariant.
+ *
+ * GROUNDING in env mode comes from the FIRST selected environment's own server
+ * group. The generation endpoints take a `serverAttachmentId` and nothing
+ * env-shaped, so an environment that defines no standalone server group cannot
+ * ground a generation today; the dialog blocks and says so rather than
+ * silently grounding on some other environment's tools. Env-native grounding
+ * (resolving the host's own server picks backend-side) is the follow-up that
+ * removes that restriction.
  */
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, Sparkles } from "lucide-react";
@@ -26,10 +41,17 @@ import {
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
+import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
 import {
   SwarmHostMultiSelect,
   type SwarmHostItem,
 } from "@/components/swarms/swarm-host-multi-select";
+import {
+  buildEnvJourneyPayload,
+  MAX_ENVIRONMENTS_PER_JOURNEY,
+} from "@/components/swarms/journey-environments";
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+import { cn } from "@/lib/utils";
 import {
   generateSwarmJourneys,
   generateSwarmPersona,
@@ -61,6 +83,10 @@ export interface GenerateSwarmDialogProps {
   onOpenChange: (open: boolean) => void;
   projectId: string;
   hosts: SwarmHostItem[];
+  /** Live project environments (flag-gated; empty when the flag is off). */
+  environments?: ProjectEnvironmentView[];
+  /** `project-environments-enabled` — gates the env target mode entirely. */
+  environmentsEnabled?: boolean;
   /** Live persona count; gates the 200-per-project cap in `persona` mode. */
   personaCount?: number;
   /** Required in `journeys` mode: the persona the journeys are generated for. */
@@ -73,14 +99,19 @@ export interface GenerateSwarmDialogProps {
     avatarShape: number;
     avatarPalette: number;
   }) => Promise<string>;
-  /** Creates one journey row against the given persona. */
+  /**
+   * Creates one journey row against the given persona. Exactly one of
+   * `serverAttachmentId` (clients mode) / `environmentIds` (env mode) is sent
+   * — the same two shapes the manual new-journey form writes.
+   */
   onCreateJourney: (
     personaRefId: string,
     draft: {
       name?: string;
       goal: string;
       hostIds: string[];
-      serverAttachmentId: string;
+      serverAttachmentId?: string;
+      environmentIds?: string[];
       config: { sessionsPerHost: number; maxTurns: number };
     }
   ) => Promise<void>;
@@ -94,6 +125,8 @@ export function GenerateSwarmDialog({
   onOpenChange,
   projectId,
   hosts,
+  environments = [],
+  environmentsEnabled = false,
   personaCount,
   persona,
   onCreatePersona,
@@ -104,6 +137,16 @@ export function GenerateSwarmDialog({
     null
   );
   const [hostIds, setHostIds] = useState<string[]>([]);
+  const [environmentIds, setEnvironmentIds] = useState<string[]>([]);
+  // Target mode is DERIVED until the user picks one, so environments arriving
+  // after mount (the Convex list is reactive) still select env mode instead of
+  // stranding the dialog on the legacy default. `null` = untouched.
+  const [modeOverride, setModeOverride] = useState<
+    "clients" | "environments" | null
+  >(null);
+  const targetMode: "clients" | "environments" = environmentsEnabled
+    ? modeOverride ?? (environments.length > 0 ? "environments" : "clients")
+    : "clients";
   const [journeyCount, setJourneyCount] = useState(DEFAULT_JOURNEY_COUNT);
   const [pending, setPending] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -122,6 +165,8 @@ export function GenerateSwarmDialog({
     if (!open) {
       setServerAttachmentId(null);
       setHostIds([]);
+      setEnvironmentIds([]);
+      setModeOverride(null);
       setJourneyCount(DEFAULT_JOURNEY_COUNT);
       setPending(false);
       setErrorMessage(null);
@@ -144,6 +189,30 @@ export function GenerateSwarmDialog({
     [hostIds, hosts]
   );
 
+  // Env-mode journey payload: `environmentIds` + compat `hostIds`. Null when
+  // the selection is unusable (empty, or an id that no longer resolves because
+  // another member archived it mid-dialog) — the same gate the manual form
+  // uses, so a stale id can never be persisted or spend generation quota.
+  const envPayload = useMemo(
+    () => buildEnvJourneyPayload(environmentIds, environments),
+    [environmentIds, environments]
+  );
+
+  // Grounding in env mode is the FIRST selected environment's own server
+  // group. `undefined` server group = "the host's own server picks", which the
+  // generation endpoints cannot resolve — surfaced as a blocking hint rather
+  // than quietly grounding on a different environment.
+  const groundingEnvironment = useMemo(
+    () =>
+      environmentIds.length > 0
+        ? environments.find((e) => e.environmentId === environmentIds[0]) ??
+          null
+        : null,
+    [environmentIds, environments]
+  );
+  const envGroundingAttachmentId =
+    groundingEnvironment?.serverAttachmentId ?? null;
+
   const countValid =
     Number.isInteger(journeyCount) &&
     journeyCount >= MIN_GENERATED_JOURNEYS &&
@@ -154,20 +223,26 @@ export function GenerateSwarmDialog({
   // mode stays disabled until the count is known.
   const personaCountKnown =
     mode !== "persona" || typeof personaCount === "number";
+  const targetsValid =
+    targetMode === "environments"
+      ? envPayload !== null && !!envGroundingAttachmentId
+      : !!serverAttachmentId && liveHostIds.length > 0;
   const canSubmit =
     !pending &&
     !personaCommitted &&
     personaCountKnown &&
-    !!serverAttachmentId &&
-    liveHostIds.length > 0 &&
+    targetsValid &&
     countValid;
 
   const createJourneyRows = async (
     personaRefId: string,
     journeys: SwarmGeneratedJourney[],
-    attachmentId: string,
     /** Snapshotted at submit — see `handleGenerate`. Never the live state. */
-    targetHostIds: string[]
+    target: {
+      hostIds: string[];
+      serverAttachmentId?: string;
+      environmentIds?: string[];
+    }
   ): Promise<{ created: number; firstError: Error | null }> => {
     let created = 0;
     let firstError: Error | null = null;
@@ -176,8 +251,7 @@ export function GenerateSwarmDialog({
         await onCreateJourney(personaRefId, {
           ...(journey.name ? { name: journey.name } : {}),
           goal: journey.goal,
-          hostIds: targetHostIds,
-          serverAttachmentId: attachmentId,
+          ...target,
           config: { sessionsPerHost: 1, maxTurns: 6 },
         });
         created += 1;
@@ -196,7 +270,15 @@ export function GenerateSwarmDialog({
   };
 
   const handleGenerate = async () => {
-    if (!serverAttachmentId || liveHostIds.length === 0 || !countValid) return;
+    if (!targetsValid || !countValid) return;
+    // Grounding id, resolved BEFORE the latch: `targetsValid` already proves
+    // it exists, but reading it here keeps every early return on the
+    // latch-free side (see the comment below).
+    const isEnvMode = targetMode === "environments";
+    const attachmentId = isEnvMode
+      ? envGroundingAttachmentId
+      : serverAttachmentId;
+    if (!attachmentId) return;
     // Every rejection that returns WITHOUT entering the try/finally below must
     // come before the latch is taken — otherwise the latch is never released
     // and the button is silently dead until the dialog is reopened.
@@ -217,19 +299,29 @@ export function GenerateSwarmDialog({
     generateInFlightRef.current = true;
     setPending(true);
     setErrorMessage(null);
-    // Snapshot BOTH targets at submit. Generation is a slow round-trip and the
-    // pickers stay mounted, so reading live state after the await would let a
-    // mid-flight change retarget the created rows — or clear the host list and
-    // fail every mutation — after the quota was already spent.
-    const attachmentId = serverAttachmentId;
-    const targetHostIds = [...liveHostIds];
+    // Snapshot BOTH grounding and targets at submit. Generation is a slow
+    // round-trip and the pickers stay mounted, so reading live state after the
+    // await would let a mid-flight change retarget the created rows — or clear
+    // the selection and fail every mutation — after the quota was already
+    // spent. In env mode the journey rows carry `environmentIds` + compat
+    // `hostIds` and OMIT `serverAttachmentId` (that id only grounds the
+    // prompt); in clients mode the shape is unchanged.
+    const target =
+      isEnvMode && envPayload
+        ? {
+            hostIds: [...envPayload.hostIds],
+            environmentIds: [...envPayload.environmentIds],
+          }
+        : { hostIds: [...liveHostIds], serverAttachmentId: attachmentId };
 
     try {
       if (mode === "persona") {
         track("swarm_generate_persona_started", {
           location: "swarms",
           journeyCount,
-          hostCount: hostIds.length,
+          hostCount: target.hostIds.length,
+          targetMode,
+          environmentCount: target.environmentIds?.length ?? 0,
         });
         const result = await generateSwarmPersona({
           projectId,
@@ -255,8 +347,7 @@ export function GenerateSwarmDialog({
         const { created, firstError } = await createJourneyRows(
           personaRefId,
           result.journeys,
-          attachmentId,
-          targetHostIds
+          target
         );
         // The persona landed either way — select it so the new row is visible
         // even when every journey write failed.
@@ -291,7 +382,9 @@ export function GenerateSwarmDialog({
       track("swarm_generate_journeys_started", {
         location: "swarms",
         journeyCount,
-        hostCount: hostIds.length,
+        hostCount: target.hostIds.length,
+        targetMode,
+        environmentCount: target.environmentIds?.length ?? 0,
       });
       const result = await generateSwarmJourneys({
         projectId,
@@ -311,8 +404,7 @@ export function GenerateSwarmDialog({
       const { created, firstError } = await createJourneyRows(
         persona._id,
         result.journeys,
-        attachmentId,
-        targetHostIds
+        target
       );
       // Every write failed (deleted server group, rejected goals, …): surface
       // the mutation error instead of closing on a "0 of N" success toast —
@@ -349,12 +441,16 @@ export function GenerateSwarmDialog({
   };
 
   const title = mode === "persona" ? "Generate persona" : "Generate journeys";
+  const grounding =
+    targetMode === "environments"
+      ? "grounded in your environment's tools"
+      : "grounded in a server group's tools";
   const description =
     mode === "persona"
-      ? "Generates one persona and its journeys, grounded in a server group's tools. Everything lands as editable rows — nothing runs until you say so."
+      ? `Generates one persona and its journeys, ${grounding}. Everything lands as editable rows — nothing runs until you say so.`
       : `Generates journeys for ${
           persona?.name ?? "this persona"
-        }, grounded in a server group's tools. Nothing runs until you say so.`;
+        }, ${grounding}. Nothing runs until you say so.`;
 
   return (
     <Dialog
@@ -375,31 +471,102 @@ export function GenerateSwarmDialog({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3 py-1">
-          <div className="flex flex-col gap-1.5">
-            <Label>Server group</Label>
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <ServerGroupPicker
-                projectId={projectId}
-                value={serverAttachmentId}
-                onChange={(id) => setServerAttachmentId(id)}
-                onClearSelection={() => setServerAttachmentId(null)}
-                emptyTriggerLabel="No server group · pick one"
-                infoText="The tools in this group ground what gets generated, and every created journey runs against it."
-                inModal
-              />
+          {environmentsEnabled ? (
+            <div
+              className="flex items-center gap-1 text-[11px]"
+              role="radiogroup"
+              aria-label="Generation target mode"
+            >
+              {[
+                { value: "environments" as const, label: "Environments" },
+                { value: "clients" as const, label: "Clients" },
+              ].map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={targetMode === opt.value}
+                  data-testid={`generate-target-mode-${opt.value}`}
+                  onClick={() => setModeOverride(opt.value)}
+                  className={cn(
+                    "rounded-full border px-2 py-0.5 font-medium transition-colors",
+                    targetMode === opt.value
+                      ? "border-primary/50 bg-primary/10 text-foreground"
+                      : "border-border/60 text-muted-foreground hover:bg-muted/50"
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
             </div>
-          </div>
+          ) : null}
 
-          <div className="flex flex-col gap-1.5">
-            <Label>Clients</Label>
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <SwarmHostMultiSelect
-                hosts={hosts}
-                hostIds={hostIds}
-                onToggle={toggleHost}
-              />
+          {targetMode === "environments" ? (
+            /* Env mode: the shared ordered ≤10 environment multi-select. Each
+               environment carries its own host + server group + skills, so
+               there is no separate server-group / clients pair to pick. */
+            <div className="flex flex-col gap-1.5">
+              <Label>Environments</Label>
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <EnvironmentPicker
+                  projectId={projectId}
+                  value={environmentIds}
+                  onChange={setEnvironmentIds}
+                  multi
+                  max={MAX_ENVIRONMENTS_PER_JOURNEY}
+                  emptyLabel="No environments · pick one"
+                  triggerTestId="generate-environments-picker"
+                  triggerAriaLabel="Attached environments"
+                  inModal
+                />
+              </div>
+              {environments.length === 0 ? (
+                <p className="text-[11px] leading-snug text-muted-foreground">
+                  This project has no environments yet. Create one, or switch to
+                  Clients.
+                </p>
+              ) : environmentIds.length > 0 && !envGroundingAttachmentId ? (
+                <p className="text-[11px] leading-snug text-muted-foreground">
+                  {groundingEnvironment?.name ?? "The first environment"} has no
+                  server group, so there are no tools to ground generation in.
+                  Add one to that environment, or switch to Clients.
+                </p>
+              ) : (
+                <p className="text-[11px] leading-snug text-muted-foreground">
+                  Generation is grounded in the first environment's tools; every
+                  created journey fans out across all of them.
+                </p>
+              )}
             </div>
-          </div>
+          ) : (
+            <>
+              <div className="flex flex-col gap-1.5">
+                <Label>Server group</Label>
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <ServerGroupPicker
+                    projectId={projectId}
+                    value={serverAttachmentId}
+                    onChange={(id) => setServerAttachmentId(id)}
+                    onClearSelection={() => setServerAttachmentId(null)}
+                    emptyTriggerLabel="No server group · pick one"
+                    infoText="The tools in this group ground what gets generated, and every created journey runs against it."
+                    inModal
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <Label>Clients</Label>
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <SwarmHostMultiSelect
+                    hosts={hosts}
+                    hostIds={hostIds}
+                    onToggle={toggleHost}
+                  />
+                </div>
+              </div>
+            </>
+          )}
 
           <div className="flex items-center gap-2">
             <Label

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -1061,6 +1061,8 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
           }}
           projectId={projectId}
           hosts={hosts ?? []}
+          environments={environments ?? []}
+          environmentsEnabled={environmentsEnabled}
           personaCount={personas?.length}
           {...(selectedPersona
             ? {
@@ -1423,10 +1425,21 @@ function NewJourneyButton({
   const [serverAttachmentId, setServerAttachmentId] = useState<string | null>(
     null
   );
-  // Target mode: "clients" (legacy, unchanged) vs "environments" (flag-gated).
+  // Target mode: "environments" (flag-gated, and the default as soon as the
+  // project HAS an environment — environments are how Swarms is meant to think
+  // about targets) vs "clients" (legacy, unchanged and still one click away).
+  const defaultTargetMode: "clients" | "environments" =
+    environmentsEnabled && environments.length > 0 ? "environments" : "clients";
   const [targetMode, setTargetMode] = useState<"clients" | "environments">(
-    "clients"
+    defaultTargetMode
   );
+  // Kept current in an effect (never assigned during render) and declared
+  // BEFORE the open-reset effect below so it is already up to date when that
+  // one runs in the same commit.
+  const defaultTargetModeRef = useRef(defaultTargetMode);
+  useEffect(() => {
+    defaultTargetModeRef.current = defaultTargetMode;
+  }, [defaultTargetMode]);
   const [environmentIds, setEnvironmentIds] = useState<string[]>([]);
   const [sessionsPerHost, setSessionsPerHost] = useState(2);
   const [maxTurns, setMaxTurns] = useState(6);
@@ -1444,9 +1457,13 @@ function NewJourneyButton({
       setGoal(goalSeed);
       setJudgeConfig(undefined);
       setAdvancedOpen(false);
-      setTargetMode("clients");
+      setTargetMode(defaultTargetModeRef.current);
       setEnvironmentIds([]);
     }
+    // `defaultTargetMode` is read through a ref ON PURPOSE: the environments
+    // list is reactive, so listing it as a dependency would re-run this reset
+    // — wiping a goal the user is mid-way through typing — the moment a
+    // teammate adds an environment.
   }, [open, goalSeed]);
   const setOpen = onOpenChange;
 
@@ -1495,8 +1512,8 @@ function NewJourneyButton({
           aria-label="Journey target mode"
         >
           {[
-            { value: "clients" as const, label: "Clients" },
             { value: "environments" as const, label: "Environments" },
+            { value: "clients" as const, label: "Clients" },
           ].map((opt) => (
             <button
               key={opt.value}
@@ -1685,7 +1702,7 @@ function NewJourneyButton({
             setGoal("");
             setHostIds([]);
             setEnvironmentIds([]);
-            setTargetMode("clients");
+            setTargetMode(defaultTargetModeRef.current);
             setServerAttachmentId(null);
             setJudgeConfig(undefined);
           }}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.envJourneyForm.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.envJourneyForm.test.tsx
@@ -66,6 +66,9 @@ const environments = [
   },
 ];
 
+/** Mutable so a test can render a project that has NO environments yet. */
+let environmentList: typeof environments = [];
+
 const { createJourneyMutation } = vi.hoisted(() => ({
   createJourneyMutation: vi.fn(),
 }));
@@ -81,7 +84,7 @@ vi.mock("convex/react", () => ({
       case "hosts:listHosts":
         return [host, hostTwo];
       case "projectEnvironments:listEnvironments":
-        return environments;
+        return environmentList;
       default:
         return undefined;
     }
@@ -130,6 +133,7 @@ import { SwarmsTab } from "../SwarmsTab";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  environmentList = environments;
   createJourneyMutation.mockResolvedValue({ _id: "journey-new" });
 });
 
@@ -198,9 +202,20 @@ describe("SwarmsTab — new journey form env mode", () => {
   // NOTE: this suite mocks out `ServerGroupPicker`, so a clients-mode submit
   // can't be driven to completion here — the payload-level byte-compatibility
   // assertion lives in the sibling `SwarmsTab.journeyForm` suite (flag OFF).
-  // What IS specific to this suite is that turning the flag ON must not change
-  // the default mode or leak the env picker into clients mode.
-  it("defaults to clients mode with no env surface when the env flag is on", async () => {
+  it("defaults to environments mode once the project HAS an environment", async () => {
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openForm();
+
+    expect(
+      screen.getByTestId("journey-target-mode-environments")
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByTestId("journey-environments-picker")
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to clients mode when the flag is on but no environment exists", async () => {
+    environmentList = [];
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
     openForm();
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.generateEnv.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.generateEnv.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * AI generation dialog ENV MODE (Project Environments): the flag-gated target
+ * toggle, grounding on the FIRST selected environment's server group, and the
+ * create payload invariant — generated journeys land with `environmentIds` +
+ * compat `hostIds` and OMIT `serverAttachmentId`, exactly like the manual
+ * new-journey form.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({ availableModels: [] }),
+}));
+
+// Flag ON for this suite (the sibling `SwarmsTab.generate` suite runs with it
+// off, and asserts the legacy clients-mode behaviour is unchanged).
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => true,
+}));
+
+vi.mock("@/contexts/db-user-ready-context", () => ({
+  useDbUserReady: () => true,
+}));
+
+const persona = {
+  _id: "persona-1",
+  personaId: "p1",
+  name: "Persona One",
+  role: "tester",
+  notes: "",
+};
+const host = {
+  hostId: "host-1",
+  name: "Host One",
+  modelId: "openai/gpt-4o-mini",
+  ownerScope: { type: "journeys" },
+};
+const hostTwo = {
+  hostId: "host-2",
+  name: "Host Two",
+  modelId: "anthropic/claude-haiku-4.5",
+  ownerScope: { type: "journeys" },
+};
+
+/** `Prod-like` carries a server group (it can ground); `Bare` does not. */
+const environments = [
+  {
+    environmentId: "env-1",
+    projectId: "proj-1",
+    name: "Prod-like",
+    hostId: "host-1",
+    serverAttachmentId: "att-env-1",
+    revision: 1,
+  },
+  {
+    environmentId: "env-2",
+    projectId: "proj-1",
+    name: "Staging-like",
+    hostId: "host-2",
+    serverAttachmentId: "att-env-2",
+    revision: 1,
+  },
+  {
+    environmentId: "env-3",
+    projectId: "proj-1",
+    name: "Bare",
+    hostId: "host-2",
+    revision: 1,
+  },
+];
+
+const {
+  createPersonaMutation,
+  createJourneyMutation,
+  generatePersonaMock,
+  toastMock,
+} = vi.hoisted(() => ({
+  createPersonaMutation: vi.fn(),
+  createJourneyMutation: vi.fn(),
+  generatePersonaMock: vi.fn(),
+  toastMock: { success: vi.fn(), error: vi.fn() },
+}));
+
+let personaList: Array<Record<string, unknown>> = [];
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    switch (name) {
+      case "personas:listPersonas":
+        return personaList;
+      case "journeys:listJourneysByPersona":
+        return [];
+      case "hosts:listHosts":
+        return [host, hostTwo];
+      case "projectEnvironments:listEnvironments":
+        return environments;
+      default:
+        return undefined;
+    }
+  },
+  useMutation: (name: string) => {
+    if (name === "personas:createPersona") return createPersonaMutation;
+    if (name === "journeys:createJourney") return createJourneyMutation;
+    return vi.fn().mockResolvedValue(undefined);
+  },
+  usePaginatedQuery: () => ({
+    results: [],
+    status: "Exhausted",
+    loadMore: vi.fn(),
+    isLoading: false,
+  }),
+  useConvexAuth: () => ({ isAuthenticated: true }),
+}));
+
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServerAttachments: () => ({
+    serverAttachments: [],
+    isLoading: false,
+  }),
+  useProjectServers: () => ({ servers: [], isLoading: false }),
+  useDbUserReady: () => true,
+}));
+
+vi.mock("@/components/hosts/ServerGroupPicker", () => ({
+  ServerGroupPicker: () => (
+    <button type="button" data-testid="mock-server-group-picker">
+      No server group · pick one
+    </button>
+  ),
+}));
+
+vi.mock("@/lib/swarm-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/swarm-api")>();
+  return {
+    ...actual,
+    launchJourneyRun: vi.fn(),
+    generateSwarmPersona: (...args: unknown[]) => generatePersonaMock(...args),
+    generateSwarmJourneys: vi.fn(),
+  };
+});
+
+vi.mock("@/components/connection/share-usage/ShareUsageThreadDetail", () => ({
+  ShareUsageThreadDetail: () => null,
+}));
+vi.mock("@/lib/chatbox-session", () => ({
+  getShareableAppOrigin: () => "https://app.test",
+}));
+vi.mock("@/lib/toast", () => ({ toast: toastMock }));
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { SwarmsTab } from "../SwarmsTab";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  personaList = [persona];
+  createPersonaMutation.mockImplementation(async (args: any) => {
+    const row = { ...args, _id: "persona-new", personaId: "pnew" };
+    personaList = [...personaList, row];
+    return row;
+  });
+  createJourneyMutation.mockResolvedValue({ _id: "journey-new" });
+});
+
+function openGeneratePersona() {
+  render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+  fireEvent.click(
+    screen.getByRole("button", { name: /generate persona with ai/i })
+  );
+}
+
+async function pickEnvironment(name: string | RegExp) {
+  fireEvent.click(screen.getByTestId("generate-environments-picker"));
+  fireEvent.click(await screen.findByRole("checkbox", { name }));
+}
+
+describe("GenerateSwarmDialog — env mode", () => {
+  it("defaults to environments and gates Generate on a selection", async () => {
+    openGeneratePersona();
+
+    expect(
+      screen.getByTestId("generate-target-mode-environments")
+    ).toHaveAttribute("aria-checked", "true");
+    // The legacy pickers belong to clients mode only.
+    expect(
+      screen.queryByTestId("mock-server-group-picker")
+    ).not.toBeInTheDocument();
+
+    const submit = screen.getByRole("button", { name: /generate persona/i });
+    expect(submit).toBeDisabled();
+    await pickEnvironment(/prod-like/i);
+    expect(submit).not.toBeDisabled();
+  });
+
+  it("blocks (with a reason) when the grounding environment has no server group", async () => {
+    openGeneratePersona();
+    await pickEnvironment(/bare/i);
+
+    expect(
+      screen.getByRole("button", { name: /generate persona/i })
+    ).toBeDisabled();
+    expect(screen.getByText(/has no\s+server group/i)).toBeInTheDocument();
+  });
+
+  it("grounds on the FIRST selected environment and writes env-shaped journeys", async () => {
+    generatePersonaMock.mockResolvedValue({
+      persona: { name: "Curious Newcomer", role: "hobbyist" },
+      journeys: [{ goal: "goal one" }],
+    });
+
+    openGeneratePersona();
+    // Selection order decides grounding: Staging-like first, then Prod-like.
+    fireEvent.click(screen.getByTestId("generate-environments-picker"));
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: /staging-like/i })
+    );
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: /prod-like/i })
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /generate persona/i }));
+
+    await waitFor(() => {
+      expect(generatePersonaMock).toHaveBeenCalledTimes(1);
+    });
+    expect(generatePersonaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj-1",
+        serverAttachmentId: "att-env-2",
+      })
+    );
+
+    await waitFor(() => {
+      expect(createJourneyMutation).toHaveBeenCalledTimes(1);
+    });
+    const payload = createJourneyMutation.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload.environmentIds).toEqual(["env-2", "env-1"]);
+    // Compat hostIds recomputed from those envs, deduped in selection order.
+    expect(payload.hostIds).toEqual(["host-2", "host-1"]);
+    // The grounding id grounds the PROMPT only — it must not be persisted on
+    // an env-based journey (that is what makes the env the source of truth).
+    expect("serverAttachmentId" in payload).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

The AI generation dialogs were the one Swarms surface that never learned about Project Environments. `GenerateSwarmDialog` landed in #3525, *after* the env journey UI (#3405/#3438), but was written against the legacy `hostIds` + `serverAttachmentId` path — and has had exactly one commit since. Net effect: every AI-generated journey came out client-targeted, and you had to convert each one to env-based by hand in the per-journey editor.

Since environments are unreleased and are where Swarms is heading, this makes environments the way the generate dialog thinks about targets, not a mode bolted on the side.

## What

- **Target-mode toggle in the generate dialog**, mirroring `NewJourneyButton`. Env submits write `environmentIds` + compat `hostIds` through the shared `buildEnvJourneyPayload` and OMIT `serverAttachmentId` — byte-identical to what the manual form writes, so the same B5 invariant holds (every write touching `environmentIds` recomputes compat `hostIds`).
- **Environments is the default in both forms** whenever the flag is on *and* the project has at least one environment. Clients is one click away; behaviour is unchanged when the flag is off or the project has no environments (covered by a test).
- **`EnvironmentPicker` gains `inModal`** — same escape hatch and name as `ServerGroupPicker`. A portalled popover inside a Radix Dialog is unclickable because of the modal overlay's `pointer-events: none`.
- Analytics gain `targetMode` + `environmentCount`.

## The one restriction, and why

Grounding in env mode comes from the **first selected environment's own server group**. `/swarms/generate-persona` and `/swarms/generate-journeys` take a `serverAttachmentId` and nothing env-shaped — `buildAttachmentToolSnapshot` needs an attachment. So an environment whose `serverAttachmentId` is absent ("the host's own server picks") cannot ground a generation today. Rather than silently grounding on some other selected environment's tools, the dialog blocks and names the environment that needs a server group.

**Follow-up (backend, separate PR):** teach the generation endpoints to take an `environmentId` and resolve grounding env-side (env server group, else the host's own picks). That removes the restriction and makes env grounding first-class instead of derived.

## Testing

- New `SwarmsTab.generateEnv.test.tsx`: default mode, gating, the no-server-group block, grounding on the *first* selected env, and the env-shaped create payload.
- `SwarmsTab.envJourneyForm.test.tsx` updated for the flipped default (plus a new case asserting the clients fallback when no environment exists).
- `client/src/components/swarms` + `project-environments` suites pass (29 files / 203 tests); `typecheck:client` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billed AI generation and journey create payloads (env vs clients invariants); client-only with tests, but wrong grounding or payload shape could mis-target runs or waste quota.
> 
> **Overview**
> **GenerateSwarmDialog** now supports **Environments vs Clients** target mode (flag-gated), aligned with the manual new-journey form. Env-mode creates journeys via `buildEnvJourneyPayload` (`environmentIds` + compat `hostIds`, no `serverAttachmentId`); AI grounding still uses the **first** selected environment’s `serverAttachmentId`, with submit blocked when that env has no server group.
> 
> **New journey** defaults to **Environments** when the flag is on and the project has at least one environment (clients fallback otherwise); toggle order puts Environments first.
> 
> **EnvironmentPicker** adds **`inModal`** (`portalled={!inModal}`) so pickers work inside Radix dialogs.
> 
> **SwarmsTab** passes environments into the generate dialog; analytics include `targetMode` and `environmentCount`.
> 
> Tests: new `SwarmsTab.generateEnv.test.tsx`; `SwarmsTab.envJourneyForm.test.tsx` updated for the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346769d2574e89018323c1089ffa192591049c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let the Swarms generate dialog target Project Environments. Environments are the default when enabled; generated journeys write environmentIds + compat hostIds and omit serverAttachmentId, grounded by the first selected environment’s server group.

- New Features
  - Target-mode toggle (Environments vs Clients) mirrors the new-journey form. Defaults to Environments when the flag is on and the project has environments; Clients is unchanged otherwise.
  - Grounding comes from the first selected environment’s server group; the dialog blocks with a clear message if it has none.
  - Env submissions use the shared `buildEnvJourneyPayload` to write `environmentIds` + compat `hostIds` and omit `serverAttachmentId`. Journeys fan out across all selected environments.
  - `EnvironmentPicker` adds `inModal` so its popover works inside dialogs; analytics now include `targetMode` and `environmentCount`. Tests added/updated for defaults, gating, grounding, and payload shape.

- Migration
  - Ensure the first selected environment has a server group to generate; otherwise add one or switch to Clients.
  - No changes needed when the environments flag is off or the project has no environments.

<sup>Written for commit 346769d2574e89018323c1089ffa192591049c2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

