### PR TITLE
feat(github-checks): rewire the worker onto the backend-owned plan loop (A3b-2)

### DIFF
--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker-source.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker-source.test.ts
@@ -78,4 +78,54 @@ describe("defaultRunEvalSuite provenance", () => {
     expect(request.refreshSnapshot).toBe(true);
     expect(result.result).toBe("passed");
   });
+
+  it("does not strand the run when BINDING it throws", async () => {
+    // `prepareEvalRun` has already created the run row and one pending
+    // iteration row per attempt by the time the `eval` attempt is posted, and a
+    // throw from there (a 409 from the state machine, an unreachable backend)
+    // bypasses the catch around `execute()` where the cleanup lives. Aborting
+    // is right — a run nothing may read must not be paid for — but the run must
+    // not be left `running` with every iteration `pending`, forever.
+    const recorder = { finalize: vi.fn().mockResolvedValue(undefined) };
+    const execute = vi.fn().mockResolvedValue(undefined);
+    prepareEvalRun.mockResolvedValue({ runId: "run-9", recorder, execute });
+    const mutation = vi.fn().mockResolvedValue(undefined);
+    createConvexClient.mockReturnValue({
+      query: vi.fn().mockResolvedValue({ configSnapshot: { environment: null } }),
+      mutation,
+    });
+
+    const run = defaultRunEvalSuiteForTests();
+    await expect(
+      run({
+        claimed: {
+          triggerId: "trig-bind",
+          repoFullName: "mcpjam/mcp-check-fixture",
+          prNumber: 1,
+          headSha: "a".repeat(40),
+          organizationId: "org-1",
+          projectId: "proj-1",
+          createdByExternalId: "user_x",
+          suiteId: "suite-1",
+        },
+        bearer: "bearer-token",
+        serverId: "srv-1",
+        serverName: "gh-check-trig-bind",
+        onRunStarted: async () => {
+          throw new Error("plan refused the eval attempt (409)");
+        },
+      })
+    ).rejects.toThrow("plan refused the eval attempt (409)");
+
+    // Nothing was evaluated…
+    expect(execute).not.toHaveBeenCalled();
+    // …and both halves of the run reached a terminal state.
+    expect(mutation).toHaveBeenCalledWith(
+      "testSuites:markSetupPendingIterationsFailed",
+      expect.objectContaining({ runId: "run-9" })
+    );
+    expect(recorder.finalize).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed" })
+    );
+  });
 });

--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -8,33 +8,42 @@ import {
   vi,
 } from "vitest";
 import {
-  classifyCheckFailure,
+  describeCheckFailure,
   effectiveRunResult,
   executeClaimedCheck,
-  outcomeForRunResult,
   runReachedAVerdict,
   verifyRunSnapshot,
   LeaseLostError,
   startGithubChecksWorker,
   type CheckExecutionDeps,
-  type CheckReport,
+  type PlanlessCheckReport,
   type ClaimedGithubCheck,
 } from "../github-checks-worker";
 import {
   CheckStepError,
   type CheckSandbox,
 } from "../github-checks/sandbox";
-import { RecipeStartError } from "../github-checks/resolve-and-start";
+import {
+  CheckStoppedByPlan,
+  PlanProtocolError,
+  PlanUnreachableError,
+  type AttemptInput,
+  type CheckPlanSession,
+} from "../github-checks/check-plan";
 
-// Two invariants drive every test here, because both are visible on somebody's
-// pull request when they break:
+// Three invariants drive every test here, because all three are visible on
+// somebody's pull request when they break:
 //
