### PR TITLE
feat(slack-app): bring the MCPJam Slack bot into the monorepo

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,7 @@
   "ignore": [
     "@mcpjam/soundcheck",
     "@mcpjam/mcp",
-    "@mcpjam/design-system"
+    "@mcpjam/design-system",
+    "@mcpjam/slack-app"
   ]
 }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -33,6 +33,9 @@ on:
       - ".github/workflows/pr-mcp-preview.yml"
       - ".github/workflows/deploy-mcp-staging.yml"
       - ".github/workflows/deploy-mcp-prod.yml"
+      # The Slack app is a standalone Socket Mode process, not part of the
+      # inspector image — a slack-app-only PR has nothing to preview.
+      - "slack-app/**"
   repository_dispatch:
     types:
       - backend_preview_ready

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "widget-react",
         "soundcheck",
         "quality-labeler",
-        "mcp"
+        "mcp",
+        "slack-app"
       ],
       "dependencies": {
         "react-force-graph-2d": "^1.29.1"
@@ -870,7 +871,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -1689,7 +1690,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -1703,7 +1704,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1713,7 +1714,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1727,7 +1728,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1737,7 +1738,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2357,6 +2358,181 @@
         "node": ">=18"
       }
     },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.6.tgz",
+      "integrity": "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.6",
+        "@biomejs/cli-darwin-x64": "2.5.6",
+        "@biomejs/cli-linux-arm64": "2.5.6",
+        "@biomejs/cli-linux-arm64-musl": "2.5.6",
+        "@biomejs/cli-linux-x64": "2.5.6",
+        "@biomejs/cli-linux-x64-musl": "2.5.6",
+        "@biomejs/cli-win32-arm64": "2.5.6",
+        "@biomejs/cli-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.6.tgz",
+      "integrity": "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.6.tgz",
+      "integrity": "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
     "node_modules/@braintree/sanitize-url": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
@@ -2927,7 +3103,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2947,7 +3123,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2971,7 +3147,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2999,7 +3175,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3022,7 +3198,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3047,7 +3223,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5287,7 +5463,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -6811,7 +6987,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -7100,6 +7276,10 @@
     },
     "node_modules/@mcpjam/sdk": {
       "resolved": "sdk",
+      "link": true
+    },
+    "node_modules/@mcpjam/slack-app": {
+      "resolved": "slack-app",
       "link": true
     },
     "node_modules/@mcpjam/soundcheck": {
@@ -9027,7 +9207,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -13007,6 +13187,150 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@slack/bolt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/bolt/-/bolt-5.0.0.tgz",
+      "integrity": "sha512-L0FTzidrDKTu4Ph8sdv0bB3acafBTAC02TBcD+hojPTTNSMX3hSK+rkpkUKkqbbc0vGpSjd6A/g71Rjy7EbBhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^5.0.0",
+        "@slack/oauth": "^4.0.0",
+        "@slack/socket-mode": "^3.0.0",
+        "@slack/types": "^3.0.0",
+        "@slack/web-api": "^8.0.0",
+        "express": "^5.0.0",
+        "path-to-regexp": "^8.1.0",
+        "raw-body": "^3",
+        "tsscmp": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=9.6.4"
+      },
+      "peerDependencies": {
+        "@types/express": "^5.0.0"
+      }
+    },
+    "node_modules/@slack/bolt/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@slack/cli-hooks": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/cli-hooks/-/cli-hooks-2.0.0.tgz",
+      "integrity": "sha512-VLxGqJZwbrH3S+ovRhqlrcrKWHRDJtn3toraZKAcLaPqca5CgqTa/PmiCvCq3uUowiFw9B7FOB0y3ikQoDppTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "semver": "^7.5.4"
+      },
+      "bin": {
+        "slack-cli-check-update": "src/check-update.js",
+        "slack-cli-doctor": "src/doctor.js",
+        "slack-cli-get-hooks": "src/get-hooks.js",
+        "slack-cli-get-manifest": "src/get-manifest.js",
+        "slack-cli-start": "src/start.js"
+      },
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
+      }
+    },
+    "node_modules/@slack/logger": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-5.0.0.tgz",
+      "integrity": "sha512-VGXhmmgsAo9shdQYh4tFDndd+7nsgp0Y5h0UPDaUp8K359pBasI6YdkMqFW3mCOxLQkq09qj7o7cq6f3DuXcJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20"
+      },
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
+      }
+    },
+    "node_modules/@slack/oauth": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-4.0.0.tgz",
+      "integrity": "sha512-Aqs5bGghT+VtNcdwVOQy7CcyCfDNd9YYnZsCRukIF9p1Mxuq4uL+BjqlWQB0SeS4wzrLzePPgvj8JDuQil+ezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^5.0.0",
+        "@slack/web-api": "^8.0.0",
+        "@types/jsonwebtoken": "^9",
+        "@types/node": ">=20",
+        "jsonwebtoken": "^9"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=9.6.4"
+      }
+    },
+    "node_modules/@slack/socket-mode": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-3.0.0.tgz",
+      "integrity": "sha512-QShO60SB0E+HH+TbcKj3CBEQbodToRyiXnxuSB4t1kvUlqEmuGA1nOOjrRDkDJbOECAZ13PLe4ek9SrntpfoYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^5.0.0",
+        "@slack/web-api": "^8.0.0",
+        "@types/node": ">=20",
+        "eventemitter3": "^5"
+      },
+      "engines": {
+        "node": ">=20",
+        "npm": ">=9.6.4"
+      },
+      "peerDependencies": {
+        "undici": "^7.0.0"
+      }
+    },
+    "node_modules/@slack/types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-3.0.0.tgz",
+      "integrity": "sha512-KNOqpnNAlsFt5Jk9XBclslQ0lobRIg/0tnhpmvZJAglHJx9E8oceN8hC3gaBzkR6UzQ9Wzq4rLsJ98wUcxWPfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
+      }
+    },
+    "node_modules/@slack/web-api": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-8.0.0.tgz",
+      "integrity": "sha512-ORx3XQryQPq2Jnxv5giSKXVoQRUeylrrymIR2S9fPzLjPcCts8RayMeBSZMcpfpAqp6fnBRuPW2UB6dUPUTEZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/logger": "^5.0.0",
+        "@slack/types": "^3.0.0",
+        "@types/node": ">=20",
+        "@types/retry": "0.12.0",
+        "eventemitter3": "^5.0.1",
+        "p-queue": "^6",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 20",
+        "npm": ">=9.6.4"
+      }
+    },
+    "node_modules/@slack/web-api/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/@smithy/core": {
       "version": "3.24.6",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
@@ -14206,6 +14530,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/keygrip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
@@ -14350,6 +14684,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -14359,7 +14694,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -14374,6 +14709,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -14765,6 +15106,346 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -16901,7 +17582,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -17119,11 +17800,17 @@
         "node": "*"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -18235,7 +18922,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -18256,7 +18943,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -18272,7 +18959,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -18843,7 +19530,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -18857,7 +19544,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -18954,7 +19641,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -19628,6 +20315,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -20331,6 +21027,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -20341,6 +21038,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23122,7 +23820,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -23189,7 +23887,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -23203,7 +23901,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -24015,7 +24713,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -25418,7 +26116,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -25458,7 +26156,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -25468,7 +26166,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -25482,7 +26180,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -25630,6 +26328,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -25702,6 +26422,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jwt-decode": {
@@ -25871,7 +26612,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -25904,6 +26645,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25924,6 +26666,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25944,6 +26687,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25964,6 +26708,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25984,6 +26729,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26004,6 +26750,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26024,6 +26771,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26044,6 +26792,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26064,6 +26813,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26084,6 +26834,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26104,6 +26855,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -26313,6 +27065,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -26325,6 +27113,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.startcase": {
@@ -27022,7 +27816,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -29586,7 +30380,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -29646,6 +30439,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -29772,7 +30621,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -30687,7 +31536,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -32110,7 +32959,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -32140,7 +32989,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -32202,7 +33050,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -32875,7 +33723,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -32894,7 +33742,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -33591,7 +34439,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -33738,7 +34586,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -33822,7 +34670,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -34080,7 +34928,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
       "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -34093,7 +34941,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -34197,7 +35045,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -34210,7 +35058,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -34484,6 +35332,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
     "node_modules/tsup": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
@@ -34558,7 +35415,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -34741,7 +35598,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -35753,7 +36610,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -35829,7 +36686,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -35934,7 +36791,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -35944,7 +36801,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -36815,7 +37672,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -36835,7 +37692,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/xpath": {
@@ -37143,6 +38000,67 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "slack-app": {
+      "name": "@mcpjam/slack-app",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/bolt": "^5.0.0",
+        "dotenv": "~17.4.2"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.5.6",
+        "@slack/cli-hooks": "^2.0.0",
+        "typescript": "^7.0.2"
+      }
+    },
+    "slack-app/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "slack-app/node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "soundcheck": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "widget-react",
     "soundcheck",
     "quality-labeler",
-    "mcp"
+    "mcp",
+    "slack-app"
   ],
   "scripts": {
     "build": "npm run build -w @mcpjam/sdk && npm run build -w @mcpjam/cli && npm run build -w @mcpjam/chat-ui && npm run build -w @mcpjam/widget-react && npm run build -w @mcpjam/inspector",
@@ -22,8 +23,8 @@
     "check:platform-runtime-safety": "! rg -n '[\"\\x27]node:|process\\.env' sdk/src/platform",
     "check:platform-runtime-safety:dist": "test -d sdk/dist/platform && ! rg -n '[\"\\x27]node:|process\\.env' sdk/dist/platform -g '!*.map'",
     "test": "npm run check:mcp-v1-runtime-imports && npm run check:bundled-runtime-paths && npm run check:platform-runtime-safety && npm run build -w @mcpjam/sdk && npm run check:platform-runtime-safety:dist && npm run test:parallel && npm run test:packaging -w @mcpjam/sdk",
-    "test:parallel": "concurrently -n sdk,cli,design,chatui,widget,inspector,mcp -c blue,green,yellow,white,red,magenta,cyan --kill-others-on-fail \"npm run test -w @mcpjam/sdk\" \"npm run test -w @mcpjam/cli\" \"npm run test -w @mcpjam/design-system\" \"npm run test -w @mcpjam/chat-ui\" \"npm run test -w @mcpjam/widget-react\" \"npm run test -w @mcpjam/inspector\" \"npm run test:fast -w @mcpjam/mcp && npm run typecheck:fast -w @mcpjam/mcp\"",
-    "test:ordered": "npm run test -w @mcpjam/sdk && npm run test:packaging -w @mcpjam/sdk && npm run test -w @mcpjam/cli && npm run test -w @mcpjam/design-system && npm run test -w @mcpjam/chat-ui && npm run test -w @mcpjam/widget-react && npm run test -w @mcpjam/inspector && npm run test -w @mcpjam/mcp && npm run typecheck -w @mcpjam/mcp",
+    "test:parallel": "concurrently -n sdk,cli,design,chatui,widget,inspector,mcp,slack -c blue,green,yellow,white,red,magenta,cyan,gray --kill-others-on-fail \"npm run test -w @mcpjam/sdk\" \"npm run test -w @mcpjam/cli\" \"npm run test -w @mcpjam/design-system\" \"npm run test -w @mcpjam/chat-ui\" \"npm run test -w @mcpjam/widget-react\" \"npm run test -w @mcpjam/inspector\" \"npm run test:fast -w @mcpjam/mcp && npm run typecheck:fast -w @mcpjam/mcp\" \"npm run verify -w @mcpjam/slack-app\"",
+    "test:ordered": "npm run test -w @mcpjam/sdk && npm run test:packaging -w @mcpjam/sdk && npm run test -w @mcpjam/cli && npm run test -w @mcpjam/design-system && npm run test -w @mcpjam/chat-ui && npm run test -w @mcpjam/widget-react && npm run test -w @mcpjam/inspector && npm run test -w @mcpjam/mcp && npm run typecheck -w @mcpjam/mcp && npm run verify -w @mcpjam/slack-app",
     "verify": "npm run typecheck && npm run test && npm run build:inspector",
     "docs:sync-tokens": "node scripts/sync-docs-tokens.mjs",
     "docs:check-tokens": "node scripts/sync-docs-tokens.mjs --check",

--- a/slack-app/.env.sample
+++ b/slack-app/.env.sample
@@ -1,0 +1,19 @@
+# Required — MCPJam public API. Mint the key in the MCPJam app
+# (Settings → API keys); the project id is in the app URL / project settings.
+MCPJAM_API_KEY=YOUR_MCPJAM_API_KEY
+MCPJAM_PROJECT_ID=YOUR_MCPJAM_PROJECT_ID
+
+# Optional, defaults to https://app.mcpjam.com. Point at a local inspector
+# (e.g. http://localhost:6274) during development.
+# MCPJAM_BASE_URL=https://app.mcpjam.com
+
+# Optional — where deep links in Slack messages point. Defaults to
+# MCPJAM_BASE_URL. In local dev the app UI (5173) differs from the API (6274).
+# MCPJAM_APP_URL=http://localhost:5173
+
+# Optional, uncomment and set when running without the Slack CLI (npm start).
+# SLACK_APP_TOKEN=YOUR_SLACK_APP_TOKEN
+# SLACK_BOT_TOKEN=YOUR_SLACK_BOT_TOKEN
+
+# Optional, uncomment and set when using a custom Slack instance.
+# SLACK_API_URL=YOUR_SLACK_API_URL

--- a/slack-app/.gitignore
+++ b/slack-app/.gitignore
@@ -1,0 +1,12 @@
+# Environment — the bot's MCPJam API key lives here
+.env*
+!.env.sample
+
+# Logs
+logs/
+
+# macOS
+.DS_Store
+
+# Node.js
+node_modules/

--- a/slack-app/.slack/.gitignore
+++ b/slack-app/.slack/.gitignore
@@ -1,0 +1,2 @@
+apps.dev.json
+cache/

--- a/slack-app/.slack/config.json
+++ b/slack-app/.slack/config.json
@@ -1,0 +1,6 @@
+{
+  "manifest": {
+    "source": "local"
+  },
+  "project_id": "2ce2a086-431d-4799-8476-3e9915ec729d"
+}

--- a/slack-app/.slack/hooks.json
+++ b/slack-app/.slack/hooks.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "get-hooks": "npx -q --no-install -p @slack/cli-hooks slack-cli-get-hooks"
+  }
+}

--- a/slack-app/LICENSE
+++ b/slack-app/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Slack Technologies, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/slack-app/NOTICE
+++ b/slack-app/NOTICE
@@ -1,6 +1,21 @@
+Third-party notices for the MCPJam Slack app
+============================================
+
+This workspace is licensed under the repository's root LICENSE (Apache-2.0,
+Copyright (c) 2025-present MCPJam Inc).
+
+It was scaffolded from the Slack sample app
+`slack-samples/bolt-js-starter-agent`, and portions of that sample survive
+(notably the Bolt app/listener wiring and the thread-context store). Those
+portions remain under the MIT license reproduced below, whose copyright
+notice is retained here as that license requires.
+
+--------------------------------------------------------------------------
+
 MIT License
 
 Copyright (c) 2026 Slack Technologies, LLC
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/slack-app/README.md
+++ b/slack-app/README.md
@@ -9,7 +9,7 @@ MCPJam project and hands back a **Run it** button.
 The bot has **no brain of its own**. It is a thin terminal over MCPJam's own
 agent engine, exactly like the CLI and the MCP worker are thin over `/api/v1`:
 
