### PR TITLE
feat(sdk): client-conformance knobs on the hostConfig mcpProfile schema (S1)

### DIFF
--- a/.changeset/hostconfig-client-conformance-knobs.md
+++ b/.changeset/hostconfig-client-conformance-knobs.md
@@ -1,0 +1,22 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Add two client-conformance knobs to the host-config `mcpProfile` schema
+(siblings of `toolParamHeaderMirroring`), modeling real differences between
+the clients MCPJam emulates:
+
+- `paginationTraversal` (`"full" | "firstPageOnly"`) — whether the simulated
+  client follows `nextCursor` to exhaustion or treats page one as the whole
+  result, the way several real hosts do. Under `firstPageOnly` the SEP-2243
+  `Mcp-Param-*` mirroring source is page-one-only, matching how such a client
+  really behaves.
+- `mrtrSupport` (`"full" | "none"`) — whether the client drives MRTR
+  `input_required` retry rounds at all. Which elicitation modes an
+  MRTR-capable client fulfills stays where it already lives, in
+  `clientCapabilities.elicitation.{form,url}`.
+
+Schema freeze only: both fields canonicalize (absent = full behavior and
+omitted, so existing hashes are stable), round-trip through `Host` /
+`HostJson` and the evals normalizer, and reduce to their wire shape in
+`hostConnectionProfile()`. Runtime enforcement lands in follow-up releases.

--- a/sdk/scripts/gen-host-config-parity-fixture.mjs
+++ b/sdk/scripts/gen-host-config-parity-fixture.mjs
@@ -138,6 +138,54 @@ const inputs = [
       },
     },
   },
