### PR TITLE
feat(oauth): emulated attempt ladder, completion-safe redirects, headless preflight (HP-43 S5)

### DIFF
--- a/.changeset/oauth-emulation-preflight.md
+++ b/.changeset/oauth-emulation-preflight.md
@@ -1,0 +1,36 @@
+---
+"@mcpjam/sdk": minor
+---
+
+OAuth client emulation: ordered attempt ladder, completion-safe redirects, and
+the headless preflight runner (HP-43 step 5).
+
+- **`runEmulatedOAuthPreflight`** (Node entry) executes an emulated client's
+  authentication ladder against a real MCP server, headlessly. Outbound
+  requests default to the hardened OAuth networking path (DNS pinning,
+  total-deadline timeouts, body caps, redirect caps, cross-origin credential
+  stripping). Reports three independent dimensions — `outcome`, `coverage`,
+  and `comparison` (always `not_compared` here; golden comparison is a later
+  step) — so a run can never imply parity on its own.
+- **Attempt ladder** — `authModel` compiles into ordered rungs. Consecutive
+  `oauth2-*` entries collapse into one OAuth attempt carrying their order as a
+  registration preference; `api-key` and `none` stay in position. A static
+  credential falls through to OAuth **only** on an evidence-backed 401, and an
+  OAuth attempt falls through to the next strategy only while nothing has been
+  committed on the wire.
+- **Completion-safe redirects** — registration replays the captured
+  `redirect_uris` in order with MCPJam's callback appended (a declared
+  substitution); authorization and token legs always use MCPJam's callback so
+  the code can be received and exchanged. Registration is retried with the
+  callback alone **only** on a structured RFC 7591 `invalid_redirect_uri` —
+  never on prose, a generic 4xx, a timeout, or an unparseable body.
+- **Bounded, disclosed side effects** — at most two DCR registrations per run,
+  reported in `sideEffects` alongside tokens issued.
+- **Completion means a real token AND a valid authenticated JSON-RPC
+  response**, not a bare 2xx.
+- **Credentials are returned separately from diagnostics**; traces carry no
+  tokens, codes, secrets, or PKCE values, including a caller-supplied static
+  credential whose header name no generic redactor could know.
+- `AuthorizationPlanInput.registrationPreference` lets an emulated client's
+  order override the built-in AUTO precedence. Absent or empty leaves every
+  existing caller's resolution byte-identical.

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -181,6 +181,16 @@ export type {
   OAuthEmulationFieldStatus,
 } from "./oauth/emulation/types.js";
 export { OAUTH_EMULATION_FIELDS } from "./oauth/emulation/types.js";
+export type {
+  EmulatedAuthAttempt,
+  EmulatedRegistrationPreference,
+} from "./oauth/emulation/types.js";
+// Pure redirect planning is browser-safe; the runner that uses it is not.
+export {
+  isInvalidRedirectUriRejection,
+  planCompletionSafeRedirects,
+} from "./oauth/emulation/redirects.js";
+export type { CompletionSafeRedirectPlan } from "./oauth/emulation/redirects.js";
 // SSRF host classification (shared hardening): the browser executor re-validates
 // the FINAL response URL after redirects using the same RFC 6890 policy the
 // factory guard applies to the initial request URL.

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -329,6 +329,23 @@ export type {
 } from "./oauth/emulation/types.js";
 export { OAUTH_EMULATION_FIELDS } from "./oauth/emulation/types.js";
 export type {
+  EmulatedAuthAttempt,
+  EmulatedRegistrationPreference,
+} from "./oauth/emulation/types.js";
+export {
+  isInvalidRedirectUriRejection,
+  planCompletionSafeRedirects,
+} from "./oauth/emulation/redirects.js";
+export type { CompletionSafeRedirectPlan } from "./oauth/emulation/redirects.js";
+// Node-only: runs the emulated ladder over the hardened OAuth networking path.
+export { runEmulatedOAuthPreflight } from "./oauth/emulation/preflight.js";
+export type {
+  EmulatedAuthAttemptResult,
+  EmulatedOAuthPreflightConfig,
+  EmulatedOAuthPreflightOutcome,
+  EmulatedOAuthPreflightResult,
+} from "./oauth/emulation/preflight.js";
+export type {
   OAuthAuthorizationRequestResult,
   OAuthStateMachineRunConfig,
   OAuthStateMachineRunResult,

--- a/sdk/src/oauth/authorization-plan.ts
+++ b/sdk/src/oauth/authorization-plan.ts
@@ -337,7 +337,9 @@ export function resolveAuthorizationPlan(
           break;
         }
         warnings.push(
-          "Emulated client prefers pre-registered credentials, but none are configured; trying its next mechanism.",
+          hasIncompletePreregisteredCredentials
+            ? "Emulated client prefers pre-registered credentials, but the configured credentials are incomplete; trying its next mechanism."
+            : "Emulated client prefers pre-registered credentials, but none are configured; trying its next mechanism.",
         );
         continue;
       }

--- a/sdk/src/oauth/authorization-plan.ts
+++ b/sdk/src/oauth/authorization-plan.ts
@@ -47,6 +47,15 @@ export interface AuthorizationPlanInput {
   useRegistryOAuthProxy?: boolean;
   authMode?: OAuthAuthMode;
   discovery?: AuthorizationDiscoverySnapshot;
+  /**
+   * AUTO-mode preference order over registration strategies, derived from an
+   * emulated client's `authModel` (HP-43). Consulted ONLY when the caller has
+   * not pinned a `registrationMode` — an explicit mode always wins.
+   *
+   * Empty or absent leaves the built-in AUTO precedence untouched, so every
+   * non-emulation caller resolves exactly as before.
+   */
+  registrationPreference?: Array<"preregistered" | "dcr" | "cimd">;
 }
 
 export interface AuthorizationPlanCapabilities {
@@ -309,6 +318,85 @@ export function resolveAuthorizationPlan(
       pushBlocker(
         "DCR_NOT_ADVERTISED",
         "The authorization server did not advertise a registration_endpoint required for DCR.",
+      );
+    }
+  } else if (
+    input.registrationPreference &&
+    input.registrationPreference.length > 0
+  ) {
+    // Emulated client preference (HP-43). Walk the client's own order and take
+    // the first strategy that is actually usable here; an entry that is not
+    // usable is SKIPPED rather than blocking, because a real client that
+    // cannot use its preferred mechanism falls through to its next one.
+    let chosen: OAuthRegistrationStrategy | undefined;
+    let needsDiscovery = false;
+    for (const preference of input.registrationPreference) {
+      if (preference === "preregistered") {
+        if (hasCompletePreregisteredCredentials) {
+          chosen = "preregistered";
+          break;
+        }
+        warnings.push(
+          "Emulated client prefers pre-registered credentials, but none are configured; trying its next mechanism.",
+        );
+        continue;
+      }
+      if (preference === "cimd") {
+        if (
+          protocolVersion !== "2025-11-25" &&
+          protocolVersion !== "2026-07-28"
+        ) {
+          warnings.push(
+            `Emulated client prefers CIMD, which protocol version ${protocolVersion} does not support; trying its next mechanism.`,
+          );
+          continue;
+        }
+        if (authMode === "client_credentials") {
+          warnings.push(
+            "Emulated client prefers CIMD, which client_credentials mode cannot use; trying its next mechanism.",
+          );
+          continue;
+        }
+        // Without a discovery snapshot, support is unknown rather than absent:
+        // ask the caller to probe and re-resolve with the preference intact.
+        if (!hasDiscovery) {
+          needsDiscovery = true;
+          break;
+        }
+        if (!capabilities.supportsCimd) {
+          warnings.push(
+            "Emulated client prefers CIMD, which the authorization server does not advertise; trying its next mechanism.",
+          );
+          continue;
+        }
+        chosen = "cimd";
+        break;
+      }
+      // dcr
+      if (!hasDiscovery) {
+        needsDiscovery = true;
+        break;
+      }
+      if (!capabilities.supportsDcr) {
+        warnings.push(
+          "Emulated client prefers DCR, but the authorization server advertises no registration_endpoint; trying its next mechanism.",
+        );
+        continue;
+      }
+      chosen = "dcr";
+      break;
+    }
+
+    if (needsDiscovery) {
+      status = "discovery_required";
+    } else if (chosen) {
+      registrationStrategy = chosen;
+    } else {
+      pushBlocker(
+        "AUTO_NO_USABLE_REGISTRATION_FLOW",
+        `The emulated client's registration preference (${input.registrationPreference.join(
+          " → ",
+        )}) has no mechanism usable against this server.`,
       );
     }
   } else if (hasIncompletePreregisteredCredentials) {

--- a/sdk/src/oauth/emulation/derive.ts
+++ b/sdk/src/oauth/emulation/derive.ts
@@ -243,9 +243,20 @@ export function deriveOAuthEmulation(
       emulation.userAgent = dcrIdentity.userAgent;
     }
     if (dcrIdentity.redirectUris !== undefined) {
-      // Captured order preserved; the runner appends its own callback and
-      // declares that addition (see `capturedRedirectUris` above).
+      // The runner appends its own callback and declares that addition (see
+      // `capturedRedirectUris` above).
       capturedRedirectUris = [...dcrIdentity.redirectUris];
+      if (profile.profileVersion === 1) {
+        // V1 canonicalization deduped and SORTED this list, so the captured
+        // registration order is not recoverable from a V1 row. Say so rather
+        // than presenting a sorted list as an exact replay — only V2 rows
+        // preserve wire order.
+        divergences.push({
+          kind: "not-enforced",
+          detail:
+            "profile is V1, whose canonicalization sorted dcrIdentity.redirectUris; the client's captured registration order is unavailable and cannot be replayed",
+        });
+      }
     }
     coverage.dcrIdentity = "modeled";
   }

--- a/sdk/src/oauth/emulation/derive.ts
+++ b/sdk/src/oauth/emulation/derive.ts
@@ -280,7 +280,11 @@ export function deriveOAuthEmulation(
     { kind: "oauth", registrationPreference: [] },
   ];
   const authModel = evidenceValue<OAuthAuthModel[]>(profile.authModel);
