### PR TITLE
Move the MCP logo to the Conformance sidebar item.

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   ShieldCheck,
   Loader2,
   Layers,
+  Cable,
 } from "lucide-react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { track } from "@/lib/analytics";
@@ -181,14 +182,14 @@ export const navigationSections: NavSection[] = [
       {
         title: "Connect",
         url: "/servers",
-        icon: MCPIcon,
+        icon: Cable,
         featureFlag: "hosts-enabled",
         matchTabs: ["clients", "host-compare", "computer", "skills"],
       },
       {
         title: "Servers",
         url: "/servers",
-        icon: MCPIcon,
+        icon: Cable,
         hiddenByFlag: "hosts-enabled",
       },
       {
@@ -251,7 +252,7 @@ export const navigationSections: NavSection[] = [
       {
         title: "Conformance",
         url: "/conformance",
-        icon: FlaskConical,
+        icon: MCPIcon,
         // MCPJam-internal flag: rollout is restricted to the MCPJam team in
         // PostHog. Keep the `mcpjam-` prefix so it's obvious at a glance that
         // this is an internal-only flag (same convention as `mcpjam-learning`).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic sidebar icon changes only; no routing, auth, or behavior impact.
> 
> **Overview**
> Updates sidebar icons in `mcp-sidebar.tsx` so **Connect** and **Servers** use Lucide **Cable** instead of **MCPIcon**, and **Conformance** uses **MCPIcon** instead of **FlaskConical**.
> 
> Nav URLs, feature flags, and labels are unchanged—this is icon-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba33079c877044a2c14900e07aa7c0ee6f8bf9de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the MCP logo (`MCPIcon`) to the Conformance sidebar item, replacing `FlaskConical`. Updated the Connect and Servers items to use `Cable` instead of `MCPIcon` for clearer semantics.

<sup>Written for commit ba33079c877044a2c14900e07aa7c0ee6f8bf9de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

