### PR TITLE
fix(chatboxes): keep the session flow headers with their columns

### DIFF
--- a/.changeset/insights-flow-header-alignment.md
+++ b/.changeset/insights-flow-header-alignment.md
@@ -1,0 +1,16 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix the session flow's column headers drifting away from their columns.
+
+The headers were a four-cell CSS grid across the full panel while the diagram
+was a fixed-width SVG, so on a wide panel the SENTIMENT header sat hundreds of
+pixels from the column it names — the first three lined up only by coincidence.
+They are drawn inside the diagram now, at the same x as the columns, which is
+the only arrangement in which they cannot come apart.
+
+The last column also labelled to the LEFT of its bar, a defensive choice from
+before the label gutter existed. That put its text on top of the ribbons
+arriving at it and read as a rendering fault. Every column now labels to the
+right, into the space already reserved for it.

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxInsightsSankey.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxInsightsSankey.tsx
@@ -45,8 +45,11 @@ const STAGE_COLOR: Record<SankeyStage, { node: string; head: string }> = {
   sentiment: { node: "#bda2d8", head: "#7a5da3" },
 };
 
-const VIEW_WIDTH = 1040;
-const LABEL_GUTTER = 200;
+const VIEW_WIDTH = 1160;
+/** Reserved to the right of the last column for its labels. */
+const LABEL_GUTTER = 260;
+/** Band at the top of the SVG holding the column headers. */
+const HEADER_HEIGHT = 26;
 
 function RebuildButton({
   onRebuild,
@@ -221,30 +224,39 @@ export function ChatboxInsightsSankey({
         </div>
       ) : null}
 
-      <div className="grid grid-cols-4 gap-2 pt-1 text-[10.5px] font-semibold uppercase tracking-[0.13em]">
-        {STAGE_ORDER.map((stage) => (
-          <span
-            key={stage}
-            style={{ color: STAGE_COLOR[stage].head }}
-            className={stage === "sentiment" ? "text-right" : undefined}
-          >
-            {STAGE_TITLES[stage]}
-          </span>
-        ))}
-      </div>
-
       <div className="overflow-x-auto">
         <svg
-          viewBox={`0 0 ${VIEW_WIDTH} ${height}`}
+          viewBox={`0 0 ${VIEW_WIDTH} ${height + HEADER_HEIGHT}`}
           width={VIEW_WIDTH}
-          height={height}
+          height={height + HEADER_HEIGHT}
           // `group`, not `img`: an image is a leaf, so `img` would hide every
           // node and ribbon button inside it from assistive tech — undoing the
           // point of making them focusable in the first place.
           role="group"
           aria-label="Session flow from goal through behavior and outcome to sentiment"
-          className="block min-w-[880px] max-w-full"
+          className="mt-1 block w-full min-w-[880px] max-w-[1160px]"
         >
+          {/*
+            Headers live INSIDE the diagram, at the same x as the columns they
+            name. As CSS they were a four-cell grid across the panel while the
+            chart was a fixed-width box, so on a wide panel the last header sat
+            hundreds of pixels from its own column. Sharing one coordinate space
+            is the only way they cannot drift apart.
+          */}
+          <g>
+            {STAGE_ORDER.map((stage, index) => (
+              <text
+                key={stage}
+                x={layout.columnX[index]}
+                y={14}
+                fill={STAGE_COLOR[stage].head}
+                className="text-[10.5px] font-semibold uppercase [letter-spacing:0.13em]"
+              >
+                {STAGE_TITLES[stage]}
+              </text>
+            ))}
+          </g>
+
           <defs>
             {layout.links.map((link) => (
               <linearGradient
@@ -275,7 +287,7 @@ export function ChatboxInsightsSankey({
             ))}
           </defs>
 
-          <g>
+          <g transform={`translate(0, ${HEADER_HEIGHT})`}>
             {layout.links.map((link) => {
               const id = `${link.source.id}→${link.target.id}`;
               const next = selectionForLink(link.source, link.target);
@@ -320,7 +332,7 @@ export function ChatboxInsightsSankey({
             })}
           </g>
 
-          <g>
+          <g transform={`translate(0, ${HEADER_HEIGHT})`}>
             {layout.nodes.map((node) => {
               const next = selectionForNode(node);
               const emphasized = selectedKeys.has(`${node.stage}:${node.key}`);
@@ -436,11 +448,11 @@ function FlowNodeShape({
   emphasized: boolean;
   selectable: boolean;
 }) {
-  // The last column's labels sit to the LEFT of their bar, so the widest names
-  // in the diagram never run past the right edge.
-  const isLast = node.stage === "sentiment";
-  const labelX = isLast ? node.x - 10 : node.x + SANKEY_NODE_WIDTH + 10;
-  const anchor = isLast ? "end" : "start";
+  // Every column labels to the right of its bar, the last one included: the
+  // gutter is reserved for it. Flipping the last column inward put its text on
+  // top of the ribbons arriving at it, which read as a rendering fault.
+  const labelX = node.x + SANKEY_NODE_WIDTH + 10;
+  const anchor = "start";
 
   return (
     <>

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxInsightsSankey.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxInsightsSankey.test.tsx
@@ -299,6 +299,23 @@ describe("ChatboxInsightsSankey", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("draws each column header at its own column's x", () => {
+    // Guards the misalignment that shipped: headers laid out by CSS across the
+    // full panel while the columns lived in a fixed-width SVG.
+    renderSankey();
+    const headers = Array.from(document.querySelectorAll("text")).filter((t) =>
+      ["GOAL", "BEHAVIOR", "OUTCOME", "SENTIMENT"].includes(
+        (t.textContent ?? "").toUpperCase(),
+      ),
+    );
+    expect(headers).toHaveLength(4);
+    const xs = headers.map((h) => Number(h.getAttribute("x")));
+    // Strictly increasing, and the last one is nowhere near the right edge —
+    // it sits over its column, with the label gutter beyond it.
+    expect(xs).toEqual([...xs].sort((a, b) => a - b));
+    expect(new Set(xs).size).toBe(4);
+  });
+
   it("says how many themes were folded away, across all columns", () => {
     renderSankey({
       breakdown: breakdown({

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/insights-sankey.test.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/insights-sankey.test.ts
@@ -209,6 +209,21 @@ describe("layoutSankey", () => {
     expect(outgoing).toBeLessThanOrEqual(g1.height + 1e-6);
   });
 
+  it("echoes the column positions back for the headers to share", () => {
+    // The headers are drawn from these exact numbers. They used to be a CSS
+    // grid across the panel while the chart was a fixed-width box, so on a wide
+    // panel the last header sat hundreds of pixels from its own column. One
+    // coordinate space is the only thing that keeps them together.
+    const laid = layoutSankey(sankey, 400, 200, columnX);
+    expect(laid.columnX).toEqual(columnX);
+    for (const stage of ["goal", "behavior", "outcome", "sentiment"] as const) {
+      const inStage = laid.nodes.filter((n) => n.stage === stage);
+      if (inStage.length === 0) continue;
+      const index = ["goal", "behavior", "outcome", "sentiment"].indexOf(stage);
+      expect(inStage.every((n) => n.x === laid.columnX[index])).toBe(true);
+    }
+  });
+
   it("drops a link whose endpoint is not drawn", () => {
     const orphaned: InsightsSankey = {
       ...sankey,

--- a/mcpjam-inspector/client/src/components/chatboxes/insights-sankey.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/insights-sankey.ts
@@ -122,6 +122,8 @@ export type SankeyLayout = {
   links: SankeyLayoutLink[];
   width: number;
   height: number;
+  /** Echoed back so headers can be drawn at the same x as their column. */
+  columnX: number[];
 };
 
 const NODE_WIDTH = 9;
@@ -233,7 +235,7 @@ export function layoutSankey(
     });
   }
 
-  return { nodes: [...laid.values()], links, width, height };
+  return { nodes: [...laid.values()], links, width, height, columnX };
 }
 
 export const SANKEY_NODE_WIDTH = NODE_WIDTH;


### PR DESCRIPTION
The SENTIMENT header sits hundreds of pixels from the column it names.

## Cause

Two coordinate systems that only agreed by accident. The stage headers were a four-cell CSS `grid-cols-4` stretched across the full panel; the diagram is a fixed-width SVG. On a panel wider than the chart the grid keeps stretching and the columns do not, so GOAL / BEHAVIOR / OUTCOME lined up roughly by coincidence and SENTIMENT — the one pinned to the right edge by `text-right` — did not line up at all.

## Fix

Headers are drawn inside the SVG, at the `columnX` the layout already computes. `layoutSankey` now echoes those positions back specifically so the headers and the nodes read from one source; sharing a coordinate space is the only arrangement in which they cannot drift.

Also unflipped the last column's labels. They were anchored to the LEFT of their bar — a defensive choice from before the label gutter existed — which by now just painted the text on top of the ribbons arriving at that column and read as a rendering fault. Every column labels to the right, into the gutter already reserved for it. The viewBox widened to 1160 with a 260px gutter so the longest sentiment names ("Neutral, mild curiosity") fit without truncation.

## Pinned

- `insights-sankey.test.ts` — every node sits on its own column's `x`, and the layout returns those positions.
- `ChatboxInsightsSankey.test.tsx` — four distinct, strictly increasing header positions.

Neither test passes against the old arrangement, since the old headers were not in the SVG at all.

## Verification

- `npm run typecheck:client` — clean
- `npm run build:inspector` — succeeds
- Full suite — 12,169 passed, 6 skipped

Rendering still wants a real look: jsdom places the text but does not measure it, so whether the longest theme names actually clear the gutter is not something these tests can answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Insights Sankey presentation-only changes with regression tests; no API, auth, or data handling impact.
> 
> **Overview**
> Fixes **session flow** column headers drifting away from their Sankey columns on wide panels by moving stage titles **into the SVG** at `layout.columnX` instead of a full-width CSS grid above a fixed-width chart. `layoutSankey` now **returns `columnX`** so headers and nodes share one coordinate system; diagram content is shifted down by a new **`HEADER_HEIGHT`** band.
> 
> **Sentiment** (and all) node labels now anchor **to the right** of each bar into the label gutter, avoiding text drawn over incoming ribbons. The view widens to **1160px** with a **260px** gutter for long theme names. Tests lock header `x` positions and layout `columnX` echo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2d17f4a5bd622b73a00ff7dc3d8f9e7f8380c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned session flow headers by rendering them inside the SVG at the computed column positions, so headers stay aligned with their columns on any panel width. Also moves the last column's labels to the right and expands the label gutter to prevent overlap.

- **Bug Fixes**
  - Render headers inside the SVG using `layoutSankey`’s `columnX`; add a header band and translate nodes/links accordingly.
  - `layoutSankey` now returns `columnX` so nodes and headers share one coordinate space.
  - Widened viewBox to 1160 with a 260px gutter and label all columns to the right to avoid ribbon overlap; tests pin header and node x-positions.

<sup>Written for commit aa2d17f4a5bd622b73a00ff7dc3d8f9e7f8380c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

