### PR TITLE
feat(conformance): give protocol and apps the not-applicable/could-not-run split

### DIFF
--- a/.changeset/conformance-skip-taxonomy.md
+++ b/.changeset/conformance-skip-taxonomy.md
@@ -1,0 +1,49 @@
+---
+"@mcpjam/inspector": minor
+"@mcpjam/sdk": minor
+"@mcpjam/cli": minor
+---
+
+Stop counting checks that never ran as passes, in the protocol and apps suites.
+
+Both runners computed their verdict as
+`checks.every(check => check.status !== "failed")`, so a run where twenty
+checks never executed still reported `passed: true`. The tasks suite fixed this
+long ago — after a run where six of eight checks silently skipped and the suite
+still reported success — and OAuth gained it recently. Protocol and apps were
+the two holdouts.
+
+They now speak the same vocabulary, extracted into one canonical module rather
+than a fourth copy:
+
+- **`skipReason`** on every skipped check: `"not-applicable"` (the requirement
+  cannot apply to this server, so nothing is left unverified) versus
+  `"could-not-run"` (it applies, but the run could not exercise it, so the
+  obligation is untested). Every existing skip site is now classified — an
+  era-gated check or an unadvertised capability is not-applicable; a broken
+  session, a missing probe, or a walk that could not enumerate every tool is
+  could-not-run.
+- **`outcome`**: `"passed" | "failed" | "incomplete"`, with `passed` true only
+  for `"passed"`.
+- **`categorySummary.couldNotRun`** alongside the existing `skipped` total, and
+  a summary line that reads `N/M checks passed, X failed, Y could not run,
+  Z not applicable`.
+
+The subscription probes needed care: one call site funnels three different
+unavailable reasons, and only "server advertises nothing subscribable" is
+genuinely inapplicable — the probe now carries its own classification rather
+than the call site guessing.
+
+**The CLI benefits too.** `protocol conformance` and `apps conformance` (and
+their `conformance-suite` forms) now use the exit-code mapping tasks already
+had: `3` for incomplete, `1` for failed, `0` for passed, with a suite taking
+the worst of its runs and a failure outranking an incomplete. The reason a run
+established nothing is written to stderr instead of having to be dug out of the
+JSON. The reporters (`--reporter json-summary` / `junit-xml`) now carry
+`skipReason` and `outcome`, which they previously dropped for **every** suite,
+tasks included.
+
+**This changes CI exit codes.** A protocol or apps run whose applicable checks
+could not be exercised previously exited `0`; it now exits `3`. That is the
+point — those runs were never establishing conformance — but pipelines that
+treated a green exit as proof will start failing, and should.

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -1,3 +1,8 @@
+import {
+  conformanceExitCode,
+  conformanceSuiteExitCode,
+  reportIncomplete,
+} from "../lib/conformance-exit-code.js";
 import { Command } from "commander";
 import {
   MCP_APPS_CHECK_CATEGORIES,
@@ -208,8 +213,12 @@ export function registerAppsCommands(program: Command): void {
     writeConformanceOutput(
       renderConformanceForCli(outputResult, reporter, globalOptions.format),
     );
-    if (!result.passed) {
-      setProcessExitCode(1);
+    // The JSON payload carries it too, but a human running this in a terminal
+    // must not have to dig for the reason a check never ran.
+    reportIncomplete(result, command);
+    const exitCode = conformanceExitCode(result);
+    if (exitCode !== 0) {
+      setProcessExitCode(exitCode);
     }
   });
 
@@ -545,8 +554,13 @@ export function registerAppsCommands(program: Command): void {
       writeConformanceOutput(
         renderConformanceForCli(outputResult, reporter, globalOptions.format),
       );
-      if (!result.passed) {
-        setProcessExitCode(1);
+      // Each run carries its own reason; a suite reports every incomplete one.
+      for (const run of result.results) {
+        reportIncomplete(run, command);
+      }
+      const exitCode = conformanceSuiteExitCode(result.results);
+      if (exitCode !== 0) {
+        setProcessExitCode(exitCode);
       }
     });
 }

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -1,4 +1,9 @@
 import {
+  conformanceExitCode,
+  conformanceSuiteExitCode,
+  reportIncomplete,
+} from "../lib/conformance-exit-code.js";
+import {
   isKnownProtocolVersion,
   MCP_CHECK_CATEGORIES,
   MCP_CHECK_IDS,
@@ -92,8 +97,12 @@ export function registerProtocolCommands(program: Command): void {
       const result = await new MCPConformanceTest(config).run();
 
       writeConformanceOutput(renderConformanceForCli(result, reporter, format));
-      if (!result.passed) {
-        setProcessExitCode(1);
+      // The JSON payload carries it too, but a human running this in a
+      // terminal must not have to dig for the reason a check never ran.
+      reportIncomplete(result, command);
+      const exitCode = conformanceExitCode(result);
+      if (exitCode !== 0) {
+        setProcessExitCode(exitCode);
       }
     });
 
@@ -114,8 +123,13 @@ export function registerProtocolCommands(program: Command): void {
       const result = await new MCPConformanceSuite(config).run();
 
       writeConformanceOutput(renderConformanceForCli(result, reporter, format));
-      if (!result.passed) {
-        setProcessExitCode(1);
+      // Each run carries its own reason; a suite reports every incomplete one.
+      for (const run of result.results) {
+        reportIncomplete(run, command);
+      }
+      const exitCode = conformanceSuiteExitCode(result.results);
+      if (exitCode !== 0) {
+        setProcessExitCode(exitCode);
       }
     });
 }

--- a/cli/src/commands/tasks.ts
+++ b/cli/src/commands/tasks.ts
@@ -1,3 +1,4 @@
+import { conformanceExitCode } from "../lib/conformance-exit-code.js";
 import { Command } from "commander";
 import {
   MCP_TASKS_CHECK_CATEGORIES,
@@ -71,24 +72,10 @@ const TASKS_CHECK_IDS_BY_CATEGORY: Record<
 };
 
 /**
- * Exit code for a finished run.
- *
- * `incomplete` gets its own code because "the server violated the spec" and
- * "we never established anything" are different failures with different fixes,
- * and a run that skipped its task-dependent checks must never look like a pass.
- * `2` is taken by usage errors, so the new state is `3`.
- *
- * The result is read structurally rather than by SDK type so an older
- * `@mcpjam/sdk` (no `outcome`) still maps cleanly through `passed`.
+ * @deprecated Use {@link conformanceExitCode}. Kept as a re-export so existing
+ * imports (and its tests) keep working.
  */