-```
+```text
 Slack event → collect thread → POST /api/v1/projects/:projectId/agent → post reply
 ```
 
@@ -54,6 +54,12 @@ billed to the project. Consequences worth knowing:
   `ack()` first.
 - **Speaker names are not resolved.** That would need the `users:read` scope,
   which the manifest deliberately does not request.
+- **The message history the bot sends is capped in bytes, not just
+  characters** (`turn-runner.js`), mirroring the server's per-message and
+  aggregate UTF-8 limits. Character-only caps let emoji/CJK threads 400.
+- **`im:read` / `im:write` are still requested but unused** by any current
+  code path — trimming them needs a reinstall, so it is a deliberate
+  follow-up rather than a silent change mid-dogfood.
 
 ## Setup
 

--- a/slack-app/README.md
+++ b/slack-app/README.md
@@ -1,0 +1,109 @@
+# MCPJam Slack app
+
+A Slack bot that turns conversations into MCPJam eval suites. Mention it (or DM
+it) with what your MCP server should do, and it authors a runnable suite in your
+MCPJam project and hands back a **Run it** button.
+
+## Architecture
+
+The bot has **no brain of its own**. It is a thin terminal over MCPJam's own
+agent engine, exactly like the CLI and the MCP worker are thin over `/api/v1`:
+
+```
+Slack event → collect thread → POST /api/v1/projects/:projectId/agent → post reply
+```
+
+That endpoint (`mcpjam-inspector/server/routes/v1/agent.ts`) runs one assistant
+turn server-side with a project-scoped workspace toolset, on a hosted model
+billed to the project. Consequences worth knowing:
+
+- **No LLM credentials live here.** There is no Anthropic/OpenAI key, no agent
+  loop, no model config in this workspace — only an MCPJam API key.
+- **The bot cannot start eval runs.** The agent's toolset is reads plus
+  `create_eval_suite`; run operations are excluded server-side because a turn
+  is unattended (`approvalMode: "auto-deny"`). Runs happen only when a human
+  clicks **Run it**, which calls `POST /eval-runs` directly.
+- **Every operation is clamped to `MCPJAM_PROJECT_ID`** by the server, not by
+  prompt instructions.
+
+### Files
+
+| Path | What it does |
+| --- | --- |
+| `app.js` | Bolt app entry (Socket Mode) |
+| `agent/mcpjam-client.js` | HTTP client for the MCPJam public API — turns, run starts, run polling |
+| `agent/turn-runner.js` | Event dedupe (TTL), per-thread serialization, thread → message-history normalization |
+| `listeners/events/run-and-reply.js` | Shared body for DM / mention triggers: run the turn, post the reply |
+| `listeners/actions/run-suite-button.js` | The human-gated **Run it** button + the detached watcher that edits the message with the run outcome |
+| `listeners/views/` | Block Kit builders (App Home, created-suite blocks, feedback) |
+| `thread-context/` | Tracks which channel threads the bot is engaged in |
+
+### Correctness details that are easy to break
+
+- **Never blind-retry a turn.** The agent endpoint is not idempotent — a lost
+  response may still have persisted a suite. Dedupe lives at the trigger
+  (`EventDedupe`, keyed on `channel + event ts`, with a TTL so a *delayed*
+  Slack retry after completion is still caught). `mcpjam-client` makes exactly
+  one attempt per call on purpose.
+- **Turns are serialized per thread** (`KeyedQueue`), so two rapid messages in
+  one thread can't race into duplicate suites.
+- **Thread history is filtered through the triggering timestamp** — messages
+  newer than the trigger belong to the next turn.
+- **Bolt v5 auto-acks Events API events** before listeners run, so a long
+  listener body is fine. Block actions (the Run button) still need an explicit
+  `ack()` first.
+- **Speaker names are not resolved.** That would need the `users:read` scope,
+  which the manifest deliberately does not request.
+
+## Setup
+
+From the repo root, `npm install` covers this workspace. You also need the
+[Slack CLI](https://docs.slack.dev/tools/slack-cli/) and a Slack workspace where
+you can install apps.
+
+Copy the env sample and fill it in:
+
+```sh
+cd slack-app
+cp .env.sample .env
+```
+
+| Variable | Required | Meaning |
+| --- | --- | --- |
+| `MCPJAM_API_KEY` | yes | MCPJam API key (`sk_…`), minted at **Settings → API keys**. Scopes the bot to one organization. |
+| `MCPJAM_PROJECT_ID` | yes | The project every turn operates in. From `GET /api/v1/projects` or the app URL. |
+| `MCPJAM_BASE_URL` | no | API host. Defaults to `https://app.mcpjam.com`; point at a local inspector (`http://localhost:6274`) for development. |
+| `MCPJAM_APP_URL` | no | Where deep links posted into Slack point. Defaults to `MCPJAM_BASE_URL`; in local dev the UI (`:5173`) differs from the API (`:6274`). |
+
+## Development
+
+```sh
+cd slack-app
+slack run          # installs the dev app + starts Socket Mode with hot reload
+```
+
+`slack run` must be run from this directory (it needs `.slack/`). On first run
+it will ask which workspace to install into; the choice is saved locally to
+`.slack/apps.dev.json` (git-ignored).
+
+Then DM the bot, or `@MCPJam` it in a thread:
+
+> create an eval suite for the excalidraw server with one case: prompt "draw a
+> small house", and assert that a drawing/create tool gets called
+
+## Tests
+
+```sh
+npm run verify -w @mcpjam/slack-app   # test + check + lint (what CI runs)
+npm test    -w @mcpjam/slack-app      # node:test only
+```
+
+Tests are `node:test` with no network: the API client takes an injectable
+`fetchImpl`, and Slack clients are hand-stubbed.
+
+## Deployment
+
+Not deployed yet — Socket Mode against a developer install is the current
+dogfood path. Hosting (a Railway service modeled on `deploy-soundcheck.yml`)
+and multi-tenant OAuth distribution are tracked as follow-ups; OAuth mode was
+deliberately removed from v1 rather than shipped half-wired.

