### PR TITLE
feat(inspector): host-editor controls for the client-conformance knobs (P2)

### DIFF
--- a/.changeset/conformance-knobs-protocol-tab.md
+++ b/.changeset/conformance-knobs-protocol-tab.md
@@ -1,0 +1,21 @@
+---
+"@mcpjam/inspector": minor
+---
+
+Add host-editor controls for the two client-conformance knobs, beside the
+existing SEP-2243 mirroring control: **Paginated list traversal** (walk every
+page / first page only) and **Multi-round tool results** (supported / not
+supported).
+
+Both follow the mirroring knob's discipline — picking the default writes
+ABSENCE rather than the literal, so a host that merely opens this tab keeps
+its canonical hash (and, since host configs are content-addressed, does not
+mint a new row). Unknown literals hand-edited into the JSON view collapse to
+the default instead of reaching the canonicalizer, which throws and would
+reject the user's whole save.
+
+The profile-collapse check that decides whether an `mcpProfile` is worth
+persisting is now a single `isMcpProfileEmpty` helper. It had been inlined at
+three write sites, which meant every new profile field had to be added in
+three places or a profile carrying only that field would silently collapse,
+losing the setting on save.

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -30,7 +30,11 @@ import {
   type HostConfigMcpProfileV1,
   type McpProtocolVersion,
 } from "@/lib/client-config-v2";
-import type { ToolParamHeaderMirroring } from "@mcpjam/sdk/browser";
+import type {
+  MrtrSupport,
+  PaginationTraversalMode,
+  ToolParamHeaderMirroring,
+} from "@mcpjam/sdk/browser";
 import type { HostAttentionIssue } from "../types";
 import { useJsonDraftBuffer } from "./useJsonDraftBuffer";
 
