### PR TITLE
feat(client): honor ?project= deep links so shared eval URLs land on the right project

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -32,6 +32,7 @@ import { EmptyState } from "./components/ui/empty-state";
 import {
   canManageAsOwnerOrAdmin,
   canViewSwarms,
+  useProjectQueries,
   useViewerProjectRole,
 } from "./hooks/useProjects";
 import { ProjectEnvironmentsRoute } from "./components/project-environments/ProjectEnvironmentsRoute";
@@ -170,6 +171,12 @@ import {
   type CheckoutIntentWithOrganization,
   writeBillingSignInReturnPath,
 } from "./lib/billing-deep-link";
+import {
+  clearProjectDeepLinkFromUrl,
+  hasProjectDeepLinkParam,
+  readProjectDeepLinkParam,
+  resolveProjectDeepLinkAction,
+} from "./lib/project-deep-link";
 import { isHostedHashTabAllowed } from "./lib/hosted-tab-policy";
 import { buildOAuthTokensByServerId } from "./lib/oauth/oauth-tokens";
 import type { OAuthTrace } from "./lib/oauth/oauth-trace";
@@ -823,6 +830,89 @@ function useTemplateVerifyDeepLink({
     themeMode,
     createHost,
     navigate,
+  ]);
+}
+
+/**
+ * `?project=<id>` deep-link: shared eval/suite/run URLs carry no project
+ * segment, so a link renders whatever project the viewer's picker is on.
+ * Surfaces that mass-produce links (the Slack bot, CLI run URLs) append the
+ * param; this switches the active project (and organization, when the link
+ * crosses orgs) to match, then strips the param. Runs once per mount.
+ */
+function useProjectDeepLinkSwitch({
+  isAuthenticated,
+  isLoadingRemoteProjects,
+  projects,
+  activeProjectId,
+  activeOrganizationId,
+  setActiveOrganizationId,
+  handleSwitchProject,
+}: {
+  isAuthenticated: boolean;
+  isLoadingRemoteProjects: boolean;
+  projects: Record<string, unknown>;
+  activeProjectId: string | null;
+  activeOrganizationId: string | undefined;
+  setActiveOrganizationId: (organizationId: string | undefined) => void;
+  handleSwitchProject: (projectId: string) => Promise<void>;
+}) {
+  const requestedProjectId = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    return readProjectDeepLinkParam(window.location.search);
+  }, []);
+  // Unfiltered membership list (same Convex query the org-filtered project
+  // list derives from, so this dedupes) — needed to resolve cross-org links.
+  const { allProjects } = useProjectQueries({ isAuthenticated });
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (!requestedProjectId || handledRef.current) return;
+    if (!isAuthenticated || isLoadingRemoteProjects) return;
+
+    const action = resolveProjectDeepLinkAction({
+      requestedProjectId,
+      activeProjectId,
+      activeOrgProjectIds: new Set(Object.keys(projects)),
+      allProjects,
+      activeOrganizationId,
+    });
+    switch (action.kind) {
+      case "wait":
+        return;
+      case "clear":
+        handledRef.current = true;
+        clearProjectDeepLinkFromUrl();
+        return;
+      case "switch-organization":
+        // The org-filtered project list re-derives; a later run of this
+        // effect lands on switch-project. handledRef stays unset on purpose.
+        setActiveOrganizationId(action.organizationId);
+        return;
+      case "switch-project":
+        handledRef.current = true;
+        void handleSwitchProject(requestedProjectId).finally(
+          clearProjectDeepLinkFromUrl
+        );
+        return;
+      case "not-found":
+        handledRef.current = true;
+        clearProjectDeepLinkFromUrl();
+        toast.error(
+          "This link points to a project you don't have access to."
+        );
+        return;
+    }
+  }, [
+    requestedProjectId,
+    isAuthenticated,
+    isLoadingRemoteProjects,
+    projects,
+    activeProjectId,
+    activeOrganizationId,
+    allProjects,
+    setActiveOrganizationId,
+    handleSwitchProject,
   ]);
 }
 
@@ -2364,10 +2454,19 @@ export default function App() {
       const raw = new URLSearchParams(window.location.search).get("template");
       return raw != null && HOST_TEMPLATES.some((t) => t.id === raw);
     })();