--- a/slack-app/agent/index.js
+++ b/slack-app/agent/index.js
@@ -1,0 +1,2 @@
+export { McpjamApiError, runAgentTurn, startSuiteRun } from './mcpjam-client.js';
+export { runTurnForEvent } from './turn-runner.js';

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -1,0 +1,175 @@
+/**
+ * Thin client for the MCPJam public API — the bot's only "brain" is the
+ * server-side agent endpoint. No LLM key or agent loop lives in this app.
+ *
+ * RETRY POLICY: never blind-retry a turn. The endpoint is not idempotent —
+ * a lost response may still have persisted an eval suite. Dedupe lives at
+ * the trigger (turn-runner's channel+event-ts registry); this client makes
+ * exactly one attempt per call, on purpose.
+ *
+ * Env:
+ *   MCPJAM_API_KEY    — sk_… key minted in the MCPJam app (Settings → API keys)
+ *   MCPJAM_PROJECT_ID — the project every turn is scoped to
+ *   MCPJAM_BASE_URL   — defaults to https://app.mcpjam.com
+ */
+
+const DEFAULT_BASE_URL = 'https://app.mcpjam.com';
+// Slightly above the server's 90s turn wall clock.
+const TURN_TIMEOUT_MS = 120_000;
+const RUN_TIMEOUT_MS = 30_000;
+
+/** @typedef {{ role: 'user' | 'assistant', content: string }} TurnMessage */
+/**
+ * @typedef {Object} AgentTurnResult
+ * @property {string} reply
+ * @property {Array<{ operation: string }>} toolCalls
+ * @property {Array<{ type: string, id: string, name?: string, url: string }>} createdResources
+ */
+
+export class McpjamApiError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ code?: string, status?: number }} [opts]
+   */
+  constructor(message, opts = {}) {
+    super(message);
+    this.name = 'McpjamApiError';
+    this.code = opts.code;
+    this.status = opts.status;
+  }
+
+  /** A short, user-facing Slack message for this failure. */
+  get friendlyMessage() {
+    if (this.code === 'RATE_LIMITED') {
+      return ":hourglass_flowing_sand: I'm at capacity right now — give it a minute and try again.";
+    }
+    if (this.code === 'TIMEOUT') {
+      return ':hourglass: That took longer than I allow for one reply. Try breaking the request into smaller steps.';
+    }
+    if (this.code === 'UNAUTHORIZED' || this.code === 'FORBIDDEN') {
+      return ':lock: My MCPJam credentials look wrong — an admin needs to check the API key configuration.';
+    }
+    return ':warning: Something went wrong talking to MCPJam. Try again in a moment.';
+  }
+}
+
+export function getConfig() {
+  const apiKey = process.env.MCPJAM_API_KEY;
+  const projectId = process.env.MCPJAM_PROJECT_ID;
+  const baseUrl = (process.env.MCPJAM_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
+  // Deep links can point somewhere other than the API host — in local dev
+  // the API is on :6274 while the app UI is served on :5173.
+  const appUrl = (process.env.MCPJAM_APP_URL || baseUrl).replace(/\/+$/, '');
+  if (!apiKey || !projectId) {
+    throw new McpjamApiError('MCPJAM_API_KEY and MCPJAM_PROJECT_ID must be set (see .env.sample).', { code: 'CONFIG' });
+  }
+  return { apiKey, projectId, baseUrl, appUrl };
+}
+
+/**
+ * @param {string} url
+ * @param {Record<string, unknown>} body
+ * @param {{ apiKey: string, timeoutMs: number, fetchImpl?: typeof fetch }} opts
+ * @returns {Promise<any>}
+ */
+async function postJson(url, body, { apiKey, timeoutMs, fetchImpl = fetch }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === 'AbortError';
+    throw new McpjamApiError(aborted ? `Request timed out after ${timeoutMs}ms` : `Request failed: ${error}`, {
+      code: aborted ? 'TIMEOUT' : 'NETWORK',
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  /** @type {any} */
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    // handled below
+  }
+  if (!response.ok) {
+    throw new McpjamApiError(payload?.message || `MCPJam API error (${response.status})`, {
+      code: payload?.code,
+      status: response.status,
+    });
+  }
+  return payload;
+}
+
+/**
+ * Run one agent turn.
+ * @param {TurnMessage[]} messages
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<AgentTurnResult>}
+ */
+export async function runAgentTurn(messages, opts = {}) {
+  const { apiKey, projectId, baseUrl } = getConfig();
+  const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/agent`;
+  const payload = await postJson(url, { messages }, { apiKey, timeoutMs: TURN_TIMEOUT_MS, fetchImpl: opts.fetchImpl });
+  return {
+    reply: typeof payload?.reply === 'string' ? payload.reply : '',
+    toolCalls: Array.isArray(payload?.toolCalls) ? payload.toolCalls : [],
+    createdResources: Array.isArray(payload?.createdResources) ? payload.createdResources : [],
+  };
+}
+
+/**
+ * Start an eval-suite run. This is the human-gated action behind the Slack
+ * "Run it" button — the agent turn itself can never start runs.
+ * @param {string} suiteId
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<{ runId: string, suiteId: string, url: string }>}
+ */
+export async function startSuiteRun(suiteId, opts = {}) {
+  const { apiKey, projectId, baseUrl, appUrl } = getConfig();
+  const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/eval-runs`;
+  const payload = await postJson(url, { suiteId }, { apiKey, timeoutMs: RUN_TIMEOUT_MS, fetchImpl: opts.fetchImpl });
+  const runId = String(payload?.runId ?? '');
+  return {
+    runId,
+    suiteId,
+    // `?project=` makes the link land on the right project for viewers whose
+    // picker is parked elsewhere (eval routes carry no project segment).
+    url: `${appUrl}/evals/suite/${encodeURIComponent(suiteId)}/runs/${encodeURIComponent(runId)}?project=${encodeURIComponent(projectId)}`,
+  };
+}
+
+/**
+ * Poll one run's status/result.
+ * @param {string} runId
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<{ status: string, result: string | null, summary?: { total?: number, passed?: number, failed?: number, passRate?: number } }>}
+ */
+export async function getEvalRun(runId, opts = {}) {
+  const { apiKey, projectId, baseUrl } = getConfig();
+  const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/eval-runs/${encodeURIComponent(runId)}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
+  try {
+    const response = await (opts.fetchImpl ?? fetch)(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new McpjamApiError(`MCPJam API error (${response.status})`, { status: response.status });
+    }
+    return await response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -67,26 +67,44 @@ export function getConfig() {
 }
 
 /**
+ * One JSON request with a timeout that covers the WHOLE exchange, body
+ * included — clearing the timer once headers arrive would let a response
+ * that never finishes its body hang the caller forever.
+ *
  * @param {string} url
- * @param {Record<string, unknown>} body
- * @param {{ apiKey: string, timeoutMs: number, fetchImpl?: typeof fetch }} opts
+ * @param {{ method?: string, body?: Record<string, unknown>, apiKey: string, timeoutMs: number, fetchImpl?: typeof fetch }} opts
  * @returns {Promise<any>}
  */
-async function postJson(url, body, { apiKey, timeoutMs, fetchImpl = fetch }) {
+async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetchImpl = fetch }) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
-  let response;
   try {
-    response = await fetchImpl(url, {
-      method: 'POST',
+    const response = await fetchImpl(url, {
+      method,
       headers: {
-        'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
       },
-      body: JSON.stringify(body),
+      ...(body ? { body: JSON.stringify(body) } : {}),
       signal: controller.signal,
     });
+
+    /** @type {any} */
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch {
+      // Non-JSON or empty body; `payload` stays null and the status decides.
+    }
+    if (!response.ok) {
+      throw new McpjamApiError(payload?.message || `MCPJam API error (${response.status})`, {
+        code: payload?.code,
+        status: response.status,
+      });
+    }
+    return payload;
   } catch (error) {
+    if (error instanceof McpjamApiError) throw error;
     const aborted = error instanceof Error && error.name === 'AbortError';
     throw new McpjamApiError(aborted ? `Request timed out after ${timeoutMs}ms` : `Request failed: ${error}`, {
       code: aborted ? 'TIMEOUT' : 'NETWORK',
@@ -94,21 +112,6 @@ async function postJson(url, body, { apiKey, timeoutMs, fetchImpl = fetch }) {
   } finally {
     clearTimeout(timer);
   }
-
-  /** @type {any} */
-  let payload = null;
-  try {
-    payload = await response.json();
-  } catch {
-    // handled below
-  }
-  if (!response.ok) {
-    throw new McpjamApiError(payload?.message || `MCPJam API error (${response.status})`, {
-      code: payload?.code,
-      status: response.status,
-    });
-  }
-  return payload;
 }
 
 /**
@@ -120,7 +123,13 @@ async function postJson(url, body, { apiKey, timeoutMs, fetchImpl = fetch }) {
 export async function runAgentTurn(messages, opts = {}) {
   const { apiKey, projectId, baseUrl } = getConfig();
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/agent`;
-  const payload = await postJson(url, { messages }, { apiKey, timeoutMs: TURN_TIMEOUT_MS, fetchImpl: opts.fetchImpl });
+  const payload = await requestJson(url, {
+    method: 'POST',
+    body: { messages },
+    apiKey,
+    timeoutMs: TURN_TIMEOUT_MS,
+    fetchImpl: opts.fetchImpl,
+  });
   return {
     reply: typeof payload?.reply === 'string' ? payload.reply : '',
     toolCalls: Array.isArray(payload?.toolCalls) ? payload.toolCalls : [],
@@ -138,8 +147,19 @@ export async function runAgentTurn(messages, opts = {}) {
 export async function startSuiteRun(suiteId, opts = {}) {
   const { apiKey, projectId, baseUrl, appUrl } = getConfig();
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/eval-runs`;
-  const payload = await postJson(url, { suiteId }, { apiKey, timeoutMs: RUN_TIMEOUT_MS, fetchImpl: opts.fetchImpl });
+  const payload = await requestJson(url, {
+    method: 'POST',
+    body: { suiteId },
+    apiKey,
+    timeoutMs: RUN_TIMEOUT_MS,
+    fetchImpl: opts.fetchImpl,
+  });
   const runId = String(payload?.runId ?? '');
+  // A run without an id can't be linked or polled — surface it instead of
+  // posting a deep link to `/runs/?project=…`.
+  if (!runId) {
+    throw new McpjamApiError('MCPJam started a run but returned no run id.', { code: 'INTERNAL_ERROR' });
+  }
   return {
     runId,
     suiteId,
@@ -158,18 +178,5 @@ export async function startSuiteRun(suiteId, opts = {}) {
 export async function getEvalRun(runId, opts = {}) {
   const { apiKey, projectId, baseUrl } = getConfig();
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/eval-runs/${encodeURIComponent(runId)}`;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
-  try {
-    const response = await (opts.fetchImpl ?? fetch)(url, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      throw new McpjamApiError(`MCPJam API error (${response.status})`, { status: response.status });
-    }
-    return await response.json();
-  } finally {
-    clearTimeout(timer);
-  }
+  return requestJson(url, { apiKey, timeoutMs: RUN_TIMEOUT_MS, fetchImpl: opts.fetchImpl });
 }

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -93,8 +93,14 @@ async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetch
     let payload = null;
     try {
       payload = await response.json();
-    } catch {
-      // Non-JSON or empty body; `payload` stays null and the status decides.
+    } catch (error) {
+      // A body that isn't JSON (an HTML error page, an empty 204) is fine —
+      // `payload` stays null and the status decides. Anything else is a real
+      // failure mid-body: the abort firing while the body streamed, or a
+      // dropped connection. Those MUST NOT be laundered into "no body" and
+      // returned as success — headers already arrived, so `response.ok` is
+      // true and the stall would be reported as an empty, successful reply.
+      if (!(error instanceof SyntaxError)) throw error;
     }
     if (!response.ok) {
       throw new McpjamApiError(payload?.message || `MCPJam API error (${response.status})`, {

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -1,0 +1,206 @@
+/**
+ * Centralized turn processing for every Slack trigger (DM message, thread
+ * reply, @mention). Owns the three correctness concerns the listeners must
+ * not re-implement:
+ *
+ *  1. TTL dedupe on `channel + event ts` — Slack retries events, and a
+ *     retry can arrive AFTER the original completed, so an in-flight-only
+ *     set is not enough; completed keys are retained for a TTL window.
+ *  2. Per-thread serialization — two rapid messages in one thread run one
+ *     at a time, so concurrent turns can't both create the same suite.
+ *  3. History normalization — the thread is refetched and filtered through
+ *     the triggering timestamp (messages newer than the trigger belong to
+ *     the NEXT turn), then mapped/truncated to the API's message contract.
+ *
+ * Note: Bolt v5 auto-acknowledges Events API events before listeners run,
+ * so a long-running listener body is fine — no detaching needed here.
+ */
+import { runAgentTurn } from './mcpjam-client.js';
+
+// API contract limits (mirror the server's schema).
+const MAX_MESSAGES = 50;
+const MAX_MESSAGE_CHARS = 8_000;
+
+const DEDUPE_TTL_MS = 30 * 60 * 1000;
+
+/** @typedef {{ role: 'user' | 'assistant', content: string }} TurnMessage */
+
+/**
+ * Dedupe registry: eventKey → completion timestamp (Infinity while
+ * in-flight). Swept lazily on insert.
+ */
+export class EventDedupe {
+  /** @param {{ ttlMs?: number, now?: () => number }} [opts] */
+  constructor(opts = {}) {
+    this.ttlMs = opts.ttlMs ?? DEDUPE_TTL_MS;
+    this.now = opts.now ?? Date.now;
+    /** @type {Map<string, number>} */
+    this.seen = new Map();
+  }
+
+  /**
+   * Returns true the FIRST time a key is claimed; false for any repeat
+   * within the TTL (in-flight or completed).
+   * @param {string} key
+   */
+  claim(key) {
+    this.sweep();
+    if (this.seen.has(key)) return false;
+    this.seen.set(key, Number.POSITIVE_INFINITY);
+    return true;
+  }
+
+  /**
+   * Mark a claimed key completed — it stays deduped for the TTL.
+   * @param {string} key
+   */
+  complete(key) {
+    if (this.seen.has(key)) this.seen.set(key, this.now());
+  }
+
+  sweep() {
+    const cutoff = this.now() - this.ttlMs;
+    for (const [key, completedAt] of this.seen) {
+      if (completedAt !== Number.POSITIVE_INFINITY && completedAt < cutoff) {
+        this.seen.delete(key);
+      }
+    }
+  }
+}
+
+/**
+ * Per-key promise chains: work for the same key runs strictly in order;
+ * different keys run concurrently. The chain entry is removed once its
+ * last job settles, so the map can't grow unbounded.
+ */
+export class KeyedQueue {
+  constructor() {
+    /** @type {Map<string, Promise<unknown>>} */
+    this.chains = new Map();
+  }
+
+  /**
+   * @template T
+   * @param {string} key
+   * @param {() => Promise<T>} job
+   * @returns {Promise<T>}
+   */
+  enqueue(key, job) {
+    const previous = this.chains.get(key) ?? Promise.resolve();
+    const next = previous.then(job, job);
+    // Track settlement without swallowing the job's error for the caller.
+    const settled = next.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.chains.set(key, settled);
+    settled.then(() => {
+      if (this.chains.get(key) === settled) this.chains.delete(key);
+    });
+    return next;
+  }
+}
+
+/**
+ * Map raw Slack thread messages to the API contract: bot messages become
+ * `assistant`, everything else `user`; filtered through the triggering
+ * timestamp, truncated per message, and capped to the most recent
+ * MAX_MESSAGES.
+ *
+ * Speaker attribution is deliberately absent: naming humans would need the
+ * `users:read` scope, which the manifest does not request. If per-speaker
+ * context is ever needed, the scope and the lookup land together.
+ *
+ * @param {Array<{ ts?: string, text?: string, bot_id?: string, user?: string }>} raw
+ * @param {{ botUserId?: string, triggerTs: string }} opts
+ * @returns {TurnMessage[]}
+ */
+export function normalizeThreadMessages(raw, opts) {
+  const trigger = Number.parseFloat(opts.triggerTs);
+  /** @type {TurnMessage[]} */
+  const messages = [];
+  for (const message of raw) {
+    const text = (message.text || '').trim();
+    if (!text) continue;
+    const ts = Number.parseFloat(message.ts || '0');
+    if (Number.isFinite(trigger) && ts > trigger) continue;
+    const isBot = Boolean(message.bot_id) || (opts.botUserId !== undefined && message.user === opts.botUserId);
+    messages.push({
+      role: isBot ? 'assistant' : 'user',
+      content: text.length > MAX_MESSAGE_CHARS ? `${text.slice(0, MAX_MESSAGE_CHARS - 1)}…` : text,
+    });
+  }
+  return messages.slice(-MAX_MESSAGES);
+}
+
+export const dedupe = new EventDedupe();
+export const threadQueue = new KeyedQueue();
+
+/**
+ * Fetch + normalize the conversation context for a trigger.
+ * Channel threads use `conversations.replies`; DM top-level messages use
+ * `conversations.history` (a DM has no thread until someone starts one).
+ *
+ * @param {import('@slack/web-api').WebClient} client
+ * @param {{ channelId: string, threadTs: string, triggerTs: string, isThread: boolean, botUserId?: string }} args
+ * @returns {Promise<TurnMessage[]>}
+ */
+export async function fetchThreadContext(client, args) {
+  /** @type {Array<Record<string, any>>} */
+  let raw = [];
+  if (args.isThread) {
+    const result = await client.conversations.replies({
+      channel: args.channelId,
+      ts: args.threadTs,
+      limit: 200,
+    });
+    raw = result.messages ?? [];
+  } else {
+    const result = await client.conversations.history({
+      channel: args.channelId,
+      latest: args.triggerTs,
+      inclusive: true,
+      limit: MAX_MESSAGES,
+    });
+    raw = (result.messages ?? []).slice().reverse(); // history is newest-first
+  }
+  return normalizeThreadMessages(raw, {
+    botUserId: args.botUserId,
+    triggerTs: args.triggerTs,
+  });
+}
+
+/**
+ * Run one full turn for a Slack trigger: dedupe, serialize per thread,
+ * gather context, call MCPJam, and hand the result back to the listener
+ * for posting. Returns null when the event was a duplicate.
+ *
+ * @param {{
+ *   client: import('@slack/web-api').WebClient,
+ *   channelId: string,
+ *   threadTs: string,
+ *   triggerTs: string,
+ *   isThread: boolean,
+ *   botUserId?: string,
+ *   fallbackText: string,
+ * }} args
+ * @returns {Promise<import('./mcpjam-client.js').AgentTurnResult | null>}
+ */
+export async function runTurnForEvent(args) {
+  const eventKey = `${args.channelId}:${args.triggerTs}`;
+  if (!dedupe.claim(eventKey)) return null;
+
+  const threadKey = `${args.channelId}:${args.threadTs}`;
+  try {
+    return await threadQueue.enqueue(threadKey, async () => {
+      let messages = await fetchThreadContext(args.client, args);
+      if (messages.length === 0) {
+        // Context fetch can miss (e.g. scopes); fall back to the trigger text.
+        messages = [{ role: 'user', content: args.fallbackText }];
+      }
+      return runAgentTurn(messages);
+    });
+  } finally {
+    dedupe.complete(eventKey);
+  }
+}

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -32,21 +32,30 @@ const DEDUPE_TTL_MS = 30 * 60 * 1000;
 const utf8Length = (/** @type {string} */ text) => Buffer.byteLength(text, 'utf8');
 
 /**
- * Truncate to a UTF-8 byte budget on code-point boundaries (never splits a
- * surrogate pair into replacement characters).
+ * Cap one message against BOTH server limits in a single pass.
+ *
+ * The two caps are independent: 8,001 ASCII characters break the character
+ * limit while staying well under the byte limit, and 4,000 emoji do the
+ * reverse. Iteration is by CODE POINT (`for…of`), so a cut never lands
+ * inside a surrogate pair — a `String.prototype.slice` on UTF-16 units
+ * would happily leave a lone surrogate behind.
+ *
  * @param {string} text
- * @param {number} maxBytes
  */
-function truncateToBytes(text, maxBytes) {
-  if (utf8Length(text) <= maxBytes) return text;
+export function capMessageContent(text) {
+  if (text.length <= MAX_MESSAGE_CHARS && utf8Length(text) <= MAX_MESSAGE_BYTES) return text;
   const suffix = '…';
-  const budget = maxBytes - utf8Length(suffix);
+  const maxUnits = MAX_MESSAGE_CHARS - suffix.length;
+  const maxBytes = MAX_MESSAGE_BYTES - utf8Length(suffix);
+  let units = 0;
   let bytes = 0;
   let out = '';
   for (const char of text) {
-    const size = utf8Length(char);
-    if (bytes + size > budget) break;
-    bytes += size;
+    const nextUnits = units + char.length;
+    const nextBytes = bytes + utf8Length(char);
+    if (nextUnits > maxUnits || nextBytes > maxBytes) break;
+    units = nextUnits;
+    bytes = nextBytes;
     out += char;
   }
   return out + suffix;
@@ -168,10 +177,9 @@ export function normalizeThreadMessages(raw, opts) {
     const ts = Number.parseFloat(message.ts || '0');
     if (Number.isFinite(trigger) && ts > trigger) continue;
     const isBot = Boolean(message.bot_id) || (opts.botUserId !== undefined && message.user === opts.botUserId);
-    const capped = text.length > MAX_MESSAGE_CHARS ? `${text.slice(0, MAX_MESSAGE_CHARS - 1)}…` : text;
     messages.push({
       role: isBot ? 'assistant' : 'user',
-      content: truncateToBytes(capped, MAX_MESSAGE_BYTES),
+      content: capMessageContent(text),
     });
   }
 
@@ -255,7 +263,17 @@ export async function runTurnForEvent(args) {
 
   // Only after the claim: a duplicate delivery must not raise a "working"
   // status that no reply will ever clear.
-  await args.onStart?.();
+  //
+  // If it throws, RELEASE the claim: no turn work has happened yet, and an
+  // in-flight claim is never swept, so keeping it would silently drop every
+  // later redelivery of this event — the user would get no answer at all
+  // because a cosmetic status update failed.
+  try {
+    await args.onStart?.();
+  } catch (error) {
+    dedupe.release(eventKey);
+    throw error;
+  }
 
   // Serialization key. A channel thread keys on its parent ts. A top-level DM
   // has NO thread, so `threadTs` is the message's own ts — keying on that

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -17,11 +17,40 @@
  */
 import { runAgentTurn } from './mcpjam-client.js';
 
-// API contract limits (mirror the server's schema).
+// API contract limits. These MIRROR the server's schema in
+// `mcpjam-inspector/server/routes/v1/agent.ts` — it enforces characters AND
+// UTF-8 bytes per message plus an aggregate byte budget, and rejects the
+// whole turn with 400 if any is exceeded. Character caps alone are not
+// enough: emoji/CJK text is up to 4 bytes per character.
 const MAX_MESSAGES = 50;
 const MAX_MESSAGE_CHARS = 8_000;
+const MAX_MESSAGE_BYTES = 8_192;
+const MAX_TOTAL_MESSAGE_BYTES = 98_304; // 96 KB across the whole history
 
 const DEDUPE_TTL_MS = 30 * 60 * 1000;
+
+const utf8Length = (/** @type {string} */ text) => Buffer.byteLength(text, 'utf8');
+
+/**
+ * Truncate to a UTF-8 byte budget on code-point boundaries (never splits a
+ * surrogate pair into replacement characters).
+ * @param {string} text
+ * @param {number} maxBytes
+ */
+function truncateToBytes(text, maxBytes) {
+  if (utf8Length(text) <= maxBytes) return text;
+  const suffix = '…';
+  const budget = maxBytes - utf8Length(suffix);
+  let bytes = 0;
+  let out = '';
+  for (const char of text) {
+    const size = utf8Length(char);
+    if (bytes + size > budget) break;
+    bytes += size;
+    out += char;
+  }
+  return out + suffix;
+}
 
 /** @typedef {{ role: 'user' | 'assistant', content: string }} TurnMessage */
 
@@ -56,6 +85,20 @@ export class EventDedupe {
    */
   complete(key) {
     if (this.seen.has(key)) this.seen.set(key, this.now());
+  }
+
+  /**
+   * Drop a claim entirely so the key can be claimed again immediately.
+   * Only for work that provably did NOT happen — never for "unsure".
+   * @param {string} key
+   */
+  release(key) {
+    this.seen.delete(key);
+  }
+
+  /** Forget every claim (tests). */
+  clear() {
+    this.seen.clear();
   }
 
   sweep() {
@@ -125,12 +168,22 @@ export function normalizeThreadMessages(raw, opts) {
     const ts = Number.parseFloat(message.ts || '0');
     if (Number.isFinite(trigger) && ts > trigger) continue;
     const isBot = Boolean(message.bot_id) || (opts.botUserId !== undefined && message.user === opts.botUserId);
+    const capped = text.length > MAX_MESSAGE_CHARS ? `${text.slice(0, MAX_MESSAGE_CHARS - 1)}…` : text;
     messages.push({
       role: isBot ? 'assistant' : 'user',
-      content: text.length > MAX_MESSAGE_CHARS ? `${text.slice(0, MAX_MESSAGE_CHARS - 1)}…` : text,
+      content: truncateToBytes(capped, MAX_MESSAGE_BYTES),
     });
   }
-  return messages.slice(-MAX_MESSAGES);
+
+  const recent = messages.slice(-MAX_MESSAGES);
+  // Aggregate budget: drop the OLDEST messages until the whole history fits.
+  // Per-message caps alone can still add up past the server's total.
+  let total = recent.reduce((sum, message) => sum + utf8Length(message.content), 0);
+  while (recent.length > 1 && total > MAX_TOTAL_MESSAGE_BYTES) {
+    total -= utf8Length(/** @type {TurnMessage} */ (recent[0]).content);
+    recent.shift();
+  }
+  return recent;
 }
 
 export const dedupe = new EventDedupe();
@@ -171,9 +224,17 @@ export async function fetchThreadContext(client, args) {
 }
 
 /**
- * Run one full turn for a Slack trigger: dedupe, serialize per thread,
- * gather context, call MCPJam, and hand the result back to the listener
- * for posting. Returns null when the event was a duplicate.
+ * Run one full turn for a Slack trigger: dedupe, then — inside the
+ * per-conversation queue — gather context, call MCPJam, and post the reply
+ * via `onResult`.
+ *
+ * `onResult` runs INSIDE the queue on purpose. If posting happened after the
+ * queue released, a rapid follow-up could start its turn before the previous
+ * answer reached the thread: its history would omit that answer (so it may
+ * redo the same work, e.g. recreate a suite) and the replies could land out
+ * of order.
+ *
+ * Returns false when the event was a duplicate delivery.
  *
  * @param {{
  *   client: import('@slack/web-api').WebClient,
@@ -183,23 +244,35 @@ export async function fetchThreadContext(client, args) {
  *   isThread: boolean,
  *   botUserId?: string,
  *   fallbackText: string,
+ *   onStart?: () => Promise<void>,
+ *   onResult: (result: import('./mcpjam-client.js').AgentTurnResult) => Promise<void>,
  * }} args
- * @returns {Promise<import('./mcpjam-client.js').AgentTurnResult | null>}
+ * @returns {Promise<boolean>}
  */
 export async function runTurnForEvent(args) {
   const eventKey = `${args.channelId}:${args.triggerTs}`;
-  if (!dedupe.claim(eventKey)) return null;
+  if (!dedupe.claim(eventKey)) return false;
 
-  const threadKey = `${args.channelId}:${args.threadTs}`;
+  // Only after the claim: a duplicate delivery must not raise a "working"
+  // status that no reply will ever clear.
+  await args.onStart?.();
+
+  // Serialization key. A channel thread keys on its parent ts. A top-level DM
+  // has NO thread, so `threadTs` is the message's own ts — keying on that
+  // would give every rapid DM its own queue and serialize nothing, which is
+  // exactly the case that can create duplicate suites. Key those per channel.
+  const queueKey = args.isThread ? `thread:${args.channelId}:${args.threadTs}` : `dm:${args.channelId}`;
   try {
-    return await threadQueue.enqueue(threadKey, async () => {
+    await threadQueue.enqueue(queueKey, async () => {
       let messages = await fetchThreadContext(args.client, args);
       if (messages.length === 0) {
         // Context fetch can miss (e.g. scopes); fall back to the trigger text.
         messages = [{ role: 'user', content: args.fallbackText }];
       }
-      return runAgentTurn(messages);
+      const result = await runAgentTurn(messages);
+      await args.onResult(result);
     });
+    return true;
   } finally {
     dedupe.complete(eventKey);
   }

--- a/slack-app/app.js
+++ b/slack-app/app.js
@@ -4,11 +4,24 @@ import { App, LogLevel } from '@slack/bolt';
 
 import { registerListeners } from './listeners/index.js';
 
+/**
+ * Bolt's DEBUG level logs full Slack payloads — message text, user ids,
+ * channel ids — so it must be opt-in, not the default. Anything hosted
+ * (Railway) runs at INFO unless someone deliberately asks for more.
+ */
+const LOG_LEVELS = new Set(Object.values(LogLevel));
+const requested = (process.env.SLACK_LOG_LEVEL || '').toLowerCase();
+const logLevel = /** @type {LogLevel} */ (
+  LOG_LEVELS.has(/** @type {LogLevel} */ (requested)) ? requested : LogLevel.INFO
+);
+
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
   appToken: process.env.SLACK_APP_TOKEN,
   socketMode: true,
-  logLevel: LogLevel.DEBUG,
+  logLevel,
+  // The bot's own replies must reach the message listener: a thread's next
+  // turn re-reads history, and `sayStream` output arrives as a bot message.
   ignoreSelf: false,
 });
 
@@ -16,5 +29,5 @@ registerListeners(app);
 
 (async () => {
   await app.start();
-  app.logger.info('MCPJam Slack app is running!');
+  app.logger.info(`MCPJam Slack app is running! (log level: ${logLevel})`);
 })();

--- a/slack-app/app.js
+++ b/slack-app/app.js
@@ -1,0 +1,20 @@
+import 'dotenv/config';
+
+import { App, LogLevel } from '@slack/bolt';
+
+import { registerListeners } from './listeners/index.js';
+
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN,
+  appToken: process.env.SLACK_APP_TOKEN,
+  socketMode: true,
+  logLevel: LogLevel.DEBUG,
+  ignoreSelf: false,
+});
+
+registerListeners(app);
+
+(async () => {
+  await app.start();
+  app.logger.info('MCPJam Slack app is running!');
+})();

--- a/slack-app/biome.json
+++ b/slack-app/biome.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "includes": ["**"],
+    "attributePosition": "auto",
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "style": {
+        "noParameterAssign": "error",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error",
+        "noUselessElse": "error"
+      }
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  }
+}

--- a/slack-app/listeners/actions/feedback-buttons.js
+++ b/slack-app/listeners/actions/feedback-buttons.js
@@ -1,0 +1,35 @@
+/**
+ * Handle feedback button interactions.
+ * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackActionMiddlewareArgs<import('@slack/bolt').BlockFeedbackButtonsAction>} args
+ * @returns {Promise<void>}
+ */
+export async function handleFeedbackButton({ ack, body, client, context, logger }) {
+  await ack();
+
+  try {
+    const userId = /** @type {string} */ (context.userId);
+    const channelId = /** @type {string} */ (body.channel?.id);
+    const messageTs = /** @type {string} */ (body.message?.ts);
+    const feedbackValue = body.actions[0].value;
+
+    if (feedbackValue === 'good-feedback') {
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: userId,
+        thread_ts: messageTs,
+        text: 'Glad that was helpful! :tada:',
+      });
+    } else {
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: userId,
+        thread_ts: messageTs,
+        text: "Sorry that wasn't helpful. :slightly_frowning_face: Try rephrasing your question and I'll give it another shot.",
+      });
+    }
+
+    logger.debug(`Feedback received: value=${feedbackValue}, message_ts=${messageTs}`);
+  } catch (e) {
+    logger.error(`Failed to handle feedback: ${e}`);
+  }
+}

--- a/slack-app/listeners/actions/index.js
+++ b/slack-app/listeners/actions/index.js
@@ -1,0 +1,13 @@
+import { RUN_SUITE_ACTION_ID } from '../views/agent-reply-builder.js';
+import { handleFeedbackButton } from './feedback-buttons.js';
+import { handleRunSuiteButton } from './run-suite-button.js';
+
+/**
+ * Register action listeners with the Bolt app.
+ * @param {import('@slack/bolt').App} app
+ * @returns {void}
+ */
+export function register(app) {
+  app.action('feedback', handleFeedbackButton);
+  app.action(RUN_SUITE_ACTION_ID, handleRunSuiteButton);
+}

--- a/slack-app/listeners/actions/run-suite-button.js
+++ b/slack-app/listeners/actions/run-suite-button.js
@@ -64,13 +64,22 @@ export async function watchRunUntilDone(client, args) {
 }
 
 /**
- * Guard against double-clicks / Slack action retries: one run per
- * (suiteId, button message) — repeat clicks get an ephemeral note instead of
- * a second billed run. Claims are released ONLY when the run provably did
- * not start; otherwise they are retained (with a TTL, so a long-lived bot
- * doesn't accumulate a permanent entry per click).
+ * Guard against double-clicks and Slack action retries: one run per
+ * (suiteId, button message) within the window below — repeat clicks get an
+ * ephemeral note instead of a second billed run. Claims are released ONLY
+ * when the run provably did not start.
+ *
+ * The window is explicit and long (a day) rather than the shared 30-minute
+ * event default: runs cost quota, and a stray second click hours later in
+ * the same working session should still be caught. Past it, a click is
+ * treated as a deliberate new decision — which is consistent with the whole
+ * design, where the human click IS the approval that spends quota. Bounded
+ * by the TTL sweep, so a long-lived bot doesn't grow an entry per click
+ * forever.
  */
-export const runDedupe = new EventDedupe();
+const RUN_DEDUPE_TTL_MS = 24 * 60 * 60 * 1000;
+
+export const runDedupe = new EventDedupe({ ttlMs: RUN_DEDUPE_TTL_MS });
 
 /**
  * Handle the "Run it" button on a created eval suite. Block actions need

--- a/slack-app/listeners/actions/run-suite-button.js
+++ b/slack-app/listeners/actions/run-suite-button.js
@@ -1,11 +1,16 @@
 import { getEvalRun, McpjamApiError, startSuiteRun } from '../../agent/mcpjam-client.js';
+import { EventDedupe } from '../../agent/turn-runner.js';
 
 // Status polling: keep the "run started" message honest by editing it with
 // the terminal result. Slack-app convention: a kicked-off job's message is
 // its status surface — never a dead end.
 const POLL_INTERVAL_MS = 10_000;
 const POLL_MAX_MS = 15 * 60 * 1000;
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+// Must match the backend's terminal set (`server/routes/v1/evals.ts`).
+// `timed_out` is emitted when the runner finalizes a run/iteration timeout;
+// omitting it would leave the poller spinning for the full watch window and
+// the Slack message stuck on "running…".
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled', 'timed_out']);
 
 /**
  * @param {{ status: string, result: string | null, summary?: { passed?: number, total?: number } }} run
@@ -19,6 +24,9 @@ export function formatRunOutcome(run, url, userId) {
   }
   if (run.status === 'cancelled') {
     return `:heavy_minus_sign: Run cancelled — started by <@${userId}>, <${url}|details>.`;
+  }
+  if (run.status === 'timed_out') {
+    return `:hourglass: Run timed out${counts} — started by <@${userId}>, <${url}|details>.`;
   }
   return `:red_circle: Run ${run.result === 'failed' ? 'failed' : run.status}${counts} — started by <@${userId}>, <${url}|see what broke>.`;
 }
@@ -57,13 +65,12 @@ export async function watchRunUntilDone(client, args) {
 
 /**
  * Guard against double-clicks / Slack action retries: one run per
- * (suiteId, message) — repeat clicks get an ephemeral note instead of a
- * second run. Completed keys are retained (a suite run started from this
- * message stays started; a NEW run should come from a fresh agent reply
- * or the app UI).
- * @type {Set<string>}
+ * (suiteId, button message) — repeat clicks get an ephemeral note instead of
+ * a second billed run. Claims are released ONLY when the run provably did
+ * not start; otherwise they are retained (with a TTL, so a long-lived bot
+ * doesn't accumulate a permanent entry per click).
  */
-export const startedRunKeys = new Set();
+export const runDedupe = new EventDedupe();
 
 /**
  * Handle the "Run it" button on a created eval suite. Block actions need
@@ -78,26 +85,52 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
   const userId = /** @type {string} */ (context.userId);
   const channelId = /** @type {string} */ (body.channel?.id);
   const messageTs = /** @type {string} */ (body.message?.ts);
+  // The button lives on the bot's reply, which is itself a thread reply.
+  // `chat.postMessage` wants the PARENT ts — passing a reply's own ts either
+  // errors or starts a stray thread, so prefer the message's `thread_ts`.
+  const parentTs = /** @type {string} */ (body.message?.thread_ts ?? body.message?.ts);
   const suiteId = action.value;
   if (!suiteId) return;
 
   const runKey = `${suiteId}:${messageTs}`;
-  if (startedRunKeys.has(runKey)) {
+  if (!runDedupe.claim(runKey)) {
     await client.chat.postEphemeral({
       channel: channelId,
       user: userId,
-      thread_ts: messageTs,
+      thread_ts: parentTs,
       text: ':information_source: That run is already going — check the run link above.',
     });
     return;
   }
-  startedRunKeys.add(runKey);
 
+  /** @type {{ runId: string, url: string }} */
+  let run;
   try {
-    const run = await startSuiteRun(suiteId);
+    run = await startSuiteRun(suiteId);
+  } catch (error) {
+    // The run provably did not start — release so a retry click can work.
+    runDedupe.release(runKey);
+    logger.error(`Failed to start suite run: ${error}`);
+    const friendly =
+      error instanceof McpjamApiError
+        ? error.friendlyMessage
+        : ':warning: Could not start the run. Try again in a moment.';
+    await client.chat.postEphemeral({
+      channel: channelId,
+      user: userId,
+      thread_ts: parentTs,
+      text: friendly,
+    });
+    return;
+  }
+
+  // Past this point the run EXISTS and is billed. Keep the claim even if
+  // announcing it fails — a retry would start (and bill) a second run.
+  runDedupe.complete(runKey);
+  try {
     const posted = await client.chat.postMessage({
       channel: channelId,
-      thread_ts: messageTs,
+      thread_ts: parentTs,
       text: `:rocket: Run started by <@${userId}> — running… <${run.url}|watch it here>.`,
     });
     // Detached watcher edits the message with the terminal result.
@@ -112,18 +145,6 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
       });
     }
   } catch (error) {
-    // The run never started; allow a retry click.
-    startedRunKeys.delete(runKey);
-    logger.error(`Failed to start suite run: ${error}`);
-    const friendly =
-      error instanceof McpjamApiError
-        ? error.friendlyMessage
-        : ':warning: Could not start the run. Try again in a moment.';
-    await client.chat.postEphemeral({
-      channel: channelId,
-      user: userId,
-      thread_ts: messageTs,
-      text: friendly,
-    });
+    logger.error(`Run ${run.runId} started but announcing it failed: ${error}`);
   }
 }

--- a/slack-app/listeners/actions/run-suite-button.js
+++ b/slack-app/listeners/actions/run-suite-button.js
@@ -1,0 +1,129 @@
+import { getEvalRun, McpjamApiError, startSuiteRun } from '../../agent/mcpjam-client.js';
+
+// Status polling: keep the "run started" message honest by editing it with
+// the terminal result. Slack-app convention: a kicked-off job's message is
+// its status surface — never a dead end.
+const POLL_INTERVAL_MS = 10_000;
+const POLL_MAX_MS = 15 * 60 * 1000;
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
+
+/**
+ * @param {{ status: string, result: string | null, summary?: { passed?: number, total?: number } }} run
+ * @param {string} url
+ * @param {string} userId
+ */
+export function formatRunOutcome(run, url, userId) {
+  const counts = run.summary?.total !== undefined ? ` (${run.summary.passed ?? 0}/${run.summary.total} passed)` : '';
+  if (run.status === 'completed' && run.result === 'passed') {
+    return `:large_green_circle: Run passed${counts} — started by <@${userId}>, <${url}|see the details>.`;
+  }
+  if (run.status === 'cancelled') {
+    return `:heavy_minus_sign: Run cancelled — started by <@${userId}>, <${url}|details>.`;
+  }
+  return `:red_circle: Run ${run.result === 'failed' ? 'failed' : run.status}${counts} — started by <@${userId}>, <${url}|see what broke>.`;
+}
+
+/**
+ * Watch a run until terminal and edit the status message in place.
+ * Detached from the button handler; failures degrade to the original
+ * "watch it here" message rather than erroring in channel.
+ * @param {import('@slack/web-api').WebClient} client
+ * @param {{ runId: string, url: string, channelId: string, statusTs: string, userId: string, logger: import('@slack/bolt').Logger }} args
+ */
+export async function watchRunUntilDone(client, args) {
+  const deadline = Date.now() + POLL_MAX_MS;
+  while (Date.now() < deadline) {
+    // unref: a detached watcher must never hold the process open.
+    await new Promise((resolve) => {
+      const timer = setTimeout(resolve, POLL_INTERVAL_MS);
+      timer.unref?.();
+    });
+    try {
+      const run = await getEvalRun(args.runId);
+      if (TERMINAL_STATUSES.has(run.status)) {
+        await client.chat.update({
+          channel: args.channelId,
+          ts: args.statusTs,
+          text: formatRunOutcome(run, args.url, args.userId),
+        });
+        return;
+      }
+    } catch (error) {
+      args.logger.warn(`Run status poll failed (will keep trying): ${error}`);
+    }
+  }
+  args.logger.warn(`Run ${args.runId} did not reach a terminal status within the watch window.`);
+}
+
+/**
+ * Guard against double-clicks / Slack action retries: one run per
+ * (suiteId, message) — repeat clicks get an ephemeral note instead of a
+ * second run. Completed keys are retained (a suite run started from this
+ * message stays started; a NEW run should come from a fresh agent reply
+ * or the app UI).
+ * @type {Set<string>}
+ */
+export const startedRunKeys = new Set();
+
+/**
+ * Handle the "Run it" button on a created eval suite. Block actions need
+ * an immediate explicit ack (unlike Events API events, which Bolt v5
+ * auto-acks before listeners run).
+ * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackActionMiddlewareArgs<import('@slack/bolt').BlockButtonAction>} args
+ * @returns {Promise<void>}
+ */
+export async function handleRunSuiteButton({ ack, body, client, context, logger, action }) {
+  await ack();
+
+  const userId = /** @type {string} */ (context.userId);
+  const channelId = /** @type {string} */ (body.channel?.id);
+  const messageTs = /** @type {string} */ (body.message?.ts);
+  const suiteId = action.value;
+  if (!suiteId) return;
+
+  const runKey = `${suiteId}:${messageTs}`;
+  if (startedRunKeys.has(runKey)) {
+    await client.chat.postEphemeral({
+      channel: channelId,
+      user: userId,
+      thread_ts: messageTs,
+      text: ':information_source: That run is already going — check the run link above.',
+    });
+    return;
+  }
+  startedRunKeys.add(runKey);
+
+  try {
+    const run = await startSuiteRun(suiteId);
+    const posted = await client.chat.postMessage({
+      channel: channelId,
+      thread_ts: messageTs,
+      text: `:rocket: Run started by <@${userId}> — running… <${run.url}|watch it here>.`,
+    });
+    // Detached watcher edits the message with the terminal result.
+    if (posted.ts) {
+      void watchRunUntilDone(client, {
+        runId: run.runId,
+        url: run.url,
+        channelId,
+        statusTs: /** @type {string} */ (posted.ts),
+        userId,
+        logger,
+      });
+    }
+  } catch (error) {
+    // The run never started; allow a retry click.
+    startedRunKeys.delete(runKey);
+    logger.error(`Failed to start suite run: ${error}`);
+    const friendly =
+      error instanceof McpjamApiError
+        ? error.friendlyMessage
+        : ':warning: Could not start the run. Try again in a moment.';
+    await client.chat.postEphemeral({
+      channel: channelId,
+      user: userId,
+      thread_ts: messageTs,
+      text: friendly,
+    });
+  }
+}

--- a/slack-app/listeners/events/app-home-opened.js
+++ b/slack-app/listeners/events/app-home-opened.js
@@ -1,0 +1,47 @@
+import { buildAppHomeView } from '../views/app-home-builder.js';
+
+const SUGGESTED_PROMPTS = [
+  {
+    title: 'Create an eval suite',
+    message: 'Create an eval suite from this conversation',
+  },
+  {
+    title: 'List my suites',
+    message: 'What eval suites does my project have?',
+  },
+  {
+    title: 'Check a run',
+    message: 'How did my latest eval run go?',
+  },
+];
+
+/**
+ * Handle app_home_opened events. Under agent_view, this event fires for both
+ * the Home tab and the Messages tab (the agent DM). Branch on event.tab:
+ *   - 'messages' → pin suggested prompts to the top of the DM
+ *   - 'home'     → publish the App Home Block Kit view
+ * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'app_home_opened'>} args
+ * @returns {Promise<void>}
+ */
+export async function handleAppHomeOpened({ client, event, context, logger }) {
+  try {
+    if (event.tab === 'messages') {
+      await client.assistant.threads.setSuggestedPrompts(
+        // Under agent_view, suggested prompts pin to the top of the Messages tab —
+        // no thread_ts is required. Cast until @slack/bolt's types catch up.
+        /** @type {import('@slack/web-api').AssistantThreadsSetSuggestedPromptsArguments} */ ({
+          channel_id: event.channel,
+          title: 'What should we test?',
+          prompts: SUGGESTED_PROMPTS,
+        }),
+      );
+      return;
+    }
+
+    const userId = /** @type {string} */ (context.userId);
+    const view = buildAppHomeView();
+    await client.views.publish({ user_id: userId, view });
+  } catch (e) {
+    logger.error(`Failed to handle app_home_opened: ${e}`);
+  }
+}

--- a/slack-app/listeners/events/app-mentioned.js
+++ b/slack-app/listeners/events/app-mentioned.js
@@ -11,17 +11,18 @@ export async function handleAppMentioned({ client, context, event, logger, say, 
   const threadTs = event.thread_ts || event.ts;
   const cleanedText = (event.text || '').replace(/<@[A-Z0-9]+>/g, '').trim();
 
+  // Mark the thread engaged BEFORE the bare-mention early return, so the
+  // user's next (unmentioned) reply is picked up by the message listener —
+  // otherwise the greeting invites a reply the bot then ignores.
+  sessionStore.setSession(channelId, threadTs, 'engaged');
+
   if (!cleanedText) {
     await say({
-      text: "Hey! I'm the MCPJam agent — mention me with what you'd like tested and I'll turn this thread into an eval suite.",
+      text: "Hey! I'm the MCPJam agent — tell me what you'd like tested and I'll turn this thread into an eval suite.",
       thread_ts: threadTs,
     });
     return;
   }
-
-  // Mark the thread engaged so follow-up replies (without a mention) are
-  // handled by the message listener.
-  sessionStore.setSession(channelId, threadTs, 'engaged');
 
   await runAndReply({
     client,

--- a/slack-app/listeners/events/app-mentioned.js
+++ b/slack-app/listeners/events/app-mentioned.js
@@ -1,0 +1,39 @@
+import { sessionStore } from '../../thread-context/index.js';
+import { runAndReply } from './run-and-reply.js';
+
+/**
+ * Handle app_mention events and run the agent.
+ * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'app_mention'>} args
+ * @returns {Promise<void>}
+ */
+export async function handleAppMentioned({ client, context, event, logger, say, sayStream, setStatus }) {
+  const channelId = event.channel;
+  const threadTs = event.thread_ts || event.ts;
+  const cleanedText = (event.text || '').replace(/<@[A-Z0-9]+>/g, '').trim();
+
+  if (!cleanedText) {
+    await say({
+      text: "Hey! I'm the MCPJam agent — mention me with what you'd like tested and I'll turn this thread into an eval suite.",
+      thread_ts: threadTs,
+    });
+    return;
+  }
+
+  // Mark the thread engaged so follow-up replies (without a mention) are
+  // handled by the message listener.
+  sessionStore.setSession(channelId, threadTs, 'engaged');
+
+  await runAndReply({
+    client,
+    context,
+    logger,
+    say,
+    sayStream,
+    setStatus,
+    channelId,
+    threadTs,
+    triggerTs: event.ts,
+    isThread: true,
+    fallbackText: cleanedText,
+  });
+}

--- a/slack-app/listeners/events/index.js
+++ b/slack-app/listeners/events/index.js
@@ -1,0 +1,14 @@
+import { handleAppHomeOpened } from './app-home-opened.js';
+import { handleAppMentioned } from './app-mentioned.js';
+import { handleMessage } from './message.js';
+
+/**
+ * Register event listeners with the Bolt app.
+ * @param {import('@slack/bolt').App} app
+ * @returns {void}
+ */
+export function register(app) {
+  app.event('app_home_opened', handleAppHomeOpened);
+  app.event('app_mention', handleAppMentioned);
+  app.event('message', handleMessage);
+}

--- a/slack-app/listeners/events/message.js
+++ b/slack-app/listeners/events/message.js
@@ -1,0 +1,52 @@
+import { sessionStore } from '../../thread-context/index.js';
+import { runAndReply } from './run-and-reply.js';
+
+/**
+ * @param {import('@slack/types').MessageEvent} event
+ * @returns {event is import('@slack/types').GenericMessageEvent}
+ */
+function isGenericMessageEvent(event) {
+  return !('subtype' in event && event.subtype !== undefined);
+}
+
+/**
+ * Handle messages sent to the agent via DM or in threads the bot is part of.
+ * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'message'>} args
+ * @returns {Promise<void>}
+ */
+export async function handleMessage({ client, context, event, logger, say, sayStream, setStatus }) {
+  // Skip message subtypes (edits, deletes, etc.)
+  if (!isGenericMessageEvent(event)) return;
+
+  // Skip bot messages
+  if (event.bot_id) return;
+
+  const isDm = event.channel_type === 'im';
+  const isThreadReply = !!event.thread_ts;
+
+  if (isDm) {
+    // DMs are always handled
+  } else if (isThreadReply) {
+    // Channel thread replies are handled only if the bot is already engaged
+    const session = sessionStore.getSession(event.channel, /** @type {string} */ (event.thread_ts));
+    if (session === null) return;
+  } else {
+    // Top-level channel messages are handled by app_mentioned
+    return;
+  }
+
+  await runAndReply({
+    client,
+    context,
+    logger,
+    say,
+    sayStream,
+    setStatus,
+    channelId: event.channel,
+    threadTs: event.thread_ts || event.ts,
+    triggerTs: event.ts,
+    // A DM top-level message has no thread yet; channel replies do.
+    isThread: isThreadReply,
+    fallbackText: event.text || '',
+  });
+}

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -26,17 +26,9 @@ import { buildFeedbackBlocks } from '../views/feedback-builder.js';
 export async function runAndReply(args) {
   const { client, context, logger, say, sayStream, setStatus } = args;
   try {
-    await setStatus({
-      status: 'Working on it…',
-      loading_messages: [
-        'Reading the thread…',
-        'Checking your MCPJam project…',
-        'Drafting eval cases…',
-        'Talking to the MCPJam agent…',
-      ],
-    });
-
-    const result = await runTurnForEvent({
+    // Posting is passed INTO the runner so it happens inside the per-thread
+    // queue — the next turn's history must already contain this reply.
+    await runTurnForEvent({
       client,
       channelId: args.channelId,
       threadTs: args.threadTs,
@@ -44,15 +36,26 @@ export async function runAndReply(args) {
       isThread: args.isThread,
       botUserId: /** @type {string | undefined} */ (context.botUserId),
       fallbackText: args.fallbackText,
-    });
-    if (result === null) return; // duplicate Slack delivery — already handled
-
-    const streamer = sayStream();
-    await streamer.append({
-      markdown_text: result.reply || 'Done — though I have nothing to add.',
-    });
-    await streamer.stop({
-      blocks: [...buildCreatedResourceBlocks(result.createdResources), ...buildFeedbackBlocks()],
+      onStart: async () => {
+        await setStatus({
+          status: 'Working on it…',
+          loading_messages: [
+            'Reading the thread…',
+            'Checking your MCPJam project…',
+            'Drafting eval cases…',
+            'Talking to the MCPJam agent…',
+          ],
+        });
+      },
+      onResult: async (result) => {
+        const streamer = sayStream();
+        await streamer.append({
+          markdown_text: result.reply || 'Done — though I have nothing to add.',
+        });
+        await streamer.stop({
+          blocks: [...buildCreatedResourceBlocks(result.createdResources), ...buildFeedbackBlocks()],
+        });
+      },
     });
   } catch (error) {
     logger.error(`Agent turn failed: ${error}`);

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -36,16 +36,22 @@ export async function runAndReply(args) {
       isThread: args.isThread,
       botUserId: /** @type {string | undefined} */ (context.botUserId),
       fallbackText: args.fallbackText,
+      // Best-effort: the status indicator is cosmetic, so a Slack hiccup
+      // here must never cost the user their answer.
       onStart: async () => {
-        await setStatus({
-          status: 'Working on it…',
-          loading_messages: [
-            'Reading the thread…',
-            'Checking your MCPJam project…',
-            'Drafting eval cases…',
-            'Talking to the MCPJam agent…',
-          ],
-        });
+        try {
+          await setStatus({
+            status: 'Working on it…',
+            loading_messages: [
+              'Reading the thread…',
+              'Checking your MCPJam project…',
+              'Drafting eval cases…',
+              'Talking to the MCPJam agent…',
+            ],
+          });
+        } catch (error) {
+          logger.warn(`Could not set the assistant status: ${error}`);
+        }
       },
       onResult: async (result) => {
         const streamer = sayStream();

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -1,0 +1,65 @@
+import { McpjamApiError } from '../../agent/mcpjam-client.js';
+import { runTurnForEvent } from '../../agent/turn-runner.js';
+import { buildCreatedResourceBlocks } from '../views/agent-reply-builder.js';
+import { buildFeedbackBlocks } from '../views/feedback-builder.js';
+
+/**
+ * Shared body for both event listeners: run the turn (deduped + serialized
+ * per thread in the runner) and post the reply with Run-it buttons for any
+ * suites the turn created.
+ *
+ * @param {{
+ *   client: import('@slack/web-api').WebClient,
+ *   context: import('@slack/bolt').Context,
+ *   logger: import('@slack/bolt').Logger,
+ *   say: Function,
+ *   sayStream: Function,
+ *   setStatus: Function,
+ *   channelId: string,
+ *   threadTs: string,
+ *   triggerTs: string,
+ *   isThread: boolean,
+ *   fallbackText: string,
+ * }} args
+ * @returns {Promise<void>}
+ */
+export async function runAndReply(args) {
+  const { client, context, logger, say, sayStream, setStatus } = args;
+  try {
+    await setStatus({
+      status: 'Working on it…',
+      loading_messages: [
+        'Reading the thread…',
+        'Checking your MCPJam project…',
+        'Drafting eval cases…',
+        'Talking to the MCPJam agent…',
+      ],
+    });
+
+    const result = await runTurnForEvent({
+      client,
+      channelId: args.channelId,
+      threadTs: args.threadTs,
+      triggerTs: args.triggerTs,
+      isThread: args.isThread,
+      botUserId: /** @type {string | undefined} */ (context.botUserId),
+      fallbackText: args.fallbackText,
+    });
+    if (result === null) return; // duplicate Slack delivery — already handled
+
+    const streamer = sayStream();
+    await streamer.append({
+      markdown_text: result.reply || 'Done — though I have nothing to add.',
+    });
+    await streamer.stop({
+      blocks: [...buildCreatedResourceBlocks(result.createdResources), ...buildFeedbackBlocks()],
+    });
+  } catch (error) {
+    logger.error(`Agent turn failed: ${error}`);
+    const text =
+      error instanceof McpjamApiError
+        ? error.friendlyMessage
+        : ':warning: Something went wrong. Try again in a moment.';
+    await say({ text, thread_ts: args.threadTs });
+  }
+}

--- a/slack-app/listeners/index.js
+++ b/slack-app/listeners/index.js
@@ -1,0 +1,14 @@
+import * as actions from './actions/index.js';
+import * as events from './events/index.js';
+import * as views from './views/index.js';
+
+/**
+ * Register all Slack event, action, and view listeners.
+ * @param {import('@slack/bolt').App} app
+ * @returns {void}
+ */
+export function registerListeners(app) {
+  actions.register(app);
+  events.register(app);
+  views.register(app);
+}

--- a/slack-app/listeners/views/agent-reply-builder.js
+++ b/slack-app/listeners/views/agent-reply-builder.js
@@ -14,6 +14,14 @@ export const RUN_SUITE_ACTION_ID = 'mcpjam_run_suite';
 const MAX_SUITE_BLOCKS = 40;
 
 /**
+ * Slack rejects a section whose `mrkdwn` text exceeds 3,000 characters, and
+ * a rejected block takes the WHOLE reply down. Suite names are agent output
+ * over user input, so cap the display label — before escaping, since
+ * escaping can quintuple length (`&` → `&amp;`).
+ */
+const MAX_SUITE_NAME_CHARS = 150;
+
+/**
  * Suite names come from user-influenced agent output. In `mrkdwn`, raw `&`,
  * `<` and `>` are parsed as markup, so a name could break the link or forge
  * a mention. Slack's documented escaping is these three, in this order.
@@ -21,6 +29,18 @@ const MAX_SUITE_BLOCKS = 40;
  */
 export function escapeSlackText(text) {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Display label for a suite: length-capped on code-point boundaries, then
+ * escaped. Order matters — capping after escaping could slice an entity
+ * like `&amp;` in half.
+ * @param {string} name
+ */
+export function toSuiteLabel(name) {
+  const chars = Array.from(name);
+  const capped = chars.length > MAX_SUITE_NAME_CHARS ? `${chars.slice(0, MAX_SUITE_NAME_CHARS - 1).join('')}…` : name;
+  return escapeSlackText(capped);
 }
 
 /**
@@ -39,7 +59,7 @@ export function buildCreatedResourceBlocks(createdResources) {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `:test_tube: *<${suite.url}|${escapeSlackText(suite.name ?? 'Eval suite')}>* is ready to run.`,
+        text: `:test_tube: *<${suite.url}|${toSuiteLabel(suite.name ?? 'Eval suite')}>* is ready to run.`,
       },
       accessory: {
         type: 'button',

--- a/slack-app/listeners/views/agent-reply-builder.js
+++ b/slack-app/listeners/views/agent-reply-builder.js
@@ -1,0 +1,35 @@
+/**
+ * Blocks for an agent reply: one "Run it" button per created eval suite.
+ * Running is deliberately NOT something the agent turn can do — the button
+ * click is the human approval that spends eval quota.
+ */
+
+export const RUN_SUITE_ACTION_ID = 'mcpjam_run_suite';
+
+/**
+ * @param {Array<{ type: string, id: string, name?: string, url: string }>} createdResources
+ * @returns {Array<Record<string, unknown>>}
+ */
+export function buildCreatedResourceBlocks(createdResources) {
+  const suites = createdResources.filter((resource) => resource.type === 'eval_suite');
+  if (suites.length === 0) return [];
+  /** @type {Array<Record<string, unknown>>} */
+  const blocks = [];
+  for (const suite of suites) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `:test_tube: *<${suite.url}|${suite.name ?? 'Eval suite'}>* is ready to run.`,
+      },
+      accessory: {
+        type: 'button',
+        text: { type: 'plain_text', text: 'Run it' },
+        style: 'primary',
+        action_id: RUN_SUITE_ACTION_ID,
+        value: suite.id,
+      },
+    });
+  }
+  return blocks;
+}

--- a/slack-app/listeners/views/agent-reply-builder.js
+++ b/slack-app/listeners/views/agent-reply-builder.js
@@ -7,20 +7,39 @@
 export const RUN_SUITE_ACTION_ID = 'mcpjam_run_suite';
 
 /**
+ * Slack allows 50 blocks per message, and the reply appends a feedback
+ * block after these — so leave headroom rather than letting `streamer.stop`
+ * reject and drop the whole reply.
+ */
+const MAX_SUITE_BLOCKS = 40;
+
+/**
+ * Suite names come from user-influenced agent output. In `mrkdwn`, raw `&`,
+ * `<` and `>` are parsed as markup, so a name could break the link or forge
+ * a mention. Slack's documented escaping is these three, in this order.
+ * @param {string} text
+ */
+export function escapeSlackText(text) {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
  * @param {Array<{ type: string, id: string, name?: string, url: string }>} createdResources
  * @returns {Array<Record<string, unknown>>}
  */
 export function buildCreatedResourceBlocks(createdResources) {
   const suites = createdResources.filter((resource) => resource.type === 'eval_suite');
   if (suites.length === 0) return [];
+
+  const shown = suites.slice(0, MAX_SUITE_BLOCKS);
   /** @type {Array<Record<string, unknown>>} */
   const blocks = [];
-  for (const suite of suites) {
+  for (const suite of shown) {
     blocks.push({
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `:test_tube: *<${suite.url}|${suite.name ?? 'Eval suite'}>* is ready to run.`,
+        text: `:test_tube: *<${suite.url}|${escapeSlackText(suite.name ?? 'Eval suite')}>* is ready to run.`,
       },
       accessory: {
         type: 'button',
@@ -29,6 +48,17 @@ export function buildCreatedResourceBlocks(createdResources) {
         action_id: RUN_SUITE_ACTION_ID,
         value: suite.id,
       },
+    });
+  }
+  if (suites.length > shown.length) {
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `_…and ${suites.length - shown.length} more — open MCPJam to run them._`,
+        },
+      ],
     });
   }
   return blocks;

--- a/slack-app/listeners/views/app-home-builder.js
+++ b/slack-app/listeners/views/app-home-builder.js
@@ -1,0 +1,39 @@
+/**
+ * Build the App Home Block Kit view.
+ * @returns {import('@slack/types').HomeView}
+ */
+export function buildAppHomeView() {
+  /** @type {import('@slack/types').KnownBlock[]} */
+  const blocks = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: ":wave: I'm the MCPJam agent.",
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text:
+          'I turn Slack conversations into *eval suites* for your MCPJam project.\n\n' +
+          'Send me a *direct message* or *mention me in a thread* — for example: ' +
+          '_"@MCPJam create an eval suite from this thread"_. ' +
+          "I'll author the cases and hand you a *Run it* button; runs only start when you click it.",
+      },
+    },
+    { type: 'divider' },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: 'Powered by the MCPJam public API — <https://app.mcpjam.com|open the app> to see your suites and runs.',
+        },
+      ],
+    },
+  ];
+
+  return { type: 'home', blocks };
+}

--- a/slack-app/listeners/views/feedback-builder.js
+++ b/slack-app/listeners/views/feedback-builder.js
@@ -1,0 +1,27 @@
+/**
+ * Build the feedback buttons blocks for agent responses.
+ * @returns {import('@slack/types').KnownBlock[]}
+ */
+export function buildFeedbackBlocks() {
+  return [
+    {
+      type: 'context_actions',
+      elements: [
+        {
+          type: 'feedback_buttons',
+          action_id: 'feedback',
+          positive_button: {
+            text: { type: 'plain_text', text: 'Good Response' },
+            accessibility_label: 'Submit positive feedback on this response',
+            value: 'good-feedback',
+          },
+          negative_button: {
+            text: { type: 'plain_text', text: 'Bad Response' },
+            accessibility_label: 'Submit negative feedback on this response',
+            value: 'bad-feedback',
+          },
+        },
+      ],
+    },
+  ];
+}

--- a/slack-app/listeners/views/index.js
+++ b/slack-app/listeners/views/index.js
@@ -1,0 +1,8 @@
+/**
+ * Register view listeners with the Bolt app.
+ * @param {import('@slack/bolt').App} _app
+ * @returns {void}
+ */
+export function register(_app) {
+  // No view submissions to register for the starter agent.
+}

--- a/slack-app/manifest.json
+++ b/slack-app/manifest.json
@@ -1,0 +1,44 @@
+{
+  "display_information": {
+    "name": "MCPJam"
+  },
+  "features": {
+    "agent_view": {
+      "agent_description": "Hi, I'm the MCPJam agent. Tell me what your MCP server should do and I'll turn this conversation into an eval suite you can run.",
+      "suggested_prompts": []
+    },
+    "app_home": {
+      "home_tab_enabled": true,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    },
+    "bot_user": {
+      "display_name": "MCPJam",
+      "always_online": true
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "app_mentions:read",
+        "channels:history",
+        "chat:write",
+        "groups:history",
+        "im:history",
+        "im:read",
+        "im:write",
+        "assistant:write"
+      ]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": ["app_home_opened", "app_mention", "message.channels", "message.groups", "message.im"]
+    },
+    "interactivity": {
+      "is_enabled": true
+    },
+    "socket_mode_enabled": true,
+    "token_rotation_enabled": false
+  }
+}

--- a/slack-app/package.json
+++ b/slack-app/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "license": "MIT",
   "scripts": {
     "check": "npx tsc --checkJs --noEmit --skipLibCheck --esModuleInterop --target esnext --module nodenext --moduleResolution nodenext app.js",
     "start": "node app.js",

--- a/slack-app/package.json
+++ b/slack-app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@mcpjam/slack-app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "check": "npx tsc --checkJs --noEmit --skipLibCheck --esModuleInterop --target esnext --module nodenext --moduleResolution nodenext app.js",
+    "start": "node app.js",
+    "lint": "npx @biomejs/biome check .",
+    "lint:fix": "npx @biomejs/biome check --write .",
+    "test": "node --test",
+    "verify": "npm run test && npm run check && npm run lint"
+  },
+  "dependencies": {
+    "@slack/bolt": "^5.0.0",
+    "dotenv": "~17.4.2"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.5.6",
+    "@slack/cli-hooks": "^2.0.0",
+    "typescript": "^7.0.2"
+  }
+}