@@ -158,6 +162,15 @@ type ProtocolDoc = {
    * a per-server override: conformance is a property of the CLIENT.
    */
   toolParamHeaderMirroring?: ToolParamHeaderMirroring;
+  /**
+   * Sibling client-conformance knobs. Absent → the full behavior, written
+   * back as absence for the same hash reason as the mirroring knob above:
+   * a host that never touches the control must keep hashing exactly as it
+   * did before the field existed. Map onto `mcpProfile.paginationTraversal`
+   * / `mcpProfile.mrtrSupport`.
+   */
+  paginationTraversal?: PaginationTraversalMode;
+  mrtrSupport?: MrtrSupport;
   capabilities?: Record<string, unknown>;
   /**
    * Host-level MCP profile extensions (`mcpProfile.extensions`) — freeform
@@ -182,6 +195,28 @@ function findAuthorizationKey(
   headers: Record<string, string>
 ): string | undefined {
   return Object.keys(headers).find((k) => k.toLowerCase() === "authorization");
+}
+
+/**
+ * True when an mcpProfile carries nothing worth persisting, so the draft
+ * collapses it to `undefined` and an untouched host keeps its canonical hash.
+ *
+ * ONE definition on purpose: this predicate used to be inlined at each of the
+ * three write sites (the JSON editor's apply, and each knob's setter), which
+ * meant every new profile field had to be added in three places or a profile
+ * carrying only that field would silently collapse — losing the user's
+ * setting on save. Adding a field here covers all of them.
+ */
+function isMcpProfileEmpty(profile: HostConfigMcpProfileV1): boolean {
+  return (
+    profile.initialize === undefined &&
+    profile.mcpProtocolVersion === undefined &&
+    profile.toolParamHeaderMirroring === undefined &&
+    profile.paginationTraversal === undefined &&
+    profile.mrtrSupport === undefined &&
+    !profile.apps &&
+    !profile.extensions
+  );
 }
 
 export function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
@@ -220,6 +255,14 @@ export function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
   // Same only-when-set rule as the pin above, for the same hash reason.
   if (draft.mcpProfile?.toolParamHeaderMirroring !== undefined) {
     doc.toolParamHeaderMirroring = draft.mcpProfile.toolParamHeaderMirroring;
+  }
+
+  // Same only-when-set rule again for the sibling conformance knobs.
+  if (draft.mcpProfile?.paginationTraversal !== undefined) {
+    doc.paginationTraversal = draft.mcpProfile.paginationTraversal;
+  }
+  if (draft.mcpProfile?.mrtrSupport !== undefined) {
+    doc.mrtrSupport = draft.mcpProfile.mrtrSupport;
   }
 
   if (
@@ -456,6 +499,17 @@ export function applyJsonToDraft(
       ? rawMirroring
       : undefined;
 
+  // Same closed-enum collapse for the sibling knobs: an unknown literal must
+  // not reach the canonicalizer, which throws and rejects the whole save.
+  const rawPagination = parsed.paginationTraversal;
+  const paginationTraversal: PaginationTraversalMode | undefined =
+    rawPagination === "full" || rawPagination === "firstPageOnly"
+      ? rawPagination
+      : undefined;
+  const rawMrtr = parsed.mrtrSupport;
+  const mrtrSupport: MrtrSupport | undefined =
+    rawMrtr === "full" || rawMrtr === "none" ? rawMrtr : undefined;
+
   // capabilities — pass through verbatim as Record<string, unknown> only if
   // the user supplied an object. Absence vs `{}` is preserved: missing key
   // clears clientCapabilities; explicit `{}` advertises nothing but keeps
@@ -525,16 +579,12 @@ export function applyJsonToDraft(
       initialize: initHasFields ? initialize : undefined,
       mcpProtocolVersion,
       toolParamHeaderMirroring,
+      paginationTraversal,
+      mrtrSupport,
       extensions: profileExtensions,
     };
 
-    const allEmpty =
-      next.initialize === undefined &&
-      next.mcpProtocolVersion === undefined &&
-      next.toolParamHeaderMirroring === undefined &&
-      !next.apps &&
-      !next.extensions;
-    return allEmpty ? undefined : next;
+    return isMcpProfileEmpty(next) ? undefined : next;
   });
 
   return {
@@ -586,15 +636,9 @@ export function ProtocolTab({
         ...base,
         mcpProtocolVersion: next,
       };
-      const allEmpty =
-        updated.initialize === undefined &&
-        updated.mcpProtocolVersion === undefined &&
-        updated.toolParamHeaderMirroring === undefined &&
-        !updated.apps &&
-        !updated.extensions;
       return {
         ...prev,
-        mcpProfile: allEmpty ? undefined : updated,
+        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
       };
     });
   };
@@ -620,13 +664,31 @@ export function ProtocolTab({
         ...base,
         toolParamHeaderMirroring: next,
       };
-      const allEmpty =
-        updated.initialize === undefined &&
-        updated.mcpProtocolVersion === undefined &&
-        updated.toolParamHeaderMirroring === undefined &&
-        !updated.apps &&
-        !updated.extensions;
-      return { ...prev, mcpProfile: allEmpty ? undefined : updated };
+      return {
+        ...prev,
+        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
+      };
+    });
+  };
+
+  // Client-conformance knobs (siblings of the mirroring control above). Both
+  // model how REAL hosts differ, so the default is written back as ABSENCE
+  // and only the degraded value is stored.
+  const storedPagination = draft.mcpProfile?.paginationTraversal;
+  const storedMrtrSupport = draft.mcpProfile?.mrtrSupport;
+  const setConformanceKnob = <K extends "paginationTraversal" | "mrtrSupport">(
+    key: K,
+    next: HostConfigMcpProfileV1[K] | undefined,
+  ) => {
+    onDraftChange((prev) => {
+      const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
+        profileVersion: 1,
+      };
+      const updated: HostConfigMcpProfileV1 = { ...base, [key]: next };
+      return {
+        ...prev,
+        mcpProfile: isMcpProfileEmpty(updated) ? undefined : updated,
+      };
     });
   };
 