-  if (authModel !== undefined) {
+  // An empty list is rejected by the canonicalizer ("omit the field instead"),
+  // but the type cannot express that, and compiling one would yield an EMPTY
+  // ladder — a run with no attempts at all, reported as blocked with nothing
+  // to explain it. Treat it as no evidence.
+  if (authModel !== undefined && authModel.length > 0) {
     authAttempts = toAuthAttempts(authModel);
     coverage.authModel = "modeled";
   }

--- a/sdk/src/oauth/emulation/derive.ts
+++ b/sdk/src/oauth/emulation/derive.ts
@@ -1,6 +1,6 @@
 /**
  * `deriveOAuthEmulation` — compile an evidence-backed OAuth profile into the
- * generic machine knobs (HP-43 step 4).
+ * generic machine knobs and the client's authentication ladder (HP-43).
  *
  * Evidence rules, applied uniformly:
  *   - `verified` → the value is used, field `modeled`.
@@ -16,6 +16,7 @@
 
 import type {
   HostConfigOAuthProfile,
+  OAuthAuthModel,
   OAuthDcrIdentity,
   OAuthProfileEvidence,
   OAuthScopeRequest,
@@ -24,6 +25,8 @@ import type {
 } from "../../host-config/types.js";
 import type { OAuthProtocolVersion } from "../state-machines/types.js";
 import type {
+  EmulatedAuthAttempt,
+  EmulatedRegistrationPreference,
   OAuthEmulationConfig,
   OAuthEmulationCoverage,
   OAuthEmulationDivergence,
@@ -50,6 +53,20 @@ export interface DerivedOAuthEmulation {
   protocolVersion: OAuthProtocolVersion;
   /** The machine-facing knobs (`BaseOAuthStateMachineConfig.emulation`). */
   emulation: OAuthEmulationConfig;
+  /**
+   * The client's authentication ladder, in profile order. Executed by
+   * `runEmulatedOAuthPreflight`; a profile with no `authModel` evidence yields
+   * a single OAuth attempt with no strategy preference (today's AUTO order).
+   */
+  authAttempts: EmulatedAuthAttempt[];
+  /**
+   * Redirect URIs observed in the real client's registration, in captured
+   * order. Deliberately NOT copied into `emulation.dcrRedirectUris`: replaying
+   * them alone would send the authorization code somewhere MCPJam cannot
+   * receive it. The runner combines them with its own callback
+   * (`planCompletionSafeRedirects`) and reports the difference.
+   */
+  capturedRedirectUris?: string[];
   /** Per-field enforcement status. */
   coverage: OAuthEmulationCoverage;
   /** `complete` iff every field is `modeled`. Partial coverage can never
@@ -95,7 +112,9 @@ function narrowLadderVersion(
     const requested = [...claim.revisions].sort().at(-1) as string;
     const atOrBelow = supported.filter((version) => version <= requested);
     const used =
-      atOrBelow.length > 0 ? (atOrBelow.at(-1) as OAuthProtocolVersion) : supported[0];
+      atOrBelow.length > 0
+        ? (atOrBelow.at(-1) as OAuthProtocolVersion)
+        : supported[0];
     divergences.push({
       kind: "version-narrowed",
       detail: `client implements OAuth spec revision(s) ${claim.revisions.join(
@@ -126,11 +145,48 @@ function narrowLadderVersion(
   return used;
 }
 
+const REGISTRATION_PREFERENCE_BY_AUTH_MODEL: Partial<
+  Record<OAuthAuthModel, EmulatedRegistrationPreference>
+> = {
+  "oauth2-dcr": "dcr",
+  "oauth2-cimd": "cimd",
+  "oauth2-preregistered": "preregistered",
+};
+
+/**
+ * Compile the ordered `authModel` list into the ladder the runner executes.
+ *
+ * Consecutive `oauth2-*` entries collapse into ONE oauth attempt carrying
+ * their relative order as its registration preference — a client that lists
+ * `[oauth2-cimd, oauth2-dcr]` performs a single OAuth dance preferring CIMD,
+ * not two dances. `api-key` and `none` stay separate rungs, in position, so a
+ * "static bearer first, OAuth on 401" client reproduces that sequence.
+ */
+function toAuthAttempts(models: OAuthAuthModel[]): EmulatedAuthAttempt[] {
+  const attempts: EmulatedAuthAttempt[] = [];
+  for (const model of models) {
+    const preference = REGISTRATION_PREFERENCE_BY_AUTH_MODEL[model];
+    if (preference) {
+      const last = attempts.at(-1);
+      if (last?.kind === "oauth") {
+        last.registrationPreference.push(preference);
+      } else {
+        attempts.push({ kind: "oauth", registrationPreference: [preference] });
+      }
+      continue;
+    }
+    // The canonicalizer guarantees "none" is the sole entry when present.
+    attempts.push(model === "api-key" ? { kind: "api-key" } : { kind: "none" });
+  }
+  return attempts;
+}
+
 export function deriveOAuthEmulation(
   profile: HostConfigOAuthProfile
 ): DerivedOAuthEmulation {
   const divergences: OAuthEmulationDivergence[] = [];
   const emulation: OAuthEmulationConfig = {};
+  let capturedRedirectUris: string[] | undefined;
   const coverage: OAuthEmulationCoverage = {
     sendsResourceIndicator: "not_modeled",
     oauthSpecVersion: "not_modeled",
@@ -138,6 +194,7 @@ export function deriveOAuthEmulation(
     scopeRequest: "not_modeled",
     dcrIdentity: "not_modeled",
     tokenEndpointAuthMethod: "not_modeled",
+    authModel: "not_modeled",
   };
 
   // ── oauthSpecVersion → machine selection ────────────────────────────────
@@ -176,7 +233,7 @@ export function deriveOAuthEmulation(
     coverage.scopeRequest = "modeled";
   }
 
-  // ── dcrIdentity → client_name + User-Agent ──────────────────────────────
+  // ── dcrIdentity → client_name + User-Agent + captured redirects ─────────
   const dcrIdentity = evidenceValue<OAuthDcrIdentity>(profile.dcrIdentity);
   if (dcrIdentity !== undefined) {
     if (dcrIdentity.clientName !== undefined) {
@@ -185,26 +242,12 @@ export function deriveOAuthEmulation(
     if (dcrIdentity.userAgent !== undefined) {
       emulation.userAgent = dcrIdentity.userAgent;
     }
-    if (
-      dcrIdentity.clientName !== undefined ||
-      dcrIdentity.userAgent !== undefined
-    ) {
-      coverage.dcrIdentity = "modeled";
+    if (dcrIdentity.redirectUris !== undefined) {
+      // Captured order preserved; the runner appends its own callback and
+      // declares that addition (see `capturedRedirectUris` above).
+      capturedRedirectUris = [...dcrIdentity.redirectUris];
     }
-    if (
-      dcrIdentity.redirectUris !== undefined &&
-      coverage.dcrIdentity === "not_modeled"
-    ) {
-      // Captured redirect URIs are real evidence, but their replay belongs
-      // to the completion-safe-redirect step of the attempt ladder — nothing
-      // in this compiler enforces them yet, and claiming coverage for
-      // unenforced evidence would overstate parity.
-      divergences.push({
-        kind: "not-enforced",
-        detail:
-          "dcrIdentity captures only redirectUris; redirect replay is handled by the attempt ladder, not this compiler",
-      });
-    }
+    coverage.dcrIdentity = "modeled";
   }
 
   // ── tokenEndpointAuthMethod (V2 only) ───────────────────────────────────
@@ -219,11 +262,31 @@ export function deriveOAuthEmulation(
     coverage.tokenEndpointAuthMethod = "modeled";
   }
 
+  // ── authModel → ordered attempt ladder ──────────────────────────────────
+  let authAttempts: EmulatedAuthAttempt[] = [
+    // No evidence: one OAuth attempt with no preference, i.e. today's AUTO
+    // precedence in the authorization plan.
+    { kind: "oauth", registrationPreference: [] },
+  ];
+  const authModel = evidenceValue<OAuthAuthModel[]>(profile.authModel);
+  if (authModel !== undefined) {
+    authAttempts = toAuthAttempts(authModel);
+    coverage.authModel = "modeled";
+  }
+
   const coverageSummary = Object.values(coverage).every(
     (status) => status === "modeled"
   )
     ? "complete"
     : "partial";
 
-  return { protocolVersion, emulation, coverage, coverageSummary, divergences };
+  return {
+    protocolVersion,
+    emulation,
+    authAttempts,
+    ...(capturedRedirectUris ? { capturedRedirectUris } : {}),
+    coverage,
+    coverageSummary,
+    divergences,
+  };
 }

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -434,6 +434,14 @@ export async function runEmulatedOAuthPreflight(
     const attemptDivergences: OAuthEmulationDivergence[] = [];
     let registrations = 0;
     let lastBlockedPlan: ResolvedAuthorizationPlan | undefined;
+    // Diagnostics from strategies that failed WITHOUT committing anything and
+    // were fallen through. Without these, a ladder that tried CIMD then DCR
+    // and exhausted both reports "blocked" with no trace of either failure.
+    const fallenThrough: Array<{
+      strategy: EmulatedRegistrationPreference;
+      detail: string;
+      httpHistory: HttpHistoryEntry[];
+    }> = [];
 
     // `dcrRedirectUris` is the completion-safe list, never the raw capture.
     let wireEmulation: OAuthEmulationConfig = {
@@ -647,15 +655,33 @@ export async function runEmulatedOAuthPreflight(
           stop: true,
         };
       }
+
+      fallenThrough.push({
+        strategy: resolvedStrategy,
+        detail:
+          run.error?.message ??
+          "attempt failed before registering or beginning authorization",
+        httpHistory: history,
+      });
     }
+
+    const exhaustedDetail = [
+      ...fallenThrough.map(
+        (entry) => `${entry.strategy}: ${entry.detail}`
+      ),
+      ...(lastBlockedPlan?.blockers ?? []),
+    ].join(" | ");
 
     return {
       result: {
         kind: "oauth",
         status: "blocked",
         plan: lastBlockedPlan,
+        // Every strategy's trace, in the order they were tried, so a blocked
+        // ladder can be explained rather than merely reported.
+        httpHistory: fallenThrough.flatMap((entry) => entry.httpHistory),
         detail:
-          lastBlockedPlan?.blockers.join(" ") ??
+          exhaustedDetail ||
           "no registration mechanism in the emulated client's preference is usable against this server",
       },
       outcome: "blocked",

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -1,0 +1,721 @@
+/**
+ * `runEmulatedOAuthPreflight` — execute an emulated client's authentication
+ * ladder against a real MCP server, headlessly (HP-43 step 5).
+ *
+ * Node-only: outbound requests default to the hardened OAuth networking path
+ * (`executeOAuthProxy` — DNS pinning, total-deadline timeouts, response-body
+ * caps, redirect caps, cross-origin credential stripping), which is where the
+ * SSRF hardening for server-controlled metadata URLs already lives.
+ *
+ * Three properties this runner is built around:
+ *
+ *  1. **Completion-first.** Every attempt is allowed to finish with a real
+ *     token; the emulation shapes the wire, it never sabotages the dance.
+ *     "Completed" means a token AND a valid authenticated JSON-RPC response,
+ *     not a bare 2xx.
+ *  2. **Bounded side effects.** DCR creates a client on someone's server and
+ *     a token exchange issues a credential. A run performs at most two
+ *     registrations (the second only after a structured `invalid_redirect_uri`
+ *     rejection) and reports what it caused in `sideEffects`.
+ *  3. **Credentials out of diagnostics.** Secrets are returned once, in
+ *     `credentials`. Everything else — traces, attempt histories — is redacted,
+ *     including the caller's own static-credential header, whose name this
+ *     runner cannot know in advance.
+ */
+
+import { executeOAuthProxy } from "../../oauth-proxy.js";
+import { redactSensitiveValue } from "../../redaction.js";
+import { getConformanceAuthCodeDynamicRegistrationMetadata } from "../client-identity.js";
+import {
+  resolveAuthorizationPlan,
+  type ResolvedAuthorizationPlan,
+} from "../authorization-plan.js";
+import { runOAuthStateMachine } from "../state-machines/runner.js";
+import {
+  buildInitializeRequestBody,
+  buildStatelessVerifyRequestBody,
+  resolveInitializeProtocolVersion,
+} from "../state-machines/shared/initialize.js";
+import { resolveEmulatedMcpVersion } from "../state-machines/shared/emulation.js";
+import {
+  EMPTY_OAUTH_FLOW_STATE,
+  type HttpHistoryEntry,
+  type OAuthFlowState,
+  type OAuthHttpRequest,
+  type OAuthProtocolVersion,
+  type OAuthRequestExecutor,
+  type OAuthRequestResult,
+} from "../state-machines/types.js";
+import type { DerivedOAuthEmulation } from "./derive.js";
+import {
+  isInvalidRedirectUriRejection,
+  planCompletionSafeRedirects,
+} from "./redirects.js";
+import type {
+  EmulatedAuthAttempt,
+  EmulatedRegistrationPreference,
+  OAuthEmulationConfig,
+  OAuthEmulationCoverage,
+  OAuthEmulationDivergence,
+} from "./types.js";
+
+const DEFAULT_CLIENT_NAME = "MCPJam Emulated Client";
+const DEFAULT_CLIENT_VERSION = "1.0.0";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_STEPS = 40;
+
+export interface EmulatedOAuthPreflightConfig {
+  serverUrl: string;
+  serverName?: string;
+  /** The compiled profile from `deriveOAuthEmulation`. */
+  emulation: DerivedOAuthEmulation;
+  /**
+   * The callback MCPJam controls. Authorization and token legs always use it;
+   * registration replays the captured list with it appended.
+   */
+  callbackUrl: string;
+  /** MCPJam-controlled client-ID metadata document, for CIMD attempts. */
+  clientIdMetadataUrl?: string;
+  /** MCPJam-controlled pre-registered credentials. */
+  preregistered?: { clientId: string; clientSecret?: string };
+  /**
+   * The static credential an `api-key` rung sends. Absent means the rung is
+   * skipped and declared — this runner never invents a credential.
+   */
+  staticCredential?: { headerName: string; value: string };
+  customHeaders?: Record<string, string>;
+  customScopes?: string;
+  timeoutMs?: number;
+  maxSteps?: number;
+  /**
+   * Completes the human leg headlessly (a compliant/mock AS that auto-consents).
+   * Absent → the run stops at the authorization redirect and reports the URL.
+   */
+  completeAuthorization?: (input: {
+    authorizationUrl: string;
+    callbackUrl: string;
+  }) => Promise<{ code: string }>;
+  /** Override the hardened default executor (tests, alternate transports). */
+  requestExecutor?: OAuthRequestExecutor;
+  allowLoopbackMetadataFetch?: boolean;
+  /**
+   * Defaults to "warn": emulation is an observational surface, and rejecting
+   * an odd resource indicator would hide the very server behavior the run
+   * exists to expose.
+   */
+  resourceIndicatorEnforcement?: "warn" | "reject" | "reject-rfc9728";
+}
+
+export type EmulatedOAuthPreflightOutcome =
+  /** Real token AND a valid authenticated JSON-RPC response. */
+  | "completed"
+  /** Ladder reached the human leg; no `completeAuthorization` supplied. */
+  | "stopped_at_redirect"
+  /** Server accepted the emulated client's static credential. */
+  | "static_credential_ok"
+  /** Server served an unauthenticated request (client models no auth). */
+  | "unauthenticated_ok"
+  /** The ladder ran out of usable mechanisms. */
+  | "blocked"
+  | "error";
+
+export interface EmulatedAuthAttemptResult {
+  kind: EmulatedAuthAttempt["kind"];
+  status:
+    | "ok"
+    | "unauthorized"
+    | "skipped"
+    | "redirected"
+    | "blocked"
+    | "error";
+  /** Which registration strategy actually ran, for `oauth` attempts. */
+  registrationStrategy?: EmulatedRegistrationPreference;
+  plan?: ResolvedAuthorizationPlan;
+  /** Redacted. Never carries tokens, codes, secrets, or PKCE values. */
+  httpHistory?: HttpHistoryEntry[];
+  detail?: string;
+}
+
+export interface EmulatedOAuthPreflightResult {
+  serverUrl: string;
+  protocolVersion: OAuthProtocolVersion;
+  outcome: EmulatedOAuthPreflightOutcome;
+  /** Per-field enforcement, carried through from the compiler. */
+  coverage: OAuthEmulationCoverage;
+  coverageSummary: "complete" | "partial";
+  /**
+   * Third, independent dimension. Golden-trace comparison is a later step; a
+   * run never claims a match on its own.
+   */
+  comparison: "not_compared";
+  attempts: EmulatedAuthAttemptResult[];
+  authorizationUrl?: string;
+  /** Compile-time divergences plus everything this run declared. */
+  divergences: OAuthEmulationDivergence[];
+  /** What this run caused on the target. */
+  sideEffects: { dcrRegistrations: number; tokensIssued: number };
+  /** Secrets, returned once and kept out of every diagnostic surface. */
+  credentials?: {
+    accessToken?: string;
+    refreshToken?: string;
+    clientId?: string;
+    clientSecret?: string;
+  };
+  error?: { message: string };
+}
+
+/**
+ * The hardened default executor. Runs every OAuth and MCP request through the
+ * SSRF-hardened proxy path rather than a bare `fetch`.
+ */
+function createHardenedExecutor(timeoutMs: number): OAuthRequestExecutor {
+  return async (request: OAuthHttpRequest): Promise<OAuthRequestResult> => {
+    const response = await executeOAuthProxy({
+      url: request.url,
+      method: request.method,
+      body: request.body,
+      headers: request.headers,
+      redirect: request.redirect,
+      timeoutMs,
+    });
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+      body: response.body,
+      ok: response.status >= 200 && response.status < 300,
+    };
+  };
+}
+
+/**
+ * Redact a diagnostic payload.
+ *
+ * The shared redactor knows the conventional credential shapes. It cannot know
+ * that THIS caller's static credential rides in, say, `X-Acme-Key`, so that
+ * header name and value are scrubbed explicitly before the generic pass.
+ */
+function redactDiagnostics<T>(
+  value: T,
+  staticCredential?: { headerName: string; value: string }
+): T {
+  let working: unknown = value;
+  if (staticCredential) {
+    const headerNeedle = staticCredential.headerName.toLowerCase();
+    const scrub = (input: unknown): unknown => {
+      if (Array.isArray(input)) return input.map(scrub);
+      if (input && typeof input === "object") {
+        return Object.fromEntries(
+          Object.entries(input as Record<string, unknown>).map(([key, val]) => [
+            key,
+            key.toLowerCase() === headerNeedle ? "[REDACTED]" : scrub(val),
+          ])
+        );
+      }
+      if (typeof input === "string" && staticCredential.value) {
+        return input.split(staticCredential.value).join("[REDACTED]");
+      }
+      return input;
+    };
+    working = scrub(working);
+  }
+  return redactSensitiveValue(working) as T;
+}
+
+/** A token alone is not success — the server must answer a real MCP call. */
+function isValidAuthenticatedJsonRpc(state: OAuthFlowState): boolean {
+  const body = state.lastResponse?.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  const message = body as Record<string, unknown>;
+  if (message.jsonrpc !== "2.0") return false;
+  if (message.error !== undefined) return false;
+  return message.result !== undefined;
+}
+
+function countRegistrationRequests(state: OAuthFlowState): number {
+  return (state.httpHistory ?? []).filter(
+    (entry) => entry.step === "request_client_registration"
+  ).length;
+}
+
+function registrationResponse(
+  state: OAuthFlowState
+): { status: number; body: unknown } | undefined {
+  const entry = [...(state.httpHistory ?? [])]
+    .reverse()
+    .find((item) => item.step === "request_client_registration");
+  if (!entry?.response) return undefined;
+  return { status: entry.response.status, body: entry.response.body };
+}
+
+/**
+ * Did this attempt commit anything the ladder must not repeat?
+ *
+ * Falling through to the next registration strategy is only safe while nothing
+ * is on the wire. Once a registration request has been sent (a client may now
+ * exist on the server) or authorization has begun, a failure stops the ladder
+ * rather than silently creating more clients or restarting a half-finished
+ * dance.
+ */
+function hasCommittedSideEffects(state: OAuthFlowState): boolean {
+  return countRegistrationRequests(state) > 0 || Boolean(state.authorizationUrl);
+}
+
+interface AttemptRunOutput {
+  result: EmulatedAuthAttemptResult;
+  state?: OAuthFlowState;
+  outcome?: EmulatedOAuthPreflightOutcome;
+  authorizationUrl?: string;
+  divergences: OAuthEmulationDivergence[];
+  registrations: number;
+  tokensIssued: number;
+  stop: boolean;
+}
+
+export async function runEmulatedOAuthPreflight(
+  config: EmulatedOAuthPreflightConfig
+): Promise<EmulatedOAuthPreflightResult> {
+  const {
+    serverUrl,
+    serverName = "Emulated OAuth Preflight",
+    emulation: derived,
+    callbackUrl,
+    clientIdMetadataUrl,
+    preregistered,
+    staticCredential,
+    customHeaders,
+    customScopes,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxSteps = DEFAULT_MAX_STEPS,
+    completeAuthorization,
+    allowLoopbackMetadataFetch,
+    resourceIndicatorEnforcement = "warn",
+  } = config;
+
+  const executor =
+    config.requestExecutor ?? createHardenedExecutor(timeoutMs);
+  const protocolVersion = derived.protocolVersion;
+  const divergences: OAuthEmulationDivergence[] = [...derived.divergences];
+  const attempts: EmulatedAuthAttemptResult[] = [];
+  const sideEffects = { dcrRegistrations: 0, tokensIssued: 0 };
+
+  const redirectPlan = planCompletionSafeRedirects({
+    capturedRedirectUris: derived.capturedRedirectUris,
+    callbackUrl,
+  });
+
+  let outcome: EmulatedOAuthPreflightOutcome = "blocked";
+  let authorizationUrl: string | undefined;
+  let credentials: EmulatedOAuthPreflightResult["credentials"];
+  let error: { message: string } | undefined;
+  let redirectDivergencesDeclared = false;
+
+  // ── direct MCP probe, shared by the `api-key` and `none` rungs ───────────
+  const probeMcp = async (
+    extraHeaders: Record<string, string>
+  ): Promise<OAuthRequestResult> => {
+    const mcpVersion = resolveEmulatedMcpVersion(
+      derived.emulation,
+      resolveInitializeProtocolVersion(protocolVersion)
+    );
+    const headerVersion = resolveEmulatedMcpVersion(
+      derived.emulation,
+      protocolVersion
+    );
+    const body =
+      protocolVersion === "2026-07-28"
+        ? buildStatelessVerifyRequestBody({
+            protocolVersion: mcpVersion,
+            clientName: derived.emulation.dcrClientName ?? DEFAULT_CLIENT_NAME,
+            clientVersion: DEFAULT_CLIENT_VERSION,
+            id: 1,
+          })
+        : buildInitializeRequestBody({
+            protocolVersion: mcpVersion,
+            clientName: derived.emulation.dcrClientName ?? DEFAULT_CLIENT_NAME,
+            clientVersion: DEFAULT_CLIENT_VERSION,
+            id: 1,
+          });
+    return executor({
+      url: serverUrl,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "MCP-Protocol-Version": headerVersion,
+        ...(derived.emulation.userAgent
+          ? { "User-Agent": derived.emulation.userAgent }
+          : {}),
+        ...(customHeaders ?? {}),
+        ...extraHeaders,
+      },
+      body,
+    });
+  };
+
+  const runOAuthAttempt = async (
+    attempt: Extract<EmulatedAuthAttempt, { kind: "oauth" }>
+  ): Promise<AttemptRunOutput> => {
+    const preference = attempt.registrationPreference;
+    const attemptDivergences: OAuthEmulationDivergence[] = [];
+    let registrations = 0;
+    let lastBlockedPlan: ResolvedAuthorizationPlan | undefined;
+
+    // `dcrRedirectUris` is the completion-safe list, never the raw capture.
+    let wireEmulation: OAuthEmulationConfig = {
+      ...derived.emulation,
+      dcrRedirectUris: redirectPlan.registrationRedirectUris,
+    };
+
+    // One pass per usable strategy. Fall-through is permitted only while
+    // nothing has been committed on the wire (see hasCommittedSideEffects).
+    const strategyQueue: Array<EmulatedRegistrationPreference | undefined> =
+      preference.length > 0 ? [...preference] : [undefined];
+
+    for (const strategy of strategyQueue) {
+      const plan = resolveAuthorizationPlan({
+        serverUrl,
+        protocolVersion,
+        registrationMode: "auto",
+        ...(preference.length > 0
+          ? { registrationPreference: strategy ? [strategy] : preference }
+          : {}),
+        clientId: preregistered?.clientId,
+        clientSecret: preregistered?.clientSecret,
+        clientIdMetadataUrl,
+        authMode: "interactive",
+      });
+
+      if (plan.status === "blocked") {
+        lastBlockedPlan = plan;
+        continue;
+      }
+
+      const resolvedStrategy = (plan.registrationStrategy ??
+        strategy ??
+        "dcr") as EmulatedRegistrationPreference;
+
+      if (
+        resolvedStrategy === "cimd" ||
+        resolvedStrategy === "preregistered"
+      ) {
+        attemptDivergences.push({
+          kind: "identity-substituted",
+          detail: `${resolvedStrategy} attempt uses an MCPJam-controlled client identity; the real client's own identity cannot be asserted`,
+        });
+      }
+
+      let runState: OAuthFlowState = {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        httpHistory: [],
+        infoLogs: [],
+      };
+
+      const runOnce = async () =>
+        runOAuthStateMachine({
+          protocolVersion,
+          registrationStrategy: resolvedStrategy,
+          state: runState,
+          getState: () => runState,
+          updateState: (updates) => {
+            runState = { ...runState, ...updates };
+          },
+          serverUrl,
+          serverName,
+          redirectUrl: redirectPlan.authorizationRedirectUri,
+          requestExecutor: executor,
+          // MCPJam's own registration identity is the base; the emulation
+          // overlay replaces `client_name`/`redirect_uris` when the profile
+          // models them. A profile with no dcrIdentity evidence therefore
+          // registers as MCPJam — normal behavior for a `not_modeled` field,
+          // and never a fabricated client name.
+          dynamicRegistration: getConformanceAuthCodeDynamicRegistrationMetadata(),
+          emulation: wireEmulation,
+          clientIdMetadataUrl,
+          customScopes,
+          customHeaders,
+          resourceIndicatorEnforcement,
+          allowLoopbackMetadataFetch,
+          maxSteps,
+          loadPreregisteredCredentials: preregistered
+            ? () => ({
+                clientId: preregistered.clientId,
+                clientSecret: preregistered.clientSecret,
+              })
+            : undefined,
+          hasClientSecret: Boolean(preregistered?.clientSecret),
+          onAuthorizationRequest: async ({ authorizationUrl: url }) => {
+            if (!completeAuthorization) return { type: "redirect" as const };
+            const { code } = await completeAuthorization({
+              authorizationUrl: url,
+              callbackUrl: redirectPlan.authorizationRedirectUri,
+            });
+            return {
+              type: "authorization_code" as const,
+              authorizationCode: code,
+            };
+          },
+        });
+
+      let run = await runOnce();
+      registrations += countRegistrationRequests(runState);
+
+      // The one sanctioned retry: the server named `invalid_redirect_uri` in
+      // the documented RFC 7591 field, so re-register with our callback alone.
+      if (!run.completed && !run.redirected) {
+        const registration = registrationResponse(runState);
+        if (registration && isInvalidRedirectUriRejection(registration)) {
+          attemptDivergences.push({
+            kind: "dcr-retried",
+            detail:
+              "the authorization server rejected the replayed redirect_uris with a structured invalid_redirect_uri; re-registered with MCPJam's callback only (second and final registration)",
+            requested: redirectPlan.registrationRedirectUris.join(" "),
+            used: redirectPlan.authorizationRedirectUri,
+          });
+          wireEmulation = {
+            ...wireEmulation,
+            dcrRedirectUris: [redirectPlan.authorizationRedirectUri],
+          };
+          runState = {
+            ...EMPTY_OAUTH_FLOW_STATE,
+            httpHistory: [],
+            infoLogs: [],
+          };
+          run = await runOnce();
+          registrations += countRegistrationRequests(runState);
+        }
+      }
+
+      const history = redactDiagnostics(
+        runState.httpHistory ?? [],
+        staticCredential
+      );
+
+      if (run.redirected) {
+        return {
+          result: {
+            kind: "oauth",
+            status: "redirected",
+            registrationStrategy: resolvedStrategy,
+            plan,
+            httpHistory: history,
+            detail:
+              "reached the human authorization leg; no headless completion handler was supplied",
+          },
+          state: runState,
+          outcome: "stopped_at_redirect",
+          authorizationUrl: run.authorizationUrl,
+          divergences: attemptDivergences,
+          registrations,
+          tokensIssued: 0,
+          stop: true,
+        };
+      }
+
+      if (run.completed) {
+        const validated = isValidAuthenticatedJsonRpc(runState);
+        return {
+          result: {
+            kind: "oauth",
+            status: validated ? "ok" : "error",
+            registrationStrategy: resolvedStrategy,
+            plan,
+            httpHistory: history,
+            detail: validated
+              ? undefined
+              : "a token was issued but the authenticated MCP request did not return a valid JSON-RPC result",
+          },
+          state: runState,
+          outcome: validated ? "completed" : "error",
+          divergences: attemptDivergences,
+          registrations,
+          tokensIssued: runState.accessToken ? 1 : 0,
+          stop: true,
+        };
+      }
+
+      // Failed. Only fall through to the next strategy if nothing was
+      // committed; otherwise the ladder stops here.
+      if (hasCommittedSideEffects(runState)) {
+        return {
+          result: {
+            kind: "oauth",
+            status: "error",
+            registrationStrategy: resolvedStrategy,
+            plan,
+            httpHistory: history,
+            detail:
+              run.error?.message ??
+              "the OAuth attempt failed after it had already registered or begun authorization",
+          },
+          state: runState,
+          outcome: "error",
+          divergences: attemptDivergences,
+          registrations,
+          tokensIssued: 0,
+          stop: true,
+        };
+      }
+    }
+
+    return {
+      result: {
+        kind: "oauth",
+        status: "blocked",
+        plan: lastBlockedPlan,
+        detail:
+          lastBlockedPlan?.blockers.join(" ") ??
+          "no registration mechanism in the emulated client's preference is usable against this server",
+      },
+      outcome: "blocked",
+      divergences: attemptDivergences,
+      registrations,
+      tokensIssued: 0,
+      stop: false,
+    };
+  };
+
+  for (const attempt of derived.authAttempts) {
+    if (attempt.kind === "none") {
+      const response = await probeMcp({});
+      const ok = response.ok;
+      attempts.push({
+        kind: "none",
+        status: ok ? "ok" : "unauthorized",
+        httpHistory: redactDiagnostics(
+          [
+            {
+              step: "request_without_token",
+              timestamp: 0,
+              request: { method: "POST", url: serverUrl, headers: {} },
+              response,
+            } as HttpHistoryEntry,
+          ],
+          staticCredential
+        ),
+        detail: ok
+          ? undefined
+          : `the emulated client models no authentication, and the server answered ${response.status}`,
+      });
+      outcome = ok ? "unauthenticated_ok" : "blocked";
+      break;
+    }
+
+    if (attempt.kind === "api-key") {
+      if (!staticCredential) {
+        attempts.push({
+          kind: "api-key",
+          status: "skipped",
+          detail:
+            "the emulated client prefers a static credential, but none was supplied",
+        });
+        divergences.push({
+          kind: "not-enforced",
+          detail:
+            "api-key rung skipped: no static credential was supplied, and the runner never invents one",
+        });
+        continue;
+      }
+
+      const response = await probeMcp({
+        [staticCredential.headerName]: staticCredential.value,
+      });
+      const history = redactDiagnostics(
+        [
+          {
+            step: "request_without_token",
+            timestamp: 0,
+            request: {
+              method: "POST",
+              url: serverUrl,
+              headers: { [staticCredential.headerName]: staticCredential.value },
+            },
+            response,
+          } as HttpHistoryEntry,
+        ],
+        staticCredential
+      );
+
+      if (response.ok) {
+        attempts.push({ kind: "api-key", status: "ok", httpHistory: history });
+        outcome = "static_credential_ok";
+        break;
+      }
+
+      // Only an evidence-backed 401 lets a static credential fall through to
+      // OAuth. Any other status is a different failure, and continuing would
+      // misreport its cause.
+      if (response.status === 401) {
+        attempts.push({
+          kind: "api-key",
+          status: "unauthorized",
+          httpHistory: history,
+          detail: "server rejected the static credential with 401; falling through to the client's next mechanism",
+        });
+        continue;
+      }
+
+      attempts.push({
+        kind: "api-key",
+        status: "error",
+        httpHistory: history,
+        detail: `server answered ${response.status} to the static credential; only a 401 authorizes falling through to OAuth`,
+      });
+      outcome = "error";
+      error = {
+        message: `Static credential attempt failed with ${response.status}.`,
+      };
+      break;
+    }
+
+    const attemptOutput = await runOAuthAttempt(attempt);
+    attempts.push(attemptOutput.result);
+    sideEffects.dcrRegistrations += attemptOutput.registrations;
+    sideEffects.tokensIssued += attemptOutput.tokensIssued;
+    // Redirect divergences describe the registration body, so they are only
+    // true once a registration actually ran.
+    if (attemptOutput.registrations > 0 && !redirectDivergencesDeclared) {
+      divergences.push(...redirectPlan.divergences);
+      redirectDivergencesDeclared = true;
+    }
+    divergences.push(...attemptOutput.divergences);
+
+    if (attemptOutput.outcome) outcome = attemptOutput.outcome;
+    if (attemptOutput.authorizationUrl) {
+      authorizationUrl = attemptOutput.authorizationUrl;
+    }
+    if (attemptOutput.state) {
+      const { accessToken, refreshToken, clientId, clientSecret } =
+        attemptOutput.state;
+      if (accessToken || refreshToken || clientId || clientSecret) {
+        credentials = {
+          ...(accessToken ? { accessToken } : {}),
+          ...(refreshToken ? { refreshToken } : {}),
+          ...(clientId ? { clientId } : {}),
+          ...(clientSecret ? { clientSecret } : {}),
+        };
+      }
+    }
+    if (attemptOutput.result.status === "error") {
+      error = {
+        message: attemptOutput.result.detail ?? "OAuth attempt failed.",
+      };
+    }
+    if (attemptOutput.stop) break;
+  }
+
+  return {
+    serverUrl,
+    protocolVersion,
+    outcome,
+    coverage: derived.coverage,
+    coverageSummary: derived.coverageSummary,
+    comparison: "not_compared",
+    attempts,
+    ...(authorizationUrl ? { authorizationUrl } : {}),
+    divergences,
+    sideEffects,
+    ...(credentials ? { credentials } : {}),
+    ...(error ? { error } : {}),
+  };
+}

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -25,9 +25,15 @@
 
 import { executeOAuthProxy } from "../../oauth-proxy.js";
 import { redactSensitiveValue } from "../../redaction.js";
-import { getConformanceAuthCodeDynamicRegistrationMetadata } from "../client-identity.js";
+import {
+  DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
+  getConformanceAuthCodeDynamicRegistrationMetadata,
+} from "../client-identity.js";
+import { assertOutboundOAuthUrlAllowed } from "../ssrf-guard.js";
+import { getSupportedRegistrationStrategies } from "../state-machines/factory.js";
 import {
   resolveAuthorizationPlan,
+  type OAuthRegistrationStrategy,
   type ResolvedAuthorizationPlan,
 } from "../authorization-plan.js";
 import { runOAuthStateMachine } from "../state-machines/runner.js";
@@ -58,6 +64,22 @@ import type {
   OAuthEmulationCoverage,
   OAuthEmulationDivergence,
 } from "./types.js";
+
+/**
+ * Drift guard: `EmulatedRegistrationPreference` is spelled independently in
+ * `emulation/types.ts` so that module stays free of any import that would
+ * close a cycle (authorization-plan → state-machines/types → emulation/types).
+ * This assertion — in a module that already imports both — fails to compile if
+ * the two unions ever diverge, which is the only real risk of the duplication.
+ */
+type _RegistrationPreferenceInSync =
+  EmulatedRegistrationPreference extends OAuthRegistrationStrategy
+    ? OAuthRegistrationStrategy extends EmulatedRegistrationPreference
+      ? true
+      : never
+    : never;
+const _registrationPreferenceInSync: _RegistrationPreferenceInSync = true;
+void _registrationPreferenceInSync;
 
 const DEFAULT_CLIENT_NAME = "MCPJam Emulated Client";
 const DEFAULT_CLIENT_VERSION = "1.0.0";
@@ -222,11 +244,54 @@ function redactDiagnostics<T>(
   return redactSensitiveValue(working) as T;
 }
 
+/**
+ * Extract the JSON-RPC message from a response body.
+ *
+ * Streamable-HTTP MCP servers answer with `text/event-stream`, and the
+ * hardened proxy buffers that as a raw string — so a body is legitimately an
+ * object, a JSON string, or a set of SSE frames. Only after decoding all three
+ * can "did the server answer a real MCP call" be judged; treating an SSE frame
+ * as a non-answer would fail every streaming server.
+ */
+function extractJsonRpcMessage(body: unknown): Record<string, unknown> | undefined {
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    return body as Record<string, unknown>;
+  }
+  if (typeof body !== "string") return undefined;
+
+  const text = body.trim();
+  if (!text) return undefined;
+
+  if (!/^(event|data|id|retry):/m.test(text)) {
+    try {
+      const parsed = JSON.parse(text);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // SSE: take the last `data:` payload that parses as a JSON-RPC message.
+  for (const line of text.split(/\r?\n/).reverse()) {
+    if (!line.startsWith("data:")) continue;
+    try {
+      const parsed = JSON.parse(line.slice(5).trim());
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Keep scanning: a multi-frame stream may carry non-JSON keepalives.
+    }
+  }
+  return undefined;
+}
+
 /** A token alone is not success — the server must answer a real MCP call. */
 function isValidAuthenticatedJsonRpc(state: OAuthFlowState): boolean {
-  const body = state.lastResponse?.body;
-  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
-  const message = body as Record<string, unknown>;
+  const message = extractJsonRpcMessage(state.lastResponse?.body);
+  if (!message) return false;
   if (message.jsonrpc !== "2.0") return false;
   if (message.error !== undefined) return false;
   return message.result !== undefined;
@@ -280,7 +345,10 @@ export async function runEmulatedOAuthPreflight(
     serverName = "Emulated OAuth Preflight",
     emulation: derived,
     callbackUrl,
-    clientIdMetadataUrl,
+    // CIMD asserts identity through a fetchable document, which must be one
+    // MCPJam controls — the real client's document is not ours to claim. Every
+    // CIMD attempt therefore declares an `identity-substituted` divergence.
+    clientIdMetadataUrl = DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
     preregistered,
     staticCredential,
     customHeaders,
@@ -311,9 +379,15 @@ export async function runEmulatedOAuthPreflight(
   let redirectDivergencesDeclared = false;
 
   // ── direct MCP probe, shared by the `api-key` and `none` rungs ───────────
+  // These rungs bypass the state machines, so they also bypass the factory's
+  // outbound guard. Apply it here: a caller-supplied executor must not turn
+  // these paths into an SSRF hole the OAuth path is closed against.
   const probeMcp = async (
     extraHeaders: Record<string, string>
   ): Promise<OAuthRequestResult> => {
+    assertOutboundOAuthUrlAllowed(serverUrl, {
+      allowLoopback: allowLoopbackMetadataFetch ?? false,
+    });
     const mcpVersion = resolveEmulatedMcpVersion(
       derived.emulation,
       resolveInitializeProtocolVersion(protocolVersion)
@@ -369,17 +443,27 @@ export async function runEmulatedOAuthPreflight(
 
     // One pass per usable strategy. Fall-through is permitted only while
     // nothing has been committed on the wire (see hasCommittedSideEffects).
-    const strategyQueue: Array<EmulatedRegistrationPreference | undefined> =
-      preference.length > 0 ? [...preference] : [undefined];
+    //
+    // With no profile preference (`authModel` not_modeled) the ladder is
+    // MCPJam's own AUTO precedence — pre-registered, then CIMD, then DCR —
+    // filtered to what this era supports, rather than a hardcoded strategy.
+    // Discovery is not pre-fetched: a strategy the server turns out not to
+    // support fails during discovery, BEFORE any registration, so the
+    // uncommitted-fallback rule moves to the next one without creating a
+    // client or repeating a committed step.
+    const eraStrategies = getSupportedRegistrationStrategies(protocolVersion);
+    const autoOrder = (
+      ["preregistered", "cimd", "dcr"] as EmulatedRegistrationPreference[]
+    ).filter((strategy) => eraStrategies.includes(strategy));
+    const strategyQueue: EmulatedRegistrationPreference[] =
+      preference.length > 0 ? [...preference] : autoOrder;
 
     for (const strategy of strategyQueue) {
       const plan = resolveAuthorizationPlan({
         serverUrl,
         protocolVersion,
         registrationMode: "auto",
-        ...(preference.length > 0
-          ? { registrationPreference: strategy ? [strategy] : preference }
-          : {}),
+        registrationPreference: [strategy],
         clientId: preregistered?.clientId,
         clientSecret: preregistered?.clientSecret,
         clientIdMetadataUrl,
@@ -392,8 +476,7 @@ export async function runEmulatedOAuthPreflight(
       }
 
       const resolvedStrategy = (plan.registrationStrategy ??
-        strategy ??
-        "dcr") as EmulatedRegistrationPreference;
+        strategy) as EmulatedRegistrationPreference;
 
       if (
         resolvedStrategy === "cimd" ||
@@ -459,12 +542,17 @@ export async function runEmulatedOAuthPreflight(
 
       let run = await runOnce();
       registrations += countRegistrationRequests(runState);
+      // Kept across a retry: without the rejected first registration in the
+      // history, the reported `dcr-retried` divergence cannot be corroborated
+      // from the trace it points at.
+      let priorHistory: HttpHistoryEntry[] = [];
 
       // The one sanctioned retry: the server named `invalid_redirect_uri` in
       // the documented RFC 7591 field, so re-register with our callback alone.
       if (!run.completed && !run.redirected) {
         const registration = registrationResponse(runState);
         if (registration && isInvalidRedirectUriRejection(registration)) {
+          priorHistory = [...(runState.httpHistory ?? [])];
           attemptDivergences.push({
             kind: "dcr-retried",
             detail:
@@ -487,7 +575,7 @@ export async function runEmulatedOAuthPreflight(
       }
 
       const history = redactDiagnostics(
-        runState.httpHistory ?? [],
+        [...priorHistory, ...(runState.httpHistory ?? [])],
         staticCredential
       );
 
@@ -552,7 +640,10 @@ export async function runEmulatedOAuthPreflight(
           outcome: "error",
           divergences: attemptDivergences,
           registrations,
-          tokensIssued: 0,
+          // A token the AS already issued is a side effect whether or not the
+          // attempt went on to succeed — reporting 0 here would understate
+          // what this run caused.
+          tokensIssued: runState.accessToken ? 1 : 0,
           stop: true,
         };
       }
@@ -575,9 +666,41 @@ export async function runEmulatedOAuthPreflight(
     };
   };
 
+  /**
+   * A transport failure on a direct rung (timeout, DNS, blocked host) is a
+   * finding about the server, not a crash: record it and return the documented
+   * result rather than rejecting out of the runner.
+   */
+  const tryProbe = async (
+    extraHeaders: Record<string, string>
+  ): Promise<
+    { ok: true; response: OAuthRequestResult } | { ok: false; message: string }
+  > => {
+    try {
+      return { ok: true, response: await probeMcp(extraHeaders) };
+    } catch (thrown) {
+      return {
+        ok: false,
+        message:
+          thrown instanceof Error ? thrown.message : String(thrown),
+      };
+    }
+  };
+
   for (const attempt of derived.authAttempts) {
     if (attempt.kind === "none") {
-      const response = await probeMcp({});
+      const probe = await tryProbe({});
+      if (!probe.ok) {
+        attempts.push({
+          kind: "none",
+          status: "error",
+          detail: probe.message,
+        });
+        outcome = "error";
+        error = { message: probe.message };
+        break;
+      }
+      const response = probe.response;
       const ok = response.ok;
       attempts.push({
         kind: "none",
@@ -617,9 +740,20 @@ export async function runEmulatedOAuthPreflight(
         continue;
       }
 
-      const response = await probeMcp({
+      const probe = await tryProbe({
         [staticCredential.headerName]: staticCredential.value,
       });
+      if (!probe.ok) {
+        attempts.push({
+          kind: "api-key",
+          status: "error",
+          detail: probe.message,
+        });
+        outcome = "error";
+        error = { message: probe.message };
+        break;
+      }
+      const response = probe.response;
       const history = redactDiagnostics(
         [
           {

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -707,8 +707,10 @@ export async function runEmulatedOAuthPreflight(
     } catch (thrown) {
       return {
         ok: false,
-        message:
+        message: redactDiagnostics(
           thrown instanceof Error ? thrown.message : String(thrown),
+          staticCredential
+        ),
       };
     }
   };

--- a/sdk/src/oauth/emulation/redirects.ts
+++ b/sdk/src/oauth/emulation/redirects.ts
@@ -1,0 +1,99 @@
+/**
+ * Completion-safe redirect planning (HP-43 step 5).
+ *
+ * The emulator must do two things that pull in opposite directions: replay the
+ * real client's registration body, and still finish the dance with a real
+ * token. A real client registers callbacks MCPJam cannot receive on
+ * (`cursor://…`, a vendor's hosted callback, a loopback port owned by another
+ * process), so a byte-exact replay would strand the authorization code.
+ *
+ * The resolution, and its honesty rules:
+ *
+ *   - The registration body carries the captured redirect URIs **in captured
+ *     order, plus MCPJam's callback appended**. The appended entry is a
+ *     DECLARED substitution — the registration step can never be presented as
+ *     byte-matched when it happens.
+ *   - The authorization and token legs **always** use MCPJam's callback, so
+ *     the code comes back to us and can be exchanged.
+ *   - If the server rejects that registration with a structured RFC 7591
+ *     `invalid_redirect_uri`, and only then, the caller may re-register with
+ *     MCPJam's callback alone (see `isInvalidRedirectUriRejection`). That is
+ *     the second and last registration a preflight will ever perform.
+ *
+ * There is no exact-foreign-redirect mode: a run that cannot complete produces
+ * no token, and a token is what the developer came for.
+ */
+
+import type { OAuthEmulationDivergence } from "./types.js";
+
+export interface CompletionSafeRedirectPlan {
+  /** `redirect_uris` for the registration body. */
+  registrationRedirectUris: string[];
+  /** The callback the authorization + token legs use. Always MCPJam's. */
+  authorizationRedirectUri: string;
+  /** Declared differences from the captured registration. */
+  divergences: OAuthEmulationDivergence[];
+}
+
+export function planCompletionSafeRedirects(input: {
+  capturedRedirectUris?: string[];
+  callbackUrl: string;
+}): CompletionSafeRedirectPlan {
+  const { capturedRedirectUris, callbackUrl } = input;
+  const divergences: OAuthEmulationDivergence[] = [];
+
+  if (!capturedRedirectUris || capturedRedirectUris.length === 0) {
+    // Nothing was captured, so nothing diverges: registering our own callback
+    // is not a substitution for a value we never had.
+    return {
+      registrationRedirectUris: [callbackUrl],
+      authorizationRedirectUri: callbackUrl,
+      divergences,
+    };
+  }
+
+  // Captured order first, ours appended. Deduped only against an exact match:
+  // if the real client already registers this very URL there is nothing to add
+  // and nothing to declare.
+  const alreadyPresent = capturedRedirectUris.includes(callbackUrl);
+  const registrationRedirectUris = alreadyPresent
+    ? [...capturedRedirectUris]
+    : [...capturedRedirectUris, callbackUrl];
+
+  if (!alreadyPresent) {
+    divergences.push({
+      kind: "redirect-uri-appended",
+      detail:
+        `registration adds MCPJam's callback to the captured redirect_uris so the ` +
+        `authorization code can be received and exchanged; the captured list is ` +
+        `otherwise replayed in order`,
+      requested: capturedRedirectUris.join(" "),
+      used: registrationRedirectUris.join(" "),
+    });
+  }
+
+  return {
+    registrationRedirectUris,
+    authorizationRedirectUri: callbackUrl,
+    divergences,
+  };
+}
+
+/**
+ * Is this registration response a STRUCTURED RFC 7591 `invalid_redirect_uri`?
+ *
+ * Deliberately narrow. Retrying registration creates a second client on the
+ * authorization server, so the trigger must be the server explicitly naming
+ * this error in the documented field — never a substring match on prose, a
+ * generic 4xx, a timeout, or a body that failed to parse. Anything else is an
+ * unrelated failure that a retry would neither diagnose nor fix.
+ */
+export function isInvalidRedirectUriRejection(response: {
+  status: number;
+  body: unknown;
+}): boolean {
+  if (response.status < 400 || response.status >= 500) return false;
+  const body = response.body;
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  return (body as { error?: unknown }).error === "invalid_redirect_uri";
+}

--- a/sdk/src/oauth/emulation/redirects.ts
+++ b/sdk/src/oauth/emulation/redirects.ts
@@ -92,7 +92,11 @@ export function isInvalidRedirectUriRejection(response: {
   status: number;
   body: unknown;
 }): boolean {
-  if (response.status < 400 || response.status >= 500) return false;
+  // Exactly 400. RFC 7591 §3.2.2 defines this error response as a 400, so any
+  // other status carrying the string is a different failure wearing the same
+  // word — an auth, routing, or rate-limit rejection must never spend the
+  // one retry and create a second client.
+  if (response.status !== 400) return false;
   const body = response.body;
   if (!body || typeof body !== "object" || Array.isArray(body)) return false;
   return (body as { error?: unknown }).error === "invalid_redirect_uri";

--- a/sdk/src/oauth/emulation/types.ts
+++ b/sdk/src/oauth/emulation/types.ts
@@ -1,5 +1,5 @@
 /**
- * OAuth client emulation — knob and coverage types (HP-43 step 4).
+ * OAuth client emulation — knob, coverage, and attempt types (HP-43).
  *
  * `OAuthEmulationConfig` is the ONLY thing the four debug OAuth state
  * machines see: generic wire knobs, derived from an evidence-backed
@@ -58,13 +58,39 @@ export interface OAuthEmulationConfig {
    * registration metadata and the token request's client authentication.
    */
   tokenEndpointAuthMethod?: OAuthTokenEndpointAuthMethod;
+  /**
+   * `redirect_uris` for the DCR registration body ONLY — the authorization and
+   * token legs always use the machine's own `redirectUrl`.
+   *
+   * This asymmetry is the completion-safe design, not an oversight: the
+   * registration body replays what the real client registers, while the code
+   * still comes back to a callback MCPJam controls so the flow can finish with
+   * a real token. Callers should not set this directly from a captured
+   * profile — `planCompletionSafeRedirects` builds the value that keeps the
+   * flow completable (see `emulation/redirects.ts`).
+   */
+  dcrRedirectUris?: string[];
 }
 
+/** A registration strategy an emulated client may prefer, in profile order. */
+export type EmulatedRegistrationPreference = "preregistered" | "dcr" | "cimd";
+
 /**
- * Profile fields step 4 can enforce. `authModel` (attempt ordering) and
- * `dcrIdentity.redirectUris` (completion-safe redirects) belong to the
- * attempt-ladder step and are not part of this coverage map yet.
+ * One rung of the emulated client's authentication ladder, derived from the
+ * profile's ordered `authModel`.
+ *
+ * Consecutive `oauth2-*` entries collapse into a single `oauth` attempt whose
+ * `registrationPreference` preserves their relative order: they are one OAuth
+ * dance with a strategy preference, not several independent attempts.
+ * `api-key` and `none` are not registration strategies and never enter the
+ * authorization plan — the runner executes them as direct MCP requests.
  */
+export type EmulatedAuthAttempt =
+  | { kind: "oauth"; registrationPreference: EmulatedRegistrationPreference[] }
+  | { kind: "api-key" }
+  | { kind: "none" };
+
+/** Profile fields the emulator can enforce. */
 export const OAUTH_EMULATION_FIELDS = [
   "sendsResourceIndicator",
   "oauthSpecVersion",
@@ -72,6 +98,7 @@ export const OAUTH_EMULATION_FIELDS = [
   "scopeRequest",
   "dcrIdentity",
   "tokenEndpointAuthMethod",
+  "authModel",
 ] as const;
 
 export type OAuthEmulationField = (typeof OAUTH_EMULATION_FIELDS)[number];
@@ -89,8 +116,23 @@ export type OAuthEmulationCoverage = Record<
   OAuthEmulationFieldStatus
 >;
 
+/**
+ * A declared, deliberate difference between what the real client does and what
+ * the emulated run did. Every one is reported: a run that diverged can never
+ * be presented as an unqualified byte-for-byte match.
+ */
 export interface OAuthEmulationDivergence {
-  kind: "version-narrowed" | "not-enforced";
+  kind:
+    | "version-narrowed"
+    /** MCPJam's callback appended to the captured registration redirect list. */
+    | "redirect-uri-appended"
+    /** DCR re-sent with our callback only, after a structured
+     * `invalid_redirect_uri` rejection (RFC 7591). */
+    | "dcr-retried"
+    /** CIMD / pre-registered identity is MCPJam's, not the real client's. */
+    | "identity-substituted"
+    /** Evidence exists but this step does not enforce it. */
+    | "not-enforced";
   /** Human-readable, includes requested vs used values where applicable. */
   detail: string;
   requested?: string;

--- a/sdk/src/oauth/state-machines/shared/emulation.ts
+++ b/sdk/src/oauth/state-machines/shared/emulation.ts
@@ -73,9 +73,14 @@ export function resolveEmulatedScopeValue(
 
 /**
  * Overlay the emulated DCR identity on the caller's registration metadata:
- * byte-exact `client_name` and the forced `token_endpoint_auth_method`.
- * Applied BEFORE the machines' client_name-required guard, so an emulated
- * client_name satisfies it.
+ * byte-exact `client_name`, the forced `token_endpoint_auth_method`, and the
+ * completion-safe `redirect_uris`. Applied BEFORE the machines'
+ * client_name-required guard, so an emulated client_name satisfies it.
+ *
+ * `redirect_uris` lands on the REGISTRATION body only — the authorization and
+ * token legs keep using the machine's `redirectUrl`. That asymmetry is what
+ * lets a replayed registration coexist with a code MCPJam can actually
+ * receive (see emulation/redirects.ts).
  */
 export function applyEmulationToDcrMetadata<
   T extends Record<string, unknown>,
@@ -87,6 +92,9 @@ export function applyEmulationToDcrMetadata<
   }
   if (emulation.tokenEndpointAuthMethod !== undefined) {
     out.token_endpoint_auth_method = emulation.tokenEndpointAuthMethod;
+  }
+  if (emulation.dcrRedirectUris !== undefined) {
+    out.redirect_uris = [...emulation.dcrRedirectUris];
   }
   return out as T;
 }

--- a/sdk/tests/oauth/authorization-plan.test.ts
+++ b/sdk/tests/oauth/authorization-plan.test.ts
@@ -199,3 +199,121 @@ describe("resolveAuthorizationPlan", () => {
     ).toBe(false);
   });
 });
+
+describe("resolveAuthorizationPlan — emulated client registration preference", () => {
+  const discovery = (metadata: Record<string, unknown>) => ({
+    authorizationServerMetadata: {
+      issuer: "https://as.example.com",
+      authorization_endpoint: "https://as.example.com/authorize",
+      token_endpoint: "https://as.example.com/token",
+      ...metadata,
+    },
+  });
+
+  it("honors the client's order over the built-in AUTO precedence", () => {
+    // AUTO would pick CIMD here; the emulated client prefers DCR.
+    const plan = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      registrationPreference: ["dcr", "cimd"],
+      discovery: discovery({
+        registration_endpoint: "https://as.example.com/register",
+        client_id_metadata_document_supported: true,
+      }),
+    });
+
+    expect(plan.status).toBe("ready");
+    expect(plan.registrationStrategy).toBe("dcr");
+  });
+
+  it("skips a preferred mechanism the server does not support and takes the next", () => {
+    const plan = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      registrationPreference: ["cimd", "dcr"],
+      discovery: discovery({
+        registration_endpoint: "https://as.example.com/register",
+      }),
+    });
+
+    expect(plan.registrationStrategy).toBe("dcr");
+    expect(plan.warnings.join(" ")).toMatch(/prefers CIMD/);
+  });
+
+  it("skips preferred pre-registration when no credentials are configured", () => {
+    const plan = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      registrationPreference: ["preregistered", "dcr"],
+      discovery: discovery({
+        registration_endpoint: "https://as.example.com/register",
+      }),
+    });
+
+    expect(plan.registrationStrategy).toBe("dcr");
+  });
+
+  it("blocks when no preferred mechanism is usable", () => {
+    const plan = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      registrationPreference: ["preregistered", "dcr"],
+      discovery: discovery({}),
+    });
+
+    expect(plan.status).toBe("blocked");
+    expect(
+      plan.blockerDetails.some(
+        (b) => b.code === "AUTO_NO_USABLE_REGISTRATION_FLOW",
+      ),
+    ).toBe(true);
+  });
+
+  it("asks for discovery rather than guessing support", () => {
+    const plan = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      registrationPreference: ["dcr"],
+    });
+
+    expect(plan.status).toBe("discovery_required");
+  });
+
+  it("an explicit registrationMode still wins over the preference", () => {
+    const plan = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      registrationMode: "cimd",
+      registrationPreference: ["dcr"],
+      discovery: discovery({
+        registration_endpoint: "https://as.example.com/register",
+        client_id_metadata_document_supported: true,
+      }),
+    });
+
+    expect(plan.registrationStrategy).toBe("cimd");
+  });
+
+  it("an empty preference leaves the built-in AUTO precedence untouched", () => {
+    const withEmpty = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      registrationPreference: [],
+      discovery: discovery({
+        registration_endpoint: "https://as.example.com/register",
+        client_id_metadata_document_supported: true,
+      }),
+    });
+    const without = resolveAuthorizationPlan({
+      serverUrl: "https://example.com/mcp",
+      authMode: "interactive",
+      discovery: discovery({
+        registration_endpoint: "https://as.example.com/register",
+        client_id_metadata_document_supported: true,
+      }),
+    });
+
+    expect(withEmpty).toEqual(without);
+    expect(withEmpty.registrationStrategy).toBe("cimd");
+  });
+});

--- a/sdk/tests/oauth/emulation-derive.test.ts
+++ b/sdk/tests/oauth/emulation-derive.test.ts
@@ -1,4 +1,5 @@
 import { deriveOAuthEmulation } from "../../src/oauth/emulation/derive.js";
+import { OAUTH_EMULATION_FIELDS } from "../../src/oauth/emulation/types.js";
 import type {
   HostConfigOAuthProfileV1,
   HostConfigOAuthProfileV2,
@@ -35,7 +36,7 @@ describe("deriveOAuthEmulation — evidence handling", () => {
     expect(out.emulation).toEqual({});
     expect(out.coverageSummary).toBe("partial");
     expect(Object.values(out.coverage)).toEqual(
-      Array(6).fill("not_modeled")
+      Array(OAUTH_EMULATION_FIELDS.length).fill("not_modeled")
     );
     expect(out.divergences).toEqual([]);
   });
@@ -73,6 +74,7 @@ describe("deriveOAuthEmulation — evidence handling", () => {
         scopeRequest: verified({ mode: "omit" as const }),
         dcrIdentity: verified({ clientName: "Emulated Client" }),
         tokenEndpointAuthMethod: verified("client_secret_post" as const),
+        authModel: verified(["oauth2-dcr"]),
       })
     );
     expect(out.coverageSummary).toBe("complete");
@@ -224,7 +226,7 @@ describe("deriveOAuthEmulation — per-field knobs", () => {
     expect(out.emulation.tokenEndpointAuthMethod).toBe("client_secret_basic");
   });
 
-  it("dcrIdentity maps clientName + userAgent; redirectUris alone is not-enforced", () => {
+  it("dcrIdentity maps clientName + userAgent, and captures redirectUris for the runner", () => {
     const withName = deriveOAuthEmulation(
       v2({
         dcrIdentity: verified({
@@ -238,6 +240,13 @@ describe("deriveOAuthEmulation — per-field knobs", () => {
     expect(withName.emulation.userAgent).toBe("RealClient/1.2.3");
     expect(withName.coverage.dcrIdentity).toBe("modeled");
     expect(withName.divergences).toEqual([]);
+    // Captured, but NOT compiled into a wire knob: replaying these alone
+    // would send the code somewhere MCPJam cannot receive it. The runner
+    // combines them with its own callback and declares the addition.
+    expect(withName.capturedRedirectUris).toEqual([
+      "https://client.example/cb",
+    ]);
+    expect(withName.emulation.dcrRedirectUris).toBeUndefined();
 
     const onlyRedirects = deriveOAuthEmulation(
       v2({
@@ -247,10 +256,11 @@ describe("deriveOAuthEmulation — per-field knobs", () => {
       })
     );
     expect(onlyRedirects.emulation.dcrClientName).toBeUndefined();
-    expect(onlyRedirects.coverage.dcrIdentity).toBe("not_modeled");
-    expect(onlyRedirects.divergences[0]).toMatchObject({
-      kind: "not-enforced",
-    });
+    expect(onlyRedirects.coverage.dcrIdentity).toBe("modeled");
+    expect(onlyRedirects.capturedRedirectUris).toEqual([
+      "https://client.example/cb",
+    ]);
+    expect(onlyRedirects.divergences).toEqual([]);
   });
 });
 

--- a/sdk/tests/oauth/emulation-derive.test.ts
+++ b/sdk/tests/oauth/emulation-derive.test.ts
@@ -3,27 +3,12 @@ import { OAUTH_EMULATION_FIELDS } from "../../src/oauth/emulation/types.js";
 import type {
   HostConfigOAuthProfileV1,
   HostConfigOAuthProfileV2,
-  OAuthProfileEvidence,
 } from "../../src/host-config/internal";
-
-const verified = <T,>(value: T): OAuthProfileEvidence<T> => ({
-  status: "verified",
-  value,
-  source: "https://example.test/capture#L1",
-  capturedAt: "2026-07-30",
-});
-
-const refuted = <T,>(value: T): OAuthProfileEvidence<T> => ({
-  status: "refuted",
-  value,
-  source: "https://example.test/refutation#L1",
-  capturedAt: "2026-07-30",
-});
-
-const unverifiable = <T,>(): OAuthProfileEvidence<T> => ({
-  status: "unverifiable",
-  reason: "closed-source client",
-});
+import {
+  refuted,
+  unverifiable,
+  verified,
+} from "../support/oauth-profiles.js";
 
 const v2 = (
   fields: Omit<HostConfigOAuthProfileV2, "profileVersion">

--- a/sdk/tests/oauth/emulation-preflight.test.ts
+++ b/sdk/tests/oauth/emulation-preflight.test.ts
@@ -734,6 +734,27 @@ describe("runEmulatedOAuthPreflight — diagnostics hygiene", () => {
     expect(diagnostics).not.toContain("super-secret-tenant-token");
     expect(diagnostics).toContain("[REDACTED]");
   });
+
+  it("redacts a static credential from a direct-rung transport error", async () => {
+    const secret = "super-secret-tenant-token";
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["api-key"]) }),
+      callbackUrl: CALLBACK,
+      staticCredential: {
+        headerName: "X-Acme-Tenant-Token",
+        value: secret,
+      },
+      requestExecutor: async () => {
+        throw new Error(`socket reset while sending X-Acme-Tenant-Token: ${secret}`);
+      },
+    });
+
+    expect(result.outcome).toBe("error");
+    expect(result.attempts[0].detail).toContain("[REDACTED]");
+    expect(result.error?.message).toContain("[REDACTED]");
+    expect(JSON.stringify(result)).not.toContain(secret);
+  });
 });
 
 describe("runEmulatedOAuthPreflight — coverage and parity", () => {

--- a/sdk/tests/oauth/emulation-preflight.test.ts
+++ b/sdk/tests/oauth/emulation-preflight.test.ts
@@ -1,0 +1,490 @@
+/**
+ * Attempt ladder, completion-safe redirects, and the headless preflight runner
+ * (HP-43 step 5).
+ */
+import { deriveOAuthEmulation } from "../../src/oauth/emulation/derive.js";
+import { runEmulatedOAuthPreflight } from "../../src/oauth/emulation/preflight.js";
+import {
+  isInvalidRedirectUriRejection,
+  planCompletionSafeRedirects,
+} from "../../src/oauth/emulation/redirects.js";
+import type { DerivedOAuthEmulation } from "../../src/oauth/emulation/derive.js";
+import type { HostConfigOAuthProfileV2 } from "../../src/host-config/internal";
+import type { OAuthProfileEvidence } from "../../src/host-config/internal";
+import {
+  autoConsent,
+  createMockOAuthServer,
+} from "../support/mock-oauth-as.js";
+
+const SERVER_URL = "https://mcp-server.example.com/mcp";
+const CALLBACK = "http://127.0.0.1:41234/callback";
+
+const verified = <T,>(value: T): OAuthProfileEvidence<T> => ({
+  status: "verified",
+  value,
+  source: "https://example.test/capture#L1",
+  capturedAt: "2026-07-30",
+});
+
+const profile = (
+  fields: Omit<HostConfigOAuthProfileV2, "profileVersion">
+): HostConfigOAuthProfileV2 => ({ profileVersion: 2, ...fields });
+
+const derive = (fields: Omit<HostConfigOAuthProfileV2, "profileVersion">) =>
+  deriveOAuthEmulation(profile(fields));
+
+describe("attempt ladder derivation", () => {
+  it("collapses consecutive oauth2-* entries into one attempt, preserving order", () => {
+    const out = derive({
+      authModel: verified(["oauth2-cimd", "oauth2-dcr", "oauth2-preregistered"]),
+    });
+    expect(out.authAttempts).toEqual([
+      {
+        kind: "oauth",
+        registrationPreference: ["cimd", "dcr", "preregistered"],
+      },
+    ]);
+    expect(out.coverage.authModel).toBe("modeled");
+  });
+
+  it("keeps api-key in position — static credential first, OAuth after", () => {
+    const out = derive({ authModel: verified(["api-key", "oauth2-dcr"]) });
+    expect(out.authAttempts).toEqual([
+      { kind: "api-key" },
+      { kind: "oauth", registrationPreference: ["dcr"] },
+    ]);
+  });
+
+  it("models a no-auth client as a single `none` rung", () => {
+    expect(derive({ authModel: verified(["none"]) }).authAttempts).toEqual([
+      { kind: "none" },
+    ]);
+  });
+
+  it("without authModel evidence falls back to one preference-free oauth attempt", () => {
+    const out = derive({});
+    expect(out.authAttempts).toEqual([
+      { kind: "oauth", registrationPreference: [] },
+    ]);
+    expect(out.coverage.authModel).toBe("not_modeled");
+  });
+});
+
+describe("completion-safe redirects", () => {
+  it("appends our callback to the captured list and declares it", () => {
+    const plan = planCompletionSafeRedirects({
+      capturedRedirectUris: ["cursor://anysphere.cursor-retrieval/callback"],
+      callbackUrl: CALLBACK,
+    });
+    expect(plan.registrationRedirectUris).toEqual([
+      "cursor://anysphere.cursor-retrieval/callback",
+      CALLBACK,
+    ]);
+    expect(plan.authorizationRedirectUri).toBe(CALLBACK);
+    expect(plan.divergences).toEqual([
+      expect.objectContaining({ kind: "redirect-uri-appended" }),
+    ]);
+  });
+
+  it("declares nothing when there was no capture to diverge from", () => {
+    const plan = planCompletionSafeRedirects({ callbackUrl: CALLBACK });
+    expect(plan.registrationRedirectUris).toEqual([CALLBACK]);
+    expect(plan.divergences).toEqual([]);
+  });
+
+  it("does not duplicate or declare when the capture already contains our callback", () => {
+    const plan = planCompletionSafeRedirects({
+      capturedRedirectUris: [CALLBACK],
+      callbackUrl: CALLBACK,
+    });
+    expect(plan.registrationRedirectUris).toEqual([CALLBACK]);
+    expect(plan.divergences).toEqual([]);
+  });
+
+  it("retries only on a structured RFC 7591 invalid_redirect_uri", () => {
+    expect(
+      isInvalidRedirectUriRejection({
+        status: 400,
+        body: { error: "invalid_redirect_uri" },
+      })
+    ).toBe(true);
+    // Everything else must NOT trigger a second registration.
+    expect(
+      isInvalidRedirectUriRejection({
+        status: 400,
+        body: { error: "invalid_client_metadata" },
+      })
+    ).toBe(false);
+    expect(
+      isInvalidRedirectUriRejection({
+        status: 400,
+        body: { error_description: "invalid_redirect_uri somewhere in prose" },
+      })
+    ).toBe(false);
+    expect(isInvalidRedirectUriRejection({ status: 400, body: null })).toBe(
+      false
+    );
+    expect(
+      isInvalidRedirectUriRejection({
+        status: 400,
+        body: "invalid_redirect_uri",
+      })
+    ).toBe(false);
+    expect(isInvalidRedirectUriRejection({ status: 500, body: { error: "invalid_redirect_uri" } })).toBe(false);
+    expect(isInvalidRedirectUriRejection({ status: 0, body: { error: "invalid_redirect_uri" } })).toBe(false);
+  });
+});
+
+describe("runEmulatedOAuthPreflight — completion", () => {
+  it("completes with a real token AND a valid authenticated JSON-RPC result", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(result.credentials?.accessToken).toBe("emulated-access-token");
+    expect(result.sideEffects).toEqual({
+      dcrRegistrations: 1,
+      tokensIssued: 1,
+    });
+    expect(result.comparison).toBe("not_compared");
+  });
+
+  it("a token without a valid JSON-RPC result is NOT a completion", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const executor: typeof mock.executor = async (request) => {
+      const response = await mock.executor(request);
+      // Authenticated MCP call returns 200 with a JSON-RPC error body.
+      if (
+        request.url === SERVER_URL &&
+        request.headers.Authorization?.startsWith("Bearer ")
+      ) {
+        return {
+          ...response,
+          body: { jsonrpc: "2.0", id: 1, error: { code: -32000, message: "nope" } },
+        };
+      }
+      return response;
+    };
+
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("error");
+    expect(result.attempts[0].detail).toMatch(/valid JSON-RPC result/);
+  });
+
+  it("stops at the redirect and reports the URL when no headless handler is given", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+    });
+
+    expect(result.outcome).toBe("stopped_at_redirect");
+    expect(result.authorizationUrl).toContain("/authorize");
+    expect(result.sideEffects.tokensIssued).toBe(0);
+  });
+});
+
+describe("runEmulatedOAuthPreflight — attempt ordering and fallback", () => {
+  it("uses the static credential when the server accepts it, and never runs OAuth", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      acceptStaticCredential: { headerName: "X-Acme-Key", value: "s3cret" },
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["api-key", "oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      staticCredential: { headerName: "X-Acme-Key", value: "s3cret" },
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("static_credential_ok");
+    expect(result.attempts.map((a) => a.kind)).toEqual(["api-key"]);
+    expect(result.sideEffects.dcrRegistrations).toBe(0);
+  });
+
+  it("falls through to OAuth on a 401 — the evidence-backed fallback", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["api-key", "oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      staticCredential: { headerName: "X-Acme-Key", value: "wrong" },
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.attempts.map((a) => `${a.kind}:${a.status}`)).toEqual([
+      "api-key:unauthorized",
+      "oauth:ok",
+    ]);
+    expect(result.outcome).toBe("completed");
+  });
+
+  it("does NOT fall through on a non-401 static-credential failure", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      unauthenticatedStatus: 500,
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["api-key", "oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      staticCredential: { headerName: "X-Acme-Key", value: "wrong" },
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("error");
+    expect(result.attempts.map((a) => a.kind)).toEqual(["api-key"]);
+    expect(result.attempts[0].detail).toMatch(/only a 401/);
+  });
+
+  it("skips the api-key rung and declares it when no credential is supplied", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["api-key", "oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.attempts[0]).toMatchObject({
+      kind: "api-key",
+      status: "skipped",
+    });
+    expect(result.outcome).toBe("completed");
+    expect(result.divergences).toContainEqual(
+      expect.objectContaining({ kind: "not-enforced" })
+    );
+  });
+
+  it("`none` against a server that demands auth is the finding, not a fallback", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["none"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+    });
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.attempts).toEqual([
+      expect.objectContaining({ kind: "none", status: "unauthorized" }),
+    ]);
+    expect(result.sideEffects.dcrRegistrations).toBe(0);
+  });
+
+  it("falls through an unusable preferred strategy before anything is committed", async () => {
+    // Client prefers pre-registered, but no credentials are configured, so it
+    // must fall through to DCR — exactly as a real client would.
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({
+        authModel: verified(["oauth2-preregistered", "oauth2-dcr"]),
+      }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(result.attempts[0].registrationStrategy).toBe("dcr");
+    expect(result.sideEffects.dcrRegistrations).toBe(1);
+  });
+
+  it("blocks when no preferred mechanism is usable, without registering", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      supportsDcr: false,
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({
+        authModel: verified(["oauth2-preregistered", "oauth2-dcr"]),
+      }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.sideEffects.dcrRegistrations).toBe(0);
+  });
+});
+
+describe("runEmulatedOAuthPreflight — registration replay and retry", () => {
+  it("registers the captured redirect_uris in order with our callback appended", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({
+        authModel: verified(["oauth2-dcr"]),
+        dcrIdentity: verified({
+          clientName: "Real Client",
+          redirectUris: ["zed://oauth", "https://real.example/cb"],
+        }),
+      }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(mock.registeredRedirectUris[0]).toEqual([
+      "zed://oauth",
+      "https://real.example/cb",
+      CALLBACK,
+    ]);
+    expect(mock.registrationBodies[0].client_name).toBe("Real Client");
+    expect(result.divergences).toContainEqual(
+      expect.objectContaining({ kind: "redirect-uri-appended" })
+    );
+    // The authorization leg still comes back to us, so the flow completes.
+    expect(result.outcome).toBe("completed");
+  });
+
+  it("re-registers with our callback alone after a structured invalid_redirect_uri", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      rejectRegistration: { attempt: 1 },
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({
+        authModel: verified(["oauth2-dcr"]),
+        dcrIdentity: verified({ redirectUris: ["zed://oauth"] }),
+      }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(mock.registrationBodies).toHaveLength(2);
+    expect(mock.registrationBodies[0].redirect_uris).toEqual([
+      "zed://oauth",
+      CALLBACK,
+    ]);
+    expect(mock.registrationBodies[1].redirect_uris).toEqual([CALLBACK]);
+    expect(result.divergences).toContainEqual(
+      expect.objectContaining({ kind: "dcr-retried" })
+    );
+    expect(result.outcome).toBe("completed");
+    // Disclosed side effect: at most two registrations.
+    expect(result.sideEffects.dcrRegistrations).toBe(2);
+  });
+
+  it("does NOT retry on a rejection that is not a structured invalid_redirect_uri", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      rejectRegistration: {
+        attempt: 1,
+        body: { error: "invalid_client_metadata" },
+      },
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({
+        authModel: verified(["oauth2-dcr"]),
+        dcrIdentity: verified({ redirectUris: ["zed://oauth"] }),
+      }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(mock.registrationBodies).toHaveLength(1);
+    expect(result.divergences).not.toContainEqual(
+      expect.objectContaining({ kind: "dcr-retried" })
+    );
+    expect(result.outcome).not.toBe("completed");
+  });
+});
+
+describe("runEmulatedOAuthPreflight — diagnostics hygiene", () => {
+  it("keeps credentials out of diagnostics and returns them separately", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      issuedClientSecret: "registered-secret-value",
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.credentials?.accessToken).toBe("emulated-access-token");
+    expect(result.credentials?.clientSecret).toBe("registered-secret-value");
+
+    // Diagnostics must carry none of it.
+    const diagnostics = JSON.stringify(result.attempts);
+    expect(diagnostics).not.toContain("emulated-access-token");
+    expect(diagnostics).not.toContain("emulated-refresh-token");
+    expect(diagnostics).not.toContain("registered-secret-value");
+    expect(diagnostics).not.toContain("mock-authorization-code");
+  });
+
+  it("redacts an unconventional caller-supplied credential header", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["api-key", "oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      // A header name no generic redactor could know about.
+      staticCredential: {
+        headerName: "X-Acme-Tenant-Token",
+        value: "super-secret-tenant-token",
+      },
+      completeAuthorization: autoConsent,
+    });
+
+    const diagnostics = JSON.stringify(result.attempts);
+    expect(diagnostics).not.toContain("super-secret-tenant-token");
+    expect(diagnostics).toContain("[REDACTED]");
+  });
+});
+
+describe("runEmulatedOAuthPreflight — coverage and parity", () => {
+  it("carries partial coverage through, so parity can never be claimed", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const derived: DerivedOAuthEmulation = derive({
+      authModel: verified(["oauth2-dcr"]),
+    });
+    expect(derived.coverageSummary).toBe("partial");
+
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derived,
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    // Three independent dimensions: the run completed, coverage is partial,
+    // and no comparison has been made.
+    expect(result.outcome).toBe("completed");
+    expect(result.coverageSummary).toBe("partial");
+    expect(result.coverage.scopeRequest).toBe("not_modeled");
+    expect(result.comparison).toBe("not_compared");
+  });
+});

