### PR TITLE
feat(sdk): enforce mrtrSupport — a client that never implemented MRTR (S3)

### DIFF
--- a/.changeset/mrtr-support-enforcement.md
+++ b/.changeset/mrtr-support-enforcement.md
@@ -1,0 +1,30 @@
+---
+"@mcpjam/sdk": minor
+---
+
+Enforce `mcpProfile.mrtrSupport: "none"` — the simulated client no longer
+drives MRTR (`resultType: "input_required"`) retry rounds.
+
+New `MCPServerConfig.supportsMrtr`. Setting it `false`:
+
+- **stops advertising `elicitation` on a modern connection**, because the MRTR
+  bridge is the only fulfiller on `2026-07-28` and advertising a capability
+  nothing can honor breaks advertise = enforce. The suppression reaches the
+  `eraCapabilities.modern` overlay and a pinned exact `clientCapabilities` set
+  too, so neither can smuggle the capability past the knob.
+- **stops driving rounds**: the verb gates resolve no collector, so calls take
+  their plain path without `allowInputRequired`, and an `input_required`
+  result surfaces as the upstream client's native `UNSUPPORTED_RESULT_TYPE`
+  rather than looping. No `allowInputRequired: true` goes out on the wire
+  claiming a capability the simulated client disclaims.
+
+Legacy connections are untouched: MRTR does not exist before `2026-07-28`, and
+elicitation there is server-initiated and fulfilled by the inbound
+`elicitation/create` bridge. The suppression is therefore era-aware rather
+than era-blind — implementing it the simple way would have silently disabled a
+2025 feature. It is also aware that hosted chat registers a *global*
+elicitation callback, which would otherwise have kept the capability
+advertised and made the knob a no-op.
+
+Which elicitation modes an MRTR-capable client fulfills remains a separate,
+already-modeled fact (`clientCapabilities.elicitation.{form,url}`).

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1027,7 +1027,7 @@ export class MCPClientManager {
     // task-augmented call, drive the manual `input_required` loop. A complete
     // result on the first leg exits immediately, so legacy servers are
     // unaffected.
-    const mrtrCollect = this.mrtrInputCollectors.get(serverId);
+    const mrtrCollect = this.resolveMrtrCollector(serverId);
     if (mrtrCollect && request.task === undefined) {
       // One result state machine: an extension-eligible call goes through the
       // SAME MRTR loop, because `resultType` is a tri-state — a call may run
@@ -1239,7 +1239,7 @@ export class MCPClientManager {
     params: ReadResourceParams,
     options?: ClientRequestOptions
   ) {
-    const mrtrCollect = this.mrtrInputCollectors.get(serverId);
+    const mrtrCollect = this.resolveMrtrCollector(serverId);
     if (mrtrCollect) {
       return this.readResourceWithInputRequired(
         serverId,
@@ -1338,7 +1338,7 @@ export class MCPClientManager {
     params: GetPromptParams,
     options?: ClientRequestOptions
   ) {
-    const mrtrCollect = this.mrtrInputCollectors.get(serverId);
+    const mrtrCollect = this.resolveMrtrCollector(serverId);
     if (mrtrCollect) {
       return this.getPromptWithInputRequired(
         serverId,
@@ -3064,9 +3064,25 @@ export class MCPClientManager {
     // is registered before connect must be reflected here. roots/sampling are
     // never advertised (this client never fulfils them; MRTR rejects embedded
     // roots/sampling at the result — advertise = enforce).
-    const hasElicitationHandler =
-      this.elicitationManager.hasHandler(serverId) ||
-      this.mrtrInputCollectors.has(serverId);
+    //
+    // `supportsMrtr: false` (the host config's `mcpProfile.mrtrSupport:
+    // "none"`) simulates a client that does not drive MRTR rounds at all, so
+    // the MRTR collector stops counting as a fulfiller. On MODERN that
+    // removes the only one there is — the inbound `elicitation/create` bridge
+    // does not exist on 2026-07-28 — so a legacy handler must not prop the
+    // advertisement up either; hosted chat registers a GLOBAL elicitation
+    // callback, which would otherwise keep `hasHandler` true and make the
+    // knob a silent no-op. On LEGACY the knob is irrelevant: elicitation
+    // there is server-initiated, not MRTR, and the SSE bridge still fulfils
+    // it. `era` is undefined at connect time, so the legacy fulfiller is
+    // still counted then and `applyModernEraCapabilities` narrows once the
+    // connection actually classifies as modern.
+    const mrtrDisabled = config.supportsMrtr === false;
+    const mrtrFulfils = !mrtrDisabled && this.mrtrInputCollectors.has(serverId);
+    const legacyFulfils =
+      this.elicitationManager.hasHandler(serverId) &&
+      !(mrtrDisabled && era === "modern");
+    const hasElicitationHandler = legacyFulfils || mrtrFulfils;
     if (config.clientCapabilities) {
       // An EXACT set is advertised verbatim (minus the elicitation gate) on
       // every era — the `eraCapabilities` overlay is deliberately ignored,
@@ -3104,9 +3120,19 @@ export class MCPClientManager {
       );
     }
 
-    return applyRuntimeClientCapabilities(configuredCapabilities, {
+    const resolved = applyRuntimeClientCapabilities(configuredCapabilities, {
       elicitation: hasElicitationHandler,
     });
+    // `applyRuntimeClientCapabilities` only ADDS the runtime gate — it cannot
+    // remove an `elicitation` that came from `config.capabilities`. That is
+    // fine everywhere else (the gate is additive by design), but a modern
+    // connection simulating a non-MRTR client must not advertise a capability
+    // nothing can fulfil, so delete it explicitly. Scoped to the knob: no
+    // other connection's advertised set changes.
+    if (mrtrDisabled && era === "modern") {
+      delete (resolved as Record<string, unknown>).elicitation;
+    }
+    return resolved;
   }
 
   /**
@@ -3145,7 +3171,19 @@ export class MCPClientManager {
     upstreamClient: Client,
     connectCapabilities: ClientCapabilityOptions
   ): ClientCapabilityOptions {
-    if (!config.eraCapabilities?.modern || config.clientCapabilities) {
+    // `supportsMrtr: false` needs this pass even without an overlay, and even
+    // for a pinned exact set: the connect-time build ran with `era`
+    // undefined, so it still counted a legacy fulfiller (see
+    // `buildCapabilities`). Without re-resolving, a modern connection built
+    // without an `eraCapabilities.modern` overlay — every hosted, CLI and raw
+    // SDK caller — would keep advertising elicitation and the knob would
+    // silently no-op. Re-running is safe for an exact set: `buildCapabilities`
+    // applies the same gate to it and otherwise advertises it verbatim.
+    const narrowsForMrtr = config.supportsMrtr === false;
+    if (
+      !narrowsForMrtr &&
+      (!config.eraCapabilities?.modern || config.clientCapabilities)
+    ) {
       return connectCapabilities;
     }
     const negotiatedVersion = upstreamClient.getNegotiatedProtocolVersion?.();
@@ -3598,6 +3636,33 @@ export class MCPClientManager {
       if (isAbortError(error)) throw error;
       return [];
     }
+  }
+
+  /**
+   * The MRTR input collector to drive rounds with, or `undefined` when this
+   * connection simulates a client that does not drive MRTR at all
+   * (`MCPServerConfig.supportsMrtr: false`, from the host config's
+   * `mcpProfile.mrtrSupport: "none"`).
+   *
+   * Returning `undefined` is the whole enforcement: every verb gate then
+   * takes its plain path, which does NOT pass `allowInputRequired`, so the
+   * upstream client rejects an `input_required` result natively with
+   * `UNSUPPORTED_RESULT_TYPE` — the same error a client that never
+   * implemented MRTR would produce. Nothing about the round-driving code
+   * needs a special case, and no `allowInputRequired: true` goes out on the
+   * wire claiming a capability the simulated client disclaims.
+   *
+   * The collector is left REGISTERED so callers that own it (hosted bridge,
+   * CLI) need no teardown, and so flipping the knob back does not require
+   * re-registration.
+   */
+  private resolveMrtrCollector(
+    serverId: string
+  ): ReturnType<Map<string, MrtrInputCollector>["get"]> {
+    if (this.registeredServers.get(serverId)?.config.supportsMrtr === false) {
+      return undefined;
+    }
+    return this.mrtrInputCollectors.get(serverId);
   }
 
   /**

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -303,6 +303,25 @@ export type BaseServerConfig = {
    * manual paging) is left alone.
    */
   firstPageOnly?: boolean;
+  /**
+   * Whether the client drives MRTR (`resultType: "input_required"`) retry
+   * rounds at all.
+   *
+   * `undefined` (the default) and `true` both drive them. `false` simulates a
+   * client that never implemented the 2026 pattern: it stops advertising
+   * `elicitation` on a modern connection — where the MRTR bridge is the only
+   * fulfiller, so advertising would be a capability nothing can honor — and
+   * an `input_required` result surfaces as the upstream client's
+   * `UNSUPPORTED_RESULT_TYPE` error instead of silently looping.
+   *
+   * Wired into the inspector via `hostConfig.mcpProfile.mrtrSupport`
+   * (`"full"` | `"none"`). Modern-era only: MRTR does not exist before
+   * `2026-07-28`, and a legacy connection keeps fulfilling elicitation
+   * through the inbound `elicitation/create` bridge, which this knob does not
+   * touch. WHICH elicitation modes an MRTR-capable client fulfills is a
+   * separate, already-modeled fact (`clientCapabilities.elicitation`).
+   */
+  supportsMrtr?: boolean;
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */

--- a/sdk/tests/mrtr-manager.integration.test.ts
+++ b/sdk/tests/mrtr-manager.integration.test.ts
@@ -262,3 +262,127 @@ describe("post-negotiation capability re-resolution (eraCapabilities.modern)", (
     expect(result.content[0]?.text).toBe("consent:accept");
   });
 });
+
+describe("supportsMrtr: false — a client that never implemented MRTR", () => {
+  let served: ServedFixture;
+  let manager: MCPClientManager;
+
+  beforeEach(async () => {
+    served = await serveFixture();
+    manager = new MCPClientManager();
+    // Registered exactly as a normal connection would — the knob, not the
+    // absence of a collector, must be what disables MRTR. (Callers like the
+    // hosted bridge and the CLI register unconditionally, so this is the
+    // realistic shape.)
+    manager.setMrtrInputCollector("fixture", acceptAllCollector());
+  });
+
+  afterEach(async () => {
+    await manager.disconnectAllServers().catch(() => {});
+    await served.close();
+  });
+
+  it("stops advertising elicitation on modern even with a collector registered", async () => {
+    // Advertise = enforce: the MRTR bridge is the only fulfiller on
+    // 2026-07-28, so a client that does not drive rounds must not claim the
+    // capability.
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      supportsMrtr: false,
+      timeout: 10_000,
+    });
+    const info = manager.getInitializationInfo("fixture");
+    const caps = (info?.clientCapabilities ?? {}) as Record<string, unknown>;
+    expect(caps.elicitation).toBeUndefined();
+  });
+
+  it("suppresses an eraCapabilities.modern overlay's elicitation too", async () => {
+    // The overlay must not smuggle the capability past the knob, the same way
+    // it cannot smuggle it past a missing fulfiller.
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      supportsMrtr: false,
+      eraCapabilities: { modern: { elicitation: { form: {}, url: {} } } },
+      timeout: 10_000,
+    });
+    const info = manager.getInitializationInfo("fixture");
+    const caps = (info?.clientCapabilities ?? {}) as Record<string, unknown>;
+    expect(caps.elicitation).toBeUndefined();
+  });
+
+  it("suppresses a PINNED exact clientCapabilities set's elicitation", async () => {
+    // An exact set is advertised verbatim MINUS the fulfiller gate, so the
+    // knob reaches it too — otherwise pinning would be a way to advertise a
+    // capability nothing can honor.
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      supportsMrtr: false,
+      clientCapabilities: { elicitation: {} },
+      timeout: 10_000,
+    });
+    const info = manager.getInitializationInfo("fixture");
+    const caps = (info?.clientCapabilities ?? {}) as Record<string, unknown>;
+    expect(caps.elicitation).toBeUndefined();
+  });
+
+  it("does not drive rounds: an input_required tool call fails instead of looping", async () => {
+    const collect = vi.fn(acceptAllCollector());
+    manager.setMrtrInputCollector("fixture", collect);
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      supportsMrtr: false,
+      timeout: 10_000,
+    });
+
+    const error = await manager
+      .executeTool("fixture", "confirm", { topic: "x" })
+      .then(() => undefined, (e: unknown) => e);
+
+    // The server refuses to embed the elicitation because the client never
+    // declared the capability — same failure a genuinely non-MRTR client
+    // sees. The decisive assertion is the one below it: the collector was
+    // never consulted, so no rounds were driven.
+    expect((error as { code?: number })?.code).toBe(-32021);
+    expect(collect).not.toHaveBeenCalled();
+  });
+
+  it("still drives rounds when the knob is absent (control)", async () => {
+    const collect = vi.fn(acceptAllCollector("apples"));
+    manager.setMrtrInputCollector("fixture", collect);
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+    });
+    const result = (await manager.executeTool("fixture", "confirm", {
+      topic: "fruit",
+    })) as { content: Array<{ text?: string }> };
+    expect(result.content[0]?.text).toBe("answer:apples");
+    expect(collect).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves LEGACY elicitation alone — that bridge is not MRTR", async () => {
+    // MRTR does not exist before 2026-07-28. On a legacy connection
+    // elicitation is server-initiated and fulfilled by the inbound
+    // `elicitation/create` bridge, so the knob must not touch it. Guards
+    // against implementing the suppression era-blind, which would silently
+    // disable a 2025 feature.
+    manager.setElicitationHandler("fixture", async () => ({
+      action: "accept" as const,
+      content: { answer: "legacy" },
+    }));
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2025-11-25",
+      supportsMrtr: false,
+      timeout: 10_000,
+    });
+    const info = manager.getInitializationInfo("fixture");
+    const caps = (info?.clientCapabilities ?? {}) as Record<string, unknown>;
+    expect(caps.elicitation).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

