### PR TITLE
fix(ci): poll Railway deploy status instead of the build-log stream

### DIFF
--- a/.github/scripts/railway-wait-deploy.sh
+++ b/.github/scripts/railway-wait-deploy.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Wait for a Railway deploy to reach a terminal status.
+#
+# Why this exists:
+#   `railway up --ci` streams build logs and exits with the *log stream's*
+#   result, not the deploy's. The build-log subscription regularly fails to
+#   connect against backboard.railway.com — the CLI retries ~12 times over
+#   ~60s and, if not a single log line arrived, gives up with "Failed to
+#   stream build logs" and exits 1. Our image takes ~6min to build (Playwright
+#   Chromium download), so the build is often still queued when that budget
+#   runs out: the workflow goes red while the deploy builds and promotes
+#   fine. So every caller deploys with `--detach` and polls status here.
+#
+# Usage:
+#   PREV=$(railway-wait-deploy.sh --latest -s SERVICE_ID -e ENV_ID)
+#   railway up --detach ...
+#   railway-wait-deploy.sh -s SERVICE_ID -e ENV_ID -p "$PREV"
+#
+# Env:
+#   RAILWAY_API_TOKEN            (required by the CLI) Workspace or account token.
+#   RAILWAY_WAIT_POLL_SECONDS    (optional) Poll interval, default 15.
+#
+# Behavior:
+#   - `--latest` prints the newest deployment id, or nothing if the service
+#     has never deployed. It retries, and fails loudly if the API never
+#     answers — a missing snapshot would make the wait below accept the
+#     *previous* deploy's SUCCESS and report a release that never shipped.
+#   - Waiting polls the topmost deployment. We can't reliably capture the id
+#     `railway up` creates, and railway-retry.sh may have triggered duplicate
+#     deploys (if a Railway API blip dropped an otherwise-successful upload
+#     response). So: if the top deployment differs from the pre-upload
+#     snapshot, treat it as ours; if a newer deploy supersedes it mid-wait,
+#     follow the new top.
+#   - Exits 0 on SUCCESS, 1 on FAILED/CRASHED. Every other status keeps
+#     polling, so callers MUST bound this with `timeout-minutes` on the step.
+
+set -uo pipefail
+
+SERVICE=""
+ENVIRONMENT=""
+PREVIOUS_ID=""
+MODE="wait"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -s) SERVICE="$2"; shift 2 ;;
+    -e) ENVIRONMENT="$2"; shift 2 ;;
+    -p) PREVIOUS_ID="$2"; shift 2 ;;
+    --latest) MODE="latest"; shift ;;
+    *)
+      echo "::error::railway-wait-deploy.sh: unexpected argument $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$SERVICE" ] || [ -z "$ENVIRONMENT" ]; then
+  echo "::error::railway-wait-deploy.sh: -s SERVICE and -e ENVIRONMENT are required" >&2
+  exit 2
+fi
+
+POLL_SECONDS="${RAILWAY_WAIT_POLL_SECONDS:-15}"
+
+# Echo "<id>\t<status>" for the newest deployment. Returns non-zero when the
+# API call itself failed, which the callers treat as "ask again" rather than
+# as a verdict. An empty id with a zero exit means the service genuinely has
+# no deployments yet.
+#
+# Deliberately not wrapped in railway-retry.sh: that helper replays every
+# attempt's output on stdout, so a failed attempt would prepend CLI error text
+# to the JSON and break the parse. Polling is its own retry.
+latest_row() {
+  local out
+  out=$(railway deployment list \
+    --service "$SERVICE" \
+    --environment "$ENVIRONMENT" \
+    --limit 1 \
+    --json 2>/dev/null) || return 1
+  printf '%s' "$out" | jq -r '(.[0] // {}) | "\(.id // "")\t\(.status // "")"' 2>/dev/null || return 1
+}
+
+if [ "$MODE" = "latest" ]; then
+  for _attempt in 1 2 3 4 5; do
+    if ROW=$(latest_row); then
+      printf '%s\n' "${ROW%%$'\t'*}"
+      exit 0
+    fi
+    sleep 5
+  done
+  echo "::error::railway-wait-deploy.sh: could not read deployments for service $SERVICE" >&2
+  exit 1
+fi
+
+echo "Waiting for a new deployment (service=$SERVICE, env=$ENVIRONMENT, previous=${PREVIOUS_ID:-<none>})"
+
+while :; do
+  if ROW=$(latest_row); then
+    ID="${ROW%%$'\t'*}"
+    STATUS="${ROW##*$'\t'}"
+    if [ -z "$ID" ] || [ "$ID" = "$PREVIOUS_ID" ]; then
+      echo "Waiting for new deployment to appear (latest=${ID:-none}, previous=${PREVIOUS_ID:-none})"
+    else
+      case "$STATUS" in
+        SUCCESS)
+          echo "Deploy $ID succeeded"
+          exit 0
+          ;;
+        FAILED|CRASHED)
+          echo "::error::Deploy $ID ended in status $STATUS"
+          exit 1
+          ;;
+        "")
+          echo "Status not readable yet for $ID"
+          ;;
+        *)
+          echo "Deploy $ID status: $STATUS"
+          ;;
+      esac
+    fi
+  else
+    echo "::warning::Could not read deployment status; retrying"
+  fi
+  sleep "$POLL_SECONDS"
+done

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -89,19 +89,14 @@ jobs:
       - name: Snapshot latest deployment id
         id: previous_deploy
         run: |
