### PR TITLE
feat(sdk): enforce paginationTraversal — a real first-page-only client (S2)

### DIFF
--- a/.changeset/first-page-only-enforcement.md
+++ b/.changeset/first-page-only-enforcement.md
@@ -1,0 +1,22 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Enforce `mcpProfile.paginationTraversal: "firstPageOnly"` — the simulated
+client now actually reads page one of a paginated list and stops.
+
+New `MCPServerConfig.firstPageOnly` is applied by a transport wrapper
+(`wrapTransportForFirstPageOnly`) that deletes `nextCursor` from the inbound
+result of a cursor-less `tools/list` / `resources/list` /
+`resources/templates/list` / `prompts/list`, which is what ends the official
+client's internal page walk. Two consequences, both intended: lists return
+page one only, and the page-one-only aggregate the client caches becomes the
+SEP-2243 `Mcp-Param-*` mirroring source — so a `tools/call` on a page-two tool
+goes out with no mirrored header and a strict server answers `-32020`, exactly
+how a real first-page-only client fails.
+
+Composed outermost so the JSON-RPC log still records the frame the server
+really sent; applies on stdio, Streamable HTTP and SSE, on every era. Requests
+carrying an explicit cursor (the debugger's own manual paging) are left alone,
+and outbound ids are correlated to inbound frames so an unrelated `nextCursor`
+is never touched.

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -29,14 +29,18 @@ export interface HostConnectionProfile {
    * Client-conformance knobs, reduced to their wire shape: only the
    * NON-default value survives (the full-behavior literal and an absent
    * field are the same instruction, and an unknown future literal fails
-   * closed into the full behavior). Enforcement lands with the matching
-   * `MCPServerConfig` wire fields in follow-up PRs; carrying the reduction
-   * here keeps the profile → wire mapping in one place.
+   * closed into the full behavior).
    *
-   * `true` = treat page one of paginated lists as the complete result.
+   * `true` = treat page one of paginated lists as the complete result. Maps
+   * onto `MCPServerConfig.firstPageOnly`, which the client manager enforces
+   * with a transport wrapper.
    */
   firstPageOnly?: true;
-  /** `false` = the client does not drive MRTR `input_required` rounds. */
+  /**
+   * `false` = the client does not drive MRTR `input_required` rounds.
+   * Enforcement lands in a follow-up PR; carrying the reduction here keeps
+   * the profile → wire mapping in one place.
+   */
   supportsMrtr?: false;
   /** undefined = spec default (filter app-only tools); false = host opts out. */
   respectToolVisibility: boolean | undefined;

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -201,8 +201,11 @@ export const TOOL_PARAM_HEADER_MIRRORING_MODES = [
  * the aggregated list cache, so under this mode params are mirrored only
  * for page-one tools — which is exactly how such a client really behaves.
  *
- * Era-agnostic (pagination exists since 2025-03-26), HTTP-scoped by
- * mechanism.
+ * Era- and transport-agnostic: pagination has existed since `2025-03-26`,
+ * and the enforcement seam is a transport wrapper (not the fetch layer), so
+ * it applies on stdio as well as Streamable HTTP. Only the cursor-less
+ * aggregation is truncated — an explicit-cursor request is the debugger's
+ * own manual paging, not something the emulated client did.
  */
 export type PaginationTraversalMode = "full" | "firstPageOnly";
 

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -89,6 +89,7 @@ import {
   stripAuthorizationFromRequestInit,
   wrapTransportForLogging,
   wrapTransportForTaskResults,
+  wrapTransportForFirstPageOnly,
   wrapFetchForTaskRouting,
   TASK_CREATED_META_KEY,
   createDefaultRpcLogger,
@@ -2381,8 +2382,13 @@ export class MCPClientManager {
     });
 
     const logger = this.resolveRpcLogger(config);
-    const transport = wrapTransportForTaskResults(
-      logger ? wrapTransportForLogging(serverId, logger, underlying) : underlying
+    const transport = this.applyFirstPageOnly(
+      config,
+      wrapTransportForTaskResults(
+        logger
+          ? wrapTransportForLogging(serverId, logger, underlying)
+          : underlying
+      )
     );
 
     const stderrDrain = this.createStdioStderrDrain(underlying);
@@ -2501,10 +2507,13 @@ export class MCPClientManager {
 
       try {
         const logger = this.resolveRpcLogger(config);
-        const wrapped = wrapTransportForTaskResults(
-          logger
-            ? wrapTransportForLogging(serverId, logger, streamableTransport)
-            : streamableTransport
+        const wrapped = this.applyFirstPageOnly(
+          config,
+          wrapTransportForTaskResults(
+            logger
+              ? wrapTransportForLogging(serverId, logger, streamableTransport)
+              : streamableTransport
+          )
         );
         await client.connect(wrapped, {
           timeout: Math.min(timeout, HTTP_CONNECT_TIMEOUT),
@@ -2537,8 +2546,13 @@ export class MCPClientManager {
 
     try {
       const logger = this.resolveRpcLogger(config);
-      const wrapped = wrapTransportForTaskResults(
-        logger ? wrapTransportForLogging(serverId, logger, sseTransport) : sseTransport
+      const wrapped = this.applyFirstPageOnly(
+        config,
+        wrapTransportForTaskResults(
+          logger
+            ? wrapTransportForLogging(serverId, logger, sseTransport)
+            : sseTransport
+        )
       );
       await client.connect(wrapped, { timeout });
       return sseTransport;
@@ -3584,6 +3598,30 @@ export class MCPClientManager {
       if (isAbortError(error)) throw error;
       return [];
     }
+  }
+
+  /**
+   * Applies the first-page-only transport wrapper when this connection is
+   * configured to simulate a client that stops after page one
+   * (`MCPServerConfig.firstPageOnly`, set from the host config's
+   * `mcpProfile.paginationTraversal: "firstPageOnly"`).
+   *
+   * OUTERMOST by design: the logging transport underneath still records the
+   * frame the server really sent, so the evidence stays truthful and only the
+   * client sees the truncated list. Applied identically on stdio, Streamable
+   * HTTP and SSE — pagination is not transport-specific.
+   *
+   * Read at connect time rather than per call, because the transport is built
+   * once per connection; changing the knob takes effect on reconnect, which is
+   * how every other connect option behaves.
+   */
+  private applyFirstPageOnly(
+    config: { firstPageOnly?: boolean },
+    transport: Transport
+  ): Transport {
+    return config.firstPageOnly === true
+      ? wrapTransportForFirstPageOnly(transport)
+      : transport;
   }
 
   /**

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -316,6 +316,8 @@ export {
   TASK_CREATED_META_KEY,
   wrapFetchForTaskRouting,
   wrapTransportForTaskResults,
+  wrapTransportForFirstPageOnly,
+  stripNextCursorFromListResult,
 } from "./transport-utils.js";
 export {
   wrapFetchForHttpLogging,

--- a/sdk/src/mcp-client-manager/transport-utils.ts
+++ b/sdk/src/mcp-client-manager/transport-utils.ts
@@ -429,3 +429,160 @@ export function rewriteTaskResultMessage(
     },
   } as unknown as JSONRPCMessage;
 }
+
+/**
+ * The paginated list methods whose aggregation a first-page-only client
+ * truncates. `resources/templates/list` is spelled in full — it is a distinct
+ * method, not a variant of `resources/list`.
+ */
+const PAGINATED_LIST_METHODS: ReadonlySet<string> = new Set([
+  "tools/list",
+  "resources/list",
+  "resources/templates/list",
+  "prompts/list",
+]);
+
+/**
+ * Simulates a client that reads page one of a paginated list and stops —
+ * `hostConfig.mcpProfile.paginationTraversal: "firstPageOnly"`. Several real
+ * hosts behave this way, and a server author's question ("do my important
+ * tools survive such a host?") can only be answered by actually being one.
+ *
+ * MECHANISM. The official client aggregates pages internally: `_listAllPages`
+ * reads `nextCursor` off the page-one *result* and loops until it is absent.
+ * Deleting that field from the inbound response frame therefore ends the walk
+ * after one page, with two consequences that are both the point:
+ *
+ *   1. `listTools()` returns only page one.
+ *   2. The aggregate the client writes to its response cache is page-one-only,
+ *      and that cache is the source `ensureXMcpHeaderMirroringSource` reads to
+ *      mirror SEP-2243 `Mcp-Param-*` headers. So a `tools/call` on a page-two
+ *      tool goes out with no mirrored header and a strict server answers
+ *      `-32020` — exactly how a real first-page-only client fails.
+ *
+ * WHY A TRANSPORT WRAPPER, not the fetch seam: `wrapFetchForHttpLogging`
+ * deliberately never reads response bodies (doing so would consume the stream
+ * the transport is about to parse, and would break SSE framing). Mutating at
+ * the JSON-RPC frame level avoids both, and works on stdio as well as HTTP —
+ * a first-page-only client is not an HTTP-specific defect.
+ *
+ * ONLY the cursor-less request is truncated. `_listAllPages` enters with no
+ * `cursor` param, so that is the aggregation this knob models. A request that
+ * carries an explicit cursor is the debugger's own manual paging — a
+ * deliberate operator action, not something the emulated client did — and
+ * truncating it would break a feature rather than simulate a client. Ids are
+ * correlated outbound → inbound so an unrelated `nextCursor` is never touched.
+ *
+ * Era-agnostic: pagination has existed since `2025-03-26`.
+ *
+ * Compose OUTERMOST, so the logging transport underneath records the frame the
+ * server really sent and only the client sees the truncated one — the same
+ * "log the raw bytes, mutate above them" ordering the task wrapper uses.
+ */
+export function wrapTransportForFirstPageOnly(transport: Transport): Transport {
+  class FirstPageOnlyTransport implements Transport {
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+    /**
+     * Ids of in-flight cursor-less paginated list requests. An entry is
+     * removed by the response that matches it (result OR error), so this
+     * cannot grow without bound on a long-lived connection.
+     */
+    private readonly pendingListRequestIds = new Set<string>();
+
+    constructor(private readonly inner: Transport) {
+      this.inner.onmessage = (
+        message: JSONRPCMessage,
+        extra?: MessageExtraInfo
+      ) => {
+        this.onmessage?.(this.truncateIfFirstPage(message), extra);
+      };
+      this.inner.onclose = () => {
+        this.pendingListRequestIds.clear();
+        this.onclose?.();
+      };
+      this.inner.onerror = (error: Error) => this.onerror?.(error);
+    }
+
+    private truncateIfFirstPage(message: JSONRPCMessage): JSONRPCMessage {
+      const id = (message as { id?: unknown }).id;
+      if (id === undefined || id === null) return message;
+      const key = String(id);
+      if (!this.pendingListRequestIds.has(key)) return message;
+      // Any response for this id closes the correlation, error included.
+      this.pendingListRequestIds.delete(key);
+      return stripNextCursorFromListResult(message);
+    }
+
+    async start(): Promise<void> {
+      if (typeof (this.inner as any).start === "function") {
+        await (this.inner as any).start();
+      }
+    }
+
+    async send(
+      message: JSONRPCMessage,
+      options?: TransportSendOptions
+    ): Promise<void> {
+      const record = message as {
+        id?: unknown;
+        method?: unknown;
+        params?: { cursor?: unknown };
+      };
+      if (
+        record.id !== undefined &&
+        record.id !== null &&
+        typeof record.method === "string" &&
+        PAGINATED_LIST_METHODS.has(record.method) &&
+        record.params?.cursor === undefined
+      ) {
+        this.pendingListRequestIds.add(String(record.id));
+      }
+      await this.inner.send(message as any, options as any);
+    }
+
+    async close(): Promise<void> {
+      this.pendingListRequestIds.clear();
+      await this.inner.close();
+    }
+
+    get sessionId(): string | undefined {
+      return (this.inner as any).sessionId;
+    }
+
+    setProtocolVersion?(version: string): void {
+      if (typeof this.inner.setProtocolVersion === "function") {
+        this.inner.setProtocolVersion(version);
+      }
+    }
+  }
+
+  return new FirstPageOnlyTransport(transport);
+}
+
+/**
+ * Removes `nextCursor` from a JSON-RPC *result*, which is what makes the
+ * official client's page walk stop. Returns the message by identity when
+ * there is nothing to strip, so non-list traffic is untouched. Exported for
+ * unit tests. Correlating the id to a cursor-less list request is the
+ * CALLER's job — this function does not inspect the method.
+ */
+export function stripNextCursorFromListResult(
+  message: JSONRPCMessage
+): JSONRPCMessage {
+  const result = (message as { result?: unknown }).result;
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    Array.isArray(result) ||
+    (result as { nextCursor?: unknown }).nextCursor === undefined
+  ) {
+    return message;
+  }
+  const { nextCursor: _truncated, ...rest } = result as Record<string, unknown>;
+  return {
+    ...(message as Record<string, unknown>),
+    result: rest,
+  } as unknown as JSONRPCMessage;
+}

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -285,6 +285,24 @@ export type BaseServerConfig = {
    * 2025-era connections never mirror, so the flag is inert there.
    */
   mirrorToolParamHeaders?: boolean;
+  /**
+   * Whether the client walks a paginated list to exhaustion, or reads page
+   * one and stops.
+   *
+   * `undefined` (the default) and `false` both walk every page. `true`
+   * deliberately simulates the real hosts that read only the first page, so a
+   * server author can see what their server looks like through one — tools
+   * beyond page one are invisible, and (on `2026-07-28`) a `tools/call` on
+   * such a tool carries no mirrored `Mcp-Param-*`, because the SEP-2243
+   * mirroring source is the page-one-only aggregate the client cached.
+   *
+   * Wired into the inspector via `hostConfig.mcpProfile.paginationTraversal`
+   * (`"full"` | `"firstPageOnly"`). Applies on every era and every transport —
+   * pagination predates 2026 and is not HTTP-specific. Only the cursor-less
+   * aggregation is truncated; an explicit-cursor request (the debugger's own
+   * manual paging) is left alone.
+   */
+  firstPageOnly?: boolean;
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */

--- a/sdk/tests/first-page-only.integration.test.ts
+++ b/sdk/tests/first-page-only.integration.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { MCPClientManager } from "../src/mcp-client-manager/index.js";
+import {
+  stripNextCursorFromListResult,
+  wrapTransportForFirstPageOnly,
+} from "../src/mcp-client-manager/transport-utils.js";
+import {
+  serveMultiPageFixtureOnPort,
+  type ServedMultiPageFixture,
+} from "./support/multi-page-fixture.js";
+import { getWireField } from "./support/raw-capture.js";
+
+/**
+ * `mcpProfile.paginationTraversal: "firstPageOnly"` — simulating the real
+ * hosts that read page one of a list and stop.
+ *
+ * The fixture serves 3 pages of 4 per primitive on a real socket, so these
+ * assert the truncation the way a server would observe it, not through a
+ * mocked client. The interesting case is the SECOND-order effect: the
+ * official client's page-one-only aggregate is what it caches, and that cache
+ * is the source SEP-2243 `Mcp-Param-*` mirroring reads — so a page-2 tool
+ * loses its mirrored header too.
+ */
+
+describe("first-page-only pagination (firstPageOnly: true)", () => {
+  let served: ServedMultiPageFixture | undefined;
+  let manager: MCPClientManager | undefined;
+
+  afterEach(async () => {
+    await manager?.disconnectAllServers().catch(() => {});
+    await served?.close();
+    served = undefined;
+    manager = undefined;
+  });
+
+  async function connect(options: {
+    firstPageOnly?: boolean;
+    fixtureOptions?: Parameters<typeof serveMultiPageFixtureOnPort>[0];
+  }) {
+    served = await serveMultiPageFixtureOnPort(options.fixtureOptions ?? {});
+    manager = new MCPClientManager();
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      ...(options.firstPageOnly !== undefined
+        ? { firstPageOnly: options.firstPageOnly }
+        : {}),
+      timeout: 10_000,
+    });
+    return { served: served!, manager: manager! };
+  }
+
+  const listRequests = (method: string) =>
+    served!.exchanges.filter(
+      (e) => getWireField(e.request.json, "method") === method
+    );
+
+  const toolCalls = () =>
+    served!.exchanges.filter(
+      (e) => getWireField(e.request.json, "method") === "tools/call"
+    );
+
+  it("returns only page one and stops requesting further pages", async () => {
+    const { manager } = await connect({ firstPageOnly: true });
+    const result = await manager.listTools("fixture");
+
+    expect(result.tools).toHaveLength(4);
+    expect(result.tools.map((t) => t.name)).toEqual([
+      "tool-0",
+      "tool-1",
+      "tool-2",
+      "tool-3",
+    ]);
+    // The decisive wire fact: the client never asked for page 2.
+    expect(listRequests("tools/list")).toHaveLength(1);
+  });
+
+  it("walks every page by default (control)", async () => {
+    const { manager } = await connect({});
+    const result = await manager.listTools("fixture");
+
+    expect(result.tools).toHaveLength(12);
+    expect(listRequests("tools/list").length).toBeGreaterThan(1);
+  });
+
+  it("truncates the other paginated primitives too", async () => {
+    const { manager } = await connect({ firstPageOnly: true });
+
+    expect((await manager.listPrompts("fixture")).prompts).toHaveLength(4);
+    expect((await manager.listResources("fixture")).resources).toHaveLength(4);
+    expect(listRequests("prompts/list")).toHaveLength(1);
+    expect(listRequests("resources/list")).toHaveLength(1);
+  });
+
+  it("leaves explicit-cursor paging alone (the debugger's own manual paging)", async () => {
+    // Truncating this would break a debugger feature rather than simulate a
+    // client: an explicit cursor is an operator action, not something the
+    // emulated client did on its own.
+    const { manager } = await connect({ firstPageOnly: true });
+    const page2 = await manager.listTools("fixture", { cursor: "page-1" });
+
+    expect(page2.tools).toHaveLength(4);
+    // Page 2 of 3 still advertises page 3 — the knob did not touch it.
+    expect(page2.nextCursor).toBeDefined();
+  });
+
+  it("mirrors no Mcp-Param-* for a page-2 tool, surfacing the server's -32020", async () => {
+    // The second-order effect and the whole point of the knob: the client
+    // cached a page-one-only tools/list, so `tool-4`'s `x-mcp-header`
+    // declaration is unreadable and its call goes out bare. A strict server
+    // answers -32020, and MCPJam surfaces that rather than masking it.
+    const { manager } = await connect({
+      firstPageOnly: true,
+      fixtureOptions: { requireParamHeaders: true },
+    });
+    await manager.listTools("fixture");
+
+    await expect(
+      manager.executeTool("fixture", "tool-4", { message: "hi" })
+    ).rejects.toThrow(/-32020|header/i);
+
+    const calls = toolCalls();
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.at(-1)!.request.headers["mcp-param-message"]).toBeUndefined();
+  });
+
+  it("still mirrors for a page-1 tool under the same knob", async () => {
+    // Proves the failure above is pagination-specific, not the knob breaking
+    // mirroring wholesale.
+    const { manager } = await connect({
+      firstPageOnly: true,
+      fixtureOptions: { requireParamHeaders: true },
+    });
+    await manager.listTools("fixture");
+    await manager.executeTool("fixture", "tool-0", { message: "hi" });
+
+    expect(toolCalls().at(-1)!.request.headers["mcp-param-message"]).toBe("hi");
+  });
+
+  it("mirrors for the SAME page-2 tool when the knob is off (control)", async () => {
+    const { manager } = await connect({
+      fixtureOptions: { requireParamHeaders: true },
+    });
+    await manager.listTools("fixture");
+    await manager.executeTool("fixture", "tool-4", { message: "hi" });
+
+    expect(toolCalls().at(-1)!.request.headers["mcp-param-message"]).toBe("hi");
+  });
+});
+
+describe("stripNextCursorFromListResult (pure)", () => {
+  it("removes nextCursor from a result", () => {
+    const out = stripNextCursorFromListResult({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { tools: [], nextCursor: "page-1" },
+    } as never) as { result: Record<string, unknown> };
+
+    expect(out.result.nextCursor).toBeUndefined();
+    expect(out.result.tools).toEqual([]);
+  });
+
+  it("returns the message by identity when there is nothing to strip", () => {
+    // Identity matters: non-list traffic must be provably untouched.
+    for (const message of [
+      { jsonrpc: "2.0", id: 1, result: { tools: [] } },
+      { jsonrpc: "2.0", id: 1, error: { code: -32603, message: "boom" } },
+      { jsonrpc: "2.0", method: "notifications/message", params: {} },
+      { jsonrpc: "2.0", id: 1, result: null },
+    ] as never[]) {
+      expect(stripNextCursorFromListResult(message)).toBe(message);
+    }
+  });
+});
+
+describe("wrapTransportForFirstPageOnly (correlation)", () => {
+  function fakeInner() {
+    const sent: unknown[] = [];
+    const inner = {
+      sent,
+      async start() {},
+      async send(message: unknown) {
+        sent.push(message);
+      },
+      async close() {},
+      onmessage: undefined as undefined | ((m: unknown) => void),
+      onclose: undefined as undefined | (() => void),
+      onerror: undefined as undefined | ((e: Error) => void),
+    };
+    return inner;
+  }
+
+  it("strips only for the id of a cursor-less list request", async () => {
+    const inner = fakeInner();
+    const wrapped = wrapTransportForFirstPageOnly(inner as never);
+    const seen: unknown[] = [];
+    wrapped.onmessage = (m) => seen.push(m);
+
+    await wrapped.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    } as never);
+    // An unrelated request that happens to answer with a nextCursor-shaped
+    // result must NOT be touched.
+    await wrapped.send({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "resources/read",
+      params: { uri: "x" },
+    } as never);
+
+    inner.onmessage!({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { tools: [], nextCursor: "page-1" },
+    });
+    inner.onmessage!({
+      jsonrpc: "2.0",
+      id: 2,
+      result: { contents: [], nextCursor: "not-a-list" },
+    });
+
+    expect((seen[0] as { result: Record<string, unknown> }).result.nextCursor)
+      .toBeUndefined();
+    expect((seen[1] as { result: Record<string, unknown> }).result.nextCursor)
+      .toBe("not-a-list");
+  });
+
+  it("does not strip a list response fetched with an explicit cursor", async () => {
+    const inner = fakeInner();
+    const wrapped = wrapTransportForFirstPageOnly(inner as never);
+    const seen: unknown[] = [];
+    wrapped.onmessage = (m) => seen.push(m);
+
+    await wrapped.send({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/list",
+      params: { cursor: "page-1" },
+    } as never);
+    inner.onmessage!({
+      jsonrpc: "2.0",
+      id: 7,
+      result: { tools: [], nextCursor: "page-2" },
+    });
+
+    expect((seen[0] as { result: Record<string, unknown> }).result.nextCursor)
+      .toBe("page-2");
+  });
+
+  it("forgets an id once answered, so a reused id is not re-stripped", async () => {
+    const inner = fakeInner();
+    const wrapped = wrapTransportForFirstPageOnly(inner as never);
+    const seen: unknown[] = [];
+    wrapped.onmessage = (m) => seen.push(m);
+
+    await wrapped.send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: {},
+    } as never);
+    inner.onmessage!({ jsonrpc: "2.0", id: 1, result: { tools: [] } });
+    // Same id, now a different (non-list) request the manager issued later.
+    inner.onmessage!({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { contents: [], nextCursor: "keep" },
+    });
+
+    expect((seen[1] as { result: Record<string, unknown> }).result.nextCursor)
+      .toBe("keep");
+  });
+});

--- a/sdk/tests/support/multi-page-fixture.ts
+++ b/sdk/tests/support/multi-page-fixture.ts
@@ -152,13 +152,18 @@ function buildItems() {
   const tools = Array.from({ length: FIXTURE_TOTAL_ITEMS }, (_, i) => ({
     name: `tool-${i}`,
     description: `Paginated tool ${i}`,
-    // `tool-0` declares a SEP-2243 `x-mcp-header` on its `message` property
-    // so a `tools/call` for it exercises the `Mcp-Param-Message` header path
-    // (the official client only mirrors `x-mcp-header` params it can read
-    // off a CACHED `tools/list` entry's `inputSchema` — see
-    // `modern-evidence.integration.test.ts`).
+    // `tool-0` (page 1) and `tool-4` (first item of page 2) declare a SEP-2243
+    // `x-mcp-header` on their `message` property, so a `tools/call` for either
+    // exercises the `Mcp-Param-Message` header path (the official client only
+    // mirrors `x-mcp-header` params it can read off a CACHED `tools/list`
+    // entry's `inputSchema` — see `modern-evidence.integration.test.ts`).
+    //
+    // The page-2 one exists so a first-page-only client can be told apart from
+    // a conforming one on a tool the server still serves: same `tools/call`,
+    // but the truncated client never cached `tool-4`'s schema, so it mirrors
+    // nothing and the server answers `-32020`.
     inputSchema:
-      i === 0
+      i === 0 || i === FIXTURE_PAGE_SIZE
         ? {
             type: "object" as const,
             properties: {
@@ -338,6 +343,8 @@ export interface ServedMultiPageFixture {
  */
 const REQUIRED_PARAM_HEADER_BY_TOOL: Record<string, string> = {
   "tool-0": "mcp-param-message",
+  // First item of page 2 (`FIXTURE_PAGE_SIZE` === 4).
+  "tool-4": "mcp-param-message",
 };
 
 /**


### PR DESCRIPTION
## What

S2 of the client-conformance knob program: makes `mcpProfile.paginationTraversal: "firstPageOnly"` (schema-frozen in #3648) actually *do* something. The simulated client now reads page one of a paginated list and stops, like the real hosts that behave this way.

New `MCPServerConfig.firstPageOnly`, applied by `wrapTransportForFirstPageOnly`: it deletes `nextCursor` from the inbound result of a **cursor-less** `tools/list` / `resources/list` / `resources/templates/list` / `prompts/list`. That single field is what ends the official client's internal page walk — `_listAllPages` loops on the page-one result's `nextCursor`.

## Why that one field does the interesting thing

Two consequences, and the second is the whole reason the knob exists:

1. Lists return page one only.
2. The page-one-only aggregate is what the client writes to its response cache — and that cache is the source `ensureXMcpHeaderMirroringSource` reads to mirror SEP-2243 `Mcp-Param-*`. So a `tools/call` on a page-two tool goes out with **no** mirrored header and a strict server answers `-32020`. That is precisely how a real first-page-only client fails, and it is not something you could get by just filtering the tool list client-side.

## Two deliberate departures from the original plan

**It is not HTTP-only.** The plan assumed a fetch-level seam, so #3648's docblock claimed this knob was "HTTP-scoped by mechanism". A transport wrapper works on JSON-RPC frames, so it applies on stdio and SSE too — and a first-page-only client is not an HTTP-specific defect, so restricting it would have been an artificial limit. This PR corrects that docblock.

The fetch seam is also structurally unable to do this: `wrapFetchForHttpLogging` deliberately never reads response bodies (it would consume the stream the transport is about to parse), and buffering one would break SSE framing.

**Explicit-cursor requests are left alone.** Correlating by id→method alone — as planned — would also truncate MCPJam's *own* manual paging, where an operator clicks through pages and the client sends `tools/list` with an explicit cursor. That is an operator action, not something the emulated client did, so truncating it would break a debugger feature rather than simulate a client. The wrapper records an id only when the outbound request carries no cursor.

Composed **outermost**, so the JSON-RPC logging transport underneath still records the frame the server really sent and only the client sees the truncated list — the same "log the raw bytes, mutate above them" ordering the task-result wrapper uses. Outbound ids are correlated to inbound frames so an unrelated `nextCursor` is never touched.

## Fixture change

`tool-4` (first item of page 2) now declares an `x-mcp-header` alongside the existing `tool-0` (page 1). Previously only a page-1 tool declared one, so there was no way to *prove* a page-2 tool loses its mirrored header — the claim would have been untestable.

## Tests

12 new, including the three-way discrimination that keeps the second-order effect honest:
- page-2 tool **under** the knob → no `Mcp-Param-*`, surfaces the server's `-32020`
- the **same** tool with the knob **off** → mirrors fine (so the failure is pagination-specific, not the knob breaking mirroring wholesale)
- a page-1 tool **under** the knob → still mirrors

Plus: only page one returned and exactly one `tools/list` on the wire (the decisive fact — the client never *asked* for page 2), the other paginated primitives truncated too, explicit-cursor paging untouched, a full-walk control, pure-function identity for non-list traffic, and correlation unit tests (unrelated method with a `nextCursor`-shaped result, explicit cursor, id reuse after an answer).

Adjacent suites unaffected by the fixture change: pagination-parity, modern-evidence, mcp-header-mirror, host-connection (124 tests). `npm run verify` green at root — SDK 3446, inspector 12096.

## Scope

SDK enforcement only. CLI flags and the product/UI plumbing are separate PRs; `mrtrSupport` enforcement (with its advertise-equals-enforce coupling) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0878825fadfadd63ba2742649805092b60cf6e74. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces first-page-only pagination in `@mcpjam/sdk`. When enabled, the client reads only page one of list APIs and stops, which also limits SEP-2243 `Mcp-Param-*` mirroring to page-one tools.

- **New Features**
  - Added `MCPServerConfig.firstPageOnly` (wired from `hostConfig.mcpProfile.paginationTraversal: "firstPageOnly"`).
  - Implemented `wrapTransportForFirstPageOnly` to delete `nextCursor` from cursor-less list results for `tools/list`, `resources/list`, `resources/templates/list`, and `prompts/list`; exported `wrapTransportForFirstPageOnly` and `stripNextCursorFromListResult`.
  - Applied as the outermost transport wrapper so logs capture the raw server frame; works over stdio, Streamable HTTP, and SSE.
  - Leaves explicit-cursor paging untouched and correlates by request id to avoid touching unrelated responses.
  - Updated fixture: `tool-4` (page 2) now declares an `x-mcp-header`; added tests proving page-2 tools lose mirrored headers and strict servers return `-32020`, while page-1 tools still mirror.

<sup>Written for commit 0878825fadfadd63ba2742649805092b60cf6e74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

