### PR TITLE
feat(conformance): protocol version pin, unconditional OAuth negative checks, hosted Tasks, and a pre-run check catalog

### DIFF
--- a/.changeset/conformance-version-pin-and-catalog.md
+++ b/.changeset/conformance-version-pin-and-catalog.md
@@ -1,0 +1,51 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/sdk": minor
+---
+
+Bring the Conformance tab up to the CLI's capability and make the suites
+legible before they run.
+
+**Protocol version is now selectable.** The CLI has taken
+`--protocol-version` since it shipped, but the UI had no selector and the
+routes dropped the pin entirely: `runProtocolConformance` built its
+`MCPConformanceConfig` from URL, token and headers only, so every UI run
+adopted whatever the server negotiated — and the OAuth suite silently fell
+back to a hardcoded `2025-11-25`. The panel now has an "Auto (negotiated)"
+plus per-version dropdown that threads through both the local and hosted
+`/protocol` routes into the SDK, and overrides the OAuth profile's version
+even when that profile is otherwise empty. Both routes validate the field
+with `z.enum(MCP_PROTOCOL_VERSIONS)`, so an unknown pin is rejected before
+any routing decision.
+
+**The negative OAuth checks are part of the suite, not an opt-in.** The
+"Run negative OAuth checks" toggle is gone and `oauthConformanceChecks` is
+always on. Verifying that a server *rejects* an invalid client, a mismatched
+redirect URI, an invalid token, and an `http://` DCR redirect is half of OAuth
+conformance; gating it behind a switch meant an OAuth section could report a
+clean pass while nine checks had never run and were not even rendered as
+skipped. The runner still only reaches them once the happy path passes end to
+end.
+
+**Tasks conformance now runs on hosted.** It was marked "requires a persistent
+connection (run it from the local inspector)", which was never true — the
+runner opens its own ephemeral client for the length of the run, exactly like
+Apps conformance, which has always worked on hosted. The real gap was a
+missing route. Adds `POST /api/web/conformance/tasks` reusing the resolver
+Apps already uses, with the task poll window clamped to 20s so it cannot
+outrun the 30s hosted call budget.
+
+**Suites explain themselves before they run.** Each section is collapsible and,
+until a result replaces it, lists the checks it will run with a one-line
+description on click. The protocol list is filtered by the pinned version's
+era, so a `2025-06-18` pin hides the modern-only checks instead of implying
+they apply; on "Auto" everything is listed with the era-restricted rows
+tagged.
+
+For that preview the SDK gains `conformance-catalog.ts` — a browser-safe,
+dependency-free record of all 47 check titles and descriptions, exported from
+the browser entry. The canonical strings live beside the check
+implementations, in modules that pull the whole runner graph and cannot be
+imported from a bundle, which is why the copy exists;
+`tests/conformance-catalog.test.ts` asserts it byte-identical to all eight
+canonical sources and exhaustive over the id unions, so the two cannot drift.

--- a/.changeset/conformance-version-pin-and-catalog.md
+++ b/.changeset/conformance-version-pin-and-catalog.md
@@ -32,8 +32,11 @@ connection (run it from the local inspector)", which was never true — the
 runner opens its own ephemeral client for the length of the run, exactly like
 Apps conformance, which has always worked on hosted. The real gap was a
 missing route. Adds `POST /api/web/conformance/tasks` reusing the resolver
-Apps already uses, with the task poll window clamped to 20s so it cannot
-outrun the 30s hosted call budget.
+Apps already uses. Three bounds keep it inside the 30s hosted call budget: the
+poll window is clamped to 20s, each MCP leg (connect, `tools/list`, the
+provoking `tools/call`) to 10s, and the run as a whole to 28s — past that the
+route answers 504 `TIMEOUT` telling the caller to run it locally, rather than
+hanging.
 
 **Suites explain themselves before they run.** Each section is collapsible and,
 until a result replaces it, lists the checks it will run with a one-line

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -1,6 +1,12 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { Button } from "@mcpjam/design-system/button";
-import { Switch } from "@mcpjam/design-system/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
   CheckCircle2,
