### PR TITLE
feat(swarms): Insights view — the four-stage session flow over swarm sessions

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle, ChevronRight, X } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
-import { useGoalOutcomeDrilldown } from "@/hooks/useUsageInsights";
+import {
+  useGoalOutcomeDrilldown,
+  type InsightsScope,
+} from "@/hooks/useUsageInsights";
 import {
   chipKey,
   isEmptySelection,
@@ -28,7 +31,8 @@ type DrilldownRow = {
 };
 
 interface ChatboxGoalOutcomeDrilldownProps {
-  chatboxId: string;
+  /** Which surface's sessions to page: a chatbox or a project's swarm. */
+  scope: InsightsScope;
   /** The open flow selection, or null when nothing is selected. */
   selection: InsightsSelection | null;
   /**
@@ -62,7 +66,7 @@ export function selectionHeading(selection: InsightsSelection): string {
 }
 
 /**
- * Identity of everything the paged request depends on: the chatbox, the
+ * Identity of everything the paged request depends on: the scope, the
  * selection, and the other active facet chips.
  *
  * The filters belong in the key because they are part of the query — and since
@@ -73,11 +77,15 @@ export function selectionHeading(selection: InsightsSelection): string {
  * page two of a set that no longer exists.
  */
 function requestKeyOf(
-  chatboxId: string,
+  scope: InsightsScope,
   selection: InsightsSelection | null,
   filter: UsageFilterState,
 ): string | null {
   if (!selection || selection.themes.length === 0) return null;
+  const scopeKey =
+    scope.kind === "swarm"
+      ? `swarm:${scope.projectId}`
+      : `chatbox:${scope.chatboxId}`;
   // Chip order is not semantically meaningful, so sort for a stable key.
   const chips = filter.chips.map(chipKey).sort().join(",");
   // The selection is keyed EXPLICITLY rather than relied on to show up in
@@ -85,7 +93,7 @@ function requestKeyOf(
   // that does not would silently keep the previous selection's cursor and page
   // two of a set that no longer exists.
   const selected = selectionChips(selection).map(chipKey).sort().join(",");
-  return [chatboxId, filter.preset, chips, selected].join("|");
+  return [scopeKey, filter.preset, chips, selected].join("|");
 }
 
 type PagingState = {
@@ -120,14 +128,14 @@ export function resolveNextBefore(
 }
 
 export function ChatboxGoalOutcomeDrilldown({
-  chatboxId,
+  scope,
   selection,
   filter,
   onClose,
   onOpenSession,
 }: ChatboxGoalOutcomeDrilldownProps) {
   const open = selection !== null && !isEmptySelection(selection);
-  const requestKey = requestKeyOf(chatboxId, open ? selection : null, filter);
+  const requestKey = requestKeyOf(scope, open ? selection : null, filter);
 
   // Cursor + accumulated pages, stored TOGETHER WITH the request they belong to.
   // Resetting in an effect instead would leave one render where the query runs
@@ -150,7 +158,7 @@ export function ChatboxGoalOutcomeDrilldown({
   }
 
   const { drilldown, isLoading } = useGoalOutcomeDrilldown({
-    chatboxId,
+    scope,
     // Absent for a behavior/outcome/sentiment selection; the server narrows by
     // chips alone in that case.
     clusterId:

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxInsightsSankey.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxInsightsSankey.tsx
@@ -31,6 +31,12 @@ interface ChatboxInsightsSankeyProps {
   onSelectLink: (selection: InsightsSelection) => void;
   onRebuild: () => void;
   rebuildBusy: boolean;
+  /**
+   * Per-stage header overrides. Swarms rename the goal column to "Journey" —
+   * their goal stage IS the journey, deterministically — while every other
+   * column keeps its shared name.
+   */
+  stageTitles?: Partial<Record<SankeyStage, string>>;
 }
 
 /**
@@ -88,6 +94,7 @@ export function ChatboxInsightsSankey({
   onSelectLink,
   onRebuild,
   rebuildBusy,
+  stageTitles,
 }: ChatboxInsightsSankeyProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const [readout, setReadout] = useState<string | null>(null);
@@ -131,7 +138,7 @@ export function ChatboxInsightsSankey({
         <p className="max-w-md text-xs text-muted-foreground">
           {signalsVersion === null
             ? "The last rebuild ran before session signals existed. Rebuild clusters to extract and group goals, behaviors, outcomes, and sentiment."
-            : "Rebuild clusters once this chatbox has enough sessions to cluster."}
+            : "Rebuild clusters once there are enough sessions to cluster."}
         </p>
         <RebuildButton
           onRebuild={onRebuild}
@@ -213,8 +220,8 @@ export function ChatboxInsightsSankey({
           className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground"
         >
           <span>
-            This chatbox was analyzed before every column was clustered, so only
-            the goal column has themes.
+            These sessions were analyzed before every column was clustered, so
+            only the goal column has themes.
           </span>
           <RebuildButton
             onRebuild={onRebuild}
@@ -252,7 +259,7 @@ export function ChatboxInsightsSankey({
                 fill={STAGE_COLOR[stage].head}
                 className="text-[10.5px] font-semibold uppercase [letter-spacing:0.13em]"
               >
-                {STAGE_TITLES[stage]}
+                {stageTitles?.[stage] ?? STAGE_TITLES[stage]}
               </text>
             ))}
           </g>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -294,7 +294,7 @@ export function ChatboxUsagePanel({
     rebuildInFlightRef.current = true;
     setRebuildBusy(true);
     try {
-      const result = await rebuild({ chatboxId: chatbox.chatboxId });
+      const result = await rebuild();
       if (result.alreadyRunning) {
         toast.info("A rebuild is already running");
       } else {
@@ -312,7 +312,7 @@ export function ChatboxUsagePanel({
         setRebuildBusy(false);
       }
     }
-  }, [rebuild, chatbox.chatboxId]);
+  }, [rebuild]);
 
   if (section === "insights") {
     return (
@@ -327,7 +327,7 @@ export function ChatboxUsagePanel({
             rebuildBusy={rebuildBusy}
           />
           <ChatboxGoalOutcomeDrilldown
-            chatboxId={chatbox.chatboxId}
+            scope={{ kind: "chatbox", chatboxId: chatbox.chatboxId }}
             selection={flowSelection}
             filter={effectiveFilter}
             onClose={handleCloseFlow}

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeDrilldown.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxGoalOutcomeDrilldown.test.tsx
@@ -44,7 +44,7 @@ function renderDrilldown(
 ) {
   return render(
     <ChatboxGoalOutcomeDrilldown
-      chatboxId="chatbox-1"
+      scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
       selection={selection}
       filter={EMPTY_USAGE_FILTER}
       onClose={vi.fn()}
@@ -238,7 +238,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     });
     rerender(
       <ChatboxGoalOutcomeDrilldown
-        chatboxId="chatbox-1"
+        scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
         selection={{
           themes: [
             { dimension: "goal", clusterId: "cluster-b", label: "Refunds" },
@@ -284,7 +284,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     await user.click(screen.getByRole("button", { name: /Load 25 more/ }));
     rerender(
       <ChatboxGoalOutcomeDrilldown
-        chatboxId="chatbox-1"
+        scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
         selection={CELL_A}
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}
@@ -330,7 +330,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     });
     const { rerender } = render(
       <ChatboxGoalOutcomeDrilldown
-        chatboxId="chatbox-1"
+        scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
         selection={CELL_A}
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}
@@ -353,7 +353,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     });
     rerender(
       <ChatboxGoalOutcomeDrilldown
-        chatboxId="chatbox-1"
+        scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
         selection={CELL_A}
         filter={toggleChip(EMPTY_USAGE_FILTER, {
           kind: "dimension",
@@ -388,7 +388,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     });
     const { rerender } = render(
       <ChatboxGoalOutcomeDrilldown
-        chatboxId="chatbox-1"
+        scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
         selection={CELL_A}
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}
@@ -404,7 +404,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     });
     rerender(
       <ChatboxGoalOutcomeDrilldown
-        chatboxId="chatbox-1"
+        scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
         selection={CELL_A}
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}
@@ -443,7 +443,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     });
     rerender(
       <ChatboxGoalOutcomeDrilldown
-        chatboxId="chatbox-1"
+        scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
         selection={CELL_A}
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}
@@ -481,7 +481,7 @@ describe("ChatboxGoalOutcomeDrilldown", () => {
     });
     rerender(
       <ChatboxGoalOutcomeDrilldown
-        chatboxId="chatbox-1"
+        scope={{ kind: "chatbox", chatboxId: "chatbox-1" }}
         selection={CELL_A}
         filter={EMPTY_USAGE_FILTER}
         onClose={vi.fn()}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmInsightsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmInsightsPanel.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "@/lib/toast";
+import {
+  EMPTY_USAGE_FILTER,
+  chipKey,
+  isSameSelection,
+  removeChipsByKeys,
+  selectionChipsToAdd,
+  type InsightsSelection,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+import { useUsageInsights, type InsightsScope } from "@/hooks/useUsageInsights";
+import { ChatboxInsightsSankey } from "@/components/chatboxes/ChatboxInsightsSankey";
+import { ChatboxGoalOutcomeDrilldown } from "@/components/chatboxes/ChatboxGoalOutcomeDrilldown";
+import { ScrollArea } from "@mcpjam/design-system/scroll-area";
+
+interface SwarmInsightsPanelProps {
+  projectId: string | null;
+  /** Open a session in the Sessions browser (the parent owns the tab flip). */
+  onOpenSession?: (sessionId: string) => void;
+}
+
+/**
+ * The Insights view for Swarms: the same four-stage session flow the chatbox
+ * Insights tab renders, over a project's swarm sessions.
+ *
+ * Shares the sankey, the drill-down, and the selection/chip mechanics with the
+ * chatbox panel — the one visible difference is the first column's header:
+ * swarm goals are journeys, assigned deterministically rather than clustered,
+ * so the column is named for what it actually is.
+ *
+ * No topic map and no feedback calibration: both are chatbox-surface features
+ * (goal embeddings / visitor feedback) that swarm sessions don't have.
+ */
+export function SwarmInsightsPanel({
+  projectId,
+  onOpenSession,
+}: SwarmInsightsPanelProps) {
+  const scope = useMemo<InsightsScope | null>(
+    () => (projectId ? { kind: "swarm", projectId } : null),
+    [projectId],
+  );
+
+  const [filter, setFilter] = useState<UsageFilterState>(EMPTY_USAGE_FILTER);
+  const [flowSelection, setFlowSelection] = useState<InsightsSelection | null>(
+    null,
+  );
+  // The chips the flow actually ADDED — ownership, not implication — mirroring
+  // the chatbox panel's contract so teardown never deletes a chip another
+  // writer put there.
+  const [flowOwnedKeys, setFlowOwnedKeys] = useState<string[]>([]);
+  const [rebuildBusy, setRebuildBusy] = useState(false);
+  const rebuildInFlightRef = useRef(false);
+
+  // Reset on project switches: a selected flow node names a cluster belonging
+  // to the previous project.
+  const prevProjectIdRef = useRef(projectId);
+  useEffect(() => {
+    if (prevProjectIdRef.current === projectId) return;
+    prevProjectIdRef.current = projectId;
+    setFilter(EMPTY_USAGE_FILTER);
+    setFlowSelection(null);
+    setFlowOwnedKeys([]);
+    rebuildInFlightRef.current = false;
+    setRebuildBusy(false);
+  }, [projectId]);
+
+  // The selection's own chips must not reach the breakdown query — they are
+  // the diagram's own output, and feeding them back collapses the diagram to
+  // the selected path. Same ownership subtraction as the chatbox panel.
+  const breakdownFilter = useMemo(
+    () => removeChipsByKeys(filter, flowOwnedKeys),
+    [filter, flowOwnedKeys],
+  );
+
+  const { breakdown, rebuild } = useUsageInsights({
+    scope,
+    filters: breakdownFilter,
+    threadsEnabled: false,
+    breakdownEnabled: scope !== null,
+  });
+
+  const handleSelectFlow = useCallback(
+    (next: InsightsSelection) => {
+      const isAlreadyOpen = isSameSelection(flowSelection, next);
+      const cleared = removeChipsByKeys(filter, flowOwnedKeys);
+      if (isAlreadyOpen) {
+        setFilter(cleared);
+        setFlowSelection(null);
+        setFlowOwnedKeys([]);
+        return;
+      }
+      const added = selectionChipsToAdd(cleared, next);
+      setFilter({ ...cleared, chips: [...cleared.chips, ...added] });
+      setFlowSelection(next);
+      setFlowOwnedKeys(added.map(chipKey));
+    },
+    [filter, flowSelection, flowOwnedKeys],
+  );
+
+  const handleCloseFlow = useCallback(() => {
+    setFilter((prev) => removeChipsByKeys(prev, flowOwnedKeys));
+    setFlowSelection(null);
+    setFlowOwnedKeys([]);
+  }, [flowOwnedKeys]);
+
+  const handleRebuild = useCallback(async () => {
+    if (rebuildInFlightRef.current) return;
+    rebuildInFlightRef.current = true;
+    setRebuildBusy(true);
+    try {
+      const result = await rebuild();
+      if (result.alreadyRunning) {
+        toast.info("A rebuild is already running");
+      } else {
+        toast.success("Rebuild queued");
+      }
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Rebuild failed. Try again in a few minutes.",
+      );
+    } finally {
+      rebuildInFlightRef.current = false;
+      setRebuildBusy(false);
+    }
+  }, [rebuild]);
+
+  if (!scope) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Sign in to view swarm insights.
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="h-full">
+      <ChatboxInsightsSankey
+        breakdown={breakdown}
+        selection={flowSelection}
+        onSelectNode={handleSelectFlow}
+        onSelectLink={handleSelectFlow}
+        onRebuild={handleRebuild}
+        rebuildBusy={rebuildBusy}
+        stageTitles={{ goal: "Journey" }}
+      />
+      <ChatboxGoalOutcomeDrilldown
+        scope={scope}
+        selection={flowSelection}
+        filter={filter}
+        onClose={handleCloseFlow}
+        onOpenSession={(sessionId) => onOpenSession?.(sessionId)}
+      />
+    </ScrollArea>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -88,6 +88,7 @@ import {
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
 import { SwarmsSessionsPanel } from "@/components/swarms/SwarmsSessionsPanel";
+import { SwarmInsightsPanel } from "@/components/swarms/SwarmInsightsPanel";
 import { SwarmLiveStreamPane } from "@/components/swarms/journey-run-results";
 import { RunSessionsProvider, useRunSessionsContext } from "@/components/swarms/run-sessions-context";
 import {
@@ -245,10 +246,11 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
     () => parseSwarmSessionParams(window.location.search),
     []
   );
-  type SwarmViewMode = "journeys" | "sessions";
+  type SwarmViewMode = "journeys" | "sessions" | "insights";
   const SWARM_VIEW_OPTIONS = [
     { value: "journeys" as const, label: "Personas" },
     { value: "sessions" as const, label: "Sessions" },
+    { value: "insights" as const, label: "Insights" },
   ];
   // Session deep-links open the flat Sessions browser; run-only links stay on
   // Journeys so the matrix / live stream can restore.
@@ -265,6 +267,14 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   const [sessionsPersonaFilter, setSessionsPersonaFilter] = useState<
     string | null
   >(() => (deepLink.threadId ? (deepLink.personaRefId ?? null) : null));
+  // Session opened from the Insights drill-down. Carried into the Sessions
+  // browser as its initial selection when the view flips; wins over the URL
+  // deep-link because it is the more recent intent.
+  const [insightsThreadId, setInsightsThreadId] = useState<string | null>(null);
+  const handleOpenSessionFromInsights = useCallback((sessionId: string) => {
+    setInsightsThreadId(sessionId);
+    setViewMode("sessions");
+  }, []);
   const journeys = useJourneys(selectedPersonaId);
   // Lifted for the agent snapshot (one subscription).
 
@@ -1028,7 +1038,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
               )}
             </main>
           </>
-        ) : (
+        ) : viewMode === "sessions" ? (
           <main className="min-w-0 flex-1 overflow-hidden">
             <SwarmsSessionsPanel
               projectId={projectId}
@@ -1036,7 +1046,14 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
               hosts={hosts ?? []}
               personaRefId={sessionsPersonaFilter}
               onPersonaRefIdChange={setSessionsPersonaFilter}
-              initialThreadId={deepLink.threadId}
+              initialThreadId={insightsThreadId ?? deepLink.threadId}
+            />
+          </main>
+        ) : (
+          <main className="min-w-0 flex-1 overflow-hidden">
+            <SwarmInsightsPanel
+              projectId={effectiveProjectId}
+              onOpenSession={handleOpenSessionFromInsights}
             />
           </main>
         )}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Panel wiring for the swarm Insights view.
+ *
+ * The heavy behavior (layout, selection chips, paging) is owned by the shared
+ * components and covered by their own tests. What is new here — and what these
+ * tests pin — is the wiring: the swarm scope reaches both hooks, the goal
+ * column is renamed to "Journey", and a flow click narrows the drill-down
+ * without feeding the selection back into the breakdown that draws it.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SwarmInsightsPanel } from "../SwarmInsightsPanel";
+import {
+  chipKey,
+  type InsightsSelection,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+
+const { mockUseUsageInsights, mockUseGoalOutcomeDrilldown } = vi.hoisted(
+  () => ({
+    mockUseUsageInsights: vi.fn(),
+    mockUseGoalOutcomeDrilldown: vi.fn(),
+  }),
+);
+
+vi.mock("@/hooks/useUsageInsights", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useUsageInsights: (...args: unknown[]) => mockUseUsageInsights(...args),
+    useGoalOutcomeDrilldown: (...args: unknown[]) =>
+      mockUseGoalOutcomeDrilldown(...args),
+  };
+});
+
+const JOURNEY_NODE: InsightsSelection = {
+  themes: [
+    { dimension: "goal", clusterId: "journey-1", label: "Draw a diagram" },
+  ],
+};
+
+vi.mock("@/components/chatboxes/ChatboxInsightsSankey", () => ({
+  ChatboxInsightsSankey: ({
+    onSelectNode,
+    stageTitles,
+  }: {
+    onSelectNode: (selection: InsightsSelection) => void;
+    stageTitles?: Partial<Record<string, string>>;
+  }) => (
+    <>
+      <span data-testid="goal-header">{stageTitles?.goal ?? "Goal"}</span>
+      <button type="button" onClick={() => onSelectNode(JOURNEY_NODE)}>
+        pick journey theme
+      </button>
+    </>
+  ),
+}));
+
+function lastInsightsCall() {
+  return mockUseUsageInsights.mock.calls.at(-1)?.[0] as {
+    scope: unknown;
+    filters: UsageFilterState;
+  };
+}
+
+function lastDrilldownCall() {
+  return mockUseGoalOutcomeDrilldown.mock.calls.at(-1)?.[0] as {
+    scope: unknown;
+    filters?: UsageFilterState;
+    enabled?: boolean;
+  };
+}
+
+beforeEach(() => {
+  mockUseUsageInsights.mockReset().mockReturnValue({
+    threads: undefined,
+    breakdown: null,
+    rebuild: vi.fn().mockResolvedValue({ alreadyRunning: false }),
+  });
+  mockUseGoalOutcomeDrilldown
+    .mockReset()
+    .mockReturnValue({ drilldown: undefined, isLoading: false });
+});
+
+describe("SwarmInsightsPanel", () => {
+  it("reads the breakdown through the swarm scope and renames the goal column", () => {
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    expect(lastInsightsCall().scope).toEqual({
+      kind: "swarm",
+      projectId: "proj-1",
+    });
+    expect(screen.getByTestId("goal-header")).toHaveTextContent("Journey");
+  });
+
+  it("a flow click narrows the drill-down but not the breakdown that draws the flow", async () => {
+    const user = userEvent.setup();
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    await user.click(screen.getByRole("button", { name: "pick journey theme" }));
+
+    // Drill-down: swarm scope, filter carrying the selection's cluster chip.
+    const drilldown = lastDrilldownCall();
+    expect(drilldown.scope).toEqual({ kind: "swarm", projectId: "proj-1" });
+
+    // Breakdown: the selection chip is the diagram's own output and must not
+    // reach the query that renders the diagram.
+    const breakdownChips = lastInsightsCall().filters.chips.map(chipKey);
+    expect(breakdownChips).toEqual([]);
+  });
+
+  it("renders a sign-in gate with no project", () => {
+    render(<SwarmInsightsPanel projectId={null} />);
+    expect(screen.getByText(/sign in/i)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useUsageInsights-scope.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useUsageInsights-scope.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Scope routing in the insights hooks.
+ *
+ * The chatbox and swarm surfaces share every component downstream of these
+ * hooks, so the ONLY place the two can diverge is which Convex function gets
+ * called with which key. A swarm scope silently hitting the chatbox query
+ * would fail auth (chatbox access check against a project id) or, worse,
+ * return another surface's cohort — hence pinning the function names and arg
+ * shapes here.
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useGoalOutcomeDrilldown,
+  useUsageInsights,
+} from "@/hooks/useUsageInsights";
+import { EMPTY_USAGE_FILTER } from "@/hooks/chatbox-usage-filters";
+
+const { mockUseQuery, mockUseMutation } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+  mockUseMutation: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: (...args: unknown[]) => mockUseMutation(...args),
+}));
+
+/** All (name, args) pairs a render passed to useQuery. */
+function queryCalls(): Array<[string, unknown]> {
+  return mockUseQuery.mock.calls.map(
+    (call) => [call[0], call[1]] as [string, unknown],
+  );
+}
+
+beforeEach(() => {
+  mockUseQuery.mockReset().mockReturnValue(undefined);
+  mockUseMutation.mockReset().mockReturnValue(vi.fn());
+});
+
+describe("useUsageInsights scope routing", () => {
+  it("chatbox sourceId hits getUsageBreakdown with a chatboxId", () => {
+    renderHook(() =>
+      useUsageInsights({ sourceId: "cb-1", filters: EMPTY_USAGE_FILTER }),
+    );
+    const breakdown = queryCalls().find(([name]) =>
+      name.includes("UsageBreakdown"),
+    );
+    expect(breakdown?.[0]).toBe("chatSessions:getUsageBreakdown");
+    expect(breakdown?.[1]).toMatchObject({ chatboxId: "cb-1" });
+  });
+
+  it("swarm scope hits getSwarmUsageBreakdown with a projectId and skips the thread list", () => {
+    renderHook(() =>
+      useUsageInsights({
+        scope: { kind: "swarm", projectId: "proj-1" },
+        filters: EMPTY_USAGE_FILTER,
+      }),
+    );
+    const breakdown = queryCalls().find(([name]) =>
+      name.includes("UsageBreakdown"),
+    );
+    expect(breakdown?.[0]).toBe("chatSessions:getSwarmUsageBreakdown");
+    expect(breakdown?.[1]).toMatchObject({ projectId: "proj-1" });
+    expect((breakdown?.[1] as Record<string, unknown>).chatboxId).toBe(
+      undefined,
+    );
+    const threads = queryCalls().find(([name]) =>
+      name.includes("listByChatbox"),
+    );
+    expect(threads?.[1]).toBe("skip");
+  });
+
+  it("rebuild() is scope-bound: swarm rebuilds the project, chatbox the chatbox", async () => {
+    const rebuildFns = new Map<string, ReturnType<typeof vi.fn>>();
+    mockUseMutation.mockImplementation((name: string) => {
+      const fn = rebuildFns.get(name) ?? vi.fn().mockResolvedValue({});
+      rebuildFns.set(name, fn);
+      return fn;
+    });
+
+    const swarm = renderHook(() =>
+      useUsageInsights({
+        scope: { kind: "swarm", projectId: "proj-1" },
+        filters: EMPTY_USAGE_FILTER,
+      }),
+    );
+    await swarm.result.current.rebuild({ force: true });
+    expect(
+      rebuildFns.get("chatSessions:rebuildSwarmInsights"),
+    ).toHaveBeenCalledWith({ projectId: "proj-1", force: true });
+    expect(
+      rebuildFns.get("chatSessions:rebuildChatboxInsights"),
+    ).not.toHaveBeenCalled();
+
+    const chatbox = renderHook(() =>
+      useUsageInsights({ sourceId: "cb-1", filters: EMPTY_USAGE_FILTER }),
+    );
+    await chatbox.result.current.rebuild();
+    expect(
+      rebuildFns.get("chatSessions:rebuildChatboxInsights"),
+    ).toHaveBeenCalledWith({ chatboxId: "cb-1" });
+  });
+});
+
+describe("useGoalOutcomeDrilldown scope routing", () => {
+  it("chatbox scope pages listSessionsByGoalOutcome", () => {
+    renderHook(() =>
+      useGoalOutcomeDrilldown({
+        scope: { kind: "chatbox", chatboxId: "cb-1" },
+        clusterId: "cluster-a",
+        outcome: undefined,
+      }),
+    );
+    const [name, args] = queryCalls()[0];
+    expect(name).toBe("chatSessions:listSessionsByGoalOutcome");
+    expect(args).toMatchObject({ chatboxId: "cb-1", clusterId: "cluster-a" });
+  });
+
+  it("swarm scope pages listSwarmSessionsBySelection with the projectId", () => {
+    renderHook(() =>
+      useGoalOutcomeDrilldown({
+        scope: { kind: "swarm", projectId: "proj-1" },
+        clusterId: "cluster-a",
+        outcome: undefined,
+      }),
+    );
+    const [name, args] = queryCalls()[0];
+    expect(name).toBe("chatSessions:listSwarmSessionsBySelection");
+    expect(args).toMatchObject({ projectId: "proj-1", clusterId: "cluster-a" });
+    expect((args as Record<string, unknown>).chatboxId).toBe(undefined);
+  });
+
+  it("null scope skips the query", () => {
+    renderHook(() =>
+      useGoalOutcomeDrilldown({
+        scope: null,
+        clusterId: null,
+        outcome: undefined,
+      }),
+    );
+    expect(queryCalls()[0][1]).toBe("skip");
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
+++ b/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useMutation, useQuery } from "convex/react";
 import type {
   SessionOutcome,
@@ -8,6 +9,16 @@ import type {
 import type { SharedChatThread } from "@/hooks/useSharedChatThreads";
 
 export type InsightsSourceType = "chatbox";
+
+/**
+ * Which surface the insights read from. Chatbox insights key on the chatbox;
+ * swarm insights key on the project, because swarm sessions belong to a
+ * project, not a chatbox. The two scopes hit different Convex queries over the
+ * same substrate, so everything downstream of the hook is scope-blind.
+ */
+export type InsightsScope =
+  | { kind: "chatbox"; chatboxId: string }
+  | { kind: "swarm"; projectId: string };
 
 export type FeedbackBucketCount = {
   segment: string;
@@ -196,14 +207,18 @@ export function toServerFilters(state: UsageFilterState) {
 }
 
 export function useUsageInsights({
-  sourceId,
+  sourceId = null,
+  scope,
   filters,
   enabled = true,
   threadsEnabled,
   breakdownEnabled,
 }: {
   sourceType?: InsightsSourceType;
-  sourceId: string | null;
+  /** Legacy chatbox key; shorthand for `scope: { kind: "chatbox", … }`. */
+  sourceId?: string | null;
+  /** Takes precedence over `sourceId` when both are given. */
+  scope?: InsightsScope | null;
   filters: UsageFilterState;
   enabled?: boolean;
   /**
@@ -217,19 +232,27 @@ export function useUsageInsights({
   const wantThreads = threadsEnabled ?? enabled;
   const wantBreakdown = breakdownEnabled ?? enabled;
 
+  const effectiveScope: InsightsScope | null =
+    scope ?? (sourceId ? { kind: "chatbox", chatboxId: sourceId } : null);
+  const isSwarm = effectiveScope?.kind === "swarm";
+
+  // The thread list is a chatbox-surface concern; the swarm Sessions browser
+  // has its own project-scoped listing, so a swarm scope never subscribes.
   const chatboxArgs =
-    wantThreads && sourceId
+    wantThreads && effectiveScope?.kind === "chatbox"
       ? ({
-          chatboxId: sourceId,
+          chatboxId: effectiveScope.chatboxId,
           limit: 100,
           includeInternal: true,
         } as any)
       : "skip";
 
   const breakdownArgs =
-    wantBreakdown && sourceId
+    wantBreakdown && effectiveScope
       ? ({
-          chatboxId: sourceId,
+          ...(effectiveScope.kind === "swarm"
+            ? { projectId: effectiveScope.projectId }
+            : { chatboxId: effectiveScope.chatboxId }),
           filters: toServerFilters(filters),
         } as any)
       : "skip";
@@ -242,17 +265,49 @@ export function useUsageInsights({
   // subscribe to `listClustersByChatbox` — UsageInsightsStrip and the rebuild
   // button both read everything they need from `breakdown`.
   const breakdown = useQuery(
-    "chatSessions:getUsageBreakdown" as any,
+    (isSwarm
+      ? "chatSessions:getSwarmUsageBreakdown"
+      : "chatSessions:getUsageBreakdown") as any,
     breakdownArgs,
   ) as UsageBreakdown | null | undefined;
 
-  const rebuild = useMutation(
+  const rebuildChatbox = useMutation(
     "chatSessions:rebuildChatboxInsights" as any,
   ) as unknown as (args: { chatboxId: string; force?: boolean }) => Promise<{
     runId: string;
     status: ClusterRunStatus;
     alreadyRunning: boolean;
   }>;
+  const rebuildSwarm = useMutation(
+    "chatSessions:rebuildSwarmInsights" as any,
+  ) as unknown as (args: { projectId: string; force?: boolean }) => Promise<{
+    runId: string;
+    status: ClusterRunStatus;
+    alreadyRunning: boolean;
+  }>;
+
+  // Scope-bound so callers don't restate the key the hook already holds — the
+  // caller restating it is exactly how a swarm surface would accidentally
+  // trigger a chatbox rebuild.
+  const rebuild = useCallback(
+    async (args?: { force?: boolean }) => {
+      if (!effectiveScope) {
+        throw new Error("No insights scope to rebuild");
+      }
+      return effectiveScope.kind === "swarm"
+        ? rebuildSwarm({ projectId: effectiveScope.projectId, ...args })
+        : rebuildChatbox({ chatboxId: effectiveScope.chatboxId, ...args });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scope identity is its key fields
+    [
+      effectiveScope?.kind,
+      effectiveScope?.kind === "swarm"
+        ? effectiveScope.projectId
+        : effectiveScope?.chatboxId,
+      rebuildChatbox,
+      rebuildSwarm,
+    ],
+  );
 
   return {
     threads,
@@ -282,7 +337,7 @@ export type GoalOutcomeDrilldown = {
  * requests the sessions with no recorded outcome.
  */
 export function useGoalOutcomeDrilldown({
-  chatboxId,
+  scope,
   clusterId,
   outcome,
   filters,
@@ -290,7 +345,7 @@ export function useGoalOutcomeDrilldown({
   before,
   enabled = true,
 }: {
-  chatboxId: string | null;
+  scope: InsightsScope | null;
   clusterId: string | null;
   outcome: SessionOutcome | null | undefined;
   filters?: UsageFilterState;
@@ -299,9 +354,11 @@ export function useGoalOutcomeDrilldown({
   enabled?: boolean;
 }) {
   const args =
-    enabled && chatboxId
+    enabled && scope
       ? ({
-          chatboxId,
+          ...(scope.kind === "swarm"
+            ? { projectId: scope.projectId }
+            : { chatboxId: scope.chatboxId }),
           ...(clusterId ? { clusterId } : {}),
           // `undefined` means "any outcome"; `null` means "no outcome
           // recorded". They are different selections, so the distinction has to
@@ -314,12 +371,14 @@ export function useGoalOutcomeDrilldown({
       : "skip";
 
   const result = useQuery(
-    "chatSessions:listSessionsByGoalOutcome" as any,
+    (scope?.kind === "swarm"
+      ? "chatSessions:listSwarmSessionsBySelection"
+      : "chatSessions:listSessionsByGoalOutcome") as any,
     args,
   ) as GoalOutcomeDrilldown | undefined;
 
   return {
     drilldown: result,
-    isLoading: enabled && !!chatboxId && result === undefined,
+    isLoading: enabled && !!scope && result === undefined,
   };
 }


### PR DESCRIPTION
## What

Adds an **Insights** tab to Swarms rendering the same Goal → Behavior → Outcome → Sentiment session flow as chatbox Insights, over the project's swarm sessions — shared components, not a fork.

Pairs with backend MCPJam/mcpjam-backend#850 (must deploy first; until then the swarm queries 404 and the tab shows the loading state).

## How

- **`InsightsScope`** (`{kind:'chatbox', chatboxId}` | `{kind:'swarm', projectId}`) threads through `useUsageInsights` / `useGoalOutcomeDrilldown`, routing to the swarm Convex queries (`getSwarmUsageBreakdown`, `listSwarmSessionsBySelection`, `rebuildSwarmInsights`). `rebuild()` is now scope-bound so a caller can't restate the wrong key.
- **`ChatboxGoalOutcomeDrilldown`** takes a `scope` instead of a `chatboxId`; the paging request key includes it.
- **`ChatboxInsightsSankey`** gains per-stage header overrides; the swarm panel renames the goal column to **Journey** — swarm goals ARE journeys, assigned deterministically server-side (no clustering), so the column is named for what it is. Everything else (emergent behavior/outcome/sentiment themes, discordant ribbons, chips, drill-down) is identical.
- **New `SwarmInsightsPanel`**: sankey + drill-down + rebuild with the same selection-chip ownership mechanics as the chatbox panel. No topic map or feedback calibration — both are chatbox-surface features (goal embeddings / visitor feedback) swarm sessions don't have.
- Drill-down rows open in the Sessions browser via the existing `initialThreadId` seam.

## Tests

- `useUsageInsights-scope.test.tsx` — pins which Convex function each scope hits and the arg shapes (the one place the two surfaces can diverge).
- `SwarmInsightsPanel.test.tsx` — swarm scope reaches both hooks, Journey header, selection chips never feed back into the breakdown that draws the diagram.
- Updated drilldown tests for the scope prop. Client typecheck green; swarms + chatboxes + hooks suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cross-surface routing in insights hooks could mis-key queries (wrong cohort or auth) if scope is passed incorrectly; depends on backend deploy for swarm endpoints.
> 
> **Overview**
> Adds an **Insights** view to Swarms that reuses the chatbox four-stage session flow (Sankey + paginated drill-down + rebuild) over **project-scoped** swarm sessions, without duplicating UI.
> 
> **`InsightsScope`** (`chatbox` vs `swarm`) is threaded through `useUsageInsights` and `useGoalOutcomeDrilldown`, selecting the right Convex queries (`getSwarmUsageBreakdown`, `listSwarmSessionsBySelection`, `rebuildSwarmInsights`) and skipping chatbox-only thread listing for swarms. **`rebuild()`** no longer takes a caller-supplied id—it rebuilds whatever scope the hook already holds.
> 
> Shared components are generalized: drill-down takes **`scope`** (paging keys include swarm vs chatbox), Sankey accepts optional **`stageTitles`** (swarm renames goal → **Journey**) and copy is surface-neutral where needed. **`SwarmInsightsPanel`** wires the same flow-selection chip ownership as chatbox insights (selection chips must not feed the breakdown query). **`SwarmsTab`** adds the Insights mode and opens drill-down sessions in the Sessions browser via `insightsThreadId`.
> 
> Tests lock scope → Convex function routing and swarm panel wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc1d254a0cb79ea6465bacd39ba4056924ab0e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Insights tab to Swarms that shows the Goal → Behavior → Outcome → Sentiment flow over a project’s swarm sessions using shared components. Drill-down opens sessions in the Sessions browser, and rebuild is scope-bound to the project.

- **New Features**
  - New Swarm “Insights” view with the shared sankey and drill-down; renames the goal column to “Journey”.
  - Selection chips mirror chatbox behavior and don’t feed back into the breakdown.
  - Drill-down pages swarm sessions and opens a session via `initialThreadId`.
  - Scope-bound rebuild queues a swarm insights rebuild with toasts.
  - Sign-in gate when no project is selected.

- **Migration**
  - Requires backend MCPJam/mcpjam-backend#850. Deploy backend first; until then, swarm queries 404 and the tab shows a loading state.

<sup>Written for commit bc1d254a0cb79ea6465bacd39ba4056924ab0e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

