### PR TITLE
feat(chatboxes): publish an environment as a chatbox from the Environments route

### DIFF
--- a/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
@@ -243,7 +243,7 @@ export function ConnectEnvironmentsStrip({
                     truncated raw id, never a silent blank. */}
                 {computersEnabled && environment.computerEnvironmentId ? (
                   <span
-                    title="Sandbox image for eval runs in this environment — Playground, chatboxes, and swarms don't use it yet."
+                    title="Sandbox image for eval runs and published chatboxes in this environment — Playground and swarms don't use it yet."
                     data-testid={`connect-environment-image-${environment.environmentId}`}
                   >
                     {" · "}

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/hooks/useProjectEnvironments";
 import { ProjectEnvironmentEditor } from "./ProjectEnvironmentEditor";
 import { useProjectEnvironmentConsumers } from "./use-project-environment-consumers";
+import { EnvironmentChatboxSection } from "./environment-chatbox-section";
 import {
   takeEnvironmentDraftSeed,
   type EnvironmentDraftSeed,
@@ -449,6 +450,17 @@ function EnvironmentDetail({
         environment={environment}
         canManage={canManage && !isArchived}
       />
+
+      {/* Publish-as-chatbox. Hidden for archived envs: the backend rejects
+          publishing an archived environment, and an existing chatbox's link is
+          already dead the moment the env archives (see the archive copy). */}
+      {!isArchived ? (
+        <EnvironmentChatboxSection
+          projectId={projectId}
+          environment={environment}
+          canManage={canManage}
+        />
+      ) : null}
 
       {canManage && !isArchived ? (
         <div className="flex items-center justify-between border-t pt-4">

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/archive-consumer-counts.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/archive-consumer-counts.test.tsx
@@ -36,6 +36,12 @@ vi.mock("../ProjectEnvironmentEditor", () => ({
 vi.mock("../use-project-environment-consumers", () => ({
   useProjectEnvironmentConsumers: () => mockConsumers.value,
 }));
+// The publish-as-chatbox section has its own suite
+// (environment-chatbox-section.test.tsx) and needs a Convex provider; stub it
+// like the editor above.
+vi.mock("../environment-chatbox-section", () => ({
+  EnvironmentChatboxSection: () => <div>Chatbox Section</div>,
+}));
 
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";
 

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Publish-as-chatbox section (env detail): publish round-trip, link actions
+ * on the published row, admin gating, and error copy passthrough.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { publishMock, unpublishMock, toastMock, copyMock } = vi.hoisted(() => ({
+  publishMock: vi.fn(),
+  unpublishMock: vi.fn(),
+  toastMock: { success: vi.fn(), error: vi.fn() },
+  copyMock: vi.fn(),
+}));
+
+/** Mutable per-test chatbox list returned by `chatboxes:listChatboxes`. */
+let chatboxList: Array<Record<string, unknown>> | undefined = [];
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+  useQuery: (name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    if (name === "chatboxes:listChatboxes") return chatboxList;
+    return undefined;
+  },
+  useMutation: (name: string) => {
+    if (name === "chatboxes:publishEnvironmentChatbox") return publishMock;
+    if (name === "chatboxes:unpublishEnvironmentChatbox") return unpublishMock;
+    return vi.fn();
+  },
+}));
+
+vi.mock("@/hooks/useProjects", () => ({
+  shouldQueryProjectId: () => true,
+}));
+vi.mock("@/lib/toast", () => ({ toast: toastMock }));
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: (...args: unknown[]) => copyMock(...args),
+}));
+vi.mock("@/lib/chatbox-session", () => ({
+  buildChatboxLink: (token: string) => `https://app.test/chat/${token}`,
+}));
+
+import { EnvironmentChatboxSection } from "../environment-chatbox-section";
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+
+const environment: ProjectEnvironmentView = {
+  environmentId: "env-1",
+  projectId: "proj-1",
+  name: "Prod-like",
+  hostId: "host-1",
+  revision: 1,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const publishedChatbox = {
+  chatboxId: "cb-1",
+  projectId: "proj-1",
+  name: "Prod-like",
+  environmentId: "env-1",
+  link: { token: "tok-1", path: "/chat/tok-1", url: "https://x/chat/tok-1" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chatboxList = [];
+  publishMock.mockResolvedValue({
+    chatboxId: "cb-1",
+    environmentId: "env-1",
+    name: "Prod-like",
+    mode: "project_members",
+    accessVersion: 1,
+    link: publishedChatbox.link,
+    created: true,
+  });
+  unpublishMock.mockResolvedValue({ deleted: true, chatboxId: "cb-1" });
+  copyMock.mockResolvedValue(true);
+});
+
+function renderSection(canManage = true) {
+  return render(
+    <EnvironmentChatboxSection
+      projectId="proj-1"
+      environment={environment}
+      canManage={canManage}
+    />
+  );
+}
+
+describe("EnvironmentChatboxSection", () => {
+  it("publishes the environment as a chatbox", async () => {
+    renderSection();
+    fireEvent.click(screen.getByTestId("environment-chatbox-publish"));
+    await waitFor(() => {
+      expect(publishMock).toHaveBeenCalledWith({ environmentId: "env-1" });
+    });
+    expect(toastMock.success).toHaveBeenCalled();
+  });
+
+  it("read-only members see state, not the publish action", () => {
+    renderSection(false);
+    expect(
+      screen.queryByTestId("environment-chatbox-publish")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/not published/i)).toBeInTheDocument();
+  });
+
+  it("published: copies the share link built from the row's token", async () => {
+    chatboxList = [publishedChatbox];
+    renderSection();
+    fireEvent.click(screen.getByTestId("environment-chatbox-copy-link"));
+    await waitFor(() => {
+      expect(copyMock).toHaveBeenCalledWith("https://app.test/chat/tok-1");
+    });
+  });
+
+  it("unpublish requires an explicit confirm and calls the mutation", async () => {
+    chatboxList = [publishedChatbox];
+    renderSection();
+    fireEvent.click(screen.getByTestId("environment-chatbox-unpublish"));
+    expect(unpublishMock).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByTestId("environment-chatbox-unpublish-confirm")
+    );
+    await waitFor(() => {
+      expect(unpublishMock).toHaveBeenCalledWith({ environmentId: "env-1" });
+    });
+  });
+
+  it("surfaces backend FORBIDDEN copy verbatim on publish", async () => {
+    publishMock.mockRejectedValue({
+      data: {
+        code: "FORBIDDEN",
+        message:
+          "Publishing an environment chatbox requires project admin (shared execution config).",
+      },
+    });
+    renderSection();
+    fireEvent.click(screen.getByTestId("environment-chatbox-publish"));
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledWith(
+        expect.stringContaining("requires project admin")
+      );
+    });
+  });
+
+  it("a chatbox for a DIFFERENT environment does not read as published", () => {
+    chatboxList = [{ ...publishedChatbox, environmentId: "env-other" }];
+    renderSection();
+    expect(
+      screen.getByTestId("environment-chatbox-publish")
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
@@ -97,6 +97,42 @@ describe("EnvironmentChatboxSection", () => {
     expect(toastMock.success).toHaveBeenCalled();
   });
 
+  it("idempotent re-publish (created: false) reports 'already published'", async () => {
+    publishMock.mockResolvedValue({
+      chatboxId: "cb-1",
+      environmentId: "env-1",
+      name: "Prod-like",
+      mode: "project_members",
+      accessVersion: 1,
+      link: publishedChatbox.link,
+      created: false,
+    });
+    renderSection();
+    fireEvent.click(screen.getByTestId("environment-chatbox-publish"));
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith(
+        expect.stringContaining("already published")
+      );
+    });
+  });
+
+  it("a published row renders the published copy and actions, not the publish button", () => {
+    chatboxList = [publishedChatbox];
+    renderSection();
+    expect(
+      screen.getByText(/published — the chatbox live-follows/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("environment-chatbox-publish")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("environment-chatbox-copy-link")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("environment-chatbox-unpublish")
+    ).toBeInTheDocument();
+  });
+
   it("read-only members see state, not the publish action", () => {
     renderSection(false);
     expect(

--- a/mcpjam-inspector/client/src/components/project-environments/environment-chatbox-section.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/environment-chatbox-section.tsx
@@ -1,0 +1,204 @@
+/**
+ * Publish-as-chatbox section for an environment's detail view.
+ *
+ * Env-backed chatboxes are POINTER rows (Phase 5, mcpjam-backend #805): no
+ * hostConfig pin, no chatbox-scope server attachment — runtime resolution
+ * re-resolves the environment fresh on every read, so editing the environment
+ * updates the published chatbox immediately. They are deliberately invisible
+ * to the host-first ChatboxesTab (`getHostPublishChatbox` filters them out),
+ * which makes THIS the management surface: publish, copy the share link, and
+ * unpublish. One chatbox per environment, backend-enforced.
+ *
+ * Deliberately minimal v1 — mode/members/link-rotation/guest-execution stay
+ * with the standard chatbox editors and can grow here later if env chatboxes
+ * need them. Publish/unpublish are project-ADMIN gated backend-side; the
+ * backend's FORBIDDEN/CONFLICT copy is surfaced verbatim.
+ */
+import { useState } from "react";
+import { useConvexAuth } from "convex/react";
+import { Copy, ExternalLink, Loader2, MessageSquare } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { toast } from "@/lib/toast";
+import { convexErrMessage } from "@/lib/convex-error";
+import { copyToClipboard } from "@/lib/clipboard";
+import { buildChatboxLink } from "@/lib/chatbox-session";
+import {
+  useEnvironmentChatbox,
+  useEnvironmentChatboxMutations,
+} from "@/hooks/useChatboxes";
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+
+export function EnvironmentChatboxSection({
+  projectId,
+  environment,
+  canManage,
+}: {
+  projectId: string;
+  environment: ProjectEnvironmentView;
+  /** Publish/unpublish are admin-gated; members see state read-only. */
+  canManage: boolean;
+}) {
+  const { isAuthenticated } = useConvexAuth();
+  const { chatbox } = useEnvironmentChatbox({
+    isAuthenticated,
+    projectId,
+    environmentId: environment.environmentId,
+  });
+  const { publishEnvironmentChatbox, unpublishEnvironmentChatbox } =
+    useEnvironmentChatboxMutations();
+  const [busy, setBusy] = useState(false);
+  const [confirmingUnpublish, setConfirmingUnpublish] = useState(false);
+
+  const link = chatbox?.link?.token
+    ? buildChatboxLink(chatbox.link.token, chatbox.name)
+    : null;
+
+  const onPublish = async () => {
+    setBusy(true);
+    try {
+      const result = await publishEnvironmentChatbox({
+        environmentId: environment.environmentId,
+      });
+      toast.success(
+        result.created
+          ? `Published “${environment.name}” as a chatbox.`
+          : `“${environment.name}” is already published.`
+      );
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Could not publish the chatbox."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onUnpublish = async () => {
+    setBusy(true);
+    try {
+      await unpublishEnvironmentChatbox({
+        environmentId: environment.environmentId,
+      });
+      toast.success(`Unpublished “${environment.name}”'s chatbox.`);
+      setConfirmingUnpublish(false);
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Could not unpublish the chatbox."));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onCopyLink = async () => {
+    if (!link) return;
+    const ok = await copyToClipboard(link);
+    if (ok) toast.success("Share link copied");
+    else toast.error("Failed to copy share link");
+  };
+
+  return (
+    <section className="rounded-md border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="flex items-center gap-1.5 text-xs font-medium">
+            <MessageSquare className="size-3.5" /> Chatbox
+          </h3>
+          <p className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+            {chatbox
+              ? "Published — the chatbox live-follows this environment; edits here apply to it immediately."
+              : "Publish this environment as a shareable chatbox. It live-follows the environment — no separate config to keep in sync."}
+          </p>
+        </div>
+
+        {chatbox === undefined ? (
+          <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+        ) : chatbox === null ? (
+          canManage ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 shrink-0 text-xs"
+              disabled={busy}
+              data-testid="environment-chatbox-publish"
+              onClick={() => void onPublish()}
+            >
+              {busy ? (
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+              ) : null}
+              Publish as chatbox
+            </Button>
+          ) : (
+            <span className="text-[11px] text-muted-foreground">
+              Not published
+            </span>
+          )
+        ) : (
+          <span className="flex shrink-0 flex-wrap items-center gap-1.5">
+            {link ? (
+              <>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 text-xs"
+                  data-testid="environment-chatbox-copy-link"
+                  onClick={() => void onCopyLink()}
+                >
+                  <Copy className="mr-1.5 size-3.5" /> Copy link
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs"
+                  onClick={() => window.open(link, "_blank", "noopener")}
+                >
+                  <ExternalLink className="mr-1.5 size-3.5" /> Open
+                </Button>
+              </>
+            ) : null}
+            {canManage ? (
+              confirmingUnpublish ? (
+                <>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="destructive"
+                    className="h-7 text-xs"
+                    disabled={busy}
+                    data-testid="environment-chatbox-unpublish-confirm"
+                    onClick={() => void onUnpublish()}
+                  >
+                    {busy ? (
+                      <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                    ) : null}
+                    Unpublish — link stops working
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 text-xs"
+                    disabled={busy}
+                    onClick={() => setConfirmingUnpublish(false)}
+                  >
+                    Cancel
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 text-xs text-destructive hover:text-destructive"
+                  data-testid="environment-chatbox-unpublish"
+                  onClick={() => setConfirmingUnpublish(true)}
+                >
+                  Unpublish
+                </Button>
+              )
+            ) : null}
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/useChatboxes.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxes.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { shouldQueryProjectId } from "./useProjects";
 import type { ChatboxHostStyle } from "@/lib/chatbox-client-style";
@@ -117,6 +118,8 @@ export interface ChatboxListItem {
    * host-backed.
    */
   environmentId?: string | null;
+  /** Shareable link (null until first publish mints one). */
+  link?: { token: string; path: string; url: string } | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -142,6 +145,62 @@ export function useChatboxList({
     chatboxes,
     isLoading: enabled && chatboxes === undefined,
   };
+}
+
+/**
+ * The 0-or-1 published chatbox BACKED BY an environment (Phase 5 live-follow
+ * pointer rows; one per environment, backend-enforced). Env-backed chatboxes
+ * are deliberately invisible to the host-first ChatboxesTab
+ * (`getHostPublishChatbox` filters them out), so the Environments route is
+ * their management surface — this hook feeds it from the same `listChatboxes`
+ * subscription the rest of the project UI uses.
+ *
+ * `undefined` while loading; `null` once settled with no backing chatbox.
+ */
+export function useEnvironmentChatbox({
+  isAuthenticated,
+  projectId,
+  environmentId,
+}: {
+  isAuthenticated: boolean;
+  projectId: string | null;
+  environmentId: string | null;
+}): { chatbox: ChatboxListItem | null | undefined; isLoading: boolean } {
+  const { chatboxes, isLoading } = useChatboxList({
+    isAuthenticated,
+    projectId,
+  });
+  const chatbox = useMemo(() => {
+    if (!environmentId || chatboxes === undefined) return undefined;
+    return chatboxes.find((row) => row.environmentId === environmentId) ?? null;
+  }, [chatboxes, environmentId]);
+  return { chatbox, isLoading };
+}
+
+/**
+ * Phase 5 environment-chatbox publish round-trip (mcpjam-backend #805).
+ * Both are PROJECT-ADMIN gated backend-side (shared mutable execution
+ * config) — surface the `FORBIDDEN` copy verbatim. Publish is idempotent
+ * (one chatbox per environment; a second publish returns the existing row).
+ */
+export function useEnvironmentChatboxMutations() {
+  const publishEnvironmentChatbox = useMutation(
+    "chatboxes:publishEnvironmentChatbox" as any,
+  ) as (args: { environmentId: string }) => Promise<{
+    chatboxId: string;
+    environmentId: string;
+    name: string;
+    mode: ChatboxMode;
+    accessVersion: number;
+    link: { token: string; path: string; url: string } | null;
+    created: boolean;
+  }>;
+  const unpublishEnvironmentChatbox = useMutation(
+    "chatboxes:unpublishEnvironmentChatbox" as any,
+  ) as (args: {
+    environmentId: string;
+  }) => Promise<{ deleted: boolean; chatboxId?: string }>;
+  return { publishEnvironmentChatbox, unpublishEnvironmentChatbox };
 }
 
 export function useChatbox({


### PR DESCRIPTION
## Why

Chatboxes should think in environments. The backend already does: Phase 5 (mcpjam-backend #805) shipped env-backed chatbox rows (live-follow pointers — no hostConfig pin, no chatbox-scope attachment; runtime resolution re-resolves the environment fresh on every read), the chat-v2 runtime path, and admin-gated `publishEnvironmentChatbox`/`unpublishEnvironmentChatbox` mutations. The inspector never exposed any of it — there was no way to publish an environment as a chatbox from the UI.

One structural fact drives the design: **env-backed chatboxes are deliberately invisible to the host-first ChatboxesTab** (`getHostPublishChatbox` filters out rows with `environmentId`, by documented design). So their management surface is the Environments route, not the chatbox publish bar.

## What

- **`EnvironmentChatboxSection`** in the environment detail view (`/environments`): publish as chatbox, copy/open the share link, unpublish behind an explicit confirm ("link stops working"). Actions are project-admin gated backend-side; members see read-only state; backend `FORBIDDEN`/`CONFLICT` copy surfaces verbatim via `convexErrMessage`. Hidden for archived environments (backend rejects publishing those; an existing link is already dead on archive per the archive-confirm copy).
- **Hooks** (`useChatboxes.ts`): `useEnvironmentChatbox` (the 0-or-1 backing row off the same `listChatboxes` subscription) + `useEnvironmentChatboxMutations`. `ChatboxListItem` gains the `link {token,path,url}` field the backend already returns. Publish is idempotent (second publish returns the existing row — surfaced as "already published").
- **Stale copy fix**: the sandbox-image tooltip in `ConnectEnvironmentsStrip` claimed chatboxes don't use the env's pinned image; `server/utils/chatbox-runtime-config.ts` has resolved it per call since Phase 5.

Deliberately minimal v1 (per the keep-UI-minimal bar): mode/members/link-rotation/guest-execution editors for env chatboxes are deferred — they're admin surfaces the standard chatbox editors own, reachable later by `chatboxId` if env chatboxes need them. Also out of scope: converting a host-backed chatbox to env-backed in place (the backend models env chatboxes as publish-of-environment rows, not re-pointed host chatboxes).

## Testing

- New `environment-chatbox-section.test.tsx`: publish round-trip, member read-only gating, link copy from the row token, unpublish confirm flow, FORBIDDEN copy passthrough, and no false "published" from another environment's chatbox.
- Full `client/src/components/project-environments` suite (79 tests) green; `typecheck:client` clean.
- Manual check once deployed: publish an env from /environments, open the link in a guest window — the runtime path is already pinned by `chat-v2.chatbox-environment.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New admin-gated publish/unpublish flows affect shareable chat execution config; backend already enforces rules, but mistakes break live guest links.
> 
> **Overview**
> Exposes **Phase 5 env-backed chatboxes** on the **Environments** detail page via new **`EnvironmentChatboxSection`**: admins can **publish** (idempotent), **copy/open** the share link, and **unpublish** with confirm; members see read-only state; the section is **hidden for archived** environments.
> 
> **`useChatboxes`** gains **`useEnvironmentChatbox`** (0-or-1 row from `listChatboxes` by `environmentId`), **`useEnvironmentChatboxMutations`** (`publishEnvironmentChatbox` / `unpublishEnvironmentChatbox`), and **`link`** on **`ChatboxListItem`**.
> 
> **`ConnectEnvironmentsStrip`** tooltip now says published chatboxes use the environment’s sandbox image (was incorrectly excluded).
> 
> Tests: new **`environment-chatbox-section.test.tsx`**; **`archive-consumer-counts`** stubs the new section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f60dcbef054f676ec4e221ed7ce4ad0a18a19c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add UI to publish an environment as a chatbox from the Environments route, manage its share link, and unpublish. Env-backed chatboxes live-follow the environment and remain hidden from the Chatboxes tab.

- **New Features**
  - `EnvironmentChatboxSection` in `/environments`: publish, copy/open share link, and unpublish with confirm. Admin-only actions; members see read-only state; hidden for archived envs. Surfaces backend `FORBIDDEN`/`CONFLICT` copy via `convexErrMessage`. Re-publish shows “already published.”
  - Hooks in `useChatboxes.ts`: `useEnvironmentChatbox` and `useEnvironmentChatboxMutations`. `ChatboxListItem` now has `link {token, path, url}`. Publish is idempotent and returns the existing row.

- **Bug Fixes**
  - `ConnectEnvironmentsStrip` tooltip now correctly states that published chatboxes use the environment’s sandbox image.

<sup>Written for commit 1f60dcbef054f676ec4e221ed7ce4ad0a18a19c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

