### PR TITLE
feat(cli): carry the client-conformance knobs through --host and new flags (S4)

### DIFF
--- a/.changeset/conformance-knobs-cli.md
+++ b/.changeset/conformance-knobs-cli.md
@@ -1,0 +1,17 @@
+---
+"@mcpjam/cli": minor
+---
+
+Carry the client-conformance knobs through the CLI.
+
+`--host` now forwards `paginationTraversal` and `mrtrSupport` onto the
+connection — previously `applyHostToConfig` mapped neither, so a host
+configured as a first-page-only or non-MRTR client silently ran as a fully
+conforming one. Unlike the protocol pin and the SEP-2243 mirroring knob beside
+them, these are **not** HTTP-only: pagination truncation is enforced on
+JSON-RPC frames and the MRTR knob works through capability advertisement, so
+gating them to `url` would make `--host` mean something different over stdio.
+
+Adds `--first-page-only` (on `tools list` and `tools call`) and `--no-mrtr`
+(on `tools call`) to reproduce the same behaviors ad hoc, without authoring a
+host.

--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -48,6 +48,8 @@ import {
 import { summarizeServerDoctorTarget } from "../lib/server-doctor.js";
 import {
   addHostOption,
+  addConformanceOptions,
+  conformanceConfigFromOptions,
   addRetryOptions,
   addSharedServerOptions,
   describeTarget,
@@ -116,6 +118,14 @@ interface ToolsCallOptions extends SharedServerTargetOptions {
   paramHeaders?: boolean;
   /** `--mcp-header Name=Value`, repeatable. Raw request headers, caller-wins. */
   mcpHeader?: string[];
+  /** `--first-page-only`. Read only page one of paginated lists. */
+  firstPageOnly?: boolean;
+  /**
+   * `--no-mrtr`. Commander defaults a `--no-x` flag to `true`, so `false`
+   * here means the user explicitly asked to call as a client that does not
+   * drive MRTR rounds.
+   */
+  mrtr?: boolean;
 }
 
 /**
@@ -521,11 +531,13 @@ export function registerToolsCommands(program: Command): void {
   addHostOption(
     addRetryOptions(
       addSharedServerOptions(
-        tools
-          .command("list")
-          .description("List tools exposed by an MCP server")
-          .option("--cursor <cursor>", "Pagination cursor")
-          .option("--model-id <model>", "Model id used for token counting"),
+        addConformanceOptions(
+          tools
+            .command("list")
+            .description("List tools exposed by an MCP server")
+            .option("--cursor <cursor>", "Pagination cursor")
+            .option("--model-id <model>", "Model id used for token counting"),
+        ),
       ),
     ),
   ).action(async (options, command) => {
@@ -536,10 +548,13 @@ export function registerToolsCommands(program: Command): void {
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
       : undefined;
-    const config = parseServerConfig({
-      ...options,
-      timeout: globalOptions.timeout,
-    });
+    const config = {
+      ...parseServerConfig({
+        ...options,
+        timeout: globalOptions.timeout,
+      }),
+      ...conformanceConfigFromOptions(options),
+    } as MCPServerConfig;
 
     const result = await withEphemeralManager(
       config,
@@ -596,6 +611,7 @@ export function registerToolsCommands(program: Command): void {
   addHostOption(
     addSharedServerOptions(
     addTaskWatchTuningOptions(
+    addConformanceOptions(
     tools
       .command("call")
       .description("Call an MCP tool")
@@ -701,6 +717,7 @@ export function registerToolsCommands(program: Command): void {
       ),
     ),
     ),
+    ),
   ).action(async (options: ToolsCallOptions, command) => {
     const globalOptions = getGlobalOptions(command);
     const host = resolveHostFromOptions(options);
@@ -750,6 +767,7 @@ export function registerToolsCommands(program: Command): void {
     const config: MCPServerConfig = {
       ...baseConfig,
       ...(suppressParamHeaders ? { mirrorToolParamHeaders: false } : {}),
+      ...conformanceConfigFromOptions(options),
       ...(paramHeaderProbe ? { httpLogger: paramHeaderProbe.httpLogger } : {}),
     } as MCPServerConfig;
     const reporter = parseReporterFormat(options.reporter);

--- a/cli/src/lib/host-resolve.ts
+++ b/cli/src/lib/host-resolve.ts
@@ -85,7 +85,22 @@ export function applyHostToConfig(
             : {}),
         }
       : {};
-  return { ...config, ...identity, ...httpOnly } as MCPServerConfig;
+  // The client-conformance knobs are NOT http-only, unlike the two above.
+  // Pagination truncation is enforced by a transport wrapper on JSON-RPC
+  // frames, and the MRTR knob works through capability advertisement and the
+  // verb gates — neither mechanism is Streamable-HTTP-specific, and both are
+  // behaviors a stdio client can exhibit. Gating them to `url` would make a
+  // `--host` silently mean something different over stdio.
+  const conformance = {
+    ...(host.firstPageOnly ? { firstPageOnly: true } : {}),
+    ...(host.supportsMrtr === false ? { supportsMrtr: false } : {}),
+  };
+  return {
+    ...config,
+    ...identity,
+    ...httpOnly,
+    ...conformance,
+  } as MCPServerConfig;
 }
 
 /**

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -116,6 +116,46 @@ export function addHostOption(command: Command): Command {
   );
 }
 
+/**
+ * Add the client-conformance knobs — call a server as a client that differs
+ * from a fully-conforming one, without having to author a host first. The
+ * same behaviors `--host` carries via `mcpProfile.paginationTraversal` /
+ * `mcpProfile.mrtrSupport`; these flags are the ad-hoc way to reproduce them.
+ *
+ * Unlike `--no-param-headers`, NEITHER is HTTP-only: pagination truncation is
+ * enforced on JSON-RPC frames and the MRTR knob works through capability
+ * advertisement, so both mean the same thing over stdio.
+ */
+export function addConformanceOptions(command: Command): Command {
+  return command
+    .option(
+      "--first-page-only",
+      "Read only the first page of paginated lists, like the real hosts that never follow nextCursor. On 2026-07-28 this also stops SEP-2243 Mcp-Param-* mirroring for tools past page one, because the mirroring source is the page-one-only list the client cached.",
+    )
+    .option(
+      "--no-mrtr",
+      "Do NOT drive MRTR (resultType: input_required) rounds — call as a client that never implemented the 2026 pattern. Stops advertising elicitation on a modern connection, so a server that would have elicited answers -32021 instead.",
+    );
+}
+
+/**
+ * Reduce the conformance flags to the wire fields `MCPServerConfig` takes.
+ * Only the NON-default value is emitted, matching how the host-config
+ * reduction behaves — an absent flag must not pin the conforming default onto
+ * a config that never carried it.
+ */
+export function conformanceConfigFromOptions(options: {
+  firstPageOnly?: boolean;
+  mrtr?: boolean;
+}): { firstPageOnly?: true; supportsMrtr?: false } {
+  return {
+    ...(options.firstPageOnly === true ? { firstPageOnly: true as const } : {}),
+    // Commander defaults a `--no-x` flag to `true`, so only an explicit
+    // `false` means the user asked to disable MRTR.
+    ...(options.mrtr === false ? { supportsMrtr: false as const } : {}),
+  };
+}
+
 export function getGlobalOptions(command: Command): GlobalOptions {
   const options = command.optsWithGlobals() as Partial<GlobalOptions>;
   return {

--- a/cli/tests/host-resolve.test.ts
+++ b/cli/tests/host-resolve.test.ts
@@ -201,3 +201,40 @@ test("applyHostToConfig does not put the mirroring knob on a stdio config", () =
   assert.ok(!("mirrorToolParamHeaders" in record));
   assert.ok(!("mcpProtocolVersion" in record));
 });
+
+// Client-conformance knobs. Unlike the two above, these are NOT http-only:
+// pagination truncation is enforced on JSON-RPC frames and the MRTR knob works
+// through capability advertisement, so both mean the same thing over stdio.
+test("applyHostToConfig forwards the conformance knobs onto an HTTP config", () => {
+  const config = applyHostToConfig({ url: "https://example.com/mcp" } as MCPServerConfig, {
+    firstPageOnly: true,
+    supportsMrtr: false,
+    respectToolVisibility: undefined,
+  });
+  const record = config as Record<string, unknown>;
+  assert.equal(record.firstPageOnly, true);
+  assert.equal(record.supportsMrtr, false);
+});
+
+test("applyHostToConfig forwards the conformance knobs onto a STDIO config too", () => {
+  // The regression this guards: gating these behind `"url" in config` (as the
+  // mirroring knob is) would make `--host` silently mean something different
+  // over stdio — a first-page-only host would quietly walk every page.
+  const config = applyHostToConfig({ command: "node" } as MCPServerConfig, {
+    firstPageOnly: true,
+    supportsMrtr: false,
+    respectToolVisibility: undefined,
+  });
+  const record = config as Record<string, unknown>;
+  assert.equal(record.firstPageOnly, true);
+  assert.equal(record.supportsMrtr, false);
+});
+
+test("applyHostToConfig leaves the conformance fields off for a default host", () => {
+  const config = applyHostToConfig({ url: "https://example.com/mcp" } as MCPServerConfig, {
+    respectToolVisibility: undefined,
+  });
+  const record = config as Record<string, unknown>;
+  assert.ok(!("firstPageOnly" in record));
+  assert.ok(!("supportsMrtr" in record));
+});

--- a/cli/tests/mcp-header-flags.test.ts
+++ b/cli/tests/mcp-header-flags.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { parseMcpHeaderOption } from "../src/commands/tools.js";
+import { conformanceConfigFromOptions } from "../src/lib/server-config.js";
 import { CliError } from "../src/lib/output.js";
 
 /**
@@ -65,5 +66,31 @@ test("the parsed headers are exactly what --mcp-header promises", () => {
       "Mcp-Param-Tenant=acme",
     ]),
     { "Mcp-Param-Region": "eu-west", "Mcp-Param-Tenant": "acme" },
+  );
+});
+
+// --first-page-only / --no-mrtr reduction. Commander gives a `--no-x` flag a
+// `true` default, so only an explicit `false` may reach the config.
+test("conformanceConfigFromOptions emits nothing when neither flag is passed", () => {
+  assert.deepEqual(conformanceConfigFromOptions({ mrtr: true }), {});
+  assert.deepEqual(conformanceConfigFromOptions({}), {});
+});
+
+test("conformanceConfigFromOptions maps --first-page-only", () => {
+  assert.deepEqual(conformanceConfigFromOptions({ firstPageOnly: true, mrtr: true }), {
+    firstPageOnly: true,
+  });
+});
+
+test("conformanceConfigFromOptions maps --no-mrtr to supportsMrtr: false", () => {
+  assert.deepEqual(conformanceConfigFromOptions({ mrtr: false }), {
+    supportsMrtr: false,
+  });
+});
+
+test("conformanceConfigFromOptions maps both together", () => {
+  assert.deepEqual(
+    conformanceConfigFromOptions({ firstPageOnly: true, mrtr: false }),
+    { firstPageOnly: true, supportsMrtr: false },
   );
 });

--- a/docs/cli/tools-resources-prompts.mdx
+++ b/docs/cli/tools-resources-prompts.mdx
@@ -66,6 +66,35 @@ Tool arguments can be inline JSON, `@path`, `-` for stdin, or `--tool-args-stdin
   not enumerated.
 </Note>
 
+### Calling as a less-capable client
+
+Real MCP clients differ from each other, and from the spec. Two flags let you
+call a server as one of those clients, without authoring a host first — the
+same behaviors a `--host` carries via its `mcpProfile`:
+
+```bash
+# Read only the first page of tools/list, like the hosts that never follow
+# nextCursor. Tools past page one are invisible to the call.
+mcpjam tools list --url https://your-server.com/mcp --first-page-only
+
+# Call as a client that never implemented MRTR. On 2026-07-28 this stops
+# advertising `elicitation`, so a server that would have elicited answers
+# -32021 instead of starting a round.
+mcpjam tools call --url https://your-server.com/mcp \
+  --tool-name confirm_delete --tool-args '{"id":"42"}' --no-mrtr
+```
+
+Unlike the header flags below, neither is HTTP-only — pagination truncation and
+the MRTR knob both work over stdio, so they mean the same thing with
+`--command`.
+
+`--first-page-only` has a second-order effect worth knowing on `2026-07-28`:
+the SEP-2243 mirroring source is the aggregated tool list the client cached, so
+a tool from page two is called with **no** `Mcp-Param-*` headers and a strict
+server answers `-32020`. That is not a bug in the flag — it is exactly how a
+real first-page-only client fails, and it is often the reason a tool "works in
+the inspector but not in that host".
+
 ### Debugging `Mcp-Param-*` headers (SEP-2243)
 
 On a `2026-07-28` HTTP connection, a tool argument annotated with `x-mcp-header`


### PR DESCRIPTION
## What

S4 of the client-conformance knob program: carries `paginationTraversal` and `mrtrSupport` (enforced in #3650 / #3653) through the CLI.

## The bug

`applyHostToConfig` mapped **neither** knob. So `--host` on a host configured as a first-page-only or non-MRTR client silently ran as a fully conforming one — on every CLI path, since both `lib/ephemeral.ts` and `commands/tools.ts` route through that function. The knobs existed, were enforced in the SDK, and simply never reached a CLI connection.

## One deliberate departure from the code beside it

These are **not** added to the `httpOnly` block. The protocol pin and the SEP-2243 mirroring knob live there for a real reason — mirroring genuinely is a Streamable HTTP concern, so the flag is inert on stdio. But:

- pagination truncation is enforced by a transport wrapper on JSON-RPC frames, and
- the MRTR knob works through capability advertisement and the verb gates.

Neither mechanism is HTTP-specific, and both are behaviors a stdio client can exhibit. Gating them to `"url" in config` would make `--host` quietly mean something different over stdio — a first-page-only host would walk every page. There's a test that fails if someone later "fixes" this for consistency with its neighbours.

## New flags

`--first-page-only` (on `tools list` and `tools call`) and `--no-mrtr` (on `tools call`), to reproduce the behaviors ad hoc without authoring a host. Both follow the `--no-param-headers` precedent for reduction (Commander defaults a `--no-x` flag to `true`, so only an explicit `false` reaches the config), but neither is refused on stdio, for the reason above.

Docs updated with a "Calling as a less-capable client" section that calls out the second-order effect explicitly, since it otherwise reads as a CLI bug: `--first-page-only` makes a page-two tool call go out with **no** `Mcp-Param-*` and take a `-32020` — which is often exactly why a tool "works in the inspector but not in that host".

## Tests

CLI suite green (547). New coverage:
- host knobs forwarded onto an HTTP config
- host knobs forwarded onto a **stdio** config (the regression guard described above)
- default host leaves both fields off entirely
- flag reduction: nothing emitted when unset, `--first-page-only` → `firstPageOnly: true`, `--no-mrtr` → `supportsMrtr: false`, and both together

## Verify

Root `npm run verify`: typecheck clean (0 TS errors), SDK 3452 passed, widget 8 passed, CLI 547 passed.

The inspector workspace hit **one** failure, `guest-token.test.ts`, with `ENOSPC: no space left on device` while writing a temp PEM — the machine's disk is at 100%. Unrelated to this change (no CLI or SDK surface involved); re-running that file in isolation passes 38/38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only wiring and flag parsing atop existing SDK enforcement; behavior changes are intentional and covered by new unit tests, with no auth or data-path changes.
> 
> **Overview**
> **Fixes `--host` ignoring pagination and MRTR client profiles** — `applyHostToConfig` now maps `firstPageOnly` and `supportsMrtr` onto `MCPServerConfig`, so hosts configured as first-page-only or non-MRTR clients no longer run as fully conforming ones.
> 
> Those knobs are applied for **both HTTP and stdio** (not gated like SEP-2243 mirroring), with tests guarding against regressing stdio behavior.
> 
> **Adds ad-hoc conformance flags** via `addConformanceOptions` / `conformanceConfigFromOptions`: `--first-page-only` on `tools list` and `tools call`, and `--no-mrtr` on `tools call`. `tools list`/`call` merge the reduced config into the ephemeral connection.
> 
> Docs add a **“Calling as a less-capable client”** section describing stdio parity and the second-order SEP-2243 effect when only page one of `tools/list` is cached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32477cec5226e9383bf3ac611f52dc000d6c181c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwarded client‑conformance knobs to all CLI connections and added flags to emulate less‑capable clients. Fixes hosts set as first‑page‑only or non‑MRTR being treated as fully conforming.

- **New Features**
  - `--first-page-only` on `tools list` and `tools call` to read only page one.
  - `--no-mrtr` on `tools call` to disable MRTR rounds.
  - Works over HTTP and stdio; flags only set fields when explicitly passed.

- **Bug Fixes**
  - `applyHostToConfig` now forwards `firstPageOnly` and `supportsMrtr` from `--host` on both HTTP and stdio.
  - Docs updated with “Calling as a less-capable client.”
  - Note: with `--first-page-only`, page‑two tools are invisible and may trigger `-32020` due to missing `Mcp-Param-*` headers.

<sup>Written for commit 32477cec5226e9383bf3ac611f52dc000d6c181c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