--- a/slack-app/tests/agent/mcpjam-client.test.js
+++ b/slack-app/tests/agent/mcpjam-client.test.js
@@ -53,6 +53,40 @@ describe('mcpjam-client', () => {
     );
   });
 
+  it('reports a mid-body abort as a TIMEOUT, not an empty success', async () => {
+    // Headers arrive 200 OK, then the body stalls until the abort fires.
+    // Swallowing that would hand the user a cheerful empty reply.
+    const stalledBody = /** @type {any} */ (
+      async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          throw error;
+        },
+      })
+    );
+    await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }], { fetchImpl: stalledBody }), (error) => {
+      assert.strictEqual(error.code, 'TIMEOUT');
+      return true;
+    });
+  });
+
+  it('still lets the status decide when the body simply is not JSON', async () => {
+    const htmlErrorPage = /** @type {any} */ (
+      async () =>
+        new Response('<html>502 upstream</html>', {
+          status: 502,
+          headers: { 'Content-Type': 'text/html' },
+        })
+    );
+    await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }], { fetchImpl: htmlErrorPage }), (error) => {
+      assert.strictEqual(error.status, 502);
+      return true;
+    });
+  });
+
   it('fails with CONFIG when env is missing', async () => {
     delete process.env.MCPJAM_API_KEY;
     await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }]), (error) => {

--- a/slack-app/tests/agent/mcpjam-client.test.js
+++ b/slack-app/tests/agent/mcpjam-client.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { McpjamApiError, runAgentTurn, startSuiteRun } from '../../agent/mcpjam-client.js';
+
+/** @param {number} status @param {unknown} body */
+function fakeFetch(status, body) {
+  return async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+describe('mcpjam-client', () => {
+  beforeEach(() => {
+    process.env.MCPJAM_API_KEY = 'sk_test';
+    process.env.MCPJAM_PROJECT_ID = 'p1';
+    process.env.MCPJAM_BASE_URL = 'https://example.test';
+  });
+
+  it('returns the turn result with defaults for missing fields', async () => {
+    const result = await runAgentTurn([{ role: 'user', content: 'hi' }], {
+      fetchImpl: fakeFetch(200, { reply: 'hello' }),
+    });
+    assert.deepStrictEqual(result, { reply: 'hello', toolCalls: [], createdResources: [] });
+  });
+
+  it('maps RATE_LIMITED errors to a capacity message', async () => {
+    await assert.rejects(
+      runAgentTurn([{ role: 'user', content: 'hi' }], {
+        fetchImpl: fakeFetch(429, { code: 'RATE_LIMITED', message: 'too many turns' }),
+      }),
+      (error) => {
+        assert.ok(error instanceof McpjamApiError);
+        assert.strictEqual(error.code, 'RATE_LIMITED');
+        assert.ok(error.friendlyMessage.includes('capacity'));
+        return true;
+      },
+    );
+  });
+
+  it('maps TIMEOUT errors to a friendly message', async () => {
+    await assert.rejects(
+      runAgentTurn([{ role: 'user', content: 'hi' }], {
+        fetchImpl: fakeFetch(504, { code: 'TIMEOUT', message: 'turn exceeded limit' }),
+      }),
+      (error) => {
+        assert.strictEqual(error.code, 'TIMEOUT');
+        assert.ok(error.friendlyMessage.includes('longer'));
+        return true;
+      },
+    );
+  });
+
+  it('fails with CONFIG when env is missing', async () => {
+    delete process.env.MCPJAM_API_KEY;
+    await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }]), (error) => {
+      assert.strictEqual(error.code, 'CONFIG');
+      return true;
+    });
+  });
+
+  it('startSuiteRun builds the run deep link', async () => {
+    const run = await startSuiteRun('ts_1', {
+      fetchImpl: fakeFetch(202, { runId: 'run_9', suiteId: 'ts_1', status: 'running' }),
+    });
+    assert.strictEqual(run.url, 'https://example.test/evals/suite/ts_1/runs/run_9?project=p1');
+  });
+
+  it('deep links use MCPJAM_APP_URL when it differs from the API host', async () => {
+    process.env.MCPJAM_APP_URL = 'http://localhost:5173';
+    try {
+      const run = await startSuiteRun('ts_1', {
+        fetchImpl: fakeFetch(202, { runId: 'run_9' }),
+      });
+      assert.strictEqual(run.url, 'http://localhost:5173/evals/suite/ts_1/runs/run_9?project=p1');
+    } finally {
+      delete process.env.MCPJAM_APP_URL;
+    }
+  });
+});