@@ -25,8 +31,21 @@ import type {
 // Import from the browser-safe SDK entry — the top-level `@mcpjam/sdk` pulls
 // Node-only transitive deps (MCP client SDK uses `node:stream`, etc.) which
 // break the Vite browser bundle.
-import { canRunConformance } from "@mcpjam/sdk/browser";
-import { isHostedMode } from "@/lib/apis/mode-client";
+import {
+  APPS_CHECK_CATALOG,
+  canRunConformance,
+  CHECK_ERAS,
+  CONFORMANCE_CHECK_METADATA,
+  MCP_APPS_CHECK_IDS,
+  MCP_CHECK_IDS,
+  MCP_PROTOCOL_VERSIONS,
+  MCP_TASKS_CHECK_IDS,
+  PROTOCOL_CHECK_CATALOG,
+  PROTOCOL_VERSION_ERAS,
+  TASKS_CHECK_CATALOG,
+  type McpProtocolVersion,
+  type OAuthConformanceCheckId,
+} from "@mcpjam/sdk/browser";
 import type { OAuthConformanceStartResult } from "@/lib/apis/mcp-conformance-api";
 import {
   runProtocolConformance,
@@ -39,6 +58,64 @@ import {
 import { deriveOAuthProfileFromServer } from "@/components/oauth/utils";
 
 type SuiteStatus = "idle" | "running" | "done" | "error" | "unavailable";
+
+/** "auto" ⇒ no pin: the run adopts whatever version the server negotiates. */
+type ProtocolVersionPin = "auto" | McpProtocolVersion;
+
+/** One row in a suite's "what this will run" preview, before any run. */
+interface CatalogEntry {
+  id: string;
+  title: string;
+  /** One-line explanation, revealed on click. */
+  description?: string;
+  /** Era restriction, shown only when no version is pinned. */
+  note?: string;
+}
+
+/**
+ * The protocol suite is era-gated: a pinned version runs only its own era's
+ * checks. With a pin we filter to exactly what will run; on "auto" the era is
+ * unknown until the connection negotiates, so we list everything and tag the
+ * checks that are era-restricted rather than implying they all apply.
+ */
+function protocolCatalog(pin: ProtocolVersionPin): CatalogEntry[] {
+  const pinnedEra = pin === "auto" ? undefined : PROTOCOL_VERSION_ERAS[pin];
+  return MCP_CHECK_IDS.filter((id) => {
+    const eras = CHECK_ERAS[id] as readonly string[];
+    return pinnedEra === undefined || eras.includes(pinnedEra);
+  }).map((id) => {
+    const eras = CHECK_ERAS[id] as readonly string[];
+    return {
+      id,
+      ...PROTOCOL_CHECK_CATALOG[id],
+      note:
+        pinnedEra === undefined && eras.length === 1
+          ? `${eras[0]} only`
+          : undefined,
+    };
+  });
+}
+
+const APPS_CATALOG: CatalogEntry[] = MCP_APPS_CHECK_IDS.map((id) => ({
+  id,
+  ...APPS_CHECK_CATALOG[id],
+}));
+
+const TASKS_CATALOG: CatalogEntry[] = MCP_TASKS_CHECK_IDS.map((id) => ({
+  id,
+  ...TASKS_CHECK_CATALOG[id],
+}));
+
+// Only the post-flow checks have static identities. The authorization flow
+// steps themselves depend on the server's registration strategy and protocol
+// version, so they are discovered during the run rather than listed here.
+const OAUTH_CATALOG: CatalogEntry[] = (
+  Object.keys(CONFORMANCE_CHECK_METADATA) as OAuthConformanceCheckId[]
+).map((id) => ({
+  id,
+  title: CONFORMANCE_CHECK_METADATA[id].title,
+  description: CONFORMANCE_CHECK_METADATA[id].summary,
+}));
 
 interface SuiteState {
   status: SuiteStatus;
@@ -94,15 +171,6 @@ function createAppsState(server: ServerWithName): AppsSuiteState {
 }
 
 function createTasksState(server: ServerWithName): TasksSuiteState {
-  // Tasks conformance provokes and then polls a real task, which needs a
-  // persistent connection: hosted mode reconnects per request.
-  if (isHostedMode()) {
-    return {
-      status: "unavailable",
-      unavailableReason:
-        "Tasks conformance requires a persistent connection (run it from the local inspector)",
-    };
-  }
   return suiteState("tasks", server);
 }
 
@@ -290,15 +358,70 @@ function OAuthStepRow({ step }: { step: OAuthConformanceStepResult }) {
   );
 }
 
+/**
+ * A not-yet-run check. Mirrors {@link CheckRow}'s interaction so the preview
+ * and the real results read as the same list in two states.
+ */
+function CatalogRow({ entry }: { entry: CatalogEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const expandable = Boolean(entry.description);
+
+  return (
+    <div className="border-b border-border/30 last:border-0">
+      <button
+        type="button"
+        className="w-full flex items-center gap-2 py-1.5 px-1 text-left transition-colors enabled:hover:bg-muted/30 enabled:cursor-pointer disabled:cursor-default"
+        onClick={() => setExpanded((value) => !value)}
+        disabled={!expandable}
+        aria-expanded={expandable ? expanded : undefined}
+      >
+        <MinusCircle className="h-3.5 w-3.5 text-muted-foreground/50 flex-shrink-0" />
+        <span className="flex-1 min-w-0 truncate text-xs text-muted-foreground">
+          {entry.title}
+        </span>
+        {entry.note && (
+          <span className="flex-shrink-0 text-[10px] text-muted-foreground/70">
+            {entry.note}
+          </span>
+        )}
+        {expandable &&
+          (expanded ? (
+            <ChevronDown className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+          ) : (
+            <ChevronRight className="h-3 w-3 text-muted-foreground flex-shrink-0" />
+          ))}
+      </button>
+      {expanded && entry.description && (
+        <div className="px-6 pb-2 text-xs text-muted-foreground whitespace-pre-wrap break-words">
+          {entry.description}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function SuiteSection({
   title,
   state,
+  catalog,
+  catalogNote,
+  hasResult,
   children,
 }: {
   title: string;
   state: SuiteState;
+  /** What this suite runs, shown until a real result replaces it. */
+  catalog: CatalogEntry[];
+  catalogNote?: string;
+  hasResult: boolean;
   children?: React.ReactNode;
 }) {
+  // `null` follows the result: a finished suite opens itself, an idle one
+  // stays shut. Clicking pins an explicit choice until the next run remounts.
+  const [override, setOverride] = useState<boolean | null>(null);
+  const collapsible = state.status !== "unavailable";
+  const expanded = collapsible && (override ?? hasResult);
+
   const badge = (() => {
     if (state.status === "running") {
       return (
@@ -323,10 +446,24 @@ function SuiteSection({
 
   return (
     <div className="rounded-md border border-border/50 overflow-hidden">
-      <div className="flex items-center justify-between px-3 py-2 bg-muted/30">
-        <span className="text-sm font-medium">{title}</span>
+      <button
+        type="button"
+        className="w-full flex items-center justify-between gap-2 px-3 py-2 bg-muted/30 text-left transition-colors enabled:hover:bg-muted/50 disabled:cursor-default"
+        onClick={() => setOverride(!expanded)}
+        disabled={!collapsible}
+        aria-expanded={collapsible ? expanded : undefined}
+      >
+        <span className="flex items-center gap-1.5 min-w-0">
+          {collapsible &&
+            (expanded ? (
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+            ))}
+          <span className="text-sm font-medium truncate">{title}</span>
+        </span>
         {badge}
-      </div>
+      </button>
       <div className="px-2 py-1">
         {state.status === "unavailable" && state.unavailableReason && (
           <div className="flex items-center gap-1.5 px-1 py-2 text-xs text-muted-foreground">
@@ -337,7 +474,20 @@ function SuiteSection({
         {state.status === "error" && state.error && (
           <div className="px-1 py-2 text-xs text-red-400">{state.error}</div>
         )}
-        {children}
+        {expanded &&
+          (hasResult ? (
+            children
+          ) : (
+            <div>
+              <div className="px-1 py-1 text-[10px] text-muted-foreground">
+                {catalog.length} checks in this suite — not run yet.
+                {catalogNote ? ` ${catalogNote}` : ""}
+              </div>
+              {catalog.map((entry) => (
+                <CatalogRow key={entry.id} entry={entry} />
+              ))}
+            </div>
+          ))}
       </div>
     </div>
   );
@@ -357,7 +507,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
   const [oauth, setOAuth] = useState<OAuthSuiteState>(() =>
     createOAuthState(server),
   );
-  const [negativeChecks, setNegativeChecks] = useState(false);
+  const [versionPin, setVersionPin] = useState<ProtocolVersionPin>("auto");
   const [runVersion, setRunVersion] = useState(0);
 
   const activeServerNameRef = useRef(server.name);
@@ -414,7 +564,9 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
       if (!httpServer) return;
       setProtocol({ status: "running" });
       try {
-        const { result } = await runProtocolConformance(serverName);
+        const { result } = await runProtocolConformance(serverName, {
+          protocolVersion: versionPin === "auto" ? undefined : versionPin,
+        });
         if (!isRunActive(runToken, serverName)) return;
         setProtocol({ status: "done", result });
       } catch (err) {
@@ -425,7 +577,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
         });
       }
     },
-    [httpServer, isRunActive],
+    [httpServer, isRunActive, versionPin],
   );
 
   const runApps = useCallback(
@@ -533,22 +685,29 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
         // server can surface the code back to the SDK runner.
         const callbackOrigin = window.location.origin;
 
+        // A run-scoped version pin beats the stored OAuth-tab profile, and
+        // must be sent even when the profile is otherwise empty (the route
+        // falls back to its own default version when no profile arrives).
+        const pinnedVersion = versionPin === "auto" ? undefined : versionPin;
+        const baseProfile = profile.serverUrl
+          ? {
+              serverUrl: profile.serverUrl,
+              protocolVersion: profile.protocolVersion,
+              registrationStrategy: profile.registrationStrategy,
+              clientId: profile.clientId || undefined,
+              clientSecret: profile.clientSecret || undefined,
+              scopes: profile.scopes || undefined,
+              customHeaders: profile.customHeaders.length
+                ? profile.customHeaders
+                : undefined,
+            }
+          : undefined;
+
         const startResult = await startOAuthConformance({
           serverNameOrId: serverName,
-          oauthProfile: profile.serverUrl
-            ? {
-                serverUrl: profile.serverUrl,
-                protocolVersion: profile.protocolVersion,
-                registrationStrategy: profile.registrationStrategy,
-                clientId: profile.clientId || undefined,
-                clientSecret: profile.clientSecret || undefined,
-                scopes: profile.scopes || undefined,
-                customHeaders: profile.customHeaders.length
-                  ? profile.customHeaders
-                  : undefined,
-              }
-            : undefined,
-          runNegativeChecks: negativeChecks,
+          oauthProfile: pinnedVersion
+            ? { ...baseProfile, protocolVersion: pinnedVersion }
+            : baseProfile,
           callbackOrigin,
         });
 
@@ -637,7 +796,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
         });
       }
     },
-    [handleOAuthCallback, isRunActive, negativeChecks, pollOAuthComplete],
+    [handleOAuthCallback, isRunActive, pollOAuthComplete, versionPin],
   );
 
   const runAll = useCallback(async () => {
@@ -656,15 +815,18 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
       promises.push(runProtocol(runToken, currentServer.name));
     }
     promises.push(runApps(runToken, currentServer.name));
-    if (!isHostedMode()) {
-      promises.push(runTasks(runToken, currentServer.name));
-    }
+    promises.push(runTasks(runToken, currentServer.name));
     if (httpServerNow) {
       promises.push(runOAuth(runToken, currentServer));
     }
 
     await Promise.allSettled(promises);
   }, [beginRun, runApps, runOAuth, runProtocol, runTasks, server]);
+
+  const protocolChecks = useMemo(
+    () => protocolCatalog(versionPin),
+    [versionPin],
+  );
 
   const isRunning =
     protocol.status === "running" ||
@@ -674,28 +836,11 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="flex items-start justify-between gap-4 border-b border-border/50 pb-4">
-        <div className="space-y-1">
-          <h2 className="text-lg font-semibold">Conformance</h2>
-          <p className="text-sm text-muted-foreground">
-            Run Protocol, Apps, Tasks, and OAuth checks against {server.name}.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <label
-            htmlFor="negative-checks"
-            className="text-xs text-muted-foreground cursor-pointer"
-          >
-            Run negative OAuth checks
-          </label>
-          <Switch
-            id="negative-checks"
-            checked={negativeChecks}
-            onCheckedChange={setNegativeChecks}
-            className="scale-75"
-            disabled={isRunning}
-          />
-        </div>
+      <div className="space-y-1 border-b border-border/50 pb-4">
+        <h2 className="text-lg font-semibold">Conformance</h2>
+        <p className="text-sm text-muted-foreground">
+          Run Protocol, Apps, Tasks, and OAuth checks against {server.name}.
+        </p>
       </div>
 
       <div className="mt-4 flex items-center justify-between gap-2">
@@ -709,10 +854,49 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
             "Run available checks"
           )}
         </Button>
+        <div className="flex items-center gap-2">
+          <label
+            htmlFor="conformance-protocol-version"
+            className="text-xs text-muted-foreground"
+          >
+            Protocol version
+          </label>
+          <Select
+            value={versionPin}
+            onValueChange={(value) => setVersionPin(value as ProtocolVersionPin)}
+            disabled={isRunning}
+          >
+            <SelectTrigger
+              id="conformance-protocol-version"
+              className="h-8 w-[170px] text-xs"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto">Auto (negotiated)</SelectItem>
+              {MCP_PROTOCOL_VERSIONS.map((version) => (
+                <SelectItem key={version} value={version}>
+                  {version}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
 
       <div className="mt-4 space-y-4 overflow-y-auto pr-1">
-        <SuiteSection title="Protocol" state={protocol}>
+        <SuiteSection
+          key={`${runVersion}-protocol`}
+          title="Protocol"
+          state={protocol}
+          catalog={protocolChecks}
+          catalogNote={
+            versionPin === "auto"
+              ? "The negotiated version decides which era's checks run."
+              : undefined
+          }
+          hasResult={Boolean(protocol.result)}
+        >
           {protocol.result ? (
             <div>
               <div className="px-1 py-1 text-[10px] text-muted-foreground">
@@ -725,7 +909,13 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           ) : null}
         </SuiteSection>
 
-        <SuiteSection title="Apps" state={apps}>
+        <SuiteSection
+          key={`${runVersion}-apps`}
+          title="Apps"
+          state={apps}
+          catalog={APPS_CATALOG}
+          hasResult={Boolean(apps.result)}
+        >
           {apps.result ? (
             <div>
               <div className="px-1 py-1 text-[10px] text-muted-foreground">
@@ -738,7 +928,13 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           ) : null}
         </SuiteSection>
 
-        <SuiteSection title="Tasks" state={tasks}>
+        <SuiteSection
+          key={`${runVersion}-tasks`}
+          title="Tasks"
+          state={tasks}
+          catalog={TASKS_CATALOG}
+          hasResult={Boolean(tasks.result)}
+        >
           {tasks.result ? (
             <div>
               <div className="px-1 py-1 text-[10px] text-muted-foreground">
@@ -751,7 +947,14 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           ) : null}
         </SuiteSection>
 
-        <SuiteSection title="OAuth" state={oauth}>
+        <SuiteSection
+          key={`${runVersion}-oauth`}
+          title="OAuth"
+          state={oauth}
+          catalog={OAUTH_CATALOG}
+          catalogNote="The authorization flow steps are recorded as the run proceeds."
+          hasResult={Boolean(oauth.result) || Boolean(oauth.waitingForAuth)}
+        >
           {oauth.waitingForAuth ? (
             <div className="flex items-center gap-2 px-1 py-3 text-xs text-muted-foreground">
               <Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -416,11 +416,15 @@ function SuiteSection({
   hasResult: boolean;
   children?: React.ReactNode;
 }) {
-  // `null` follows the result: a finished suite opens itself, an idle one
-  // stays shut. Clicking pins an explicit choice until the next run remounts.
+  // `null` follows the suite: one that is running or finished opens itself, an
+  // idle one stays shut. Clicking pins an explicit choice until the next run
+  // remounts. Tracking `running` — not just `hasResult` — matters most for
+  // OAuth, whose section would otherwise snap shut the moment the browser
+  // callback lands and the run moves from "waiting for auth" to polling.
   const [override, setOverride] = useState<boolean | null>(null);
+  const running = state.status === "running";
   const collapsible = state.status !== "unavailable";
-  const expanded = collapsible && (override ?? hasResult);
+  const expanded = collapsible && (override ?? (hasResult || running));
 
   const badge = (() => {
     if (state.status === "running") {
@@ -477,6 +481,13 @@ function SuiteSection({
         {expanded &&
           (hasResult ? (
             children
+          ) : running ? (
+            // Mid-run with nothing to show yet: the catalog would read as
+            // "not run yet", which is exactly wrong while the run is live.
+            <div className="flex items-center gap-2 px-1 py-3 text-xs text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Running {catalog.length} checks...
+            </div>
           ) : (
             <div>
               <div className="px-1 py-1 text-[10px] text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type {
   MCPConformanceResult,
   MCPAppsConformanceResult,
@@ -22,10 +23,6 @@ vi.mock("@/lib/apis/mcp-conformance-api", () => ({
   startOAuthConformance: (...args: unknown[]) => mockStartOAuth(...args),
   submitOAuthConformanceCode: (...args: unknown[]) => mockSubmitCode(...args),
   completeOAuthConformance: (...args: unknown[]) => mockCompleteOAuth(...args),
-}));
-
-vi.mock("@/lib/apis/mode-client", () => ({
-  isHostedMode: () => false,
 }));
 
 vi.mock("@/components/oauth/utils", () => ({
@@ -256,10 +253,148 @@ describe("ConformanceTab", () => {
     expect(unavailableMessages.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("shows the negative checks toggle", () => {
+  it("runs unpinned by default and forwards the OAuth profile's own version", async () => {
+    setupSuccessfulRunMocks();
     render(<ConformanceTab server={createHttpServer()} />);
 
-    expect(screen.getByText("Run negative OAuth checks")).toBeDefined();
+    fireEvent.click(screen.getByText("Run available checks"));
+
+    await waitFor(() => {
+      expect(mockRunProtocol).toHaveBeenCalledWith("http-server", {
+        protocolVersion: undefined,
+      });
+    });
+    await waitFor(() => {
+      expect(mockStartOAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          oauthProfile: expect.objectContaining({
+            protocolVersion: "2025-11-25",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("threads a pinned protocol version into the protocol and OAuth runs", async () => {
+    const user = userEvent.setup();
+    setupSuccessfulRunMocks();
+    render(<ConformanceTab server={createHttpServer()} />);
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Protocol version" }),
+    );
+    await user.click(screen.getByRole("option", { name: "2026-07-28" }));
+
+    fireEvent.click(screen.getByText("Run available checks"));
+
+    await waitFor(() => {
+      expect(mockRunProtocol).toHaveBeenCalledWith("http-server", {
+        protocolVersion: "2026-07-28",
+      });
+    });
+    await waitFor(() => {
+      expect(mockStartOAuth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          oauthProfile: expect.objectContaining({
+            protocolVersion: "2026-07-28",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("reveals what a suite will run when its header is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ConformanceTab server={createHttpServer()} />);
+
+    // Nothing has run, so the sections start closed.
+    expect(screen.queryByText("Ping")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: /Protocol/ }));
+
+    expect(screen.getByText("Ping")).toBeDefined();
+    expect(screen.getByText(/checks in this suite — not run yet/)).toBeDefined();
+  });
+
+  it("explains a check when its catalog row is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ConformanceTab server={createHttpServer()} />);
+
+    await user.click(screen.getByRole("button", { name: /Protocol/ }));
+
+    // The row shows the canonical title; the explanation stays hidden until
+    // the row itself is opened.
+    expect(
+      screen.queryByText("Server responds to ping requests."),
+    ).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: /^Ping/ }));
+
+    expect(
+      screen.getByText("Server responds to ping requests."),
+    ).toBeDefined();
+  });
+
+  it("narrows the protocol catalog to the pinned version's era", async () => {
+    const user = userEvent.setup();
+    render(<ConformanceTab server={createHttpServer()} />);
+
+    await user.click(screen.getByRole("button", { name: /Protocol/ }));
+
+    // On "auto" the era is unknown, so both eras are listed.
+    expect(screen.getByText("Ping")).toBeDefined();
+    expect(screen.getByText("Modern Client Handshake")).toBeDefined();
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Protocol version" }),
+    );
+    await user.click(screen.getByRole("option", { name: "2025-06-18" }));
+
+    // A legacy pin drops the modern-only checks entirely.
+    expect(screen.queryByText("Modern Client Handshake")).toBeNull();
+    expect(screen.getByText("Ping")).toBeDefined();
+  });
+
+  it("replaces the catalog with real results once a suite runs", async () => {
+    setupSuccessfulRunMocks({
+      protocol: createProtocolResult({
+        checks: [
+          {
+            id: "ping",
+            category: "core",
+            title: "Ping",
+            description: "Round trip",
+            status: "passed",
+            durationMs: 1,
+          },
+        ],
+      }),
+    });
+    render(<ConformanceTab server={createHttpServer()} />);
+
+    fireEvent.click(screen.getByText("Run available checks"));
+    await screen.findByText("Protocol summary");
+
+    // The suite auto-opens on completion and the preview line is gone.
+    expect(screen.queryByText(/checks in this suite — not run yet/)).toBeNull();
+  });
+
+  it("runs the OAuth suite without a negative-checks opt-in", async () => {
+    setupSuccessfulRunMocks();
+    render(<ConformanceTab server={createHttpServer()} />);
+
+    // The negative checks are part of the OAuth suite now — no toggle gates
+    // them, and the client sends no opt-in flag.
+    expect(screen.queryByText("Run negative OAuth checks")).toBeNull();
+
+    fireEvent.click(screen.getByText("Run available checks"));
+
+    await waitFor(() => {
+      expect(mockStartOAuth).toHaveBeenCalledTimes(1);
+    });
+    expect(mockStartOAuth.mock.calls[0][0]).not.toHaveProperty(
+      "runNegativeChecks",
+    );
   });
 
   it("expands passed protocol rows and shows descriptions and details", async () => {

--- a/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
@@ -379,6 +379,66 @@ describe("ConformanceTab", () => {
     expect(screen.queryByText(/checks in this suite — not run yet/)).toBeNull();
   });
 
+  it("keeps a running suite open instead of falling back to the catalog", async () => {
+    const pending = createDeferred<{
+      success: true;
+      result: MCPConformanceResult;
+    }>();
+    setupSuccessfulRunMocks();
+    mockRunProtocol.mockReturnValue(pending.promise);
+
+    render(<ConformanceTab server={createHttpServer()} />);
+    fireEvent.click(screen.getByText("Run available checks"));
+
+    // Mid-run the section opens itself and says so. The catalog line would
+    // read "not run yet", which is exactly wrong while the run is live.
+    await screen.findByText(/Running \d+ checks/);
+    expect(screen.queryByText(/checks in this suite — not run yet/)).toBeNull();
+
+    pending.resolve({ success: true, result: createProtocolResult() });
+    await screen.findByText("Protocol summary");
+  });
+
+  it("stays in the run for OAuth between the callback and the result", async () => {
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockReturnValue(null as unknown as Window);
+    const poll = createDeferred<{ phase: string; result?: unknown }>();
+    setupSuccessfulRunMocks();
+    mockStartOAuth.mockResolvedValue({
+      phase: "authorization_needed",
+      sessionId: "session-1",
+      authorizationUrl: "https://auth.example.com/authorize",
+    });
+    mockSubmitCode.mockResolvedValue({ success: true });
+    mockCompleteOAuth.mockReturnValue(poll.promise);
+
+    render(<ConformanceTab server={createHttpServer()} />);
+    fireEvent.click(screen.getByText("Run available checks"));
+
+    await screen.findByText("Waiting for browser authorization...");
+
+    // The callback lands and the run moves from "waiting" to polling. Keyed on
+    // `hasResult` alone that dropped back to false, snapping the section shut
+    // and offering the pre-run catalog for a run already in flight.
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "OAUTH_CALLBACK", code: "auth-code" },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockCompleteOAuth).toHaveBeenCalledWith("session-1");
+    });
+    const oauthHeader = screen.getByRole("button", { name: /OAuth/ });
+    expect(oauthHeader.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.queryByText(/checks in this suite — not run yet/)).toBeNull();
+
+    poll.resolve({ phase: "complete", result: createOAuthResult() });
+    await screen.findByText("OAuth summary");
+    openSpy.mockRestore();
+  });
+
   it("runs the OAuth suite without a negative-checks opt-in", async () => {
     setupSuccessfulRunMocks();
     render(<ConformanceTab server={createHttpServer()} />);

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-conformance-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-conformance-api.hosted.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Hosted build: every suite that has a `/api/web/conformance/*` route must
+// route there rather than falling back to (or refusing) the local endpoint.
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: true,
+}));
+
+vi.mock("@/lib/apis/web/context", () => ({
+  buildServerRequest: vi.fn(() => ({
+    projectId: "ws-1",
+    serverId: "srv-1",
+  })),
+}));
+
+vi.mock("@/lib/apis/web/base", () => ({
+  webPost: vi.fn(() => Promise.resolve({ success: true, result: {} })),
+}));
+
+import { webPost } from "@/lib/apis/web/base";
+import { runTasksConformance } from "../mcp-conformance-api";
+
+beforeEach(() => {
+  vi.mocked(webPost).mockClear();
+});
+
+describe("runTasksConformance (hosted)", () => {
+  it("posts to the hosted tasks route with the resolved server request", async () => {
+    await runTasksConformance("tasks-server");
+
+    expect(webPost).toHaveBeenCalledWith("/api/web/conformance/tasks", {
+      projectId: "ws-1",
+      serverId: "srv-1",
+    });
+  });
+
+  it("forwards the probe tool options", async () => {
+    await runTasksConformance("tasks-server", {
+      toolName: "long_job",
+      toolArguments: { seconds: 5 },
+    });
+
+    expect(webPost).toHaveBeenCalledWith("/api/web/conformance/tasks", {
+      projectId: "ws-1",
+      serverId: "srv-1",
+      toolName: "long_job",
+      toolArguments: { seconds: 5 },
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-conformance-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/mcp-conformance-api.test.ts
@@ -148,7 +148,6 @@ describe("startOAuthConformance (local)", () => {
         serverUrl: "https://oauth-server.com",
         protocolVersion: "2025-11-25",
       },
-      runNegativeChecks: true,
       callbackOrigin: "http://localhost:5173",
     });
 
@@ -157,7 +156,6 @@ describe("startOAuthConformance (local)", () => {
 
     const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(sentBody.serverId).toBe("oauth-server");
-    expect(sentBody.runNegativeChecks).toBe(true);
     expect(sentBody.callbackOrigin).toBe("http://localhost:5173");
   });
 });

--- a/mcpjam-inspector/client/src/lib/apis/mcp-conformance-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-conformance-api.ts
@@ -2,13 +2,10 @@ import type {
   MCPConformanceResult,
   MCPAppsConformanceResult,
   MCPTasksConformanceResult,
+  McpProtocolVersion,
   ConformanceResult as OAuthConformanceResult,
 } from "@mcpjam/sdk";
-import {
-  ensureLocalMode,
-  isHostedMode,
-  runByMode,
-} from "@/lib/apis/mode-client";
+import { isHostedMode, runByMode } from "@/lib/apis/mode-client";
 import { buildServerRequest } from "@/lib/apis/web/context";
 import { webPost } from "@/lib/apis/web/base";
 import { localPost } from "@/lib/apis/local-post";
@@ -40,7 +37,6 @@ export interface OAuthStartInput {
     scopes?: string;
     customHeaders?: Array<{ key: string; value: string }>;
   };
-  runNegativeChecks?: boolean;
   callbackOrigin?: string;
 }
 
@@ -48,15 +44,23 @@ export interface OAuthStartInput {
 
 export async function runProtocolConformance(
   serverNameOrId: string,
+  options?: { protocolVersion?: McpProtocolVersion },
 ): Promise<{ success: boolean; result: MCPConformanceResult }> {
+  const versionFields = options?.protocolVersion
+    ? { protocolVersion: options.protocolVersion }
+    : {};
   return runByMode({
     local: () =>
       localPost("/api/mcp/conformance/protocol", {
         serverId: serverNameOrId,
+        ...versionFields,
       }),
     hosted: () => {
       const request = buildServerRequest(serverNameOrId);
-      return webPost("/api/web/conformance/protocol", request);
+      return webPost("/api/web/conformance/protocol", {
+        ...request,
+        ...versionFields,
+      });
     },
   });
 }
@@ -77,21 +81,31 @@ export async function runAppsConformance(
 }
 
 /**
- * Tasks conformance provokes a real task and then polls it, which needs a
- * stable connection for the length of the run — hosted mode reconnects per
- * request, so the suite is local-only.
+ * The runner opens its own ephemeral client for the length of the run, so
+ * this works on both modes. Hosted clamps the task poll window server-side to
+ * fit inside its per-request budget.
  */
 export async function runTasksConformance(
   serverNameOrId: string,
   options?: { toolName?: string; toolArguments?: Record<string, unknown> },
 ): Promise<{ success: boolean; result: MCPTasksConformanceResult }> {
-  ensureLocalMode(
-    "Tasks conformance requires a persistent connection; run it from the local inspector.",
-  );
-  return localPost("/api/mcp/conformance/tasks", {
-    serverId: serverNameOrId,
+  const optionFields = {
     ...(options?.toolName ? { toolName: options.toolName } : {}),
     ...(options?.toolArguments ? { toolArguments: options.toolArguments } : {}),
+  };
+  return runByMode({
+    local: () =>
+      localPost("/api/mcp/conformance/tasks", {
+        serverId: serverNameOrId,
+        ...optionFields,
+      }),
+    hosted: () => {
+      const request = buildServerRequest(serverNameOrId);
+      return webPost("/api/web/conformance/tasks", {
+        ...request,
+        ...optionFields,
+      });
+    },
   });
 }
 
@@ -103,7 +117,6 @@ export async function startOAuthConformance(
       localPost("/api/mcp/conformance/oauth/start", {
         serverId: input.serverNameOrId,
         oauthProfile: input.oauthProfile,
-        runNegativeChecks: input.runNegativeChecks,
         callbackOrigin: input.callbackOrigin,
       }),
     hosted: () => {
@@ -111,7 +124,6 @@ export async function startOAuthConformance(
       return webPost("/api/web/conformance/oauth/start", {
         ...request,
         oauthProfile: input.oauthProfile,
-        runNegativeChecks: input.runNegativeChecks,
         callbackOrigin: input.callbackOrigin,
       });
     },

--- a/mcpjam-inspector/server/routes/mcp/__tests__/conformance.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/conformance.test.ts
@@ -73,6 +73,22 @@ describe("POST /api/mcp/conformance/protocol", () => {
     const body = await res.json();
     expect(body.code).toBe("unsupportedTransport");
   });
+
+  it("rejects an unknown protocolVersion pin", async () => {
+    const manager = createMockManager({
+      getServerConfig: vi
+        .fn()
+        .mockReturnValue({ url: new URL("https://example.test/mcp") }),
+    });
+    const app = createTestApp(manager);
+    const res = await postJson(app, "/api/mcp/conformance/protocol", {
+      serverId: "test-server",
+      protocolVersion: "DRAFT-2027-zzz",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
 });
 
 describe("POST /api/mcp/conformance/apps", () => {

--- a/mcpjam-inspector/server/routes/mcp/conformance.ts
+++ b/mcpjam-inspector/server/routes/mcp/conformance.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import {
+  MCP_PROTOCOL_VERSIONS,
   oauthConformanceProfileSchema,
   type HttpServerConfig,
   type MCPServerConfig,
@@ -68,6 +69,8 @@ function handleUnsupportedTransport(
 
 const protocolSchema = z.object({
   serverId: z.string().min(1),
+  /** Pin the run to one protocol version; absent ⇒ adopt the negotiated one. */
+  protocolVersion: z.enum(MCP_PROTOCOL_VERSIONS).optional(),
 });
 
 conformance.post("/protocol", async (c) => {
@@ -90,9 +93,10 @@ conformance.post("/protocol", async (c) => {
     }
 
     assertHttpSupported("protocol", resolved.config);
-    const { result } = await runProtocolConformance(
-      toHttpResolved(resolved.config as HttpServerConfig),
-    );
+    const { result } = await runProtocolConformance({
+      ...toHttpResolved(resolved.config as HttpServerConfig),
+      protocolVersion: parsed.data.protocolVersion,
+    });
     return c.json({ success: true, result });
   } catch (error) {
     const unsupported = handleUnsupportedTransport(c, error);
@@ -160,7 +164,7 @@ const tasksSchema = z.object({
   /** Tool used to provoke a task; required on the extension wire, where tools
    *  carry no task metadata to pick from. */
   toolName: z.string().min(1).optional(),
-  toolArguments: z.record(z.unknown()).optional(),
+  toolArguments: z.record(z.string(), z.unknown()).optional(),
   pollTimeoutMs: z.number().int().positive().max(120_000).optional(),
 });
 
@@ -212,7 +216,6 @@ conformance.post("/tasks", async (c) => {
 const oauthStartSchema = z.object({
   serverId: z.string().min(1),
   oauthProfile: oauthConformanceProfileSchema.optional(),
-  runNegativeChecks: z.boolean().optional(),
   callbackOrigin: z.string().optional(),
 });
 
@@ -230,8 +233,7 @@ conformance.post("/oauth/start", async (c) => {
       );
     }
 
-    const { serverId, oauthProfile, runNegativeChecks, callbackOrigin } =
-      parsed.data;
+    const { serverId, oauthProfile, callbackOrigin } = parsed.data;
     const resolved = resolveServerConfig(c.mcpClientManager, serverId);
     if ("error" in resolved) {
       return c.json({ success: false, ...resolved }, 400);
@@ -257,7 +259,6 @@ conformance.post("/oauth/start", async (c) => {
       defaultCustomHeaders: http.customHeaders,
       redirectUrl: `${callbackOrigin.replace(/\/$/, "")}/oauth/callback/debug`,
       oauthProfile,
-      runNegativeChecks,
     });
     return c.json(result);
   } catch (error) {

--- a/mcpjam-inspector/server/routes/shared/conformance.ts
+++ b/mcpjam-inspector/server/routes/shared/conformance.ts
@@ -22,6 +22,7 @@ import {
   type MCPConformanceConfig,
   type MCPConformanceResult,
   type MCPServerConfig,
+  type McpProtocolVersion,
   type MCPTasksConformanceConfig,
   type MCPTasksConformanceResult,
   type OAuthConformanceConfig,
@@ -66,6 +67,8 @@ export interface ResolvedHttpConfig {
   serverUrl: string;
   accessToken?: string;
   customHeaders?: Record<string, string>;
+  /** Pin the run to one protocol version; absent ⇒ adopt the negotiated one. */
+  protocolVersion?: McpProtocolVersion;
 }
 
 export class UnsupportedTransportError extends Error {
@@ -90,6 +93,7 @@ export async function runProtocolConformance(
     serverUrl: input.serverUrl,
     accessToken: input.accessToken,
     customHeaders: input.customHeaders,
+    protocolVersion: input.protocolVersion,
   };
   const test = new MCPConformanceTest(config);
   const result = await test.run();
@@ -126,7 +130,6 @@ export interface StartOAuthConformanceInput {
   /** Public callback URL that the authorization server will redirect to. */
   redirectUrl: string;
   oauthProfile?: OAuthConformanceProfile;
-  runNegativeChecks?: boolean;
   /** How long to wait for the runner to produce an auth URL before assuming it
    * completed without needing user auth. Defaults to 3s. */
   authorizationUrlGraceMs?: number;
@@ -167,7 +170,11 @@ export async function startOAuthConformance(
     scopes: input.oauthProfile?.scopes,
     customHeaders,
     redirectUrl: input.redirectUrl,
-    oauthConformanceChecks: input.runNegativeChecks ?? false,
+    // The negative checks (invalid client, mismatched redirect, invalid token,
+    // http:// DCR redirect) are part of the OAuth suite, not an opt-in extra:
+    // verifying the server *rejects* bad input is half of OAuth conformance.
+    // The runner only reaches them once the happy path passes end to end.
+    oauthConformanceChecks: true,
   };
 
   const test = new OAuthConformanceTest(oauthConfig, {

--- a/mcpjam-inspector/server/routes/web/__tests__/conformance-tasks.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/conformance-tasks.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The hosted tasks route has to answer inside the hosted call budget. Capping
+ * only the poll window is not enough — connect, `tools/list` and the provoking
+ * `tools/call` each carry their own timeout — so the route also pins a
+ * per-call ceiling and races the whole run against a wall-clock deadline.
+ */
+
+const runTasksConformanceMock = vi.hoisted(() => vi.fn());
+const authorizeServerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../auth.js", async () => {
+  const { z } = await import("zod");
+  return {
+    handleRoute: async (c: any, handler: () => Promise<any>) => {
+      try {
+        return c.json(await handler(), 200);
+      } catch (error: any) {
+        return c.json(
+          { code: error?.code ?? "INTERNAL_ERROR", message: error?.message },
+          error?.status ?? 500,
+        );
+      }
+    },
+    projectServerSchema: z.object({}).passthrough(),
+    authorizeServer: authorizeServerMock,
+    toHttpConfig: (_auth: unknown, timeoutMs: number) => ({
+      url: "https://example.test/mcp",
+      requestInit: { headers: {} },
+      timeout: timeoutMs,
+    }),
+  };
+});
+
+// Path is relative to this test file: the route imports `../shared/conformance`
+// from routes/web, which is routes/shared/conformance from routes/web/__tests__.
+vi.mock("../../shared/conformance", () => ({
+  runTasksConformance: runTasksConformanceMock,
+  runAppsConformance: vi.fn(),
+  runProtocolConformance: vi.fn(),
+  startOAuthConformance: vi.fn(),
+  completeOAuthConformance: vi.fn(),
+  submitOAuthConformanceCode: vi.fn(),
+  UnsupportedTransportError: class extends Error {},
+  OAuthConformanceSessionNotFoundError: class extends Error {},
+  OAuthConformanceSessionFailedError: class extends Error {},
+}));
+
+const post = async (body: Record<string, unknown>) => {
+  const { default: conformanceWeb } = await import("../conformance.js");
+  return conformanceWeb.request("/tasks", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer test-token",
+    },
+    body: JSON.stringify(body),
+  });
+};
+
+describe("POST /api/web/conformance/tasks — hosted budget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authorizeServerMock.mockResolvedValue({
+      serverConfig: { url: "https://example.test/mcp" },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clamps the poll window and pins a per-call timeout under the budget", async () => {
+    runTasksConformanceMock.mockResolvedValue({
+      result: { outcome: "passed", checks: [] },
+    });
+
+    const res = await post({
+      projectId: "p1",
+      serverId: "s1",
+      pollTimeoutMs: 120_000,
+    });
+
+    expect(res.status).toBe(200);
+    const config = runTasksConformanceMock.mock.calls[0][0];
+    // Caller asked for two minutes; the hosted cap wins.
+    expect(config.pollTimeoutMs).toBe(20_000);
+    // And each MCP leg is bounded well below WEB_CALL_TIMEOUT_MS (30s), so
+    // three slow legs cannot compose past the request budget.
+    expect(config.timeout).toBe(10_000);
+  });
+
+  it("answers 504 when the whole run outlives the request budget", async () => {
+    vi.useFakeTimers();
+    // A run that never settles: only the route-level deadline can end it.
+    runTasksConformanceMock.mockReturnValue(new Promise(() => {}));
+
+    const pending = post({ projectId: "p1", serverId: "s1" });
+    await vi.advanceTimersByTimeAsync(30_000);
+    const res = await pending;
+
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as { code: string; message: string };
+    expect(body.code).toBe("TIMEOUT");
+    expect(body.message).toMatch(/hosted request budget/);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/conformance.ts
+++ b/mcpjam-inspector/server/routes/web/conformance.ts
@@ -122,6 +122,33 @@ async function resolveHostedServerConfig(
   return httpConfig as MCPServerConfig;
 }
 
+/**
+ * Bound a whole conformance run by wall-clock, not just its individual legs.
+ * Losing the race rejects with a 504 so the route always answers inside the
+ * hosted budget; the run itself keeps unwinding in the background (its legs
+ * are individually timed out) and closes its own client.
+ */
+async function withHostedDeadline<T>(
+  run: Promise<T>,
+  deadlineMs: number,
+  message: string
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new WebRouteError(504, ErrorCode.TIMEOUT, message)),
+      deadlineMs
+    );
+  });
+  // Never leave the losing run as an unhandled rejection.
+  run.catch(() => {});
+  try {
+    return await Promise.race([run, deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 function toWebError(error: unknown): WebRouteError {
   if (error instanceof WebRouteError) return error;
   if (error instanceof UnsupportedTransportError) {
@@ -194,12 +221,29 @@ conformanceWeb.post("/apps", async (c) =>
 /**
  * Tasks conformance provokes a real task and polls it to a terminal status,
  * all inside this single request — the runner opens its own ephemeral client,
- * so it needs no long-lived connection. The poll window does have to fit
- * inside the hosted call budget with room left for connect, listTools, and
- * provoking the task, so it is capped well under `WEB_CALL_TIMEOUT_MS`
- * regardless of what the caller asks for.
+ * so it needs no long-lived connection.
+ *
+ * Fitting that into the hosted budget takes three bounds, not one. Capping the
+ * poll window alone leaves connect, `tools/list` and the provoking
+ * `tools/call` free to burn a full `WEB_CALL_TIMEOUT_MS` *each* before polling
+ * even starts, so the request could run for minutes:
+ *
+ * - `HOSTED_TASKS_CALL_TIMEOUT_MS` bounds each individual MCP leg, replacing
+ *   the route-wide `WEB_CALL_TIMEOUT_MS` this run's config would otherwise
+ *   carry.
+ * - `HOSTED_TASKS_POLL_TIMEOUT_MS` bounds the poll window regardless of what
+ *   the caller asks for.
+ * - `HOSTED_TASKS_DEADLINE_MS` bounds the *whole* run, so however the legs
+ *   compose, the route answers with a 504 instead of hanging past the budget.
+ *   The abandoned run still unwinds on its own — every leg inside it is
+ *   bounded by the per-call timeout — so its ephemeral client is closed by
+ *   `withEphemeralClient`'s own teardown shortly after.
  */
 const HOSTED_TASKS_POLL_TIMEOUT_MS = 20_000;
+/** Per-MCP-call ceiling inside a hosted tasks run (connect, list, call). */
+const HOSTED_TASKS_CALL_TIMEOUT_MS = 10_000;
+/** Wall-clock ceiling for the whole run, held just under the call budget. */
+const HOSTED_TASKS_DEADLINE_MS = WEB_CALL_TIMEOUT_MS - 2_000;
 
 const tasksSchema = z
   .object({
@@ -219,17 +263,22 @@ conformanceWeb.post("/tasks", async (c) =>
     const parsed = parseWithSchema(tasksSchema, body);
 
     try {
-      const { result } = await runTasksConformance({
-        ...config,
-        ...(parsed.toolName ? { toolName: parsed.toolName } : {}),
-        ...(parsed.toolArguments
-          ? { toolArguments: parsed.toolArguments }
-          : {}),
-        pollTimeoutMs: Math.min(
-          parsed.pollTimeoutMs ?? HOSTED_TASKS_POLL_TIMEOUT_MS,
-          HOSTED_TASKS_POLL_TIMEOUT_MS
-        ),
-      });
+      const result = await withHostedDeadline(
+        runTasksConformance({
+          ...config,
+          timeout: HOSTED_TASKS_CALL_TIMEOUT_MS,
+          ...(parsed.toolName ? { toolName: parsed.toolName } : {}),
+          ...(parsed.toolArguments
+            ? { toolArguments: parsed.toolArguments }
+            : {}),
+          pollTimeoutMs: Math.min(
+            parsed.pollTimeoutMs ?? HOSTED_TASKS_POLL_TIMEOUT_MS,
+            HOSTED_TASKS_POLL_TIMEOUT_MS
+          ),
+        }),
+        HOSTED_TASKS_DEADLINE_MS,
+        `Tasks conformance exceeded the hosted request budget (${HOSTED_TASKS_DEADLINE_MS}ms); run it from the local inspector for a longer poll window`
+      ).then((r) => r.result);
       return { success: true, result };
     } catch (error) {
       throw toWebError(error);

--- a/mcpjam-inspector/server/routes/web/conformance.ts
+++ b/mcpjam-inspector/server/routes/web/conformance.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import {
+  MCP_PROTOCOL_VERSIONS,
   oauthConformanceProfileSchema,
-  type MCPAppsConformanceConfig,
+  type MCPServerConfig,
 } from "@mcpjam/sdk";
 import {
   handleRoute,
@@ -22,6 +23,7 @@ import {
   completeOAuthConformance,
   runAppsConformance,
   runProtocolConformance,
+  runTasksConformance,
   startOAuthConformance,
   submitOAuthConformanceCode,
 } from "../shared/conformance";
@@ -89,12 +91,12 @@ async function resolveHostedHttpConfig(
   };
 }
 
-/** Resolve any-transport server config for Apps conformance on hosted. */
+/** Resolve any-transport server config for Apps/Tasks conformance on hosted. */
 async function resolveHostedServerConfig(
   c: any,
   bearerToken: string,
   body: Record<string, unknown>
-): Promise<MCPAppsConformanceConfig> {
+): Promise<MCPServerConfig> {
   const wsBody = parseWithSchema(projectServerSchema, body);
   const auth = await authorizeServer(
     c,
@@ -117,7 +119,7 @@ async function resolveHostedServerConfig(
     wsBody.clientCapabilities as Record<string, unknown> | undefined
   );
 
-  return httpConfig as MCPAppsConformanceConfig;
+  return httpConfig as MCPServerConfig;
 }
 
 function toWebError(error: unknown): WebRouteError {
@@ -144,14 +146,25 @@ function toWebError(error: unknown): WebRouteError {
 
 // ── POST /protocol ──────────────────────────────────────────────────────
 
+const protocolSchema = z
+  .object({
+    /** Pin the run to one protocol version; absent ⇒ adopt the negotiated one. */
+    protocolVersion: z.enum(MCP_PROTOCOL_VERSIONS).optional(),
+  })
+  .passthrough(); // project/guest fields pass through to resolveHostedHttpConfig
+
 conformanceWeb.post("/protocol", async (c) =>
   handleRoute(c, async () => {
     const bearerToken = assertBearerToken(c);
     const body = await readJsonBody<Record<string, unknown>>(c);
     const resolved = await resolveHostedHttpConfig(c, bearerToken, body);
+    const parsed = parseWithSchema(protocolSchema, body);
 
     try {
-      const { result } = await runProtocolConformance(resolved);
+      const { result } = await runProtocolConformance({
+        ...resolved,
+        protocolVersion: parsed.protocolVersion,
+      });
       return { success: true, result };
     } catch (error) {
       throw toWebError(error);
@@ -176,12 +189,59 @@ conformanceWeb.post("/apps", async (c) =>
   })
 );
 
+// ── POST /tasks ─────────────────────────────────────────────────────────
+
+/**
+ * Tasks conformance provokes a real task and polls it to a terminal status,
+ * all inside this single request — the runner opens its own ephemeral client,
+ * so it needs no long-lived connection. The poll window does have to fit
+ * inside the hosted call budget with room left for connect, listTools, and
+ * provoking the task, so it is capped well under `WEB_CALL_TIMEOUT_MS`
+ * regardless of what the caller asks for.
+ */
+const HOSTED_TASKS_POLL_TIMEOUT_MS = 20_000;
+
+const tasksSchema = z
+  .object({
+    /** Tool used to provoke a task; required on the extension wire, where
+     *  tools carry no task metadata to pick from. */
+    toolName: z.string().min(1).optional(),
+    toolArguments: z.record(z.string(), z.unknown()).optional(),
+    pollTimeoutMs: z.number().int().positive().max(120_000).optional(),
+  })
+  .passthrough(); // project/guest fields pass through to resolveHostedServerConfig
+
+conformanceWeb.post("/tasks", async (c) =>
+  handleRoute(c, async () => {
+    const bearerToken = assertBearerToken(c);
+    const body = await readJsonBody<Record<string, unknown>>(c);
+    const config = await resolveHostedServerConfig(c, bearerToken, body);
+    const parsed = parseWithSchema(tasksSchema, body);
+
+    try {
+      const { result } = await runTasksConformance({
+        ...config,
+        ...(parsed.toolName ? { toolName: parsed.toolName } : {}),
+        ...(parsed.toolArguments
+          ? { toolArguments: parsed.toolArguments }
+          : {}),
+        pollTimeoutMs: Math.min(
+          parsed.pollTimeoutMs ?? HOSTED_TASKS_POLL_TIMEOUT_MS,
+          HOSTED_TASKS_POLL_TIMEOUT_MS
+        ),
+      });
+      return { success: true, result };
+    } catch (error) {
+      throw toWebError(error);
+    }
+  })
+);
+
 // ── POST /oauth/start ───────────────────────────────────────────────────
 
 const oauthStartSchema = z
   .object({
     oauthProfile: oauthConformanceProfileSchema.optional(),
-    runNegativeChecks: z.boolean().optional(),
     callbackOrigin: z.string().optional(),
   })
   .passthrough(); // project/guest fields pass through to resolveHostedHttpConfig
@@ -210,7 +270,6 @@ conformanceWeb.post("/oauth/start", async (c) =>
           ""
         )}/oauth/callback/debug`,
         oauthProfile: parsed.oauthProfile,
-        runNegativeChecks: parsed.runNegativeChecks,
       });
     } catch (error) {
       throw toWebError(error);

--- a/sdk/src/apps-conformance/runner.ts
+++ b/sdk/src/apps-conformance/runner.ts
@@ -19,7 +19,9 @@ import {
 } from "./types.js";
 import { normalizeMCPAppsConformanceConfig } from "./validation.js";
 
-const APPS_CHECK_METADATA: Record<
+// Exported so `tests/conformance-catalog.test.ts` can assert the browser-safe
+// catalog still matches these canonical strings.
+export const APPS_CHECK_METADATA: Record<
   MCPAppsCheckId,
   Pick<MCPAppsCheckResult, "id" | "category" | "title" | "description">
 > = {

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -342,6 +342,37 @@ export type {
   ConformanceSupport,
 } from "./mcp-conformance/transport-support.js";
 
+// Static check inventories. Every one of these modules reaches its non-leaf
+// dependencies through `import type` only, so the runtime value exports here
+// carry no Node-only code into the browser bundle. UIs use them to show what
+// a suite WILL run before it has run — `CHECK_ERAS` + `PROTOCOL_VERSION_ERAS`
+// narrow the protocol list to the era a pinned version actually exercises.
+export {
+  CHECK_ERAS,
+  MCP_CHECK_CATEGORIES,
+  MCP_CHECK_IDS,
+  PROTOCOL_VERSION_ERAS,
+} from "./mcp-conformance/types.js";
+export type {
+  MCPCheckEra,
+  MCPCheckId,
+} from "./mcp-conformance/types.js";
+export { MCP_APPS_CHECK_IDS } from "./apps-conformance/types.js";
+export type { MCPAppsCheckId } from "./apps-conformance/types.js";
+export { MCP_TASKS_CHECK_IDS } from "./tasks-conformance/types.js";
+export type { MCPTasksCheckId } from "./tasks-conformance/types.js";
+export { CONFORMANCE_CHECK_METADATA } from "./oauth-conformance/types.js";
+export type { OAuthConformanceCheckId } from "./oauth-conformance/types.js";
+
+// Each check's title and one-line description, kept byte-identical to the
+// strings on the check implementations by `tests/conformance-catalog.test.ts`.
+export {
+  APPS_CHECK_CATALOG,
+  PROTOCOL_CHECK_CATALOG,
+  TASKS_CHECK_CATALOG,
+} from "./conformance-catalog.js";
+export type { ConformanceCheckInfo } from "./conformance-catalog.js";
+
 // Host-side sandbox policy resolver (SEP-1865 + ChatGPT Apps). Pure
 // resolver — DOM-free, React-free, Convex-free. Browser-safe by
 // construction. Re-exported here so client renderers can import it

--- a/sdk/src/conformance-catalog.ts
+++ b/sdk/src/conformance-catalog.ts
@@ -1,0 +1,261 @@
+/**
+ * Static, browser-safe catalog of every conformance check's title and
+ * one-line description.
+ *
+ * WHY THIS EXISTS SEPARATELY: the canonical title/description strings live
+ * next to the check implementations (`CORE_CHECKS`, `MODERN_CHECK_METADATA`,
+ * the apps/tasks runner metadata, …), and those modules pull the whole
+ * runner graph — raw HTTP probes, the MCP client, Node-only transitive deps.
+ * A UI that wants to show what a suite WILL run, before it has run, cannot
+ * import them. This module carries the same strings with no runtime
+ * dependencies at all, so it is safe from the browser entry.
+ *
+ * DRIFT IS NOT ALLOWED TO PASS SILENTLY: every entry here is asserted equal
+ * to its canonical source in `__tests__/conformance-catalog.test.ts`. Editing
+ * a check's title or description without updating this file fails that test,
+ * and vice versa. Adding a check fails typecheck here, because each record is
+ * exhaustive over its suite's id union.
+ */
+
+import type { MCPCheckId } from "./mcp-conformance/types.js";
+import type { MCPAppsCheckId } from "./apps-conformance/types.js";
+import type { MCPTasksCheckId } from "./tasks-conformance/types.js";
+
+export interface ConformanceCheckInfo {
+  title: string;
+  description: string;
+}
+
+/** Protocol suite. Keys follow `MCP_CHECK_IDS` order. */
+export const PROTOCOL_CHECK_CATALOG = {
+  "server-initialize": {
+    title: "Server Initialize",
+    description: "Server responds to initialize and reports capabilities.",
+  },
+  ping: {
+    title: "Ping",
+    description: "Server responds to ping requests.",
+  },
+  "logging-set-level": {
+    title: "Logging Set Level",
+    description: "Server accepts logging/setLevel requests.",
+  },
+  "completion-complete": {
+    title: "Completion Complete",
+    description: "Server responds to completion/complete requests.",
+  },
+  "capabilities-consistent": {
+    title: "Capabilities Consistent",
+    description:
+      "Advertised server capabilities match the features actually exposed.",
+  },
+  "tools-list": {
+    title: "Tools List",
+    description: "Server lists tools with name, description, and input schema.",
+  },
+  "tools-input-schemas-valid": {
+    title: "Tool Input Schemas Valid",
+    description:
+      'Every tool\'s inputSchema has type "object" and valid properties/required fields.',
+  },
+  "tools-x-mcp-header-declarations-valid": {
+    title: "x-mcp-header Declarations Valid",
+    description:
+      "Every published tool's SEP-2243 x-mcp-header declarations satisfy the spec's constraints: statically reachable through a chain of `properties`, an RFC 9110 token name, a primitive type, and case-insensitively unique.",
+  },
+  "prompts-list": {
+    title: "Prompts List",
+    description: "Server lists prompts with name and description.",
+  },
+  "resources-list": {
+    title: "Resources List",
+    description: "Server lists resources with uri and name.",
+  },
+  "protocol-invalid-method-error": {
+    title: "Invalid Method Error",
+    description:
+      "Server returns a valid JSON-RPC error for an unrecognized method name.",
+  },
+  "localhost-host-rebinding-rejected": {
+    title: "Reject Evil Host Header",
+    description:
+      "Local servers reject initialize requests with a non-localhost Host/Origin header.",
+  },
+  "localhost-host-valid-accepted": {
+    title: "Accept Valid Local Host Header",
+    description:
+      "Local servers accept initialize requests with a valid localhost Host/Origin header.",
+  },
+  "server-sse-polling-session": {
+    title: "SSE Polling Session",
+    description: "Server provides a streamable HTTP session id.",
+  },
+  "server-accepts-multiple-post-streams": {
+    title: "Multiple POST Streams",
+    description: "The server accepts multiple concurrent POST requests.",
+  },
+  "server-sse-streams-functional": {
+    title: "Functional SSE Streams",
+    description: "Concurrent SSE streams remain readable.",
+  },
+  "modern-client-handshake": {
+    title: "Modern Client Handshake",
+    description:
+      "The official client negotiates the modern revision and receives the server identity and capabilities.",
+  },
+  "modern-server-discover": {
+    title: "Modern Server Discovery",
+    description:
+      "server/discover returns the supported protocol versions, capabilities, and server identity.",
+  },
+  "modern-result-type-present": {
+    title: "Modern Result Type",
+    description: "Every modern result carries the wire member resultType.",
+  },
+  "modern-cacheable-result-hints": {
+    title: "Cacheable Result Hints",
+    description: "Cacheable modern results carry ttlMs and cacheScope.",
+  },
+  "modern-protocol-version-header-mismatch": {
+    title: "Protocol Version Header Mismatch",
+    description:
+      "A MCP-Protocol-Version header disagreeing with the request envelope is rejected with HTTP 400 and JSON-RPC -32020.",
+  },
+  "modern-method-header-mismatch": {
+    title: "Mcp-Method Header Mismatch",
+    description:
+      "An Mcp-Method header disagreeing with the body method is rejected with HTTP 400 and JSON-RPC -32020.",
+  },
+  "modern-name-header-mismatch": {
+    title: "Mcp-Name Header Mismatch",
+    description:
+      "An Mcp-Name header disagreeing with the body target is rejected with HTTP 400 and JSON-RPC -32020.",
+  },
+  "modern-unsupported-version-error": {
+    title: "Unsupported Envelope Version",
+    description:
+      "An unsupported envelope protocol version is rejected with JSON-RPC -32022 naming the supported versions.",
+  },
+  "modern-undeclared-capability-error": {
+    title: "Undeclared Client Capability",
+    description:
+      "A server that needs an undeclared client capability for input_required answers JSON-RPC -32021.",
+  },
+  "modern-no-session-id": {
+    title: "No Session Id Minted",
+    description: "A modern server never mints an Mcp-Session-Id.",
+  },
+  "modern-removed-methods-not-found": {
+    title: "Removed Methods Rejected",
+    description:
+      "Methods removed by the 2026 revision answer JSON-RPC -32601 with HTTP 404.",
+  },
+  "modern-resource-not-found-invalid-params": {
+    title: "Resource Not Found",
+    description:
+      "Reading an unknown resource answers in-band JSON-RPC -32602 on HTTP 200.",
+  },
+  "modern-logs-require-log-level": {
+    title: "Logs Require A Log Level",
+    description:
+      "No log notifications are emitted for a request that carried no modern log level.",
+  },
+  "modern-subscription-ack-precedes-notifications": {
+    title: "Subscription Acknowledgement Ordering",
+    description:
+      "A subscriptions/listen stream acknowledges before it emits any notification.",
+  },
+  "modern-subscription-filter-and-tagging": {
+    title: "Subscription Filtering And Tagging",
+    description:
+      "A subscription emits only the requested notification types and tags every message with the subscription id.",
+  },
+  "modern-subscription-graceful-close": {
+    title: "Subscription Graceful Close",
+    description:
+      "Closing a subscription gracefully returns the subscriptions/listen completion result.",
+  },
+} as const satisfies Record<MCPCheckId, ConformanceCheckInfo>;
+
+/** MCP Apps suite. Keys follow `MCP_APPS_CHECK_IDS` order. */
+export const APPS_CHECK_CATALOG = {
+  "ui-tools-present": {
+    title: "UI Tools Present",
+    description:
+      "At least one tool advertises MCP Apps UI metadata through _meta.ui.resourceUri or the deprecated ui/resourceUri field.",
+  },
+  "ui-tool-metadata-valid": {
+    title: "UI Tool Metadata Valid",
+    description:
+      "Tools with UI metadata use a ui:// resource URI and valid visibility values.",
+  },
+  "ui-tool-input-schema-valid": {
+    title: "UI Tool Input Schema Valid",
+    description:
+      "UI tools provide a non-null JSON Schema object as their inputSchema.",
+  },
+  "ui-listed-resources-valid": {
+    title: "Listed UI Resources Valid",
+    description:
+      "UI resources returned by resources/list use ui:// URIs and the MCP Apps HTML MIME type.",
+  },
+  "ui-resources-readable": {
+    title: "UI Resources Readable",
+    description:
+      "Every UI resource referenced by a tool or listed by the server can be fetched with resources/read.",
+  },
+  "ui-resource-contents-valid": {
+    title: "UI Resource Contents Valid",
+    description:
+      "UI resource contents use the MCP Apps HTML MIME type and provide exactly one HTML payload via text or blob.",
+  },
+  "ui-resource-meta-valid": {
+    title: "UI Resource Metadata Valid",
+    description:
+      "UI resource metadata uses valid csp, permissions, domain, and prefersBorder shapes.",
+  },
+} as const satisfies Record<MCPAppsCheckId, ConformanceCheckInfo>;
+
+/** Tasks suite. Keys follow `MCP_TASKS_CHECK_IDS` order. */
+export const TASKS_CHECK_CATALOG = {
+  "tasks-wire-resolvable": {
+    title: "Tasks Wire Resolvable",
+    description:
+      "The negotiated protocol version and advertised capabilities resolve to exactly one tasks wire, and the server does not advertise capabilities for the other era.",
+  },
+  "tasks-declaration-hygiene": {
+    title: "Per-Version Declaration Hygiene",
+    description:
+      "Outgoing requests carry `params.task` only on the legacy wire and the tasks extension declaration only on the extension wire; a connection with no tasks wire sends neither.",
+  },
+  "tasks-result-type-discipline": {
+    title: "Result Type Discipline",
+    description:
+      'A task-eligible tools/call returns either a normal tool result or a flat CreateTaskResult with resultType "task" and a server-generated taskId.',
+  },
+  "tasks-undeclared-creation-refused": {
+    title: "Undeclared Task Creation Refused",
+    description:
+      "On the extension wire, a tools/call that did not carry the extension declaration must not come back as a CreateTaskResult: the server either answers normally or rejects with -32003.",
+  },
+  "tasks-undeclared-capability-rejected": {
+    title: "Undeclared Capability Rejected",
+    description:
+      "tasks/get, tasks/update, tasks/cancel and a task-filtered subscriptions/listen sent WITHOUT the extension declaration must each be rejected with -32003 (Missing Required Client Capability).",
+  },
+  "tasks-ttl-shape": {
+    title: "TTL And Poll Interval Shapes",
+    description:
+      "Task TTL and poll interval use the era-native shapes: `ttlMs: number|null` / `pollIntervalMs` on the extension, `ttl` / `pollInterval` on the legacy wire.",
+  },
+  "tasks-inline-result": {
+    title: "Completed Task Carries Its Result",
+    description:
+      "A completed task exposes its result the era-native way: inline on the extension's tasks/get, via tasks/result on the legacy wire.",
+  },
+  "tasks-mcp-name-routing": {
+    title: "Mcp-Name Task Routing",
+    description:
+      "Over HTTP, tasks/get is sent with Mcp-Name set to the task id (captured off the fetch seam) and accepted by the server.",
+  },
+} as const satisfies Record<MCPTasksCheckId, ConformanceCheckInfo>;

--- a/sdk/src/mcp-conformance/checks/protocol.ts
+++ b/sdk/src/mcp-conformance/checks/protocol.ts
@@ -27,7 +27,9 @@ import { hasWireField } from "../raw-capture.js";
 // server pass this check with an unrelated error (e.g. -32602 Invalid params).
 const METHOD_NOT_FOUND = -32601;
 
-const PROTOCOL_CHECK_METADATA = {
+// Exported so `tests/conformance-catalog.test.ts` can assert the browser-safe
+// catalog still matches these canonical strings.
+export const PROTOCOL_CHECK_METADATA = {
   "protocol-invalid-method-error": {
     id: "protocol-invalid-method-error",
     category: "protocol",

--- a/sdk/src/mcp-conformance/checks/security.ts
+++ b/sdk/src/mcp-conformance/checks/security.ts
@@ -25,7 +25,9 @@ type RawHttpResponse = {
   body: unknown;
 };
 
-const SECURITY_CHECK_METADATA = {
+// Exported so `tests/conformance-catalog.test.ts` can assert the browser-safe
+// catalog still matches these canonical strings.
+export const SECURITY_CHECK_METADATA = {
   "localhost-host-rebinding-rejected": {
     id: "localhost-host-rebinding-rejected",
     category: "security",

--- a/sdk/src/mcp-conformance/checks/transport.ts
+++ b/sdk/src/mcp-conformance/checks/transport.ts
@@ -21,7 +21,9 @@ import {
 
 type TransportCheckId = keyof typeof TRANSPORT_CHECK_METADATA;
 
-const TRANSPORT_CHECK_METADATA = {
+// Exported so `tests/conformance-catalog.test.ts` can assert the browser-safe
+// catalog still matches these canonical strings.
+export const TRANSPORT_CHECK_METADATA = {
   "server-sse-polling-session": {
     id: "server-sse-polling-session",
     category: "transport",

--- a/sdk/src/tasks-conformance/runner.ts
+++ b/sdk/src/tasks-conformance/runner.ts
@@ -36,7 +36,9 @@ import {
 } from "./types.js";
 import { normalizeMCPTasksConformanceConfig } from "./validation.js";
 
-const CHECK_METADATA: Record<
+// Exported so `tests/conformance-catalog.test.ts` can assert the browser-safe
+// catalog still matches these canonical strings.
+export const CHECK_METADATA: Record<
   MCPTasksCheckId,
   Pick<MCPTasksCheckResult, "id" | "category" | "title" | "description">
 > = {

--- a/sdk/tests/conformance-catalog.test.ts
+++ b/sdk/tests/conformance-catalog.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  APPS_CHECK_CATALOG,
+  PROTOCOL_CHECK_CATALOG,
+  TASKS_CHECK_CATALOG,
+  type ConformanceCheckInfo,
+} from "../src/conformance-catalog.js";
+import { MCP_CHECK_IDS } from "../src/mcp-conformance/types.js";
+import { MCP_APPS_CHECK_IDS } from "../src/apps-conformance/types.js";
+import { MCP_TASKS_CHECK_IDS } from "../src/tasks-conformance/types.js";
+import { CORE_CHECKS } from "../src/mcp-conformance/checks/core.js";
+import { TOOL_CHECKS } from "../src/mcp-conformance/checks/tools.js";
+import { PROMPT_CHECKS } from "../src/mcp-conformance/checks/prompts.js";
+import { RESOURCE_CHECKS } from "../src/mcp-conformance/checks/resources.js";
+import { MODERN_CHECK_METADATA } from "../src/mcp-conformance/checks/modern.js";
+import { PROTOCOL_CHECK_METADATA } from "../src/mcp-conformance/checks/protocol.js";
+import { SECURITY_CHECK_METADATA } from "../src/mcp-conformance/checks/security.js";
+import { TRANSPORT_CHECK_METADATA } from "../src/mcp-conformance/checks/transport.js";
+import { APPS_CHECK_METADATA } from "../src/apps-conformance/runner.js";
+import { CHECK_METADATA as TASKS_CHECK_METADATA } from "../src/tasks-conformance/runner.js";
+
+/**
+ * `src/conformance-catalog.ts` is a browser-safe copy of strings whose
+ * canonical home is next to each check implementation — the runner modules
+ * are unimportable from a browser bundle, which is the whole reason the copy
+ * exists. These tests are what keeps the copy honest: edit a title or
+ * description on either side without the other and this fails.
+ */
+
+type CanonicalInfo = { title: string; description: string };
+
+/** Every canonical protocol source, flattened to id → {title, description}. */
+function canonicalProtocolInfo(): Record<string, CanonicalInfo> {
+  const flat: Record<string, CanonicalInfo> = {};
+
+  for (const definition of [
+    ...CORE_CHECKS,
+    ...TOOL_CHECKS,
+    ...PROMPT_CHECKS,
+    ...RESOURCE_CHECKS,
+  ]) {
+    flat[definition.id] = {
+      title: definition.title,
+      description: definition.description,
+    };
+  }
+
+  for (const source of [
+    MODERN_CHECK_METADATA,
+    PROTOCOL_CHECK_METADATA,
+    SECURITY_CHECK_METADATA,
+    TRANSPORT_CHECK_METADATA,
+  ]) {
+    for (const entry of Object.values(
+      source as Record<string, CanonicalInfo & { id: string }>,
+    )) {
+      flat[entry.id] = { title: entry.title, description: entry.description };
+    }
+  }
+
+  return flat;
+}
+
+function toInfo(entry: CanonicalInfo): ConformanceCheckInfo {
+  return { title: entry.title, description: entry.description };
+}
+
+describe("conformance catalog", () => {
+  it("covers every protocol check id, and only those", () => {
+    expect(Object.keys(PROTOCOL_CHECK_CATALOG).sort()).toEqual(
+      [...MCP_CHECK_IDS].sort(),
+    );
+  });
+
+  it("covers every apps check id, and only those", () => {
+    expect(Object.keys(APPS_CHECK_CATALOG).sort()).toEqual(
+      [...MCP_APPS_CHECK_IDS].sort(),
+    );
+  });
+
+  it("covers every tasks check id, and only those", () => {
+    expect(Object.keys(TASKS_CHECK_CATALOG).sort()).toEqual(
+      [...MCP_TASKS_CHECK_IDS].sort(),
+    );
+  });
+
+  it("matches the canonical protocol titles and descriptions", () => {
+    const canonical = canonicalProtocolInfo();
+
+    // Non-vacuity: a refactor that stops exporting the canonical sources must
+    // fail loudly here rather than leave an empty comparison passing.
+    expect(Object.keys(canonical).sort()).toEqual([...MCP_CHECK_IDS].sort());
+
+    for (const id of MCP_CHECK_IDS) {
+      expect({ id, ...PROTOCOL_CHECK_CATALOG[id] }).toEqual({
+        id,
+        ...toInfo(canonical[id]!),
+      });
+    }
+  });
+
+  it("matches the canonical apps titles and descriptions", () => {
+    for (const id of MCP_APPS_CHECK_IDS) {
+      expect({ id, ...APPS_CHECK_CATALOG[id] }).toEqual({
+        id,
+        ...toInfo(APPS_CHECK_METADATA[id]),
+      });
+    }
+  });
+
+  it("matches the canonical tasks titles and descriptions", () => {
+    for (const id of MCP_TASKS_CHECK_IDS) {
+      expect({ id, ...TASKS_CHECK_CATALOG[id] }).toEqual({
+        id,
+        ...toInfo(TASKS_CHECK_METADATA[id]),
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Why

The Conformance tab lagged the CLI in three ways, and hid what it was doing in a fourth. All four turned up while comparing the UI against `mcpjam protocol conformance` / `mcpjam oauth conformance`.

## What changed

**1. Protocol version is selectable (parity with `--protocol-version`).**

The CLI has taken `--protocol-version` since it shipped — required for `oauth conformance`, matrix-able via suite configs. The UI had no selector at all, and the routes dropped the pin the SDK already supported: `runProtocolConformance` built its `MCPConformanceConfig` from URL, token and headers only, so every UI run adopted whatever the server negotiated. The OAuth suite separately fell back to a hardcoded `2025-11-25`.

There's now an "Auto (negotiated)" + per-version dropdown that threads through both the local and hosted `/protocol` routes into the SDK, and overrides the OAuth profile's version even when that profile is otherwise empty (previously that case silently took the hardcoded default). Both routes validate with `z.enum(MCP_PROTOCOL_VERSIONS)`, so an unknown pin is rejected before any routing decision. `Auto` preserves today's behavior exactly.

**2. The negative OAuth checks are part of the suite, not a toggle.**

The "Run negative OAuth checks" switch is gone; `oauthConformanceChecks` is always on. Confirming a server *rejects* an invalid client, a mismatched redirect URI, an invalid token, and an `http://` DCR redirect is half of OAuth conformance. Behind a toggle, a section could report a clean pass while nine checks had never run — and they weren't rendered as skipped either, so the omission was invisible. The runner still only reaches them once the happy path passes end to end.

**3. Tasks conformance runs on hosted.**

It was marked *"requires a persistent connection (run it from the local inspector)"*. That reason was false: the runner calls `withEphemeralClient(...)` and opens its own client for the length of the run, exactly like Apps conformance — which has always worked on hosted. The real gap was that `/api/web/conformance/tasks` was never written. Added, reusing the resolver Apps already uses, with the poll window clamped to 20s so it can't outrun the 30s `WEB_CALL_TIMEOUT_MS` budget.

**4. Suites explain themselves before they run.**

Sections are collapsible; until a result replaces it, each lists the checks it will run, with a one-line description on click. The protocol list is filtered to the pinned version's era — a `2025-06-18` pin drops the modern-only checks rather than implying they apply — and on "Auto" everything is listed with era-restricted rows tagged.

That preview needs check metadata in the browser bundle, which the runner modules can't supply. Hence `sdk/src/conformance-catalog.ts`: a dependency-free record of all 47 titles and descriptions, exported from the browser entry.

## On the duplicated strings

The catalog necessarily copies strings whose canonical home is beside each check implementation. `sdk/tests/conformance-catalog.test.ts` asserts it byte-identical to all eight canonical sources (four check-definition arrays, four metadata maps) and exhaustive over the id unions, with a non-vacuity guard so a refactor that stops exporting a source fails loudly rather than comparing nothing. Each record also uses `satisfies Record<Id, …>`, so adding a check breaks typecheck until it's described. Five previously module-private metadata maps are exported solely for that test; no package-level public API changed.

A side effect worth noting: the preview shows the checks' real titles, so a row's title no longer changes when a result replaces it.

## Verification

- Full SDK suite: **3462 passed**, 1 skipped, 189 files
- Inspector conformance tests: **43 passed** across 4 files
- SDK typecheck, client typecheck, and a real `build:client` all clean
- The existing `browser-entry-guard` test — which walks the actual esbuild import graph from `browser.ts` — confirms the new exports pull no Node-only code into the bundle

New coverage: hosted tasks routing (the case that previously threw), an unknown-`protocolVersion` 400, the pin reaching both protocol and OAuth runs, catalog reveal on header click, per-era filtering, click-to-explain, and catalog replacement by real results.

## Not done

The hosted `/tasks` route is verified by typecheck and structural identity to the working Apps route, not against a live deployment — worth a smoke test on preview against a task-capable server, particularly to see whether 20s is enough headroom in practice. That number is reasoned, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches conformance API contracts (removed `runNegativeChecks`, new optional `protocolVersion`) and hosted Tasks timing; OAuth conformance behavior changes for all runs, not only when users opted in before.
> 
> **Overview**
> Brings the **Conformance** tab closer to the CLI: selectable protocol version, always-on OAuth negative checks, **Tasks** on hosted, and collapsible **pre-run check catalogs**.
> 
> The UI adds **Auto (negotiated)** plus per-version pinning; the choice flows through local/hosted protocol routes into the SDK and overrides OAuth’s `protocolVersion` when set. Invalid pins are rejected via `z.enum(MCP_PROTOCOL_VERSIONS)`. The **Run negative OAuth checks** toggle and `runNegativeChecks` API field are removed; `oauthConformanceChecks` is always enabled server-side.
> 
> **Tasks** no longer blocks in hosted mode: `runTasksConformance` uses `POST /api/web/conformance/tasks` with poll clamp (20s), per-MCP-leg timeout (10s), and a ~28s wall-clock deadline that returns **504 TIMEOUT** if exceeded.
> 
> Suites are collapsible and show a clickable preview from `@mcpjam/sdk/browser` catalogs (era-filtered for protocol when pinned). The SDK adds browser-safe `conformance-catalog.ts` with drift tests against canonical check metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e7babb2bdb5ba725dc8d7296e13d441cd7a9a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds protocol version pinning, makes OAuth negative checks always run, enables Tasks conformance on hosted with request-budget safeguards, and adds a pre-run check catalog with in-UI previews. Brings the Conformance tab to parity with the CLI and makes runs predictable and self-explanatory.

- **New Features**
  - Protocol version pin: UI dropdown with Auto + per-version. Pin is validated and passed through local/hosted `/protocol` routes to the SDK and overrides the OAuth profile when present. Unknown pins 400. Auto preserves negotiated behavior.
  - OAuth negative checks are always part of the suite; the toggle is removed. These run after the happy path succeeds.
  - Hosted Tasks: new `POST /api/web/conformance/tasks` reuses the existing resolver. Hosted clamps the poll to 20s, bounds each MCP leg to 10s, and races the whole run against a ~28s deadline that returns 504 TIMEOUT if exceeded. The runner opens its own ephemeral client, so hosted now works like local.
  - Pre-run catalog and previews: each suite lists its checks before a run with one-line descriptions on click. Protocol checks are filtered by the pinned era; on Auto, era-limited rows are tagged. Running suites show progress and stay open (OAuth remains open between callback and result). The browser bundle exposes a dependency-free catalog via `@mcpjam/sdk/browser` (`APPS_CHECK_CATALOG`, `PROTOCOL_CHECK_CATALOG`, `TASKS_CHECK_CATALOG`, plus IDs/eras).
  - Server/UI validations and tests: protocol version is validated via `z.enum(MCP_PROTOCOL_VERSIONS)`; added coverage for hosted tasks routing and time bounds, version pin threading and unknown-pin 400s, and the catalog UI.

- **Migration**
  - If you call these APIs directly:
    - Remove runNegativeChecks from OAuth start requests; negative checks always run.
    - Optional protocol pin: send `protocolVersion` to `/protocol` routes (and OAuth profile) to fix the version (`McpProtocolVersion`).
    - Hosted Tasks is available at `/api/web/conformance/tasks` and may return 504 TIMEOUT for long runs; use the local route for longer poll windows.

<sup>Written for commit 2e7babb2bdb5ba725dc8d7296e13d441cd7a9a08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

