### PR TITLE
feat(inspector): carry the client-conformance knobs through every connection (P1)

### DIFF
--- a/.changeset/conformance-knobs-product-plumbing.md
+++ b/.changeset/conformance-knobs-product-plumbing.md
@@ -1,0 +1,29 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Carry the client-conformance knobs (`mcpProfile.paginationTraversal` /
+`mcpProfile.mrtrSupport`) from the active host through every connection the
+product opens — local and hosted, connect and the ephemeral managers that
+chat, eval, prompt and journey runs build.
+
+The knobs are only ever *carried*, never derived, and the failure mode of
+missing one site is silent: a host configured as a degraded client would
+execute as a fully conforming one on whichever flow got skipped. The four
+hosted body builders now emit them through a single shared helper for that
+reason, and the hosted route schema declares them (Zod strips what it does not
+declare).
+
+The host stays authoritative in BOTH directions via a new
+`applyHostConformanceKnobs` overlay, the sibling of the existing mirroring
+overlay: because these wire fields are suppression switches with no positive
+state, a body pin must be REMOVED when the host wants the full behavior, not
+merely left unmatched. Otherwise a share-link body could post
+`firstPageOnly: true` / `supportsMrtr: false` and silently degrade a
+conforming host — hiding tools from the model, or dropping MRTR rounds
+mid-conversation.
+
+Unlike the SEP-2243 mirroring knob beside them, both are forwarded on the
+**stdio** branch too: pagination truncation is enforced on JSON-RPC frames and
+the MRTR knob works through capability advertisement, so neither is a
+Streamable HTTP concern.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2859,6 +2859,14 @@ export default function App() {
     // only `"omit"` reaches the wire, as `false`.
     const mirrorToolParamHeaders =
       activeMcpProfile?.toolParamHeaderMirroring === "omit" ? false : undefined;
+    // Sibling conformance knobs — same host-level shape, only the non-default
+    // value reaches the wire.
+    const firstPageOnly =
+      activeMcpProfile?.paginationTraversal === "firstPageOnly"
+        ? (true as const)
+        : undefined;
+    const supportsMrtr =
+      activeMcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
 
     return {
       clientInfo,
@@ -2868,6 +2876,8 @@ export default function App() {
           ? mcpProtocolVersionsByServerId
           : undefined,
       mirrorToolParamHeaders,
+      firstPageOnly,
+      supportsMrtr,
       xaaPolicy,
     };
   }, [
@@ -2889,6 +2899,8 @@ export default function App() {
     mcpProtocolVersionsByServerId:
       hostedMcpProfilePins.mcpProtocolVersionsByServerId,
     mirrorToolParamHeaders: hostedMcpProfilePins.mirrorToolParamHeaders,
+    firstPageOnly: hostedMcpProfilePins.firstPageOnly,
+    supportsMrtr: hostedMcpProfilePins.supportsMrtr,
     xaaPolicy: hostedMcpProfilePins.xaaPolicy,
     clientConfigSyncPending:
       isClientConfigSyncPending || isProjectServerConfigLoading,

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -15,6 +15,9 @@ interface UseApiContextOptions {
   // SEP-2243 mirroring, resolved from the active host's
   // `mcpProfile.toolParamHeaderMirroring`. Only ever `false`.
   mirrorToolParamHeaders?: boolean;
+  // Sibling conformance knobs; only the non-default value is ever set.
+  firstPageOnly?: true;
+  supportsMrtr?: false;
   // Active host's enterprise-managed authorization policy (validated `on`
   // value only) — rides ad-hoc chat/eval request bodies.
   xaaPolicy?: XaaEnterprisePolicy;
@@ -38,6 +41,8 @@ export function useApiContext({
   supportedProtocolVersions,
   mcpProtocolVersionsByServerId,
   mirrorToolParamHeaders,
+  firstPageOnly,
+  supportsMrtr,
   xaaPolicy,
   clientConfigSyncPending,
   getAccessToken,
@@ -66,6 +71,8 @@ export function useApiContext({
       supportedProtocolVersions,
       mcpProtocolVersionsByServerId,
       mirrorToolParamHeaders,
+      firstPageOnly,
+      supportsMrtr,
       xaaPolicy,
       clientConfigSyncPending,
       getAccessToken,
@@ -88,6 +95,8 @@ export function useApiContext({
     supportedProtocolVersions,
     mcpProtocolVersionsByServerId,
     mirrorToolParamHeaders,
+    firstPageOnly,
+    supportsMrtr,
     xaaPolicy,
     clientConfigSyncPending,
     getAccessToken,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1390,6 +1390,14 @@ export function useServerState({
       if (mcpProfile?.toolParamHeaderMirroring === "omit") {
         defaults.mirrorToolParamHeaders = false;
       }
+      // Sibling client-conformance knobs, same host-level/only-the-
+      // non-default-value discipline as the mirroring knob above.
+      if (mcpProfile?.paginationTraversal === "firstPageOnly") {
+        defaults.firstPageOnly = true;
+      }
+      if (mcpProfile?.mrtrSupport === "none") {
+        defaults.supportsMrtr = false;
+      }
       // Enterprise-managed authorization policy from the active host's
       // mcpProfile. Sent only when validly ON; an `invalid` stored policy
       // fails the connect client-side with an actionable message instead of

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -39,6 +39,16 @@ export interface ApiContext {
    */
   mirrorToolParamHeaders?: boolean;
   /**
+   * Sibling client-conformance knobs from the active host's
+   * `mcpProfile.paginationTraversal` / `mcpProfile.mrtrSupport`. Same
+   * carry-everywhere hazard as the mirroring knob above: every ephemeral
+   * manager (chat, eval, prompt, journey) must see them, or those runs
+   * quietly execute as a fully conforming client. Only the non-default value
+   * is ever set.
+   */
+  firstPageOnly?: true;
+  supportsMrtr?: false;
+  /**
    * The active host's enterprise-managed authorization policy (validated
    * `on` value only). Rides ad-hoc chat/eval bodies; ignored server-side
    * whenever a backend host config exists (chatbox/host-bound turns read
@@ -396,6 +406,36 @@ function getHostedAccessScope(): HostedAccessScope | undefined {
   return getHostedChatboxId() ? "chat_v2" : undefined;
 }
 
+/**
+ * The client-conformance knobs, reduced to the wire fields the hosted routes
+ * accept. ONE emitter for all four body builders: these fields are only ever
+ * carried, never derived, and the failure mode of forgetting one is silent —
+ * a host configured as a non-conforming client would execute as a conforming
+ * one on whichever flow got missed. Declaring them on `ApiContext` is not
+ * enough; they only reach the wire if they are spread into the body.
+ *
+ * Only the NON-default value is emitted, matching how the SDK reads them: an
+ * absent field means the full behavior, so sending the default would put a
+ * field on every request that never carried one.
+ */
+function conformanceWireFields(apiContext: ApiContext): {
+  mirrorToolParamHeaders?: false;
+  firstPageOnly?: true;
+  supportsMrtr?: false;
+} {
+  return {
+    ...(apiContext.mirrorToolParamHeaders === false
+      ? { mirrorToolParamHeaders: false as const }
+      : {}),
+    ...(apiContext.firstPageOnly === true
+      ? { firstPageOnly: true as const }
+      : {}),
+    ...(apiContext.supportsMrtr === false
+      ? { supportsMrtr: false as const }
+      : {}),
+  };
+}
+
 export function buildServerRequest(
   serverNameOrId: string
 ): Record<string, unknown> {
@@ -441,9 +481,7 @@ export function buildServerRequest(
     // ephemeral connections bypass enterprise-managed auth. Ignored
     // server-side for chatbox-scoped calls (server-authoritative fetch wins).
     // Only `false` reaches the wire; see `ApiContext.mirrorToolParamHeaders`.
-    ...(apiContext.mirrorToolParamHeaders === false
-      ? { mirrorToolParamHeaders: false }
-      : {}),
+    ...conformanceWireFields(apiContext),
     ...(apiContext.xaaPolicy ? { xaaPolicy: apiContext.xaaPolicy } : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
@@ -460,6 +498,8 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   supportedProtocolVersions?: string[];
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
   mirrorToolParamHeaders?: boolean;
+  firstPageOnly?: true;
+  supportsMrtr?: false;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -491,9 +531,7 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
       ? { mcpProtocolVersionsByServerId: protocolVersions }
       : {}),
     // Only `false` reaches the wire; see `ApiContext.mirrorToolParamHeaders`.
-    ...(apiContext.mirrorToolParamHeaders === false
-      ? { mirrorToolParamHeaders: false }
-      : {}),
+    ...conformanceWireFields(apiContext),
     ...(apiContext.xaaPolicy ? { xaaPolicy: apiContext.xaaPolicy } : {}),
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
@@ -537,6 +575,8 @@ export function buildResolvedServerBatchRequest(input: {
   supportedProtocolVersions?: string[];
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
   mirrorToolParamHeaders?: boolean;
+  firstPageOnly?: true;
+  supportsMrtr?: false;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -560,9 +600,7 @@ export function buildResolvedServerBatchRequest(input: {
       ? { mcpProtocolVersionsByServerId: protocolVersions }
       : {}),
     // Only `false` reaches the wire; see `ApiContext.mirrorToolParamHeaders`.
-    ...(apiContext.mirrorToolParamHeaders === false
-      ? { mirrorToolParamHeaders: false }
-      : {}),
+    ...conformanceWireFields(apiContext),
     ...(apiContext.xaaPolicy ? { xaaPolicy: apiContext.xaaPolicy } : {}),
     ...(input.oauthTokens ? { oauthTokens: input.oauthTokens } : {}),
     ...(input.accessScope ? { accessScope: input.accessScope } : {}),
@@ -582,6 +620,8 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   supportedProtocolVersions?: string[];
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
   mirrorToolParamHeaders?: boolean;
+  firstPageOnly?: true;
+  supportsMrtr?: false;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -614,9 +654,7 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
       ? { mcpProtocolVersionsByServerId: protocolVersions }
       : {}),
     // Only `false` reaches the wire; see `ApiContext.mirrorToolParamHeaders`.
-    ...(apiContext.mirrorToolParamHeaders === false
-      ? { mirrorToolParamHeaders: false }
-      : {}),
+    ...conformanceWireFields(apiContext),
     ...(apiContext.xaaPolicy ? { xaaPolicy: apiContext.xaaPolicy } : {}),
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -49,6 +49,12 @@ export type HostedServerValidateContext = {
    * does.
    */
   mirrorToolParamHeaders?: boolean;
+  /**
+   * Sibling conformance knobs from `mcpProfile.paginationTraversal` /
+   * `mcpProfile.mrtrSupport`. Only the non-default value is ever set.
+   */
+  firstPageOnly?: true;
+  supportsMrtr?: false;
 };
 
 export interface HostedServerValidateResponse {
@@ -116,6 +122,12 @@ export async function validateHostedServer(
         // the same drop-on-the-floor step the pins above were plumbed to fix.
         ...(hostedContext.mirrorToolParamHeaders === false
           ? { mirrorToolParamHeaders: false }
+          : {}),
+        ...(hostedContext.firstPageOnly === true
+          ? { firstPageOnly: true }
+          : {}),
+        ...(hostedContext.supportsMrtr === false
+          ? { supportsMrtr: false }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -105,6 +105,13 @@ function buildHostedValidationContext(
     ...(options.connectionDefaults?.mirrorToolParamHeaders === false
       ? { mirrorToolParamHeaders: false }
       : {}),
+    // Sibling conformance knobs — same plumb-or-drop-silently hazard.
+    ...(options.connectionDefaults?.firstPageOnly === true
+      ? { firstPageOnly: true }
+      : {}),
+    ...(options.connectionDefaults?.supportsMrtr === false
+      ? { supportsMrtr: false }
+      : {}),
   };
 }
 

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -147,6 +147,12 @@ export const projectServerSchema = z.object({
   // client sends it on every hosted route call once the host opts in. Only
   // `false` is ever sent: `"mirror"` is the SDK's no-field default.
   mirrorToolParamHeaders: z.boolean().optional(),
+  // Sibling client-conformance knobs. Declared for the SAME reason as the
+  // field above: Zod strips what it does not declare, so a knob the client
+  // faithfully sends would vanish here and the hosted session would execute
+  // as a fully conforming client. Only the non-default value is ever sent.
+  firstPageOnly: z.boolean().optional(),
+  supportsMrtr: z.boolean().optional(),
   // Host enterprise-managed authorization policy, resolved client-side from
   // `hostConfig.mcpProfile.extensions`. Declared here (like the pins above)
   // so the wire contract documents it, but VALIDATED by
@@ -768,6 +774,13 @@ export function toHttpConfig(
      * `BaseServerConfig.mirrorToolParamHeaders`.
      */
     mirrorToolParamHeaders?: boolean;
+    /**
+     * Client-conformance knobs (`mcpProfile.paginationTraversal` /
+     * `mcpProfile.mrtrSupport`), forwarded onto
+     * `BaseServerConfig.firstPageOnly` / `.supportsMrtr`.
+     */
+    firstPageOnly?: boolean;
+    supportsMrtr?: boolean;
   }
 ): HttpServerConfig {
   if (authResponse.serverConfig.transportType !== "http") {
@@ -829,6 +842,11 @@ export function toHttpConfig(
     ...(initializePins?.mirrorToolParamHeaders === false
       ? { mirrorToolParamHeaders: false }
       : {}),
+    // Same host-level treatment for the sibling conformance knobs: only the
+    // non-default value is meaningful, and there is no per-server map to
+    // resolve against.
+    ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
+    ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
   };
 }
 
@@ -847,6 +865,8 @@ function resolveEffectiveInitializePinsForServer(
     supportedProtocolVersions?: string[];
     mcpProtocolVersion?: McpProtocolVersion;
     mirrorToolParamHeaders?: boolean;
+    firstPageOnly?: boolean;
+    supportsMrtr?: boolean;
   },
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>
 ):
@@ -886,6 +906,11 @@ function resolveEffectiveInitializePinsForServer(
     ...(initializePins?.mirrorToolParamHeaders === false
       ? { mirrorToolParamHeaders: false }
       : {}),
+    // Same host-level treatment for the sibling conformance knobs: only the
+    // non-default value is meaningful, and there is no per-server map to
+    // resolve against.
+    ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
+    ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
   };
 
   return Object.keys(resolved).length > 0 ? resolved : undefined;
@@ -1551,6 +1576,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     supportedProtocolVersions?: string[];
     mcpProtocolVersion?: McpProtocolVersion;
     mirrorToolParamHeaders?: boolean;
+    firstPageOnly?: boolean;
+    supportsMrtr?: boolean;
   };
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
 } {
@@ -1583,11 +1610,16 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
   // Only an explicit `false` opts into the non-conforming simulation; every
   // other value (including a stray `true`) falls back to mirroring.
   const suppressParamMirroring = raw.mirrorToolParamHeaders === false;
+  // Same one-explicit-value rule for the sibling knobs.
+  const truncatePagination = raw.firstPageOnly === true;
+  const disableMrtr = raw.supportsMrtr === false;
   const initializePins =
     initializeClientInfo ||
     initializeSupportedVersions ||
     initializeWireMode ||
-    suppressParamMirroring
+    suppressParamMirroring ||
+    truncatePagination ||
+    disableMrtr
       ? {
           ...(initializeClientInfo ? { clientInfo: initializeClientInfo } : {}),
           ...(initializeSupportedVersions
@@ -1596,6 +1628,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
           ...(initializeWireMode
             ? { mcpProtocolVersion: initializeWireMode }
             : {}),
+          ...(truncatePagination ? { firstPageOnly: true } : {}),
+          ...(disableMrtr ? { supportsMrtr: false } : {}),
           ...(suppressParamMirroring
             ? { mirrorToolParamHeaders: false }
             : {}),

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -67,8 +67,10 @@ import {
 } from "../../utils/chatbox-runtime-config.js";
 import { fetchHostRuntimeConfig } from "../../utils/host-runtime-config.js";
 import {
+  applyHostConformanceKnobs,
   applyHostParamMirroring,
   parseXaaPolicyValue,
+  conformanceKnobsFromMcpProfile,
   mirrorToolParamHeadersFromMcpProfile,
   xaaPolicyFromMcpProfile,
 } from "../../utils/effective-auth.js";
@@ -526,9 +528,14 @@ chatV2.post("/", async (c) => {
     // silently stops sending headers the server cross-checks. On ad-hoc
     // turns the body value stands: the caller owns that session.
     const effectiveInitializePins = hostRuntimeConfig
-      ? applyHostParamMirroring(
-          initializePins,
-          mirrorToolParamHeadersFromMcpProfile(
+      ? applyHostConformanceKnobs(
+          applyHostParamMirroring(
+            initializePins,
+            mirrorToolParamHeadersFromMcpProfile(
+              (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile
+            )
+          ),
+          conformanceKnobsFromMcpProfile(
             (hostRuntimeConfig as { mcpProfile?: unknown }).mcpProfile
           )
         )

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { XAA_MCP_EXTENSION } from "@mcpjam/sdk";
 import {
+  applyHostConformanceKnobs,
   applyHostParamMirroring,
+  conformanceKnobsFromMcpProfile,
   mirrorToolParamHeadersFromMcpProfile,
   resolveEffectiveAuthMethod,
   withXaaExtensionCapability,
@@ -225,5 +227,83 @@ describe("applyHostParamMirroring", () => {
     const pins = { protocolVersion: "2026-07-28" };
     expect(applyHostParamMirroring(pins, undefined)).toBe(pins);
     expect(applyHostParamMirroring(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("conformanceKnobsFromMcpProfile", () => {
+  it("reads the non-default literals", () => {
+    expect(
+      conformanceKnobsFromMcpProfile({
+        paginationTraversal: "firstPageOnly",
+        mrtrSupport: "none",
+      })
+    ).toEqual({ firstPageOnly: true, supportsMrtr: false });
+  });
+
+  it("collapses the default literals, an absent profile and junk to undefined", () => {
+    // Unreadable input must mean "behave conformantly", never the simulation.
+    for (const profile of [
+      { paginationTraversal: "full", mrtrSupport: "full" },
+      { paginationTraversal: "sometimes", mrtrSupport: "partial" },
+      {},
+      undefined,
+      null,
+      "nope",
+    ]) {
+      expect(conformanceKnobsFromMcpProfile(profile)).toEqual({
+        firstPageOnly: undefined,
+        supportsMrtr: undefined,
+      });
+    }
+  });
+});
+
+describe("applyHostConformanceKnobs", () => {
+  const off = { firstPageOnly: undefined, supportsMrtr: undefined } as const;
+
+  it("forces the pins on when the host asks for the degraded client", () => {
+    expect(
+      applyHostConformanceKnobs(undefined, {
+        firstPageOnly: true,
+        supportsMrtr: false,
+      })
+    ).toEqual({ firstPageOnly: true, supportsMrtr: false });
+    expect(
+      applyHostConformanceKnobs(
+        { protocolVersion: "2026-07-28" } as Record<string, unknown>,
+        { firstPageOnly: true, supportsMrtr: undefined }
+      )
+    ).toEqual({ protocolVersion: "2026-07-28", firstPageOnly: true });
+  });
+
+  it("strips caller pins when the host wants the full behavior", () => {
+    // The security-relevant direction: a share-link body must not be able to
+    // degrade a conforming host into one that hides tools from the model or
+    // silently drops MRTR rounds.
+    expect(
+      applyHostConformanceKnobs(
+        {
+          protocolVersion: "2026-07-28",
+          firstPageOnly: true,
+          supportsMrtr: false,
+        } as Record<string, unknown>,
+        off
+      )
+    ).toEqual({ protocolVersion: "2026-07-28" });
+  });
+
+  it("strips only the knob the host reclaims, keeping the other", () => {
+    expect(
+      applyHostConformanceKnobs(
+        { firstPageOnly: true, supportsMrtr: false } as Record<string, unknown>,
+        { firstPageOnly: undefined, supportsMrtr: false }
+      )
+    ).toEqual({ supportsMrtr: false });
+  });
+
+  it("leaves untouched pins alone", () => {
+    const pins = { protocolVersion: "2026-07-28" };
+    expect(applyHostConformanceKnobs(pins, off)).toBe(pins);
+    expect(applyHostConformanceKnobs(undefined, off)).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -226,6 +226,72 @@ export function applyHostParamMirroring<
 }
 
 /**
+ * The client-conformance knobs a host config asks for, read from its
+ * `mcpProfile`. Each collapses to `undefined` when the host wants the full
+ * (spec-conforming) behavior, exactly as
+ * {@link mirrorToolParamHeadersFromMcpProfile} does — the wire fields are
+ * suppression switches with no positive state.
+ *
+ * Like the mirroring reader, this cannot fail closed into an error: an
+ * unreadable value means "behave conformantly", which is always safe.
+ */
+export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
+  firstPageOnly: true | undefined;
+  supportsMrtr: false | undefined;
+} {
+  const profile =
+    mcpProfile !== null && typeof mcpProfile === "object"
+      ? (mcpProfile as {
+          paginationTraversal?: unknown;
+          mrtrSupport?: unknown;
+        })
+      : undefined;
+  return {
+    firstPageOnly:
+      profile?.paginationTraversal === "firstPageOnly" ? true : undefined,
+    supportsMrtr: profile?.mrtrSupport === "none" ? false : undefined,
+  };
+}
+
+/**
+ * Overlay a host's client-conformance decisions onto the initialize pins a
+ * request body carried — the sibling of {@link applyHostParamMirroring}, and
+ * an overlay for the identical reason.
+ *
+ * These pins are suppression switches with no positive state, so a body pin
+ * has to be REMOVED when the host wants the full behavior, not merely left
+ * unmatched. Merging instead would make a published host only half
+ * authoritative: it could turn a knob on but never keep it off, and a
+ * share-link body could post `firstPageOnly: true` or `supportsMrtr: false`
+ * to make a conforming host silently execute as a degraded client — hiding
+ * tools from the model, or dropping MRTR rounds mid-conversation.
+ *
+ * Every other pin is passed through, and an absent-pins body stays absent
+ * unless the host actually asks for a non-default knob.
+ */
+export function applyHostConformanceKnobs<
+  T extends { firstPageOnly?: boolean; supportsMrtr?: boolean }
+>(
+  pins: T | undefined,
+  host: { firstPageOnly: true | undefined; supportsMrtr: false | undefined }
+): T | undefined {
+  let next = pins;
+  if (host.firstPageOnly === true) {
+    next = { ...((next ?? {}) as T), firstPageOnly: true };
+  } else if (next?.firstPageOnly !== undefined) {
+    const { firstPageOnly: _hostOverrides, ...rest } = next;
+    next = rest as T;
+  }
+  if (host.supportsMrtr === false) {
+    next = { ...((next ?? {}) as T), supportsMrtr: false };
+  } else if (next?.supportsMrtr !== undefined) {
+    const { supportsMrtr: _hostOverrides, ...rest } = next;
+    next = rest as T;
+  }
+  return next;
+}
+
+/**
  * Server-authoritative policy read from a BACKEND-PROJECTED host config's
  * `mcpProfile` (chatbox turns, host-bound turns, swarm snapshots, eval host
  * configs). Three-state: off → undefined, on → the policy, invalid →

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -412,6 +412,15 @@ export function parseConnectionDefaults(
     out.mirrorToolParamHeaders = false;
   }
 
+  // Sibling client-conformance knobs, same fail-closed reading: only the
+  // explicit non-default value opts into the simulation.
+  if (input.firstPageOnly === true) {
+    out.firstPageOnly = true;
+  }
+  if (input.supportsMrtr === false) {
+    out.supportsMrtr = false;
+  }
+
   // Enterprise-managed authorization policy. UNLIKE every field above, this
   // one is enforcement, not advisory: silently dropping a malformed value
   // would un-enforce a policy the host believes is on (fail-open), so the
@@ -545,6 +554,14 @@ export function toMCPServerConfig(
      */
     mirrorToolParamHeaders?: boolean;
     /**
+     * Client-conformance knobs. UNLIKE the mirroring flag above these are NOT
+     * HTTP-only — pagination truncation is enforced on JSON-RPC frames and
+     * the MRTR knob works through capability advertisement — so they are
+     * forwarded on the stdio branch too.
+     */
+    firstPageOnly?: boolean;
+    supportsMrtr?: boolean;
+    /**
      * The host's enterprise-managed authorization policy (validated `on`
      * value). Present ⇒ the EMA extension is advertised on EVERY server of
      * this host — including explicit-OAuth overrides and stdio servers: the
@@ -600,6 +617,10 @@ export function toMCPServerConfig(
     ) {
       stdio.supportedProtocolVersions = options.supportedProtocolVersions;
     }
+    // The conformance knobs DO apply on stdio (see the options docblock), so
+    // unlike the mirroring flag they are forwarded here as well as on HTTP.
+    if (options?.firstPageOnly === true) stdio.firstPageOnly = true;
+    if (options?.supportsMrtr === false) stdio.supportsMrtr = false;
     return stdio as MCPServerConfig;
   }
 
@@ -661,6 +682,8 @@ export function toMCPServerConfig(
   // carried one.
   if (options?.mirrorToolParamHeaders === false)
     http.mirrorToolParamHeaders = false;
+  if (options?.firstPageOnly === true) http.firstPageOnly = true;
+  if (options?.supportsMrtr === false) http.supportsMrtr = false;
 
   // Attach the SDK's 401-recovery hook only when this is a hosted-OAuth
   // server (we have a token from `authorize-batch-local`) AND the caller
@@ -1023,6 +1046,9 @@ export async function resolveLocalServerForConnect(
     mcpProtocolVersion: options?.defaults?.mcpProtocolVersion,
     // Same path again for the SEP-2243 mirroring knob.
     mirrorToolParamHeaders: options?.defaults?.mirrorToolParamHeaders,
+    // Same path again for the sibling conformance knobs.
+    firstPageOnly: options?.defaults?.firstPageOnly,
+    supportsMrtr: options?.defaults?.supportsMrtr,
     oauthAccessToken: resolvedOauthAccessToken,
     refreshContext: {
       bearerToken,

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -75,6 +75,19 @@ export type ConnectionDefaults = {
    */
   mirrorToolParamHeaders?: boolean;
   /**
+   * Client-conformance knobs resolved from the active host's
+   * `mcpProfile.paginationTraversal` / `mcpProfile.mrtrSupport`. Like the
+   * mirroring field above, only the NON-default value is ever sent — the SDK
+   * treats an absent field as the full behavior, so sending the default
+   * would put a field on every connection that never carried one.
+   *
+   * Unlike mirroring, neither is HTTP-only: pagination truncation is enforced
+   * on JSON-RPC frames and the MRTR knob works through capability
+   * advertisement, so both apply on stdio too.
+   */
+  firstPageOnly?: true;
+  supportsMrtr?: false;
+  /**
    * The host's enterprise-managed authorization policy, resolved client-side
    * via `readXaaEnterprisePolicy(hostConfig.mcpProfile)`. Present only when
    * the policy is validly ON — the client surfaces an `invalid` policy as a


### PR DESCRIPTION
## What

P1 of the client-conformance knob program: threads `mcpProfile.paginationTraversal` and `mcpProfile.mrtrSupport` (enforced in #3650 / #3653) from the active host to the SDK config on **every** connection the product opens — local and hosted, the connect path and the ephemeral managers that chat, eval, prompt and journey runs build.

11 files, following the `mirrorToolParamHeaders` precedent from #3632 — with three deliberate departures from it, below.

## Why the shape, not just the wiring

These fields are only ever **carried**, never derived, and the failure mode of missing a site is *silent*: a host configured as a degraded client would execute as a fully conforming one on whichever flow got skipped. That drove two choices:

- The four hosted body builders emit them through **one** `conformanceWireFields` helper rather than eight more near-identical spread blocks.
- The hosted route schema **declares** them, because Zod strips what it does not declare — the same drop-on-the-floor step the initialize pins were plumbed to fix.

## The overlay is security-relevant

New `applyHostConformanceKnobs`, the sibling of the existing `applyHostParamMirroring`, keeps the host authoritative in **both** directions.

These wire fields are suppression switches with no positive state, so a body pin has to be *removed* when the host wants the full behavior, not merely left unmatched. Applied to these knobs the argument gets sharper than it was for mirroring: without it, a share-link body could post `firstPageOnly: true` or `supportsMrtr: false` and silently degrade a conforming host — **hiding tools from the model**, or **dropping MRTR rounds mid-conversation**. Tests cover that direction specifically, including the case where the host reclaims one knob and leaves the other.

## stdio is not excluded

`toMCPServerConfig` has separate stdio and HTTP branches, and the mirroring knob is deliberately HTTP-only (mirroring really is a Streamable HTTP concern). Copying that shape would have made both new knobs **silently inert on stdio** — wrong for the same reason it was wrong in the CLI (#3656): pagination truncation is enforced on JSON-RPC frames and the MRTR knob works through capability advertisement. Both branches forward them.

## Tests

- `conformanceKnobsFromMcpProfile`: reads the non-default literals; collapses default literals, an absent profile, and junk to `undefined` (unreadable input must mean "behave conformantly", never the simulation).
- `applyHostConformanceKnobs`: forces pins on when the host asks; **strips caller pins when the host wants full behavior** (the tampering direction); strips only the knob the host reclaims; returns untouched pins by identity.

Suites run for the touched areas: server 582 passed (52 files), client 741 passed (70 files), plus the 20 in `effective-auth.test.ts`.

**Root `npm run verify` was still running when this PR was opened** — I'll report the result on the PR rather than claim it. The SDK/CLI surfaces are unchanged by this PR; the risk is concentrated in the inspector suites above, which pass.

## Scope

Plumbing only — no UI. `ProtocolTab` controls for the two knobs are the next PR; after that, publish `@mcpjam/sdk` and drop the two backend SDK-pin shims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection initialization across many hosted and local paths; a missed site would silently ignore host conformance settings, though tests cover the security-sensitive overlay behavior.
> 
> **Overview**
> **Plumbs** `mcpProfile.paginationTraversal` (`firstPageOnly`) and `mcpProfile.mrtrSupport` (`supportsMrtr`) from the active host through **every** inspector connection path—local connect defaults, hosted API context, validate/connect batch bodies, and server-side manager initialization—mirroring the existing SEP-2243 mirroring knob pattern.
> 
> On the **client**, pins are derived in `App.tsx` / `use-server-state`, stored on `ApiContext`, and emitted via a new **`conformanceWireFields`** helper shared across all four hosted body builders so chat/eval/prompt/journey ephemeral managers cannot silently run as a fully conforming client.
> 
> On the **server**, hosted Zod schemas accept the fields, `extractMcpInitializeOptions` forwards them onto SDK config, and **`applyHostConformanceKnobs`** (with **`conformanceKnobsFromMcpProfile`**) keeps the host authoritative in both directions—stripping body pins when the host wants full behavior so share-link callers cannot degrade a conforming host. Unlike mirroring, both knobs are forwarded on **stdio** as well as HTTP.
> 
> Adds unit tests for the new overlay helpers; no UI in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7514ce5b31b7af925f9671b6ab71ece06a82d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Carry the host’s client-conformance knobs through every connection and enforce host authority. We propagate `firstPageOnly` and `supportsMrtr` from `mcpProfile` across local and hosted paths (chat, eval, prompt, journey) on both HTTP and stdio.

- **New Features**
  - Added `applyHostConformanceKnobs` to enforce host decisions and strip caller pins when the host wants full behavior.
  - Read knobs via `conformanceKnobsFromMcpProfile` and plumb them into `ApiContext`, hosted request builders, validation, and initialize extraction.
  - Introduced `conformanceWireFields` to emit the knobs once and only when non-default.
  - Declared `firstPageOnly` and `supportsMrtr` in hosted route schema to avoid Zod dropping them.
  - Forwarded knobs in `toMCPServerConfig` for HTTP and stdio; updated local resolver and `ConnectionDefaults`.

<sup>Written for commit e7514ce5b31b7af925f9671b6ab71ece06a82d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