@@ -780,6 +842,74 @@ export function ProtocolTab({
               <SelectItem value="omit">
                 Omit (simulate non-conforming client)
               </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
+          <div className="min-w-0">
+            <span className="text-[12px] font-medium">
+              Paginated list traversal
+            </span>
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              {storedPagination === "firstPageOnly"
+                ? "Reading only the first page, like the hosts that never follow nextCursor. Tools past page one are invisible — and on 2026-07-28 their calls also lose the mirrored Mcp-Param-* headers, because the mirroring source is the page-one list this client cached."
+                : "Following nextCursor to the end of the list, as a conforming client does. Switch to first page only to see your server through a host that stops after one page."}
+            </p>
+          </div>
+          <Select
+            value={storedPagination ?? "full"}
+            onValueChange={(next) => {
+              // "full" writes ABSENCE — the default must keep hashing like a
+              // host that never opted in.
+              setConformanceKnob(
+                "paginationTraversal",
+                next === "firstPageOnly" ? "firstPageOnly" : undefined,
+              );
+            }}
+            disabled={readOnly}
+          >
+            <SelectTrigger
+              aria-label="Paginated list traversal"
+              className="h-9 w-[220px] flex-shrink-0 text-xs"
+            >
+              <SelectValue placeholder="Walk every page" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="full">Walk every page (default)</SelectItem>
+              <SelectItem value="firstPageOnly">First page only</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
+          <div className="min-w-0">
+            <span className="text-[12px] font-medium">
+              Multi-round tool results (MRTR)
+            </span>
+            <p className="text-[11px] leading-snug text-muted-foreground">
+              {storedMrtrSupport === "none"
+                ? "Not driving input_required rounds — this client behaves like one that never implemented the 2026 pattern. It stops advertising elicitation on a modern connection, so a server that would have elicited answers -32021 instead."
+                : "Driving input_required rounds, so a server can collect input mid-call. Switch to Not supported to see what your server does with a client that cannot. Which elicitation modes are offered is set by this host's client capabilities."}
+            </p>
+          </div>
+          <Select
+            value={storedMrtrSupport ?? "full"}
+            onValueChange={(next) => {
+              setConformanceKnob(
+                "mrtrSupport",
+                next === "none" ? "none" : undefined,
+              );
+            }}
+            disabled={readOnly}
+          >
+            <SelectTrigger
+              aria-label="Multi-round tool results"
+              className="h-9 w-[220px] flex-shrink-0 text-xs"
+            >
+              <SelectValue placeholder="Supported" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="full">Supported (default)</SelectItem>
+              <SelectItem value="none">Not supported</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -26,6 +26,7 @@ import {
   type TasksPolicy,
 } from "@mcpjam/sdk/browser";
 import {
+  isMcpProfileEmpty,
   type HostConfigInputV2,
   type HostConfigMcpProfileV1,
   type McpProtocolVersion,
@@ -195,28 +196,6 @@ function findAuthorizationKey(
   headers: Record<string, string>
 ): string | undefined {
   return Object.keys(headers).find((k) => k.toLowerCase() === "authorization");
-}
-
-/**
- * True when an mcpProfile carries nothing worth persisting, so the draft
- * collapses it to `undefined` and an untouched host keeps its canonical hash.
- *
- * ONE definition on purpose: this predicate used to be inlined at each of the
- * three write sites (the JSON editor's apply, and each knob's setter), which
- * meant every new profile field had to be added in three places or a profile
- * carrying only that field would silently collapse — losing the user's
- * setting on save. Adding a field here covers all of them.
- */
-function isMcpProfileEmpty(profile: HostConfigMcpProfileV1): boolean {
-  return (
-    profile.initialize === undefined &&
-    profile.mcpProtocolVersion === undefined &&
-    profile.toolParamHeaderMirroring === undefined &&
-    profile.paginationTraversal === undefined &&
-    profile.mrtrSupport === undefined &&
-    !profile.apps &&
-    !profile.extensions
-  );
 }
 
 export function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  emptyHostConfigInputV2,
+  type HostConfigInputV2,
+} from "@/lib/client-config-v2";
+
+vi.mock("@/components/ui/json-editor", () => ({
+  JsonEditor: ({
+    rawContent,
+    onRawChange,
+  }: {
+    rawContent: string;
+    onRawChange: (next: string) => void;
+  }) => (
+    <textarea
+      aria-label="json"
+      value={rawContent}
+      onChange={(e) => onRawChange(e.target.value)}
+    />
+  ),
+}));
+
+import { ProtocolTab, protocolToJson, applyJsonToDraft } from "../ProtocolTab";
+
+function Harness({ initial }: { initial: HostConfigInputV2 }) {
+  const [draft, setDraft] = useState(initial);
+  return (
+    <div>
+      <div data-testid="pagination">
+        {draft.mcpProfile?.paginationTraversal ?? "<undefined>"}
+      </div>
+      <div data-testid="mrtr">
+        {draft.mcpProfile?.mrtrSupport ?? "<undefined>"}
+      </div>
+      <div data-testid="profile">
+        {draft.mcpProfile === undefined ? "<no-profile>" : "profile"}
+      </div>
+      <ProtocolTab
+        draft={draft}
+        onDraftChange={(updater) => setDraft((prev) => updater(prev))}
+        attention={[]}
+      />
+    </div>
+  );
+}
+
+const paginationCombo = () =>
+  screen.getByRole("combobox", { name: "Paginated list traversal" });
+const mrtrCombo = () =>
+  screen.getByRole("combobox", { name: "Multi-round tool results" });
+
+/**
+ * Like the mirroring knob beside them, these controls' whole value is that
+ * the DEFAULT and "not configured" are the same stored state. If picking the
+ * default ever wrote a literal, every host that merely opened this tab would
+ * get a new canonical hash — and, because the backend content-addresses host
+ * configs, a new row.
+ */
+describe("ProtocolTab client-conformance controls", () => {
+  it("shows the defaults for a host that never configured them", () => {
+    render(<Harness initial={emptyHostConfigInputV2()} />);
+    expect(paginationCombo()).toHaveTextContent("Walk every page (default)");
+    expect(mrtrCombo()).toHaveTextContent("Supported (default)");
+    expect(screen.getByTestId("pagination").textContent).toBe("<undefined>");
+    expect(screen.getByTestId("mrtr").textContent).toBe("<undefined>");
+  });
+
+  it("stores the degraded value when the user picks it", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={emptyHostConfigInputV2()} />);
+
+    await user.click(paginationCombo());
+    await user.click(screen.getByRole("option", { name: "First page only" }));
+    expect(screen.getByTestId("pagination").textContent).toBe("firstPageOnly");
+
+    await user.click(mrtrCombo());
+    await user.click(screen.getByRole("option", { name: "Not supported" }));
+    expect(screen.getByTestId("mrtr").textContent).toBe("none");
+  });
+
+  it("writes ABSENCE when the user picks the default back", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initial={{
+          ...emptyHostConfigInputV2(),
+          mcpProfile: {
+            profileVersion: 1,
+            paginationTraversal: "firstPageOnly",
+            mrtrSupport: "none",
+          },
+        }}
+      />,
+    );
+
+    await user.click(paginationCombo());
+    await user.click(
+      screen.getByRole("option", { name: "Walk every page (default)" }),
+    );
+    expect(screen.getByTestId("pagination").textContent).toBe("<undefined>");
+
+    await user.click(mrtrCombo());
+    await user.click(
+      screen.getByRole("option", { name: "Supported (default)" }),
+    );
+    expect(screen.getByTestId("mrtr").textContent).toBe("<undefined>");
+    // Nothing left in the profile ⇒ it collapses, so the host hashes exactly
+    // as one that never opened this tab.
+    expect(screen.getByTestId("profile").textContent).toBe("<no-profile>");
+  });
+
+  it("keeps a profile alive while a SIBLING field is still set", async () => {
+    // The regression the shared `isMcpProfileEmpty` helper guards: the
+    // collapse check used to be inlined per setter, so a field the setter
+    // didn't know about could be silently dropped on the next edit.
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initial={{
+          ...emptyHostConfigInputV2(),
+          mcpProfile: {
+            profileVersion: 1,
+            paginationTraversal: "firstPageOnly",
+            mrtrSupport: "none",
+          },
+        }}
+      />,
+    );
+
+    await user.click(paginationCombo());
+    await user.click(
+      screen.getByRole("option", { name: "Walk every page (default)" }),
+    );
+
+    expect(screen.getByTestId("pagination").textContent).toBe("<undefined>");
+    // mrtrSupport survives — clearing one knob must not take the other with it.
+    expect(screen.getByTestId("mrtr").textContent).toBe("none");
+    expect(screen.getByTestId("profile").textContent).toBe("profile");
+  });
+});
+
+describe("ProtocolTab JSON round-trip for the conformance knobs", () => {
+  it("omits the keys entirely when unset", () => {
+    const doc = protocolToJson(emptyHostConfigInputV2());
+    expect("paginationTraversal" in doc).toBe(false);
+    expect("mrtrSupport" in doc).toBe(false);
+  });
+
+  it("surfaces and re-applies stored values", () => {
+    const draft: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        profileVersion: 1,
+        paginationTraversal: "firstPageOnly",
+        mrtrSupport: "none",
+      },
+    };
+    const doc = protocolToJson(draft);
+    expect(doc.paginationTraversal).toBe("firstPageOnly");
+    expect(doc.mrtrSupport).toBe("none");
+
+    const applied = applyJsonToDraft(doc, emptyHostConfigInputV2());
+    expect(applied?.mcpProfile?.paginationTraversal).toBe("firstPageOnly");
+    expect(applied?.mcpProfile?.mrtrSupport).toBe("none");
+  });
+
+  it("collapses unknown literals to undefined instead of failing the save", () => {
+    // The canonicalizer THROWS on an unknown literal, which would reject the
+    // user's whole edit. Collapsing to the conforming default keeps the save
+    // working and fails safe.
+    const applied = applyJsonToDraft(
+      {
+        ...protocolToJson(emptyHostConfigInputV2()),
+        paginationTraversal: "everyOtherPage",
+        mrtrSupport: "partial",
+      } as ReturnType<typeof protocolToJson>,
+      emptyHostConfigInputV2(),
+    );
+    expect(applied?.mcpProfile?.paginationTraversal).toBeUndefined();
+    expect(applied?.mcpProfile?.mrtrSupport).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
@@ -163,8 +163,9 @@ describe("ProtocolTab JSON round-trip for the conformance knobs", () => {
     expect(doc.mrtrSupport).toBe("none");
 
     const applied = applyJsonToDraft(doc, emptyHostConfigInputV2());
-    expect(applied?.mcpProfile?.paginationTraversal).toBe("firstPageOnly");
-    expect(applied?.mcpProfile?.mrtrSupport).toBe("none");
+    expect(applied).not.toBeNull();
+    expect(applied!.mcpProfile?.paginationTraversal).toBe("firstPageOnly");
+    expect(applied!.mcpProfile?.mrtrSupport).toBe("none");
   });
 
   it("collapses unknown literals to undefined instead of failing the save", () => {
@@ -179,7 +180,12 @@ describe("ProtocolTab JSON round-trip for the conformance knobs", () => {
       } as ReturnType<typeof protocolToJson>,
       emptyHostConfigInputV2(),
     );
-    expect(applied?.mcpProfile?.paginationTraversal).toBeUndefined();
-    expect(applied?.mcpProfile?.mrtrSupport).toBeUndefined();
+    // Assert the save SURVIVED first: `applyJsonToDraft` returns null when it
+    // rejects the document, and optional chaining below would read `undefined`
+    // for that too — passing on exactly the failure this test exists to rule
+    // out.
+    expect(applied).not.toBeNull();
+    expect(applied!.mcpProfile?.paginationTraversal).toBeUndefined();
+    expect(applied!.mcpProfile?.mrtrSupport).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-config-v2-mcp-profile.test.ts
@@ -18,6 +18,7 @@
 
 import { describe, expect, test } from "vitest";
 import {
+  isMcpProfileEmpty,
   type HostConfigDtoV2,
   type HostConfigInputV2,
   type HostConfigMcpProfileV1,
@@ -415,5 +416,44 @@ describe("resolveEffectiveMcpProtocolVersion — per-server override precedence"
     expect(
       resolveEffectiveMcpProtocolVersion("2025-11-25", "2026-07-28"),
     ).toBe("2025-11-25");
+  });
+});
+
+describe("isMcpProfileEmpty (shared by every profile write path)", () => {
+  it("treats a profile carrying only a conformance knob as NON-empty", () => {
+    // The regression the shared helper exists to prevent: this predicate was
+    // inlined at four write sites, so a field one of them didn't know about
+    // silently collapsed the profile — losing the user's setting on save.
+    for (const profile of [
+      { profileVersion: 1 as const, paginationTraversal: "firstPageOnly" as const },
+      { profileVersion: 1 as const, mrtrSupport: "none" as const },
+      { profileVersion: 1 as const, toolParamHeaderMirroring: "omit" as const },
+    ]) {
+      expect(isMcpProfileEmpty(profile)).toBe(false);
+    }
+  });
+
+  it("treats an EMPTY initialize envelope as empty", () => {
+    // The canonicalizer drops an empty `initialize`, so persisting a profile
+    // that holds only one would mint a row hashing identically to no profile.
+    expect(
+      isMcpProfileEmpty({ profileVersion: 1, initialize: {} }),
+    ).toBe(true);
+    expect(
+      isMcpProfileEmpty({
+        profileVersion: 1,
+        initialize: { supportedProtocolVersions: [] },
+      }),
+    ).toBe(true);
+    expect(
+      isMcpProfileEmpty({
+        profileVersion: 1,
+        initialize: { supportedProtocolVersions: ["2026-07-28"] },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats a bare profileVersion as empty", () => {
+    expect(isMcpProfileEmpty({ profileVersion: 1 })).toBe(true);
   });
 });

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -767,12 +767,19 @@ export function setMcpAppsOverridesOnDraft(
   // drop the SEP-2243 mirroring knob along with the envelope that carries it.
   const hasToolParamHeaderMirroring =
     baseProfile.toolParamHeaderMirroring !== undefined;
+  // Same first-class treatment for the sibling conformance knobs: clearing
+  // the apps overrides must not silently drop the client's pagination or
+  // MRTR behavior along with the envelope that carries it.
+  const hasConformanceKnobs =
+    baseProfile.paginationTraversal !== undefined ||
+    baseProfile.mrtrSupport !== undefined;
   const hasExtensions = baseProfile.extensions !== undefined;
   const profileEmpty =
     appsEmpty &&
     !hasInitialize &&
     !hasMcpProtocolVersion &&
     !hasToolParamHeaderMirroring &&
+    !hasConformanceKnobs &&
     !hasExtensions;
 
   return {

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -732,6 +732,39 @@ export function hostCapabilitiesOverrideToMatrix(
  * Preserves sibling `mcpProfile.apps` fields and collapses an otherwise empty
  * profile back to `undefined`, matching the JSON editor's draft cleanup.
  */
+/**
+ * True when an `mcpProfile` carries nothing worth persisting, so a write
+ * collapses it to `undefined` and an untouched host keeps its canonical hash
+ * (host configs are content-addressed, so a spurious profile mints a row).
+ *
+ * ONE definition for every write path — the host editor's three sites and the
+ * apps-override clear below. It used to be inlined at each, which meant every
+ * new profile field had to be added in four places; miss one and a profile
+ * carrying only that field silently collapses, losing the user's setting on
+ * save with no error.
+ *
+ * `initialize` counts as carrying nothing unless it actually holds a
+ * `clientInfo` or a non-empty `supportedProtocolVersions`: an empty envelope
+ * is dropped by the canonicalizer anyway, so treating it as content would
+ * persist a profile that hashes identically to no profile at all.
+ */
+export function isMcpProfileEmpty(profile: HostConfigMcpProfileV1): boolean {
+  const hasInitialize =
+    profile.initialize !== undefined &&
+    (profile.initialize.clientInfo !== undefined ||
+      (profile.initialize.supportedProtocolVersions !== undefined &&
+        profile.initialize.supportedProtocolVersions.length > 0));
+  return (
+    !hasInitialize &&
+    profile.mcpProtocolVersion === undefined &&
+    profile.toolParamHeaderMirroring === undefined &&
+    profile.paginationTraversal === undefined &&
+    profile.mrtrSupport === undefined &&
+    !profile.apps &&
+    !profile.extensions
+  );
+}
+
 export function setMcpAppsOverridesOnDraft(
   prev: HostConfigInputV2,
   next: McpAppsCapabilities | undefined
@@ -757,36 +790,16 @@ export function setMcpAppsOverridesOnDraft(
   const baseProfile: HostConfigMcpProfileV1 = prevProfile ?? {
     profileVersion: 1,
   };
-  const hasInitialize =
-    baseProfile.initialize !== undefined &&
-    (baseProfile.initialize.clientInfo !== undefined ||
-      (baseProfile.initialize.supportedProtocolVersions &&
-        baseProfile.initialize.supportedProtocolVersions.length > 0));
-  const hasMcpProtocolVersion = baseProfile.mcpProtocolVersion !== undefined;
-  // A first-class sibling of the pin: clearing the apps overrides must not
-  // drop the SEP-2243 mirroring knob along with the envelope that carries it.
-  const hasToolParamHeaderMirroring =
-    baseProfile.toolParamHeaderMirroring !== undefined;
-  // Same first-class treatment for the sibling conformance knobs: clearing
-  // the apps overrides must not silently drop the client's pagination or
-  // MRTR behavior along with the envelope that carries it.
-  const hasConformanceKnobs =
-    baseProfile.paginationTraversal !== undefined ||
-    baseProfile.mrtrSupport !== undefined;
-  const hasExtensions = baseProfile.extensions !== undefined;
-  const profileEmpty =
-    appsEmpty &&
-    !hasInitialize &&
-    !hasMcpProtocolVersion &&
-    !hasToolParamHeaderMirroring &&
-    !hasConformanceKnobs &&
-    !hasExtensions;
+  // Evaluate emptiness on the profile this write actually produces — the
+  // apps envelope has already been cleared when `appsEmpty`.
+  const nextProfile: HostConfigMcpProfileV1 = {
+    ...baseProfile,
+    apps: appsEmpty ? undefined : nextApps,
+  };
 
   return {
     ...prev,
-    mcpProfile: profileEmpty
-      ? undefined
-      : { ...baseProfile, apps: appsEmpty ? undefined : nextApps },
+    mcpProfile: isMcpProfileEmpty(nextProfile) ? undefined : nextProfile,
   };
 }
 


### PR DESCRIPTION
## What

P2, the last behavioral piece of the client-conformance knob program: host-editor controls for the two knobs, beside the existing SEP-2243 mirroring control.

| Control | Options |
|---|---|
| **Paginated list traversal** | Walk every page (default) / First page only |
| **Multi-round tool results (MRTR)** | Supported (default) / Not supported |

Each control's helper text says what the *server* will see, not just what the setting is — e.g. picking first-page-only explains that tools past page one become invisible **and** that their calls lose the mirrored `Mcp-Param-*` headers, because the mirroring source is the page-one list the client cached. That second-order effect is the single most confusing symptom of this knob, and the place someone will be looking when they hit it.

## Discipline copied from the mirroring knob

- **Picking the default writes ABSENCE, not the literal.** Host configs are content-addressed, so writing `"full"` would give every host that merely opened this tab a new canonical hash — and a new row in the backend.
- **Unknown literals collapse instead of failing the save.** The canonicalizer throws on an unknown value, which would reject the user's entire edit; a junk literal hand-edited into the JSON view resolves to the default and the save proceeds.
- JSON round-trip emits the keys only when set.

## The bug this also fixes

The predicate deciding whether an `mcpProfile` is worth persisting was **inlined at three write sites** (the JSON-editor apply, and each knob's setter). Every new profile field had to be added in all three, and missing one meant a profile carrying *only* that field silently collapsed to `undefined` — losing the user's setting on save, with no error.

It is now a single `isMcpProfileEmpty` helper. The test `keeps a profile alive while a SIBLING field is still set` fails under the old inlined shape.

`client-config-v2.ts`'s separate `profileEmpty` check (used when clearing apps overrides) learned the two fields for the same reason: clearing the apps envelope must not take the client's pagination or MRTR behavior with it.

## Tests

7 new (22 files / 167 tests green in the ProtocolTab suites):
- defaults shown for a host that never configured them, with nothing stored
- picking the degraded value stores it
- picking the default back writes absence **and** collapses the profile entirely
- clearing one knob leaves its sibling intact (the regression guard above)
- JSON round-trip: keys omitted when unset, surfaced and re-applied when set
- unknown literals collapse rather than failing the save

## Verify

**Root `npm run verify` was still running when this PR was opened** — I'll post the result as a comment rather than claim it here. Same as #3659.

Worth noting one thing the existing suite caught during development: an early version of my refactor anchored a helper insertion on `function protocolToJson(`, which lives inside `export function protocolToJson(` — silently un-exporting it. Four existing tests failed immediately with `protocolToJson is not a function`.

## What's left in the program

Publish `@mcpjam/sdk`, then drop the two backend SDK-pin shims (the canonicalizer one and the wire-edge one in `convex/http.ts`) once the bumped SDK knows these fields natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inspector host-editor and draft persistence only; behavior mirrors existing mirroring-knob patterns with new tests covering hash discipline and sibling-field retention.
> 
> **Overview**
> Adds **Paginated list traversal** and **Multi-round tool results (MRTR)** selects on the host Protocol tab, next to the existing SEP-2243 mirroring control. Both map to `mcpProfile.paginationTraversal` and `mcpProfile.mrtrSupport`, with helper copy describing server-visible effects (e.g. first-page-only hiding tools and affecting `Mcp-Param-*` mirroring).
> 
> Defaults follow the mirroring discipline: choosing the conforming option **clears** the field (undefined) so content-addressed host configs do not get a new hash from merely opening the tab. JSON `protocolToJson` / `applyJsonToDraft` round-trip includes these keys only when set; invalid enum literals collapse to undefined so saves are not rejected by the canonicalizer.
> 
> Introduces shared **`isMcpProfileEmpty`** in `client-config-v2.ts` and uses it across Protocol tab setters, JSON apply, and MCP Apps override clearing—replacing duplicated inline checks so profiles that only set a new knob (or a sibling field) are not dropped on save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b00d137672a2c230b521c972727b449642f9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds host-editor controls for two client-conformance knobs—Paginated list traversal and Multi‑round tool results—next to the existing mirroring control. Defaults write as absence to preserve canonical hashes; unknown JSON literals collapse to defaults to avoid canonicalizer errors.

- **New Features**
  - Added selects for Paginated list traversal (walk every page / first page only) and MRTR (supported / not supported), following the same discipline as mirroring: defaults store as absence. Helper text explains the server-visible effects.
  - JSON round‑trip omits keys when unset and collapses unknown literals to defaults instead of failing the save.

- **Bug Fixes**
  - Unified the profile-collapse check into a single exported `isMcpProfileEmpty` used by all write paths (JSON apply, both knob setters, and apps‑override clear). The predicate now ignores empty `initialize` envelopes (no `clientInfo` and no `supportedProtocolVersions`) to avoid minting rows that hash like no profile.
  - Hardened tests: assert saves survive when collapsing unknown literals; added direct tests for the shared emptiness helper and sibling-field preservation.

<sup>Written for commit e4b00d137672a2c230b521c972727b449642f9bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