-          PREV=$(.github/scripts/railway-retry.sh railway deployment list \
-            --service "$RAILWAY_INSPECTOR_SERVICE" \
-            --environment "$RAILWAY_STAGING_ENVIRONMENT" \
-            --limit 1 \
-            --json | jq -r '.[0].id // empty')
+          PREV=$(.github/scripts/railway-wait-deploy.sh --latest \
+            -s "$RAILWAY_INSPECTOR_SERVICE" \
+            -e "$RAILWAY_STAGING_ENVIRONMENT")
           echo "id=$PREV" >> "$GITHUB_OUTPUT"
           echo "Previous deployment: ${PREV:-<none>}"
 
-      # `--detach` uploads and returns immediately. The `--ci` log-stream
-      # mode regularly times out against backboard.railway.com even though
-      # the deploy itself succeeds; that mismatch was failing the workflow
-      # while staging was getting updated correctly. We poll status below
-      # instead of relying on the streaming connection.
+      # `--detach` uploads and returns immediately. See railway-wait-deploy.sh
+      # for why `--ci`'s build-log stream is not a usable success signal.
       - name: Deploy inspector to Railway staging
         run: |
           .github/scripts/railway-retry.sh railway up \
@@ -110,49 +105,15 @@ jobs:
             --environment "$RAILWAY_STAGING_ENVIRONMENT" \
             --service "$RAILWAY_INSPECTOR_SERVICE"
 
-      # We can't reliably capture the deployment id railway up creates, and
-      # railway-retry.sh may have triggered duplicate deploys (if a Railway
-      # API blip dropped an otherwise-successful upload response). Strategy:
-      # poll the topmost deployment. If it differs from the pre-upload
-      # snapshot, treat it as ours and wait for terminal status. If a newer
-      # deploy supersedes it mid-wait (retry duplicate), follow the new top.
       - name: Wait for Railway staging deploy to finish
         timeout-minutes: 20
         env:
           PREVIOUS_DEPLOY_ID: ${{ steps.previous_deploy.outputs.id }}
         run: |