-//   1. A claimed trigger ALWAYS gets exactly one reported outcome, on every
-//      path, and the sandbox is always torn down. An unreported claim shows up
-//      as a check that hangs for five minutes and then goes neutral.
-//   2. The outcome distinguishes the PR's fault from ours. `build_failed` and
-//      `server_unhealthy` are the PR's; `infra_error` is ours. Backwards, and a
-//      good PR gets a red X (or a real breakage is hidden).
+//   1. A claimed trigger ALWAYS gets exactly one COMPLETION, on every path, and
+//      the sandbox is always torn down. An unreported claim shows up as a check
+//      that hangs for five minutes and then goes neutral.
+//   2. THE WORKER NO LONGER NAMES THE VERDICT. `/complete` carries no `outcome`;
+//      the backend derives it from the attempt log and the BOUND run. The one
+//      exception is a check that never got a plan at all, which is neutral by
+//      construction.
+//   3. THE EVAL ATTEMPT IS POSTED AT LAUNCH, carrying the runId — that attempt
+//      is what binds the run to the check, and a check whose run is not bound
+//      can only ever be `infra_error`.
 
 const CLAIM: ClaimedGithubCheck = {
   triggerId: "trig-1",
@@ -57,9 +66,21 @@ const RECIPE = {
   evidence: ["operator override for mcpjam/mcp-check-fixture"],
 };
 
+type Completion = {
+  runId?: string;
+  summary?: unknown;
+  detailsMarkdown?: string;
+  terminalAttempt?: AttemptInput;
+};
+
 type Harness = {
   deps: Partial<CheckExecutionDeps>;
-  reports: CheckReport[];
+  /** Planless reports — reachable ONLY when `/plan/begin` produced no plan. */
+  reports: PlanlessCheckReport[];
+  /** Every `/attempt` the worker itself posted (the resolver's are its own). */
+  attempts: AttemptInput[];
+  /** Every `/complete`. Exactly one per claim, on every path but a lost lease. */
+  completions: Completion[];
   events: string[];
   heartbeats: string[];
   /**
@@ -77,11 +98,39 @@ type Harness = {
  */
 function harness(
   overrides?: Partial<CheckExecutionDeps>,
-  liveness?: string
+  liveness?: string,
+  planOptions?: {
+    beginThrows?: unknown;
+    attemptThrows?: (input: AttemptInput) => unknown;
+  }
 ): Harness {
-  const reports: CheckReport[] = [];
+  const reports: PlanlessCheckReport[] = [];
+  const attempts: AttemptInput[] = [];
+  const completions: Completion[] = [];
   const events: string[] = [];
   const heartbeats: string[] = [];
+
+  const session: CheckPlanSession = {
+    planId: "plan-1",
+    candidates: async () => ({
+      candidates: [],
+      stopPolicy: { maxCandidates: 3, wallClockMs: 1_200_000 },
+    }),
+    attempt: async (input) => {
+      attempts.push(input);
+      events.push(`attempt:${input.phase}:${input.ok ? "ok" : "fail"}`);
+      const thrown = planOptions?.attemptThrows?.(input);
+      if (thrown) throw thrown;
+      if (input.phase === "eval" && input.ok) {
+        return { action: "complete", reason: "verdict_established" };
+      }
+      return { action: "continue_phase" };
+    },
+    complete: async (input) => {
+      completions.push(input);
+      events.push("complete");
+    },
+  };
 
   const sandbox = {
     sandboxId: "sb_1",
@@ -102,20 +151,26 @@ function harness(
   } as unknown as CheckSandbox;
 
   const deps: Partial<CheckExecutionDeps> = {
-    // The ladder, the boxes and the runtime verification are one collaborator
-    // now (`resolve-and-start.ts`, tested in its own suite). What the WORKER
-    // owes is unchanged: exactly one reported outcome per claim, provenance on
-    // it, and teardown of whatever box it was handed.
+    beginPlan: async () => {
+      events.push("beginPlan");
+      if (planOptions?.beginThrows) throw planOptions.beginThrows;
+      return session;
+    },
+    // The ladder, the boxes, the plan loop and the runtime verification are one
+    // collaborator (`resolve-and-start.ts`, tested in its own suite). What the
+    // WORKER owes is exactly one completion per claim, the eval attempt posted
+    // at launch, and teardown of whatever box it was handed.
     resolveAndStart: async (_args, overrides) => {
       events.push("resolveAndStart");
       overrides?.onSandbox?.(sandbox);
       return {
         sandbox,
         recipe: RECIPE,
+        candidateId: "c1",
         started: {
           url: "https://3001-sb_1.e2b.app/mcp",
           readStderrTail: async () => "",
-            spawn: { pid: 1234, pgrp: 1234 },
+          spawn: { pid: 1234, pgrp: 1234 },
         },
         provenance: {
           recipeRung: RECIPE.rung,
@@ -140,8 +195,9 @@ function harness(
     recordServer: async (triggerId, serverId) => {
       events.push(`recordServer:${triggerId}:${serverId}`);
     },
-    runEvalSuite: async () => {
+    runEvalSuite: async (args) => {
       events.push("runEvalSuite");
+      await args.onRunStarted?.("run-1");
       return {
         runId: "run-1",
         result: "passed",
@@ -159,64 +215,97 @@ function harness(
     ...overrides,
   };
 
-  return { deps, reports, events, heartbeats, sandbox };
+  return {
+    deps,
+    reports,
+    attempts,
+    completions,
+    events,
+    heartbeats,
+    sandbox,
+  };
 }
 
 describe("executeClaimedCheck — happy path", () => {
-  it("builds, creates the ephemeral server, runs the suite, reports passed, cleans up", async () => {
+  it("begins the plan FIRST, runs the suite, completes with no outcome, cleans up", async () => {
     const h = harness();
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
 
     expect(h.events).toEqual([
+      // Before any sandbox work — that is what makes a provision or clone
+      // failure attributable instead of planless.
+      "beginPlan",
       "resolveAndStart",
       "getBearer",
       "createServer:gh-check-trig-1:https://3001-sb_1.e2b.app/mcp",
       "recordServer:trig-1:server-1",
       "runEvalSuite",
-      "report:passed",
+      "attempt:eval:ok",
+      "complete",
       "deleteServer:server-1",
       "killSandbox",
     ]);
-    expect(h.reports).toEqual([
+    expect(h.completions).toEqual([
       {
-        triggerId: "trig-1",
-        outcome: "passed",
         runId: "run-1",
-        recipeRung: "override",
-        recipeEvidence: ["operator override for mcpjam/mcp-check-fixture"],
         summary: { total: 3, passed: 3, failed: 0, passRate: 1 },
       },
     ]);
+    // NO OUTCOME. The backend derives it from the attempts and the bound run;
+    // sending one would take the legacy path and put the verdict back here.
+    expect(h.completions[0]).not.toHaveProperty("outcome");
+    // And the planless path — the only one that still names an outcome — was
+    // never taken.
+    expect(h.reports).toHaveLength(0);
   });
 
-  it("reports the rung and evidence that produced the recipe", async () => {
-    // Provenance is what makes a red X attributable: "your mcpjam.yaml said so"
-    // reads very differently from "we guessed". The backend clamps both fields;
-    // dropping them here would silently make every check look unattributed.
+  it("posts the eval attempt AT LAUNCH, carrying the runId that binds the run", async () => {
+    // The binding is what turns "belongs to the shared github-checks suite" into
+    // "belongs to THIS check". Posted after the run instead, every completion in
+    // between could only ever be `infra_error`.
+    const order: string[] = [];
     const h = harness({
-      resolveAndStart: async (_args, overrides) => {
-        overrides?.onSandbox?.(h.sandbox);
+      runEvalSuite: async (args) => {
+        order.push("launch");
+        await args.onRunStarted?.("run-7");
+        order.push("execute");
+        return { runId: "run-7", result: "passed" };
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(order).toEqual(["launch", "execute"]);
+    expect(h.attempts).toEqual([
+      {
+        candidateId: "c1",
+        phase: "eval",
+        ok: true,
+        runId: "run-7",
+        durationMs: 0,
+      },
+    ]);
+    expect(h.completions[0].runId).toBe("run-7");
+  });
+
+  it("never reports `evals_failed` itself when the run fails", async () => {
+    // The kind was removed from the backend union entirely: "evals failed" is a
+    // statement about the pull request, and it comes only from the backend
+    // reading the bound run's result.
+    const h = harness({
+      runEvalSuite: async (args) => {
+        await args.onRunStarted?.("run-2");
         return {
-          sandbox: h.sandbox,
-          recipe: { ...RECIPE, rung: "detected", ownershipProof: "unverified" },
-          started: {
-            url: "https://3001-sb_1.e2b.app/mcp",
-            readStderrTail: async () => "",
-            spawn: { pid: 1234, pgrp: 1234 },
-          },
-          provenance: {
-            recipeRung: "detected",
-            recipeEvidence: ["package.json scripts.start with package-lock.json"],
-          },
+          runId: "run-2",
+          result: "failed",
+          summary: { total: 4, passed: 1, failed: 3, passRate: 0.25 },
         };
       },
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0]).toMatchObject({
-      outcome: "passed",
-      recipeRung: "detected",
-      recipeEvidence: ["package.json scripts.start with package-lock.json"],
-    });
+
+    expect(h.completions[0]).toMatchObject({ runId: "run-2" });
+    expect(JSON.stringify(h.attempts)).not.toContain("evals_failed");
+    expect(JSON.stringify(h.completions)).not.toContain("evals_failed");
   });
 
   it("records the ephemeral server BEFORE running the suite, so a mid-run death is recoverable", async () => {
@@ -252,85 +341,32 @@ describe("executeClaimedCheck — happy path", () => {
     });
   });
 
-  it("reports evals_failed with the pass counts when the run does not pass", async () => {
-    const h = harness({
-      runEvalSuite: async () => ({
-        runId: "run-2",
-        result: "failed",
-        summary: { total: 4, passed: 1, failed: 3, passRate: 0.25 },
-      }),
-    });
-    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0]).toMatchObject({
-      outcome: "evals_failed",
-      runId: "run-2",
-      summary: { total: 4, passed: 1, failed: 3 },
-    });
-  });
 });
 
-describe("executeClaimedCheck — failure attribution", () => {
-  it("reports recipe_unresolvable — neutral — when no rung produced a recipe", async () => {
+describe("executeClaimedCheck — the plan owns the verdict", () => {
+  it("completes with the author-facing copy when the resolver stopped, and no outcome", async () => {
     const h = harness({
       resolveAndStart: async () => {
-        throw new RecipeStartError(
-          "recipe_unresolvable",
-          "no usable recipe for mcpjam/mcp-check-fixture",
-          "Add `mcpjam.yaml` at the repository root:"
+        throw new CheckStoppedByPlan(
+          "no_candidates",
+          "Add `mcpjam.yaml` at the repository root:",
+          true
         );
       },
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
 
-    expect(h.reports[0]).toMatchObject({ outcome: "recipe_unresolvable" });
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0]).not.toHaveProperty("outcome");
     // The resolver's copy is OUR prose and reaches the check output as markdown,
     // not wrapped in a `text` fence that would render it as source.
-    expect(h.reports[0].detailsMarkdown).toContain("mcpjam.yaml");
-    expect(h.reports[0].detailsMarkdown).not.toContain("```text");
+    expect(h.completions[0].detailsMarkdown).toContain("mcpjam.yaml");
+    expect(h.completions[0].detailsMarkdown).not.toContain("```text");
     expect(h.events).not.toContain("runEvalSuite");
-  });
-
-  it("reports recipe_invalid — a FAILURE — when the declared config is broken", async () => {
-    // The whole point of the distinction: a broken `mcpjam.yaml` is the author's
-    // to fix, so it must not read as our neutral "could not work it out", and it
-    // must not read as `build_failed` for a build that never ran.
-    const h = harness({
-      resolveAndStart: async () => {
-        throw new RecipeStartError(
-          "recipe_invalid",
-          "mcpjam.yaml: checks.port: must be an integer",
-          "Your mcpjam.yaml is present but not usable.",
-          { recipeRung: "declared", recipeEvidence: ["mcpjam.yaml at repo root"] }
-        );
-      },
-    });
-    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-
-    expect(h.reports[0]).toMatchObject({
-      outcome: "recipe_invalid",
-      recipeRung: "declared",
-      recipeEvidence: ["mcpjam.yaml at repo root"],
-    });
-    expect(h.reports[0].failureReason).toContain("checks.port");
     expect(h.events).toContain("killSandbox");
   });
 
-  it("reports infra_error when the sandbox cannot be provisioned", async () => {
-    const h = harness({
-      resolveAndStart: async () => {
-        throw new CheckStepError("infra_error", "E2B 503");
-      },
-    });
-    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0]).toMatchObject({
-      outcome: "infra_error",
-      failureReason: "E2B 503",
-    });
-    // Nothing to delete, but teardown still runs.
-    expect(h.events).toContain("killSandbox");
-  });
-
-  it("reports build_failed — the PR's fault — with the clamped log tail", async () => {
+  it("passes a clamped build log through without double-fencing it", async () => {
     const h = harness({
       resolveAndStart: async () => {
         throw new CheckStepError(
@@ -342,99 +378,193 @@ describe("executeClaimedCheck — failure attribution", () => {
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
 
-    expect(h.reports[0].outcome).toBe("build_failed");
-    expect(h.reports[0].detailsMarkdown).toContain("missing script: build");
-    // Re-clamping our own already-fenced block must not double-fence it.
-    expect(h.reports[0].detailsMarkdown).not.toContain("```text\n```text");
-    // No eval run was attempted, and the box was killed.
+    expect(h.completions[0].detailsMarkdown).toContain("missing script: build");
+    expect(h.completions[0].detailsMarkdown).not.toContain("```text\n```text");
     expect(h.events).not.toContain("runEvalSuite");
     expect(h.events).toContain("killSandbox");
   });
 
-  it("reports server_unhealthy when the built server never speaks MCP", async () => {
+  it("completes with the DEGRADED marker when the backend went away mid-flight", async () => {
+    // Countable rather than inferred: `backend_unreachable` attributes to
+    // `infra_error` — neutral, never a green, never PR-blamed.
     const h = harness({
       resolveAndStart: async () => {
-        throw new CheckStepError(
-          "server_unhealthy",
-          "server never completed MCP initialize on port 3001/mcp",
-          "```text\nlisten EADDRINUSE 127.0.0.1:3001\n```"
-        );
+        throw new PlanUnreachableError("attempt", "ECONNRESET", {
+          phase: "probe",
+          candidateId: "c2",
+        });
       },
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0].outcome).toBe("server_unhealthy");
-    expect(h.reports[0].detailsMarkdown).toContain("EADDRINUSE");
+
+    expect(h.completions[0].terminalAttempt).toMatchObject({
+      phase: "probe",
+      candidateId: "c2",
+      ok: false,
+      failureKind: "backend_unreachable",
+    });
+    expect(h.completions[0]).not.toHaveProperty("outcome");
+  });
+
+  it("completes WITHOUT a marker when the backend refused us (409)", async () => {
+    // A 409 means we violated the state machine, not that the backend is gone —
+    // so there is nothing degraded to record, and nothing is retried.
+    const h = harness({
+      resolveAndStart: async () => {
+        throw new PlanProtocolError("attempt", "candidate_out_of_order", 409);
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.completions).toHaveLength(1);
+    expect(h.completions[0]).not.toHaveProperty("terminalAttempt");
+    expect(h.events).not.toContain("runEvalSuite");
+  });
+
+  it("reports infra_error — planless — when /plan/begin never gave us a plan, and runs NOTHING", async () => {
+    // No plan means no attempt log to derive from, so this is the one path that
+    // still names an outcome. Critically, no box is provisioned: executing a
+    // check we could not plan would mean running our own candidate policy
+    // invisibly, which is exactly what degraded mode forbids.
+    const h = harness(undefined, undefined, {
+      beginThrows: new PlanUnreachableError("plan/begin", "ECONNREFUSED"),
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.reports).toEqual([
+      {
+        triggerId: "trig-1",
+        outcome: "infra_error",
+        failureReason: expect.stringContaining("ECONNREFUSED"),
+      },
+    ]);
+    expect(h.events).toEqual(["beginPlan", "report:infra_error"]);
+    expect(h.completions).toHaveLength(0);
+  });
+
+  it("surfaces the reason when /plan/begin is REFUSED, and still runs nothing", async () => {
+    const h = harness(undefined, undefined, {
+      beginThrows: new PlanProtocolError("plan/begin", "trigger_failed", 409),
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.reports[0].failureReason).toContain("trigger_failed");
+    expect(h.events).not.toContain("resolveAndStart");
+  });
+
+  it("reports a failed eval LAUNCH as an eval attempt, never as `evals_failed`", async () => {
+    const h = harness({
+      runEvalSuite: async () => {
+        throw new Error("prepareEvalRun blew up");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.attempts).toEqual([
+      expect.objectContaining({
+        candidateId: "c1",
+        phase: "eval",
+        ok: false,
+        failureKind: "sandbox_error",
+      }),
+    ]);
+    expect(h.completions).toHaveLength(1);
+  });
+
+  it("posts NO second attempt once the run is already bound", async () => {
+    // After the `eval` attempt the plan is terminal: another attempt is a 409,
+    // and the verdict comes from the bound run — an unfinished one derives
+    // `infra_error`, never a pass.
+    const h = harness({
+      runEvalSuite: async (args) => {
+        await args.onRunStarted?.("run-3");
+        throw new Error("the runner died mid-suite");
+      },
+    });
+    await executeClaimedCheck(CLAIM, "worker-1", h.deps);
+
+    expect(h.attempts.map((a) => `${a.phase}:${a.ok}`)).toEqual(["eval:true"]);
+    expect(h.completions).toHaveLength(1);
   });
 
   const evalDies = {
-    runEvalSuite: async () => {
+    runEvalSuite: async (args: { onRunStarted?: (id: string) => Promise<void> }) => {
+      await args.onRunStarted?.("run-1");
       throw new Error("fetch failed: ECONNREFUSED");
     },
   };
 
-  it("blames the PR when its server stops accepting connections during the eval", async () => {
-    // The server passed the health probe and then died. Asked from inside the box,
-    // the connection is refused — so this is the PR's server, not a network path of
-    // ours, and it must earn `server_unhealthy`.
+  it("says so in the check output when the PR's server stopped accepting connections", async () => {
+    // The server passed the health probe and then died. Asked from inside the
+    // box, the connection is refused — so this is the PR's server, not a network
+    // path of ours, and the author is told exactly that. It is DISPLAY text now:
+    // the verdict comes from the bound run, and the worker has no channel to
+    // assert `server_unhealthy` after the eval attempt landed.
     const h = harness(evalDies, "MCPJAM_CHECK_PORT_CLOSED\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0]).toMatchObject({ outcome: "server_unhealthy" });
-    expect(h.reports[0].detailsMarkdown).toContain("ECONNREFUSED");
-    expect(h.reports[0].detailsMarkdown).toContain("stopped answering");
+    expect(h.completions[0].detailsMarkdown).toContain("ECONNREFUSED");
+    expect(h.completions[0].detailsMarkdown).toContain("stopped answering");
+    expect(h.completions[0]).not.toHaveProperty("outcome");
     expect(h.events).toContain("livenessCheck");
   });
 
-  it("stays neutral when the eval fails but the PR's server still answers", async () => {
-    // Same transport-shaped error, but the process is alive. The failure came from
-    // somewhere else — ours — so the check must not blame the PR.
+  it("says nothing about the PR when its server still answers", async () => {
+    // Same transport-shaped error, but the process is alive. The failure came
+    // from somewhere else — ours — so the output must not point at the PR.
     const h = harness(evalDies, "MCPJAM_CHECK_HTTP_ANSWERED 200\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0].outcome).toBe("infra_error");
+    expect(h.completions[0].detailsMarkdown ?? "").not.toContain(
+      "stopped answering"
+    );
   });
 
-  it("blames the PR when its listener stays bound but answers nothing", async () => {
+  it("names the PR's server when its listener stays bound but answers nothing", async () => {
     // A bound socket proves very little: an event loop that is wedged, deadlocked
-    // or thrashing still accepts connections while answering nothing. That is the
-    // PR's bug, and a TCP-connect-only diagnostic would have called it healthy and
-    // left the eval failure neutral.
+    // or thrashing still accepts connections while answering nothing. A
+    // TCP-connect-only diagnostic would have called it healthy.
     const h = harness(evalDies, "MCPJAM_CHECK_HTTP_SILENT\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0]).toMatchObject({ outcome: "server_unhealthy" });
-    expect(h.reports[0].detailsMarkdown).toContain("sent nothing back");
+    expect(h.completions[0].detailsMarkdown).toContain("sent nothing back");
   });
 
-  it("blames the PR when its server answers the liveness request with a 5xx", async () => {
+  it("names the PR's server when it answers the liveness request with a 5xx", async () => {
     // Running but not serving: a 500 is the server failing on its own terms, and
     // the eval transport would fail on it too.
     const h = harness(evalDies, "MCPJAM_CHECK_HTTP_ANSWERED 500\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0]).toMatchObject({ outcome: "server_unhealthy" });
+    expect(h.completions[0].detailsMarkdown).toContain("stopped answering");
   });
 
-  it("stays neutral when the liveness request draws a 4xx", async () => {
+  it("stays silent when the liveness request draws a 4xx", async () => {
     // The liveness request is a simplified, legacy-shaped `initialize` without the
     // modern `_meta` envelope headers the real client sends, so a modern-only server
     // can reject it correctly while still being drivable by the eval run. A 4xx is
     // therefore evidence about OUR request, not about the PR's server.
     const h = harness(evalDies, "MCPJAM_CHECK_HTTP_ANSWERED 400\n");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0].outcome).toBe("infra_error");
+    expect(h.completions[0].detailsMarkdown ?? "").not.toContain(
+      "stopped answering"
+    );
   });
 
-  it("stays neutral when the sandbox command channel has gone away", async () => {
+  it("stays silent when the sandbox command channel has gone away", async () => {
     // The box no longer answers, so we cannot tell whose fault the eval failure
-    // was — and an E2B outage is ours. Ambiguity must never produce a red X.
+    // was — and an E2B outage is ours. Ambiguity must never point at the PR.
     const h = harness(evalDies, "throws");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0].outcome).toBe("infra_error");
+    expect(h.completions[0].detailsMarkdown ?? "").not.toContain(
+      "stopped answering"
+    );
   });
 
-  it("stays neutral when the liveness check answers with neither sentinel", async () => {
+  it("stays silent when the liveness check answers with neither sentinel", async () => {
     // A connect that timed out, or a node that printed nothing. Silence is not
     // evidence against the PR.
     const h = harness(evalDies, "");
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0].outcome).toBe("infra_error");
+    expect(h.completions[0].detailsMarkdown ?? "").not.toContain(
+      "stopped answering"
+    );
   });
 
   it("abandons the check when the lease is lost during a SUCCESSFUL eval", async () => {
@@ -457,7 +587,8 @@ describe("executeClaimedCheck — failure attribution", () => {
     });
 
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    // Abandoned rather than reported, and the box is still torn down.
+    // Abandoned rather than completed, and the box is still torn down.
+    expect(h.completions).toHaveLength(0);
     expect(h.reports).toHaveLength(0);
     expect(h.events).toContain("killSandbox");
   });
@@ -493,8 +624,8 @@ describe("executeClaimedCheck — failure attribution", () => {
     };
 
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    // Abandoned, not reported — and the box is still torn down.
-    expect(h.reports).toHaveLength(0);
+    // Abandoned, not completed — and the box is still torn down.
+    expect(h.completions).toHaveLength(0);
     expect(h.events).toContain("killSandbox");
   });
 
@@ -520,41 +651,45 @@ describe("executeClaimedCheck — failure attribution", () => {
     expect(liveness).not.toContain("e2b.app");
   });
 
-  it("reports infra_error — not evals_failed — when the org is out of credits", async () => {
+  it("completes — never with an eval verdict — when the org is out of credits", async () => {
     const h = harness({
       runEvalSuite: async () => {
         throw new Error("billing_limit_reached: eval iterations");
       },
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0]).toMatchObject({
-      outcome: "infra_error",
-      failureReason: "billing_limit_reached",
+    // An MCPJam-side limit is ours; it reaches the check as an infrastructure
+    // attempt and the backend concludes it neutral.
+    expect(h.attempts.at(-1)).toMatchObject({
+      phase: "eval",
+      ok: false,
+      failureKind: "sandbox_error",
     });
+    expect(h.completions).toHaveLength(1);
   });
 
-  it("reports infra_error when the delegated token cannot be minted", async () => {
+  it("completes when the delegated token cannot be minted", async () => {
     const h = harness({
       getBearer: async () => {
         throw new Error("Delegated token exchange failed (403)");
       },
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports[0].outcome).toBe("infra_error");
+    expect(h.completions).toHaveLength(1);
     // No server row was created, so nothing to delete…
     expect(h.events.some((e) => e.startsWith("deleteServer"))).toBe(false);
     // …but the sandbox was already provisioned, and a leaked box costs money.
     expect(h.events).toContain("killSandbox");
   });
 
-  it("still reports and cleans up when the clone drifts from the claimed sha", async () => {
+  it("still completes and cleans up when the clone drifts from the claimed sha", async () => {
     const h = harness({
       resolveAndStart: async () => {
         throw new CheckStepError("infra_error", "checkout drifted");
       },
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
-    expect(h.reports).toHaveLength(1);
+    expect(h.completions).toHaveLength(1);
     expect(h.events).toContain("killSandbox");
   });
 });
@@ -581,7 +716,7 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
     // A cleanup failure that costs money (a live sandbox) must not be skipped
     // because a cheaper one (a soft-deletable row) failed first.
     expect(h.events).toContain("killSandbox");
-    expect(h.reports[0].outcome).toBe("passed");
+    expect(h.completions[0].runId).toBe("run-1");
   });
 
   it("does not fail the check when recording the ephemeral server fails", async () => {
@@ -592,18 +727,23 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
     });
     await executeClaimedCheck(CLAIM, "worker-1", h.deps);
     // Recovery loses its cleanup pointer, but the PR still gets its verdict.
-    expect(h.reports[0].outcome).toBe("passed");
+    expect(h.completions[0].runId).toBe("run-1");
   });
 
-  it("never throws, even when reporting itself fails", async () => {
+  it("never throws, even when completing itself fails", async () => {
     const h = harness({
-      report: async () => {
-        throw new Error("convex unreachable");
-      },
       runEvalSuite: async () => {
         throw new Error("boom");
       },
     });
+    const session = await h.deps.beginPlan!({} as ClaimedGithubCheck);
+    // A completion that cannot be delivered is logged, not thrown: the poll loop
+    // would read a throw as a transport failure and back off, while the
+    // backend's heartbeat sweep concludes the check anyway.
+    (session as { complete: unknown }).complete = async () => {
+      throw new Error("convex unreachable");
+    };
+    h.deps.beginPlan = async () => session;
     await expect(
       executeClaimedCheck(CLAIM, "worker-1", h.deps)
     ).resolves.toBeUndefined();
@@ -689,68 +829,51 @@ describe("executeClaimedCheck — cleanup and heartbeat", () => {
       await vi.advanceTimersByTimeAsync(3_000);
       releaseRun();
       await expect(pending).resolves.toBeUndefined();
-      expect(h.reports[0].outcome).toBe("passed");
+      expect(h.completions[0].runId).toBe("run-1");
     } finally {
       vi.useRealTimers();
     }
   });
 });
 
-describe("classifyCheckFailure", () => {
-  it("keeps a CheckStepError's own verdict rather than re-deriving one", () => {
-    expect(
-      classifyCheckFailure(
-        new CheckStepError("build_failed", "exit 1", "```text\nlog\n```")
-      )
-    ).toMatchObject({
-      outcome: "build_failed",
-      detailsMarkdown: expect.any(String),
-    });
-    expect(
-      classifyCheckFailure(new CheckStepError("server_unhealthy", "no init"))
-    ).toMatchObject({ outcome: "server_unhealthy" });
+describe("describeCheckFailure", () => {
+  it("names no outcome at all — that is the backend's now", () => {
+    const described = describeCheckFailure(
+      new CheckStepError("build_failed", "exit 1", "```text\nlog\n```")
+    );
+    expect(described).not.toHaveProperty("outcome");
+    expect(described.failureReason).toBe("exit 1");
+    expect(described.detailsMarkdown).toContain("log");
   });
 
-  it("maps only the canonical billing marker, never a loose substring", () => {
+  it("passes a plan stop's author-facing copy through unfenced", () => {
+    // Our prose, not clamped PR output: re-clamping would wrap a markdown block
+    // — headings, a yaml example — in a `text` fence and render it as source.
+    const described = describeCheckFailure(
+      new CheckStoppedByPlan("recipe_invalid", "# Your mcpjam.yaml", true)
+    );
+    expect(described).toMatchObject({
+      failureReason: "recipe_invalid",
+      detailsPreformatted: true,
+    });
+  });
+
+  it("names only the canonical billing marker, never a loose substring", () => {
     expect(
-      classifyCheckFailure(new Error("billing_limit_reached: iterations"))
+      describeCheckFailure(new Error("billing_limit_reached: iterations"))
     ).toMatchObject({ failureReason: "billing_limit_reached" });
-    // An MCP server error that merely mentions billing must not be reclassified.
+    // An MCP server error that merely mentions billing must not be relabelled.
     expect(
-      classifyCheckFailure(new Error("tool failed: check your billing page"))
+      describeCheckFailure(new Error("tool failed: check your billing page"))
     ).toMatchObject({
-      outcome: "infra_error",
       failureReason: "tool failed: check your billing page",
     });
   });
 
-  it("defaults unknown failures to infra_error, never to the PR's fault", () => {
-    // Guessing from a message would mean a red X on a good PR when we guess
-    // wrong, so an unrecognized failure is always OURS.
-    expect(classifyCheckFailure(new Error("???")).outcome).toBe("infra_error");
-    expect(classifyCheckFailure("a bare string").outcome).toBe("infra_error");
-  });
-
   it("bounds the failure reason", () => {
     expect(
-      classifyCheckFailure(new Error("x".repeat(1_000))).failureReason.length
+      describeCheckFailure(new Error("x".repeat(1_000))).failureReason.length
     ).toBe(200);
-  });
-});
-
-describe("outcomeForRunResult", () => {
-  it("treats only `passed` as a pass", () => {
-    expect(outcomeForRunResult("passed")).toBe("passed");
-    for (const result of [
-      "failed",
-      "cancelled",
-      "timed_out",
-      "pending",
-      null,
-      undefined,
-    ]) {
-      expect(outcomeForRunResult(result)).toBe("evals_failed");
-    }
   });
 });
 
@@ -768,7 +891,6 @@ describe("effectiveRunResult", () => {
       summary: { total: 4, passed: 4, failed: 0, passRate: 1 },
     };
     expect(effectiveRunResult(perfect)).toBe("passed");
-    expect(outcomeForRunResult(effectiveRunResult(perfect))).toBe("passed");
   });
 
   it("compares a PERCENTAGE against the threshold, not the stored fraction", () => {
@@ -1060,8 +1182,8 @@ describe("runReachedAVerdict", () => {
     expect(runReachedAVerdict("completed")).toBe(true);
     // Each of these means the machinery stopped, not that the PR failed — and
     // `timed_out`/`cancelled` reach the verdict path WITHOUT a throw, because a
-    // lifecycle stop is finalized and returned normally. `outcomeForRunResult`
-    // would turn every one of them into `evals_failed`.
+    // lifecycle stop is finalized and returned normally. Letting one through
+    // would hand the backend a run whose assertions were never judged.
     for (const status of [
       "timed_out",
       "cancelled",
@@ -1071,12 +1193,5 @@ describe("runReachedAVerdict", () => {
     ]) {
       expect(runReachedAVerdict(status)).toBe(false);
     }
-  });
-
-  it("guards exactly the statuses outcomeForRunResult would misread", async () => {
-    // The pairing is the point: anything not `passed` is a PR failure downstream,
-    // so anything not `completed` has to be stopped before it gets there.
-    expect(outcomeForRunResult("timed_out")).toBe("evals_failed");
-    expect(runReachedAVerdict("timed_out")).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -738,6 +738,56 @@ export async function verifyRunSnapshot(
   return named.includes(triggerId) ? "ours" : "stolen";
 }
 
+/**
+ * Tidy up a run that `prepareEvalRun` created but that must never be evaluated.
+ *
+ * By the time this is reachable the run row exists AND so does one pending
+ * iteration row per attempt, and the throw that follows bypasses the catch
+ * around `execute()` where the normal cleanup lives. Left alone the run sits in
+ * `running` with every iteration `pending`, forever.
+ *
+ * Every abort between "the run exists" and "the run is running" goes through
+ * here so the three sites cannot drift: fail the iterations first, then the run,
+ * both best effort — failing to tidy up must never replace the reason we are
+ * bailing out.
+ */
+async function abandonPreparedRun(
+  client: ReturnType<typeof createConvexClient>,
+  prepared: Awaited<ReturnType<typeof prepareEvalRun>>,
+  ctx: { triggerId: string; reason: string; what: string }
+): Promise<void> {
+  const notes = ctx.reason.slice(0, 500);
+  await client
+    .mutation("testSuites:markSetupPendingIterationsFailed" as any, {
+      runId: prepared.runId,
+      error: notes,
+    })
+    .catch((cleanupError: unknown) => {
+      logger.warn(
+        `[github-checks] failed to fail pending iterations after ${ctx.what}`,
+        {
+          triggerId: ctx.triggerId,
+          runId: prepared.runId,
+          error:
+            cleanupError instanceof Error
+              ? cleanupError.message
+              : String(cleanupError),
+        }
+      );
+    });
+  if (prepared.recorder) {
+    await prepared.recorder
+      .finalize({ status: "failed", notes })
+      .catch((finalizeError: unknown) => {
+        logger.error(
+          `[github-checks] failed to finalize ${ctx.what}`,
+          finalizeError,
+          { triggerId: ctx.triggerId, runId: prepared.runId }
+        );
+      });
+  }
+}
+
 async function defaultRunEvalSuite(args: {
   claimed: ClaimedGithubCheck;
   bearer: string;
@@ -807,42 +857,12 @@ async function defaultRunEvalSuite(args: {
         ownership === "stolen"
           ? "another check's server was snapshotted onto this run"
           : "could not verify which server this run was bound to";
-      // The run row already exists — `prepareEvalRun` created it, along with a
-      // pending iteration row per attempt — and this throw bypasses the catch
-      // around `execute()` where the cleanup lives. Left alone the run sits in
-      // `running` with every iteration `pending`, and each raced check strands
-      // another set. Mirrors `prepareEvalRun`'s own setup-abort cleanup: fail the
-      // iterations first, then the run, both best effort, because failing to tidy
-      // up must not replace the reason we are bailing out.
-      await client
-        .mutation("testSuites:markSetupPendingIterationsFailed" as any, {
-          runId: prepared.runId,
-          error: reason,
-        })
-        .catch((cleanupError: unknown) => {
-          logger.warn(
-            "[github-checks] failed to fail pending iterations after an unowned run",
-            {
-              triggerId: args.claimed.triggerId,
-              runId: prepared.runId,
-              error:
-                cleanupError instanceof Error
-                  ? cleanupError.message
-                  : String(cleanupError),
-            }
-          );
-        });
-      if (prepared.recorder) {
-        await prepared.recorder
-          .finalize({ status: "failed", notes: reason })
-          .catch((finalizeError: unknown) => {
-            logger.error(
-              "[github-checks] failed to finalize an unowned eval run",
-              finalizeError,
-              { triggerId: args.claimed.triggerId, runId: prepared.runId }
-            );
-          });
-      }
+      // Each raced check would otherwise strand another set of pending rows.
+      await abandonPreparedRun(client, prepared, {
+        triggerId: args.claimed.triggerId,
+        reason,
+        what: "an unowned eval run",
+      });
       throw new CheckStepError("infra_error", reason);
     }
 
@@ -853,8 +873,20 @@ async function defaultRunEvalSuite(args: {
     // "no other plan holds it" is what turns "belongs to the shared suite" into
     // "belongs to THIS check". A throw from here (a 409, an unreachable backend)
     // aborts before a single test runs, which is right — a run nothing may read
-    // is a run not worth paying for.
-    await args.onRunStarted?.(prepared.runId);
+    // is a run not worth paying for — but it must not be a run left `running`
+    // with pending iterations either, so the abort tidies up the same way the
+    // unowned-run branch above does before the error propagates.
+    try {
+      await args.onRunStarted?.(prepared.runId);
+    } catch (bindError) {
+      await abandonPreparedRun(client, prepared, {
+        triggerId: args.claimed.triggerId,
+        reason:
+          bindError instanceof Error ? bindError.message : String(bindError),
+        what: "an unbindable eval run",
+      });
+      throw bindError;
+    }
 
     try {
       await prepared.execute();

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -9,19 +9,24 @@
  * pipeline against it.
  *
  * The worker never talks to GitHub, and it holds no GitHub credential. It
- * reports an OUTCOME; the control plane turns that into a check conclusion.
- * That split is why a compromised worker cannot write to anyone's repo.
+ * reports FACTS; the control plane derives the check conclusion. That split is
+ * why a compromised worker cannot write to anyone's repo.
  *
- * Two invariants this file is responsible for, and they are the reason every
- * exit path goes through `report()`:
+ * ═══════════════════════════════════════════════════════════════════════════
+ * A3b-2: THE VERDICT IS NO LONGER COMPUTED HERE
+ * ═══════════════════════════════════════════════════════════════════════════
  *
- *   1. A claimed trigger ALWAYS gets a verdict. An unreported claim sits until
- *      the backend's heartbeat sweep fails it ~5 minutes later, which shows up
- *      on someone's PR as a check that hung then went neutral.
- *   2. The verdict distinguishes the PR's fault from ours. `build_failed` and
- *      `server_unhealthy` are the PR's (→ check failure); `infra_error` is ours
- *      (→ neutral). Getting that backwards puts a red X on a good PR, or hides
- *      a real breakage.
+ * The loop is now `/plan/begin` → attempts → `/complete`, and the backend owns
+ * candidate ORDERING, CONTINUE/STOP and ATTRIBUTION (`convex/github/
+ * checkPlans.ts`). `/complete` carries NO `outcome` field; the outcome is
+ * derived from the attempt log and the BOUND `testSuiteRun`. See
+ * `github-checks/check-plan.ts` for the full sequence and the three rules
+ * (409 = hard stop, degraded mode, unknown action) that must not be softened.
+ *
+ * The invariant that survives unchanged: A CLAIMED TRIGGER ALWAYS GETS A
+ * COMPLETION. An unreported claim sits until the backend's heartbeat sweep
+ * fails it ~5 minutes later, which shows up on someone's PR as a check that
+ * hung and then went neutral.
  *
  * Gated by `GITHUB_CHECKS_WORKER_ENABLED === '1'`; the backend has its own
  * `GITHUB_CHECKS_ENABLED` gate and 404s this whole surface when it is off.
@@ -41,26 +46,31 @@ import {
   killCheckSandbox,
   type CheckSandbox,
 } from "./github-checks/sandbox.js";
+import { resolveAndStart } from "./github-checks/resolve-and-start.js";
 import {
-  resolveAndStart,
-  RecipeStartError,
-  type RecipeProvenance,
-} from "./github-checks/resolve-and-start.js";
+  beginCheckPlan,
+  CheckStoppedByPlan,
+  PlanProtocolError,
+  PlanUnreachableError,
+  type AttemptInput,
+  type CheckPlanSession,
+} from "./github-checks/check-plan.js";
+import {
+  GITHUB_CHECKS_SERVICE_BASE as SERVICE_BASE,
+  githubChecksServiceEnv,
+  postServiceRoute,
+} from "./github-checks/service-route.js";
 
 const POLL_INTERVAL_MS = 15_000;
 const POLL_JITTER_MS = 5_000;
 /** Backoff after claim/transport errors so a broken backend isn't hammered. */
 const ERROR_BACKOFF_MS = 60_000;
-/** Per-request cap on service-route calls so a stalled Convex can't wedge the loop. */
-const SERVICE_ROUTE_TIMEOUT_MS = 15_000;
 /**
  * Heartbeat cadence. The backend fails a claim whose heartbeat is >5 minutes
  * stale, so 60s leaves room for ~5 consecutive misses before a healthy worker
  * gets its check taken away mid-build.
  */
 const HEARTBEAT_INTERVAL_MS = 60_000;
-
-const SERVICE_BASE = "/internal/v1/github-checks";
 
 /**
  * The claim payload, HAND-MIRRORED from the backend's `ClaimedGithubCheck`
@@ -79,29 +89,6 @@ export type ClaimedGithubCheck = {
   suiteId: string;
 };
 
-/**
- * The verdict vocabulary, also hand-mirrored. The backend maps these to check
- * conclusions (`convex/github/checkRuns.ts`); an unknown value is rejected by
- * the complete route rather than defaulted, so a typo here fails loudly instead
- * of mislabeling a PR.
- */
-export type GithubCheckOutcome =
-  | "passed"
-  | "evals_failed"
-  | "build_failed"
-  | "server_unhealthy"
-  /**
-   * An AUTHORITATIVE config (operator override or the repo's own `mcpjam.yaml`)
-   * that is present but broken. A check FAILURE, and deliberately distinct from
-   * both neighbours: `recipe_unresolvable` is neutral ("we could not work it
-   * out"), and `build_failed` would blame a build that never ran. The backend
-   * accepts and renders this value (#838/#841).
-   */
-  | "recipe_invalid"
-  | "recipe_unresolvable"
-  | "unsupported_fork"
-  | "infra_error";
-
 export type CheckSummary = {
   total: number;
   passed: number;
@@ -109,21 +96,25 @@ export type CheckSummary = {
   passRate: number;
 };
 
-export type CheckReport = {
+/**
+ * The PLANLESS completion, and the ONLY place this worker still names an
+ * outcome.
+ *
+ * It is reachable in exactly one situation: `/plan/begin` did not give us a
+ * plan, so there is nothing to derive a verdict from and the derived shape
+ * cannot be used at all. The alternative is leaving a claimed check silent
+ * until the heartbeat sweep times it out five minutes later, which is a worse
+ * experience for the same conclusion.
+ *
+ * `infra_error` is the only value it ever carries — never a green, never a
+ * PR-blamed outcome, which is the degraded-mode contract. It retires with the
+ * legacy explicit-`outcome` `/complete` shape, in the same follow-up.
+ */
+export type PlanlessCheckReport = {
   triggerId: string;
-  outcome: GithubCheckOutcome;
-  runId?: string;
-  summary?: CheckSummary;
-  detailsMarkdown?: string;
+  outcome: "infra_error";
   failureReason?: string;
-  /**
-   * WHICH rung produced the recipe, and the evidence for it. Reported on every
-   * path where a recipe was actually resolved — success and failure alike — so a
-   * red X is always attributable to a source of truth ("your mcpjam.yaml", "our
-   * guess"). The backend clamps both fields.
-   */
-  recipeRung?: string;
-  recipeEvidence?: string[];
+  detailsMarkdown?: string;
 };
 
 export function isGithubChecksWorkerEnabled(): boolean {
@@ -131,61 +122,7 @@ export function isGithubChecksWorkerEnabled(): boolean {
 }
 
 function requiredEnv(): { convexUrl: string; serviceToken: string } | null {
-  const convexUrl = process.env.CONVEX_HTTP_URL;
-  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  if (!convexUrl || !serviceToken) return null;
-  return { convexUrl, serviceToken };
-}
-
-async function postServiceRoute(
-  path: string,
-  body: Record<string, unknown>
-): Promise<{ status: number; body: any }> {
-  const env = requiredEnv();
-  if (!env) {
-    throw new Error(
-      "github-checks worker requires CONVEX_HTTP_URL and INSPECTOR_SERVICE_TOKEN"
-    );
-  }
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    SERVICE_ROUTE_TIMEOUT_MS
-  );
-  // The timer stays armed through the BODY read, not just the headers: a
-  // response that stalls mid-body would otherwise hang the poll loop for as long
-  // as the socket stays open, and the loop is what recovers from a sick backend.
-  try {
-    const response = await fetch(`${env.convexUrl}${path}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-inspector-service-token": env.serviceToken,
-      },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
-    let parsed: any = null;
-    try {
-      parsed = await response.json();
-    } catch (error) {
-      // A malformed body is tolerated — the status carries the signal. A body
-      // read that hit the abort deadline is NOT: silently returning
-      // `body: null` would make a timed-out call look like a successful one
-      // whose response merely lacked a body. Rethrown as a TIMEOUT, since the
-      // underlying error is a parse failure and would otherwise read in the
-      // logs (and in an `infra_error` detail) as a malformed-response bug.
-      if (controller.signal.aborted) {
-        throw new Error(
-          `service route ${path} timed out after ${SERVICE_ROUTE_TIMEOUT_MS}ms while reading the response body`,
-          { cause: error }
-        );
-      }
-    }
-    return { status: response.status, body: parsed };
-  } finally {
-    clearTimeout(timeout);
-  }
+  return githubChecksServiceEnv();
 }
 
 async function claimNext(
@@ -203,7 +140,9 @@ async function claimNext(
   return (body.claimed as ClaimedGithubCheck | null) ?? null;
 }
 
-async function reportOutcome(report: CheckReport): Promise<void> {
+async function reportPlanlessOutcome(
+  report: PlanlessCheckReport
+): Promise<void> {
   try {
     const { status, body } = await postServiceRoute(
       `${SERVICE_BASE}/complete`,
@@ -308,23 +247,23 @@ async function recordEphemeralServer(
 }
 
 /**
- * Map a thrown error to an outcome.
+ * DESCRIBE a thrown failure. It no longer classifies one.
  *
- * `CheckStepError` and `RecipeStartError` already carry their verdict (the
- * sandbox module decided whether a failure was the PR's or ours; the resolver
- * decided whether a broken recipe was declared or guessed), so they win
- * outright. `RecipeStartError` additionally carries the PROVENANCE of the recipe
- * it failed under, when one had been resolved. Beyond that,
- * only ONE marker is matched: the backend's canonical `billing_limit_reached`
- * code, which is an MCPJam-side limit and must never show as the PR's failure.
- * Everything else is `infra_error` — deliberately, because the alternative is
- * guessing from a message, and a wrong guess means a red X on a good PR.
+ * The outcome used to be decided here, from the error's type: `CheckStepError`
+ * carried the sandbox's verdict and `RecipeStartError` the resolver's. Both are
+ * gone as verdict sources — attribution moved to `convex/github/checkPlans.ts`,
+ * where "a candidate build failure is a miss, not a red X" can change without
+ * an Inspector deploy. What is left is DISPLAY: the short reason for the logs
+ * and the author-facing markdown for the check output, neither of which has any
+ * verdict authority.
+ *
+ * The one message match that survives is the backend's canonical
+ * `billing_limit_reached` code — an MCPJam-side limit, worth naming plainly in
+ * the check output so nobody debugs their build over it.
  */
-export function classifyCheckFailure(error: unknown): {
-  outcome: GithubCheckOutcome;
+export function describeCheckFailure(error: unknown): {
   failureReason: string;
   detailsMarkdown?: string;
-  provenance?: RecipeProvenance;
   /**
    * The details are OUR prose, not clamped PR output — the resolver's failure
    * copy is constant text (plus, for `recipe_invalid`, the yaml parser message
@@ -334,25 +273,22 @@ export function classifyCheckFailure(error: unknown): {
    */
   detailsPreformatted?: boolean;
 } {
-  if (error instanceof RecipeStartError) {
+  if (error instanceof CheckStoppedByPlan) {
     return {
-      outcome: error.outcome,
-      failureReason: error.message.slice(0, 200),
+      failureReason: error.reason.slice(0, 200),
       ...(error.detailsMarkdown
         ? {
             detailsMarkdown: error.detailsMarkdown.slice(
               0,
               RESOLVER_DETAILS_MAX_CHARS
             ),
-            detailsPreformatted: true,
+            ...(error.detailsPreformatted ? { detailsPreformatted: true } : {}),
           }
         : {}),
-      ...(error.provenance ? { provenance: error.provenance } : {}),
     };
   }
   if (error instanceof CheckStepError) {
     return {
-      outcome: error.outcome,
       failureReason: error.message.slice(0, 200),
       ...(error.detailsMarkdown
         ? { detailsMarkdown: error.detailsMarkdown }
@@ -361,12 +297,9 @@ export function classifyCheckFailure(error: unknown): {
   }
   const message = error instanceof Error ? error.message : String(error);
   if (/billing_limit_reached/i.test(message)) {
-    return {
-      outcome: "infra_error",
-      failureReason: "billing_limit_reached",
-    };
+    return { failureReason: "billing_limit_reached" };
   }
-  return { outcome: "infra_error", failureReason: message.slice(0, 200) };
+  return { failureReason: message.slice(0, 200) };
 }
 
 /**
@@ -375,32 +308,6 @@ export function classifyCheckFailure(error: unknown): {
  * against a future message growing without anyone noticing, not a sanitizer.
  */
 const RESOLVER_DETAILS_MAX_CHARS = 8_000;
-
-/**
- * Provenance as report fields, or nothing at all.
- *
- * Omitted rather than defaulted when no recipe was resolved: a check that failed
- * BEFORE resolution has no rung, and inventing one ("override", say) would
- * attribute the failure to a source of truth that was never consulted.
- */
-function provenanceFields(
-  provenance: RecipeProvenance | null | undefined
-): Pick<CheckReport, "recipeRung" | "recipeEvidence"> {
-  if (!provenance) return {};
-  return {
-    recipeRung: provenance.recipeRung,
-    ...(provenance.recipeEvidence.length > 0
-      ? { recipeEvidence: provenance.recipeEvidence }
-      : {}),
-  };
-}
-
-/** Terminal run result → outcome. Only `passed` is a pass. */
-export function outcomeForRunResult(
-  result: string | null | undefined
-): GithubCheckOutcome {
-  return result === "passed" ? "passed" : "evals_failed";
-}
 
 /**
  * The run's verdict, derived when the record does not carry one.
@@ -461,10 +368,16 @@ export function effectiveRunResult(
  */
 export type CheckExecutionDeps = {
   /**
-   * The resolver ladder plus the sandboxes it needs — provisioning, cloning,
-   * building, the runtime verification, and a FRESH BOX PER CANDIDATE. The
-   * worker no longer looks a recipe up: rung 0 is the operator override table,
-   * reached through `resolver/overrides.ts` inside this call.
+   * Mint the plan SHELL. Called FIRST — before a box is provisioned, before the
+   * checkout exists — so that provision, clone and detection failures are
+   * attributable through the ordinary attempt path instead of needing a second,
+   * planless completion contract forever.
+   */
+  beginPlan: (claimed: ClaimedGithubCheck) => Promise<CheckPlanSession>;
+  /**
+   * The deterministic ladder plus the sandboxes it needs — provisioning,
+   * cloning, building, the runtime verification, and a FRESH BOX PER CANDIDATE
+   * — executing the BACKEND'S plan, in the backend's order.
    *
    * On success exactly one box is alive (the one in the result); on failure this
    * call has already killed every box it created. `onSandbox` keeps the
@@ -490,8 +403,20 @@ export type CheckExecutionDeps = {
     bearer: string;
     serverId: string;
     serverName: string;
+    /**
+     * Called with the run's id THE MOMENT IT EXISTS, before the suite is
+     * executed. That call is what posts the `eval` attempt, and that attempt is
+     * what BINDS the run to this check — the backend records it as
+     * `plan.boundRunId` and reads the verdict from there. Posting it after the
+     * run finished would leave a window in which the check has a running suite
+     * and no binding, and a completion in that window can only ever be
+     * `infra_error`. A throw from here aborts the run, deliberately: an
+     * unbindable run is a run whose result nothing may read.
+     */
+    onRunStarted?: (runId: string) => Promise<void>;
   }) => Promise<{ runId: string; result?: string; summary?: CheckSummary }>;
-  report: (report: CheckReport) => Promise<void>;
+  /** The PLANLESS completion. Only reachable when `/plan/begin` gave us none. */
+  report: (report: PlanlessCheckReport) => Promise<void>;
   heartbeat: (triggerId: string, claimedBy: string) => Promise<void>;
   heartbeatIntervalMs: number;
 };
@@ -610,37 +535,37 @@ async function serverStillResponding(
 }
 
 /**
- * Decide whether an eval-phase failure belongs to the PR or to us.
+ * SAY whether an eval-phase failure looks like the PR's server dying.
  *
  * `runEvalSuite` throws an ordinary transport error for two very different
- * situations: the PR's server died after passing the health probe, or something on
- * OUR side broke (Convex, the provider, E2B). Both used to land on neutral
- * `infra_error`, which lets a PR whose server crashes seconds after `initialize`
- * escape the `server_unhealthy` it earned.
+ * situations: the PR's server died after passing the health probe, or something
+ * on OUR side broke (Convex, the provider, E2B). Rather than pattern-matching
+ * error messages — fragile, and wrong the first time a provider rewords a
+ * timeout — this asks the box whether the server process is still listening,
+ * and speaks up ONLY on a definite "no". A `null` verdict (command channel
+ * down, or no answer at all) and a "yes" both leave the error's own text alone.
  *
- * Rather than pattern-matching error messages — fragile, and wrong the first time a
- * provider rewords a timeout — this asks the box whether the server process is
- * still listening, and reclassifies ONLY on a definite "no". A `null` verdict
- * (command channel down, or no answer at all) and a "yes" both leave the original
- * error alone, so they stay neutral. Ambiguity must never produce a red X.
+ * IT NO LONGER RECLASSIFIES THE OUTCOME. Once the eval attempt is posted the
+ * plan is terminal and the verdict comes from the BOUND run; there is no legal
+ * channel for the worker to assert `server_unhealthy` after that, and inventing
+ * one would put the verdict back in this process. So the diagnostic survives as
+ * what it always really was — the sentence that tells the author what happened
+ * — and it rides to `/complete` as DISPLAY text with no verdict authority.
  */
-async function attributeEvalFailure(
+async function describeEvalFailure(
   error: unknown,
   sandbox: CheckSandbox,
   recipe: CheckRecipe
-): Promise<unknown> {
-  // Our own typed failures and the lease guard already know what they are.
+): Promise<string | undefined> {
+  // Our own typed failures and the lease guard already say what they are.
   if (error instanceof CheckStepError || error instanceof LeaseLostError) {
-    return error;
+    return undefined;
   }
-  if ((await serverStillResponding(sandbox, recipe)) !== false) return error;
+  if ((await serverStillResponding(sandbox, recipe)) !== false)
+    return undefined;
   const message = error instanceof Error ? error.message : String(error);
-  return new CheckStepError(
-    "server_unhealthy",
-    "the server stopped answering after it started",
-    clampOutput(
-      `The server answered the health probe, then stopped answering on port ${recipe.port} while the eval suite was running — it either refused the connection or accepted it and sent nothing back. Checked from inside the sandbox, so this is the server process and not the network path to it.\n\n${message}`
-    )
+  return clampOutput(
+    `The server answered the health probe, then stopped answering on port ${recipe.port} while the eval suite was running — it either refused the connection or accepted it and sent nothing back. Checked from inside the sandbox, so this is the server process and not the network path to it.\n\n${message}`
   );
 }
 
@@ -818,6 +743,7 @@ async function defaultRunEvalSuite(args: {
   bearer: string;
   serverId: string;
   serverName: string;
+  onRunStarted?: (runId: string) => Promise<void>;
 }): Promise<{ runId: string; result?: string; summary?: CheckSummary }> {
   // Empty caller context = plain-JWT caller; the delegated JWT is the principal
   // (same contract as the scheduled worker).
@@ -920,6 +846,16 @@ async function defaultRunEvalSuite(args: {
       throw new CheckStepError("infra_error", reason);
     }
 
+    // BIND THE RUN, NOW. The run row exists, it has been proven to be ours, and
+    // nothing has been evaluated yet — so this is the launch moment the `eval`
+    // attempt names. Posting it here rather than after `execute()` is what makes
+    // the binding hold for the whole run: `run.createdAt >= plan.createdAt` plus
+    // "no other plan holds it" is what turns "belongs to the shared suite" into
+    // "belongs to THIS check". A throw from here (a 409, an unreachable backend)
+    // aborts before a single test runs, which is right — a run nothing may read
+    // is a run not worth paying for.
+    await args.onRunStarted?.(prepared.runId);
+
     try {
       await prepared.execute();
     } catch (error) {
@@ -1009,6 +945,12 @@ async function defaultRunEvalSuite(args: {
 
 function defaultDeps(): CheckExecutionDeps {
   return {
+    beginPlan: (claimed) =>
+      beginCheckPlan({
+        triggerId: claimed.triggerId,
+        repoFullName: claimed.repoFullName,
+        headSha: claimed.headSha,
+      }),
     resolveAndStart,
     killSandbox: killCheckSandbox,
     getBearer: getConvexBearerForDelegation,
@@ -1016,7 +958,7 @@ function defaultDeps(): CheckExecutionDeps {
     deleteEphemeralServer: defaultDeleteEphemeralServer,
     recordServer: recordEphemeralServer,
     runEvalSuite: defaultRunEvalSuite,
-    report: reportOutcome,
+    report: reportPlanlessOutcome,
     heartbeat: sendHeartbeat,
     heartbeatIntervalMs: HEARTBEAT_INTERVAL_MS,
   };
@@ -1024,7 +966,7 @@ function defaultDeps(): CheckExecutionDeps {
 
 /**
  * Execute one claimed check end to end. NEVER throws, and every exit path
- * reports an outcome — see the invariants at the top of the file.
+ * completes the check — see the invariants at the top of the file.
  */
 export async function executeClaimedCheck(
   claimed: ClaimedGithubCheck,
@@ -1075,18 +1017,12 @@ export async function executeClaimedCheck(
   let sandbox: CheckSandbox | null = null;
   let serverId: string | null = null;
   let bearer: string | null = null;
-  /**
-   * Set the moment a recipe is resolved, so every report from there on names
-   * the rung that produced it — including the failure reports, which are the
-   * ones an author actually reads.
-   */
-  let provenance: RecipeProvenance | null = null;
 
   // Reporting is the last thing that can fail, and it must not turn a delivered
-  // verdict into a thrown error — the poll loop would read that as a transport
-  // failure and back off, while the backend's heartbeat sweep would eventually
-  // conclude the check `infra_error` anyway.
-  const safeReport = async (report: CheckReport): Promise<void> => {
+  // completion into a thrown error — the poll loop would read that as a
+  // transport failure and back off, while the backend's heartbeat sweep would
+  // eventually conclude the check `infra_error` anyway.
+  const safeReport = async (report: PlanlessCheckReport): Promise<void> => {
     try {
       await deps.report(report);
     } catch (error) {
@@ -1098,12 +1034,99 @@ export async function executeClaimedCheck(
     }
   };
 
+  // ═══════════════════════════════════════════════════════════════════════
+  // STEP 2 — MINT THE PLAN SHELL, BEFORE ANY SANDBOX WORK.
+  // ═══════════════════════════════════════════════════════════════════════
+  //
+  // Everything after this point is attributable through the ordinary
+  // attempt/complete path — including a provision that never came up and a
+  // clone that 404'd, which is exactly the class of failure operators most need
+  // counted. Failing HERE is the one case with no plan to complete against, so
+  // it is also the one case that still names an outcome, and only ever the
+  // neutral one.
+  let session: CheckPlanSession;
   try {
-    // Resolves the ladder against the checkout and leaves the WINNING box
-    // running a verified server. Provisioning, cloning, building, egress
-    // lockdown, the probe and both runtime checks all live in there, because
-    // the fresh-box-per-candidate policy is only expressible where the boxes
-    // are made.
+    session = await deps.beginPlan(claimed);
+  } catch (error) {
+    clearInterval(heartbeat);
+    const detail =
+      error instanceof PlanProtocolError
+        ? `the backend refused to open a plan for this check: ${error.reason}`
+        : error instanceof PlanUnreachableError
+        ? `the backend could not be reached to open a plan: ${error.detail}`
+        : error instanceof Error
+        ? error.message
+        : String(error);
+    logger.warn("[github-checks] could not begin a plan; nothing was run", {
+      ...logContext,
+      detail,
+    });
+    // No local fallback, and NOTHING is provisioned: a check we cannot plan is a
+    // check we must not execute, because executing it would mean running our own
+    // candidate policy invisibly — the one thing degraded mode forbids.
+    await safeReport({
+      triggerId: claimed.triggerId,
+      outcome: "infra_error",
+      failureReason: detail.slice(0, 200),
+    });
+    return;
+  }
+
+  /**
+   * Complete the check. NO `outcome` — the backend derives it from the attempt
+   * log and the bound run.
+   */
+  const safeComplete = async (input: {
+    runId?: string;
+    summary?: CheckSummary;
+    detailsMarkdown?: string;
+    terminalAttempt?: AttemptInput;
+  }): Promise<void> => {
+    try {
+      await session.complete(input);
+    } catch (error) {
+      logger.warn("[github-checks] completing the check failed", {
+        ...logContext,
+        planId: session.planId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+
+  /**
+   * The DEGRADED marker, when the loop stopped because the backend went away.
+   *
+   * `backend_unreachable` is legal at every phase and either scope, and the
+   * backend attributes it to `infra_error` — neutral, never a green, never
+   * PR-blamed. It is what makes degraded runs COUNTABLE rather than inferred
+   * from a check that simply went quiet.
+   */
+  const degradedMarker = (error: unknown): AttemptInput | undefined => {
+    if (!(error instanceof PlanUnreachableError)) return undefined;
+    return {
+      ...(error.at?.candidateId ? { candidateId: error.at.candidateId } : {}),
+      phase: error.at?.phase ?? "resolve",
+      ok: false,
+      failureKind: "backend_unreachable",
+      durationMs: 0,
+      detailsClamped: error.detail.slice(0, 500),
+    };
+  };
+
+  /** The plan's id for the candidate the backend ACCEPTED, once it has one. */
+  let acceptedCandidateId: string | null = null;
+  /** Set once the `eval` attempt landed: after that the plan is terminal. */
+  let runBound = false;
+  /** The in-box diagnostic for an eval that died. DISPLAY text, no authority. */
+  let evalFailureDetails: string | undefined;
+
+  try {
+    // Runs the deterministic ladder against the checkout, then executes the
+    // BACKEND'S candidates in the BACKEND'S order, reporting every phase, and
+    // leaves the accepted box running a verified server. Provisioning, cloning,
+    // building, egress lockdown, the probe and the listener-identity check all
+    // live in there, because the fresh-box-per-candidate policy is only
+    // expressible where the boxes are made.
     const resolved = await deps.resolveAndStart(
       {
         triggerId: claimed.triggerId,
@@ -1112,6 +1135,7 @@ export async function executeClaimedCheck(
         headSha: claimed.headSha,
       },
       {
+        plan: session,
         // Keeps this function's handle on the LIVE box current, so the
         // `finally` below kills whatever is still alive and never a box that
         // was already torn down and replaced.
@@ -1122,15 +1146,17 @@ export async function executeClaimedCheck(
       }
     );
     sandbox = resolved.sandbox;
-    provenance = resolved.provenance;
+    acceptedCandidateId = resolved.candidateId;
     const recipe = resolved.recipe;
     const started = resolved.started;
     assertLeaseHeld();
 
     logger.info("[github-checks] PR server is reachable", {
       ...logContext,
+      planId: session.planId,
+      candidate: resolved.candidateId,
       url: started.url,
-      rung: provenance.recipeRung,
+      rung: resolved.provenance.recipeRung,
     });
 
     bearer = await deps.getBearer(
@@ -1165,11 +1191,27 @@ export async function executeClaimedCheck(
         bearer,
         serverId,
         serverName,
+        // STEP 9 — the attempt that BINDS the run, posted AT LAUNCH.
+        onRunStarted: async (runId) => {
+          await session.attempt({
+            candidateId: resolved.candidateId,
+            phase: "eval",
+            ok: true,
+            runId,
+            durationMs: 0,
+          });
+          // The returned action is `complete` (`verdict_established`) and the
+          // plan is now terminal: no further attempt is legal, and none is
+          // sent. We still WAIT for the run — the backend reads the verdict off
+          // the row, and an unfinished one derives `infra_error`, never a pass.
+          runBound = true;
+        },
       })
       .catch(async (error: unknown) => {
-        // A failure here may be the PR's server dying mid-run rather than an
-        // outage of ours, and the difference decides who gets the red X.
-        const attributed = await attributeEvalFailure(
+        // The PR's server dying mid-run and an outage of ours read identically
+        // in the error text, so the box is asked directly. The answer is
+        // DISPLAY only now — the verdict comes from the BOUND run.
+        evalFailureDetails = await describeEvalFailure(
           error,
           runningBox,
           recipe
@@ -1179,57 +1221,81 @@ export async function executeClaimedCheck(
         // a check somebody else has already concluded is abandoned rather than
         // reported on, which is what every other step boundary does.
         assertLeaseHeld();
-        throw attributed;
+
+        // A LAUNCH that never bound a run is still reportable as an eval
+        // attempt; one that already bound is not, because the plan is terminal.
+        // `sandbox_error` is the honest kind — the launch is OURS — and
+        // `evals_failed` is not worker-reportable at all: that statement about
+        // the pull request comes only from the backend reading the bound run.
+        // A plan-level failure is excluded: the backend either refused us or is
+        // gone, and either way another attempt is not the answer.
+        if (
+          !runBound &&
+          !(error instanceof PlanProtocolError) &&
+          !(error instanceof PlanUnreachableError)
+        ) {
+          await session
+            .attempt({
+              candidateId: resolved.candidateId,
+              phase: "eval",
+              ok: false,
+              failureKind: "sandbox_error",
+              durationMs: 0,
+              detailsClamped:
+                error instanceof Error
+                  ? error.message.slice(0, 500)
+                  : String(error).slice(0, 500),
+            })
+            .catch(() => {});
+        }
+        throw error;
       });
 
     // The eval is the widest window in this flow — twenty minutes — so the lease
     // can be taken away while it runs and still resolve normally. The failure path
     // re-checks; this one has to as well, or a check the backend already concluded
-    // gets a verdict reported over the top of it.
+    // gets a completion posted over the top of it.
     assertLeaseHeld();
 
-    const outcome = outcomeForRunResult(run.result);
-    await safeReport({
-      triggerId: claimed.triggerId,
-      outcome,
+    await safeComplete({
+      // VERIFIED, never adopted: this must equal the run the `eval` attempt
+      // bound, and the backend 409s if it does not.
       runId: run.runId,
-      ...provenanceFields(provenance),
       ...(run.summary ? { summary: run.summary } : {}),
-      ...(outcome === "evals_failed"
-        ? { failureReason: `run result: ${run.result ?? "unknown"}` }
-        : {}),
     });
   } catch (error) {
     if (error instanceof LeaseLostError) {
-      // Nothing to report: the backend already concluded this check, which is why
-      // the lease was taken away. Reporting anyway would just be rejected. The
-      // `finally` below still tears the sandbox down.
+      // Nothing to complete: the backend already concluded this check, which is
+      // why the lease was taken away. Completing anyway would just be rejected.
+      // The `finally` below still tears the sandbox down.
       logger.warn("[github-checks] abandoned a check whose lease was lost", {
         ...logContext,
         reason: error.reason,
       });
       return;
     }
-    const classified = classifyCheckFailure(error);
+    const described = describeCheckFailure(error);
     logger.error("[github-checks] check failed", error, {
       ...logContext,
-      outcome: classified.outcome,
+      planId: session.planId,
+      reason: described.failureReason,
+      candidate: acceptedCandidateId,
     });
-    await safeReport({
-      triggerId: claimed.triggerId,
-      outcome: classified.outcome,
-      failureReason: classified.failureReason,
-      // The error's own provenance wins: a failure thrown DURING resolution
-      // knows which rung it failed under, while `provenance` is only set once
-      // resolution has succeeded.
-      ...provenanceFields(classified.provenance ?? provenance),
-      ...(classified.detailsMarkdown
+    // NO OUTCOME. Every failure that got this far was reported as an attempt at
+    // the phase it happened at; the backend derives what it adds up to. The only
+    // things travelling here are display text and — when the backend went away
+    // mid-flight — the degraded marker.
+    const details = described.detailsMarkdown ?? evalFailureDetails;
+    const marker = degradedMarker(error);
+    await safeComplete({
+      ...(details
         ? {
-            detailsMarkdown: classified.detailsPreformatted
-              ? classified.detailsMarkdown
-              : clampOutput(rawOf(classified.detailsMarkdown)),
+            detailsMarkdown: described.detailsPreformatted
+              ? details
+              : clampOutput(rawOf(details)),
           }
         : {}),
+      ...(marker ? { terminalAttempt: marker } : {}),
     });
   } finally {
     clearInterval(heartbeat);

--- a/mcpjam-inspector/server/services/github-checks/__tests__/check-plan.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/check-plan.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from "vitest";
+import {
+  beginCheckPlan,
+  HttpCheckPlanSession,
+  PlanProtocolError,
+  PlanUnreachableError,
+} from "../check-plan";
+
+// The wire half of the loop. Three rules are the whole reason this file exists,
+// and each of them is a way a check could otherwise go green (or go red on an
+// innocent PR) when the backend said something else:
+//
+//   1. A 409 IS A HARD STOP. Never retried, never fallen back from.
+//   2. UNREACHABLE IS UNREACHABLE. One replay where the idempotency key makes
+//      it safe, then stop — never "assume continue".
+//   3. AN UNKNOWN ACTION FAILS CLOSED to `complete`.
+
+type Call = { path: string; body: any };
+
+function recorder(
+  script: Array<{ status: number; body: any } | (() => never)>
+): { post: any; calls: Call[] } {
+  const calls: Call[] = [];
+  let index = 0;
+  const post = async (path: string, body: Record<string, unknown>) => {
+    calls.push({ path, body });
+    const step = script[Math.min(index, script.length - 1)];
+    index += 1;
+    if (typeof step === "function") return step();
+    return step;
+  };
+  return { post, calls };
+}
+
+const OK_ACTION = { status: 200, body: { ok: true, action: "continue_phase" } };
+
+describe("beginCheckPlan", () => {
+  it("mints a session from the returned planId", async () => {
+    const r = recorder([{ status: 200, body: { ok: true, planId: "plan-9" } }]);
+    const session = await beginCheckPlan(
+      { triggerId: "t1", repoFullName: "acme/x", headSha: "abc" },
+      r.post
+    );
+    expect(session.planId).toBe("plan-9");
+    expect(r.calls[0].path).toBe("/internal/v1/github-checks/plan/begin");
+    expect(r.calls[0].body).toEqual({
+      triggerId: "t1",
+      repoFullName: "acme/x",
+      headSha: "abc",
+    });
+  });
+
+  it("raises a PROTOCOL error on a 409 and does not retry", async () => {
+    const r = recorder([
+      { status: 409, body: { ok: false, error: "trigger_completed" } },
+    ]);
+    await expect(
+      beginCheckPlan(
+        { triggerId: "t1", repoFullName: "acme/x", headSha: "abc" },
+        r.post
+      )
+    ).rejects.toBeInstanceOf(PlanProtocolError);
+    expect(r.calls).toHaveLength(1);
+  });
+
+  it("raises an UNREACHABLE error on a 404 — the surface is off or undeployed", async () => {
+    const r = recorder([{ status: 404, body: null }]);
+    await expect(
+      beginCheckPlan(
+        { triggerId: "t1", repoFullName: "acme/x", headSha: "abc" },
+        r.post
+      )
+    ).rejects.toBeInstanceOf(PlanUnreachableError);
+  });
+
+  it("replays ONCE on a transport failure, then gives up as unreachable", async () => {
+    const r = recorder([
+      () => {
+        throw new Error("ECONNREFUSED");
+      },
+    ]);
+    await expect(
+      beginCheckPlan(
+        { triggerId: "t1", repoFullName: "acme/x", headSha: "abc" },
+        r.post
+      )
+    ).rejects.toBeInstanceOf(PlanUnreachableError);
+    expect(r.calls).toHaveLength(2);
+  });
+});
+
+describe("HttpCheckPlanSession.attempt", () => {
+  it("carries an explicit idempotency key, fresh per DISTINCT attempt", async () => {
+    // No natural-key fallback: a natural key silently collapses two
+    // legitimately distinct attempts, and the ambiguity only ever shows up as a
+    // corrupted corpus row.
+    const r = recorder([OK_ACTION]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    await session.attempt({ phase: "provision", ok: true, durationMs: 5 });
+    await session.attempt({ phase: "clone", ok: true, durationMs: 5 });
+    const keys = r.calls.map((call) => call.body.idempotencyKey);
+    expect(keys[0]).toBe("plan-1:ladder:provision:1");
+    expect(keys[1]).toBe("plan-1:ladder:clone:2");
+  });
+
+  it("reuses the SAME key on a transport replay, so the backend replays its answer", async () => {
+    const seen: Call[] = [];
+    let calls = 0;
+    const post = async (path: string, body: any) => {
+      calls += 1;
+      seen.push({ path, body });
+      if (calls === 1) throw new Error("socket hang up");
+      return OK_ACTION;
+    };
+    const session = new HttpCheckPlanSession("t1", "plan-1", post);
+    const decision = await session.attempt({
+      phase: "build",
+      ok: false,
+      failureKind: "build_failed",
+      candidateId: "c1",
+      durationMs: 10,
+    });
+    expect(decision.action).toBe("continue_phase");
+    expect(seen).toHaveLength(2);
+    expect(seen[0].body.idempotencyKey).toBe(seen[1].body.idempotencyKey);
+  });
+
+  it("never sends `evals_failed` — it is not in the union at all", async () => {
+    // Compile-time in the type, restated here because it is the one failure
+    // kind whose removal is a SECURITY property: a worker-asserted
+    // `evals_failed` is a red verdict about somebody's PR with no run involved.
+    const r = recorder([OK_ACTION]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    await session.attempt({
+      phase: "eval",
+      ok: true,
+      runId: "run-1",
+      candidateId: "c1",
+      durationMs: 0,
+    });
+    expect(r.calls[0].body.runId).toBe("run-1");
+    expect(JSON.stringify(r.calls[0].body)).not.toContain("evals_failed");
+  });
+
+  it("fails CLOSED on an action it does not recognize", async () => {
+    const r = recorder([
+      { status: 200, body: { ok: true, action: "escalate_to_agent" } },
+    ]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    const decision = await session.attempt({
+      phase: "probe",
+      ok: true,
+      candidateId: "c1",
+      durationMs: 1,
+    });
+    expect(decision).toEqual({
+      action: "complete",
+      reason: "unknown_action",
+      unknownAction: true,
+    });
+  });
+
+  it("fails CLOSED on a 200 with no action at all", async () => {
+    const r = recorder([{ status: 200, body: { ok: true } }]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    const decision = await session.attempt({
+      phase: "probe",
+      ok: true,
+      candidateId: "c1",
+      durationMs: 1,
+    });
+    expect(decision.action).toBe("complete");
+    expect(decision.unknownAction).toBe(true);
+  });
+
+  it("turns a 409 into a hard stop that names the reason, with no retry", async () => {
+    const r = recorder([
+      { status: 409, body: { ok: false, error: "candidate_out_of_order" } },
+    ]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    await expect(
+      session.attempt({
+        phase: "build",
+        ok: true,
+        candidateId: "c1",
+        durationMs: 1,
+      })
+    ).rejects.toMatchObject({
+      name: "PlanProtocolError",
+      reason: "candidate_out_of_order",
+    });
+    expect(r.calls).toHaveLength(1);
+  });
+
+  it("carries WHERE it was when the backend went away, for the degraded marker", async () => {
+    const r = recorder([{ status: 503, body: null }]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    await expect(
+      session.attempt({
+        phase: "probe",
+        ok: true,
+        candidateId: "c2",
+        durationMs: 1,
+      })
+    ).rejects.toMatchObject({
+      name: "PlanUnreachableError",
+      at: { phase: "probe", candidateId: "c2" },
+    });
+  });
+});
+
+describe("HttpCheckPlanSession.complete", () => {
+  it("sends NO outcome — the backend derives it", async () => {
+    const r = recorder([{ status: 200, body: { ok: true } }]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    await session.complete({
+      runId: "run-1",
+      summary: { total: 3, passed: 3, failed: 0, passRate: 1 },
+    });
+    expect(r.calls[0].path).toBe("/internal/v1/github-checks/complete");
+    expect(r.calls[0].body).toEqual({
+      triggerId: "t1",
+      planId: "plan-1",
+      runId: "run-1",
+      summary: { total: 3, passed: 3, failed: 0, passRate: 1 },
+    });
+    expect(r.calls[0].body).not.toHaveProperty("outcome");
+  });
+
+  it("retries WITHOUT the degraded marker when the marker itself is refused", async () => {
+    // The marker rides inline, so the backend appends it as a real attempt — and
+    // it can legitimately be refused when the call this run lost was in fact
+    // committed. Losing one telemetry row beats leaving a claimed check with no
+    // verdict until the heartbeat sweep times it out.
+    let calls = 0;
+    const bodies: any[] = [];
+    const post = async (_path: string, body: any) => {
+      calls += 1;
+      bodies.push(body);
+      return calls === 1
+        ? { status: 409, body: { ok: false, error: "phase_out_of_order" } }
+        : { status: 200, body: { ok: true } };
+    };
+    const session = new HttpCheckPlanSession("t1", "plan-1", post);
+    await session.complete({
+      terminalAttempt: {
+        phase: "probe",
+        ok: false,
+        failureKind: "backend_unreachable",
+        durationMs: 0,
+        candidateId: "c1",
+      },
+    });
+    expect(calls).toBe(2);
+    expect(bodies[0].terminalAttempt).toMatchObject({
+      failureKind: "backend_unreachable",
+      candidateId: "c1",
+    });
+    expect(bodies[1]).not.toHaveProperty("terminalAttempt");
+  });
+});
+
+describe("HttpCheckPlanSession.candidates", () => {
+  it("returns the plan's candidates and stop policy", async () => {
+    const r = recorder([
+      {
+        status: 200,
+        body: {
+          ok: true,
+          candidates: [{ candidateId: "c1" }],
+          stopPolicy: { maxCandidates: 3, wallClockMs: 1_200_000 },
+        },
+      },
+    ]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    const issued = await session.candidates({
+      evidenceDigest: "a".repeat(64),
+      resolverVersion: "r2/1",
+      localCandidates: [],
+    });
+    expect(issued.candidates).toHaveLength(1);
+    expect(issued.stopPolicy).toEqual({
+      maxCandidates: 3,
+      wallClockMs: 1_200_000,
+    });
+    expect(r.calls[0].body.planId).toBe("plan-1");
+  });
+
+  it("hard-stops on a 409 (a re-plan the backend refuses)", async () => {
+    const r = recorder([
+      {
+        status: 409,
+        body: { ok: false, error: "plan_candidates_already_issued" },
+      },
+    ]);
+    const session = new HttpCheckPlanSession("t1", "plan-1", r.post);
+    await expect(
+      session.candidates({
+        evidenceDigest: "a".repeat(64),
+        resolverVersion: "r2/1",
+        localCandidates: [],
+      })
+    ).rejects.toBeInstanceOf(PlanProtocolError);
+    expect(r.calls).toHaveLength(1);
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/evidence-digest.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/evidence-digest.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeRecipeEvidenceHash,
+  computeResolverEvidenceDigest,
+  encodeRecipeEvidence,
+  isRecipeEvidenceHash,
+  RECIPE_EVIDENCE_GOLDEN_VECTOR_SHA256,
+  RECIPE_EVIDENCE_MAX_FILE_BYTES,
+  DETECTOR_READ_LIMITS,
+  RECIPE_EVIDENCE_PATHS,
+  assertEvidenceBudgetsCoverDetector,
+} from "../evidence-digest";
+
+// This suite guards ONE encoder — the Inspector is the sole author of this
+// digest now, and the backend stores it opaquely. So the properties that matter
+// are:
+//
+//   1. THE GOLDEN VECTOR. A hard-coded digest over fixed inputs is the only
+//      thing that catches a silent encoding change, and this particular value
+//      is the one the retired backend encoder produced — so cache entries
+//      written before the move are still addressable.
+//   2. THE BUDGETS COVER THE DETECTOR. A byte detection can read but the digest
+//      cannot see is a byte that changes the answer without changing the key,
+//      which is a stale cache hit that re-probes green on the wrong server.
+//   3. ABSENT ≠ EMPTY, and framing is unforgeable.
+
+const GOLDEN = {
+  resolverVersion: "golden-r1",
+  promptVersion: "golden-p1",
+  model: "golden-model",
+  runtimeImageVersion: "golden-img-1",
+  agenticContextDigest: "golden-ctx-1",
+  files: {
+    "package.json": '{"name":"golden","scripts":{"start":"node index.js"}}',
+    "package-lock.json": '{"lockfileVersion":3}',
+    README: "golden fixture: port 3001, path /mcp\n",
+  },
+} as const;
+
+describe("evidence digest — the golden vector", () => {
+  it("reproduces the pinned digest", () => {
+    expect(computeRecipeEvidenceHash(GOLDEN)).toBe(
+      RECIPE_EVIDENCE_GOLDEN_VECTOR_SHA256
+    );
+  });
+
+  it("is a lowercase hex sha-256, which is all the backend checks", () => {
+    expect(isRecipeEvidenceHash(computeRecipeEvidenceHash(GOLDEN))).toBe(true);
+    expect(isRecipeEvidenceHash("")).toBe(false);
+    expect(isRecipeEvidenceHash("ZZ".repeat(32))).toBe(false);
+  });
+});
+
+describe("evidence digest — what must change the key", () => {
+  it("changes when the resolver version changes", () => {
+    // The detection LOGIC is an input to the answer: a resolver change must
+    // MISS the cache rather than resurrect a recipe the old logic produced.
+    expect(
+      computeRecipeEvidenceHash({ ...GOLDEN, resolverVersion: "golden-r2" })
+    ).not.toBe(RECIPE_EVIDENCE_GOLDEN_VECTOR_SHA256);
+  });
+
+  it("changes when one byte of one file changes", () => {
+    expect(
+      computeRecipeEvidenceHash({
+        ...GOLDEN,
+        files: { ...GOLDEN.files, "package.json": '{"name":"goldeN"}' },
+      })
+    ).not.toBe(RECIPE_EVIDENCE_GOLDEN_VECTOR_SHA256);
+  });
+
+  it("distinguishes ABSENT from PRESENT-AND-EMPTY", () => {
+    // An empty `mcpjam.yaml` is a very different repository from one with no
+    // `mcpjam.yaml` at all — the first is an authoritative rung that will refuse
+    // the check, the second is no rung at all.
+    const absent = computeRecipeEvidenceHash({
+      resolverVersion: "r",
+      files: {},
+    });
+    const empty = computeRecipeEvidenceHash({
+      resolverVersion: "r",
+      files: { "mcpjam.yaml": "" },
+    });
+    expect(absent).not.toBe(empty);
+  });
+
+  it("distinguishes the same content under different paths", () => {
+    const a = computeRecipeEvidenceHash({
+      resolverVersion: "r",
+      files: { "package.json": "x" },
+    });
+    const b = computeRecipeEvidenceHash({
+      resolverVersion: "r",
+      files: { "server.json": "x" },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("cannot be forged by embedding a separator in file content", () => {
+    // Length-prefixed framing is the reason: file content is attacker-supplied,
+    // and any separator can be embedded in it to make two different evidence
+    // sets produce identical bytes.
+    const a = computeRecipeEvidenceHash({
+      resolverVersion: "r",
+      files: { "package.json": "a", "package-lock.json": "b" },
+    });
+    const b = computeRecipeEvidenceHash({
+      resolverVersion: "r",
+      files: { "package.json": "a\0package-lock.json\0b" },
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("counts BYTES, not UTF-16 code units, when it truncates", () => {
+    // `String.prototype.slice` would cut at a different place for non-ASCII
+    // content, so two different files could hash the same (or one file could
+    // hash differently) depending on where its multi-byte characters fall.
+    const cap = RECIPE_EVIDENCE_MAX_FILE_BYTES["package.json"];
+    const emoji = "😀"; // 4 UTF-8 bytes, 2 UTF-16 units
+    const long = emoji.repeat(cap); // far past the cap either way
+    const bytes = encodeRecipeEvidence({
+      resolverVersion: "r",
+      files: { "package.json": long },
+    });
+    // The framed segment for package.json's content is exactly the cap.
+    expect(bytes.byteLength).toBeGreaterThan(cap);
+    expect(
+      computeRecipeEvidenceHash({
+        resolverVersion: "r",
+        files: { "package.json": long },
+      })
+    ).toBe(
+      computeRecipeEvidenceHash({
+        resolverVersion: "r",
+        // Same first `cap` BYTES, different tail: the tail is past the budget.
+        files: { "package.json": long + "tail" },
+      })
+    );
+  });
+});
+
+describe("evidence digest — budgets", () => {
+  it("covers every byte the detector can read, for every path", () => {
+    for (const path of RECIPE_EVIDENCE_PATHS) {
+      expect(RECIPE_EVIDENCE_MAX_FILE_BYTES[path]).toBeGreaterThanOrEqual(
+        DETECTOR_READ_LIMITS[path]
+      );
+    }
+    expect(() => assertEvidenceBudgetsCoverDetector()).not.toThrow();
+  });
+});
+
+describe("computeResolverEvidenceDigest", () => {
+  const inputs = {
+    mcpjamYaml: { kind: "absent" } as const,
+    detection: {
+      packageJson: '{"name":"x"}',
+      packageLockJson: "{}",
+      pnpmLockYaml: null,
+      yarnLock: null,
+      pyprojectToml: null,
+      uvLock: null,
+      serverJson: null,
+      readme: null,
+      repoFiles: [],
+    },
+  };
+
+  it("hashes exactly what the resolver was fed", () => {
+    expect(computeResolverEvidenceDigest(inputs, "r2/1")).toBe(
+      computeRecipeEvidenceHash({
+        resolverVersion: "r2/1",
+        files: {
+          "package.json": '{"name":"x"}',
+          "package-lock.json": "{}",
+        },
+      })
+    );
+  });
+
+  it("treats an OVER-CAP mcpjam.yaml as absent for the KEY only", () => {
+    // The ladder refuses an over-cap declared config outright (`recipe_invalid`),
+    // so this digest is never used to look one up. What matters here is that the
+    // digest reflects what detection SAW — an unreadable file contributed
+    // nothing to the answer — rather than inventing content for it.
+    const overCap = computeResolverEvidenceDigest(
+      { ...inputs, mcpjamYaml: { kind: "over_cap" } },
+      "r2/1"
+    );
+    expect(overCap).toBe(computeResolverEvidenceDigest(inputs, "r2/1"));
+  });
+
+  it("moves when the declared config's content moves", () => {
+    expect(
+      computeResolverEvidenceDigest(
+        { ...inputs, mcpjamYaml: { kind: "present", text: "version: 1\n" } },
+        "r2/1"
+      )
+    ).not.toBe(computeResolverEvidenceDigest(inputs, "r2/1"));
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -408,6 +408,37 @@ describe("resolveAndStart — the typed action decides what happens next", () =>
     ).toHaveLength(1);
   });
 
+  it("re-reads the deadline AFTER provisioning, before the build", async () => {
+    // Provision and clone are minutes of budget themselves. A candidate that
+    // was inside the deadline when its iteration began can be outside it by the
+    // time there is a box to build in — and the build is the expensive half.
+    const session = fakeSession({
+      candidates: [planned("c1"), planned("c2")],
+      actions: { "build:fail": { action: "try_next_candidate" } },
+      stopPolicy: { maxCandidates: 3, wallClockMs: 60_000 },
+    });
+    // Still inside the deadline at the top of candidate 2's iteration — its own
+    // provision is what spends the rest of the budget.
+    let clock = 0;
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      attempt: failing("build_failed"),
+      provision: (index) => {
+        if (index === 2) clock = 90_000;
+      },
+    });
+    f.deps.now = () => clock;
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("plan_wall_clock_exhausted");
+    // The second box WAS provisioned — and then nothing was built in it.
+    expect(f.events).toContain("provision:sb_2");
+    expect(
+      f.events.filter((event) => event.startsWith("buildAndStart"))
+    ).toHaveLength(1);
+  });
+
   it("treats `wallClockMs: 0` as NO deadline, not an expired one", async () => {
     const session = fakeSession({
       stopPolicy: { maxCandidates: 3, wallClockMs: 0 },

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -2,27 +2,34 @@ import { describe, expect, it } from "vitest";
 import {
   judgeListeners,
   resolveAndStart,
-  RecipeStartError,
   type ResolveAndStartDeps,
 } from "../resolve-and-start";
 import { CheckStepError, type CheckSandbox } from "../sandbox";
 import type { ResolvedRecipe } from "../resolver/index";
 import type { ListenerReport } from "../sandbox-inspect";
+import {
+  CheckStoppedByPlan,
+  PlanProtocolError,
+  PlanUnreachableError,
+  type AttemptDecision,
+  type AttemptInput,
+  type CheckPlanSession,
+  type PlannedCandidate,
+} from "../check-plan";
 
-// What this suite is actually protecting, in the order the review rounds
-// produced the requirements:
+// What this suite protects, after A3b-2 moved attribution to the backend:
 //
-//   1. ATTRIBUTION. An authoritative rung never falls through: broken config is
-//      `recipe_invalid` (the author's), a failing build under a VALID one is
-//      `build_failed`. A heuristic guess that fails is a MISS, never a red X.
-//   2. INFRASTRUCTURE IS NEVER A MISS. Provision/lockdown/E2B failures abort
-//      with `infra_error` instead of burning the remaining candidates.
-//   3. A FRESH BOX PER CANDIDATE, with the previous one dead BEFORE the next is
-//      provisioned.
-//   4. LISTENER IDENTITY, ANCHORED AT SPAWN. A listener that is not the process
-//      we started never turns a check green — and the identity it is compared
-//      against comes from the spawn (`StartedServer.spawn`), so nothing the box
-//      writes can forge it.
+//   1. THE PLAN IS THE PROGRAM. Candidates run in the PLAN's order, not the
+//      detector's, and the typed ACTION decides what happens next. Nothing here
+//      computes an outcome any more.
+//   2. FAIL CLOSED. An unknown action, a 409, or an unreachable backend all
+//      STOP. None of them falls back to a local candidate policy — behaviour
+//      must not differ invisibly between healthy and degraded runs.
+//   3. THE #3644 HARDENING SURVIVES THE REFACTOR. A fresh box per candidate with
+//      the previous one dead BEFORE the next is provisioned; listener identity
+//      anchored at SPAWN, so nothing the box writes can forge it; an over-cap
+//      `mcpjam.yaml` reported as `recipe_invalid` rather than collapsing to
+//      "absent".
 
 const ARGS = {
   triggerId: "trig-1",
@@ -31,8 +38,12 @@ const ARGS = {
   headSha: "b".repeat(40),
 };
 
-const EMPTY_INPUTS = {
-  mcpjamYaml: { kind: "absent" } as const,
+type ResolverInputs = Awaited<
+  ReturnType<ResolveAndStartDeps["readResolverInputs"]>
+>;
+
+const EMPTY_INPUTS: ResolverInputs = {
+  mcpjamYaml: { kind: "absent" },
   detection: {
     packageJson: null,
     packageLockJson: null,
@@ -61,6 +72,26 @@ function recipe(
   };
 }
 
+function planned(
+  candidateId: string,
+  overrides: Partial<ResolvedRecipe> = {}
+): PlannedCandidate {
+  const full = recipe(overrides);
+  return {
+    candidateId,
+    recipe: {
+      build: full.build,
+      start: full.start,
+      port: full.port,
+      mcpPath: full.mcpPath,
+    },
+    rung: full.rung,
+    evidence: full.evidence,
+    ownershipProof: full.ownershipProof,
+    source: "detected",
+  };
+}
+
 /** The identity `buildAndStart` captured for the command it spawned. */
 const SPAWN = { pid: 100, pgrp: 100 };
 
@@ -69,32 +100,97 @@ function goodReport(pid = SPAWN.pid): ListenerReport {
   return { processes: [{ pid, ppids: [], pgrp: pid }] };
 }
 
+type RecordedAttempt = AttemptInput;
+
+/**
+ * A fake plan session.
+ *
+ * `actions` scripts the backend's replies by `phase` (optionally `phase:ok`),
+ * which is how a test says "the first candidate's build failure gets
+ * `try_next_candidate`" without restating the state machine. Anything not
+ * scripted answers the boring default: `continue_phase` for progress,
+ * `run_eval` for an accepted candidate, `complete` for a failure.
+ */
+function fakeSession(options?: {
+  candidates?: PlannedCandidate[];
+  actions?: Record<string, AttemptDecision | (() => AttemptDecision)>;
+  onCandidates?: (input: {
+    evidenceDigest: string;
+    resolverVersion: string;
+    localCandidates: unknown[];
+  }) => void;
+  candidatesThrows?: unknown;
+  attemptThrows?: Record<string, unknown>;
+}): {
+  session: CheckPlanSession;
+  attempts: RecordedAttempt[];
+  completions: unknown[];
+} {
+  const attempts: RecordedAttempt[] = [];
+  const completions: unknown[] = [];
+  const session: CheckPlanSession = {
+    planId: "plan-1",
+    candidates: async (input) => {
+      options?.onCandidates?.(input);
+      if (options?.candidatesThrows) throw options.candidatesThrows;
+      return {
+        candidates: options?.candidates ?? [planned("c1")],
+        stopPolicy: { maxCandidates: 3, wallClockMs: 20 * 60_000 },
+      };
+    },
+    attempt: async (input) => {
+      attempts.push(input);
+      const keys = [`${input.phase}:${input.ok ? "ok" : "fail"}`, input.phase];
+      for (const key of keys) {
+        const thrown = options?.attemptThrows?.[key];
+        if (thrown) throw thrown;
+        const scripted = options?.actions?.[key];
+        if (scripted) {
+          return typeof scripted === "function" ? scripted() : scripted;
+        }
+      }
+      if (!input.ok) return { action: "complete", reason: input.failureKind };
+      if (input.phase === "verify") {
+        return { action: "run_eval", reason: "candidate_accepted" };
+      }
+      return { action: "continue_phase" };
+    },
+    complete: async (input) => {
+      completions.push(input);
+    },
+  };
+  return { session, attempts, completions };
+}
+
 type Fakes = {
-  deps: Partial<ResolveAndStartDeps>;
+  deps: Partial<ResolveAndStartDeps> & { plan: CheckPlanSession };
   events: string[];
   boxes: CheckSandbox[];
+  attempts: RecordedAttempt[];
 };
 
 /**
- * `scripted` maps a recipe's `start` command to what its attempt should do —
- * which is how a test says "candidate 1 fails to build, candidate 2 works"
- * without knowing anything about box plumbing.
+ * `attempt` maps a recipe's `start` command to what its build should do — which
+ * is how a test says "candidate 1 fails to build, candidate 2 works" without
+ * knowing anything about box plumbing.
  */
 function fakes(options: {
-  ladder: ReturnType<ResolveAndStartDeps["resolveLadder"]>;
+  ladder?: ReturnType<ResolveAndStartDeps["resolveLadder"]>;
+  session?: ReturnType<typeof fakeSession>;
   attempt?: (recipe: ResolvedRecipe, boxId: string) => void | never;
   listener?: (recipe: ResolvedRecipe) => ListenerReport | null;
   spawn?: { pid: number; pgrp: number | null };
   provision?: (index: number) => void | never;
-  now?: () => number;
-  maxCandidates?: number;
-  budgetMs?: number;
+  clone?: (index: number) => void | never;
+  inputs?: ResolverInputs;
 }): Fakes {
   const events: string[] = [];
   const boxes: CheckSandbox[] = [];
   let provisioned = 0;
+  const scripted = options.session ?? fakeSession();
 
-  const deps: Partial<ResolveAndStartDeps> = {
+  const deps: Partial<ResolveAndStartDeps> & { plan: CheckPlanSession } = {
+    plan: scripted.session,
     provisionSandbox: async () => {
       provisioned += 1;
       options.provision?.(provisioned);
@@ -110,6 +206,7 @@ function fakes(options: {
       return box;
     },
     cloneAndCheckout: async (sandbox) => {
+      options.clone?.(boxes.length);
       events.push(`clone:${sandbox.sandboxId}`);
     },
     buildAndStart: async (sandbox, built) => {
@@ -124,8 +221,8 @@ function fakes(options: {
     killSandbox: async (sandbox) => {
       events.push(`kill:${sandbox?.sandboxId ?? "none"}`);
     },
-    resolveLadder: () => options.ladder,
-    readResolverInputs: async () => EMPTY_INPUTS,
+    ...(options.ladder ? { resolveLadder: () => options.ladder! } : {}),
+    readResolverInputs: async () => options.inputs ?? EMPTY_INPUTS,
     inspectListener: async (_sandbox, args) => {
       events.push(`inspect:${args.port}`);
       return options.listener
@@ -134,317 +231,495 @@ function fakes(options: {
     },
     onSandbox: () => {},
     assertLeaseHeld: () => {},
-    ...(options.now ? { now: options.now } : {}),
-    ...(options.maxCandidates !== undefined
-      ? { maxCandidates: options.maxCandidates }
-      : {}),
-    ...(options.budgetMs !== undefined ? { budgetMs: options.budgetMs } : {}),
+    now: () => 0,
   };
 
-  return { deps, events, boxes };
+  return { deps, events, boxes, attempts: scripted.attempts };
 }
 
-async function failureOf(promise: Promise<unknown>): Promise<RecipeStartError> {
+async function stopOf(promise: Promise<unknown>): Promise<CheckStoppedByPlan> {
   try {
     await promise;
   } catch (error) {
-    if (error instanceof RecipeStartError) return error;
+    if (error instanceof CheckStoppedByPlan) return error;
     throw error;
   }
-  throw new Error("expected the resolution to fail");
+  throw new Error("expected the check to stop");
 }
 
-describe("resolveAndStart — authoritative rungs", () => {
-  it("reports recipe_invalid for a present-but-broken mcpjam.yaml, and runs nothing", async () => {
-    // The real ladder, so the mapping from its `RecipeResolutionError` to the
-    // outcome is exercised rather than restated.
-    const f = fakes({ ladder: { kind: "candidates", candidates: [] } });
-    delete f.deps.resolveLadder;
-    f.deps.readResolverInputs = async () => ({
-      ...EMPTY_INPUTS,
-      mcpjamYaml: {
-        kind: "present",
-        text: "version: 1\nchecks:\n  build: npm ci\n",
-      },
+const failing = (kind: "build_failed" | "server_unhealthy") => () => {
+  throw new CheckStepError(kind, `${kind} for the test`);
+};
+
+describe("resolveAndStart — the plan is the program", () => {
+  it("executes the PLAN's candidates, in the PLAN's order", async () => {
+    // The detector's own order is deliberately the reverse: the backend owns
+    // ordering now, so what the detector preferred must not decide anything.
+    const local = [
+      recipe({ start: "node local-first.js" }),
+      recipe({ start: "node local-second.js" }),
+    ];
+    const session = fakeSession({
+      candidates: [
+        planned("c1", { start: "node plan-first.js" }),
+        planned("c2", { start: "node plan-second.js" }),
+      ],
+      actions: { "build:fail": { action: "try_next_candidate" } },
     });
-
-    const error = await failureOf(resolveAndStart(ARGS, f.deps));
-    expect(error.outcome).toBe("recipe_invalid");
-    expect(error.message).toContain("mcpjam.yaml");
-    // Nothing was built: a broken declaration is not a licence to guess.
-    expect(f.events.some((e) => e.startsWith("buildAndStart"))).toBe(false);
-    expect(f.events).toContain("kill:sb_1");
-  });
-
-  it("reports recipe_invalid for an OVER-CAP mcpjam.yaml, and never falls through", async () => {
-    // The defect this pins: the sandbox reader cannot pull an unbounded file
-    // across the command channel, and reporting "absent" made an oversized
-    // (therefore invalid) declared config look like no declaration at all — so
-    // the ladder guessed, ran a command nobody wrote, and reported the result
-    // under the author's name. `resolveLadder` is the REAL one here, so the
-    // whole path from reader to outcome is exercised.
-    const f = fakes({ ladder: { kind: "candidates", candidates: [] } });
-    delete f.deps.resolveLadder;
-    f.deps.readResolverInputs = async () => ({
-      ...EMPTY_INPUTS,
-      mcpjamYaml: { kind: "over_cap" },
-      // A perfectly detectable repo, so there IS something to fall through to.
-      detection: {
-        ...EMPTY_INPUTS.detection,
-        packageJson: JSON.stringify({
-          name: "x",
-          scripts: { start: "node dist/index.js", build: "tsc" },
-        }),
-        packageLockJson: "{}",
-      },
-    });
-
-    const error = await failureOf(resolveAndStart(ARGS, f.deps));
-    expect(error.outcome).toBe("recipe_invalid");
-    expect(error.message).toContain("mcpjam.yaml");
-    expect(error.message).toContain("limit for declared config");
-    // Nothing was built: the fall-through is the bug, not the fix.
-    expect(f.events.some((e) => e.startsWith("buildAndStart"))).toBe(false);
-  });
-
-  it("reports build_failed — not a miss — under a VALID authoritative recipe", async () => {
-    const declared = recipe({ rung: "declared", ownershipProof: "verified" });
     const f = fakes({
-      ladder: { kind: "authoritative", recipe: declared },
-      attempt: () => {
-        throw new CheckStepError(
-          "build_failed",
-          "build command exited 1",
-          "```text\nboom\n```"
-        );
+      ladder: { kind: "candidates", candidates: local },
+      session,
+      attempt: (built) => {
+        if (built.start === "node plan-first.js") failing("build_failed")();
       },
     });
-
-    const error = await failureOf(resolveAndStart(ARGS, f.deps));
-    expect(error.outcome).toBe("build_failed");
-    expect(error.provenance).toEqual({
-      recipeRung: "declared",
-      recipeEvidence: declared.evidence,
-    });
-    // No fall-through: exactly one attempt, in exactly one box.
-    expect(f.events.filter((e) => e.startsWith("buildAndStart"))).toHaveLength(
-      1
-    );
-    expect(f.boxes).toHaveLength(1);
-  });
-
-  it("blames the declared recipe — server_unhealthy — when a squatter holds the port", async () => {
-    // Authoritative rungs do not fall through, so the only question is which
-    // verdict the author sees. `recipe_unresolvable` would be false (we DID
-    // resolve it) and `recipe_invalid` would be false (it parsed); what actually
-    // happened is that the declared server did not serve.
-    const declared = recipe({ rung: "declared", ownershipProof: "verified" });
-    const f = fakes({
-      ladder: { kind: "authoritative", recipe: declared },
-      listener: () => ({
-        processes: [{ pid: 555, ppids: [1], pgrp: 42 }],
-      }),
-    });
-
-    const error = await failureOf(resolveAndStart(ARGS, f.deps));
-    expect(error.outcome).toBe("server_unhealthy");
-    expect(error.detailsMarkdown).toContain(
-      "not the server your `start` command"
-    );
-  });
-
-  it("returns the running server without restarting it", async () => {
-    const declared = recipe({ rung: "override", ownershipProof: "verified" });
-    const f = fakes({ ladder: { kind: "authoritative", recipe: declared } });
 
     const result = await resolveAndStart(ARGS, f.deps);
-    expect(result.provenance.recipeRung).toBe("override");
-    expect(result.sandbox.sandboxId).toBe("sb_1");
-    expect(result.started.url).toBe("https://3001-sb_1.e2b.app/mcp");
-    // The winning box is the one that stays alive.
-    expect(f.events).not.toContain("kill:sb_1");
+    expect(result.candidateId).toBe("c2");
+    expect(result.recipe.start).toBe("node plan-second.js");
+    expect(
+      f.events.filter((event) => event.startsWith("buildAndStart"))
+    ).toEqual([
+      "buildAndStart:sb_1:node plan-first.js",
+      "buildAndStart:sb_2:node plan-second.js",
+    ]);
+    // Nothing the detector proposed was executed directly.
+    expect(f.events.join("|")).not.toContain("local-first");
+  });
+
+  it("hands the backend the digest, the resolver version and the local candidates", async () => {
+    let seen: any = null;
+    const session = fakeSession({ onCandidates: (input) => (seen = input) });
+    const f = fakes({
+      ladder: {
+        kind: "candidates",
+        candidates: [recipe({ start: "node a.js", evidence: ["A"] })],
+      },
+      session,
+    });
+    f.deps.resolverVersion = "test-resolver/9";
+
+    await resolveAndStart(ARGS, f.deps);
+    expect(seen.resolverVersion).toBe("test-resolver/9");
+    expect(seen.evidenceDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(seen.localCandidates).toEqual([
+      {
+        recipe: {
+          build: "npm ci",
+          start: "node a.js",
+          port: 3001,
+          mcpPath: "/mcp",
+        },
+        rung: "detected",
+        evidence: ["A"],
+        ownershipProof: "unverified",
+      },
+    ]);
+  });
+
+  it("reports the ladder phases with NO candidateId, in order", async () => {
+    const session = fakeSession();
+    const f = fakes({
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      session,
+    });
+    await resolveAndStart(ARGS, f.deps);
+
+    const ladder = f.attempts.filter((a) => !a.candidateId);
+    expect(ladder.map((a) => a.phase)).toEqual([
+      "provision",
+      "clone",
+      "resolve",
+    ]);
+    // And the candidate's own rows all carry one.
+    expect(f.attempts.filter((a) => a.candidateId).map((a) => a.phase)).toEqual(
+      ["probe", "verify"]
+    );
   });
 });
 
-describe("resolveAndStart — heuristic candidates", () => {
-  const candidateA = recipe({ start: "npm start", evidence: ["A"] });
-  const candidateB = recipe({ start: "node dist/server.js", evidence: ["B"] });
-
-  it("kills candidate A's box BEFORE provisioning candidate B's, and returns B", async () => {
+describe("resolveAndStart — the typed action decides what happens next", () => {
+  it("`try_next_candidate` moves to the next planned candidate", async () => {
+    const session = fakeSession({
+      candidates: [planned("c1", { start: "node a.js" }), planned("c2")],
+      actions: { "build:fail": { action: "try_next_candidate" } },
+    });
     const f = fakes({
-      ladder: { kind: "candidates", candidates: [candidateA, candidateB] },
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
       attempt: (built) => {
-        if (built.start === candidateA.start) {
-          throw new CheckStepError("build_failed", "exit 1");
-        }
+        if (built.start === "node a.js") failing("build_failed")();
+      },
+    });
+    const result = await resolveAndStart(ARGS, f.deps);
+    expect(result.candidateId).toBe("c2");
+  });
+
+  it("`complete` on a candidate failure stops without trying the next", async () => {
+    // This is the authoritative-rung case from the worker's side: the backend
+    // refuses to fall through, and the Inspector no longer has an opinion.
+    const session = fakeSession({
+      candidates: [planned("c1"), planned("c2")],
+      actions: {
+        "build:fail": { action: "complete", reason: "authoritative_failure" },
+      },
+    });
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      attempt: failing("build_failed"),
+    });
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("authoritative_failure");
+    expect(f.boxes).toHaveLength(1);
+    expect(
+      f.events.filter((event) => event.startsWith("buildAndStart"))
+    ).toHaveLength(1);
+  });
+
+  it("`run_eval` on an accepted candidate returns the running server", async () => {
+    const f = fakes({ ladder: { kind: "candidates", candidates: [recipe()] } });
+    const result = await resolveAndStart(ARGS, f.deps);
+    expect(result.started.url).toBe("https://3001-sb_1.e2b.app/mcp");
+    expect(result.sandbox.sandboxId).toBe("sb_1");
+    // The winning box is the one that stays alive.
+    expect(f.events).not.toContain("kill:sb_1");
+  });
+
+  it("stops when `verify` ok is answered with anything but `run_eval`", async () => {
+    // Fail closed: an accepted candidate that is not told to run the eval is a
+    // contract we do not understand, and running one anyway could green a check
+    // the backend meant to abort.
+    const session = fakeSession({
+      actions: { "verify:ok": { action: "continue_phase" } },
+    });
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+    });
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("continue_phase");
+  });
+
+  it("treats an UNKNOWN action as `complete`, and executes nothing further", async () => {
+    // The client-side normalization lives in `check-plan.ts`; what this pins is
+    // the orchestrator's half — it obeys the resulting `complete` and does not
+    // carry on with the plan.
+    const session = fakeSession({
+      candidates: [planned("c1"), planned("c2")],
+      actions: {
+        "build:fail": {
+          action: "complete",
+          reason: "unknown_action",
+          unknownAction: true,
+        },
+      },
+    });
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      attempt: failing("build_failed"),
+    });
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("unknown_action");
+    expect(f.boxes).toHaveLength(1);
+  });
+});
+
+describe("resolveAndStart — degraded and refused", () => {
+  it("a 409 is a HARD STOP: no retry, no local fallback, no further candidates", async () => {
+    const refusal = new PlanProtocolError("attempt", "phase_out_of_order", 409);
+    const session = fakeSession({
+      candidates: [planned("c1"), planned("c2")],
+      attemptThrows: { "probe:ok": refusal },
+    });
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe(), recipe()] },
+    });
+
+    await expect(resolveAndStart(ARGS, f.deps)).rejects.toBe(refusal);
+    // One box, one build: the second planned candidate was never touched, and
+    // the refused call was never repeated.
+    expect(f.boxes).toHaveLength(1);
+    expect(f.attempts.filter((a) => a.phase === "probe" && a.ok)).toHaveLength(
+      1
+    );
+    // Every box is dead on the failure path.
+    expect(f.events).toContain("kill:sb_1");
+  });
+
+  it("an unreachable /plan/candidates executes NO local candidate", async () => {
+    // The whole point of degraded mode: falling back to `localCandidates` in our
+    // own order would make behaviour differ invisibly between healthy and
+    // degraded runs, and every verdict un-reproducible.
+    const unreachable = new PlanUnreachableError(
+      "plan/candidates",
+      "ECONNREFUSED"
+    );
+    const session = fakeSession({ candidatesThrows: unreachable });
+    const f = fakes({
+      session,
+      ladder: {
+        kind: "candidates",
+        candidates: [recipe({ start: "node a.js" }), recipe()],
+      },
+    });
+
+    await expect(resolveAndStart(ARGS, f.deps)).rejects.toBe(unreachable);
+    expect(f.events.some((event) => event.startsWith("buildAndStart"))).toBe(
+      false
+    );
+    expect(f.events).toContain("kill:sb_1");
+  });
+
+  it("stops when the plan comes back with no candidates at all", async () => {
+    const session = fakeSession({ candidates: [] });
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+    });
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("plan_has_no_candidates");
+    expect(f.events.some((event) => event.startsWith("buildAndStart"))).toBe(
+      false
+    );
+  });
+});
+
+describe("resolveAndStart — pre-candidate failures are attributable", () => {
+  it("reports a provision failure against the begun plan, with no candidateId", async () => {
+    const session = fakeSession();
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      provision: () => {
+        throw new CheckStepError("infra_error", "E2B 503");
+      },
+    });
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("provision_failed");
+    expect(f.attempts).toEqual([
+      expect.objectContaining({
+        phase: "provision",
+        ok: false,
+        failureKind: "provision_failed",
+      }),
+    ]);
+    expect(f.attempts[0].candidateId).toBeUndefined();
+  });
+
+  it("reports a clone failure the same way", async () => {
+    const session = fakeSession();
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      clone: () => {
+        throw new CheckStepError("infra_error", "clone/checkout failed");
+      },
+    });
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("clone_failed");
+    expect(f.attempts.map((a) => `${a.phase}:${a.ok}`)).toEqual([
+      "provision:true",
+      "clone:false",
+    ]);
+  });
+
+  it("reports `recipe_invalid` at `resolve` for a broken mcpjam.yaml, and runs nothing", async () => {
+    // The REAL ladder, so the mapping from its `RecipeResolutionError` to the
+    // reported failure kind is exercised rather than restated.
+    const session = fakeSession();
+    const f = fakes({
+      session,
+      inputs: {
+        ...EMPTY_INPUTS,
+        mcpjamYaml: {
+          kind: "present",
+          text: "version: 1\nchecks:\n  build: npm ci\n",
+        },
+      },
+    });
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("recipe_invalid");
+    expect(stop.detailsMarkdown).toContain("present but not usable");
+    expect(f.attempts.at(-1)).toMatchObject({
+      phase: "resolve",
+      ok: false,
+      failureKind: "recipe_invalid",
+    });
+    // LADDER-scoped, which is what makes the authoritative-rung requirement true
+    // by construction: `resolve` carries no candidate and therefore no rung.
+    expect(f.attempts.at(-1)?.candidateId).toBeUndefined();
+    expect(f.events.some((event) => event.startsWith("buildAndStart"))).toBe(
+      false
+    );
+  });
+
+  it("reports `recipe_invalid` for an OVER-CAP mcpjam.yaml, and never falls through", async () => {
+    // The #3644 defect this pins: the sandbox reader cannot pull an unbounded
+    // file across the command channel, and reporting "absent" made an oversized
+    // (therefore invalid) declared config look like no declaration at all — so
+    // the ladder guessed, ran a command nobody wrote, and the result was
+    // reported under the author's name.
+    const session = fakeSession();
+    const f = fakes({
+      session,
+      inputs: {
+        ...EMPTY_INPUTS,
+        mcpjamYaml: { kind: "over_cap" },
+        // A perfectly detectable repo, so there IS something to fall through to.
+        detection: {
+          ...EMPTY_INPUTS.detection,
+          packageJson: JSON.stringify({
+            name: "x",
+            scripts: { start: "node dist/index.js", build: "tsc" },
+          }),
+          packageLockJson: "{}",
+        },
+      },
+    });
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("recipe_invalid");
+    expect(f.attempts.at(-1)).toMatchObject({ failureKind: "recipe_invalid" });
+    expect(f.events.some((event) => event.startsWith("buildAndStart"))).toBe(
+      false
+    );
+  });
+
+  it("reports `no_candidates` at `resolve` when nothing is detectable", async () => {
+    const session = fakeSession();
+    const f = fakes({ session });
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("no_candidates");
+    // The author-facing copy still points at the one-file fix.
+    expect(stop.detailsMarkdown).toContain("mcpjam.yaml");
+    expect(f.attempts.at(-1)).toMatchObject({
+      phase: "resolve",
+      ok: false,
+      failureKind: "no_candidates",
+    });
+  });
+});
+
+describe("resolveAndStart — a fresh sandbox per candidate", () => {
+  it("kills candidate A's box BEFORE provisioning candidate B's", async () => {
+    // The ordering IS the requirement: A's box must be gone before B's exists,
+    // or B builds beside A's leftovers with egress already revoked, and A's
+    // server may still hold the port B is about to probe.
+    const session = fakeSession({
+      candidates: [
+        planned("c1", { start: "node a.js" }),
+        planned("c2", { start: "node b.js" }),
+      ],
+      actions: { "build:fail": { action: "try_next_candidate" } },
+    });
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      attempt: (built) => {
+        if (built.start === "node a.js") failing("build_failed")();
       },
     });
 
     const result = await resolveAndStart(ARGS, f.deps);
-    expect(result.recipe.start).toBe(candidateB.start);
     expect(result.sandbox.sandboxId).toBe("sb_2");
     expect(f.boxes).toHaveLength(2);
-
-    // The ordering IS the requirement: A's box must be gone before B's exists,
-    // or B builds beside A's leftovers with egress already revoked.
     expect(f.events.indexOf("kill:sb_1")).toBeGreaterThan(-1);
     expect(f.events.indexOf("kill:sb_1")).toBeLessThan(
       f.events.indexOf("provision:sb_2")
     );
-    expect(f.events).toContain("buildAndStart:sb_2:node dist/server.js");
     // And B's build ran in B's own box, never in A's.
-    expect(f.events).not.toContain("buildAndStart:sb_1:node dist/server.js");
+    expect(f.events).not.toContain("buildAndStart:sb_1:node b.js");
   });
 
-  it("reports recipe_unresolvable — neutral — when every candidate fails", async () => {
-    const f = fakes({
-      ladder: { kind: "candidates", candidates: [candidateA, candidateB] },
-      attempt: () => {
-        throw new CheckStepError("server_unhealthy", "never answered");
-      },
+  it("reports the second candidate's own provision and clone against IT", async () => {
+    const session = fakeSession({
+      candidates: [planned("c1", { start: "node a.js" }), planned("c2")],
+      actions: { "build:fail": { action: "try_next_candidate" } },
     });
-
-    const error = await failureOf(resolveAndStart(ARGS, f.deps));
-    // NOT `server_unhealthy`: nobody asked us to run those commands, so the PR
-    // must not wear the failure of our guesses.
-    expect(error.outcome).toBe("recipe_unresolvable");
-    expect(error.detailsMarkdown).toContain("mcpjam.yaml");
-    expect(f.boxes).toHaveLength(2);
-    // Every box is dead on the failure path.
-    expect(f.events).toContain("kill:sb_1");
-    expect(f.events).toContain("kill:sb_2");
-  });
-
-  it("aborts with infra_error on a provision failure, and tries no further candidates", async () => {
     const f = fakes({
-      ladder: { kind: "candidates", candidates: [candidateA, candidateB] },
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
       attempt: (built) => {
-        if (built.start === candidateA.start) {
-          throw new CheckStepError("build_failed", "exit 1");
-        }
-      },
-      provision: (index) => {
-        if (index === 2) throw new CheckStepError("infra_error", "E2B 503");
+        if (built.start === "node a.js") failing("build_failed")();
       },
     });
+    await resolveAndStart(ARGS, f.deps);
 
-    await expect(resolveAndStart(ARGS, f.deps)).rejects.toMatchObject({
-      outcome: "infra_error",
-    });
-    // Candidate B never ran: an outage consumed as a miss would spend the whole
-    // ladder rediscovering it and then conclude a neutral verdict.
-    expect(f.events.filter((e) => e.startsWith("buildAndStart"))).toHaveLength(
-      1
-    );
-  });
-
-  it("aborts with infra_error when the egress lockdown fails mid-candidate", async () => {
-    const f = fakes({
-      ladder: { kind: "candidates", candidates: [candidateA, candidateB] },
-      attempt: () => {
-        throw new CheckStepError(
-          "infra_error",
-          "failed to disable sandbox egress before starting PR code"
-        );
-      },
-    });
-
-    await expect(resolveAndStart(ARGS, f.deps)).rejects.toMatchObject({
-      outcome: "infra_error",
-    });
-    expect(f.boxes).toHaveLength(1);
-    expect(f.events).toContain("kill:sb_1");
-  });
-
-  it("stops at MAX_CANDIDATES even when the detector offered more", async () => {
-    const many = [1, 2, 3, 4, 5].map((n) =>
-      recipe({ start: `node ${n}.js`, evidence: [`c${n}`] })
-    );
-    const f = fakes({
-      ladder: { kind: "candidates", candidates: many },
-      attempt: () => {
-        throw new CheckStepError("build_failed", "exit 1");
-      },
-      maxCandidates: 3,
-    });
-
-    const error = await failureOf(resolveAndStart(ARGS, f.deps));
-    expect(error.outcome).toBe("recipe_unresolvable");
-    expect(f.boxes).toHaveLength(3);
-  });
-
-  it("stops when the wall-clock budget is spent, rather than starting another box", async () => {
-    let clock = 0;
-    const f = fakes({
-      ladder: {
-        kind: "candidates",
-        candidates: [candidateA, candidateB, recipe({ start: "node c.js" })],
-      },
-      attempt: () => {
-        // Each attempt costs twelve minutes — more than the budget below, so
-        // the second candidate must not be started at all.
-        clock += 12 * 60_000;
-        throw new CheckStepError("build_failed", "exit 1");
-      },
-      now: () => clock,
-      budgetMs: 10 * 60_000,
-    });
-
-    const error = await failureOf(resolveAndStart(ARGS, f.deps));
-    expect(error.outcome).toBe("recipe_unresolvable");
-    expect(error.detailsMarkdown).toContain("time budget");
-    // One attempt ran, the budget was spent, and no second box was paid for.
-    expect(f.boxes).toHaveLength(1);
+    // A fresh box per candidate means each candidate provisions and clones for
+    // itself; which row is a LADDER row is decided by the candidateId, never by
+    // the phase name.
+    expect(
+      f.attempts
+        .filter((a) => a.phase === "provision" || a.phase === "clone")
+        .map((a) => `${a.phase}:${a.candidateId ?? "-"}`)
+    ).toEqual(["provision:-", "clone:-", "provision:c2", "clone:c2"]);
   });
 });
 
 describe("resolveAndStart — runtime verification", () => {
-  const candidateA = recipe({ start: "node a.js", evidence: ["A"] });
-  const candidateB = recipe({ start: "node b.js", evidence: ["B"] });
-
-  it("discards a candidate whose listener is not the process we spawned", async () => {
+  it("reports `listener_mismatch` when the listener is not the process we spawned", async () => {
     // The install-hook class: `"prepare": "nohup acme-server &"` squats the port
     // and answers our probe while the start command never binds.
-    let attempt = 0;
+    const session = fakeSession({
+      candidates: [planned("c1", { start: "node a.js" }), planned("c2")],
+      actions: { "verify:fail": { action: "try_next_candidate" } },
+    });
+    let inspected = 0;
     const f = fakes({
-      ladder: { kind: "candidates", candidates: [candidateA, candidateB] },
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
     });
     f.deps.inspectListener = async () => {
-      attempt += 1;
-      return attempt === 1
+      inspected += 1;
+      return inspected === 1
         ? { processes: [{ pid: 777, ppids: [1], pgrp: 31 }] }
         : goodReport();
     };
 
     const result = await resolveAndStart(ARGS, f.deps);
-    expect(result.recipe.start).toBe(candidateB.start);
+    expect(result.candidateId).toBe("c2");
+    expect(f.attempts).toContainEqual(
+      expect.objectContaining({
+        phase: "verify",
+        ok: false,
+        failureKind: "listener_mismatch",
+      })
+    );
   });
 
   it("cannot be fooled by a squatter that FORGES our pid inside the box", async () => {
     // The adversarial case the pid file created. A squatter that writes
     // `/tmp/mcp-server.pid` — or names any pid it likes anywhere in the box —
-    // changes nothing here, because the expected identity is the one
-    // `buildAndStart` captured at spawn and it never leaves this process.
+    // changes nothing, because the expected identity is the one `buildAndStart`
+    // captured at spawn and it never leaves this process.
+    const session = fakeSession();
     const f = fakes({
-      ladder: { kind: "candidates", candidates: [candidateA] },
-      // The real spawn produced pid 100.
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
       spawn: { pid: 100, pgrp: 100 },
-      // The squatter is pid 900 in its own group, and would have claimed to be
-      // pid 900 in a pid file it controls. The report carries only kernel facts.
       listener: () => ({ processes: [{ pid: 900, ppids: [1], pgrp: 900 }] }),
     });
 
-    const error = await failureOf(resolveAndStart(ARGS, f.deps));
-    expect(error.outcome).toBe("recipe_unresolvable");
+    await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(f.attempts.at(-1)).toMatchObject({
+      failureKind: "listener_mismatch",
+    });
     // And the box was never asked to supply the pid we compare against.
     expect(f.events).toContain("inspect:3001");
   });
 
   it("asks the box only which port to look at — never who to look for", async () => {
     let seen: unknown = null;
-    const f = fakes({
-      ladder: { kind: "candidates", candidates: [candidateA] },
-    });
+    const f = fakes({ ladder: { kind: "candidates", candidates: [recipe()] } });
     f.deps.inspectListener = async (_sandbox, args) => {
       seen = args;
       return goodReport();
@@ -453,17 +728,60 @@ describe("resolveAndStart — runtime verification", () => {
     expect(seen).toEqual({ port: 3001 });
   });
 
-  it("treats an unreadable inspection as infra_error, never as a pass or a miss", async () => {
+  it("reports `listener_unknown` — never a pass, never a miss — when it cannot look", async () => {
+    const session = fakeSession();
     const f = fakes({
-      ladder: { kind: "candidates", candidates: [candidateA, candidateB] },
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
       listener: () => null,
     });
 
-    await expect(resolveAndStart(ARGS, f.deps)).rejects.toMatchObject({
-      outcome: "infra_error",
+    await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(f.attempts.at(-1)).toMatchObject({
+      phase: "verify",
+      ok: false,
+      failureKind: "listener_unknown",
     });
-    // Not consumed as a miss: candidate B never ran.
-    expect(f.boxes).toHaveLength(1);
+  });
+
+  it("maps a build failure to `build` and an unhealthy server to `probe`", async () => {
+    for (const [outcome, phase, kind] of [
+      ["build_failed", "build", "build_failed"],
+      ["server_unhealthy", "probe", "probe_failed"],
+    ] as const) {
+      const session = fakeSession();
+      const f = fakes({
+        session,
+        ladder: { kind: "candidates", candidates: [recipe()] },
+        attempt: failing(outcome),
+      });
+      await stopOf(resolveAndStart(ARGS, f.deps));
+      expect(f.attempts.at(-1)).toMatchObject({
+        phase,
+        ok: false,
+        failureKind: kind,
+        candidateId: "c1",
+      });
+    }
+  });
+
+  it("maps an infrastructure failure inside the build to `sandbox_error`", async () => {
+    // Not `build_failed`: nothing about the PR's build is established by our
+    // egress lockdown or E2B falling over, and the backend aborts on the
+    // infrastructure kinds rather than burning the remaining candidates.
+    const session = fakeSession();
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      attempt: () => {
+        throw new CheckStepError(
+          "infra_error",
+          "failed to disable sandbox egress before starting PR code"
+        );
+      },
+    });
+    await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(f.attempts.at(-1)).toMatchObject({ failureKind: "sandbox_error" });
   });
 });
 
@@ -478,14 +796,13 @@ describe("judgeListeners", () => {
   });
 
   it("accepts a reparented server AFTER its supervisor is gone", () => {
-    // THE case the process-group fallback exists for, and the one the previous
-    // test for it never actually exercised: a double-forked server is reparented
-    // to init (`ppids: [1]`), so ancestry is lost, and the supervisor we spawned
-    // has EXITED — so `/proc/<spawn pid>` does not exist and the report says
-    // nothing at all about pid 100. The only thing left that can identify this
-    // process is the group we recorded at spawn time. Reading the group out of
-    // the box at this moment, as an earlier revision did, returns null here by
-    // construction, and the fallback could never fire.
+    // THE case the process-group fallback exists for: a double-forked server is
+    // reparented to init (`ppids: [1]`), so ancestry is lost, and the supervisor
+    // we spawned has EXITED — so `/proc/<spawn pid>` does not exist and the
+    // report says nothing at all about pid 100. The only thing left that can
+    // identify this process is the group we recorded at spawn time. Reading the
+    // group out of the box at this moment returns null here by construction, and
+    // the fallback could never fire.
     const report = { processes: [{ pid: 200, ppids: [1], pgrp: 100 }] };
     expect(report.processes.some((process) => process.pid === spawn.pid)).toBe(
       false

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -121,6 +121,7 @@ function fakeSession(options?: {
   }) => void;
   candidatesThrows?: unknown;
   attemptThrows?: Record<string, unknown>;
+  stopPolicy?: { maxCandidates: number; wallClockMs: number };
 }): {
   session: CheckPlanSession;
   attempts: RecordedAttempt[];
@@ -135,7 +136,10 @@ function fakeSession(options?: {
       if (options?.candidatesThrows) throw options.candidatesThrows;
       return {
         candidates: options?.candidates ?? [planned("c1")],
-        stopPolicy: { maxCandidates: 3, wallClockMs: 20 * 60_000 },
+        stopPolicy: options?.stopPolicy ?? {
+          maxCandidates: 3,
+          wallClockMs: 20 * 60_000,
+        },
       };
     },
     attempt: async (input) => {
@@ -376,6 +380,47 @@ describe("resolveAndStart — the typed action decides what happens next", () =>
     expect(
       f.events.filter((event) => event.startsWith("buildAndStart"))
     ).toHaveLength(1);
+  });
+
+  it("stops at a candidate boundary once the plan's wall clock is spent", async () => {
+    // The backend can bound the SEARCH by issuing fewer candidates, but nothing
+    // else stops a build-and-probe cycle per candidate while it keeps answering
+    // `try_next_candidate` — the lease heartbeat keeps succeeding throughout.
+    const session = fakeSession({
+      candidates: [planned("c1"), planned("c2")],
+      actions: { "build:fail": { action: "try_next_candidate" } },
+      stopPolicy: { maxCandidates: 3, wallClockMs: 60_000 },
+    });
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+      attempt: failing("build_failed"),
+    });
+    let clock = 0;
+    // The first candidate is inside the deadline; it overruns while running.
+    f.deps.now = () => (clock += 45_000);
+
+    const stop = await stopOf(resolveAndStart(ARGS, f.deps));
+    expect(stop.reason).toBe("plan_wall_clock_exhausted");
+    // The second candidate is never provisioned, let alone built.
+    expect(
+      f.events.filter((event) => event.startsWith("buildAndStart"))
+    ).toHaveLength(1);
+  });
+
+  it("treats `wallClockMs: 0` as NO deadline, not an expired one", async () => {
+    const session = fakeSession({
+      stopPolicy: { maxCandidates: 3, wallClockMs: 0 },
+    });
+    const f = fakes({
+      session,
+      ladder: { kind: "candidates", candidates: [recipe()] },
+    });
+    let clock = 0;
+    f.deps.now = () => (clock += 10 * 60_000);
+
+    const result = await resolveAndStart(ARGS, f.deps);
+    expect(result.started.url).toBe("https://3001-sb_1.e2b.app/mcp");
   });
 
   it("`run_eval` on an accepted candidate returns the running server", async () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/service-route.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/service-route.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GITHUB_CHECKS_SERVICE_BASE,
+  SERVICE_ROUTE_TIMEOUT_MS,
+  githubChecksServiceEnv,
+  postServiceRoute,
+} from "../service-route";
+
+// The transport every plan call goes through, and the one boundary in this flow
+// where a mistake is INVISIBLE to the layer above: `check-plan.ts` classifies on
+// `{status, body}` alone, so anything this function gets wrong arrives there
+// wearing the shape of a legitimate answer. Three behaviours carry that weight:
+//
+//   1. A MALFORMED BODY IS TOLERATED — the status carries the signal.
+//   2. A BODY READ THAT HIT THE DEADLINE IS NOT. It must surface as a TIMEOUT,
+//      never as `body: null`, which would be indistinguishable from (1) and
+//      would let a stalled backend read as one that answered.
+//   3. The deadline covers the BODY READ, not just the headers.
+
+const ORIGINAL_ENV = {
+  convexUrl: process.env.CONVEX_HTTP_URL,
+  serviceToken: process.env.INSPECTOR_SERVICE_TOKEN,
+};
+
+/** A `Response` shaped just enough for what the transport actually touches. */
+function response(status: number, json: () => Promise<any>) {
+  return { status, json } as unknown as Response;
+}
+
+function jsonBody(value: unknown) {
+  return () => Promise.resolve(value);
+}
+
+beforeEach(() => {
+  process.env.CONVEX_HTTP_URL = "https://convex.test";
+  process.env.INSPECTOR_SERVICE_TOKEN = "svc-token";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  if (ORIGINAL_ENV.convexUrl === undefined) delete process.env.CONVEX_HTTP_URL;
+  else process.env.CONVEX_HTTP_URL = ORIGINAL_ENV.convexUrl;
+  if (ORIGINAL_ENV.serviceToken === undefined) {
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+  } else {
+    process.env.INSPECTOR_SERVICE_TOKEN = ORIGINAL_ENV.serviceToken;
+  }
+});
+
+describe("postServiceRoute", () => {
+  it("posts JSON to the configured Convex host with the service token", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response(200, jsonBody({ ok: true, planId: "p1" })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await postServiceRoute(
+      `${GITHUB_CHECKS_SERVICE_BASE}/plan/begin`,
+      { triggerId: "trig-1" }
+    );
+
+    expect(result).toEqual({ status: 200, body: { ok: true, planId: "p1" } });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://convex.test/internal/v1/github-checks/plan/begin");
+    expect(init.method).toBe("POST");
+    // The token is what makes this route reachable at all; a dropped header is
+    // a 401 that would classify as a PROTOCOL error, not as "misconfigured".
+    expect(init.headers["x-inspector-service-token"]).toBe("svc-token");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init.body)).toEqual({ triggerId: "trig-1" });
+  });
+
+  it("TOLERATES a malformed body — the status carries the signal", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        response(500, () => Promise.reject(new SyntaxError("Unexpected token")))
+      )
+    );
+
+    // 500 + `null` is exactly what the caller classifies as unreachable; the
+    // parse failure must not escape as its own error class.
+    await expect(postServiceRoute("/x", {})).resolves.toEqual({
+      status: 500,
+      body: null,
+    });
+  });
+
+  it("keeps the deadline armed through the BODY read", async () => {
+    vi.useFakeTimers();
+    // A response whose headers arrive and whose body then stalls past the cap.
+    // Left unguarded this hangs the poll loop for as long as the socket lives.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        response(200, async () => {
+          await vi.advanceTimersByTimeAsync(SERVICE_ROUTE_TIMEOUT_MS + 1);
+          throw new Error("aborted");
+        })
+      )
+    );
+
+    const call = postServiceRoute("/slow", {});
+    // A TIMEOUT, not `body: null`: a stalled read must never be reported as a
+    // backend that answered without a body.
+    await expect(call).rejects.toThrow(/timed out after 15000ms/);
+    await expect(call).rejects.toThrow(/\/slow/);
+  });
+
+  it("propagates an aborted fetch rather than inventing a status", async () => {
+    const aborted = new DOMException("The operation was aborted.", "AbortError");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(aborted));
+
+    // The caller replays a transport throw exactly once; swallowing it into a
+    // synthetic status would spend that replay on nothing.
+    await expect(postServiceRoute("/x", {})).rejects.toThrow(/aborted/);
+  });
+
+  it("disarms the deadline once the call returns", async () => {
+    vi.useFakeTimers();
+    let captured: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        captured = init.signal ?? undefined;
+        return Promise.resolve(response(200, jsonBody({ ok: true })));
+      })
+    );
+
+    await postServiceRoute("/x", {});
+    // A timer left armed would abort a controller nobody is using — harmless
+    // here, but it also keeps the event loop alive in a process that polls.
+    await vi.advanceTimersByTimeAsync(SERVICE_ROUTE_TIMEOUT_MS * 2);
+    expect(captured?.aborted).toBe(false);
+  });
+
+  it("refuses to call at all when the service env is missing", async () => {
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(postServiceRoute("/x", {})).rejects.toThrow(
+      /CONVEX_HTTP_URL and INSPECTOR_SERVICE_TOKEN/
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(githubChecksServiceEnv()).toBeNull();
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/check-plan.ts
+++ b/mcpjam-inspector/server/services/github-checks/check-plan.ts
@@ -477,50 +477,71 @@ export class HttpCheckPlanSession implements CheckPlanSession {
     body: Record<string, unknown>,
     at?: { phase: AttemptPhase; candidateId?: string }
   ): Promise<any> {
-    let lastTransportError: unknown;
-    for (let attempt = 0; attempt <= TRANSPORT_RETRIES; attempt += 1) {
-      let response;
-      try {
-        response = await this.post(path, body);
-      } catch (error) {
-        // A transport failure is the one thing worth replaying: the request may
-        // never have arrived, and the idempotency key makes it safe if it did.
-        lastTransportError = error;
-        continue;
+    return callPlanRoute(this.post, step, path, body, at);
+  }
+}
+
+/**
+ * The retry-and-classify loop, in ONE place.
+ *
+ * `beginCheckPlan` needs it before a session exists and `HttpCheckPlanSession`
+ * needs it after, and the two must agree — a future timeout or status-policy
+ * edit has to land somewhere it cannot half-apply. One transport replay (safe
+ * because every body carries an idempotency key, or is idempotent by
+ * construction), then the three failure classes separated at the boundary so no
+ * caller re-derives them from a status code.
+ */
+async function callPlanRoute(
+  post: PostServiceRoute,
+  step: string,
+  path: string,
+  body: Record<string, unknown>,
+  at?: { phase: AttemptPhase; candidateId?: string }
+): Promise<any> {
+  let lastTransportError: unknown;
+  for (let attempt = 0; attempt <= TRANSPORT_RETRIES; attempt += 1) {
+    let response;
+    try {
+      response = await post(path, body);
+    } catch (error) {
+      // A transport failure is the one thing worth replaying: the request may
+      // never have arrived, and the idempotency key makes it safe if it did.
+      lastTransportError = error;
+      continue;
+    }
+    if (response.status === 200 && response.body?.ok) return response.body;
+    if (response.status >= 400 && response.status < 500) {
+      if (response.status === 404) {
+        // The surface is switched off backend-side, or not deployed yet.
+        // That is unreachability, not a state-machine violation.
+        throw new PlanUnreachableError(step, "route not found (404)", at);
       }
-      if (response.status === 200 && response.body?.ok) return response.body;
-      if (response.status >= 400 && response.status < 500) {
-        if (response.status === 404) {
-          // The surface is switched off backend-side, or not deployed yet.
-          // That is unreachability, not a state-machine violation.
-          throw new PlanUnreachableError(step, "route not found (404)", at);
-        }
-        // 409 (state machine) and 400 (invalid request) are both OURS to fix
-        // and neither is retryable — retrying cannot make a rejected assertion
-        // true, and a local fallback would be exactly the invisible behaviour
-        // change degraded mode forbids.
-        throw new PlanProtocolError(
-          step,
-          String(response.body?.error ?? "unknown"),
-          response.status
-        );
-      }
-      throw new PlanUnreachableError(
+      // 409 (state machine) and 400 (invalid request) are both OURS to fix
+      // and neither is retryable — retrying cannot make a rejected assertion
+      // true, and a local fallback would be exactly the invisible behaviour
+      // change degraded mode forbids.
+      throw new PlanProtocolError(
         step,
-        `status ${response.status}: ${JSON.stringify(
-          response.body ?? null
-        ).slice(0, 200)}`,
-        at
+        String(response.body?.error ?? "unknown"),
+        response.status
       );
     }
     throw new PlanUnreachableError(
       step,
-      lastTransportError instanceof Error
-        ? lastTransportError.message.slice(0, 200)
-        : String(lastTransportError),
+      `status ${response.status}: ${JSON.stringify(response.body ?? null).slice(
+        0,
+        200
+      )}`,
       at
     );
   }
+  throw new PlanUnreachableError(
+    step,
+    lastTransportError instanceof Error
+      ? lastTransportError.message.slice(0, 200)
+      : String(lastTransportError),
+    at
+  );
 }
 
 /**
@@ -531,54 +552,23 @@ export async function beginCheckPlan(
   args: { triggerId: string; repoFullName: string; headSha: string },
   post: PostServiceRoute = postServiceRoute
 ): Promise<CheckPlanSession> {
-  let lastTransportError: unknown;
-  for (let attempt = 0; attempt <= TRANSPORT_RETRIES; attempt += 1) {
-    let response;
-    try {
-      response = await post(`${GITHUB_CHECKS_SERVICE_BASE}/plan/begin`, {
-        triggerId: args.triggerId,
-        repoFullName: args.repoFullName,
-        headSha: args.headSha,
-      });
-    } catch (error) {
-      // Idempotent by construction: the same trigger always gets the same
-      // planId back, so a replay can never mint a second plan whose candidate
-      // ids mean something different from the ones in-flight attempts cite.
-      lastTransportError = error;
-      continue;
-    }
-    if (response.status === 200 && response.body?.ok) {
-      const planId = String(response.body.planId ?? "");
-      if (!planId) {
-        throw new PlanUnreachableError(
-          "plan/begin",
-          "no planId in the response"
-        );
-      }
-      return new HttpCheckPlanSession(args.triggerId, planId, post);
-    }
-    if (response.status === 404) {
-      throw new PlanUnreachableError("plan/begin", "route not found (404)");
-    }
-    if (response.status >= 400 && response.status < 500) {
-      throw new PlanProtocolError(
-        "plan/begin",
-        String(response.body?.error ?? "unknown"),
-        response.status
-      );
-    }
-    throw new PlanUnreachableError(
-      "plan/begin",
-      `status ${response.status}: ${JSON.stringify(response.body ?? null).slice(
-        0,
-        200
-      )}`
-    );
-  }
-  throw new PlanUnreachableError(
+  // The replay this shares with every other call is idempotent by construction
+  // here: the same trigger always gets the same planId back, so it can never
+  // mint a second plan whose candidate ids mean something different from the
+  // ones in-flight attempts cite.
+  const body = await callPlanRoute(
+    post,
     "plan/begin",
-    lastTransportError instanceof Error
-      ? lastTransportError.message.slice(0, 200)
-      : String(lastTransportError)
+    `${GITHUB_CHECKS_SERVICE_BASE}/plan/begin`,
+    {
+      triggerId: args.triggerId,
+      repoFullName: args.repoFullName,
+      headSha: args.headSha,
+    }
   );
+  const planId = String(body?.planId ?? "");
+  if (!planId) {
+    throw new PlanUnreachableError("plan/begin", "no planId in the response");
+  }
+  return new HttpCheckPlanSession(args.triggerId, planId, post);
 }

--- a/mcpjam-inspector/server/services/github-checks/check-plan.ts
+++ b/mcpjam-inspector/server/services/github-checks/check-plan.ts
@@ -1,0 +1,584 @@
+/**
+ * The BACKEND-OWNED plan / verdict loop, from the worker's side.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHAT THIS MODULE MOVED OUT OF THE INSPECTOR, AND WHY
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * Settled architecture (plan 5, 08-03): the moat is the DATA FLYWHEEL, not the
+ * security logic. Sandbox execution stays open and inspectable — attackers
+ * observe behaviour anyway, and correctness must never depend on secrecy. What
+ * compounds across repositories is which recipes worked, why attempts failed,
+ * and how candidates get ordered. So:
+ *
+ *   THE INSPECTOR STOPPED    ordering candidates; deciding continue/stop;
+ *                            computing the final outcome. `resolveAndStart`'s
+ *                            local attribution mapping is gone — it reports a
+ *                            `failureKind` and the backend derives the verdict.
+ *   THE INSPECTOR KEPT       deterministic `mcpjam.yaml` parsing and detection;
+ *                            clone/build/start/probe; E2B lifecycle; egress
+ *                            lockdown; cleanup; `/proc` listener identity;
+ *                            telemetry. All still in the open.
+ *
+ * The accepted cost, named: a check now depends on this backend mid-flight, so
+ * a self-hosted Inspector cannot run checks standalone. That is the moat
+ * working as intended, and it is a deliberate position rather than an emergent
+ * one.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE SEQUENCE
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ *   1. claim (unchanged)
+ *   2. POST /plan/begin { triggerId, repoFullName, headSha } → { planId }
+ *      ← FIRST, before ANY sandbox work. Provisioning, cloning and detection
+ *        all fail BEFORE candidates exist, and a derived completion REQUIRES a
+ *        planId; minting the shell up front is what makes those failures
+ *        attributable through the ordinary path instead of needing a second,
+ *        planless completion contract forever.
+ *   3. provision → clone → bounded reads, each reported as a LADDER attempt
+ *      (no candidateId)
+ *   4. the deterministic ladder → localCandidates
+ *   5. compute the evidence digest (this repo is the SOLE encoder)
+ *   6. POST /plan/candidates → { candidates[], stopPolicy }
+ *   7. execute the candidates IN THE PLAN'S ORDER, fresh box per candidate
+ *   8. obey the typed ACTION returned by every /attempt
+ *   9. on `run_eval`: launch the suite, then IMMEDIATELY post
+ *      { phase:'eval', ok:true, runId } — that attempt is what BINDS the run
+ *   10. POST /complete { triggerId, planId, runId } — NO `outcome` field
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THREE RULES THAT ARE EASY TO SOFTEN AND MUST NOT BE
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * 1. A 409 IS A HARD STOP, NEVER RETRIED. It means we violated the state
+ *    machine — we cited a candidate out of order, reported a phase backwards,
+ *    kept going after a stop, or asserted something untrue about this check.
+ *    Retrying cannot make any of those true. The reason is surfaced in the
+ *    check output and the run stops.
+ * 2. DEGRADED MODE IS A CONTRACT. Backend unreachable after the claim ⇒ stop
+ *    conservatively and report `backend_unreachable`, which the backend
+ *    attributes as `infra_error`. Never a green, never a PR-blamed outcome, and
+ *    NEVER a silent local fallback to our own candidate policy — behaviour must
+ *    not differ invisibly between healthy and degraded runs.
+ * 3. AN UNKNOWN ACTION IS THE SAME CASE. A response we cannot interpret is no
+ *    more evidence about the pull request than no response at all, so it fails
+ *    closed to `complete` + the degraded marker.
+ */
+
+import { logger } from "../../utils/logger.js";
+import type { CheckRecipe } from "./recipes.js";
+import type { OwnershipProof, RecipeRung } from "./resolver/index.js";
+import {
+  GITHUB_CHECKS_SERVICE_BASE,
+  postServiceRoute,
+  type PostServiceRoute,
+} from "./service-route.js";
+
+// ---------------------------------------------------------------------------
+// The wire vocabulary, hand-mirrored from `convex/github/checkPlans.ts`
+// ---------------------------------------------------------------------------
+
+/**
+ * Where in a check's life an attempt landed.
+ *
+ * `provision`, `clone` and `resolve` are also the LADDER phases — reportable
+ * with no `candidateId` while the plan is still candidate-less. Which one a row
+ * is is decided by whether it carries a `candidateId`, never by the phase name.
+ */
+export const ATTEMPT_PHASES = [
+  "resolve",
+  "provision",
+  "clone",
+  "build",
+  "start",
+  "probe",
+  "verify",
+  "eval",
+] as const;
+export type AttemptPhase = (typeof ATTEMPT_PHASES)[number];
+
+/**
+ * Everything an attempt may fail as.
+ *
+ * `evals_failed` IS NOT A MEMBER, and that is the point: it was removed from
+ * the backend union entirely and sending it is a 400. "Evals failed" is a
+ * statement about the PULL REQUEST, and those come only from the backend
+ * reading the BOUND `testSuiteRun` — never from a worker assertion, which could
+ * otherwise produce a red verdict from a candidate-less `resolve` attempt with
+ * no run involved at all. A failed eval LAUNCH is `ok: false` with an
+ * infrastructure kind.
+ */
+export const ATTEMPT_FAILURE_KINDS = [
+  "recipe_invalid",
+  "build_failed",
+  "probe_failed",
+  "listener_mismatch",
+  "listener_unknown",
+  "provision_failed",
+  "clone_failed",
+  "lockdown_failed",
+  "sandbox_error",
+  "lease_lost",
+  "backend_unreachable",
+  "budget_exhausted",
+  "no_candidates",
+] as const;
+export type AttemptFailureKind = (typeof ATTEMPT_FAILURE_KINDS)[number];
+
+/**
+ * What the backend tells the worker to do next. A TYPED action, not
+ * `continue: boolean` — that boolean meant both "this candidate was accepted,
+ * stop searching" and "abort the check", and guessing wrong either runs an eval
+ * against a server nobody verified or skips the eval the search existed for.
+ */
+export const ATTEMPT_ACTIONS = [
+  "continue_phase",
+  "try_next_candidate",
+  "run_eval",
+  "complete",
+] as const;
+export type AttemptAction = (typeof ATTEMPT_ACTIONS)[number];
+
+export function isAttemptAction(value: unknown): value is AttemptAction {
+  return (
+    typeof value === "string" &&
+    (ATTEMPT_ACTIONS as readonly string[]).includes(value)
+  );
+}
+
+/** One candidate the backend planned, in the order it must be executed. */
+export type PlannedCandidate = {
+  candidateId: string;
+  recipe: CheckRecipe;
+  rung: RecipeRung;
+  evidence: string[];
+  ownershipProof: OwnershipProof;
+  /** `cache` | `detected` | `agentic` — the A4 seam. Display/telemetry only. */
+  source?: string;
+};
+
+export type PlanStopPolicy = { maxCandidates: number; wallClockMs: number };
+
+export type PlanCandidateInput = {
+  recipe: CheckRecipe;
+  rung: RecipeRung;
+  evidence: string[];
+  ownershipProof: OwnershipProof;
+};
+
+export type AttemptInput = {
+  candidateId?: string;
+  phase: AttemptPhase;
+  ok: boolean;
+  failureKind?: AttemptFailureKind;
+  durationMs: number;
+  detailsClamped?: string;
+  /** REQUIRED when `phase === 'eval' && ok`, REFUSED anywhere else. */
+  runId?: string;
+};
+
+export type AttemptDecision = {
+  action: AttemptAction;
+  reason?: string;
+  /**
+   * The backend answered with an action this build does not know. The caller
+   * must treat it as `complete` plus the degraded marker — see rule 3 above.
+   */
+  unknownAction?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Failures, kept APART because the correct response to each one differs
+// ---------------------------------------------------------------------------
+
+/**
+ * The backend REFUSED (4xx). We violated the state machine or sent something
+ * invalid; the reason names which. NEVER retried, and never fallen back from.
+ */
+export class PlanProtocolError extends Error {
+  constructor(
+    readonly step: string,
+    readonly reason: string,
+    readonly status: number
+  ) {
+    super(`${step} refused (${status}): ${reason}`);
+    this.name = "PlanProtocolError";
+  }
+}
+
+/**
+ * The backend could not be REACHED (transport failure, 5xx, or the surface is
+ * switched off / not deployed). The degraded-mode marker travels with it so the
+ * completion can say WHERE the loop stopped.
+ */
+export class PlanUnreachableError extends Error {
+  constructor(
+    readonly step: string,
+    readonly detail: string,
+    /** The attempt this call was carrying, when it was carrying one. */
+    readonly at?: { phase: AttemptPhase; candidateId?: string }
+  ) {
+    super(`${step} unreachable: ${detail}`);
+    this.name = "PlanUnreachableError";
+  }
+}
+
+/**
+ * The backend said STOP, or a failure was reported and the plan is finished.
+ *
+ * Carries no outcome, deliberately: the worker's job from here is to post
+ * `/complete` and let the backend derive one. `detailsMarkdown` is the
+ * author-facing copy (the resolver's "add an mcpjam.yaml" block, a clamped
+ * build log tail) — display only, with no verdict authority.
+ */
+export class CheckStoppedByPlan extends Error {
+  constructor(
+    readonly reason: string,
+    readonly detailsMarkdown?: string,
+    /** Preformatted markdown (our prose) vs clamped untrusted output. */
+    readonly detailsPreformatted?: boolean
+  ) {
+    super(`check stopped: ${reason}`);
+    this.name = "CheckStoppedByPlan";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The session
+// ---------------------------------------------------------------------------
+
+/**
+ * The seam the orchestrator and the worker both speak to. An interface rather
+ * than the class, so the unit tests drive the whole loop through a fake without
+ * a Convex deployment — which is the only way the 409, degraded and
+ * unknown-action paths are testable at all.
+ */
+export interface CheckPlanSession {
+  readonly planId: string;
+  candidates(input: {
+    evidenceDigest: string;
+    resolverVersion: string;
+    localCandidates: PlanCandidateInput[];
+  }): Promise<{ candidates: PlannedCandidate[]; stopPolicy: PlanStopPolicy }>;
+  attempt(input: AttemptInput): Promise<AttemptDecision>;
+  complete(input: {
+    runId?: string;
+    summary?: {
+      total: number;
+      passed: number;
+      failed: number;
+      passRate: number;
+    };
+    detailsMarkdown?: string;
+    /**
+     * The DEGRADED marker only. Ordinary attempts go through `attempt()` as
+     * they happen; an inline one here exists so a run that lost the backend
+     * mid-flight can still say so on the first call that gets through.
+     */
+    terminalAttempt?: AttemptInput;
+  }): Promise<void>;
+}
+
+/**
+ * How many times a call may be REPLAYED after a transport failure.
+ *
+ * One, and only where the idempotency key makes it safe: `/attempt` persists
+ * the original response against the key and replays it byte-for-byte, so a
+ * retry can never observe a different action than the first call returned.
+ * `/plan/begin` and `/plan/candidates` are idempotent by construction (same
+ * trigger → same plan; same digest + resolver → the issued plan replayed).
+ */
+const TRANSPORT_RETRIES = 1;
+
+export class HttpCheckPlanSession implements CheckPlanSession {
+  /**
+   * Monotone per-session counter behind every idempotency key.
+   *
+   * A caller-generated key, never a natural one: a natural key (plan +
+   * candidate + phase) silently collapses two legitimately distinct attempts —
+   * a retried phase and a genuine re-execution — and the ambiguity only ever
+   * surfaces as corrupted corpus data. A fresh key per DISTINCT attempt, the
+   * same key on a transport RETRY, is exactly the distinction the backend's
+   * `requestFingerprint` check expects.
+   */
+  private attemptSeq = 0;
+
+  constructor(
+    private readonly triggerId: string,
+    readonly planId: string,
+    private readonly post: PostServiceRoute
+  ) {}
+
+  async candidates(input: {
+    evidenceDigest: string;
+    resolverVersion: string;
+    localCandidates: PlanCandidateInput[];
+  }): Promise<{ candidates: PlannedCandidate[]; stopPolicy: PlanStopPolicy }> {
+    const body = await this.call(
+      "plan/candidates",
+      `${GITHUB_CHECKS_SERVICE_BASE}/plan/candidates`,
+      {
+        planId: this.planId,
+        evidenceDigest: input.evidenceDigest,
+        resolverVersion: input.resolverVersion,
+        localCandidates: input.localCandidates,
+      }
+    );
+    const candidates = Array.isArray(body?.candidates)
+      ? (body.candidates as PlannedCandidate[])
+      : [];
+    const stopPolicy: PlanStopPolicy = {
+      maxCandidates: Number(
+        body?.stopPolicy?.maxCandidates ?? candidates.length
+      ),
+      wallClockMs: Number(body?.stopPolicy?.wallClockMs ?? 0),
+    };
+    return { candidates, stopPolicy };
+  }
+
+  async attempt(input: AttemptInput): Promise<AttemptDecision> {
+    this.attemptSeq += 1;
+    const idempotencyKey = `${this.planId}:${input.candidateId ?? "ladder"}:${
+      input.phase
+    }:${this.attemptSeq}`;
+    const body = await this.call(
+      "attempt",
+      `${GITHUB_CHECKS_SERVICE_BASE}/attempt`,
+      {
+        triggerId: this.triggerId,
+        planId: this.planId,
+        ...(input.candidateId ? { candidateId: input.candidateId } : {}),
+        phase: input.phase,
+        ok: input.ok,
+        ...(input.failureKind ? { failureKind: input.failureKind } : {}),
+        durationMs: Math.max(0, Math.round(input.durationMs)),
+        ...(input.detailsClamped
+          ? { detailsClamped: input.detailsClamped }
+          : {}),
+        ...(input.runId ? { runId: input.runId } : {}),
+        idempotencyKey,
+      },
+      { phase: input.phase, candidateId: input.candidateId }
+    );
+    if (!isAttemptAction(body?.action)) {
+      // FAIL CLOSED. An action we do not understand is a contract we do not
+      // understand, and the only safe reading of that is a neutral stop.
+      logger.warn(
+        "[github-checks] unrecognized attempt action; failing closed",
+        {
+          planId: this.planId,
+          phase: input.phase,
+          action: String(body?.action),
+        }
+      );
+      return {
+        action: "complete",
+        reason: "unknown_action",
+        unknownAction: true,
+      };
+    }
+    return {
+      action: body.action,
+      ...(typeof body?.reason === "string" ? { reason: body.reason } : {}),
+    };
+  }
+
+  async complete(input: {
+    runId?: string;
+    summary?: {
+      total: number;
+      passed: number;
+      failed: number;
+      passRate: number;
+    };
+    detailsMarkdown?: string;
+    terminalAttempt?: AttemptInput;
+  }): Promise<void> {
+    const base: Record<string, unknown> = {
+      triggerId: this.triggerId,
+      planId: this.planId,
+      // NO `outcome`. The backend derives it from the attempts it holds and the
+      // run it is BOUND to; sending one would take the legacy explicit path and
+      // put the verdict back in this process, which is the whole thing A3b
+      // moved.
+      ...(input.runId ? { runId: input.runId } : {}),
+      ...(input.summary ? { summary: input.summary } : {}),
+      ...(input.detailsMarkdown
+        ? { detailsMarkdown: input.detailsMarkdown }
+        : {}),
+    };
+
+    if (!input.terminalAttempt) {
+      await this.call(
+        "complete",
+        `${GITHUB_CHECKS_SERVICE_BASE}/complete`,
+        base
+      );
+      return;
+    }
+
+    this.attemptSeq += 1;
+    const attempt = input.terminalAttempt;
+    const withMarker = {
+      ...base,
+      terminalAttempt: {
+        ...(attempt.candidateId ? { candidateId: attempt.candidateId } : {}),
+        phase: attempt.phase,
+        ok: attempt.ok,
+        ...(attempt.failureKind ? { failureKind: attempt.failureKind } : {}),
+        durationMs: Math.max(0, Math.round(attempt.durationMs)),
+        ...(attempt.detailsClamped
+          ? { detailsClamped: attempt.detailsClamped }
+          : {}),
+        idempotencyKey: `${this.planId}:${attempt.candidateId ?? "ladder"}:${
+          attempt.phase
+        }:degraded:${this.attemptSeq}`,
+      },
+    };
+    try {
+      await this.call(
+        "complete",
+        `${GITHUB_CHECKS_SERVICE_BASE}/complete`,
+        withMarker
+      );
+    } catch (error) {
+      if (!(error instanceof PlanProtocolError)) throw error;
+      // THE MARKER IS BEST EFFORT; THE COMPLETION IS NOT.
+      //
+      // The marker rides inline, so the backend appends it as a real attempt —
+      // and it can legitimately be refused: if the call this run lost was in
+      // fact COMMITTED before the response went missing, a second row at the
+      // same phase is `phase_out_of_order`. Refusing the whole completion over
+      // that would leave a claimed check with no verdict at all until the
+      // heartbeat sweep timed it out, which is a worse outcome than losing one
+      // telemetry row. So the completion is retried once WITHOUT the marker;
+      // the attempt log already ends where the run stopped, and the derivation
+      // reads `infra_error` from it either way.
+      logger.warn(
+        "[github-checks] degraded marker refused; completing without it",
+        { planId: this.planId, reason: error.reason }
+      );
+      await this.call(
+        "complete",
+        `${GITHUB_CHECKS_SERVICE_BASE}/complete`,
+        base
+      );
+    }
+  }
+
+  /**
+   * One service call, with the three failure classes separated at the boundary
+   * so no caller has to re-derive them from a status code.
+   */
+  private async call(
+    step: string,
+    path: string,
+    body: Record<string, unknown>,
+    at?: { phase: AttemptPhase; candidateId?: string }
+  ): Promise<any> {
+    let lastTransportError: unknown;
+    for (let attempt = 0; attempt <= TRANSPORT_RETRIES; attempt += 1) {
+      let response;
+      try {
+        response = await this.post(path, body);
+      } catch (error) {
+        // A transport failure is the one thing worth replaying: the request may
+        // never have arrived, and the idempotency key makes it safe if it did.
+        lastTransportError = error;
+        continue;
+      }
+      if (response.status === 200 && response.body?.ok) return response.body;
+      if (response.status >= 400 && response.status < 500) {
+        if (response.status === 404) {
+          // The surface is switched off backend-side, or not deployed yet.
+          // That is unreachability, not a state-machine violation.
+          throw new PlanUnreachableError(step, "route not found (404)", at);
+        }
+        // 409 (state machine) and 400 (invalid request) are both OURS to fix
+        // and neither is retryable — retrying cannot make a rejected assertion
+        // true, and a local fallback would be exactly the invisible behaviour
+        // change degraded mode forbids.
+        throw new PlanProtocolError(
+          step,
+          String(response.body?.error ?? "unknown"),
+          response.status
+        );
+      }
+      throw new PlanUnreachableError(
+        step,
+        `status ${response.status}: ${JSON.stringify(
+          response.body ?? null
+        ).slice(0, 200)}`,
+        at
+      );
+    }
+    throw new PlanUnreachableError(
+      step,
+      lastTransportError instanceof Error
+        ? lastTransportError.message.slice(0, 200)
+        : String(lastTransportError),
+      at
+    );
+  }
+}
+
+/**
+ * Mint the plan SHELL. Called before any sandbox work, so every failure from
+ * that point on has a plan to be attributed against.
+ */
+export async function beginCheckPlan(
+  args: { triggerId: string; repoFullName: string; headSha: string },
+  post: PostServiceRoute = postServiceRoute
+): Promise<CheckPlanSession> {
+  let lastTransportError: unknown;
+  for (let attempt = 0; attempt <= TRANSPORT_RETRIES; attempt += 1) {
+    let response;
+    try {
+      response = await post(`${GITHUB_CHECKS_SERVICE_BASE}/plan/begin`, {
+        triggerId: args.triggerId,
+        repoFullName: args.repoFullName,
+        headSha: args.headSha,
+      });
+    } catch (error) {
+      // Idempotent by construction: the same trigger always gets the same
+      // planId back, so a replay can never mint a second plan whose candidate
+      // ids mean something different from the ones in-flight attempts cite.
+      lastTransportError = error;
+      continue;
+    }
+    if (response.status === 200 && response.body?.ok) {
+      const planId = String(response.body.planId ?? "");
+      if (!planId) {
+        throw new PlanUnreachableError(
+          "plan/begin",
+          "no planId in the response"
+        );
+      }
+      return new HttpCheckPlanSession(args.triggerId, planId, post);
+    }
+    if (response.status === 404) {
+      throw new PlanUnreachableError("plan/begin", "route not found (404)");
+    }
+    if (response.status >= 400 && response.status < 500) {
+      throw new PlanProtocolError(
+        "plan/begin",
+        String(response.body?.error ?? "unknown"),
+        response.status
+      );
+    }
+    throw new PlanUnreachableError(
+      "plan/begin",
+      `status ${response.status}: ${JSON.stringify(response.body ?? null).slice(
+        0,
+        200
+      )}`
+    );
+  }
+  throw new PlanUnreachableError(
+    "plan/begin",
+    lastTransportError instanceof Error
+      ? lastTransportError.message.slice(0, 200)
+      : String(lastTransportError)
+  );
+}

--- a/mcpjam-inspector/server/services/github-checks/evidence-digest.ts
+++ b/mcpjam-inspector/server/services/github-checks/evidence-digest.ts
@@ -321,12 +321,32 @@ export function isRecipeEvidenceHash(value: unknown): value is string {
  * collapse. A file the reader could not read is `absent` here for the same
  * reason it is absent to the detector: it contributed nothing to the answer.
  *
- * ONE deliberate exception to "every byte detection is capable of reading":
- * `DetectionInputs.repoFiles`. It is a listing of the same commit the digest is
- * already keyed to, so it cannot vary independently of the bytes above — the
- * detector says as much where it documents `repoFiles.kind` as not joining the
- * R3 cache key. Adding it here would churn the digest (and orphan every cache
- * entry) without distinguishing a single pair of inputs.
+ * ONE INPUT IS NOT COVERED, AND IT IS NOT AIRTIGHT: `DetectionInputs.repoFiles`.
+ *
+ * The listing is a real detection input — it is what turns rule C from a guess
+ * into a proof, and it can SUPPRESS a candidate (a symlinked entry point, a
+ * python `[project.scripts]` entry) that the syntactic rules alone would let
+ * through. By the invariant above it therefore belongs in the digest, and it is
+ * absent. `resolver/detect.ts` justifies the omission on the grounds that the
+ * listing is derived from the same commit the hashed files are read at.
+ *
+ * What that argument does and does not buy, stated plainly so the next person
+ * does not have to re-derive it:
+ *
+ *   - Cross-repository replay is NOT possible regardless: the backend's recipe
+ *     cache is keyed by `by_repo_evidence` — `(repoFullName, evidenceHash)` —
+ *     so a digest collision between two different repositories cannot hit.
+ *   - WITHIN one repository it is not tight. A commit can leave every hashed
+ *     byte identical and still change the listing — most sharply, by replacing
+ *     a tracked `server.js` with a SYMLINK into `node_modules/`. Fresh
+ *     detection suppresses that candidate; a cache hit issued when the same
+ *     path was a regular file does not, which is the exact ownership proof
+ *     `repoFiles` was added to establish.
+ *
+ * Closing it means hashing a bounded, deterministic encoding of the listing
+ * (path + kind) and bumping `RECIPE_EVIDENCE_HASH_VERSION`, which orphans every
+ * entry written so far — a deliberate cost, and a decision that belongs with
+ * the cache owner rather than in a drive-by. Tracked, not settled.
  */
 export function computeResolverEvidenceDigest(
   inputs: { mcpjamYaml: CappedRead; detection: DetectionInputs },

--- a/mcpjam-inspector/server/services/github-checks/evidence-digest.ts
+++ b/mcpjam-inspector/server/services/github-checks/evidence-digest.ts
@@ -320,6 +320,13 @@ export function isRecipeEvidenceHash(value: unknown): value is string {
  * are the bytes detection saw, including the reader's caps and its `over_cap`
  * collapse. A file the reader could not read is `absent` here for the same
  * reason it is absent to the detector: it contributed nothing to the answer.
+ *
+ * ONE deliberate exception to "every byte detection is capable of reading":
+ * `DetectionInputs.repoFiles`. It is a listing of the same commit the digest is
+ * already keyed to, so it cannot vary independently of the bytes above — the
+ * detector says as much where it documents `repoFiles.kind` as not joining the
+ * R3 cache key. Adding it here would churn the digest (and orphan every cache
+ * entry) without distinguishing a single pair of inputs.
  */
 export function computeResolverEvidenceDigest(
   inputs: { mcpjamYaml: CappedRead; detection: DetectionInputs },

--- a/mcpjam-inspector/server/services/github-checks/evidence-digest.ts
+++ b/mcpjam-inspector/server/services/github-checks/evidence-digest.ts
@@ -1,0 +1,343 @@
+/**
+ * The canonical run-recipe EVIDENCE DIGEST — and the Inspector is its only
+ * author.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY THIS FILE EXISTS HERE AND NOWHERE ELSE
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * This encoding used to live in the backend (`convex/github/recipeEvidence.ts`)
+ * and was to be HAND-MIRRORED here, with a golden vector acting as a cross-repo
+ * treaty. A3b-1 retired that: the backend now treats the digest as OPAQUE — it
+ * stores and compares the value as a cache key and never recomputes it, and its
+ * only remaining check is that the string is shaped like a hex sha-256.
+ *
+ * So there is exactly ONE encoder, and it is this one. That removes the entire
+ * class of failure where two implementations disagree on one byte and silently
+ * become two cache namespaces wearing the same key. What it does NOT remove is
+ * the need for the format to stay STABLE: every cache entry ever written is
+ * keyed by it, so changing the encoding without bumping
+ * `RECIPE_EVIDENCE_HASH_VERSION` orphans the cache instead of invalidating it.
+ * The golden vector below is no longer a treaty — it is a plain regression test
+ * guarding that stability.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE RULES, AND WHY EACH ONE IS LOAD-BEARING
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ *   1. The input paths are a FIXED, ORDERED list (`RECIPE_EVIDENCE_PATHS`).
+ *      Order is the list's order, never the caller's iteration order, and never
+ *      sorted at runtime — the list IS the ordering.
+ *   2. Each path contributes three segments: the path, a `present`/`absent`
+ *      marker, and the first `RECIPE_EVIDENCE_MAX_FILE_BYTES[path]` BYTES of
+ *      its content (UTF-8, byte-measured — NOT `String.prototype.slice`, which
+ *      counts UTF-16 code units and would make two different files hash the
+ *      same, or the same file hash differently, depending on where its
+ *      non-ASCII characters fall).
+ *   3. Segments are concatenated LENGTH-PREFIXED (4-byte big-endian byte
+ *      length). Plain concatenation with a separator is forgeable: file content
+ *      is attacker-controlled, and any separator can be embedded in it to make
+ *      two different evidence sets produce identical bytes.
+ *   4. The hash also covers `resolverVersion` — the detection LOGIC is an input
+ *      to the answer, so a resolver change must MISS the cache rather than
+ *      resurrect a recipe the old logic produced.
+ *   5. For agentic entries it additionally covers `promptVersion`, `model`,
+ *      `runtimeImageVersion` and `agenticContextDigest`. Nothing produces those
+ *      today (the agentic rung is backend-owned and lands in A4), but they are
+ *      part of the encoding and removing them would move every existing key.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY RE-PROBING DOES NOT EXCUSE A NARROW HASH. READ THIS BEFORE TUNING IT.
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * It is tempting to argue the byte budget can be anything, because the worker
+ * re-builds and re-probes every cache hit anyway. That argument is wrong, and
+ * subtly so:
+ *
+ *   Re-probing only proves the STALE CANDIDATE STILL RUNS.
+ *   It does not prove it is the candidate THIS CHECKOUT SHOULD HAVE SELECTED.
+ *
+ * Concretely: a PR moves the real entry point and adds `"start": "node
+ * dist/new.js"` 30KB into a `package.json`. The old cached `node dist/old.js`
+ * still builds and still speaks MCP, so it re-probes green — and the check
+ * reports on the wrong server, forever, because the digest never moved. So the
+ * invariant is not "roughly representative", it is:
+ *
+ *   THE DIGEST MUST COVER EVERY BYTE DETECTION IS CAPABLE OF READING.
+ *
+ * Covering MORE than detection reads is safe (extra misses); covering LESS is a
+ * correctness bug. `assertEvidenceBudgetsCoverDetector()` enforces the
+ * direction at module load, and the budgets are taken from the detector's OWN
+ * constants rather than copied — the two cannot drift apart at all now that
+ * both live in this repository.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  DETECTION_MAX_BYTES,
+  DETECTION_README_MAX_BYTES,
+  MCPJAM_YAML_MAX_BYTES,
+  type DetectionInputs,
+} from "./resolver/index.js";
+import type { CappedRead } from "./sandbox-inspect.js";
+
+/**
+ * The fixed, ordered evidence path list. Appending to the END is the only
+ * backwards-tolerable edit, and even that changes every digest (an appended
+ * path contributes an `absent` marker to repositories that lack it) — which is
+ * correct, and is exactly why `RECIPE_EVIDENCE_HASH_VERSION` exists.
+ *
+ * `README` is the section a resolver reads for port/path HINTS, not a path read
+ * verbatim; callers pass the text they actually read (or omit it).
+ */
+export const RECIPE_EVIDENCE_PATHS = [
+  "mcpjam.yaml",
+  "package.json",
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "pyproject.toml",
+  "uv.lock",
+  "server.json",
+  "README",
+] as const;
+
+export type RecipeEvidencePath = (typeof RECIPE_EVIDENCE_PATHS)[number];
+
+/**
+ * What the DETECTOR reads, per path. Not a policy knob — a projection of the
+ * resolver's real constants, imported rather than copied.
+ *
+ * The lockfiles are the one place this is deliberately GENEROUS. Detection only
+ * tests them for PRESENCE today, so a zero budget would technically do. They
+ * are budgeted at the manifest cap anyway: the day detection starts reading a
+ * lockfile's contents — pinned versions are the obvious next signal — the
+ * digest already covers them, instead of the change landing as a fleet of stale
+ * hits nobody connects to the edit.
+ */
+export const DETECTOR_READ_LIMITS: Record<RecipeEvidencePath, number> = {
+  "mcpjam.yaml": MCPJAM_YAML_MAX_BYTES,
+  "package.json": DETECTION_MAX_BYTES,
+  "package-lock.json": DETECTION_MAX_BYTES,
+  "pnpm-lock.yaml": DETECTION_MAX_BYTES,
+  "yarn.lock": DETECTION_MAX_BYTES,
+  "pyproject.toml": DETECTION_MAX_BYTES,
+  "uv.lock": DETECTION_MAX_BYTES,
+  "server.json": DETECTION_MAX_BYTES,
+  README: DETECTION_README_MAX_BYTES,
+};
+
+/** Per-path byte budget for the DIGEST. At or above the detector's own limit. */
+export const RECIPE_EVIDENCE_MAX_FILE_BYTES: Record<
+  RecipeEvidencePath,
+  number
+> = { ...DETECTOR_READ_LIMITS };
+
+/**
+ * The coupling, enforced rather than commented. Runs at module load (both
+ * tables are constants, so it can only fire on an edit) and throws, because a
+ * budget that has silently fallen below the detector's read limit is a
+ * correctness bug that produces green checks on the wrong server — failing the
+ * boot is the cheap outcome.
+ */
+export function assertEvidenceBudgetsCoverDetector(): void {
+  for (const path of RECIPE_EVIDENCE_PATHS) {
+    const budget = RECIPE_EVIDENCE_MAX_FILE_BYTES[path];
+    const read = DETECTOR_READ_LIMITS[path];
+    if (!(budget >= read)) {
+      throw new Error(
+        `recipe evidence budget for '${path}' is ${budget} bytes but the ` +
+          `detector reads ${read} — bytes detection can read that the cache ` +
+          `key cannot see let a stale recipe win on a checkout that should ` +
+          `have selected a different one`
+      );
+    }
+  }
+}
+assertEvidenceBudgetsCoverDetector();
+
+/**
+ * Bumped whenever the ENCODING changes (path list, markers, framing, digest, or
+ * any per-path byte budget). It is the first segment, so a bump invalidates
+ * every cache entry at once — which is what makes changing this file safe.
+ *
+ * /2 — per-path byte budgets aligned with the detector's read limits (was a
+ *      flat 8KB), and `agenticContextDigest` added to the covered scalars.
+ *      Carried across from the backend unchanged: the value is what existing
+ *      cache entries were written under, so renaming it would orphan them.
+ */
+export const RECIPE_EVIDENCE_HASH_VERSION = "mcpjam.recipe-evidence/2";
+
+/**
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE GOLDEN VECTOR — a regression test, no longer a cross-repo treaty.
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * "Same inputs → same hash" and "one byte differs → different hash" are
+ * properties of ANY encoder, including one that silently changed. A fixed input
+ * with a hard-coded digest is what pins THIS encoder's bytes, and the value
+ * below is the one the backend's encoder produced before it was retired — so a
+ * cache entry written by the old backend path is still addressable by this one.
+ *
+ *   resolverVersion      = "golden-r1"
+ *   promptVersion        = "golden-p1"
+ *   model                = "golden-model"
+ *   runtimeImageVersion  = "golden-img-1"
+ *   agenticContextDigest = "golden-ctx-1"
+ *   files:
+ *     package.json      = {"name":"golden","scripts":{"start":"node index.js"}}
+ *     package-lock.json = {"lockfileVersion":3}
+ *     README            = golden fixture: port 3001, path /mcp\n
+ *     (everything else ABSENT)
+ *
+ * Changing the encoding means bumping `RECIPE_EVIDENCE_HASH_VERSION` and this
+ * digest together, deliberately, in one commit.
+ */
+export const RECIPE_EVIDENCE_GOLDEN_VECTOR_SHA256 =
+  "139b76e3c34696b550e48d39f8ae5705027db66bb19b44ab37e7dd0b6e6ecb06";
+
+export type RecipeEvidenceInput = {
+  /**
+   * Version of the resolver LOGIC that would consume this evidence. Required:
+   * defaulting it would let a digest outlive the code that produced its answer.
+   */
+  resolverVersion: string;
+  /**
+   * Path → content prefix. An omitted key and an explicit `null`/`undefined`
+   * both mean ABSENT; an empty string means PRESENT AND EMPTY, and the two hash
+   * differently (an empty `mcpjam.yaml` is a very different repository from one
+   * with no `mcpjam.yaml` at all). Unknown keys are ignored — only
+   * `RECIPE_EVIDENCE_PATHS` contributes.
+   */
+  files: Partial<Record<RecipeEvidencePath, string | null | undefined>>;
+  /** Agentic rung only: the prompt template's version. */
+  promptVersion?: string | null;
+  /** Agentic rung only: the model id that proposed the candidate. */
+  model?: string | null;
+  /** Agentic rung only: the sandbox base image the candidate was built on. */
+  runtimeImageVersion?: string | null;
+  /**
+   * Agentic rung only: a digest of ANY repo content fed to the agent beyond the
+   * `RECIPE_EVIDENCE_PATHS` prefixes above. Whatever the agentic rung reads, it
+   * digests into here — otherwise the stale-key failure mode above reappears
+   * one rung down, where the agent's inputs are exactly the files this fixed
+   * path list does not observe.
+   */
+  agenticContextDigest?: string | null;
+};
+
+const encoder = new TextEncoder();
+
+/**
+ * First `maxBytes` bytes of the UTF-8 encoding of `text`.
+ *
+ * A cut may land mid-codepoint. That is fine and deliberate: we hash BYTES, and
+ * the cut position is a pure function of the content. Preserving codepoint
+ * boundaries would make the boundary depend on the decoder.
+ */
+function utf8Prefix(text: string, maxBytes: number): Uint8Array {
+  const bytes = encoder.encode(text);
+  return bytes.length <= maxBytes ? bytes : bytes.subarray(0, maxBytes);
+}
+
+/**
+ * Length-prefixed framing: each segment is `u32be(byteLength) || bytes`. With
+ * this, no arrangement of attacker-supplied content can imitate a different
+ * segmentation.
+ */
+function frame(segments: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const segment of segments) total += 4 + segment.byteLength;
+  const buffer = new ArrayBuffer(total);
+  const out = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+  let offset = 0;
+  for (const segment of segments) {
+    view.setUint32(offset, segment.byteLength, false);
+    offset += 4;
+    out.set(segment, offset);
+    offset += segment.byteLength;
+  }
+  return out;
+}
+
+/**
+ * Build the exact byte string that gets hashed. Exported for tests and for
+ * localizing a disagreement: comparing these bytes says WHERE two inputs
+ * diverged, which comparing two hex digests cannot.
+ */
+export function encodeRecipeEvidence(input: RecipeEvidenceInput): Uint8Array {
+  const segments: Uint8Array[] = [encoder.encode(RECIPE_EVIDENCE_HASH_VERSION)];
+
+  // Scalars first, each with its own present/absent marker so `undefined` and
+  // `''` are distinguishable, and each LABELLED so moving a value between
+  // fields changes the digest.
+  const scalars: Array<[string, string | null | undefined]> = [
+    ["resolverVersion", input.resolverVersion],
+    ["promptVersion", input.promptVersion],
+    ["model", input.model],
+    ["runtimeImageVersion", input.runtimeImageVersion],
+    ["agenticContextDigest", input.agenticContextDigest],
+  ];
+  for (const [name, value] of scalars) {
+    segments.push(encoder.encode(name));
+    const present = typeof value === "string";
+    segments.push(encoder.encode(present ? "present" : "absent"));
+    segments.push(encoder.encode(present ? value : ""));
+  }
+
+  // Then the files, in the LIST's order — never the caller's.
+  for (const path of RECIPE_EVIDENCE_PATHS) {
+    const content = input.files?.[path];
+    const present = typeof content === "string";
+    segments.push(encoder.encode(path));
+    segments.push(encoder.encode(present ? "present" : "absent"));
+    segments.push(
+      present
+        ? utf8Prefix(content, RECIPE_EVIDENCE_MAX_FILE_BYTES[path])
+        : new Uint8Array(0)
+    );
+  }
+
+  return frame(segments);
+}
+
+/** The canonical digest: lowercase hex sha-256 over `encodeRecipeEvidence`. */
+export function computeRecipeEvidenceHash(input: RecipeEvidenceInput): string {
+  return createHash("sha256").update(encodeRecipeEvidence(input)).digest("hex");
+}
+
+/** Cheap shape check — the same one the backend applies to what it receives. */
+export function isRecipeEvidenceHash(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{64}$/.test(value);
+}
+
+/**
+ * The digest for a checkout, computed from EXACTLY what the resolver was fed.
+ *
+ * Taking the reader's own output — rather than re-reading, or accepting a
+ * hand-assembled map — is what keeps rule 4 true in practice: the bytes hashed
+ * are the bytes detection saw, including the reader's caps and its `over_cap`
+ * collapse. A file the reader could not read is `absent` here for the same
+ * reason it is absent to the detector: it contributed nothing to the answer.
+ */
+export function computeResolverEvidenceDigest(
+  inputs: { mcpjamYaml: CappedRead; detection: DetectionInputs },
+  resolverVersion: string
+): string {
+  return computeRecipeEvidenceHash({
+    resolverVersion,
+    files: {
+      "mcpjam.yaml":
+        inputs.mcpjamYaml.kind === "present" ? inputs.mcpjamYaml.text : null,
+      "package.json": inputs.detection.packageJson,
+      "package-lock.json": inputs.detection.packageLockJson,
+      "pnpm-lock.yaml": inputs.detection.pnpmLockYaml,
+      "yarn.lock": inputs.detection.yarnLock,
+      "pyproject.toml": inputs.detection.pyprojectToml,
+      "uv.lock": inputs.detection.uvLock,
+      "server.json": inputs.detection.serverJson,
+      README: inputs.detection.readme,
+    },
+  });
+}

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -417,17 +417,25 @@ export async function resolveAndStart(
       issued.stopPolicy.wallClockMs > 0
         ? deps.now() + issued.stopPolicy.wallClockMs
         : null;
+    const assertWithinDeadline = () => {
+      if (deadlineAt !== null && deps.now() >= deadlineAt) {
+        throw new CheckStoppedByPlan("plan_wall_clock_exhausted");
+      }
+    };
 
     for (let index = 0; index < issued.candidates.length; index += 1) {
       const planned = issued.candidates[index];
       const recipe = recipeOf(planned);
-      if (deadlineAt !== null && deps.now() >= deadlineAt) {
-        throw new CheckStoppedByPlan("plan_wall_clock_exhausted");
-      }
+      assertWithinDeadline();
       if (index > 0) {
         // The previous candidate's box dies HERE, before the next is
         // provisioned — see the module docblock on why B must never meet A.
         box = await freshSandbox(planned.candidateId);
+        // Provisioning and cloning are themselves minutes of budget, so the
+        // deadline is re-read AFTER them: a candidate that was inside it when
+        // the iteration began can be outside it by the time there is a box to
+        // build in, and the build is the expensive half.
+        assertWithinDeadline();
       }
       deps.assertLeaseHeld();
       logger.info("[github-checks] trying a planned candidate", {

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -405,9 +405,25 @@ export async function resolveAndStart(
       maxCandidates: issued.stopPolicy.maxCandidates,
     });
 
+    // `maxCandidates` needs no local enforcement — the backend bounds the search
+    // by issuing fewer candidates and by returning `complete` once the cap is
+    // spent. `wallClockMs` has no such second enforcement point: while the
+    // backend keeps answering `try_next_candidate`, each candidate spends a full
+    // build-and-probe cycle, and the lease heartbeat keeps succeeding
+    // throughout, so it is not a backstop either. Checked here, at a boundary
+    // where stopping is clean, against the deadline the backend itself sent.
+    // `0` means "no deadline issued", not "already expired".
+    const deadlineAt =
+      issued.stopPolicy.wallClockMs > 0
+        ? deps.now() + issued.stopPolicy.wallClockMs
+        : null;
+
     for (let index = 0; index < issued.candidates.length; index += 1) {
       const planned = issued.candidates[index];
       const recipe = recipeOf(planned);
+      if (deadlineAt !== null && deps.now() >= deadlineAt) {
+        throw new CheckStoppedByPlan("plan_wall_clock_exhausted");
+      }
       if (index > 0) {
         // The previous candidate's box dies HERE, before the next is
         // provisioned — see the module docblock on why B must never meet A.

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -1,70 +1,50 @@
 /**
- * `resolveAndStart` — the ladder, the sandboxes, and the runtime identity check.
- *
- * This is the piece the worker used to do with a hardcoded table lookup: turn a
- * PR checkout into a RUNNING, VERIFIED MCP server, or fail in a way somebody can
- * act on. Everything here is about the second half of that sentence.
+ * `resolveAndStart` — the boxes, the deterministic ladder, and the runtime
+ * identity check, driven by the BACKEND'S plan.
  *
  * ═══════════════════════════════════════════════════════════════════════════
- * THE ATTRIBUTION MODEL (this is the point of the whole module)
+ * WHAT THIS MODULE STOPPED DOING (A3b-2), AND WHY THAT IS THE POINT
  * ═══════════════════════════════════════════════════════════════════════════
  *
- * AUTHORITATIVE rungs — an operator override, or the author's `mcpjam.yaml`.
- * Somebody wrote this configuration down deliberately, so:
+ * It used to own the attribution model: which candidate to try, in what order,
+ * whether a failure was a resolver MISS or the author's `build_failed`, and
+ * what the whole thing added up to. All of that now lives in
+ * `convex/github/checkPlans.ts`, because the DATA FLYWHEEL is the moat and the
+ * sandbox execution is not — and because "a candidate's build failure is a miss,
+ * not a red X" should be a backend edit rather than an Inspector deploy.
  *
- *   - a present-but-BROKEN config is the author's bug, not a reason to guess:
- *     `recipe_invalid`, a check FAILURE. Falling through to a heuristic would
- *     run something they never declared and then report the result under their
- *     name;
- *   - a VALID authoritative recipe whose build breaks is `build_failed`, and one
- *     whose server never speaks MCP is `server_unhealthy` — exactly as before
- *     the ladder existed. No fall-through, no second chance: there is nothing to
- *     fall through TO that would not be a lie about what was tested.
+ * So this module reports FACTS and obeys ACTIONS:
  *
- * HEURISTIC candidates (rung `detected`) — our guesses, tried best-first:
- *
- *   - a candidate whose build or probe fails is a RESOLVER MISS. It is discarded
- *     and the next candidate is tried. Reporting `build_failed` for a command we
- *     invented would put a red X on a PR for failing to run a build it never
- *     asked for;
- *   - PROVISION / LOCKDOWN / E2B failures are `infra_error` and ABORT the whole
- *     check immediately. Consuming an outage as a miss would spend three
- *     sandboxes discovering that E2B is down and then conclude a neutral
- *     `recipe_unresolvable` — a wrong answer at triple cost;
- *   - candidates exhausted (or the budget spent) ⇒ neutral `recipe_unresolvable`
- *     with copy pointing at `mcpjam.yaml`, which is the one-file fix.
+ *   - every phase boundary is a `/attempt` with a `failureKind` when it failed;
+ *   - the returned action (`continue_phase` | `try_next_candidate` | `run_eval`
+ *     | `complete`) is honoured verbatim, and an action we do not recognize is
+ *     treated as `complete` (fail closed — see `check-plan.ts`);
+ *   - nothing here computes an outcome, and there is no local fall-back
+ *     ordering. A backend we cannot reach means we STOP, never that we quietly
+ *     revert to our own policy.
  *
  * ═══════════════════════════════════════════════════════════════════════════
- * A FRESH SANDBOX PER CANDIDATE
+ * WHAT IT DELIBERATELY KEPT — all of it in the open
  * ═══════════════════════════════════════════════════════════════════════════
  *
- * Candidate B never runs in candidate A's box. Two reasons, both of which would
- * silently corrupt the verdict rather than merely waste resources:
+ * A FRESH SANDBOX PER CANDIDATE. Candidate B never runs in candidate A's box,
+ * and A's box is KILLED BEFORE B's is provisioned (not merely before B's build):
  *
  *   1. EGRESS IS ALREADY REVOKED. `buildAndStart` locks the box down between
- *      build and start, on purpose. B's build would then run with no network at
- *      all and fail for a reason that has nothing to do with B.
+ *      build and start, on purpose. B's build would run with no network and
+ *      fail for a reason that has nothing to do with B.
  *   2. A's PROCESSES ARE STILL ALIVE. A's server may hold the port, and it is
- *      A's code. B's probe would then be answered by A — the exact
- *      wrong-process-answering-the-probe class this module's runtime checks
- *      exist to close, reintroduced by our own reuse.
+ *      A's code — so B's probe would be answered by A, which is the exact
+ *      wrong-process-answering-the-probe class the runtime check below exists
+ *      to close, reintroduced by our own reuse.
  *
- * So each attempt gets a clean box, and the previous box is KILLED BEFORE the
- * next one is provisioned (not merely before the next build): a leaked box costs
- * money for the full 45-minute TTL.
- *
- * ═══════════════════════════════════════════════════════════════════════════
- * THE RUNTIME CHECK: LISTENER IDENTITY
- * ═══════════════════════════════════════════════════════════════════════════
- *
- * It runs AFTER the probe answers and BEFORE the server is accepted, and it asks
- * a question static analysis provably cannot answer (see the review history in
- * `resolver/detect.ts`): is the process bound to the probed port the start
- * command WE spawned, or a descendant of it? That closes the install-hook class
- * — `"prepare": "nohup acme-server &"` and its endless spellings — where a
- * detached published server squats the port and answers our probe while the
- * validated start command never binds. Static analysis has taken nine rounds on
- * that class and still leaks; one `/proc` read settles it.
+ * THE RUNTIME LISTENER-IDENTITY CHECK. It runs AFTER the probe answers and
+ * BEFORE the server is accepted, and it asks what static analysis provably
+ * cannot: is the process bound to the probed port the start command WE spawned,
+ * or a descendant of it? That closes the install-hook class — `"prepare":
+ * "nohup acme-server &"` and its endless spellings — where a detached published
+ * server squats the port and answers our probe while the validated start
+ * command never binds.
  *
  * IDENTITY COMES FROM THE SPAWN, NOT FROM THE BOX. `buildAndStart` returns a
  * `SpawnIdentity` — the pid E2B reports for the command it started for us, plus
@@ -72,69 +52,19 @@
  * the box after the build is PR code, so an identity fact the box WRITES is one
  * the PR chooses: an earlier revision had the start wrapper write its pid to
  * `/tmp/mcp-server.pid` and read it back, and a squatter could overwrite that
- * file with its own pid and be recognised as ours, which defeats the entire
- * check. The box is now only ever asked for kernel facts (who holds the socket,
- * their ancestry, their process group) and the comparison happens here.
+ * file and be recognised as ours. The box is only ever asked for kernel facts.
  *
- * Failing it is a MISS for a heuristic candidate: try the next, never a green.
- *
- * ═══════════════════════════════════════════════════════════════════════════
- * WHY THERE IS NO RUNTIME "OWNERSHIP" CHECK ANY MORE
- * ═══════════════════════════════════════════════════════════════════════════
- *
- * An earlier revision added a second runtime check: resolve the listening
- * process's MAIN MODULE from `/proc/<pid>/cmdline` (first argument that stats as
- * a regular file, else `/proc/<pid>/exe`), `realpath` it, and require the result
- * to be inside the checkout and outside `node_modules`. It is removed, because
- * that inference is wrong in both directions and covers nothing the other two
- * layers do not:
- *
- *   - FALSE REJECTS, systematically. `tsx src/index.ts` runs as `node
- *     .../node_modules/tsx/dist/cli.mjs src/index.ts`, whose first file-valued
- *     argument is under `node_modules`; `uv run python -m server` has no
- *     file-valued argument at all and falls back to `/proc/<pid>/exe`, which is
- *     `/usr/bin/python3`. Both are ordinary, correct MCP servers, and both are
- *     `rung: 'detected'`, which is exactly the population this check gated. It
- *     would have rejected them all.
- *   - FALSE ACCEPTS. A config-file argument (`node server.js --config
- *     ./mcp.json` reordered, or any launcher that takes a path) can be the first
- *     thing that stats as a file, so the check would happily "verify" a path
- *     that is not executable code at all.
- *   - AND IT NEVER COVERED THE CASE IT WAS INVENTED FOR. The motivating shape is
- *     a build that copies a dependency into the tree (`cp
- *     node_modules/acme/server.js dist/index.js`, then `node dist/index.js`).
- *     The listening process's main module is then `/home/user/repo/dist/index.js`
- *     — inside the checkout, outside `node_modules` — and the check PASSES.
- *
- * WHAT COVERS WHAT NOW:
- *
- *   - that the entry point is checkout code — STATIC, in `detect.ts` rule C and
- *     `verifyExtensionlessStart`: a candidate's entry path must be
- *     checkout-relative and present in the `git ls-files` listing as a REGULAR
- *     file (a symlink or submodule is rejected outright), and a bare-word start
- *     resolved from `node_modules/.bin` is suppressed;
- *   - that the thing answering the probe is that entry point and not a squatter
- *     — RUNTIME, listener identity above.
- *
- * RESIDUAL, KNOWN AND ACCEPTED: (a) the copied-dependency case above, which the
- * removed check did not catch either, and which `ownershipProof: 'unverified'`
- * records honestly rather than pretending to have settled; (b) the degenerate
- * case where `git ls-files` yields nothing, so there is no listing to verify
- * against and a bare-word start cannot be suppressed. Both end in a green check
- * on a server whose code came from a dependency — a wrong PASS on a repo that
- * went out of its way to look like this, which is a smaller harm than the
- * blanket false-rejects the removed check produced on normal repos.
- *
- * WHY A SQUATTER UNDER AN AUTHORITATIVE RECIPE IS `server_unhealthy`, NOT A MISS.
- * There is nothing to fall through to — authoritative rungs do not fall through
- * — so the only choice is which verdict the author sees. `recipe_unresolvable`
- * (neutral) would be wrong twice over: we DID resolve the recipe, and the thing
- * that happened is that the declared start command did not end up serving the
- * probed port. `recipe_invalid` would be wrong too — the config parsed fine.
- * What is left is exactly what `server_unhealthy` already means: the declared
- * server did not serve. The detail text names the cause so it is actionable,
- * and the failure stays attributed to the declaration, which is the promise the
- * authoritative rung makes.
+ * WHY THERE IS NO RUNTIME "OWNERSHIP" CHECK. An earlier revision resolved the
+ * listening process's MAIN MODULE from `/proc/<pid>/cmdline`, `realpath`d it and
+ * required it inside the checkout and outside `node_modules`. Removed: `tsx
+ * src/index.ts` runs as `node .../node_modules/tsx/dist/cli.mjs src/index.ts`
+ * and `uv run python -m server` has no file-valued argument at all, so it
+ * rejected ordinary servers; a path-valued option accepted things that are not
+ * code; and it never caught the motivating case anyway (a build that COPIES a
+ * dependency into the tree produces a main module inside the checkout). What
+ * covers what now: STATIC entry validation in `detect.ts` rule C, and the
+ * RUNTIME listener identity here. `ownershipProof: 'unverified'` records the
+ * residual honestly instead of pretending it is settled.
  */
 
 import { logger } from "../../utils/logger.js";
@@ -145,7 +75,6 @@ import {
   killCheckSandbox,
   provisionCheckSandbox,
   type CheckSandbox,
-  type CheckStepOutcome,
   type SpawnIdentity,
   type StartedServer,
 } from "./sandbox.js";
@@ -158,78 +87,33 @@ import {
 import {
   RecipeResolutionError,
   resolveRecipeLadder,
-  type RecipeRung,
+  RESOLVER_VERSION,
   type ResolvedRecipe,
 } from "./resolver/index.js";
+import { computeResolverEvidenceDigest } from "./evidence-digest.js";
+import {
+  CheckStoppedByPlan,
+  type AttemptDecision,
+  type AttemptFailureKind,
+  type AttemptPhase,
+  type CheckPlanSession,
+  type PlannedCandidate,
+} from "./check-plan.js";
 
-/**
- * How many heuristic candidates are worth a sandbox each.
- *
- * Three, because the detector emits candidates best-first and a fourth guess is
- * one nobody has evidence for — while every attempt costs a provision, a clone
- * and a build. An author whose repo needs a fourth guess is better served by
- * `mcpjam.yaml`, which the `recipe_unresolvable` output points at.
- */
-export const MAX_CANDIDATES = 3;
-
-/**
- * Total wall clock for resolution, across ALL candidates.
- *
- * The box lives 45 minutes and the eval suite legitimately wants twenty of them,
- * so resolution cannot be allowed to eat the budget it is resolving FOR: three
- * candidates each taking a full build (10m) and health window (2m) would spend
- * 36 minutes and leave nothing. Checked at candidate BOUNDARIES — an attempt
- * already in flight is bounded by its own build and health deadlines, so
- * interrupting one would buy nothing that is not already bounded.
- */
-export const RESOLUTION_BUDGET_MS = 20 * 60_000;
-
-/** Provenance the check output and the trigger row carry. */
+/** Provenance for logs and telemetry. The VERDICT's provenance is the plan's. */
 export type RecipeProvenance = {
-  recipeRung: RecipeRung;
+  recipeRung: ResolvedRecipe["rung"];
   /** Constant strings + operator-controlled names; never PR file content. */
   recipeEvidence: string[];
 };
 
-/**
- * Outcomes resolution can produce: the sandbox module's three, plus the two the
- * ladder introduces.
- *
- * `recipe_invalid` is a FAILURE (the author's declared config is broken);
- * `recipe_unresolvable` is NEUTRAL (we could not work the repo out, which is
- * ours to improve, not the PR's to answer for).
- */
-export type ResolveOutcome =
-  | CheckStepOutcome
-  | "recipe_invalid"
-  | "recipe_unresolvable";
-
-/**
- * A resolution failure that already knows how the check should conclude.
- *
- * A sibling of `CheckStepError` rather than a subclass, because that class's
- * outcome type is deliberately the narrow set the SANDBOX can produce, and
- * widening it would let a sandbox-level failure claim a ladder-level verdict.
- * The worker's classifier handles both.
- */
-export class RecipeStartError extends Error {
-  constructor(
-    readonly outcome: ResolveOutcome,
-    message: string,
-    readonly detailsMarkdown?: string,
-    /** Present when the failure happened AFTER a recipe was resolved. */
-    readonly provenance?: RecipeProvenance
-  ) {
-    super(message);
-    this.name = "RecipeStartError";
-  }
-}
-
 export type ResolveAndStartResult = {
   /** The live box. Every other box this call created is already dead. */
   sandbox: CheckSandbox;
-  /** The recipe that actually built and served, with its rung and evidence. */
+  /** The candidate that built and served, as the PLAN issued it. */
   recipe: ResolvedRecipe;
+  /** The plan's id for it — the eval attempt must cite this one. */
+  candidateId: string;
   /** Running and verified — NOT restarted after verification. */
   started: StartedServer;
   provenance: RecipeProvenance;
@@ -237,8 +121,8 @@ export type ResolveAndStartResult = {
 
 /**
  * Injectable collaborators. Every external effect is one of these, so the tests
- * drive real control flow — including the fresh-box policy and the `finally`
- * teardown — without E2B.
+ * drive real control flow — including the fresh-box policy, the plan's ordering
+ * and the `finally` teardown — without E2B or a Convex deployment.
  */
 export type ResolveAndStartDeps = {
   provisionSandbox: typeof provisionCheckSandbox;
@@ -248,6 +132,9 @@ export type ResolveAndStartDeps = {
   resolveLadder: typeof resolveRecipeLadder;
   readResolverInputs: typeof readResolverInputs;
   inspectListener: typeof inspectListener;
+  computeEvidenceDigest: typeof computeResolverEvidenceDigest;
+  /** The backend-owned plan loop. REQUIRED — there is no planless mode. */
+  plan: CheckPlanSession;
   /**
    * Called with the box this call currently owns, and with `null` once it is
    * dead. The worker mirrors it into the variable its own `finally` kills, so a
@@ -257,11 +144,10 @@ export type ResolveAndStartDeps = {
   /** Throws `LeaseLostError` when the claim stopped being ours. */
   assertLeaseHeld: () => void;
   now: () => number;
-  maxCandidates: number;
-  budgetMs: number;
+  resolverVersion: string;
 };
 
-function defaultDeps(): ResolveAndStartDeps {
+function defaultDeps(): Omit<ResolveAndStartDeps, "plan"> {
   return {
     provisionSandbox: provisionCheckSandbox,
     cloneAndCheckout,
@@ -270,11 +156,11 @@ function defaultDeps(): ResolveAndStartDeps {
     resolveLadder: resolveRecipeLadder,
     readResolverInputs,
     inspectListener,
+    computeEvidenceDigest: computeResolverEvidenceDigest,
     onSandbox: () => {},
     assertLeaseHeld: () => {},
     now: () => Date.now(),
-    maxCandidates: MAX_CANDIDATES,
-    budgetMs: RESOLUTION_BUDGET_MS,
+    resolverVersion: RESOLVER_VERSION,
   };
 }
 
@@ -285,15 +171,38 @@ export type ResolveAndStartArgs = {
   headSha: string;
 };
 
-/** What one attempt in one box produced. */
-type Attempt =
-  /** Built, served, and passed both runtime checks. */
-  | { kind: "started"; started: StartedServer }
-  /** A heuristic guess that did not pan out. Discard, try the next. */
-  | { kind: "miss"; reason: string };
-
 function provenanceOf(recipe: ResolvedRecipe): RecipeProvenance {
   return { recipeRung: recipe.rung, recipeEvidence: [...recipe.evidence] };
+}
+
+/**
+ * A `CheckStepError` from the sandbox, as the phase and failure kind it should
+ * be REPORTED at.
+ *
+ * `buildAndStart` is one call covering build → lockdown → start → probe, so the
+ * phase is inferred from the outcome the sandbox module already decided:
+ * `build_failed` happened at the build, `server_unhealthy` means it built and
+ * started and then never answered `initialize`, and anything else is our
+ * infrastructure. Note that the OUTCOME the sandbox names is used only to pick
+ * the phase and kind here — what it MEANS (the author's build vs a resolver
+ * miss) is the backend's call now, and depends on the candidate's rung, which
+ * this module deliberately no longer reasons about.
+ */
+function reportableStepFailure(error: CheckStepError): {
+  phase: AttemptPhase;
+  failureKind: AttemptFailureKind;
+} {
+  if (error.outcome === "build_failed") {
+    return { phase: "build", failureKind: "build_failed" };
+  }
+  if (error.outcome === "server_unhealthy") {
+    return { phase: "probe", failureKind: "probe_failed" };
+  }
+  // `sandbox_error` rather than `lockdown_failed`: the lockdown lives inside
+  // `buildAndStart`, and guessing which of its infrastructure failures we hit
+  // from an error string would file a wrong row in the corpus. Both attribute
+  // to `infra_error`, so the honest, coarser kind is the right one.
+  return { phase: "build", failureKind: "sandbox_error" };
 }
 
 /**
@@ -302,17 +211,22 @@ function provenanceOf(recipe: ResolvedRecipe): RecipeProvenance {
  * On EVERY failure path, every sandbox this function created is killed before it
  * throws — including the one an attempt was using. On success exactly one box is
  * alive, and it is the one in the result.
+ *
+ * Throws `CheckStoppedByPlan` when the backend said stop (or a reported failure
+ * ended the plan), and `PlanProtocolError` / `PlanUnreachableError` straight
+ * through — the worker owns what each of those means for the completion.
  */
 export async function resolveAndStart(
   args: ResolveAndStartArgs,
-  overrides?: Partial<ResolveAndStartDeps>
+  overrides: Partial<ResolveAndStartDeps> & { plan: CheckPlanSession }
 ): Promise<ResolveAndStartResult> {
   const deps: ResolveAndStartDeps = { ...defaultDeps(), ...overrides };
-  const startedAt = deps.now();
+  const plan = deps.plan;
   const logContext = {
     triggerId: args.triggerId,
     repo: args.repoFullName,
     pr: args.prNumber,
+    planId: plan.planId,
   };
 
   let sandbox: CheckSandbox | null = null;
@@ -322,128 +236,291 @@ export async function resolveAndStart(
     if (!sandbox) return;
     const dying = sandbox;
     // Cleared FIRST: if `killSandbox` throws (it does not — it is best effort —
-    // but the dep is injectable), the caller must not be handed a box we already
-    // gave up on.
+    // but the dep is injectable), the caller must not be handed a box we
+    // already gave up on.
     sandbox = null;
     deps.onSandbox(null);
     await deps.killSandbox(dying);
   };
 
-  /** A clean box with the PR checked out in it. */
-  const freshSandbox = async (): Promise<CheckSandbox> => {
+  /**
+   * A decision that is only ever allowed to be "carry on".
+   *
+   * Applied to the phases where nothing else can be legitimate (a successful
+   * provision, clone or resolve). Anything else is honoured as a STOP rather
+   * than second-guessed — obeying an unexpected instruction conservatively is
+   * the fail-closed direction.
+   */
+  const mustContinue = (decision: AttemptDecision): void => {
+    if (decision.action === "continue_phase") return;
+    throw new CheckStoppedByPlan(decision.reason ?? decision.action);
+  };
+
+  /** A clean box with the PR checked out in it, both phases reported. */
+  const freshSandbox = async (candidateId?: string): Promise<CheckSandbox> => {
     await releaseSandbox();
-    const box = await deps.provisionSandbox({
-      triggerId: args.triggerId,
-      repoFullName: args.repoFullName,
-      prNumber: args.prNumber,
-    });
+    const provisionStartedAt = deps.now();
+    let box: CheckSandbox;
+    try {
+      box = await deps.provisionSandbox({
+        triggerId: args.triggerId,
+        repoFullName: args.repoFullName,
+        prNumber: args.prNumber,
+      });
+    } catch (error) {
+      await plan.attempt({
+        ...(candidateId ? { candidateId } : {}),
+        phase: "provision",
+        ok: false,
+        failureKind: "provision_failed",
+        durationMs: deps.now() - provisionStartedAt,
+        detailsClamped: errorDetail(error),
+      });
+      throw new CheckStoppedByPlan("provision_failed");
+    }
     sandbox = box;
     deps.onSandbox(box);
     deps.assertLeaseHeld();
-    await deps.cloneAndCheckout(box, {
-      repoFullName: args.repoFullName,
-      prNumber: args.prNumber,
-      headSha: args.headSha,
-    });
+    mustContinue(
+      await plan.attempt({
+        ...(candidateId ? { candidateId } : {}),
+        phase: "provision",
+        ok: true,
+        durationMs: deps.now() - provisionStartedAt,
+      })
+    );
+
+    const cloneStartedAt = deps.now();
+    try {
+      await deps.cloneAndCheckout(box, {
+        repoFullName: args.repoFullName,
+        prNumber: args.prNumber,
+        headSha: args.headSha,
+      });
+    } catch (error) {
+      await plan.attempt({
+        ...(candidateId ? { candidateId } : {}),
+        phase: "clone",
+        ok: false,
+        failureKind: "clone_failed",
+        durationMs: deps.now() - cloneStartedAt,
+        detailsClamped: errorDetail(error),
+      });
+      throw new CheckStoppedByPlan("clone_failed");
+    }
     deps.assertLeaseHeld();
+    mustContinue(
+      await plan.attempt({
+        ...(candidateId ? { candidateId } : {}),
+        phase: "clone",
+        ok: true,
+        durationMs: deps.now() - cloneStartedAt,
+      })
+    );
     return box;
   };
 
   try {
     // Box #1 is provisioned before anything is known about the repo, because
-    // reading the repo REQUIRES a checkout. It is pristine at this point — only
-    // byte-capped reads have touched it — so the first attempt reuses it rather
-    // than paying for a second provision to prove a point.
-    const box = await freshSandbox();
+    // reading the repo REQUIRES a checkout. Its provision and clone are LADDER
+    // attempts (no candidateId) — the plan has no candidates yet, and that is
+    // precisely the window `/plan/begin` exists to make attributable.
+    let box = await freshSandbox();
+
+    const resolveStartedAt = deps.now();
     const inputs = await deps.readResolverInputs(box);
     deps.assertLeaseHeld();
 
-    let resolution;
+    let localCandidates: ResolvedRecipe[];
     try {
-      resolution = deps.resolveLadder({
+      const resolution = deps.resolveLadder({
         repoFullName: args.repoFullName,
         // The reader's three-way answer, handed over WHOLE. Collapsing
         // `over_cap` into `null` here is the bug this shape exists to prevent:
-        // an oversized declared config is invalid, and `null` means absent,
+        // an oversized declared config is INVALID, and `null` means absent,
         // which is the one thing an authoritative rung must never fall through
-        // on. `resolveRecipeLadder` owns the ordering (an operator override
-        // still outranks it), so the decision belongs there, not here.
+        // on.
         mcpjamYaml:
           inputs.mcpjamYaml.kind === "present" ? inputs.mcpjamYaml.text : null,
         mcpjamYamlOverCap: inputs.mcpjamYaml.kind === "over_cap",
         detection: inputs.detection,
       });
+      localCandidates =
+        resolution.kind === "authoritative"
+          ? [resolution.recipe]
+          : resolution.candidates;
     } catch (error) {
-      throw ladderFailure(error, args.repoFullName);
+      throw await reportLadderFailure(
+        plan,
+        error,
+        args.repoFullName,
+        deps.now() - resolveStartedAt
+      );
     }
 
-    if (resolution.kind === "authoritative") {
-      const recipe = resolution.recipe;
-      logger.info("[github-checks] authoritative recipe resolved", {
+    mustContinue(
+      await plan.attempt({
+        phase: "resolve",
+        ok: true,
+        durationMs: deps.now() - resolveStartedAt,
+      })
+    );
+
+    // THE INSPECTOR IS THE SOLE ENCODER of this digest — the backend stores and
+    // compares it and never recomputes it. See `evidence-digest.ts`.
+    const evidenceDigest = deps.computeEvidenceDigest(
+      inputs,
+      deps.resolverVersion
+    );
+
+    const issued = await plan.candidates({
+      evidenceDigest,
+      resolverVersion: deps.resolverVersion,
+      // Reported as facts, in OUR order. Which of them run, in what order, and
+      // whether the backend adds one of its own, is the backend's call.
+      localCandidates: localCandidates.map((candidate) => ({
+        recipe: {
+          build: candidate.build,
+          start: candidate.start,
+          port: candidate.port,
+          mcpPath: candidate.mcpPath,
+        },
+        rung: candidate.rung,
+        evidence: candidate.evidence,
+        ownershipProof: candidate.ownershipProof,
+      })),
+    });
+
+    if (issued.candidates.length === 0) {
+      // We handed over candidates (or the ladder would have thrown) and got a
+      // plan with nothing in it. Nothing to execute and nothing to report as a
+      // failure of the repository's — stop, and let the derivation call an
+      // empty search what it is.
+      throw new CheckStoppedByPlan("plan_has_no_candidates");
+    }
+
+    logger.info("[github-checks] executing the plan", {
+      ...logContext,
+      candidates: issued.candidates.length,
+      maxCandidates: issued.stopPolicy.maxCandidates,
+    });
+
+    for (let index = 0; index < issued.candidates.length; index += 1) {
+      const planned = issued.candidates[index];
+      const recipe = recipeOf(planned);
+      if (index > 0) {
+        // The previous candidate's box dies HERE, before the next is
+        // provisioned — see the module docblock on why B must never meet A.
+        box = await freshSandbox(planned.candidateId);
+      }
+      deps.assertLeaseHeld();
+      logger.info("[github-checks] trying a planned candidate", {
         ...logContext,
-        rung: recipe.rung,
+        candidate: planned.candidateId,
+        position: index + 1,
+        of: issued.candidates.length,
+        rung: planned.rung,
+        source: planned.source,
+        ownershipProof: planned.ownershipProof,
       });
-      // No fall-through and no miss arm: under an authoritative rung every
-      // failure is attributable, so `attempt` throws rather than returning one.
-      const attempt = await runAttempt(box, recipe, deps, true);
-      if (attempt.kind !== "started") {
-        // Unreachable — `authoritative: true` never yields a miss — and asserted
-        // rather than assumed, because the alternative is silently returning a
-        // server nothing verified.
-        throw new RecipeStartError(
-          "infra_error",
-          `authoritative attempt produced a miss: ${attempt.reason}`,
-          undefined,
-          provenanceOf(recipe)
+
+      const buildStartedAt = deps.now();
+      let started: StartedServer;
+      try {
+        started = await deps.buildAndStart(box, recipe);
+      } catch (error) {
+        if (!(error instanceof CheckStepError)) throw error;
+        const { phase, failureKind } = reportableStepFailure(error);
+        const decision = await plan.attempt({
+          candidateId: planned.candidateId,
+          phase,
+          ok: false,
+          failureKind,
+          durationMs: deps.now() - buildStartedAt,
+          detailsClamped: error.detailsMarkdown ?? error.message,
+        });
+        if (decision.action === "try_next_candidate") continue;
+        throw new CheckStoppedByPlan(
+          decision.reason ?? failureKind,
+          error.detailsMarkdown
         );
+      }
+
+      // ONE ok row for the whole build→start→probe call, at `probe`.
+      //
+      // `buildAndStart` does not surface the three boundaries separately, and
+      // splitting the elapsed time across invented rows would put numbers in
+      // the corpus that were never measured. A failure still lands at its REAL
+      // phase (above), which is the direction the corpus is read in — "what
+      // failed, for which repo, at which phase".
+      mustContinue(
+        await plan.attempt({
+          candidateId: planned.candidateId,
+          phase: "probe",
+          ok: true,
+          durationMs: deps.now() - buildStartedAt,
+        })
+      );
+
+      deps.assertLeaseHeld();
+      const verifyStartedAt = deps.now();
+      const verdict = await verifyRunningServer(
+        box,
+        recipe,
+        started.spawn,
+        deps
+      );
+      if (verdict.status !== "ok") {
+        // `listener_mismatch` — something answered and it was not ours — and
+        // `listener_unknown` — we could not LOOK — are kept apart on the wire
+        // because they mean opposite things: the first is evidence about this
+        // candidate, the second is evidence about US, and the backend aborts on
+        // it rather than burning the remaining candidates on an outage.
+        const failureKind: AttemptFailureKind =
+          verdict.status === "mismatch"
+            ? "listener_mismatch"
+            : "listener_unknown";
+        const decision = await plan.attempt({
+          candidateId: planned.candidateId,
+          phase: "verify",
+          ok: false,
+          failureKind,
+          durationMs: deps.now() - verifyStartedAt,
+          detailsClamped: verdict.reason,
+        });
+        if (decision.action === "try_next_candidate") continue;
+        throw new CheckStoppedByPlan(
+          decision.reason ?? failureKind,
+          squatterDetails(recipe, verdict.reason),
+          true
+        );
+      }
+
+      const decision = await plan.attempt({
+        candidateId: planned.candidateId,
+        phase: "verify",
+        ok: true,
+        durationMs: deps.now() - verifyStartedAt,
+      });
+      // `run_eval` is the ONLY action that may follow an accepted candidate.
+      // Anything else — including an action this build does not know — stops.
+      if (decision.action !== "run_eval") {
+        throw new CheckStoppedByPlan(decision.reason ?? decision.action);
       }
       return {
         sandbox: box,
         recipe,
-        started: attempt.started,
+        candidateId: planned.candidateId,
+        started,
         provenance: provenanceOf(recipe),
       };
     }
 
-    const candidates = resolution.candidates.slice(0, deps.maxCandidates);
-    const misses: string[] = [];
-    let currentBox = box;
-    for (let index = 0; index < candidates.length; index += 1) {
-      if (index > 0) {
-        const elapsed = deps.now() - startedAt;
-        if (elapsed >= deps.budgetMs) {
-          misses.push(
-            `stopped after ${index} candidate(s): the resolution time budget (${Math.round(
-              deps.budgetMs / 60_000
-            )} minutes) was spent`
-          );
-          break;
-        }
-        // The previous candidate's box dies HERE, before the next is
-        // provisioned — see the module docblock on why B must never meet A.
-        currentBox = await freshSandbox();
-      }
-      const candidate = candidates[index];
-      logger.info("[github-checks] trying a detected candidate", {
-        ...logContext,
-        candidate: index + 1,
-        of: candidates.length,
-        ownershipProof: candidate.ownershipProof,
-      });
-      const attempt = await runAttempt(currentBox, candidate, deps, false);
-      if (attempt.kind === "started") {
-        return {
-          sandbox: currentBox,
-          recipe: candidate,
-          started: attempt.started,
-          provenance: provenanceOf(candidate),
-        };
-      }
-      misses.push(`candidate ${index + 1}: ${attempt.reason}`);
-      deps.assertLeaseHeld();
-    }
-
-    throw unresolvable(args.repoFullName, misses);
+    // Every planned candidate failed and the backend never said `complete`.
+    // Unreachable through the documented state machine (the last miss returns
+    // `complete` once the cap is spent), and asserted rather than assumed:
+    // silently returning nothing would be a check with no server and no stop.
+    throw new CheckStoppedByPlan("plan_exhausted_without_stop");
   } catch (error) {
     // Every box this call created is dead before the error leaves — including
     // the one an attempt was mid-way through.
@@ -452,87 +529,126 @@ export async function resolveAndStart(
   }
 }
 
-/**
- * Build, start, probe, and VERIFY one recipe in one box.
- *
- * `authoritative` decides only what a failure MEANS, never what is checked: the
- * same build runs, the same probe runs, and the same runtime checks run. That is
- * deliberate — a squatting listener is not the declared server either, so
- * skipping the identity check for authoritative rungs would leave the one class
- * it exists to close open on exactly the repos we trust most.
- */
-async function runAttempt(
-  sandbox: CheckSandbox,
-  recipe: ResolvedRecipe,
-  deps: ResolveAndStartDeps,
-  authoritative: boolean
-): Promise<Attempt> {
-  let started: StartedServer;
-  try {
-    started = await deps.buildAndStart(sandbox, recipe);
-  } catch (error) {
-    if (!(error instanceof CheckStepError)) throw error;
-    // INFRASTRUCTURE ABORTS, ALWAYS. A provision, lockdown or E2B failure is
-    // ours, and consuming it as a miss would spend the remaining candidates
-    // rediscovering the same outage before concluding a neutral verdict that
-    // says nothing true about the repo.
-    if (error.outcome === "infra_error") throw error;
-    if (authoritative) {
-      throw new RecipeStartError(
-        error.outcome,
-        error.message,
-        error.detailsMarkdown,
-        provenanceOf(recipe)
-      );
-    }
-    return {
-      kind: "miss",
-      reason:
-        error.outcome === "build_failed"
-          ? "the detected build command failed"
-          : "the detected start command never served MCP on the expected port and path",
-    };
-  }
+function recipeOf(planned: PlannedCandidate): ResolvedRecipe {
+  return {
+    build: planned.recipe.build,
+    start: planned.recipe.start,
+    port: planned.recipe.port,
+    mcpPath: planned.recipe.mcpPath,
+    rung: planned.rung,
+    ownershipProof: planned.ownershipProof,
+    evidence: planned.evidence ?? [],
+  };
+}
 
-  deps.assertLeaseHeld();
-  const verdict = await verifyRunningServer(
-    sandbox,
-    recipe,
-    started.spawn,
-    deps
+function errorDetail(error: unknown): string | undefined {
+  if (error instanceof CheckStepError) {
+    return error.detailsMarkdown ?? error.message.slice(0, 500);
+  }
+  if (error instanceof Error) return error.message.slice(0, 500);
+  return undefined;
+}
+
+/**
+ * Report a ladder refusal at the `resolve` phase and stop.
+ *
+ * The two kinds are the compatibility matrix's two `resolve`-only, LADDER-scoped
+ * members, and the distinction is the whole reason the ladder exists:
+ *
+ *   `recipe_invalid`  — a DECLARED config is present and broken. The author's to
+ *                       fix; the backend concludes a check FAILURE. Falling
+ *                       through to a guess would run something they never
+ *                       declared and report the result under their name.
+ *   `no_candidates`   — nobody declared anything and nothing was detectable.
+ *                       Neutral (`recipe_unresolvable`), pointing at the
+ *                       one-file fix.
+ *
+ * The author-facing copy travels on the thrown stop, not on the attempt: it is
+ * display data, and the backend's `detailsClamped` is bounded telemetry.
+ */
+async function reportLadderFailure(
+  plan: CheckPlanSession,
+  error: unknown,
+  repoFullName: string,
+  durationMs: number
+): Promise<CheckStoppedByPlan> {
+  if (!(error instanceof RecipeResolutionError)) {
+    // The ladder is pure and deterministic; anything else thrown by it is ours.
+    await plan.attempt({
+      phase: "resolve",
+      ok: false,
+      failureKind: "sandbox_error",
+      durationMs,
+      detailsClamped: errorDetail(error),
+    });
+    return new CheckStoppedByPlan(
+      error instanceof Error ? error.message.slice(0, 200) : String(error)
+    );
+  }
+  if (error.reason === "no_recipe") {
+    await plan.attempt({
+      phase: "resolve",
+      ok: false,
+      failureKind: "no_candidates",
+      durationMs,
+      detailsClamped: error.message.slice(0, 500),
+    });
+    return new CheckStoppedByPlan(
+      "no_candidates",
+      unresolvableDetails(repoFullName, error.detailsMarkdown),
+      true
+    );
+  }
+  await plan.attempt({
+    phase: "resolve",
+    ok: false,
+    failureKind: "recipe_invalid",
+    durationMs,
+    detailsClamped: error.message.slice(0, 500),
+  });
+  return new CheckStoppedByPlan(
+    "recipe_invalid",
+    [
+      "The configuration this repository declares for MCPJam checks is present but not usable, so the check ran nothing rather than guessing at what you meant.",
+      ...(error.detailsMarkdown ? ["", error.detailsMarkdown] : []),
+    ].join("\n"),
+    true
   );
-  if (verdict.status === "ok") return { kind: "started", started };
-  if (verdict.status === "unknown") {
-    // We could not LOOK. That is the command channel or `/proc`, i.e. ours —
-    // and it must not stand in for either verdict: not a pass (the whole point
-    // of the check) and not a miss (which would burn the remaining candidates
-    // on an outage).
-    throw new RecipeStartError(
-      "infra_error",
-      `could not verify what is listening on port ${recipe.port}: ${verdict.reason}`,
-      undefined,
-      provenanceOf(recipe)
-    );
-  }
-  if (authoritative) {
-    // See the module docblock: the declared recipe genuinely failed to serve.
-    throw new RecipeStartError(
-      "server_unhealthy",
-      "the declared start command did not end up serving the probed port",
-      [
-        `Something answered the MCP probe on port ${recipe.port}${recipe.mcpPath}, but it is not the server your \`start\` command produced: ${verdict.reason}.`,
-        "",
-        "A detached process left behind by an install or build lifecycle hook is the usual cause; the check refuses to report on it, because a verdict about it would say nothing about this pull request.",
-      ].join("\n"),
-      provenanceOf(recipe)
-    );
-  }
-  return { kind: "miss", reason: verdict.reason };
+}
+
+/** The neutral end of the ladder, with the one-file fix spelled out. */
+function unresolvableDetails(
+  repoFullName: string,
+  detailsBlock?: string
+): string {
+  return [
+    "MCPJam could not work out how to build and start this repository's MCP server, so nothing was tested. This is not a failure of your pull request.",
+    "",
+    "Declare it once and this becomes exact — add `mcpjam.yaml` at the repository root:",
+    "",
+    "```yaml",
+    "version: 1",
+    "checks:",
+    "  build: npm ci && npm run build",
+    "  start: npm start",
+    "  port: 3001",
+    "  path: /mcp",
+    "```",
+    ...(detailsBlock ? ["", detailsBlock] : []),
+  ].join("\n");
+}
+
+function squatterDetails(recipe: ResolvedRecipe, reason: string): string {
+  return [
+    `Something answered the MCP probe on port ${recipe.port}${recipe.mcpPath}, but it is not the server the \`start\` command produced: ${reason}.`,
+    "",
+    "A detached process left behind by an install or build lifecycle hook is the usual cause; the check refuses to report on it, because a verdict about it would say nothing about this pull request.",
+  ].join("\n");
 }
 
 type VerificationVerdict =
   | { status: "ok" }
-  /** Definite: something is listening, and it is not ours / not the checkout. */
+  /** Definite: something is listening, and it is not ours. */
   | { status: "mismatch"; reason: string }
   /** We could not tell. Infrastructure, never a pass and never a miss. */
   | { status: "unknown"; reason: string };
@@ -611,81 +727,12 @@ export function judgeListeners(
  * the build, the clone and the start command all sit in one group, and a
  * squatter detached by a build lifecycle hook matched the server we started.
  * That was observed against a real sandbox, not reasoned about — see
- * scripts/verify-listener-identity.ts. With `setsid` the group begins at our
- * spawn, so nothing that predates it can be in it, and a new session means an
- * outside process cannot `setpgid` its way in either.
- *
- * BOTH expected values come from the spawn. The group in particular CANNOT be
- * recovered later: the shape it exists to cover is a supervisor that exits, and
- * once it has exited `/proc/<pid>` is gone and its pgrp reads as null — so a
- * fallback that read the group at verification time was guaranteed to be
- * unavailable in exactly the case it was written for.
+ * scripts/verify-listener-identity.ts.
  */
 function isOurs(process: ListenerProcess, spawn: SpawnIdentity): boolean {
   if (process.pid === spawn.pid) return true;
   if (process.ppids.includes(spawn.pid)) return true;
   return (
     spawn.pgrp !== null && process.pgrp !== null && process.pgrp === spawn.pgrp
-  );
-}
-
-/**
- * A ladder throw, mapped to its outcome.
- *
- * `no_recipe` is the HEURISTIC exhaustion case — nobody declared anything and
- * nothing was detectable — so it is neutral. Every other `RecipeResolutionError`
- * comes from an AUTHORITATIVE rung refusing a config that is present and broken,
- * which is the PR author's to fix and therefore a failure.
- */
-function ladderFailure(error: unknown, repoFullName: string): RecipeStartError {
-  if (!(error instanceof RecipeResolutionError)) {
-    return new RecipeStartError(
-      "infra_error",
-      error instanceof Error ? error.message.slice(0, 200) : String(error)
-    );
-  }
-  if (error.reason === "no_recipe") {
-    // `detailsMarkdown` here is detect.ts's discard reasons: constant strings,
-    // multi-line, and already formatted as a list — so it is appended as its own
-    // block rather than folded into a bullet.
-    return unresolvable(repoFullName, [], error.detailsMarkdown);
-  }
-  return new RecipeStartError(
-    "recipe_invalid",
-    error.message,
-    [
-      "The configuration this repository declares for MCPJam checks is present but not usable, so the check ran nothing rather than guessing at what you meant.",
-      ...(error.detailsMarkdown ? ["", error.detailsMarkdown] : []),
-    ].join("\n")
-  );
-}
-
-/** The neutral end of the ladder, with the one-file fix spelled out. */
-function unresolvable(
-  repoFullName: string,
-  notes: string[],
-  detailsBlock?: string
-): RecipeStartError {
-  return new RecipeStartError(
-    "recipe_unresolvable",
-    `no usable recipe for ${repoFullName}`,
-    [
-      "MCPJam could not work out how to build and start this repository's MCP server, so nothing was tested. This is not a failure of your pull request.",
-      "",
-      "Declare it once and this becomes exact — add `mcpjam.yaml` at the repository root:",
-      "",
-      "```yaml",
-      "version: 1",
-      "checks:",
-      "  build: npm ci && npm run build",
-      "  start: npm start",
-      "  port: 3001",
-      "  path: /mcp",
-      "```",
-      ...(notes.length > 0
-        ? ["", "What was tried:", ...notes.map((note) => `- ${note}`)]
-        : []),
-      ...(detailsBlock ? ["", detailsBlock] : []),
-    ].join("\n")
   );
 }

--- a/mcpjam-inspector/server/services/github-checks/resolver/index.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/index.ts
@@ -50,6 +50,18 @@ export {
   type ResolvedRecipe,
 } from "./types";
 
+/**
+ * The version of the resolver LOGIC, not of this file.
+ *
+ * It is covered by the evidence digest (`../evidence-digest.ts`) and travels to
+ * the backend with every plan request, so it is what stops a cached recipe
+ * outliving the detection rules that produced it: change how the ladder decides
+ * anything and the cache MISSES rather than resurrecting an answer the current
+ * logic would not have given. Bump it when detection's behaviour changes —
+ * never for a refactor that cannot change an outcome.
+ */
+export const RESOLVER_VERSION = "r2/1";
+
 export type LadderInput = {
   repoFullName: string;
   /** Contents of mcpjam.yaml at the repo root, or null if the file is absent. */

--- a/mcpjam-inspector/server/services/github-checks/service-route.ts
+++ b/mcpjam-inspector/server/services/github-checks/service-route.ts
@@ -1,0 +1,84 @@
+/**
+ * The service-token-gated transport to `/internal/v1/github-checks/*`.
+ *
+ * Extracted from the worker because the plan/verdict loop now speaks to four of
+ * these routes from two modules, and two copies of "how do we call the backend"
+ * is how a timeout policy or an auth header ends up applied on one path and not
+ * the other.
+ */
+
+export const GITHUB_CHECKS_SERVICE_BASE = "/internal/v1/github-checks";
+
+/**
+ * Per-request cap on service-route calls so a stalled Convex cannot wedge the
+ * loop.
+ */
+export const SERVICE_ROUTE_TIMEOUT_MS = 15_000;
+
+export type ServiceRouteResponse = { status: number; body: any };
+
+export type PostServiceRoute = (
+  path: string,
+  body: Record<string, unknown>
+) => Promise<ServiceRouteResponse>;
+
+export function githubChecksServiceEnv(): {
+  convexUrl: string;
+  serviceToken: string;
+} | null {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!convexUrl || !serviceToken) return null;
+  return { convexUrl, serviceToken };
+}
+
+export async function postServiceRoute(
+  path: string,
+  body: Record<string, unknown>
+): Promise<ServiceRouteResponse> {
+  const env = githubChecksServiceEnv();
+  if (!env) {
+    throw new Error(
+      "github-checks worker requires CONVEX_HTTP_URL and INSPECTOR_SERVICE_TOKEN"
+    );
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    SERVICE_ROUTE_TIMEOUT_MS
+  );
+  // The timer stays armed through the BODY read, not just the headers: a
+  // response that stalls mid-body would otherwise hang the poll loop for as long
+  // as the socket stays open, and the loop is what recovers from a sick backend.
+  try {
+    const response = await fetch(`${env.convexUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-inspector-service-token": env.serviceToken,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    let parsed: any = null;
+    try {
+      parsed = await response.json();
+    } catch (error) {
+      // A malformed body is tolerated — the status carries the signal. A body
+      // read that hit the abort deadline is NOT: silently returning
+      // `body: null` would make a timed-out call look like a successful one
+      // whose response merely lacked a body. Rethrown as a TIMEOUT, since the
+      // underlying error is a parse failure and would otherwise read in the
+      // logs (and in an `infra_error` detail) as a malformed-response bug.
+      if (controller.signal.aborted) {
+        throw new Error(
+          `service route ${path} timed out after ${SERVICE_ROUTE_TIMEOUT_MS}ms while reading the response body`,
+          { cause: error }
+        );
+      }
+    }
+    return { status: response.status, body: parsed };
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## What this does

Rewires the GitHub-checks worker onto the **backend-owned plan/verdict loop** that landed in backend #843 + #847. Receiver-first: the backend already speaks this contract; this is the caller.

### The new sequence

```
1.  claim                                   (unchanged)
2.  POST /plan/begin {triggerId, repoFullName, headSha} → {planId}
      ← BEFORE any sandbox work, so provision/clone/detect failures are attributable
3.  provision → clone → bounded reads       (reported as LADDER attempts, no candidateId)
4.  the deterministic ladder                → localCandidates[]
5.  compute evidenceDigest                  (this repo is now the SOLE encoder)
6.  POST /plan/candidates {planId, evidenceDigest, resolverVersion, localCandidates}
                                            → {candidates[], stopPolicy}
7.  execute the candidates IN THE PLAN'S ORDER, fresh sandbox per candidate,
    previous box killed BEFORE the next is provisioned; POST /attempt at each
    phase boundary with an explicit idempotencyKey
8.  obey the typed action: continue_phase | try_next_candidate | run_eval | complete
9.  on run_eval: launch the suite, then IMMEDIATELY
      POST /attempt {phase:'eval', ok:true, runId}   ← this is what BINDS the run
    then await the run
10. POST /complete {triggerId, planId, runId}        ← NO `outcome` field
11. cleanup unchanged (ephemeral server row, sandboxes, heartbeat, lease)
```

### The moat boundary — what the inspector stopped owning

| stopped | why |
| --- | --- |
| ordering candidates | the backend orders them (cache hit first, then ours, capped at 3) |
| deciding continue/stop | the returned action is authoritative |
| computing the outcome | derived backend-side from the attempt log + the BOUND run |
| `resolveAndStart`'s attribution mapping | it reports a `failureKind`; `FAILURE_KIND_POLICY` decides what it means |

Kept, deliberately and in the open: deterministic `mcpjam.yaml` parsing and detection, clone/build/start/probe, E2B lifecycle, egress lockdown, cleanup, `/proc` listener identity, structured telemetry.

Accepted cost, named: a check is now backend-dependent mid-flight, so a self-hosted inspector cannot run checks standalone. That is the moat working as intended, stated rather than emergent.

### The encoder move

`server/services/github-checks/evidence-digest.ts` is new and is the **single** encoder — the backend retired its own and now shape-checks the digest only (opaque hex sha-256). Ported verbatim in behaviour: fixed ordered path list, present/absent markers, per-path byte budgets, length-prefixed framing, sha-256, covering `resolverVersion`. Two improvements over the mirrored version: the budgets are now *imported* from the detector's real constants instead of hand-copied (`assertEvidenceBudgetsCoverDetector()` still runs at module load), and `computeResolverEvidenceDigest()` takes the reader's own output, so what is hashed is exactly what detection saw.

The golden vector came across as an inspector regression test and **reproduces the pinned digest** `139b76e3…cb06`, so cache entries written under the old backend encoder stay addressable.

### Typed action + fail closed

`continue_phase` / `try_next_candidate` / `run_eval` / `complete`, obeyed verbatim. An action this build does not recognize — or a 200 with no action at all — is normalized to `complete` with `unknownAction`, never "carry on". `run_eval` is the only action allowed to follow an accepted candidate; anything else stops.

### Degraded mode and 409s

- **409 (and 400) = HARD STOP.** Never retried, never fallen back from. The reason is surfaced in the check output.
- **Unreachable / 5xx / 404** = degraded: stop, and record `backend_unreachable` on the first call that gets through (a `terminalAttempt` on `/complete`). Never a green, never a PR-blamed outcome, and **never** a silent local fallback — `localCandidates` are never executed in our own order.
- `/plan/begin` failing means no plan exists, so **nothing is provisioned at all** and the check is completed neutral through the legacy planless shape (the only place the worker still names an outcome; it retires with that shape).
- Transport replays happen exactly once, only where the idempotency key makes them safe. Every `/attempt` carries an explicit caller-generated key (`plan:candidate:phase:seq`), fresh per distinct attempt and identical on a replay, so a retry replays rather than duplicating a corpus row.
- `evals_failed` is never sent: it is not in the worker-facing union. A failed eval **launch** is `{phase:'eval', ok:false, failureKind:'sandbox_error'}`; once the run is bound, no further attempt is posted at all.

The in-box eval-failure diagnostic survives as **display text only** — it no longer reclassifies an outcome, because after the eval attempt the verdict comes from the bound run.

### #3644 hardening — verified intact after the refactor

- launch identity from the spawn handle (never a writable `/tmp` PID file);
- bounded in-box reads (`head -c`, never `cat`);
- `setsid` wrapping, process group trusted only when `pgrp === pid`;
- listener identity checked for **every** listener on the port, with `listener_mismatch` (evidence about the candidate) and `listener_unknown` (evidence about us) reported as different kinds;
- an oversized `mcpjam.yaml` still attributed `recipe_invalid` rather than collapsing to "absent" — pinned by a test that runs the REAL ladder.

**Re-run against a live E2B sandbox** after the refactor (`scripts/verify-listener-identity.ts`, four scenarios, four fresh boxes, all killed):

```
SUMMARY
  ✓ happy        our spawned server binds the port          → ok
  ✓ squatter     detached hook process binds first          → mismatch
  ✓ doublefork   reparented, ancestry gone, pgrp identifies → ok
  ✓ ipv6         binds `::` only, walk still attributes it  → ok
exit 0
```

## Tests

New/rewritten, all over the existing injected-fake dep seam:

- `check-plan.test.ts` (15) — idempotency keys, the same key on a replay, 409 = one call and a hard stop, 404/5xx = unreachable carrying the phase it was at, unknown action fails closed, `/complete` sends no `outcome`, and the degraded marker being dropped (not the completion) when the backend refuses it.
- `resolve-and-start.test.ts` (31) — the plan's order beats the detector's, each typed action drives the right next step, unknown action stops, 409 = no retry and no local fallback, `/plan/candidates` unreachable executes nothing, pre-candidate provision/clone failures reported against the begun plan, `recipe_invalid` (incl. over-cap) and `no_candidates` as ladder-scoped `resolve` failures, fresh box per candidate with kill-before-provision, listener mismatch/unknown, plus the unchanged `judgeListeners` matrix.
- `evidence-digest.test.ts` (12) — the golden vector, budgets covering the detector, absent ≠ empty, unforgeable framing, byte- not code-unit truncation.
- `github-checks-worker.test.ts` (56) — plan begun before any sandbox work, eval attempt posted AT LAUNCH carrying the runId, no second attempt once bound, no `evals_failed` anywhere, degraded marker on the completion, planless `infra_error` with nothing executed.

```
npx vitest run server/services/__tests__/github-checks-worker.test.ts \
  server/services/__tests__/github-checks-worker-source.test.ts \
  server/services/github-checks/__tests__
→ 10 files, 451 tests passed, EXIT CODE 0
npm run check:mcp-v1-runtime-imports  → EXIT CODE 0
```

(`github-checks-worker.test.ts` needs `mcpjam-inspector/node_modules` and the generated harness bundle present; in a bare worktree it fails to *load* on `@ai-sdk/harness/agent` at unmodified HEAD too. Both were supplied before the runs above, and the suite loads and passes.)

## Not done here

**e2e awaits the backend deploy.** The routes are merged on backend `main` but `plan/begin` still 404s in prod, so no live end-to-end was attempted. Once deployed: fixture with `mcpjam.yaml` → declared; yaml deleted → detected; broken yaml → `recipe_invalid`; nothing resolvable → `recipe_unresolvable`.

The follow-up that retires the legacy explicit-`outcome` `/complete` shape and the worker-facing recipe PUT stays tracked; the planless report path in this PR is the last consumer of the former.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large refactor of GitHub check execution and verdict attribution; incorrect binding, completion, or degraded-mode handling could mis-report PR checks or strand runs until backend deploy aligns with the new routes.
> 
> **Overview**
> Moves GitHub PR checks onto a **backend-owned plan loop**: `begin` → ladder attempts → `candidates` → per-phase `/attempt` with idempotency keys → `/complete` **without** an `outcome`. The control plane derives pass/fail from the attempt log and the **bound** eval run; the worker no longer sends `evals_failed` or other PR verdicts.
> 
> **Worker flow:** `/plan/begin` runs before any sandbox work. `resolveAndStart` executes candidates in the **plan’s** order and obeys typed actions (`continue_phase`, `try_next_candidate`, `run_eval`, `complete`). On eval launch, `onRunStarted` posts `{ phase: 'eval', ok: true, runId }` immediately so the run binds to the check. Failures use `describeCheckFailure` for display only; planless `infra_error` remains only when begin never returns a plan.
> 
> **New modules:** `check-plan.ts` (HTTP session, 409 hard-stop, degraded `backend_unreachable`, unknown action → fail closed), `evidence-digest.ts` (sole recipe evidence encoder + golden vector), `service-route.ts` (shared Convex transport). `classifyCheckFailure` / `outcomeForRunResult` and worker-side outcome reporting are removed.
> 
> **Reliability:** `abandonPreparedRun` finalizes runs when eval binding (`onRunStarted`) throws so rows are not left `running` with pending iterations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada5921b9ec990e89f9ae3767343c08e4334d187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewired the GitHub-checks worker onto the backend-owned plan/verdict loop so the backend orders candidates, returns typed actions, and derives the conclusion. The worker reports attempts with idempotency keys, binds the eval run at launch, completes with no outcome, and now uses a single evidence-digest encoder and a shared service-route transport with pinned behavior.

- **New Features**
  - Plan loop: begin → candidates → per-phase attempts with idempotency keys → complete (no outcome).
  - Typed actions enforced (`continue_phase`, `try_next_candidate`, `run_eval`, `complete`); unknown actions fail closed.
  - Eval run bound at launch; no local outcome classification.
  - Fresh sandbox per candidate with kill-before-provision; strict degraded policy (409/400 = hard stop; 5xx/404/unreachable = degraded, no local fallback).
  - Evidence-digest encoder moved here; golden vector preserved; budgets imported; covers `RESOLVER_VERSION`; shared service-route transport.

- **Bug Fixes**
  - Prevent stranded runs when binding throws by abandoning prepared runs to reach a terminal state.
  - Enforce the plan wall-clock deadline at candidate boundaries and again after provisioning; `0` means no deadline.
  - Unified plan-route retry/classify into one helper; added tests for binding abort and deadline checks.
  - Pinned service-route transport behavior with tests: correct token/URL, tolerate malformed bodies, propagate timeouts/aborts, and ensure the deadline covers the body read.
  - Clarified `repoFiles` note in the evidence digest: no cross-repo replay (cache keyed by repo+evidence), but within-repo listing changes may require a future hash-version bump.

<sup>Written for commit ada5921b9ec990e89f9ae3767343c08e4334d187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

