### PR TITLE
fix(oauth): send MCP-Protocol-Version on the executed authenticated r…

### DIFF
--- a/.changeset/oauth-replay-protocol-version-header.md
+++ b/.changeset/oauth-replay-protocol-version-header.md
@@ -1,0 +1,13 @@
+---
+"@mcpjam/sdk": patch
+---
+
+Fix: the OAuth debug flow's executed authenticated replay now sends the
+`MCP-Protocol-Version` header it already previewed (2025-06-18 and
+2025-11-25 state machines), matching the 2026-07-28 machine.
+
+The 2025-06-18 spec's Protocol Version Header section requires the header on
+all requests to the MCP server after initialization; the preview step already
+advertised it, but the request that actually went over the wire omitted it.
+The 2025-03-26 machine is deliberately untouched — that revision predates the
+header, so omitting it on the replay is correct there.

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -1875,6 +1875,7 @@ export const createDebugOAuthStateMachine = (
                   Authorization: `Bearer ${state.accessToken}`,
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
+                  "MCP-Protocol-Version": "2025-06-18",
                 }),
                 body: JSON.stringify(
                   buildInitializeRequestBody({

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -2168,6 +2168,7 @@ export const createDebugOAuthStateMachine = (
                   Authorization: `Bearer ${state.accessToken}`,
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
+                  "MCP-Protocol-Version": "2025-11-25",
                 }),
                 body: JSON.stringify(
                   buildInitializeRequestBody({

--- a/sdk/tests/oauth/hardening-shared-pass.test.ts
+++ b/sdk/tests/oauth/hardening-shared-pass.test.ts
@@ -414,3 +414,53 @@ describe("pre-401 probe carries the MCP-Protocol-Version header", () => {
     },
   );
 });
+
+// -----------------------------------------------------------------------------
+// Defect 5: the executed authenticated replay must carry the same
+// MCP-Protocol-Version header its preview advertises. The header exists from
+// the 2025-06-18 revision onward ("MUST include on all subsequent requests");
+// 2025-03-26 predates it, so that machine must NOT send it on the replay.
+// -----------------------------------------------------------------------------
+describe("authenticated replay carries MCP-Protocol-Version where the spec defines it", () => {
+  const REPLAY_VERSIONS: Array<[OAuthProtocolVersion, string | undefined]> = [
+    ["2025-03-26", undefined],
+    ["2025-06-18", "2025-06-18"],
+    ["2025-11-25", "2025-11-25"],
+    ["2026-07-28", "2026-07-28"],
+  ];
+
+  it.each(REPLAY_VERSIONS)(
+    "executed authenticated replay header for %s",
+    async (version, expectedHeaderValue) => {
+      const requestExecutor = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: { "content-type": "application/json" },
+        body: { jsonrpc: "2.0", id: 2, result: {} },
+      });
+
+      const seed: Partial<OAuthFlowState> = {
+        currentStep: "authenticated_mcp_request",
+        serverUrl: SERVER_URL,
+        accessToken: "test-access-token",
+      };
+
+      const { machine } = makeMachine(version, seed, { requestExecutor });
+      await machine.proceedToNextStep();
+
+      expect(requestExecutor).toHaveBeenCalledTimes(1);
+      const replay = requestExecutor.mock.calls[0][0];
+      const headerEntry = Object.entries(replay.headers ?? {}).find(
+        ([k]) => k.toLowerCase() === "mcp-protocol-version",
+      );
+      if (expectedHeaderValue === undefined) {
+        expect(headerEntry).toBeUndefined();
+      } else {
+        expect(headerEntry?.[1]).toBe(expectedHeaderValue);
+      }
+      // The replay must actually be authenticated.
+      expect(replay.headers?.Authorization).toBe("Bearer test-access-token");
+    },
+  );
+});


### PR DESCRIPTION
…eplay

The 2025-06-18 and 2025-11-25 debug OAuth machines previewed the MCP-Protocol-Version header on the post-token authenticated replay but omitted it from the request that actually went over the wire. The 2025-06-18 spec's Protocol Version Header section requires the header on all requests to the MCP server after initialization; 2026-07-28 already sent it on both. 2025-03-26 is deliberately untouched — that revision predates the header — and the new regression test locks in both the fix and the deliberate omission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `MCP-Protocol-Version` header on the executed authenticated replay in OAuth debug flows. Aligns 2025-06-18 and 2025-11-25 machines with the spec and existing 2026-07-28 behavior.

- **Bug Fixes**
  - Add `MCP-Protocol-Version` to replay requests in `debug-oauth-2025-06-18.ts` and `debug-oauth-2025-11-25.ts`.
  - Keep 2025-03-26 machine unchanged (header predates that revision).
  - Add regression tests to assert header presence/absence per version and that the replay is authenticated.
  - Patch release for `@mcpjam/sdk`.

<sup>Written for commit 3a35062f16bb5581d1cda07e4fa03b857e042039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

