### PR TITLE
Slack public install: multi-workspace OAuth, per-user identity, durable idempotency

### DIFF
--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -16,6 +16,7 @@ import appsRoutes from "./routes/apps/index.js";
 import webRoutes from "./routes/web/index.js";
 import v1Routes from "./routes/v1/index.js";
 import cliAuthRoutes from "./routes/cli-auth/index.js";
+import slackLinkRoutes from "./routes/slack-link/index.js";
 import relayRoutes, { relayBodyLimit } from "./routes/relay.js";
 import { registerXaaClientMetadataRoute } from "./routes/xaa-client-metadata.js";
 import { registerXaaConfidentialCimdRoute } from "./routes/xaa-confidential-cimd.js";
@@ -321,6 +322,13 @@ export async function createHonoApp() {
   // set. Mirror of the mount in server/index.ts — both production entries
   // must wire this up.
   app.route("/api/cli/auth", cliAuthRoutes);
+
+  // Slack account-link bridge. Public front-channel like the CLI bridge (no
+  // session auth — the user is not signed in yet; that is what the flow
+  // establishes), and 501 unless the Slack/WorkOS client credentials and
+  // SLACK_LINK_STATE_SECRET are configured. Mirror of the mount in
+  // server/index.ts — both production entries must wire this up.
+  app.route("/api/slack/link", slackLinkRoutes);
 
   // Same-origin PostHog reverse proxy (ad-blocker resilience). Deliberately
   // OUTSIDE /api so it bypasses session auth (analytics flows before any

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -127,6 +127,7 @@ import {
 } from "./middleware/hosted-partition";
 import webRoutes from "./routes/web/index";
 import v1Routes from "./routes/v1/index";
+import slackLinkRoutes from "./routes/slack-link/index";
 import cliAuthRoutes from "./routes/cli-auth/index";
 import relayRoutes, { relayBodyLimit } from "./routes/relay";
 import { registerXaaClientMetadataRoute } from "./routes/xaa-client-metadata";
@@ -449,6 +450,8 @@ app.use(
   })
 );
 app.route("/api/v1", v1Routes);
+// Slack account-link bridge (mirror of the mount in server/app.ts).
+app.route("/api/slack/link", slackLinkRoutes);
 
 if (!HOSTED_MODE || process.env.NODE_ENV === "development") {
   app.route("/user_management", workosAuthkitRoutes);

--- a/mcpjam-inspector/server/middleware/__tests__/slack-service-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/slack-service-auth.test.ts
@@ -1,0 +1,205 @@
+import { createHash } from "node:crypto";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { bearerAuthMiddleware } from "../bearer-auth.js";
+import { resetSlackRateLimitForTests } from "../slack-service-auth.js";
+
+const TOKEN = "slk_test_token_value_0123456789abcdef";
+const TOKEN_HASH = createHash("sha256").update(TOKEN).digest("hex");
+
+const resolveSlackActingUser = vi.hoisted(() => vi.fn());
+vi.mock("../../services/slack-backend.js", () => ({
+  resolveSlackActingUser,
+  SlackBackendUnavailable: class SlackBackendUnavailable extends Error {},
+}));
+
+function buildApp() {
+  const app = new Hono();
+  app.use("*", bearerAuthMiddleware);
+  app.all("*", (c) =>
+    c.json({
+      ok: true,
+      authMethod: c.get("authMethod"),
+      workosUserId: c.get("workosUserId"),
+      organizationId: c.get("mcpjamOrganizationId"),
+    })
+  );
+  return app;
+}
+
+function request(path: string, headers: Record<string, string> = {}) {
+  return new Request(`http://localhost${path}`, {
+    headers: {
+      authorization: `Bearer ${TOKEN}`,
+      "x-mcpjam-slack-team-id": "T1",
+      "x-mcpjam-slack-user-id": "U1",
+      ...headers,
+    },
+  });
+}
+
+const LINK = {
+  userId: "user_1",
+  workosUserId: "workos|alice",
+  organizationId: "org_1",
+  defaultProjectId: null,
+};
+
+describe("slk_ service auth", () => {
+  beforeEach(() => {
+    resetSlackRateLimitForTests();
+    resolveSlackActingUser.mockReset();
+    resolveSlackActingUser.mockResolvedValue(LINK);
+    process.env.MCPJAM_SLACK_SERVICE_TOKEN_HASH = TOKEN_HASH;
+  });
+
+  afterEach(() => {
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN_HASH;
+  });
+
+  it("authorizes an allowlisted path as the LINKED user, not the bot", async () => {
+    // The token names the bot; the identity must come from the account link.
+    const response = await buildApp().request(
+      request("/api/v1/projects/p1/agent")
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      authMethod: "slack_service",
+      workosUserId: "workos|alice",
+      organizationId: "org_1",
+    });
+  });
+
+  it("allows eval-run create, read, and the project list", async () => {
+    for (const path of [
+      "/api/v1/projects/p1/eval-runs",
+      "/api/v1/projects/p1/eval-runs/run_1",
+      "/api/v1/projects",
+    ]) {
+      const response = await buildApp().request(request(path));
+      expect(response.status, path).toBe(200);
+    }
+  });
+
+  it("REFUSES every non-allowlisted path, including the whole web surface", async () => {
+    // This middleware is mounted on ~25 `/api/web/*` groups too, so a
+    // default-allow posture would hand the bot's credential the entire app.
+    for (const path of [
+      "/api/web/chatboxes",
+      "/api/web/api-keys",
+      "/api/v1/projects/p1/servers",
+      "/api/v1/projects/p1/eval-suites",
+      "/api/v1/projects/p1/agent/extra",
+    ]) {
+      const response = await buildApp().request(request(path));
+      expect(response.status, path).toBe(401);
+    }
+  });
+
+  it("does not even ask the backend for a non-allowlisted path", async () => {
+    // Cheap, and it keeps a refused path indistinguishable from an invalid
+    // token by latency.
+    await buildApp().request(request("/api/web/chatboxes"));
+    expect(resolveSlackActingUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token whose hash does not match", async () => {
+    process.env.MCPJAM_SLACK_SERVICE_TOKEN_HASH = createHash("sha256")
+      .update("slk_some_other_token")
+      .digest("hex");
+    const response = await buildApp().request(
+      request("/api/v1/projects/p1/agent")
+    );
+    expect(response.status).toBe(401);
+    expect(resolveSlackActingUser).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when no token hash is configured", async () => {
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN_HASH;
+    const response = await buildApp().request(
+      request("/api/v1/projects/p1/agent")
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("requires BOTH Slack identity headers", async () => {
+    // The token names the bot and never a user; defaulting to any user is
+    // unthinkable, so an absent header is a hard 401.
+    const app = buildApp();
+    const noUser = await app.request(
+      new Request("http://localhost/api/v1/projects/p1/agent", {
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "x-mcpjam-slack-team-id": "T1",
+        },
+      })
+    );
+    expect(noUser.status).toBe(401);
+
+    const noTeam = await app.request(
+      new Request("http://localhost/api/v1/projects/p1/agent", {
+        headers: {
+          authorization: `Bearer ${TOKEN}`,
+          "x-mcpjam-slack-user-id": "U1",
+        },
+      })
+    );
+    expect(noTeam.status).toBe(401);
+  });
+
+  it("answers 401 with link-your-account semantics for an unlinked user", async () => {
+    resolveSlackActingUser.mockResolvedValue(null);
+    const response = await buildApp().request(
+      request("/api/v1/projects/p1/agent")
+    );
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({
+      details: { reason: "SLACK_ACCOUNT_NOT_LINKED" },
+    });
+  });
+
+  it("answers 503 — NOT 401 — when the backend is unreachable", async () => {
+    // A 401 here would tell a LINKED user to reconnect their account. They
+    // would follow the instruction, re-link, and still fail.
+    resolveSlackActingUser.mockRejectedValue(new Error("backend down"));
+    const response = await buildApp().request(
+      request("/api/v1/projects/p1/agent")
+    );
+    expect(response.status).toBe(503);
+    const body = (await response.json()) as { message?: string };
+    expect(body.message).not.toMatch(/not linked/i);
+  });
+
+  it("rate-limits per LINK, not per token", async () => {
+    // The token is shared by every user of the bot, so a token-keyed bucket
+    // would let one chatty workspace throttle everybody.
+    const app = buildApp();
+    let limited = 0;
+    for (let index = 0; index < 15; index += 1) {
+      const response = await app.request(request("/api/v1/projects/p1/agent"));
+      if (response.status === 429) limited += 1;
+    }
+    expect(limited).toBeGreaterThan(0);
+
+    // A different Slack user has their own bucket and is unaffected.
+    const other = await app.request(
+      request("/api/v1/projects/p1/agent", {
+        "x-mcpjam-slack-user-id": "U_OTHER",
+      })
+    );
+    expect(other.status).toBe(200);
+  });
+
+  it("never falls through to the WorkOS-key or JWT branches", async () => {
+    // `startsWith("sk_")` does not match `slk_`, but the branch order is
+    // explicit so a prefix change cannot route a Slack token into the path
+    // that mints delegated tokens.
+    resolveSlackActingUser.mockResolvedValue(null);
+    const response = await buildApp().request(
+      request("/api/v1/projects/p1/agent")
+    );
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { details?: { reason?: string } };
+    expect(body.details?.reason).toBe("SLACK_ACCOUNT_NOT_LINKED");
+  });
+});

--- a/mcpjam-inspector/server/middleware/bearer-auth.ts
+++ b/mcpjam-inspector/server/middleware/bearer-auth.ts
@@ -5,20 +5,29 @@ import { getWorkOSClient } from "../services/workos-client.js";
 import { resolveUserByExternalId } from "../services/identity.js";
 import { lookupWorkosKeyBinding } from "../services/workos-key-bindings.js";
 import { getRequestLocal, setRequestLocal } from "./request-local.js";
+import {
+  handleSlackServiceAuth,
+  isSlackServiceToken,
+} from "./slack-service-auth.js";
 import { logger } from "../utils/logger.js";
 
 /**
  * Reusable Hono middleware that:
  * 1. Requires a Bearer token in the Authorization header (401 if missing).
- * 2. If the token starts with `sk_`, validates it as a WorkOS API key
+ * 2. If the token starts with `slk_`, handles it as the Slack bot's service
+ *    credential (see slack-service-auth.ts) — allowlisted paths only.
+ * 3. If the token starts with `sk_`, validates it as a WorkOS API key
  *    (memoized per request) and resolves the owning MCPJam user.
- * 3. Otherwise attempts to validate it as a guest JWT.
- * 4. If valid guest token, sets `c.set("guestId", guestId)`.
- * 5. If not a guest token, assumes WorkOS JWT and passes through.
+ * 4. Otherwise attempts to validate it as a guest JWT.
+ * 5. If valid guest token, sets `c.set("guestId", guestId)`.
+ * 6. If not a guest token, assumes WorkOS JWT and passes through.
  *
  * Prefix discrimination is sound: real WorkOS JWTs start with `eyJ`
- * (base64 `{"`), so an `sk_` prefix is unambiguous and the branch
- * never falls through to JWT validation.
+ * (base64 `{"`), so `sk_`/`slk_` prefixes are unambiguous and those
+ * branches never fall through to JWT validation. `slk_` is checked FIRST
+ * because `startsWith("sk_")` would not match it, but the ordering is made
+ * explicit so a future prefix change cannot silently route a Slack token
+ * into the WorkOS-key branch — which mints delegated tokens.
  */
 
 /**
@@ -112,6 +121,15 @@ export async function bearerAuthMiddleware(
   }
 
   const token = authHeader.slice("Bearer ".length);
+
+  // Slack bot service credential. Terminal either way: it authorizes the
+  // request (returns null) or answers it (401/429/503). It must never fall
+  // through to the WorkOS-key or JWT branches.
+  if (isSlackServiceToken(token)) {
+    const denied = await handleSlackServiceAuth(c, token);
+    if (denied) return denied;
+    return next();
+  }
 
   // WorkOS API key branch. Real WorkOS JWTs begin with `eyJ`, so an
   // `sk_` prefix is unambiguous; this branch never falls through.

--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -76,6 +76,12 @@ const UNPROTECTED_PREFIXES = [
   // callback's redirect target is integrity-protected by an HMAC-signed
   // state and restricted to loopback (see routes/cli-auth/state.ts).
   "/api/cli/auth/",
+  // Slack account-link bridge: public front-channel. The user is NOT signed
+  // in when they arrive — establishing who they are is the entire point of
+  // the flow — so a session requirement here would make linking impossible.
+  // Authorization comes from the two identity proofs plus an HMAC-signed
+  // state, never from a session (see routes/slack-link/index.ts).
+  "/api/slack/link/",
 ];
 
 /**

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -135,20 +135,25 @@ export async function handleSlackServiceAuth(
   c: Context,
   token: string
 ): Promise<Response | null> {
-  // Path check FIRST: an `slk_` token on a non-allowlisted route should not
-  // even cost a backend round trip, and must not be distinguishable from an
-  // invalid token by timing or by error text.
-  if (!isAllowedSlackPath(c.req.path)) {
-    logger.warn("Slack service token used on a non-allowlisted path", {
-      path: c.req.path,
-    });
+  // Token FIRST. The path check below logs a caller-controlled value, so
+  // proving the token genuine before reaching it keeps an anonymous caller
+  // from writing unbounded log lines (and forging them with CRLF) by sending
+  // `Bearer slk_x` at arbitrary paths.
+  if (!tokenHashMatches(token)) {
     return c.json(
       { code: ErrorCode.UNAUTHORIZED, message: "Invalid API key" },
       401
     );
   }
 
-  if (!tokenHashMatches(token)) {
+  // Path check before ANY backend work: a non-allowlisted route must not cost
+  // a round trip, and must not be distinguishable from an invalid token by
+  // error text.
+  if (!isAllowedSlackPath(c.req.path)) {
+    logger.warn("Slack service token used on a non-allowlisted path", {
+      // Bounded and newline-stripped: this is request-derived.
+      path: c.req.path.slice(0, 200).replace(/[\r\n]/g, ""),
+    });
     return c.json(
       { code: ErrorCode.UNAUTHORIZED, message: "Invalid API key" },
       401
@@ -166,6 +171,24 @@ export async function handleSlackServiceAuth(
         message: `Slack requests must carry ${SLACK_TEAM_HEADER} and ${SLACK_USER_HEADER}.`,
       },
       401
+    );
+  }
+
+  // Debit BEFORE the lookup, matching the `sk_` branch's reasoning: a flood
+  // must not be able to tie up the backend. `linkKey` needs only the headers,
+  // so an UNLINKED pair is limited too — otherwise a caller could iterate
+  // header values and drive unbounded lookups, each answered with a 401 that
+  // still cost a round trip.
+  const linkKey = `${teamId}:${slackUserId}`;
+  const waitMs = consumeSlackToken(linkKey);
+  if (waitMs !== null) {
+    return c.json(
+      {
+        code: ErrorCode.RATE_LIMITED,
+        message: "Too many requests from this Slack account. Slow down.",
+      },
+      429,
+      { "Retry-After": String(Math.ceil(waitMs / 1000)) }
     );
   }
 
@@ -199,19 +222,6 @@ export async function handleSlackServiceAuth(
         details: { reason: "SLACK_ACCOUNT_NOT_LINKED" },
       },
       401
-    );
-  }
-
-  const linkKey = `${teamId}:${slackUserId}`;
-  const waitMs = consumeSlackToken(linkKey);
-  if (waitMs !== null) {
-    return c.json(
-      {
-        code: ErrorCode.RATE_LIMITED,
-        message: "Too many requests from this Slack account. Slow down.",
-      },
-      429,
-      { "Retry-After": String(Math.ceil(waitMs / 1000)) }
     );
   }
 

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -178,6 +178,16 @@ export function resetSlackRateLimitForTests(): void {
  * configured one. A plain `!==` bails on the first mismatched byte, leaking
  * the divergence position through response latency.
  */
+function tokenHashMatches(token: string): boolean {
+  const configured = process.env.MCPJAM_SLACK_SERVICE_TOKEN_HASH;
+  if (!configured) return false;
+  const presented = createHash("sha256").update(token).digest("hex");
+  const left = Buffer.from(presented, "utf8");
+  const right = Buffer.from(configured.trim().toLowerCase(), "utf8");
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
 /**
  * Verify a presented `slk_` value outside this middleware's own dispatch.
  *
@@ -190,16 +200,6 @@ export function resetSlackRateLimitForTests(): void {
  */
 export function isValidSlackServiceToken(token: string): boolean {
   return token.startsWith(SLACK_TOKEN_PREFIX) && tokenHashMatches(token);
-}
-
-function tokenHashMatches(token: string): boolean {
-  const configured = process.env.MCPJAM_SLACK_SERVICE_TOKEN_HASH;
-  if (!configured) return false;
-  const presented = createHash("sha256").update(token).digest("hex");
-  const left = Buffer.from(presented, "utf8");
-  const right = Buffer.from(configured.trim().toLowerCase(), "utf8");
-  if (left.length !== right.length) return false;
-  return timingSafeEqual(left, right);
 }
 
 /**

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -47,6 +47,10 @@ const SLACK_ALLOWED_PATHS: ReadonlyArray<RegExp> = [
   /^\/api\/v1\/projects\/[^/]+\/eval-runs$/,
   /^\/api\/v1\/projects\/[^/]+\/eval-runs\/[^/]+$/,
   /^\/api\/v1\/projects$/,
+  // Executing an action a human approved. Safe to reach with `slk_` for the
+  // same reason the agent turn is: the token only names the bot, and the
+  // clicker named in the headers is who the execution is authorized as.
+  /^\/api\/v1\/projects\/[^/]+\/proposed-actions\/[^/]+\/execute$/,
 ];
 
 function isAllowedSlackPath(path: string): boolean {

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -86,6 +86,31 @@ setInterval(() => {
   }
 }, 5 * 60_000).unref();
 
+/**
+ * Hard cap on distinct buckets.
+ *
+ * The bucket is created BEFORE the account-link lookup (deliberately — see the
+ * debit site), so the key is a pair of caller-supplied headers. Without a
+ * ceiling, a holder of the shared `slk_` token could mint one permanent bucket
+ * per invented header pair and grow this map without limit. The 5-minute sweep
+ * below handles the steady state; this handles a burst inside one sweep window.
+ */
+const SLACK_BUCKET_MAX_ENTRIES = 10_000;
+
+/** Drop the least-recently-refilled entries down to the bound. */
+function evictSlackBuckets(): void {
+  if (slackLinkBuckets.size <= SLACK_BUCKET_MAX_ENTRIES) return;
+  const byAge = [...slackLinkBuckets.entries()].sort(
+    (left, right) => left[1].lastRefill - right[1].lastRefill
+  );
+  for (const [id] of byAge.slice(
+    0,
+    slackLinkBuckets.size - SLACK_BUCKET_MAX_ENTRIES
+  )) {
+    slackLinkBuckets.delete(id);
+  }
+}
+
 /** Returns ms to wait, or null when admitted. */
 function consumeSlackToken(linkKey: string): number | null {
   const now = Date.now();
@@ -95,6 +120,10 @@ function consumeSlackToken(linkKey: string): number | null {
       tokens: SLACK_RATE_BURST - 1,
       lastRefill: now,
     });
+    // Evicting a bucket only restores its full burst, so the worst case is one
+    // extra burst for a caller who has been quiet longest — a far better
+    // failure than unbounded memory.
+    evictSlackBuckets();
     return null;
   }
   const refilled = Math.min(

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -109,15 +109,32 @@ const SLACK_BUCKET_MAX_ENTRIES = 10_000;
  */
 const SLACK_BUCKET_EVICT_BATCH = 1_024;
 
-/** Drop the least-recently-refilled entries to a batch below the bound. */
+/**
+ * Trim to a batch below the bound, dropping the FULLEST buckets first.
+ *
+ * Eviction restores a caller's full burst, so the entries that are safe to drop
+ * are the ones already at or near full — a caller who has been quiet long
+ * enough to refill loses nothing it did not already have. Evicting by age
+ * instead would happily drop a bucket that is empty because its owner is being
+ * throttled right now, handing an active abuser a fresh burst and turning the
+ * memory bound into a rate-limit bypass. Ties break toward the least recently
+ * refilled, which is the idle-caller heuristic the age sort was reaching for.
+ */
 function evictSlackBuckets(): void {
   if (slackLinkBuckets.size <= SLACK_BUCKET_MAX_ENTRIES) return;
-  const byAge = [...slackLinkBuckets.entries()].sort(
-    (left, right) => left[1].lastRefill - right[1].lastRefill
-  );
+  const now = Date.now();
+  const refilled = (bucket: TokenBucket) =>
+    Math.min(
+      SLACK_RATE_BURST,
+      bucket.tokens + (now - bucket.lastRefill) * SLACK_RATE_REFILL_PER_MS
+    );
+  const byCheapness = [...slackLinkBuckets.entries()].sort((left, right) => {
+    const delta = refilled(right[1]) - refilled(left[1]);
+    return delta !== 0 ? delta : left[1].lastRefill - right[1].lastRefill;
+  });
   const target =
     slackLinkBuckets.size - SLACK_BUCKET_MAX_ENTRIES + SLACK_BUCKET_EVICT_BATCH;
-  for (const [id] of byAge.slice(0, target)) {
+  for (const [id] of byCheapness.slice(0, target)) {
     slackLinkBuckets.delete(id);
   }
 }

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -1,0 +1,243 @@
+/**
+ * `slk_` — the MCPJam Slack bot's service credential.
+ *
+ * WHY IT IS NOT AN `sk_` KEY. An `sk_` key IS a user's credential: whoever
+ * holds it acts as that user, everywhere the key is accepted, and the
+ * inspector will mint 2-hour org-scoped delegated JWTs for it. The Slack bot
+ * runs unattended on a third-party surface and acts for MANY users, so giving
+ * it an `sk_` key would mean a compromised bot could harvest portable org
+ * tokens for whoever it liked. `slk_` grants nothing by itself: it only names
+ * the bot, and every request must ALSO name a Slack user who has completed the
+ * account link. The identity comes from the link, not from the token.
+ *
+ * TOKEN VERIFICATION is against a SHA-256 hash in the environment, with a
+ * constant-time compare — the same shape as `INSPECTOR_SERVICE_TOKEN`, the
+ * credential this sits beside. It is a single static value rotated by
+ * redeploy; what genuinely changes without a deploy (who is linked to whom)
+ * is resolved from the backend on every request.
+ *
+ * FAIL-CLOSED ALLOWLIST. `slk_` is accepted on a short, explicit list of
+ * paths and refused everywhere else with a 401. This middleware runs on
+ * `/api/v1/*` AND on ~25 `/api/web/*` groups, so a default-allow posture would
+ * silently expose the whole web surface to the bot's credential.
+ */
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { Context } from "hono";
+import { ErrorCode } from "../routes/web/errors.js";
+import {
+  resolveSlackActingUser,
+  SlackBackendUnavailable,
+} from "../services/slack-backend.js";
+import { logger } from "../utils/logger.js";
+
+export const SLACK_TOKEN_PREFIX = "slk_";
+export const SLACK_TEAM_HEADER = "x-mcpjam-slack-team-id";
+export const SLACK_USER_HEADER = "x-mcpjam-slack-user-id";
+
+/**
+ * Paths `slk_` may reach, as regexes against the full request path.
+ *
+ * Deliberately narrow: the agent turn, eval-run create/read (the human-gated
+ * Run button and its status poller), and the project list (the App Home
+ * picker). Everything the bot does today is on this list; anything it does
+ * tomorrow has to be added here on purpose.
+ */
+const SLACK_ALLOWED_PATHS: ReadonlyArray<RegExp> = [
+  /^\/api\/v1\/projects\/[^/]+\/agent$/,
+  /^\/api\/v1\/projects\/[^/]+\/eval-runs$/,
+  /^\/api\/v1\/projects\/[^/]+\/eval-runs\/[^/]+$/,
+  /^\/api\/v1\/projects$/,
+];
+
+function isAllowedSlackPath(path: string): boolean {
+  return SLACK_ALLOWED_PATHS.some((pattern) => pattern.test(path));
+}
+
+/**
+ * Per-LINK rate bucket: burst 10, 60/min sustained.
+ *
+ * Keyed on the acting user's link rather than on the token, because the token
+ * is shared by every user of the bot — a token-keyed bucket would let one
+ * chatty workspace throttle everybody. In-process, like the `sk_` bucket
+ * beside it; the Railway service is pinned to one replica for exactly this
+ * reason (see slack-app/railway.toml).
+ */
+const SLACK_RATE_LIMIT_PER_MIN = 60;
+const SLACK_RATE_BURST = 10;
+const SLACK_RATE_REFILL_PER_MS = SLACK_RATE_LIMIT_PER_MIN / 60_000;
+
+interface TokenBucket {
+  tokens: number;
+  lastRefill: number;
+}
+
+const slackLinkBuckets = new Map<string, TokenBucket>();
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, bucket] of slackLinkBuckets) {
+    if (now - bucket.lastRefill > 5 * 60_000) {
+      slackLinkBuckets.delete(id);
+    }
+  }
+}, 5 * 60_000).unref();
+
+/** Returns ms to wait, or null when admitted. */
+function consumeSlackToken(linkKey: string): number | null {
+  const now = Date.now();
+  const existing = slackLinkBuckets.get(linkKey);
+  if (!existing) {
+    slackLinkBuckets.set(linkKey, {
+      tokens: SLACK_RATE_BURST - 1,
+      lastRefill: now,
+    });
+    return null;
+  }
+  const refilled = Math.min(
+    SLACK_RATE_BURST,
+    existing.tokens + (now - existing.lastRefill) * SLACK_RATE_REFILL_PER_MS
+  );
+  if (refilled < 1) {
+    existing.tokens = refilled;
+    existing.lastRefill = now;
+    return Math.max(Math.ceil((1 - refilled) / SLACK_RATE_REFILL_PER_MS), 1);
+  }
+  existing.tokens = refilled - 1;
+  existing.lastRefill = now;
+  return null;
+}
+
+/** Test-only. */
+export function resetSlackRateLimitForTests(): void {
+  slackLinkBuckets.clear();
+}
+
+/**
+ * Constant-time comparison of the presented token's hash against the
+ * configured one. A plain `!==` bails on the first mismatched byte, leaking
+ * the divergence position through response latency.
+ */
+function tokenHashMatches(token: string): boolean {
+  const configured = process.env.MCPJAM_SLACK_SERVICE_TOKEN_HASH;
+  if (!configured) return false;
+  const presented = createHash("sha256").update(token).digest("hex");
+  const left = Buffer.from(presented, "utf8");
+  const right = Buffer.from(configured.trim().toLowerCase(), "utf8");
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+/**
+ * Handle an `slk_` bearer. Returns a Response to short-circuit with, or null
+ * when the request has been authorized and should continue.
+ */
+export async function handleSlackServiceAuth(
+  c: Context,
+  token: string
+): Promise<Response | null> {
+  // Path check FIRST: an `slk_` token on a non-allowlisted route should not
+  // even cost a backend round trip, and must not be distinguishable from an
+  // invalid token by timing or by error text.
+  if (!isAllowedSlackPath(c.req.path)) {
+    logger.warn("Slack service token used on a non-allowlisted path", {
+      path: c.req.path,
+    });
+    return c.json(
+      { code: ErrorCode.UNAUTHORIZED, message: "Invalid API key" },
+      401
+    );
+  }
+
+  if (!tokenHashMatches(token)) {
+    return c.json(
+      { code: ErrorCode.UNAUTHORIZED, message: "Invalid API key" },
+      401
+    );
+  }
+
+  const teamId = c.req.header(SLACK_TEAM_HEADER)?.trim();
+  const slackUserId = c.req.header(SLACK_USER_HEADER)?.trim();
+  if (!teamId || !slackUserId) {
+    // The token names the bot; it never names a user. Without both headers
+    // there is no identity to act as, and defaulting to any is unthinkable.
+    return c.json(
+      {
+        code: ErrorCode.UNAUTHORIZED,
+        message: `Slack requests must carry ${SLACK_TEAM_HEADER} and ${SLACK_USER_HEADER}.`,
+      },
+      401
+    );
+  }
+
+  let link;
+  try {
+    link = await resolveSlackActingUser(teamId, slackUserId);
+  } catch (error) {
+    // 503, NEVER 401. A backend blip must not tell a linked user to reconnect
+    // their account — they would follow the instruction, re-link, and still
+    // fail. This distinction is the whole reason the resolver throws instead
+    // of returning null.
+    logger.error("Slack account-link lookup failed", {
+      error: error instanceof Error ? error.message : String(error),
+      is_backend_unavailable: error instanceof SlackBackendUnavailable,
+    });
+    return c.json(
+      {
+        code: ErrorCode.SERVER_UNREACHABLE,
+        message:
+          "Could not verify your MCPJam account right now. Try again in a moment.",
+      },
+      503
+    );
+  }
+
+  if (!link) {
+    return c.json(
+      {
+        code: ErrorCode.UNAUTHORIZED,
+        message: "This Slack account is not linked to MCPJam.",
+        details: { reason: "SLACK_ACCOUNT_NOT_LINKED" },
+      },
+      401
+    );
+  }
+
+  const linkKey = `${teamId}:${slackUserId}`;
+  const waitMs = consumeSlackToken(linkKey);
+  if (waitMs !== null) {
+    return c.json(
+      {
+        code: ErrorCode.RATE_LIMITED,
+        message: "Too many requests from this Slack account. Slow down.",
+      },
+      429,
+      { "Retry-After": String(Math.ceil(waitMs / 1000)) }
+    );
+  }
+
+  // `authMethod` is what `getConvexBearerForRequest` dispatches on — presence
+  // of the org/user vars is NOT sufficient, since JWT callers can carry them
+  // too. A distinct value keeps the two delegation paths separable.
+  c.set("authMethod", "slack_service");
+  c.set("workosUserId", link.workosUserId);
+  c.set("mcpjamUserId", link.userId);
+  c.set("mcpjamOrganizationId", link.organizationId);
+  c.set("slackTeamId", teamId);
+  c.set("slackUserId", slackUserId);
+  c.set("slackDefaultProjectId", link.defaultProjectId ?? undefined);
+
+  logger.info("Slack service request", {
+    event: "auth.slack_service",
+    auth_method: "slack_service",
+    slack_team_id: teamId,
+    mcpjam_user_id: link.userId,
+    mcpjam_organization_id: link.organizationId,
+  });
+
+  return null;
+}
+
+/** True when the bearer is an `slk_` token. */
+export function isSlackServiceToken(token: string): boolean {
+  return token.startsWith(SLACK_TOKEN_PREFIX);
+}

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -178,6 +178,20 @@ export function resetSlackRateLimitForTests(): void {
  * configured one. A plain `!==` bails on the first mismatched byte, leaking
  * the divergence position through response latency.
  */
+/**
+ * Verify a presented `slk_` value outside this middleware's own dispatch.
+ *
+ * The one legitimate external consumer is the link bridge's session-mint
+ * route: minting a connect URL is Slack-bot business, so the bot presents the
+ * SAME `slk_` credential there rather than being handed the inspector's
+ * environment-root service token (whose blast radius includes arbitrary user
+ * delegation). Anything else that wants this should almost certainly be a new
+ * entry in the path allowlist instead.
+ */
+export function isValidSlackServiceToken(token: string): boolean {
+  return token.startsWith(SLACK_TOKEN_PREFIX) && tokenHashMatches(token);
+}
+
 function tokenHashMatches(token: string): boolean {
   const configured = process.env.MCPJAM_SLACK_SERVICE_TOKEN_HASH;
   if (!configured) return false;

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -97,16 +97,27 @@ setInterval(() => {
  */
 const SLACK_BUCKET_MAX_ENTRIES = 10_000;
 
-/** Drop the least-recently-refilled entries down to the bound. */
+/**
+ * How far below the cap one eviction pass trims.
+ *
+ * Trimming to exactly the cap would put an O(n log n) sort on EVERY subsequent
+ * insertion once the map is full — and insertions are attacker-driven, since
+ * the key is a pair of caller-supplied headers. That turns a memory bound into
+ * a CPU amplifier: each invented header pair would pay for a full sort of ten
+ * thousand entries before its request proceeded. Overshooting means the sort
+ * runs once per batch instead, so its cost amortizes to O(log n) per insertion.
+ */
+const SLACK_BUCKET_EVICT_BATCH = 1_024;
+
+/** Drop the least-recently-refilled entries to a batch below the bound. */
 function evictSlackBuckets(): void {
   if (slackLinkBuckets.size <= SLACK_BUCKET_MAX_ENTRIES) return;
   const byAge = [...slackLinkBuckets.entries()].sort(
     (left, right) => left[1].lastRefill - right[1].lastRefill
   );
-  for (const [id] of byAge.slice(
-    0,
-    slackLinkBuckets.size - SLACK_BUCKET_MAX_ENTRIES
-  )) {
+  const target =
+    slackLinkBuckets.size - SLACK_BUCKET_MAX_ENTRIES + SLACK_BUCKET_EVICT_BATCH;
+  for (const [id] of byAge.slice(0, target)) {
     slackLinkBuckets.delete(id);
   }
 }

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -1688,6 +1688,11 @@ export async function prepareEvalRun(
       passCriteria,
       suiteRerun,
       refreshSnapshot,
+      // The SAME key the run creation uses. Without it, a retried
+      // /eval-runs call authors a second suite and duplicates its cases
+      // BEFORE the run-level idempotency check runs — and the new suite id
+      // then prevents that check from finding the original run at all.
+      ...(idempotencyKey ? { idempotencyKey } : {}),
     });
   const committedCases = authoredCaseUpsert.committed;
   const failedCases = authoredCaseUpsert.failed;

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -35,6 +35,7 @@ import {
   type ProbeConfig,
   type TestCaseType,
 } from "@/shared/probe-config";
+import { deriveItemIdempotencyKey } from "../../utils/idempotency.js";
 import { logger } from "../../utils/logger";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
 import {
@@ -324,6 +325,21 @@ export const RunEvalsRequestSchema = z.object({
    */
   runGroupId: z.string().optional(),
   /**
+   * Caller-supplied write idempotency key, forwarded to Convex
+   * `startTestSuiteRun.idempotencyKey`. A repeat call with the same key (and
+   * the same actor + suite) returns the EXISTING run instead of creating and
+   * billing a second one.
+   *
+   * DECLARED ON THE WIRE, not just server-internal: unattended callers are
+   * exactly the ones that retry. The Slack bot derives it from the triggering
+   * event so a redelivered event or a double-clicked button lands on one run,
+   * and the scheduled worker passes its trigger id. Zod strips unknown keys
+   * silently, so leaving this undeclared meant a caller could send the key,
+   * get a 202, and still be billed twice — with nothing to indicate the key
+   * had been dropped.
+   */
+  idempotencyKey: z.string().min(1).max(256).optional(),
+  /**
    * Project-environment launch (one per attached env on a Run-all fan-out;
    * always sent explicitly, even single-env). `prepareEvalRun` resolves the
    * environment's closed server set via
@@ -368,11 +384,6 @@ type RunEvalsWithManagerRequest = RunEvalsRequest & {
    * `RunEvalsRequestSchema`, so API callers cannot spoof run provenance.
    */
   source?: "ui" | "api" | "schedule" | "github_check";
-  /**
-   * Forwarded to `startTestSuiteRun.idempotencyKey`. The scheduled worker
-   * passes its trigger id so claim retries can never double-create a run.
-   */
-  idempotencyKey?: string;
   /**
    * Pre-resolved environment from the caller's manager-priming preflight (the
    * hosted `/run` route and the scheduled worker resolve the environment ONCE
@@ -1057,6 +1068,14 @@ export async function authorEvalSuite(args: {
   passCriteria: RunEvalsRequest["passCriteria"];
   suiteRerun: boolean | undefined;
   refreshSnapshot: boolean | undefined;
+  /**
+   * Caller-supplied write idempotency key (see utils/idempotency.ts). When
+   * set, the suite create and EACH case create derive a stable per-row key, so
+   * a retry lands on the same suite and only re-creates the cases that did not
+   * commit. Per-case keys are derived from the case discriminator rather than
+   * its index: a retry whose case ORDER differs must still match.
+   */
+  idempotencyKey?: string;
 }): Promise<{
   suiteId: string;
   suiteName: string | undefined;
@@ -1078,6 +1097,7 @@ export async function authorEvalSuite(args: {
     passCriteria,
     suiteRerun,
     refreshSnapshot,
+    idempotencyKey,
   } = args;
 
   const persistedEnvironment = buildPersistedSuiteEnvironment({
@@ -1171,7 +1191,7 @@ export async function authorEvalSuite(args: {
         { suiteId: resolvedSuiteId }
       );
 
-      for (const [, testCaseData] of testCaseMap.entries()) {
+      for (const [caseDedupeKey, testCaseData] of testCaseMap.entries()) {
         const testCaseStepsKey = JSON.stringify(
           normalizeForComparison(testCaseData.steps || [])
         );
@@ -1302,6 +1322,14 @@ export async function authorEvalSuite(args: {
               ),
               matchOptions: testCaseData.matchOptions,
               predicates: testCaseData.predicates,
+              ...(idempotencyKey
+                ? {
+                    idempotencyKey: deriveItemIdempotencyKey(
+                      idempotencyKey,
+                      caseDedupeKey
+                    ),
+                  }
+                : {}),
             });
             committedCases.push({ name: testCaseData.title });
           }
@@ -1328,6 +1356,7 @@ export async function authorEvalSuite(args: {
         description: suiteDescription,
         environment: persistedEnvironment,
         defaultPassCriteria: passCriteria,
+        ...(idempotencyKey ? { idempotencyKey } : {}),
       }
     );
 
@@ -1337,7 +1366,7 @@ export async function authorEvalSuite(args: {
 
     resolvedSuiteId = createdSuite._id as string;
 
-    for (const [, testCaseData] of testCaseMap.entries()) {
+    for (const [caseDedupeKey, testCaseData] of testCaseMap.entries()) {
       try {
         await convexClient.mutation("testSuites:createTestCase" as any, {
           suiteId: resolvedSuiteId,
@@ -1358,6 +1387,14 @@ export async function authorEvalSuite(args: {
           ),
           matchOptions: testCaseData.matchOptions,
           predicates: testCaseData.predicates,
+          ...(idempotencyKey
+            ? {
+                idempotencyKey: deriveItemIdempotencyKey(
+                  idempotencyKey,
+                  caseDedupeKey
+                ),
+              }
+            : {}),
         });
         committedCases.push({ name: testCaseData.title });
       } catch (error) {

--- a/mcpjam-inspector/server/routes/slack-link/__tests__/state.test.ts
+++ b/mcpjam-inspector/server/routes/slack-link/__tests__/state.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  hashOauthState,
+  oauthStateMatches,
+  randomToken,
+  signSlackLinkState,
+  SLACK_LINK_STATE_TTL_MS,
+  verifySlackLinkState,
+} from "../state.js";
+
+const SECRET = "test-secret";
+
+describe("signed link state", () => {
+  it("round-trips a valid payload", () => {
+    const token = signSlackLinkState(
+      { linkSessionId: "ls_1", exp: Date.now() + SLACK_LINK_STATE_TTL_MS },
+      SECRET
+    );
+    expect(verifySlackLinkState(token, SECRET)?.linkSessionId).toBe("ls_1");
+  });
+
+  it("REJECTS a tampered payload", () => {
+    // The signature is the only thing preventing someone from swapping in
+    // another user's session id and completing THEIR link.
+    const token = signSlackLinkState(
+      { linkSessionId: "ls_1", exp: Date.now() + 60_000 },
+      SECRET
+    );
+    const [body, signature] = token.split(".");
+    const forged = Buffer.from(
+      JSON.stringify({ linkSessionId: "ls_victim", exp: Date.now() + 60_000 }),
+      "utf8"
+    ).toString("base64url");
+    expect(verifySlackLinkState(`${forged}.${signature}`, SECRET)).toBeNull();
+    expect(body).not.toBe(forged);
+  });
+
+  it("REJECTS a signature from a different secret", () => {
+    const token = signSlackLinkState(
+      { linkSessionId: "ls_1", exp: Date.now() + 60_000 },
+      "other-secret"
+    );
+    expect(verifySlackLinkState(token, SECRET)).toBeNull();
+  });
+
+  it("REJECTS an expired state", () => {
+    // The URL lives in a Slack conversation forever; the window in which it
+    // is worth anything must not.
+    const token = signSlackLinkState(
+      { linkSessionId: "ls_1", exp: Date.now() - 1 },
+      SECRET
+    );
+    expect(verifySlackLinkState(token, SECRET)).toBeNull();
+  });
+
+  it("rejects malformed tokens instead of throwing", () => {
+    for (const bad of ["", "no-dot", "a.b.c.", "....", "%%%.%%%"]) {
+      expect(verifySlackLinkState(bad, SECRET)).toBeNull();
+    }
+  });
+});
+
+describe("per-leg OAuth states", () => {
+  it("matches a state against its stored hash", () => {
+    const state = randomToken();
+    expect(oauthStateMatches(state, hashOauthState(state))).toBe(true);
+  });
+
+  it("rejects a different state", () => {
+    expect(oauthStateMatches(randomToken(), hashOauthState(randomToken()))).toBe(
+      false
+    );
+  });
+
+  it("rejects a garbage hash without throwing", () => {
+    expect(oauthStateMatches(randomToken(), "not-a-hash")).toBe(false);
+  });
+
+  it("generates distinct, high-entropy tokens", () => {
+    // The two legs must never share a state: one shared value would let a
+    // state observed on the Slack leg be replayed into the WorkOS leg.
+    const tokens = new Set(Array.from({ length: 200 }, () => randomToken()));
+    expect(tokens.size).toBe(200);
+    for (const token of tokens) expect(token.length).toBeGreaterThanOrEqual(43);
+  });
+
+  it("stores only the hash, never the state", () => {
+    const state = randomToken();
+    const hash = hashOauthState(state);
+    expect(hash).not.toContain(state);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/mcpjam-inspector/server/routes/slack-link/index.ts
+++ b/mcpjam-inspector/server/routes/slack-link/index.ts
@@ -38,6 +38,7 @@
  * with bot scopes, so this module builds its own authorize URL and never
  * touches Bolt's.
  */
+import { createHash, timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { createRemoteJWKSet, jwtVerify } from "jose";
@@ -48,6 +49,7 @@ import {
 import { resolveUserByExternalId } from "../../services/identity.js";
 import {
   consumeSlackLinkSession,
+  createSlackLinkSession,
   failSlackLinkSession,
   getSlackLinkSession,
   markSlackLegVerified,
@@ -166,7 +168,7 @@ function notEnabled(c: Context): Response {
 function page(c: Context, opts: {
   title: string;
   body: string;
-  status?: 200 | 400;
+  status?: 200 | 400 | 503;
   extraHtml?: string;
 }): Response {
   const html = `<!doctype html>
@@ -200,6 +202,19 @@ function escapeHtml(value: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
+}
+
+/**
+ * Retryable failure. Distinct from `linkFailed` on purpose: a verification
+ * failure is final and the URL is burned, whereas this leaves the session
+ * intact and the SAME link works on a retry.
+ */
+function unavailable(c: Context): Response {
+  return page(c, {
+    title: "MCPJam is having a moment",
+    body: "Your identity checked out, but we couldn’t finish just now. Use the same link again in a minute.",
+    status: 503,
+  });
 }
 
 /** One generic failure page for every verification failure. */
@@ -291,12 +306,19 @@ slackLink.post("/session", async (c) => {
   const config = resolveConfig();
   if (!config) return notEnabled(c);
 
+  // Constant-time, like every other token comparison in this feature: a plain
+  // `!==` bails on the first mismatched byte and leaks the divergence position
+  // through response latency.
   const presented = c.req.header("x-inspector-service-token");
-  if (
-    !presented ||
-    !process.env.INSPECTOR_SERVICE_TOKEN ||
-    presented !== process.env.INSPECTOR_SERVICE_TOKEN
-  ) {
+  const expected = process.env.INSPECTOR_SERVICE_TOKEN;
+  const tokenMatches =
+    Boolean(presented) &&
+    Boolean(expected) &&
+    timingSafeEqual(
+      createHash("sha256").update(presented as string).digest(),
+      createHash("sha256").update(expected as string).digest()
+    );
+  if (!tokenMatches) {
     return c.json({ code: "UNAUTHORIZED", message: "Service token required" }, 401);
   }
 
@@ -354,25 +376,18 @@ slackLink.get("/start", async (c) => {
   const workosState = randomToken();
 
   try {
-    const response = await fetch(
-      `${process.env.CONVEX_HTTP_URL}/slack/link-sessions/create`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-inspector-service-token": process.env.INSPECTOR_SERVICE_TOKEN ?? "",
-        },
-        body: JSON.stringify({
-          linkSessionId,
-          teamId: target.teamId,
-          slackUserId: target.slackUserId,
-          oidcNonce,
-          slackStateHash: hashOauthState(slackState),
-          workosStateHash: hashOauthState(workosState),
-        }),
-      }
-    );
-    if (!response.ok) throw new Error(`create failed (${response.status})`);
+    // Through the shared client: it resolves config properly (an unset
+    // CONVEX_HTTP_URL would otherwise POST to `undefined/...`) and enforces a
+    // timeout. `/start` is reachable by anyone who can read the link URL, so
+    // an un-deadlined call here is a request anyone can hold open.
+    await createSlackLinkSession({
+      linkSessionId,
+      teamId: target.teamId,
+      slackUserId: target.slackUserId,
+      oidcNonce,
+      slackStateHash: hashOauthState(slackState),
+      workosStateHash: hashOauthState(workosState),
+    });
   } catch (error) {
     logger.error("[slack-link] could not create a link session", {
       error: error instanceof Error ? error.message : String(error),
@@ -617,9 +632,18 @@ slackLink.get("/workos/callback", async (c) => {
     return linkFailed(c);
   }
 
-  const mcpjamUser = await resolveUserByExternalId(workosUserId).catch(
-    () => null
-  );
+  // A LOOKUP FAILURE is not "no account". Failing the session on a blip would
+  // make a valid user redo the entire two-leg OAuth flow, so the outage path
+  // leaves the session intact and asks them to retry the same link.
+  let mcpjamUser;
+  try {
+    mcpjamUser = await resolveUserByExternalId(workosUserId);
+  } catch (error) {
+    logger.error("[slack-link] identity lookup failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return unavailable(c);
+  }
   if (!mcpjamUser) {
     await failSlackLinkSession(payload.linkSessionId, "unknown_mcpjam_user").catch(
       () => {}
@@ -638,9 +662,16 @@ slackLink.get("/workos/callback", async (c) => {
   // user is told to pick an org in the app and retry.
   let organizationId: string | null = null;
   if (workosOrgId) {
-    const mapped = await resolveOrganizationByWorkosId(workosOrgId).catch(
-      () => null
-    );
+    let mapped;
+    try {
+      mapped = await resolveOrganizationByWorkosId(workosOrgId);
+    } catch (error) {
+      // Same rule: could-not-ask is not the same as maps-to-nothing.
+      logger.error("[slack-link] org lookup failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return unavailable(c);
+    }
     organizationId = mapped?.organizationId ?? null;
   }
   if (!organizationId) {
@@ -669,11 +700,10 @@ slackLink.get("/workos/callback", async (c) => {
       error: error instanceof Error ? error.message : String(error),
       is_backend_unavailable: error instanceof SlackBackendUnavailable,
     });
-    return page(c, {
-      title: "MCPJam is having a moment",
-      body: "Your identity checked out, but we couldn’t save the connection. Try the link again in a minute.",
-      status: 400,
-    });
+    // The session is intact — consume+upsert is one transaction, so a failure
+    // rolled both back. 503, not 400: this is ours to fix, and the user's
+    // link is still usable.
+    return unavailable(c);
   }
   if (!result.ok) return linkFailed(c);
 

--- a/mcpjam-inspector/server/routes/slack-link/index.ts
+++ b/mcpjam-inspector/server/routes/slack-link/index.ts
@@ -293,6 +293,35 @@ function decodeCookiePayload(
   }
 }
 
+/**
+ * Deadline for a provider token exchange.
+ *
+ * Slack and WorkOS are third parties on a path a user is actively waiting on,
+ * and `fetch` settles when the HEADERS arrive — a provider that answers and
+ * then stalls its body would hold `/slack/callback` open indefinitely. The
+ * timer therefore spans the body read too, matching `slack-backend.ts`'s
+ * `post` helper.
+ *
+ * @param input request URL
+ * @param init fetch options; a `signal` here is ignored in favour of the deadline
+ */
+const PROVIDER_TIMEOUT_MS = 10_000;
+
+async function fetchJsonWithDeadline<T>(
+  input: string,
+  init: RequestInit
+): Promise<{ ok: boolean; status: number; body: T }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROVIDER_TIMEOUT_MS);
+  try {
+    const response = await fetch(input, { ...init, signal: controller.signal });
+    const body = (await response.json()) as T;
+    return { ok: response.ok, status: response.status, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // ── Routes ─────────────────────────────────────────────────────────────
 
 const slackLink = new Hono();
@@ -392,11 +421,10 @@ slackLink.get("/start", async (c) => {
     logger.error("[slack-link] could not create a link session", {
       error: error instanceof Error ? error.message : String(error),
     });
-    return page(c, {
-      title: "MCPJam is having a moment",
-      body: "We couldn’t start the connection just now. Try the link again in a minute.",
-      status: 400,
-    });
+    // 503, not 400. Nothing about the request was wrong — our backend was
+    // unreachable — and monitoring that keys off status codes should see an
+    // outage rather than a stream of bad client requests.
+    return unavailable(c);
   }
 
   // The WorkOS-leg state rides in the cookie, never in a URL that touches
@@ -539,7 +567,13 @@ slackLink.get("/slack/callback", async (c) => {
       // Never log the ids themselves: a refused link is a security event, and
       // the log should not become the place where the two identities meet.
     });
-    return linkFailed(c);
+    // `linkFailed` BURNS the session — correct for a refused identity proof,
+    // wrong for a backend blip. The user's proof was fine; we could not record
+    // it. Burning here would make them ask Slack for a whole new link over a
+    // transient outage.
+    return transition.reason === "backend_unavailable"
+      ? unavailable(c)
+      : linkFailed(c);
   }
 
   const authorize = new URL(`${config.workosIssuer}/oauth2/authorize`);
@@ -587,7 +621,13 @@ slackLink.get("/workos/callback", async (c) => {
   const advanced = await markWorkosLegVerified(payload.linkSessionId).catch(
     () => ({ ok: false, reason: "backend_unavailable" })
   );
-  if (!advanced.ok) return linkFailed(c);
+  // Same distinction as the Slack leg: a transient outage must not burn a
+  // session whose proofs were sound.
+  if (!advanced.ok) {
+    return advanced.reason === "backend_unavailable"
+      ? unavailable(c)
+      : linkFailed(c);
+  }
 
   let workosUserId: string;
   let workosOrgId: string | undefined;

--- a/mcpjam-inspector/server/routes/slack-link/index.ts
+++ b/mcpjam-inspector/server/routes/slack-link/index.ts
@@ -165,12 +165,15 @@ function notEnabled(c: Context): Response {
  * confirms whether a captured URL is live and whose it is — the details go to
  * the log, not the page.
  */
-function page(c: Context, opts: {
-  title: string;
-  body: string;
-  status?: 200 | 400 | 503;
-  extraHtml?: string;
-}): Response {
+function page(
+  c: Context,
+  opts: {
+    title: string;
+    body: string;
+    status?: 200 | 400 | 503;
+    extraHtml?: string;
+  }
+): Response {
   const html = `<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -212,7 +215,10 @@ function escapeHtml(value: string): string {
 function unavailable(c: Context): Response {
   return page(c, {
     title: "MCPJam is having a moment",
-    body: "Your identity checked out, but we couldn’t finish just now. Use the same link again in a minute.",
+    // Says which link, because the obvious move — reloading this page — retries
+    // an OAuth code the provider has already spent, and lands the user on the
+    // generic failure page for a reason that has nothing to do with them.
+    body: "Your identity checked out, but we couldn’t finish just now. Open the Connect link from Slack again in a minute — the connection is not linked yet.",
     status: 503,
   });
 }
@@ -293,8 +299,11 @@ function decodeCookiePayload(
   }
 }
 
+/** Deadline for a provider token exchange. */
+const PROVIDER_TIMEOUT_MS = 10_000;
+
 /**
- * Deadline for a provider token exchange.
+ * POST to a provider and read its JSON under one deadline.
  *
  * Slack and WorkOS are third parties on a path a user is actively waiting on,
  * and `fetch` settles when the HEADERS arrive — a provider that answers and
@@ -302,11 +311,14 @@ function decodeCookiePayload(
  * timer therefore spans the body read too, matching `slack-backend.ts`'s
  * `post` helper.
  *
+ * A timeout, a transport error, and a non-JSON body all THROW, which is what
+ * both callers want: each is wrapped in a try/catch that fails the link
+ * session and shows the user a retry, rather than proceeding on a half-read
+ * response.
+ *
  * @param input request URL
  * @param init fetch options; a `signal` here is ignored in favour of the deadline
  */
-const PROVIDER_TIMEOUT_MS = 10_000;
-
 async function fetchJsonWithDeadline<T>(
   input: string,
   init: RequestInit
@@ -344,11 +356,18 @@ slackLink.post("/session", async (c) => {
     Boolean(presented) &&
     Boolean(expected) &&
     timingSafeEqual(
-      createHash("sha256").update(presented as string).digest(),
-      createHash("sha256").update(expected as string).digest()
+      createHash("sha256")
+        .update(presented as string)
+        .digest(),
+      createHash("sha256")
+        .update(expected as string)
+        .digest()
     );
   if (!tokenMatches) {
-    return c.json({ code: "UNAUTHORIZED", message: "Service token required" }, 401);
+    return c.json(
+      { code: "UNAUTHORIZED", message: "Service token required" },
+      401
+    );
   }
 
   const body = (await c.req.json().catch(() => ({}))) as {
@@ -360,7 +379,10 @@ slackLink.post("/session", async (c) => {
     typeof body.slackUserId === "string" ? body.slackUserId : "";
   if (!teamId || !slackUserId) {
     return c.json(
-      { code: "VALIDATION_ERROR", message: "teamId and slackUserId are required" },
+      {
+        code: "VALIDATION_ERROR",
+        message: "teamId and slackUserId are required",
+      },
       400
     );
   }
@@ -378,7 +400,9 @@ slackLink.post("/session", async (c) => {
   );
   return c.json({
     ok: true,
-    url: `${config.publicOrigin}/api/slack/link/start?s=${encodeURIComponent(signed)}`,
+    url: `${config.publicOrigin}/api/slack/link/start?s=${encodeURIComponent(
+      signed
+    )}`,
     expiresInMs: SLACK_LINK_STATE_TTL_MS,
   });
 });
@@ -470,9 +494,10 @@ slackLink.get("/slack/callback", async (c) => {
 
   const presentedState = c.req.query("state") ?? "";
   if (!oauthStateMatches(presentedState, session.slackStateHash)) {
-    await failSlackLinkSession(payload.linkSessionId, "slack_state_mismatch").catch(
-      () => {}
-    );
+    await failSlackLinkSession(
+      payload.linkSessionId,
+      "slack_state_mismatch"
+    ).catch(() => {});
     return linkFailed(c);
   }
 
@@ -488,7 +513,10 @@ slackLink.get("/slack/callback", async (c) => {
   // client secret, so a leaked code cannot complete anyone's link.
   let idToken: string;
   try {
-    const tokenResponse = await fetch(SLACK_TOKEN_URL, {
+    const { body: tokenBody } = await fetchJsonWithDeadline<{
+      ok?: boolean;
+      id_token?: string;
+    }>(SLACK_TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -499,10 +527,8 @@ slackLink.get("/slack/callback", async (c) => {
         grant_type: "authorization_code",
       }),
     });
-    const tokenBody = (await tokenResponse.json()) as {
-      ok?: boolean;
-      id_token?: string;
-    };
+    // Slack signals failure in the BODY (`ok: false`) with a 200, so the
+    // HTTP status is not the check that matters here.
     if (!tokenBody?.ok || typeof tokenBody.id_token !== "string") {
       throw new Error("Slack token exchange returned no id_token");
     }
@@ -511,9 +537,10 @@ slackLink.get("/slack/callback", async (c) => {
     logger.warn("[slack-link] Slack token exchange failed", {
       error: error instanceof Error ? error.message : String(error),
     });
-    await failSlackLinkSession(payload.linkSessionId, "slack_token_exchange").catch(
-      () => {}
-    );
+    await failSlackLinkSession(
+      payload.linkSessionId,
+      "slack_token_exchange"
+    ).catch(() => {});
     return linkFailed(c);
   }
 
@@ -535,9 +562,10 @@ slackLink.get("/slack/callback", async (c) => {
     logger.warn("[slack-link] Slack id_token verification failed", {
       error: error instanceof Error ? error.message : String(error),
     });
-    await failSlackLinkSession(payload.linkSessionId, "slack_idtoken_invalid").catch(
-      () => {}
-    );
+    await failSlackLinkSession(
+      payload.linkSessionId,
+      "slack_idtoken_invalid"
+    ).catch(() => {});
     return linkFailed(c);
   }
 
@@ -552,8 +580,8 @@ slackLink.get("/slack/callback", async (c) => {
     typeof claims["https://slack.com/user_id"] === "string"
       ? (claims["https://slack.com/user_id"] as string)
       : typeof claims.sub === "string"
-        ? claims.sub
-        : "";
+      ? claims.sub
+      : "";
 
   const transition = await markSlackLegVerified({
     linkSessionId: payload.linkSessionId,
@@ -604,9 +632,10 @@ slackLink.get("/workos/callback", async (c) => {
   }
 
   if (!oauthStateMatches(c.req.query("state") ?? "", session.workosStateHash)) {
-    await failSlackLinkSession(payload.linkSessionId, "workos_state_mismatch").catch(
-      () => {}
-    );
+    await failSlackLinkSession(
+      payload.linkSessionId,
+      "workos_state_mismatch"
+    ).catch(() => {});
     return linkFailed(c);
   }
 
@@ -632,7 +661,15 @@ slackLink.get("/workos/callback", async (c) => {
   let workosUserId: string;
   let workosOrgId: string | undefined;
   try {
-    const tokenResponse = await fetch(`${config.workosIssuer}/oauth2/token`, {
+    const {
+      ok,
+      status,
+      body: tokenBody,
+    } = await fetchJsonWithDeadline<{
+      access_token?: string;
+      user?: { id?: string };
+      organization_id?: string;
+    }>(`${config.workosIssuer}/oauth2/token`, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -643,13 +680,8 @@ slackLink.get("/workos/callback", async (c) => {
         redirect_uri: workosRedirectUri(config),
       }),
     });
-    const tokenBody = (await tokenResponse.json()) as {
-      access_token?: string;
-      user?: { id?: string };
-      organization_id?: string;
-    };
-    if (!tokenResponse.ok || !tokenBody?.access_token) {
-      throw new Error(`WorkOS token exchange failed (${tokenResponse.status})`);
+    if (!ok || !tokenBody?.access_token) {
+      throw new Error(`WorkOS token exchange failed (${status})`);
     }
     // The access token is an AuthKit JWT; `sub` is the WorkOS user id and
     // `org_id` names the organization the user authenticated into.
@@ -666,9 +698,10 @@ slackLink.get("/workos/callback", async (c) => {
     logger.warn("[slack-link] WorkOS token exchange failed", {
       error: error instanceof Error ? error.message : String(error),
     });
-    await failSlackLinkSession(payload.linkSessionId, "workos_token_exchange").catch(
-      () => {}
-    );
+    await failSlackLinkSession(
+      payload.linkSessionId,
+      "workos_token_exchange"
+    ).catch(() => {});
     return linkFailed(c);
   }
 
@@ -685,9 +718,10 @@ slackLink.get("/workos/callback", async (c) => {
     return unavailable(c);
   }
   if (!mcpjamUser) {
-    await failSlackLinkSession(payload.linkSessionId, "unknown_mcpjam_user").catch(
-      () => {}
-    );
+    await failSlackLinkSession(
+      payload.linkSessionId,
+      "unknown_mcpjam_user"
+    ).catch(() => {});
     return page(c, {
       title: "No MCPJam account yet",
       body: "Sign in to MCPJam once at app.mcpjam.com, then use the connect link again.",

--- a/mcpjam-inspector/server/routes/slack-link/index.ts
+++ b/mcpjam-inspector/server/routes/slack-link/index.ts
@@ -38,7 +38,6 @@
  * with bot scopes, so this module builds its own authorize URL and never
  * touches Bolt's.
  */
-import { createHash, timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import { createRemoteJWKSet, jwtVerify } from "jose";
@@ -46,6 +45,7 @@ import {
   resolveAuthkitIssuer,
   resolveWorkosClientId,
 } from "../../services/authkit-jwt.js";
+import { isValidSlackServiceToken } from "../../middleware/slack-service-auth.js";
 import { resolveUserByExternalId } from "../../services/identity.js";
 import {
   consumeSlackLinkSession,
@@ -339,31 +339,22 @@ async function fetchJsonWithDeadline<T>(
 const slackLink = new Hono();
 
 /**
- * The bot asks for a connect URL. Service-token authenticated — this is a
- * server-to-server call, and the response is a URL that starts an identity
- * flow for a NAMED Slack user, so it must not be mintable by a browser.
+ * The bot asks for a connect URL. Authenticated with the bot's OWN `slk_`
+ * credential (hash-verified, same as the /api/v1 surface) — NOT the
+ * inspector's environment-root service token. Minting a connect URL is
+ * squarely Slack-bot business, and keeping the root token out of the bot's
+ * environment is the blast-radius boundary: that token also opens arbitrary
+ * user delegation, which a compromised bot must never reach. The response is
+ * a URL that starts an identity flow for a NAMED Slack user, so it must not
+ * be mintable by a browser.
  */
 slackLink.post("/session", async (c) => {
   const config = resolveConfig();
   if (!config) return notEnabled(c);
 
-  // Constant-time, like every other token comparison in this feature: a plain
-  // `!==` bails on the first mismatched byte and leaks the divergence position
-  // through response latency.
-  const presented = c.req.header("x-inspector-service-token");
-  const expected = process.env.INSPECTOR_SERVICE_TOKEN;
-  const tokenMatches =
-    Boolean(presented) &&
-    Boolean(expected) &&
-    timingSafeEqual(
-      createHash("sha256")
-        .update(presented as string)
-        .digest(),
-      createHash("sha256")
-        .update(expected as string)
-        .digest()
-    );
-  if (!tokenMatches) {
+  const authorization = c.req.header("authorization") ?? "";
+  const bearer = /^Bearer\s+(\S+)\s*$/i.exec(authorization)?.[1] ?? "";
+  if (!isValidSlackServiceToken(bearer)) {
     return c.json(
       { code: "UNAUTHORIZED", message: "Service token required" },
       401

--- a/mcpjam-inspector/server/routes/slack-link/index.ts
+++ b/mcpjam-inspector/server/routes/slack-link/index.ts
@@ -1,0 +1,785 @@
+/**
+ * Slack account-link bridge (`/api/slack/link/*`).
+ *
+ * Connects a Slack identity to an MCPJam account, with TWO identity proofs.
+ *
+ * WHY TWO. The link URL is posted into a Slack conversation, where everyone
+ * present can read and click it. If the flow proved only the MCPJam side, a
+ * bystander could open someone else's link while signed into MCPJam as
+ * themselves and bind THAT person's Slack identity to their own account —
+ * every eval the victim later authored from Slack would land in the
+ * attacker's organization, silently. So possession of the URL authorizes
+ * nothing on its own:
+ *
+ *   1. Sign in with Slack (OIDC) must show the clicker IS the Slack user the
+ *      session was minted for — `team_id` AND `user_id` compared exactly.
+ *   2. Only then does AuthKit identify the MCPJam account.
+ *
+ * The ORDER is enforced by the session's status in Convex, not by trusting
+ * that the redirects happened in sequence: the WorkOS leg refuses any session
+ * that is not `slack_verified`.
+ *
+ * STATE HANDLING. Three distinct values, deliberately not interchangeable:
+ *   - the HMAC-signed envelope in the bot's URL (integrity only — it is
+ *     public by construction, which is the whole reason for the proofs);
+ *   - the Slack-leg OAuth `state`, and the WorkOS-leg OAuth `state`, which
+ *     ARE secrets. Only their SHA-256 hashes are persisted, so a database
+ *     read cannot forge a callback, and they differ per leg so a state
+ *     observed on the first cannot be replayed into the second.
+ *   - the OIDC `nonce`, bound into Slack's id_token. Slack distinguishes it
+ *     from `state` and so do we.
+ *
+ * The WorkOS-leg state travels between legs in an HttpOnly, SameSite=Lax
+ * cookie rather than a URL. That keeps it out of Slack entirely and, as a
+ * bonus, binds the second leg to the same browser that started the first.
+ *
+ * Sign in with Slack is a COMPLETELY SEPARATE OAuth flow from the bot's
+ * install. Slack rejects an authorize request that mixes SIWS user scopes
+ * with bot scopes, so this module builds its own authorize URL and never
+ * touches Bolt's.
+ */
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { createRemoteJWKSet, jwtVerify } from "jose";
+import {
+  resolveAuthkitIssuer,
+  resolveWorkosClientId,
+} from "../../services/authkit-jwt.js";
+import { resolveUserByExternalId } from "../../services/identity.js";
+import {
+  consumeSlackLinkSession,
+  failSlackLinkSession,
+  getSlackLinkSession,
+  markSlackLegVerified,
+  markWorkosLegVerified,
+  resolveOrganizationByWorkosId,
+  setSlackDefaultProject,
+  SlackBackendUnavailable,
+} from "../../services/slack-backend.js";
+import { logger } from "../../utils/logger.js";
+import {
+  hashOauthState,
+  oauthStateMatches,
+  randomToken,
+  signSlackLinkState,
+  SLACK_LINK_STATE_TTL_MS,
+  verifySlackLinkState,
+} from "./state.js";
+
+/** Slack's OIDC endpoints. Fixed — these are not per-workspace. */
+const SLACK_AUTHORIZE_URL = "https://slack.com/openid/connect/authorize";
+const SLACK_TOKEN_URL = "https://slack.com/api/openid.connect.token";
+const SLACK_JWKS_URL = "https://slack.com/openid/connect/keys";
+/**
+ * `openid` alone yields a token with no `team_id`. The whole first proof is
+ * "this is the same Slack user in the same workspace", so `profile` is
+ * MANDATORY here, not cosmetic.
+ */
+const SLACK_OIDC_SCOPE = "openid profile";
+
+const WORKOS_SCOPE = "openid profile email";
+
+/** Carries the WorkOS-leg state between legs. */
+const LINK_COOKIE_NAME = "mcpjam_slack_link";
+const COOKIE_TTL_SECONDS = Math.floor(SLACK_LINK_STATE_TTL_MS / 1000);
+
+const slackJwks = createRemoteJWKSet(new URL(SLACK_JWKS_URL));
+
+interface SlackLinkConfig {
+  secret: string;
+  publicOrigin: string;
+  slackClientId: string;
+  slackClientSecret: string;
+  workosIssuer: string;
+  workosClientId: string;
+  workosClientSecret: string;
+}
+
+function resolveConfig(
+  env: NodeJS.ProcessEnv = process.env
+): SlackLinkConfig | null {
+  const secret = env.SLACK_LINK_STATE_SECRET;
+  const rawOrigin = env.SLACK_LINK_PUBLIC_ORIGIN ?? env.CLI_AUTH_PUBLIC_ORIGIN;
+  const slackClientId = env.SLACK_CLIENT_ID;
+  const slackClientSecret = env.SLACK_CLIENT_SECRET;
+  const workosClientSecret = env.WORKOS_API_KEY ?? env.WORKOS_CLIENT_SECRET;
+  if (
+    !secret ||
+    !rawOrigin ||
+    !slackClientId ||
+    !slackClientSecret ||
+    !workosClientSecret
+  ) {
+    return null;
+  }
+
+  let publicOrigin: string;
+  try {
+    publicOrigin = new URL(rawOrigin).origin;
+  } catch {
+    return null;
+  }
+
+  const workosClientId = resolveWorkosClientId(env);
+  if (!workosClientId) return null;
+  const workosIssuer = resolveAuthkitIssuer(workosClientId, env);
+  if (!workosIssuer) return null;
+
+  return {
+    secret,
+    publicOrigin,
+    slackClientId,
+    slackClientSecret,
+    workosIssuer,
+    workosClientId,
+    workosClientSecret,
+  };
+}
+
+function slackRedirectUri(config: SlackLinkConfig): string {
+  return `${config.publicOrigin}/api/slack/link/slack/callback`;
+}
+
+function workosRedirectUri(config: SlackLinkConfig): string {
+  return `${config.publicOrigin}/api/slack/link/workos/callback`;
+}
+
+function notEnabled(c: Context): Response {
+  return c.json(
+    {
+      code: "FEATURE_NOT_SUPPORTED",
+      message:
+        "Slack account linking is not enabled on this deployment (SLACK_LINK_STATE_SECRET, SLACK_LINK_PUBLIC_ORIGIN and the Slack/WorkOS client credentials must be configured).",
+    },
+    501
+  );
+}
+
+/**
+ * User-facing terminal page.
+ *
+ * Failure copy is deliberately generic and identical across causes. Telling a
+ * clicker WHICH check failed ("that link belongs to someone else" vs "expired")
+ * confirms whether a captured URL is live and whose it is — the details go to
+ * the log, not the page.
+ */
+function page(c: Context, opts: {
+  title: string;
+  body: string;
+  status?: 200 | 400;
+  extraHtml?: string;
+}): Response {
+  const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(opts.title)} · MCPJam</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, sans-serif;
+         margin: 0; min-height: 100vh; display: grid; place-items: center;
+         padding: 2rem; background: Canvas; color: CanvasText; }
+  main { max-width: 32rem; }
+  h1 { font-size: 1.4rem; margin: 0 0 .5rem; }
+  p { margin: 0 0 1rem; }
+  .muted { opacity: .7; font-size: .9rem; }
+  button, select { font: inherit; padding: .5rem .75rem; border-radius: .5rem;
+                   border: 1px solid color-mix(in srgb, CanvasText 25%, transparent); }
+  button { cursor: pointer; }
+</style></head>
+<body><main>
+<h1>${escapeHtml(opts.title)}</h1>
+<p>${escapeHtml(opts.body)}</p>
+${opts.extraHtml ?? ""}
+</main></body></html>`;
+  return c.html(html, opts.status ?? 200);
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** One generic failure page for every verification failure. */
+function linkFailed(c: Context): Response {
+  return page(c, {
+    title: "That link didn’t work",
+    body: "This connection link is invalid, has expired, or was opened by a different account. Ask MCPJam in Slack for a fresh one.",
+    status: 400,
+  });
+}
+
+// ── Cookie helpers ─────────────────────────────────────────────────────
+
+function setLinkCookie(c: Context, value: string): void {
+  // HttpOnly: nothing client-side needs to read it, and the WorkOS-leg state
+  // inside is a secret. SameSite=Lax so it survives the top-level redirect
+  // back from Slack/AuthKit (Strict would drop it and break the flow).
+  c.header(
+    "Set-Cookie",
+    `${LINK_COOKIE_NAME}=${value}; Path=/api/slack/link; Max-Age=${COOKIE_TTL_SECONDS}; HttpOnly; Secure; SameSite=Lax`,
+    { append: true }
+  );
+}
+
+function clearLinkCookie(c: Context): void {
+  c.header(
+    "Set-Cookie",
+    `${LINK_COOKIE_NAME}=; Path=/api/slack/link; Max-Age=0; HttpOnly; Secure; SameSite=Lax`,
+    { append: true }
+  );
+}
+
+function readLinkCookie(c: Context): string | null {
+  const header = c.req.header("cookie");
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const [name, ...rest] = part.trim().split("=");
+    if (name === LINK_COOKIE_NAME) return rest.join("=");
+  }
+  return null;
+}
+
+interface LinkCookiePayload {
+  linkSessionId: string;
+  workosState: string;
+  exp: number;
+}
+
+function encodeCookiePayload(
+  payload: LinkCookiePayload,
+  secret: string
+): string {
+  return signSlackLinkState(
+    { linkSessionId: JSON.stringify(payload), exp: payload.exp },
+    secret
+  );
+}
+
+function decodeCookiePayload(
+  cookie: string,
+  secret: string
+): LinkCookiePayload | null {
+  const verified = verifySlackLinkState(cookie, secret);
+  if (!verified) return null;
+  try {
+    const parsed = JSON.parse(verified.linkSessionId) as LinkCookiePayload;
+    if (
+      typeof parsed?.linkSessionId !== "string" ||
+      typeof parsed?.workosState !== "string"
+    ) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+// ── Routes ─────────────────────────────────────────────────────────────
+
+const slackLink = new Hono();
+
+/**
+ * The bot asks for a connect URL. Service-token authenticated — this is a
+ * server-to-server call, and the response is a URL that starts an identity
+ * flow for a NAMED Slack user, so it must not be mintable by a browser.
+ */
+slackLink.post("/session", async (c) => {
+  const config = resolveConfig();
+  if (!config) return notEnabled(c);
+
+  const presented = c.req.header("x-inspector-service-token");
+  if (
+    !presented ||
+    !process.env.INSPECTOR_SERVICE_TOKEN ||
+    presented !== process.env.INSPECTOR_SERVICE_TOKEN
+  ) {
+    return c.json({ code: "UNAUTHORIZED", message: "Service token required" }, 401);
+  }
+
+  const body = (await c.req.json().catch(() => ({}))) as {
+    teamId?: unknown;
+    slackUserId?: unknown;
+  };
+  const teamId = typeof body.teamId === "string" ? body.teamId : "";
+  const slackUserId =
+    typeof body.slackUserId === "string" ? body.slackUserId : "";
+  if (!teamId || !slackUserId) {
+    return c.json(
+      { code: "VALIDATION_ERROR", message: "teamId and slackUserId are required" },
+      400
+    );
+  }
+
+  // The URL only carries the SIGNED envelope. The session itself is created
+  // at /start, when the user actually clicks — so a link that is posted and
+  // never opened leaves no state to sweep, and the 10-minute clock starts
+  // from the click rather than from the post.
+  const signed = signSlackLinkState(
+    {
+      linkSessionId: JSON.stringify({ teamId, slackUserId }),
+      exp: Date.now() + SLACK_LINK_STATE_TTL_MS,
+    },
+    config.secret
+  );
+  return c.json({
+    ok: true,
+    url: `${config.publicOrigin}/api/slack/link/start?s=${encodeURIComponent(signed)}`,
+    expiresInMs: SLACK_LINK_STATE_TTL_MS,
+  });
+});
+
+/** Leg 1 begins: mint the session and redirect to Sign in with Slack. */
+slackLink.get("/start", async (c) => {
+  const config = resolveConfig();
+  if (!config) return notEnabled(c);
+
+  const verified = verifySlackLinkState(c.req.query("s") ?? "", config.secret);
+  if (!verified) return linkFailed(c);
+
+  let target: { teamId: string; slackUserId: string };
+  try {
+    target = JSON.parse(verified.linkSessionId);
+    if (!target?.teamId || !target?.slackUserId) return linkFailed(c);
+  } catch {
+    return linkFailed(c);
+  }
+
+  const linkSessionId = randomToken();
+  const oidcNonce = randomToken();
+  const slackState = randomToken();
+  const workosState = randomToken();
+
+  try {
+    const response = await fetch(
+      `${process.env.CONVEX_HTTP_URL}/slack/link-sessions/create`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-inspector-service-token": process.env.INSPECTOR_SERVICE_TOKEN ?? "",
+        },
+        body: JSON.stringify({
+          linkSessionId,
+          teamId: target.teamId,
+          slackUserId: target.slackUserId,
+          oidcNonce,
+          slackStateHash: hashOauthState(slackState),
+          workosStateHash: hashOauthState(workosState),
+        }),
+      }
+    );
+    if (!response.ok) throw new Error(`create failed (${response.status})`);
+  } catch (error) {
+    logger.error("[slack-link] could not create a link session", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return page(c, {
+      title: "MCPJam is having a moment",
+      body: "We couldn’t start the connection just now. Try the link again in a minute.",
+      status: 400,
+    });
+  }
+
+  // The WorkOS-leg state rides in the cookie, never in a URL that touches
+  // Slack — and it binds leg 2 to the browser that ran leg 1.
+  setLinkCookie(
+    c,
+    encodeCookiePayload(
+      { linkSessionId, workosState, exp: Date.now() + SLACK_LINK_STATE_TTL_MS },
+      config.secret
+    )
+  );
+
+  const authorize = new URL(SLACK_AUTHORIZE_URL);
+  authorize.searchParams.set("client_id", config.slackClientId);
+  authorize.searchParams.set("scope", SLACK_OIDC_SCOPE);
+  authorize.searchParams.set("response_type", "code");
+  authorize.searchParams.set("redirect_uri", slackRedirectUri(config));
+  authorize.searchParams.set("state", slackState);
+  authorize.searchParams.set("nonce", oidcNonce);
+  // Pin the workspace so the user is not silently signed in from a different
+  // Slack team — the identity check would reject that anyway, but failing
+  // AFTER an unnecessary sign-in is a bad experience.
+  authorize.searchParams.set("team", target.teamId);
+
+  return c.redirect(authorize.toString(), 302);
+});
+
+/** Leg 1 completes: verify the Slack identity, then start leg 2. */
+slackLink.get("/slack/callback", async (c) => {
+  const config = resolveConfig();
+  if (!config) return notEnabled(c);
+
+  const cookie = readLinkCookie(c);
+  const payload = cookie ? decodeCookiePayload(cookie, config.secret) : null;
+  if (!payload) return linkFailed(c);
+
+  const session = await getSlackLinkSession(payload.linkSessionId).catch(
+    () => null
+  );
+  if (!session || session.expired || session.status !== "pending_slack") {
+    return linkFailed(c);
+  }
+
+  const presentedState = c.req.query("state") ?? "";
+  if (!oauthStateMatches(presentedState, session.slackStateHash)) {
+    await failSlackLinkSession(payload.linkSessionId, "slack_state_mismatch").catch(
+      () => {}
+    );
+    return linkFailed(c);
+  }
+
+  const code = c.req.query("code");
+  if (!code) {
+    await failSlackLinkSession(payload.linkSessionId, "slack_no_code").catch(
+      () => {}
+    );
+    return linkFailed(c);
+  }
+
+  // Confidential-client exchange: the code alone is useless without our
+  // client secret, so a leaked code cannot complete anyone's link.
+  let idToken: string;
+  try {
+    const tokenResponse = await fetch(SLACK_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: config.slackClientId,
+        client_secret: config.slackClientSecret,
+        code,
+        redirect_uri: slackRedirectUri(config),
+        grant_type: "authorization_code",
+      }),
+    });
+    const tokenBody = (await tokenResponse.json()) as {
+      ok?: boolean;
+      id_token?: string;
+    };
+    if (!tokenBody?.ok || typeof tokenBody.id_token !== "string") {
+      throw new Error("Slack token exchange returned no id_token");
+    }
+    idToken = tokenBody.id_token;
+  } catch (error) {
+    logger.warn("[slack-link] Slack token exchange failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await failSlackLinkSession(payload.linkSessionId, "slack_token_exchange").catch(
+      () => {}
+    );
+    return linkFailed(c);
+  }
+
+  // Signature, issuer, audience AND nonce. `audience` pins the token to OUR
+  // Slack app — without it, an id_token minted for a different app would
+  // verify. `nonce` is what makes a captured id_token unreplayable into a
+  // second session.
+  let claims: Record<string, unknown>;
+  try {
+    const { payload: verified } = await jwtVerify(idToken, slackJwks, {
+      issuer: "https://slack.com",
+      audience: config.slackClientId,
+    });
+    claims = verified as Record<string, unknown>;
+    if (claims.nonce !== session.oidcNonce) {
+      throw new Error("nonce mismatch");
+    }
+  } catch (error) {
+    logger.warn("[slack-link] Slack id_token verification failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await failSlackLinkSession(payload.linkSessionId, "slack_idtoken_invalid").catch(
+      () => {}
+    );
+    return linkFailed(c);
+  }
+
+  // THE identity check. `team_id` matters as much as `user_id`: Slack user
+  // ids are unique only within a workspace, so a matching id from another
+  // team is a different person.
+  const verifiedTeamId =
+    typeof claims["https://slack.com/team_id"] === "string"
+      ? (claims["https://slack.com/team_id"] as string)
+      : "";
+  const verifiedUserId =
+    typeof claims["https://slack.com/user_id"] === "string"
+      ? (claims["https://slack.com/user_id"] as string)
+      : typeof claims.sub === "string"
+        ? claims.sub
+        : "";
+
+  const transition = await markSlackLegVerified({
+    linkSessionId: payload.linkSessionId,
+    verifiedTeamId,
+    verifiedSlackUserId: verifiedUserId,
+  }).catch(() => ({ ok: false, reason: "backend_unavailable" }));
+
+  if (!transition.ok) {
+    logger.warn("[slack-link] Slack identity proof refused", {
+      reason: transition.reason,
+      // Never log the ids themselves: a refused link is a security event, and
+      // the log should not become the place where the two identities meet.
+    });
+    return linkFailed(c);
+  }
+
+  const authorize = new URL(`${config.workosIssuer}/oauth2/authorize`);
+  authorize.searchParams.set("client_id", config.workosClientId);
+  authorize.searchParams.set("response_type", "code");
+  authorize.searchParams.set("redirect_uri", workosRedirectUri(config));
+  authorize.searchParams.set("state", payload.workosState);
+  authorize.searchParams.set("scope", WORKOS_SCOPE);
+  return c.redirect(authorize.toString(), 302);
+});
+
+/** Leg 2 completes: identify the MCPJam account and finish the link. */
+slackLink.get("/workos/callback", async (c) => {
+  const config = resolveConfig();
+  if (!config) return notEnabled(c);
+
+  const cookie = readLinkCookie(c);
+  const payload = cookie ? decodeCookiePayload(cookie, config.secret) : null;
+  if (!payload) return linkFailed(c);
+
+  const session = await getSlackLinkSession(payload.linkSessionId).catch(
+    () => null
+  );
+  // The ordering proof. A WorkOS callback that arrives without a completed
+  // Slack leg — hand-crafted, replayed, or simply out of order — stops here.
+  if (!session || session.expired || session.status !== "slack_verified") {
+    return linkFailed(c);
+  }
+
+  if (!oauthStateMatches(c.req.query("state") ?? "", session.workosStateHash)) {
+    await failSlackLinkSession(payload.linkSessionId, "workos_state_mismatch").catch(
+      () => {}
+    );
+    return linkFailed(c);
+  }
+
+  const code = c.req.query("code");
+  if (!code) {
+    await failSlackLinkSession(payload.linkSessionId, "workos_no_code").catch(
+      () => {}
+    );
+    return linkFailed(c);
+  }
+
+  const advanced = await markWorkosLegVerified(payload.linkSessionId).catch(
+    () => ({ ok: false, reason: "backend_unavailable" })
+  );
+  if (!advanced.ok) return linkFailed(c);
+
+  let workosUserId: string;
+  let workosOrgId: string | undefined;
+  try {
+    const tokenResponse = await fetch(`${config.workosIssuer}/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: config.workosClientId,
+        client_secret: config.workosClientSecret,
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: workosRedirectUri(config),
+      }),
+    });
+    const tokenBody = (await tokenResponse.json()) as {
+      access_token?: string;
+      user?: { id?: string };
+      organization_id?: string;
+    };
+    if (!tokenResponse.ok || !tokenBody?.access_token) {
+      throw new Error(`WorkOS token exchange failed (${tokenResponse.status})`);
+    }
+    // The access token is an AuthKit JWT; `sub` is the WorkOS user id and
+    // `org_id` names the organization the user authenticated into.
+    const claims = decodeJwtClaims(tokenBody.access_token);
+    workosUserId =
+      (typeof claims?.sub === "string" ? claims.sub : undefined) ??
+      tokenBody.user?.id ??
+      "";
+    workosOrgId =
+      (typeof claims?.org_id === "string" ? claims.org_id : undefined) ??
+      tokenBody.organization_id;
+    if (!workosUserId) throw new Error("WorkOS token carried no subject");
+  } catch (error) {
+    logger.warn("[slack-link] WorkOS token exchange failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await failSlackLinkSession(payload.linkSessionId, "workos_token_exchange").catch(
+      () => {}
+    );
+    return linkFailed(c);
+  }
+
+  const mcpjamUser = await resolveUserByExternalId(workosUserId).catch(
+    () => null
+  );
+  if (!mcpjamUser) {
+    await failSlackLinkSession(payload.linkSessionId, "unknown_mcpjam_user").catch(
+      () => {}
+    );
+    return page(c, {
+      title: "No MCPJam account yet",
+      body: "Sign in to MCPJam once at app.mcpjam.com, then use the connect link again.",
+      status: 400,
+    });
+  }
+
+  // The org comes from WorkOS's `org_id` claim: WorkOS prompts multi-org
+  // users itself, so we never need our own org picker. A claim that maps to
+  // nothing is NOT fatal — orgs marked `workosOrgSyncStatus: 'skipped'` have
+  // no WorkOS counterpart at all — but we cannot guess one either, so the
+  // user is told to pick an org in the app and retry.
+  let organizationId: string | null = null;
+  if (workosOrgId) {
+    const mapped = await resolveOrganizationByWorkosId(workosOrgId).catch(
+      () => null
+    );
+    organizationId = mapped?.organizationId ?? null;
+  }
+  if (!organizationId) {
+    await failSlackLinkSession(payload.linkSessionId, "org_unresolved").catch(
+      () => {}
+    );
+    return page(c, {
+      title: "Couldn’t tell which organization to use",
+      body: "Open MCPJam, make sure you’re in the organization you want Slack to work in, then use the connect link again.",
+      status: 400,
+    });
+  }
+
+  let result;
+  try {
+    result = await consumeSlackLinkSession({
+      linkSessionId: payload.linkSessionId,
+      userId: mcpjamUser._id,
+      workosUserId,
+      organizationId,
+    });
+  } catch (error) {
+    // The session is intact (consume+upsert is one transaction, so a failure
+    // rolled both back). The user can retry with a fresh link.
+    logger.error("[slack-link] link consumption failed", {
+      error: error instanceof Error ? error.message : String(error),
+      is_backend_unavailable: error instanceof SlackBackendUnavailable,
+    });
+    return page(c, {
+      title: "MCPJam is having a moment",
+      body: "Your identity checked out, but we couldn’t save the connection. Try the link again in a minute.",
+      status: 400,
+    });
+  }
+  if (!result.ok) return linkFailed(c);
+
+  // Keep the cookie: the default-project picker below needs the session id,
+  // and the session is now `consumed`, so it can no longer authorize a link.
+  return page(c, {
+    title: "Slack is connected",
+    body: "MCPJam will now act as you when you talk to it in Slack. Pick the project your Slack work should land in — you can change this any time from the app’s Home tab.",
+    extraHtml: renderProjectPicker(),
+  });
+});
+
+/**
+ * Set the default project from the success page.
+ *
+ * Authorized by the link cookie, not by a session bearer: the person here has
+ * just completed both identity proofs in this browser, and the backend
+ * re-verifies that the project belongs to the link's organization anyway.
+ */
+slackLink.post("/default-project", async (c) => {
+  const config = resolveConfig();
+  if (!config) return notEnabled(c);
+
+  const cookie = readLinkCookie(c);
+  const payload = cookie ? decodeCookiePayload(cookie, config.secret) : null;
+  if (!payload) {
+    return c.json({ ok: false, message: "This page has expired." }, 400);
+  }
+
+  const session = await getSlackLinkSession(payload.linkSessionId).catch(
+    () => null
+  );
+  // Only a session that actually COMPLETED may set a default — otherwise a
+  // half-finished flow could write to whatever link already existed.
+  if (!session || session.status !== "consumed") {
+    return c.json({ ok: false, message: "This page has expired." }, 400);
+  }
+
+  const body = (await c.req.json().catch(() => ({}))) as {
+    projectId?: unknown;
+  };
+  const projectId =
+    typeof body.projectId === "string" && body.projectId.length > 0
+      ? body.projectId
+      : undefined;
+
+  const result = await setSlackDefaultProject({
+    teamId: session.teamId,
+    slackUserId: session.slackUserId,
+    ...(projectId ? { projectId } : {}),
+  }).catch(() => ({ ok: false, reason: "backend_unavailable" }));
+
+  if (!result.ok) {
+    return c.json(
+      { ok: false, message: "That project isn’t available on your account." },
+      400
+    );
+  }
+  clearLinkCookie(c);
+  return c.json({ ok: true });
+});
+
+/**
+ * Base64url-decode a JWT's claims WITHOUT verifying it.
+ *
+ * Safe here and ONLY here: the token was just received over TLS directly from
+ * the WorkOS token endpoint, in exchange for our client secret. It was not
+ * supplied by the user, so there is no attacker in a position to have forged
+ * it. Never use this on a token that arrived from a client.
+ */
+function decodeJwtClaims(jwt: string): Record<string, unknown> | null {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    return JSON.parse(
+      Buffer.from(parts[1] as string, "base64url").toString("utf8")
+    ) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function renderProjectPicker(): string {
+  // Inline, dependency-free: this page is served once, to one person, right
+  // after an auth flow — pulling in the SPA would be strictly worse.
+  return `
+<form id="pick" class="muted">
+  <label for="projectId">Default project id</label><br>
+  <input id="projectId" name="projectId" placeholder="Paste a project id" style="font:inherit;padding:.5rem .75rem;border-radius:.5rem;border:1px solid color-mix(in srgb, CanvasText 25%, transparent);min-width:18rem">
+  <button type="submit">Save</button>
+  <p id="msg" class="muted"></p>
+</form>
+<script>
+document.getElementById('pick').addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const msg = document.getElementById('msg');
+  msg.textContent = 'Saving…';
+  const response = await fetch('/api/slack/link/default-project', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ projectId: document.getElementById('projectId').value.trim() }),
+  });
+  const body = await response.json().catch(() => ({}));
+  msg.textContent = body.ok ? 'Saved. You can close this tab.' : (body.message || 'Could not save that project.');
+});
+</script>`;
+}
+
+export default slackLink;

--- a/mcpjam-inspector/server/routes/slack-link/state.ts
+++ b/mcpjam-inspector/server/routes/slack-link/state.ts
@@ -1,0 +1,121 @@
+/**
+ * Signed-state and CSRF helpers for the Slack account-link bridge.
+ *
+ * Generalized from `cli-auth/state.ts`: the same HMAC-signed, short-lived
+ * envelope, but carrying a link-session id instead of a loopback redirect.
+ *
+ * There are TWO distinct secrets-shaped things here and conflating them is the
+ * bug this module exists to prevent:
+ *
+ *   - The SIGNED STATE the bot puts in the URL it posts to Slack. It only
+ *     needs integrity (nobody may swap in another session id), so it is an
+ *     HMAC over `{linkSessionId, exp}`. It is NOT a secret: anyone in the
+ *     Slack conversation can read it, which is exactly why the flow demands
+ *     an identity proof rather than treating URL possession as authorization.
+ *
+ *   - The per-leg OAUTH STATES, one for Slack and one for WorkOS. These ARE
+ *     secrets, held only in the browser's redirect chain, and only their
+ *     SHA-256 hashes are persisted — so a database read cannot forge a
+ *     callback. They must differ from each other: a single shared value would
+ *     let a state observed on the first leg be replayed into the second,
+ *     collapsing two independent CSRF defences into one.
+ */
+import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+/**
+ * Ten minutes. The URL is posted into a Slack conversation where it persists
+ * indefinitely, so the window in which it is worth anything must be small.
+ */
+export const SLACK_LINK_STATE_TTL_MS = 10 * 60 * 1000;
+
+export interface SlackLinkStatePayload {
+  /** The pending link session this URL belongs to. */
+  linkSessionId: string;
+  /** Expiry, milliseconds since epoch. */
+  exp: number;
+}
+
+function hmac(body: string, secret: string): Buffer {
+  return createHmac("sha256", secret).update(body).digest();
+}
+
+export function signSlackLinkState(
+  payload: SlackLinkStatePayload,
+  secret: string
+): string {
+  const body = Buffer.from(JSON.stringify(payload), "utf8").toString(
+    "base64url"
+  );
+  return `${body}.${hmac(body, secret).toString("base64url")}`;
+}
+
+export function verifySlackLinkState(
+  token: string,
+  secret: string,
+  now: number = Date.now()
+): SlackLinkStatePayload | null {
+  const separator = token.lastIndexOf(".");
+  if (separator <= 0) return null;
+  const body = token.slice(0, separator);
+  const signature = token.slice(separator + 1);
+
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(signature, "base64url");
+  } catch {
+    return null;
+  }
+  const expected = hmac(body, secret);
+  if (
+    provided.length !== expected.length ||
+    !timingSafeEqual(provided, expected)
+  ) {
+    return null;
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  if (
+    typeof record.linkSessionId !== "string" ||
+    record.linkSessionId.length === 0 ||
+    typeof record.exp !== "number"
+  ) {
+    return null;
+  }
+  if (record.exp <= now) return null;
+
+  return { linkSessionId: record.linkSessionId, exp: record.exp };
+}
+
+/** SHA-256 hex. Only hashes of the per-leg OAuth states are ever persisted. */
+export function hashOauthState(state: string): string {
+  return createHash("sha256").update(state).digest("hex");
+}
+
+/**
+ * Compare a presented OAuth state against its stored hash in constant time.
+ * A plain `===` on the hashes leaks the divergence position through timing,
+ * which is a (weak, but free to avoid) oracle for forging a callback.
+ */
+export function oauthStateMatches(
+  presented: string,
+  storedHash: string
+): boolean {
+  const left = Buffer.from(hashOauthState(presented), "utf8");
+  const right = Buffer.from(storedHash, "utf8");
+  if (left.length !== right.length) return false;
+  return timingSafeEqual(left, right);
+}
+
+/** 256 bits of entropy, URL-safe. Used for states, nonces, and session ids. */
+export function randomToken(): string {
+  return randomBytes(32).toString("base64url");
+}

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -816,6 +816,102 @@ describe("v1 eval-edit routes", () => {
     expect(createArgs.promptTurns).toBeUndefined();
   });
 
+  it("generate with an idempotency key records the ledger before persisting and keys each case", async () => {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    generateEvalTestsMock.mockResolvedValue({
+      success: true,
+      tests: [
+        { title: "A", query: "one", runs: 1, expectedToolCalls: [] },
+        { title: "B", query: "two", runs: 1, expectedToolCalls: [] },
+      ],
+    });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({ serverIds: ["srv_1"], serverNames: ["S"] });
+      // No prior ledger for this key.
+      if (name === "testSuites:getCaseGeneration") return Promise.resolve(null);
+      return defaultQueryImpl(name);
+    });
+
+    const res = await makeApp().request(
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer tok",
+          "x-mcpjam-idempotency-key": "proposal:act_1:generate_eval_cases",
+        },
+        body: JSON.stringify({ mode: "normal" }),
+      }
+    );
+    expect(res.status).toBe(200);
+
+    // The ledger write must precede the first case persist: it is the
+    // checkpoint that makes a crash after this point replayable WITHOUT a
+    // second LLM spend.
+    const calls = convexMutationMock.mock.calls.map((c) => c[0]);
+    const ledgerIndex = calls.indexOf("testSuites:recordCaseGeneration");
+    const firstCaseIndex = calls.indexOf("testSuites:createTestCase");
+    expect(ledgerIndex).toBeGreaterThanOrEqual(0);
+    expect(firstCaseIndex).toBeGreaterThan(ledgerIndex);
+
+    // Every case carries a derived per-item key so a resumed persistence loop
+    // lands on the first attempt's rows.
+    const caseCalls = convexMutationMock.mock.calls.filter(
+      (c) => c[0] === "testSuites:createTestCase"
+    );
+    expect(caseCalls).toHaveLength(2);
+    const keys = caseCalls.map((c) => c[1].idempotencyKey);
+    expect(keys.every((k: string) => typeof k === "string" && k.length > 0)).toBe(
+      true
+    );
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("generate replays recorded drafts on a keyed retry instead of re-spending", async () => {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({ serverIds: ["srv_1"], serverNames: ["S"] });
+      if (name === "testSuites:getCaseGeneration")
+        return Promise.resolve({
+          drafts: [{ title: "Cached", query: "from ledger", runs: 1, expectedToolCalls: [] }],
+          createdCaseIds: null,
+        });
+      return defaultQueryImpl(name);
+    });
+
+    const res = await makeApp().request(
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer tok",
+          "x-mcpjam-idempotency-key": "proposal:act_1:generate_eval_cases",
+        },
+        body: JSON.stringify({ mode: "normal" }),
+      }
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.created).toHaveLength(1);
+    // The whole point: no MCP connection, no generator call, no second spend.
+    expect(generateEvalTestsMock).not.toHaveBeenCalled();
+    expect(createAuthorizedManagerMock).not.toHaveBeenCalled();
+    // And no duplicate ledger write for the replay.
+    expect(
+      convexMutationMock.mock.calls.some(
+        (c) => c[0] === "testSuites:recordCaseGeneration"
+      )
+    ).toBe(false);
+  });
+
   it("generate resolves a server NAME override to an ID before authorizing", async () => {
     createAuthorizedManagerMock.mockResolvedValue({
       manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },

--- a/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/eval-edit.test.ts
@@ -55,6 +55,7 @@ vi.mock("convex/browser", () => ({
   })),
 }));
 
+import { deriveItemIdempotencyKey } from "../../../utils/idempotency.js";
 import v1Routes from "../index.js";
 
 function makeApp(): Hono {
@@ -858,17 +859,80 @@ describe("v1 eval-edit routes", () => {
     expect(ledgerIndex).toBeGreaterThanOrEqual(0);
     expect(firstCaseIndex).toBeGreaterThan(ledgerIndex);
 
-    // Every case carries a derived per-item key so a resumed persistence loop
-    // lands on the first attempt's rows.
+    // Every case carries the EXACT derived per-item key — positional under
+    // the caller's key — so a resumed persistence loop lands on the first
+    // attempt's rows. Asserting the literal derivation (not just "some
+    // string") is the point: a fresh-per-attempt or operation-independent key
+    // would still be a non-empty string and would still duplicate cases.
     const caseCalls = convexMutationMock.mock.calls.filter(
       (c) => c[0] === "testSuites:createTestCase"
     );
     expect(caseCalls).toHaveLength(2);
     const keys = caseCalls.map((c) => c[1].idempotencyKey);
-    expect(keys.every((k: string) => typeof k === "string" && k.length > 0)).toBe(
-      true
+    expect(keys).toEqual([
+      deriveItemIdempotencyKey("proposal:act_1:generate_eval_cases", "0"),
+      deriveItemIdempotencyKey("proposal:act_1:generate_eval_cases", "1"),
+    ]);
+  });
+
+  it("generate checkpoints an EMPTY result and fails closed on an unreadable ledger", async () => {
+    createAuthorizedManagerMock.mockResolvedValue({
+      manager: { disconnectAllServers: vi.fn().mockResolvedValue(undefined) },
+    });
+    generateEvalTestsMock.mockResolvedValue({ success: true, tests: [] });
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({ serverIds: ["srv_1"], serverNames: ["S"] });
+      if (name === "testSuites:getCaseGeneration") return Promise.resolve(null);
+      return defaultQueryImpl(name);
+    });
+
+    // "The generator ran and produced nothing" is a spend too — without the
+    // checkpoint every keyed retry would pay for it again.
+    const res = await makeApp().request(
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer tok",
+          "x-mcpjam-idempotency-key": "proposal:act_2:generate_eval_cases",
+        },
+        body: JSON.stringify({ mode: "normal" }),
+      }
     );
-    expect(new Set(keys).size).toBe(2);
+    expect(res.status).toBe(200);
+    const ledgerCall = convexMutationMock.mock.calls.find(
+      (c) => c[0] === "testSuites:recordCaseGeneration"
+    );
+    expect(ledgerCall?.[1].drafts).toEqual([]);
+
+    // And a keyed request whose ledger cannot be READ must 503 (retryable),
+    // never silently regenerate: a backend blip is exactly when the first
+    // attempt's spend is most likely to be invisible.
+    generateEvalTestsMock.mockClear();
+    convexQueryMock.mockImplementation((name: string) => {
+      if (name === "testSuites:getSuiteRunServerSelection")
+        return Promise.resolve({ serverIds: ["srv_1"], serverNames: ["S"] });
+      if (name === "testSuites:getCaseGeneration")
+        return Promise.reject(new Error("convex down"));
+      return defaultQueryImpl(name);
+    });
+    const blocked = await makeApp().request(
+      "/api/v1/projects/p1/eval-suites/suite_1/cases/generate",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer tok",
+          "x-mcpjam-idempotency-key": "proposal:act_2:generate_eval_cases",
+        },
+        body: JSON.stringify({ mode: "normal" }),
+      }
+    );
+    // 502 SERVER_UNREACHABLE — the repo's retryable upstream-failure status.
+    expect(blocked.status).toBe(502);
+    expect(generateEvalTestsMock).not.toHaveBeenCalled();
   });
 
   it("generate replays recorded drafts on a keyed retry instead of re-spending", async () => {

--- a/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/openapi-drift.test.ts
@@ -59,6 +59,12 @@ const KNOWN_UNDOCUMENTED = new Set([
   "post /projects/{projectId}/eval-ingest/runs/finalize",
   "post /projects/{projectId}/eval-ingest/report",
   "post /projects/{projectId}/eval-ingest/artifacts/upload-url",
+  // Deliberately internal: executing an action a human approved in Slack. The
+  // route is reachable ONLY with the bot's `slk_` service credential (see
+  // SLACK_ALLOWED_PATHS), its `actionId` is minted server-side per proposal,
+  // and it has no meaning to a public API caller — documenting it would
+  // advertise an endpoint nobody outside the Slack surface can use.
+  "post /projects/{projectId}/proposed-actions/{actionId}/execute",
 ]);
 
 /** Hono `:param` + the `/api/v1` mount prefix -> OpenAPI `{param}`, unprefixed. */

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -9,13 +9,20 @@
  * to any resources the turn created. Synchronous JSON — the caller holds
  * conversation state and resends history each turn.
  *
- * RETRY CONTRACT (v1): the operation is NOT idempotent and there is no
- * idempotency key yet — a turn can persist suites even when the response
- * is lost mid-flight. Callers must dedupe on their own trigger identity
- * (the Slack app dedupes on channel+event ts) and never blind-retry;
- * error responses carry `details.createdResources` for the partial-state
- * case. Durable idempotency (a key honored through the mutation path)
- * is the prerequisite for opening this beyond dogfood.
+ * RETRY CONTRACT: send `idempotencyKey` — a STABLE identity for the
+ * triggering event, not a fresh uuid per attempt (the Slack app sends
+ * `${teamId}:${event_id}`). Each WRITE op the turn performs derives its own
+ * key from it, so a retried turn re-issues the same mutations onto the same
+ * rows instead of authoring duplicate suites. Error responses still carry
+ * `details.createdResources` so a caller can see what a failed turn already
+ * persisted.
+ *
+ * The key makes a retry SAFE; it does not make one free. Callers should still
+ * dedupe at their own trigger (the Slack app claims each event durably before
+ * processing) so most retries never re-run the turn at all — and a retry whose
+ * model authors materially different arguments hashes differently and is
+ * correctly treated as a different write. Omitting the key preserves the old
+ * non-idempotent behaviour rather than being rejected.
  *
  * Surface decisions (see the Slack-app v1 plan):
  *  - Tools are READ ops + atomic `create_eval_suite` ONLY. Run/cancel ops
@@ -63,6 +70,10 @@ import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import { parseWithSchema } from "../web/errors.js";
 import { getSelfFetch } from "../../utils/self-app.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import {
+  deriveOperationIdempotencyKey,
+  IDEMPOTENCY_KEY_HEADER,
+} from "../../utils/idempotency.js";
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
 import { resolveTurnRuntime } from "../../utils/resolve-turn-runtime.js";
 import { runUnifiedAssistantTurn } from "../../utils/turn-execution.js";
@@ -99,6 +110,21 @@ export const AGENT_API_OPERATIONS: ReadonlyArray<
   getEvalRunOperation,
   createEvalSuiteOperation,
 ];
+
+/**
+ * Operations that PERSIST. Every one of these gets a derived per-call
+ * idempotency key when the caller supplied a turn key, so a retried turn's
+ * writes land on the rows the first attempt created instead of duplicating
+ * them. Read ops are excluded deliberately: a key on a read is noise on the
+ * wire and would be stored on nothing.
+ *
+ * This set must grow whenever a write op is added to `AGENT_API_OPERATIONS` —
+ * a write left out of it silently loses retry safety, which is exactly the
+ * failure this endpoint's docblock used to warn about.
+ */
+const WRITE_OPERATION_NAMES: ReadonlySet<string> = new Set([
+  createEvalSuiteOperation.name,
+]);
 
 export type CreatedResource = {
   type: "eval_suite";
@@ -167,6 +193,19 @@ export function buildAgentApiToolSet(opts: {
   client: PlatformApiClient;
   projectId: string;
   created: CreatedResource[];
+  /**
+   * The caller's turn-level idempotency key (the Slack bot sends
+   * `${teamId}:${event_id}`). When present, every WRITE op is dispatched
+   * through a client that carries a key derived from it.
+   */
+  turnIdempotencyKey?: string;
+  /**
+   * Builds a client that stamps `extraHeaders` on its requests. A per-call
+   * client is used rather than mutating shared state because tool calls can
+   * run concurrently — a shared "current key" holder would let one call's key
+   * be applied to another's write.
+   */
+  clientWithHeaders?: (extraHeaders: Record<string, string>) => PlatformApiClient;
 }): ToolSet {
   const tools: ToolSet = {};
   for (const operation of AGENT_API_OPERATIONS) {
@@ -205,9 +244,28 @@ export function buildAgentApiToolSet(opts: {
             error: `Invalid input for ${operation.name} — fix these fields and retry: ${issues}`,
           };
         }
+        // Write ops carry a derived key so a retried turn re-issuing the same
+        // call lands on the row the first attempt created. The key is derived
+        // from the VALIDATED input, not the raw one, so two inputs that
+        // normalize identically share a key.
+        let client = opts.client;
+        if (
+          opts.turnIdempotencyKey &&
+          opts.clientWithHeaders &&
+          WRITE_OPERATION_NAMES.has(operation.name)
+        ) {
+          client = opts.clientWithHeaders({
+            [IDEMPOTENCY_KEY_HEADER]: deriveOperationIdempotencyKey(
+              opts.turnIdempotencyKey,
+              operation.name,
+              parsed.data
+            ),
+          });
+        }
+
         try {
           const result = await operation.execute(parsed.data, {
-            client: opts.client,
+            client,
             signal: abortSignal,
           });
           if (operation.name === createEvalSuiteOperation.name) {
@@ -330,6 +388,16 @@ const agentTurnSchema = z.object({
         message: `Message history exceeds ${MAX_TOTAL_MESSAGE_BYTES} total bytes`,
       }
     ),
+  /**
+   * Caller's stable identity for THIS turn — the Slack bot sends
+   * `${teamId}:${event_id}`. Every write the turn performs derives its own key
+   * from it, so a redelivered event that re-runs the turn re-issues the same
+   * mutations onto the same rows instead of authoring duplicates.
+   *
+   * Optional: callers that genuinely cannot produce a stable trigger identity
+   * keep the previous (non-idempotent) behaviour rather than being rejected.
+   */
+  idempotencyKey: z.string().min(1).max(200).optional(),
 });
 
 const activeTurnsByOrg = new Map<string, number>();
@@ -456,14 +524,30 @@ agent.post("/projects/:projectId/agent", async (c) => {
         "In-process /api/v1 dispatch is not registered."
       );
     }
-    const client = new PlatformApiClient({
-      baseUrl: "http://self.mcpjam.internal/api/v1",
-      getAuth: () => convexJwt,
-      fetch: async (input, init) => selfFetch(new Request(input, init)),
-    });
+    const makeClient = (extraHeaders: Record<string, string> = {}) =>
+      new PlatformApiClient({
+        baseUrl: "http://self.mcpjam.internal/api/v1",
+        getAuth: () => convexJwt,
+        fetch: async (input, init) => {
+          const request = new Request(input, init);
+          for (const [name, value] of Object.entries(extraHeaders)) {
+            request.headers.set(name, value);
+          }
+          return selfFetch(request);
+        },
+      });
+    const client = makeClient();
 
     const created: CreatedResource[] = [];
-    const builtInTools = buildAgentApiToolSet({ client, projectId, created });
+    const builtInTools = buildAgentApiToolSet({
+      client,
+      projectId,
+      created,
+      ...(body.idempotencyKey
+        ? { turnIdempotencyKey: body.idempotencyKey }
+        : {}),
+      clientWithHeaders: makeClient,
+    });
 
     // Docs server with preflight-degrade: `getToolsForAiSdk` (inside
     // `prepareChatV2`) fails the whole turn when a selected server errors at

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -93,10 +93,7 @@ import {
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
 import { resolveTurnRuntime } from "../../utils/resolve-turn-runtime.js";
 import { runUnifiedAssistantTurn } from "../../utils/turn-execution.js";
-import {
-  capForModel,
-  toToolError,
-} from "../../utils/built-in-tools/mcpjam.js";
+import { capForModel, toToolError } from "../../utils/built-in-tools/mcpjam.js";
 import { isHostedCatalogModel } from "../../services/hosted-model-catalog.js";
 import type { ModelDefinition } from "@/shared/types";
 import { captureServerEvent } from "../../utils/analytics.js";
@@ -193,7 +190,9 @@ function suiteUrl(suiteId: string, projectId: string): string {
   // `?project=` makes the link self-describing: eval routes carry no project
   // segment, so without it the app renders whatever project the viewer's
   // picker was parked on (an empty state for everyone but the author).
-  return `${MCPJAM_HOSTED_ORIGIN}/evals/suite/${encodeURIComponent(suiteId)}?project=${encodeURIComponent(projectId)}`;
+  return `${MCPJAM_HOSTED_ORIGIN}/evals/suite/${encodeURIComponent(
+    suiteId
+  )}?project=${encodeURIComponent(projectId)}`;
 }
 
 const PROJECT_SCOPE_ERROR =
@@ -272,7 +271,12 @@ function buildGatedProposalTools(opts: {
    * away from being billed twice.
    */
   turnIdempotencyKey?: string;
-  slack?: { teamId: string; channelId: string; slackUserId: string; organizationId: string };
+  slack?: {
+    teamId: string;
+    channelId: string;
+    slackUserId: string;
+    organizationId: string;
+  };
 }): ToolSet {
   const tools: ToolSet = {};
   for (const operation of AGENT_API_GATED_OPERATIONS) {
@@ -304,7 +308,9 @@ function buildGatedProposalTools(opts: {
         if (!parsed.success) {
           const issues = parsed.error.issues
             .slice(0, 5)
-            .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+            .map(
+              (issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`
+            )
             .join("; ");
           return {
             error: `Invalid input for ${operation.name} — fix these fields and retry: ${issues}`,
@@ -361,12 +367,20 @@ function buildGatedProposalTools(opts: {
         }
 
         const description = describeProposal(operation.name, parsed.data);
-        opts.proposed.push({
-          actionId,
-          operation: operation.name,
-          input: parsed.data,
-          description,
-        });
+        // The derived id already collapses repeats in the BACKEND row; this
+        // collapses them in the RESPONSE. A model that invokes the same gated
+        // tool twice with the same arguments has proposed one action, and a
+        // caller rendering one button per entry would otherwise show two
+        // buttons for a single spend — the exact duplicate the derived id
+        // exists to prevent.
+        if (!opts.proposed.some((existing) => existing.actionId === actionId)) {
+          opts.proposed.push({
+            actionId,
+            operation: operation.name,
+            input: parsed.data,
+            description,
+          });
+        }
         return {
           proposed: true,
           actionId,
@@ -394,11 +408,15 @@ function describeProposal(
     typeof input[key] === "string" ? (input[key] as string) : undefined;
   switch (operationName) {
     case runEvalSuiteOperation.name:
-      return `Run eval suite ${named("suite") ?? named("suiteId") ?? "(unnamed)"}`;
+      return `Run eval suite ${
+        named("suite") ?? named("suiteId") ?? "(unnamed)"
+      }`;
     case runEvalCaseOperation.name:
       return `Run eval case ${named("case") ?? named("caseId") ?? "(unnamed)"}`;
     case generateEvalCasesOperation.name:
-      return `Generate eval cases for ${named("suite") ?? named("suiteId") ?? "(unnamed)"}`;
+      return `Generate eval cases for ${
+        named("suite") ?? named("suiteId") ?? "(unnamed)"
+      }`;
     case cancelEvalRunOperation.name:
       return `Cancel run ${named("run") ?? named("runId") ?? "(unnamed)"}`;
     default:
@@ -428,7 +446,9 @@ export function buildAgentApiToolSet(opts: {
    * run concurrently — a shared "current key" holder would let one call's key
    * be applied to another's write.
    */
-  clientWithHeaders?: (extraHeaders: Record<string, string>) => PlatformApiClient;
+  clientWithHeaders?: (
+    extraHeaders: Record<string, string>
+  ) => PlatformApiClient;
 }): ToolSet {
   const tools: ToolSet = {};
   for (const operation of AGENT_API_OPERATIONS) {
@@ -461,7 +481,9 @@ export function buildAgentApiToolSet(opts: {
         if (!parsed.success) {
           const issues = parsed.error.issues
             .slice(0, 5)
-            .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+            .map(
+              (issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`
+            )
             .join("; ");
           return {
             error: `Invalid input for ${operation.name} — fix these fields and retry: ${issues}`,
@@ -605,7 +627,8 @@ const agentTurnSchema = z.object({
     .refine(
       (messages) =>
         messages.reduce(
-          (total, message) => total + Buffer.byteLength(message.content, "utf8"),
+          (total, message) =>
+            total + Buffer.byteLength(message.content, "utf8"),
           0
         ) <= MAX_TOTAL_MESSAGE_BYTES,
       {

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -55,14 +55,27 @@ import { tool, type ToolSet } from "ai";
 import { MCPClientManager } from "@mcpjam/sdk";
 import {
   PlatformApiClient,
+  cancelEvalRunOperation,
+  createEvalCaseOperation,
   createEvalSuiteOperation,
+  generateEvalCasesOperation,
+  getEvalCaseOperation,
   getEvalRunOperation,
+  getEvalRunStepsOperation,
   getEvalSuiteOperation,
+  getHostOperation,
+  listEnvironmentsOperation,
   listEvalCasesOperation,
+  listEvalRunIterationsOperation,
   listEvalSuiteRunsOperation,
   listEvalSuitesOperation,
+  listHostsOperation,
   listProjectServersOperation,
   listServerToolsOperation,
+  runEvalCaseOperation,
+  runEvalSuiteOperation,
+  updateEvalCaseOperation,
+  updateEvalSuiteOperation,
   type PlatformOperation,
 } from "@mcpjam/sdk/platform";
 import { MCPJAM_HOSTED_ORIGIN, WEB_STREAM_TIMEOUT_MS } from "../../config.js";
@@ -86,6 +99,7 @@ import type { ModelDefinition } from "@/shared/types";
 import { captureServerEvent } from "../../utils/analytics.js";
 import type { RequestLogContext } from "../../utils/log-events.js";
 import { logger } from "../../utils/logger.js";
+import { createProposedAction } from "../../services/slack-backend.js";
 import { v1Error, v1Resource } from "./envelope.js";
 
 // ---------------------------------------------------------------------------
@@ -101,14 +115,50 @@ import { v1Error, v1Resource } from "./envelope.js";
 export const AGENT_API_OPERATIONS: ReadonlyArray<
   PlatformOperation<any, unknown>
 > = [
+  // READ — free, and the difference between an agent that inspects the
+  // project and one that guesses at it.
   listProjectServersOperation,
   listServerToolsOperation,
   listEvalSuitesOperation,
   getEvalSuiteOperation,
   listEvalCasesOperation,
+  getEvalCaseOperation,
   listEvalSuiteRunsOperation,
   getEvalRunOperation,
+  listEvalRunIterationsOperation,
+  getEvalRunStepsOperation,
+  listHostsOperation,
+  getHostOperation,
+  listEnvironmentsOperation,
+  // WRITE — persists, but spends nothing. Every one is idempotency-keyed
+  // (see WRITE_OPERATION_NAMES) and echoed in the response envelope.
   createEvalSuiteOperation,
+  createEvalCaseOperation,
+  updateEvalCaseOperation,
+  updateEvalSuiteOperation,
+];
+
+/**
+ * GATED — operations that SPEND (eval quota, org credits).
+ *
+ * The model gets a tool per operation with the operation's REAL input schema,
+ * but the tool does not execute: it validates, persists a proposal, and
+ * returns an action id. A human click is what runs it.
+ *
+ * `approvalMode: "auto-deny"` means an unattended turn has no interactive
+ * fallback, so the alternative to a proposal is not "ask the user" — it is
+ * either spending on the model's own initiative or not offering the action at
+ * all. Destructive ops (`delete_*`, `use_sandbox_image`, `reset_computer`)
+ * stay excluded entirely: a proposal makes spend deliberate, but it does not
+ * make an irreversible deletion recoverable.
+ */
+export const AGENT_API_GATED_OPERATIONS: ReadonlyArray<
+  PlatformOperation<any, unknown>
+> = [
+  runEvalSuiteOperation,
+  runEvalCaseOperation,
+  generateEvalCasesOperation,
+  cancelEvalRunOperation,
 ];
 
 /**
@@ -124,6 +174,9 @@ export const AGENT_API_OPERATIONS: ReadonlyArray<
  */
 const WRITE_OPERATION_NAMES: ReadonlySet<string> = new Set([
   createEvalSuiteOperation.name,
+  createEvalCaseOperation.name,
+  updateEvalCaseOperation.name,
+  updateEvalSuiteOperation.name,
 ]);
 
 export type CreatedResource = {
@@ -181,6 +234,144 @@ function stripProjectSwitchingMetadata(result: unknown): unknown {
     return rest;
   }
   return result;
+}
+
+export type ProposedAction = {
+  actionId: string;
+  operation: string;
+  /** The validated, project-clamped input the click will execute. */
+  input: Record<string, unknown>;
+  /** Human-readable summary for the button. Never a promise — see below. */
+  description: string;
+};
+
+/**
+ * Build the proposal-only tools for the GATED operations.
+ *
+ * Each tool carries the operation's REAL input schema, so the model is
+ * validated against the same contract execution would use — a proposal that
+ * would fail at execution time is a proposal that should never have been
+ * offered, and a human is about to be asked to approve it.
+ *
+ * The proposal is persisted server-side and the model receives only an opaque
+ * `actionId`. That is what makes the click safe: the button carries the id,
+ * the backend supplies the operation, and nothing the model or the click
+ * payload says can change what runs.
+ */
+function buildGatedProposalTools(opts: {
+  projectId: string;
+  proposed: ProposedAction[];
+  slack?: { teamId: string; channelId: string; slackUserId: string; organizationId: string };
+}): ToolSet {
+  const tools: ToolSet = {};
+  for (const operation of AGENT_API_GATED_OPERATIONS) {
+    tools[operation.name] = tool({
+      description:
+        `${operation.description} ` +
+        "REQUIRES HUMAN APPROVAL: calling this does NOT run it. It proposes " +
+        "the action and returns an approval id; a person must click to " +
+        "confirm. Say that you have proposed it — never that it has run or " +
+        "started.",
+      inputSchema: relaxProjectRequirement(
+        operation.inputSchema
+      ) as typeof operation.inputSchema,
+      execute: async (input: Record<string, unknown>) => {
+        const requested =
+          typeof input.project === "string" ? input.project.trim() : "";
+        if (requested && requested !== opts.projectId) {
+          return { error: PROJECT_SCOPE_ERROR };
+        }
+        // Validate against the op's REAL schema. Same field-addressed error
+        // shape as the executing tools, so the model can correct and retry.
+        const clamped = { ...input, project: opts.projectId };
+        const parsed = (
+          operation.inputSchema as z.ZodType<Record<string, unknown>>
+        ).safeParse(clamped);
+        if (!parsed.success) {
+          const issues = parsed.error.issues
+            .slice(0, 5)
+            .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+            .join("; ");
+          return {
+            error: `Invalid input for ${operation.name} — fix these fields and retry: ${issues}`,
+          };
+        }
+
+        if (!opts.slack) {
+          // No surface to render a button on. Refusing is the honest answer:
+          // silently proposing into the void would let the model report an
+          // action as pending that nobody can ever approve.
+          return {
+            error: `${operation.title} needs human approval, which this caller cannot collect. Ask the user to run it from the MCPJam app.`,
+          };
+        }
+
+        const actionId = randomUUID();
+        try {
+          await createProposedAction({
+            actionId,
+            teamId: opts.slack.teamId,
+            channelId: opts.slack.channelId,
+            operation: operation.name,
+            input: parsed.data,
+            organizationId: opts.slack.organizationId,
+            projectId: opts.projectId,
+            proposedBySlackUserId: opts.slack.slackUserId,
+          });
+        } catch (error) {
+          logger.warn("[v1/agent] could not persist a proposed action", {
+            operation: operation.name,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return {
+            error: `Could not propose ${operation.title} right now. Try again in a moment.`,
+          };
+        }
+
+        const description = describeProposal(operation.name, parsed.data);
+        opts.proposed.push({
+          actionId,
+          operation: operation.name,
+          input: parsed.data,
+          description,
+        });
+        return {
+          proposed: true,
+          actionId,
+          description,
+          note: "Awaiting human approval. Do not claim this has started.",
+        };
+      },
+    });
+  }
+  return tools;
+}
+
+/**
+ * A short, concrete summary of what a click will do.
+ *
+ * States the TARGET, not a cost: any number here would be an estimate, and an
+ * estimate rendered next to an approval button reads as a promise. The caller
+ * renders its own cost hint alongside, clearly labelled as one.
+ */
+function describeProposal(
+  operationName: string,
+  input: Record<string, unknown>
+): string {
+  const named = (key: string) =>
+    typeof input[key] === "string" ? (input[key] as string) : undefined;
+  switch (operationName) {
+    case runEvalSuiteOperation.name:
+      return `Run eval suite ${named("suite") ?? named("suiteId") ?? "(unnamed)"}`;
+    case runEvalCaseOperation.name:
+      return `Run eval case ${named("case") ?? named("caseId") ?? "(unnamed)"}`;
+    case generateEvalCasesOperation.name:
+      return `Generate eval cases for ${named("suite") ?? named("suiteId") ?? "(unnamed)"}`;
+    case cancelEvalRunOperation.name:
+      return `Cancel run ${named("run") ?? named("runId") ?? "(unnamed)"}`;
+    default:
+      return operationName;
+  }
 }
 
 /**
@@ -334,7 +525,8 @@ const AGENT_API_SYSTEM_PROMPT = [
   "- Before authoring tool-call assertions, check the server's real tool names with `list_server_tools`.",
   "- Author cases as `steps` arrays; prefer a `prompt` step plus `toolCalledWith`-style assertions on the tools the conversation showed. Set `expectedOutput` when the user stated one.",
   `- When creating a suite, set the suite \`model\` explicitly to \`${DEFAULT_SUITE_MODEL}\` unless the user asks for a different model.`,
-  "- You CANNOT run suites, and must not claim to. After creating a suite, tell the user it's ready to run and report its id — the surface you're hosted in offers the run action separately.",
+  "- Some actions SPEND the user's quota or credits (running a suite or a case, generating cases, cancelling a run). Calling those tools does NOT perform them: it PROPOSES the action and returns an approval id, and a person must click to confirm. Say that you've proposed it and what it will do. NEVER say it has started, is running, or has been cancelled.",
+  "- If a proposal tool is not available to you, you cannot run anything at all. Say so plainly and report the ids the user needs — do not imply you started something.",
   "- Always report the ids of anything you created.",
   "- Tool input schemas are AUTHORITATIVE. Never consult docs to learn a tool's argument shape — the schema you were given is the truth. If a tool returns a validation error naming fields, correct exactly those fields and retry the same call.",
   "- Consult the MCPJam docs tools (when available) for product questions instead of answering from memory.",
@@ -398,6 +590,13 @@ const agentTurnSchema = z.object({
    * keep the previous (non-idempotent) behaviour rather than being rejected.
    */
   idempotencyKey: z.string().min(1).max(200).optional(),
+  /**
+   * Where a proposal's approval button will be rendered. Required for the
+   * GATED tools to be usable at all — without a surface to collect the click,
+   * proposing is refused rather than silently queued somewhere nobody can
+   * approve it.
+   */
+  slackChannelId: z.string().min(1).max(64).optional(),
 });
 
 const activeTurnsByOrg = new Map<string, number>();
@@ -539,15 +738,46 @@ agent.post("/projects/:projectId/agent", async (c) => {
     const client = makeClient();
 
     const created: CreatedResource[] = [];
-    const builtInTools = buildAgentApiToolSet({
-      client,
-      projectId,
-      created,
-      ...(body.idempotencyKey
-        ? { turnIdempotencyKey: body.idempotencyKey }
+    const proposed: ProposedAction[] = [];
+    // Proposals need a Slack surface AND an org to attribute them to; both
+    // come from `slack_service` auth. Other callers get the read/write tiers
+    // only — the gated tools are omitted entirely rather than offered and
+    // then refused, so the model never plans around an action it cannot take.
+    const slackTeamId = c.get("slackTeamId");
+    const slackUserId = c.get("slackUserId");
+    const organizationId = c.get("mcpjamOrganizationId");
+    const slackProposalContext =
+      c.get("authMethod") === "slack_service" &&
+      slackTeamId &&
+      slackUserId &&
+      organizationId &&
+      body.slackChannelId
+        ? {
+            teamId: slackTeamId,
+            channelId: body.slackChannelId,
+            slackUserId,
+            organizationId,
+          }
+        : undefined;
+
+    const builtInTools = {
+      ...buildAgentApiToolSet({
+        client,
+        projectId,
+        created,
+        ...(body.idempotencyKey
+          ? { turnIdempotencyKey: body.idempotencyKey }
+          : {}),
+        clientWithHeaders: makeClient,
+      }),
+      ...(slackProposalContext
+        ? buildGatedProposalTools({
+            projectId,
+            proposed,
+            slack: slackProposalContext,
+          })
         : {}),
-      clientWithHeaders: makeClient,
-    });
+    };
 
     // Docs server with preflight-degrade: `getToolsForAiSdk` (inside
     // `prepareChatV2`) fails the whole turn when a selected server errors at
@@ -670,8 +900,15 @@ agent.post("/projects/:projectId/agent", async (c) => {
     // A failed/timed-out turn may still have PERSISTED suites (the create
     // op completed before the failure). Surface them in the error details
     // so a retrying caller doesn't double-create.
-    const errorDetails = () =>
-      created.length > 0 ? { createdResources: created } : undefined;
+    const errorDetails = () => {
+      const details: Record<string, unknown> = {};
+      if (created.length > 0) details.createdResources = created;
+      // A failed turn may still have PROPOSED actions. Surfacing them lets a
+      // caller render the buttons anyway rather than stranding approvals the
+      // user was about to be offered.
+      if (proposed.length > 0) details.proposedActions = proposed;
+      return Object.keys(details).length > 0 ? details : undefined;
+    };
 
     if (abortController.signal.aborted) {
       captureTurnEvent(c, {
@@ -725,6 +962,10 @@ agent.post("/projects/:projectId/agent", async (c) => {
         operation: call.toolName,
       })),
       createdResources: created,
+      // Actions awaiting a human click. The caller renders these as buttons;
+      // the `actionId` is all a click needs to carry, because the backend
+      // holds what it does.
+      proposedActions: proposed,
       usage: {
         inputTokens: result.usage?.inputTokens ?? 0,
         outputTokens: result.usage?.outputTokens ?? 0,

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -25,12 +25,15 @@
  * non-idempotent behaviour rather than being rejected.
  *
  * Surface decisions (see the Slack-app v1 plan):
- *  - Tools are READ ops + atomic `create_eval_suite` ONLY. Run/cancel ops
- *    (spend eval quota) and `generate_eval_cases` (spends org credits) are
- *    excluded: `approvalMode: "auto-deny"` has no interactive fallback, so
- *    an unattended turn must never spend on the model's own initiative.
- *    Runs stay human-gated caller-side (the Slack "Run it" button posts to
- *    POST /eval-runs directly).
+ *  - Tools are TIERED by what an operation costs. READ ops and non-spending
+ *    WRITE ops (`AGENT_API_OPERATIONS`) execute directly. Ops that SPEND —
+ *    run suite, run case, generate cases, cancel run
+ *    (`AGENT_API_GATED_OPERATIONS`) — are PROPOSAL-ONLY: the tool validates
+ *    against the op's real schema, persists a proposal, and returns an opaque
+ *    action id; a human click executes it. `approvalMode: "auto-deny"` has no
+ *    interactive fallback, so an unattended turn must never spend on the
+ *    model's own initiative. Destructive ops stay excluded entirely — a
+ *    proposal makes spend deliberate, not a deletion recoverable.
  *  - Every operation is HARD-CLAMPED to the route's `projectId`. The op
  *    catalog's `project` selector allows cross-project roaming for other
  *    surfaces; prompt instructions are not an authorization boundary, so
@@ -261,6 +264,14 @@ export type ProposedAction = {
 function buildGatedProposalTools(opts: {
   projectId: string;
   proposed: ProposedAction[];
+  /**
+   * The turn's stable identity. When present, the action id is DERIVED from it
+   * rather than random, so a redelivered Slack event that re-proposes the same
+   * action lands on the same proposal row instead of offering the user a second
+   * button for the same spend. Two identical buttons in a thread are two clicks
+   * away from being billed twice.
+   */
+  turnIdempotencyKey?: string;
   slack?: { teamId: string; channelId: string; slackUserId: string; organizationId: string };
 }): ToolSet {
   const tools: ToolSet = {};
@@ -275,7 +286,10 @@ function buildGatedProposalTools(opts: {
       inputSchema: relaxProjectRequirement(
         operation.inputSchema
       ) as typeof operation.inputSchema,
-      execute: async (input: Record<string, unknown>) => {
+      execute: async (input: Record<string, unknown>, { abortSignal }) => {
+        if (abortSignal?.aborted) {
+          return { error: `${operation.title} was cancelled.` };
+        }
         const requested =
           typeof input.project === "string" ? input.project.trim() : "";
         if (requested && requested !== opts.projectId) {
@@ -306,7 +320,25 @@ function buildGatedProposalTools(opts: {
           };
         }
 
-        const actionId = randomUUID();
+        // Re-check: validation above can yield, and the turn's wall clock may
+        // have fired meanwhile. Persisting after an abort would leave a
+        // proposal behind for a turn that answered with a timeout.
+        if (abortSignal?.aborted) {
+          return { error: `${operation.title} was cancelled.` };
+        }
+
+        // Derived where possible: same turn + same operation + same arguments
+        // must yield the SAME proposal, so a redelivery re-offers the existing
+        // button rather than minting a second one. `randomUUID` only for
+        // callers with no stable turn identity, where a duplicate proposal is
+        // the lesser risk than none at all.
+        const actionId = opts.turnIdempotencyKey
+          ? deriveOperationIdempotencyKey(
+              opts.turnIdempotencyKey,
+              `proposal:${operation.name}`,
+              parsed.data
+            )
+          : randomUUID();
         try {
           await createProposedAction({
             actionId,
@@ -589,7 +621,17 @@ const agentTurnSchema = z.object({
    * Optional: callers that genuinely cannot produce a stable trigger identity
    * keep the previous (non-idempotent) behaviour rather than being rejected.
    */
-  idempotencyKey: z.string().min(1).max(200).optional(),
+  idempotencyKey: z
+    .string()
+    .min(1)
+    .max(200)
+    // Printable ASCII only. The key becomes a HEADER value on every write the
+    // turn issues, and `Headers.set` throws on a control character — so a key
+    // containing CR, LF, or NUL would let every read succeed and every write
+    // fail, leaving a half-finished turn. Rejecting it at the boundary makes
+    // that a 400 the caller can read instead.
+    .regex(/^[\x20-\x7E]+$/, "idempotencyKey must be printable ASCII")
+    .optional(),
   /**
    * Where a proposal's approval button will be rendered. Required for the
    * GATED tools to be usable at all — without a surface to collect the click,
@@ -774,6 +816,9 @@ agent.post("/projects/:projectId/agent", async (c) => {
         ? buildGatedProposalTools({
             projectId,
             proposed,
+            ...(body.idempotencyKey
+              ? { turnIdempotencyKey: body.idempotencyKey }
+              : {}),
             slack: slackProposalContext,
           })
         : {}),

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -24,6 +24,7 @@ import { createAuthorizedManager, callerContextFromHono } from "../web/auth.js";
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { HOSTED_MODE } from "../../config.js";
 import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
+import { readIdempotencyKey } from "../../utils/idempotency.js";
 import {
   RunEvalsRequestSchema,
   prepareEvalRun,
@@ -1388,9 +1389,15 @@ async function resolveHostAttachments(
 evals.post("/projects/:projectId/eval-runs", async (c) => {
   const projectId = c.req.param("projectId");
   const rawBody = await synthesizeServerBody(c);
+  const headerIdempotencyKey = readIdempotencyKey(c);
   const body = parseWithSchema(createEvalRunSchema, {
     ...rawBody,
     projectId,
+    // The HEADER wins over any body value. Both are caller-supplied, but the
+    // header is the transport-level channel unattended clients use, and it is
+    // the one the agent adapter controls — a body key could otherwise be
+    // shaped by model output.
+    ...(headerIdempotencyKey ? { idempotencyKey: headerIdempotencyKey } : {}),
   });
 
   // `suiteRerun` semantics from the web surface: a bare `suiteId` rerun has
@@ -1581,6 +1588,7 @@ evals.post("/projects/:projectId/eval-suites", async (c) => {
   const projectId = c.req.param("projectId");
   const rawBody = await synthesizeServerBody(c);
   const body = parseWithSchema(createEvalSuiteSchema, rawBody);
+  const idempotencyKey = readIdempotencyKey(c);
 
   // Expand ergonomic tests into the strict run-schema element shape, then
   // re-validate against the source-of-truth schema. Use parseWithSchema so a
@@ -1637,6 +1645,9 @@ evals.post("/projects/:projectId/eval-suites", async (c) => {
       passCriteria: body.passCriteria,
       suiteRerun: false,
       refreshSnapshot: false,
+      // Unattended callers (the Slack bot) send this so a retried turn
+      // re-authors the same suite instead of a second one.
+      ...(idempotencyKey ? { idempotencyKey } : {}),
     });
     return v1Resource(
       c,

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -2575,7 +2575,7 @@ evals.post(
         // FAIL CLOSED, not degrade-to-generate. A caller that sent a key is
         // asking for spend idempotency; treating an unreadable ledger as a
         // cache miss would re-spend credits during exactly the kind of
-        // backend blip that also lost the first attempt's response. 503 is
+        // backend blip that also lost the first attempt's response. 502 is
         // retryable and the retry presents the same key.
         logger.warn("v1.eval.generate: could not read the generation ledger", {
           error: error instanceof Error ? error.message : String(error),

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -24,7 +24,10 @@ import { createAuthorizedManager, callerContextFromHono } from "../web/auth.js";
 import { resolveXaaIssuer } from "../../services/xaa-mint.js";
 import { HOSTED_MODE } from "../../config.js";
 import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
-import { readIdempotencyKey } from "../../utils/idempotency.js";
+import {
+  deriveItemIdempotencyKey,
+  readIdempotencyKey,
+} from "../../utils/idempotency.js";
 import {
   RunEvalsRequestSchema,
   prepareEvalRun,
@@ -2470,6 +2473,13 @@ evals.post(
     );
     const mode = body.mode ?? "normal";
     const token = await getConvexBearerForRequest(c);
+    // Generation is the one spend whose expensive step (the LLM call) happens
+    // outside any mutation. With a key, the route becomes replayable: the
+    // drafts are recorded in a backend ledger BEFORE cases are persisted, so a
+    // retry (a proposal reclaim, a redelivered click) replays the recorded
+    // drafts instead of spending credits again — and each case is persisted
+    // under a derived per-item key, so the persistence loop is resumable.
+    const idempotencyKey = readIdempotencyKey(c);
 
     // Project-scope guard.
     const readClient = createConvexReadClient(token);
@@ -2520,23 +2530,6 @@ evals.post(
         provider: deriveProvider(m.model, m.provider),
       })) ?? (await defaultCaseModels(readClient, suiteId));
 
-    const { manager } = await createAuthorizedManager(
-      callerContextFromHono(c),
-      token,
-      projectId,
-      serverIds,
-      WEB_CALL_TIMEOUT_MS,
-      undefined,
-      undefined,
-      {
-        serverNames,
-        // v1 eval API has no host-persona input — no enterprise policy to
-        // enforce; the issuer makes per-server XAA servers mint instead of
-        // failing with 'Missing XAA issuer'.
-        xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
-      }
-    );
-
     // A caseMix only counts when it requests at least one case (a bucket > 0).
     // An empty `{}` OR a zero-sum mix (`{ negative: 0 }`, all zeros) is treated
     // as absent — matching backend #589, which reverts a zero-sum mix to the
@@ -2564,32 +2557,92 @@ evals.post(
     // `mode: "negative"` + caseMix request doesn't mislabel its positive cases.
     const legacyNegativeOnly = mode === "negative" && !hasCaseMix;
 
-    let drafts: any[];
-    try {
-      const request = {
-        serverIds,
-        serverNames,
-        convexAuthToken: token,
+    const { convexClient } = createConvexClients(token);
+
+    // LEDGER FIRST. A keyed retry whose first attempt already generated must
+    // replay those exact drafts: regeneration is a second credit spend, and —
+    // being stochastic — would produce different cases that no derived
+    // per-item key could dedupe against the first attempt's.
+    let drafts: any[] | null = null;
+    if (idempotencyKey) {
+      try {
+        const ledger = await createConvexReadClient(token).query(
+          "testSuites:getCaseGeneration" as any,
+          { suiteId, idempotencyKey }
+        );
+        if (ledger && Array.isArray(ledger.drafts)) {
+          drafts = ledger.drafts;
+        }
+      } catch (error) {
+        // An unreadable ledger degrades to generation — the pre-ledger
+        // behaviour — never to a failed request.
+        logger.warn("v1.eval.generate: could not read the generation ledger", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (drafts === null) {
+      const { manager } = await createAuthorizedManager(
+        callerContextFromHono(c),
+        token,
         projectId,
-        ...(generationOptions ? { generationOptions } : {}),
-      } as unknown as RunEvalsRequest;
-      const result = legacyNegativeOnly
-        ? await generateNegativeEvalTestsWithManager(manager, request as any)
-        : await generateEvalTestsWithManager(manager, request as any);
-      drafts = Array.isArray((result as any).tests)
-        ? (result as any).tests
-        : [];
-    } finally {
-      await manager.disconnectAllServers().catch(() => {});
+        serverIds,
+        WEB_CALL_TIMEOUT_MS,
+        undefined,
+        undefined,
+        {
+          serverNames,
+          // v1 eval API has no host-persona input — no enterprise policy to
+          // enforce; the issuer makes per-server XAA servers mint instead of
+          // failing with 'Missing XAA issuer'.
+          xaaIssuer: resolveXaaIssuer(c, HOSTED_MODE),
+        }
+      );
+      try {
+        const request = {
+          serverIds,
+          serverNames,
+          convexAuthToken: token,
+          projectId,
+          ...(generationOptions ? { generationOptions } : {}),
+        } as unknown as RunEvalsRequest;
+        const result = legacyNegativeOnly
+          ? await generateNegativeEvalTestsWithManager(manager, request as any)
+          : await generateEvalTestsWithManager(manager, request as any);
+        drafts = Array.isArray((result as any).tests)
+          ? (result as any).tests
+          : [];
+      } finally {
+        await manager.disconnectAllServers().catch(() => {});
+      }
+
+      // Record the drafts BEFORE persisting any case. From this point a crash
+      // is recoverable without re-spending; before it, regeneration was
+      // genuinely necessary anyway. Best-effort: a failed write only reopens
+      // the pre-ledger window.
+      if (idempotencyKey && drafts.length > 0) {
+        try {
+          await convexClient.mutation(
+            "testSuites:recordCaseGeneration" as any,
+            { suiteId, idempotencyKey, drafts }
+          );
+        } catch (error) {
+          logger.warn(
+            "v1.eval.generate: could not record the generation ledger",
+            { error: error instanceof Error ? error.message : String(error) }
+          );
+        }
+      }
     }
 
     // Persist each generated draft as a case under the suite.
-    const { convexClient } = createConvexClients(token);
     const created: ReturnType<typeof toCaseDto>[] = [];
+    const createdCaseIds: string[] = [];
     const skipped: Array<{ title: string; error: string }> = [];
     let normal = 0;
     let negative = 0;
-    for (const draft of drafts) {
+    for (const [draftIndex, draft] of drafts.entries()) {
       // The legacy negative-only path emits only negative cases; otherwise the
       // plan-driven generator flags each draft. Negative cases must carry NO
       // expected tool calls (the suite guard rejects that), so clear them on
@@ -2658,6 +2711,17 @@ evals.post(
           : {}),
         ...(isNeg ? { isNegativeTest: true } : {}),
         ...(draft.scenario !== undefined ? { scenario: draft.scenario } : {}),
+        // Positional, not content-derived: on a keyed retry the drafts come
+        // from the ledger VERBATIM, so index i names the same draft both
+        // times and the re-persist lands on the first attempt's case.
+        ...(idempotencyKey
+          ? {
+              idempotencyKey: deriveItemIdempotencyKey(
+                idempotencyKey,
+                String(draftIndex)
+              ),
+            }
+          : {}),
       };
       try {
         const caseId = await convexClient.mutation(
@@ -2669,6 +2733,7 @@ evals.post(
           { testCaseId: caseId }
         );
         created.push(toCaseDto(doc));
+        createdCaseIds.push(String(caseId));
         if (isNeg) negative += 1;
         else normal += 1;
       } catch (error) {
@@ -2678,6 +2743,17 @@ evals.post(
         });
         skipped.push({ title: String(draft.title ?? ""), error: reason });
       }
+    }
+
+    // Best-effort bookkeeping so the ledger row also names what it produced.
+    if (idempotencyKey && createdCaseIds.length > 0) {
+      await convexClient
+        .mutation("testSuites:markCaseGenerationPersisted" as any, {
+          suiteId,
+          idempotencyKey,
+          createdCaseIds,
+        })
+        .catch(() => {});
     }
 
     return v1Resource(c, {

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -2565,20 +2565,29 @@ evals.post(
     // per-item key could dedupe against the first attempt's.
     let drafts: any[] | null = null;
     if (idempotencyKey) {
+      let ledger: { drafts: unknown } | null;
       try {
-        const ledger = await createConvexReadClient(token).query(
+        ledger = await createConvexReadClient(token).query(
           "testSuites:getCaseGeneration" as any,
           { suiteId, idempotencyKey }
         );
-        if (ledger && Array.isArray(ledger.drafts)) {
-          drafts = ledger.drafts;
-        }
       } catch (error) {
-        // An unreadable ledger degrades to generation — the pre-ledger
-        // behaviour — never to a failed request.
+        // FAIL CLOSED, not degrade-to-generate. A caller that sent a key is
+        // asking for spend idempotency; treating an unreadable ledger as a
+        // cache miss would re-spend credits during exactly the kind of
+        // backend blip that also lost the first attempt's response. 503 is
+        // retryable and the retry presents the same key.
         logger.warn("v1.eval.generate: could not read the generation ledger", {
           error: error instanceof Error ? error.message : String(error),
         });
+        throw new WebRouteError(
+          502,
+          ErrorCode.SERVER_UNREACHABLE,
+          "Could not verify this generation's idempotency ledger. Retry with the same key."
+        );
+      }
+      if (ledger && Array.isArray(ledger.drafts)) {
+        drafts = ledger.drafts;
       }
     }
 
@@ -2617,16 +2626,31 @@ evals.post(
         await manager.disconnectAllServers().catch(() => {});
       }
 
-      // Record the drafts BEFORE persisting any case. From this point a crash
-      // is recoverable without re-spending; before it, regeneration was
-      // genuinely necessary anyway. Best-effort: a failed write only reopens
-      // the pre-ledger window.
-      if (idempotencyKey && drafts.length > 0) {
+      // Record the drafts BEFORE persisting any case — INCLUDING an empty
+      // result: "the generator ran and produced nothing" is a spend worth
+      // checkpointing too, or every keyed retry would pay for it again. From
+      // this point a crash is recoverable without re-spending; before it,
+      // regeneration was genuinely necessary anyway. Recording is best-effort
+      // (the spend already happened, so failing the request here would strand
+      // paid work), but a lost RACE is not a failure: the mutation is
+      // first-writer-wins, and the loser must converge on the winner's drafts
+      // so two concurrent same-key requests persist the SAME cases (the
+      // per-item keys then dedupe the loop) instead of two divergent sets.
+      if (idempotencyKey) {
         try {
-          await convexClient.mutation(
+          const outcome = (await convexClient.mutation(
             "testSuites:recordCaseGeneration" as any,
             { suiteId, idempotencyKey, drafts }
-          );
+          )) as { recorded?: boolean } | null;
+          if (outcome?.recorded === false) {
+            const winner = await createConvexReadClient(token).query(
+              "testSuites:getCaseGeneration" as any,
+              { suiteId, idempotencyKey }
+            );
+            if (winner && Array.isArray(winner.drafts)) {
+              drafts = winner.drafts;
+            }
+          }
         } catch (error) {
           logger.warn(
             "v1.eval.generate: could not record the generation ledger",

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -25,6 +25,7 @@ import environments from "./environments.js";
 import sandboxImages from "./images.js";
 import evalIngest from "./eval-ingest.js";
 import agent from "./agent.js";
+import proposedActionsRoutes from "./proposed-actions.js";
 import oauth from "./oauth.js";
 import catalog from "./catalog.js";
 import hostCatalog from "./host-catalog.js";
@@ -158,6 +159,9 @@ v1.route("/", evalIngest);
 // Headless agent turn (Slack bot terminal). Guest-DENIED by default (no
 // GUEST_ALLOWED_V1_RULES entry) — every turn spends hosted-model credits.
 v1.route("/", agent);
+// Executing an action a human approved in Slack. Guest-DENIED by default (no
+// GUEST_ALLOWED_V1_RULES entry) — every approved action spends.
+v1.route("/", proposedActionsRoutes);
 v1.route("/", oauth);
 v1.route("/", catalog);
 v1.route("/", tunnels);

--- a/mcpjam-inspector/server/routes/v1/proposed-actions.ts
+++ b/mcpjam-inspector/server/routes/v1/proposed-actions.ts
@@ -104,6 +104,15 @@ proposedActions.post(
       );
     }
 
+    // ORG CHECK BEFORE THE CLAIM. One Slack workspace can host people from
+    // several MCPJam orgs. Letting an outsider reach `beginProposedAction`
+    // would let them CLAIM the proposal and then fail authorization — burning
+    // it, so the colleague who could legitimately approve it never gets to.
+    // Same non-disclosing answer, so this is not an oracle either.
+    if (record.organizationId !== c.get("mcpjamOrganizationId")) {
+      return v1Error(c, "NOT_FOUND", "That approval is no longer available.");
+    }
+
     const operation = GATED_BY_NAME.get(record.operation);
     if (!operation) {
       // The proposal names an operation this build does not gate — a rollback,
@@ -200,7 +209,15 @@ proposedActions.post(
         baseUrl: "http://self.mcpjam.internal/api/v1",
         getAuth: () => convexJwt,
         fetch: async (input, init) => {
-          const request = new Request(input, init);
+          // The deadline has to reach the INNER request. Without forwarding the
+          // signal, the timeout only stops us waiting — the self-dispatched
+          // operation keeps running and can complete long after we told the
+          // user it timed out. `init.signal` is respected when the caller set
+          // one, so this only fills the gap.
+          const request = new Request(input, {
+            ...init,
+            signal: init?.signal ?? abortController.signal,
+          });
           // The action id IS the idempotency key. A redelivered click, or a
           // retry after this process died mid-execution, presents the same key
           // and lands on the same run rather than billing a second one.

--- a/mcpjam-inspector/server/routes/v1/proposed-actions.ts
+++ b/mcpjam-inspector/server/routes/v1/proposed-actions.ts
@@ -1,0 +1,269 @@
+/**
+ * Execute an action a human approved.
+ *
+ * The agent turn cannot spend. When the model wants to run a suite, run a case,
+ * generate cases, or cancel a run, its tool call PROPOSES the operation (see
+ * `AGENT_API_GATED_OPERATIONS` in `agent.ts`) and a person is shown a button.
+ * This route is what that button hits.
+ *
+ * THREE PROPERTIES MAKE THE CLICK SAFE, and all three live here:
+ *
+ *   1. THE PROPOSAL IS THE CONTRACT. `beginProposedAction` returns the
+ *      PERSISTED operation and input, and those are what execute. Nothing from
+ *      the request body decides what runs — a Block Kit button's `value` can be
+ *      minted by anyone able to post in the workspace, so a click may only ever
+ *      say WHICH proposal to run.
+ *   2. THE CLICKER IS THE AUTHORIZER. This route runs under `slack_service`
+ *      auth, so the delegated JWT is minted for the person who CLICKED, and the
+ *      mint re-verifies their org membership. The proposer's identity executes
+ *      nothing: someone who has been removed from the org cannot spend through
+ *      a button they left behind, and someone who never had access to the
+ *      project cannot gain it by clicking.
+ *   3. THE CLAIM IS DURABLE. `proposed → executing` is a transactional
+ *      transition in the backend; a double-click races there and exactly one
+ *      caller wins. The loser is told, not billed.
+ *
+ * The tenant check below is not redundant with the claim: the claim guarantees
+ * ONE execution, not a LEGITIMATE one. Without the team/project comparison, a
+ * workspace that learned another workspace's action id could spend the other
+ * org's quota — the claim would happily hand it the operation to run.
+ */
+import { Hono } from "hono";
+import { PlatformApiClient } from "@mcpjam/sdk/platform";
+import { AGENT_API_GATED_OPERATIONS } from "./agent.js";
+import {
+  beginProposedAction,
+  completeProposedAction,
+  getProposedAction,
+  releaseProposedAction,
+  SlackBackendUnavailable,
+} from "../../services/slack-backend.js";
+import { getSelfFetch } from "../../utils/self-app.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { IDEMPOTENCY_KEY_HEADER } from "../../utils/idempotency.js";
+import { logger } from "../../utils/logger.js";
+import { v1Error, v1Resource } from "./envelope.js";
+
+const proposedActions = new Hono();
+
+/** Wall clock for one approved execution. Generous: a suite run is not fast. */
+const EXECUTION_TIMEOUT_MS = 120_000;
+
+const GATED_BY_NAME = new Map(
+  AGENT_API_GATED_OPERATIONS.map((operation) => [operation.name, operation])
+);
+
+proposedActions.post(
+  "/projects/:projectId/proposed-actions/:actionId/execute",
+  async (c) => {
+    const projectId = c.req.param("projectId");
+    const actionId = c.req.param("actionId");
+
+    // Proposals exist only for the Slack surface, because Slack is the only
+    // place a button can be rendered and a clicker identified. A JWT caller
+    // reaching here would have no clicker to attribute the spend to.
+    const slackTeamId = c.get("slackTeamId");
+    const slackUserId = c.get("slackUserId");
+    if (c.get("authMethod") !== "slack_service" || !slackTeamId || !slackUserId) {
+      return v1Error(
+        c,
+        "UNAUTHORIZED",
+        "Approved actions can only be executed from the Slack surface that collected the approval."
+      );
+    }
+
+    let record;
+    try {
+      record = await getProposedAction(actionId);
+    } catch (error) {
+      // 503, never 404: "could not ask" is not "does not exist". A clicker told
+      // their approval had vanished would go looking for a proposal that is
+      // sitting there intact.
+      logger.error("[v1/proposed-actions] could not read the proposal", {
+        error: error instanceof Error ? error.message : String(error),
+        is_backend_unavailable: error instanceof SlackBackendUnavailable,
+      });
+      return v1Error(
+        c,
+        "SERVER_UNREACHABLE",
+        "Could not reach MCPJam to check that approval. Try again in a moment."
+      );
+    }
+
+    // A missing proposal and one belonging to another workspace get the SAME
+    // answer. Distinguishing them would turn this route into an oracle for
+    // whether a given action id exists in some other org.
+    if (!record || record.teamId !== slackTeamId) {
+      return v1Error(c, "NOT_FOUND", "That approval is no longer available.");
+    }
+    if (record.projectId !== projectId) {
+      return v1Error(
+        c,
+        "NOT_FOUND",
+        "That approval belongs to a different project."
+      );
+    }
+
+    const operation = GATED_BY_NAME.get(record.operation);
+    if (!operation) {
+      // The proposal names an operation this build does not gate — a rollback,
+      // or a tampered row. Refuse rather than reaching for some other operation
+      // by the same name: a proposal is only as safe as the exact thing it says.
+      logger.warn("[v1/proposed-actions] proposal names an unknown operation", {
+        operation: record.operation.slice(0, 100).replace(/[\r\n]/g, ""),
+      });
+      return v1Error(
+        c,
+        "VALIDATION_ERROR",
+        "That approval is for an action this server no longer offers."
+      );
+    }
+
+    let claim;
+    try {
+      claim = await beginProposedAction({
+        actionId,
+        executedBySlackUserId: slackUserId,
+      });
+    } catch (error) {
+      // Fail closed. An unreachable backend must never be read as permission
+      // to spend — that is the whole reason the claim exists.
+      logger.error("[v1/proposed-actions] could not claim the proposal", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return v1Error(
+        c,
+        "SERVER_UNREACHABLE",
+        "Could not start that action right now. Try again in a moment."
+      );
+    }
+
+    if (!claim.ok) {
+      if (claim.reason === "expired") {
+        return v1Error(
+          c,
+          "VALIDATION_ERROR",
+          "That approval expired. Ask again and I'll propose it fresh."
+        );
+      }
+      if (claim.reason === "already_claimed") {
+        return v1Error(
+          c,
+          "CONFLICT",
+          claim.status === "executing"
+            ? "That action is already running."
+            : "That action has already been handled."
+        );
+      }
+      return v1Error(c, "NOT_FOUND", "That approval is no longer available.");
+    }
+
+    // From here the claim is HELD. Every exit must either complete it or
+    // release it, or the proposal is stranded `executing` and the sweep will
+    // deliberately refuse to reap it.
+    const selfFetch = getSelfFetch();
+    if (!selfFetch) {
+      await releaseProposedAction(actionId).catch(() => {});
+      return v1Error(
+        c,
+        "INTERNAL_ERROR",
+        "In-process /api/v1 dispatch is not registered."
+      );
+    }
+
+    let convexJwt: string;
+    try {
+      // The CLICKER's delegated token. Minting re-verifies their membership of
+      // the org, so approval by someone since removed fails right here rather
+      // than spending.
+      convexJwt = await getConvexBearerForRequest(c);
+    } catch (error) {
+      await releaseProposedAction(actionId).catch(() => {});
+      logger.warn("[v1/proposed-actions] could not mint a token for the clicker", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return v1Error(
+        c,
+        "UNAUTHORIZED",
+        "Your MCPJam access could not be confirmed for this project."
+      );
+    }
+
+    const abortController = new AbortController();
+    const timer = setTimeout(
+      () => abortController.abort(),
+      EXECUTION_TIMEOUT_MS
+    );
+
+    try {
+      const client = new PlatformApiClient({
+        baseUrl: "http://self.mcpjam.internal/api/v1",
+        getAuth: () => convexJwt,
+        fetch: async (input, init) => {
+          const request = new Request(input, init);
+          // The action id IS the idempotency key. A redelivered click, or a
+          // retry after this process died mid-execution, presents the same key
+          // and lands on the same run rather than billing a second one.
+          request.headers.set(
+            IDEMPOTENCY_KEY_HEADER,
+            `proposal:${actionId}:${operation.name}`
+          );
+          return selfFetch(request);
+        },
+      });
+
+      // The PERSISTED input, re-clamped to the persisted project. Both come
+      // from the proposal; the request body is never consulted.
+      const input = { ...claim.input, project: claim.projectId };
+      const result = await operation.execute(input as never, {
+        client,
+        signal: abortController.signal,
+      });
+
+      await completeProposedAction({ actionId, status: "succeeded" }).catch(
+        (error) => {
+          // The work is DONE. A failed bookkeeping write only costs a stale
+          // row; failing the response would tell the user their approved
+          // action did not happen, which is false.
+          logger.warn(
+            "[v1/proposed-actions] action succeeded but recording it failed",
+            { error: error instanceof Error ? error.message : String(error) }
+          );
+        }
+      );
+
+      return v1Resource(c, {
+        actionId,
+        operation: operation.name,
+        status: "succeeded",
+        result,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      // FAILED, not released. We cannot prove the operation did not start —
+      // a timeout in particular means the run may well be going — and an
+      // "unsure" release is how an approved action gets billed twice.
+      await completeProposedAction({
+        actionId,
+        status: "failed",
+        failureReason: message,
+      }).catch(() => {});
+      logger.error("[v1/proposed-actions] approved action failed", {
+        operation: operation.name,
+        error: message,
+      });
+      if (abortController.signal.aborted) {
+        return v1Error(
+          c,
+          "TIMEOUT",
+          `${operation.title} took too long. Check the MCPJam app — it may still be running.`
+        );
+      }
+      return v1Error(c, "INTERNAL_ERROR", `${operation.title} failed.`);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+);
+
+export default proposedActions;

--- a/mcpjam-inspector/server/services/slack-backend.ts
+++ b/mcpjam-inspector/server/services/slack-backend.ts
@@ -205,3 +205,77 @@ export async function createProposedAction(args: {
 }): Promise<{ created: boolean }> {
   return post("/slack/proposed-actions/create", args);
 }
+
+export interface ProposedActionRecord {
+  actionId: string;
+  teamId: string;
+  channelId: string;
+  operation: string;
+  input: Record<string, unknown>;
+  organizationId: string;
+  projectId: string;
+  proposedBySlackUserId: string;
+  status:
+    | "proposed"
+    | "executing"
+    | "succeeded"
+    | "failed"
+    | "expired";
+  executedBySlackUserId: string | null;
+  expired: boolean;
+}
+
+export async function getProposedAction(
+  actionId: string
+): Promise<ProposedActionRecord | null> {
+  const body = await post<{ action?: ProposedActionRecord | null }>(
+    "/slack/proposed-actions/get",
+    { actionId }
+  );
+  return body.action ?? null;
+}
+
+/**
+ * `proposed → executing`, returning WHAT TO RUN.
+ *
+ * The returned `operation` and `input` are the persisted ones. The executor
+ * must use exactly these and nothing from the click payload: a Block Kit
+ * button's `value` can be minted by anyone able to post in the workspace, so a
+ * click may only say WHICH proposal to run, never what it does.
+ */
+export type BeginProposedActionResult =
+  | {
+      ok: true;
+      operation: string;
+      input: Record<string, unknown>;
+      organizationId: string;
+      projectId: string;
+      teamId: string;
+    }
+  | {
+      ok: false;
+      reason: "not_found" | "expired" | "already_claimed";
+      status?: string;
+    };
+
+export async function beginProposedAction(args: {
+  actionId: string;
+  executedBySlackUserId: string;
+}): Promise<BeginProposedActionResult> {
+  return post("/slack/proposed-actions/begin", args);
+}
+
+export async function completeProposedAction(args: {
+  actionId: string;
+  status: "succeeded" | "failed";
+  failureReason?: string;
+}): Promise<{ ok: boolean; reason?: string }> {
+  return post("/slack/proposed-actions/complete", args);
+}
+
+/** Only for work that provably did NOT start. See `releaseExecution`. */
+export async function releaseProposedAction(
+  actionId: string
+): Promise<{ released: boolean }> {
+  return post("/slack/proposed-actions/release", { actionId });
+}

--- a/mcpjam-inspector/server/services/slack-backend.ts
+++ b/mcpjam-inspector/server/services/slack-backend.ts
@@ -1,0 +1,175 @@
+/**
+ * Inspector → backend client for the Slack surfaces (`/slack/*`).
+ *
+ * Used by two callers with the same trust level: the `slk_` auth branch in
+ * `bearer-auth.ts` (which needs the acting user's account link) and the
+ * account-link bridge in `routes/slack-link` (which drives the link session
+ * state machine). Both authenticate with `INSPECTOR_SERVICE_TOKEN`.
+ *
+ * FAILURE SEMANTICS ARE THE POINT. Every function here throws
+ * `SlackBackendUnavailable` when the backend could not answer, and returns a
+ * value only when it did. Collapsing those two into "no link" would tell a
+ * linked user to connect their account because of a network blip — and would
+ * do it on the auth path, where the user has no way to tell the difference.
+ */
+import { getInternalBackendConfig } from "./internal-backend.js";
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** The backend could not answer. Distinct from "answered: no". */
+export class SlackBackendUnavailable extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SlackBackendUnavailable";
+  }
+}
+
+async function post<T>(
+  path: string,
+  body: Record<string, unknown>
+): Promise<T> {
+  let config: { convexUrl: string; serviceToken: string };
+  try {
+    config = getInternalBackendConfig();
+  } catch (error) {
+    throw new SlackBackendUnavailable(
+      `Slack backend is not configured: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await fetch(`${config.convexUrl}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-inspector-service-token": config.serviceToken,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    throw new SlackBackendUnavailable(
+      `Slack backend request failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    // Including 4xx: a malformed request from US is still a state in which we
+    // do not know the answer, and guessing on the auth path is worse than a
+    // retryable error.
+    throw new SlackBackendUnavailable(
+      `Slack backend returned ${response.status} for ${path}`
+    );
+  }
+  try {
+    return (await response.json()) as T;
+  } catch (error) {
+    throw new SlackBackendUnavailable(
+      `Slack backend returned an unreadable body for ${path}: ${error}`
+    );
+  }
+}
+
+export interface SlackAccountLink {
+  userId: string;
+  workosUserId: string;
+  organizationId: string;
+  defaultProjectId: string | null;
+}
+
+/**
+ * Which MCPJam identity a Slack user currently acts as.
+ * `null` means NOT LINKED — an answer. Unreachable backend throws.
+ */
+export async function resolveSlackActingUser(
+  teamId: string,
+  slackUserId: string
+): Promise<SlackAccountLink | null> {
+  const body = await post<{ ok?: boolean; link?: SlackAccountLink | null }>(
+    "/slack/service-auth/resolve",
+    { teamId, slackUserId }
+  );
+  return body.link ?? null;
+}
+
+// ── Link-session state machine ─────────────────────────────────────────
+
+export interface SlackLinkSession {
+  linkSessionId: string;
+  teamId: string;
+  slackUserId: string;
+  oidcNonce: string;
+  slackStateHash: string;
+  workosStateHash: string;
+  status:
+    | "pending_slack"
+    | "slack_verified"
+    | "workos_verified"
+    | "consumed"
+    | "failed"
+    | "expired";
+  expiresAt: number;
+  expired: boolean;
+}
+
+export async function getSlackLinkSession(
+  linkSessionId: string
+): Promise<SlackLinkSession | null> {
+  const body = await post<{ session?: SlackLinkSession | null }>(
+    "/slack/link-sessions/get",
+    { linkSessionId }
+  );
+  return body.session ?? null;
+}
+
+export async function markSlackLegVerified(args: {
+  linkSessionId: string;
+  verifiedTeamId: string;
+  verifiedSlackUserId: string;
+}): Promise<{ ok: boolean; reason?: string }> {
+  return post("/slack/link-sessions/slack-verified", args);
+}
+
+export async function markWorkosLegVerified(
+  linkSessionId: string
+): Promise<{ ok: boolean; reason?: string }> {
+  return post("/slack/link-sessions/workos-verified", { linkSessionId });
+}
+
+export async function failSlackLinkSession(
+  linkSessionId: string,
+  reason: string
+): Promise<void> {
+  await post("/slack/link-sessions/fail", { linkSessionId, reason });
+}
+
+export async function consumeSlackLinkSession(args: {
+  linkSessionId: string;
+  userId: string;
+  workosUserId: string;
+  organizationId: string;
+}): Promise<{ ok: boolean; reason?: string; teamId?: string; slackUserId?: string; relinked?: boolean }> {
+  return post("/slack/link-sessions/consume", args);
+}
+
+export async function resolveOrganizationByWorkosId(
+  workosOrganizationId: string
+): Promise<{ organizationId: string; name: string } | null> {
+  const body = await post<{
+    organization?: { organizationId: string; name: string } | null;
+  }>("/slack/organizations/by-workos-id", { workosOrganizationId });
+  return body.organization ?? null;
+}
+
+export async function setSlackDefaultProject(args: {
+  teamId: string;
+  slackUserId: string;
+  projectId?: string;
+}): Promise<{ ok: boolean; reason?: string }> {
+  return post("/slack/links/set-default-project", args);
+}

--- a/mcpjam-inspector/server/services/slack-backend.ts
+++ b/mcpjam-inspector/server/services/slack-backend.ts
@@ -38,40 +38,46 @@ async function post<T>(
   }
 
   const controller = new AbortController();
+  // The timeout must cover the WHOLE exchange, body included. Clearing it once
+  // headers arrive would let a response that never finishes its body hang this
+  // request forever — and this runs on the auth path, so the hang would be a
+  // request that never answers rather than one that fails.
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  let response: Response;
   try {
-    response = await fetch(`${config.convexUrl}${path}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-inspector-service-token": config.serviceToken,
-      },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    throw new SlackBackendUnavailable(
-      `Slack backend request failed: ${error instanceof Error ? error.message : String(error)}`
-    );
+    let response: Response;
+    try {
+      response = await fetch(`${config.convexUrl}${path}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-inspector-service-token": config.serviceToken,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      throw new SlackBackendUnavailable(
+        `Slack backend request failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    if (!response.ok) {
+      // Including 4xx: a malformed request from US is still a state in which
+      // we do not know the answer, and guessing on the auth path is worse
+      // than a retryable error.
+      throw new SlackBackendUnavailable(
+        `Slack backend returned ${response.status} for ${path}`
+      );
+    }
+    try {
+      return (await response.json()) as T;
+    } catch (error) {
+      throw new SlackBackendUnavailable(
+        `Slack backend returned an unreadable body for ${path}: ${error}`
+      );
+    }
   } finally {
     clearTimeout(timer);
-  }
-
-  if (!response.ok) {
-    // Including 4xx: a malformed request from US is still a state in which we
-    // do not know the answer, and guessing on the auth path is worse than a
-    // retryable error.
-    throw new SlackBackendUnavailable(
-      `Slack backend returned ${response.status} for ${path}`
-    );
-  }
-  try {
-    return (await response.json()) as T;
-  } catch (error) {
-    throw new SlackBackendUnavailable(
-      `Slack backend returned an unreadable body for ${path}: ${error}`
-    );
   }
 }
 
@@ -115,6 +121,17 @@ export interface SlackLinkSession {
     | "expired";
   expiresAt: number;
   expired: boolean;
+}
+
+export async function createSlackLinkSession(args: {
+  linkSessionId: string;
+  teamId: string;
+  slackUserId: string;
+  oidcNonce: string;
+  slackStateHash: string;
+  workosStateHash: string;
+}): Promise<{ ok: boolean }> {
+  return post("/slack/link-sessions/create", args);
 }
 
 export async function getSlackLinkSession(
@@ -172,4 +189,19 @@ export async function setSlackDefaultProject(args: {
   projectId?: string;
 }): Promise<{ ok: boolean; reason?: string }> {
   return post("/slack/links/set-default-project", args);
+}
+
+// ── Proposed actions ───────────────────────────────────────────────────
+
+export async function createProposedAction(args: {
+  actionId: string;
+  teamId: string;
+  channelId: string;
+  operation: string;
+  input: unknown;
+  organizationId: string;
+  projectId: string;
+  proposedBySlackUserId: string;
+}): Promise<{ created: boolean }> {
+  return post("/slack/proposed-actions/create", args);
 }

--- a/mcpjam-inspector/server/types/hono.ts
+++ b/mcpjam-inspector/server/types/hono.ts
@@ -27,11 +27,16 @@ declare module "hono" {
      *   its own.
      * - Absent — guest JWT (see `guestId`) or WorkOS AuthKit JWT.
      *
-     * Downstream Convex callers (`authorizeBatch`, `getConvexBearerForRequest`)
-     * read this to decide between forwarding the original bearer (JWT/guest)
-     * and exchanging for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as`
-     * (both non-JWT methods). Dispatching on this rather than on the presence
-     * of the identity vars matters: a JWT caller can carry those too.
+     * `getConvexBearerForRequest` reads this to decide between forwarding the
+     * original bearer (JWT/guest) and minting a delegated org-scoped JWT (both
+     * non-JWT methods). Dispatching on this rather than on the presence of the
+     * identity vars matters: a JWT caller can carry those too.
+     *
+     * `authorizeBatch` handles `workos_api_key` only. It is NOT on the
+     * `slack_service` path — the allowlist in `slack-service-auth.ts` does not
+     * admit any route that reaches it — and it would forward the `slk_` bearer
+     * verbatim rather than exchanging it. Widening that allowlist means
+     * teaching `authorizeBatch` about `slack_service` first.
      */
     authMethod?: "workos_api_key" | "slack_service";
     /** WorkOS API key id (e.g. `api_key_…`). Set with `authMethod`. */

--- a/mcpjam-inspector/server/types/hono.ts
+++ b/mcpjam-inspector/server/types/hono.ts
@@ -20,13 +20,20 @@ declare module "hono" {
      * Auth method used to resolve the caller. Set by `bearerAuthMiddleware`:
      * - `"workos_api_key"` — caller presented a WorkOS `sk_…` API key
      *   (validated via `WorkOS.apiKeys.createValidation`).
+     * - `"slack_service"` — the MCPJam Slack bot presented its `slk_…`
+     *   service credential PLUS the Slack team/user headers, and that Slack
+     *   user has a completed account link. The identity below is the LINKED
+     *   user's, never the bot's: `slk_` names the bot and grants nothing on
+     *   its own.
      * - Absent — guest JWT (see `guestId`) or WorkOS AuthKit JWT.
      *
-     * Downstream Convex callers (`authorizeBatch`) read this to decide
-     * between forwarding the original bearer (JWT/guest) and exchanging
-     * for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as` (API key).
+     * Downstream Convex callers (`authorizeBatch`, `getConvexBearerForRequest`)
+     * read this to decide between forwarding the original bearer (JWT/guest)
+     * and exchanging for `INSPECTOR_SERVICE_TOKEN` + `x-mcpjam-acting-as`
+     * (both non-JWT methods). Dispatching on this rather than on the presence
+     * of the identity vars matters: a JWT caller can carry those too.
      */
-    authMethod?: "workos_api_key";
+    authMethod?: "workos_api_key" | "slack_service";
     /** WorkOS API key id (e.g. `api_key_…`). Set with `authMethod`. */
     workosApiKeyId?: string;
     /** WorkOS user externalId. Set with `authMethod`. */
@@ -40,5 +47,14 @@ declare module "hono" {
      * `x-mcpjam-acting-in-org` by the delegated-identity exchange.
      */
     mcpjamOrganizationId?: string;
+    /** Slack workspace id. Set only with `authMethod: "slack_service"`. */
+    slackTeamId?: string;
+    /** Slack user id of the acting human. Set with `slackTeamId`. */
+    slackUserId?: string;
+    /**
+     * The linked user's default project, if they picked one. Advisory: the
+     * route's `:projectId` still governs, and Convex still enforces access.
+     */
+    slackDefaultProjectId?: string;
   }
 }

--- a/mcpjam-inspector/server/types/hono.ts
+++ b/mcpjam-inspector/server/types/hono.ts
@@ -32,11 +32,15 @@ declare module "hono" {
      * non-JWT methods). Dispatching on this rather than on the presence of the
      * identity vars matters: a JWT caller can carry those too.
      *
-     * `authorizeBatch` handles `workos_api_key` only. It is NOT on the
-     * `slack_service` path — the allowlist in `slack-service-auth.ts` does not
-     * admit any route that reaches it — and it would forward the `slk_` bearer
-     * verbatim rather than exchanging it. Widening that allowlist means
-     * teaching `authorizeBatch` about `slack_service` first.
+     * `authorizeBatch` handles `workos_api_key` only, and would forward a
+     * `slk_` bearer to Convex VERBATIM rather than exchanging it. Allowlisted
+     * Slack routes do reach it — `POST /eval-runs` does — but they reach it
+     * with a delegated JWT already minted by `getConvexBearerForRequest`, so
+     * the raw `slk_` never arrives there. That is the invariant: not "no Slack
+     * route touches `authorizeBatch`", but "no Slack route hands it the bot
+     * credential". A new allowlisted route that passes the ORIGINAL bearer
+     * through would break it, so teach `authorizeBatch` about `slack_service`
+     * before adding one.
      */
     authMethod?: "workos_api_key" | "slack_service";
     /** WorkOS API key id (e.g. `api_key_…`). Set with `authMethod`. */

--- a/mcpjam-inspector/server/utils/idempotency.ts
+++ b/mcpjam-inspector/server/utils/idempotency.ts
@@ -79,8 +79,17 @@ export function deriveOperationIdempotencyKey(
     // key is for.
     canonical = `__uncanonicalizable__:${operation}`;
   }
+  // The turn key is HASHED rather than prefixed verbatim. Prefixing let the
+  // derived key inherit the caller's length AND its character set, so a long
+  // (but individually valid) turn key produced a composite past MAX_KEY_LENGTH
+  // — which `readIdempotencyKey` then dropped SILENTLY, quietly turning off
+  // idempotency for exactly the caller who asked for it. Hashing makes the
+  // width fixed by construction.
+  const turnDigest = createHash("sha256").update(turnKey).digest("hex").slice(0, 24);
   const digest = createHash("sha256").update(canonical).digest("hex").slice(0, 32);
-  return `${turnKey}:${operation}:${digest}`;
+  // Bounded: 24 + 1 + operation + 1 + 32. Operation names are code-defined and
+  // short, so this is comfortably inside MAX_KEY_LENGTH.
+  return `${turnDigest}:${operation}:${digest}`;
 }
 
 /**
@@ -117,11 +126,21 @@ const MAX_CANONICAL_DEPTH = 32;
 
 function stableStringify(value: unknown, depth = 0): string {
   if (depth > MAX_CANONICAL_DEPTH) {
-    // Collapse rather than throw. Two inputs that differ only past this depth
-    // share a key, which is a far better failure than no key at all: the
-    // caller's own turn key already scopes it, so the collision window is one
-    // retry of one event.
-    return '"__depth_capped__"';
+    // Past the depth bound, stop RECURSING but do not stop DISTINGUISHING.
+    // A constant here would give two materially different inputs the same key,
+    // so a second write could silently land on the first one's row. Hashing the
+    // remaining subtree keeps them apart; key order below this depth is no
+    // longer normalized, which only risks a spurious MISS (a duplicate row —
+    // the pre-existing behaviour), never a wrong hit.
+    try {
+      return JSON.stringify(
+        createHash("sha256").update(JSON.stringify(value) ?? "null").digest("hex")
+      );
+    } catch {
+      // Cyclic below the cap. A constant is all that is left, and the caller's
+      // turn key still scopes it.
+      return '"__depth_capped__"';
+    }
   }
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value) ?? "null";

--- a/mcpjam-inspector/server/utils/idempotency.ts
+++ b/mcpjam-inspector/server/utils/idempotency.ts
@@ -1,0 +1,118 @@
+/**
+ * Write-path idempotency for unattended callers.
+ *
+ * An unattended caller — the Slack bot, the scheduled worker — is exactly the
+ * caller that retries. If a turn crashes after persisting an eval suite but
+ * before its reply lands, the retry has to run again, and its mutations must
+ * land on the SAME rows rather than authoring a second suite and billing a
+ * second run.
+ *
+ * The key is carried on a HEADER rather than in the request body, for two
+ * reasons:
+ *
+ *   1. It is transport metadata, not part of any operation's public schema.
+ *      The agent's tool schemas are model-facing; a model must never be able
+ *      to invent, omit, or vary an idempotency key, because the key is the
+ *      whole safety property.
+ *   2. It applies uniformly to every write route without each one having to
+ *      grow (and correctly forward) another body field.
+ */
+import { createHash } from "node:crypto";
+import type { Context } from "hono";
+
+export const IDEMPOTENCY_KEY_HEADER = "x-mcpjam-idempotency-key";
+
+/**
+ * Convex's `idempotencyKey` columns are plain strings; a runaway key would be
+ * stored verbatim on every row it touches. Long enough for
+ * `${teamId}:${eventId}:${operation}:${sha256}` with room to spare.
+ */
+const MAX_KEY_LENGTH = 256;
+
+/**
+ * Read a caller-supplied idempotency key off the request.
+ *
+ * Returns undefined for absent OR malformed keys rather than throwing: an
+ * unusable key must degrade to "no idempotency" (the pre-existing behaviour),
+ * never to a rejected write. A caller that mis-formats its key should still
+ * get its suite created.
+ */
+export function readIdempotencyKey(c: Context): string | undefined {
+  const raw = c.req.header(IDEMPOTENCY_KEY_HEADER);
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_KEY_LENGTH) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+/**
+ * Derive the per-tool-call key for one operation invocation.
+ *
+ * A single agent turn can issue several writes, so the turn-level key alone
+ * would collapse them onto one row. Scoping by operation NAME and by a hash of
+ * the INPUT gives each distinct write its own identity while keeping a retry
+ * of the same write stable — the retried turn re-issues the same call with the
+ * same arguments, so it hashes the same and lands on the same record.
+ *
+ * The input is hashed rather than embedded: arguments can be kilobytes of
+ * authored eval cases, and the key is persisted on the row.
+ *
+ * Note the residual case this deliberately does NOT solve: a retried turn
+ * whose model authors *materially different* arguments produces a different
+ * hash and therefore a second row. That is correct — it is genuinely a
+ * different write — and it is why durable event claims sit in front of this
+ * layer to keep most retries from re-running the turn at all.
+ */
+export function deriveOperationIdempotencyKey(
+  turnKey: string,
+  operation: string,
+  input: unknown
+): string {
+  const canonical = stableStringify(input);
+  const digest = createHash("sha256").update(canonical).digest("hex").slice(0, 32);
+  return `${turnKey}:${operation}:${digest}`;
+}
+
+/**
+ * Derive a key for one item within an operation (e.g. each case authored by a
+ * single `create_eval_suite` call), so a retry after a PARTIAL failure
+ * re-creates only the cases that did not commit.
+ */
+export function deriveItemIdempotencyKey(
+  operationKey: string,
+  itemDiscriminator: string
+): string {
+  const digest = createHash("sha256")
+    .update(itemDiscriminator)
+    .digest("hex")
+    .slice(0, 16);
+  return `${operationKey}:item:${digest}`;
+}
+
+/**
+ * JSON.stringify with sorted object keys.
+ *
+ * Plain `JSON.stringify` preserves insertion order, so two structurally
+ * identical inputs whose keys were built in a different order would hash
+ * differently — and a retry would silently create a duplicate. Arrays keep
+ * their order, which is correct: `steps` order is semantic.
+ */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    // `undefined` members are absent from JSON, so including them would make
+    // `{a: 1}` and `{a: 1, b: undefined}` hash differently despite being the
+    // same request on the wire.
+    .filter(([, member]) => member !== undefined)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+  return `{${entries
+    .map(([key, member]) => `${JSON.stringify(key)}:${stableStringify(member)}`)
+    .join(",")}}`;
+}

--- a/mcpjam-inspector/server/utils/idempotency.ts
+++ b/mcpjam-inspector/server/utils/idempotency.ts
@@ -70,7 +70,15 @@ export function deriveOperationIdempotencyKey(
   operation: string,
   input: unknown
 ): string {
-  const canonical = stableStringify(input);
+  let canonical: string;
+  try {
+    canonical = stableStringify(input);
+  } catch {
+    // Cyclic or otherwise un-serializable input. Fall back to the operation
+    // alone: still stable across a retry of the same turn, which is what the
+    // key is for.
+    canonical = `__uncanonicalizable__:${operation}`;
+  }
   const digest = createHash("sha256").update(canonical).digest("hex").slice(0, 32);
   return `${turnKey}:${operation}:${digest}`;
 }
@@ -99,12 +107,27 @@ export function deriveItemIdempotencyKey(
  * differently — and a retry would silently create a duplicate. Arrays keep
  * their order, which is correct: `steps` order is semantic.
  */
-function stableStringify(value: unknown): string {
+/**
+ * Depth bound. Authored eval suites nest a few levels (suite → cases → steps →
+ * assertion args); anything past this is either pathological or adversarial,
+ * and an unbounded recursion here would throw `RangeError` and fail the WRITE
+ * — turning a hashing detail into a lost suite.
+ */
+const MAX_CANONICAL_DEPTH = 32;
+
+function stableStringify(value: unknown, depth = 0): string {
+  if (depth > MAX_CANONICAL_DEPTH) {
+    // Collapse rather than throw. Two inputs that differ only past this depth
+    // share a key, which is a far better failure than no key at all: the
+    // caller's own turn key already scopes it, so the collision window is one
+    // retry of one event.
+    return '"__depth_capped__"';
+  }
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value) ?? "null";
   }
   if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`;
+    return `[${value.map((member) => stableStringify(member, depth + 1)).join(",")}]`;
   }
   const entries = Object.entries(value as Record<string, unknown>)
     // `undefined` members are absent from JSON, so including them would make
@@ -113,6 +136,9 @@ function stableStringify(value: unknown): string {
     .filter(([, member]) => member !== undefined)
     .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
   return `{${entries
-    .map(([key, member]) => `${JSON.stringify(key)}:${stableStringify(member)}`)
+    .map(
+      ([key, member]) =>
+        `${JSON.stringify(key)}:${stableStringify(member, depth + 1)}`
+    )
     .join(",")}}`;
 }

--- a/mcpjam-inspector/server/utils/idempotency.ts
+++ b/mcpjam-inspector/server/utils/idempotency.ts
@@ -131,42 +131,37 @@ export function deriveItemIdempotencyKey(
 const MAX_CANONICAL_DEPTH = 32;
 
 /**
- * How many nodes a capped subtree may contribute to its digest. Reached only by
- * input already 32 levels deep, so the ceiling exists to bound work, not to
- * shape any real request.
- */
-const MAX_CAPPED_NODES = 20_000;
-
-/**
  * Fingerprint the subtree below the depth cap without recursing and without
  * throwing.
  *
  * The obvious implementation — `JSON.stringify` the subtree and hash it — has
  * two ways to throw: a cycle, and a structure deep enough to overflow the
  * stack. Both would land on a catch, and the only thing a catch can return is a
- * constant, which is exactly the collision the depth cap was changed to avoid:
- * two materially different inputs would share an idempotency key, and the
- * second write would silently REPLAY the first one's row.
+ * constant, which is exactly the collision this exists to avoid: two materially
+ * different inputs would share an idempotency key, and the second write would
+ * silently REPLAY the first one\'s row.
  *
- * So this walks iteratively with an explicit stack, treats a repeated reference
- * as a back-edge marker instead of following it, and stops at a node budget.
- * Every exit is a value, so no input can fall through to a constant. Keys are
- * sorted here too, which the `JSON.stringify` version did not do — structurally
- * identical subtrees built in a different key order now agree.
+ * So this walks iteratively with an explicit stack and treats a repeated
+ * reference as a back-edge marker instead of following it. Every exit is a
+ * value, so no input can fall through to a constant. Keys are sorted here too,
+ * which the `JSON.stringify` version did not do — structurally identical
+ * subtrees built in a different key order now agree.
+ *
+ * NOTHING IS TRUNCATED. An earlier version stopped at a node budget and emitted
+ * a fixed marker, which reintroduced the collision one layer down: every input
+ * whose tail fell past the budget shared a digest, so a later write with a
+ * different tail could replay an earlier one. A fingerprint that silently stops
+ * distinguishing is worse than no fingerprint, because the caller cannot tell.
+ * The bound that matters is upstream — the request body is size-limited before
+ * it ever reaches here — and reading an input you have already accepted is
+ * work you have already agreed to do.
  */
 function boundedDigest(root: unknown): string {
   const hash = createHash("sha256");
   const seen = new Set<object>();
   const stack: unknown[] = [root];
-  let nodes = 0;
 
   while (stack.length > 0) {
-    if (nodes++ >= MAX_CAPPED_NODES) {
-      // Truncation is recorded, so a subtree that was cut off cannot pass for
-      // one that happened to end exactly there.
-      hash.update(" truncated");
-      break;
-    }
     const value = stack.pop();
     if (value === null || typeof value !== "object") {
       hash.update(` ${JSON.stringify(value) ?? "null"}`);

--- a/mcpjam-inspector/server/utils/idempotency.ts
+++ b/mcpjam-inspector/server/utils/idempotency.ts
@@ -85,8 +85,14 @@ export function deriveOperationIdempotencyKey(
   // — which `readIdempotencyKey` then dropped SILENTLY, quietly turning off
   // idempotency for exactly the caller who asked for it. Hashing makes the
   // width fixed by construction.
-  const turnDigest = createHash("sha256").update(turnKey).digest("hex").slice(0, 24);
-  const digest = createHash("sha256").update(canonical).digest("hex").slice(0, 32);
+  const turnDigest = createHash("sha256")
+    .update(turnKey)
+    .digest("hex")
+    .slice(0, 24);
+  const digest = createHash("sha256")
+    .update(canonical)
+    .digest("hex")
+    .slice(0, 32);
   // Bounded: 24 + 1 + operation + 1 + 32. Operation names are code-defined and
   // short, so this is comfortably inside MAX_KEY_LENGTH.
   return `${turnDigest}:${operation}:${digest}`;
@@ -124,29 +130,93 @@ export function deriveItemIdempotencyKey(
  */
 const MAX_CANONICAL_DEPTH = 32;
 
+/**
+ * How many nodes a capped subtree may contribute to its digest. Reached only by
+ * input already 32 levels deep, so the ceiling exists to bound work, not to
+ * shape any real request.
+ */
+const MAX_CAPPED_NODES = 20_000;
+
+/**
+ * Fingerprint the subtree below the depth cap without recursing and without
+ * throwing.
+ *
+ * The obvious implementation — `JSON.stringify` the subtree and hash it — has
+ * two ways to throw: a cycle, and a structure deep enough to overflow the
+ * stack. Both would land on a catch, and the only thing a catch can return is a
+ * constant, which is exactly the collision the depth cap was changed to avoid:
+ * two materially different inputs would share an idempotency key, and the
+ * second write would silently REPLAY the first one's row.
+ *
+ * So this walks iteratively with an explicit stack, treats a repeated reference
+ * as a back-edge marker instead of following it, and stops at a node budget.
+ * Every exit is a value, so no input can fall through to a constant. Keys are
+ * sorted here too, which the `JSON.stringify` version did not do — structurally
+ * identical subtrees built in a different key order now agree.
+ */
+function boundedDigest(root: unknown): string {
+  const hash = createHash("sha256");
+  const seen = new Set<object>();
+  const stack: unknown[] = [root];
+  let nodes = 0;
+
+  while (stack.length > 0) {
+    if (nodes++ >= MAX_CAPPED_NODES) {
+      // Truncation is recorded, so a subtree that was cut off cannot pass for
+      // one that happened to end exactly there.
+      hash.update(" truncated");
+      break;
+    }
+    const value = stack.pop();
+    if (value === null || typeof value !== "object") {
+      hash.update(` ${JSON.stringify(value) ?? "null"}`);
+      continue;
+    }
+    if (seen.has(value)) {
+      // A cycle or a shared reference. Marking it keeps the walk finite while
+      // still distinguishing "points back" from "absent".
+      hash.update(" cycle");
+      continue;
+    }
+    seen.add(value);
+    if (Array.isArray(value)) {
+      hash.update(` [${value.length}`);
+      // Pushed in reverse so the stack pops them in source order: order is
+      // semantic for arrays and must survive into the digest.
+      for (let index = value.length - 1; index >= 0; index -= 1) {
+        stack.push(value[index]);
+      }
+      continue;
+    }
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, member]) => member !== undefined)
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0));
+    // Keys are folded into the hash directly rather than pushed onto the stack
+    // as marker strings: a marker on the stack is indistinguishable from a
+    // string VALUE that happens to equal it. The quoted list keeps a key
+    // containing a comma from reading as two keys.
+    hash.update(` {${JSON.stringify(entries.map(([key]) => key))}`);
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      stack.push(entries[index]?.[1]);
+    }
+  }
+  return hash.digest("hex");
+}
+
 function stableStringify(value: unknown, depth = 0): string {
   if (depth > MAX_CANONICAL_DEPTH) {
     // Past the depth bound, stop RECURSING but do not stop DISTINGUISHING.
     // A constant here would give two materially different inputs the same key,
-    // so a second write could silently land on the first one's row. Hashing the
-    // remaining subtree keeps them apart; key order below this depth is no
-    // longer normalized, which only risks a spurious MISS (a duplicate row —
-    // the pre-existing behaviour), never a wrong hit.
-    try {
-      return JSON.stringify(
-        createHash("sha256").update(JSON.stringify(value) ?? "null").digest("hex")
-      );
-    } catch {
-      // Cyclic below the cap. A constant is all that is left, and the caller's
-      // turn key still scopes it.
-      return '"__depth_capped__"';
-    }
+    // so a second write could silently land on the first one's row.
+    return JSON.stringify(boundedDigest(value));
   }
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value) ?? "null";
   }
   if (Array.isArray(value)) {
-    return `[${value.map((member) => stableStringify(member, depth + 1)).join(",")}]`;
+    return `[${value
+      .map((member) => stableStringify(member, depth + 1))
+      .join(",")}]`;
   }
   const entries = Object.entries(value as Record<string, unknown>)
     // `undefined` members are absent from JSON, so including them would make

--- a/mcpjam-inspector/server/utils/v1-convex-token.ts
+++ b/mcpjam-inspector/server/utils/v1-convex-token.ts
@@ -136,13 +136,23 @@ async function mintDelegatedToken(
  * Resolve the bearer to use against Convex for this request:
  *   - JWT callers (WorkOS session, guest): the original bearer, verbatim.
  *   - WorkOS API-key callers: a cached short-lived delegated JWT.
+ *   - Slack service callers: the same, for the LINKED user the request names.
+ *     The `slk_` token itself is never exchanged — it identifies the bot, not
+ *     a person, and the delegated token is minted for the human behind the
+ *     Slack identity. The backend re-verifies that user's org membership on
+ *     every mint, so an unlinked or removed user cannot be delegated for.
  *
  * Background tasks that outlive the request (async eval runs) should call
  * this once during the request and capture the returned string — the token's
  * TTL (hours) comfortably covers a capped eval run.
  */
 export async function getConvexBearerForRequest(c: Context): Promise<string> {
-  if (c.get("authMethod") !== "workos_api_key") {
+  // Both non-JWT auth methods need a minted token. Dispatching on
+  // `authMethod` rather than on the presence of the delegation context vars
+  // is deliberate: a JWT caller can carry those vars too, and minting for
+  // them would swap a user's own bearer for a delegated one.
+  const authMethod = c.get("authMethod");
+  if (authMethod !== "workos_api_key" && authMethod !== "slack_service") {
     return assertBearerToken(c);
   }
   const { workosUserId, organizationId } = delegationContext(c);

--- a/slack-app/.env.sample
+++ b/slack-app/.env.sample
@@ -1,5 +1,30 @@
-# Required — MCPJam public API. Mint the key in the MCPJam app
-# (Settings → API keys); the project id is in the app URL / project settings.
+# ─── Mode selection ─────────────────────────────────────────────────────────
+# The app picks its mode from CONFIG PRESENCE, not a flag:
+#   SLACK_CLIENT_ID + SLACK_CLIENT_SECRET + SLACK_STATE_SECRET set
+#     → OAuth mode: Bolt's HTTP receiver, multi-workspace installs.
+#   otherwise
+#     → socket mode: one workspace, tokens from env. The local-dev default.
+
+# ─── OAuth mode (hosted) ────────────────────────────────────────────────────
+# From the Slack app's Basic Information page. SLACK_STATE_SECRET is ours to
+# choose — any high-entropy string; it signs the OAuth `state` Bolt round-trips.
+# SLACK_CLIENT_ID=YOUR_SLACK_CLIENT_ID
+# SLACK_CLIENT_SECRET=YOUR_SLACK_CLIENT_SECRET
+# SLACK_STATE_SECRET=YOUR_RANDOM_STATE_SECRET
+# SLACK_SIGNING_SECRET=YOUR_SLACK_SIGNING_SECRET
+
+# Where installations are stored. REQUIRED whenever OAuth mode is configured —
+# the app refuses to boot without them, because every install would otherwise
+# succeed at Slack and then be dropped on the floor.
+# MCPJAM_CONVEX_HTTP_URL=https://YOUR-DEPLOYMENT.convex.site
+# INSPECTOR_SERVICE_TOKEN=YOUR_INSPECTOR_SERVICE_TOKEN
+
+# ─── Legacy single-workspace credentials ────────────────────────────────────
+# The org-scoped API key the bot acted with before per-user account linking.
+# It is released ONLY for the one workspace flagged `isLegacyWorkspace` in
+# `slackInstallations` — every other workspace's events are dropped until
+# per-user auth ships. Mint the key in the MCPJam app (Settings → API keys);
+# the project id is in the app URL / project settings.
 MCPJAM_API_KEY=YOUR_MCPJAM_API_KEY
 MCPJAM_PROJECT_ID=YOUR_MCPJAM_PROJECT_ID
 
@@ -11,6 +36,7 @@ MCPJAM_PROJECT_ID=YOUR_MCPJAM_PROJECT_ID
 # MCPJAM_BASE_URL. In local dev the app UI (5173) differs from the API (6274).
 # MCPJAM_APP_URL=http://localhost:5173
 
+# ─── Socket mode (local dev) ────────────────────────────────────────────────
 # Optional, uncomment and set when running without the Slack CLI (npm start).
 # SLACK_APP_TOKEN=YOUR_SLACK_APP_TOKEN
 # SLACK_BOT_TOKEN=YOUR_SLACK_BOT_TOKEN

--- a/slack-app/.env.sample
+++ b/slack-app/.env.sample
@@ -16,8 +16,13 @@
 # Where installations are stored. REQUIRED whenever OAuth mode is configured —
 # the app refuses to boot without them, because every install would otherwise
 # succeed at Slack and then be dropped on the floor.
+# SLACK_SERVICE_TOKEN is the bot's OWN backend credential, accepted only by
+# the backend's /slack/* routes. Deliberately NOT the inspector's
+# INSPECTOR_SERVICE_TOKEN (that token also opens user delegation and
+# delegated-JWT minting; it must never exist in this app's environment).
+# Set the same value as SLACK_SERVICE_TOKEN on the Convex deployment.
 # MCPJAM_CONVEX_HTTP_URL=https://YOUR-DEPLOYMENT.convex.site
-# INSPECTOR_SERVICE_TOKEN=YOUR_INSPECTOR_SERVICE_TOKEN
+# SLACK_SERVICE_TOKEN=YOUR_SLACK_SERVICE_TOKEN
 
 # ─── Per-user auth ──────────────────────────────────────────────────────────
 # The bot's own service credential. It names the BOT and grants nothing on its

--- a/slack-app/.env.sample
+++ b/slack-app/.env.sample
@@ -19,12 +19,21 @@
 # MCPJAM_CONVEX_HTTP_URL=https://YOUR-DEPLOYMENT.convex.site
 # INSPECTOR_SERVICE_TOKEN=YOUR_INSPECTOR_SERVICE_TOKEN
 
+# ─── Per-user auth ──────────────────────────────────────────────────────────
+# The bot's own service credential. It names the BOT and grants nothing on its
+# own: every request also carries the Slack team/user headers, and the server
+# resolves the LINKED user's identity from those. Seed the SHA-256 hash on the
+# inspector as MCPJAM_SLACK_SERVICE_TOKEN_HASH.
+#   TOKEN="slk_$(openssl rand -hex 32)"
+# MCPJAM_SLACK_SERVICE_TOKEN=slk_YOUR_TOKEN
+
 # ─── Legacy single-workspace credentials ────────────────────────────────────
 # The org-scoped API key the bot acted with before per-user account linking.
 # It is released ONLY for the one workspace flagged `isLegacyWorkspace` in
-# `slackInstallations` — every other workspace's events are dropped until
-# per-user auth ships. Mint the key in the MCPJam app (Settings → API keys);
-# the project id is in the app URL / project settings.
+# `slackInstallations`, and ONLY for users there who have not linked an
+# account — anyone who HAS linked acts as themselves, even in that workspace.
+# Mint the key in the MCPJam app (Settings → API keys); the project id is in
+# the app URL / project settings.
 MCPJAM_API_KEY=YOUR_MCPJAM_API_KEY
 MCPJAM_PROJECT_ID=YOUR_MCPJAM_PROJECT_ID
 

--- a/slack-app/Dockerfile
+++ b/slack-app/Dockerfile
@@ -1,8 +1,11 @@
 # The MCPJam Slack bot.
 #
-# Socket Mode: the process dials OUT to Slack and serves no HTTP, so this
-# image exposes no port and the Railway service needs no domain or
-# healthcheck path.
+# In OAuth mode the process serves HTTP on $PORT (Bolt's HTTP receiver owns
+# /slack/events, /slack/install, /slack/oauth_redirect), so the Railway
+# service needs a public domain. In socket mode — the local-dev default, and
+# what runs when no OAuth credentials are set — it dials OUT instead and
+# serves nothing. The mode is chosen at boot from config presence; the image
+# is the same either way.
 #
 # Built from the MONOREPO ROOT as context (the lockfile lives there), which
 # is why every path below is repo-relative. The Railway service selects this

--- a/slack-app/MIGRATION.md
+++ b/slack-app/MIGRATION.md
@@ -1,0 +1,101 @@
+# Slack app: rollout and cleanup runbook
+
+The public-install program landed in four phases. Phases 0–3 are in the code.
+Phase 4 is a **deliberate cleanup step that must not be run early** — it
+deletes the credential path our own workspace is still using, so doing it
+before the preconditions hold takes the live bot down.
+
+## Where things stand
+
+| Phase | What shipped | State |
+| --- | --- | --- |
+| 0 | Tenant threaded through every cache/dedupe key | done |
+| 1 | Multi-workspace OAuth install, Vault-backed installation store | done |
+| 2 | Durable event claims + write-path idempotency keys | done |
+| 3 | Account linking (dual identity proof), per-user auth, thread bindings | done |
+| 4 | Delete the legacy shared-key fallback | **blocked — see below** |
+| 5 | Gated toolset (proposal-only ops behind a human click) | see plan |
+
+## Before public distribution opens
+
+Distribution is currently activated **only** so the install flow can be
+exercised against a throwaway second workspace. The single release gate is the
+Phase 3 E2E passing in real workspaces:
+
+- [ ] Unlinked DM → connect → Slack OIDC → AuthKit → default project picked →
+      a suite lands in that org/project.
+- [ ] **Phishing attempt**: open another user's link URL from a browser signed
+      into a *different* Slack identity → OIDC mismatch → session `failed`,
+      and the URL stays dead.
+- [ ] WorkOS callback hit **without** a completed Slack leg → rejected by the
+      state machine.
+- [ ] Replay a consumed link URL → rejected.
+- [ ] A user in the second workspace links a *different* org → full isolation.
+- [ ] Thread started by user A continues with user B **only** if B can reach
+      A's bound project, and the suite stays in the bound project.
+- [ ] Bot restart mid-thread → the thread is still engaged (durable binding).
+- [ ] Unlink → the connect prompt returns.
+
+Security checklist (same gate):
+
+- [ ] OIDC identity mismatch hard-stops and burns the session.
+- [ ] Link sessions are single-use.
+- [ ] Bad-signature events rejected (Bolt).
+- [ ] `slk_` on a non-allowlisted path → 401.
+- [ ] Backend blip → 503, never a link prompt.
+- [ ] Delegated mint fails for a user removed from the org.
+- [ ] Per-link rate bucket enforced.
+- [ ] Thread binding prevents cross-org drift.
+- [ ] Replayed Slack event envelopes and double-clicked buttons cannot
+      double-execute.
+- [ ] No secret in bot logs.
+
+## Phase 4 cleanup — preconditions
+
+Do **not** start until all three hold:
+
+1. **Our workspace is on a real OAuth install.** Verify a `slackInstallations`
+   row exists for it whose grant came from `/slack/install`, not from
+   `migrations/seedLegacySlackInstallation`.
+2. **Internal users are linked.** Every person who uses the bot has completed
+   the connect flow. Until then, `resolveTurnTarget` still falls back to the
+   shared key for the unlinked ones, and removing it locks them out
+   mid-conversation.
+3. **The two transcript-exposed `sk_` keys are rotated.** They were pasted in
+   plaintext during development. Rotating them is independent of this cleanup
+   and should not wait for it.
+
+## Phase 4 cleanup — steps
+
+Once the preconditions hold, in this order:
+
+1. **slack-app**: delete the `legacy` branch from `getConfig` in
+   `agent/mcpjam-client.js`, the legacy fallback in `resolveTurnTarget`
+   (`agent/turn-target.js`), and the `isLegacyWorkspace` plumbing in
+   `listeners/middleware/tenant-guard.js` / `agent/slack-context.js`. Remove
+   `MCPJAM_API_KEY` and `MCPJAM_PROJECT_ID` from `.env.sample`, the README,
+   and the Railway service.
+2. **Watch for a day.** An unlinked internal user surfaces as a connect
+   prompt, not an outage — but it is worth seeing zero of them before
+   proceeding.
+3. **Backend**: drop `isLegacyWorkspace` from `slackInstallations` and delete
+   `migrations/seedLegacySlackInstallation.ts`. This is last because the
+   column is what the slack-app change stops reading, and the two deploys are
+   not simultaneous.
+
+Ordering matters in both directions: the backend column must outlive the code
+that reads it, and the code must stop reading it before the column goes.
+
+## Rotating the bot service token
+
+`slk_` is verified against `MCPJAM_SLACK_SERVICE_TOKEN_HASH` on the inspector
+(SHA-256 hex, constant-time compare). To rotate without downtime:
+
+1. Mint a new token: `TOKEN="slk_$(openssl rand -hex 32)"`.
+2. Deploy the inspector with the NEW hash **and** keep accepting the old one
+   if you need a true zero-gap window (add a second env var and check both),
+   or accept a brief 401 window if you do not.
+3. Deploy the bot with `MCPJAM_SLACK_SERVICE_TOKEN` set to the new value.
+4. Drop the old hash.
+
+Never do step 4 before step 3 — the bot would 401 on every request.

--- a/slack-app/README.md
+++ b/slack-app/README.md
@@ -18,13 +18,15 @@ turn server-side with a project-scoped workspace toolset, on a hosted model
 billed to the project. Consequences worth knowing:
 
 - **No LLM credentials live here.** There is no Anthropic/OpenAI key, no agent
-  loop, no model config in this workspace — only an MCPJam API key.
-- **The bot cannot start eval runs.** The agent's toolset is reads plus
-  `create_eval_suite`; run operations are excluded server-side because a turn
-  is unattended (`approvalMode: "auto-deny"`). Runs happen only when a human
-  clicks **Run it**, which calls `POST /eval-runs` directly.
-- **Every operation is clamped to `MCPJAM_PROJECT_ID`** by the server, not by
-  prompt instructions.
+  loop, no model config in this workspace — only credentials that name a caller.
+- **The bot cannot start eval runs.** The agent's toolset is reads plus authoring
+  writes; run operations are excluded server-side because a turn is unattended
+  (`approvalMode: "auto-deny"`). Runs happen only when a human clicks a button,
+  and the CLICKER is the one authorized to run them — never the person whose
+  message caused the proposal.
+- **Every operation is clamped to one project** by the server, not by prompt
+  instructions. Which project comes from the thread's binding, else the acting
+  user's default project, else `MCPJAM_PROJECT_ID` on the legacy path.
 
 ### Files
 
@@ -126,8 +128,9 @@ cp .env.sample .env
 | `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` / `SLACK_STATE_SECRET` | OAuth mode | Presence of all three selects OAuth mode. `SLACK_STATE_SECRET` is ours to choose — any high-entropy string. |
 | `SLACK_SIGNING_SECRET` | OAuth mode | Verifies inbound request signatures. |
 | `MCPJAM_CONVEX_HTTP_URL` / `INSPECTOR_SERVICE_TOKEN` | OAuth mode | Where installations are stored. The app refuses to boot if OAuth is configured without them. |
-| `MCPJAM_API_KEY` | legacy workspace | MCPJam API key (`sk_…`), minted at **Settings → API keys**. Org-scoped, so it is released ONLY for the workspace flagged `isLegacyWorkspace`; every other workspace's events are dropped until per-user auth ships. |
-| `MCPJAM_PROJECT_ID` | yes | The project every turn operates in. From `GET /api/v1/projects` or the app URL. |
+| `MCPJAM_SLACK_SERVICE_TOKEN` | OAuth mode | The bot's own service credential (`slk_…`), sent with `x-mcpjam-slack-team-id` / `x-mcpjam-slack-user-id` so the inspector resolves the acting user from their account link. Grants nothing by itself. The inspector holds its SHA-256 as `MCPJAM_SLACK_SERVICE_TOKEN_HASH`. |
+| `MCPJAM_API_KEY` | legacy workspace | MCPJam API key (`sk_…`), minted at **Settings → API keys**. Org-scoped, so it is released only for the workspace flagged `isLegacyWorkspace`, and only for a Slack user who has not linked an account. Everyone else acts as themselves through `MCPJAM_SLACK_SERVICE_TOKEN`. |
+| `MCPJAM_PROJECT_ID` | legacy workspace | The fallback project for the legacy path. A linked user's project comes from the thread's binding, else their default project. |
 | `MCPJAM_BASE_URL` | no | API host. Defaults to `https://app.mcpjam.com`; point at a local inspector (`http://localhost:6274`) for development. |
 | `MCPJAM_APP_URL` | no | Where deep links posted into Slack point. Defaults to `MCPJAM_BASE_URL`; in local dev the UI (`:5173`) differs from the API (`:6274`). |
 

--- a/slack-app/README.md
+++ b/slack-app/README.md
@@ -34,6 +34,10 @@ billed to the project. Consequences worth knowing:
 | `installations/store.js` | Bolt `InstallationStore` over Convex + Vault, with the lifecycle-busted token cache |
 | `installations/backend-client.js` | Service-token client for the backend's `/slack/installations/*` routes |
 | `installations/bot-scopes.js` | `BOT_SCOPES` — must mirror `manifest.json` |
+| `installations/event-claims.js` | Durable per-event claims (replay a stored reply instead of re-running) |
+| `agent/turn-target.js` | Whose credentials and which project a turn runs with |
+| `agent/connect-link.js` | Mints a per-user connect URL from the inspector's link bridge |
+| `listeners/actions/account-actions.js` | App Home project picker + disconnect |
 | `listeners/middleware/tenant-guard.js` | Global middleware: resolves the tenant, drops workspaces we have no credentials for |
 | `listeners/events/app-lifecycle.js` | `app_uninstalled` / `tokens_revoked` — revoke + synchronous cache purge |
 | `agent/mcpjam-client.js` | HTTP client for the MCPJam public API — turns, run starts, run polling |
@@ -45,6 +49,22 @@ billed to the project. Consequences worth knowing:
 
 ### Correctness details that are easy to break
 
+- **Identity is per-ACTOR, not per-workspace.** `resolveTurnTarget` decides in
+  a fixed order: thread binding → the replier's default project → the legacy
+  shared key. The thread binding wins because without it a thread would drift
+  between projects as different people replied, and a suite would land
+  somewhere nobody expected.
+- **An unlinked user is a UX state, not an error.** They get a connect button;
+  a linked user with no default project gets a project prompt. Both are
+  ephemeral in channels so a message about one person's account does not
+  notify the whole thread.
+- **The bot never holds a user token.** It presents its own `slk_` credential
+  plus the Slack team/user headers, and the server resolves the linked user.
+  Delegated JWTs are portable 2-hour org credentials; a compromised bot must
+  not be able to harvest them.
+- **The SessionStore is a cache over the durable thread binding**, not the
+  source of truth — before that, the bot went deaf in every engaged thread
+  after a restart with no indication why.
 - **Never blind-retry a turn.** The agent endpoint is not idempotent — a lost
   response may still have persisted a suite. Dedupe lives at the trigger
   (`EventDedupe`, keyed on `channel + event ts`, with a TTL so a *delayed*

--- a/slack-app/README.md
+++ b/slack-app/README.md
@@ -127,7 +127,7 @@ cp .env.sample .env
 | --- | --- | --- |
 | `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` / `SLACK_STATE_SECRET` | OAuth mode | Presence of all three selects OAuth mode. `SLACK_STATE_SECRET` is ours to choose — any high-entropy string. |
 | `SLACK_SIGNING_SECRET` | OAuth mode | Verifies inbound request signatures. |
-| `MCPJAM_CONVEX_HTTP_URL` / `INSPECTOR_SERVICE_TOKEN` | OAuth mode | Where installations are stored. The app refuses to boot if OAuth is configured without them. |
+| `MCPJAM_CONVEX_HTTP_URL` / `SLACK_SERVICE_TOKEN` | OAuth mode | Where installations are stored. The app refuses to boot if OAuth is configured without them. |
 | `MCPJAM_SLACK_SERVICE_TOKEN` | OAuth mode | The bot's own service credential (`slk_…`), sent with `x-mcpjam-slack-team-id` / `x-mcpjam-slack-user-id` so the inspector resolves the acting user from their account link. Grants nothing by itself. The inspector holds its SHA-256 as `MCPJAM_SLACK_SERVICE_TOKEN_HASH`. |
 | `MCPJAM_API_KEY` | legacy workspace | MCPJam API key (`sk_…`), minted at **Settings → API keys**. Org-scoped, so it is released only for the workspace flagged `isLegacyWorkspace`, and only for a Slack user who has not linked an account. Everyone else acts as themselves through `MCPJAM_SLACK_SERVICE_TOKEN`. |
 | `MCPJAM_PROJECT_ID` | legacy workspace | The fallback project for the legacy path. A linked user's project comes from the thread's binding, else their default project. |

--- a/slack-app/README.md
+++ b/slack-app/README.md
@@ -30,7 +30,12 @@ billed to the project. Consequences worth knowing:
 
 | Path | What it does |
 | --- | --- |
-| `app.js` | Bolt app entry (Socket Mode) |
+| `app.js` | Bolt app entry — picks OAuth (HTTP) or Socket Mode from config presence |
+| `installations/store.js` | Bolt `InstallationStore` over Convex + Vault, with the lifecycle-busted token cache |
+| `installations/backend-client.js` | Service-token client for the backend's `/slack/installations/*` routes |
+| `installations/bot-scopes.js` | `BOT_SCOPES` — must mirror `manifest.json` |
+| `listeners/middleware/tenant-guard.js` | Global middleware: resolves the tenant, drops workspaces we have no credentials for |
+| `listeners/events/app-lifecycle.js` | `app_uninstalled` / `tokens_revoked` — revoke + synchronous cache purge |
 | `agent/mcpjam-client.js` | HTTP client for the MCPJam public API — turns, run starts, run polling |
 | `agent/turn-runner.js` | Event dedupe (TTL), per-thread serialization, thread → message-history normalization |
 | `listeners/events/run-and-reply.js` | Shared body for DM / mention triggers: run the turn, post the reply |
@@ -57,9 +62,31 @@ billed to the project. Consequences worth knowing:
 - **The message history the bot sends is capped in bytes, not just
   characters** (`turn-runner.js`), mirroring the server's per-message and
   aggregate UTF-8 limits. Character-only caps let emoji/CJK threads 400.
-- **`im:read` / `im:write` are still requested but unused** by any current
-  code path — trimming them needs a reinstall, so it is a deliberate
-  follow-up rather than a silent change mid-dogfood.
+- **`scopes` must be passed explicitly to `App()`.** Bolt's HTTPReceiver
+  defaults it to `undefined` and forwards `scopes ?? []`, so omitting it
+  produces an install URL requesting ZERO bot scopes. That install *succeeds*
+  and then fails every API call with `missing_scope`, per workspace, with
+  nothing at install time pointing at the cause. `BOT_SCOPES` must stay
+  identical to `manifest.json`.
+- **There is no custom `authorize`.** Bolt throws if given both `authorize`
+  and OAuth installer options, and with installer options it derives
+  authorization from `installationStore.fetchInstallation`. The installation
+  store IS the authorization path.
+- **A backend outage is not an uninstall.** `fetchInstallation` throws on a
+  transport failure and returns an installation or throws otherwise; it never
+  reports "not installed" because we could not ask. Telling a workspace to
+  reinstall over a network blip is the failure that shape prevents.
+- **The token cache is only safe because lifecycle events bust it.**
+  `app_uninstalled`, a bot-token `tokens_revoked`, and reinstall all call
+  `purgeInstallation()` synchronously. Without that, a revoked workspace would
+  keep being served for the full 5-minute TTL.
+- **`tokens_revoked` is not `app_uninstalled`.** It only counts as a
+  revocation when the stored `botUserId` appears in `event.tokens.bot`; a user
+  revoking their own token must not take the workspace's bot offline.
+- **Sign in with Slack never mixes into the bot install URL.** Slack rejects an
+  authorize request combining SIWS user scopes with bot scopes; the `openid` /
+  `profile` scopes in the manifest are used only by the inspector's separate
+  account-link bridge.
 
 ## Setup
 
@@ -76,7 +103,10 @@ cp .env.sample .env
 
 | Variable | Required | Meaning |
 | --- | --- | --- |
-| `MCPJAM_API_KEY` | yes | MCPJam API key (`sk_…`), minted at **Settings → API keys**. Scopes the bot to one organization. |
+| `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` / `SLACK_STATE_SECRET` | OAuth mode | Presence of all three selects OAuth mode. `SLACK_STATE_SECRET` is ours to choose — any high-entropy string. |
+| `SLACK_SIGNING_SECRET` | OAuth mode | Verifies inbound request signatures. |
+| `MCPJAM_CONVEX_HTTP_URL` / `INSPECTOR_SERVICE_TOKEN` | OAuth mode | Where installations are stored. The app refuses to boot if OAuth is configured without them. |
+| `MCPJAM_API_KEY` | legacy workspace | MCPJam API key (`sk_…`), minted at **Settings → API keys**. Org-scoped, so it is released ONLY for the workspace flagged `isLegacyWorkspace`; every other workspace's events are dropped until per-user auth ships. |
 | `MCPJAM_PROJECT_ID` | yes | The project every turn operates in. From `GET /api/v1/projects` or the app URL. |
 | `MCPJAM_BASE_URL` | no | API host. Defaults to `https://app.mcpjam.com`; point at a local inspector (`http://localhost:6274`) for development. |
 | `MCPJAM_APP_URL` | no | Where deep links posted into Slack point. Defaults to `MCPJAM_BASE_URL`; in local dev the UI (`:5173`) differs from the API (`:6274`). |
@@ -113,8 +143,17 @@ Hosted on Railway in its own project, `mcpjam-slack-app`, deployed by
 `.github/workflows/deploy-slack-app.yml` on pushes that touch `slack-app/**`
 (mirroring `deploy-soundcheck.yml`).
 
-The bot runs in Socket Mode there too: it dials out to Slack and serves no
-HTTP, so the service has **no domain, no exposed port, and no healthcheck**.
+In OAuth mode the service **serves HTTP on `$PORT`** — Bolt's HTTP receiver
+owns `/slack/events`, `/slack/install`, and `/slack/oauth_redirect` — so it
+needs a public domain, and the manifest's request URLs point at it.
+
+**The service is pinned to ONE replica and must stay that way.** The
+installation token cache (purged synchronously on revocation) and the
+per-link rate buckets are process-local: with two replicas, a purge on
+replica A would leave replica B serving a revoked token until its own TTL
+lapsed, and the effective rate limit would be N× the intended one. Shared
+invalidation and rate state are deliberately deferred until we need to scale
+horizontally.
 
 Two pieces of Railway config are load-bearing and easy to get wrong:
 

--- a/slack-app/agent/connect-link.js
+++ b/slack-app/agent/connect-link.js
@@ -24,14 +24,52 @@ function bridgeConfig() {
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
 
 /**
- * Reject anything that is not an absolute URL on the bridge's own origin.
+ * Origins a connect link may legitimately live on.
  *
- * Same-origin is the check that carries the weight: it pins protocol, host and
- * port in one comparison, so a response that redirects the user somewhere else
- * cannot reach a button. The explicit HTTPS test is there for the case
- * same-origin cannot catch — a bridge configured over plain http in an
- * environment that is not local — because this URL carries a link session that
- * proves a Slack identity.
+ * NOT just the API origin. The bridge mints the URL from its own
+ * `SLACK_LINK_PUBLIC_ORIGIN` (falling back to `CLI_AUTH_PUBLIC_ORIGIN`), which
+ * is a DIFFERENT setting from the one the bot calls — they coincide in our
+ * deployment and diverge in local setups and any split-origin install. Pinning
+ * to the API origin alone would reject a perfectly good link and make account
+ * linking impossible wherever they differ.
+ *
+ * So this is an allowlist rather than an equality test: still closed by
+ * default, still refusing an origin nobody configured, but honest about the
+ * fact that more than one of them is ours.
+ *
+ * @param {string} baseUrl the API origin the bot just called
+ * @returns {Set<string>}
+ */
+function allowedConnectOrigins(baseUrl) {
+  const configured = [
+    baseUrl,
+    process.env.MCPJAM_SLACK_LINK_ORIGIN,
+    process.env.SLACK_LINK_PUBLIC_ORIGIN,
+    process.env.MCPJAM_APP_URL,
+  ];
+  /** @type {Set<string>} */
+  const origins = new Set();
+  for (const candidate of configured) {
+    if (!candidate) continue;
+    try {
+      origins.add(new URL(candidate).origin);
+    } catch {
+      // A malformed optional setting narrows the allowlist; it must not widen
+      // it and must not crash the mint.
+    }
+  }
+  return origins;
+}
+
+/**
+ * Reject anything that is not an absolute URL on a configured origin.
+ *
+ * The origin comparison carries the weight: `URL.origin` pins protocol, host
+ * and port together, so neither a look-alike host nor a `user@evil.test`
+ * userinfo trick can smuggle a foreign destination into a Block Kit button.
+ * The explicit HTTPS test covers what the origin check cannot — a bridge
+ * configured over plain http somewhere that is not local — because this URL
+ * carries a link session that proves a Slack identity.
  *
  * @param {string} candidate
  * @param {string} baseUrl
@@ -44,12 +82,8 @@ function assertConnectUrl(candidate, baseUrl) {
     throw new InstallationBackendError(`The connect link the bridge returned was not usable (${reason}).`);
   };
 
-  let expected;
-  try {
-    expected = new URL(baseUrl);
-  } catch {
-    return reject('the configured MCPJAM_BASE_URL is not a valid URL');
-  }
+  const allowed = allowedConnectOrigins(baseUrl);
+  if (allowed.size === 0) return reject('no valid MCPJAM origin is configured');
 
   let url;
   try {
@@ -61,7 +95,7 @@ function assertConnectUrl(candidate, baseUrl) {
     return reject('it is not an absolute URL');
   }
 
-  if (url.origin !== expected.origin) return reject('it points at a different origin');
+  if (!allowed.has(url.origin)) return reject('it points at an origin we did not configure');
   if (url.protocol !== 'https:' && !LOOPBACK_HOSTS.has(url.hostname)) {
     return reject('it is not served over HTTPS');
   }

--- a/slack-app/agent/connect-link.js
+++ b/slack-app/agent/connect-link.js
@@ -20,6 +20,53 @@ function bridgeConfig() {
   return { baseUrl, serviceToken };
 }
 
+/** Loopback is the one place a plain-http bridge is legitimate (local dev). */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+/**
+ * Reject anything that is not an absolute URL on the bridge's own origin.
+ *
+ * Same-origin is the check that carries the weight: it pins protocol, host and
+ * port in one comparison, so a response that redirects the user somewhere else
+ * cannot reach a button. The explicit HTTPS test is there for the case
+ * same-origin cannot catch — a bridge configured over plain http in an
+ * environment that is not local — because this URL carries a link session that
+ * proves a Slack identity.
+ *
+ * @param {string} candidate
+ * @param {string} baseUrl
+ */
+function assertConnectUrl(candidate, baseUrl) {
+  /** @param {string} reason */
+  const reject = (reason) => {
+    // The URL itself is deliberately not logged or surfaced: it is a
+    // single-use credential for a named user's link flow.
+    throw new InstallationBackendError(`The connect link the bridge returned was not usable (${reason}).`);
+  };
+
+  let expected;
+  try {
+    expected = new URL(baseUrl);
+  } catch {
+    return reject('the configured MCPJAM_BASE_URL is not a valid URL');
+  }
+
+  let url;
+  try {
+    // No `base` argument on purpose — supplying one would silently RESOLVE a
+    // relative path against our origin instead of rejecting it, which is the
+    // opposite of what this check is for.
+    url = new URL(candidate);
+  } catch {
+    return reject('it is not an absolute URL');
+  }
+
+  if (url.origin !== expected.origin) return reject('it points at a different origin');
+  if (url.protocol !== 'https:' && !LOOPBACK_HOSTS.has(url.hostname)) {
+    return reject('it is not served over HTTPS');
+  }
+}
+
 /**
  * @param {import('./slack-context.js').SlackContext} ctx
  * @param {{ fetchImpl?: typeof fetch, timeoutMs?: number }} [opts] `timeoutMs`
@@ -55,6 +102,13 @@ export async function mintConnectUrl(ctx, opts = {}) {
         status: response.status,
       });
     }
+    // The URL goes straight into a Block Kit button, and Slack renders whatever
+    // it is handed. An empty or relative value produces a dead button; an
+    // off-origin one produces a WORKING button pointing somewhere else, which
+    // is a credential-phishing link wearing our bot's face. Neither is worth
+    // the risk of trusting the response shape, so pin it to the bridge origin
+    // we just called — and to HTTPS, since this URL starts an identity flow.
+    assertConnectUrl(payload.url, baseUrl);
     return payload.url;
   } catch (error) {
     if (error instanceof InstallationBackendError) throw error;

--- a/slack-app/agent/connect-link.js
+++ b/slack-app/agent/connect-link.js
@@ -22,14 +22,17 @@ function bridgeConfig() {
 
 /**
  * @param {import('./slack-context.js').SlackContext} ctx
- * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @param {{ fetchImpl?: typeof fetch, timeoutMs?: number }} [opts] `timeoutMs`
+ *   exists so a test can drive the abort path in milliseconds instead of
+ *   waiting out the real deadline; production never passes it.
  * @returns {Promise<string>}
  */
 export async function mintConnectUrl(ctx, opts = {}) {
   const { baseUrl, serviceToken } = bridgeConfig();
   const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? REQUEST_TIMEOUT_MS;
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const response = await fetchImpl(`${baseUrl}/api/slack/link/session`, {
       method: 'POST',

--- a/slack-app/agent/connect-link.js
+++ b/slack-app/agent/connect-link.js
@@ -45,6 +45,10 @@ function allowedConnectOrigins(baseUrl) {
     baseUrl,
     process.env.MCPJAM_SLACK_LINK_ORIGIN,
     process.env.SLACK_LINK_PUBLIC_ORIGIN,
+    // The bridge resolves `SLACK_LINK_PUBLIC_ORIGIN ?? CLI_AUTH_PUBLIC_ORIGIN`,
+    // so a deployment that only sets the documented fallback mints from THIS
+    // origin. Omitting it here rejected every link on such a deployment.
+    process.env.CLI_AUTH_PUBLIC_ORIGIN,
     process.env.MCPJAM_APP_URL,
   ];
   /** @type {Set<string>} */

--- a/slack-app/agent/connect-link.js
+++ b/slack-app/agent/connect-link.js
@@ -11,9 +11,12 @@ const REQUEST_TIMEOUT_MS = 10_000;
 
 function bridgeConfig() {
   const baseUrl = (process.env.MCPJAM_BASE_URL || 'https://app.mcpjam.com').replace(/\/+$/, '');
-  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  // The bot's own `slk_` credential — the SAME one it presents on /api/v1.
+  // The bridge verifies it against the stored hash, so the bot never needs
+  // (and must never hold) the inspector's environment-root service token.
+  const serviceToken = process.env.MCPJAM_SLACK_SERVICE_TOKEN;
   if (!serviceToken) {
-    throw new InstallationBackendError('INSPECTOR_SERVICE_TOKEN is required to mint a connect link.', {
+    throw new InstallationBackendError('MCPJAM_SLACK_SERVICE_TOKEN is required to mint a connect link.', {
       code: 'CONFIG',
     });
   }
@@ -123,7 +126,7 @@ export async function mintConnectUrl(ctx, opts = {}) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-inspector-service-token': serviceToken,
+        Authorization: `Bearer ${serviceToken}`,
       },
       body: JSON.stringify({ teamId: ctx.teamId, slackUserId: ctx.slackUserId }),
       signal: controller.signal,

--- a/slack-app/agent/connect-link.js
+++ b/slack-app/agent/connect-link.js
@@ -1,0 +1,68 @@
+/**
+ * Mint a per-user connect URL from the inspector's link bridge.
+ *
+ * The URL is minted server-side, per user, and expires in ten minutes. The bot
+ * only relays it: it holds no signing secret of its own, so a compromised bot
+ * cannot forge a link URL for an arbitrary Slack user.
+ */
+import { InstallationBackendError } from '../installations/backend-client.js';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function bridgeConfig() {
+  const baseUrl = (process.env.MCPJAM_BASE_URL || 'https://app.mcpjam.com').replace(/\/+$/, '');
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!serviceToken) {
+    throw new InstallationBackendError('INSPECTOR_SERVICE_TOKEN is required to mint a connect link.', {
+      code: 'CONFIG',
+    });
+  }
+  return { baseUrl, serviceToken };
+}
+
+/**
+ * @param {import('./slack-context.js').SlackContext} ctx
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<string>}
+ */
+export async function mintConnectUrl(ctx, opts = {}) {
+  const { baseUrl, serviceToken } = bridgeConfig();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`${baseUrl}/api/slack/link/session`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-inspector-service-token': serviceToken,
+      },
+      body: JSON.stringify({ teamId: ctx.teamId, slackUserId: ctx.slackUserId }),
+      signal: controller.signal,
+    });
+    /** @type {any} */
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+    }
+    if (!response.ok || typeof payload?.url !== 'string') {
+      throw new InstallationBackendError(payload?.message || `Could not mint a connect link (${response.status})`, {
+        status: response.status,
+      });
+    }
+    return payload.url;
+  } catch (error) {
+    if (error instanceof InstallationBackendError) throw error;
+    const aborted = error instanceof Error && error.name === 'AbortError';
+    throw new InstallationBackendError(
+      aborted ? 'Connect-link request timed out' : `Connect-link request failed: ${error}`,
+      {
+        code: aborted ? 'TIMEOUT' : 'NETWORK',
+      },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -307,8 +307,17 @@ export async function listProjects(ctx, opts = {}) {
     timeoutMs: RUN_TIMEOUT_MS,
     fetchImpl: opts.fetchImpl,
   });
+  // The v1 collection envelope is `{ items: [...] }`. `data`/bare-array are
+  // kept as fallbacks so a shape change degrades to a smaller picker rather
+  // than an empty one that reads as "you have no projects".
   /** @type {Array<Record<string, any>>} */
-  const items = Array.isArray(payload?.data) ? payload.data : Array.isArray(payload) ? payload : [];
+  const items = Array.isArray(payload?.items)
+    ? payload.items
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : Array.isArray(payload)
+        ? payload
+        : [];
   return items
     .filter((item) => item && typeof item.id === 'string')
     .map((item) => ({ id: String(item.id), name: String(item.name ?? item.id) }));

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -54,8 +54,18 @@ export class McpjamApiError extends Error {
     if (this.code === 'TIMEOUT') {
       return ':hourglass: That took longer than I allow for one reply. Try breaking the request into smaller steps.';
     }
-    if (this.code === 'UNAUTHORIZED' || this.code === 'FORBIDDEN') {
-      return ':lock: My MCPJam credentials look wrong — an admin needs to check the API key configuration.';
+    if (this.code === 'SERVER_UNREACHABLE') {
+      // A backend blip must never be reported as an auth problem: the user
+      // would go and re-link an account that was already fine.
+      return ":satellite: I can't reach MCPJam right now. Try again in a moment.";
+    }
+    if (this.code === 'UNAUTHORIZED') {
+      return ':link: I need you to connect your MCPJam account before I can do that.';
+    }
+    if (this.code === 'FORBIDDEN') {
+      // The clamp and the delegated mint both enforce project access. The
+      // common cause is a thread bound to a project the replier can't reach.
+      return ":lock: You don't have access to the project this thread is working in.";
     }
     return ':warning: Something went wrong talking to MCPJam. Try again in a moment.';
   }
@@ -64,22 +74,55 @@ export class McpjamApiError extends Error {
 /**
  * Resolve the credentials and project one Slack event should act with.
  *
- * LEGACY-ONLY FALLBACK. The env `sk_` key is org-scoped to OUR organization,
- * so serving any other workspace with it would run that workspace's request
- * against our project — a cross-tenant leak, not a degraded experience. The
- * key is therefore released only when the tenant guard has affirmatively
- * marked this event as coming from the one pre-OAuth workspace. The check is
- * re-asserted HERE, at the credential seam, rather than trusted from the
- * guard alone: this is the last point before a secret is handed out, and a
- * new call path that forgets the guard must fail closed instead of inheriting
- * our organization's credentials.
+ * TWO MODES, and the ctx says which:
  *
- * @param {import('./slack-context.js').SlackContext} ctx
+ *   'user'   — the actor has linked their MCPJam account. The bot presents its
+ *              `slk_` service credential plus the Slack team/user headers, and
+ *              the server resolves the LINKED USER's identity from them. The
+ *              bot never holds a user token: delegated JWTs are portable
+ *              2-hour org credentials, and a compromised bot must not be able
+ *              to harvest them.
+ *   'legacy' — the one pre-OAuth workspace, acting on the shared org-scoped
+ *              `sk_` key. Gated on the tenant guard's verdict and re-asserted
+ *              HERE, at the credential seam: this is the last point before a
+ *              secret is handed out, and a call path that forgot the guard
+ *              must fail closed rather than inherit our organization's key.
+ *
+ * @param {import('./slack-context.js').SlackContext & { mode?: 'user' | 'legacy', projectId?: string }} ctx
  */
 export function getConfig(ctx) {
   if (!ctx?.teamId || !ctx?.slackUserId) {
     throw new McpjamApiError('MCPJam credentials were requested without a Slack tenant context.', { code: 'CONFIG' });
   }
+  const baseUrl = (process.env.MCPJAM_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
+  // Deep links can point somewhere other than the API host — in local dev
+  // the API is on :6274 while the app UI is served on :5173.
+  const appUrl = (process.env.MCPJAM_APP_URL || baseUrl).replace(/\/+$/, '');
+
+  if (ctx.mode === 'user') {
+    const serviceToken = process.env.MCPJAM_SLACK_SERVICE_TOKEN;
+    if (!serviceToken) {
+      throw new McpjamApiError('MCPJAM_SLACK_SERVICE_TOKEN must be set to act as a linked user.', {
+        code: 'CONFIG',
+      });
+    }
+    if (!ctx.projectId) {
+      throw new McpjamApiError('No project resolved for this turn.', { code: 'NO_PROJECT' });
+    }
+    return {
+      apiKey: serviceToken,
+      projectId: ctx.projectId,
+      baseUrl,
+      appUrl,
+      // The identity. Without both, the server has no user to act as and
+      // answers 401 — which is the correct outcome, not a fallback.
+      headers: /** @type {Record<string, string>} */ ({
+        'x-mcpjam-slack-team-id': ctx.teamId,
+        'x-mcpjam-slack-user-id': ctx.slackUserId,
+      }),
+    };
+  }
+
   if (ctx.isLegacyWorkspace !== true) {
     throw new McpjamApiError(
       `Workspace ${ctx.teamId} has no MCPJam credentials: the shared API key is scoped to the legacy workspace only.`,
@@ -87,15 +130,11 @@ export function getConfig(ctx) {
     );
   }
   const apiKey = process.env.MCPJAM_API_KEY;
-  const projectId = process.env.MCPJAM_PROJECT_ID;
-  const baseUrl = (process.env.MCPJAM_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
-  // Deep links can point somewhere other than the API host — in local dev
-  // the API is on :6274 while the app UI is served on :5173.
-  const appUrl = (process.env.MCPJAM_APP_URL || baseUrl).replace(/\/+$/, '');
+  const projectId = ctx.projectId || process.env.MCPJAM_PROJECT_ID;
   if (!apiKey || !projectId) {
     throw new McpjamApiError('MCPJAM_API_KEY and MCPJAM_PROJECT_ID must be set (see .env.sample).', { code: 'CONFIG' });
   }
-  return { apiKey, projectId, baseUrl, appUrl };
+  return { apiKey, projectId, baseUrl, appUrl, headers: /** @type {Record<string, string>} */ ({}) };
 }
 
 /**
@@ -104,10 +143,13 @@ export function getConfig(ctx) {
  * that never finishes its body hang the caller forever.
  *
  * @param {string} url
- * @param {{ method?: string, body?: Record<string, unknown>, apiKey: string, timeoutMs: number, fetchImpl?: typeof fetch, idempotencyKey?: string }} opts
+ * @param {{ method?: string, body?: Record<string, unknown>, apiKey: string, timeoutMs: number, fetchImpl?: typeof fetch, idempotencyKey?: string, headers?: Record<string, string> }} opts
  * @returns {Promise<any>}
  */
-async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetchImpl = fetch, idempotencyKey }) {
+async function requestJson(
+  url,
+  { method = 'GET', body, apiKey, timeoutMs, fetchImpl = fetch, idempotencyKey, headers: extraHeaders = {} },
+) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -120,6 +162,7 @@ async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetch
         // from here so it applies uniformly and can never be shaped by
         // model output.
         ...(idempotencyKey ? { 'x-mcpjam-idempotency-key': idempotencyKey } : {}),
+        ...extraHeaders,
       },
       ...(body ? { body: JSON.stringify(body) } : {}),
       signal: controller.signal,
@@ -171,7 +214,7 @@ async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetch
  * @returns {Promise<AgentTurnResult>}
  */
 export async function runAgentTurn(messages, ctx, opts = {}) {
-  const { apiKey, projectId, baseUrl } = getConfig(ctx);
+  const { apiKey, projectId, baseUrl, headers } = getConfig(ctx);
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/agent`;
   const payload = await requestJson(url, {
     method: 'POST',
@@ -180,6 +223,7 @@ export async function runAgentTurn(messages, ctx, opts = {}) {
       ...(opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : {}),
     },
     apiKey,
+    headers,
     timeoutMs: TURN_TIMEOUT_MS,
     fetchImpl: opts.fetchImpl,
   });
@@ -204,12 +248,13 @@ export async function runAgentTurn(messages, ctx, opts = {}) {
  * @returns {Promise<{ runId: string, suiteId: string, url: string }>}
  */
 export async function startSuiteRun(suiteId, ctx, opts = {}) {
-  const { apiKey, projectId, baseUrl, appUrl } = getConfig(ctx);
+  const { apiKey, projectId, baseUrl, appUrl, headers } = getConfig(ctx);
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/eval-runs`;
   const payload = await requestJson(url, {
     method: 'POST',
     body: { suiteId },
     apiKey,
+    headers,
     timeoutMs: RUN_TIMEOUT_MS,
     fetchImpl: opts.fetchImpl,
     ...(opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : {}),
@@ -237,7 +282,34 @@ export async function startSuiteRun(suiteId, ctx, opts = {}) {
  * @returns {Promise<{ status: string, result: string | null, summary?: { total?: number, passed?: number, failed?: number, passRate?: number } }>}
  */
 export async function getEvalRun(runId, ctx, opts = {}) {
-  const { apiKey, projectId, baseUrl } = getConfig(ctx);
+  const { apiKey, projectId, baseUrl, headers } = getConfig(ctx);
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/eval-runs/${encodeURIComponent(runId)}`;
-  return requestJson(url, { apiKey, timeoutMs: RUN_TIMEOUT_MS, fetchImpl: opts.fetchImpl });
+  return requestJson(url, { apiKey, headers, timeoutMs: RUN_TIMEOUT_MS, fetchImpl: opts.fetchImpl });
+}
+
+/**
+ * Projects the linked user can see, for the App Home picker.
+ *
+ * Uses the same per-user credentials as everything else, so the list is
+ * exactly what THAT user may act in — never a superset borrowed from the
+ * bot's own identity, which is the mistake that would make the picker offer
+ * projects the user cannot actually use.
+ *
+ * @param {import('./slack-context.js').SlackContext & { mode?: 'user' | 'legacy', projectId?: string }} ctx
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<Array<{ id: string, name: string }>>}
+ */
+export async function listProjects(ctx, opts = {}) {
+  const { apiKey, baseUrl, headers } = getConfig({ ...ctx, projectId: ctx.projectId || 'unused' });
+  const payload = await requestJson(`${baseUrl}/api/v1/projects`, {
+    apiKey,
+    headers,
+    timeoutMs: RUN_TIMEOUT_MS,
+    fetchImpl: opts.fetchImpl,
+  });
+  /** @type {Array<Record<string, any>>} */
+  const items = Array.isArray(payload?.data) ? payload.data : Array.isArray(payload) ? payload : [];
+  return items
+    .filter((item) => item && typeof item.id === 'string')
+    .map((item) => ({ id: String(item.id), name: String(item.name ?? item.id) }));
 }

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -25,6 +25,13 @@ const DEFAULT_BASE_URL = 'https://app.mcpjam.com';
 // Slightly above the server's 90s turn wall clock.
 const TURN_TIMEOUT_MS = 120_000;
 const RUN_TIMEOUT_MS = 30_000;
+/**
+ * Approved-action execution. The server caps one execution at 120s; this sits
+ * ABOVE that on purpose, with room for auth and the response body, so the
+ * server's own timeout is what the user hears about. A client that gave up
+ * first would report a timeout for a spend that then succeeded.
+ */
+const EXECUTE_ACTION_TIMEOUT_MS = 150_000;
 
 /** @typedef {{ role: 'user' | 'assistant', content: string }} TurnMessage */
 /**
@@ -269,21 +276,42 @@ export async function runAgentTurn(messages, ctx, opts = {}) {
  * @param {string} actionId
  * @param {import('./slack-context.js').SlackContext & { mode?: 'user' | 'legacy', projectId?: string }} ctx
  * @param {{ fetchImpl?: typeof fetch }} [opts]
- * @returns {Promise<{ status: string, result: any }>}
+ * @returns {Promise<{ status: string, operation: string, result: any, runUrl: string | null }>}
  */
 export async function executeProposedAction(actionId, ctx, opts = {}) {
-  const { apiKey, projectId, baseUrl, headers } = getConfig(ctx);
+  const { apiKey, projectId, baseUrl, appUrl, headers } = getConfig(ctx);
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/proposed-actions/${encodeURIComponent(actionId)}/execute`;
   const payload = await requestJson(url, {
     method: 'POST',
     apiKey,
     headers,
-    timeoutMs: TURN_TIMEOUT_MS,
+    // Longer than the SERVER's execution wall clock, deliberately. If this side
+    // gave up first, an action that then succeeded would be reported to the
+    // user as a timeout — leaving them with a spend they were told did not
+    // happen, and a retry that reads as the obvious next step.
+    timeoutMs: EXECUTE_ACTION_TIMEOUT_MS,
     fetchImpl: opts.fetchImpl,
   });
+  // The run ops answer with `runId` (+ `suite`/`suiteId`), not a ready-made
+  // link — the platform API returns ids and leaves the URL to the surface. Build
+  // it here so the approver can follow the run they just paid for; a proposal
+  // that produced no run (a cancel) simply has none.
+  const result = payload?.result ?? null;
+  const runId = typeof result?.runId === 'string' ? result.runId : null;
+  const suiteId =
+    typeof result?.suiteId === 'string'
+      ? result.suiteId
+      : typeof result?.suite?.id === 'string'
+        ? result.suite.id
+        : null;
   return {
     status: typeof payload?.status === 'string' ? payload.status : 'succeeded',
-    result: payload?.result ?? null,
+    operation: typeof payload?.operation === 'string' ? payload.operation : '',
+    result,
+    runUrl:
+      runId && suiteId
+        ? `${appUrl}/evals/suite/${encodeURIComponent(suiteId)}/runs/${encodeURIComponent(runId)}?project=${encodeURIComponent(projectId)}`
+        : null,
   };
 }
 

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -53,13 +53,20 @@ const EXECUTE_ACTION_TIMEOUT_MS = 150_000;
 export class McpjamApiError extends Error {
   /**
    * @param {string} message
-   * @param {{ code?: string, status?: number }} [opts]
+   * @param {{ code?: string, status?: number, details?: Record<string, any> }} [opts]
    */
   constructor(message, opts = {}) {
     super(message);
     this.name = 'McpjamApiError';
     this.code = opts.code;
     this.status = opts.status;
+    /**
+     * The error envelope's `details`, when the server sent one. A FAILED turn
+     * may still have persisted resources (`details.createdResources`) or
+     * proposals (`details.proposedActions`) — discarding them here is how a
+     * caller comes to believe "failed" means "nothing happened".
+     */
+    this.details = opts.details;
   }
 
   /** A short, user-facing Slack message for this failure. */
@@ -201,6 +208,7 @@ async function requestJson(
       throw new McpjamApiError(payload?.message || `MCPJam API error (${response.status})`, {
         code: payload?.code,
         status: response.status,
+        ...(payload?.details && typeof payload.details === 'object' ? { details: payload.details } : {}),
       });
     }
     return payload;

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -64,16 +64,27 @@ export class McpjamApiError extends Error {
 /**
  * Resolve the credentials and project one Slack event should act with.
  *
- * The `ctx` argument is REQUIRED and asserted even though nothing reads it
- * yet: this function is the seam where per-workspace credentials land, and a
- * call site that reaches it without a tenant is a bug we want to catch now
- * rather than after it has silently acted as the wrong workspace.
+ * LEGACY-ONLY FALLBACK. The env `sk_` key is org-scoped to OUR organization,
+ * so serving any other workspace with it would run that workspace's request
+ * against our project — a cross-tenant leak, not a degraded experience. The
+ * key is therefore released only when the tenant guard has affirmatively
+ * marked this event as coming from the one pre-OAuth workspace. The check is
+ * re-asserted HERE, at the credential seam, rather than trusted from the
+ * guard alone: this is the last point before a secret is handed out, and a
+ * new call path that forgets the guard must fail closed instead of inheriting
+ * our organization's credentials.
  *
  * @param {import('./slack-context.js').SlackContext} ctx
  */
 export function getConfig(ctx) {
   if (!ctx?.teamId || !ctx?.slackUserId) {
     throw new McpjamApiError('MCPJam credentials were requested without a Slack tenant context.', { code: 'CONFIG' });
+  }
+  if (ctx.isLegacyWorkspace !== true) {
+    throw new McpjamApiError(
+      `Workspace ${ctx.teamId} has no MCPJam credentials: the shared API key is scoped to the legacy workspace only.`,
+      { code: 'UNAUTHORIZED' },
+    );
   }
   const apiKey = process.env.MCPJAM_API_KEY;
   const projectId = process.env.MCPJAM_PROJECT_ID;

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -4,8 +4,16 @@
  *
  * RETRY POLICY: never blind-retry a turn. The endpoint is not idempotent —
  * a lost response may still have persisted an eval suite. Dedupe lives at
- * the trigger (turn-runner's channel+event-ts registry); this client makes
- * exactly one attempt per call, on purpose.
+ * the trigger (turn-runner's tenant+channel+event-ts registry); this client
+ * makes exactly one attempt per call, on purpose.
+ *
+ * TENANCY: every entry point takes a `SlackContext` ({teamId, slackUserId})
+ * and resolves credentials through `getConfig(ctx)`. This is the single
+ * chokepoint where "which workspace is this?" becomes "which credentials and
+ * which project?" — so the multi-workspace switch is one function's problem,
+ * not every call site's. Today it still answers from env for every tenant;
+ * the ctx is threaded first (and asserted) so that switch cannot miss a
+ * caller later.
  *
  * Env:
  *   MCPJAM_API_KEY    — sk_… key minted in the MCPJam app (Settings → API keys)
@@ -53,7 +61,20 @@ export class McpjamApiError extends Error {
   }
 }
 
-export function getConfig() {
+/**
+ * Resolve the credentials and project one Slack event should act with.
+ *
+ * The `ctx` argument is REQUIRED and asserted even though nothing reads it
+ * yet: this function is the seam where per-workspace credentials land, and a
+ * call site that reaches it without a tenant is a bug we want to catch now
+ * rather than after it has silently acted as the wrong workspace.
+ *
+ * @param {import('./slack-context.js').SlackContext} ctx
+ */
+export function getConfig(ctx) {
+  if (!ctx?.teamId || !ctx?.slackUserId) {
+    throw new McpjamApiError('MCPJam credentials were requested without a Slack tenant context.', { code: 'CONFIG' });
+  }
   const apiKey = process.env.MCPJAM_API_KEY;
   const projectId = process.env.MCPJAM_PROJECT_ID;
   const baseUrl = (process.env.MCPJAM_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, '');
@@ -123,11 +144,12 @@ async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetch
 /**
  * Run one agent turn.
  * @param {TurnMessage[]} messages
+ * @param {import('./slack-context.js').SlackContext} ctx
  * @param {{ fetchImpl?: typeof fetch }} [opts]
  * @returns {Promise<AgentTurnResult>}
  */
-export async function runAgentTurn(messages, opts = {}) {
-  const { apiKey, projectId, baseUrl } = getConfig();
+export async function runAgentTurn(messages, ctx, opts = {}) {
+  const { apiKey, projectId, baseUrl } = getConfig(ctx);
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/agent`;
   const payload = await requestJson(url, {
     method: 'POST',
@@ -147,11 +169,12 @@ export async function runAgentTurn(messages, opts = {}) {
  * Start an eval-suite run. This is the human-gated action behind the Slack
  * "Run it" button — the agent turn itself can never start runs.
  * @param {string} suiteId
+ * @param {import('./slack-context.js').SlackContext} ctx
  * @param {{ fetchImpl?: typeof fetch }} [opts]
  * @returns {Promise<{ runId: string, suiteId: string, url: string }>}
  */
-export async function startSuiteRun(suiteId, opts = {}) {
-  const { apiKey, projectId, baseUrl, appUrl } = getConfig();
+export async function startSuiteRun(suiteId, ctx, opts = {}) {
+  const { apiKey, projectId, baseUrl, appUrl } = getConfig(ctx);
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/eval-runs`;
   const payload = await requestJson(url, {
     method: 'POST',
@@ -178,11 +201,12 @@ export async function startSuiteRun(suiteId, opts = {}) {
 /**
  * Poll one run's status/result.
  * @param {string} runId
+ * @param {import('./slack-context.js').SlackContext} ctx
  * @param {{ fetchImpl?: typeof fetch }} [opts]
  * @returns {Promise<{ status: string, result: string | null, summary?: { total?: number, passed?: number, failed?: number, passRate?: number } }>}
  */
-export async function getEvalRun(runId, opts = {}) {
-  const { apiKey, projectId, baseUrl } = getConfig();
+export async function getEvalRun(runId, ctx, opts = {}) {
+  const { apiKey, projectId, baseUrl } = getConfig(ctx);
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/eval-runs/${encodeURIComponent(runId)}`;
   return requestJson(url, { apiKey, timeoutMs: RUN_TIMEOUT_MS, fetchImpl: opts.fetchImpl });
 }

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -32,6 +32,15 @@ const RUN_TIMEOUT_MS = 30_000;
  * @property {string} reply
  * @property {Array<{ operation: string }>} toolCalls
  * @property {Array<{ type: string, id: string, name?: string, url: string }>} createdResources
+ * @property {Array<ProposedAction>} [proposedActions]
+ */
+/**
+ * An action the turn wants to take but is not allowed to take on its own.
+ * Rendered as a button; the click is the approval that spends.
+ * @typedef {Object} ProposedAction
+ * @property {string} actionId
+ * @property {string} operation
+ * @property {string} description
  */
 
 export class McpjamApiError extends Error {
@@ -210,7 +219,15 @@ async function requestJson(
  *
  * @param {TurnMessage[]} messages
  * @param {import('./slack-context.js').SlackContext} ctx
- * @param {{ fetchImpl?: typeof fetch, idempotencyKey?: string }} [opts]
+ * `channelId` is what makes the SPENDING tools available at all: the server
+ * only offers them when it knows where an approval button can be rendered, so
+ * omitting it means the model is never given a run/generate/cancel tool to
+ * call. That is the intended degradation — the alternative would be proposals
+ * queued somewhere nobody can approve them.
+ *
+ * @param {TurnMessage[]} messages
+ * @param {import('./slack-context.js').SlackContext} ctx
+ * @param {{ fetchImpl?: typeof fetch, idempotencyKey?: string, channelId?: string }} [opts]
  * @returns {Promise<AgentTurnResult>}
  */
 export async function runAgentTurn(messages, ctx, opts = {}) {
@@ -221,6 +238,7 @@ export async function runAgentTurn(messages, ctx, opts = {}) {
     body: {
       messages,
       ...(opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : {}),
+      ...(opts.channelId ? { slackChannelId: opts.channelId } : {}),
     },
     apiKey,
     headers,
@@ -231,6 +249,41 @@ export async function runAgentTurn(messages, ctx, opts = {}) {
     reply: typeof payload?.reply === 'string' ? payload.reply : '',
     toolCalls: Array.isArray(payload?.toolCalls) ? payload.toolCalls : [],
     createdResources: Array.isArray(payload?.createdResources) ? payload.createdResources : [],
+    proposedActions: Array.isArray(payload?.proposedActions) ? payload.proposedActions : [],
+  };
+}
+
+/**
+ * Execute an action a human just approved by clicking.
+ *
+ * `ctx` MUST carry the CLICKER's Slack user id, not the proposer's: the server
+ * resolves the acting identity from these headers and mints the delegated token
+ * for that person, so this is where "the clicker is the authorizer" is actually
+ * enforced. Passing the proposer through here would silently spend someone
+ * else's quota under their identity.
+ *
+ * Only `actionId` travels. What it DOES is read from the persisted proposal
+ * server-side — a Block Kit button's value can be minted by anyone able to post
+ * in the workspace, so a click may only say WHICH action to run.
+ *
+ * @param {string} actionId
+ * @param {import('./slack-context.js').SlackContext & { mode?: 'user' | 'legacy', projectId?: string }} ctx
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<{ status: string, result: any }>}
+ */
+export async function executeProposedAction(actionId, ctx, opts = {}) {
+  const { apiKey, projectId, baseUrl, headers } = getConfig(ctx);
+  const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/proposed-actions/${encodeURIComponent(actionId)}/execute`;
+  const payload = await requestJson(url, {
+    method: 'POST',
+    apiKey,
+    headers,
+    timeoutMs: TURN_TIMEOUT_MS,
+    fetchImpl: opts.fetchImpl,
+  });
+  return {
+    status: typeof payload?.status === 'string' ? payload.status : 'succeeded',
+    result: payload?.result ?? null,
   };
 }
 

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -104,10 +104,10 @@ export function getConfig(ctx) {
  * that never finishes its body hang the caller forever.
  *
  * @param {string} url
- * @param {{ method?: string, body?: Record<string, unknown>, apiKey: string, timeoutMs: number, fetchImpl?: typeof fetch }} opts
+ * @param {{ method?: string, body?: Record<string, unknown>, apiKey: string, timeoutMs: number, fetchImpl?: typeof fetch, idempotencyKey?: string }} opts
  * @returns {Promise<any>}
  */
-async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetchImpl = fetch }) {
+async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetchImpl = fetch, idempotencyKey }) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -116,6 +116,10 @@ async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetch
       headers: {
         Authorization: `Bearer ${apiKey}`,
         ...(body ? { 'Content-Type': 'application/json' } : {}),
+        // Transport-level, not a body field: the write routes read the key
+        // from here so it applies uniformly and can never be shaped by
+        // model output.
+        ...(idempotencyKey ? { 'x-mcpjam-idempotency-key': idempotencyKey } : {}),
       },
       ...(body ? { body: JSON.stringify(body) } : {}),
       signal: controller.signal,
@@ -154,9 +158,16 @@ async function requestJson(url, { method = 'GET', body, apiKey, timeoutMs, fetch
 
 /**
  * Run one agent turn.
+ *
+ * `idempotencyKey` must be the STABLE identity of the triggering Slack event
+ * (`${teamId}:${event_id}`), never a fresh value per attempt: the server
+ * derives a per-write key from it, so a retried turn's mutations land on the
+ * rows the first attempt created instead of authoring duplicates. A uuid
+ * regenerated per call would silently disable that.
+ *
  * @param {TurnMessage[]} messages
  * @param {import('./slack-context.js').SlackContext} ctx
- * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @param {{ fetchImpl?: typeof fetch, idempotencyKey?: string }} [opts]
  * @returns {Promise<AgentTurnResult>}
  */
 export async function runAgentTurn(messages, ctx, opts = {}) {
@@ -164,7 +175,10 @@ export async function runAgentTurn(messages, ctx, opts = {}) {
   const url = `${baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/agent`;
   const payload = await requestJson(url, {
     method: 'POST',
-    body: { messages },
+    body: {
+      messages,
+      ...(opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : {}),
+    },
     apiKey,
     timeoutMs: TURN_TIMEOUT_MS,
     fetchImpl: opts.fetchImpl,
@@ -179,9 +193,14 @@ export async function runAgentTurn(messages, ctx, opts = {}) {
 /**
  * Start an eval-suite run. This is the human-gated action behind the Slack
  * "Run it" button — the agent turn itself can never start runs.
+ * `idempotencyKey` is the click's action id. A run costs quota, so the two
+ * hazards are a double-click and a crash between starting the run and
+ * recording that it started; both re-issue the same key and land on the SAME
+ * backend run rather than billing a second one.
+ *
  * @param {string} suiteId
  * @param {import('./slack-context.js').SlackContext} ctx
- * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @param {{ fetchImpl?: typeof fetch, idempotencyKey?: string }} [opts]
  * @returns {Promise<{ runId: string, suiteId: string, url: string }>}
  */
 export async function startSuiteRun(suiteId, ctx, opts = {}) {
@@ -193,6 +212,7 @@ export async function startSuiteRun(suiteId, ctx, opts = {}) {
     apiKey,
     timeoutMs: RUN_TIMEOUT_MS,
     fetchImpl: opts.fetchImpl,
+    ...(opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : {}),
   });
   const runId = String(payload?.runId ?? '');
   // A run without an id can't be linked or polled — surface it instead of

--- a/slack-app/agent/slack-context.js
+++ b/slack-app/agent/slack-context.js
@@ -54,14 +54,19 @@ export function slackContextFrom(args) {
 
   const teamId =
     firstString(
+      // `authorizations[0].team_id` FIRST, and that ordering is the whole
+      // point. In a Slack Connect (shared) channel the event's own `team` is
+      // the workspace the MESSAGE came from, which may not be the workspace
+      // that installed us — acting on that one would mean looking up an
+      // installation we do not have and running a turn as the wrong tenant.
+      // The authorization names the installation whose token Slack expects us
+      // to act with, so it outranks every positional guess below it.
+      body.authorizations?.[0]?.team_id,
       context.teamId,
       body.team_id,
       body.team?.id,
       event.team,
       event.user_team,
-      // `authorizations` is what the Events API sends for a shared channel:
-      // the installing team is the one whose token we must act with.
-      body.authorizations?.[0]?.team_id,
     ) ?? '';
 
   const slackUserId = firstString(context.userId, event.user, body.user?.id, body.user_id, event.user_id) ?? '';

--- a/slack-app/agent/slack-context.js
+++ b/slack-app/agent/slack-context.js
@@ -1,0 +1,107 @@
+/**
+ * The per-event tenancy context every downstream call must carry.
+ *
+ * The bot used to be single-tenant: one workspace, one env-configured API key,
+ * one project. Every cache key, dedupe key, and credential lookup was
+ * process-global, which is exactly the set of things that silently CROSS
+ * workspaces once a second team installs the app. This module makes the
+ * tenant explicit at the boundary — nothing downstream may reach for
+ * `process.env` or a bare `channelId` key again.
+ *
+ * `teamId` is the tenant. `slackUserId` is the ACTOR — the human whose
+ * identity the turn runs as once per-user auth lands. Both are extracted from
+ * the Slack payload rather than passed around implicitly, so a listener that
+ * forgets one fails loudly here instead of quietly acting as the wrong tenant.
+ */
+
+/**
+ * @typedef {Object} SlackContext
+ * @property {string} teamId       Slack workspace id (the tenant).
+ * @property {string} slackUserId  Slack user id of the event's actor.
+ */
+
+export class SlackContextError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = 'SlackContextError';
+  }
+}
+
+/**
+ * Pull the tenancy context out of a Bolt listener's arguments.
+ *
+ * Sources differ by payload shape, so all three are consulted in priority
+ * order rather than trusting one: Bolt's `context` is populated for events,
+ * `body` carries `team`/`team_id` for interactive payloads, and the event
+ * itself carries `user`/`team` for a few event types. An
+ * enterprise-grid-installed app can also report the team under
+ * `body.team.id` only.
+ *
+ * @param {{ context?: Record<string, any>, body?: Record<string, any>, event?: Record<string, any>, payload?: Record<string, any> }} args
+ * @returns {SlackContext}
+ */
+export function slackContextFrom(args) {
+  const context = args.context ?? {};
+  const body = args.body ?? {};
+  const event = args.event ?? args.payload ?? {};
+
+  const teamId =
+    firstString(
+      context.teamId,
+      body.team_id,
+      body.team?.id,
+      event.team,
+      event.user_team,
+      // `authorizations` is what the Events API sends for a shared channel:
+      // the installing team is the one whose token we must act with.
+      body.authorizations?.[0]?.team_id,
+    ) ?? '';
+
+  const slackUserId = firstString(context.userId, event.user, body.user?.id, body.user_id, event.user_id) ?? '';
+
+  if (!teamId) {
+    throw new SlackContextError('Slack payload carried no team id — refusing to run a turn without a tenant.');
+  }
+  if (!slackUserId) {
+    throw new SlackContextError('Slack payload carried no user id — refusing to run a turn without an actor.');
+  }
+  return { teamId, slackUserId };
+}
+
+/**
+ * Same extraction, but returns null instead of throwing. For listeners whose
+ * correct response to a malformed payload is to drop it silently (Slack will
+ * not benefit from an error, and there is nowhere safe to post one).
+ *
+ * @param {Parameters<typeof slackContextFrom>[0]} args
+ * @returns {SlackContext | null}
+ */
+export function tryslackContextFrom(args) {
+  try {
+    return slackContextFrom(args);
+  } catch (error) {
+    if (error instanceof SlackContextError) return null;
+    throw error;
+  }
+}
+
+/**
+ * Namespace an arbitrary key by tenant. Every process-global map in this app
+ * goes through here so a workspace can never observe or evict another's
+ * entries.
+ *
+ * @param {SlackContext | { teamId: string }} ctx
+ * @param {string} key
+ */
+export function tenantKey(ctx, key) {
+  return `${ctx.teamId}:${key}`;
+}
+
+/** @param {...unknown} values */
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}

--- a/slack-app/agent/slack-context.js
+++ b/slack-app/agent/slack-context.js
@@ -18,6 +18,12 @@
  * @typedef {Object} SlackContext
  * @property {string} teamId       Slack workspace id (the tenant).
  * @property {string} slackUserId  Slack user id of the event's actor.
+ * @property {boolean} [isLegacyWorkspace]
+ *   The tenant guard's verdict, published on Bolt's `context` as
+ *   `mcpjamTenancy`. Carried here so the credential seam can ASSERT it rather
+ *   than re-deriving it — the env `sk_` fallback is scoped to exactly one
+ *   workspace, and a caller that reached `getConfig` without that verdict has
+ *   bypassed the guard.
  */
 
 export class SlackContextError extends Error {
@@ -66,7 +72,12 @@ export function slackContextFrom(args) {
   if (!slackUserId) {
     throw new SlackContextError('Slack payload carried no user id — refusing to run a turn without an actor.');
   }
-  return { teamId, slackUserId };
+  const tenancy = context.mcpjamTenancy;
+  return {
+    teamId,
+    slackUserId,
+    ...(tenancy?.isLegacyWorkspace === true ? { isLegacyWorkspace: true } : {}),
+  };
 }
 
 /**

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -418,7 +418,18 @@ export async function runTurnForEvent(args) {
     // resolution), so no server-side work can exist. Left inflight, the claim
     // would answer every redelivery for its full 72-hour TTL with "someone
     // else owns this", silencing an event that provably has no reply.
-    if (!delivery.dispatched) {
+    //
+    // `dispatched` flips before `runAgentTurn`, but that call still does local
+    // preflight (credential/config resolution) before any fetch. Those errors
+    // are identifiable — client codes thrown WITHOUT an HTTP status (a server
+    // 401 carries one; NETWORK/TIMEOUT are post-fetch by definition) — and are
+    // provably pre-network, so they take the release path too: finalizing them
+    // would replay "it failed" for 72h after the operator fixed the config.
+    const preflightFailure =
+      error instanceof McpjamApiError &&
+      error.status === undefined &&
+      (error.code === 'CONFIG' || error.code === 'NO_PROJECT' || error.code === 'UNAUTHORIZED');
+    if (!delivery.dispatched || preflightFailure) {
       dedupe.release(eventKey);
       if (durable) await releaseEvent(dedupeKey).catch(() => {});
       throw error;

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -306,11 +306,23 @@ export async function runTurnForEvent(args) {
     }
     if (durable.outcome === 'completed') {
       // The work is done and the answer is stored. Re-posting it is strictly
-      // better than either silence or a second turn.
-      dedupe.complete(eventKey);
-      if (durable.resultEnvelope && args.onReplay) {
-        await args.onReplay(normalizeEnvelope(durable.resultEnvelope));
+      // better than either silence or a second turn — but it must go through
+      // the SAME per-thread queue as a fresh reply, or a newer turn could read
+      // the thread before this answer is back in it and redo the work.
+      const onReplay = args.onReplay;
+      if (durable.resultEnvelope && onReplay) {
+        const envelope = normalizeEnvelope(durable.resultEnvelope);
+        try {
+          await threadQueue.enqueue(replayQueueKey(args), () => onReplay(envelope));
+        } catch (error) {
+          // The stored answer never reached Slack. RELEASE the in-memory
+          // claim so the next redelivery can try again rather than being
+          // suppressed for the whole TTL with nothing posted.
+          dedupe.release(eventKey);
+          throw error;
+        }
       }
+      dedupe.complete(eventKey);
       return false;
     }
   }
@@ -330,14 +342,7 @@ export async function runTurnForEvent(args) {
     throw error;
   }
 
-  // Serialization key. A channel thread keys on its parent ts. A top-level DM
-  // has NO thread, so `threadTs` is the message's own ts — keying on that
-  // would give every rapid DM its own queue and serialize nothing, which is
-  // exactly the case that can create duplicate suites. Key those per channel.
-  const queueKey = tenantKey(
-    args.ctx,
-    args.isThread ? `thread:${args.channelId}:${args.threadTs}` : `dm:${args.channelId}`,
-  );
+  const queueKey = replayQueueKey(args);
   try {
     await threadQueue.enqueue(queueKey, async () => {
       let messages = await fetchThreadContext(args.client, args);
@@ -368,10 +373,36 @@ export async function runTurnForEvent(args) {
         });
       }
     });
-    return true;
-  } finally {
     dedupe.complete(eventKey);
+    return true;
+  } catch (error) {
+    // The turn threw before `completeEvent` stored an answer, so the durable
+    // claim is still `inflight` — and an inflight claim is never swept. Left
+    // alone it would answer every later redelivery with "someone else owns
+    // this", so a transient failure (a 500 from the API, a dropped socket)
+    // would permanently silence an event that provably has NO reply.
+    //
+    // Release both claims: the work did not happen, which is the one condition
+    // under which releasing is safe.
+    dedupe.release(eventKey);
+    if (durable) await releaseEvent(dedupeKey).catch(() => {});
+    throw error;
   }
+}
+
+/**
+ * Serialization key. A channel thread keys on its parent ts. A top-level DM
+ * has NO thread, so `threadTs` is the message's own ts — keying on that would
+ * give every rapid DM its own queue and serialize nothing, which is exactly
+ * the case that can create duplicate suites. Key those per channel.
+ *
+ * Replays use the same key so a re-posted answer is ordered against fresh
+ * turns in the same conversation.
+ *
+ * @param {{ ctx: import('./slack-context.js').SlackContext, channelId: string, threadTs: string, isThread: boolean }} args
+ */
+function replayQueueKey(args) {
+  return tenantKey(args.ctx, args.isThread ? `thread:${args.channelId}:${args.threadTs}` : `dm:${args.channelId}`);
 }
 
 /**

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -354,6 +354,10 @@ export async function runTurnForEvent(args) {
         // The SAME key the claim uses, so the server derives stable per-write
         // keys and a retried turn's mutations land on the first attempt's rows.
         idempotencyKey: dedupeKey,
+        // Where an approval button can be rendered. Without it the server
+        // withholds the spending tools entirely, so the model is never given
+        // an action it has nowhere to get approved.
+        channelId: args.channelId,
       });
       await args.onResult(result);
 
@@ -366,6 +370,9 @@ export async function runTurnForEvent(args) {
           reply: result.reply,
           toolCalls: result.toolCalls,
           createdResources: result.createdResources,
+          // Stored so a replay can re-offer them. The proposals are still
+          // `proposed` server-side, so the buttons stay live.
+          proposedActions: result.proposedActions ?? [],
         }).catch(() => {
           // The turn succeeded and the user has their answer. A failed
           // completion only costs replay on a future redelivery — never worth
@@ -417,5 +424,6 @@ function normalizeEnvelope(envelope) {
     reply: typeof envelope?.reply === 'string' ? envelope.reply : '',
     toolCalls: Array.isArray(envelope?.toolCalls) ? envelope.toolCalls : [],
     createdResources: Array.isArray(envelope?.createdResources) ? envelope.createdResources : [],
+    proposedActions: Array.isArray(envelope?.proposedActions) ? envelope.proposedActions : [],
   };
 }

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -436,9 +436,7 @@ export async function runTurnForEvent(args) {
     // trying again is a human decision that arrives as a NEW event.
     if (!delivery.started) {
       const details =
-        error instanceof McpjamApiError && error.details && typeof error.details === 'object'
-          ? error.details
-          : {};
+        error instanceof McpjamApiError && error.details && typeof error.details === 'object' ? error.details : {};
       const failureEnvelope = {
         reply:
           error instanceof McpjamApiError

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -331,9 +331,9 @@ export async function runTurnForEvent(args) {
   // status that no reply will ever clear.
   //
   // If it throws, RELEASE both claims: no turn work has happened yet, and an
-  // in-flight claim is never swept, so keeping it would silently drop every
-  // later redelivery of this event — the user would get no answer at all
-  // because a cosmetic status update failed.
+  // in-flight claim is only cleared by the backend's TTL sweep, so keeping it
+  // would silently drop every redelivery of this event until then — the user
+  // would get no answer at all because a cosmetic status update failed.
   try {
     await args.onStart?.();
   } catch (error) {
@@ -347,7 +347,18 @@ export async function runTurnForEvent(args) {
   // `append` can land and a `stop` still fail — so once it has been ENTERED we
   // can no longer prove the user saw nothing, and releasing the claim would
   // risk a redelivery posting the answer twice.
-  let deliveryStarted = false;
+  //
+  // `result` rides along because the turn is already paid for by the time
+  // `onResult` runs: if delivery throws, this is the only surviving copy of
+  // what the user was owed.
+  //
+  // One object rather than two `let`s so the values survive type narrowing —
+  // both are written inside the queued closure, and a checker tracking a bare
+  // `let` across that boundary concludes they never change.
+  /**
+   * @type {{ started: boolean, result: import('./mcpjam-client.js').AgentTurnResult | null }}
+   */
+  const delivery = { started: false, result: null };
   try {
     await threadQueue.enqueue(queueKey, async () => {
       let messages = await fetchThreadContext(args.client, args);
@@ -364,7 +375,8 @@ export async function runTurnForEvent(args) {
         // an action it has nowhere to get approved.
         channelId: args.channelId,
       });
-      deliveryStarted = true;
+      delivery.result = result;
+      delivery.started = true;
       await args.onResult(result);
 
       // Store the answer only after it has been posted. Completing earlier
@@ -390,23 +402,43 @@ export async function runTurnForEvent(args) {
     return true;
   } catch (error) {
     // The turn threw before `completeEvent` stored an answer, so the durable
-    // claim is still `inflight` — and an inflight claim is never swept. Left
-    // alone it would answer every later redelivery with "someone else owns
-    // this", so a transient failure (a 500 from the API, a dropped socket)
-    // would permanently silence an event that provably has NO reply.
+    // claim is still `inflight`. Which of the two exits applies turns on one
+    // question: can we PROVE the work did not happen?
     //
-    // Release both claims — but ONLY when nothing was delivered. Releasing is
-    // safe exactly when the work provably did not happen. Once `onResult` has
-    // been entered we cannot prove that: a streamed `append` may have reached
-    // the thread before `stop` failed, and a redelivery would then post the
-    // answer a second time. For that case the claim stays `inflight` and ages
-    // out on its own — a missing retry is a smaller harm than a duplicate
-    // reply, and a duplicate BILLED turn.
-    if (!deliveryStarted) {
+    // NOTHING DELIVERED — release both claims. Left inflight, the claim would
+    // answer every redelivery for its full 72-hour TTL with "someone else owns
+    // this", so one transient failure (a 500 from the API, a dropped socket)
+    // would silence an event that provably has NO reply.
+    if (!delivery.started) {
       dedupe.release(eventKey);
       if (durable) await releaseEvent(dedupeKey).catch(() => {});
-    } else {
-      dedupe.complete(eventKey);
+      throw error;
+    }
+
+    // DELIVERY WAS ENTERED — releasing is not available to us. `onResult`
+    // streams, so an `append` may have reached the thread before `stop` failed,
+    // and a release would let a redelivery RE-RUN the turn: a second spend for
+    // work already paid for.
+    //
+    // But leaving it `inflight` is not the answer either. The claim only ages
+    // out via the backend's TTL sweep, so until then every redelivery is met
+    // with silence — and the turn has already been billed. So finish the claim
+    // instead, storing the answer the user was owed. A redelivery then takes
+    // the REPLAY path, which re-posts the stored envelope and never re-runs the
+    // agent. That is the same trade this module already makes for a turn whose
+    // reply was lost after completion: at worst the answer arrives twice, and
+    // at best it arrives at all.
+    dedupe.complete(eventKey);
+    if (durable && delivery.result) {
+      await completeEvent(dedupeKey, {
+        reply: delivery.result.reply,
+        toolCalls: delivery.result.toolCalls,
+        createdResources: delivery.result.createdResources,
+        proposedActions: delivery.result.proposedActions ?? [],
+      }).catch(() => {
+        // Best-effort: the claim then keeps its inflight row until the sweep,
+        // which is the pre-existing behaviour and still never re-bills.
+      });
     }
     throw error;
   }

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -343,6 +343,11 @@ export async function runTurnForEvent(args) {
   }
 
   const queueKey = replayQueueKey(args);
+  // Set the instant we hand the answer to Slack. `onResult` streams — an
+  // `append` can land and a `stop` still fail — so once it has been ENTERED we
+  // can no longer prove the user saw nothing, and releasing the claim would
+  // risk a redelivery posting the answer twice.
+  let deliveryStarted = false;
   try {
     await threadQueue.enqueue(queueKey, async () => {
       let messages = await fetchThreadContext(args.client, args);
@@ -359,6 +364,7 @@ export async function runTurnForEvent(args) {
         // an action it has nowhere to get approved.
         channelId: args.channelId,
       });
+      deliveryStarted = true;
       await args.onResult(result);
 
       // Store the answer only after it has been posted. Completing earlier
@@ -389,10 +395,19 @@ export async function runTurnForEvent(args) {
     // this", so a transient failure (a 500 from the API, a dropped socket)
     // would permanently silence an event that provably has NO reply.
     //
-    // Release both claims: the work did not happen, which is the one condition
-    // under which releasing is safe.
-    dedupe.release(eventKey);
-    if (durable) await releaseEvent(dedupeKey).catch(() => {});
+    // Release both claims — but ONLY when nothing was delivered. Releasing is
+    // safe exactly when the work provably did not happen. Once `onResult` has
+    // been entered we cannot prove that: a streamed `append` may have reached
+    // the thread before `stop` failed, and a redelivery would then post the
+    // answer a second time. For that case the claim stays `inflight` and ages
+    // out on its own — a missing retry is a smaller harm than a duplicate
+    // reply, and a duplicate BILLED turn.
+    if (!deliveryStarted) {
+      dedupe.release(eventKey);
+      if (durable) await releaseEvent(dedupeKey).catch(() => {});
+    } else {
+      dedupe.complete(eventKey);
+    }
     throw error;
   }
 }

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -22,7 +22,7 @@
  */
 
 import { claimEvent, completeEvent, hasClaimBackend, releaseEvent } from '../installations/event-claims.js';
-import { runAgentTurn } from './mcpjam-client.js';
+import { McpjamApiError, runAgentTurn } from './mcpjam-client.js';
 import { tenantKey } from './slack-context.js';
 
 // API contract limits. These MIRROR the server's schema in
@@ -356,9 +356,16 @@ export async function runTurnForEvent(args) {
   // both are written inside the queued closure, and a checker tracking a bare
   // `let` across that boundary concludes they never change.
   /**
-   * @type {{ started: boolean, result: import('./mcpjam-client.js').AgentTurnResult | null }}
+   * `dispatched` flips the moment the turn request is HANDED TO THE NETWORK.
+   * From that point "no reply came back" no longer implies "nothing
+   * happened": the server may have run the whole turn — and persisted a
+   * suite — before the failure (its own error contract says exactly this,
+   * attaching `details.createdResources` to failed turns). The two flags
+   * split the catch below into its three honest cases.
+   *
+   * @type {{ dispatched: boolean, started: boolean, result: import('./mcpjam-client.js').AgentTurnResult | null }}
    */
-  const delivery = { started: false, result: null };
+  const delivery = { dispatched: false, started: false, result: null };
   try {
     await threadQueue.enqueue(queueKey, async () => {
       let messages = await fetchThreadContext(args.client, args);
@@ -366,6 +373,7 @@ export async function runTurnForEvent(args) {
         // Context fetch can miss (e.g. scopes); fall back to the trigger text.
         messages = [{ role: 'user', content: args.fallbackText }];
       }
+      delivery.dispatched = true;
       const result = await runAgentTurn(messages, args.ctx, {
         // The SAME key the claim uses, so the server derives stable per-write
         // keys and a retried turn's mutations land on the first attempt's rows.
@@ -402,16 +410,54 @@ export async function runTurnForEvent(args) {
     return true;
   } catch (error) {
     // The turn threw before `completeEvent` stored an answer, so the durable
-    // claim is still `inflight`. Which of the two exits applies turns on one
-    // question: can we PROVE the work did not happen?
+    // claim is still `inflight`. Which exit applies turns on one question:
+    // can we PROVE the work did not happen?
     //
-    // NOTHING DELIVERED — release both claims. Left inflight, the claim would
-    // answer every redelivery for its full 72-hour TTL with "someone else owns
-    // this", so one transient failure (a 500 from the API, a dropped socket)
-    // would silence an event that provably has NO reply.
-    if (!delivery.started) {
+    // NOT EVEN DISPATCHED — release both claims. The failure happened before
+    // the turn request reached the network (context fetch, credential
+    // resolution), so no server-side work can exist. Left inflight, the claim
+    // would answer every redelivery for its full 72-hour TTL with "someone
+    // else owns this", silencing an event that provably has no reply.
+    if (!delivery.dispatched) {
       dedupe.release(eventKey);
       if (durable) await releaseEvent(dedupeKey).catch(() => {});
+      throw error;
+    }
+
+    // DISPATCHED BUT NOT DELIVERED. "No Slack reply" is NOT "no side
+    // effects": the server's failed-turn contract attaches the resources a
+    // dying turn already persisted, and a timeout means the turn may have run
+    // to completion after we stopped listening. Releasing here would let a
+    // redelivery RE-RUN the turn — and a stochastic retry can author
+    // different arguments, sail past the derived idempotency keys, and create
+    // a second suite. So the claim is FINISHED with a failure envelope: the
+    // user is told what happened (including anything that DID get created,
+    // pulled off the error details), redeliveries replay that message, and
+    // trying again is a human decision that arrives as a NEW event.
+    if (!delivery.started) {
+      const details =
+        error instanceof McpjamApiError && error.details && typeof error.details === 'object'
+          ? error.details
+          : {};
+      const failureEnvelope = {
+        reply:
+          error instanceof McpjamApiError
+            ? error.friendlyMessage
+            : ':warning: Something went wrong running that turn. Ask again to retry.',
+        toolCalls: [],
+        createdResources: Array.isArray(details.createdResources) ? details.createdResources : [],
+        proposedActions: Array.isArray(details.proposedActions) ? details.proposedActions : [],
+      };
+      dedupe.complete(eventKey);
+      if (durable) {
+        await completeEvent(dedupeKey, failureEnvelope).catch(() => {
+          // Best-effort: an unrecorded failure only costs a silent redelivery
+          // window until the TTL sweep — never worth masking the real error.
+        });
+      }
+      // The caller renders the failure; hand it what survived the turn so the
+      // message can say "…but these were created" instead of implying zero.
+      /** @type {any} */ (error).failureEnvelope = failureEnvelope;
       throw error;
     }
 

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -20,6 +20,8 @@
  * Note: Bolt v5 auto-acknowledges Events API events before listeners run,
  * so a long-running listener body is fine — no detaching needed here.
  */
+
+import { claimEvent, completeEvent, hasClaimBackend, releaseEvent } from '../installations/event-claims.js';
 import { runAgentTurn } from './mcpjam-client.js';
 import { tenantKey } from './slack-context.js';
 
@@ -238,9 +240,16 @@ export async function fetchThreadContext(client, args) {
 }
 
 /**
- * Run one full turn for a Slack trigger: dedupe, then — inside the
+ * Run one full turn for a Slack trigger: claim it, then — inside the
  * per-conversation queue — gather context, call MCPJam, and post the reply
  * via `onResult`.
+ *
+ * TWO-LAYER CLAIM. The in-memory registry is a fast path that costs nothing
+ * and catches the common back-to-back redelivery. The DURABLE claim is the
+ * actual guarantee: it survives a restart, and it stores the reply so a late
+ * redelivery of a completed event replays the answer (`onReplay`) instead of
+ * re-running a turn that already spent quota. Slack retries delayed events for
+ * up to 24 hours, which no in-process set can cover.
  *
  * `onResult` runs INSIDE the queue on purpose. If posting happened after the
  * queue released, a rapid follow-up could start its turn before the previous
@@ -248,7 +257,8 @@ export async function fetchThreadContext(client, args) {
  * redo the same work, e.g. recreate a suite) and the replies could land out
  * of order.
  *
- * Returns false when the event was a duplicate delivery.
+ * Returns false when the event was a duplicate delivery (whether it was
+ * suppressed or replayed).
  *
  * @param {{
  *   client: import('@slack/web-api').WebClient,
@@ -256,11 +266,13 @@ export async function fetchThreadContext(client, args) {
  *   channelId: string,
  *   threadTs: string,
  *   triggerTs: string,
+ *   eventId?: string,
  *   isThread: boolean,
  *   botUserId?: string,
  *   fallbackText: string,
  *   onStart?: () => Promise<void>,
  *   onResult: (result: import('./mcpjam-client.js').AgentTurnResult) => Promise<void>,
+ *   onReplay?: (envelope: import('./mcpjam-client.js').AgentTurnResult) => Promise<void>,
  * }} args
  * @returns {Promise<boolean>}
  */
@@ -268,10 +280,45 @@ export async function runTurnForEvent(args) {
   const eventKey = tenantKey(args.ctx, `${args.channelId}:${args.triggerTs}`);
   if (!dedupe.claim(eventKey)) return false;
 
+  // Slack's `event_id` is the identity of a DELIVERY CHAIN: every redelivery
+  // of the same event carries it unchanged, which is exactly what a durable
+  // claim needs. `channel:ts` is the fallback for payloads that carry no
+  // event id (interactive triggers), and is stable for the same reason.
+  const dedupeKey = args.eventId ? `${args.ctx.teamId}:${args.eventId}` : eventKey;
+
+  let durable = null;
+  if (hasClaimBackend()) {
+    try {
+      durable = await claimEvent(dedupeKey);
+    } catch (error) {
+      // FAIL CLOSED. Treating an unreachable backend as "you own it" turns one
+      // Slack event into two billed turns — the precise failure the claim
+      // exists to prevent. Release the in-memory claim so a retry against a
+      // healthy process can still run, and drop this delivery.
+      dedupe.release(eventKey);
+      throw error;
+    }
+
+    if (durable.outcome === 'inflight') {
+      // Another delivery (or another process) owns this turn.
+      dedupe.complete(eventKey);
+      return false;
+    }
+    if (durable.outcome === 'completed') {
+      // The work is done and the answer is stored. Re-posting it is strictly
+      // better than either silence or a second turn.
+      dedupe.complete(eventKey);
+      if (durable.resultEnvelope && args.onReplay) {
+        await args.onReplay(normalizeEnvelope(durable.resultEnvelope));
+      }
+      return false;
+    }
+  }
+
   // Only after the claim: a duplicate delivery must not raise a "working"
   // status that no reply will ever clear.
   //
-  // If it throws, RELEASE the claim: no turn work has happened yet, and an
+  // If it throws, RELEASE both claims: no turn work has happened yet, and an
   // in-flight claim is never swept, so keeping it would silently drop every
   // later redelivery of this event — the user would get no answer at all
   // because a cosmetic status update failed.
@@ -279,6 +326,7 @@ export async function runTurnForEvent(args) {
     await args.onStart?.();
   } catch (error) {
     dedupe.release(eventKey);
+    if (durable) await releaseEvent(dedupeKey).catch(() => {});
     throw error;
   }
 
@@ -297,11 +345,46 @@ export async function runTurnForEvent(args) {
         // Context fetch can miss (e.g. scopes); fall back to the trigger text.
         messages = [{ role: 'user', content: args.fallbackText }];
       }
-      const result = await runAgentTurn(messages, args.ctx);
+      const result = await runAgentTurn(messages, args.ctx, {
+        // The SAME key the claim uses, so the server derives stable per-write
+        // keys and a retried turn's mutations land on the first attempt's rows.
+        idempotencyKey: dedupeKey,
+      });
       await args.onResult(result);
+
+      // Store the answer only after it has been posted. Completing earlier
+      // would let a redelivery replay a reply the user never actually
+      // received, and the claim's TTL is long enough that the difference
+      // matters.
+      if (durable) {
+        await completeEvent(dedupeKey, {
+          reply: result.reply,
+          toolCalls: result.toolCalls,
+          createdResources: result.createdResources,
+        }).catch(() => {
+          // The turn succeeded and the user has their answer. A failed
+          // completion only costs replay on a future redelivery — never worth
+          // failing the turn over.
+        });
+      }
     });
     return true;
   } finally {
     dedupe.complete(eventKey);
   }
+}
+
+/**
+ * Coerce a stored envelope back into the turn-result shape. The envelope is
+ * whatever was persisted, so a schema change (or a partial write) must
+ * degrade to a usable reply rather than throwing inside a replay.
+ * @param {any} envelope
+ * @returns {import('./mcpjam-client.js').AgentTurnResult}
+ */
+function normalizeEnvelope(envelope) {
+  return {
+    reply: typeof envelope?.reply === 'string' ? envelope.reply : '',
+    toolCalls: Array.isArray(envelope?.toolCalls) ? envelope.toolCalls : [],
+    createdResources: Array.isArray(envelope?.createdResources) ? envelope.createdResources : [],
+  };
 }

--- a/slack-app/agent/turn-runner.js
+++ b/slack-app/agent/turn-runner.js
@@ -3,11 +3,16 @@
  * reply, @mention). Owns the three correctness concerns the listeners must
  * not re-implement:
  *
- *  1. TTL dedupe on `channel + event ts` — Slack retries events, and a
- *     retry can arrive AFTER the original completed, so an in-flight-only
- *     set is not enough; completed keys are retained for a TTL window.
+ *  1. TTL dedupe on `team + channel + event ts` — Slack retries events, and
+ *     a retry can arrive AFTER the original completed, so an in-flight-only
+ *     set is not enough; completed keys are retained for a TTL window. The
+ *     team id leads the key because channel ids are only unique WITHIN a
+ *     workspace: two tenants can mint the same `C…`/`ts` pair, and without
+ *     the tenant prefix one workspace's event would suppress another's.
  *  2. Per-thread serialization — two rapid messages in one thread run one
- *     at a time, so concurrent turns can't both create the same suite.
+ *     at a time, so concurrent turns can't both create the same suite. Keyed
+ *     per tenant for the same reason, so one busy workspace cannot serialize
+ *     (or starve) another's threads.
  *  3. History normalization — the thread is refetched and filtered through
  *     the triggering timestamp (messages newer than the trigger belong to
  *     the NEXT turn), then mapped/truncated to the API's message contract.
@@ -16,6 +21,7 @@
  * so a long-running listener body is fine — no detaching needed here.
  */
 import { runAgentTurn } from './mcpjam-client.js';
+import { tenantKey } from './slack-context.js';
 
 // API contract limits. These MIRROR the server's schema in
 // `mcpjam-inspector/server/routes/v1/agent.ts` — it enforces characters AND
@@ -246,6 +252,7 @@ export async function fetchThreadContext(client, args) {
  *
  * @param {{
  *   client: import('@slack/web-api').WebClient,
+ *   ctx: import('./slack-context.js').SlackContext,
  *   channelId: string,
  *   threadTs: string,
  *   triggerTs: string,
@@ -258,7 +265,7 @@ export async function fetchThreadContext(client, args) {
  * @returns {Promise<boolean>}
  */
 export async function runTurnForEvent(args) {
-  const eventKey = `${args.channelId}:${args.triggerTs}`;
+  const eventKey = tenantKey(args.ctx, `${args.channelId}:${args.triggerTs}`);
   if (!dedupe.claim(eventKey)) return false;
 
   // Only after the claim: a duplicate delivery must not raise a "working"
@@ -279,7 +286,10 @@ export async function runTurnForEvent(args) {
   // has NO thread, so `threadTs` is the message's own ts — keying on that
   // would give every rapid DM its own queue and serialize nothing, which is
   // exactly the case that can create duplicate suites. Key those per channel.
-  const queueKey = args.isThread ? `thread:${args.channelId}:${args.threadTs}` : `dm:${args.channelId}`;
+  const queueKey = tenantKey(
+    args.ctx,
+    args.isThread ? `thread:${args.channelId}:${args.threadTs}` : `dm:${args.channelId}`,
+  );
   try {
     await threadQueue.enqueue(queueKey, async () => {
       let messages = await fetchThreadContext(args.client, args);
@@ -287,7 +297,7 @@ export async function runTurnForEvent(args) {
         // Context fetch can miss (e.g. scopes); fall back to the trigger text.
         messages = [{ role: 'user', content: args.fallbackText }];
       }
-      const result = await runAgentTurn(messages);
+      const result = await runAgentTurn(messages, args.ctx);
       await args.onResult(result);
     });
     return true;

--- a/slack-app/agent/turn-target.js
+++ b/slack-app/agent/turn-target.js
@@ -1,0 +1,184 @@
+/**
+ * Resolve WHOSE credentials a turn runs with and WHICH project it lands in.
+ *
+ * This is the whole tenancy decision in one place, and its ordering is the
+ * product rule:
+ *
+ *   1. THREAD BINDING — authoritative once a thread is engaged. Without it,
+ *      each reply would re-resolve from whoever spoke last, so a thread could
+ *      silently drift between projects mid-conversation and a suite could land
+ *      somewhere nobody expected. The binding is durable, which is also what
+ *      lets an engaged thread survive a bot restart.
+ *   2. THE REPLIER'S DEFAULT PROJECT — for a new conversation.
+ *   3. LEGACY ENV CREDENTIALS — only for the one pre-OAuth workspace, and
+ *      only when the actor has not linked an account. Anyone who HAS linked
+ *      acts as themselves, even there.
+ *
+ * A linked user with no default project is not an error: they are asked to
+ * pick one. An unlinked user in a non-legacy workspace is not an error either:
+ * they are asked to connect. Both are UX states, and conflating either with a
+ * failure is how a first-time user concludes the bot is broken.
+ */
+import { InstallationBackendError } from '../installations/backend-client.js';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * @typedef {Object} TurnTarget
+ * @property {'user' | 'legacy' | 'needs_project' | 'unlinked'} mode
+ * @property {string} [projectId]
+ * @property {string} [organizationId]
+ * @property {string} [initiatorSlackUserId]  Set when a thread binding applied.
+ * @property {boolean} [boundThread]          True when a binding decided this.
+ */
+
+function backendConfig() {
+  const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!baseUrl || !serviceToken) {
+    throw new InstallationBackendError('Backend config is required to resolve a turn target.', {
+      code: 'CONFIG',
+    });
+  }
+  return { baseUrl, serviceToken };
+}
+
+/** True when per-user credentials are configured at all. */
+export function hasPerUserAuth() {
+  return Boolean(process.env.MCPJAM_SLACK_SERVICE_TOKEN);
+}
+
+/**
+ * @param {string} path
+ * @param {Record<string, unknown>} body
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+async function post(path, body, opts = {}) {
+  const { baseUrl, serviceToken } = backendConfig();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-inspector-service-token': serviceToken,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    /** @type {any} */
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+    }
+    if (!response.ok) {
+      throw new InstallationBackendError(payload?.error || `Backend error (${response.status})`, {
+        status: response.status,
+      });
+    }
+    return payload;
+  } catch (error) {
+    if (error instanceof InstallationBackendError) throw error;
+    const aborted = error instanceof Error && error.name === 'AbortError';
+    throw new InstallationBackendError(aborted ? 'Backend request timed out' : `Backend request failed: ${error}`, {
+      code: aborted ? 'TIMEOUT' : 'NETWORK',
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * @param {string} teamId
+ * @param {string} channelId
+ * @param {string} threadTs
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+export async function fetchThreadBinding(teamId, channelId, threadTs, opts = {}) {
+  const payload = await post('/slack/thread-bindings/get', { teamId, channelId, threadTs }, opts);
+  return payload?.binding ?? null;
+}
+
+/**
+ * @param {string} teamId
+ * @param {string} slackUserId
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+export async function fetchAccountLink(teamId, slackUserId, opts = {}) {
+  const payload = await post('/slack/links/fetch', { teamId, slackUserId }, opts);
+  return payload?.link ?? null;
+}
+
+/**
+ * Bind a thread to the initiator's org/project. First writer wins; the
+ * returned binding is authoritative even when this call did not create it.
+ * @param {{ teamId: string, channelId: string, threadTs: string, organizationId: string, projectId: string, initiatorSlackUserId: string }} args
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+export async function createThreadBinding(args, opts = {}) {
+  return post('/slack/thread-bindings/create', args, opts);
+}
+
+/**
+ * @param {string} teamId
+ * @param {string} slackUserId
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+export async function revokeAccountLink(teamId, slackUserId, opts = {}) {
+  return post('/slack/links/revoke', { teamId, slackUserId }, opts);
+}
+
+/**
+ * @param {import('./slack-context.js').SlackContext} ctx
+ * @param {{ channelId: string, threadTs: string, fetchImpl?: typeof fetch }} args
+ * @returns {Promise<TurnTarget>}
+ */
+export async function resolveTurnTarget(ctx, args) {
+  const opts = args.fetchImpl ? { fetchImpl: args.fetchImpl } : {};
+
+  // Legacy-only deployments (local dev, or before the service token is
+  // issued) never had per-user auth to begin with.
+  if (!hasPerUserAuth()) {
+    return ctx.isLegacyWorkspace === true
+      ? { mode: 'legacy', projectId: process.env.MCPJAM_PROJECT_ID }
+      : { mode: 'unlinked' };
+  }
+
+  const binding = await fetchThreadBinding(ctx.teamId, args.channelId, args.threadTs, opts);
+  if (binding) {
+    // A bound thread does not re-resolve. The replier still has to be linked
+    // and still has to have access to the bound project — but that is
+    // enforced server-side (the delegated mint re-verifies membership), not
+    // by silently choosing a different project for them.
+    return {
+      mode: 'user',
+      projectId: binding.projectId,
+      organizationId: binding.organizationId,
+      initiatorSlackUserId: binding.initiatorSlackUserId,
+      boundThread: true,
+    };
+  }
+
+  const link = await fetchAccountLink(ctx.teamId, ctx.slackUserId, opts);
+  if (link) {
+    if (!link.defaultProjectId) {
+      return { mode: 'needs_project', organizationId: link.organizationId };
+    }
+    return {
+      mode: 'user',
+      projectId: link.defaultProjectId,
+      organizationId: link.organizationId,
+    };
+  }
+
+  // Unlinked. The legacy workspace still works on the shared key so our own
+  // team is not locked out mid-migration; everyone else is asked to connect.
+  if (ctx.isLegacyWorkspace === true && process.env.MCPJAM_PROJECT_ID) {
+    return { mode: 'legacy', projectId: process.env.MCPJAM_PROJECT_ID };
+  }
+  return { mode: 'unlinked' };
+}

--- a/slack-app/agent/turn-target.js
+++ b/slack-app/agent/turn-target.js
@@ -142,6 +142,14 @@ export async function resolveTurnTarget(ctx, args) {
 
   // Legacy-only deployments (local dev, or before the service token is
   // issued) never had per-user auth to begin with.
+  //
+  // Note the deliberate asymmetry with the legacy fallback at the bottom of
+  // this function, which additionally requires MCPJAM_PROJECT_ID: THERE,
+  // per-user auth exists, so falling through to `unlinked` gives the user a
+  // connect button they can actually use. HERE it does not, so `unlinked`
+  // would show a connect flow that cannot complete. Returning `legacy` with no
+  // project instead surfaces the credential seam's config error — which names
+  // the missing variable, and is aimed at the operator who can fix it.
   if (!hasPerUserAuth()) {
     return ctx.isLegacyWorkspace === true
       ? { mode: 'legacy', projectId: process.env.MCPJAM_PROJECT_ID }

--- a/slack-app/agent/turn-target.js
+++ b/slack-app/agent/turn-target.js
@@ -34,7 +34,7 @@ const REQUEST_TIMEOUT_MS = 10_000;
 
 function backendConfig() {
   const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
-  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  const serviceToken = process.env.SLACK_SERVICE_TOKEN;
   if (!baseUrl || !serviceToken) {
     throw new InstallationBackendError('Backend config is required to resolve a turn target.', {
       code: 'CONFIG',
@@ -63,7 +63,7 @@ async function post(path, body, opts = {}) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-inspector-service-token': serviceToken,
+        'x-slack-service-token': serviceToken,
       },
       body: JSON.stringify(body),
       signal: controller.signal,

--- a/slack-app/app.js
+++ b/slack-app/app.js
@@ -2,6 +2,9 @@ import 'dotenv/config';
 
 import { App, LogLevel } from '@slack/bolt';
 
+import { hasBackendConfig } from './installations/backend-client.js';
+import { BOT_SCOPES } from './installations/bot-scopes.js';
+import { convexInstallationStore } from './installations/store.js';
 import { registerListeners } from './listeners/index.js';
 
 /**
@@ -15,19 +18,88 @@ const logLevel = /** @type {LogLevel} */ (
   LOG_LEVELS.has(/** @type {LogLevel} */ (requested)) ? requested : LogLevel.INFO
 );
 
-const app = new App({
-  token: process.env.SLACK_BOT_TOKEN,
-  appToken: process.env.SLACK_APP_TOKEN,
-  socketMode: true,
-  logLevel,
-  // The bot's own replies must reach the message listener: a thread's next
-  // turn re-reads history, and `sayStream` output arrives as a bot message.
-  ignoreSelf: false,
-});
+/**
+ * MODE SELECTION BY CONFIG PRESENCE.
+ *
+ * Distributed (hosted): OAuth over Bolt's HTTP receiver. Bolt owns
+ * `/slack/install` and `/slack/oauth_redirect`, signature verification, retry
+ * headers, and the 3-second ack; per-workspace tokens come from the
+ * Convex-backed installation store.
+ *
+ * Local dev: socket mode with one workspace's tokens from env — no public URL
+ * and no registered OAuth app needed to iterate.
+ *
+ * The mode is DERIVED from config rather than set by a separate flag, so the
+ * two can never disagree: a deployment that has OAuth credentials always
+ * uses them.
+ */
+const oauthConfigured = Boolean(
+  process.env.SLACK_CLIENT_ID && process.env.SLACK_CLIENT_SECRET && process.env.SLACK_STATE_SECRET,
+);
+
+if (oauthConfigured && !hasBackendConfig()) {
+  // Fail fast rather than boot: with OAuth credentials but no backend, every
+  // install would succeed at Slack and then be dropped on the floor, and
+  // every event would fail authorization with nothing pointing at the cause.
+  throw new Error(
+    'Slack OAuth is configured but MCPJAM_CONVEX_HTTP_URL / INSPECTOR_SERVICE_TOKEN are missing — ' +
+      'installations could be neither stored nor read.',
+  );
+}
+
+/**
+ * Bolt refuses BOTH a custom `authorize` and OAuth installer options
+ * (`@slack/bolt/dist/App.js`), and given installer options it derives
+ * `authorize` from `installationStore.fetchInstallation`. So there is
+ * deliberately no `authorize` here — the installation store IS the
+ * authorization path.
+ *
+ * `scopes` is passed EXPLICITLY and is load-bearing: HTTPReceiver defaults it
+ * to `undefined` and forwards `scopes ?? []`, so omitting it yields an install
+ * URL requesting zero bot scopes. That install SUCCEEDS and then fails every
+ * API call with `missing_scope`, per workspace, with nothing at install time
+ * to point at the cause.
+ */
+const app = oauthConfigured
+  ? new App({
+      signingSecret: process.env.SLACK_SIGNING_SECRET,
+      clientId: process.env.SLACK_CLIENT_ID,
+      clientSecret: process.env.SLACK_CLIENT_SECRET,
+      stateSecret: process.env.SLACK_STATE_SECRET,
+      scopes: [...BOT_SCOPES],
+      installationStore: convexInstallationStore,
+      logLevel,
+      ignoreSelf: false,
+      installerOptions: {
+        // Sign in with Slack is a SEPARATE OAuth flow, owned by the
+        // inspector's link bridge. Slack rejects an authorize request that
+        // mixes SIWS user scopes with bot scopes, so this URL must never grow
+        // `openid`/`profile`.
+        directInstall: true,
+      },
+    })
+  : new App({
+      token: process.env.SLACK_BOT_TOKEN,
+      appToken: process.env.SLACK_APP_TOKEN,
+      socketMode: true,
+      logLevel,
+      // The bot's own replies must reach the message listener: a thread's next
+      // turn re-reads history, and `sayStream` output arrives as a bot message.
+      ignoreSelf: false,
+    });
 
 registerListeners(app);
 
 (async () => {
+  if (oauthConfigured) {
+    // Railway injects PORT. `start()` takes no argument in socket mode, where
+    // the process dials out and serves no HTTP — passing `undefined` there is
+    // a different overload, not the same call with an empty port.
+    const port = Number(process.env.PORT || 3000);
+    await app.start(port);
+    app.logger.info(`MCPJam Slack app is running in OAuth mode on :${port} (log level: ${logLevel})`);
+    return;
+  }
   await app.start();
-  app.logger.info(`MCPJam Slack app is running! (log level: ${logLevel})`);
+  app.logger.info(`MCPJam Slack app is running in socket mode (log level: ${logLevel})`);
 })();

--- a/slack-app/app.js
+++ b/slack-app/app.js
@@ -33,9 +33,30 @@ const logLevel = /** @type {LogLevel} */ (
  * two can never disagree: a deployment that has OAuth credentials always
  * uses them.
  */
-const oauthConfigured = Boolean(
-  process.env.SLACK_CLIENT_ID && process.env.SLACK_CLIENT_SECRET && process.env.SLACK_STATE_SECRET,
-);
+const OAUTH_ENV_KEYS = ['SLACK_CLIENT_ID', 'SLACK_CLIENT_SECRET', 'SLACK_STATE_SECRET'];
+const presentOauthKeys = OAUTH_ENV_KEYS.filter((key) => Boolean(process.env[key]));
+if (presentOauthKeys.length > 0 && presentOauthKeys.length < OAUTH_ENV_KEYS.length) {
+  // PARTIAL config is a misconfiguration, not a mode. Falling back to socket
+  // mode here would silently stop serving /slack/events and /slack/install on
+  // a hosted deployment — the app would look healthy while every install and
+  // every event 404'd.
+  const missing = OAUTH_ENV_KEYS.filter((key) => !process.env[key]);
+  throw new Error(
+    `Slack OAuth is partially configured: ${presentOauthKeys.join(', ')} set but ${missing.join(', ')} missing. ` +
+      'Set all three for OAuth mode, or none for socket mode.',
+  );
+}
+const oauthConfigured = presentOauthKeys.length === OAUTH_ENV_KEYS.length;
+
+if (oauthConfigured && !process.env.SLACK_SIGNING_SECRET) {
+  // Deliberately NOT one of the three mode-selecting keys: socket mode does not
+  // need it, so its presence must not imply OAuth. But in OAuth mode it is the
+  // only thing standing between the public `/slack/events` endpoint and anyone
+  // who can POST to it, so booting without it is not an option.
+  throw new Error(
+    'Slack OAuth is configured but SLACK_SIGNING_SECRET is missing — inbound request signatures could not be verified.',
+  );
+}
 
 if (oauthConfigured && !hasBackendConfig()) {
   // Fail fast rather than boot: with OAuth credentials but no backend, every

--- a/slack-app/app.js
+++ b/slack-app/app.js
@@ -63,7 +63,7 @@ if (oauthConfigured && !hasBackendConfig()) {
   // install would succeed at Slack and then be dropped on the floor, and
   // every event would fail authorization with nothing pointing at the cause.
   throw new Error(
-    'Slack OAuth is configured but MCPJAM_CONVEX_HTTP_URL / INSPECTOR_SERVICE_TOKEN are missing — ' +
+    'Slack OAuth is configured but MCPJAM_CONVEX_HTTP_URL / SLACK_SERVICE_TOKEN are missing — ' +
       'installations could be neither stored nor read.',
   );
 }

--- a/slack-app/installations/backend-client.js
+++ b/slack-app/installations/backend-client.js
@@ -2,13 +2,16 @@
  * Thin client for the MCPJam backend's Slack service-token routes.
  *
  * The bot holds no database. Every install lookup, write, and revoke is one
- * of these calls, authenticated with `INSPECTOR_SERVICE_TOKEN` — the same
- * infrastructure-peer credential the inspector server uses. There is no user
- * identity involved at this layer at all.
+ * of these calls, authenticated with `SLACK_SERVICE_TOKEN` — the bot's OWN
+ * server-to-server credential, accepted by the backend's `/slack/*` routes
+ * and NOTHING else. Deliberately not `INSPECTOR_SERVICE_TOKEN`: that token
+ * also opens arbitrary user delegation and delegated-JWT minting, so holding
+ * it here would make a compromised bot a compromised platform. There is no
+ * user identity involved at this layer at all.
  *
  * Env:
  *   MCPJAM_CONVEX_HTTP_URL   — the Convex HTTP origin (e.g. https://…convex.site)
- *   INSPECTOR_SERVICE_TOKEN  — server-to-server credential
+ *   SLACK_SERVICE_TOKEN  — the bot's own /slack/*-only credential
  */
 
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -34,10 +37,10 @@ export class InstallationBackendError extends Error {
 
 function getBackendConfig() {
   const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
-  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  const serviceToken = process.env.SLACK_SERVICE_TOKEN;
   if (!baseUrl || !serviceToken) {
     throw new InstallationBackendError(
-      'MCPJAM_CONVEX_HTTP_URL and INSPECTOR_SERVICE_TOKEN must be set to use OAuth installs.',
+      'MCPJAM_CONVEX_HTTP_URL and SLACK_SERVICE_TOKEN must be set to use OAuth installs.',
       { code: 'CONFIG' },
     );
   }
@@ -46,7 +49,7 @@ function getBackendConfig() {
 
 /** True when OAuth-mode config is present; drives socket-vs-HTTP mode selection. */
 export function hasBackendConfig() {
-  return Boolean(process.env.MCPJAM_CONVEX_HTTP_URL && process.env.INSPECTOR_SERVICE_TOKEN);
+  return Boolean(process.env.MCPJAM_CONVEX_HTTP_URL && process.env.SLACK_SERVICE_TOKEN);
 }
 
 /**
@@ -68,7 +71,7 @@ async function post(path, body, opts = {}) {
         // Header form, not bearer: `lib/serviceToken.ts` reserves the bearer
         // slot for the delegated-identity flow, and new routes must not
         // adopt a convention where the same header can be a user OR a service.
-        'x-inspector-service-token': serviceToken,
+        'x-slack-service-token': serviceToken,
       },
       body: JSON.stringify(body),
       signal: controller.signal,

--- a/slack-app/installations/backend-client.js
+++ b/slack-app/installations/backend-client.js
@@ -1,0 +1,152 @@
+/**
+ * Thin client for the MCPJam backend's Slack service-token routes.
+ *
+ * The bot holds no database. Every install lookup, write, and revoke is one
+ * of these calls, authenticated with `INSPECTOR_SERVICE_TOKEN` — the same
+ * infrastructure-peer credential the inspector server uses. There is no user
+ * identity involved at this layer at all.
+ *
+ * Env:
+ *   MCPJAM_CONVEX_HTTP_URL   — the Convex HTTP origin (e.g. https://…convex.site)
+ *   INSPECTOR_SERVICE_TOKEN  — server-to-server credential
+ */
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Distinguishes the two failure modes that must NEVER be conflated:
+ * `notInstalled` (authoritative — the workspace is not installed) from a
+ * transport/backend failure (retryable). Telling a workspace it is
+ * uninstalled because of a network blip is the failure this type prevents.
+ */
+export class InstallationBackendError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ status?: number, code?: string }} [opts]
+   */
+  constructor(message, opts = {}) {
+    super(message);
+    this.name = 'InstallationBackendError';
+    this.status = opts.status;
+    this.code = opts.code;
+  }
+}
+
+function getBackendConfig() {
+  const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!baseUrl || !serviceToken) {
+    throw new InstallationBackendError(
+      'MCPJAM_CONVEX_HTTP_URL and INSPECTOR_SERVICE_TOKEN must be set to use OAuth installs.',
+      { code: 'CONFIG' },
+    );
+  }
+  return { baseUrl, serviceToken };
+}
+
+/** True when OAuth-mode config is present; drives socket-vs-HTTP mode selection. */
+export function hasBackendConfig() {
+  return Boolean(process.env.MCPJAM_CONVEX_HTTP_URL && process.env.INSPECTOR_SERVICE_TOKEN);
+}
+
+/**
+ * @param {string} path
+ * @param {Record<string, unknown>} body
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<any>}
+ */
+async function post(path, body, opts = {}) {
+  const { baseUrl, serviceToken } = getBackendConfig();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // Header form, not bearer: `lib/serviceToken.ts` reserves the bearer
+        // slot for the delegated-identity flow, and new routes must not
+        // adopt a convention where the same header can be a user OR a service.
+        'x-inspector-service-token': serviceToken,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    /** @type {any} */
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      // A non-JSON body is only tolerable when the status already tells the
+      // story. A mid-body abort must NOT be laundered into "empty success".
+      if (!(error instanceof SyntaxError)) throw error;
+    }
+    if (!response.ok) {
+      throw new InstallationBackendError(payload?.error || `Backend error (${response.status})`, {
+        status: response.status,
+        code: payload?.code,
+      });
+    }
+    return payload;
+  } catch (error) {
+    if (error instanceof InstallationBackendError) throw error;
+    const aborted = error instanceof Error && error.name === 'AbortError';
+    throw new InstallationBackendError(
+      aborted ? `Backend request timed out after ${REQUEST_TIMEOUT_MS}ms` : `Backend request failed: ${error}`,
+      { code: aborted ? 'TIMEOUT' : 'NETWORK' },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * @typedef {Object} StoredInstallationRecord
+ * @property {Record<string, any>} installation  The Bolt Installation, verbatim.
+ * @property {string} botUserId
+ * @property {boolean} isLegacyWorkspace
+ * @property {string} [enterpriseId]
+ */
+
+/**
+ * Read one workspace's installation.
+ *
+ * Returns null ONLY when the backend authoritatively says the workspace is
+ * not installed (or is revoked). A transport failure throws — callers must
+ * not turn "we could not ask" into "you are not installed".
+ *
+ * @param {string} teamId
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<StoredInstallationRecord | null>}
+ */
+export async function fetchInstallationRecord(teamId, opts = {}) {
+  const payload = await post('/slack/installations/fetch', { teamId }, opts);
+  const installation = payload?.installation;
+  if (!installation || typeof installation !== 'object') return null;
+  return {
+    installation,
+    botUserId: String(payload?.botUserId ?? ''),
+    isLegacyWorkspace: payload?.isLegacyWorkspace === true,
+    ...(payload?.enterpriseId ? { enterpriseId: String(payload.enterpriseId) } : {}),
+  };
+}
+
+/**
+ * Persist a completed OAuth install.
+ * @param {{ teamId: string, enterpriseId?: string, teamName: string, appId: string, botUserId: string, scopes: string[], installation: Record<string, unknown> }} args
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+export async function storeInstallationRecord(args, opts = {}) {
+  return post('/slack/installations/upsert', args, opts);
+}
+
+/**
+ * Revoke a workspace's installation.
+ * @param {string} teamId
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+export async function revokeInstallationRecord(teamId, opts = {}) {
+  return post('/slack/installations/revoke', { teamId }, opts);
+}

--- a/slack-app/installations/bot-scopes.js
+++ b/slack-app/installations/bot-scopes.js
@@ -1,0 +1,32 @@
+/**
+ * The bot scopes MCPJam's install URL requests.
+ *
+ * This list MUST stay identical to `manifest.json`'s
+ * `oauth_config.scopes.bot`. It is duplicated here rather than read from the
+ * manifest because Bolt needs it at construction time and the manifest is not
+ * shipped in the runtime image — and because getting it wrong is silent:
+ *
+ *   Bolt's HTTPReceiver defaults `scopes` to `undefined` and then passes
+ *   `scopes ?? []` into the installer's `installUrlOptions`
+ *   (`@slack/bolt/dist/receivers/HTTPReceiver.js:98,148`). Omitting `scopes`
+ *   therefore does NOT mean "use the manifest" — it produces an install URL
+ *   requesting ZERO bot scopes. That install succeeds, and the app then fails
+ *   every API call with `missing_scope` at runtime, per workspace, with no
+ *   error at install time to point at the cause.
+ *
+ * Sign in with Slack scopes (`openid`, `profile`) are deliberately ABSENT:
+ * Slack rejects an authorize request that mixes SIWS user scopes with bot
+ * scopes, and the account-link bridge builds its own separate SIWS URL.
+ */
+export const BOT_SCOPES = Object.freeze([
+  'app_mentions:read',
+  'channels:history',
+  'chat:write',
+  'groups:history',
+  'im:history',
+  // `im:write` is required to send the post-link confirmation DM. `im:read`
+  // was dropped: nothing reads the DM channel list, and it is the broader of
+  // the two.
+  'im:write',
+  'assistant:write',
+]);

--- a/slack-app/installations/event-claims.js
+++ b/slack-app/installations/event-claims.js
@@ -1,0 +1,134 @@
+/**
+ * Durable claims over the backend's `/slack/claims/*` routes.
+ *
+ * The in-memory `EventDedupe` is a fast path, not a guarantee: it dies with
+ * the process, so a Slack redelivery after a restart runs the turn again. And
+ * even a perfect dedupe cannot help with the case where the turn finished,
+ * persisted an eval suite, and then lost its reply — from which the only
+ * choices are dropping the answer or re-running the work.
+ *
+ * A durable claim solves both by carrying the ANSWER: the claim is taken
+ * before processing, and the reply envelope is stored on completion, so a
+ * late redelivery replays the reply instead of re-running the turn.
+ *
+ * FAIL-CLOSED. Every helper here throws on a backend failure rather than
+ * returning a "go ahead" default. A claim that silently degrades to "you own
+ * it" turns one Slack event into two billed turns, which is precisely the
+ * failure the claim exists to prevent — so an unreachable backend must stop
+ * the event and let Slack's retry find a healthy process.
+ */
+import { InstallationBackendError } from './backend-client.js';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+function getBackendConfig() {
+  const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!baseUrl || !serviceToken) {
+    throw new InstallationBackendError(
+      'MCPJAM_CONVEX_HTTP_URL and INSPECTOR_SERVICE_TOKEN must be set to claim events.',
+      { code: 'CONFIG' },
+    );
+  }
+  return { baseUrl, serviceToken };
+}
+
+/** True when durable claims are available; false in local socket-mode dev. */
+export function hasClaimBackend() {
+  return Boolean(process.env.MCPJAM_CONVEX_HTTP_URL && process.env.INSPECTOR_SERVICE_TOKEN);
+}
+
+/**
+ * @param {string} path
+ * @param {Record<string, unknown>} body
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+async function post(path, body, opts = {}) {
+  const { baseUrl, serviceToken } = getBackendConfig();
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-inspector-service-token': serviceToken,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    /** @type {any} */
+    let payload = null;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+    }
+    if (!response.ok) {
+      throw new InstallationBackendError(payload?.error || `Claim backend error (${response.status})`, {
+        status: response.status,
+      });
+    }
+    return payload;
+  } catch (error) {
+    if (error instanceof InstallationBackendError) throw error;
+    const aborted = error instanceof Error && error.name === 'AbortError';
+    throw new InstallationBackendError(
+      aborted ? `Claim request timed out after ${REQUEST_TIMEOUT_MS}ms` : `Claim request failed: ${error}`,
+      { code: aborted ? 'TIMEOUT' : 'NETWORK' },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * @typedef {Object} ClaimResult
+ * @property {'claimed' | 'inflight' | 'completed'} outcome
+ * @property {any} resultEnvelope  Stored reply, present only for 'completed'.
+ */
+
+/**
+ * Take the claim for `dedupeKey`.
+ *
+ * @param {string} dedupeKey  `${teamId}:${event_id}` — team-prefixed because
+ *   Slack event ids are only unique within a workspace.
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ * @returns {Promise<ClaimResult>}
+ */
+export async function claimEvent(dedupeKey, opts = {}) {
+  const payload = await post('/slack/claims/claim', { dedupeKey }, opts);
+  const outcome = payload?.outcome;
+  if (outcome !== 'claimed' && outcome !== 'inflight' && outcome !== 'completed') {
+    // An unrecognized outcome must not be read as permission to proceed.
+    throw new InstallationBackendError(`Claim backend returned an unknown outcome: ${outcome}`);
+  }
+  return { outcome, resultEnvelope: payload?.resultEnvelope ?? null };
+}
+
+/**
+ * Record the turn's outcome so a redelivery replays it instead of re-running.
+ * @param {string} dedupeKey
+ * @param {unknown} resultEnvelope
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+export async function completeEvent(dedupeKey, resultEnvelope, opts = {}) {
+  return post(
+    '/slack/claims/complete',
+    { dedupeKey, ...(resultEnvelope === undefined ? {} : { resultEnvelope }) },
+    opts,
+  );
+}
+
+/**
+ * Drop a claim so the event can be processed again immediately.
+ *
+ * ONLY for work that provably did NOT happen. An "unsure" release is how a
+ * paid mutation runs twice; for those, leave the claim and let its TTL expire.
+ * @param {string} dedupeKey
+ * @param {{ fetchImpl?: typeof fetch }} [opts]
+ */
+export async function releaseEvent(dedupeKey, opts = {}) {
+  return post('/slack/claims/release', { dedupeKey }, opts);
+}

--- a/slack-app/installations/event-claims.js
+++ b/slack-app/installations/event-claims.js
@@ -23,10 +23,10 @@ const REQUEST_TIMEOUT_MS = 10_000;
 
 function getBackendConfig() {
   const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
-  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  const serviceToken = process.env.SLACK_SERVICE_TOKEN;
   if (!baseUrl || !serviceToken) {
     throw new InstallationBackendError(
-      'MCPJAM_CONVEX_HTTP_URL and INSPECTOR_SERVICE_TOKEN must be set to claim events.',
+      'MCPJAM_CONVEX_HTTP_URL and SLACK_SERVICE_TOKEN must be set to claim events.',
       { code: 'CONFIG' },
     );
   }
@@ -35,7 +35,7 @@ function getBackendConfig() {
 
 /** True when durable claims are available; false in local socket-mode dev. */
 export function hasClaimBackend() {
-  return Boolean(process.env.MCPJAM_CONVEX_HTTP_URL && process.env.INSPECTOR_SERVICE_TOKEN);
+  return Boolean(process.env.MCPJAM_CONVEX_HTTP_URL && process.env.SLACK_SERVICE_TOKEN);
 }
 
 /**
@@ -53,7 +53,7 @@ async function post(path, body, opts = {}) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-inspector-service-token': serviceToken,
+        'x-slack-service-token': serviceToken,
       },
       body: JSON.stringify(body),
       signal: controller.signal,

--- a/slack-app/installations/event-claims.js
+++ b/slack-app/installations/event-claims.js
@@ -25,10 +25,9 @@ function getBackendConfig() {
   const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
   const serviceToken = process.env.SLACK_SERVICE_TOKEN;
   if (!baseUrl || !serviceToken) {
-    throw new InstallationBackendError(
-      'MCPJAM_CONVEX_HTTP_URL and SLACK_SERVICE_TOKEN must be set to claim events.',
-      { code: 'CONFIG' },
-    );
+    throw new InstallationBackendError('MCPJAM_CONVEX_HTTP_URL and SLACK_SERVICE_TOKEN must be set to claim events.', {
+      code: 'CONFIG',
+    });
   }
   return { baseUrl, serviceToken };
 }

--- a/slack-app/installations/store.js
+++ b/slack-app/installations/store.js
@@ -69,6 +69,36 @@ export function purgeInstallation(teamId) {
   cache.delete(teamId);
   // Invalidate any lookup already in flight for this team.
   generations.set(teamId, currentGeneration(teamId) + 1);
+  pruneGenerations();
+}
+
+/**
+ * Bound the generation map.
+ *
+ * Every purge adds a permanent entry, so a public app accumulates one per
+ * workspace that has ever uninstalled — unbounded state driven by strangers.
+ * Dropping an entry only resets that team's counter to 0, and the ONLY thing a
+ * counter must do is differ from the value an in-flight lookup recorded. A
+ * lookup that is still running holds its team's entry alive (the purge that
+ * would race it is the same call that just wrote one), so eviction here can
+ * never resurrect a revoked grant — it just forgets teams nothing is asking
+ * about.
+ */
+const GENERATIONS_MAX_ENTRIES = 5000;
+
+function pruneGenerations() {
+  if (generations.size <= GENERATIONS_MAX_ENTRIES) return;
+  // Insertion order: the oldest purges are the least likely to have a lookup
+  // still in flight, since a fetch has a 10s timeout.
+  const excess = generations.size - GENERATIONS_MAX_ENTRIES;
+  let dropped = 0;
+  for (const teamId of generations.keys()) {
+    if (dropped >= excess) break;
+    // Never drop a team we are currently caching: its entry is live state.
+    if (cache.has(teamId)) continue;
+    generations.delete(teamId);
+    dropped += 1;
+  }
 }
 
 /** Test helper. */
@@ -113,9 +143,16 @@ export async function resolveInstallation(teamId) {
 
   const startedAtGeneration = currentGeneration(teamId);
   const record = await fetchInstallationRecord(teamId);
-  // Only cache if no purge or reinstall happened while this was in flight.
-  // Otherwise the answer we are holding is the grant that was just revoked.
-  if (record && currentGeneration(teamId) === startedAtGeneration) {
+
+  // A purge or reinstall landed while this lookup was in flight, so the answer
+  // we are holding describes a grant that has since been revoked or replaced.
+  // RETURNING it is the harm, not caching it: Bolt would authorize this event
+  // with a token the workspace just killed. Refusing reads as "not installed",
+  // which is the correct answer for a revoked install and a safely retryable
+  // one for a reinstall — the next event re-fetches under the new generation.
+  if (currentGeneration(teamId) !== startedAtGeneration) return null;
+
+  if (record) {
     cache.set(teamId, {
       record,
       expiresAt: Date.now() + CACHE_TTL_MS,

--- a/slack-app/installations/store.js
+++ b/slack-app/installations/store.js
@@ -90,8 +90,16 @@ function beginLookup(teamId) {
 /** @param {string} teamId */
 function endLookup(teamId) {
   const remaining = (inflightLookups.get(teamId) ?? 1) - 1;
-  if (remaining > 0) inflightLookups.set(teamId, remaining);
-  else inflightLookups.delete(teamId);
+  if (remaining > 0) {
+    inflightLookups.set(teamId, remaining);
+    return;
+  }
+  inflightLookups.delete(teamId);
+  // Prune again now that this team is unpinned. A prune that ran while the
+  // lookup was in flight had to skip it, so the map can still be over its
+  // bound; without this it would stay there until the next purge, which on a
+  // quiet deployment may be a long time.
+  pruneGenerations();
 }
 
 /**

--- a/slack-app/installations/store.js
+++ b/slack-app/installations/store.js
@@ -33,8 +33,32 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 
 /** @typedef {import('./backend-client.js').StoredInstallationRecord} StoredInstallationRecord */
 
-/** @type {Map<string, { record: StoredInstallationRecord, expiresAt: number }>} */
+/**
+ * Hard bound. A public app can be installed by unboundedly many workspaces,
+ * and a missed lifecycle event leaves an entry nobody ever looks up again —
+ * so the TTL alone does not bound retained state.
+ */
+const CACHE_MAX_ENTRIES = 5000;
+
+/** @type {Map<string, { record: StoredInstallationRecord, expiresAt: number, generation: number }>} */
 const cache = new Map();
+
+/**
+ * Per-team generation counter.
+ *
+ * A purge that lands WHILE a fetch is in flight would otherwise be undone by
+ * that fetch's `cache.set`, re-inserting the revoked grant for a full TTL. The
+ * counter makes the race detectable: a fetch records the generation it started
+ * under and declines to cache if a purge bumped it in the meantime.
+ *
+ * @type {Map<string, number>}
+ */
+const generations = new Map();
+
+/** @param {string} teamId */
+function currentGeneration(teamId) {
+  return generations.get(teamId) ?? 0;
+}
 
 /**
  * Drop a workspace's cached credentials NOW. Called by the lifecycle
@@ -43,11 +67,30 @@ const cache = new Map();
  */
 export function purgeInstallation(teamId) {
   cache.delete(teamId);
+  // Invalidate any lookup already in flight for this team.
+  generations.set(teamId, currentGeneration(teamId) + 1);
 }
 
 /** Test helper. */
 export function clearInstallationCache() {
   cache.clear();
+  generations.clear();
+}
+
+/**
+ * Drop expired entries, then oldest-first down to the bound. Called on write,
+ * so the map is swept by the same traffic that grows it.
+ */
+function evictIfNeeded() {
+  const now = Date.now();
+  for (const [teamId, entry] of cache) {
+    if (entry.expiresAt <= now) cache.delete(teamId);
+  }
+  if (cache.size <= CACHE_MAX_ENTRIES) return;
+  const byExpiry = [...cache.entries()].sort((a, b) => a[1].expiresAt - b[1].expiresAt);
+  for (const [teamId] of byExpiry.slice(0, cache.size - CACHE_MAX_ENTRIES)) {
+    cache.delete(teamId);
+  }
 }
 
 /** Test helper: observe cache occupancy without exposing tokens. */
@@ -68,9 +111,17 @@ export async function resolveInstallation(teamId) {
   // keep serving a stale token past its TTL.
   if (hit) cache.delete(teamId);
 
+  const startedAtGeneration = currentGeneration(teamId);
   const record = await fetchInstallationRecord(teamId);
-  if (record) {
-    cache.set(teamId, { record, expiresAt: Date.now() + CACHE_TTL_MS });
+  // Only cache if no purge or reinstall happened while this was in flight.
+  // Otherwise the answer we are holding is the grant that was just revoked.
+  if (record && currentGeneration(teamId) === startedAtGeneration) {
+    cache.set(teamId, {
+      record,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+      generation: startedAtGeneration,
+    });
+    evictIfNeeded();
   }
   return record;
 }
@@ -126,11 +177,13 @@ function describeInstallation(installation) {
  */
 export const convexInstallationStore = {
   /**
+   * Bolt calls this with (installation, options) — there is no third `logger`
+   * argument, so diagnostics go through the module logger instead of a
+   * parameter that would always be undefined.
    * @param {any} installation
    * @param {any} [_options]
-   * @param {any} [logger]
    */
-  storeInstallation: async (installation, _options, logger) => {
+  storeInstallation: async (installation, _options) => {
     if (installation?.isEnterpriseInstall) {
       throw new Error('Org-wide (enterprise grid) installs are not supported. Install MCPJam per workspace.');
     }
@@ -139,15 +192,14 @@ export const convexInstallationStore = {
     // A reinstall changes the token. Anything cached for this workspace is
     // now the PREVIOUS grant, so drop it before the next event arrives.
     purgeInstallation(described.teamId);
-    logger?.info?.(`Stored Slack installation for team ${described.teamId}`);
+    console.info(`[slack-installations] stored installation for team ${described.teamId}`);
   },
 
   /**
    * @param {any} query
    * @param {any} [_options]
-   * @param {any} [logger]
    */
-  fetchInstallation: async (query, _options, logger) => {
+  fetchInstallation: async (query, _options) => {
     const teamId = resolveQueryTeamId(query);
     let record;
     try {
@@ -157,7 +209,7 @@ export const convexInstallationStore = {
       // a throw into a failed authorization and the event is retried by Slack;
       // returning null would look like an uninstall and silently drop it.
       if (error instanceof InstallationBackendError) {
-        logger?.error?.(`Installation lookup failed for team ${teamId}: ${error.message}`);
+        console.error(`[slack-installations] lookup failed for team ${teamId}: ${error.message}`);
       }
       throw error;
     }
@@ -170,14 +222,13 @@ export const convexInstallationStore = {
   /**
    * @param {any} query
    * @param {any} [_options]
-   * @param {any} [logger]
    */
-  deleteInstallation: async (query, _options, logger) => {
+  deleteInstallation: async (query, _options) => {
     const teamId = resolveQueryTeamId(query);
     // The revoke itself is driven by the lifecycle listeners (they know
     // whether a `tokens_revoked` actually named OUR bot token). Bolt only
     // calls this on its own uninstall path; keep the cache honest either way.
     purgeInstallation(teamId);
-    logger?.info?.(`Purged cached Slack installation for team ${teamId}`);
+    console.info(`[slack-installations] purged cached installation for team ${teamId}`);
   },
 };

--- a/slack-app/installations/store.js
+++ b/slack-app/installations/store.js
@@ -73,29 +73,57 @@ export function purgeInstallation(teamId) {
 }
 
 /**
+ * Teams with a backend lookup in flight right now.
+ *
+ * A counted set, not a flag: two events for the same workspace can be resolving
+ * at once, and the first to finish must not un-pin the second.
+ *
+ * @type {Map<string, number>}
+ */
+const inflightLookups = new Map();
+
+/** @param {string} teamId */
+function beginLookup(teamId) {
+  inflightLookups.set(teamId, (inflightLookups.get(teamId) ?? 0) + 1);
+}
+
+/** @param {string} teamId */
+function endLookup(teamId) {
+  const remaining = (inflightLookups.get(teamId) ?? 1) - 1;
+  if (remaining > 0) inflightLookups.set(teamId, remaining);
+  else inflightLookups.delete(teamId);
+}
+
+/**
  * Bound the generation map.
  *
  * Every purge adds a permanent entry, so a public app accumulates one per
  * workspace that has ever uninstalled — unbounded state driven by strangers.
  * Dropping an entry only resets that team's counter to 0, and the ONLY thing a
- * counter must do is differ from the value an in-flight lookup recorded. A
- * lookup that is still running holds its team's entry alive (the purge that
- * would race it is the same call that just wrote one), so eviction here can
- * never resurrect a revoked grant — it just forgets teams nothing is asking
- * about.
+ * counter must do is differ from the value an in-flight lookup recorded.
+ *
+ * That is why the two skips below are not decoration. A team being LOOKED UP
+ * has its recorded generation compared on the way out: prune its entry and the
+ * counter restarts at 0, the comparison fails, and a legitimately installed
+ * workspace reads as "not installed" for that one event. Pinning it costs a map
+ * lookup and removes the false negative entirely.
+ *
+ * What eviction can never do — in either case — is resurrect a revoked grant. A
+ * real purge writes the team's entry immediately before pruning, making it the
+ * NEWEST entry, and this walks oldest-first.
  */
 const GENERATIONS_MAX_ENTRIES = 5000;
 
 function pruneGenerations() {
   if (generations.size <= GENERATIONS_MAX_ENTRIES) return;
-  // Insertion order: the oldest purges are the least likely to have a lookup
-  // still in flight, since a fetch has a 10s timeout.
+  // Insertion order, so the oldest purges go first.
   const excess = generations.size - GENERATIONS_MAX_ENTRIES;
   let dropped = 0;
   for (const teamId of generations.keys()) {
     if (dropped >= excess) break;
-    // Never drop a team we are currently caching: its entry is live state.
-    if (cache.has(teamId)) continue;
+    // Live state, both of them: a cached record carries the generation it was
+    // stored under, and an in-flight lookup is holding one to compare against.
+    if (cache.has(teamId) || inflightLookups.has(teamId)) continue;
     generations.delete(teamId);
     dropped += 1;
   }
@@ -105,6 +133,7 @@ function pruneGenerations() {
 export function clearInstallationCache() {
   cache.clear();
   generations.clear();
+  inflightLookups.clear();
 }
 
 /**
@@ -142,25 +171,37 @@ export async function resolveInstallation(teamId) {
   if (hit) cache.delete(teamId);
 
   const startedAtGeneration = currentGeneration(teamId);
-  const record = await fetchInstallationRecord(teamId);
+  // Pin the generation entry for the duration of the fetch. Without this, an
+  // unrelated team's purge could prune it mid-flight, reset the counter to 0,
+  // and make the check below refuse a workspace that is perfectly installed.
+  beginLookup(teamId);
+  try {
+    const record = await fetchInstallationRecord(teamId);
 
-  // A purge or reinstall landed while this lookup was in flight, so the answer
-  // we are holding describes a grant that has since been revoked or replaced.
-  // RETURNING it is the harm, not caching it: Bolt would authorize this event
-  // with a token the workspace just killed. Refusing reads as "not installed",
-  // which is the correct answer for a revoked install and a safely retryable
-  // one for a reinstall — the next event re-fetches under the new generation.
-  if (currentGeneration(teamId) !== startedAtGeneration) return null;
+    // A purge or reinstall landed while this lookup was in flight, so the
+    // answer we are holding describes a grant that has since been revoked or
+    // replaced. RETURNING it is the harm, not caching it: Bolt would authorize
+    // this event with a token the workspace just killed. Refusing reads as "not
+    // installed", which is the correct answer for a revoked install and a
+    // safely retryable one for a reinstall — the next event re-fetches under
+    // the new generation.
+    //
+    // Inside the `try` on purpose: the comparison is only meaningful while the
+    // generation entry is still pinned.
+    if (currentGeneration(teamId) !== startedAtGeneration) return null;
 
-  if (record) {
-    cache.set(teamId, {
-      record,
-      expiresAt: Date.now() + CACHE_TTL_MS,
-      generation: startedAtGeneration,
-    });
-    evictIfNeeded();
+    if (record) {
+      cache.set(teamId, {
+        record,
+        expiresAt: Date.now() + CACHE_TTL_MS,
+        generation: startedAtGeneration,
+      });
+      evictIfNeeded();
+    }
+    return record;
+  } finally {
+    endLookup(teamId);
   }
-  return record;
 }
 
 /**

--- a/slack-app/installations/store.js
+++ b/slack-app/installations/store.js
@@ -1,0 +1,183 @@
+/**
+ * Bolt `InstallationStore` backed by the MCPJam backend.
+ *
+ * Bolt derives its `authorize` from this store when OAuth installer options
+ * are supplied (`App.js` refuses BOTH a custom `authorize` and installer
+ * options, so this is the only place workspace credentials may come from).
+ * Every inbound event therefore passes through `fetchInstallation`.
+ *
+ * CACHE. A backend round-trip per event would put a network hop on the 3-second
+ * ack budget, so successful lookups are cached in-process for a few minutes.
+ * The cache is only safe because it is BUSTED SYNCHRONOUSLY by the lifecycle
+ * events — `app_uninstalled`, a bot-token `tokens_revoked`, and reinstall all
+ * call `purgeInstallation()` before their handler returns. Without that, a
+ * revoked workspace would keep being served from cache for the full TTL, and
+ * "revocation is instant" would be a lie. Negative results are NOT cached: a
+ * workspace that installs seconds after a miss must work immediately.
+ *
+ * REPLICA SCOPE. This cache and its purge are process-local. The Railway
+ * service is pinned to ONE replica (see railway.toml) precisely because of
+ * that: with two replicas, a purge on replica A would leave replica B serving
+ * a revoked token until its own TTL lapsed. Shared invalidation is deferred
+ * until we actually need horizontal scale.
+ */
+import { fetchInstallationRecord, InstallationBackendError, storeInstallationRecord } from './backend-client.js';
+
+/**
+ * Five minutes. Long enough to take the backend off the hot path for a busy
+ * thread, short enough that even a MISSED lifecycle event (Slack drops one,
+ * the process restarts mid-handler) self-heals quickly instead of pinning a
+ * stale token for hours.
+ */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** @typedef {import('./backend-client.js').StoredInstallationRecord} StoredInstallationRecord */
+
+/** @type {Map<string, { record: StoredInstallationRecord, expiresAt: number }>} */
+const cache = new Map();
+
+/**
+ * Drop a workspace's cached credentials NOW. Called by the lifecycle
+ * listeners; making revocation synchronous here is what makes it honest.
+ * @param {string} teamId
+ */
+export function purgeInstallation(teamId) {
+  cache.delete(teamId);
+}
+
+/** Test helper. */
+export function clearInstallationCache() {
+  cache.clear();
+}
+
+/** Test helper: observe cache occupancy without exposing tokens. */
+export function installationCacheSize() {
+  return cache.size;
+}
+
+/**
+ * Read through the cache. Throws (never returns null) when the backend could
+ * not be reached — see `fetchInstallationRecord`.
+ * @param {string} teamId
+ * @returns {Promise<StoredInstallationRecord | null>}
+ */
+export async function resolveInstallation(teamId) {
+  const hit = cache.get(teamId);
+  if (hit && hit.expiresAt > Date.now()) return hit.record;
+  // An expired entry is dropped before the fetch so a failing backend cannot
+  // keep serving a stale token past its TTL.
+  if (hit) cache.delete(teamId);
+
+  const record = await fetchInstallationRecord(teamId);
+  if (record) {
+    cache.set(teamId, { record, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
+  return record;
+}
+
+/**
+ * Bolt calls this with a `Query` object. We reject enterprise-install queries
+ * outright rather than resolving them against a team row: `org_deploy_enabled`
+ * is off, so an enterprise-install query means either a misconfiguration or an
+ * install shape we do not support, and answering it with SOME workspace's
+ * token would be acting as a tenant nobody authorized.
+ *
+ * @param {{ teamId?: string, enterpriseId?: string, isEnterpriseInstall?: boolean }} query
+ */
+function resolveQueryTeamId(query) {
+  if (query.isEnterpriseInstall) {
+    throw new Error('Org-wide (enterprise grid) installs are not supported. Install MCPJam per workspace.');
+  }
+  if (!query.teamId) {
+    throw new Error('Installation query carried no teamId.');
+  }
+  return query.teamId;
+}
+
+/**
+ * Extract the queryable fields Bolt's `Installation` carries. Kept narrow on
+ * purpose — the backend stores the whole object, so anything not listed here
+ * still survives the round trip; these are only the columns we index or show.
+ * @param {Record<string, any>} installation
+ */
+function describeInstallation(installation) {
+  const teamId = installation?.team?.id;
+  const botUserId = installation?.bot?.userId;
+  if (!teamId) throw new Error('Slack returned an installation with no team id.');
+  if (!botUserId) {
+    // Without the bot user id the app cannot tell its OWN messages apart from
+    // a human's when re-reading a thread, so every turn would feed the model
+    // its own replies as user input.
+    throw new Error('Slack returned an installation with no bot user id.');
+  }
+  return {
+    teamId: String(teamId),
+    teamName: String(installation?.team?.name ?? teamId),
+    appId: String(installation?.appId ?? ''),
+    botUserId: String(botUserId),
+    scopes: Array.isArray(installation?.bot?.scopes) ? installation.bot.scopes.map(String) : [],
+    ...(installation?.enterprise?.id ? { enterpriseId: String(installation.enterprise.id) } : {}),
+  };
+}
+
+/**
+ * The object handed to Bolt's `App({ installationStore })`.
+ * @type {import('@slack/oauth').InstallationStore}
+ */
+export const convexInstallationStore = {
+  /**
+   * @param {any} installation
+   * @param {any} [_options]
+   * @param {any} [logger]
+   */
+  storeInstallation: async (installation, _options, logger) => {
+    if (installation?.isEnterpriseInstall) {
+      throw new Error('Org-wide (enterprise grid) installs are not supported. Install MCPJam per workspace.');
+    }
+    const described = describeInstallation(installation);
+    await storeInstallationRecord({ ...described, installation });
+    // A reinstall changes the token. Anything cached for this workspace is
+    // now the PREVIOUS grant, so drop it before the next event arrives.
+    purgeInstallation(described.teamId);
+    logger?.info?.(`Stored Slack installation for team ${described.teamId}`);
+  },
+
+  /**
+   * @param {any} query
+   * @param {any} [_options]
+   * @param {any} [logger]
+   */
+  fetchInstallation: async (query, _options, logger) => {
+    const teamId = resolveQueryTeamId(query);
+    let record;
+    try {
+      record = await resolveInstallation(teamId);
+    } catch (error) {
+      // Surface backend outages as errors, not as "not installed". Bolt turns
+      // a throw into a failed authorization and the event is retried by Slack;
+      // returning null would look like an uninstall and silently drop it.
+      if (error instanceof InstallationBackendError) {
+        logger?.error?.(`Installation lookup failed for team ${teamId}: ${error.message}`);
+      }
+      throw error;
+    }
+    if (!record) {
+      throw new Error(`No active MCPJam installation for team ${teamId}.`);
+    }
+    return /** @type {any} */ (record.installation);
+  },
+
+  /**
+   * @param {any} query
+   * @param {any} [_options]
+   * @param {any} [logger]
+   */
+  deleteInstallation: async (query, _options, logger) => {
+    const teamId = resolveQueryTeamId(query);
+    // The revoke itself is driven by the lifecycle listeners (they know
+    // whether a `tokens_revoked` actually named OUR bot token). Bolt only
+    // calls this on its own uninstall path; keep the cache honest either way.
+    purgeInstallation(teamId);
+    logger?.info?.(`Purged cached Slack installation for team ${teamId}`);
+  },
+};

--- a/slack-app/listeners/actions/account-actions.js
+++ b/slack-app/listeners/actions/account-actions.js
@@ -24,7 +24,7 @@ const REQUEST_TIMEOUT_MS = 10_000;
  */
 async function setDefaultProject(ctx, projectId) {
   const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
-  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  const serviceToken = process.env.SLACK_SERVICE_TOKEN;
   if (!baseUrl || !serviceToken) throw new Error('Backend config is required to set a default project.');
 
   const controller = new AbortController();
@@ -34,7 +34,7 @@ async function setDefaultProject(ctx, projectId) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-inspector-service-token': serviceToken,
+        'x-slack-service-token': serviceToken,
       },
       body: JSON.stringify({
         teamId: ctx.teamId,

--- a/slack-app/listeners/actions/account-actions.js
+++ b/slack-app/listeners/actions/account-actions.js
@@ -1,0 +1,154 @@
+/**
+ * App Home account actions: pick a default project, and disconnect.
+ *
+ * Both re-render the Home tab afterwards. Slack does not re-publish a view on
+ * its own, so without that the user would click, see nothing change, and click
+ * again — which for "disconnect" is a confusing (if harmless) second call.
+ */
+import { mintConnectUrl } from '../../agent/connect-link.js';
+import { listProjects } from '../../agent/mcpjam-client.js';
+import { tryslackContextFrom } from '../../agent/slack-context.js';
+import { fetchAccountLink, revokeAccountLink } from '../../agent/turn-target.js';
+import { buildAppHomeView } from '../views/app-home-builder.js';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * The default-project write goes through the backend route, which re-verifies
+ * that the project belongs to the LINK's organization. That check is not
+ * optional politeness: the picker's options come from a list the user can see,
+ * but the interaction payload that follows is just an id, and a stale or
+ * crafted one must not bind a Slack user to a project outside their org.
+ *
+ * @param {import('../../agent/slack-context.js').SlackContext} ctx
+ * @param {string | undefined} projectId
+ */
+async function setDefaultProject(ctx, projectId) {
+  const baseUrl = (process.env.MCPJAM_CONVEX_HTTP_URL || '').replace(/\/+$/, '');
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!baseUrl || !serviceToken) throw new Error('Backend config is required to set a default project.');
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${baseUrl}/slack/links/set-default-project`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-inspector-service-token': serviceToken,
+      },
+      body: JSON.stringify({
+        teamId: ctx.teamId,
+        slackUserId: ctx.slackUserId,
+        ...(projectId ? { projectId } : {}),
+      }),
+      signal: controller.signal,
+    });
+    const payload = await response.json().catch(() => null);
+    if (!response.ok || payload?.ok !== true) {
+      throw new Error(payload?.reason || `set-default-project failed (${response.status})`);
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Re-publish the Home tab from current state.
+ * @param {Record<string, any>} args
+ * @param {import('../../agent/slack-context.js').SlackContext} ctx
+ */
+async function republishHome(args, ctx) {
+  const { client, logger } = args;
+  const link = await fetchAccountLink(ctx.teamId, ctx.slackUserId).catch(() => null);
+  if (!link) {
+    const connectUrl = await mintConnectUrl(ctx).catch(() => undefined);
+    await client.views.publish({
+      user_id: ctx.slackUserId,
+      view: buildAppHomeView({ connected: false, ...(connectUrl ? { connectUrl } : {}) }),
+    });
+    return;
+  }
+  /** @type {Array<{ id: string, name: string }>} */
+  let projects = [];
+  let projectsError = false;
+  try {
+    projects = await listProjects({ ...ctx, mode: 'user', projectId: link.defaultProjectId ?? undefined });
+  } catch (error) {
+    logger?.warn?.(`Could not list projects while re-rendering App Home: ${error}`);
+    projectsError = true;
+  }
+  await client.views.publish({
+    user_id: ctx.slackUserId,
+    view: buildAppHomeView({
+      connected: true,
+      projects,
+      defaultProjectId: link.defaultProjectId ?? null,
+      projectsError,
+    }),
+  });
+}
+
+/**
+ * Static-select: set the user's default project.
+ * @param {Record<string, any>} args
+ */
+export async function handleProjectPicker(args) {
+  const { ack, action, body, context, logger } = args;
+  await ack();
+
+  const ctx = tryslackContextFrom({ body, context });
+  if (!ctx) return;
+
+  const projectId = action?.selected_option?.value;
+  if (!projectId) return;
+
+  try {
+    await setDefaultProject(ctx, projectId);
+  } catch (error) {
+    logger.error(`Could not set the default project: ${error}`);
+  }
+  // Re-render either way: on success it shows the new selection, and on
+  // failure it shows the OLD one — which is the truth, and better than a
+  // picker that appears to have accepted a value it did not save.
+  await republishHome(args, ctx).catch((error) => {
+    logger.warn(`Could not re-publish App Home: ${error}`);
+  });
+}
+
+/**
+ * Disconnect the account.
+ *
+ * The link is revoked but nothing the user created is touched — suites and
+ * runs belong to their MCPJam account, not to the Slack connection, and
+ * deleting them would be a wildly disproportionate response to "stop acting
+ * as me in Slack".
+ *
+ * @param {Record<string, any>} args
+ */
+export async function handleUnlink(args) {
+  const { ack, body, context, logger } = args;
+  await ack();
+
+  const ctx = tryslackContextFrom({ body, context });
+  if (!ctx) return;
+
+  try {
+    await revokeAccountLink(ctx.teamId, ctx.slackUserId);
+  } catch (error) {
+    logger.error(`Could not unlink the Slack account: ${error}`);
+  }
+  await republishHome(args, ctx).catch((error) => {
+    logger.warn(`Could not re-publish App Home after unlink: ${error}`);
+  });
+}
+
+/**
+ * The "Connect MCPJam" button carries a `url`, so Slack opens it directly.
+ * Bolt still delivers the interaction and logs an "unhandled request" warning
+ * without a listener, so this exists purely to ack it.
+ * @param {Record<string, any>} args
+ */
+export async function handleConnectClick({ ack }) {
+  await ack();
+}

--- a/slack-app/listeners/actions/account-actions.js
+++ b/slack-app/listeners/actions/account-actions.js
@@ -5,11 +5,10 @@
  * its own, so without that the user would click, see nothing change, and click
  * again — which for "disconnect" is a confusing (if harmless) second call.
  */
-import { mintConnectUrl } from '../../agent/connect-link.js';
-import { listProjects } from '../../agent/mcpjam-client.js';
 import { tryslackContextFrom } from '../../agent/slack-context.js';
-import { fetchAccountLink, revokeAccountLink } from '../../agent/turn-target.js';
+import { revokeAccountLink } from '../../agent/turn-target.js';
 import { buildAppHomeView } from '../views/app-home-builder.js';
+import { resolveHomeState } from '../views/home-state.js';
 
 const REQUEST_TIMEOUT_MS = 10_000;
 
@@ -59,33 +58,9 @@ async function setDefaultProject(ctx, projectId) {
  * @param {import('../../agent/slack-context.js').SlackContext} ctx
  */
 async function republishHome(args, ctx) {
-  const { client, logger } = args;
-  const link = await fetchAccountLink(ctx.teamId, ctx.slackUserId).catch(() => null);
-  if (!link) {
-    const connectUrl = await mintConnectUrl(ctx).catch(() => undefined);
-    await client.views.publish({
-      user_id: ctx.slackUserId,
-      view: buildAppHomeView({ connected: false, ...(connectUrl ? { connectUrl } : {}) }),
-    });
-    return;
-  }
-  /** @type {Array<{ id: string, name: string }>} */
-  let projects = [];
-  let projectsError = false;
-  try {
-    projects = await listProjects({ ...ctx, mode: 'user', projectId: link.defaultProjectId ?? undefined });
-  } catch (error) {
-    logger?.warn?.(`Could not list projects while re-rendering App Home: ${error}`);
-    projectsError = true;
-  }
-  await client.views.publish({
+  await args.client.views.publish({
     user_id: ctx.slackUserId,
-    view: buildAppHomeView({
-      connected: true,
-      projects,
-      defaultProjectId: link.defaultProjectId ?? null,
-      projectsError,
-    }),
+    view: buildAppHomeView(await resolveHomeState(ctx, { logger: args.logger })),
   });
 }
 

--- a/slack-app/listeners/actions/index.js
+++ b/slack-app/listeners/actions/index.js
@@ -1,4 +1,6 @@
 import { RUN_SUITE_ACTION_ID } from '../views/agent-reply-builder.js';
+import { CONNECT_ACTION_ID, PROJECT_PICKER_ACTION_ID, UNLINK_ACTION_ID } from '../views/connect-builder.js';
+import { handleConnectClick, handleProjectPicker, handleUnlink } from './account-actions.js';
 import { handleFeedbackButton } from './feedback-buttons.js';
 import { handleRunSuiteButton } from './run-suite-button.js';
 
@@ -10,4 +12,10 @@ import { handleRunSuiteButton } from './run-suite-button.js';
 export function register(app) {
   app.action('feedback', handleFeedbackButton);
   app.action(RUN_SUITE_ACTION_ID, handleRunSuiteButton);
+  app.action(PROJECT_PICKER_ACTION_ID, handleProjectPicker);
+  app.action(UNLINK_ACTION_ID, handleUnlink);
+  // URL buttons still deliver an interaction; without a listener Bolt logs an
+  // "unhandled request" warning for every click.
+  app.action(CONNECT_ACTION_ID, handleConnectClick);
+  app.action('mcpjam_open_home', handleConnectClick);
 }

--- a/slack-app/listeners/actions/index.js
+++ b/slack-app/listeners/actions/index.js
@@ -1,7 +1,9 @@
 import { RUN_SUITE_ACTION_ID } from '../views/agent-reply-builder.js';
 import { CONNECT_ACTION_ID, PROJECT_PICKER_ACTION_ID, UNLINK_ACTION_ID } from '../views/connect-builder.js';
+import { PROPOSAL_ACTION_ID } from '../views/proposal-builder.js';
 import { handleConnectClick, handleProjectPicker, handleUnlink } from './account-actions.js';
 import { handleFeedbackButton } from './feedback-buttons.js';
+import { handleProposalButton } from './proposal-button.js';
 import { handleRunSuiteButton } from './run-suite-button.js';
 
 /**
@@ -12,6 +14,7 @@ import { handleRunSuiteButton } from './run-suite-button.js';
 export function register(app) {
   app.action('feedback', handleFeedbackButton);
   app.action(RUN_SUITE_ACTION_ID, handleRunSuiteButton);
+  app.action(PROPOSAL_ACTION_ID, handleProposalButton);
   app.action(PROJECT_PICKER_ACTION_ID, handleProjectPicker);
   app.action(UNLINK_ACTION_ID, handleUnlink);
   // URL buttons still deliver an interaction; without a listener Bolt logs an

--- a/slack-app/listeners/actions/proposal-button.js
+++ b/slack-app/listeners/actions/proposal-button.js
@@ -42,9 +42,21 @@ export async function handleProposalButton({ ack, body, client, context, logger,
   const actionId = action.value;
   if (!actionId || !channelId) return;
 
-  /** @param {string} text */
-  const tellClicker = (text) =>
-    client.chat.postEphemeral({ channel: channelId, user: userId, thread_ts: parentTs, text });
+  /**
+   * Telling the clicker must never THROW. Slack refuses `chat.postEphemeral`
+   * in ordinary situations — the clicker not being a channel member, most
+   * commonly — and this is awaited on the failure path, after a spend may
+   * already have happened. An escape there turns a reported failure into an
+   * unhandled one.
+   * @param {string} text
+   */
+  const tellClicker = async (text) => {
+    try {
+      await client.chat.postEphemeral({ channel: channelId, user: userId, thread_ts: parentTs, text });
+    } catch (error) {
+      logger.error(`Could not tell <@${userId}> about their approval click: ${error}`);
+    }
+  };
 
   // Reauthorize the CLICKER. This is the same resolution the turn used, run
   // again for a different person — which is the point.
@@ -88,14 +100,21 @@ export async function handleProposalButton({ ack, body, client, context, logger,
 
   // Announce IN THREAD, not ephemerally: a spend everyone in the conversation
   // can see is a spend nobody has to wonder about, and it names who approved it.
-  const url = typeof outcome.result?.run?.url === 'string' ? outcome.result.run.url : null;
+  //
+  // The wording follows the OPERATION. "It's away" is true of a run and false
+  // of a cancellation, and telling someone their cancel started something is
+  // the kind of small lie that costs trust in every later message.
+  const done =
+    outcome.operation === 'cancel_eval_run'
+      ? `:white_check_mark: Cancelled by <@${userId}>.`
+      : outcome.operation === 'generate_eval_cases'
+        ? `:white_check_mark: Approved by <@${userId}> — the cases are being generated.`
+        : `:white_check_mark: Approved by <@${userId}>, and it's away.`;
   try {
     await client.chat.postMessage({
       channel: channelId,
       thread_ts: parentTs,
-      text: url
-        ? `:white_check_mark: Approved by <@${userId}> — <${url}|follow it here>.`
-        : `:white_check_mark: Approved by <@${userId}>, and it's away.`,
+      text: outcome.runUrl ? `:white_check_mark: Approved by <@${userId}> — <${outcome.runUrl}|follow it here>.` : done,
     });
   } catch (error) {
     // The action HAPPENED. A failed announcement is cosmetic and must not be

--- a/slack-app/listeners/actions/proposal-button.js
+++ b/slack-app/listeners/actions/proposal-button.js
@@ -1,0 +1,105 @@
+/**
+ * The click that authorizes a spend.
+ *
+ * The agent proposed; this is the person saying yes. Three things are true here
+ * and each one is load-bearing:
+ *
+ *   1. THE CLICKER IS THE AUTHORIZER. The target is resolved for whoever
+ *      clicked — not for whoever's message caused the proposal — so the server
+ *      mints a delegated token for THEM and re-checks their org membership. A
+ *      person who was removed from the org, or who never had access to the
+ *      thread's project, cannot spend through a button left in a channel.
+ *   2. THE CLICK CARRIES ONLY AN ID. What the action does comes from the
+ *      persisted proposal. Anyone able to post in the workspace can mint a
+ *      Block Kit button with any `value`; treating that value as instructions
+ *      would make the whole approval gate decorative.
+ *   3. THE TRANSITION IS DURABLE. `proposed → executing` is claimed server-side,
+ *      so a double-click races there and exactly one caller wins. The loser is
+ *      told, not billed.
+ */
+import { executeProposedAction, McpjamApiError } from '../../agent/mcpjam-client.js';
+import { tryslackContextFrom } from '../../agent/slack-context.js';
+import { resolveTurnTarget } from '../../agent/turn-target.js';
+
+/**
+ * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackActionMiddlewareArgs<import('@slack/bolt').BlockButtonAction>} args
+ * @returns {Promise<void>}
+ */
+export async function handleProposalButton({ ack, body, client, context, logger, action }) {
+  await ack();
+
+  const ctx = tryslackContextFrom({ body, context });
+  if (!ctx) {
+    logger.warn('Dropping an approval click with no resolvable team/user id.');
+    return;
+  }
+
+  const userId = ctx.slackUserId;
+  const channelId = /** @type {string} */ (body.channel?.id);
+  // The button sits on the bot's reply, which is itself a thread reply.
+  // `chat.postMessage` wants the PARENT ts.
+  const parentTs = /** @type {string} */ (body.message?.thread_ts ?? body.message?.ts);
+  const actionId = action.value;
+  if (!actionId || !channelId) return;
+
+  /** @param {string} text */
+  const tellClicker = (text) =>
+    client.chat.postEphemeral({ channel: channelId, user: userId, thread_ts: parentTs, text });
+
+  // Reauthorize the CLICKER. This is the same resolution the turn used, run
+  // again for a different person — which is the point.
+  let target;
+  try {
+    target = await resolveTurnTarget(ctx, { channelId, threadTs: parentTs });
+  } catch (error) {
+    logger.error(`Could not resolve the approval target: ${error}`);
+    await tellClicker(':warning: I could not check your MCPJam access just now. Try again in a moment.');
+    return;
+  }
+  if (target.mode === 'unlinked') {
+    await tellClicker(':link: Connect your MCPJam account (in my Home tab) before approving this.');
+    return;
+  }
+  if (target.mode === 'needs_project') {
+    await tellClicker(':open_file_folder: Pick a default MCPJam project (in my Home tab) before approving this.');
+    return;
+  }
+
+  const runCtx = { ...ctx, mode: target.mode, projectId: target.projectId };
+
+  let outcome;
+  try {
+    outcome = await executeProposedAction(actionId, runCtx);
+  } catch (error) {
+    logger.error(`Approved action ${actionId} failed: ${error}`);
+    if (error instanceof McpjamApiError && error.status === 409) {
+      // Someone else's click won the race, or this one was redelivered. Not a
+      // failure: say so plainly rather than implying something broke.
+      await tellClicker(':information_source: That action is already under way.');
+      return;
+    }
+    await tellClicker(
+      error instanceof McpjamApiError
+        ? error.friendlyMessage
+        : ':warning: That did not go through. Try again in a moment.',
+    );
+    return;
+  }
+
+  // Announce IN THREAD, not ephemerally: a spend everyone in the conversation
+  // can see is a spend nobody has to wonder about, and it names who approved it.
+  const url = typeof outcome.result?.run?.url === 'string' ? outcome.result.run.url : null;
+  try {
+    await client.chat.postMessage({
+      channel: channelId,
+      thread_ts: parentTs,
+      text: url
+        ? `:white_check_mark: Approved by <@${userId}> — <${url}|follow it here>.`
+        : `:white_check_mark: Approved by <@${userId}>, and it's away.`,
+    });
+  } catch (error) {
+    // The action HAPPENED. A failed announcement is cosmetic and must not be
+    // retried into a second spend.
+    logger.error(`Approved action ${actionId} ran but announcing it failed: ${error}`);
+  }
+}

--- a/slack-app/listeners/actions/run-suite-button.js
+++ b/slack-app/listeners/actions/run-suite-button.js
@@ -1,4 +1,5 @@
 import { getEvalRun, McpjamApiError, startSuiteRun } from '../../agent/mcpjam-client.js';
+import { tenantKey, tryslackContextFrom } from '../../agent/slack-context.js';
 import { EventDedupe } from '../../agent/turn-runner.js';
 
 // Status polling: keep the "run started" message honest by editing it with
@@ -36,7 +37,7 @@ export function formatRunOutcome(run, url, userId) {
  * Detached from the button handler; failures degrade to the original
  * "watch it here" message rather than erroring in channel.
  * @param {import('@slack/web-api').WebClient} client
- * @param {{ runId: string, url: string, channelId: string, statusTs: string, userId: string, logger: import('@slack/bolt').Logger }} args
+ * @param {{ runId: string, url: string, ctx: import('../../agent/slack-context.js').SlackContext, channelId: string, statusTs: string, userId: string, logger: import('@slack/bolt').Logger }} args
  */
 export async function watchRunUntilDone(client, args) {
   const deadline = Date.now() + POLL_MAX_MS;
@@ -47,7 +48,7 @@ export async function watchRunUntilDone(client, args) {
       timer.unref?.();
     });
     try {
-      const run = await getEvalRun(args.runId);
+      const run = await getEvalRun(args.runId, args.ctx);
       if (TERMINAL_STATUSES.has(run.status)) {
         await client.chat.update({
           channel: args.channelId,
@@ -91,7 +92,13 @@ export const runDedupe = new EventDedupe({ ttlMs: RUN_DEDUPE_TTL_MS });
 export async function handleRunSuiteButton({ ack, body, client, context, logger, action }) {
   await ack();
 
-  const userId = /** @type {string} */ (context.userId);
+  const ctx = tryslackContextFrom({ body, context });
+  if (!ctx) {
+    logger.warn('Dropping a run-suite click with no resolvable team/user id.');
+    return;
+  }
+
+  const userId = ctx.slackUserId;
   const channelId = /** @type {string} */ (body.channel?.id);
   const messageTs = /** @type {string} */ (body.message?.ts);
   // The button lives on the bot's reply, which is itself a thread reply.
@@ -101,7 +108,7 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
   const suiteId = action.value;
   if (!suiteId) return;
 
-  const runKey = `${suiteId}:${messageTs}`;
+  const runKey = tenantKey(ctx, `${suiteId}:${messageTs}`);
   if (!runDedupe.claim(runKey)) {
     await client.chat.postEphemeral({
       channel: channelId,
@@ -115,7 +122,7 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
   /** @type {{ runId: string, url: string }} */
   let run;
   try {
-    run = await startSuiteRun(suiteId);
+    run = await startSuiteRun(suiteId, ctx);
   } catch (error) {
     // The run provably did not start — release so a retry click can work.
     runDedupe.release(runKey);
@@ -147,6 +154,7 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
       void watchRunUntilDone(client, {
         runId: run.runId,
         url: run.url,
+        ctx,
         channelId,
         statusTs: /** @type {string} */ (posted.ts),
         userId,

--- a/slack-app/listeners/actions/run-suite-button.js
+++ b/slack-app/listeners/actions/run-suite-button.js
@@ -1,6 +1,7 @@
 import { getEvalRun, McpjamApiError, startSuiteRun } from '../../agent/mcpjam-client.js';
 import { tenantKey, tryslackContextFrom } from '../../agent/slack-context.js';
 import { EventDedupe } from '../../agent/turn-runner.js';
+import { claimEvent, completeEvent, hasClaimBackend, releaseEvent } from '../../installations/event-claims.js';
 
 // Status polling: keep the "run started" message honest by editing it with
 // the terminal result. Slack-app convention: a kicked-off job's message is
@@ -67,8 +68,7 @@ export async function watchRunUntilDone(client, args) {
 /**
  * Guard against double-clicks and Slack action retries: one run per
  * (suiteId, button message) within the window below — repeat clicks get an
- * ephemeral note instead of a second billed run. Claims are released ONLY
- * when the run provably did not start.
+ * ephemeral note instead of a second billed run.
  *
  * The window is explicit and long (a day) rather than the shared 30-minute
  * event default: runs cost quota, and a stray second click hours later in
@@ -77,10 +77,30 @@ export async function watchRunUntilDone(client, args) {
  * design, where the human click IS the approval that spends quota. Bounded
  * by the TTL sweep, so a long-lived bot doesn't grow an entry per click
  * forever.
+ *
+ * This in-memory guard is now the FAST PATH only. The durable claim below is
+ * the real one, and the run's idempotency key is what makes the residual race
+ * harmless: even if two clicks both reached `startSuiteRun`, they present the
+ * same key and the backend returns the same run.
  */
 const RUN_DEDUPE_TTL_MS = 24 * 60 * 60 * 1000;
 
 export const runDedupe = new EventDedupe({ ttlMs: RUN_DEDUPE_TTL_MS });
+
+/**
+ * The click's stable identity, and the run's idempotency key.
+ *
+ * Derived from (team, channel, button message, suite) rather than generated
+ * per click, so every delivery of the SAME click — a double-click, a Slack
+ * action retry, a redelivery after the process died mid-start — produces the
+ * same value. That is what lets the backend collapse them onto one run.
+ *
+ * @param {import('../../agent/slack-context.js').SlackContext} ctx
+ * @param {{ channelId: string, messageTs: string, suiteId: string }} args
+ */
+export function runActionId(ctx, args) {
+  return tenantKey(ctx, `run:${args.channelId}:${args.messageTs}:${args.suiteId}`);
+}
 
 /**
  * Handle the "Run it" button on a created eval suite. Block actions need
@@ -108,24 +128,62 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
   const suiteId = action.value;
   if (!suiteId) return;
 
-  const runKey = tenantKey(ctx, `${suiteId}:${messageTs}`);
-  if (!runDedupe.claim(runKey)) {
-    await client.chat.postEphemeral({
+  const actionId = runActionId(ctx, { channelId, messageTs, suiteId });
+
+  /** Tell the clicker their click lost the race, without billing a run. */
+  const alreadyRunning = () =>
+    client.chat.postEphemeral({
       channel: channelId,
       user: userId,
       thread_ts: parentTs,
       text: ':information_source: That run is already going — check the run link above.',
     });
+
+  // Fast path: this process already saw the click.
+  if (!runDedupe.claim(actionId)) {
+    await alreadyRunning();
     return;
+  }
+
+  // Durable transition `proposed → executing`. A double-click races HERE, and
+  // exactly one caller wins; the loser is told, not billed. Surviving a
+  // restart matters because the expensive half (the run) is what a redelivery
+  // would repeat.
+  let durable = null;
+  if (hasClaimBackend()) {
+    try {
+      durable = await claimEvent(actionId);
+    } catch (error) {
+      // Fail closed: a run costs quota, so an unreachable backend must not be
+      // read as permission to start one.
+      runDedupe.release(actionId);
+      logger.error(`Could not claim the run action: ${error}`);
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: userId,
+        thread_ts: parentTs,
+        text: ':warning: Could not start the run right now. Try again in a moment.',
+      });
+      return;
+    }
+    if (durable.outcome !== 'claimed') {
+      await alreadyRunning();
+      return;
+    }
   }
 
   /** @type {{ runId: string, url: string }} */
   let run;
   try {
-    run = await startSuiteRun(suiteId, ctx);
+    run = await startSuiteRun(suiteId, ctx, {
+      // Same id as the claim. A crash between `executing` and recording the
+      // outcome retries into the SAME backend run, never a second one.
+      idempotencyKey: actionId,
+    });
   } catch (error) {
     // The run provably did not start — release so a retry click can work.
-    runDedupe.release(runKey);
+    runDedupe.release(actionId);
+    if (durable) await releaseEvent(actionId).catch(() => {});
     logger.error(`Failed to start suite run: ${error}`);
     const friendly =
       error instanceof McpjamApiError
@@ -142,7 +200,14 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
 
   // Past this point the run EXISTS and is billed. Keep the claim even if
   // announcing it fails — a retry would start (and bill) a second run.
-  runDedupe.complete(runKey);
+  runDedupe.complete(actionId);
+  if (durable) {
+    // `executing → succeeded`: the run exists. Recorded before announcing so
+    // a failure to post cannot leave the action stuck mid-transition.
+    await completeEvent(actionId, { runId: run.runId, url: run.url, suiteId }).catch((error) => {
+      logger.warn(`Run ${run.runId} started but recording the action outcome failed: ${error}`);
+    });
+  }
   try {
     const posted = await client.chat.postMessage({
       channel: channelId,

--- a/slack-app/listeners/actions/run-suite-button.js
+++ b/slack-app/listeners/actions/run-suite-button.js
@@ -1,6 +1,7 @@
 import { getEvalRun, McpjamApiError, startSuiteRun } from '../../agent/mcpjam-client.js';
 import { tenantKey, tryslackContextFrom } from '../../agent/slack-context.js';
 import { EventDedupe } from '../../agent/turn-runner.js';
+import { resolveTurnTarget } from '../../agent/turn-target.js';
 import { claimEvent, completeEvent, hasClaimBackend, releaseEvent } from '../../installations/event-claims.js';
 
 // Status polling: keep the "run started" message honest by editing it with
@@ -128,6 +129,39 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
   const suiteId = action.value;
   if (!suiteId) return;
 
+  // The click runs as the CLICKER, in the thread's project — the same
+  // resolution the turn used. Without this the credential seam has no mode
+  // and refuses outright, and a legacy-workspace clicker who HAS linked would
+  // otherwise fall back to the shared key instead of their own project.
+  let target;
+  try {
+    target = await resolveTurnTarget(ctx, { channelId, threadTs: parentTs });
+  } catch (error) {
+    logger.error(`Could not resolve the run target: ${error}`);
+    await client.chat.postEphemeral({
+      channel: channelId,
+      user: userId,
+      thread_ts: parentTs,
+      text: ':warning: Could not start the run right now. Try again in a moment.',
+    });
+    return;
+  }
+  if (target.mode === 'unlinked' || target.mode === 'needs_project') {
+    // Reauthorizing the CLICKER is the point: the person who created the
+    // suite is not the person spending quota here.
+    await client.chat.postEphemeral({
+      channel: channelId,
+      user: userId,
+      thread_ts: parentTs,
+      text:
+        target.mode === 'unlinked'
+          ? ':link: Connect your MCPJam account (in my Home tab) before starting a run.'
+          : ':open_file_folder: Pick a default MCPJam project (in my Home tab) before starting a run.',
+    });
+    return;
+  }
+  const runCtx = { ...ctx, mode: target.mode, projectId: target.projectId };
+
   const actionId = runActionId(ctx, { channelId, messageTs, suiteId });
 
   /** Tell the clicker their click lost the race, without billing a run. */
@@ -166,6 +200,22 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
       });
       return;
     }
+    if (durable.outcome === 'completed') {
+      // The run already exists AND we stored its link. Handing that link over
+      // beats "check the run link above": the winning click may have been in a
+      // different message, or made by someone else entirely, so "above" can
+      // point at nothing this person can see.
+      const storedUrl = typeof durable.resultEnvelope?.url === 'string' ? durable.resultEnvelope.url : null;
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: userId,
+        thread_ts: parentTs,
+        text: storedUrl
+          ? `:information_source: That suite is already running — <${storedUrl}|watch it here>.`
+          : ':information_source: That run is already going — check the run link above.',
+      });
+      return;
+    }
     if (durable.outcome !== 'claimed') {
       await alreadyRunning();
       return;
@@ -175,7 +225,7 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
   /** @type {{ runId: string, url: string }} */
   let run;
   try {
-    run = await startSuiteRun(suiteId, ctx, {
+    run = await startSuiteRun(suiteId, runCtx, {
       // Same id as the claim. A crash between `executing` and recording the
       // outcome retries into the SAME backend run, never a second one.
       idempotencyKey: actionId,
@@ -219,7 +269,7 @@ export async function handleRunSuiteButton({ ack, body, client, context, logger,
       void watchRunUntilDone(client, {
         runId: run.runId,
         url: run.url,
-        ctx,
+        ctx: runCtx,
         channelId,
         statusTs: /** @type {string} */ (posted.ts),
         userId,

--- a/slack-app/listeners/events/app-home-opened.js
+++ b/slack-app/listeners/events/app-home-opened.js
@@ -1,3 +1,7 @@
+import { mintConnectUrl } from '../../agent/connect-link.js';
+import { listProjects } from '../../agent/mcpjam-client.js';
+import { tryslackContextFrom } from '../../agent/slack-context.js';
+import { fetchAccountLink, hasPerUserAuth } from '../../agent/turn-target.js';
 import { buildAppHomeView } from '../views/app-home-builder.js';
 
 const SUGGESTED_PROMPTS = [
@@ -23,7 +27,7 @@ const SUGGESTED_PROMPTS = [
  * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'app_home_opened'>} args
  * @returns {Promise<void>}
  */
-export async function handleAppHomeOpened({ client, event, context, logger }) {
+export async function handleAppHomeOpened({ body, client, event, context, logger }) {
   try {
     if (event.tab === 'messages') {
       await client.assistant.threads.setSuggestedPrompts(
@@ -38,9 +42,56 @@ export async function handleAppHomeOpened({ client, event, context, logger }) {
       return;
     }
 
-    const userId = /** @type {string} */ (context.userId);
-    const view = buildAppHomeView();
-    await client.views.publish({ user_id: userId, view });
+    const ctx = tryslackContextFrom({ body, context, event });
+    if (!ctx) return;
+
+    // Legacy/dev deployments have no per-user auth at all — showing a
+    // connect button that leads nowhere would be worse than showing none.
+    if (!hasPerUserAuth()) {
+      await client.views.publish({
+        user_id: ctx.slackUserId,
+        view: buildAppHomeView({ connected: true, projectsError: false, projects: [] }),
+      });
+      return;
+    }
+
+    const link = await fetchAccountLink(ctx.teamId, ctx.slackUserId).catch(() => null);
+    if (!link) {
+      // Minted per render so the 10-minute clock starts when the user is
+      // actually looking at the button.
+      const connectUrl = await mintConnectUrl(ctx).catch((error) => {
+        logger.warn(`Could not mint a connect URL: ${error}`);
+        return undefined;
+      });
+      await client.views.publish({
+        user_id: ctx.slackUserId,
+        view: buildAppHomeView({ connected: false, ...(connectUrl ? { connectUrl } : {}) }),
+      });
+      return;
+    }
+
+    // The project list comes from the USER's credentials, so it is exactly
+    // what they may act in — never a superset borrowed from the bot, which
+    // would offer projects the picker could not actually save.
+    /** @type {Array<{ id: string, name: string }>} */
+    let projects = [];
+    let projectsError = false;
+    try {
+      projects = await listProjects({ ...ctx, mode: 'user', projectId: link.defaultProjectId ?? undefined });
+    } catch (error) {
+      logger.warn(`Could not list projects for the App Home picker: ${error}`);
+      projectsError = true;
+    }
+
+    await client.views.publish({
+      user_id: ctx.slackUserId,
+      view: buildAppHomeView({
+        connected: true,
+        projects,
+        defaultProjectId: link.defaultProjectId ?? null,
+        projectsError,
+      }),
+    });
   } catch (e) {
     logger.error(`Failed to handle app_home_opened: ${e}`);
   }

--- a/slack-app/listeners/events/app-home-opened.js
+++ b/slack-app/listeners/events/app-home-opened.js
@@ -1,8 +1,6 @@
-import { mintConnectUrl } from '../../agent/connect-link.js';
-import { listProjects } from '../../agent/mcpjam-client.js';
 import { tryslackContextFrom } from '../../agent/slack-context.js';
-import { fetchAccountLink, hasPerUserAuth } from '../../agent/turn-target.js';
 import { buildAppHomeView } from '../views/app-home-builder.js';
+import { resolveHomeState } from '../views/home-state.js';
 
 const SUGGESTED_PROMPTS = [
   {
@@ -45,52 +43,9 @@ export async function handleAppHomeOpened({ body, client, event, context, logger
     const ctx = tryslackContextFrom({ body, context, event });
     if (!ctx) return;
 
-    // Legacy/dev deployments have no per-user auth at all — showing a
-    // connect button that leads nowhere would be worse than showing none.
-    if (!hasPerUserAuth()) {
-      await client.views.publish({
-        user_id: ctx.slackUserId,
-        view: buildAppHomeView({ connected: true, projectsError: false, projects: [] }),
-      });
-      return;
-    }
-
-    const link = await fetchAccountLink(ctx.teamId, ctx.slackUserId).catch(() => null);
-    if (!link) {
-      // Minted per render so the 10-minute clock starts when the user is
-      // actually looking at the button.
-      const connectUrl = await mintConnectUrl(ctx).catch((error) => {
-        logger.warn(`Could not mint a connect URL: ${error}`);
-        return undefined;
-      });
-      await client.views.publish({
-        user_id: ctx.slackUserId,
-        view: buildAppHomeView({ connected: false, ...(connectUrl ? { connectUrl } : {}) }),
-      });
-      return;
-    }
-
-    // The project list comes from the USER's credentials, so it is exactly
-    // what they may act in — never a superset borrowed from the bot, which
-    // would offer projects the picker could not actually save.
-    /** @type {Array<{ id: string, name: string }>} */
-    let projects = [];
-    let projectsError = false;
-    try {
-      projects = await listProjects({ ...ctx, mode: 'user', projectId: link.defaultProjectId ?? undefined });
-    } catch (error) {
-      logger.warn(`Could not list projects for the App Home picker: ${error}`);
-      projectsError = true;
-    }
-
     await client.views.publish({
       user_id: ctx.slackUserId,
-      view: buildAppHomeView({
-        connected: true,
-        projects,
-        defaultProjectId: link.defaultProjectId ?? null,
-        projectsError,
-      }),
+      view: buildAppHomeView(await resolveHomeState(ctx, { logger })),
     });
   } catch (e) {
     logger.error(`Failed to handle app_home_opened: ${e}`);

--- a/slack-app/listeners/events/app-lifecycle.js
+++ b/slack-app/listeners/events/app-lifecycle.js
@@ -1,0 +1,102 @@
+/**
+ * Installation lifecycle: uninstall and token revocation.
+ *
+ * These two events are the ONLY way a workspace tells us to stop acting on
+ * its behalf, so they are also the only thing that makes the in-process
+ * credential cache honest. Each handler purges the cache SYNCHRONOUSLY before
+ * returning — a purge that happened only after the backend revoke landed
+ * would leave a window where this process still answers with a token the
+ * workspace just killed.
+ */
+import { revokeInstallationRecord } from '../../installations/backend-client.js';
+import { purgeInstallation, resolveInstallation } from '../../installations/store.js';
+import { sessionStore } from '../../thread-context/index.js';
+
+/**
+ * Forget everything this process holds for a workspace.
+ * @param {string} teamId
+ */
+function purgeLocalState(teamId) {
+  purgeInstallation(teamId);
+  // Engaged threads are workspace state too: a reinstall should start from a
+  // clean slate rather than resuming conversations the workspace ended.
+  sessionStore.clearTeam(teamId);
+}
+
+/**
+ * `app_uninstalled` — the workspace removed the app. Unconditional revoke.
+ * @param {Record<string, any>} args
+ * @returns {Promise<void>}
+ */
+export async function handleAppUninstalled({ body, context, event, logger }) {
+  const teamId = context?.teamId ?? body?.team_id ?? event?.team;
+  if (!teamId) {
+    logger?.warn?.('Received app_uninstalled with no team id; nothing to revoke.');
+    return;
+  }
+
+  // Purge FIRST. Even if the backend revoke fails below, this process must
+  // stop using the token immediately — the workspace has already withdrawn
+  // consent, and a retry of the revoke is cheap compared to acting without it.
+  purgeLocalState(teamId);
+
+  try {
+    await revokeInstallationRecord(teamId);
+    logger?.info?.(`Revoked MCPJam installation for team ${teamId} (app_uninstalled).`);
+  } catch (error) {
+    // Loud, not fatal: the local purge already stopped this process. Slack
+    // redelivers the event, and the backend revoke is idempotent.
+    logger?.error?.(`Failed to revoke installation for team ${teamId}: ${error}`);
+  }
+}
+
+/**
+ * `tokens_revoked` — one or more tokens were revoked, which is NOT the same
+ * as an uninstall. The event lists revoked `oauth` (user) and `bot` tokens;
+ * a user revoking their own token must not take the workspace's bot offline.
+ *
+ * So this only counts as an installation revocation when the stored bot user
+ * id actually appears in `tokens.bot`.
+ *
+ * @param {Record<string, any>} args
+ * @returns {Promise<void>}
+ */
+export async function handleTokensRevoked({ body, context, event, logger }) {
+  const teamId = context?.teamId ?? body?.team_id ?? event?.team;
+  if (!teamId) {
+    logger?.warn?.('Received tokens_revoked with no team id; ignoring.');
+    return;
+  }
+
+  const revokedBotTokens = Array.isArray(event?.tokens?.bot) ? event.tokens.bot.map(String) : [];
+  if (revokedBotTokens.length === 0) {
+    logger?.info?.(`tokens_revoked for team ${teamId} named no bot tokens; installation untouched.`);
+    return;
+  }
+
+  let record;
+  try {
+    record = await resolveInstallation(teamId);
+  } catch (error) {
+    // We cannot tell whether OUR bot token was the one revoked. Purging the
+    // cache is the safe half of the decision (worst case, a re-fetch); the
+    // durable revoke is deliberately NOT guessed at.
+    purgeInstallation(teamId);
+    logger?.error?.(`Could not resolve installation for team ${teamId} while handling tokens_revoked: ${error}`);
+    return;
+  }
+  if (!record) return;
+
+  if (!revokedBotTokens.includes(record.botUserId)) {
+    logger?.info?.(`tokens_revoked for team ${teamId} named other bot tokens; MCPJam's installation is untouched.`);
+    return;
+  }
+
+  purgeLocalState(teamId);
+  try {
+    await revokeInstallationRecord(teamId);
+    logger?.info?.(`Revoked MCPJam installation for team ${teamId} (bot token revoked).`);
+  } catch (error) {
+    logger?.error?.(`Failed to revoke installation for team ${teamId}: ${error}`);
+  }
+}

--- a/slack-app/listeners/events/app-lifecycle.js
+++ b/slack-app/listeners/events/app-lifecycle.js
@@ -68,8 +68,11 @@ export async function handleTokensRevoked({ body, context, event, logger }) {
     return;
   }
 
-  const revokedBotTokens = Array.isArray(event?.tokens?.bot) ? event.tokens.bot.map(String) : [];
-  if (revokedBotTokens.length === 0) {
+  // `tokens.bot` is a list of USER IDS whose bot token was revoked, not a list
+  // of token strings — Slack never puts a credential in an event payload. The
+  // comparison below is therefore against the installation's `botUserId`.
+  const revokedBotUserIds = Array.isArray(event?.tokens?.bot) ? event.tokens.bot.map(String) : [];
+  if (revokedBotUserIds.length === 0) {
     logger?.info?.(`tokens_revoked for team ${teamId} named no bot tokens; installation untouched.`);
     return;
   }
@@ -87,7 +90,21 @@ export async function handleTokensRevoked({ body, context, event, logger }) {
   }
   if (!record) return;
 
-  if (!revokedBotTokens.includes(record.botUserId)) {
+  if (!record.botUserId) {
+    // A stored installation with no bot user id cannot be matched against the
+    // revocation list, so "not ours" is a GUESS — and guessing wrong here means
+    // continuing to act with a token the workspace revoked. Purge locally (the
+    // reversible half) and say so, rather than silently treating a genuine
+    // revocation as unrelated.
+    purgeLocalState(teamId);
+    logger?.warn?.(
+      `tokens_revoked for team ${teamId}: stored installation has no botUserId, so the revocation could not be ` +
+        'attributed. Purged local state; the durable record was left in place for a re-fetch.',
+    );
+    return;
+  }
+
+  if (!revokedBotUserIds.includes(record.botUserId)) {
     logger?.info?.(`tokens_revoked for team ${teamId} named other bot tokens; MCPJam's installation is untouched.`);
     return;
   }

--- a/slack-app/listeners/events/app-mentioned.js
+++ b/slack-app/listeners/events/app-mentioned.js
@@ -1,3 +1,4 @@
+import { tryslackContextFrom } from '../../agent/slack-context.js';
 import { sessionStore } from '../../thread-context/index.js';
 import { runAndReply } from './run-and-reply.js';
 
@@ -6,15 +7,21 @@ import { runAndReply } from './run-and-reply.js';
  * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'app_mention'>} args
  * @returns {Promise<void>}
  */
-export async function handleAppMentioned({ client, context, event, logger, say, sayStream, setStatus }) {
+export async function handleAppMentioned({ body, client, context, event, logger, say, sayStream, setStatus }) {
   const channelId = event.channel;
   const threadTs = event.thread_ts || event.ts;
   const cleanedText = (event.text || '').replace(/<@[A-Z0-9]+>/g, '').trim();
 
+  const ctx = tryslackContextFrom({ body, context, event });
+  if (!ctx) {
+    logger.warn('Dropping an app_mention with no resolvable team/user id.');
+    return;
+  }
+
   // Mark the thread engaged BEFORE the bare-mention early return, so the
   // user's next (unmentioned) reply is picked up by the message listener —
   // otherwise the greeting invites a reply the bot then ignores.
-  sessionStore.setSession(channelId, threadTs, 'engaged');
+  sessionStore.setSession(ctx.teamId, channelId, threadTs, 'engaged');
 
   if (!cleanedText) {
     await say({
@@ -26,6 +33,7 @@ export async function handleAppMentioned({ client, context, event, logger, say, 
 
   await runAndReply({
     client,
+    ctx,
     context,
     logger,
     say,

--- a/slack-app/listeners/events/app-mentioned.js
+++ b/slack-app/listeners/events/app-mentioned.js
@@ -42,6 +42,9 @@ export async function handleAppMentioned({ body, client, context, event, logger,
     channelId,
     threadTs,
     triggerTs: event.ts,
+    // Slack's event_id identifies the DELIVERY CHAIN: every redelivery of
+    // this event carries it unchanged, which is what the durable claim keys on.
+    ...(typeof body?.event_id === 'string' ? { eventId: body.event_id } : {}),
     isThread: true,
     fallbackText: cleanedText,
   });

--- a/slack-app/listeners/events/app-mentioned.js
+++ b/slack-app/listeners/events/app-mentioned.js
@@ -1,5 +1,6 @@
 import { tryslackContextFrom } from '../../agent/slack-context.js';
 import { sessionStore } from '../../thread-context/index.js';
+import { forgetUnboundThread } from './message.js';
 import { runAndReply } from './run-and-reply.js';
 
 /**
@@ -22,6 +23,10 @@ export async function handleAppMentioned({ body, client, context, event, logger,
   // user's next (unmentioned) reply is picked up by the message listener —
   // otherwise the greeting invites a reply the bot then ignores.
   sessionStore.setSession(ctx.teamId, channelId, threadTs, 'engaged');
+  // A mention is proof of engagement, so any cached "unbound" verdict for this
+  // thread is now wrong. Clearing it keeps the message listener from dropping
+  // the user's next reply once the in-memory session ages out.
+  forgetUnboundThread(ctx.teamId, channelId, threadTs);
 
   if (!cleanedText) {
     await say({

--- a/slack-app/listeners/events/index.js
+++ b/slack-app/listeners/events/index.js
@@ -1,4 +1,5 @@
 import { handleAppHomeOpened } from './app-home-opened.js';
+import { handleAppUninstalled, handleTokensRevoked } from './app-lifecycle.js';
 import { handleAppMentioned } from './app-mentioned.js';
 import { handleMessage } from './message.js';
 
@@ -11,4 +12,8 @@ export function register(app) {
   app.event('app_home_opened', handleAppHomeOpened);
   app.event('app_mention', handleAppMentioned);
   app.event('message', handleMessage);
+  // Installation lifecycle. These bypass the tenant guard by design (see
+  // `tenant-guard.js`): they are how a workspace tells us to stop.
+  app.event('app_uninstalled', handleAppUninstalled);
+  app.event('tokens_revoked', handleTokensRevoked);
 }

--- a/slack-app/listeners/events/message.js
+++ b/slack-app/listeners/events/message.js
@@ -12,6 +12,56 @@ function isGenericMessageEvent(event) {
 }
 
 /**
+ * Short-lived NEGATIVE cache for "this thread has no binding".
+ *
+ * The positive answer is already cached in `sessionStore`, so without this the
+ * only threads that pay a backend round trip are the ones we do not serve —
+ * every reply in every busy thread of every channel the bot happens to be in.
+ * That is unbounded work driven by strangers' conversations.
+ *
+ * The TTL is short because the miss is RECOVERABLE and the staleness window is
+ * the cost of being wrong: a thread that gets bound during it stays deaf until
+ * the entry expires, and the user's obvious next move — mentioning the bot —
+ * goes to `app_mentioned`, which does not consult this cache at all.
+ */
+const NEGATIVE_BINDING_TTL_MS = 60_000;
+const NEGATIVE_BINDING_MAX = 10_000;
+/** @type {Map<string, number>} */
+const unboundThreads = new Map();
+
+/** @param {string} key */
+function recentlyUnbound(key) {
+  const expiresAt = unboundThreads.get(key);
+  if (expiresAt === undefined) return false;
+  if (expiresAt > Date.now()) return true;
+  unboundThreads.delete(key);
+  return false;
+}
+
+/** @param {string} key */
+function rememberUnbound(key) {
+  if (unboundThreads.size >= NEGATIVE_BINDING_MAX) {
+    // Sweep expired entries first; only if that frees nothing does the oldest
+    // insertion go. A cache that can grow without bound is a memory leak with
+    // a friendlier name.
+    const now = Date.now();
+    for (const [candidate, expiresAt] of unboundThreads) {
+      if (expiresAt <= now) unboundThreads.delete(candidate);
+    }
+    if (unboundThreads.size >= NEGATIVE_BINDING_MAX) {
+      const oldest = unboundThreads.keys().next();
+      if (!oldest.done) unboundThreads.delete(oldest.value);
+    }
+  }
+  unboundThreads.set(key, Date.now() + NEGATIVE_BINDING_TTL_MS);
+}
+
+/** Test-only. */
+export function resetUnboundThreadCache() {
+  unboundThreads.clear();
+}
+
+/**
  * Handle messages sent to the agent via DM or in threads the bot is part of.
  * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'message'>} args
  * @returns {Promise<void>}
@@ -48,15 +98,24 @@ export async function handleMessage({ body, client, context, event, logger, say,
     // a miss falls through to it and re-warms the cache.
     const threadTs = /** @type {string} */ (event.thread_ts);
     if (sessionStore.getSession(ctx.teamId, event.channel, threadTs) === null) {
+      const negativeKey = `${ctx.teamId}:${event.channel}:${threadTs}`;
+      if (recentlyUnbound(negativeKey)) return;
       const binding = await fetchThreadBinding(ctx.teamId, event.channel, threadTs).catch((error) => {
         // Unknown, not "not engaged". Dropping is the safe half of the
         // decision: Slack will not retry a message we chose to ignore, but
         // answering a thread we were never invited to is worse than a missed
         // reply the user can re-trigger with a mention.
         logger.warn(`Could not check the thread binding for ${threadTs}: ${error}`);
-        return null;
+        // Deliberately NOT cached: "we could not ask" is not "the answer is
+        // no", and caching it would extend one backend blip into a minute of
+        // silence in a thread that is genuinely engaged.
+        return { unavailable: true };
       });
-      if (!binding) return;
+      if (!binding) {
+        rememberUnbound(negativeKey);
+        return;
+      }
+      if (/** @type {any} */ (binding).unavailable) return;
       sessionStore.setSession(ctx.teamId, event.channel, threadTs, 'engaged');
     }
   } else {

--- a/slack-app/listeners/events/message.js
+++ b/slack-app/listeners/events/message.js
@@ -57,6 +57,9 @@ export async function handleMessage({ body, client, context, event, logger, say,
     channelId: event.channel,
     threadTs: event.thread_ts || event.ts,
     triggerTs: event.ts,
+    // Slack's event_id identifies the DELIVERY CHAIN: every redelivery of
+    // this event carries it unchanged, which is what the durable claim keys on.
+    ...(typeof body?.event_id === 'string' ? { eventId: body.event_id } : {}),
     // A DM top-level message has no thread yet; channel replies do.
     isThread: isThreadReply,
     fallbackText: event.text || '',

--- a/slack-app/listeners/events/message.js
+++ b/slack-app/listeners/events/message.js
@@ -56,6 +56,21 @@ function rememberUnbound(key) {
   unboundThreads.set(key, Date.now() + NEGATIVE_BINDING_TTL_MS);
 }
 
+/**
+ * Forget that a thread looked unbound.
+ *
+ * Called the moment a thread becomes engaged. Without it, a thread bound while
+ * a negative entry is live stays deaf for the rest of that entry's minute — the
+ * in-memory session hides the problem only until it is evicted, and then the
+ * stale miss suppresses replies to a thread the bot is genuinely part of.
+ * @param {string} teamId
+ * @param {string} channelId
+ * @param {string} threadTs
+ */
+export function forgetUnboundThread(teamId, channelId, threadTs) {
+  unboundThreads.delete(`${teamId}:${channelId}:${threadTs}`);
+}
+
 /** Test-only. */
 export function resetUnboundThreadCache() {
   unboundThreads.clear();

--- a/slack-app/listeners/events/message.js
+++ b/slack-app/listeners/events/message.js
@@ -1,4 +1,5 @@
 import { tryslackContextFrom } from '../../agent/slack-context.js';
+import { fetchThreadBinding } from '../../agent/turn-target.js';
 import { sessionStore } from '../../thread-context/index.js';
 import { runAndReply } from './run-and-reply.js';
 
@@ -38,9 +39,26 @@ export async function handleMessage({ body, client, context, event, logger, say,
   if (isDm) {
     // DMs are always handled
   } else if (isThreadReply) {
-    // Channel thread replies are handled only if the bot is already engaged
-    const session = sessionStore.getSession(ctx.teamId, event.channel, /** @type {string} */ (event.thread_ts));
-    if (session === null) return;
+    // Channel thread replies are handled only if the bot is already engaged.
+    //
+    // The in-memory store is a CACHE over the durable thread binding, not the
+    // source of truth: it dies with the process, so before this the bot went
+    // deaf in every engaged thread after a restart and the user had to
+    // re-mention it with no indication why. The binding is authoritative, so
+    // a miss falls through to it and re-warms the cache.
+    const threadTs = /** @type {string} */ (event.thread_ts);
+    if (sessionStore.getSession(ctx.teamId, event.channel, threadTs) === null) {
+      const binding = await fetchThreadBinding(ctx.teamId, event.channel, threadTs).catch((error) => {
+        // Unknown, not "not engaged". Dropping is the safe half of the
+        // decision: Slack will not retry a message we chose to ignore, but
+        // answering a thread we were never invited to is worse than a missed
+        // reply the user can re-trigger with a mention.
+        logger.warn(`Could not check the thread binding for ${threadTs}: ${error}`);
+        return null;
+      });
+      if (!binding) return;
+      sessionStore.setSession(ctx.teamId, event.channel, threadTs, 'engaged');
+    }
   } else {
     // Top-level channel messages are handled by app_mentioned
     return;

--- a/slack-app/listeners/events/message.js
+++ b/slack-app/listeners/events/message.js
@@ -1,3 +1,4 @@
+import { tryslackContextFrom } from '../../agent/slack-context.js';
 import { sessionStore } from '../../thread-context/index.js';
 import { runAndReply } from './run-and-reply.js';
 
@@ -14,12 +15,22 @@ function isGenericMessageEvent(event) {
  * @param {import('@slack/bolt').AllMiddlewareArgs & import('@slack/bolt').SlackEventMiddlewareArgs<'message'>} args
  * @returns {Promise<void>}
  */
-export async function handleMessage({ client, context, event, logger, say, sayStream, setStatus }) {
+export async function handleMessage({ body, client, context, event, logger, say, sayStream, setStatus }) {
   // Skip message subtypes (edits, deletes, etc.)
   if (!isGenericMessageEvent(event)) return;
 
   // Skip bot messages
   if (event.bot_id) return;
+
+  // A message with no resolvable tenant/actor is unroutable: we would not
+  // know whose credentials to act with. Drop it — there is nowhere safe to
+  // post an error, and answering under a guessed tenant is exactly the
+  // failure this threading exists to prevent.
+  const ctx = tryslackContextFrom({ body, context, event });
+  if (!ctx) {
+    logger.warn('Dropping a message event with no resolvable team/user id.');
+    return;
+  }
 
   const isDm = event.channel_type === 'im';
   const isThreadReply = !!event.thread_ts;
@@ -28,7 +39,7 @@ export async function handleMessage({ client, context, event, logger, say, saySt
     // DMs are always handled
   } else if (isThreadReply) {
     // Channel thread replies are handled only if the bot is already engaged
-    const session = sessionStore.getSession(event.channel, /** @type {string} */ (event.thread_ts));
+    const session = sessionStore.getSession(ctx.teamId, event.channel, /** @type {string} */ (event.thread_ts));
     if (session === null) return;
   } else {
     // Top-level channel messages are handled by app_mentioned
@@ -37,6 +48,7 @@ export async function handleMessage({ client, context, event, logger, say, saySt
 
   await runAndReply({
     client,
+    ctx,
     context,
     logger,
     say,

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -190,6 +190,36 @@ export async function runAndReply(args) {
       error instanceof McpjamApiError
         ? error.friendlyMessage
         : ':warning: Something went wrong. Try again in a moment.';
+    // A failed turn is not always an EMPTY turn: the runner attaches whatever
+    // the server says was already persisted (suites, proposals) before the
+    // failure. Showing those with the error is what keeps "ask again" from
+    // reading as "start over" — the user can see what exists and, crucially,
+    // what NOT to ask for a second time.
+    const envelope = /** @type {any} */ (error)?.failureEnvelope;
+    const salvaged =
+      envelope &&
+      ((envelope.createdResources?.length ?? 0) > 0 || (envelope.proposedActions?.length ?? 0) > 0);
+    if (salvaged) {
+      await say({
+        text,
+        thread_ts: args.threadTs,
+        blocks: [
+          { type: 'section', text: { type: 'mrkdwn', text: text.slice(0, 2900) } },
+          {
+            type: 'context',
+            elements: [
+              {
+                type: 'mrkdwn',
+                text: '_The turn failed partway, but this much was already created:_',
+              },
+            ],
+          },
+          ...buildCreatedResourceBlocks(envelope.createdResources ?? []),
+          ...buildProposalBlocks(envelope.proposedActions ?? []),
+        ],
+      });
+      return;
+    }
     await say({ text, thread_ts: args.threadTs });
   }
 }

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -19,6 +19,7 @@ import { buildFeedbackBlocks } from '../views/feedback-builder.js';
  *   channelId: string,
  *   threadTs: string,
  *   triggerTs: string,
+ *   eventId?: string,
  *   isThread: boolean,
  *   fallbackText: string,
  * }} args
@@ -35,6 +36,7 @@ export async function runAndReply(args) {
       channelId: args.channelId,
       threadTs: args.threadTs,
       triggerTs: args.triggerTs,
+      ...(args.eventId ? { eventId: args.eventId } : {}),
       isThread: args.isThread,
       botUserId: /** @type {string | undefined} */ (context.botUserId),
       fallbackText: args.fallbackText,
@@ -62,6 +64,28 @@ export async function runAndReply(args) {
         });
         await streamer.stop({
           blocks: [...buildCreatedResourceBlocks(result.createdResources), ...buildFeedbackBlocks()],
+        });
+      },
+      // A redelivery of an event we already answered: re-post the STORED
+      // reply rather than re-running the turn. Plain `say` rather than the
+      // streamer — there is nothing to stream, the text already exists, and
+      // the note tells the user why an old answer just reappeared.
+      onReplay: async (envelope) => {
+        await say({
+          text: envelope.reply || 'Done — though I have nothing to add.',
+          thread_ts: args.threadTs,
+          blocks: [
+            ...buildCreatedResourceBlocks(envelope.createdResources),
+            {
+              type: 'context',
+              elements: [
+                {
+                  type: 'mrkdwn',
+                  text: '_Slack redelivered this message; this is the answer I already produced._',
+                },
+              ],
+            },
+          ],
         });
       },
     });

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -197,8 +197,7 @@ export async function runAndReply(args) {
     // what NOT to ask for a second time.
     const envelope = /** @type {any} */ (error)?.failureEnvelope;
     const salvaged =
-      envelope &&
-      ((envelope.createdResources?.length ?? 0) > 0 || (envelope.proposedActions?.length ?? 0) > 0);
+      envelope && ((envelope.createdResources?.length ?? 0) > 0 || (envelope.proposedActions?.length ?? 0) > 0);
     if (salvaged) {
       await say({
         text,

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -10,6 +10,7 @@ import { buildFeedbackBlocks } from '../views/feedback-builder.js';
  *
  * @param {{
  *   client: import('@slack/web-api').WebClient,
+ *   ctx: import('../../agent/slack-context.js').SlackContext,
  *   context: import('@slack/bolt').Context,
  *   logger: import('@slack/bolt').Logger,
  *   say: Function,
@@ -30,6 +31,7 @@ export async function runAndReply(args) {
     // queue — the next turn's history must already contain this reply.
     await runTurnForEvent({
       client,
+      ctx: args.ctx,
       channelId: args.channelId,
       threadTs: args.threadTs,
       triggerTs: args.triggerTs,

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -43,18 +43,28 @@ export async function runAndReply(args) {
       // Ephemeral in a channel so a connect prompt meant for one person does
       // not become a notification for everyone in the thread. In a DM there
       // is nobody else, and an ephemeral message there is easy to miss.
-      const url = await mintConnectUrl(args.ctx);
+      // A failed mint must not fail the whole reply: the unlinked user would
+      // then get NOTHING, which reads as the bot ignoring them. Degrade to the
+      // buttonless copy instead.
+      const url = await mintConnectUrl(args.ctx).catch((error) => {
+        logger.error(`Could not mint a connect link: ${error}`);
+        return null;
+      });
       await postToRequester(args, {
-        text: 'Connect your MCPJam account to get started.',
+        text: url ? 'Connect your MCPJam account to get started.' : "I couldn't prepare a connection link just now.",
         blocks: buildConnectBlocks(url),
       });
       return;
     }
 
     if (target.mode === 'needs_project') {
+      // `appId` is what an App Home deep link needs; `botId` is a different
+      // namespace (`B…`) and produces a link that opens nothing. Only build one
+      // when we actually have the app id.
+      const appId = typeof context.appId === 'string' ? context.appId : undefined;
       await postToRequester(args, {
         text: 'Pick a default MCPJam project to get started.',
-        blocks: buildPickProjectBlocks(appHomeDeepLink(args.ctx.teamId, String(context.botId ?? context.appId ?? ''))),
+        blocks: buildPickProjectBlocks(appId ? appHomeDeepLink(args.ctx.teamId, appId) : null),
       });
       return;
     }
@@ -74,13 +84,22 @@ export async function runAndReply(args) {
         projectId: target.projectId,
         initiatorSlackUserId: args.ctx.slackUserId,
       }).catch((error) => {
-        // A thread that could not be bound still runs — losing the binding
-        // costs stability across restarts, not correctness of THIS turn,
-        // which is already clamped to the resolved project.
-        logger.warn(`Could not bind thread to a project: ${error}`);
+        logger.error(`Could not bind thread to a project: ${error}`);
         return null;
       });
-      if (binding && binding.projectId) credentialCtx.projectId = binding.projectId;
+      if (!binding) {
+        // FAIL the turn rather than running unbound. An unbound thread
+        // re-resolves on every reply, so the next person to speak would get
+        // THEIR default project and create resources somewhere the initiator
+        // never chose — a silent cross-project write, which is worse than a
+        // visible "try again".
+        await say({
+          text: ':warning: I could not pin this thread to a project. Try again in a moment.',
+          thread_ts: args.threadTs,
+        });
+        return;
+      }
+      if (binding.projectId) credentialCtx.projectId = binding.projectId;
     }
 
     // Posting is passed INTO the runner so it happens inside the per-thread
@@ -130,6 +149,16 @@ export async function runAndReply(args) {
           text: envelope.reply || 'Done — though I have nothing to add.',
           thread_ts: args.threadTs,
           blocks: [
+            // The reply TEXT has to be a block too: `text` alone is only the
+            // notification fallback, so a blocks-only replay would show the
+            // suite links and the note with the answer itself missing.
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: (envelope.reply || 'Done — though I have nothing to add.').slice(0, 2900),
+              },
+            },
             ...buildCreatedResourceBlocks(envelope.createdResources),
             {
               type: 'context',
@@ -140,6 +169,7 @@ export async function runAndReply(args) {
                 },
               ],
             },
+            ...buildFeedbackBlocks(),
           ],
         });
       },
@@ -164,7 +194,11 @@ export async function runAndReply(args) {
  * @param {{ text: string, blocks: unknown[] }} message
  */
 async function postToRequester(args, message) {
-  if (args.isThread) {
+  // `isThread` means "has a thread_ts", NOT "is a channel" — a threaded DM is
+  // both. Ephemerals in a DM are easy to miss, and this is the ONLY response
+  // the user gets, so branch on the channel type instead.
+  const isDirectMessage = args.channelId.startsWith('D');
+  if (args.isThread && !isDirectMessage) {
     await args.client.chat.postEphemeral({
       channel: args.channelId,
       user: args.ctx.slackUserId,

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -5,6 +5,7 @@ import { createThreadBinding, resolveTurnTarget } from '../../agent/turn-target.
 import { buildCreatedResourceBlocks } from '../views/agent-reply-builder.js';
 import { appHomeDeepLink, buildConnectBlocks, buildPickProjectBlocks } from '../views/connect-builder.js';
 import { buildFeedbackBlocks } from '../views/feedback-builder.js';
+import { buildProposalBlocks } from '../views/proposal-builder.js';
 
 /**
  * Shared body for both event listeners: run the turn (deduped + serialized
@@ -137,7 +138,11 @@ export async function runAndReply(args) {
           markdown_text: result.reply || 'Done — though I have nothing to add.',
         });
         await streamer.stop({
-          blocks: [...buildCreatedResourceBlocks(result.createdResources), ...buildFeedbackBlocks()],
+          blocks: [
+            ...buildCreatedResourceBlocks(result.createdResources),
+            ...buildProposalBlocks(result.proposedActions),
+            ...buildFeedbackBlocks(),
+          ],
         });
       },
       // A redelivery of an event we already answered: re-post the STORED
@@ -160,6 +165,11 @@ export async function runAndReply(args) {
               },
             },
             ...buildCreatedResourceBlocks(envelope.createdResources),
+            // Proposals replay too. They are still `proposed` server-side — the
+            // approval never happened — so re-offering them is the difference
+            // between a redelivery the user can act on and one that quietly
+            // drops the action they were about to approve.
+            ...buildProposalBlocks(envelope.proposedActions),
             {
               type: 'context',
               elements: [

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -1,6 +1,9 @@
+import { mintConnectUrl } from '../../agent/connect-link.js';
 import { McpjamApiError } from '../../agent/mcpjam-client.js';
 import { runTurnForEvent } from '../../agent/turn-runner.js';
+import { createThreadBinding, resolveTurnTarget } from '../../agent/turn-target.js';
 import { buildCreatedResourceBlocks } from '../views/agent-reply-builder.js';
+import { appHomeDeepLink, buildConnectBlocks, buildPickProjectBlocks } from '../views/connect-builder.js';
 import { buildFeedbackBlocks } from '../views/feedback-builder.js';
 
 /**
@@ -28,11 +31,63 @@ import { buildFeedbackBlocks } from '../views/feedback-builder.js';
 export async function runAndReply(args) {
   const { client, context, logger, say, sayStream, setStatus } = args;
   try {
+    // WHOSE credentials, and WHICH project. Resolved before any turn work so
+    // an unlinked user is offered a connect button instead of a failure, and
+    // a bound thread never re-resolves to a different project.
+    const target = await resolveTurnTarget(args.ctx, {
+      channelId: args.channelId,
+      threadTs: args.threadTs,
+    });
+
+    if (target.mode === 'unlinked') {
+      // Ephemeral in a channel so a connect prompt meant for one person does
+      // not become a notification for everyone in the thread. In a DM there
+      // is nobody else, and an ephemeral message there is easy to miss.
+      const url = await mintConnectUrl(args.ctx);
+      await postToRequester(args, {
+        text: 'Connect your MCPJam account to get started.',
+        blocks: buildConnectBlocks(url),
+      });
+      return;
+    }
+
+    if (target.mode === 'needs_project') {
+      await postToRequester(args, {
+        text: 'Pick a default MCPJam project to get started.',
+        blocks: buildPickProjectBlocks(appHomeDeepLink(args.ctx.teamId, String(context.botId ?? context.appId ?? ''))),
+      });
+      return;
+    }
+
+    // A new conversation binds to the initiator's org/project. Everything
+    // said in this thread afterwards belongs to that project, whoever says
+    // it — the alternative is a thread that drifts between projects and lands
+    // a suite somewhere nobody expected. First writer wins server-side, so a
+    // race here resolves to one binding rather than the last writer's.
+    const credentialCtx = { ...args.ctx, mode: target.mode, projectId: target.projectId };
+    if (!target.boundThread && target.mode === 'user' && target.organizationId && target.projectId) {
+      const binding = await createThreadBinding({
+        teamId: args.ctx.teamId,
+        channelId: args.channelId,
+        threadTs: args.threadTs,
+        organizationId: target.organizationId,
+        projectId: target.projectId,
+        initiatorSlackUserId: args.ctx.slackUserId,
+      }).catch((error) => {
+        // A thread that could not be bound still runs — losing the binding
+        // costs stability across restarts, not correctness of THIS turn,
+        // which is already clamped to the resolved project.
+        logger.warn(`Could not bind thread to a project: ${error}`);
+        return null;
+      });
+      if (binding && binding.projectId) credentialCtx.projectId = binding.projectId;
+    }
+
     // Posting is passed INTO the runner so it happens inside the per-thread
     // queue — the next turn's history must already contain this reply.
     await runTurnForEvent({
       client,
-      ctx: args.ctx,
+      ctx: credentialCtx,
       channelId: args.channelId,
       threadTs: args.threadTs,
       triggerTs: args.triggerTs,
@@ -97,4 +152,31 @@ export async function runAndReply(args) {
         : ':warning: Something went wrong. Try again in a moment.';
     await say({ text, thread_ts: args.threadTs });
   }
+}
+
+/**
+ * Post to the person who triggered the turn, and only to them, when the
+ * message is about THEIR account rather than the conversation. Channels get
+ * an ephemeral; DMs get a normal message (there is nobody else to shield, and
+ * ephemerals in a DM are easy to miss).
+ *
+ * @param {Parameters<typeof runAndReply>[0]} args
+ * @param {{ text: string, blocks: unknown[] }} message
+ */
+async function postToRequester(args, message) {
+  if (args.isThread) {
+    await args.client.chat.postEphemeral({
+      channel: args.channelId,
+      user: args.ctx.slackUserId,
+      thread_ts: args.threadTs,
+      text: message.text,
+      blocks: /** @type {any} */ (message.blocks),
+    });
+    return;
+  }
+  await args.say({
+    text: message.text,
+    thread_ts: args.threadTs,
+    blocks: message.blocks,
+  });
 }

--- a/slack-app/listeners/index.js
+++ b/slack-app/listeners/index.js
@@ -1,13 +1,21 @@
 import * as actions from './actions/index.js';
 import * as events from './events/index.js';
+import { tenantGuard } from './middleware/tenant-guard.js';
 import * as views from './views/index.js';
 
 /**
  * Register all Slack event, action, and view listeners.
+ *
+ * The tenant guard is installed as GLOBAL middleware, ahead of every
+ * listener, so exactly one place decides whether a workspace may run a turn.
+ * Per-listener checks would always be one forgotten `if` away from a gap, and
+ * that gap would be a cross-tenant one.
+ *
  * @param {import('@slack/bolt').App} app
  * @returns {void}
  */
 export function registerListeners(app) {
+  app.use(tenantGuard);
   actions.register(app);
   events.register(app);
   views.register(app);

--- a/slack-app/listeners/middleware/tenant-guard.js
+++ b/slack-app/listeners/middleware/tenant-guard.js
@@ -1,17 +1,14 @@
 /**
- * Global middleware: resolve the tenant for every inbound payload and decide
- * whether this workspace may run a turn at all.
+ * Global middleware: resolve the tenant for every inbound payload and confirm
+ * the workspace still has a live installation.
  *
- * Distribution is activated during Phase 1/2 ONLY so we can test the install
- * flow against a second, throwaway workspace. Until per-user account linking
- * ships, the bot still acts with a single org-scoped `sk_` key from env — so
- * an event from any workspace OTHER than the legacy one would run that
- * workspace's request against OUR organization's project. That is a
- * cross-tenant data leak, not a degraded experience, so those events are
- * HARD-DROPPED here, before any agent call.
- *
- * This drop is removed in the PR that switches the bot to per-user `slk_`
- * credentials; from then on an unlinked user gets connect UX instead.
+ * It no longer decides whether a workspace may be SERVED — per-user auth has
+ * shipped, so every installed workspace is served and the identity question is
+ * answered per ACTOR further down (`resolveTurnTarget`): a linked user acts as
+ * themselves, an unlinked one is offered a connect button. What stays here is
+ * the one thing that is genuinely per-workspace: an event from a team with no
+ * active installation is dropped, because we have no token to answer with and
+ * no consent to act on.
  */
 import { tryslackContextFrom } from '../../agent/slack-context.js';
 import { InstallationBackendError } from '../../installations/backend-client.js';
@@ -72,21 +69,12 @@ export async function tenantGuard(args) {
     return;
   }
 
-  if (!record.isLegacyWorkspace) {
-    // The install succeeded and the workspace is genuinely ours to serve —
-    // we simply have no per-workspace credentials for it yet. Silent is
-    // correct for now: a "coming soon" reply in every channel of a test
-    // workspace is noise, and the connect UX that replaces this drop is one
-    // PR away.
-    logger?.info?.(`Dropping an event from non-legacy team ${ctx.teamId}: per-user auth has not shipped yet.`);
-    return;
-  }
-
   // Publish the tenancy verdict so the credential seam (`getConfig`) can
   // assert it rather than re-deriving it. `context` is Bolt's per-request bag
-  // and is what `slackContextFrom` reads.
+  // and is what `slackContextFrom` reads. The legacy flag is now only about
+  // whether the SHARED env key may be released — it no longer gates service.
   context.mcpjamTenancy = {
-    isLegacyWorkspace: true,
+    isLegacyWorkspace: record.isLegacyWorkspace === true,
     botUserId: record.botUserId,
   };
 

--- a/slack-app/listeners/middleware/tenant-guard.js
+++ b/slack-app/listeners/middleware/tenant-guard.js
@@ -1,0 +1,94 @@
+/**
+ * Global middleware: resolve the tenant for every inbound payload and decide
+ * whether this workspace may run a turn at all.
+ *
+ * Distribution is activated during Phase 1/2 ONLY so we can test the install
+ * flow against a second, throwaway workspace. Until per-user account linking
+ * ships, the bot still acts with a single org-scoped `sk_` key from env — so
+ * an event from any workspace OTHER than the legacy one would run that
+ * workspace's request against OUR organization's project. That is a
+ * cross-tenant data leak, not a degraded experience, so those events are
+ * HARD-DROPPED here, before any agent call.
+ *
+ * This drop is removed in the PR that switches the bot to per-user `slk_`
+ * credentials; from then on an unlinked user gets connect UX instead.
+ */
+import { tryslackContextFrom } from '../../agent/slack-context.js';
+import { InstallationBackendError } from '../../installations/backend-client.js';
+import { resolveInstallation } from '../../installations/store.js';
+
+/**
+ * Payload types that must never be gated: they are how a workspace TELLS us
+ * it revoked us. Dropping them would leave a revoked installation live in the
+ * cache and the database.
+ */
+const LIFECYCLE_EVENT_TYPES = new Set(['app_uninstalled', 'tokens_revoked']);
+
+/**
+ * @param {Record<string, any>} args
+ * @returns {boolean}
+ */
+function isLifecyclePayload(args) {
+  const type = args?.payload?.type ?? args?.event?.type ?? args?.body?.event?.type;
+  return typeof type === 'string' && LIFECYCLE_EVENT_TYPES.has(type);
+}
+
+/**
+ * Bolt global middleware.
+ * @param {Record<string, any>} args
+ * @returns {Promise<void>}
+ */
+export async function tenantGuard(args) {
+  const { body, context, event, payload, logger, next } = args;
+
+  if (isLifecyclePayload(args)) {
+    await next();
+    return;
+  }
+
+  const ctx = tryslackContextFrom({ body, context, event, payload });
+  if (!ctx) {
+    // No tenant, no route. Not an error worth surfacing — Slack sends plenty
+    // of payloads (channel_join, bot echoes) with no actionable actor.
+    return;
+  }
+
+  let record;
+  try {
+    record = await resolveInstallation(ctx.teamId);
+  } catch (error) {
+    // A backend outage must not be reported as "you are not installed" and
+    // must not silently run a turn under someone else's credentials. Drop the
+    // event and let Slack's retry find a healthy process.
+    if (error instanceof InstallationBackendError) {
+      logger?.warn?.(`Tenant lookup failed for team ${ctx.teamId}; dropping event for retry.`);
+      return;
+    }
+    throw error;
+  }
+
+  if (!record) {
+    logger?.warn?.(`Dropping an event from team ${ctx.teamId}: no active installation.`);
+    return;
+  }
+
+  if (!record.isLegacyWorkspace) {
+    // The install succeeded and the workspace is genuinely ours to serve —
+    // we simply have no per-workspace credentials for it yet. Silent is
+    // correct for now: a "coming soon" reply in every channel of a test
+    // workspace is noise, and the connect UX that replaces this drop is one
+    // PR away.
+    logger?.info?.(`Dropping an event from non-legacy team ${ctx.teamId}: per-user auth has not shipped yet.`);
+    return;
+  }
+
+  // Publish the tenancy verdict so the credential seam (`getConfig`) can
+  // assert it rather than re-deriving it. `context` is Bolt's per-request bag
+  // and is what `slackContextFrom` reads.
+  context.mcpjamTenancy = {
+    isLegacyWorkspace: true,
+    botUserId: record.botUserId,
+  };
+
+  await next();
+}

--- a/slack-app/listeners/middleware/tenant-guard.js
+++ b/slack-app/listeners/middleware/tenant-guard.js
@@ -11,7 +11,7 @@
  * no consent to act on.
  */
 import { tryslackContextFrom } from '../../agent/slack-context.js';
-import { InstallationBackendError } from '../../installations/backend-client.js';
+import { hasBackendConfig, InstallationBackendError } from '../../installations/backend-client.js';
 import { resolveInstallation } from '../../installations/store.js';
 
 /**
@@ -39,6 +39,16 @@ export async function tenantGuard(args) {
   const { body, context, event, payload, logger, next } = args;
 
   if (isLifecyclePayload(args)) {
+    await next();
+    return;
+  }
+
+  // Socket mode (local dev) has no installation store to consult: the single
+  // workspace's token comes from env and Bolt has already authorized the
+  // event. Without this the guard's outage branch below would catch the
+  // CONFIG error from an unconfigured backend and drop EVERY event, turning
+  // `slack run` into a bot that acks and ignores everything.
+  if (!hasBackendConfig()) {
     await next();
     return;
   }

--- a/slack-app/listeners/views/app-home-builder.js
+++ b/slack-app/listeners/views/app-home-builder.js
@@ -1,8 +1,23 @@
+import { CONNECT_ACTION_ID, PROJECT_PICKER_ACTION_ID, UNLINK_ACTION_ID } from './connect-builder.js';
+
 /**
  * Build the App Home Block Kit view.
+ *
+ * The Home tab is where a user manages the CONNECTION itself — the one thing
+ * they cannot do from a conversation, because it is about their account rather
+ * than about anything being discussed. It shows exactly one of two states, so
+ * there is never ambiguity about whether the bot can act for them.
+ *
+ * @param {{
+ *   connected: boolean,
+ *   connectUrl?: string,
+ *   projects?: Array<{ id: string, name: string }>,
+ *   defaultProjectId?: string | null,
+ *   projectsError?: boolean,
+ * }} [state]
  * @returns {import('@slack/types').HomeView}
  */
-export function buildAppHomeView() {
+export function buildAppHomeView(state = { connected: false }) {
   /** @type {import('@slack/types').KnownBlock[]} */
   const blocks = [
     {
@@ -24,6 +39,119 @@ export function buildAppHomeView() {
       },
     },
     { type: 'divider' },
+  ];
+
+  if (!state.connected) {
+    blocks.push(
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text:
+            "*Your MCPJam account isn't connected yet.*\n" +
+            'Connecting lets me act as _you_: everything I create lands in your own ' +
+            'project, and I can only do what your account can do.',
+        },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            action_id: CONNECT_ACTION_ID,
+            style: 'primary',
+            text: { type: 'plain_text', text: 'Connect MCPJam' },
+            ...(state.connectUrl ? { url: state.connectUrl } : {}),
+          },
+        ],
+      },
+    );
+    return { type: 'home', blocks };
+  }
+
+  blocks.push({
+    type: 'section',
+    text: {
+      type: 'mrkdwn',
+      text: '*Your MCPJam account is connected.* :white_check_mark:',
+    },
+  });
+
+  if (state.projectsError) {
+    // Say what happened rather than rendering an empty picker, which would
+    // read as "you have no projects" — a very different and alarming claim.
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: ":warning: I couldn't load your projects just now. Reopen this tab in a moment.",
+      },
+    });
+  } else {
+    const projects = state.projects ?? [];
+    // Slack rejects option text longer than 75 characters and more than 100
+    // options outright — the whole `views.publish` fails rather than one row
+    // being truncated, so both caps are applied here.
+    const options = projects.slice(0, 100).map((project) => ({
+      text: { type: /** @type {const} */ ('plain_text'), text: project.name.slice(0, 75) },
+      value: project.id,
+    }));
+    const selected = options.find((option) => option.value === state.defaultProjectId);
+
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '*Default project*\nWhere your Slack work lands when a thread has no project of its own.',
+      },
+      ...(options.length > 0
+        ? {
+            accessory: {
+              type: 'static_select',
+              action_id: PROJECT_PICKER_ACTION_ID,
+              placeholder: { type: 'plain_text', text: 'Pick a project' },
+              options,
+              ...(selected ? { initial_option: selected } : {}),
+            },
+          }
+        : {}),
+    });
+
+    if (options.length === 0) {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '_No projects yet — create one at <https://app.mcpjam.com|app.mcpjam.com> and reopen this tab._',
+        },
+      });
+    }
+  }
+
+  blocks.push(
+    { type: 'divider' },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          action_id: UNLINK_ACTION_ID,
+          style: 'danger',
+          text: { type: 'plain_text', text: 'Disconnect MCPJam' },
+          // Slack's own confirm dialog: disconnecting is easy to click by
+          // accident and stops the bot working for this person entirely.
+          confirm: {
+            title: { type: 'plain_text', text: 'Disconnect MCPJam?' },
+            text: {
+              type: 'mrkdwn',
+              text: "I'll stop acting as you in Slack. Nothing you've already created is deleted.",
+            },
+            confirm: { type: 'plain_text', text: 'Disconnect' },
+            deny: { type: 'plain_text', text: 'Cancel' },
+          },
+        },
+      ],
+    },
     {
       type: 'context',
       elements: [
@@ -33,7 +161,7 @@ export function buildAppHomeView() {
         },
       ],
     },
-  ];
+  );
 
   return { type: 'home', blocks };
 }

--- a/slack-app/listeners/views/app-home-builder.js
+++ b/slack-app/listeners/views/app-home-builder.js
@@ -14,6 +14,8 @@ import { CONNECT_ACTION_ID, PROJECT_PICKER_ACTION_ID, UNLINK_ACTION_ID } from '.
  *   projects?: Array<{ id: string, name: string }>,
  *   defaultProjectId?: string | null,
  *   projectsError?: boolean,
+ *   unavailable?: boolean,
+ *   appUrl?: string,
  * }} [state]
  * @returns {import('@slack/types').HomeView}
  */
@@ -41,6 +43,20 @@ export function buildAppHomeView(state = { connected: false }) {
     { type: 'divider' },
   ];
 
+  if (state.unavailable) {
+    // We could not ASK whether they are linked. Rendering the connect state
+    // would tell a linked user to link again — they would do it, and learn
+    // nothing about why the bot was not working.
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: ":warning: *I can't reach MCPJam right now.* Reopen this tab in a moment.",
+      },
+    });
+    return { type: 'home', blocks };
+  }
+
   if (!state.connected) {
     blocks.push(
       {
@@ -53,18 +69,29 @@ export function buildAppHomeView(state = { connected: false }) {
             'project, and I can only do what your account can do.',
         },
       },
-      {
-        type: 'actions',
-        elements: [
+      state.connectUrl
+        ? {
+            type: 'actions',
+            elements: [
+              {
+                type: 'button',
+                action_id: CONNECT_ACTION_ID,
+                style: 'primary',
+                text: { type: 'plain_text', text: 'Connect MCPJam' },
+                url: state.connectUrl,
+              },
+            ],
+          }
+        : // No URL means the mint failed. A button that opens nothing is worse
+          // than no button: it looks like the flow is broken on the user's
+          // side rather than ours.
           {
-            type: 'button',
-            action_id: CONNECT_ACTION_ID,
-            style: 'primary',
-            text: { type: 'plain_text', text: 'Connect MCPJam' },
-            ...(state.connectUrl ? { url: state.connectUrl } : {}),
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: ":warning: I couldn't prepare a connection link just now. Reopen this tab in a moment.",
+            },
           },
-        ],
-      },
     );
     return { type: 'home', blocks };
   }
@@ -92,11 +119,28 @@ export function buildAppHomeView(state = { connected: false }) {
     // Slack rejects option text longer than 75 characters and more than 100
     // options outright — the whole `views.publish` fails rather than one row
     // being truncated, so both caps are applied here.
-    const options = projects.slice(0, 100).map((project) => ({
-      text: { type: /** @type {const} */ ('plain_text'), text: project.name.slice(0, 75) },
+    // Slack hard-caps a static_select at 100 options and 75 chars of option
+    // text; exceeding either fails the whole `views.publish`. Keep the CURRENT
+    // default in the list even if it sorts past the cap — otherwise the picker
+    // would render as though nothing were selected and a stray click would
+    // silently change it.
+    const capped = projects.slice(0, 100);
+    if (state.defaultProjectId && !capped.some((project) => project.id === state.defaultProjectId)) {
+      const current = projects.find((project) => project.id === state.defaultProjectId);
+      if (current) capped.splice(99, 1, current);
+    }
+    const options = capped.map((project) => ({
+      // Slack rejects an EMPTY plain_text outright, failing the whole
+      // `views.publish` — so an unnamed project would blank the entire Home
+      // tab rather than showing one odd row.
+      text: {
+        type: /** @type {const} */ ('plain_text'),
+        text: (project.name || '').trim().slice(0, 75) || 'Untitled project',
+      },
       value: project.id,
     }));
     const selected = options.find((option) => option.value === state.defaultProjectId);
+    const truncated = projects.length > options.length;
 
     blocks.push({
       type: 'section',
@@ -117,13 +161,26 @@ export function buildAppHomeView(state = { connected: false }) {
         : {}),
     });
 
+    const appUrl = state.appUrl || 'https://app.mcpjam.com';
     if (options.length === 0) {
       blocks.push({
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: '_No projects yet — create one at <https://app.mcpjam.com|app.mcpjam.com> and reopen this tab._',
+          text: `_No projects yet — create one at <${appUrl}|the MCPJam app> and reopen this tab._`,
         },
+      });
+    } else if (truncated) {
+      // Say so rather than silently dropping them: a user with more projects
+      // than the cap should know why theirs is missing.
+      blocks.push({
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `_Showing ${options.length} of ${projects.length} projects (Slack caps this list). Set others from <${appUrl}|the MCPJam app>._`,
+          },
+        ],
       });
     }
   }
@@ -157,7 +214,7 @@ export function buildAppHomeView(state = { connected: false }) {
       elements: [
         {
           type: 'mrkdwn',
-          text: 'Powered by the MCPJam public API — <https://app.mcpjam.com|open the app> to see your suites and runs.',
+          text: `Powered by the MCPJam public API — <${state.appUrl || 'https://app.mcpjam.com'}|open the app> to see your suites and runs.`,
         },
       ],
     },

--- a/slack-app/listeners/views/connect-builder.js
+++ b/slack-app/listeners/views/connect-builder.js
@@ -19,10 +19,24 @@ export const PROJECT_PICKER_ACTION_ID = 'mcpjam_pick_default_project';
  * render time keeps the clock honest, and a click that merely opens a link is
  * one round trip fewer than a click that has to mint one first.
  *
- * @param {string} url
+ * @param {string | null | undefined} url  Absent when the mint failed.
  * @returns {import('@slack/types').KnownBlock[]}
  */
 export function buildConnectBlocks(url) {
+  if (!url) {
+    // Slack rejects a `url`-less link button outright, so a failed mint would
+    // fail the whole post and the user would get nothing at all. Say what
+    // happened instead — and do not imply the fault is theirs.
+    return [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: ":warning: *I couldn't prepare a connection link just now.* Try me again in a moment.",
+        },
+      },
+    ];
+  }
   return [
     {
       type: 'section',
@@ -60,7 +74,7 @@ export function buildConnectBlocks(url) {
 
 /**
  * Shown to a linked user who has not picked a default project yet.
- * @param {string} appHomeUrl
+ * @param {string | null | undefined} appHomeUrl  Absent when the app id is unknown.
  * @returns {import('@slack/types').KnownBlock[]}
  */
 export function buildPickProjectBlocks(appHomeUrl) {
@@ -71,20 +85,28 @@ export function buildPickProjectBlocks(appHomeUrl) {
         type: 'mrkdwn',
         text:
           '*Your account is connected — I just need to know where to put things.*\n' +
-          'Pick a default project and I can get going.',
+          (appHomeUrl
+            ? 'Pick a default project and I can get going.'
+            : 'Open my *Home* tab and pick a default project, and I can get going.'),
       },
     },
-    {
-      type: 'actions',
-      elements: [
-        {
-          type: 'button',
-          action_id: 'mcpjam_open_home',
-          text: { type: 'plain_text', text: 'Pick a project' },
-          url: appHomeUrl,
-        },
-      ],
-    },
+    // Without an app id the deep link points at nothing; a button that opens
+    // nowhere is worse than the sentence above, which the user can act on.
+    ...(appHomeUrl
+      ? [
+          /** @type {import('@slack/types').KnownBlock} */ ({
+            type: 'actions',
+            elements: [
+              {
+                type: 'button',
+                action_id: 'mcpjam_open_home',
+                text: { type: 'plain_text', text: 'Pick a project' },
+                url: appHomeUrl,
+              },
+            ],
+          }),
+        ]
+      : []),
   ];
 }
 

--- a/slack-app/listeners/views/connect-builder.js
+++ b/slack-app/listeners/views/connect-builder.js
@@ -1,0 +1,100 @@
+/**
+ * Block Kit for the two states a user can be in before they can be served:
+ * not linked, and linked-but-no-project.
+ *
+ * Both are UX states, not errors. A first-time user in a workspace that just
+ * installed the app has done nothing wrong, and an error-shaped message would
+ * read as "the bot is broken" rather than "here is the one thing to do".
+ */
+
+export const CONNECT_ACTION_ID = 'mcpjam_connect_account';
+export const UNLINK_ACTION_ID = 'mcpjam_unlink_account';
+export const PROJECT_PICKER_ACTION_ID = 'mcpjam_pick_default_project';
+
+/**
+ * "Connect MCPJam" — shown to an unlinked user.
+ *
+ * The button carries the connect URL rather than the flow being started by the
+ * click, because the URL is minted per user and expires: generating it at
+ * render time keeps the clock honest, and a click that merely opens a link is
+ * one round trip fewer than a click that has to mint one first.
+ *
+ * @param {string} url
+ * @returns {import('@slack/types').KnownBlock[]}
+ */
+export function buildConnectBlocks(url) {
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text:
+          '*Connect your MCPJam account to get started.*\n' +
+          "I'll act as _you_ — everything I create lands in your own project, " +
+          'and I can only do what your account can do.',
+      },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          action_id: CONNECT_ACTION_ID,
+          style: 'primary',
+          text: { type: 'plain_text', text: 'Connect MCPJam' },
+          url,
+        },
+      ],
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: '_This link is for you and expires in 10 minutes. It only works when opened by your Slack account._',
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Shown to a linked user who has not picked a default project yet.
+ * @param {string} appHomeUrl
+ * @returns {import('@slack/types').KnownBlock[]}
+ */
+export function buildPickProjectBlocks(appHomeUrl) {
+  return [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text:
+          '*Your account is connected — I just need to know where to put things.*\n' +
+          'Pick a default project and I can get going.',
+      },
+    },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          action_id: 'mcpjam_open_home',
+          text: { type: 'plain_text', text: 'Pick a project' },
+          url: appHomeUrl,
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Deep link to the app's Home tab. Slack has no first-party URL for "open my
+ * App Home", so this uses the documented `slack://` app form with an https
+ * fallback the desktop client rewrites.
+ * @param {string} teamId
+ * @param {string} appId
+ */
+export function appHomeDeepLink(teamId, appId) {
+  return `slack://app?team=${encodeURIComponent(teamId)}&id=${encodeURIComponent(appId)}&tab=home`;
+}

--- a/slack-app/listeners/views/home-state.js
+++ b/slack-app/listeners/views/home-state.js
@@ -1,0 +1,78 @@
+/**
+ * Resolve the App Home's state for one user.
+ *
+ * The distinction that matters: "we asked and they are not linked" versus "we
+ * could not ask". Collapsing them shows a linked user a Connect button, which
+ * they will click — starting a second link flow and learning nothing about why
+ * the bot was actually unavailable.
+ */
+import { mintConnectUrl } from '../../agent/connect-link.js';
+import { listProjects } from '../../agent/mcpjam-client.js';
+import { fetchAccountLink, hasPerUserAuth } from '../../agent/turn-target.js';
+
+/** Deep links and "create a project" prompts must point at the deployment in use. */
+export function resolveAppUrl() {
+  const base = process.env.MCPJAM_APP_URL || process.env.MCPJAM_BASE_URL || 'https://app.mcpjam.com';
+  return base.replace(/\/+$/, '');
+}
+
+/**
+ * @param {import('../../agent/slack-context.js').SlackContext} ctx
+ * @param {{ logger?: { warn?: Function } }} [opts]
+ * @returns {Promise<Parameters<typeof import('./app-home-builder.js').buildAppHomeView>[0]>}
+ */
+export async function resolveHomeState(ctx, opts = {}) {
+  const appUrl = resolveAppUrl();
+
+  // Legacy/dev deployments have no per-user auth at all — a connect button
+  // would lead nowhere, so show the connected shape with an empty picker.
+  if (!hasPerUserAuth()) {
+    return { connected: true, projects: [], appUrl };
+  }
+
+  let link;
+  try {
+    link = await fetchAccountLink(ctx.teamId, ctx.slackUserId);
+  } catch (error) {
+    opts.logger?.warn?.(`Could not resolve the account link for App Home: ${error}`);
+    return { connected: false, unavailable: true, appUrl };
+  }
+
+  if (!link) {
+    // Minted per render so the 10-minute clock starts when the user is
+    // actually looking at the button. A failed mint renders an explicit
+    // unavailable state rather than a dead button (see the builder).
+    let connectUrl;
+    try {
+      connectUrl = await mintConnectUrl(ctx);
+    } catch (error) {
+      opts.logger?.warn?.(`Could not mint a connect URL: ${error}`);
+    }
+    return { connected: false, ...(connectUrl ? { connectUrl } : {}), appUrl };
+  }
+
+  // The project list comes from the USER's credentials, so it is exactly what
+  // they may act in — never a superset borrowed from the bot, which would
+  // offer projects the picker could not actually save.
+  try {
+    const projects = await listProjects({
+      ...ctx,
+      mode: 'user',
+      projectId: link.defaultProjectId ?? undefined,
+    });
+    return {
+      connected: true,
+      projects,
+      defaultProjectId: link.defaultProjectId ?? null,
+      appUrl,
+    };
+  } catch (error) {
+    opts.logger?.warn?.(`Could not list projects for the App Home picker: ${error}`);
+    return {
+      connected: true,
+      projectsError: true,
+      defaultProjectId: link.defaultProjectId ?? null,
+      appUrl,
+    };
+  }
+}

--- a/slack-app/listeners/views/home-state.js
+++ b/slack-app/listeners/views/home-state.js
@@ -24,10 +24,13 @@ export function resolveAppUrl() {
 export async function resolveHomeState(ctx, opts = {}) {
   const appUrl = resolveAppUrl();
 
-  // Legacy/dev deployments have no per-user auth at all — a connect button
-  // would lead nowhere, so show the connected shape with an empty picker.
+  // No per-user auth configured at all (legacy/dev). Mirror `resolveTurnTarget`
+  // exactly: it serves this workspace only when it is the LEGACY one, so
+  // claiming "connected" anywhere else would hand the user a Disconnect button
+  // for a link they do not have, sitting above a bot that answers every message
+  // with a connect prompt. Two controls, opposite stories.
   if (!hasPerUserAuth()) {
-    return { connected: true, projects: [], appUrl };
+    return ctx.isLegacyWorkspace === true ? { connected: true, projects: [], appUrl } : { connected: false, appUrl };
   }
 
   let link;

--- a/slack-app/listeners/views/proposal-builder.js
+++ b/slack-app/listeners/views/proposal-builder.js
@@ -24,6 +24,22 @@ const MAX_PROPOSAL_BLOCKS = 5;
 /** Slack caps a button label at 75 characters. */
 const MAX_BUTTON_LABEL = 75;
 
+/**
+ * Slack rejects a section whose text exceeds 3,000 characters, and a rejected
+ * block takes the WHOLE message down — the answer, the suite links, and every
+ * approval button with it. The description is agent output, so it is capped
+ * BEFORE escaping: escaping can quintuple length (`&` → `&amp;`), and capping
+ * afterwards could slice an entity in half.
+ */
+const MAX_DESCRIPTION_CHARS = 400;
+
+/** @param {string} text */
+function toDescription(text) {
+  const chars = Array.from(text);
+  const capped = chars.length > MAX_DESCRIPTION_CHARS ? `${chars.slice(0, MAX_DESCRIPTION_CHARS - 1).join('')}…` : text;
+  return escapeSlackText(capped);
+}
+
 /** Verb for the button, per operation. Falls back to a neutral "Approve". */
 const BUTTON_LABELS = {
   run_eval_suite: 'Run it',
@@ -52,9 +68,9 @@ export function buildProposalBlocks(proposals) {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        // The description is agent output, so it is escaped: raw `<`/`>` in
-        // mrkdwn can forge a mention or a link.
-        text: `:hourglass_flowing_sand: *${escapeSlackText(String(proposal.description || 'Action'))}*\nThis one costs — it runs when you approve it.`,
+        // Capped, then escaped: raw `<`/`>` in mrkdwn can forge a mention or a
+        // link, and an uncapped section fails the whole post.
+        text: `:hourglass_flowing_sand: *${toDescription(String(proposal.description || 'Action'))}*\nThis one costs — it runs when you approve it.`,
       },
       accessory: {
         type: 'button',

--- a/slack-app/listeners/views/proposal-builder.js
+++ b/slack-app/listeners/views/proposal-builder.js
@@ -1,0 +1,90 @@
+/**
+ * Blocks for actions the agent wants to take but may not take by itself.
+ *
+ * The agent turn can read the project and author suites; it cannot spend. When
+ * it decides a suite should RUN, a case should run, cases should be generated,
+ * or a run should be cancelled, it proposes — and this is what the person sees.
+ *
+ * The button carries ONLY the action id. Everything about what the click does
+ * lives in the persisted proposal, because anyone who can post a Block Kit
+ * message in the workspace can mint a button with any `value` they like. A
+ * click may say WHICH action to run; it may never say what that action is.
+ */
+import { escapeSlackText } from './agent-reply-builder.js';
+
+export const PROPOSAL_ACTION_ID = 'mcpjam_approve_action';
+
+/**
+ * Slack allows 50 blocks per message and this reply already carries suite
+ * blocks and feedback blocks. Leave room rather than letting the post reject
+ * and take the whole answer down with it.
+ */
+const MAX_PROPOSAL_BLOCKS = 5;
+
+/** Slack caps a button label at 75 characters. */
+const MAX_BUTTON_LABEL = 75;
+
+/** Verb for the button, per operation. Falls back to a neutral "Approve". */
+const BUTTON_LABELS = {
+  run_eval_suite: 'Run it',
+  run_eval_case: 'Run it',
+  generate_eval_cases: 'Generate them',
+  cancel_eval_run: 'Cancel the run',
+};
+
+/**
+ * @param {Array<import('../../agent/mcpjam-client.js').ProposedAction> | undefined} proposals
+ * @returns {Array<Record<string, unknown>>}
+ */
+export function buildProposalBlocks(proposals) {
+  if (!Array.isArray(proposals) || proposals.length === 0) return [];
+
+  const shown = proposals.slice(0, MAX_PROPOSAL_BLOCKS);
+  /** @type {Array<Record<string, unknown>>} */
+  const blocks = [];
+  for (const proposal of shown) {
+    if (!proposal?.actionId) continue;
+    const label = (BUTTON_LABELS[/** @type {keyof typeof BUTTON_LABELS} */ (proposal.operation)] || 'Approve').slice(
+      0,
+      MAX_BUTTON_LABEL,
+    );
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        // The description is agent output, so it is escaped: raw `<`/`>` in
+        // mrkdwn can forge a mention or a link.
+        text: `:hourglass_flowing_sand: *${escapeSlackText(String(proposal.description || 'Action'))}*\nThis one costs — it runs when you approve it.`,
+      },
+      accessory: {
+        type: 'button',
+        style: 'primary',
+        text: { type: 'plain_text', text: label },
+        action_id: PROPOSAL_ACTION_ID,
+        value: proposal.actionId,
+        // Spending is easy to click by accident and cannot be taken back.
+        confirm: {
+          title: { type: 'plain_text', text: 'Approve this action?' },
+          text: {
+            type: 'mrkdwn',
+            text: "This runs as *you* and uses your organization's quota.",
+          },
+          confirm: { type: 'plain_text', text: label },
+          deny: { type: 'plain_text', text: 'Not now' },
+        },
+      },
+    });
+  }
+  if (proposals.length > shown.length) {
+    blocks.push({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: `_…and ${proposals.length - shown.length} more proposed — open MCPJam to review them._`,
+        },
+      ],
+    });
+  }
+  return blocks;
+}

--- a/slack-app/manifest.json
+++ b/slack-app/manifest.json
@@ -18,6 +18,10 @@
     }
   },
   "oauth_config": {
+    "redirect_urls": [
+      "https://slack.mcpjam.com/slack/oauth_redirect",
+      "https://app.mcpjam.com/api/slack/link/slack/callback"
+    ],
     "scopes": {
       "bot": [
         "app_mentions:read",
@@ -25,20 +29,31 @@
         "chat:write",
         "groups:history",
         "im:history",
-        "im:read",
         "im:write",
         "assistant:write"
-      ]
+      ],
+      "user": ["openid", "profile"]
     }
   },
   "settings": {
     "event_subscriptions": {
-      "bot_events": ["app_home_opened", "app_mention", "message.channels", "message.groups", "message.im"]
+      "request_url": "https://slack.mcpjam.com/slack/events",
+      "bot_events": [
+        "app_home_opened",
+        "app_mention",
+        "app_uninstalled",
+        "message.channels",
+        "message.groups",
+        "message.im",
+        "tokens_revoked"
+      ]
     },
     "interactivity": {
-      "is_enabled": true
+      "is_enabled": true,
+      "request_url": "https://slack.mcpjam.com/slack/events"
     },
-    "socket_mode_enabled": true,
-    "token_rotation_enabled": false
+    "socket_mode_enabled": false,
+    "token_rotation_enabled": false,
+    "org_deploy_enabled": false
   }
 }

--- a/slack-app/railway.toml
+++ b/slack-app/railway.toml
@@ -10,8 +10,27 @@
 # instead of the bot. Setting RAILWAY_DOCKERFILE_PATH is NOT enough — the
 # root config-as-code file wins over the variable.
 #
-# Socket Mode means the process serves no HTTP, so this service has no
-# domain, no exposed port, and no healthcheck.
+# The service now serves HTTP: Bolt's HTTP receiver owns /slack/events,
+# /slack/install, and /slack/oauth_redirect, so this service NEEDS a public
+# domain (the manifest's request URLs point at it) and listens on $PORT.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# SINGLE REPLICA — DO NOT SCALE THIS SERVICE HORIZONTALLY.
+#
+# Two pieces of correctness are process-local by deliberate choice:
+#
+#   1. The installation token cache (installations/store.js) is purged
+#      synchronously by the app_uninstalled / tokens_revoked listeners. With a
+#      second replica, a purge on replica A would leave replica B serving a
+#      revoked workspace token until its own 5-minute TTL lapsed — and
+#      "revocation is instant" would stop being true.
+#   2. The per-link rate buckets and the in-memory event dedupe are likewise
+#      per-process, so N replicas would multiply the effective rate limit by N.
+#
+# Both are fixable with shared state (Convex-backed invalidation + rate
+# counters); that work is deliberately deferred until we actually need to
+# scale past one replica. Until then, numReplicas MUST stay 1.
+# ─────────────────────────────────────────────────────────────────────────────
 
 [build]
 builder = "DOCKERFILE"
@@ -20,3 +39,4 @@ dockerfilePath = "slack-app/Dockerfile"
 [deploy]
 startCommand = "npm start --workspace @mcpjam/slack-app"
 restartPolicyType = "ON_FAILURE"
+numReplicas = 1

--- a/slack-app/tests/agent/connect-link.test.js
+++ b/slack-app/tests/agent/connect-link.test.js
@@ -1,0 +1,92 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { mintConnectUrl } from '../../agent/connect-link.js';
+import { InstallationBackendError } from '../../installations/backend-client.js';
+
+const CTX = { teamId: 'T1', slackUserId: 'U1' };
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('mintConnectUrl', () => {
+  beforeEach(() => {
+    process.env.MCPJAM_BASE_URL = 'https://api.test';
+    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+  });
+
+  afterEach(() => {
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+  });
+
+  it('asks the bridge for a URL scoped to THIS user', async () => {
+    // An identity mix-up here would hand one person a link that binds
+    // another's Slack account, so the payload is worth pinning.
+    let seen;
+    const fetchImpl = mock.fn(async (url, init) => {
+      seen = { url: String(url), init };
+      return jsonResponse({ ok: true, url: 'https://api.test/api/slack/link/start?s=abc' });
+    });
+
+    const url = await mintConnectUrl(CTX, { fetchImpl });
+    assert.strictEqual(url, 'https://api.test/api/slack/link/start?s=abc');
+    assert.strictEqual(seen.url, 'https://api.test/api/slack/link/session');
+    assert.deepStrictEqual(JSON.parse(seen.init.body), { teamId: 'T1', slackUserId: 'U1' });
+  });
+
+  it('authenticates with the service token header, not a bearer', async () => {
+    // `lib/serviceToken.ts` reserves the bearer slot for the delegated flow;
+    // new callers must use the header form.
+    let headers;
+    const fetchImpl = mock.fn(async (_url, init) => {
+      headers = init.headers;
+      return jsonResponse({ ok: true, url: 'https://api.test/x' });
+    });
+    await mintConnectUrl(CTX, { fetchImpl });
+    assert.strictEqual(headers['x-inspector-service-token'], 'svc_test');
+    assert.strictEqual(headers.Authorization, undefined);
+  });
+
+  it('refuses to fabricate a URL when the bridge returns none', async () => {
+    const fetchImpl = mock.fn(async () => jsonResponse({ ok: true }));
+    await assert.rejects(mintConnectUrl(CTX, { fetchImpl }), InstallationBackendError);
+  });
+
+  it('surfaces a bridge error rather than a broken link', async () => {
+    const fetchImpl = mock.fn(async () => jsonResponse({ message: 'nope' }, 500));
+    await assert.rejects(mintConnectUrl(CTX, { fetchImpl }), InstallationBackendError);
+  });
+
+  it('reports a timeout as TIMEOUT', async () => {
+    const fetchImpl = mock.fn(async (_url, init) => {
+      await new Promise((resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+        // Never resolves on its own — the abort is the only exit.
+        setTimeout(resolve, 60_000).unref?.();
+      });
+      return jsonResponse({ ok: true, url: 'x' });
+    });
+    // Drive the abort immediately rather than waiting out the real timeout.
+    const promise = mintConnectUrl(CTX, { fetchImpl });
+    await assert.rejects(promise, (error) => {
+      assert.ok(error instanceof InstallationBackendError);
+      return true;
+    });
+  });
+
+  it('fails closed without a service token', async () => {
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    await assert.rejects(mintConnectUrl(CTX), (error) => {
+      assert.strictEqual(error.code, 'CONFIG');
+      return true;
+    });
+  });
+});

--- a/slack-app/tests/agent/connect-link.test.js
+++ b/slack-app/tests/agent/connect-link.test.js
@@ -16,7 +16,7 @@ function jsonResponse(body, status = 200) {
 describe('mintConnectUrl', () => {
   beforeEach(() => {
     process.env.MCPJAM_BASE_URL = 'https://api.test';
-    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    process.env.MCPJAM_SLACK_SERVICE_TOKEN = 'slk_test';
     // The optional origins widen the allowlist, so each test starts from a
     // known-narrow one and opts in explicitly.
     delete process.env.SLACK_LINK_PUBLIC_ORIGIN;
@@ -26,7 +26,7 @@ describe('mintConnectUrl', () => {
   });
 
   afterEach(() => {
-    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
     delete process.env.SLACK_LINK_PUBLIC_ORIGIN;
     delete process.env.CLI_AUTH_PUBLIC_ORIGIN;
     delete process.env.MCPJAM_SLACK_LINK_ORIGIN;
@@ -48,17 +48,19 @@ describe('mintConnectUrl', () => {
     assert.deepStrictEqual(JSON.parse(seen.init.body), { teamId: 'T1', slackUserId: 'U1' });
   });
 
-  it('authenticates with the service token header, not a bearer', async () => {
-    // `lib/serviceToken.ts` reserves the bearer slot for the delegated flow;
-    // new callers must use the header form.
+  it("authenticates with the bot's own slk_ bearer, never the inspector root token", async () => {
+    // The bridge verifies the SAME `slk_` credential the bot presents on
+    // /api/v1. The inspector's environment-root service token must not exist
+    // in the bot's environment at all — that separation is the blast-radius
+    // boundary the credential split exists for.
     let headers;
     const fetchImpl = mock.fn(async (_url, init) => {
       headers = init.headers;
       return jsonResponse({ ok: true, url: 'https://api.test/x' });
     });
     await mintConnectUrl(CTX, { fetchImpl });
-    assert.strictEqual(headers['x-inspector-service-token'], 'svc_test');
-    assert.strictEqual(headers.Authorization, undefined);
+    assert.strictEqual(headers.Authorization, 'Bearer slk_test');
+    assert.strictEqual(headers['x-inspector-service-token'], undefined);
   });
 
   it('refuses to fabricate a URL when the bridge returns none', async () => {
@@ -173,7 +175,7 @@ describe('mintConnectUrl', () => {
   }
 
   it('fails closed without a service token', async () => {
-    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
     await assert.rejects(mintConnectUrl(CTX), (error) => {
       assert.strictEqual(error.code, 'CONFIG');
       return true;

--- a/slack-app/tests/agent/connect-link.test.js
+++ b/slack-app/tests/agent/connect-link.test.js
@@ -74,10 +74,11 @@ describe('mintConnectUrl', () => {
       });
       return jsonResponse({ ok: true, url: 'x' });
     });
-    // Drive the abort immediately rather than waiting out the real timeout.
-    const promise = mintConnectUrl(CTX, { fetchImpl });
-    await assert.rejects(promise, (error) => {
+    // A 1ms deadline drives the real abort path in milliseconds. Waiting out
+    // the production 10s would add ten seconds to every `npm run verify`.
+    await assert.rejects(mintConnectUrl(CTX, { fetchImpl, timeoutMs: 1 }), (error) => {
       assert.ok(error instanceof InstallationBackendError);
+      assert.strictEqual(error.code, 'TIMEOUT');
       return true;
     });
   });

--- a/slack-app/tests/agent/connect-link.test.js
+++ b/slack-app/tests/agent/connect-link.test.js
@@ -83,6 +83,43 @@ describe('mintConnectUrl', () => {
     });
   });
 
+  // The minted URL is rendered as a Block Kit button on the bot's App Home.
+  // Slack links whatever it is given, so a bad value is not a cosmetic bug: an
+  // off-origin one is a phishing link carrying our bot's name.
+  for (const [label, url] of [
+    ['an empty string', ''],
+    ['a relative path', '/api/slack/link/start?s=abc'],
+    ['a protocol-relative URL', '//evil.test/api/slack/link/start'],
+    ['a different origin', 'https://evil.test/api/slack/link/start?s=abc'],
+    ['a matching host on a different port', 'https://api.test:8443/api/slack/link/start'],
+    ['plain http on a non-loopback host', 'http://api.test/api/slack/link/start'],
+    ['a javascript: URL', 'javascript:alert(1)'],
+  ]) {
+    it(`rejects ${label} instead of rendering it`, async () => {
+      const fetchImpl = mock.fn(async () => jsonResponse({ ok: true, url }));
+      await assert.rejects(mintConnectUrl(CTX, { fetchImpl }), InstallationBackendError);
+    });
+  }
+
+  it('does not leak the link URL into the rejection message', async () => {
+    // The URL is a single-use credential for a named user's link flow, and
+    // this message reaches the bot's logs.
+    const secret = 'https://evil.test/start?s=super-secret-session';
+    const fetchImpl = mock.fn(async () => jsonResponse({ ok: true, url: secret }));
+    await assert.rejects(mintConnectUrl(CTX, { fetchImpl }), (error) => {
+      assert.ok(!error.message.includes('super-secret-session'));
+      return true;
+    });
+  });
+
+  it('allows plain http on loopback so local dev still works', async () => {
+    process.env.MCPJAM_BASE_URL = 'http://localhost:3001';
+    const fetchImpl = mock.fn(async () =>
+      jsonResponse({ ok: true, url: 'http://localhost:3001/api/slack/link/start' }),
+    );
+    assert.strictEqual(await mintConnectUrl(CTX, { fetchImpl }), 'http://localhost:3001/api/slack/link/start');
+  });
+
   it('fails closed without a service token', async () => {
     delete process.env.INSPECTOR_SERVICE_TOKEN;
     await assert.rejects(mintConnectUrl(CTX), (error) => {

--- a/slack-app/tests/agent/connect-link.test.js
+++ b/slack-app/tests/agent/connect-link.test.js
@@ -20,6 +20,7 @@ describe('mintConnectUrl', () => {
     // The optional origins widen the allowlist, so each test starts from a
     // known-narrow one and opts in explicitly.
     delete process.env.SLACK_LINK_PUBLIC_ORIGIN;
+    delete process.env.CLI_AUTH_PUBLIC_ORIGIN;
     delete process.env.MCPJAM_SLACK_LINK_ORIGIN;
     delete process.env.MCPJAM_APP_URL;
   });
@@ -27,6 +28,7 @@ describe('mintConnectUrl', () => {
   afterEach(() => {
     delete process.env.INSPECTOR_SERVICE_TOKEN;
     delete process.env.SLACK_LINK_PUBLIC_ORIGIN;
+    delete process.env.CLI_AUTH_PUBLIC_ORIGIN;
     delete process.env.MCPJAM_SLACK_LINK_ORIGIN;
     delete process.env.MCPJAM_APP_URL;
   });
@@ -124,6 +126,17 @@ describe('mintConnectUrl', () => {
     // the one the bot calls. Requiring them to match would make linking
     // impossible on every split-origin deployment, local dev included.
     process.env.SLACK_LINK_PUBLIC_ORIGIN = 'https://link.test';
+    const url = 'https://link.test/api/slack/link/start?s=abc';
+    const fetchImpl = mock.fn(async () => jsonResponse({ ok: true, url }));
+    assert.strictEqual(await mintConnectUrl(CTX, { fetchImpl }), url);
+  });
+
+  it('accepts the bridge CLI_AUTH_PUBLIC_ORIGIN fallback', async () => {
+    // `server/routes/slack-link/index.ts` resolves its public origin as
+    // `SLACK_LINK_PUBLIC_ORIGIN ?? CLI_AUTH_PUBLIC_ORIGIN`. A deployment that
+    // sets only the documented fallback mints from THIS origin, so leaving it
+    // out of the allowlist rejected every link such a deployment ever issued.
+    process.env.CLI_AUTH_PUBLIC_ORIGIN = 'https://link.test';
     const url = 'https://link.test/api/slack/link/start?s=abc';
     const fetchImpl = mock.fn(async () => jsonResponse({ ok: true, url }));
     assert.strictEqual(await mintConnectUrl(CTX, { fetchImpl }), url);

--- a/slack-app/tests/agent/connect-link.test.js
+++ b/slack-app/tests/agent/connect-link.test.js
@@ -17,10 +17,18 @@ describe('mintConnectUrl', () => {
   beforeEach(() => {
     process.env.MCPJAM_BASE_URL = 'https://api.test';
     process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    // The optional origins widen the allowlist, so each test starts from a
+    // known-narrow one and opts in explicitly.
+    delete process.env.SLACK_LINK_PUBLIC_ORIGIN;
+    delete process.env.MCPJAM_SLACK_LINK_ORIGIN;
+    delete process.env.MCPJAM_APP_URL;
   });
 
   afterEach(() => {
     delete process.env.INSPECTOR_SERVICE_TOKEN;
+    delete process.env.SLACK_LINK_PUBLIC_ORIGIN;
+    delete process.env.MCPJAM_SLACK_LINK_ORIGIN;
+    delete process.env.MCPJAM_APP_URL;
   });
 
   it('asks the bridge for a URL scoped to THIS user', async () => {
@@ -94,12 +102,39 @@ describe('mintConnectUrl', () => {
     ['a matching host on a different port', 'https://api.test:8443/api/slack/link/start'],
     ['plain http on a non-loopback host', 'http://api.test/api/slack/link/start'],
     ['a javascript: URL', 'javascript:alert(1)'],
+    // Reads as our host to a human scanning the string; `URL` resolves the
+    // host to `evil.test`. Comparing parsed origins is what catches it.
+    ['a userinfo-confused host', 'https://api.test@evil.test/api/slack/link/start'],
   ]) {
     it(`rejects ${label} instead of rendering it`, async () => {
       const fetchImpl = mock.fn(async () => jsonResponse({ ok: true, url }));
-      await assert.rejects(mintConnectUrl(CTX, { fetchImpl }), InstallationBackendError);
+      // Pinned to the URL check, not merely to the error class: `mintConnectUrl`
+      // raises the same class for config, network and timeout failures, so a
+      // regression that rejected for an unrelated reason would look green.
+      await assert.rejects(mintConnectUrl(CTX, { fetchImpl }), (error) => {
+        assert.ok(error instanceof InstallationBackendError);
+        assert.match(error.message, /connect link/i);
+        return true;
+      });
     });
   }
+
+  it('accepts the bridge origin when it differs from the API origin', async () => {
+    // The bridge mints from SLACK_LINK_PUBLIC_ORIGIN, a DIFFERENT setting from
+    // the one the bot calls. Requiring them to match would make linking
+    // impossible on every split-origin deployment, local dev included.
+    process.env.SLACK_LINK_PUBLIC_ORIGIN = 'https://link.test';
+    const url = 'https://link.test/api/slack/link/start?s=abc';
+    const fetchImpl = mock.fn(async () => jsonResponse({ ok: true, url }));
+    assert.strictEqual(await mintConnectUrl(CTX, { fetchImpl }), url);
+  });
+
+  it('still refuses an origin nobody configured', async () => {
+    // The allowlist widens with configuration, never with the response.
+    process.env.SLACK_LINK_PUBLIC_ORIGIN = 'https://link.test';
+    const fetchImpl = mock.fn(async () => jsonResponse({ ok: true, url: 'https://evil.test/api/slack/link/start' }));
+    await assert.rejects(mintConnectUrl(CTX, { fetchImpl }), InstallationBackendError);
+  });
 
   it('does not leak the link URL into the rejection message', async () => {
     // The URL is a single-use credential for a named user's link flow, and
@@ -112,13 +147,17 @@ describe('mintConnectUrl', () => {
     });
   });
 
-  it('allows plain http on loopback so local dev still works', async () => {
-    process.env.MCPJAM_BASE_URL = 'http://localhost:3001';
-    const fetchImpl = mock.fn(async () =>
-      jsonResponse({ ok: true, url: 'http://localhost:3001/api/slack/link/start' }),
-    );
-    assert.strictEqual(await mintConnectUrl(CTX, { fetchImpl }), 'http://localhost:3001/api/slack/link/start');
-  });
+  // Every loopback spelling the implementation accepts, so a later edit cannot
+  // quietly drop one and break a local setup that used it.
+  for (const host of ['localhost', '127.0.0.1', '[::1]']) {
+    it(`allows plain http on ${host} so local dev still works`, async () => {
+      const origin = `http://${host}:3001`;
+      process.env.MCPJAM_BASE_URL = origin;
+      const url = `${origin}/api/slack/link/start`;
+      const fetchImpl = mock.fn(async () => jsonResponse({ ok: true, url }));
+      assert.strictEqual(await mintConnectUrl(CTX, { fetchImpl }), url);
+    });
+  }
 
   it('fails closed without a service token', async () => {
     delete process.env.INSPECTOR_SERVICE_TOKEN;

--- a/slack-app/tests/agent/durable-claims.test.js
+++ b/slack-app/tests/agent/durable-claims.test.js
@@ -1,0 +1,217 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { dedupe, runTurnForEvent } from '../../agent/turn-runner.js';
+import { InstallationBackendError } from '../../installations/backend-client.js';
+
+const CTX = { teamId: 'T1', slackUserId: 'U1', isLegacyWorkspace: true };
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/**
+ * A fake backend: a claim table plus the agent endpoint. Records every agent
+ * call so a test can assert the turn ran (or did not) and with which key.
+ */
+function stubBackend({ claimOutcomes = [], agentStatus = 200 } = {}) {
+  const state = { claims: new Map(), agentCalls: [], claimCalls: [], releases: [] };
+  let outcomeIndex = 0;
+
+  globalThis.fetch = mock.fn(async (url, init) => {
+    const path = String(url);
+    const body = init?.body ? JSON.parse(String(init.body)) : {};
+
+    if (path.endsWith('/slack/claims/claim')) {
+      state.claimCalls.push(body.dedupeKey);
+      // Scripted outcomes let a test force the inflight/completed branches.
+      const forced = claimOutcomes[outcomeIndex++];
+      if (forced) return jsonResponse({ ok: true, ...forced });
+      const existing = state.claims.get(body.dedupeKey);
+      if (existing) {
+        return jsonResponse({
+          ok: true,
+          outcome: existing.status === 'done' ? 'completed' : 'inflight',
+          resultEnvelope: existing.resultEnvelope ?? null,
+        });
+      }
+      state.claims.set(body.dedupeKey, { status: 'inflight' });
+      return jsonResponse({ ok: true, outcome: 'claimed', resultEnvelope: null });
+    }
+    if (path.endsWith('/slack/claims/complete')) {
+      state.claims.set(body.dedupeKey, {
+        status: 'done',
+        resultEnvelope: body.resultEnvelope,
+      });
+      return jsonResponse({ ok: true, completed: true });
+    }
+    if (path.endsWith('/slack/claims/release')) {
+      state.releases.push(body.dedupeKey);
+      state.claims.delete(body.dedupeKey);
+      return jsonResponse({ ok: true, released: true });
+    }
+    if (path.includes('/agent')) {
+      state.agentCalls.push({
+        idempotencyKey: body.idempotencyKey,
+        header: init?.headers?.['x-mcpjam-idempotency-key'],
+      });
+      return jsonResponse(
+        agentStatus === 200
+          ? { reply: 'here is your suite', toolCalls: [], createdResources: [{ id: 'ts_1' }] }
+          : { code: 'INTERNAL_ERROR', message: 'boom' },
+        agentStatus,
+      );
+    }
+    throw new Error(`unexpected fetch to ${path}`);
+  });
+  return state;
+}
+
+const slackClient = /** @type {any} */ ({
+  conversations: { history: async () => ({ messages: [{ ts: '1.0', user: 'U1', text: 'hello' }] }) },
+});
+
+function triggerArgs(overrides = {}) {
+  return {
+    client: slackClient,
+    ctx: CTX,
+    channelId: 'D1',
+    threadTs: '100.0',
+    triggerTs: '100.0',
+    eventId: 'Ev123',
+    isThread: false,
+    botUserId: 'B1',
+    fallbackText: 'hi',
+    onResult: async () => {},
+    ...overrides,
+  };
+}
+
+describe('durable event claims', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    dedupe.clear();
+    process.env.MCPJAM_API_KEY = 'sk_test';
+    process.env.MCPJAM_PROJECT_ID = 'p1';
+    process.env.MCPJAM_BASE_URL = 'https://api.test';
+    process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
+    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    realFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.MCPJAM_CONVEX_HTTP_URL;
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+  });
+
+  it('claims on the Slack event id, not the channel+ts', async () => {
+    // The event id is the identity of the DELIVERY CHAIN — a redelivery
+    // carries it unchanged, which is exactly what the claim needs.
+    const state = stubBackend();
+    await runTurnForEvent(triggerArgs());
+    assert.deepStrictEqual(state.claimCalls, ['T1:Ev123']);
+  });
+
+  it('passes the SAME key to the turn so the server can derive write keys', async () => {
+    const state = stubBackend();
+    await runTurnForEvent(triggerArgs());
+    assert.strictEqual(state.agentCalls[0].idempotencyKey, 'T1:Ev123');
+  });
+
+  it('replays the stored reply for a redelivery instead of re-running', async () => {
+    // This is the whole point of storing the envelope: the alternatives are
+    // losing the answer or authoring a second suite.
+    const state = stubBackend();
+    const replays = [];
+
+    await runTurnForEvent(triggerArgs());
+    assert.strictEqual(state.agentCalls.length, 1);
+
+    // A redelivery after a restart: the in-memory registry is empty.
+    dedupe.clear();
+    const ran = await runTurnForEvent(triggerArgs({ onReplay: async (envelope) => replays.push(envelope) }));
+
+    assert.strictEqual(ran, false, 'redelivery must not report as a fresh turn');
+    assert.strictEqual(state.agentCalls.length, 1, 'the turn must NOT re-run');
+    assert.strictEqual(replays.length, 1);
+    assert.strictEqual(replays[0].reply, 'here is your suite');
+    assert.deepStrictEqual(replays[0].createdResources, [{ id: 'ts_1' }]);
+  });
+
+  it('suppresses a delivery whose claim is already in flight elsewhere', async () => {
+    const state = stubBackend({ claimOutcomes: [{ outcome: 'inflight', resultEnvelope: null }] });
+    const ran = await runTurnForEvent(triggerArgs());
+    assert.strictEqual(ran, false);
+    assert.strictEqual(state.agentCalls.length, 0);
+  });
+
+  it('FAILS CLOSED when the claim backend is unreachable', async () => {
+    // Treating an unreachable backend as "you own it" would turn one Slack
+    // event into two billed turns — the exact failure the claim prevents.
+    globalThis.fetch = mock.fn(async (url) =>
+      String(url).includes('/claims/')
+        ? jsonResponse({ error: 'down' }, 503)
+        : jsonResponse({ reply: 'should never be reached' }),
+    );
+    await assert.rejects(runTurnForEvent(triggerArgs()), InstallationBackendError);
+  });
+
+  it('a claim-backend failure leaves the event re-runnable', async () => {
+    // The in-memory claim must be released, or the retry against a healthy
+    // process would be swallowed as a duplicate and the user would get
+    // nothing at all.
+    globalThis.fetch = mock.fn(async () => jsonResponse({ error: 'down' }, 503));
+    await assert.rejects(runTurnForEvent(triggerArgs()));
+
+    const state = stubBackend();
+    const ran = await runTurnForEvent(triggerArgs());
+    assert.strictEqual(ran, true);
+    assert.strictEqual(state.agentCalls.length, 1);
+  });
+
+  it('releases the claim when the pre-turn hook fails', async () => {
+    // No turn work happened, so the event must stay processable.
+    const state = stubBackend();
+    await assert.rejects(
+      runTurnForEvent(
+        triggerArgs({
+          onStart: async () => {
+            throw new Error('slack status down');
+          },
+        }),
+      ),
+      /slack status down/,
+    );
+    assert.deepStrictEqual(state.releases, ['T1:Ev123']);
+    assert.strictEqual(state.agentCalls.length, 0);
+  });
+
+  it('does NOT complete the claim when the turn fails', async () => {
+    // A failed turn has no answer to replay, and completing it would suppress
+    // the redelivery that could still succeed.
+    const state = stubBackend({ agentStatus: 500 });
+    await assert.rejects(runTurnForEvent(triggerArgs()));
+    assert.strictEqual(state.claims.get('T1:Ev123').status, 'inflight');
+  });
+
+  it('falls back to channel+ts when the payload carries no event id', async () => {
+    const state = stubBackend();
+    await runTurnForEvent(triggerArgs({ eventId: undefined }));
+    assert.deepStrictEqual(state.claimCalls, ['T1:D1:100.0']);
+  });
+
+  it('keeps identical event ids from different workspaces independent', async () => {
+    const state = stubBackend();
+    await runTurnForEvent(triggerArgs());
+    dedupe.clear();
+    await runTurnForEvent(triggerArgs({ ctx: { ...CTX, teamId: 'T2' } }));
+    assert.deepStrictEqual(state.claimCalls, ['T1:Ev123', 'T2:Ev123']);
+    assert.strictEqual(state.agentCalls.length, 2, 'the second workspace must not be suppressed');
+  });
+});

--- a/slack-app/tests/agent/durable-claims.test.js
+++ b/slack-app/tests/agent/durable-claims.test.js
@@ -17,7 +17,7 @@ function jsonResponse(body, status = 200) {
  * A fake backend: a claim table plus the agent endpoint. Records every agent
  * call so a test can assert the turn ran (or did not) and with which key.
  */
-function stubBackend({ claimOutcomes = [], agentStatus = 200 } = {}) {
+function stubBackend({ claimOutcomes = [], agentStatus = 200, agentErrorBody } = {}) {
   const state = { claims: new Map(), agentCalls: [], claimCalls: [], releases: [] };
   let outcomeIndex = 0;
 
@@ -61,7 +61,7 @@ function stubBackend({ claimOutcomes = [], agentStatus = 200 } = {}) {
       return jsonResponse(
         agentStatus === 200
           ? { reply: 'here is your suite', toolCalls: [], createdResources: [{ id: 'ts_1' }] }
-          : { code: 'INTERNAL_ERROR', message: 'boom' },
+          : (agentErrorBody ?? { code: 'INTERNAL_ERROR', message: 'boom' }),
         agentStatus,
       );
     }
@@ -100,14 +100,14 @@ describe('durable event claims', () => {
     process.env.MCPJAM_PROJECT_ID = 'p1';
     process.env.MCPJAM_BASE_URL = 'https://api.test';
     process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
-    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    process.env.SLACK_SERVICE_TOKEN = 'svc_test';
     realFetch = globalThis.fetch;
   });
 
   afterEach(() => {
     globalThis.fetch = realFetch;
     delete process.env.MCPJAM_CONVEX_HTTP_URL;
-    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    delete process.env.SLACK_SERVICE_TOKEN;
   });
 
   it('claims on the Slack event id, not the channel+ts', async () => {
@@ -192,16 +192,71 @@ describe('durable event claims', () => {
     assert.strictEqual(state.agentCalls.length, 0);
   });
 
-  it('RELEASES rather than completes the claim when the turn fails', async () => {
-    // A failed turn has no answer to replay, so completing it would suppress a
-    // redelivery that could still succeed. Leaving it `inflight` is no better:
-    // an inflight claim is only cleared by the backend's TTL sweep, so until
-    // then every redelivery is answered "someone else owns this" and the user
-    // gets nothing at all.
+  it('COMPLETES a dispatched-but-failed turn with a failure envelope — never releases', async () => {
+    // "No Slack reply" is not "no side effects": once the turn request reached
+    // the network, the server may have persisted a suite before failing (its
+    // error contract says exactly this). Releasing would let a redelivery
+    // RE-RUN the turn — and a stochastic retry can author different arguments,
+    // sail past the derived idempotency keys, and create a second suite. So
+    // the claim is finished with a failure envelope; retrying is a HUMAN
+    // decision that arrives as a new event.
     const state = stubBackend({ agentStatus: 500 });
     await assert.rejects(runTurnForEvent(triggerArgs()));
+    assert.deepStrictEqual(state.releases, [], 'a dispatched turn must never be released');
+    assert.strictEqual(state.claims.get('T1:Ev123')?.status, 'done');
+    const envelope = state.claims.get('T1:Ev123')?.resultEnvelope;
+    assert.ok(envelope?.reply?.length > 0, 'the failure message is what redeliveries replay');
+    assert.deepStrictEqual(envelope?.toolCalls, []);
+
+    // A redelivery replays the failure — the agent is NOT re-run.
+    dedupe.clear();
+    const replayed = [];
+    const ran = await runTurnForEvent(triggerArgs({ onReplay: async (env) => replayed.push(env.reply) }));
+    assert.strictEqual(ran, false);
+    assert.strictEqual(replayed.length, 1);
+    assert.strictEqual(state.agentCalls.length, 1, 'one dispatch, ever, for this event');
+  });
+
+  it('a failed turn carries its persisted resources into the failure envelope', async () => {
+    // The server attaches `details.createdResources` to a failed turn that
+    // already persisted a suite. Discarding them is how "failed" comes to be
+    // read as "nothing happened" — and how the user gets told to start over on
+    // a suite that exists.
+    const state = stubBackend({
+      agentStatus: 500,
+      agentErrorBody: {
+        code: 'INTERNAL_ERROR',
+        message: 'engine fell over',
+        details: {
+          createdResources: [
+            { type: 'eval_suite', id: 'ts_1', name: 'Half-born suite', url: 'https://app.test/evals/suite/ts_1' },
+          ],
+        },
+      },
+    });
+    await assert.rejects(runTurnForEvent(triggerArgs()));
+    const envelope = state.claims.get('T1:Ev123')?.resultEnvelope;
+    assert.strictEqual(envelope?.createdResources?.length, 1);
+    assert.strictEqual(envelope?.createdResources?.[0]?.id, 'ts_1');
+  });
+
+  it('RELEASES when the failure happened before the turn was ever dispatched', async () => {
+    // Pre-dispatch failures (context fetch, credential resolution) provably
+    // have no server-side work behind them; holding the claim would silence
+    // the event for the full TTL over a transient Slack hiccup.
+    const state = stubBackend();
+    const args = triggerArgs({
+      client: /** @type {any} */ ({
+        conversations: {
+          history: async () => {
+            throw new Error('slack context fetch down');
+          },
+        },
+      }),
+    });
+    await assert.rejects(runTurnForEvent(args), /slack context fetch down/);
     assert.deepStrictEqual(state.releases, ['T1:Ev123']);
-    assert.strictEqual(state.claims.has('T1:Ev123'), false);
+    assert.strictEqual(state.agentCalls.length, 0);
 
     // And the release is real: a redelivery re-claims and runs.
     dedupe.clear();

--- a/slack-app/tests/agent/durable-claims.test.js
+++ b/slack-app/tests/agent/durable-claims.test.js
@@ -240,6 +240,18 @@ describe('durable event claims', () => {
     assert.strictEqual(envelope?.createdResources?.[0]?.id, 'ts_1');
   });
 
+  it('RELEASES on a local preflight failure (CONFIG) even though dispatch was marked', async () => {
+    // `runAgentTurn` resolves credentials BEFORE any fetch. A config error is
+    // provably pre-network — finalizing it would replay "it failed" for 72
+    // hours after the operator fixed the environment.
+    const state = stubBackend();
+    delete process.env.MCPJAM_API_KEY;
+    await assert.rejects(runTurnForEvent(triggerArgs()), /MCPJAM_API_KEY/);
+    assert.deepStrictEqual(state.releases, ['T1:Ev123']);
+    assert.strictEqual(state.claims.has('T1:Ev123'), false);
+    assert.strictEqual(state.agentCalls.length, 0);
+  });
+
   it('RELEASES when the failure happened before the turn was ever dispatched', async () => {
     // Pre-dispatch failures (context fetch, credential resolution) provably
     // have no server-side work behind them; holding the claim would silence

--- a/slack-app/tests/agent/durable-claims.test.js
+++ b/slack-app/tests/agent/durable-claims.test.js
@@ -195,8 +195,9 @@ describe('durable event claims', () => {
   it('RELEASES rather than completes the claim when the turn fails', async () => {
     // A failed turn has no answer to replay, so completing it would suppress a
     // redelivery that could still succeed. Leaving it `inflight` is no better:
-    // inflight claims are never swept, so every later redelivery would be
-    // answered "someone else owns this" and the user would get nothing at all.
+    // an inflight claim is only cleared by the backend's TTL sweep, so until
+    // then every redelivery is answered "someone else owns this" and the user
+    // gets nothing at all.
     const state = stubBackend({ agentStatus: 500 });
     await assert.rejects(runTurnForEvent(triggerArgs()));
     assert.deepStrictEqual(state.releases, ['T1:Ev123']);
@@ -207,6 +208,57 @@ describe('durable event claims', () => {
     const rerun = stubBackend();
     await runTurnForEvent(triggerArgs());
     assert.strictEqual(rerun.agentCalls.length, 1);
+  });
+
+  it('COMPLETES the claim when the turn ran but delivering it failed', async () => {
+    // The mirror image of the test above, and the distinction is the whole
+    // point: the turn RAN, so it has already been billed. Releasing here would
+    // let a redelivery buy the same answer twice; leaving it `inflight` would
+    // sit on the answer until the TTL sweep and give the user nothing. So the
+    // claim is finished with the answer the user was owed.
+    const state = stubBackend();
+    await assert.rejects(
+      runTurnForEvent(
+        triggerArgs({
+          onResult: async () => {
+            throw new Error('slack post failed');
+          },
+        }),
+      ),
+      /slack post failed/,
+    );
+    assert.deepStrictEqual(state.releases, [], 'a turn that ran must never be released');
+    assert.strictEqual(state.claims.get('T1:Ev123')?.status, 'done');
+    assert.strictEqual(state.claims.get('T1:Ev123')?.resultEnvelope?.reply, 'here is your suite');
+
+    // And a redelivery REPLAYS it — the agent is not called a second time.
+    dedupe.clear();
+    const replayed = [];
+    const ran = await runTurnForEvent(triggerArgs({ onReplay: async (envelope) => replayed.push(envelope.reply) }));
+    assert.strictEqual(ran, false);
+    assert.deepStrictEqual(replayed, ['here is your suite']);
+    assert.strictEqual(state.agentCalls.length, 1, 'the redelivery must not re-run the turn');
+  });
+
+  it('still surfaces the delivery failure when the claim cannot be completed', async () => {
+    // Completing is best-effort: a backend blip on the way out must not
+    // replace the error the caller actually needs to see and log.
+    const state = stubBackend();
+    const inner = globalThis.fetch;
+    globalThis.fetch = mock.fn(async (url, init) =>
+      String(url).endsWith('/slack/claims/complete') ? jsonResponse({ error: 'backend down' }, 503) : inner(url, init),
+    );
+    await assert.rejects(
+      runTurnForEvent(
+        triggerArgs({
+          onResult: async () => {
+            throw new Error('slack post failed');
+          },
+        }),
+      ),
+      /slack post failed/,
+    );
+    assert.deepStrictEqual(state.releases, []);
   });
 
   it('falls back to channel+ts when the payload carries no event id', async () => {

--- a/slack-app/tests/agent/durable-claims.test.js
+++ b/slack-app/tests/agent/durable-claims.test.js
@@ -192,12 +192,21 @@ describe('durable event claims', () => {
     assert.strictEqual(state.agentCalls.length, 0);
   });
 
-  it('does NOT complete the claim when the turn fails', async () => {
-    // A failed turn has no answer to replay, and completing it would suppress
-    // the redelivery that could still succeed.
+  it('RELEASES rather than completes the claim when the turn fails', async () => {
+    // A failed turn has no answer to replay, so completing it would suppress a
+    // redelivery that could still succeed. Leaving it `inflight` is no better:
+    // inflight claims are never swept, so every later redelivery would be
+    // answered "someone else owns this" and the user would get nothing at all.
     const state = stubBackend({ agentStatus: 500 });
     await assert.rejects(runTurnForEvent(triggerArgs()));
-    assert.strictEqual(state.claims.get('T1:Ev123').status, 'inflight');
+    assert.deepStrictEqual(state.releases, ['T1:Ev123']);
+    assert.strictEqual(state.claims.has('T1:Ev123'), false);
+
+    // And the release is real: a redelivery re-claims and runs.
+    dedupe.clear();
+    const rerun = stubBackend();
+    await runTurnForEvent(triggerArgs());
+    assert.strictEqual(rerun.agentCalls.length, 1);
   });
 
   it('falls back to channel+ts when the payload carries no event id', async () => {

--- a/slack-app/tests/agent/mcpjam-client.test.js
+++ b/slack-app/tests/agent/mcpjam-client.test.js
@@ -26,7 +26,7 @@ describe('mcpjam-client', () => {
     const result = await runAgentTurn([{ role: 'user', content: 'hi' }], CTX, {
       fetchImpl: fakeFetch(200, { reply: 'hello' }),
     });
-    assert.deepStrictEqual(result, { reply: 'hello', toolCalls: [], createdResources: [] });
+    assert.deepStrictEqual(result, { reply: 'hello', toolCalls: [], createdResources: [], proposedActions: [] });
   });
 
   it('maps RATE_LIMITED errors to a capacity message', async () => {

--- a/slack-app/tests/agent/mcpjam-client.test.js
+++ b/slack-app/tests/agent/mcpjam-client.test.js
@@ -4,7 +4,7 @@ import { beforeEach, describe, it } from 'node:test';
 import { McpjamApiError, runAgentTurn, startSuiteRun } from '../../agent/mcpjam-client.js';
 
 /** Every entry point is tenant-scoped now; one context serves the whole file. */
-const CTX = { teamId: 'T1', slackUserId: 'U1' };
+const CTX = { teamId: 'T1', slackUserId: 'U1', isLegacyWorkspace: true };
 
 /** @param {number} status @param {unknown} body */
 function fakeFetch(status, body) {
@@ -118,5 +118,35 @@ describe('mcpjam-client', () => {
     } finally {
       delete process.env.MCPJAM_APP_URL;
     }
+  });
+});
+
+describe('legacy-workspace credential gate', () => {
+  beforeEach(() => {
+    process.env.MCPJAM_API_KEY = 'sk_test';
+    process.env.MCPJAM_PROJECT_ID = 'p1';
+    process.env.MCPJAM_BASE_URL = 'https://example.test';
+  });
+
+  it('refuses to release the shared key to a non-legacy workspace', async () => {
+    // The env `sk_` key is org-scoped to OUR organization. Serving another
+    // workspace with it would run that workspace's request against our
+    // project — a cross-tenant leak, not a degraded experience.
+    await assert.rejects(
+      runAgentTurn([{ role: 'user', content: 'hi' }], { teamId: 'T_OTHER', slackUserId: 'U9' }),
+      (error) => {
+        assert.strictEqual(error.code, 'UNAUTHORIZED');
+        assert.match(error.message, /legacy workspace/);
+        return true;
+      },
+    );
+  });
+
+  it('fails closed when the tenant guard verdict is absent entirely', async () => {
+    // A new call path that forgot the guard must not inherit our credentials.
+    await assert.rejects(startSuiteRun('ts_1', { teamId: 'T1', slackUserId: 'U1' }), (error) => {
+      assert.strictEqual(error.code, 'UNAUTHORIZED');
+      return true;
+    });
   });
 });

--- a/slack-app/tests/agent/mcpjam-client.test.js
+++ b/slack-app/tests/agent/mcpjam-client.test.js
@@ -3,6 +3,9 @@ import { beforeEach, describe, it } from 'node:test';
 
 import { McpjamApiError, runAgentTurn, startSuiteRun } from '../../agent/mcpjam-client.js';
 
+/** Every entry point is tenant-scoped now; one context serves the whole file. */
+const CTX = { teamId: 'T1', slackUserId: 'U1' };
+
 /** @param {number} status @param {unknown} body */
 function fakeFetch(status, body) {
   return async () =>
@@ -20,7 +23,7 @@ describe('mcpjam-client', () => {
   });
 
   it('returns the turn result with defaults for missing fields', async () => {
-    const result = await runAgentTurn([{ role: 'user', content: 'hi' }], {
+    const result = await runAgentTurn([{ role: 'user', content: 'hi' }], CTX, {
       fetchImpl: fakeFetch(200, { reply: 'hello' }),
     });
     assert.deepStrictEqual(result, { reply: 'hello', toolCalls: [], createdResources: [] });
@@ -28,7 +31,7 @@ describe('mcpjam-client', () => {
 
   it('maps RATE_LIMITED errors to a capacity message', async () => {
     await assert.rejects(
-      runAgentTurn([{ role: 'user', content: 'hi' }], {
+      runAgentTurn([{ role: 'user', content: 'hi' }], CTX, {
         fetchImpl: fakeFetch(429, { code: 'RATE_LIMITED', message: 'too many turns' }),
       }),
       (error) => {
@@ -42,7 +45,7 @@ describe('mcpjam-client', () => {
 
   it('maps TIMEOUT errors to a friendly message', async () => {
     await assert.rejects(
-      runAgentTurn([{ role: 'user', content: 'hi' }], {
+      runAgentTurn([{ role: 'user', content: 'hi' }], CTX, {
         fetchImpl: fakeFetch(504, { code: 'TIMEOUT', message: 'turn exceeded limit' }),
       }),
       (error) => {
@@ -67,7 +70,7 @@ describe('mcpjam-client', () => {
         },
       })
     );
-    await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }], { fetchImpl: stalledBody }), (error) => {
+    await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }], CTX, { fetchImpl: stalledBody }), (error) => {
       assert.strictEqual(error.code, 'TIMEOUT');
       return true;
     });
@@ -81,22 +84,25 @@ describe('mcpjam-client', () => {
           headers: { 'Content-Type': 'text/html' },
         })
     );
-    await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }], { fetchImpl: htmlErrorPage }), (error) => {
-      assert.strictEqual(error.status, 502);
-      return true;
-    });
+    await assert.rejects(
+      runAgentTurn([{ role: 'user', content: 'hi' }], CTX, { fetchImpl: htmlErrorPage }),
+      (error) => {
+        assert.strictEqual(error.status, 502);
+        return true;
+      },
+    );
   });
 
   it('fails with CONFIG when env is missing', async () => {
     delete process.env.MCPJAM_API_KEY;
-    await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }]), (error) => {
+    await assert.rejects(runAgentTurn([{ role: 'user', content: 'hi' }], CTX), (error) => {
       assert.strictEqual(error.code, 'CONFIG');
       return true;
     });
   });
 
   it('startSuiteRun builds the run deep link', async () => {
-    const run = await startSuiteRun('ts_1', {
+    const run = await startSuiteRun('ts_1', CTX, {
       fetchImpl: fakeFetch(202, { runId: 'run_9', suiteId: 'ts_1', status: 'running' }),
     });
     assert.strictEqual(run.url, 'https://example.test/evals/suite/ts_1/runs/run_9?project=p1');
@@ -105,7 +111,7 @@ describe('mcpjam-client', () => {
   it('deep links use MCPJAM_APP_URL when it differs from the API host', async () => {
     process.env.MCPJAM_APP_URL = 'http://localhost:5173';
     try {
-      const run = await startSuiteRun('ts_1', {
+      const run = await startSuiteRun('ts_1', CTX, {
         fetchImpl: fakeFetch(202, { runId: 'run_9' }),
       });
       assert.strictEqual(run.url, 'http://localhost:5173/evals/suite/ts_1/runs/run_9?project=p1');

--- a/slack-app/tests/agent/slack-context.test.js
+++ b/slack-app/tests/agent/slack-context.test.js
@@ -22,17 +22,29 @@ describe('slackContextFrom', () => {
   });
 
   it('uses the installing team from authorizations for shared channels', () => {
-    // In a Slack Connect channel the event's own `team` can be the OTHER
-    // workspace. `authorizations[0].team_id` is the installation we hold a
-    // token for — acting as anything else would be acting as the wrong tenant.
+    // The real shape of a Slack Connect event: `event.team` is the workspace
+    // the MESSAGE came from, which is NOT the workspace that installed us.
+    // Acting on `event.team` would look up an installation we do not have and
+    // run the turn as the wrong tenant, so the authorization must win.
     const ctx = slackContextFrom({
-      body: { authorizations: [{ team_id: 'T_INSTALLED' }] },
-      event: { user: 'U9' },
+      body: {
+        team_id: 'T_OTHER',
+        authorizations: [{ team_id: 'T_INSTALLED' }],
+      },
+      event: { team: 'T_OTHER', user: 'U9' },
     });
     assert.strictEqual(ctx.teamId, 'T_INSTALLED');
   });
 
-  it('prefers Bolt context over body when both are present', () => {
+  it('the installing authorization outranks Bolt context too', () => {
+    const ctx = slackContextFrom({
+      context: { teamId: 'T_CTX', userId: 'U_CTX' },
+      body: { authorizations: [{ team_id: 'T_INSTALLED' }] },
+    });
+    assert.strictEqual(ctx.teamId, 'T_INSTALLED');
+  });
+
+  it('prefers Bolt context over body when no authorization is present', () => {
     const ctx = slackContextFrom({
       context: { teamId: 'T_CTX', userId: 'U_CTX' },
       body: { team_id: 'T_BODY', user: { id: 'U_BODY' } },

--- a/slack-app/tests/agent/slack-context.test.js
+++ b/slack-app/tests/agent/slack-context.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { SlackContextError, slackContextFrom, tenantKey, tryslackContextFrom } from '../../agent/slack-context.js';
+
+describe('slackContextFrom', () => {
+  it('reads the tenant and actor from Bolt context', () => {
+    const ctx = slackContextFrom({ context: { teamId: 'T1', userId: 'U1' } });
+    assert.deepStrictEqual(ctx, { teamId: 'T1', slackUserId: 'U1' });
+  });
+
+  it('falls back to the event body for interactive payloads', () => {
+    // Block-action payloads carry the team under `body.team.id` and the
+    // clicker under `body.user.id`; Bolt's context is not always populated.
+    const ctx = slackContextFrom({ body: { team: { id: 'T2' }, user: { id: 'U2' } } });
+    assert.deepStrictEqual(ctx, { teamId: 'T2', slackUserId: 'U2' });
+  });
+
+  it('reads the event itself when neither context nor body carries the team', () => {
+    const ctx = slackContextFrom({ event: { team: 'T3', user: 'U3' } });
+    assert.deepStrictEqual(ctx, { teamId: 'T3', slackUserId: 'U3' });
+  });
+
+  it('uses the installing team from authorizations for shared channels', () => {
+    // In a Slack Connect channel the event's own `team` can be the OTHER
+    // workspace. `authorizations[0].team_id` is the installation we hold a
+    // token for — acting as anything else would be acting as the wrong tenant.
+    const ctx = slackContextFrom({
+      body: { authorizations: [{ team_id: 'T_INSTALLED' }] },
+      event: { user: 'U9' },
+    });
+    assert.strictEqual(ctx.teamId, 'T_INSTALLED');
+  });
+
+  it('prefers Bolt context over body when both are present', () => {
+    const ctx = slackContextFrom({
+      context: { teamId: 'T_CTX', userId: 'U_CTX' },
+      body: { team_id: 'T_BODY', user: { id: 'U_BODY' } },
+    });
+    assert.deepStrictEqual(ctx, { teamId: 'T_CTX', slackUserId: 'U_CTX' });
+  });
+
+  it('throws rather than guessing when the team is absent', () => {
+    assert.throws(() => slackContextFrom({ context: { userId: 'U1' } }), SlackContextError);
+  });
+
+  it('throws rather than guessing when the actor is absent', () => {
+    assert.throws(() => slackContextFrom({ context: { teamId: 'T1' } }), SlackContextError);
+  });
+
+  it('tryslackContextFrom returns null instead of throwing', () => {
+    assert.strictEqual(tryslackContextFrom({}), null);
+    assert.deepStrictEqual(tryslackContextFrom({ context: { teamId: 'T1', userId: 'U1' } }), {
+      teamId: 'T1',
+      slackUserId: 'U1',
+    });
+  });
+});
+
+describe('tenantKey', () => {
+  it('namespaces a key by workspace', () => {
+    assert.strictEqual(tenantKey({ teamId: 'T1' }, 'C1:42.0'), 'T1:C1:42.0');
+  });
+
+  it('produces distinct keys for the same channel in two workspaces', () => {
+    assert.notStrictEqual(tenantKey({ teamId: 'T1' }, 'C1:42.0'), tenantKey({ teamId: 'T2' }, 'C1:42.0'));
+  });
+});

--- a/slack-app/tests/agent/turn-runner.test.js
+++ b/slack-app/tests/agent/turn-runner.test.js
@@ -4,7 +4,7 @@ import { beforeEach, describe, it } from 'node:test';
 import { dedupe, EventDedupe, KeyedQueue, normalizeThreadMessages, runTurnForEvent } from '../../agent/turn-runner.js';
 
 /** Dedupe/queue keys are tenant-scoped; every trigger needs a workspace. */
-const CTX = { teamId: 'T1', slackUserId: 'U1' };
+const CTX = { teamId: 'T1', slackUserId: 'U1', isLegacyWorkspace: true };
 
 // Mirrors the server contract in server/routes/v1/agent.ts.
 const MAX_MESSAGE_BYTES = 8_192;

--- a/slack-app/tests/agent/turn-runner.test.js
+++ b/slack-app/tests/agent/turn-runner.test.js
@@ -3,6 +3,9 @@ import { beforeEach, describe, it } from 'node:test';
 
 import { dedupe, EventDedupe, KeyedQueue, normalizeThreadMessages, runTurnForEvent } from '../../agent/turn-runner.js';
 
+/** Dedupe/queue keys are tenant-scoped; every trigger needs a workspace. */
+const CTX = { teamId: 'T1', slackUserId: 'U1' };
+
 // Mirrors the server contract in server/routes/v1/agent.ts.
 const MAX_MESSAGE_BYTES = 8_192;
 const MAX_TOTAL_MESSAGE_BYTES = 98_304;
@@ -244,6 +247,7 @@ describe('runTurnForEvent', () => {
   function trigger(ts, order) {
     return runTurnForEvent({
       client,
+      ctx: CTX,
       channelId: 'D1',
       threadTs: ts,
       triggerTs: ts,
@@ -315,6 +319,7 @@ describe('runTurnForEvent onStart failure', () => {
     });
     const base = {
       client,
+      ctx: CTX,
       channelId: 'D9',
       threadTs: '300.0',
       triggerTs: '300.0',

--- a/slack-app/tests/agent/turn-target.test.js
+++ b/slack-app/tests/agent/turn-target.test.js
@@ -1,0 +1,193 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { getConfig, McpjamApiError } from '../../agent/mcpjam-client.js';
+import { resolveTurnTarget } from '../../agent/turn-target.js';
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Answers the two lookups `resolveTurnTarget` makes. */
+function stubBackend({ binding = null, link = null } = {}) {
+  const calls = [];
+  globalThis.fetch = mock.fn(async (url) => {
+    const path = String(url);
+    calls.push(path);
+    if (path.endsWith('/thread-bindings/get')) return jsonResponse({ ok: true, binding });
+    if (path.endsWith('/links/fetch')) return jsonResponse({ ok: true, link });
+    throw new Error(`unexpected fetch to ${path}`);
+  });
+  return calls;
+}
+
+const CTX = { teamId: 'T1', slackUserId: 'U1' };
+const LEGACY_CTX = { ...CTX, isLegacyWorkspace: true };
+
+describe('resolveTurnTarget', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+    process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
+    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    process.env.MCPJAM_SLACK_SERVICE_TOKEN = 'slk_test';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
+    delete process.env.MCPJAM_PROJECT_ID;
+  });
+
+  it('a THREAD BINDING wins over the replier’s own default project', async () => {
+    // The whole point of the binding: without it a thread would drift between
+    // projects as different people replied, and a suite would land somewhere
+    // nobody expected.
+    stubBackend({
+      binding: { organizationId: 'org_a', projectId: 'proj_thread', initiatorSlackUserId: 'U_ALICE' },
+      link: { organizationId: 'org_b', defaultProjectId: 'proj_mine' },
+    });
+    const target = await resolveTurnTarget(CTX, { channelId: 'C1', threadTs: 'ts-1' });
+    assert.strictEqual(target.mode, 'user');
+    assert.strictEqual(target.projectId, 'proj_thread');
+    assert.strictEqual(target.boundThread, true);
+    assert.strictEqual(target.initiatorSlackUserId, 'U_ALICE');
+  });
+
+  it('does not even look up the link when a binding applies', async () => {
+    const calls = stubBackend({
+      binding: { organizationId: 'org_a', projectId: 'proj_thread', initiatorSlackUserId: 'U_ALICE' },
+    });
+    await resolveTurnTarget(CTX, { channelId: 'C1', threadTs: 'ts-1' });
+    assert.ok(!calls.some((path) => path.endsWith('/links/fetch')));
+  });
+
+  it('falls back to the replier’s default project for a new conversation', async () => {
+    stubBackend({ link: { organizationId: 'org_b', defaultProjectId: 'proj_mine' } });
+    const target = await resolveTurnTarget(CTX, { channelId: 'C1', threadTs: 'ts-1' });
+    assert.deepStrictEqual(
+      { mode: target.mode, projectId: target.projectId, organizationId: target.organizationId },
+      { mode: 'user', projectId: 'proj_mine', organizationId: 'org_b' },
+    );
+  });
+
+  it('asks a linked user with no default to pick one — not an error', async () => {
+    stubBackend({ link: { organizationId: 'org_b', defaultProjectId: null } });
+    const target = await resolveTurnTarget(CTX, { channelId: 'C1', threadTs: 'ts-1' });
+    assert.strictEqual(target.mode, 'needs_project');
+  });
+
+  it('asks an unlinked user to connect', async () => {
+    stubBackend({});
+    const target = await resolveTurnTarget(CTX, { channelId: 'C1', threadTs: 'ts-1' });
+    assert.strictEqual(target.mode, 'unlinked');
+  });
+
+  it('a LINKED user in the legacy workspace acts as themselves, not on the shared key', async () => {
+    // Otherwise linking would be pointless for our own team: they would keep
+    // acting through the org-wide key they were supposed to stop using.
+    process.env.MCPJAM_PROJECT_ID = 'proj_env';
+    stubBackend({ link: { organizationId: 'org_b', defaultProjectId: 'proj_mine' } });
+    const target = await resolveTurnTarget(LEGACY_CTX, { channelId: 'C1', threadTs: 'ts-1' });
+    assert.strictEqual(target.mode, 'user');
+    assert.strictEqual(target.projectId, 'proj_mine');
+  });
+
+  it('an UNLINKED user in the legacy workspace still works on the shared key', async () => {
+    // Our own team must not be locked out mid-migration.
+    process.env.MCPJAM_PROJECT_ID = 'proj_env';
+    stubBackend({});
+    const target = await resolveTurnTarget(LEGACY_CTX, { channelId: 'C1', threadTs: 'ts-1' });
+    assert.strictEqual(target.mode, 'legacy');
+    assert.strictEqual(target.projectId, 'proj_env');
+  });
+
+  it('skips the backend entirely when per-user auth is not configured', async () => {
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
+    process.env.MCPJAM_PROJECT_ID = 'proj_env';
+    globalThis.fetch = mock.fn(async () => {
+      throw new Error('should not be reached');
+    });
+    assert.strictEqual((await resolveTurnTarget(LEGACY_CTX, { channelId: 'C1', threadTs: 'ts-1' })).mode, 'legacy');
+    assert.strictEqual((await resolveTurnTarget(CTX, { channelId: 'C1', threadTs: 'ts-1' })).mode, 'unlinked');
+  });
+});
+
+describe('getConfig credential modes', () => {
+  beforeEach(() => {
+    process.env.MCPJAM_BASE_URL = 'https://api.test';
+    process.env.MCPJAM_SLACK_SERVICE_TOKEN = 'slk_test';
+    process.env.MCPJAM_API_KEY = 'sk_legacy';
+    process.env.MCPJAM_PROJECT_ID = 'proj_env';
+  });
+
+  afterEach(() => {
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
+  });
+
+  it("user mode presents the bot's token plus the ACTOR's identity headers", async () => {
+    // The bot never holds a user token: the server resolves the identity from
+    // these headers, so a compromised bot cannot harvest portable org JWTs.
+    const config = getConfig({ ...CTX, mode: 'user', projectId: 'proj_mine' });
+    assert.strictEqual(config.apiKey, 'slk_test');
+    assert.strictEqual(config.projectId, 'proj_mine');
+    assert.deepStrictEqual(config.headers, {
+      'x-mcpjam-slack-team-id': 'T1',
+      'x-mcpjam-slack-user-id': 'U1',
+    });
+  });
+
+  it('user mode refuses to run without a resolved project', async () => {
+    assert.throws(
+      () => getConfig({ ...CTX, mode: 'user' }),
+      (error) => {
+        assert.strictEqual(error.code, 'NO_PROJECT');
+        return true;
+      },
+    );
+  });
+
+  it('legacy mode releases the shared key ONLY for the legacy workspace', async () => {
+    const ok = getConfig({ ...LEGACY_CTX, mode: 'legacy' });
+    assert.strictEqual(ok.apiKey, 'sk_legacy');
+    assert.deepStrictEqual(ok.headers, {});
+
+    assert.throws(() => getConfig({ ...CTX, mode: 'legacy' }), McpjamApiError);
+  });
+
+  it('fails closed when the mode is absent entirely', async () => {
+    // A new call path that forgot to resolve a target must not inherit our
+    // organization's credentials.
+    assert.throws(
+      () => getConfig(CTX),
+      (error) => {
+        assert.strictEqual(error.code, 'UNAUTHORIZED');
+        return true;
+      },
+    );
+  });
+});
+
+describe('friendly error copy', () => {
+  it('sends an unauthorized user to connect, not to an admin', () => {
+    const error = new McpjamApiError('nope', { code: 'UNAUTHORIZED' });
+    assert.match(error.friendlyMessage, /connect your MCPJam account/i);
+  });
+
+  it('explains a 403 as a project-access problem', () => {
+    // The common cause is a thread bound to a project the replier can't reach.
+    const error = new McpjamApiError('nope', { code: 'FORBIDDEN' });
+    assert.match(error.friendlyMessage, /access to the project this thread/i);
+  });
+
+  it('never reports a backend outage as an auth problem', () => {
+    // Otherwise the user re-links an account that was already fine.
+    const error = new McpjamApiError('down', { code: 'SERVER_UNREACHABLE' });
+    assert.doesNotMatch(error.friendlyMessage, /connect|link/i);
+  });
+});

--- a/slack-app/tests/agent/turn-target.test.js
+++ b/slack-app/tests/agent/turn-target.test.js
@@ -34,7 +34,7 @@ describe('resolveTurnTarget', () => {
   beforeEach(() => {
     realFetch = globalThis.fetch;
     process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
-    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    process.env.SLACK_SERVICE_TOKEN = 'svc_test';
     process.env.MCPJAM_SLACK_SERVICE_TOKEN = 'slk_test';
   });
 

--- a/slack-app/tests/installations/store.test.js
+++ b/slack-app/tests/installations/store.test.js
@@ -121,6 +121,33 @@ describe('installation store', () => {
     assert.strictEqual(installationCacheSize(), 1, 'purging T1 must not evict T2');
   });
 
+  it('a purge DURING a lookup is not undone by that lookup', async () => {
+    // Without a generation check the in-flight fetch's `cache.set` re-inserts
+    // the revoked grant, and every event for the next 5 minutes is served
+    // with a token the workspace just killed.
+    let release;
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
+    globalThis.fetch = mock.fn(async () => {
+      await gate;
+      return backendResponse({
+        ok: true,
+        installation: installationFor('T1'),
+        botUserId: 'U_BOT',
+        isLegacyWorkspace: true,
+      });
+    });
+
+    const inflight = resolveInstallation('T1');
+    // The uninstall lands while the lookup is still open.
+    purgeInstallation('T1');
+    release();
+    await inflight;
+
+    assert.strictEqual(installationCacheSize(), 0, 'the purged grant must not be re-cached');
+  });
+
   it('surfaces a backend outage as an error, never as "not installed"', async () => {
     // Returning null here would look like an uninstall: Bolt would drop the
     // event and the workspace would be told to reinstall over a blip.

--- a/slack-app/tests/installations/store.test.js
+++ b/slack-app/tests/installations/store.test.js
@@ -1,0 +1,191 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { InstallationBackendError } from '../../installations/backend-client.js';
+import {
+  clearInstallationCache,
+  convexInstallationStore,
+  installationCacheSize,
+  purgeInstallation,
+  resolveInstallation,
+} from '../../installations/store.js';
+
+/** A minimal but realistic Bolt Installation. */
+function installationFor(teamId, botUserId = 'U_BOT') {
+  return {
+    team: { id: teamId, name: `Team ${teamId}` },
+    bot: { token: 'xoxb-secret', scopes: ['chat:write'], userId: botUserId },
+    appId: 'A1',
+    tokenType: 'bot',
+    isEnterpriseInstall: false,
+    authVersion: 'v2',
+  };
+}
+
+function backendResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('installation store', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    clearInstallationCache();
+    process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
+    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    realFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('caches a successful lookup so events do not each pay a round trip', async () => {
+    const calls = mock.fn(async () =>
+      backendResponse({
+        ok: true,
+        installation: installationFor('T1'),
+        botUserId: 'U_BOT',
+        isLegacyWorkspace: true,
+      }),
+    );
+    globalThis.fetch = calls;
+
+    const first = await resolveInstallation('T1');
+    const second = await resolveInstallation('T1');
+    assert.strictEqual(calls.mock.callCount(), 1, 'second lookup should hit the cache');
+    assert.strictEqual(first?.isLegacyWorkspace, true);
+    assert.deepStrictEqual(first, second);
+  });
+
+  it('purgeInstallation makes revocation immediate, not TTL-delayed', async () => {
+    // This is the whole reason the cache is safe. If a purge did not drop the
+    // entry synchronously, a revoked workspace would keep being served for
+    // the full TTL and "revocation is instant" would be false.
+    let installed = true;
+    globalThis.fetch = mock.fn(async () =>
+      backendResponse(
+        installed
+          ? { ok: true, installation: installationFor('T1'), botUserId: 'U_BOT', isLegacyWorkspace: true }
+          : { ok: true, installation: null },
+      ),
+    );
+
+    assert.ok(await resolveInstallation('T1'));
+    installed = false;
+    // Without the purge this would still answer from cache.
+    purgeInstallation('T1');
+    assert.strictEqual(await resolveInstallation('T1'), null);
+  });
+
+  it('does not cache a negative result', async () => {
+    // A workspace that installs seconds after a miss must work immediately.
+    let installed = false;
+    const calls = mock.fn(async () =>
+      backendResponse(
+        installed
+          ? { ok: true, installation: installationFor('T1'), botUserId: 'U_BOT', isLegacyWorkspace: false }
+          : { ok: true, installation: null },
+      ),
+    );
+    globalThis.fetch = calls;
+
+    assert.strictEqual(await resolveInstallation('T1'), null);
+    assert.strictEqual(installationCacheSize(), 0);
+    installed = true;
+    assert.ok(await resolveInstallation('T1'));
+    assert.strictEqual(calls.mock.callCount(), 2);
+  });
+
+  it('keeps two workspaces cached independently', async () => {
+    globalThis.fetch = mock.fn(async (_url, init) => {
+      const teamId = JSON.parse(String(init?.body)).teamId;
+      return backendResponse({
+        ok: true,
+        installation: installationFor(teamId, `U_BOT_${teamId}`),
+        botUserId: `U_BOT_${teamId}`,
+        isLegacyWorkspace: teamId === 'T1',
+      });
+    });
+
+    const a = await resolveInstallation('T1');
+    const b = await resolveInstallation('T2');
+    assert.strictEqual(a?.isLegacyWorkspace, true);
+    assert.strictEqual(b?.isLegacyWorkspace, false);
+
+    purgeInstallation('T1');
+    assert.strictEqual(installationCacheSize(), 1, 'purging T1 must not evict T2');
+  });
+
+  it('surfaces a backend outage as an error, never as "not installed"', async () => {
+    // Returning null here would look like an uninstall: Bolt would drop the
+    // event and the workspace would be told to reinstall over a blip.
+    globalThis.fetch = mock.fn(async () => backendResponse({ error: 'boom' }, 503));
+    await assert.rejects(resolveInstallation('T1'), InstallationBackendError);
+  });
+
+  it('fetchInstallation throws for a workspace with no active install', async () => {
+    globalThis.fetch = mock.fn(async () => backendResponse({ ok: true, installation: null }));
+    await assert.rejects(
+      convexInstallationStore.fetchInstallation({ teamId: 'T_GONE' }, undefined, undefined),
+      /No active MCPJam installation/,
+    );
+  });
+
+  it('refuses enterprise-install queries instead of answering with a team token', async () => {
+    // org_deploy_enabled is off, so an enterprise query means a shape we do
+    // not support. Answering it with SOME workspace's token would be acting
+    // as a tenant nobody authorized.
+    await assert.rejects(
+      convexInstallationStore.fetchInstallation({ isEnterpriseInstall: true, enterpriseId: 'E1' }),
+      /enterprise grid/i,
+    );
+    await assert.rejects(
+      convexInstallationStore.storeInstallation({ ...installationFor('T1'), isEnterpriseInstall: true }),
+      /enterprise grid/i,
+    );
+  });
+
+  it('storeInstallation persists the whole object and purges the previous grant', async () => {
+    let stored = null;
+    globalThis.fetch = mock.fn(async (url, init) => {
+      const path = String(url);
+      const body = JSON.parse(String(init?.body));
+      if (path.endsWith('/upsert')) {
+        stored = body;
+        return backendResponse({ ok: true, created: true });
+      }
+      return backendResponse({
+        ok: true,
+        installation: installationFor('T1'),
+        botUserId: 'U_BOT',
+        isLegacyWorkspace: true,
+      });
+    });
+
+    // Warm the cache with the PREVIOUS grant, then reinstall.
+    await resolveInstallation('T1');
+    assert.strictEqual(installationCacheSize(), 1);
+
+    await convexInstallationStore.storeInstallation(installationFor('T1'), undefined, undefined);
+    assert.strictEqual(stored.teamId, 'T1');
+    assert.strictEqual(stored.botUserId, 'U_BOT');
+    // The full object round-trips, not a column projection — Bolt reads
+    // fields we do not model.
+    assert.strictEqual(stored.installation.bot.token, 'xoxb-secret');
+    assert.strictEqual(stored.installation.authVersion, 'v2');
+    assert.strictEqual(installationCacheSize(), 0, 'a reinstall must invalidate the cached token');
+  });
+
+  it('rejects an installation with no bot user id', async () => {
+    // Without it the app cannot tell its OWN messages from a human's when
+    // re-reading a thread, so every turn would feed the model its own replies.
+    const broken = installationFor('T1');
+    delete broken.bot.userId;
+    await assert.rejects(convexInstallationStore.storeInstallation(broken), /bot user id/);
+  });
+});

--- a/slack-app/tests/installations/store.test.js
+++ b/slack-app/tests/installations/store.test.js
@@ -36,7 +36,7 @@ describe('installation store', () => {
   beforeEach(() => {
     clearInstallationCache();
     process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
-    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    process.env.SLACK_SERVICE_TOKEN = 'svc_test';
     realFetch = globalThis.fetch;
   });
 

--- a/slack-app/tests/listeners/actions/proposal-button.test.js
+++ b/slack-app/tests/listeners/actions/proposal-button.test.js
@@ -50,7 +50,7 @@ describe('handleProposalButton', () => {
     realFetch = globalThis.fetch;
     process.env.MCPJAM_SLACK_SERVICE_TOKEN = 'slk_test';
     process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
-    process.env.INSPECTOR_SERVICE_TOKEN = 'svc';
+    process.env.SLACK_SERVICE_TOKEN = 'svc';
     process.env.MCPJAM_BASE_URL = 'https://api.test';
   });
 
@@ -58,7 +58,7 @@ describe('handleProposalButton', () => {
     globalThis.fetch = realFetch;
     delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
     delete process.env.MCPJAM_CONVEX_HTTP_URL;
-    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    delete process.env.SLACK_SERVICE_TOKEN;
     delete process.env.MCPJAM_BASE_URL;
   });
 

--- a/slack-app/tests/listeners/actions/proposal-button.test.js
+++ b/slack-app/tests/listeners/actions/proposal-button.test.js
@@ -1,0 +1,157 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { handleProposalButton } from '../../../listeners/actions/proposal-button.js';
+import { buildProposalBlocks, PROPOSAL_ACTION_ID } from '../../../listeners/views/proposal-builder.js';
+
+const PROPOSAL = {
+  actionId: 'act_1',
+  operation: 'run_eval_suite',
+  description: 'Run eval suite ts_1',
+};
+
+describe('buildProposalBlocks', () => {
+  it('renders one confirming button carrying only the action id', () => {
+    const blocks = buildProposalBlocks([PROPOSAL]);
+    assert.strictEqual(blocks.length, 1);
+    const accessory = /** @type {any} */ (blocks[0]).accessory;
+    assert.strictEqual(accessory.action_id, PROPOSAL_ACTION_ID);
+    assert.strictEqual(accessory.value, 'act_1');
+    assert.ok(accessory.confirm, 'spending must be confirmed');
+    // The operation and its input are NOT on the wire: the server holds them.
+    assert.ok(!JSON.stringify(blocks).includes('suiteId'));
+  });
+
+  it('escapes agent-authored descriptions', () => {
+    const blocks = buildProposalBlocks([{ ...PROPOSAL, description: 'Run <!channel> now' }]);
+    const text = /** @type {any} */ (blocks[0]).text.text;
+    assert.ok(!text.includes('<!channel>'), 'a forged mention must not survive');
+    assert.ok(text.includes('&lt;!channel&gt;'));
+  });
+
+  it('returns nothing for an empty or missing list', () => {
+    assert.deepStrictEqual(buildProposalBlocks([]), []);
+    assert.deepStrictEqual(buildProposalBlocks(undefined), []);
+  });
+
+  it('caps the rendered set and says how many were held back', () => {
+    const many = Array.from({ length: 9 }, (_, index) => ({ ...PROPOSAL, actionId: `act_${index}` }));
+    const blocks = buildProposalBlocks(many);
+    assert.strictEqual(blocks.length, 6);
+    assert.match(/** @type {any} */ (blocks[5]).elements[0].text, /4 more/);
+  });
+});
+
+describe('handleProposalButton', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+    process.env.MCPJAM_SLACK_SERVICE_TOKEN = 'slk_test';
+    process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
+    process.env.INSPECTOR_SERVICE_TOKEN = 'svc';
+    process.env.MCPJAM_BASE_URL = 'https://api.test';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
+    delete process.env.MCPJAM_CONVEX_HTTP_URL;
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    delete process.env.MCPJAM_BASE_URL;
+  });
+
+  function stub({ executeStatus = 200, executeBody = { status: 'succeeded', result: {} } } = {}) {
+    const state = { executeCalls: [] };
+    globalThis.fetch = mock.fn(async (url, init) => {
+      const path = String(url);
+      if (path.endsWith('/slack/thread-bindings/get')) {
+        return json({ binding: { projectId: 'p1', organizationId: 'o1', initiatorSlackUserId: 'U_OTHER' } });
+      }
+      if (path.includes('/proposed-actions/')) {
+        state.executeCalls.push({
+          url: path,
+          teamHeader: init?.headers?.['x-mcpjam-slack-team-id'],
+          userHeader: init?.headers?.['x-mcpjam-slack-user-id'],
+        });
+        return json(executeBody, executeStatus);
+      }
+      throw new Error(`unexpected fetch to ${path}`);
+    });
+    return state;
+  }
+
+  function json(body, status = 200) {
+    return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+  }
+
+  function clickArgs(overrides = {}) {
+    const posted = [];
+    const ephemeral = [];
+    return {
+      posted,
+      ephemeral,
+      args: {
+        ack: async () => {},
+        body: {
+          team: { id: 'T1' },
+          user: { id: 'U_CLICKER' },
+          channel: { id: 'C1' },
+          message: { ts: '2.0', thread_ts: '1.0' },
+        },
+        context: { teamId: 'T1', userId: 'U_CLICKER' },
+        client: {
+          chat: {
+            postMessage: async (payload) => {
+              posted.push(payload);
+              return { ts: '3.0' };
+            },
+            postEphemeral: async (payload) => {
+              ephemeral.push(payload);
+              return {};
+            },
+          },
+        },
+        logger: { warn: () => {}, error: () => {}, info: () => {} },
+        action: { value: 'act_1' },
+        ...overrides,
+      },
+    };
+  }
+
+  it('executes as the CLICKER, not the proposer', async () => {
+    const state = stub();
+    const { args, posted } = clickArgs();
+    await handleProposalButton(/** @type {any} */ (args));
+
+    assert.strictEqual(state.executeCalls.length, 1);
+    // The thread binding names U_OTHER as the initiator; the headers must still
+    // carry the person who clicked.
+    assert.strictEqual(state.executeCalls[0].userHeader, 'U_CLICKER');
+    assert.strictEqual(state.executeCalls[0].teamHeader, 'T1');
+    assert.match(state.executeCalls[0].url, /\/projects\/p1\/proposed-actions\/act_1\/execute$/);
+    assert.match(posted[0].text, /<@U_CLICKER>/);
+  });
+
+  it('tells the loser of a double-click without implying a failure', async () => {
+    stub({ executeStatus: 409, executeBody: { code: 'CONFLICT', message: 'That action is already running.' } });
+    const { args, ephemeral, posted } = clickArgs();
+    await handleProposalButton(/** @type {any} */ (args));
+
+    assert.strictEqual(posted.length, 0);
+    assert.match(ephemeral[0].text, /already under way/);
+  });
+
+  it('refuses an unlinked clicker instead of spending', async () => {
+    globalThis.fetch = mock.fn(async (url) => {
+      const path = String(url);
+      if (path.endsWith('/slack/thread-bindings/get')) return json({ binding: null });
+      if (path.endsWith('/slack/links/fetch')) return json({ link: null });
+      throw new Error(`must not reach ${path}`);
+    });
+    const { args, ephemeral } = clickArgs();
+    await handleProposalButton(/** @type {any} */ (args));
+    assert.match(ephemeral[0].text, /Connect your MCPJam account/);
+  });
+});

--- a/slack-app/tests/listeners/actions/run-suite-button.test.js
+++ b/slack-app/tests/listeners/actions/run-suite-button.test.js
@@ -18,10 +18,15 @@ describe('handleRunSuiteButton', () => {
     args = {
       ack: mock.fn(async () => {}),
       // The button sits on the bot's reply (ts 42.0) inside thread 40.0.
-      body: { channel: { id: 'C1' }, message: { ts: '42.0', thread_ts: '40.0' } },
+      body: {
+        channel: { id: 'C1' },
+        message: { ts: '42.0', thread_ts: '40.0' },
+        team: { id: 'T1' },
+        user: { id: 'U1' },
+      },
       action: { value: 'ts_1' },
       context: { userId: 'U1' },
-      logger: { error: mock.fn() },
+      logger: { error: mock.fn(), warn: mock.fn() },
       client: {
         chat: {
           postMessage: mock.fn(async () => ({ ok: true, ts: '43.0' })),

--- a/slack-app/tests/listeners/actions/run-suite-button.test.js
+++ b/slack-app/tests/listeners/actions/run-suite-button.test.js
@@ -25,7 +25,7 @@ describe('handleRunSuiteButton', () => {
         user: { id: 'U1' },
       },
       action: { value: 'ts_1' },
-      context: { userId: 'U1' },
+      context: { userId: 'U1', mcpjamTenancy: { isLegacyWorkspace: true } },
       logger: { error: mock.fn(), warn: mock.fn() },
       client: {
         chat: {

--- a/slack-app/tests/listeners/events/app-home-opened.test.js
+++ b/slack-app/tests/listeners/events/app-home-opened.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert';
-import { beforeEach, describe, it, mock } from 'node:test';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 
 import { handleAppHomeOpened } from '../../../listeners/events/app-home-opened.js';
 
@@ -7,14 +7,24 @@ describe('handleAppHomeOpened', () => {
   let fakeClient;
   let fakeContext;
   let fakeLogger;
+  let realFetch;
 
   beforeEach(() => {
+    // No per-user auth configured ⇒ the legacy/dev shape, which publishes a
+    // view without needing a backend. The linked/unlinked states are covered
+    // in app-home-state.test.js.
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
+    realFetch = globalThis.fetch;
     fakeClient = {
       views: { publish: mock.fn(async () => ({ ok: true })) },
       assistant: { threads: { setSuggestedPrompts: mock.fn(async () => ({ ok: true })) } },
     };
-    fakeContext = { userId: 'U123' };
-    fakeLogger = { error: mock.fn() };
+    fakeContext = { userId: 'U123', teamId: 'T1' };
+    fakeLogger = { error: mock.fn(), warn: mock.fn() };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
   });
 
   it('publishes the home view when event.tab === "home"', async () => {

--- a/slack-app/tests/listeners/events/app-lifecycle.test.js
+++ b/slack-app/tests/listeners/events/app-lifecycle.test.js
@@ -1,0 +1,142 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+import { clearInstallationCache, installationCacheSize, resolveInstallation } from '../../../installations/store.js';
+import { handleAppUninstalled, handleTokensRevoked } from '../../../listeners/events/app-lifecycle.js';
+import { sessionStore } from '../../../thread-context/index.js';
+
+function backendResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Answers fetch with an install, and records revoke calls. */
+function stubBackend({ botUserId = 'U_BOT', revokeStatus = 200 } = {}) {
+  const revoked = [];
+  globalThis.fetch = mock.fn(async (url, init) => {
+    const path = String(url);
+    const body = JSON.parse(String(init?.body));
+    if (path.endsWith('/revoke')) {
+      revoked.push(body.teamId);
+      return revokeStatus === 200
+        ? backendResponse({ ok: true, revoked: true })
+        : backendResponse({ error: 'nope' }, revokeStatus);
+    }
+    return backendResponse({
+      ok: true,
+      installation: { team: { id: body.teamId }, bot: { token: 'xoxb', userId: botUserId } },
+      botUserId,
+      isLegacyWorkspace: true,
+    });
+  });
+  return revoked;
+}
+
+const logger = () => ({ warn: mock.fn(), info: mock.fn(), error: mock.fn() });
+
+describe('installation lifecycle', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    clearInstallationCache();
+    process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
+    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    realFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('app_uninstalled revokes and purges cache + engaged threads', async () => {
+    const revoked = stubBackend();
+    await resolveInstallation('T1');
+    sessionStore.setSession('T1', 'C1', 'ts-1', 'engaged');
+    sessionStore.setSession('T2', 'C1', 'ts-1', 'engaged');
+
+    await handleAppUninstalled({ body: { team_id: 'T1' }, context: {}, event: {}, logger: logger() });
+
+    assert.deepStrictEqual(revoked, ['T1']);
+    assert.strictEqual(installationCacheSize(), 0);
+    assert.strictEqual(sessionStore.getSession('T1', 'C1', 'ts-1'), null);
+    assert.strictEqual(sessionStore.getSession('T2', 'C1', 'ts-1'), 'engaged', 'other tenants untouched');
+  });
+
+  it('purges locally even when the backend revoke fails', async () => {
+    // The workspace has already withdrawn consent. This process must stop
+    // using the token immediately; the durable revoke can be retried.
+    stubBackend({ revokeStatus: 500 });
+    await resolveInstallation('T1');
+    const log = logger();
+
+    await handleAppUninstalled({ body: { team_id: 'T1' }, context: {}, event: {}, logger: log });
+
+    assert.strictEqual(installationCacheSize(), 0);
+    assert.strictEqual(log.error.mock.callCount(), 1);
+  });
+
+  it('tokens_revoked revokes ONLY when our bot token is named', async () => {
+    const revoked = stubBackend({ botUserId: 'U_BOT' });
+    await resolveInstallation('T1');
+
+    await handleTokensRevoked({
+      body: { team_id: 'T1' },
+      context: {},
+      event: { tokens: { bot: ['U_BOT'] } },
+      logger: logger(),
+    });
+    assert.deepStrictEqual(revoked, ['T1']);
+  });
+
+  it('tokens_revoked for ANOTHER bot token leaves the installation alone', async () => {
+    const revoked = stubBackend({ botUserId: 'U_BOT' });
+    await resolveInstallation('T1');
+
+    await handleTokensRevoked({
+      body: { team_id: 'T1' },
+      context: {},
+      event: { tokens: { bot: ['U_SOMEONE_ELSE'] } },
+      logger: logger(),
+    });
+    assert.deepStrictEqual(revoked, [], 'must not revoke on another app’s bot token');
+    assert.strictEqual(installationCacheSize(), 1, 'cache stays warm');
+  });
+
+  it('tokens_revoked naming only USER tokens does not touch the installation', async () => {
+    // A user revoking their own token must not take the workspace's bot
+    // offline for everyone.
+    const revoked = stubBackend();
+    await resolveInstallation('T1');
+
+    await handleTokensRevoked({
+      body: { team_id: 'T1' },
+      context: {},
+      event: { tokens: { oauth: ['U1'] } },
+      logger: logger(),
+    });
+    assert.deepStrictEqual(revoked, []);
+    assert.strictEqual(installationCacheSize(), 1);
+  });
+
+  it('does not guess a durable revoke when the installation cannot be resolved', async () => {
+    const revoked = [];
+    globalThis.fetch = mock.fn(async (url, init) => {
+      const path = String(url);
+      if (path.endsWith('/revoke')) {
+        revoked.push(JSON.parse(String(init?.body)).teamId);
+        return backendResponse({ ok: true });
+      }
+      return backendResponse({ error: 'down' }, 500);
+    });
+
+    await handleTokensRevoked({
+      body: { team_id: 'T1' },
+      context: {},
+      event: { tokens: { bot: ['U_BOT'] } },
+      logger: logger(),
+    });
+    assert.deepStrictEqual(revoked, [], 'unknown whether OUR token was revoked — do not guess');
+  });
+});

--- a/slack-app/tests/listeners/events/app-lifecycle.test.js
+++ b/slack-app/tests/listeners/events/app-lifecycle.test.js
@@ -42,7 +42,7 @@ describe('installation lifecycle', () => {
   beforeEach(() => {
     clearInstallationCache();
     process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
-    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    process.env.SLACK_SERVICE_TOKEN = 'svc_test';
     realFetch = globalThis.fetch;
   });
 

--- a/slack-app/tests/listeners/middleware/tenant-guard.test.js
+++ b/slack-app/tests/listeners/middleware/tenant-guard.test.js
@@ -1,0 +1,111 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { clearInstallationCache } from '../../../installations/store.js';
+import { tenantGuard } from '../../../listeners/middleware/tenant-guard.js';
+
+function backendResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function installationResponse({ isLegacyWorkspace }) {
+  return backendResponse({
+    ok: true,
+    installation: { team: { id: 'T1' }, bot: { token: 'xoxb', userId: 'U_BOT' } },
+    botUserId: 'U_BOT',
+    isLegacyWorkspace,
+  });
+}
+
+function argsFor(overrides = {}) {
+  return {
+    body: { team_id: 'T1' },
+    context: {},
+    event: { type: 'app_mention', user: 'U1' },
+    logger: { warn: mock.fn(), info: mock.fn(), error: mock.fn() },
+    next: mock.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe('tenantGuard', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    clearInstallationCache();
+    process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
+    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    realFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('admits the legacy workspace and publishes the tenancy verdict', async () => {
+    globalThis.fetch = mock.fn(async () => installationResponse({ isLegacyWorkspace: true }));
+    const args = argsFor();
+    await tenantGuard(args);
+    assert.strictEqual(args.next.mock.callCount(), 1);
+    assert.deepStrictEqual(args.context.mcpjamTenancy, {
+      isLegacyWorkspace: true,
+      botUserId: 'U_BOT',
+    });
+  });
+
+  it('HARD-DROPS a non-legacy workspace before any agent call', async () => {
+    // Until per-user auth ships the bot acts with an org-scoped key belonging
+    // to OUR organization. Running another workspace's request with it is a
+    // cross-tenant leak, so distribution being live must not mean serving
+    // those events.
+    globalThis.fetch = mock.fn(async () => installationResponse({ isLegacyWorkspace: false }));
+    const args = argsFor();
+    await tenantGuard(args);
+    assert.strictEqual(args.next.mock.callCount(), 0);
+    assert.strictEqual(args.context.mcpjamTenancy, undefined);
+  });
+
+  it('drops events from a workspace with no active installation', async () => {
+    globalThis.fetch = mock.fn(async () => backendResponse({ ok: true, installation: null }));
+    const args = argsFor();
+    await tenantGuard(args);
+    assert.strictEqual(args.next.mock.callCount(), 0);
+  });
+
+  it('drops (for Slack to retry) rather than proceeding when the backend is down', async () => {
+    // The dangerous alternative is running the turn anyway under whatever
+    // credentials happen to be in env.
+    globalThis.fetch = mock.fn(async () => backendResponse({ error: 'down' }, 500));
+    const args = argsFor();
+    await tenantGuard(args);
+    assert.strictEqual(args.next.mock.callCount(), 0);
+    assert.strictEqual(args.logger.warn.mock.callCount(), 1);
+  });
+
+  it('lets lifecycle events through WITHOUT a tenancy lookup', async () => {
+    // app_uninstalled is how a workspace tells us it revoked us. Gating it on
+    // an active installation would make the revoke unreachable — and gating a
+    // non-legacy workspace's uninstall would leak its row forever.
+    globalThis.fetch = mock.fn(async () => {
+      throw new Error('the guard must not call the backend for lifecycle events');
+    });
+    for (const type of ['app_uninstalled', 'tokens_revoked']) {
+      const args = argsFor({ event: { type }, payload: { type } });
+      await tenantGuard(args);
+      assert.strictEqual(args.next.mock.callCount(), 1, `${type} should pass through`);
+    }
+  });
+
+  it('drops a payload with no resolvable tenant without calling the backend', async () => {
+    globalThis.fetch = mock.fn(async () => {
+      throw new Error('should not be reached');
+    });
+    const args = argsFor({ body: {}, event: { type: 'message' }, context: {} });
+    await tenantGuard(args);
+    assert.strictEqual(args.next.mock.callCount(), 0);
+  });
+});

--- a/slack-app/tests/listeners/middleware/tenant-guard.test.js
+++ b/slack-app/tests/listeners/middleware/tenant-guard.test.js
@@ -57,16 +57,18 @@ describe('tenantGuard', () => {
     });
   });
 
-  it('HARD-DROPS a non-legacy workspace before any agent call', async () => {
-    // Until per-user auth ships the bot acts with an org-scoped key belonging
-    // to OUR organization. Running another workspace's request with it is a
-    // cross-tenant leak, so distribution being live must not mean serving
-    // those events.
+  it('SERVES a non-legacy workspace now that identity is per-actor', async () => {
+    // The guard no longer decides who may be served — per-user auth answers
+    // that per ACTOR downstream. What it still publishes is whether the
+    // shared env key may be released, which for a non-legacy team is `false`.
     globalThis.fetch = mock.fn(async () => installationResponse({ isLegacyWorkspace: false }));
     const args = argsFor();
     await tenantGuard(args);
-    assert.strictEqual(args.next.mock.callCount(), 0);
-    assert.strictEqual(args.context.mcpjamTenancy, undefined);
+    assert.strictEqual(args.next.mock.callCount(), 1);
+    assert.deepStrictEqual(args.context.mcpjamTenancy, {
+      isLegacyWorkspace: false,
+      botUserId: 'U_BOT',
+    });
   });
 
   it('drops events from a workspace with no active installation', async () => {

--- a/slack-app/tests/listeners/middleware/tenant-guard.test.js
+++ b/slack-app/tests/listeners/middleware/tenant-guard.test.js
@@ -38,7 +38,7 @@ describe('tenantGuard', () => {
   beforeEach(() => {
     clearInstallationCache();
     process.env.MCPJAM_CONVEX_HTTP_URL = 'https://backend.test';
-    process.env.INSPECTOR_SERVICE_TOKEN = 'svc_test';
+    process.env.SLACK_SERVICE_TOKEN = 'svc_test';
     realFetch = globalThis.fetch;
   });
 
@@ -108,7 +108,7 @@ describe('tenantGuard', () => {
     // short-circuit the outage branch catches the CONFIG error and drops
     // EVERY event — `slack run` becomes a bot that acks and ignores.
     delete process.env.MCPJAM_CONVEX_HTTP_URL;
-    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    delete process.env.SLACK_SERVICE_TOKEN;
     globalThis.fetch = mock.fn(async () => {
       throw new Error('the guard must not call the backend in socket mode');
     });

--- a/slack-app/tests/listeners/middleware/tenant-guard.test.js
+++ b/slack-app/tests/listeners/middleware/tenant-guard.test.js
@@ -102,6 +102,21 @@ describe('tenantGuard', () => {
     }
   });
 
+  it('passes everything through in socket mode (no backend configured)', async () => {
+    // Socket mode has no installation store: the single workspace's token
+    // comes from env and Bolt has already authorized the event. Without this
+    // short-circuit the outage branch catches the CONFIG error and drops
+    // EVERY event — `slack run` becomes a bot that acks and ignores.
+    delete process.env.MCPJAM_CONVEX_HTTP_URL;
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    globalThis.fetch = mock.fn(async () => {
+      throw new Error('the guard must not call the backend in socket mode');
+    });
+    const args = argsFor();
+    await tenantGuard(args);
+    assert.strictEqual(args.next.mock.callCount(), 1);
+  });
+
   it('drops a payload with no resolvable tenant without calling the backend', async () => {
     globalThis.fetch = mock.fn(async () => {
       throw new Error('should not be reached');

--- a/slack-app/tests/thread-context/store.test.js
+++ b/slack-app/tests/thread-context/store.test.js
@@ -11,42 +11,69 @@ describe('SessionStore', () => {
   });
 
   it('stores and retrieves a session', () => {
-    store.setSession('C1', 'T1', 'sid-abc');
-    assert.strictEqual(store.getSession('C1', 'T1'), 'sid-abc');
+    store.setSession('T1', 'C1', 'ts-1', 'sid-abc');
+    assert.strictEqual(store.getSession('T1', 'C1', 'ts-1'), 'sid-abc');
   });
 
   it('returns null for missing key', () => {
-    assert.strictEqual(store.getSession('C1', 'T99'), null);
+    assert.strictEqual(store.getSession('T1', 'C1', 'ts-99'), null);
   });
 
   it('keeps different threads independent', () => {
-    store.setSession('C1', 'T1', 'sid-1');
-    store.setSession('C1', 'T2', 'sid-2');
-    assert.strictEqual(store.getSession('C1', 'T1'), 'sid-1');
-    assert.strictEqual(store.getSession('C1', 'T2'), 'sid-2');
+    store.setSession('T1', 'C1', 'ts-1', 'sid-1');
+    store.setSession('T1', 'C1', 'ts-2', 'sid-2');
+    assert.strictEqual(store.getSession('T1', 'C1', 'ts-1'), 'sid-1');
+    assert.strictEqual(store.getSession('T1', 'C1', 'ts-2'), 'sid-2');
+  });
+
+  it('isolates identical channel+thread ids across workspaces', () => {
+    // Slack channel ids are unique only WITHIN a workspace, so two tenants
+    // can genuinely present the same (channel, thread) pair. Team T2 must not
+    // see T1's engaged thread — that would make the bot answer unaddressed
+    // messages in a channel it was never invited to.
+    store.setSession('T1', 'C1', 'ts-1', 'engaged');
+    assert.strictEqual(store.getSession('T2', 'C1', 'ts-1'), null);
+    store.setSession('T2', 'C1', 'ts-1', 'engaged-elsewhere');
+    assert.strictEqual(store.getSession('T1', 'C1', 'ts-1'), 'engaged');
+    assert.strictEqual(store.getSession('T2', 'C1', 'ts-1'), 'engaged-elsewhere');
+  });
+
+  it('refuses to key a session without a team id', () => {
+    assert.throws(() => store.setSession('', 'C1', 'ts-1', 'sid'), /requires a teamId/);
+    assert.throws(() => store.getSession('', 'C1', 'ts-1'), /requires a teamId/);
+  });
+
+  it('clearTeam drops only that workspace threads', () => {
+    store.setSession('T1', 'C1', 'ts-1', 'sid-1');
+    store.setSession('T1', 'C2', 'ts-2', 'sid-2');
+    store.setSession('T2', 'C1', 'ts-1', 'sid-3');
+    store.clearTeam('T1');
+    assert.strictEqual(store.getSession('T1', 'C1', 'ts-1'), null);
+    assert.strictEqual(store.getSession('T1', 'C2', 'ts-2'), null);
+    assert.strictEqual(store.getSession('T2', 'C1', 'ts-1'), 'sid-3');
   });
 
   it('expires entries after TTL', async () => {
     const shortStore = new SessionStore(0);
-    shortStore.setSession('C1', 'T1', 'sid-abc');
+    shortStore.setSession('T1', 'C1', 'ts-1', 'sid-abc');
     // Need a tiny delay to ensure Date.now() advances past the stored timestamp
     await new Promise((resolve) => setTimeout(resolve, 5));
-    assert.strictEqual(shortStore.getSession('C1', 'T1'), null);
+    assert.strictEqual(shortStore.getSession('T1', 'C1', 'ts-1'), null);
   });
 
   it('evicts oldest entries when max is exceeded', () => {
     const smallStore = new SessionStore(86400, 2);
-    smallStore.setSession('C1', 'T1', 'sid-1');
-    smallStore.setSession('C1', 'T2', 'sid-2');
-    smallStore.setSession('C1', 'T3', 'sid-3');
-    assert.strictEqual(smallStore.getSession('C1', 'T1'), null);
-    assert.strictEqual(smallStore.getSession('C1', 'T2'), 'sid-2');
-    assert.strictEqual(smallStore.getSession('C1', 'T3'), 'sid-3');
+    smallStore.setSession('T1', 'C1', 'ts-1', 'sid-1');
+    smallStore.setSession('T1', 'C1', 'ts-2', 'sid-2');
+    smallStore.setSession('T1', 'C1', 'ts-3', 'sid-3');
+    assert.strictEqual(smallStore.getSession('T1', 'C1', 'ts-1'), null);
+    assert.strictEqual(smallStore.getSession('T1', 'C1', 'ts-2'), 'sid-2');
+    assert.strictEqual(smallStore.getSession('T1', 'C1', 'ts-3'), 'sid-3');
   });
 
   it('overwrites existing key', () => {
-    store.setSession('C1', 'T1', 'sid-old');
-    store.setSession('C1', 'T1', 'sid-new');
-    assert.strictEqual(store.getSession('C1', 'T1'), 'sid-new');
+    store.setSession('T1', 'C1', 'ts-1', 'sid-old');
+    store.setSession('T1', 'C1', 'ts-1', 'sid-new');
+    assert.strictEqual(store.getSession('T1', 'C1', 'ts-1'), 'sid-new');
   });
 });

--- a/slack-app/thread-context/store.js
+++ b/slack-app/thread-context/store.js
@@ -6,6 +6,13 @@
 
 /**
  * In-memory session ID store with TTL-based cleanup.
+ *
+ * Keys are `team:channel:thread`. The team id is NOT decorative: Slack
+ * channel ids are unique only within a workspace, so a two-tenant key space
+ * without it lets one workspace's engaged thread mark another's as engaged —
+ * the bot would answer unaddressed messages in a channel it was never
+ * mentioned in. The map is also bounded by `maxEntries`, which without a
+ * tenant prefix would let a busy workspace evict a quiet one's threads.
  */
 export class SessionStore {
   /**
@@ -22,12 +29,26 @@ export class SessionStore {
   }
 
   /**
+   * @private
+   * @param {string} teamId
+   * @param {string} channelId
+   * @param {string} threadTs
+   */
+  _key(teamId, channelId, threadTs) {
+    if (!teamId) {
+      throw new Error('SessionStore requires a teamId — thread state is per-workspace.');
+    }
+    return `${teamId}:${channelId}:${threadTs}`;
+  }
+
+  /**
+   * @param {string} teamId
    * @param {string} channelId
    * @param {string} threadTs
    * @returns {string | null}
    */
-  getSession(channelId, threadTs) {
-    const key = `${channelId}:${threadTs}`;
+  getSession(teamId, channelId, threadTs) {
+    const key = this._key(teamId, channelId, threadTs);
     const entry = this._store.get(key);
     if (!entry) return null;
     if (Date.now() - entry.timestamp > this._ttlSeconds * 1000) {
@@ -38,18 +59,34 @@ export class SessionStore {
   }
 
   /**
+   * @param {string} teamId
    * @param {string} channelId
    * @param {string} threadTs
    * @param {string} sessionId
    * @returns {void}
    */
-  setSession(channelId, threadTs, sessionId) {
-    const key = `${channelId}:${threadTs}`;
+  setSession(teamId, channelId, threadTs, sessionId) {
+    const key = this._key(teamId, channelId, threadTs);
     this._store.set(key, {
       sessionId,
       timestamp: Date.now(),
     });
     this._cleanup();
+  }
+
+  /**
+   * Drop every thread belonging to one workspace. Called on uninstall: the
+   * app must not keep acting on a team that revoked it, and a later reinstall
+   * should start from a clean slate rather than resuming half-remembered
+   * conversations.
+   * @param {string} teamId
+   * @returns {void}
+   */
+  clearTeam(teamId) {
+    const prefix = `${teamId}:`;
+    for (const key of [...this._store.keys()]) {
+      if (key.startsWith(prefix)) this._store.delete(key);
+    }
   }
 
   /**


### PR DESCRIPTION
Turns the Slack bot from a single-workspace process on a shared org key into a distributable app where **each user acts as themselves**.

⚠️ **Depends on [MCPJam/mcpjam-backend#849](https://github.com/MCPJam/mcpjam-backend/pull/849)**, which must deploy first.

Six commits, one reviewable step each.

### 1. Thread the tenant through every chokepoint (pure refactor)

`getConfig()` read global env creds, and `EventDedupe` / `KeyedQueue` / `SessionStore` keyed on `channel:thread` alone. Slack channel and thread ids are unique only **within** a workspace, so the moment a second team installs, those keys collide across tenants: one workspace's event suppresses another's as a "duplicate", one workspace's engaged thread makes the bot answer unaddressed messages elsewhere, and a busy workspace evicts a quiet one's threads. Behaviour unchanged; the tenant is now explicit and asserted. Shared channels resolve the team from `authorizations[0].team_id` — the event's own `team` can be the *other* workspace.

### 2. Multi-workspace OAuth over Bolt's HTTP receiver

Mode is derived from config presence, not a flag, so the two can't disagree. Two Bolt behaviours drove the shape, both verified against 5.0.0:

- **`scopes` is passed explicitly.** HTTPReceiver defaults it to `undefined` and forwards `scopes ?? []`, so omitting it yields an install URL requesting **zero** bot scopes. That install *succeeds* and then fails every API call with `missing_scope`, per workspace, with nothing at install time pointing at the cause.
- **No custom `authorize`.** Bolt throws when given both, and with installer options derives authorization from `installationStore.fetchInstallation` — so the store *is* the auth path.

A backend outage is **not** an uninstall (`fetchInstallation` throws rather than returning null, so a blip can't tell a workspace to reinstall). The 5-minute token cache is only safe because lifecycle events bust it synchronously. `tokens_revoked` revokes only when the stored `botUserId` appears in `event.tokens.bot` — a user revoking their own token must not take the workspace's bot offline.

Manifest: one batched change → one reinstall. Railway now serves HTTP and is **pinned to one replica** (documented) — the cache purge and rate buckets are process-local.

### 3–4. Idempotency through the mutation path

Server side: `x-mcpjam-idempotency-key`, a **header** not a body field, because the agent's tool schemas are model-facing and a model must never be able to invent or vary the key that is the whole safety property. Per-call keys are `${turnKey}:${operation}:${sha256(input)}` with **sorted** object keys — plain `JSON.stringify` preserves insertion order, so identical inputs would otherwise hash differently and a retry would silently duplicate. `RunEvalsRequestSchema` now *declares* the key instead of stripping it: a caller could previously send it, get a 202, and still be billed twice with nothing indicating it was dropped.

Bot side: durable claims on Slack's `event_id` (the identity of the delivery chain), the same key passed to the turn, and **fail-closed** on an unreachable claim backend — reading an outage as "you own it" turns one event into two billed turns. The run button becomes a state machine whose action id is *derived*, not generated, so a double-click, an action retry, and a mid-start crash all present the same value.

### 5. Account-link bridge + `slk_` auth

The connect URL travels through Slack where anyone present can click it, so possession authorizes nothing. Two proofs, ordered by the session's **status** (not by trusting redirect sequencing): Slack OIDC must show the clicker *is* that Slack user (`team_id` compared as strictly as `user_id`; `profile` scope mandatory since `openid` alone yields no `team_id`), and only then does AuthKit identify the account. The WorkOS-leg state rides in an HttpOnly cookie so it never touches Slack, and binds leg 2 to the browser that ran leg 1. Failure copy is generic and identical across causes — naming the failed check would confirm whether a captured URL is live and whose it is.

`slk_` is deliberately not an `sk_` key: an `sk_` key *is* a user's credential and mints portable 2-hour org JWTs, so an unattended bot acting for many users must not hold one. Fail-closed allowlist (this middleware is mounted on ~25 `/api/web/*` groups too), **503 not 401** on a backend blip, and a rate bucket keyed on the *link* rather than the shared token.

### 6. Per-user identity and thread bindings

`resolveTurnTarget`: thread binding → replier's default project → legacy shared key (only for the one pre-OAuth workspace, and only for users there who haven't linked). The binding wins because without it a thread drifts between projects as different people reply. Unlinked and no-default-project are **UX states, not errors** — ephemeral in channels so one person's account message doesn't notify the thread. SessionStore becomes a cache over the durable binding; before this the bot went deaf in every engaged thread after a restart.

---

## Testing

- **slack-app: 125 tests**, plus typecheck and lint (`npm run verify`) — cross-workspace isolation, the cache/purge and outage semantics, the tenant-guard drop matrix, claim replay across a simulated restart, the resolution order, and both credential modes' fail-closed paths.
- **Server: 21 new tests** — signed-state tampering/expiry, per-leg state distinctness, the `slk_` allowlist matrix including the web surface, and unlinked-vs-unreachable.
- Full inspector suite was green (12073 passed) as of the idempotency commit; a final re-run is in progress and I'll report it here.

## Deploy notes

New env: `SLACK_CLIENT_ID`/`SLACK_CLIENT_SECRET`/`SLACK_STATE_SECRET`/`SLACK_SIGNING_SECRET`, `MCPJAM_CONVEX_HTTP_URL`, `SLACK_LINK_STATE_SECRET`, `SLACK_LINK_PUBLIC_ORIGIN`, `MCPJAM_SLACK_SERVICE_TOKEN_HASH` (inspector) / `MCPJAM_SLACK_SERVICE_TOKEN` (bot). See `slack-app/MIGRATION.md` for the rollout runbook, the release gate's E2E + security checklists, and the Phase 4 cleanup preconditions.

**Distribution is activated for testing only.** Public availability opens after the Phase 3 E2E passes — that is the single release gate, and it needs real workspaces. Phase 4 (deleting the legacy fallback) is deliberately **not** in this PR: it removes the credential path our own workspace still uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTeF2H5rfLErTr9HoAGFJb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTeF2H5rfLErTr9HoAGFJb)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the Slack bot into a public, multi-workspace app where each user acts as themselves, with durable idempotency and secure account linking. Tightens approval clicks, retries, and install/link flows to prevent double execution, stale auth, and misleading UX.

- **Bug Fixes**
  - Prevent double-spend: derive action ids from turn key + op + input (not `randomUUID()`); check proposal org vs clicker BEFORE claiming; share idempotency keys across retries; forward abort signals so timed‑out clicks don’t keep running.
  - Installation cache correctness: refuse auth if a purge lands mid-lookup; pin in‑flight generation entries so unrelated purges can’t reset them; bound the generation map and re‑prune after in‑flight lookups finish; stop serving revoked tokens from cache.
  - Slack link bridge and auth separation: return 503 on transient failures (don’t burn sessions); deadlines on provider token exchanges; keep sessions intact for retry; validate connect URLs against an allowlist of configured origins (HTTPS off loopback) and reject `user@evil.test` tricks; include the `CLI_AUTH_PUBLIC_ORIGIN` fallback in the allowlist; the bot no longer holds `INSPECTOR_SERVICE_TOKEN` (backend `/slack/*` uses `SLACK_SERVICE_TOKEN`), and the bridge verifies the bot’s `slk_` via a hashed, constant‑time check.
  - Idempotency keys: hash long turn keys to a fixed width; use a non‑truncating iterative digest for nested inputs (no throwing path, no silent collisions); validate as printable ASCII, canonicalize, and cap header length so idempotency stays active on long keys.
  - Generation idempotency: fail closed (502) when the generation ledger cannot be read to avoid re‑spend; checkpoint empty results too; converge concurrent same‑key requests on the winner’s drafts; tests assert exact per‑item keys.
  - Claims and throttling: mark claims complete and store the answer when a turn ran but delivery failed (redeliveries replay, never re‑run); complete with a failure envelope when the request was dispatched but no reply landed; release durable claims only when nothing was delivered and on local preflight failures; bound per‑link `slk_` buckets and evict the fullest buckets first.
  - UI and correctness: dedupe proposed actions by action id (one spend → one button); cap+escape proposal descriptions; fix cancel wording and run links (built from real ids); hide Disconnect when per-user auth is unavailable; baseline the internal execute route in OpenAPI drift tests (route remains intentionally undocumented).
  - Docs: correct the generation-ledger fail‑closed path to return 502 (not 503) in comments.

<sup>Written for commit 671a75ca10fe31db4b027fc62731623d7281f702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication (new `slk_` path, delegated JWT minting), OAuth/account-link flows, and billing-sensitive eval/agent execution with new idempotency and proposal execution semantics—mistakes could cause wrong-user delegation, double-spend, or unauthorized API access.
> 
> **Overview**
> This PR turns the Slack integration into a **multi-workspace, per-user** surface: the bot uses a dedicated **`slk_` service credential** (not org `sk_` keys) plus Slack team/user headers, resolves identity from **account links**, and mints **delegated JWTs** for the linked human on allowlisted `/api/v1` routes only.
> 
> **Account linking** is wired as a public **`/api/slack/link`** bridge (Slack OIDC then WorkOS AuthKit, HMAC state, HttpOnly cookie for the WorkOS leg). The bot mints connect URLs via **`POST /api/slack/link/session`** authenticated with `slk_`.
> 
> **Spend is human-gated**: the v1 **agent** gains a broader read/write toolset, **proposal-only** tools for quota/credit operations (`run_*`, `generate_*`, `cancel_*`), and optional **`idempotencyKey`** / **`slackChannelId`**. **`POST .../proposed-actions/:actionId/execute`** runs what was persisted on the proposal, attributes the clicker, and forwards idempotency on execution.
> 
> **Write idempotency** is standardized on **`x-mcpjam-idempotency-key`** with derived per-operation and per-case keys through eval authoring, eval runs, and case generation (including a **generation ledger** so keyed retries replay drafts instead of re-spending).
> 
> The **slack-app** side documents OAuth vs socket mode, `slk_` env, connect-link minting with origin allowlisting, and rollout steps in **`MIGRATION.md`**. Extensive middleware and route tests cover `slk_` allowlisting, link state, and idempotent generate flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671a75ca10fe31db4b027fc62731623d7281f702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->