-export function tasksConformanceExitCode(result: {
-  passed: boolean;
-  outcome?: "passed" | "failed" | "incomplete";
-}): number {
-  if (result.outcome === "incomplete") return 3;
-  if (result.outcome === "failed") return 1;
-  return result.passed ? 0 : 1;
-}
+export const tasksConformanceExitCode = conformanceExitCode;
 
 export interface TasksConformanceOptions extends SharedServerTargetOptions {
   category?: string[];

--- a/cli/src/lib/conformance-exit-code.ts
+++ b/cli/src/lib/conformance-exit-code.ts
@@ -1,0 +1,47 @@
+/**
+ * Exit code for a finished conformance run, shared by every suite.
+ *
+ * `incomplete` gets its own code because "the server violated the spec" and
+ * "we never established anything" are different failures with different fixes,
+ * and a run that skipped applicable checks must never look like a pass. `2` is
+ * taken by usage errors, so the third state is `3`.
+ *
+ * The result is read structurally rather than by SDK type so an older
+ * `@mcpjam/sdk` (no `outcome`) still maps cleanly through `passed`.
+ */
+export function conformanceExitCode(result: {
+  passed: boolean;
+  outcome?: "passed" | "failed" | "incomplete";
+}): number {
+  if (result.outcome === "incomplete") return 3;
+  if (result.outcome === "failed") return 1;
+  return result.passed ? 0 : 1;
+}
+
+/**
+ * A suite runs many flows; its exit code is the worst of them. A failure
+ * outranks an incomplete, because a violation is a stronger statement than an
+ * unestablished one.
+ */
+export function conformanceSuiteExitCode(
+  results: Array<{ passed: boolean; outcome?: "passed" | "failed" | "incomplete" }>,
+): number {
+  const codes = results.map(conformanceExitCode);
+  if (codes.includes(1)) return 1;
+  if (codes.includes(3)) return 3;
+  return 0;
+}
+
+/**
+ * Surface why a run established nothing. The JSON payload carries it too, but
+ * a human in a terminal must not have to dig for the reason a check never ran.
+ */
+export function reportIncomplete(
+  result: { incompleteReason?: string },
+  command: { optsWithGlobals(): { quiet?: boolean } },
+): void {
+  const reason = result.incompleteReason;
+  if (!reason) return;
+  if (command.optsWithGlobals().quiet) return;
+  process.stderr.write(`Run incomplete: ${reason}\n`);
+}

--- a/cli/tests/conformance-exit-code.test.ts
+++ b/cli/tests/conformance-exit-code.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  conformanceExitCode,
+  conformanceSuiteExitCode,
+} from "../src/lib/conformance-exit-code.js";
+
+test("incomplete gets its own exit code, distinct from a violation", () => {
+  // "The server violated the spec" and "we never established anything" are
+  // different failures with different fixes. 2 is taken by usage errors.
+  assert.equal(conformanceExitCode({ passed: false, outcome: "incomplete" }), 3);
+  assert.equal(conformanceExitCode({ passed: false, outcome: "failed" }), 1);
+  assert.equal(conformanceExitCode({ passed: true, outcome: "passed" }), 0);
+});
+
+test("falls back to passed when the SDK predates outcome", () => {
+  assert.equal(conformanceExitCode({ passed: true }), 0);
+  assert.equal(conformanceExitCode({ passed: false }), 1);
+});
+
+test("a suite takes the worst of its runs, failure outranking incomplete", () => {
+  assert.equal(
+    conformanceSuiteExitCode([
+      { passed: true, outcome: "passed" },
+      { passed: false, outcome: "incomplete" },
+      { passed: false, outcome: "failed" },
+    ]),
+    1,
+  );
+  assert.equal(
+    conformanceSuiteExitCode([
+      { passed: true, outcome: "passed" },
+      { passed: false, outcome: "incomplete" },
+    ]),
+    3,
+  );
+  assert.equal(
+    conformanceSuiteExitCode([{ passed: true, outcome: "passed" }]),
+    0,
+  );
+});

