### PR TITLE
feat(slack-app): host the bot on Railway

### DIFF
--- a/.github/workflows/deploy-slack-app.yml
+++ b/.github/workflows/deploy-slack-app.yml
@@ -1,0 +1,41 @@
+name: Deploy Slack app
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "slack-app/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/deploy-slack-app.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: slack-app
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to Railway
+    runs-on: ubuntu-latest
+    environment:
+      name: slack-app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Railway CLI
+        run: npm i -g @railway/cli
+
+      # The service is configured with root directory "/" and config-as-code
+      # at slack-app/railway.toml, so the upload is the whole monorepo (the
+      # lockfile lives at the root) but only the bot's Dockerfile is built.
+      - name: Deploy
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_SLACK_APP_TOKEN }}
+        run: railway up --service mcpjam-slack-app --ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -35742,7 +35742,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
       "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -38005,10 +38004,10 @@
     "slack-app": {
       "name": "@mcpjam/slack-app",
       "version": "0.1.0",
-      "license": "MIT",
       "dependencies": {
         "@slack/bolt": "^5.0.0",
-        "dotenv": "~17.4.2"
+        "dotenv": "~17.4.2",
+        "undici": "^7.24.8"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.6",

--- a/slack-app/Dockerfile
+++ b/slack-app/Dockerfile
@@ -1,0 +1,41 @@
+# The MCPJam Slack bot.
+#
+# Socket Mode: the process dials OUT to Slack and serves no HTTP, so this
+# image exposes no port and the Railway service needs no domain or
+# healthcheck path.
+#
+# Built from the MONOREPO ROOT as context (the lockfile lives there), which
+# is why every path below is repo-relative. The Railway service selects this
+# file with the RAILWAY_DOCKERFILE_PATH variable, because the root
+# railway.json points at the inspector's Dockerfile.
+
+FROM node:24-alpine
+
+WORKDIR /app
+
+# Manifests + lockfile first so the dependency layer survives source-only
+# changes. Every workspace's package.json is copied because `npm ci`
+# validates the whole lockfile graph even when installing a subset.
+COPY package.json package-lock.json ./
+COPY sdk/package.json sdk/
+COPY cli/package.json cli/
+COPY mcpjam-inspector/package.json mcpjam-inspector/
+COPY design-system/package.json design-system/
+COPY chat-ui/package.json chat-ui/
+COPY widget-react/package.json widget-react/
+COPY soundcheck/package.json soundcheck/
+COPY mcp/package.json mcp/
+COPY slack-app/package.json slack-app/
+
+# Install ONLY this workspace's runtime subset (~38 MB) instead of the whole
+# monorepo — the bot needs @slack/bolt and dotenv, not the inspector's build
+# toolchain. --legacy-peer-deps matches CI.
+RUN npm ci --legacy-peer-deps \
+  --workspace @mcpjam/slack-app \
+  --include-workspace-root \
+  --omit=dev
+
+COPY slack-app slack-app
+
+# Fail fast and loudly if the process dies; Railway restarts it.
+CMD ["npm", "start", "--workspace", "@mcpjam/slack-app"]

--- a/slack-app/README.md
+++ b/slack-app/README.md
@@ -109,7 +109,37 @@ Tests are `node:test` with no network: the API client takes an injectable
 
 ## Deployment
 
-Not deployed yet — Socket Mode against a developer install is the current
-dogfood path. Hosting (a Railway service modeled on `deploy-soundcheck.yml`)
-and multi-tenant OAuth distribution are tracked as follow-ups; OAuth mode was
+Hosted on Railway in its own project, `mcpjam-slack-app`, deployed by
+`.github/workflows/deploy-slack-app.yml` on pushes that touch `slack-app/**`
+(mirroring `deploy-soundcheck.yml`).
+
+The bot runs in Socket Mode there too: it dials out to Slack and serves no
+HTTP, so the service has **no domain, no exposed port, and no healthcheck**.
+
+Two pieces of Railway config are load-bearing and easy to get wrong:
+
+- **Config as code = `slack-app/railway.toml`.** Without it Railway falls back
+  to the repo-root `railway.json` and builds the *inspector's* Dockerfile
+  (playwright and all). Setting `RAILWAY_DOCKERFILE_PATH` is NOT enough — the
+  root config-as-code file wins over the variable.
+- **Root directory = `/`.** The build context has to be the monorepo root
+  because the lockfile lives there; `Dockerfile` paths are repo-relative.
+
+### Why `undici` is a direct dependency
+
+`@slack/socket-mode` requires `undici` at runtime and declares it properly,
+but in this monorepo the hoisted copy is also pinned by `miniflare` (a dev
+dependency elsewhere), so npm records the single hoisted entry as `dev` — and
+a workspace-scoped install then omits it, crashing the container with
+`Cannot find module 'undici'`. Declaring it here makes the attribution
+unambiguous. Remove it only if that hoist stops colliding.
+
+### Deploying by hand
+
+```sh
+railway link --project mcpjam-slack-app   # once per machine
+railway up --service mcpjam-slack-app --ci
+```
+
+Multi-tenant OAuth distribution remains a follow-up; OAuth mode was
 deliberately removed from v1 rather than shipped half-wired.

--- a/slack-app/package.json
+++ b/slack-app/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@slack/bolt": "^5.0.0",
-    "dotenv": "~17.4.2"
+    "dotenv": "~17.4.2",
+    "undici": "^7.24.8"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",

--- a/slack-app/railway.toml
+++ b/slack-app/railway.toml
@@ -1,0 +1,22 @@
+# Railway service config for mcpjam-slack-app.
+#
+# The Railway service is configured with:
+#   - Root directory:  /                        (monorepo root — the
+#                                                lockfile lives there)
+#   - Config as code:  slack-app/railway.toml   (this file)
+#
+# That second setting is load-bearing: without it Railway reads the ROOT
+# railway.json, which builds the inspector's Dockerfile (playwright and all)
+# instead of the bot. Setting RAILWAY_DOCKERFILE_PATH is NOT enough — the
+# root config-as-code file wins over the variable.
+#
+# Socket Mode means the process serves no HTTP, so this service has no
+# domain, no exposed port, and no healthcheck.
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "slack-app/Dockerfile"
+
+[deploy]
+startCommand = "npm start --workspace @mcpjam/slack-app"
+restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
Puts the Slack bot on Railway in its own project (`mcpjam-slack-app`), deployed by CI on `slack-app/**` pushes — the same shape as `deploy-soundcheck.yml`. Socket Mode, so the service has no domain, no exposed port, and no healthcheck.

## Two findings that only showed up by actually deploying

- **`RAILWAY_DOCKERFILE_PATH` does not redirect the build.** The first deploy cheerfully built the *inspector's* Dockerfile — playwright download and all — because the repo-root `railway.json` (config-as-code) wins over the variable. The fix is the service-level config-as-code path pointing at `slack-app/railway.toml`, which is what soundcheck quietly relies on too. Documented in the toml itself so the next person doesn't repeat it.
- **The container crashed on `Cannot find module 'undici'`.** `@slack/socket-mode` declares `undici` correctly, but `miniflare` (a dev dependency of another workspace) pins the same version and wins the hoist, so npm records the single hoisted entry as `dev` — and a workspace-scoped install then omits it, **with or without `--omit=dev`**. Declaring `undici` in this workspace makes the attribution unambiguous. I then imported the app's entire require graph against a fresh subset install to confirm no *second* missing transitive dep was hiding behind the first.

## Image

Installs only this workspace's dependency subset (~40 MB) rather than the full monorepo, so the bot doesn't ship the inspector's build toolchain. All workspace manifests are copied before `npm ci` because it validates the whole lockfile graph even when installing a subset.

## State

Build and deploy are green: the running container reaches `SocketModeClient.start()` and fails only on placeholder Slack credentials, which is the expected pre-credentials state. Real values go in as Railway variables (not in the repo).

Also drops a stale `license` field the lockfile still carried for slack-app — `npm install` rewrites it anyway, so it was churning every developer's tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces production deployment and a subtle dependency-install fix; misconfigured Railway config-as-code could still build the wrong image, but app logic and auth are unchanged.
> 
> **Overview**
> Adds **Railway hosting** for the Slack bot with CI deploys on `main` when `slack-app/**` (or root lockfiles) change, mirroring the soundcheck workflow.
> 
> **Build/deploy wiring:** `slack-app/railway.toml` forces the bot Dockerfile instead of the repo-root inspector config; a monorepo-root **Dockerfile** installs only `@mcpjam/slack-app` runtime deps and starts via `npm start --workspace`. Socket Mode stays outbound-only (no HTTP port/healthcheck).
> 
> **Runtime fix:** `undici` is added as a direct dependency so workspace-scoped `npm ci --omit=dev` still ships it despite monorepo hoist/dev attribution with `miniflare`. README documents Railway pitfalls and manual `railway up`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1bb24f5d865a9258dfb9134f1f586d71e23b645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Host the Slack bot on Railway (`mcpjam-slack-app`) with CI deploys on `slack-app/**` pushes. Runs in Socket Mode with a slim Docker image and fixes the build path and missing `undici` runtime dependency.

- **New Features**
  - Added CI workflow to deploy to Railway using `@railway/cli`; triggers on `slack-app/**`.
  - Added `slack-app/Dockerfile` that installs only the `@mcpjam/slack-app` runtime subset.
  - Added `slack-app/railway.toml` so Railway builds the correct Dockerfile; no domain/ports/healthcheck.
  - Updated README with deployment notes and manual `railway up` steps.

- **Dependencies**
  - Added direct `undici` to `@mcpjam/slack-app` to avoid hoist/omit dropping a runtime dep.
  - Cleaned a stale `license` field from the lockfile entry for the Slack app.

<sup>Written for commit f1bb24f5d865a9258dfb9134f1f586d71e23b645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

