### PR TITLE
feat(chatboxes): full admin parity for environment-backed chatboxes

### DIFF
--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-chatbox-section.test.tsx
@@ -20,6 +20,9 @@ vi.mock("convex/react", () => ({
   useQuery: (name: string, args: unknown) => {
     if (args === "skip") return undefined;
     if (name === "chatboxes:listChatboxes") return chatboxList;
+    if (name === "chatboxes:getChatbox") {
+      return { chatboxId: (args as { chatboxId: string }).chatboxId };
+    }
     return undefined;
   },
   useMutation: (name: string) => {
@@ -38,6 +41,14 @@ vi.mock("@/lib/clipboard", () => ({
 }));
 vi.mock("@/lib/chatbox-session", () => ({
   buildChatboxLink: (token: string) => `https://app.test/chat/${token}`,
+}));
+// The full share/access editors have their own suite
+// (ChatboxShareSection.test.tsx); here we only assert they MOUNT for the
+// published row with the fetched settings.
+vi.mock("@/components/chatboxes/ChatboxShareSection", () => ({
+  ChatboxShareSection: ({ chatbox }: { chatbox: { chatboxId: string } }) => (
+    <div data-testid="mock-share-section">{chatbox.chatboxId}</div>
+  ),
 }));
 
 import { EnvironmentChatboxSection } from "../environment-chatbox-section";
@@ -131,6 +142,19 @@ describe("EnvironmentChatboxSection", () => {
     expect(
       screen.getByTestId("environment-chatbox-unpublish")
     ).toBeInTheDocument();
+  });
+
+  it("mounts the full sharing/access editors for the published row (admins only)", () => {
+    chatboxList = [publishedChatbox];
+    renderSection();
+    // Fed by getChatbox for THIS row — full parity with host-backed chatboxes.
+    expect(screen.getByTestId("mock-share-section")).toHaveTextContent("cb-1");
+  });
+
+  it("members do not get the admin share editors", () => {
+    chatboxList = [publishedChatbox];
+    renderSection(false);
+    expect(screen.queryByTestId("mock-share-section")).not.toBeInTheDocument();
   });
 
   it("read-only members see state, not the publish action", () => {

--- a/mcpjam-inspector/client/src/components/project-environments/environment-chatbox-section.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/environment-chatbox-section.tsx
@@ -9,10 +9,14 @@
  * which makes THIS the management surface: publish, copy the share link, and
  * unpublish. One chatbox per environment, backend-enforced.
  *
- * Deliberately minimal v1 — mode/members/link-rotation/guest-execution stay
- * with the standard chatbox editors and can grow here later if env chatboxes
- * need them. Publish/unpublish are project-ADMIN gated backend-side; the
- * backend's FORBIDDEN/CONFLICT copy is surfaced verbatim.
+ * Full admin parity with host-backed chatboxes: once published, the standard
+ * `ChatboxShareSection` (access mode, member invites, guest execution) renders
+ * here against the row's full `getChatbox` settings — the backend's row-level
+ * editors (`setChatboxMode`, `upsertChatboxMember`, `setChatboxGuestExecution`)
+ * are not env-guarded; only server editing is (the environment owns the server
+ * set, so there is deliberately no server picker). Publish/unpublish are
+ * project-ADMIN gated backend-side; the backend's FORBIDDEN/CONFLICT copy is
+ * surfaced verbatim.
  */
 import { useState } from "react";
 import { useConvexAuth } from "convex/react";
@@ -23,9 +27,11 @@ import { convexErrMessage } from "@/lib/convex-error";
 import { copyToClipboard } from "@/lib/clipboard";
 import { buildChatboxLink } from "@/lib/chatbox-session";
 import {
+  useChatbox,
   useEnvironmentChatbox,
   useEnvironmentChatboxMutations,
 } from "@/hooks/useChatboxes";
+import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection";
 import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
 
 export function EnvironmentChatboxSection({
@@ -46,6 +52,13 @@ export function EnvironmentChatboxSection({
   });
   const { publishEnvironmentChatbox, unpublishEnvironmentChatbox } =
     useEnvironmentChatboxMutations();
+  // Full settings for the published row — powers the standard share/access
+  // editors below. Null/undefined until published (the list row above only
+  // carries the summary projection).
+  const { chatbox: chatboxSettings } = useChatbox({
+    isAuthenticated,
+    chatboxId: chatbox?.chatboxId ?? null,
+  });
   const [busy, setBusy] = useState(false);
   const [confirmingUnpublish, setConfirmingUnpublish] = useState(false);
 
@@ -199,6 +212,19 @@ export function EnvironmentChatboxSection({
           </span>
         )}
       </div>
+
+      {/* Full sharing & access controls — the SAME component host-backed
+          chatboxes use (mode, member invites, guest execution). Rendered only
+          for admins: every mutation inside is admin/owner-gated backend-side,
+          and read-only members already get the state line above. */}
+      {chatbox && canManage && chatboxSettings ? (
+        <div
+          className="mt-3 border-t pt-3"
+          data-testid="environment-chatbox-share-section"
+        >
+          <ChatboxShareSection chatbox={chatboxSettings} />
+        </div>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Why

Follow-up to #3642. Chatboxes/swarms are unreleased and environments-first, so a published environment chatbox must not be a second-class citizen: #3642 shipped publish/link/unpublish but left the admin surfaces (access mode, member invites, guest execution) unreachable for env-backed chatboxes — those editors live in host-first ChatboxesTab, which deliberately can't see env rows.

## What

The published row in the Environments route now mounts the **same `ChatboxShareSection`** host-backed chatboxes use — access mode, member invites, guest-execution opt-in/caps — fed by the row's full `getChatbox` settings (works for env rows via their compat `namedHostId`; all mutations involved are row-level and not env-guarded backend-side). Admins only; the read-only member state line is unchanged.

Deliberately still absent, by design rather than gap:
- **Server editing** — the environment owns the server set (`setChatboxServers` rejects env rows backend-side with "edit the environment instead").
- **Link rotation** — `rotateChatboxLink` has no UI for host-backed chatboxes either, so there is no parity gap to close.

## Testing

`environment-chatbox-section.test.tsx`: share editors mount for the published row with the fetched settings (admins), and not for read-only members. Full project-environments suite (83 tests) + `typecheck:client` green. The editors themselves are covered by the existing `ChatboxShareSection.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reuses existing share/access UI and row-level Convex mutations with unchanged admin gating; no new backend or server-picker surface for env rows.
> 
> **Overview**
> Published environment chatboxes on the **Environments** detail view now expose the same **sharing and access** UI as host-backed chatboxes, instead of stopping at publish / copy link / unpublish.
> 
> When a row is published and the viewer is a project admin (`canManage`), **`EnvironmentChatboxSection`** loads full settings via **`useChatbox`** (`getChatbox`) and renders **`ChatboxShareSection`** (access mode, member invites, guest execution). Read-only members still only see the existing status line; the share block is omitted.
> 
> Tests mock **`ChatboxShareSection`** and **`getChatbox`**, and assert the editors mount for admins on a published row but not for members.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1040df78547bdb3cfe898e13be711add06851d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Environment-backed chatboxes now have full admin controls after publish, matching host-backed chatboxes. Admins can manage access mode, member invites, and guest execution from the Environments page; members still see read-only state.

- **New Features**
  - Renders the same `ChatboxShareSection` for published environment chatboxes, backed by `getChatbox` settings.
  - Admin-only surface; backend enforces all mutations. Publish/unpublish remains unchanged.
  - Out of scope by design: server selection (controlled by the environment) and link rotation (no UI to match).

<sup>Written for commit de1040df78547bdb3cfe898e13be711add06851d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

