### PR TITLE
fix(slack-link): authenticate the WorkOS leg as a dedicated OAuth application

### DIFF
--- a/mcpjam-inspector/server/routes/slack-link/index.ts
+++ b/mcpjam-inspector/server/routes/slack-link/index.ts
@@ -104,12 +104,21 @@ function resolveConfig(
   const rawOrigin = env.SLACK_LINK_PUBLIC_ORIGIN ?? env.CLI_AUTH_PUBLIC_ORIGIN;
   const slackClientId = env.SLACK_CLIENT_ID;
   const slackClientSecret = env.SLACK_CLIENT_SECRET;
-  const workosClientSecret = env.WORKOS_API_KEY ?? env.WORKOS_CLIENT_SECRET;
+  // The `/oauth2/*` surface on the AuthKit domain serves WorkOS OAUTH
+  // APPLICATIONS — a separate registry from the environment's user-management
+  // client, whose id it rejects with `application_not_found`. So the bridge
+  // authenticates as a dedicated confidential OAuth application (its own
+  // id + secret, registered with this module's callback as redirect URI).
+  // The environment client id keeps ONE job below: deriving the AuthKit
+  // ISSUER, which is a property of the environment, not of any one app.
+  const workosClientId = env.SLACK_LINK_WORKOS_CLIENT_ID;
+  const workosClientSecret = env.SLACK_LINK_WORKOS_CLIENT_SECRET;
   if (
     !secret ||
     !rawOrigin ||
     !slackClientId ||
     !slackClientSecret ||
+    !workosClientId ||
     !workosClientSecret
   ) {
     return null;
@@ -122,9 +131,9 @@ function resolveConfig(
     return null;
   }
 
-  const workosClientId = resolveWorkosClientId(env);
-  if (!workosClientId) return null;
-  const workosIssuer = resolveAuthkitIssuer(workosClientId, env);
+  const environmentClientId = resolveWorkosClientId(env);
+  if (!environmentClientId) return null;
+  const workosIssuer = resolveAuthkitIssuer(environmentClientId, env);
   if (!workosIssuer) return null;
 
   return {


### PR DESCRIPTION
The AuthKit domain's `/oauth2/*` endpoints serve WorkOS **OAuth applications** — a separate registry from the environment's user-management client. The bridge was sending the environment client id, which that surface rejects with `application_not_found` (hit live on the first production link attempt; `CLI_AUTH_CLIENT_ID` probes as `invalid_redirect_uri`, confirming the registry, while `WORKOS_CLIENT_ID` probes as `application_not_found`).

The bridge now authenticates as a dedicated **confidential OAuth application** via `SLACK_LINK_WORKOS_CLIENT_ID` / `SLACK_LINK_WORKOS_CLIENT_SECRET`, registered with `/api/slack/link/workos/callback` as its redirect URI. The environment client id keeps exactly one job — deriving the AuthKit issuer, which is a property of the environment, not of any one app. Missing vars degrade to the existing 501 not-enabled behavior.

No secret values appear anywhere in this diff; the two new env vars are set directly on the deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production OAuth identity configuration; deployments must set the new env vars or linking stays disabled, but runtime auth flow behavior is unchanged aside from fixing the wrong client registry.
> 
> **Overview**
> Fixes production Slack account linking by using the correct WorkOS OAuth client on AuthKit’s `/oauth2/*` surface, which only accepts registered **OAuth applications**, not the environment user-management client (which caused `application_not_found`).
> 
> **`resolveConfig`** now reads **`SLACK_LINK_WORKOS_CLIENT_ID`** and **`SLACK_LINK_WORKOS_CLIENT_SECRET`** for the WorkOS authorize/token leg (confidential app with `/api/slack/link/workos/callback` as redirect URI). **`resolveWorkosClientId`** is renamed in spirit to **`environmentClientId`** and is used **only** to derive the AuthKit **issuer**. Both new vars are required alongside existing Slack-link secrets; if any are missing, config still resolves to `null` and the route returns **501** not-enabled.
> 
> No changes to the two-leg flow, cookies, or session logic—only which credentials are passed into the existing WorkOS redirects and token exchange.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f74a4f4ed700447452379180d47c141209125b87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack linking by authenticating the WorkOS leg as a dedicated confidential OAuth application. Prevents application_not_found errors and keeps the environment client id only for deriving the AuthKit issuer.

- **Bug Fixes**
  - Authenticate against a dedicated WorkOS OAuth app using `SLACK_LINK_WORKOS_CLIENT_ID` and `SLACK_LINK_WORKOS_CLIENT_SECRET`.
  - Environment client id is now used only to derive the AuthKit issuer.
  - Callback URI: `/api/slack/link/workos/callback`. Missing vars return 501 (feature not enabled).

- **Migration**
  - Set `SLACK_LINK_WORKOS_CLIENT_ID` and `SLACK_LINK_WORKOS_CLIENT_SECRET` in the deployment.
  - Ensure the OAuth app redirect URI is `/api/slack/link/workos/callback`.

<sup>Written for commit f74a4f4ed700447452379180d47c141209125b87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