--- a/slack-app/tests/agent/turn-runner.test.js
+++ b/slack-app/tests/agent/turn-runner.test.js
@@ -7,6 +7,9 @@ import { dedupe, EventDedupe, KeyedQueue, normalizeThreadMessages, runTurnForEve
 const MAX_MESSAGE_BYTES = 8_192;
 const MAX_TOTAL_MESSAGE_BYTES = 98_304;
 const utf8 = (/** @type {string} */ s) => Buffer.byteLength(s, 'utf8');
+/** True if any surrogate survives after removing well-formed pairs. */
+const hasLoneSurrogate = (/** @type {string} */ s) =>
+  /[\uD800-\uDFFF]/.test(s.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, ''));
 
 describe('EventDedupe', () => {
   it('claims a key once and rejects repeats while in flight', () => {
@@ -155,6 +158,16 @@ describe('normalizeThreadMessages', () => {
     assert.ok(last.content.endsWith('…'));
   });
 
+  it('never leaves a lone surrogate when the CHARACTER cap is what trips', () => {
+    // 8,002 UTF-16 units / 8,006 bytes: over the 8,000-char cap but UNDER
+    // the byte cap, so byte truncation cannot rescue a bad slice. A UTF-16
+    // `slice` here cuts an emoji in half.
+    const text = `${'a'.repeat(7_998)}${'😀'.repeat(2)}`;
+    const [message] = normalizeThreadMessages([{ ts: '1.0', user: 'U1', text }], { ...opts, triggerTs: '999.0' });
+    assert.ok(message.content.length <= 8_000, `got ${message.content.length} units`);
+    assert.ok(!hasLoneSurrogate(message.content), 'truncation split a surrogate pair');
+  });
+
   it('enforces the per-message BYTE cap, not just characters', () => {
     // 4,000 emoji = 4,000 chars (under the 8,000 char cap) but 16,000 bytes.
     const [message] = normalizeThreadMessages([{ ts: '1.0', user: 'U1', text: '😀'.repeat(4_000) }], {
@@ -163,8 +176,7 @@ describe('normalizeThreadMessages', () => {
     });
     assert.ok(utf8(message.content) <= MAX_MESSAGE_BYTES, `got ${utf8(message.content)} bytes`);
     assert.ok(message.content.endsWith('…'));
-    // Truncation must not leave a broken surrogate pair behind.
-    assert.ok(!/[\uD800-\uDFFF]/.test(message.content.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '')));
+    assert.ok(!hasLoneSurrogate(message.content));
   });
 
   it('drops oldest messages until the history fits the aggregate budget', () => {
@@ -277,5 +289,64 @@ describe('runTurnForEvent', () => {
       globalThis.fetch = realFetch;
     }
     assert.strictEqual(order.filter((step) => step === 'api-call').length, 1);
+  });
+});
+
+describe('runTurnForEvent onStart failure', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    dedupe.clear();
+    process.env.MCPJAM_API_KEY = 'sk_test';
+    process.env.MCPJAM_PROJECT_ID = 'p1';
+    process.env.MCPJAM_BASE_URL = 'https://stub.test';
+    realFetch = globalThis.fetch;
+  });
+
+  it('releases the claim so a redelivery can still run the turn', async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ reply: 'ok', toolCalls: [], createdResources: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    const client = /** @type {any} */ ({
+      conversations: { history: async () => ({ messages: [{ ts: '1.0', user: 'U1', text: 'hello' }] }) },
+    });
+    const base = {
+      client,
+      channelId: 'D9',
+      threadTs: '300.0',
+      triggerTs: '300.0',
+      isThread: false,
+      botUserId: 'B1',
+      fallbackText: 'hi',
+    };
+    try {
+      // A cosmetic status failure must not permanently swallow the event:
+      // in-flight claims are never swept, so the user would never get a reply.
+      await assert.rejects(
+        runTurnForEvent({
+          ...base,
+          onStart: async () => {
+            throw new Error('slack status down');
+          },
+          onResult: async () => {},
+        }),
+        /slack status down/,
+      );
+
+      let replied = false;
+      const ok = await runTurnForEvent({
+        ...base,
+        onResult: async () => {
+          replied = true;
+        },
+      });
+      assert.strictEqual(ok, true, 'redelivery was dropped as a duplicate');
+      assert.strictEqual(replied, true);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
   });
 });

--- a/slack-app/tests/agent/turn-runner.test.js
+++ b/slack-app/tests/agent/turn-runner.test.js
@@ -1,7 +1,12 @@
 import assert from 'node:assert';
-import { describe, it } from 'node:test';
+import { beforeEach, describe, it } from 'node:test';
 
-import { EventDedupe, KeyedQueue, normalizeThreadMessages } from '../../agent/turn-runner.js';
+import { dedupe, EventDedupe, KeyedQueue, normalizeThreadMessages, runTurnForEvent } from '../../agent/turn-runner.js';
+
+// Mirrors the server contract in server/routes/v1/agent.ts.
+const MAX_MESSAGE_BYTES = 8_192;
+const MAX_TOTAL_MESSAGE_BYTES = 98_304;
+const utf8 = (/** @type {string} */ s) => Buffer.byteLength(s, 'utf8');
 
 describe('EventDedupe', () => {
   it('claims a key once and rejects repeats while in flight', () => {
@@ -25,6 +30,13 @@ describe('EventDedupe', () => {
     dedupe.claim('C1:1');
     dedupe.complete('C1:1');
     clock += 200;
+    assert.strictEqual(dedupe.claim('C1:1'), true);
+  });
+
+  it('release() allows an immediate re-claim', () => {
+    const dedupe = new EventDedupe();
+    dedupe.claim('C1:1');
+    dedupe.release('C1:1');
     assert.strictEqual(dedupe.claim('C1:1'), true);
   });
 
@@ -143,6 +155,41 @@ describe('normalizeThreadMessages', () => {
     assert.ok(last.content.endsWith('…'));
   });
 
+  it('enforces the per-message BYTE cap, not just characters', () => {
+    // 4,000 emoji = 4,000 chars (under the 8,000 char cap) but 16,000 bytes.
+    const [message] = normalizeThreadMessages([{ ts: '1.0', user: 'U1', text: '😀'.repeat(4_000) }], {
+      ...opts,
+      triggerTs: '999.0',
+    });
+    assert.ok(utf8(message.content) <= MAX_MESSAGE_BYTES, `got ${utf8(message.content)} bytes`);
+    assert.ok(message.content.endsWith('…'));
+    // Truncation must not leave a broken surrogate pair behind.
+    assert.ok(!/[\uD800-\uDFFF]/.test(message.content.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '')));
+  });
+
+  it('drops oldest messages until the history fits the aggregate budget', () => {
+    // 40 × ~6 KB of multibyte text = ~240 KB, well past the 96 KB total.
+    const raw = Array.from({ length: 40 }, (_, i) => ({
+      ts: `${i + 1}.0`,
+      user: 'U1',
+      text: `${i}-${'é'.repeat(3_000)}`,
+    }));
+    const messages = normalizeThreadMessages(raw, { ...opts, triggerTs: '999.0' });
+    const total = messages.reduce((sum, m) => sum + utf8(m.content), 0);
+    assert.ok(total <= MAX_TOTAL_MESSAGE_BYTES, `got ${total} bytes`);
+    assert.ok(messages.length > 0);
+    // The NEWEST messages survive — the trigger must always be included.
+    assert.ok(messages[messages.length - 1].content.startsWith('39-'));
+  });
+
+  it('keeps at least one message even if it alone is large', () => {
+    const messages = normalizeThreadMessages([{ ts: '1.0', user: 'U1', text: 'é'.repeat(5_000) }], {
+      ...opts,
+      triggerTs: '999.0',
+    });
+    assert.strictEqual(messages.length, 1);
+  });
+
   it('drops empty messages', () => {
     const messages = normalizeThreadMessages(
       [
@@ -152,5 +199,83 @@ describe('normalizeThreadMessages', () => {
       opts,
     );
     assert.strictEqual(messages.length, 1);
+  });
+});
+
+describe('runTurnForEvent', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    dedupe.clear();
+    process.env.MCPJAM_API_KEY = 'sk_test';
+    process.env.MCPJAM_PROJECT_ID = 'p1';
+    process.env.MCPJAM_BASE_URL = 'https://stub.test';
+    realFetch = globalThis.fetch;
+  });
+
+  function stubApi(order) {
+    globalThis.fetch = async () => {
+      order.push('api-call');
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      return new Response(JSON.stringify({ reply: 'ok', toolCalls: [], createdResources: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+  }
+
+  const client = /** @type {any} */ ({
+    conversations: { history: async () => ({ messages: [{ ts: '1.0', user: 'U1', text: 'hello' }] }) },
+  });
+
+  function trigger(ts, order) {
+    return runTurnForEvent({
+      client,
+      channelId: 'D1',
+      threadTs: ts,
+      triggerTs: ts,
+      isThread: false,
+      botUserId: 'B1',
+      fallbackText: 'hi',
+      onResult: async () => {
+        order.push(`post-${ts}`);
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        order.push(`post-done-${ts}`);
+      },
+    });
+  }
+
+  it('serializes rapid top-level DMs, reply included', async () => {
+    // Each DM has its own ts, so a ts-keyed queue would not serialize them —
+    // and posting outside the queue would let turn 2 start before turn 1's
+    // answer landed. Both are the duplicate-suite hazard.
+    const order = [];
+    stubApi(order);
+    try {
+      await Promise.all([trigger('100.0', order), trigger('101.0', order)]);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    assert.deepStrictEqual(order, [
+      'api-call',
+      'post-100.0',
+      'post-done-100.0',
+      'api-call',
+      'post-101.0',
+      'post-done-101.0',
+    ]);
+  });
+
+  it('refuses a duplicate delivery of the same event', async () => {
+    const order = [];
+    stubApi(order);
+    try {
+      assert.strictEqual(await trigger('200.0', order), true);
+      assert.strictEqual(await trigger('200.0', order), false);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    assert.strictEqual(order.filter((step) => step === 'api-call').length, 1);
   });
 });

--- a/slack-app/tests/agent/turn-runner.test.js
+++ b/slack-app/tests/agent/turn-runner.test.js
@@ -1,0 +1,156 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { EventDedupe, KeyedQueue, normalizeThreadMessages } from '../../agent/turn-runner.js';
+
+describe('EventDedupe', () => {
+  it('claims a key once and rejects repeats while in flight', () => {
+    const dedupe = new EventDedupe();
+    assert.strictEqual(dedupe.claim('C1:1'), true);
+    assert.strictEqual(dedupe.claim('C1:1'), false);
+  });
+
+  it('keeps rejecting a completed key within the TTL (delayed Slack retry)', () => {
+    let clock = 1_000;
+    const dedupe = new EventDedupe({ ttlMs: 100, now: () => clock });
+    dedupe.claim('C1:1');
+    dedupe.complete('C1:1');
+    clock += 50; // retry arrives after completion, inside the TTL
+    assert.strictEqual(dedupe.claim('C1:1'), false);
+  });
+
+  it('expires completed keys after the TTL', () => {
+    let clock = 1_000;
+    const dedupe = new EventDedupe({ ttlMs: 100, now: () => clock });
+    dedupe.claim('C1:1');
+    dedupe.complete('C1:1');
+    clock += 200;
+    assert.strictEqual(dedupe.claim('C1:1'), true);
+  });
+
+  it('never expires an in-flight key', () => {
+    let clock = 1_000;
+    const dedupe = new EventDedupe({ ttlMs: 100, now: () => clock });
+    dedupe.claim('C1:1');
+    clock += 10_000;
+    assert.strictEqual(dedupe.claim('C1:1'), false);
+  });
+});
+
+describe('KeyedQueue', () => {
+  it('serializes jobs on the same key', async () => {
+    const queue = new KeyedQueue();
+    const order = [];
+    /** @type {() => void} */
+    let releaseFirst = () => {};
+    const first = queue.enqueue('t1', async () => {
+      order.push('first-start');
+      await new Promise((resolve) => {
+        releaseFirst = resolve;
+      });
+      order.push('first-end');
+    });
+    const second = queue.enqueue('t1', async () => {
+      order.push('second-start');
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.deepStrictEqual(order, ['first-start']); // second waits
+    releaseFirst();
+    await Promise.all([first, second]);
+    assert.deepStrictEqual(order, ['first-start', 'first-end', 'second-start']);
+  });
+
+  it('runs different keys concurrently', async () => {
+    const queue = new KeyedQueue();
+    const order = [];
+    let releaseA = () => {};
+    const a = queue.enqueue('a', async () => {
+      await new Promise((resolve) => {
+        releaseA = resolve;
+      });
+      order.push('a');
+    });
+    const b = queue.enqueue('b', async () => {
+      order.push('b');
+    });
+    await b;
+    assert.deepStrictEqual(order, ['b']); // b did not wait for a
+    releaseA();
+    await a;
+  });
+
+  it('keeps running after a failed job and surfaces the error', async () => {
+    const queue = new KeyedQueue();
+    await assert.rejects(
+      queue.enqueue('t1', async () => {
+        throw new Error('boom');
+      }),
+      /boom/,
+    );
+    const result = await queue.enqueue('t1', async () => 'ok');
+    assert.strictEqual(result, 'ok');
+  });
+
+  it('cleans up settled chains', async () => {
+    const queue = new KeyedQueue();
+    await queue.enqueue('t1', async () => 'done');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.strictEqual(queue.chains.size, 0);
+  });
+});
+
+describe('normalizeThreadMessages', () => {
+  const opts = { botUserId: 'B_BOT', triggerTs: '100.000' };
+
+  it('maps bot messages to assistant and humans to user', () => {
+    const messages = normalizeThreadMessages(
+      [
+        { ts: '1.0', user: 'U1', text: 'test my server' },
+        { ts: '2.0', bot_id: 'B99', text: 'sure thing' },
+        { ts: '3.0', user: 'B_BOT', text: 'also me' },
+      ],
+      opts,
+    );
+    assert.deepStrictEqual(
+      messages.map((m) => m.role),
+      ['user', 'assistant', 'assistant'],
+    );
+  });
+
+  it('filters out messages newer than the trigger', () => {
+    const messages = normalizeThreadMessages(
+      [
+        { ts: '99.0', user: 'U1', text: 'in scope' },
+        { ts: '100.000', user: 'U1', text: 'the trigger' },
+        { ts: '101.0', user: 'U2', text: 'next turn' },
+      ],
+      opts,
+    );
+    assert.strictEqual(messages.length, 2);
+    assert.ok(!messages.some((m) => m.content.includes('next turn')));
+  });
+
+  it('truncates oversized messages and caps the count', () => {
+    const raw = Array.from({ length: 60 }, (_, i) => ({
+      ts: `${i + 1}.0`,
+      user: 'U1',
+      text: i === 59 ? 'x'.repeat(10_000) : `msg ${i}`,
+    }));
+    const messages = normalizeThreadMessages(raw, { ...opts, triggerTs: '999.0' });
+    assert.strictEqual(messages.length, 50);
+    const last = messages[messages.length - 1];
+    assert.ok(last.content.length <= 8_000);
+    assert.ok(last.content.endsWith('…'));
+  });
+
+  it('drops empty messages', () => {
+    const messages = normalizeThreadMessages(
+      [
+        { ts: '1.0', user: 'U1', text: '   ' },
+        { ts: '2.0', user: 'U1', text: 'real' },
+      ],
+      opts,
+    );
+    assert.strictEqual(messages.length, 1);
+  });
+});

--- a/slack-app/tests/listeners/actions/run-outcome.test.js
+++ b/slack-app/tests/listeners/actions/run-outcome.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { formatRunOutcome } from '../../../listeners/actions/run-suite-button.js';
+
+describe('formatRunOutcome', () => {
+  const url = 'https://x/evals/suite/s/runs/r';
+
+  it('formats a pass with counts', () => {
+    const text = formatRunOutcome(
+      { status: 'completed', result: 'passed', summary: { passed: 3, total: 3 } },
+      url,
+      'U1',
+    );
+    assert.ok(text.includes(':large_green_circle:'));
+    assert.ok(text.includes('(3/3 passed)'));
+    assert.ok(text.includes(url));
+  });
+
+  it('formats a failure', () => {
+    const text = formatRunOutcome(
+      { status: 'completed', result: 'failed', summary: { passed: 1, total: 3 } },
+      url,
+      'U1',
+    );
+    assert.ok(text.includes(':red_circle:'));
+    assert.ok(text.includes('(1/3 passed)'));
+  });
+
+  it('formats a cancellation', () => {
+    const text = formatRunOutcome({ status: 'cancelled', result: null }, url, 'U1');
+    assert.ok(text.includes('cancelled'));
+  });
+});

--- a/slack-app/tests/listeners/actions/run-outcome.test.js
+++ b/slack-app/tests/listeners/actions/run-outcome.test.js
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 
 import { formatRunOutcome } from '../../../listeners/actions/run-suite-button.js';
@@ -30,5 +31,23 @@ describe('formatRunOutcome', () => {
   it('formats a cancellation', () => {
     const text = formatRunOutcome({ status: 'cancelled', result: null }, url, 'U1');
     assert.ok(text.includes('cancelled'));
+  });
+
+  it('formats a backend timeout', () => {
+    const text = formatRunOutcome({ status: 'timed_out', result: null }, url, 'U1');
+    assert.ok(text.includes('timed out'));
+    assert.ok(!text.includes('timed_out'), 'raw status should not leak into Slack copy');
+  });
+});
+
+describe('terminal statuses', () => {
+  it('treats every backend terminal status as terminal', async () => {
+    // Guards the poller against spinning for the full watch window on a
+    // status the backend considers finished (server/routes/v1/evals.ts).
+    const source = await readFile(new URL('../../../listeners/actions/run-suite-button.js', import.meta.url), 'utf8');
+    const line = source.split('\n').find((l) => l.includes('TERMINAL_STATUSES = new Set'));
+    for (const status of ['completed', 'failed', 'cancelled', 'timed_out']) {
+      assert.ok(line?.includes(`'${status}'`), `${status} missing from TERMINAL_STATUSES`);
+    }
   });
 });

--- a/slack-app/tests/listeners/actions/run-suite-button.test.js
+++ b/slack-app/tests/listeners/actions/run-suite-button.test.js
@@ -1,0 +1,85 @@
+import assert from 'node:assert';
+import { beforeEach, describe, it, mock } from 'node:test';
+
+import { handleRunSuiteButton, startedRunKeys } from '../../../listeners/actions/run-suite-button.js';
+
+describe('handleRunSuiteButton', () => {
+  /** @type {any} */
+  let args;
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    startedRunKeys.clear();
+    process.env.MCPJAM_API_KEY = 'sk_test';
+    process.env.MCPJAM_PROJECT_ID = 'p1';
+    process.env.MCPJAM_BASE_URL = 'https://example.test';
+    realFetch = globalThis.fetch;
+    args = {
+      ack: mock.fn(async () => {}),
+      body: { channel: { id: 'C1' }, message: { ts: '42.0' } },
+      action: { value: 'ts_1' },
+      context: { userId: 'U1' },
+      logger: { error: mock.fn() },
+      client: {
+        chat: {
+          postMessage: mock.fn(async () => ({ ok: true })),
+          postEphemeral: mock.fn(async () => ({ ok: true })),
+        },
+      },
+    };
+  });
+
+  function stubApi(status, body) {
+    globalThis.fetch = mock.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+  }
+
+  function restore() {
+    globalThis.fetch = realFetch;
+  }
+
+  it('acks, starts the run once, and posts the run link', async () => {
+    stubApi(202, { runId: 'run_9' });
+    try {
+      await handleRunSuiteButton(args);
+    } finally {
+      restore();
+    }
+    assert.strictEqual(args.ack.mock.callCount(), 1);
+    assert.strictEqual(args.client.chat.postMessage.mock.callCount(), 1);
+    const posted = args.client.chat.postMessage.mock.calls[0].arguments[0];
+    assert.ok(posted.text.includes('/evals/suite/ts_1/runs/run_9'));
+  });
+
+  it('ignores a second click for the same suite+message (no second run)', async () => {
+    stubApi(202, { runId: 'run_9' });
+    try {
+      await handleRunSuiteButton(args);
+      const callsAfterFirst = /** @type {any} */ (globalThis.fetch).mock.callCount();
+      await handleRunSuiteButton(args);
+      assert.strictEqual(/** @type {any} */ (globalThis.fetch).mock.callCount(), callsAfterFirst);
+    } finally {
+      restore();
+    }
+    assert.strictEqual(args.client.chat.postMessage.mock.callCount(), 1);
+    assert.strictEqual(args.client.chat.postEphemeral.mock.callCount(), 1);
+  });
+
+  it('allows a retry after a failed start', async () => {
+    stubApi(500, { code: 'INTERNAL_ERROR', message: 'nope' });
+    try {
+      await handleRunSuiteButton(args);
+    } finally {
+      restore();
+    }
+    assert.strictEqual(args.client.chat.postMessage.mock.callCount(), 0);
+    assert.strictEqual(startedRunKeys.size, 0); // retry permitted
+    assert.strictEqual(args.client.chat.postEphemeral.mock.callCount(), 1);
+  });
+});

--- a/slack-app/tests/listeners/actions/run-suite-button.test.js
+++ b/slack-app/tests/listeners/actions/run-suite-button.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { beforeEach, describe, it, mock } from 'node:test';
 
-import { handleRunSuiteButton, startedRunKeys } from '../../../listeners/actions/run-suite-button.js';
+import { handleRunSuiteButton, runDedupe } from '../../../listeners/actions/run-suite-button.js';
 
 describe('handleRunSuiteButton', () => {
   /** @type {any} */
@@ -10,20 +10,21 @@ describe('handleRunSuiteButton', () => {
   let realFetch;
 
   beforeEach(() => {
-    startedRunKeys.clear();
+    runDedupe.clear();
     process.env.MCPJAM_API_KEY = 'sk_test';
     process.env.MCPJAM_PROJECT_ID = 'p1';
     process.env.MCPJAM_BASE_URL = 'https://example.test';
     realFetch = globalThis.fetch;
     args = {
       ack: mock.fn(async () => {}),
-      body: { channel: { id: 'C1' }, message: { ts: '42.0' } },
+      // The button sits on the bot's reply (ts 42.0) inside thread 40.0.
+      body: { channel: { id: 'C1' }, message: { ts: '42.0', thread_ts: '40.0' } },
       action: { value: 'ts_1' },
       context: { userId: 'U1' },
       logger: { error: mock.fn() },
       client: {
         chat: {
-          postMessage: mock.fn(async () => ({ ok: true })),
+          postMessage: mock.fn(async () => ({ ok: true, ts: '43.0' })),
           postEphemeral: mock.fn(async () => ({ ok: true })),
         },
       },
@@ -57,6 +58,28 @@ describe('handleRunSuiteButton', () => {
     assert.ok(posted.text.includes('/evals/suite/ts_1/runs/run_9'));
   });
 
+  it('replies on the PARENT thread ts, not the button message ts', async () => {
+    stubApi(202, { runId: 'run_9' });
+    try {
+      await handleRunSuiteButton(args);
+    } finally {
+      restore();
+    }
+    const posted = args.client.chat.postMessage.mock.calls[0].arguments[0];
+    assert.strictEqual(posted.thread_ts, '40.0');
+  });
+
+  it('falls back to the message ts when it is itself the parent', async () => {
+    args.body.message = { ts: '42.0' }; // top-level message, no thread_ts
+    stubApi(202, { runId: 'run_9' });
+    try {
+      await handleRunSuiteButton(args);
+    } finally {
+      restore();
+    }
+    assert.strictEqual(args.client.chat.postMessage.mock.calls[0].arguments[0].thread_ts, '42.0');
+  });
+
   it('ignores a second click for the same suite+message (no second run)', async () => {
     stubApi(202, { runId: 'run_9' });
     try {
@@ -75,11 +98,42 @@ describe('handleRunSuiteButton', () => {
     stubApi(500, { code: 'INTERNAL_ERROR', message: 'nope' });
     try {
       await handleRunSuiteButton(args);
+      assert.strictEqual(args.client.chat.postMessage.mock.callCount(), 0);
+      assert.strictEqual(args.client.chat.postEphemeral.mock.callCount(), 1);
+      // The retry must actually start a run, not just find the key cleared.
+      stubApi(202, { runId: 'run_9' });
+      await handleRunSuiteButton(args);
+    } finally {
+      restore();
+    }
+    assert.strictEqual(args.client.chat.postMessage.mock.callCount(), 1);
+  });
+
+  it('does NOT allow a retry when the run started but announcing it failed', async () => {
+    stubApi(202, { runId: 'run_9' });
+    args.client.chat.postMessage = mock.fn(async () => {
+      throw new Error('slack down');
+    });
+    try {
+      await handleRunSuiteButton(args);
+      const callsAfterFirst = /** @type {any} */ (globalThis.fetch).mock.callCount();
+      // A second click must not bill a second run for an already-started one.
+      await handleRunSuiteButton(args);
+      assert.strictEqual(/** @type {any} */ (globalThis.fetch).mock.callCount(), callsAfterFirst);
+    } finally {
+      restore();
+    }
+    assert.strictEqual(args.logger.error.mock.callCount(), 1);
+  });
+
+  it('surfaces an error instead of linking a run with no id', async () => {
+    stubApi(202, { status: 'running' }); // runId missing
+    try {
+      await handleRunSuiteButton(args);
     } finally {
       restore();
     }
     assert.strictEqual(args.client.chat.postMessage.mock.callCount(), 0);
-    assert.strictEqual(startedRunKeys.size, 0); // retry permitted
     assert.strictEqual(args.client.chat.postEphemeral.mock.callCount(), 1);
   });
 });

--- a/slack-app/tests/listeners/events/app-home-opened.test.js
+++ b/slack-app/tests/listeners/events/app-home-opened.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import { beforeEach, describe, it, mock } from 'node:test';
+
+import { handleAppHomeOpened } from '../../../listeners/events/app-home-opened.js';
+
+describe('handleAppHomeOpened', () => {
+  let fakeClient;
+  let fakeContext;
+  let fakeLogger;
+
+  beforeEach(() => {
+    fakeClient = {
+      views: { publish: mock.fn(async () => ({ ok: true })) },
+      assistant: { threads: { setSuggestedPrompts: mock.fn(async () => ({ ok: true })) } },
+    };
+    fakeContext = { userId: 'U123' };
+    fakeLogger = { error: mock.fn() };
+  });
+
+  it('publishes the home view when event.tab === "home"', async () => {
+    const event = { tab: 'home', channel: 'D123' };
+    await handleAppHomeOpened({ client: fakeClient, event, context: fakeContext, logger: fakeLogger });
+    assert.strictEqual(fakeClient.views.publish.mock.callCount(), 1);
+    const callArgs = fakeClient.views.publish.mock.calls[0].arguments[0];
+    assert.strictEqual(callArgs.user_id, 'U123');
+    assert.strictEqual(callArgs.view.type, 'home');
+    assert.strictEqual(fakeClient.assistant.threads.setSuggestedPrompts.mock.callCount(), 0);
+  });
+
+  it('sets suggested prompts when event.tab === "messages"', async () => {
+    const event = { tab: 'messages', channel: 'D123' };
+    await handleAppHomeOpened({ client: fakeClient, event, context: fakeContext, logger: fakeLogger });
+    assert.strictEqual(fakeClient.assistant.threads.setSuggestedPrompts.mock.callCount(), 1);
+    const callArgs = fakeClient.assistant.threads.setSuggestedPrompts.mock.calls[0].arguments[0];
+    assert.strictEqual(callArgs.channel_id, 'D123');
+    assert.ok(Array.isArray(callArgs.prompts));
+    assert.strictEqual(fakeClient.views.publish.mock.callCount(), 0);
+  });
+
+  it('logs error when views.publish fails', async () => {
+    fakeClient.views.publish = mock.fn(async () => {
+      throw new Error('API error');
+    });
+    const event = { tab: 'home', channel: 'D123' };
+    await handleAppHomeOpened({ client: fakeClient, event, context: fakeContext, logger: fakeLogger });
+    assert.strictEqual(fakeLogger.error.mock.callCount(), 1);
+  });
+});

--- a/slack-app/tests/listeners/views/agent-reply-builder.test.js
+++ b/slack-app/tests/listeners/views/agent-reply-builder.test.js
@@ -1,7 +1,11 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { buildCreatedResourceBlocks, RUN_SUITE_ACTION_ID } from '../../../listeners/views/agent-reply-builder.js';
+import {
+  buildCreatedResourceBlocks,
+  escapeSlackText,
+  RUN_SUITE_ACTION_ID,
+} from '../../../listeners/views/agent-reply-builder.js';
 
 describe('buildCreatedResourceBlocks', () => {
   it('returns no blocks when nothing was created', () => {
@@ -20,5 +24,41 @@ describe('buildCreatedResourceBlocks', () => {
     }
     assert.strictEqual(blocks[0].accessory.value, 'ts_1');
     assert.ok(blocks[0].text.text.includes('smoke'));
+  });
+
+  it('escapes Slack markup in agent-supplied suite names', () => {
+    const [block] = buildCreatedResourceBlocks([
+      { type: 'eval_suite', id: 'ts_1', name: '<!channel> & "weird" <name>', url: 'https://x/s' },
+    ]);
+    const text = block.text.text;
+    assert.ok(!text.includes('<!channel>'), 'raw mention markup must not survive');
+    assert.ok(text.includes('&lt;!channel&gt;'));
+    assert.ok(text.includes('&amp;'));
+    // The real link markup is still intact.
+    assert.ok(text.includes('<https://x/s|'));
+  });
+
+  it('stays within Slack block limits when many suites are created', () => {
+    const many = Array.from({ length: 60 }, (_, i) => ({
+      type: 'eval_suite',
+      id: `ts_${i}`,
+      name: `suite ${i}`,
+      url: `https://x/s${i}`,
+    }));
+    const blocks = buildCreatedResourceBlocks(many);
+    // Room for the feedback block the reply appends, under Slack's 50 cap.
+    assert.ok(blocks.length < 50, `got ${blocks.length} blocks`);
+    assert.strictEqual(blocks[blocks.length - 1].type, 'context');
+    assert.ok(blocks[blocks.length - 1].elements[0].text.includes('more'));
+  });
+});
+
+describe('escapeSlackText', () => {
+  it('escapes &, < and > in that order', () => {
+    assert.strictEqual(escapeSlackText('a & b < c > d'), 'a &amp; b &lt; c &gt; d');
+  });
+
+  it('does not double-escape the ampersand it just wrote', () => {
+    assert.strictEqual(escapeSlackText('<'), '&lt;');
   });
 });

--- a/slack-app/tests/listeners/views/agent-reply-builder.test.js
+++ b/slack-app/tests/listeners/views/agent-reply-builder.test.js
@@ -62,3 +62,23 @@ describe('escapeSlackText', () => {
     assert.strictEqual(escapeSlackText('<'), '&lt;');
   });
 });
+
+describe('toSuiteLabel', () => {
+  it('caps a long name so the section stays under Slack limits', () => {
+    const [block] = buildCreatedResourceBlocks([
+      { type: 'eval_suite', id: 'ts_1', name: 'x'.repeat(5_000), url: 'https://x/s' },
+    ]);
+    assert.ok(block.text.text.length < 3_000, `section was ${block.text.text.length} chars`);
+    assert.ok(block.text.text.includes('…'));
+  });
+
+  it('caps BEFORE escaping so no entity is sliced in half', () => {
+    const [block] = buildCreatedResourceBlocks([
+      { type: 'eval_suite', id: 'ts_1', name: '&'.repeat(5_000), url: 'https://x/s' },
+    ]);
+    const text = block.text.text;
+    assert.ok(text.length < 3_000);
+    // Every ampersand present must be a complete &amp; entity.
+    assert.strictEqual(text.split('&').length - 1, text.split('&amp;').length - 1);
+  });
+});

--- a/slack-app/tests/listeners/views/agent-reply-builder.test.js
+++ b/slack-app/tests/listeners/views/agent-reply-builder.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { buildCreatedResourceBlocks, RUN_SUITE_ACTION_ID } from '../../../listeners/views/agent-reply-builder.js';
+
+describe('buildCreatedResourceBlocks', () => {
+  it('returns no blocks when nothing was created', () => {
+    assert.deepStrictEqual(buildCreatedResourceBlocks([]), []);
+  });
+
+  it('builds one Run-it button per created suite', () => {
+    const blocks = buildCreatedResourceBlocks([
+      { type: 'eval_suite', id: 'ts_1', name: 'smoke', url: 'https://x/evals/suite/ts_1' },
+      { type: 'eval_suite', id: 'ts_2', url: 'https://x/evals/suite/ts_2' },
+      { type: 'eval_run', id: 'run_1', url: 'https://x/run' },
+    ]);
+    assert.strictEqual(blocks.length, 2);
+    for (const block of blocks) {
+      assert.strictEqual(block.accessory.action_id, RUN_SUITE_ACTION_ID);
+    }
+    assert.strictEqual(blocks[0].accessory.value, 'ts_1');
+    assert.ok(blocks[0].text.text.includes('smoke'));
+  });
+});

--- a/slack-app/tests/listeners/views/app-home-builder.test.js
+++ b/slack-app/tests/listeners/views/app-home-builder.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { buildAppHomeView } from '../../../listeners/views/app-home-builder.js';
+
+describe('buildAppHomeView', () => {
+  it('returns a home view', () => {
+    const view = buildAppHomeView();
+    assert.strictEqual(view.type, 'home');
+  });
+
+  it('has a blocks array with header and section', () => {
+    const view = buildAppHomeView();
+    assert.ok(Array.isArray(view.blocks));
+    assert.ok(view.blocks.length >= 3);
+    assert.strictEqual(view.blocks[0].type, 'header');
+    assert.strictEqual(view.blocks[1].type, 'section');
+  });
+
+  it('describes the eval-suite workflow', () => {
+    const view = buildAppHomeView();
+    const sectionTexts = view.blocks.filter((b) => b.type === 'section').map((b) => b.text.text);
+    assert.ok(sectionTexts.some((t) => t.includes('eval suites')));
+  });
+});

--- a/slack-app/tests/listeners/views/feedback-builder.test.js
+++ b/slack-app/tests/listeners/views/feedback-builder.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { buildFeedbackBlocks } from '../../../listeners/views/feedback-builder.js';
+
+describe('buildFeedbackBlocks', () => {
+  it('returns a non-empty array', () => {
+    const blocks = buildFeedbackBlocks();
+    assert.ok(Array.isArray(blocks));
+    assert.ok(blocks.length > 0);
+  });
+
+  it('first block has type context_actions', () => {
+    const blocks = buildFeedbackBlocks();
+    assert.strictEqual(blocks[0].type, 'context_actions');
+  });
+
+  it('contains feedback action_id', () => {
+    const blocks = buildFeedbackBlocks();
+    const element = blocks[0].elements[0];
+    assert.strictEqual(element.action_id, 'feedback');
+  });
+
+  it('has positive and negative buttons', () => {
+    const blocks = buildFeedbackBlocks();
+    const element = blocks[0].elements[0];
+    assert.ok(element.positive_button);
+    assert.ok(element.negative_button);
+  });
+});

--- a/slack-app/tests/thread-context/store.test.js
+++ b/slack-app/tests/thread-context/store.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { SessionStore } from '../../thread-context/store.js';
+
+describe('SessionStore', () => {
+  let store;
+
+  beforeEach(() => {
+    store = new SessionStore();
+  });
+
+  it('stores and retrieves a session', () => {
+    store.setSession('C1', 'T1', 'sid-abc');
+    assert.strictEqual(store.getSession('C1', 'T1'), 'sid-abc');
+  });
+
+  it('returns null for missing key', () => {
+    assert.strictEqual(store.getSession('C1', 'T99'), null);
+  });
+
+  it('keeps different threads independent', () => {
+    store.setSession('C1', 'T1', 'sid-1');
+    store.setSession('C1', 'T2', 'sid-2');
+    assert.strictEqual(store.getSession('C1', 'T1'), 'sid-1');
+    assert.strictEqual(store.getSession('C1', 'T2'), 'sid-2');
+  });
+
+  it('expires entries after TTL', async () => {
+    const shortStore = new SessionStore(0);
+    shortStore.setSession('C1', 'T1', 'sid-abc');
+    // Need a tiny delay to ensure Date.now() advances past the stored timestamp
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.strictEqual(shortStore.getSession('C1', 'T1'), null);
+  });
+
+  it('evicts oldest entries when max is exceeded', () => {
+    const smallStore = new SessionStore(86400, 2);
+    smallStore.setSession('C1', 'T1', 'sid-1');
+    smallStore.setSession('C1', 'T2', 'sid-2');
+    smallStore.setSession('C1', 'T3', 'sid-3');
+    assert.strictEqual(smallStore.getSession('C1', 'T1'), null);
+    assert.strictEqual(smallStore.getSession('C1', 'T2'), 'sid-2');
+    assert.strictEqual(smallStore.getSession('C1', 'T3'), 'sid-3');
+  });
+
+  it('overwrites existing key', () => {
+    store.setSession('C1', 'T1', 'sid-old');
+    store.setSession('C1', 'T1', 'sid-new');
+    assert.strictEqual(store.getSession('C1', 'T1'), 'sid-new');
+  });
+});

--- a/slack-app/thread-context/index.js
+++ b/slack-app/thread-context/index.js
@@ -1,0 +1,3 @@
+import { SessionStore } from './store.js';
+
+export const sessionStore = new SessionStore();

--- a/slack-app/thread-context/store.js
+++ b/slack-app/thread-context/store.js
@@ -1,0 +1,74 @@
+/**
+ * @typedef {Object} StoreEntry
+ * @property {string} sessionId
+ * @property {number} timestamp
+ */
+
+/**
+ * In-memory session ID store with TTL-based cleanup.
+ */
+export class SessionStore {
+  /**
+   * @param {number} [ttlSeconds=86400]
+   * @param {number} [maxEntries=1000]
+   */
+  constructor(ttlSeconds = 86400, maxEntries = 1000) {
+    /** @type {Map<string, StoreEntry>} */
+    this._store = new Map();
+    /** @private @type {number} */
+    this._ttlSeconds = ttlSeconds;
+    /** @private @type {number} */
+    this._maxEntries = maxEntries;
+  }
+
+  /**
+   * @param {string} channelId
+   * @param {string} threadTs
+   * @returns {string | null}
+   */
+  getSession(channelId, threadTs) {
+    const key = `${channelId}:${threadTs}`;
+    const entry = this._store.get(key);
+    if (!entry) return null;
+    if (Date.now() - entry.timestamp > this._ttlSeconds * 1000) {
+      this._store.delete(key);
+      return null;
+    }
+    return entry.sessionId;
+  }
+
+  /**
+   * @param {string} channelId
+   * @param {string} threadTs
+   * @param {string} sessionId
+   * @returns {void}
+   */
+  setSession(channelId, threadTs, sessionId) {
+    const key = `${channelId}:${threadTs}`;
+    this._store.set(key, {
+      sessionId,
+      timestamp: Date.now(),
+    });
+    this._cleanup();
+  }
+
+  /**
+   * @private
+   * @returns {void}
+   */
+  _cleanup() {
+    const now = Date.now();
+    for (const [key, entry] of this._store) {
+      if (now - entry.timestamp > this._ttlSeconds * 1000) {
+        this._store.delete(key);
+      }
+    }
+    if (this._store.size > this._maxEntries) {
+      const sorted = [...this._store.entries()].sort((a, b) => a[1].timestamp - b[1].timestamp);
+      const toRemove = sorted.slice(0, this._store.size - this._maxEntries);
+      for (const [key] of toRemove) {
+        this._store.delete(key);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Moves the MCPJam Slack bot from a private standalone repo into this monorepo as the `slack-app/` workspace.

## Why

The bot is a **thin terminal over `POST /api/v1/projects/:id/agent`** — the same relationship `cli/` and `mcp/` have to the public API. Keeping it outside meant no shared contract, none of this repo's review/CI pipeline, and cross-repo coordination for changes that are inherently atomic (both fixes found during dogfood — the opaque validation error and the dev deep-link 404 — spanned server and bot).

## Workspace registration

- **Root `package.json`**: added to `workspaces`, plus an 8th slot in `test:parallel` and the tail of `test:ordered`.
- **CI enforces more than tests**: the workspace exposes `verify` = `test && check && lint`, and the root test lists call *that*. Without it, root `npm test` would have run only the bot's unit tests and left type-check and lint unenforced.
- **`.changeset/config.json`**: added to `ignore` (private package, matching `@mcpjam/soundcheck` / `@mcpjam/mcp`). `changeset status` confirmed clean.
- **`pr-preview.yml`**: `slack-app/**` added to `paths-ignore` — a slack-app-only PR has no inspector image to preview. `pr-mcp-preview.yml` needs no change (positive `paths:` filter, can't be triggered by this).
- **Lockfile** regenerated with `--legacy-peer-deps` to match CI's install. Verified against the pre-change lock: `@types/express` stays `4.17.25` (bolt@5's `^5` peer is *not* auto-installed — plain `npm install` would have forked it), root `typescript` stays `5.9.3` with slack-app's `7.0.2` nested, nothing removed; the only edits to existing entries are `dev`/`devOptional` reclassification.

## Cleanups the move earned

- **OAuth mode deleted** (`app-oauth.js` + `@slack/oauth`). Socket Mode is the active dogfood path; the file carried a hard-coded state secret and a file-backed installation store that couldn't survive Railway. Multi-tenant OAuth is a fresh v2 design with real credential storage — not a half-wired file kept warm.
- **`users:read` dropped** from the manifest, along with the never-wired `resolveUserName` hook it existed for (advertise == enforce). Speaker attribution comes back with the scope if it's ever wanted.
- **README rewritten** — it still documented the Claude Agent SDK, Anthropic API keys, the Slack MCP server, and an emoji tool, none of which survive in v1. Now covers the thin-client architecture, the non-obvious correctness rules (TTL event dedupe, per-thread serialization, trigger-timestamp filtering, no-blind-retry), env vars, and the dev flow.
- **Biome**: migrated the deprecated `recommended` field to `preset`, pinned `$schema` to the versioned URL (the `./node_modules/...` path dangles under workspace hoisting), and fixed the missing trailing newline in `.slack/config.json` — a pre-existing `lint` failure that had to go before lint could be wired into CI.
- **Stale `.claude/CLAUDE.md` dropped** rather than carried: it described the deleted in-process agent, no workspace in this repo has one, and the root `.gitignore`'s `.claude/` pattern would have silently excluded it from the PR anyway. Its useful content is now in the README.

## Verification (from the new location)

- `npm run verify -w @mcpjam/slack-app` → **exit 0**: 42 tests, `tsc --checkJs`, biome all clean.
- `concurrently` arg counts asserted aligned (8 names / 8 colors / 8 commands).
- `slack app list` from `slack-app/` resolves the same dev app — `.slack/` project config travels correctly.
- **Live agent turn** from the new working directory against a local inspector: `.env` loads, module resolution works, the API answers with the project's real eval suites.
- `git status --ignored --short slack-app` + `git check-ignore -v`: `.env`, `.slack/apps.dev.json`, and `node_modules/` all confirmed ignored; no `sk_` key anywhere in the diff (only `sk_test` fixtures).

## Follow-ups (deliberately not here)

- Railway deploy workflow modeled on `deploy-soundcheck.yml` (+ service and token) — the bot is still laptop-hosted.
- Promoting the agent-turn request/response DTOs into `sdk/src/public-api/` so the bot and `server/routes/v1/agent.ts` share one contract (touches the published SDK → own PR + changeset).
- Durable `Idempotency-Key` through suite creation, the gate for opening the endpoint beyond dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New long-lived integration that holds MCPJam API keys and can create suites and start billed eval runs on button click, though runs are human-gated and the package is isolated from inspector core auth.
> 
> **Overview**
> Adds **`slack-app/`** as a new workspace: a Socket Mode Slack bot that forwards DMs and @mentions to **`POST /api/v1/projects/:id/agent`**, posts the reply with **Run it** buttons for created suites, and starts eval runs only on explicit button clicks via the public API.
> 
> **Monorepo wiring:** root workspaces and **`test:parallel` / `test:ordered`** now run **`npm run verify`** on `@mcpjam/slack-app`; Changesets ignores the private package; **`pr-preview`** skips **`slack-app/**`** because it is not part of the inspector image.
> 
> **v1 scope vs. old standalone bot:** OAuth entry and **`users:read`** are removed; the app is API-key + project-id only (no in-process LLM). Correctness is centralized in **`turn-runner`** (TTL event dedupe, per-thread/DM serialization, trigger-timestamp history, UTF-8 byte caps) and **`run-suite-button`** (24h run dedupe, terminal-status polling including **`timed_out`**).
> 
> Includes Bolt listeners, MCPJam HTTP client, manifest/Slack CLI config, Biome + **`node:test`** suite, and a NOTICE for Slack sample-derived code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eca409586650af8263f8704670e83fba3cabb3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the MCPJam Slack bot into this monorepo as `slack-app/`. Unifies CI and the public API contract so server and bot changes can land together; the bot is a thin client over POST /api/v1/projects/:id/agent.

- New Features
  - Socket Mode Slack bot that turns DMs/threads into eval suites via the agent API, adds “Run it” buttons, and edits messages with run results.
  - Correctness guards: TTL event dedupe, per-thread serialization, and trigger-timestamp filtering.
  - App Home view and feedback buttons.
  - `verify` runs tests (64), `tsc --checkJs`, and Biome lint.

- Bug Fixes
  - Concurrency/threading: reply to the parent thread_ts; post replies inside the per-thread queue; serialize top-level DMs per channel; release event claims on early status failures; no “working” messages left on duplicates.
  - Payload/history: single pass that enforces both character and UTF-8 byte budgets (8,192/message, 96 KB total) without broken surrogates; history filtered to the trigger timestamp.
  - Runs: button clicks deduped with a 24h TTL and only released when a run didn’t start; poller treats timed_out as terminal; missing runId errors early.
  - Network/logging: timeouts cover the full response body; mid-body aborts no longer read as success (only SyntaxError is swallowed; TIMEOUT and HTML error bodies are classified correctly); DEBUG is opt-in via SLACK_LOG_LEVEL (default INFO).
  - Safety/UI: escape suite names and cap labels before escaping; cap blocks with an overflow footer; replace workspace LICENSE with a NOTICE aligned to the repo license.

<sup>Written for commit 1eca409586650af8263f8704670e83fba3cabb3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