-          set -uo pipefail
-          while :; do
-            ROW=$(.github/scripts/railway-retry.sh railway deployment list \
-              --service "$RAILWAY_INSPECTOR_SERVICE" \
-              --environment "$RAILWAY_STAGING_ENVIRONMENT" \
-              --limit 1 \
-              --json | jq -r '.[0] | "\(.id // "")\t\(.status // "")"')
-            ID="${ROW%%	*}"
-            STATUS="${ROW##*	}"
-            if [ -z "$ID" ] || [ "$ID" = "$PREVIOUS_DEPLOY_ID" ]; then
-              echo "Waiting for new deployment to appear (latest=${ID:-none}, prev=$PREVIOUS_DEPLOY_ID)"
-              sleep 10
-              continue
-            fi
-            case "$STATUS" in
-              SUCCESS)
-                echo "Deploy $ID succeeded"
-                exit 0
-                ;;
-              FAILED|CRASHED)
-                echo "::error::Deploy $ID ended in status $STATUS"
-                exit 1
-                ;;
-              "")
-                echo "Status not readable yet for $ID"
-                ;;
-              *)
-                echo "Deploy $ID status: $STATUS"
-                ;;
-            esac
-            sleep 15
-          done
+          .github/scripts/railway-wait-deploy.sh \
+            -s "$RAILWAY_INSPECTOR_SERVICE" \
+            -e "$RAILWAY_STAGING_ENVIRONMENT" \
+            -p "$PREVIOUS_DEPLOY_ID"
 
   smoke:
     needs: deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -455,16 +455,42 @@ jobs:
       - name: Apply release patch
         run: git apply --binary .release-plan/release.patch
 
+      # Pinned to match deploy-staging.yml and pr-preview.yml. An unpinned
+      # install picks up whatever shipped that morning, on the one workflow
+      # where a CLI regression is most expensive.
       - name: Install Railway CLI
-        run: npm install -g @railway/cli
+        run: npm install -g @railway/cli@4.57.1
 
+      # Capture the newest deployment id before we trigger a new one so the
+      # wait step below can tell *our* deploy from the previous-good one.
+      - name: Snapshot latest deployment id
+        id: previous_deploy
+        run: |
+          PREV=$(.github/scripts/railway-wait-deploy.sh --latest \
+            -s "$RAILWAY_INSPECTOR_SERVICE" \
+            -e "$RAILWAY_PRODUCTION_ENVIRONMENT")
+          echo "id=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous deployment: ${PREV:-<none>}"
+
+      # `--detach` uploads and returns immediately. See railway-wait-deploy.sh
+      # for why `--ci`'s build-log stream is not a usable success signal.
       - name: Deploy inspector to Railway production
         run: |
-          railway up \
-            --ci \
+          .github/scripts/railway-retry.sh railway up \
+            --detach \
             --project "$RAILWAY_PROJECT_ID" \
             --environment "$RAILWAY_PRODUCTION_ENVIRONMENT" \
             --service "$RAILWAY_INSPECTOR_SERVICE"
+
+      - name: Wait for Railway production deploy to finish
+        timeout-minutes: 20
+        env:
+          PREVIOUS_DEPLOY_ID: ${{ steps.previous_deploy.outputs.id }}
+        run: |
+          .github/scripts/railway-wait-deploy.sh \
+            -s "$RAILWAY_INSPECTOR_SERVICE" \
+            -e "$RAILWAY_PRODUCTION_ENVIRONMENT" \
+            -p "$PREVIOUS_DEPLOY_ID"
 
   finalize:
     needs:


### PR DESCRIPTION
## The bug