--- a/sdk/tests/oauth/emulation-preflight.test.ts
+++ b/sdk/tests/oauth/emulation-preflight.test.ts
@@ -133,6 +133,25 @@ describe("completion-safe redirects", () => {
     expect(isInvalidRedirectUriRejection({ status: 500, body: { error: "invalid_redirect_uri" } })).toBe(false);
     expect(isInvalidRedirectUriRejection({ status: 0, body: { error: "invalid_redirect_uri" } })).toBe(false);
   });
+
+  it("only HTTP 400 spends the retry — no other 4xx may create a second client", () => {
+    // RFC 7591 §3.2.2 defines this error as a 400. An auth, routing, or
+    // rate-limit rejection carrying the same word is a different failure.
+    for (const status of [401, 403, 404, 409, 429]) {
+      expect(
+        isInvalidRedirectUriRejection({
+          status,
+          body: { error: "invalid_redirect_uri" },
+        })
+      ).toBe(false);
+    }
+    expect(
+      isInvalidRedirectUriRejection({
+        status: 400,
+        body: { error: "invalid_redirect_uri" },
+      })
+    ).toBe(true);
+  });
 });
 
 describe("runEmulatedOAuthPreflight — completion", () => {
@@ -415,6 +434,228 @@ describe("runEmulatedOAuthPreflight — registration replay and retry", () => {
       expect.objectContaining({ kind: "dcr-retried" })
     );
     expect(result.outcome).not.toBe("completed");
+  });
+});
+
+describe("runEmulatedOAuthPreflight — review regressions", () => {
+  it("without authModel evidence, follows AUTO precedence: CIMD when advertised", async () => {
+    // Not a hardcoded DCR default — `not_modeled` means normal MCPJam
+    // behavior, and normal behavior prefers CIMD on a server that offers it.
+    const cimdUrl = "https://cimd.example/client-metadata.json";
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      supportsCimd: true,
+      supportsDcr: true,
+      clientIdMetadataUrl: cimdUrl,
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({}),
+      callbackUrl: CALLBACK,
+      clientIdMetadataUrl: cimdUrl,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.attempts[0].registrationStrategy).toBe("cimd");
+    expect(mock.registrationBodies).toHaveLength(0);
+    expect(result.divergences).toContainEqual(
+      expect.objectContaining({ kind: "identity-substituted" })
+    );
+    expect(result.outcome).toBe("completed");
+  });
+
+  it("without authModel evidence, falls back to DCR when CIMD is not advertised", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      supportsCimd: false,
+      supportsDcr: true,
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({}),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.attempts[0].registrationStrategy).toBe("dcr");
+    expect(result.outcome).toBe("completed");
+  });
+
+  it("accepts a valid MCP response delivered as text/event-stream", async () => {
+    // Streamable-HTTP servers answer with SSE frames, which the hardened
+    // proxy buffers as a raw string. That is still a real MCP answer.
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const executor: typeof mock.executor = async (request) => {
+      const response = await mock.executor(request);
+      if (
+        request.url === SERVER_URL &&
+        request.headers.Authorization?.startsWith("Bearer ")
+      ) {
+        return {
+          ...response,
+          headers: { "content-type": "text/event-stream" },
+          body: `event: message\ndata: ${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            result: { tools: [] },
+          })}\n\n`,
+        };
+      }
+      return response;
+    };
+
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("completed");
+  });
+
+  it("an SSE stream carrying a JSON-RPC error is still not a completion", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const executor: typeof mock.executor = async (request) => {
+      const response = await mock.executor(request);
+      if (
+        request.url === SERVER_URL &&
+        request.headers.Authorization?.startsWith("Bearer ")
+      ) {
+        return {
+          ...response,
+          headers: { "content-type": "text/event-stream" },
+          body: `data: ${JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            error: { code: -32000, message: "nope" },
+          })}\n\n`,
+        };
+      }
+      return response;
+    };
+
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("error");
+  });
+
+  it("a transport failure on a direct rung is recorded, not thrown", async () => {
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["none"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: async () => {
+        throw new Error("socket hang up");
+      },
+    });
+
+    expect(result.outcome).toBe("error");
+    expect(result.attempts[0]).toMatchObject({
+      kind: "none",
+      status: "error",
+      detail: "socket hang up",
+    });
+    expect(result.error?.message).toBe("socket hang up");
+  });
+
+  it("blocks a private-network target on the direct rungs too", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: "http://169.254.169.254/mcp",
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: "http://169.254.169.254/mcp",
+      emulation: derive({ authModel: verified(["none"]) }),
+      callbackUrl: CALLBACK,
+      // Even with a caller-supplied executor that would happily connect.
+      requestExecutor: mock.executor,
+    });
+
+    expect(result.outcome).toBe("error");
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  it("keeps the rejected first registration in the retry's diagnostics", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      rejectRegistration: { attempt: 1 },
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({
+        authModel: verified(["oauth2-dcr"]),
+        dcrIdentity: verified({ redirectUris: ["zed://oauth"] }),
+      }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    // The declared `dcr-retried` divergence must be corroborated by the trace
+    // it points at: both registrations are present.
+    const registrations = (result.attempts[0].httpHistory ?? []).filter(
+      (entry) => entry.step === "request_client_registration"
+    );
+    expect(registrations).toHaveLength(2);
+    expect(registrations[0].response?.status).toBe(400);
+  });
+
+  it("counts a token the AS issued even when verification later failed", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const executor: typeof mock.executor = async (request) => {
+      const response = await mock.executor(request);
+      if (
+        request.url === SERVER_URL &&
+        request.headers.Authorization?.startsWith("Bearer ")
+      ) {
+        return { ...response, status: 500, ok: false, body: null };
+      }
+      return response;
+    };
+
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({ authModel: verified(["oauth2-dcr"]) }),
+      callbackUrl: CALLBACK,
+      requestExecutor: executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).not.toBe("completed");
+    // The credential exists on the AS regardless of what happened next.
+    expect(result.sideEffects.tokensIssued).toBe(1);
+  });
+
+  it("declares that a V1 profile cannot supply captured redirect order", () => {
+    const v1 = deriveOAuthEmulation({
+      profileVersion: 1,
+      dcrIdentity: verified({
+        redirectUris: ["https://b.example/cb", "https://a.example/cb"],
+      }),
+    });
+    expect(v1.divergences).toContainEqual(
+      expect.objectContaining({ kind: "not-enforced" })
+    );
+    // V2 preserves order and declares nothing.
+    const v2out = derive({
+      dcrIdentity: verified({
+        redirectUris: ["https://b.example/cb", "https://a.example/cb"],
+      }),
+    });
+    expect(v2out.capturedRedirectUris).toEqual([
+      "https://b.example/cb",
+      "https://a.example/cb",
+    ]);
+    expect(v2out.divergences).toEqual([]);
   });
 });
 