+  // ── Client-conformance knobs (siblings of toolParamHeaderMirroring) ──
+  // One vector per knob's non-default value, a default-literals vector
+  // (stored, hashes distinctly from absent), and a combined vector with a
+  // stateful pin that pins profile KEY ORDER against the backend shim.
+  {
+    label: "mcp-profile-conformance-pagination-first-page-only",
+    input: {
+      ...base(),
+      mcpProfile: { profileVersion: 1, paginationTraversal: "firstPageOnly" },
+    },
+  },
+  {
+    label: "mcp-profile-conformance-mrtr-support-none",
+    input: {
+      ...base(),
+      mcpProfile: { profileVersion: 1, mrtrSupport: "none" },
+    },
+  },
+  {
+    // Default literals are storable and hash distinctly from absent
+    // (same discipline as toolParamHeaderMirroring: "mirror").
+    label: "mcp-profile-conformance-default-literals",
+    input: {
+      ...base(),
+      mcpProfile: {
+        profileVersion: 1,
+        paginationTraversal: "full",
+        mrtrSupport: "full",
+      },
+    },
+  },
+  {
+    // Both knobs non-default + mirroring + a stateful pin. The pin makes
+    // the SDK derive `initialize`, so this vector pins the full profile KEY
+    // ORDER (profileVersion first, then alphabetical) that the backend
+    // shim must reproduce byte-identically.
+    label: "mcp-profile-conformance-combined-with-stateful-pin",
+    input: {
+      ...base(),
+      mcpProfile: {
+        profileVersion: 1,
+        mcpProtocolVersion: "2025-11-25",
+        toolParamHeaderMirroring: "omit",
+        paginationTraversal: "firstPageOnly",
+        mrtrSupport: "none",
+      },
+    },
+  },
   {
     label: "sandbox-csp-restrictto-sorted-plus-directives",
     input: {

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -454,6 +454,8 @@ export type {
   OpenAiAppsCapabilities,
   McpAppsCapabilities,
   ToolParamHeaderMirroring,
+  PaginationTraversalMode,
+  MrtrSupport,
 } from "./host-config/index.js";
 
 // Shared task lifecycle engine. Browser-safe by construction: it performs no

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -26,6 +26,8 @@ import {
   isHarness,
   OAUTH_AUTH_MODELS,
   OAUTH_PROFILE_EVIDENCE_STATUSES,
+  MRTR_SUPPORT_MODES,
+  PAGINATION_TRAVERSAL_MODES,
   SEP_1865_PERMISSION_FEATURES,
   TOOL_PARAM_HEADER_MIRRORING_MODES,
   type CanonicalHostConfigSkillSelection,
@@ -715,6 +717,27 @@ function canonicalizeMcpProfile(
       );
     }
     out.toolParamHeaderMirroring = input.toolParamHeaderMirroring;
+  }
+
+  // Client-conformance knobs (siblings of toolParamHeaderMirroring). Same
+  // omit-when-absent discipline: absent → spec-conforming, hashes stable.
+  // One validation loop; the top-level re-key below sorts every emitted
+  // field into canonical position.
+  const conformanceKnobs = [
+    ["paginationTraversal", PAGINATION_TRAVERSAL_MODES],
+    ["mrtrSupport", MRTR_SUPPORT_MODES],
+  ] as const;
+  for (const [key, modes] of conformanceKnobs) {
+    const value = input[key];
+    if (value === undefined) continue;
+    if (!(modes as readonly string[]).includes(value as string)) {
+      throw new Error(
+        `hostConfigV2: mcpProfile.${key} must be one of ${modes.join(
+          ", "
+        )} (got "${String(value)}")`
+      );
+    }
+    (out as Record<string, unknown>)[key] = value;
   }
 
   if (input.initialize !== undefined) {

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -25,6 +25,19 @@ export interface HostConnectionProfile {
    * `"mirror"` collapses to absent so the wire config stays untouched.
    */
   mirrorToolParamHeaders?: boolean;
+  /**
+   * Client-conformance knobs, reduced to their wire shape: only the
+   * NON-default value survives (the full-behavior literal and an absent
+   * field are the same instruction, and an unknown future literal fails
+   * closed into the full behavior). Enforcement lands with the matching
+   * `MCPServerConfig` wire fields in follow-up PRs; carrying the reduction
+   * here keeps the profile → wire mapping in one place.
+   *
+   * `true` = treat page one of paginated lists as the complete result.
+   */
+  firstPageOnly?: true;
+  /** `false` = the client does not drive MRTR `input_required` rounds. */
+  supportsMrtr?: false;
   /** undefined = spec default (filter app-only tools); false = host opts out. */
   respectToolVisibility: boolean | undefined;
 }
@@ -81,6 +94,15 @@ export function hostConnectionProfile(
   const mirrorToolParamHeaders =
     mcpProfile?.toolParamHeaderMirroring === "omit" ? false : undefined;
 
+  // Same reduction discipline for the sibling conformance knobs: only a
+  // recognized NON-default literal produces a wire field.
+  const firstPageOnly =
+    mcpProfile?.paginationTraversal === "firstPageOnly"
+      ? (true as const)
+      : undefined;
+  const supportsMrtr =
+    mcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
+
   const clientCapabilities = isRecord(hostConfig.clientCapabilities)
     ? hostConfig.clientCapabilities
     : undefined;
@@ -97,6 +119,8 @@ export function hostConnectionProfile(
     ...(mirrorToolParamHeaders === false
       ? { mirrorToolParamHeaders: false }
       : {}),
+    ...(firstPageOnly ? { firstPageOnly } : {}),
+    ...(supportsMrtr === false ? { supportsMrtr: false } : {}),
     respectToolVisibility,
   };
 }

--- a/sdk/src/host-config/host.ts
+++ b/sdk/src/host-config/host.ts
@@ -33,10 +33,11 @@
  */
 
 import { canonicalizeHostConfigV2 } from "./canonicalize.js";
-import type {
-  CanonicalHostConfigV2,
-  HostConfigInputV2,
-  HostConfigMcpProfileV1,
+import {
+  CONFORMANCE_PROFILE_KEYS,
+  type CanonicalHostConfigV2,
+  type HostConfigInputV2,
+  type HostConfigMcpProfileV1,
 } from "./types.js";
 import type {
   HostComputerInput,
@@ -75,6 +76,13 @@ function hostMcpToProfile(mcp: HostMcp): HostConfigMcpProfileV1 {
   if (mcp.toolParamHeaderMirroring !== undefined) {
     profile.toolParamHeaderMirroring = mcp.toolParamHeaderMirroring;
   }
+  // Conformance knobs share names on both sides — copy in one loop.
+  for (const key of CONFORMANCE_PROFILE_KEYS) {
+    const value = (mcp as Record<string, unknown>)[key];
+    if (value !== undefined) {
+      (profile as Record<string, unknown>)[key] = value;
+    }
+  }
   if (mcp.initialize !== undefined) profile.initialize = mcp.initialize;
   if (mcp.apps !== undefined) profile.apps = mcp.apps;
   if (mcp.extensions !== undefined) profile.extensions = mcp.extensions;
@@ -94,6 +102,9 @@ function isEmptyHostMcp(mcp: HostMcp | undefined): boolean {
   return (
     mcp.protocolVersion === undefined &&
     mcp.toolParamHeaderMirroring === undefined &&
+    CONFORMANCE_PROFILE_KEYS.every(
+      (key) => (mcp as Record<string, unknown>)[key] === undefined
+    ) &&
     mcp.initialize === undefined &&
     mcp.apps === undefined &&
     mcp.extensions === undefined
@@ -136,6 +147,12 @@ function profileToHostMcp(profile: HostConfigMcpProfileV1): HostMcp {
   }
   if (profile.toolParamHeaderMirroring !== undefined) {
     mcp.toolParamHeaderMirroring = profile.toolParamHeaderMirroring;
+  }
+  for (const key of CONFORMANCE_PROFILE_KEYS) {
+    const value = (profile as Record<string, unknown>)[key];
+    if (value !== undefined) {
+      (mcp as Record<string, unknown>)[key] = value;
+    }
   }
   if (profile.initialize !== undefined) mcp.initialize = profile.initialize;
   if (profile.apps !== undefined) mcp.apps = profile.apps;

--- a/sdk/src/host-config/index.ts
+++ b/sdk/src/host-config/index.ts
@@ -50,6 +50,8 @@ export type {
   OpenAiAppsCapabilities,
   McpAppsCapabilities,
   ToolParamHeaderMirroring,
+  PaginationTraversalMode,
+  MrtrSupport,
 } from "./public-types.js";
 
 // Tasks PRODUCT policy (`com.mcpjam/tasks`). Kept apart from the wire

--- a/sdk/src/host-config/public-types.ts
+++ b/sdk/src/host-config/public-types.ts
@@ -30,6 +30,8 @@ import type {
   OpenAiAppsCapabilities,
   ServerId,
   ToolParamHeaderMirroring,
+  PaginationTraversalMode,
+  MrtrSupport,
 } from "./types.js";
 
 export type {
@@ -45,6 +47,8 @@ export type {
   McpAppsCapabilities,
   ModelVisibleMcpToolResults,
   ToolParamHeaderMirroring,
+  PaginationTraversalMode,
+  MrtrSupport,
 };
 
 /**

--- a/sdk/src/host-config/sdk-evals-normalizer.ts
+++ b/sdk/src/host-config/sdk-evals-normalizer.ts
@@ -45,7 +45,11 @@
  * that the inspector client and the Convex backend can both consume.
  */
 
-import type { HostConfigInputV2, HostConfigMcpProfileV1 } from "./types.js";
+import {
+  CONFORMANCE_PROFILE_KEYS,
+  type HostConfigInputV2,
+  type HostConfigMcpProfileV1,
+} from "./types.js";
 import type { HostJson, HostMcp } from "./public-types.js";
 
 /**
@@ -78,6 +82,13 @@ function hostMcpToProfile(mcp: HostMcp): HostConfigMcpProfileV1 {
   }
   if (mcp.toolParamHeaderMirroring !== undefined) {
     profile.toolParamHeaderMirroring = mcp.toolParamHeaderMirroring;
+  }
+  // Conformance knobs share names on both sides — copy in one loop.
+  for (const key of CONFORMANCE_PROFILE_KEYS) {
+    const value = (mcp as Record<string, unknown>)[key];
+    if (value !== undefined) {
+      (profile as Record<string, unknown>)[key] = value;
+    }
   }
   if (mcp.initialize !== undefined) profile.initialize = mcp.initialize;
   if (mcp.apps !== undefined) profile.apps = mcp.apps;

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -155,6 +155,101 @@ export const TOOL_PARAM_HEADER_MIRRORING_MODES = [
   "omit",
 ] as const satisfies readonly ToolParamHeaderMirroring[];
 
+// ── Client-conformance knobs ──────────────────────────────────────────
+//
+// Siblings of `toolParamHeaderMirroring`: each field models a way REAL
+// clients differ from each other, so a server author can see their server
+// through a specific client's eyes. Shared rules:
+//
+// - Absent = the spec-conforming/full behavior, and the field is OMITTED
+//   from canonical output, so pre-feature rows keep their hash. The
+//   conforming literal is storable but hashes distinctly; UIs write absence.
+// - Each knob is a property of the simulated CLIENT, so it lives here
+//   rather than on `serverConnectionOverrides`.
+// - Enforcement is era- and transport-scoped: a knob whose mechanism
+//   doesn't exist on the negotiated era (or on stdio) is silently inert.
+//
+// Deliberately NOT modeled here (each was considered and rejected):
+// - `Mcp-Method`/`Mcp-Name` emission — the official client attaches these
+//   on every modern enveloped request with no browser carve-out, so every
+//   SDK-built client sends them. (Only `Mcp-Param-*` mirroring is browser-
+//   gated, which is why `toolParamHeaderMirroring` exists and this does
+//   not.) "What does my server do without them" is conformance-harness
+//   territory, which already sends hostile frames outside the client.
+// - A vestigial `Mcp-Session-Id`, or per-request `_meta` sent only on the
+//   first request — no real client does either; the SDKs handle both.
+// - `requestState` echo fidelity — synthetic fault injection against the
+//   server's integrity check; belongs to the conformance harness.
+// - Elicitation form/url support — already modeled, as
+//   `clientCapabilities.elicitation.{form,url}`. Do not duplicate it here.
+// - list_changed handling — a real divergence between hosts, but making
+//   MCPJam's own tool list go stale is an anti-feature for a debugger.
+//   It belongs in the host catalog as a fact to DISPLAY about a host, not
+//   as a behavior to simulate.
+
+/**
+ * How the simulated client walks paginated list results (`tools/list`,
+ * `resources/list`, `resources/templates/list`, `prompts/list`).
+ *
+ * - `"full"` — follow `nextCursor` to exhaustion (spec-conforming client
+ *   behavior, and what an ABSENT field means).
+ * - `"firstPageOnly"` — treat page one as the complete result, the way
+ *   several real hosts notoriously do. Lets a server author answer "do my
+ *   important tools survive a first-page-only host?".
+ *
+ * Deliberate interaction: the SEP-2243 `Mcp-Param-*` mirroring source is
+ * the aggregated list cache, so under this mode params are mirrored only
+ * for page-one tools — which is exactly how such a client really behaves.
+ *
+ * Era-agnostic (pagination exists since 2025-03-26), HTTP-scoped by
+ * mechanism.
+ */
+export type PaginationTraversalMode = "full" | "firstPageOnly";
+
+/** The permitted {@link PaginationTraversalMode} literals, for validation. */
+export const PAGINATION_TRAVERSAL_MODES = [
+  "full",
+  "firstPageOnly",
+] as const satisfies readonly PaginationTraversalMode[];
+
+/**
+ * Whether the simulated client drives MRTR (multi-round tool result) at
+ * all — i.e. whether it understands `resultType: "input_required"` and
+ * retries the original request with `inputResponses`, or treats the result
+ * as terminal. Real clients differ on whether they implement the 2026
+ * pattern at all, which is the fact this models.
+ *
+ * - `"full"` — drive `input_required` rounds (and what an ABSENT field
+ *   means).
+ * - `"none"` — no MRTR: the modern connection must not advertise a
+ *   capability the MRTR bridge would have to fulfill (advertise = enforce),
+ *   and an `input_required` result surfaces to the caller instead of
+ *   silently looping.
+ *
+ * WHICH elicitation modes an MRTR-capable client fulfills is a separate,
+ * already-modeled fact: `clientCapabilities.elicitation.{form,url}`.
+ * This knob is only about the retry loop existing.
+ */
+export type MrtrSupport = "full" | "none";
+
+/** The permitted {@link MrtrSupport} literals, for validation. */
+export const MRTR_SUPPORT_MODES = [
+  "full",
+  "none",
+] as const satisfies readonly MrtrSupport[];
+
+/**
+ * The conformance-knob keys shared verbatim between the public `HostMcp`
+ * authoring shape and the internal `mcpProfile` (same names on both sides),
+ * so the profile ⇄ HostMcp round-trip helpers can copy them in one loop
+ * instead of a hand-maintained block per knob. `toolParamHeaderMirroring`
+ * predates this list and is copied individually at its call sites.
+ */
+export const CONFORMANCE_PROFILE_KEYS = [
+  "paginationTraversal",
+  "mrtrSupport",
+] as const;
+
 export type CspDomainSet = {
   connectDomains?: string[];
   resourceDomains?: string[];
@@ -178,6 +273,14 @@ export type HostConfigMcpProfileV1 = {
   // server can be tested against one. Host-level on purpose — conformance is
   // a property of the client, not of an individual server.
   toolParamHeaderMirroring?: ToolParamHeaderMirroring;
+  // Client-conformance knobs (siblings of `toolParamHeaderMirroring`; see
+  // the type docblocks above for per-knob semantics, and for the list of
+  // knobs deliberately NOT modeled). Absent always means "spec-conforming"
+  // and is omitted from canonical output.
+  paginationTraversal?: PaginationTraversalMode;
+  // Whether the client drives MRTR retry rounds at all. WHICH elicitation
+  // modes it fulfills stays in `clientCapabilities.elicitation`.
+  mrtrSupport?: MrtrSupport;
   initialize?: {
     // Order is semantic. The first entry is sent in
     // `initialize.params.protocolVersion`; all entries form the

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -812,6 +812,8 @@ export type {
   OpenAiAppsCapabilities,
   McpAppsCapabilities,
   ToolParamHeaderMirroring,
+  PaginationTraversalMode,
+  MrtrSupport,
 } from "./host-config/index.js";
 
 // MCPJam's Tasks **product policy** (`com.mcpjam/tasks`) — never a wire

--- a/sdk/tests/fixtures/host-config-parity-fixtures.json
+++ b/sdk/tests/fixtures/host-config-parity-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "__inputHash": "e8dfd38f6095ef57bf6165e7e2e98dbb68e2f363bcb845e11bda5da93a88e568",
+  "__inputHash": "2c96f034fc20e6e7693cfab343a8ad6ff7a61fa35695af4243553e7e5adb634a",
   "rows": [
     {
       "label": "base-minimal",
@@ -251,6 +251,98 @@
       },
       "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"initialize\":{\"supportedProtocolVersions\":[\"2025-11-25\"]},\"mcpProtocolVersion\":\"2025-11-25\",\"toolParamHeaderMirroring\":\"omit\"}}",
       "sha256": "4b94e193f7ac323b934ec473657896890535e3dd57a8a1e3a3dcc4439e09e005"
+    },
+    {
+      "label": "mcp-profile-conformance-pagination-first-page-only",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "paginationTraversal": "firstPageOnly"
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"paginationTraversal\":\"firstPageOnly\"}}",
+      "sha256": "fd2d494396220de04985f8e32d483cf2325c608b28936daf1716a9f93178b018"
+    },
+    {
+      "label": "mcp-profile-conformance-mrtr-support-none",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "mrtrSupport": "none"
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"mrtrSupport\":\"none\"}}",
+      "sha256": "bf524edc7087c896eeb3fd9cd530cd931abe02e38ab7262853104d6c5c493ca1"
+    },
+    {
+      "label": "mcp-profile-conformance-default-literals",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "paginationTraversal": "full",
+          "mrtrSupport": "full"
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"mrtrSupport\":\"full\",\"paginationTraversal\":\"full\"}}",
+      "sha256": "dafe3a62a49594b77a226a45b0d76f64418baab033ef3cc16b28c7857403ffb5"
+    },
+    {
+      "label": "mcp-profile-conformance-combined-with-stateful-pin",
+      "input": {
+        "hostStyle": "claude",
+        "modelId": "anthropic/claude-sonnet-4-6",
+        "systemPrompt": "You are a helpful assistant.",
+        "temperature": 0.7,
+        "requireToolApproval": false,
+        "connectionDefaults": {
+          "headers": {},
+          "requestTimeout": 10000
+        },
+        "clientCapabilities": {},
+        "hostContext": {},
+        "mcpProfile": {
+          "profileVersion": 1,
+          "mcpProtocolVersion": "2025-11-25",
+          "toolParamHeaderMirroring": "omit",
+          "paginationTraversal": "firstPageOnly",
+          "mrtrSupport": "none"
+        }
+      },
+      "canonicalJson": "{\"schemaVersion\":2,\"hostStyle\":\"claude\",\"modelId\":\"anthropic/claude-sonnet-4-6\",\"systemPrompt\":\"You are a helpful assistant.\",\"temperature\":0.7,\"requireToolApproval\":false,\"serverIds\":[],\"optionalServerIds\":[],\"connectionDefaults\":{\"headers\":{},\"requestTimeout\":10000},\"clientCapabilities\":{},\"hostContext\":{},\"mcpProfile\":{\"profileVersion\":1,\"initialize\":{\"supportedProtocolVersions\":[\"2025-11-25\"]},\"mcpProtocolVersion\":\"2025-11-25\",\"mrtrSupport\":\"none\",\"paginationTraversal\":\"firstPageOnly\",\"toolParamHeaderMirroring\":\"omit\"}}",
+      "sha256": "e53af8cd4cc892fde4cdef6efe912ac8e246594f507afcdc3525ec1a9ad4ac6f"
     },
     {
       "label": "sandbox-csp-restrictto-sorted-plus-directives",

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -495,6 +495,78 @@ describe("canonicalizeHostConfigV2 — toolParamHeaderMirroring", () => {
   });
 });
 
+describe("canonicalizeHostConfigV2 — client-conformance knobs", () => {
+  const KNOBS = [
+    ["paginationTraversal", ["full", "firstPageOnly"]],
+    ["mrtrSupport", ["full", "none"]],
+  ] as const;
+
+  it("round-trips every literal of every knob", () => {
+    for (const [key, modes] of KNOBS) {
+      for (const mode of modes) {
+        const c = canonicalizeHostConfigV2(
+          base({ mcpProfile: { profileVersion: 1, [key]: mode } })
+        );
+        expect(
+          (c.mcpProfile as Record<string, unknown> | undefined)?.[key]
+        ).toBe(mode);
+      }
+    }
+  });
+
+  it("omits every knob when absent, so pre-feature configs keep their hash", () => {
+    const c = canonicalizeHostConfigV2(base());
+    expect(c.mcpProfile).toBeUndefined();
+    for (const [key] of KNOBS) {
+      expect(JSON.stringify(c)).not.toContain(key);
+    }
+  });
+
+  it("hashes the default literal distinctly from absent", async () => {
+    // Same discipline as toolParamHeaderMirroring: "mirror" — explicit
+    // default values are stored, and absence stays the canonical spelling.
+    for (const [key, modes] of KNOBS) {
+      expect(
+        await hash(base({ mcpProfile: { profileVersion: 1, [key]: modes[0] } }))
+      ).not.toBe(await hash(base()));
+    }
+  });
+
+  it("throws on an unknown literal rather than storing it", () => {
+    for (const [key, modes] of KNOBS) {
+      expect(() =>
+        canonicalizeHostConfigV2(
+          base({
+            mcpProfile: {
+              profileVersion: 1,
+              [key]: "bogus",
+            } as never,
+          })
+        )
+      ).toThrow(new RegExp(`${key} must be one of ${modes.join(", ")}`));
+    }
+  });
+
+  it("emits profileVersion first then alphabetical keys when combined", () => {
+    const c = canonicalizeHostConfigV2(
+      base({
+        mcpProfile: {
+          profileVersion: 1,
+          toolParamHeaderMirroring: "omit",
+          mrtrSupport: "none",
+          paginationTraversal: "firstPageOnly",
+        },
+      })
+    );
+    expect(Object.keys(c.mcpProfile ?? {})).toEqual([
+      "profileVersion",
+      "mrtrSupport",
+      "paginationTraversal",
+      "toolParamHeaderMirroring",
+    ]);
+  });
+});
+
 describe("canonicalizeHostConfigV2 — tightening (Stage B)", () => {
   // Item 5: fail-fast on missing required record fields. The previous
   // `?? {}` coalescing silently merged undefined-cap rows with explicit-{}

--- a/sdk/tests/host-config-parity.test.ts
+++ b/sdk/tests/host-config-parity.test.ts
@@ -24,7 +24,7 @@ import type { HostConfigInputV2 } from "../src/host-config/internal";
  * directly, so the SDK-side constant is the single source of truth.
  */
 const EXPECTED_INPUT_HASH =
-  "e8dfd38f6095ef57bf6165e7e2e98dbb68e2f363bcb845e11bda5da93a88e568";
+  "2c96f034fc20e6e7693cfab343a8ad6ff7a61fa35695af4243553e7e5adb634a";
 
 type FixtureRow = {
   label: string;

--- a/sdk/tests/host-config-sdk-evals-normalizer.test.ts
+++ b/sdk/tests/host-config-sdk-evals-normalizer.test.ts
@@ -260,6 +260,16 @@ describe("normalizeSdkEvalHostConfigForWire — public HostJson acceptance", () 
     expect(out.mcpProfile?.profileVersion).toBe(1);
   });
 
+  it("projects the client-conformance knobs from HostJson.mcp to mcpProfile", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" });
+    host.mcp.paginationTraversal = "firstPageOnly";
+    host.mcp.mrtrSupport = "none";
+
+    const out = normalizeSdkEvalHostConfigForWire(host.toJSON());
+    expect(out.mcpProfile?.paginationTraversal).toBe("firstPageOnly");
+    expect(out.mcpProfile?.mrtrSupport).toBe("none");
+  });
+
   it("strips public-shape per-server overrides too", () => {
     const host = new Host({ style: "mcpjam", model: "test-model" })
       .requireServer("a")

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -88,4 +88,45 @@ describe("hostConnectionProfile", () => {
       expect(p.mirrorToolParamHeaders).toBeUndefined();
     });
   });
+
+  describe("client-conformance knob reduction", () => {
+    it("reduces each non-default literal to its wire field", () => {
+      const p = hostConnectionProfile({
+        mcpProfile: {
+          profileVersion: 1,
+          paginationTraversal: "firstPageOnly",
+          mrtrSupport: "none",
+        },
+      });
+      expect(p.firstPageOnly).toBe(true);
+      expect(p.supportsMrtr).toBe(false);
+    });
+
+    it("collapses default literals AND absent fields to no wire field", () => {
+      for (const mcpProfile of [
+        { profileVersion: 1, paginationTraversal: "full", mrtrSupport: "full" },
+        { profileVersion: 1 },
+        undefined,
+      ]) {
+        const p = hostConnectionProfile(mcpProfile ? { mcpProfile } : {});
+        for (const key of ["firstPageOnly", "supportsMrtr"]) {
+          expect(key in p).toBe(false);
+        }
+      }
+    });
+
+    it("fails closed on unrecognized literals", () => {
+      // A future mode this SDK build does not know must not read as the
+      // non-default value.
+      const p = hostConnectionProfile({
+        mcpProfile: {
+          profileVersion: 1,
+          paginationTraversal: "everyOtherPage",
+          mrtrSupport: "partial",
+        },
+      });
+      expect("firstPageOnly" in p).toBe(false);
+      expect("supportsMrtr" in p).toBe(false);
+    });
+  });
 });

--- a/sdk/tests/host.test.ts
+++ b/sdk/tests/host.test.ts
@@ -52,6 +52,27 @@ describe("Host — public surface", () => {
     expect(json.mcp).toBeUndefined();
   });
 
+  it("round-trips the client-conformance knobs through toJSON()", () => {
+    const host = new Host({ style: "mcpjam", model: "test-model" });
+    host.mcp.paginationTraversal = "firstPageOnly";
+    host.mcp.mrtrSupport = "none";
+
+    const json = host.toJSON();
+    expect(json.mcp?.paginationTraversal).toBe("firstPageOnly");
+    expect(json.mcp?.mrtrSupport).toBe("none");
+
+    // And a rebuilt host reproduces the same JSON (true round-trip).
+    expect(new Host(json).toJSON()).toEqual(json);
+  });
+
+  it("a conformance knob alone keeps mcp present in toJSON()", () => {
+    // Guards isEmptyHostMcp: a profile carrying ONLY a new knob must not
+    // collapse to "untouched".
+    const host = new Host({ style: "mcpjam", model: "test-model" });
+    host.mcp.paginationTraversal = "firstPageOnly";
+    expect(host.toJSON().mcp?.paginationTraversal).toBe("firstPageOnly");
+  });
+
   it("exposes only public MCP vocabulary in toJSON() — no impl names leak", () => {
     const host = new Host({
       style: "chatgpt",


### PR DESCRIPTION
## What

Schema freeze (S1) for the client-conformance knob program — the follow-up to #3632's `toolParamHeaderMirroring`. Two sibling fields on `HostConfigMcpProfileV1`, each modeling a way **real clients actually differ**, so a server author can see their server through a specific client's eyes:

| Field | Literals | Models |
|---|---|---|
| `paginationTraversal` | `full \| firstPageOnly` | hosts that read page one of `tools/list` and stop. Answers "do my important tools survive a first-page-only host?" |
| `mrtrSupport` | `full \| none` | whether the client drives MRTR `input_required` retry rounds at all, vs treating the result as terminal |

Absent = full behavior. Deliberate interaction worth calling out: under `firstPageOnly` the SEP-2243 `Mcp-Param-*` mirroring source (the aggregated list cache) becomes page-one-only — which is exactly how such a client really behaves.

## Scope cut after review

The first draft of this PR had seven knobs. Five were cut, because a knob has to model a client that exists:

- **`Mcp-Method`/`Mcp-Name` omission** — verified against the installed `@modelcontextprotocol/client@2.0.0`: `_applyBodyDerivedHeaders` attaches these on every modern enveloped request with **no browser gating**. (Only `Mcp-Param-*` mirroring is browser-gated — which is precisely why the mirroring knob earns its place and this one doesn't.) Every SDK-built client sends them; "what does my server do without them" is conformance-harness territory, which already sends hostile frames outside the client.
- **Vestigial `Mcp-Session-Id`** and **first-request-only per-request `_meta`** — no real client does either; the SDKs handle both.
- **`requestState` echo corruption** — synthetic fault injection against the server's integrity check → conformance harness.
- **`list_changed` handling** — a genuine host divergence, but simulating it makes MCPJam's own tool list go stale, which is an anti-feature for a debugger. It belongs in the **host catalog** as a fact to *display* about a host, not a behavior to simulate.

Also: elicitation form/url support is **already modeled** as `clientCapabilities.elicitation.{form,url}` (works for both the legacy `elicitation/create` path and the modern capabilities envelope), so the draft's `mrtrElicitationModes` was a duplicate. `mrtrSupport` replaces it with the fact that was actually missing — does the client do MRTR at all.

## Discipline (same as toolParamHeaderMirroring)

- **Absent = full behavior**, omitted from canonical bytes → every pre-existing row keeps its hash.
- Default literals are storable but hash distinctly; UIs write absence.
- Unknown literals **throw** at canonicalize; the wire reduction **fails closed** into the default behavior.
- Canonical key order is the SDK's own rule (`profileVersion` first, then alphabetical) — the new fields just sort into place.

## Scope

**Schema freeze only — no runtime behavior changes.** `hostConnectionProfile()` reduces the knobs to their wire shape (`firstPageOnly?: true`, `supportsMrtr?: false`), but nothing consumes those fields yet.

Follow-ups, each its own PR: transport-wrapper pagination enforcement (no fetch seam needed now that the header knobs are gone), the MRTR driver gate (including advertise = enforce — with MRTR off, a modern connection must not advertise a capability only the MRTR bridge could fulfill), CLI flags, product plumbing, and the ProtocolTab UI. The backend hand-mirror + consolidated three-field restore shim (replacing `restoreToolParamHeaderMirroring`) starts from this PR's frozen vectors and must be **deployed** before the product lets users save these fields.

## Fixtures / tests

- 4 new golden parity vectors (28 rows, `__inputHash` bumped): one per knob, a default-literals vector, and a combined-with-stateful-pin vector that pins the full profile key order the backend shim must reproduce byte-identically.
- New canonicalize / wire-reduction / round-trip tests (through `Host`/`HostJson` and the evals normalizer; `isEmptyHostMcp` guard so a knob-only profile doesn't collapse to untouched).
- `npm run verify` green at root (SDK 3434 tests, inspector 12023 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