Release run [30838938175](https://github.com/MCPJam/inspector/actions/runs/30838938175) went red on `promote-production` — but **the deploy succeeded**. Deployment `cb434080-a9fb-44bc-8a6b-d57663e895ae` built, health-checked and promoted normally.

```
18:28:47  upload done, build queued, "CI mode enabled"
18:29:51  Failed to stream build logs: Failed to retrieve build log  → exit 1
18:34:51  build actually finishes, image pushed, deploy promoted
```

`railway up --ci` streams build logs and exits with the *stream's* result, not the deploy's. In `stream_build_logs` ([`src/controllers/deployment.rs`](https://github.com/railwayapp/cli/blob/master/src/controllers/deployment.rs)) the CLI retries the log subscription 12 times with 1s→8s backoff — about a 68s budget, matching the 64s to failure. It has an escape hatch (if *any* log line arrived, treat a later stream error as success), but our image takes ~6min to build (Playwright Chromium download), so the build was still queued and nothing had been emitted.

Known upstream flake: railwayapp/cli#743, *"fix: Fix flaky 'Failed to stream build logs' error in railway up"*.

## The fix

`deploy-staging.yml` already solved this — deploy with `--detach`, poll `railway deployment list` for a terminal status. Production was never updated to match.

- **New `.github/scripts/railway-wait-deploy.sh`** — that loop extracted, so there is one implementation instead of two copies. `--latest` prints the newest deployment id; default mode polls the top deployment until it differs from that snapshot and reaches `SUCCESS` (exit 0) or `FAILED`/`CRASHED` (exit 1).
- **`release.yml`** — `promote-production` snapshots → `railway up --detach` → waits, bounded by `timeout-minutes: 20`. CLI pinned to `@railway/cli@4.57.1`, matching `deploy-staging.yml` and `pr-preview.yml`; the failing run installed `5.30.4`, published nine hours earlier that morning.
- **`deploy-staging.yml`** — its inline loop now calls the script.

### Two deliberate changes from the staging original

- **The poll no longer goes through `railway-retry.sh`.** That helper replays *every* attempt's output on stdout, so one failed attempt prepends CLI error text to the JSON, `jq` chokes, and the loop reads it as "no deployment yet" — spinning until the step timeout. Polling is already its own retry. This is a latent bug in staging today.
- **The pre-deploy snapshot fails loudly if the API never answers.** Silently returning an empty id would make the wait accept the *previous* deploy's `SUCCESS` and report a release that never shipped.

## Verification

Ran the script against the real production service with the pinned 4.57.1 CLI, from an unlinked directory (matching CI, which has no linked project):

| case | result |
|---|---|
| `--latest` | prints `cb434080-…` ✓ |
| wait, `-p` = older deploy id | `Deploy cb434080-… succeeded`, exit 0 ✓ |
| wait, `-p` = current top id | keeps waiting, no false positive ✓ |

Remaining branches against a stub CLI: `FAILED`→1, `CRASHED`→1, `BUILDING`→`SUCCESS`→0, empty service list → empty id + exit 0, API always failing → `--latest` exits 1 loudly while wait mode warns and retries.

`shellcheck` clean. `actionlint` reports the same 5 pre-existing `fromJSON(bool)` findings as `main`, none new.

## Not in scope

`deploy-slack-app.yml` and `deploy-soundcheck.yml` still use `railway up --ci` and have the identical flaw — smaller images, so they hit it less often. Happy to port them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production release gating and deploy verification behavior; mis-polling could false-pass or false-fail promotes, though snapshot hardening and explicit terminal statuses reduce that risk.
> 
> **Overview**
> Fixes release workflows failing red when Railway deploys actually succeed, by treating **deploy terminal status** as the success signal instead of `railway up --ci`’s flaky build-log stream.
> 
> Adds **`.github/scripts/railway-wait-deploy.sh`** as the single implementation: `--latest` snapshots the newest deployment id (and **errors** if the API never responds, so the wait step can’t mistake the previous deploy’s `SUCCESS` for this release), then default mode polls until a **new** top deployment reaches `SUCCESS` or `FAILED`/`CRASHED`. Polling **does not** use `railway-retry.sh`, so failed CLI attempts don’t prepend garbage that breaks JSON parsing.
> 
> **`release.yml` `promote-production`** now matches staging: pins `@railway/cli@4.57.1`, runs `railway up --detach` via `railway-retry.sh`, and waits up to 20 minutes with the script. **`deploy-staging.yml`** drops its inline wait loop in favor of the same script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25db4643bec88d7bde088c2ac3cb5b69cc8efc7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky Railway deploy checks by detaching deploys and polling for terminal status, so CI reflects the real outcome. Prevents false failures in `promote-production` when the log stream drops.

- **Bug Fixes**
  - Added `.github/scripts/railway-wait-deploy.sh` to poll the newest deployment until it reaches SUCCESS or FAILED/CRASHED. Includes `--latest` snapshot mode, follows newer deploys if they appear, avoids `railway-retry.sh` JSON noise, and fails loudly if the API never answers.
  - `release.yml`: switch to `railway up --detach`, snapshot the previous deploy id, and wait via the script (20 min timeout). Pin `@railway/cli@4.57.1` to match other workflows.
  - `deploy-staging.yml`: replace the inline polling loop with the shared script.

<sup>Written for commit 25db4643bec88d7bde088c2ac3cb5b69cc8efc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

