### PR TITLE
fix(github-checks): empty the operator override table and make rung 0 injectable

### DIFF
--- a/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/detect.test.ts
@@ -5,13 +5,13 @@ import {
   parseMcpjamYaml,
   detectCandidates,
   detectCandidatesWithReasons,
+  makeOverrideResolver,
   RecipeResolutionError,
   resolveRecipe,
   resolveRecipeLadder,
   type DetectionInputs,
   type RepoFileEntry,
 } from "../resolver";
-import { listRecipeRepos } from "../recipes";
 
 // Detection is a HEURISTIC rung, so the tests pin the properties that make a
 // guess safe to act on rather than "does it guess right":
@@ -2005,18 +2005,43 @@ function parseMcpjamYamlMessageForOversize(): string {
 }
 
 describe("resolveRecipeLadder", () => {
-  const OVERRIDE_REPO = listRecipeRepos()[0];
+  // Rung 0 is injected, never taken from the production override table: that
+  // table is empty on purpose (an entry masks the repo's own mcpjam.yaml), and
+  // the ordering properties below are about the LADDER, not about config.
+  const OVERRIDE_REPO = "synthetic/override-repo";
+  const resolveOverride = makeOverrideResolver({
+    [OVERRIDE_REPO]: {
+      build: "make override-build",
+      start: "./override-start",
+      port: 4321,
+      mcpPath: "/override-mcp",
+    },
+  });
   const VALID_YAML =
     "version: 1\nchecks:\n  build: npm ci\n  start: npm start\n  port: 3001\n  path: /mcp\n";
   const DETECTABLE = inputs({ packageJson: PKG, packageLockJson: "{}" });
 
   it("override beats detection", () => {
+    // Control first: the same repo with the same detectable inputs and NO
+    // override lands on candidates, so the assertion below is about rung 0.
+    expect(
+      resolveRecipeLadder({
+        repoFullName: OVERRIDE_REPO,
+        mcpjamYaml: null,
+        detection: DETECTABLE,
+      }).kind,
+    ).toBe("candidates");
+
     const result = resolveRecipeLadder({
       repoFullName: OVERRIDE_REPO,
       mcpjamYaml: null,
       detection: DETECTABLE,
+      resolveOverride,
     });
-    expect(result.kind).toBe("authoritative");
+    expect(result).toMatchObject({
+      kind: "authoritative",
+      recipe: { rung: "override", port: 4321 },
+    });
   });
 
   it("declared config beats detection", () => {
@@ -2098,6 +2123,7 @@ describe("resolveRecipeLadder", () => {
       mcpjamYaml: null,
       mcpjamYamlOverCap: true,
       detection: DETECTABLE,
+      resolveOverride,
     });
     expect(result).toMatchObject({ kind: "authoritative" });
     if (result.kind !== "authoritative") throw new Error("unreachable");

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolver.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolver.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
+  makeOverrideResolver,
   MCPJAM_YAML_MAX_BYTES,
   parseMcpjamYaml,
   RecipeResolutionError,
   resolveOverrideRecipe,
   resolveRecipe,
 } from "../resolver";
-import { listRecipeRepos, resolveCheckRecipe } from "../recipes";
+import { listRecipeRepos, type CheckRecipe } from "../recipes";
 
 // The resolver decides whose configuration ran and, when it fails, whose
 // fault that is. The tests pin the two properties that matter:
@@ -17,8 +18,20 @@ import { listRecipeRepos, resolveCheckRecipe } from "../recipes";
 //   2. evidence strings never carry untrusted file content, because they are
 //      rendered into GitHub check output.
 
-/** A repo that exists in the operator override table. */
-const OVERRIDE_REPO = listRecipeRepos()[0];
+// Override behaviour is tested against a SYNTHETIC table, never the production
+// one. The production table is empty on purpose (an entry masks that repo's own
+// mcpjam.yaml — see ../recipes), and a rung whose coverage disappears the moment
+// production config is emptied was never really covered.
+const OVERRIDE_REPO = "synthetic/override-repo";
+const OVERRIDE_RECIPE: CheckRecipe = {
+  build: "make override-build",
+  start: "./override-start",
+  port: 4321,
+  mcpPath: "/override-mcp",
+};
+const resolveSyntheticOverride = makeOverrideResolver({
+  [OVERRIDE_REPO]: OVERRIDE_RECIPE,
+});
 
 const VALID_YAML = `
 version: 1
@@ -149,17 +162,32 @@ describe("parseMcpjamYaml (declared rung)", () => {
   });
 });
 
-describe("resolveOverrideRecipe (override rung)", () => {
-  it("wraps the existing RECIPES table without changing it", () => {
-    const raw = resolveCheckRecipe(OVERRIDE_REPO);
-    const resolved = resolveOverrideRecipe(OVERRIDE_REPO);
-    expect(raw).not.toBeNull();
-    expect(resolved).toMatchObject({ ...raw, rung: "override" });
+describe("makeOverrideResolver (override rung)", () => {
+  it("wraps a table entry without changing it, adding rung + evidence", () => {
+    const resolved = resolveSyntheticOverride(OVERRIDE_REPO);
+    expect(resolved).toMatchObject({
+      ...OVERRIDE_RECIPE,
+      rung: "override",
+      ownershipProof: "verified",
+    });
     expect(resolved?.evidence.join(" ")).toContain(OVERRIDE_REPO);
   });
 
+  it("matches case-insensitively, like the GitHub repo names it keys on", () => {
+    expect(resolveSyntheticOverride("  Synthetic/Override-Repo ")).toMatchObject(
+      { ...OVERRIDE_RECIPE, rung: "override" },
+    );
+  });
+
   it("returns null for repos without an override", () => {
-    expect(resolveOverrideRecipe("nobody/nothing")).toBeNull();
+    expect(resolveSyntheticOverride("nobody/nothing")).toBeNull();
+  });
+
+  it("the PRODUCTION resolver overrides nothing — the table is empty", () => {
+    // Paired with the guard test in sandbox.test.ts. If this ever needs
+    // changing, read what an override costs in ../recipes first.
+    expect(resolveOverrideRecipe(OVERRIDE_REPO)).toBeNull();
+    expect(listRecipeRepos()).toEqual([]);
   });
 });
 
@@ -168,10 +196,21 @@ describe("resolveRecipe (the ladder)", () => {
     const resolved = resolveRecipe({
       repoFullName: OVERRIDE_REPO,
       mcpjamYaml: VALID_YAML.replace("port: 3001", "port: 9999"),
+      resolveOverride: resolveSyntheticOverride,
     });
     expect(resolved.rung).toBe("override");
-    expect(resolved.port).toBe(resolveCheckRecipe(OVERRIDE_REPO)!.port);
+    expect(resolved.port).toBe(OVERRIDE_RECIPE.port);
     expect(resolved.evidence.join(" ")).toContain("outranked");
+  });
+
+  it("without an override the SAME repo resolves at the declared rung", () => {
+    // The control for the case above: it is the injected override doing the
+    // outranking, not anything about the repo name.
+    const resolved = resolveRecipe({
+      repoFullName: OVERRIDE_REPO,
+      mcpjamYaml: VALID_YAML,
+    });
+    expect(resolved.rung).toBe("declared");
   });
 
   it("uses the declared config when there is no override", () => {

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -11,7 +11,7 @@ import {
   waitForMcpInitialize,
   type CheckSandbox,
 } from "../sandbox";
-import { listRecipeRepos, resolveCheckRecipe } from "../recipes";
+import { listRecipeRepos, lookupRecipe, resolveCheckRecipe } from "../recipes";
 
 // Everything this module runs is untrusted PR code, so the tests are written
 // around the two properties that make that safe rather than around happy-path
@@ -2171,19 +2171,42 @@ describe("clampOutput", () => {
 });
 
 describe("recipes", () => {
-  it("resolves the fixture repo case-insensitively", () => {
-    expect(resolveCheckRecipe("MCPJam/MCP-Check-Fixture")).toMatchObject({
-      port: 3001,
-      mcpPath: "/mcp",
+  // The LOOKUP is tested against a synthetic table, so it stays covered no
+  // matter what the production override table contains (today: nothing).
+  const TABLE = {
+    "synthetic/override-repo": {
+      build: "make override-build",
+      start: "./override-start",
+      port: 4321,
+      mcpPath: "/override-mcp",
+    },
+  };
+
+  it("looks up case-insensitively, and trims", () => {
+    expect(lookupRecipe(TABLE, "  Synthetic/Override-Repo ")).toMatchObject({
+      port: 4321,
+      mcpPath: "/override-mcp",
     });
   });
 
   it("returns null for anything else — the worker maps that to recipe_unresolvable", () => {
+    expect(lookupRecipe(TABLE, "someone/unknown-server")).toBeNull();
+    expect(lookupRecipe(TABLE, "")).toBeNull();
     expect(resolveCheckRecipe("someone/unknown-server")).toBeNull();
     expect(resolveCheckRecipe("")).toBeNull();
   });
 
-  it("only the fixture repo is wired up in the skeleton", () => {
-    expect(listRecipeRepos()).toEqual(["mcpjam/mcp-check-fixture"]);
+  it("the production override table is EMPTY, and must stay that way", () => {
+    // GUARD, not an incidental assertion. The override rung outranks a repo's
+    // own mcpjam.yaml, so every entry added here MASKS that repository's
+    // declared config for as long as it is present — which is exactly how the
+    // old mcpjam/mcp-check-fixture entry made the resolver ladder untestable
+    // (delete its yaml, break its yaml, or exercise detection: same override
+    // recipe, same green check).
+    //
+    // Updating this test is a deliberate act. Read the docblock in ../recipes
+    // first, and remove the entry as soon as whatever it unblocks is fixed.
+    expect(listRecipeRepos()).toEqual([]);
+    expect(resolveCheckRecipe("mcpjam/mcp-check-fixture")).toBeNull();
   });
 });

--- a/mcpjam-inspector/server/services/github-checks/recipes.ts
+++ b/mcpjam-inspector/server/services/github-checks/recipes.ts
@@ -1,20 +1,36 @@
 /**
- * Run recipes: how to turn a PR checkout into a reachable MCP server.
+ * Run recipes: the OPERATOR OVERRIDE table (rung 0 of the resolution ladder).
  *
- * This is the ONE hardcoded piece of the GitHub-checks walking skeleton, and it
- * is hardcoded on purpose. The unsolved problem in "test an arbitrary MCP
- * server's PR" is not the testing — eval suites and the runner already exist —
- * it is knowing how to build and start the server. The eventual answer is a
- * resolution ladder (declared config → repo metadata → detection → agentic
- * fallback). Everything AROUND that ladder is production plumbing, so it is
- * built first against a single controlled fixture repo, and the ladder later
- * replaces `RECIPES` without touching anything else.
+ * This started life as the ONE hardcoded piece of the GitHub-checks walking
+ * skeleton — the unsolved problem in "test an arbitrary MCP server's PR" is not
+ * the testing but knowing how to build and start the server, so the plumbing was
+ * built first against a single controlled fixture repo. The resolution ladder
+ * (declared config → detection → agentic fallback) has since landed, and this
+ * table is no longer how any repo is expected to resolve. It is an operator
+ * ESCAPE HATCH, and it is deliberately EMPTY.
  *
- * A repo with no recipe resolves to `recipe_unresolvable` (a NEUTRAL check —
- * "we couldn't figure this out", never a failure attributed to the PR). In the
- * skeleton that state is unreachable through the webhook, since the repo
- * allowlist and this table are configured together; the worker still handles it
- * defensively, because the resolver era makes it routine.
+ * ┌─────────────────────────────────────────────────────────────────────────┐
+ * │ WHAT AN ENTRY HERE COSTS — read before adding one.                      │
+ * │                                                                         │
+ * │ The override rung sits ABOVE the declared rung (resolver/index.ts): an  │
+ * │ override outranks a repo's own `mcpjam.yaml` even when both exist. So   │
+ * │ an entry here MASKS that repository's declared config for as long as it │
+ * │ is present, and every check on that repo resolves through this table    │
+ * │ instead of through the ladder.                                          │
+ * │                                                                         │
+ * │ That is exactly how the fixture entry that used to live here made the   │
+ * │ ladder untestable: deleting the fixture's yaml, breaking it, or         │
+ * │ exercising detection all produced the same override recipe and the same │
+ * │ green check. A smoke test that goes green while testing nothing.        │
+ * │                                                                         │
+ * │ Add an entry only to unblock a repo the ladder genuinely cannot resolve │
+ * │ (and prefer fixing the ladder), remove it as soon as it is unblocked,   │
+ * │ and update the guard test that asserts this table is empty — the guard  │
+ * │ exists so the cost is acknowledged rather than discovered later.        │
+ * └─────────────────────────────────────────────────────────────────────────┘
+ *
+ * A repo with no recipe at all resolves to `recipe_unresolvable` (a NEUTRAL
+ * check — "we couldn't figure this out", never a failure attributed to the PR).
  */
 
 export type CheckRecipe = {
@@ -38,21 +54,38 @@ export type CheckRecipe = {
  * Keyed by lowercased `owner/repo`, matching the backend's allowlist
  * normalization (GitHub repo names are case-insensitive).
  */
-const RECIPES: Record<string, CheckRecipe> = {
-  "mcpjam/mcp-check-fixture": {
-    build: "npm ci && npm run build",
-    start: "npm start",
-    port: 3001,
-    mcpPath: "/mcp",
-  },
-};
+export type RecipeTable = Readonly<Record<string, CheckRecipe>>;
+
+/**
+ * The PRODUCTION override table. Empty on purpose — see the module docblock for
+ * what an entry costs. `mcpjam/mcp-check-fixture` used to live here; it now
+ * carries its own `mcpjam.yaml` and resolves at rung 1 like any other repo,
+ * which is the only way the ladder is actually exercised end to end.
+ */
+export const RECIPES_TABLE: RecipeTable = {};
+
+/**
+ * The lookup itself, over an EXPLICIT table.
+ *
+ * Separated from the production table so the lookup's behaviour — the trim, the
+ * case fold, the null for anything absent — is testable as a FUNCTION rather
+ * than as a property of whatever happens to be configured. The old tests read
+ * `RECIPES[0]` to get a repo to look up, which meant emptying the table (the
+ * correct change) broke tests that were never about the table's contents.
+ */
+export function lookupRecipe(
+  table: RecipeTable,
+  repoFullName: string
+): CheckRecipe | null {
+  if (typeof repoFullName !== "string") return null;
+  return table[repoFullName.trim().toLowerCase()] ?? null;
+}
 
 export function resolveCheckRecipe(repoFullName: string): CheckRecipe | null {
-  if (typeof repoFullName !== "string") return null;
-  return RECIPES[repoFullName.trim().toLowerCase()] ?? null;
+  return lookupRecipe(RECIPES_TABLE, repoFullName);
 }
 
 /** Exposed for tests and for an operator sanity-checking a deployment. */
 export function listRecipeRepos(): string[] {
-  return Object.keys(RECIPES);
+  return Object.keys(RECIPES_TABLE);
 }

--- a/mcpjam-inspector/server/services/github-checks/resolver/index.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/index.ts
@@ -7,7 +7,9 @@
  *
  * Ladder order and the attribution contract live in ./types.ts. Today:
  *
- *   0. operator override  (authoritative) — present wins outright
+ *   0. operator override  (authoritative) — present wins outright, which is
+ *      why the production table is empty (see ../recipes); tests inject a
+ *      synthetic table via `LadderInput.resolveOverride`
  *   1. declared mcpjam.yaml (authoritative) — invalid FAILS, never falls through
  *   2. detected (heuristic) — MULTIPLE candidates, verified one at a time
  *   3+ agentic (heuristic) — lands in R5
@@ -22,7 +24,7 @@
  * verification that answer still owes.
  */
 
-import { resolveOverrideRecipe } from "./overrides";
+import { resolveOverrideRecipe, type OverrideResolver } from "./overrides";
 import { parseMcpjamYaml, MCPJAM_YAML_MAX_BYTES } from "./mcpjamYaml";
 import { detectCandidatesWithReasons, type DetectionInputs } from "./detect";
 import { RecipeResolutionError, type ResolvedRecipe } from "./types";
@@ -42,7 +44,11 @@ export {
   MAX_REPO_FILES,
 } from "./repoFiles";
 export { parseMcpjamYaml, MCPJAM_YAML_MAX_BYTES } from "./mcpjamYaml";
-export { resolveOverrideRecipe } from "./overrides";
+export {
+  makeOverrideResolver,
+  resolveOverrideRecipe,
+  type OverrideResolver,
+} from "./overrides";
 export {
   RecipeResolutionError,
   type OwnershipProof,
@@ -103,6 +109,19 @@ export type LadderInput = {
    * populates it from the sandbox.
    */
   detection?: DetectionInputs;
+  /**
+   * Rung 0's lookup. Defaults to the production operator override table, which
+   * is where every real caller leaves it.
+   *
+   * It is a PARAMETER because rung 0's ordering — an override outranks a
+   * declared config, an over-cap one, and detection — is a property of this
+   * ladder, and a property that can only be exercised through module-level
+   * production config is not really tested at all. The production table is
+   * (correctly) empty, and before this seam existed emptying it silently
+   * deleted the coverage for the highest rung. Tests build a synthetic table
+   * with `makeOverrideResolver` instead.
+   */
+  resolveOverride?: OverrideResolver;
 };
 
 export type LadderResolution =
@@ -116,7 +135,9 @@ export type LadderResolution =
   | { kind: "candidates"; candidates: ResolvedRecipe[] };
 
 export function resolveRecipeLadder(input: LadderInput): LadderResolution {
-  const override = resolveOverrideRecipe(input.repoFullName);
+  const override = (input.resolveOverride ?? resolveOverrideRecipe)(
+    input.repoFullName,
+  );
   if (override) {
     // An override outranks a declared config even when both exist; say so in
     // the evidence so an author staring at ignored yaml understands why.
@@ -172,10 +193,9 @@ export function resolveRecipeLadder(input: LadderInput): LadderResolution {
  * throws). Kept because a caller that only wants "is this configured?" should
  * not have to destructure a union it can never observe the second arm of.
  */
-export function resolveRecipe(input: {
-  repoFullName: string;
-  mcpjamYaml: string | null;
-}): ResolvedRecipe {
+export function resolveRecipe(
+  input: Pick<LadderInput, "repoFullName" | "mcpjamYaml" | "resolveOverride">,
+): ResolvedRecipe {
   const resolution = resolveRecipeLadder(input);
   // Unreachable: without `detection`, rung 2 produces nothing and the ladder
   // throws `no_recipe` above. Asserted rather than assumed.

--- a/mcpjam-inspector/server/services/github-checks/resolver/overrides.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolver/overrides.ts
@@ -1,32 +1,47 @@
 /**
  * Rung 0: the operator override table.
  *
- * This wraps the existing hardcoded `RECIPES` table rather than replacing it:
- * the live worker still calls `resolveCheckRecipe` directly until the ladder
- * is wired in (R4), so the table keeps its current shape and behavior and
- * this module only adds the rung/evidence attribution on top.
+ * This adds rung/evidence attribution on top of the `../recipes` table without
+ * changing that table's shape or behavior.
  *
  * Overrides are AUTHORITATIVE (types.ts): an operator put the entry there
  * deliberately, so when one exists it wins over anything the repo declares.
+ * That is precisely why the production table is EMPTY (see `../recipes`) — an
+ * entry masks the repo's own `mcpjam.yaml`.
+ *
+ * The attribution is exposed as a resolver BUILT OVER A TABLE
+ * (`makeOverrideResolver`) rather than as a function closed over the production
+ * one, so override BEHAVIOUR can be exercised with a synthetic table. Override
+ * semantics are a property of the ladder, not of what an operator happens to
+ * have configured today, and coupling the two meant the tests could only test
+ * whatever production config contained.
  */
 
-import { resolveCheckRecipe } from "../recipes";
+import { lookupRecipe, RECIPES_TABLE, type RecipeTable } from "../recipes";
 import type { ResolvedRecipe } from "./types";
 
-export function resolveOverrideRecipe(
-  repoFullName: string,
-): ResolvedRecipe | null {
-  const recipe = resolveCheckRecipe(repoFullName);
-  if (!recipe) return null;
-  return {
-    ...recipe,
-    rung: "override",
-    // AUTHORITATIVE rung: an operator wrote this command down deliberately, so
-    // the declaration IS the ownership fact the ladder attributes to. There is
-    // nothing left for A3's runtime check to establish.
-    ownershipProof: "verified",
-    // repoFullName is operator/allowlist-controlled, not PR content, so it is
-    // safe to echo into evidence.
-    evidence: [`operator override for ${repoFullName.trim().toLowerCase()}`],
+/** Rung 0's lookup: `owner/repo` → an attributed override recipe, or null. */
+export type OverrideResolver = (repoFullName: string) => ResolvedRecipe | null;
+
+/** Build a rung-0 resolver over an explicit table (tests pass a synthetic one). */
+export function makeOverrideResolver(table: RecipeTable): OverrideResolver {
+  return (repoFullName: string): ResolvedRecipe | null => {
+    const recipe = lookupRecipe(table, repoFullName);
+    if (!recipe) return null;
+    return {
+      ...recipe,
+      rung: "override",
+      // AUTHORITATIVE rung: an operator wrote this command down deliberately,
+      // so the declaration IS the ownership fact the ladder attributes to.
+      // There is nothing left for A3's runtime check to establish.
+      ownershipProof: "verified",
+      // repoFullName is operator/allowlist-controlled, not PR content, so it is
+      // safe to echo into evidence.
+      evidence: [`operator override for ${repoFullName.trim().toLowerCase()}`],
+    };
   };
 }
+
+/** The production rung 0, over the (empty) production override table. */
+export const resolveOverrideRecipe: OverrideResolver =
+  makeOverrideResolver(RECIPES_TABLE);


### PR DESCRIPTION
## The problem

`RECIPES` in `server/services/github-checks/recipes.ts` hardcoded `mcpjam/mcp-check-fixture`, and the resolver ladder puts the **operator override rung ABOVE the declared `mcpjam.yaml` rung** (`resolver/index.ts` — with an explicit comment that an override outranks a declared config even when both exist).

So every check on the fixture repo resolved through that hardcoded table, and the resolver ladder we just spent several PRs building **never ran on it**. The planned e2e smoke matrix would have been worthless: deleting the fixture's yaml, breaking its yaml, and exercising detection would all have silently produced the same override recipe and the same green check. A test that goes green while testing nothing.

The fixture repo now carries a valid `mcpjam.yaml` on its `main`, so with the override entry gone it resolves at **rung 1 (declared)** and exercises the real path.

## What changed

**1. The production override table is empty.** With a docblock stating what an entry costs: it MASKS that repository's own `mcpjam.yaml` for as long as it is present, and routes every check on that repo around the ladder. It is an operator escape hatch now, not how any repo is expected to resolve.

**2. A test seam for rung 0 — the actual fix.** `resolveRecipeLadder` called the module-level `resolveOverrideRecipe` directly, so override behaviour could ONLY be exercised through whatever production config happened to contain. That coupling is why emptying the table broke six tests: the highest rung's coverage evaporated the moment production config was emptied, which means it was never really covered.

- `LadderInput.resolveOverride?: OverrideResolver` — optional, defaults to the production resolver, so every real caller is unchanged.
- `makeOverrideResolver(table)` builds a rung-0 resolver over an explicit table; production is `makeOverrideResolver(RECIPES_TABLE)`, tests pass a synthetic one and get the real rung/evidence attribution.
- `lookupRecipe(table, repoFullName)` splits the lookup from the production table, so trim/case-fold is tested as a FUNCTION rather than as a property of the table's contents.

These modules are already pure and take their inputs as parameters, so the seam is one more parameter rather than a mock or a module registry.

**3. The six tests are rewritten to inject a synthetic override**, not to depend on production config. Override semantics stay fully covered — beats declared, beats detection, beats an over-cap declared config, and the evidence still says it outranked — and each now has a *no-override control* proving it is the injected override doing the outranking.

**4. A guard test** asserts the production table is empty, with a comment that adding an entry masks that repo's own `mcpjam.yaml` and that this test must be updated deliberately.

## Verification

- `npx vitest run server/services/github-checks server/services/__tests__` — **exit code 0**, 36 files / 781 tests passed (checked unpiped; `github-checks-worker.test.ts` loads and runs, 56 tests).
- `npm run check:mcp-v1-runtime-imports` (workspace root) — **exit code 0**.
- `tsc --noEmit` reports **zero** errors under `server/services/github-checks`; the remaining errors are pre-existing and in unrelated files (computer-use tools, guest-spend-ip, local-server-resolver, …).

## Cache note

The recipe evidence digest does not cover the override table. It does not need a `RESOLVER_VERSION` bump here: the fixture's own evidence changed when `mcpjam.yaml` was added to it, so its cache key moved and a stale override-rung entry cannot be hit.

## Ordering

**This must merge and deploy BEFORE the e2e smoke matrix is run.** Running the matrix against a deployment that still has the fixture in the override table produces green checks that prove nothing about the ladder.

Do not merge on my behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5dc6141240eaa4ff8bb750a182dd28055a61289a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emptied the production operator override table and made rung 0 injectable so the resolver ladder runs on the fixture repo and override ordering is covered in tests.

- **Bug Fixes**
  - Removed the hardcoded `mcpjam/mcp-check-fixture` from the override table; the fixture now resolves at the declared rung via its `mcpjam.yaml`.
  - Added a guard test that asserts the production override table is empty.
  - Note: run the e2e smoke matrix only after this deploys; otherwise checks may pass without exercising the ladder.

- **Refactors**
  - Introduced `makeOverrideResolver(table)` and `lookupRecipe(table, repo)`; production uses an empty `RECIPES_TABLE`.
  - Added `resolveOverride?: OverrideResolver` to `resolveRecipeLadder`/`resolveRecipe` so tests inject a synthetic rung 0; production defaults remain unchanged.
  - Rewrote six tests to inject an override and added controls that verify behavior without an override.

<sup>Written for commit 5dc6141240eaa4ff8bb750a182dd28055a61289a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