--- a/cli/tests/conformance-output.test.ts
+++ b/cli/tests/conformance-output.test.ts
@@ -20,6 +20,7 @@ import { CliError } from "../src/lib/output.js";
 function createProtocolResult(): MCPConformanceResult {
   return {
     passed: false,
+    outcome: "failed" as const,
     serverUrl: "https://mcp.example.com/mcp",
     checks: [
       {
@@ -46,13 +47,13 @@ function createProtocolResult(): MCPConformanceResult {
     durationMs: 24,
     readiness: [],
     categorySummary: {
-      core: { total: 1, passed: 0, failed: 1, skipped: 0 },
-      protocol: { total: 0, passed: 0, failed: 0, skipped: 0 },
-      tools: { total: 1, passed: 0, failed: 0, skipped: 1 },
-      prompts: { total: 0, passed: 0, failed: 0, skipped: 0 },
-      resources: { total: 0, passed: 0, failed: 0, skipped: 0 },
-      security: { total: 0, passed: 0, failed: 0, skipped: 0 },
-      transport: { total: 0, passed: 0, failed: 0, skipped: 0 },
+      core: { total: 1, passed: 0, failed: 1, skipped: 0 , couldNotRun: 0 },
+      protocol: { total: 0, passed: 0, failed: 0, skipped: 0 , couldNotRun: 0 },
+      tools: { total: 1, passed: 0, failed: 0, skipped: 1 , couldNotRun: 0 },
+      prompts: { total: 0, passed: 0, failed: 0, skipped: 0 , couldNotRun: 0 },
+      resources: { total: 0, passed: 0, failed: 0, skipped: 0 , couldNotRun: 0 },
+      security: { total: 0, passed: 0, failed: 0, skipped: 0 , couldNotRun: 0 },
+      transport: { total: 0, passed: 0, failed: 0, skipped: 0 , couldNotRun: 0 },
     },
   };
 }
@@ -60,6 +61,7 @@ function createProtocolResult(): MCPConformanceResult {
 function createAppsResult(): MCPAppsConformanceResult {
   return {
     passed: true,
+    outcome: "passed" as const,
     target: "node mock-server.js",
     checks: [
       {
@@ -74,8 +76,8 @@ function createAppsResult(): MCPAppsConformanceResult {
     summary: "1/1 checks passed, 0 failed, 0 skipped",
     durationMs: 5,
     categorySummary: {
-      tools: { total: 1, passed: 1, failed: 0, skipped: 0 },
-      resources: { total: 0, passed: 0, failed: 0, skipped: 0 },
+      tools: { total: 1, passed: 1, failed: 0, skipped: 0 , couldNotRun: 0 },
+      resources: { total: 0, passed: 0, failed: 0, skipped: 0 , couldNotRun: 0 },
     },
     discovery: {
       toolCount: 1,

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -654,7 +654,14 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
         setProtocol({
           status: "done",
           result,
-          verdict: result.passed ? "passed" : "failed",
+          // All four suites now report a three-value outcome, so an
+          // incomplete run is badged as such rather than flattened to failed.
+          verdict:
+            result.outcome === "incomplete"
+              ? "incomplete"
+              : result.passed
+                ? "passed"
+                : "failed",
         });
       } catch (err) {
         if (!isRunActive(runToken, serverName)) return;
@@ -676,7 +683,14 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
         setApps({
           status: "done",
           result,
-          verdict: result.passed ? "passed" : "failed",
+          // All four suites now report a three-value outcome, so an
+          // incomplete run is badged as such rather than flattened to failed.
+          verdict:
+            result.outcome === "incomplete"
+              ? "incomplete"
+              : result.passed
+                ? "passed"
+                : "failed",
         });
       } catch (err) {
         if (!isRunActive(runToken, serverName)) return;

--- a/sdk/src/apps-conformance/runner.ts
+++ b/sdk/src/apps-conformance/runner.ts
@@ -1,3 +1,8 @@
+import {
+  buildOutcomeSummary,
+  decideConformanceOutcome,
+  isUnrunCheck,
+} from "../conformance-outcome.js";
 import { Buffer } from "node:buffer";
 import {
   MCP_UI_RESOURCE_MIME_TYPE,
@@ -12,6 +17,7 @@ import {
   MCP_APPS_CHECK_CATEGORIES,
   type MCPAppsCheckId,
   type MCPAppsCheckResult,
+  type MCPAppsSkipReason,
   type MCPAppsConformanceConfig,
   type MCPAppsConformanceResult,
   type MCPAppsResourceReadOutcome,
@@ -133,12 +139,14 @@ function failedResult(
 
 function skippedResult(
   id: MCPAppsCheckId,
+  skipReason: MCPAppsSkipReason,
   message: string,
   details?: Record<string, unknown>,
 ): MCPAppsCheckResult {
   return {
     ...APPS_CHECK_METADATA[id],
     status: "skipped",
+    skipReason,
     durationMs: 0,
     error: { message },
     ...(details ? { details } : {}),
@@ -162,18 +170,14 @@ function summarizeChecks(checks: MCPAppsCheckResult[]) {
           passed: categoryChecks.filter((check) => check.status === "passed").length,
           failed: categoryChecks.filter((check) => check.status === "failed").length,
           skipped: categoryChecks.filter((check) => check.status === "skipped").length,
+          couldNotRun: categoryChecks.filter(isUnrunCheck).length,
         },
       ];
     }),
   ) as MCPAppsConformanceResult["categorySummary"];
 }
 
-function buildSummary(checks: MCPAppsCheckResult[]): string {
-  const passed = checks.filter((check) => check.status === "passed").length;
-  const failed = checks.filter((check) => check.status === "failed").length;
-  const skipped = checks.filter((check) => check.status === "skipped").length;
-  return `${passed}/${checks.length} checks passed, ${failed} failed, ${skipped} skipped`;
-}
+const buildSummary = buildOutcomeSummary;
 
 function extractUiToolReference(tool: MCPListedTool): UIToolReference | undefined {
   const toolMeta = isPlainObject(tool._meta) ? tool._meta : undefined;
@@ -408,14 +412,24 @@ function buildConnectionFailureResult(
       checks.push(
         skippedResult(
           checkId,
+          "could-not-run",
           "Skipping check because the MCP server could not be connected",
         ),
       );
     }
   }
 
+  // One check carries the connection failure and the rest are skipped, so the
+  // shared verdict lands on "failed" — same as the hardcoded value it replaces,
+  // but derived rather than asserted.
+  const verdict = decideConformanceOutcome(checks);
+
   return {
-    passed: false,
+    passed: verdict.outcome === "passed",
+    outcome: verdict.outcome,
+    ...(verdict.incompleteReason
+      ? { incompleteReason: verdict.incompleteReason }
+      : {}),
     target: config.target,
     checks,
     summary: buildSummary(checks),
@@ -540,6 +554,7 @@ export class MCPAppsConformanceTest {
               checks.push(
                 skippedResult(
                   "ui-tool-metadata-valid",
+                  "could-not-run",
                   "Skipping check because tools/list did not complete",
                 ),
               );
@@ -547,6 +562,7 @@ export class MCPAppsConformanceTest {
               checks.push(
                 skippedResult(
                   "ui-tool-metadata-valid",
+                  "not-applicable",
                   "Skipping check because no MCP Apps tools were discovered",
                 ),
               );
@@ -670,6 +686,7 @@ export class MCPAppsConformanceTest {
               checks.push(
                 skippedResult(
                   "ui-tool-input-schema-valid",
+                  "could-not-run",
                   "Skipping check because tools/list did not complete",
                 ),
               );
@@ -677,6 +694,7 @@ export class MCPAppsConformanceTest {
               checks.push(
                 skippedResult(
                   "ui-tool-input-schema-valid",
+                  "not-applicable",
                   "Skipping check because no MCP Apps tools were discovered",
                 ),
               );
@@ -741,6 +759,7 @@ export class MCPAppsConformanceTest {
               checks.push(
                 skippedResult(
                   "ui-listed-resources-valid",
+                  "not-applicable",
                   "Skipping check because resources/list did not expose any UI resources",
                 ),
               );
@@ -797,6 +816,7 @@ export class MCPAppsConformanceTest {
               checks.push(
                 skippedResult(
                   "ui-resources-readable",
+                  "not-applicable",
                   "Skipping check because no UI resources were discovered",
                 ),
               );
@@ -841,6 +861,7 @@ export class MCPAppsConformanceTest {
               checks.push(
                 skippedResult(
                   "ui-resource-contents-valid",
+                  "not-applicable",
                   "Skipping check because no UI resources were read successfully",
                 ),
               );
@@ -945,6 +966,7 @@ export class MCPAppsConformanceTest {
               checks.push(
                 skippedResult(
                   "ui-resource-meta-valid",
+                  "not-applicable",
                   "Skipping check because no UI resources were read successfully",
                 ),
               );
@@ -985,8 +1007,16 @@ export class MCPAppsConformanceTest {
             }
           }
 
+          // A check that COULD NOT RUN is neither a violation nor a pass: the
+          // obligation went untested, so the run is `incomplete`.
+          const verdict = decideConformanceOutcome(checks);
+
           return {
-            passed: checks.every((check) => check.status !== "failed"),
+            passed: verdict.outcome === "passed",
+            outcome: verdict.outcome,
+            ...(verdict.incompleteReason
+              ? { incompleteReason: verdict.incompleteReason }
+              : {}),
             target: this.config.target,
             checks,
             summary: buildSummary(checks),

--- a/sdk/src/apps-conformance/types.ts
+++ b/sdk/src/apps-conformance/types.ts
@@ -1,4 +1,8 @@
 import type {
+  ConformanceRunOutcome,
+  ConformanceSkipReason,
+} from "../conformance-outcome.js";
+import type {
   MCPReadResourceResult,
   MCPServerConfig,
 } from "../mcp-client-manager/index.js";
@@ -21,12 +25,20 @@ export type MCPAppsCheckId = (typeof MCP_APPS_CHECK_IDS)[number];
 
 export type MCPAppsCheckStatus = "passed" | "failed" | "skipped";
 
+/** @see {@link ConformanceSkipReason} — the vocabulary is shared by every suite. */
+export type MCPAppsSkipReason = ConformanceSkipReason;
+
+/** @see {@link ConformanceRunOutcome} — the vocabulary is shared by every suite. */
+export type MCPAppsRunOutcome = ConformanceRunOutcome;
+
 export interface MCPAppsCheckResult {
   id: MCPAppsCheckId;
   category: MCPAppsCheckCategory;
   title: string;
   description: string;
   status: MCPAppsCheckStatus;
+  /** Always set when `status` is `"skipped"`. */
+  skipReason?: MCPAppsSkipReason;
   durationMs: number;
   error?: {
     message: string;
@@ -66,7 +78,18 @@ export interface MCPAppsResourceReadOutcome {
 }
 
 export interface MCPAppsConformanceResult {
+  /**
+   * True ONLY when `outcome` is `"passed"`: every selected check either ran and
+   * passed or was inapplicable to this server. A check that could not run keeps
+   * this false, so a skip can never add up to a green run.
+   */
   passed: boolean;
+  outcome: MCPAppsRunOutcome;
+  /**
+   * Present when `outcome` is `"incomplete"`: which checks did not run and what
+   * the caller has to change to make them run.
+   */
+  incompleteReason?: string;
   target: string;
   checks: MCPAppsCheckResult[];
   summary: string;
@@ -77,7 +100,10 @@ export interface MCPAppsConformanceResult {
       total: number;
       passed: number;
       failed: number;
+      /** Every skip, of either reason. */
       skipped: number;
+      /** The subset of `skipped` that is `"could-not-run"`. */
+      couldNotRun: number;
     }
   >;
   discovery: {

--- a/sdk/src/conformance-outcome.ts
+++ b/sdk/src/conformance-outcome.ts
@@ -1,0 +1,103 @@
+/**
+ * The verdict vocabulary shared by every conformance suite.
+ *
+ * The tasks suite arrived at this model first, after a run where six of eight
+ * checks silently skipped and the suite still reported success. The rule it
+ * encodes is the whole point: **"did not run" must never read as "conformed"**.
+ * Protocol, apps and OAuth now speak the same vocabulary, so a caller —
+ * inspector, CLI, or a score — can reason about any suite the same way.
+ *
+ * This module is pure data reasoning: no MCP client, no transport, no Node
+ * built-ins, so it is safe from the browser entry.
+ */
+
+/**
+ * Why a skipped check produced no verdict. The two are NOT interchangeable:
+ *
+ *   - `"not-applicable"` — the requirement cannot apply to THIS server, so
+ *     nothing is left unverified. An era-gated check on the wrong protocol
+ *     version, a capability the server never advertised, a transport-specific
+ *     requirement on another transport. A run may still pass with these, and
+ *     a score must leave them out of its denominator entirely.
+ *   - `"could-not-run"` — the requirement DOES apply, but the run could not
+ *     exercise it: a missing probe tool, an unreachable prerequisite, an
+ *     opt-in the caller did not supply. The obligation is untested, so the
+ *     run cannot claim conformance.
+ */
+export type ConformanceSkipReason = "not-applicable" | "could-not-run";
+
+/**
+ * A run's verdict.
+ *
+ *   - `"passed"` — every selected check either ran and passed, or was
+ *     inapplicable to this server.
+ *   - `"failed"` — at least one check produced a violation.
+ *   - `"incomplete"` — nothing failed, but at least one selected check could
+ *     not be run, so the run does not establish conformance.
+ */
+export type ConformanceRunOutcome = "passed" | "failed" | "incomplete";
+
+/** The minimum a check must expose for the shared verdict logic to read it. */
+export interface OutcomeCheckLike {
+  id: string;
+  status: "passed" | "failed" | "skipped";
+  skipReason?: ConformanceSkipReason;
+  error?: { message: string };
+}
+
+/** Selected, applicable, and never exercised. */
+export function isUnrunCheck(check: OutcomeCheckLike): boolean {
+  return check.status === "skipped" && check.skipReason === "could-not-run";
+}
+
+/** Skipped because it could not apply here — nothing was left unverified. */
+export function isInapplicableCheck(check: OutcomeCheckLike): boolean {
+  return check.status === "skipped" && check.skipReason !== "could-not-run";
+}
+
+/**
+ * The run's verdict, plus the reason when it is `incomplete`.
+ *
+ * `passed` requires that every SELECTED check actually produced a verdict —
+ * either it ran, or it was inapplicable to this server. A check that could not
+ * run is neither a violation nor a pass, and collapsing it into "not failed"
+ * is what let a two-of-eight run report success.
+ */
+export function decideConformanceOutcome(checks: OutcomeCheckLike[]): {
+  outcome: ConformanceRunOutcome;
+  incompleteReason?: string;
+} {
+  if (checks.some((check) => check.status === "failed")) {
+    return { outcome: "failed" };
+  }
+  const unrun = checks.filter(isUnrunCheck);
+  if (unrun.length === 0) {
+    return checks.length === 0
+      ? {
+          outcome: "incomplete",
+          incompleteReason:
+            "no checks were selected, so this run establishes nothing",
+        }
+      : { outcome: "passed" };
+  }
+  const reasons = Array.from(
+    new Set(unrun.map((check) => check.error?.message ?? "reason unavailable")),
+  );
+  return {
+    outcome: "incomplete",
+    incompleteReason: `${unrun.length} of ${
+      checks.length
+    } selected check(s) could not run, so this run does not establish conformance (${unrun
+      .map((check) => check.id)
+      .join(", ")}): ${reasons.join(" ")}`,
+  };
+}
+
+/** The one-line tally every suite prints. */
+export function buildOutcomeSummary(checks: OutcomeCheckLike[]): string {
+  const passedCount = checks.filter((c) => c.status === "passed").length;
+  const failedCount = checks.filter((c) => c.status === "failed").length;
+  const unrunCount = checks.filter(isUnrunCheck).length;
+  const inapplicableCount = checks.filter(isInapplicableCheck).length;
+  return `${passedCount}/${checks.length} checks passed, ${failedCount} failed, ${unrunCount} could not run, ${inapplicableCount} not applicable`;
+}

--- a/sdk/src/conformance-reporting.ts
+++ b/sdk/src/conformance-reporting.ts
@@ -1,3 +1,7 @@
+import type {
+  ConformanceRunOutcome,
+  ConformanceSkipReason,
+} from "./conformance-outcome.js";
 import { redactSensitiveValue } from "./redaction.js";
 import type {
   MCPConformanceResult,
@@ -32,6 +36,12 @@ export interface ConformanceReportCase {
   title: string;
   category: string;
   status: ConformanceReportCaseStatus;
+  /**
+   * Why a skipped case produced no verdict. CI needs this: a
+   * `"not-applicable"` skip left nothing unverified, while a
+   * `"could-not-run"` skip means an obligation went untested.
+   */
+  skipReason?: ConformanceSkipReason;
   durationMs: number;
   description?: string;
   error?: string;
@@ -53,7 +63,14 @@ export interface ConformanceReport {
   schemaVersion: 1;
   kind: ConformanceReportKind;
   name: string;
+  /** True only when `outcome` is `"passed"`. */
   passed: boolean;
+  /**
+   * The three-value verdict. Absent only for suites that predate it, so
+   * consumers should treat a missing value as `passed ? "passed" : "failed"`.
+   */
+  outcome?: ConformanceRunOutcome;
+  incompleteReason?: string;
   durationMs: number;
   groups: ConformanceReportGroup[];
 }
@@ -135,6 +152,7 @@ function reportCaseFromMcpCheck(check: MCPCheckResult): ConformanceReportCase {
     title: check.title,
     category: check.category,
     status: check.status,
+    ...(check.skipReason ? { skipReason: check.skipReason } : {}),
     durationMs: check.durationMs,
     description: check.description,
     ...(check.error?.message ? { error: check.error.message } : {}),
@@ -158,6 +176,7 @@ function reportCaseFromCheck(
     title: check.title,
     category: check.category,
     status: check.status,
+    ...(check.skipReason ? { skipReason: check.skipReason } : {}),
     durationMs: check.durationMs,
     description: check.description,
     ...(check.error?.message ? { error: check.error.message } : {}),

--- a/sdk/src/mcp-conformance/checks/core.ts
+++ b/sdk/src/mcp-conformance/checks/core.ts
@@ -128,6 +128,7 @@ export const CORE_CHECKS: MCPClientCheckDefinition[] = [
         return {
           ...this,
           status: "skipped" as const,
+          skipReason: "not-applicable" as const,
           durationMs: 0,
           error: {
             message: "Server does not advertise the optional logging capability",
@@ -167,6 +168,7 @@ export const CORE_CHECKS: MCPClientCheckDefinition[] = [
         return {
           ...this,
           status: "skipped" as const,
+          skipReason: "not-applicable" as const,
           durationMs: 0,
           error: {
             message:
@@ -180,6 +182,9 @@ export const CORE_CHECKS: MCPClientCheckDefinition[] = [
         return {
           ...this,
           status: "skipped" as const,
+          // Completions IS advertised, so the requirement applies here — we
+          // simply found no subject to exercise it against.
+          skipReason: "could-not-run" as const,
           durationMs: 0,
           error: {
             message:

--- a/sdk/src/mcp-conformance/checks/helpers.ts
+++ b/sdk/src/mcp-conformance/checks/helpers.ts
@@ -1,4 +1,5 @@
-import type { MCPCheckEra, MCPCheckResult } from "../types.js";
+import type {
+  MCPCheckSkipReason, MCPCheckEra, MCPCheckResult } from "../types.js";
 
 type CheckMetadata = Pick<
   MCPCheckResult,
@@ -37,20 +38,50 @@ export function failedResult(
   };
 }
 
-export function skippedResult(
+function skipped(
   check: CheckMetadata,
+  skipReason: MCPCheckSkipReason,
   message: string,
   details?: Record<string, unknown>,
 ): MCPCheckResult {
   return {
     ...check,
     status: "skipped",
+    skipReason,
     durationMs: 0,
     error: {
       message,
     },
     details,
   };
+}
+
+/**
+ * The requirement cannot apply to THIS server, so nothing is left unverified:
+ * an era-gated check on another protocol version, a capability the server
+ * never advertised, a localhost-only requirement against a remote target. A
+ * run may still legitimately pass with these.
+ */
+export function notApplicableResult(
+  check: CheckMetadata,
+  message: string,
+  details?: Record<string, unknown>,
+): MCPCheckResult {
+  return skipped(check, "not-applicable", message, details);
+}
+
+/**
+ * The requirement DOES apply here, but the run could not exercise it — a
+ * broken session, no suitable subject, an opt-in probe the caller did not
+ * supply. The obligation is untested, so the run reports `incomplete` and can
+ * never claim conformance.
+ */
+export function couldNotRunResult(
+  check: CheckMetadata,
+  message: string,
+  details?: Record<string, unknown>,
+): MCPCheckResult {
+  return skipped(check, "could-not-run", message, details);
 }
 
 export function errorMessage(error: unknown): string {

--- a/sdk/src/mcp-conformance/checks/modern.ts
+++ b/sdk/src/mcp-conformance/checks/modern.ts
@@ -29,6 +29,7 @@
  */
 
 import type {
+  MCPCheckSkipReason,
   MCPCheckId,
   MCPCheckResult,
   RawHttpCheckContext,
@@ -39,7 +40,8 @@ import {
   eraSkipMessage,
   failedResult,
   passedResult,
-  skippedResult,
+  couldNotRunResult,
+  notApplicableResult,
 } from "./helpers.js";
 import {
   jsonRpcError,
@@ -519,7 +521,7 @@ function runResultTypeCheck(
   }
 
   if (Object.keys(observed).length === 0) {
-    return skippedResult(
+    return couldNotRunResult(
       meta,
       "No modern result could be obtained to inspect for resultType"
     );
@@ -571,7 +573,7 @@ function runCacheHintsCheck(
   }
 
   if (Object.keys(observed).length === 0) {
-    return skippedResult(
+    return couldNotRunResult(
       meta,
       "No cacheable modern result could be obtained to inspect"
     );
@@ -708,7 +710,7 @@ async function runNameHeaderMismatchCheck(
   const target = selectNameHeaderTarget(ctx, await discoverOnce(ctx, state));
 
   if (!target) {
-    return skippedResult(
+    return couldNotRunResult(
       meta,
       "Server exposes no read-only named target (resource or prompt) to probe the Mcp-Name header with"
     );
@@ -806,7 +808,7 @@ async function runUndeclaredCapabilityCheck(
   const probe = ctx.config.inputRequiredProbe;
 
   if (!probe) {
-    return skippedResult(
+    return couldNotRunResult(
       meta,
       "No inputRequiredProbe configured: set inputRequiredProbe.toolName to a tool that requests input so the check can prove the -32021 rejection"
     );
@@ -837,7 +839,7 @@ async function runUndeclaredCapabilityCheck(
   }
 
   if (payload) {
-    return skippedResult(
+    return couldNotRunResult(
       meta,
       `Tool "${probe.toolName}" completed without requesting input, so the undeclared-capability path was never exercised`,
       { httpStatus: result.status, resultType: payload.resultType }
@@ -922,7 +924,7 @@ async function runResourceNotFoundCheck(
   const capabilities = advertisedCapabilities(await discoverOnce(ctx, state));
 
   if (capabilities.resources === undefined) {
-    return skippedResult(
+    return notApplicableResult(
       meta,
       "Server does not advertise the resources capability"
     );
@@ -1082,9 +1084,37 @@ async function runNoSessionIdCheck(
  * a check that failed on them would be reporting a conformance failure it did
  * not observe.
  */
+/**
+ * Forward the probe's own classification: one call site funnels three distinct
+ * unavailable reasons, and only the "nothing subscribable advertised" one is
+ * genuinely inapplicable. Hardcoding either value here would mislabel two of
+ * the three.
+ */
+function skippedFromProbe(
+  check: Parameters<typeof notApplicableResult>[0],
+  reason: string,
+  skipReason: MCPCheckSkipReason,
+  details?: Record<string, unknown>,
+): MCPCheckResult {
+  return skipReason === "could-not-run"
+    ? couldNotRunResult(check, reason, details)
+    : notApplicableResult(check, reason, details);
+}
+
 type SubscriptionProbe =
   | { kind: "observed"; observation: ListenObservation }
-  | { kind: "unavailable"; reason: string; details?: Record<string, unknown> };
+  | {
+      kind: "unavailable";
+      reason: string;
+      /**
+       * Why the probe yielded nothing. A server that advertises nothing
+       * subscribable has no obligation to test; one that refused to open a
+       * stream, or whose stream could not be read, leaves the subscription
+       * MUSTs untested.
+       */
+      skipReason: MCPCheckSkipReason;
+      details?: Record<string, unknown>;
+    };
 
 /**
  * The filter to request, derived from what the server ADVERTISES. Asking for
@@ -1138,6 +1168,7 @@ async function probeSubscription(
   if (isEmptyFilter(filter)) {
     return {
       kind: "unavailable",
+      skipReason: "not-applicable",
       reason: `Server advertises no subscribable notification type (tools/prompts/resources listChanged, or resources.subscribe with a listed resource), so no ${LISTEN_METHOD} stream can be opened`,
     };
   }
@@ -1155,6 +1186,7 @@ async function probeSubscription(
     )?.error?.code;
     return {
       kind: "unavailable",
+      skipReason: "could-not-run",
       reason: `Server did not open a ${LISTEN_METHOD} stream (HTTP ${observation.status}, content-type "${observation.contentType}"), so the subscription MUSTs could not be observed`,
       details: { httpStatus: observation.status, jsonRpcCode: code },
     };
@@ -1162,6 +1194,7 @@ async function probeSubscription(
   if (observation.outcome === "stream-error") {
     return {
       kind: "unavailable",
+      skipReason: "could-not-run",
       reason: `The ${LISTEN_METHOD} stream could not be read to a stopping point (${observation.streamError}); reported as a skip rather than a conformance failure`,
       details: { httpStatus: observation.status },
     };
@@ -1213,7 +1246,7 @@ async function runSubscriptionAckOrderingCheck(
   const startedAt = Date.now();
   const probe = await subscriptionOnce(ctx, state);
   if (probe.kind === "unavailable") {
-    return skippedResult(meta, probe.reason, probe.details);
+    return skippedFromProbe(meta, probe.reason, probe.skipReason, probe.details);
   }
 
   const { observation } = probe;
@@ -1229,7 +1262,7 @@ async function runSubscriptionAckOrderingCheck(
   };
 
   if (ackIndex === -1 && notifications.length === 0) {
-    return skippedResult(
+    return couldNotRunResult(
       meta,
       `The ${LISTEN_METHOD} stream carried neither an acknowledgement nor a notification within ${observation.observedMs}ms, so the ordering MUST was never exercised`,
       details
@@ -1269,12 +1302,12 @@ async function runSubscriptionFilterAndTaggingCheck(
   const startedAt = Date.now();
   const probe = await subscriptionOnce(ctx, state);
   if (probe.kind === "unavailable") {
-    return skippedResult(meta, probe.reason, probe.details);
+    return skippedFromProbe(meta, probe.reason, probe.skipReason, probe.details);
   }
 
   const { observation } = probe;
   if (observation.messages.length === 0) {
-    return skippedResult(
+    return couldNotRunResult(
       meta,
       `The ${LISTEN_METHOD} stream carried no message within ${observation.observedMs}ms, so neither filtering nor tagging could be observed`,
       observationDetails(observation)
@@ -1351,7 +1384,7 @@ async function runSubscriptionGracefulCloseCheck(
   const startedAt = Date.now();
   const probe = await subscriptionOnce(ctx, state);
   if (probe.kind === "unavailable") {
-    return skippedResult(meta, probe.reason, probe.details);
+    return skippedFromProbe(meta, probe.reason, probe.skipReason, probe.details);
   }
 
   const { observation } = probe;
@@ -1376,7 +1409,7 @@ async function runSubscriptionGracefulCloseCheck(
     );
   }
 
-  return skippedResult(
+  return couldNotRunResult(
     meta,
     `The subscription was still open after ${observation.observedMs}ms. A graceful close is server-initiated, so a client-side probe cannot induce one; reported as a skip rather than a failure`,
     details
@@ -1453,7 +1486,7 @@ async function runXMcpHeaderDeclarationsCheck(
 
   const discover = await discoverOnce(ctx, state);
   if (advertisedCapabilities(discover).tools === undefined) {
-    return skippedResult(meta, "Server does not advertise the tools capability");
+    return notApplicableResult(meta, "Server does not advertise the tools capability");
   }
 
   // Shared with the readiness sibling: one bounded, cycle-safe walk, so a
@@ -1526,7 +1559,7 @@ async function runXMcpHeaderDeclarationsCheck(
     // all. "Passed" would certify coverage the run never achieved, and an
     // offender on an unreachable page would be silently blessed. A skip is the
     // honest verdict: the MUST was not established either way.
-    return skippedResult(
+    return couldNotRunResult(
       meta,
       `Could not enumerate every tool: ${terminationReason(termination)}. The declarations on ${toolCount} scanned tool(s) are valid, but the rest were unreachable.`,
       { toolCount, declaringTools, termination, pagesRead }
@@ -1569,7 +1602,7 @@ export async function runModernChecks(
       // legacy run every modern check is a deterministic skip and no HTTP is
       // attempted, which is what keeps a legacy report byte-identical.
       results.push(
-        skippedResult(
+        notApplicableResult(
           MODERN_CHECK_METADATA[id],
           eraSkipMessage(ctx.config.era, ctx.config.protocolVersion)
         )

--- a/sdk/src/mcp-conformance/checks/protocol.ts
+++ b/sdk/src/mcp-conformance/checks/protocol.ts
@@ -8,7 +8,7 @@ import {
   eraSkipMessage,
   failedResult,
   passedResult,
-  skippedResult,
+  notApplicableResult,
 } from "./helpers.js";
 import {
   DEFAULT_LEGACY_PROTOCOL_VERSION,
@@ -106,7 +106,7 @@ export async function runProtocolChecks(
   // safe era-skip instead of silently drifting into a false failure.
   if (!CHECK_ERAS["protocol-invalid-method-error"].includes(ctx.config.era)) {
     results.push(
-      skippedResult(
+      notApplicableResult(
         PROTOCOL_CHECK_METADATA["protocol-invalid-method-error"],
         eraSkipMessage(ctx.config.era, ctx.config.protocolVersion),
       ),

--- a/sdk/src/mcp-conformance/checks/security.ts
+++ b/sdk/src/mcp-conformance/checks/security.ts
@@ -10,7 +10,7 @@ import { CHECK_ERAS } from "../types.js";
 import {
   eraSkipMessage,
   failedResult,
-  skippedResult,
+  notApplicableResult,
   passedResult,
 } from "./helpers.js";
 
@@ -171,7 +171,7 @@ export async function runSecurityChecks(
       applicable.add(id);
     } else {
       results.push(
-        skippedResult(
+        notApplicableResult(
           SECURITY_CHECK_METADATA[id],
           eraSkipMessage(ctx.config.era, ctx.config.protocolVersion),
         ),
@@ -189,7 +189,7 @@ export async function runSecurityChecks(
     for (const id of LOCALHOST_SECURITY_CHECK_IDS) {
       if (applicable.has(id)) {
         results.push(
-          skippedResult(
+          notApplicableResult(
             SECURITY_CHECK_METADATA[id],
             "Security host-header checks only apply to localhost servers",
             {

--- a/sdk/src/mcp-conformance/checks/transport.ts
+++ b/sdk/src/mcp-conformance/checks/transport.ts
@@ -8,7 +8,8 @@ import {
   errorMessage,
   eraSkipMessage,
   failedResult,
-  skippedResult,
+  couldNotRunResult,
+  notApplicableResult,
   passedResult,
 } from "./helpers.js";
 import {
@@ -118,7 +119,7 @@ export async function runTransportChecks(
       applicableTransportChecks.push(id);
     } else {
       results.push(
-        skippedResult(
+        notApplicableResult(
           TRANSPORT_CHECK_METADATA[id],
           eraSkipMessage(ctx.config.era, ctx.config.protocolVersion),
         ),
@@ -163,7 +164,7 @@ export async function runTransportChecks(
       ] as const) {
         if (selectedCheckIds.has(id)) {
           results.push(
-            skippedResult(
+            couldNotRunResult(
               TRANSPORT_CHECK_METADATA[id],
               `Skipping check because the Streamable HTTP session could not be initialized: ${errorMessage(error)}`,
             ),
@@ -198,7 +199,7 @@ export async function runTransportChecks(
                 status: session.status,
               },
             )
-          : skippedResult(
+          : notApplicableResult(
               TRANSPORT_CHECK_METADATA["server-sse-polling-session"],
               "Server initialized successfully without an mcp-session-id header (stateless Streamable HTTP)",
               {
@@ -216,7 +217,7 @@ export async function runTransportChecks(
       ] as const) {
         if (selectedCheckIds.has(id)) {
           results.push(
-            skippedResult(
+            couldNotRunResult(
               TRANSPORT_CHECK_METADATA[id],
               "Streamable HTTP session could not be initialized",
             ),

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -1,3 +1,8 @@
+import {
+  buildOutcomeSummary,
+  decideConformanceOutcome,
+  isUnrunCheck,
+} from "../conformance-outcome.js";
 import type { HttpServerConfig } from "../mcp-client-manager/index.js";
 import { isKnownProtocolVersion } from "../mcp-client-manager/mcp-protocol-version.js";
 import {
@@ -18,7 +23,8 @@ import {
   errorMessage,
   eraSkipMessage,
   failedResult,
-  skippedResult,
+  couldNotRunResult,
+  notApplicableResult,
 } from "./checks/helpers.js";
 import type {
   MCPCheckCategory,
@@ -105,18 +111,14 @@ function summarizeChecks(checks: MCPCheckResult[]) {
           passed: categoryChecks.filter((check) => check.status === "passed").length,
           failed: categoryChecks.filter((check) => check.status === "failed").length,
           skipped: categoryChecks.filter((check) => check.status === "skipped").length,
+          couldNotRun: categoryChecks.filter(isUnrunCheck).length,
         },
       ];
     }),
   ) as MCPConformanceResult["categorySummary"];
 }
 
-function buildSummary(checks: MCPCheckResult[]): string {
-  const passed = checks.filter((check) => check.status === "passed").length;
-  const failed = checks.filter((check) => check.status === "failed").length;
-  const skipped = checks.filter((check) => check.status === "skipped").length;
-  return `${passed}/${checks.length} checks passed, ${failed} failed, ${skipped} skipped`;
-}
+const buildSummary = buildOutcomeSummary;
 
 function createServerConfig(
   config: NormalizedMCPConformanceConfig,
@@ -151,7 +153,7 @@ function eraGate(
   if (CHECK_ERAS[check.id].includes(era)) {
     return undefined;
   }
-  return skippedResult(check, eraSkipMessage(era, protocolVersion));
+  return notApplicableResult(check, eraSkipMessage(era, protocolVersion));
 }
 
 async function safeListResourceTemplates(
@@ -325,7 +327,7 @@ async function runClientChecks(
 
           if (connectionLost) {
             results.push(
-              skippedResult(
+              couldNotRunResult(
                 check,
                 "Skipping check because the MCP client session is no longer healthy",
               ),
@@ -398,7 +400,7 @@ async function runClientChecks(
           index === 0
             ? failedResult(check, 0, errorMessage(error), undefined, error)
             : (eraGate(check, config.era, config.protocolVersion) ??
-              skippedResult(
+              couldNotRunResult(
                 check,
                 "Skipping check because the MCP client session could not be established",
               )),
@@ -430,7 +432,7 @@ async function runClientChecks(
         );
       } else {
         checks.push(
-          skippedResult(
+          couldNotRunResult(
             check,
             "Skipping check because the MCP client session could not be established",
           ),
@@ -487,10 +489,20 @@ export class MCPConformanceTest {
     ];
     const categorySummary = summarizeChecks(checks);
 
+    // A check that COULD NOT RUN is neither a violation nor a pass: the
+    // obligation went untested, so the run is `incomplete`. Collapsing that
+    // into "nothing failed" is what let a run with unexercised checks report
+    // success.
+    const verdict = decideConformanceOutcome(checks);
+
     return {
       // Readiness is deliberately absent from this expression: the verdict is
       // a statement about MUSTs only (§15.4).
-      passed: checks.every((check) => check.status !== "failed"),
+      passed: verdict.outcome === "passed",
+      outcome: verdict.outcome,
+      ...(verdict.incompleteReason
+        ? { incompleteReason: verdict.incompleteReason }
+        : {}),
       serverUrl: this.config.serverUrl,
       checks,
       summary: buildSummary(checks),

--- a/sdk/src/mcp-conformance/types.ts
+++ b/sdk/src/mcp-conformance/types.ts
@@ -1,4 +1,8 @@
 import type {
+  ConformanceRunOutcome,
+  ConformanceSkipReason,
+} from "../conformance-outcome.js";
+import type {
   ManagedMcpClient,
   MCPClientManager,
 } from "../mcp-client-manager/index.js";
@@ -64,6 +68,12 @@ export const MCP_CHECK_IDS = [
 export type MCPCheckId = (typeof MCP_CHECK_IDS)[number];
 
 export type MCPCheckStatus = "passed" | "failed" | "skipped";
+
+/** @see {@link ConformanceSkipReason} — the vocabulary is shared by every suite. */
+export type MCPCheckSkipReason = ConformanceSkipReason;
+
+/** @see {@link ConformanceRunOutcome} — the vocabulary is shared by every suite. */
+export type MCPRunOutcome = ConformanceRunOutcome;
 
 /**
  * Protocol era a conformance run targets. Derived once in
@@ -198,6 +208,8 @@ export interface MCPCheckResult {
   title: string;
   description: string;
   status: MCPCheckStatus;
+  /** Always set when `status` is `"skipped"`. */
+  skipReason?: MCPCheckSkipReason;
   durationMs: number;
   error?: {
     message: string;
@@ -321,7 +333,18 @@ export interface MCPReadinessWarning {
 }
 
 export interface MCPConformanceResult {
+  /**
+   * True ONLY when `outcome` is `"passed"`: every selected check either ran and
+   * passed or was inapplicable to this server. A check that could not run keeps
+   * this false, so a skip can never add up to a green run.
+   */
   passed: boolean;
+  outcome: MCPRunOutcome;
+  /**
+   * Present when `outcome` is `"incomplete"`: which checks did not run and what
+   * the caller has to change to make them run.
+   */
+  incompleteReason?: string;
   serverUrl: string;
   checks: MCPCheckResult[];
   summary: string;
@@ -332,7 +355,10 @@ export interface MCPConformanceResult {
       total: number;
       passed: number;
       failed: number;
+      /** Every skip, of either reason. */
       skipped: number;
+      /** The subset of `skipped` that is `"could-not-run"`. */
+      couldNotRun: number;
     }
   >;
   /**

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -1,3 +1,4 @@
+import type { ConformanceSkipReason } from "../conformance-outcome.js";
 import type {
   InfoLogEntry,
   HttpHistoryEntry,
@@ -170,7 +171,8 @@ export interface OAuthConformanceConfig {
  *     not exercise it. The obligation is untested, so this must never be
  *     summed into a passing verdict.
  */
-export type OAuthSkipReason = "not-applicable" | "could-not-run";
+/** @see {@link ConformanceSkipReason} — the vocabulary is shared by every suite. */
+export type OAuthSkipReason = ConformanceSkipReason;
 
 /**
  * Suite-level verdict. `passed` stays a boolean for existing consumers and is

--- a/sdk/src/tasks-conformance/runner.ts
+++ b/sdk/src/tasks-conformance/runner.ts
@@ -25,6 +25,11 @@ import { ensureTasksExtensionEraGateShadow } from "../mcp-client-manager/tasks-e
 import { TASK_CREATED_META_KEY } from "../mcp-client-manager/transport-utils.js";
 import { withEphemeralClient } from "../operations.js";
 import {
+  buildOutcomeSummary,
+  decideConformanceOutcome,
+  isUnrunCheck,
+} from "../conformance-outcome.js";
+import {
   MCP_TASKS_CHECK_IDS,
   MCP_TASKS_CHECK_CATEGORIES,
   type MCPTasksCheckId,
@@ -193,9 +198,7 @@ function couldNotRun(
 }
 
 /** Selected, applicable, and never exercised. */
-function isUnrun(check: MCPTasksCheckResult): boolean {
-  return check.status === "skipped" && check.skipReason === "could-not-run";
-}
+const isUnrun = isUnrunCheck;
 
 function summarizeChecks(checks: MCPTasksCheckResult[]) {
   return Object.fromEntries(
@@ -215,15 +218,7 @@ function summarizeChecks(checks: MCPTasksCheckResult[]) {
   ) as MCPTasksConformanceResult["categorySummary"];
 }
 
-function buildSummary(checks: MCPTasksCheckResult[]): string {
-  const passedCount = checks.filter((c) => c.status === "passed").length;
-  const failedCount = checks.filter((c) => c.status === "failed").length;
-  const unrunCount = checks.filter(isUnrun).length;
-  const inapplicableCount = checks.filter(
-    (c) => c.status === "skipped" && c.skipReason !== "could-not-run"
-  ).length;
-  return `${passedCount}/${checks.length} checks passed, ${failedCount} failed, ${unrunCount} could not run, ${inapplicableCount} not applicable`;
-}
+const buildSummary = buildOutcomeSummary;
 
 /**
  * The run's verdict, plus the reason when it is `incomplete`.
@@ -237,30 +232,7 @@ export function decideOutcome(checks: MCPTasksCheckResult[]): {
   outcome: MCPTasksRunOutcome;
   incompleteReason?: string;
 } {
-  if (checks.some((check) => check.status === "failed")) {
-    return { outcome: "failed" };
-  }
-  const unrun = checks.filter(isUnrun);
-  if (unrun.length === 0) {
-    return checks.length === 0
-      ? {
-          outcome: "incomplete",
-          incompleteReason:
-            "no checks were selected, so this run establishes nothing",
-        }
-      : { outcome: "passed" };
-  }
-  const reasons = Array.from(
-    new Set(unrun.map((check) => check.error?.message ?? "reason unavailable"))
-  );
-  return {
-    outcome: "incomplete",
-    incompleteReason: `${unrun.length} of ${
-      checks.length
-    } selected check(s) could not run, so this run does not establish conformance (${unrun
-      .map((check) => check.id)
-      .join(", ")}): ${reasons.join(" ")}`,
-  };
+  return decideConformanceOutcome(checks);
 }
 
 /** `execution.taskSupport` on a listed tool (legacy 2025-11-25 metadata). */

--- a/sdk/src/tasks-conformance/types.ts
+++ b/sdk/src/tasks-conformance/types.ts
@@ -1,3 +1,7 @@
+import type {
+  ConformanceRunOutcome,
+  ConformanceSkipReason,
+} from "../conformance-outcome.js";
 import type { MCPServerConfig } from "../mcp-client-manager/index.js";
 import type { TasksWire } from "../mcp-client-manager/tasks-dispatch.js";
 
@@ -38,7 +42,8 @@ export type MCPTasksCheckStatus = "passed" | "failed" | "skipped";
  *     then `incomplete`, never `passed` — "did not run" must never be read as
  *     "conformed".
  */
-export type MCPTasksSkipReason = "not-applicable" | "could-not-run";
+/** @see {@link ConformanceSkipReason} — the vocabulary is shared by every suite. */
+export type MCPTasksSkipReason = ConformanceSkipReason;
 
 /**
  * A run's verdict.
@@ -48,7 +53,8 @@ export type MCPTasksSkipReason = "not-applicable" | "could-not-run";
  *   - `"incomplete"` — nothing failed, but at least one selected check could
  *     not be run, so the run does not establish conformance.
  */
-export type MCPTasksRunOutcome = "passed" | "failed" | "incomplete";
+/** @see {@link ConformanceRunOutcome} — the vocabulary is shared by every suite. */
+export type MCPTasksRunOutcome = ConformanceRunOutcome;
 
 export interface MCPTasksCheckResult {
   id: MCPTasksCheckId;

--- a/sdk/tests/mcp-conformance/era.integration.test.ts
+++ b/sdk/tests/mcp-conformance/era.integration.test.ts
@@ -150,7 +150,21 @@ describe("MCP conformance × era-awareness against the dual-era fixture", () => 
 
     // Exit gate: no false failures, no crash.
     expect(result.checks.filter((c) => c.status === "failed")).toEqual([]);
-    expect(result.passed).toBe(true);
+    // NOT `passed`: two modern obligations cannot be exercised here — the
+    // -32021 path needs an `inputRequiredProbe` this fixture does not
+    // configure, and a graceful subscription close is server-initiated and
+    // cannot be induced by a client-side probe. Both report `could-not-run`,
+    // so the run is honestly `incomplete` rather than green.
+    expect(result.outcome).toBe("incomplete");
+    expect(
+      result.checks
+        .filter((c) => c.skipReason === "could-not-run")
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual([
+      "modern-subscription-graceful-close",
+      "modern-undeclared-capability-error",
+    ]);
 
     // Legacy-only checks appear (not filtered out) and are era-skipped.
     for (const id of LEGACY_ONLY) {
@@ -226,7 +240,10 @@ describe("MCP conformance × era-awareness against the dual-era fixture", () => 
       expect(["SHOULD", "RECOMMENDED", "MAY"]).toContain(item.specStrength);
       expect(item.message.length).toBeGreaterThan(0);
     }
-    expect(result.passed).toBe(true);
+    // The point of §15.4 is that advice never becomes a violation. `passed` is
+    // false here only because two obligations could not be run, so assert the
+    // thing readiness could have broken: it never turns the verdict red.
+    expect(result.outcome).not.toBe("failed");
 
     // The fixture advertises no logging/completions capability, so these
     // both-era checks self-skip on capability (NOT the era gate).
@@ -244,7 +261,21 @@ describe("MCP conformance × era-awareness against the dual-era fixture", () => 
     }).run();
 
     expect(result.checks.filter((c) => c.status === "failed")).toEqual([]);
-    expect(result.passed).toBe(true);
+    // NOT `passed`: two modern obligations cannot be exercised here — the
+    // -32021 path needs an `inputRequiredProbe` this fixture does not
+    // configure, and a graceful subscription close is server-initiated and
+    // cannot be induced by a client-side probe. Both report `could-not-run`,
+    // so the run is honestly `incomplete` rather than green.
+    expect(result.outcome).toBe("incomplete");
+    expect(
+      result.checks
+        .filter((c) => c.skipReason === "could-not-run")
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual([
+      "modern-subscription-graceful-close",
+      "modern-undeclared-capability-error",
+    ]);
     for (const id of LEGACY_ONLY) {
       const check = byId(result.checks, id);
       expect(check.status).toBe("skipped");

--- a/sdk/tests/mcp-conformance/subscription-checks.integration.test.ts
+++ b/sdk/tests/mcp-conformance/subscription-checks.integration.test.ts
@@ -104,7 +104,10 @@ describe("subscription checks against a conforming listen stream", () => {
     const graceful = byId(result.checks, "modern-subscription-graceful-close");
     expect([graceful.id, graceful.status]).toEqual([graceful.id, "skipped"]);
     expect(graceful.error?.message).toMatch(/still open/);
-    expect(result.passed).toBe(true);
+    // A skip, never a failure — but also never a pass: the MUST went
+    // unexercised, so the run is `incomplete`.
+    expect(graceful.skipReason).toBe("could-not-run");
+    expect(result.outcome).toBe("incomplete");
   });
 
   it("proves the graceful close returns the completion result", async () => {

--- a/sdk/tests/mcp-conformance/x-mcp-header-declarations.integration.test.ts
+++ b/sdk/tests/mcp-conformance/x-mcp-header-declarations.integration.test.ts
@@ -264,7 +264,11 @@ describe("tools-x-mcp-header-declarations-valid", () => {
     // Not a pass: the walk never established that every tool was read.
     expect(check.status).toBe("skipped");
     expect(check.error?.message).toMatch(/reissued a cursor/);
-    expect(passed).toBe(true);
+    // Not a pass, and now the verdict says so: the walk never established that
+    // every tool was read, so the obligation is untested and the run is
+    // `incomplete` rather than green.
+    expect(check.skipReason).toBe("could-not-run");
+    expect(passed).toBe(false);
     // Terminated at the cycle, not at the 64-page cap. The counter is shared
     // by every tools/list this run makes — the check's walk, the readiness
     // walk, and the cache-TTL probe — so the bound is a handful of pages


### PR DESCRIPTION
PR #2 of the conformance-score sequence, and the prerequisite for scoring: without this, any score would be computed from data that cannot tell "doesn't apply to you" from "we never tested it."

## The bug

Both runners computed their verdict as:

```ts
passed: checks.every((check) => check.status !== "failed")
```

So a run where twenty checks never executed still reported `passed: true`. A skip counted as a pass.

The tasks suite fixed this long ago — its own comment records the incident, a run where six of eight checks silently skipped and the suite still reported success — and OAuth gained it in #3675. Protocol and apps were the two holdouts.

## The vocabulary, extracted once

Rather than a fourth copy of subtly-important logic, this lifts it into `sdk/src/conformance-outcome.ts`, and tasks + OAuth now alias it, so all four suites agree by construction:

- **`skipReason`** on every skipped check:
  - `"not-applicable"` — the requirement cannot apply to THIS server, so nothing is left unverified. A run may still legitimately pass. A score must leave these out of its denominator entirely.
  - `"could-not-run"` — the requirement applies, but the run could not exercise it. The obligation is untested, so the run cannot claim conformance.
- **`outcome`**: `"passed" | "failed" | "incomplete"`, with `passed` true only for `"passed"`.
- **`categorySummary.couldNotRun`** alongside the existing `skipped` total (additive, so existing consumers keep working), and a summary line reading `N/M checks passed, X failed, Y could not run, Z not applicable`.

## Classifying the skip sites is the actual work

All 26 protocol sites plus 9 apps sites are now classified rather than lumped. The rule applied throughout: *if this server violated the requirement, would this run have caught it?* If it could never apply → not-applicable. If it would apply but we failed to test it → could-not-run.

So an era-gated check, an unadvertised `logging`/`completions`/`tools`/`resources` capability, or a localhost-only requirement against a remote server is **not-applicable**. A broken session, a missing `inputRequiredProbe`, a completions capability with no subject to complete against, or a tool walk that hit a cursor cycle before enumerating everything is **could-not-run**.

Rather than a positional flag, protocol call sites now name their own reason via `notApplicableResult(...)` / `couldNotRunResult(...)`, mirroring the tasks suite.

The subscription checks needed particular care: one call site funnels three distinct "unavailable" reasons, and only "server advertises nothing subscribable" is genuinely inapplicable — the other two (server refused to open a listen stream, stream unreadable) leave real MUSTs untested. The probe now carries its own classification instead of the call site guessing one for all three.

## The CLI benefits too

- `protocol conformance` and `apps conformance`, plus both `conformance-suite` forms, adopt the exit-code mapping tasks already had: **`3` = incomplete**, `1` = failed, `0` = passed. A suite takes the worst of its runs, with a failure outranking an incomplete. The helper reads the result structurally with `outcome?` optional, so an older `@mcpjam/sdk` still degrades cleanly through `passed`.
- The reason a run established nothing goes to **stderr**, instead of having to be dug out of the JSON payload.
- The **reporters** (`--reporter json-summary` / `junit-xml`) now carry `skipReason` and `outcome`. They previously dropped both for **every** suite, tasks included — so CI consumers reading JUnit could not see the distinction at all.

## ⚠️ This changes CI exit codes

A protocol or apps run whose applicable checks could not be exercised previously exited **0**; it now exits **3**. That is the point — those runs were never establishing conformance — but pipelines treating a green exit as proof will start failing, and should. Flagging it explicitly because it is the kind of change that surprises people mid-release.

## Verification

- Full SDK suite: **3471 passed**, 1 skipped, 190 files
- CLI: **550 passed** (547 existing + 3 new exit-code tests), CLI typecheck clean
- Root `npm run typecheck` (all six releasable packages) clean — the gate that caught the CLI fixtures in the last PR
- Inspector client typecheck clean; conformance panel + server route tests pass

Four SDK tests changed, and all four now assert the honest verdict their own comments already described. The x-mcp-header cursor-cycle test is the clearest: its comment read *"Not a pass: the walk never established that every tool was read"* directly above `expect(passed).toBe(true)`. The era integration test now pins exactly which two obligations its fixture cannot exercise — the `-32021` path needs an `inputRequiredProbe` it does not configure, and a graceful subscription close is server-initiated — rather than asserting a green run.

## Next

PR #3 is the score itself, which by then is arithmetic over honest data: `passed / (passed + failed)` with not-applicable out of the denominator, `could-not-run` suppressing any claim of 100%, the denominator always displayed, and the whole thing labelled with the protocol version it was scored against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split skipped checks into “not-applicable” vs “could-not-run” for protocol and apps, and introduced a three-state outcome so runs with unexercised applicable checks no longer appear as passes. This is the prerequisite for accurate scoring.

- New Features
  - Added shared outcome vocab in `sdk/src/conformance-outcome.ts`: `skipReason` and `outcome` (`passed`/`failed`/`incomplete`) with `incompleteReason`.
  - Protocol and apps now classify every skip; subscription probes distinguish inapplicable vs could-not-run.
  - Category summaries include `couldNotRun`; summary line shows “could not run” and “not applicable”.
  - CLI uses exit codes 0 (passed), 1 (failed), 3 (incomplete); prints incomplete reason to stderr; suites take the worst run. Reporters (`--reporter json-summary`, `junit-xml`) include `skipReason` and `outcome`. `@mcpjam/inspector` badges “incomplete”.

- Migration
  - CI exit codes changed: runs that couldn’t exercise applicable checks now exit 3 instead of 0. Update pipelines accordingly.
  - `passed` remains for compatibility; consumers can read `outcome` and `skipReason` from JSON/JUnit.

<sup>Written for commit 6071c4f8e3bdb827ad19dfebb942090551b98e39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