+  // Same clobber hazard for `?project=` deep links: the onboarding redirect
+  // would drop the path + param before the switch handler consumes it. Unlike
+  // `?template`, membership can't be checked synchronously — but the handler
+  // always strips the param once project data settles (including the
+  // no-access case), so the suppression is transient by construction.
+  const hasProjectSwitchDeepLinkParam =
+    typeof window !== "undefined" &&
+    hasProjectDeepLinkParam(window.location.search);
   const shouldRouteToFirstRunOnboarding =
     !isHostedChatRoute &&
     !isBareCaniuseRoute &&
     !hasHostTemplateVerifyParam &&
+    !hasProjectSwitchDeepLinkParam &&
     !isWorkOsLoading &&
     effectiveHostedShellGateState === "ready" &&
     !(isAuthenticated && currentUser === undefined) &&
@@ -3561,6 +3660,16 @@ export default function App() {
       setActiveOrganizationId,
     ]
   );
+
+  useProjectDeepLinkSwitch({
+    isAuthenticated,
+    isLoadingRemoteProjects,
+    projects,
+    activeProjectId,
+    activeOrganizationId,
+    setActiveOrganizationId,
+    handleSwitchProject,
+  });
 
   const handleSidebarSwitchProject = useCallback(
     async (projectId: string) => {

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -891,9 +891,16 @@ function useProjectDeepLinkSwitch({
         return;
       case "switch-project":
         handledRef.current = true;
-        void handleSwitchProject(requestedProjectId).finally(
-          clearProjectDeepLinkFromUrl
-        );
+        // .catch BEFORE .finally: finally re-throws rejections, so a bare
+        // .finally chain would turn a failed switch into an unhandled
+        // rejection with the user silently left on the wrong project.
+        void handleSwitchProject(requestedProjectId)
+          .catch(() => {
+            toast.error(
+              "Couldn't switch to the linked project — use the project picker."
+            );
+          })
+          .finally(clearProjectDeepLinkFromUrl);
         return;
       case "not-found":
         handledRef.current = true;

--- a/mcpjam-inspector/client/src/lib/__tests__/project-deep-link.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-deep-link.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasProjectDeepLinkParam,
+  readProjectDeepLinkParam,
+  resolveProjectDeepLinkAction,
+} from "../project-deep-link";
+
+const PROJECT_ID = "y976c61ap6w524jsrcgx8s4pkx88acvr";
+const OTHER_ID = "n170njxr45myj755fc3d5cbe5n8brrgj";
+
+describe("readProjectDeepLinkParam", () => {
+  it("reads a well-formed id", () => {
+    expect(readProjectDeepLinkParam(`?project=${PROJECT_ID}`)).toBe(
+      PROJECT_ID
+    );
+  });
+
+  it("tolerates a missing leading question mark", () => {
+    expect(readProjectDeepLinkParam(`project=${PROJECT_ID}`)).toBe(PROJECT_ID);
+  });
+
+  it("ignores other params and absence", () => {
+    expect(readProjectDeepLinkParam("?plan=team")).toBeNull();
+    expect(readProjectDeepLinkParam("")).toBeNull();
+  });
+
+  it("rejects values that don't look like Convex ids", () => {
+    expect(readProjectDeepLinkParam("?project=")).toBeNull();
+    expect(readProjectDeepLinkParam("?project=UPPER")).toBeNull();
+    expect(readProjectDeepLinkParam("?project=short")).toBeNull();
+    expect(
+      readProjectDeepLinkParam(`?project=${"a".repeat(80)}`)
+    ).toBeNull();
+    expect(
+      readProjectDeepLinkParam("?project=../../evil%20path")
+    ).toBeNull();
+  });
+
+  it("hasProjectDeepLinkParam mirrors the validated read", () => {
+    expect(hasProjectDeepLinkParam(`?project=${PROJECT_ID}`)).toBe(true);
+    expect(hasProjectDeepLinkParam("?project=bogus!")).toBe(false);
+  });
+});
+
+describe("resolveProjectDeepLinkAction", () => {
+  const base = {
+    requestedProjectId: PROJECT_ID,
+    activeProjectId: OTHER_ID,
+    activeOrgProjectIds: new Set<string>(),
+    allProjects: [] as Array<{ _id: string; organizationId?: string }>,
+    activeOrganizationId: "org_a",
+  };
+
+  it("clears when already on the requested project", () => {
+    expect(
+      resolveProjectDeepLinkAction({ ...base, activeProjectId: PROJECT_ID })
+    ).toEqual({ kind: "clear" });
+  });
+
+  it("switches when the project is visible under the active org", () => {
+    expect(
+      resolveProjectDeepLinkAction({
+        ...base,
+        activeOrgProjectIds: new Set([PROJECT_ID]),
+      })
+    ).toEqual({ kind: "switch-project" });
+  });
+
+  it("waits while the membership list is still loading", () => {
+    expect(
+      resolveProjectDeepLinkAction({ ...base, allProjects: undefined })
+    ).toEqual({ kind: "wait" });
+  });
+
+  it("switches organization first for a cross-org link", () => {
+    expect(
+      resolveProjectDeepLinkAction({
+        ...base,
+        allProjects: [{ _id: PROJECT_ID, organizationId: "org_b" }],
+      })
+    ).toEqual({ kind: "switch-organization", organizationId: "org_b" });
+  });
+
+  it("waits when the org matches but the filtered set lags a render", () => {
+    expect(
+      resolveProjectDeepLinkAction({
+        ...base,
+        allProjects: [{ _id: PROJECT_ID, organizationId: "org_a" }],
+      })
+    ).toEqual({ kind: "wait" });
+  });
+
+  it("reports not-found for projects outside the user's membership", () => {
+    expect(
+      resolveProjectDeepLinkAction({
+        ...base,
+        allProjects: [{ _id: OTHER_ID, organizationId: "org_a" }],
+      })
+    ).toEqual({ kind: "not-found" });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/project-deep-link.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-deep-link.test.ts
@@ -90,6 +90,28 @@ describe("resolveProjectDeepLinkAction", () => {
     ).toEqual({ kind: "wait" });
   });
 
+  it("reports not-found for an org-less project while an org filter is active", () => {
+    // Waiting here would hang forever: an org-less project can never enter
+    // the org-filtered set, so the param would never strip.
+    expect(
+      resolveProjectDeepLinkAction({
+        ...base,
+        allProjects: [{ _id: PROJECT_ID }],
+      })
+    ).toEqual({ kind: "not-found" });
+  });
+
+  it("waits for an org-less project when no org filter is active", () => {
+    // Unfiltered set includes it next render; not-found would be premature.
+    expect(
+      resolveProjectDeepLinkAction({
+        ...base,
+        allProjects: [{ _id: PROJECT_ID }],
+        activeOrganizationId: undefined,
+      })
+    ).toEqual({ kind: "wait" });
+  });
+
   it("reports not-found for projects outside the user's membership", () => {
     expect(
       resolveProjectDeepLinkAction({

--- a/mcpjam-inspector/client/src/lib/project-deep-link.ts
+++ b/mcpjam-inspector/client/src/lib/project-deep-link.ts
@@ -80,7 +80,13 @@ export function resolveProjectDeepLinkAction(args: {
 
   const match = allProjects.find((p) => p._id === requestedProjectId);
   if (!match) return { kind: "not-found" };
-  if (match.organizationId && match.organizationId !== activeOrganizationId) {
+  if (!match.organizationId) {
+    // An org-less project can never enter an org-filtered project set, so
+    // waiting would hang forever and the param would never strip. With no
+    // org filter active the unfiltered set includes it next render — wait.
+    return activeOrganizationId ? { kind: "not-found" } : { kind: "wait" };
+  }
+  if (match.organizationId !== activeOrganizationId) {
     return { kind: "switch-organization", organizationId: match.organizationId };
   }
   // Right org but the filtered set hasn't caught up yet — transient.

--- a/mcpjam-inspector/client/src/lib/project-deep-link.ts
+++ b/mcpjam-inspector/client/src/lib/project-deep-link.ts
@@ -1,0 +1,88 @@
+/**
+ * `?project=<id>` deep-link support.
+ *
+ * Eval/suite/run URLs carry no project segment, so a shared link renders
+ * whatever project the viewer's picker happens to be on — an empty state for
+ * anyone parked elsewhere. Surfaces that mass-produce links (the Slack bot,
+ * CLI run URLs) append `?project=<id>`; on load the app switches the active
+ * project (and organization, when the link crosses orgs) to match, then
+ * strips the param from the URL.
+ */
+
+export const PROJECT_DEEP_LINK_PARAM = "project";
+
+// Convex ids are lowercase alphanumeric. The shape check keeps mangled or
+// hand-typed params from suppressing first-run onboarding or firing switches.
+const PROJECT_ID_SHAPE = /^[a-z0-9]{16,64}$/;
+
+export function readProjectDeepLinkParam(search: string): string | null {
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search : `?${search}`
+  );
+  const raw = params.get(PROJECT_DEEP_LINK_PARAM);
+  return raw && PROJECT_ID_SHAPE.test(raw) ? raw : null;
+}
+
+export function hasProjectDeepLinkParam(search: string): boolean {
+  return readProjectDeepLinkParam(search) !== null;
+}
+
+/** Strip the param in place, preserving path, other params, and hash. */
+export function clearProjectDeepLinkFromUrl(): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (!url.searchParams.has(PROJECT_DEEP_LINK_PARAM)) return;
+  url.searchParams.delete(PROJECT_DEEP_LINK_PARAM);
+  window.history.replaceState({}, "", url.pathname + url.search + url.hash);
+}
+
+export type ProjectDeepLinkAction =
+  | { kind: "wait" }
+  | { kind: "clear" }
+  | { kind: "switch-project" }
+  | { kind: "switch-organization"; organizationId: string }
+  | { kind: "not-found" };
+
+/**
+ * Decide what the deep-link handler should do this render. Pure so the
+ * ordering rules are unit-testable without mounting App:
+ *  - already on the project → just clear the param;
+ *  - project visible under the active org → switch to it;
+ *  - project belongs to another org the user is in → switch orgs first
+ *    (the filtered project list re-derives and a later render switches);
+ *  - membership list still loading → wait;
+ *  - otherwise → not a project this user can see.
+ */
+export function resolveProjectDeepLinkAction(args: {
+  requestedProjectId: string;
+  activeProjectId: string | null;
+  /** Ids of projects visible under the ACTIVE organization. */
+  activeOrgProjectIds: ReadonlySet<string>;
+  /** ALL projects the user belongs to (unfiltered); undefined while loading. */
+  allProjects:
+    | ReadonlyArray<{ _id: string; organizationId?: string }>
+    | undefined;
+  activeOrganizationId: string | undefined;
+}): ProjectDeepLinkAction {
+  const {
+    requestedProjectId,
+    activeProjectId,
+    activeOrgProjectIds,
+    allProjects,
+    activeOrganizationId,
+  } = args;
+
+  if (activeProjectId === requestedProjectId) return { kind: "clear" };
+  if (activeOrgProjectIds.has(requestedProjectId)) {
+    return { kind: "switch-project" };
+  }
+  if (allProjects === undefined) return { kind: "wait" };
+
+  const match = allProjects.find((p) => p._id === requestedProjectId);
+  if (!match) return { kind: "not-found" };
+  if (match.organizationId && match.organizationId !== activeOrganizationId) {
+    return { kind: "switch-organization", organizationId: match.organizationId };
+  }
+  // Right org but the filtered set hasn't caught up yet — transient.
+  return { kind: "wait" };
+}

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
@@ -523,7 +523,9 @@ describe("agent tool surface", () => {
         type: "eval_suite",
         id: "ts_1",
         name: "smoke",
-        url: expect.stringContaining("/evals/suite/ts_1"),
+        // `?project=` makes the link land on the right project for viewers
+        // parked elsewhere (eval routes carry no project segment).
+        url: expect.stringContaining("/evals/suite/ts_1?project=p1"),
       },
     ]);
     // The model-facing result may be truncated; the collector must not be.

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -107,8 +107,11 @@ export type CreatedResource = {
   url: string;
 };
 
-function suiteUrl(suiteId: string): string {
-  return `${MCPJAM_HOSTED_ORIGIN}/evals/suite/${encodeURIComponent(suiteId)}`;
+function suiteUrl(suiteId: string, projectId: string): string {
+  // `?project=` makes the link self-describing: eval routes carry no project
+  // segment, so without it the app renders whatever project the viewer's
+  // picker was parked on (an empty state for everyone but the author).
+  return `${MCPJAM_HOSTED_ORIGIN}/evals/suite/${encodeURIComponent(suiteId)}?project=${encodeURIComponent(projectId)}`;
 }
 
 const PROJECT_SCOPE_ERROR =
@@ -215,7 +218,7 @@ export function buildAgentApiToolSet(opts: {
                 type: "eval_suite",
                 id: suite.id,
                 ...(suite.name ? { name: suite.name } : {}),
-                url: suiteUrl(suite.id),
+                url: suiteUrl(suite.id, opts.projectId),
               });
             }
           }


### PR DESCRIPTION
## Problem

Eval/suite/run URLs (`/evals/suite/:suiteId/runs/:runId`) carry no project information — the page renders whatever project the viewer's client-side picker happens to be on. Any shared link (Slack bot messages, PR descriptions, pasted URLs) silently shows an empty state for anyone parked on a different project. Found while dogfooding the Slack bot (#3629): clicking a run link landed on an empty evals list because the picker was on another project.

## Fix

**Client** — new `client/src/lib/project-deep-link.ts` + a `useProjectDeepLinkSwitch` hook in `App.tsx`:
- On load, a `?project=<id>` param switches the active project via the same `handleSwitchProject` path the picker uses (membership-guarded, disconnects servers, persists), then strips the param via `replaceState` — following the existing `?plan=`/`?template=` deep-link patterns.
- Cross-org links work: the unfiltered `projects:getMyProjects` result (same Convex query, deduped) resolves the project's organization; the hook switches org first, then the project on a later render.
- Unknown/no-access ids strip the param and toast, no switch. Param values must look like Convex ids (shape-checked) before anything reacts to them.
- The param suppresses the first-run onboarding redirect (same clobber hazard as `?template`: onboarding would navigate away and drop the param before it's consumed). Unlike `?template`, membership can't be checked synchronously — but the handler always strips the param once data settles, including the no-access case, so suppression is transient by construction.
- Deliberately **not** `handleSidebarSwitchProject`: that variant navigates to a tab target, which would clobber the deep-linked path.

**Server** — the v1 agent endpoint (`server/routes/v1/agent.ts`) now appends `?project=<projectId>` to the suite URLs it returns in `createdResources`, so every link the Slack bot posts is self-describing.

The decision logic is a pure function (`resolveProjectDeepLinkAction`) so the ordering rules (clear / switch / switch-org / wait / not-found) are unit-tested without mounting App.

## Testing

- New `client/src/lib/__tests__/project-deep-link.test.ts` (11 tests: param parsing/shape rejection + all five action branches).
- `agent.test.ts` updated to assert the `?project=` suffix on created-resource URLs (22 pass).
- Full v1 route suite: 267 pass. `typecheck:client` clean; server tsc has no errors in touched files.

## Out of scope

Path-based routing (`/projects/:projectId/...`) is the structural fix but a full-app migration; this param approach is additive and doesn't block it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes active project and organization on initial load via membership-guarded switching; mistakes could leave users on the wrong project or show incorrect toasts, but it reuses the standard switch path and does not bypass auth.
> 
> **Overview**
> Shared eval/suite/run URLs have no project in the path, so recipients often saw an empty list when their picker was on another project. This PR adds **`?project=<id>`** handling so links can name the intended project.
> 
> **Client:** New `project-deep-link` helpers validate Convex-shaped ids, decide switch vs wait vs not-found (including cross-org org-switch-first), and strip the query param via `replaceState`. `useProjectDeepLinkSwitch` in `App.tsx` runs that logic through existing `handleSwitchProject` (not sidebar navigation, so the deep-linked path is preserved). A valid `?project=` also blocks first-run onboarding from clobbering the URL before the handler runs.
> 
> **Server:** The v1 agent’s suite URLs in `createdResources` now include `?project=<projectId>` so Slack-bot links are self-describing.
> 
> Unit tests cover param parsing and all `resolveProjectDeepLinkAction` branches; `agent.test.ts` asserts the new URL shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36398e412e948f05099ccbdd325e6aedb52b5d84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `?project=<id>` deep links so shared eval/suite/run URLs open on the correct project. The client switches project/org on load and cleans the URL; the v1 agent appends the param to suite links it returns.

- **New Features**
  - Client reads `?project=<id>`, switches via `handleSwitchProject`, then strips the param.
  - Cross‑org links auto‑switch organizations; invalid/no‑access ids strip and toast.
  - Temporarily blocks first‑run onboarding until the param is handled; pure `resolveProjectDeepLinkAction` with unit tests.

- **Bug Fixes**
  - Failed project switches now show a toast and only clear the param after handling.
  - Correct org‑less project behavior: `not-found` under an active org filter; `wait` when no org filter is active.

<sup>Written for commit 36398e412e948f05099ccbdd325e6aedb52b5d84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