S3 of the client-conformance knob program: makes `mcpProfile.mrtrSupport: "none"` (schema-frozen in #3648) actually *do* something. New `MCPServerConfig.supportsMrtr`; setting it `false` simulates a client that never implemented the 2026 MRTR pattern.

Two enforcement halves:

1. **Stops advertising `elicitation` on a modern connection.** The MRTR bridge is the only fulfiller on `2026-07-28`, so claiming the capability would break advertise = enforce. The suppression reaches the `eraCapabilities.modern` overlay and a pinned exact `clientCapabilities` set too — neither may smuggle it past the knob.
2. **Stops driving rounds.** The verb gates (`executeTool` / `readResource` / `getPrompt`) resolve no collector, so calls take their plain path without `allowInputRequired`, and an `input_required` result surfaces as the upstream client's native `UNSUPPORTED_RESULT_TYPE`.

## Why not a driver-level early exit

A client that does not implement MRTR is *exactly* a client that does not pass `allowInputRequired`. A guard inside `mrtr-driver.ts` would leave that flag hardcoded `true` on three send paths, so the wire would still opt into a result the client claims not to support — a lie on the wire rather than a simulation. Routing the verb gates through a knob-aware resolver means no round-driving code needs a special case at all.

The collector is left **registered** so callers that own it (hosted bridge, CLI) need no teardown and flipping the knob back needs no re-registration.

## Two traps the obvious implementation falls into

Both are now covered by tests that fail if the code is later "simplified":

**Skipping collector registration is not enough.** Hosted chat registers a *global* elicitation callback alongside the per-server collector, and `elicitationManager.hasHandler()` returns true for it. Not registering the collector would leave `elicitation` still advertised — the knob would look implemented and do nothing on the surface that matters most.

**The suppression must be era-aware.** MRTR does not exist before `2026-07-28`. On a legacy connection, elicitation is server-initiated and fulfilled by the inbound `elicitation/create` SSE bridge, which has nothing to do with MRTR. Suppressing era-blind would silently disable a 2025 feature. The `era` argument is `undefined` at connect time, so a legacy fulfiller still counts then and the post-negotiation pass narrows once the connection actually classifies as modern.

## A latent no-op this also fixes

`applyModernEraCapabilities` early-returns unless the config carries an `eraCapabilities.modern` overlay. The local path always injects one, but hosted, CLI and raw-SDK callers may not — so without relaxing that guard for this knob, the suppression would have applied only on the local path and silently no-opped everywhere else. Re-running is safe for a pinned exact set: `buildCapabilities` applies the same gate to it and otherwise advertises it verbatim.

Also adds an explicit delete on the base path, because `applyRuntimeClientCapabilities` only ever *adds* the runtime gate — it cannot remove an `elicitation` that came from `config.capabilities`. Scoped to the knob, so no other connection's advertised set changes.

## Tests

6 new, against the real loopback MRTR fixture:
- elicitation suppressed on modern **with a collector registered** (the knob, not its absence, is what disables MRTR)
- suppressed for an `eraCapabilities.modern` overlay
- suppressed for a pinned exact `clientCapabilities` set
- an `input_required` tool call fails instead of looping, **and the collector is never consulted** (the decisive assertion — no rounds driven)
- knob absent → rounds still drive to completion (control)
- **legacy connection keeps advertising elicitation** — the era guard

`npm run verify` green at root: SDK 3452, inspector 12096.

## Scope

SDK enforcement only. `cli/src/lib/host-resolve.ts` currently maps neither `firstPageOnly` nor `supportsMrtr` onto a config — that's the next PR, followed by the product plumbing and UI.

Deferred deliberately: extending the hosted MRTR binding digest (`deriveServerConfigDigest`). A `supportsMrtr: false` connection never suspends in the first place, so it would only guard the flip-after-suspend case, and any digest change invalidates every in-flight continuation on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches modern capability negotiation and MRTR verb routing in `MCPClientManager`; behavior is well-tested but wrong era gating could break elicitation or MRTR for some connection shapes.
> 
> **Overview**
> Adds **`MCPServerConfig.supportsMrtr`** so `mcpProfile.mrtrSupport: "none"` simulates a client that never implemented 2026 MRTR.
> 
> When **`supportsMrtr: false`** on a **modern** connection, the SDK **stops advertising `elicitation`** (including via `eraCapabilities.modern`, pinned `clientCapabilities`, or base `capabilities`) so a global legacy elicitation handler cannot keep the capability on the wire. **`applyModernEraCapabilities`** re-runs capability resolution after negotiation even without a modern overlay, fixing a path where hosted/CLI callers would otherwise keep advertising elicitation.
> 
> **`resolveMrtrCollector`** makes `executeTool`, `readResource`, and `getPrompt` skip the MRTR loop while leaving collectors registered; calls use the plain path without **`allowInputRequired`**, so **`input_required`** surfaces as **`UNSUPPORTED_RESULT_TYPE`** / protocol errors instead of retry rounds. **Legacy** connections still advertise and fulfill server-initiated elicitation.
> 
> Six integration tests cover advertising suppression, round suppression, overlay/pin behavior, and the legacy era guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778f6485ccc5a8d6462f80e20093226a0626e34d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `mcpProfile.mrtrSupport: "none"` in the SDK. Adds `MCPServerConfig.supportsMrtr` to simulate a client that never implemented MRTR: on modern connections we stop advertising `elicitation` and we do not drive retry rounds; legacy stays the same.

- **New Features**
  - New `MCPServerConfig.supportsMrtr` (from host `mcpProfile.mrtrSupport`). Set `false` to disable MRTR.
  - Modern only: remove `elicitation` from advertised capabilities, including `eraCapabilities.modern` overlays and pinned `clientCapabilities`.
  - Verb gates no longer resolve an MRTR collector, so calls do not pass `allowInputRequired`; an `input_required` result returns upstream `UNSUPPORTED_RESULT_TYPE` instead of looping.
  - Era-aware re-resolution: legacy uses the inbound `elicitation/create` bridge (unchanged). Post-negotiation narrowing runs even without an overlay, and we explicitly delete `elicitation` to prevent leaking the capability.

<sup>Written for commit 778f6485ccc5a8d6462f80e20093226a0626e34d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