--- a/sdk/tests/oauth/emulation-preflight.test.ts
+++ b/sdk/tests/oauth/emulation-preflight.test.ts
@@ -10,21 +10,14 @@ import {
 } from "../../src/oauth/emulation/redirects.js";
 import type { DerivedOAuthEmulation } from "../../src/oauth/emulation/derive.js";
 import type { HostConfigOAuthProfileV2 } from "../../src/host-config/internal";
-import type { OAuthProfileEvidence } from "../../src/host-config/internal";
 import {
   autoConsent,
   createMockOAuthServer,
 } from "../support/mock-oauth-as.js";
+import { verified } from "../support/oauth-profiles.js";
 
 const SERVER_URL = "https://mcp-server.example.com/mcp";
 const CALLBACK = "http://127.0.0.1:41234/callback";
-
-const verified = <T,>(value: T): OAuthProfileEvidence<T> => ({
-  status: "verified",
-  value,
-  source: "https://example.test/capture#L1",
-  capturedAt: "2026-07-30",
-});
 
 const profile = (
   fields: Omit<HostConfigOAuthProfileV2, "profileVersion">
@@ -63,6 +56,17 @@ describe("attempt ladder derivation", () => {
 
   it("without authModel evidence falls back to one preference-free oauth attempt", () => {
     const out = derive({});
+    expect(out.authAttempts).toEqual([
+      { kind: "oauth", registrationPreference: [] },
+    ]);
+    expect(out.coverage.authModel).toBe("not_modeled");
+  });
+
+  it("an empty authModel list never compiles to an empty ladder", () => {
+    // The canonicalizer rejects `[]`, but the type cannot say so. Compiling
+    // one would produce a run with NO attempts, reported as blocked with
+    // nothing to explain it.
+    const out = derive({ authModel: verified([] as never) });
     expect(out.authAttempts).toEqual([
       { kind: "oauth", registrationPreference: [] },
     ]);
@@ -633,6 +637,33 @@ describe("runEmulatedOAuthPreflight — review regressions", () => {
     expect(result.outcome).not.toBe("completed");
     // The credential exists on the AS regardless of what happened next.
     expect(result.sideEffects.tokensIssued).toBe(1);
+  });
+
+  it("a blocked ladder reports why each strategy was abandoned", async () => {
+    // CIMD is advertised but its document is unreachable, and DCR is not
+    // advertised: both fall through without committing, and the blocked
+    // result must explain both rather than reporting a bare "blocked".
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      supportsCimd: true,
+      supportsDcr: false,
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive({
+        authModel: verified(["oauth2-cimd", "oauth2-dcr"]),
+      }),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("blocked");
+    const attempt = result.attempts[0];
+    expect(attempt.detail).toMatch(/cimd:/);
+    // The trace that explains it survives the fall-through.
+    expect(attempt.httpHistory?.length).toBeGreaterThan(0);
+    expect(mock.registrationBodies).toHaveLength(0);
   });
 
   it("declares that a V1 profile cannot supply captured redirect order", () => {

--- a/sdk/tests/oauth/emulation-preflight.test.ts
+++ b/sdk/tests/oauth/emulation-preflight.test.ts
@@ -661,6 +661,7 @@ describe("runEmulatedOAuthPreflight — review regressions", () => {
     expect(result.outcome).toBe("blocked");
     const attempt = result.attempts[0];
     expect(attempt.detail).toMatch(/cimd:/);
+    expect(attempt.detail).toMatch(/dcr:/);
     // The trace that explains it survives the fall-through.
     expect(attempt.httpHistory?.length).toBeGreaterThan(0);
     expect(mock.registrationBodies).toHaveLength(0);

--- a/sdk/tests/oauth/emulation-wire-knobs.test.ts
+++ b/sdk/tests/oauth/emulation-wire-knobs.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../../src/oauth/state-machines/types.js";
 import type { OAuthEmulationConfig } from "../../src/oauth/emulation/types.js";
 import { deriveOAuthEmulation } from "../../src/oauth/emulation/derive.js";
-import type { OAuthProfileEvidence } from "../../src/host-config/internal";
+import { verified } from "../support/oauth-profiles.js";
 
 const SERVER_URL = "https://mcp-server.example.com/mcp";
 const SERVER_ORIGIN = "https://mcp-server.example.com";
@@ -462,13 +462,6 @@ describe("emulation wire knobs — token endpoint auth method", () => {
 
 describe("emulation — derive → machine integration", () => {
   it("a derived profile drives ladder selection and every knob end-to-end", async () => {
-    const verified = <T,>(value: T): OAuthProfileEvidence<T> => ({
-      status: "verified",
-      value,
-      source: "https://example.test/capture#L1",
-      capturedAt: "2026-07-30",
-    });
-
     const derived = deriveOAuthEmulation({
       profileVersion: 2,
       oauthSpecVersion: verified({

--- a/sdk/tests/oauth/emulation-wire-knobs.test.ts
+++ b/sdk/tests/oauth/emulation-wire-knobs.test.ts
@@ -486,6 +486,7 @@ describe("emulation — derive → machine integration", () => {
         userAgent: "SplitRev/2.0",
       }),
       tokenEndpointAuthMethod: verified("none" as const),
+      authModel: verified(["oauth2-dcr"]),
     });
 
     expect(derived.protocolVersion).toBe("2025-06-18");

--- a/sdk/tests/support/mock-oauth-as.ts
+++ b/sdk/tests/support/mock-oauth-as.ts
@@ -39,6 +39,12 @@ export interface MockOAuthServerOptions {
   /** 2026-07-28 answers `tools/list`; earlier versions answer `initialize`. */
   stateless?: boolean;
   /**
+   * The `protocolVersion` this server negotiates in its `initialize` result.
+   * Defaults to `2025-11-25`; set it to emulate a server on another era so a
+   * test's server and client are not silently describing different protocols.
+   */
+  negotiatedProtocolVersion?: string;
+  /**
    * Serve a client-ID metadata document at this URL, so a CIMD attempt can
    * actually complete. Only meaningful together with `supportsCimd`.
    */
@@ -81,6 +87,7 @@ export function createMockOAuthServer(
     unauthenticatedStatus = 401,
     stateless = false,
     clientIdMetadataUrl,
+    negotiatedProtocolVersion = "2025-11-25",
   } = options;
 
   const serverOrigin = new URL(serverUrl).origin;
@@ -96,7 +103,7 @@ export function createMockOAuthServer(
   const mcpResult = stateless
     ? { tools: [] }
     : {
-        protocolVersion: "2025-11-25",
+        protocolVersion: negotiatedProtocolVersion,
         serverInfo: { name: "mock", version: "1.0.0" },
         capabilities: {},
       };

--- a/sdk/tests/support/mock-oauth-as.ts
+++ b/sdk/tests/support/mock-oauth-as.ts
@@ -38,6 +38,11 @@ export interface MockOAuthServerOptions {
   unauthenticatedStatus?: number;
   /** 2026-07-28 answers `tools/list`; earlier versions answer `initialize`. */
   stateless?: boolean;
+  /**
+   * Serve a client-ID metadata document at this URL, so a CIMD attempt can
+   * actually complete. Only meaningful together with `supportsCimd`.
+   */
+  clientIdMetadataUrl?: string;
 }
 
 export interface MockOAuthServer {
@@ -75,6 +80,7 @@ export function createMockOAuthServer(
     acceptStaticCredential,
     unauthenticatedStatus = 401,
     stateless = false,
+    clientIdMetadataUrl,
   } = options;
 
   const serverOrigin = new URL(serverUrl).origin;
@@ -147,7 +153,22 @@ export function createMockOAuthServer(
       });
     }
 
+    if (clientIdMetadataUrl && request.url === clientIdMetadataUrl) {
+      // The machine requires `client_id` to equal the document's own URL.
+      return json(200, {
+        client_id: clientIdMetadataUrl,
+        client_name: "MCPJam Inspector",
+        redirect_uris: ["http://127.0.0.1:41234/callback"],
+      });
+    }
+
     if (request.url === `${authServerBase}/register`) {
+      // Consistent with the advertised metadata: a server that offers no
+      // registration_endpoint must not quietly accept registrations, or a
+      // wrongly-attempted DCR would pass unnoticed.
+      if (!supportsDcr) {
+        return json(404, { error: "not_found" });
+      }
       registrationCount += 1;
       const body = (request.body ?? {}) as Record<string, unknown>;
       registrationBodies.push(body);

--- a/sdk/tests/support/mock-oauth-as.ts
+++ b/sdk/tests/support/mock-oauth-as.ts
@@ -1,0 +1,193 @@
+/**
+ * A configurable in-memory MCP server + authorization server, as an
+ * `OAuthRequestExecutor`.
+ *
+ * The OAuth suites each grew their own inline URL-switch router; this is the
+ * shared one, with the knobs the emulation tests need: recording, a scripted
+ * registration rejection, a static-credential gate, and auto-consent.
+ */
+import type {
+  OAuthHttpRequest,
+  OAuthRequestExecutor,
+  OAuthRequestResult,
+} from "../../src/oauth/state-machines/types.js";
+
+export interface MockOAuthServerOptions {
+  serverUrl: string;
+  /** Defaults to a distinct origin, i.e. the PRM-era shape. */
+  authServerBase?: string;
+  /** Omit to advertise no `registration_endpoint` (DCR unsupported). */
+  supportsDcr?: boolean;
+  supportsCimd?: boolean;
+  scopesSupported?: string[];
+  /** `client_secret` issued by DCR, if any. */
+  issuedClientSecret?: string;
+  tokenEndpointAuthMethodsSupported?: string[];
+  /**
+   * Reject the Nth registration (1-based) with a structured RFC 7591
+   * `invalid_redirect_uri`, or with a custom body for negative tests.
+   */
+  rejectRegistration?: {
+    attempt: number;
+    status?: number;
+    body?: unknown;
+  };
+  /** A header name/value the server accepts INSTEAD of OAuth. */
+  acceptStaticCredential?: { headerName: string; value: string };
+  /** Status for an unauthenticated MCP request. Defaults to 401. */
+  unauthenticatedStatus?: number;
+  /** 2026-07-28 answers `tools/list`; earlier versions answer `initialize`. */
+  stateless?: boolean;
+}
+
+export interface MockOAuthServer {
+  executor: OAuthRequestExecutor;
+  requests: OAuthHttpRequest[];
+  registrationBodies: Array<Record<string, unknown>>;
+  /** Redirect URIs the AS has registered, newest last. */
+  registeredRedirectUris: string[][];
+}
+
+const json = (
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {}
+): OAuthRequestResult => ({
+  status,
+  statusText: status === 200 ? "OK" : status === 401 ? "Unauthorized" : "Error",
+  headers: { "content-type": "application/json", ...headers },
+  body,
+  ok: status >= 200 && status < 300,
+});
+
+export function createMockOAuthServer(
+  options: MockOAuthServerOptions
+): MockOAuthServer {
+  const {
+    serverUrl,
+    authServerBase = "https://auth-server.example.com",
+    supportsDcr = true,
+    supportsCimd = false,
+    scopesSupported = ["as:advertised"],
+    issuedClientSecret,
+    tokenEndpointAuthMethodsSupported = ["none", "client_secret_basic"],
+    rejectRegistration,
+    acceptStaticCredential,
+    unauthenticatedStatus = 401,
+    stateless = false,
+  } = options;
+
+  const serverOrigin = new URL(serverUrl).origin;
+  const resourceMetadataUrl = `${serverOrigin}/.well-known/oauth-protected-resource${
+    new URL(serverUrl).pathname
+  }`;
+
+  const requests: OAuthHttpRequest[] = [];
+  const registrationBodies: Array<Record<string, unknown>> = [];
+  const registeredRedirectUris: string[][] = [];
+  let registrationCount = 0;
+
+  const mcpResult = stateless
+    ? { tools: [] }
+    : {
+        protocolVersion: "2025-11-25",
+        serverInfo: { name: "mock", version: "1.0.0" },
+        capabilities: {},
+      };
+
+  const executor: OAuthRequestExecutor = async (request) => {
+    requests.push(request);
+
+    if (request.url === serverUrl) {
+      const authorization = request.headers.Authorization;
+      if (authorization?.startsWith("Bearer ")) {
+        return json(200, { jsonrpc: "2.0", id: 1, result: mcpResult });
+      }
+      if (acceptStaticCredential) {
+        const supplied = Object.entries(request.headers).find(
+          ([key]) =>
+            key.toLowerCase() === acceptStaticCredential.headerName.toLowerCase()
+        );
+        if (supplied?.[1] === acceptStaticCredential.value) {
+          return json(200, { jsonrpc: "2.0", id: 1, result: mcpResult });
+        }
+      }
+      return {
+        ...json(unauthenticatedStatus, null),
+        headers: {
+          "www-authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
+        },
+      };
+    }
+
+    if (request.url === resourceMetadataUrl) {
+      return json(200, {
+        resource: serverUrl,
+        authorization_servers: [authServerBase],
+      });
+    }
+
+    if (request.url.includes("/.well-known/oauth-authorization-server")) {
+      return json(200, {
+        issuer: authServerBase,
+        authorization_endpoint: `${authServerBase}/authorize`,
+        token_endpoint: `${authServerBase}/token`,
+        ...(supportsDcr
+          ? { registration_endpoint: `${authServerBase}/register` }
+          : {}),
+        ...(supportsCimd
+          ? { client_id_metadata_document_supported: true }
+          : {}),
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code"],
+        code_challenge_methods_supported: ["S256"],
+        scopes_supported: scopesSupported,
+        token_endpoint_auth_methods_supported:
+          tokenEndpointAuthMethodsSupported,
+      });
+    }
+
+    if (request.url === `${authServerBase}/register`) {
+      registrationCount += 1;
+      const body = (request.body ?? {}) as Record<string, unknown>;
+      registrationBodies.push(body);
+
+      if (rejectRegistration && rejectRegistration.attempt === registrationCount) {
+        return json(
+          rejectRegistration.status ?? 400,
+          rejectRegistration.body ?? {
+            error: "invalid_redirect_uri",
+            error_description: "one or more redirect_uris are not permitted",
+          }
+        );
+      }
+
+      registeredRedirectUris.push(
+        Array.isArray(body.redirect_uris) ? (body.redirect_uris as string[]) : []
+      );
+      return json(200, {
+        client_id: `client-${registrationCount}`,
+        ...(issuedClientSecret ? { client_secret: issuedClientSecret } : {}),
+        token_endpoint_auth_method: issuedClientSecret
+          ? "client_secret_basic"
+          : "none",
+      });
+    }
+
+    if (request.url === `${authServerBase}/token`) {
+      return json(200, {
+        access_token: "emulated-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+        refresh_token: "emulated-refresh-token",
+      });
+    }
+
+    return json(404, null);
+  };
+
+  return { executor, requests, registrationBodies, registeredRedirectUris };
+}
+
+/** Auto-consenting authorization leg: hands back a fixed code. */
+export const autoConsent = async () => ({ code: "mock-authorization-code" });

--- a/sdk/tests/support/oauth-profiles.ts
+++ b/sdk/tests/support/oauth-profiles.ts
@@ -1,0 +1,32 @@
+/**
+ * Evidence-envelope fixtures for the OAuth emulation suites.
+ *
+ * Shared so the three suites cannot drift on the envelope shape — a change to
+ * what a valid `capturedAt` or `source` looks like should break one place, not
+ * silently pass in two of three.
+ */
+import type { OAuthProfileEvidence } from "../../src/host-config/internal";
+
+export const verified = <T,>(value: T): OAuthProfileEvidence<T> => ({
+  status: "verified",
+  value,
+  source: "https://example.test/capture#L1",
+  capturedAt: "2026-07-30",
+});
+
+/**
+ * A refuted claim carries the TRUE value — the disproven part is the claim,
+ * not the recording — so the emulator uses it exactly like a verified one.
+ */
+export const refuted = <T,>(value: T): OAuthProfileEvidence<T> => ({
+  status: "refuted",
+  value,
+  source: "https://example.test/refutation#L1",
+  capturedAt: "2026-07-30",
+});
+
+/** Carries no value, by construction. */
+export const unverifiable = <T,>(): OAuthProfileEvidence<T> => ({
+  status: "unverifiable",
+  reason: "closed-source client",
+});


### PR DESCRIPTION
Step 5 of the OAuth Client Emulation plan (v3), **stacked on #3666** (S4, which is stacked on #3664/S3). Review those first — this PR's base is S4's branch. **Do not merge yet.**

## What

`runEmulatedOAuthPreflight` executes an emulated client's authentication ladder against a real MCP server, headlessly, over the **hardened OAuth networking path** (`executeOAuthProxy`: DNS pinning, total-deadline timeouts, body caps, redirect caps, cross-origin credential stripping).

### Ordered attempt ladder
`authModel` compiles into ordered rungs. Consecutive `oauth2-*` entries collapse into **one** OAuth attempt carrying their order as a registration preference (one dance with a preference, not several dances); `api-key` and `none` stay in position, so "static bearer first, OAuth on 401" reproduces exactly.

Fallback rules, as specified:
- A static credential falls through to OAuth **only on an evidence-backed 401**. Any other status stops the ladder and reports its own cause.
- An OAuth attempt falls through to the next strategy **only while nothing is committed on the wire** — once a registration request has been sent or authorization has begun, failure stops. Strategy fallback can therefore never create extra clients on someone's server.
- No static credential supplied → the `api-key` rung is **skipped and declared**; the runner never invents one.

### Completion-safe redirects
Registration replays the captured `redirect_uris` **in captured order with MCPJam's callback appended** — the appended entry is itself a declared substitution, since the registration step can never be byte-matched when it happens. Authorization and token legs **always** use MCPJam's callback, so the code comes back to us and the run finishes with a real token.

Registration is retried with the callback alone **only** on a structured RFC 7591 `invalid_redirect_uri` — never on a prose match, a generic 4xx, a 5xx, a timeout, or an unparseable body. That is the second and final registration a run will ever perform.

### Reporting discipline
- Three independent dimensions: `outcome`, `coverage`, and `comparison` (always `not_compared` here — golden comparison is step 6). A run can never imply parity on its own.
- **Completion = real token AND a valid authenticated JSON-RPC response**, not a bare 2xx.
- Side effects are bounded and disclosed: `sideEffects.dcrRegistrations` (≤2) and `tokensIssued`.
- **Credentials are returned separately from diagnostics.** Traces carry no tokens, codes, secrets, or PKCE values — including a caller-supplied static credential whose header name no generic redactor could know.
- A profile with no `dcrIdentity` evidence registers as **MCPJam**, not a fabricated name — the `not_modeled` rule applied to identity.

### Plan resolver
`AuthorizationPlanInput.registrationPreference` honors the emulated client's order over the built-in AUTO precedence, skipping unusable mechanisms with a warning rather than blocking. Absent or empty leaves every existing caller byte-identical (pinned by an equality test against the no-preference resolution).

## Tests

- `emulation-preflight.test.ts` (24): ladder derivation, redirect planning, the four retry-rejection negatives, completion vs token-without-valid-JSON-RPC, stop-at-redirect, static-credential 401 fallback vs non-401 stop, skip-and-declare, `none` against an auth-demanding server, uncommitted-strategy fallback, registration replay + ordering, retry-once, no-retry-on-other-errors, credential/diagnostics separation, unconventional-header redaction, coverage passthrough.
- `authorization-plan.test.ts` +7 preference cases.
- Shared `tests/support/mock-oauth-as.ts` replaces the per-suite inline routers.
- Four S4 tests updated deliberately where S5 supersedes them (coverage gained `authModel`; `redirectUris` is now enforced rather than declared not-enforced).
- `tsc --noEmit` clean; full SDK suite green (**3570 passed**); no-emulation wire goldens unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a headless OAuth preflight that runs an emulated client’s auth ladder against a real MCP server over the hardened OAuth path, with completion‑safe redirects and AUTO precedence when `authModel` is absent (HP‑43 S5). Exposes the Node runner and browser‑safe redirect planners, with tightened SSRF checks, SSE‑aware completion, and redacted diagnostics.

- **New Features**
  - Attempt ladder from `authModel`: consecutive `oauth2-*` collapse into one OAuth attempt; `api-key`/`none` keep order. Static creds fall through to OAuth only on 401; OAuth falls through only before anything is committed. Empty/absent `authModel` uses AUTO (`preregistered` → `cimd` → `dcr`, by era).
  - Completion‑safe redirects: registration replays captured `redirect_uris` in order with MCPJam’s callback appended (declared). Authorization and token always use MCPJam’s callback. Retry registration once only on RFC 7591 `invalid_redirect_uri` with exact HTTP 400.
  - Headless runner: `runEmulatedOAuthPreflight` executes the ladder over the hardened path. Direct `api-key`/`none` probes assert the same SSRF policy. Completion requires a token and a valid authenticated JSON‑RPC result (SSE accepted). Side effects are disclosed; `tokensIssued` counts even if later verification fails. Credentials are returned separately; diagnostics are redacted. Exposes `runEmulatedOAuthPreflight` and types via `index.ts`, and browser‑safe `planCompletionSafeRedirects`, `isInvalidRedirectUriRejection`, and `CompletionSafeRedirectPlan`.

- **Bug Fixes**
  - Empty `authModel` is treated as no evidence (default OAuth attempt remains). Uncommitted‑failure diagnostics accumulate per strategy; preregistered warnings distinguish incomplete vs missing credentials.
  - Registration retry requires exact HTTP 400; the first rejected registration stays in diagnostics. V1 profiles declare redirect order unavailable to avoid false “exact replay” claims.
  - Transport errors on direct rungs are recorded as error attempts; SSRF is enforced on direct probes; SSE responses count for completion.

<sup>Written for commit 3b9773156c0dfc0503625532a6a77798bf788c72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

