### PR TITLE
feat(swarm): journey rubric authoring, grading, and criterion insights

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -443,6 +443,15 @@ function CheckFields({
           compact={compactGlobalGate}
         />
       );
+    case "turnCountUnder":
+      return (
+        <TurnCountField
+          predicate={predicate}
+          onChange={onChange}
+          readOnly={readOnly}
+          compact={compactGlobalGate}
+        />
+      );
     case "widgetRendered":
       return (
         <div className="space-y-2">
@@ -1324,6 +1333,44 @@ function TokenBudgetField({
           const n = Number(e.target.value);
           if (!Number.isFinite(n)) return;
           onChange({ ...predicate, tokens: Math.floor(n) });
+        }}
+        className="h-8 w-32 text-xs"
+        disabled={readOnly}
+      />
+    </div>
+  );
+}
+
+function TurnCountField({
+  predicate,
+  onChange,
+  readOnly,
+  compact = false,
+}: {
+  predicate: Extract<Predicate, { type: "turnCountUnder" }>;
+  onChange: (next: Predicate) => void;
+  readOnly: boolean;
+  compact?: boolean;
+}) {
+  const id = useId();
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id} className="text-[11px]">
+        {/* Strictly under, like the token budget: `3` passes at 2 turns and
+            fails at 3. The label says so rather than leaving the author to
+            discover it from a failing run. */}
+        {compact ? "Max user turns" : "User turns (strictly under)"}
+      </Label>
+      <Input
+        id={id}
+        type="number"
+        min={1}
+        step={1}
+        value={predicate.turns}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          if (!Number.isFinite(n)) return;
+          onChange({ ...predicate, turns: Math.floor(n) });
         }}
         className="h-8 w-32 text-xs"
         disabled={readOnly}

--- a/mcpjam-inspector/client/src/components/evals/checks-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/checks-section.tsx
@@ -1359,7 +1359,9 @@ function TurnCountField({
         {/* Strictly under, like the token budget: `3` passes at 2 turns and
             fails at 3. The label says so rather than leaving the author to
             discover it from a failing run. */}
-        {compact ? "Max user turns" : "User turns (strictly under)"}
+        {/* Never "Max": `turnCountUnder: 3` FAILS at exactly 3, and a label
+            reading "max 3" would promise the opposite. */}
+        {compact ? "Fewer than N user turns" : "User turns (strictly under)"}
       </Label>
       <Input
         id={id}

--- a/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
@@ -267,6 +267,8 @@ export function summarizePredicate(predicate: Predicate): string {
         return "final assistant message non-empty";
       case "tokenBudgetUnder":
         return `tokens < ${predicate.tokens.toLocaleString()}`;
+      case "turnCountUnder":
+        return `user turns < ${predicate.turns.toLocaleString()}`;
       case "widgetRendered":
         return `widget rendered${
           predicate.toolName ? ` for "${predicate.toolName}"` : ""

--- a/mcpjam-inspector/client/src/components/evals/preview/expected-conversation.tsx
+++ b/mcpjam-inspector/client/src/components/evals/preview/expected-conversation.tsx
@@ -39,6 +39,8 @@ export function describeCheck(p: Predicate): string {
       return "replies";
     case "tokenBudgetUnder":
       return `< ${p.tokens} tok`;
+    case "turnCountUnder":
+      return `< ${p.turns} turns`;
     case "widgetRendered":
       return "widget renders";
     case "widgetRenderLatencyUnder":

--- a/mcpjam-inspector/client/src/components/swarms/CriterionFacetCards.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/CriterionFacetCards.tsx
@@ -69,8 +69,14 @@ export function CriterionFacetCards({
           const graded = facet.passCount + facet.failCount;
           const failChip = chipFor(facet.criterionId, "fail", `${name}: failed`);
           const passChip = chipFor(facet.criterionId, "pass", `${name}: passed`);
+          const ungradedChip = chipFor(
+            facet.criterionId,
+            "ungraded",
+            `${name}: not graded`,
+          );
           const failActive = activeKeys.has(chipKey(failChip));
           const passActive = activeKeys.has(chipKey(passChip));
+          const ungradedActive = activeKeys.has(chipKey(ungradedChip));
 
           return (
             <div
@@ -89,6 +95,10 @@ export function CriterionFacetCards({
                   onClick={() => onToggleChip(failChip)}
                   disabled={facet.failCount === 0}
                   aria-pressed={failActive}
+                  // The criterion name lives in a sibling element, so without
+                  // this two cards with the same count present identical
+                  // accessible names ("6 failed").
+                  aria-label={`${name}: ${facet.failCount} failed`}
                   className={cn(
                     "rounded-md border px-2 py-1 text-left transition-colors",
                     "disabled:cursor-default disabled:opacity-50",
@@ -109,6 +119,7 @@ export function CriterionFacetCards({
                   onClick={() => onToggleChip(passChip)}
                   disabled={facet.passCount === 0}
                   aria-pressed={passActive}
+                  aria-label={`${name}: ${facet.passCount} passed`}
                   className={cn(
                     "rounded-md border px-2 py-1 text-left transition-colors",
                     "disabled:cursor-default disabled:opacity-50",
@@ -123,15 +134,30 @@ export function CriterionFacetCards({
                   </div>
                 </button>
               </div>
-              <div className="mt-2 text-[11px] text-muted-foreground">
-                {graded === 0
-                  ? "No completed grades yet"
-                  : `${facet.failCount}/${graded} sessions failed`}
-                {/* Ungraded is reported, never folded into the fail count: a
-                    crashed runner is not a product regression. */}
-                {facet.ungradedCount > 0
-                  ? ` · ${facet.ungradedCount} not graded`
-                  : ""}
+              <div className="mt-2 flex flex-wrap items-baseline gap-x-2 text-[11px] text-muted-foreground">
+                <span>
+                  {graded === 0
+                    ? "No completed grades yet"
+                    : `${facet.failCount}/${graded} sessions failed`}
+                </span>
+                {/* Ungraded is reported separately, never folded into the fail
+                    count — a crashed runner is not a product regression — and
+                    it is CLICKABLE, because "which sessions never got graded?"
+                    is exactly the question this number provokes. */}
+                {facet.ungradedCount > 0 ? (
+                  <button
+                    type="button"
+                    onClick={() => onToggleChip(ungradedChip)}
+                    aria-pressed={ungradedActive}
+                    aria-label={`${name}: ${facet.ungradedCount} not graded`}
+                    className={cn(
+                      "rounded px-1 underline-offset-2 transition-colors hover:underline",
+                      ungradedActive && "bg-muted font-medium text-foreground",
+                    )}
+                  >
+                    {facet.ungradedCount} not graded
+                  </button>
+                ) : null}
               </div>
             </div>
           );

--- a/mcpjam-inspector/client/src/components/swarms/CriterionFacetCards.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/CriterionFacetCards.tsx
@@ -1,0 +1,160 @@
+import { cn } from "@/lib/utils";
+import {
+  chipKey,
+  criterionChipValue,
+  type CriterionVerdict,
+  type UsageFilterChip,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+import type { CriterionFacet } from "@/hooks/useUsageInsights";
+import {
+  PREDICATE_KIND_LABELS,
+  type PredicateKind,
+} from "@/shared/predicate-kinds";
+
+/**
+ * Per-criterion pass/fail cards for the swarm Insights view.
+ *
+ * Each criterion is its own boolean dimension, so each card is its own filter:
+ * clicking two DIFFERENT criteria's fail counts narrows to the sessions that
+ * failed both, which is the read worth having. Two verdicts on the SAME
+ * criterion widen (a session cannot be both) — the grouping rule in
+ * `chipGroupKey` handles that, and these are ordinary filter chips, so they
+ * narrow the sankey and the drilldown like any other.
+ *
+ * Fail is the primary affordance. The reason people open this view is to find
+ * what broke, and a card that led with the pass count would bury it.
+ */
+export function CriterionFacetCards({
+  facets,
+  filter,
+  onToggleChip,
+}: {
+  facets: CriterionFacet[] | undefined;
+  filter: UsageFilterState;
+  onToggleChip: (chip: UsageFilterChip) => void;
+}) {
+  // No rubric anywhere in the scanned window. Rendering an empty section here
+  // would advertise a feature the project has not configured; silence is the
+  // honest state.
+  if (!facets || facets.length === 0) return null;
+
+  const activeKeys = new Set(filter.chips.map(chipKey));
+  const chipFor = (
+    criterionId: string,
+    verdict: CriterionVerdict,
+    label: string,
+  ): UsageFilterChip => ({
+    kind: "dimension",
+    key: "criterion",
+    value: criterionChipValue(criterionId, verdict),
+    label,
+  });
+
+  return (
+    <div className="px-5 pb-4">
+      <div className="mb-2 flex items-baseline gap-2">
+        <h3 className="text-xs font-medium">Pass criteria</h3>
+        <span className="text-[11px] text-muted-foreground">
+          Deterministic checks across graded sessions
+        </span>
+      </div>
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3">
+        {facets.map((facet) => {
+          const name = criterionDisplayName(facet);
+          // The DENOMINATOR is only the sessions whose run carried this
+          // criterion — sessions from rubric-less runs are excluded upstream,
+          // so this rate never depends on how many ungraded sessions happened
+          // to be in the scan window.
+          const graded = facet.passCount + facet.failCount;
+          const failChip = chipFor(facet.criterionId, "fail", `${name}: failed`);
+          const passChip = chipFor(facet.criterionId, "pass", `${name}: passed`);
+          const failActive = activeKeys.has(chipKey(failChip));
+          const passActive = activeKeys.has(chipKey(passChip));
+
+          return (
+            <div
+              key={facet.criterionId}
+              className="rounded-lg border bg-card/40 p-3"
+            >
+              <div
+                className="truncate text-xs font-medium"
+                title={name}
+              >
+                {name}
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => onToggleChip(failChip)}
+                  disabled={facet.failCount === 0}
+                  aria-pressed={failActive}
+                  className={cn(
+                    "rounded-md border px-2 py-1 text-left transition-colors",
+                    "disabled:cursor-default disabled:opacity-50",
+                    failActive
+                      ? "border-destructive bg-destructive/10"
+                      : "hover:bg-muted/60",
+                  )}
+                >
+                  <div className="text-sm font-semibold tabular-nums">
+                    {facet.failCount}
+                  </div>
+                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    failed
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onToggleChip(passChip)}
+                  disabled={facet.passCount === 0}
+                  aria-pressed={passActive}
+                  className={cn(
+                    "rounded-md border px-2 py-1 text-left transition-colors",
+                    "disabled:cursor-default disabled:opacity-50",
+                    passActive ? "border-primary bg-primary/10" : "hover:bg-muted/60",
+                  )}
+                >
+                  <div className="text-sm font-medium tabular-nums text-muted-foreground">
+                    {facet.passCount}
+                  </div>
+                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                    passed
+                  </div>
+                </button>
+              </div>
+              <div className="mt-2 text-[11px] text-muted-foreground">
+                {graded === 0
+                  ? "No completed grades yet"
+                  : `${facet.failCount}/${graded} sessions failed`}
+                {/* Ungraded is reported, never folded into the fail count: a
+                    crashed runner is not a product regression. */}
+                {facet.ungradedCount > 0
+                  ? ` · ${facet.ungradedCount} not graded`
+                  : ""}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * What to call a criterion on screen.
+ *
+ * The author's `label` wins. Failing that, the predicate KIND's label — the
+ * facet row carries no predicate arguments, so this is as specific as the
+ * server-side data allows. Failing even that, the raw id: ugly, but it names
+ * a real row, which beats inventing a friendlier name for a criterion no run
+ * in the window defines.
+ */
+function criterionDisplayName(facet: CriterionFacet): string {
+  const label = facet.label?.trim();
+  if (label) return label;
+  if (facet.kind && facet.kind in PREDICATE_KIND_LABELS) {
+    return PREDICATE_KIND_LABELS[facet.kind as PredicateKind];
+  }
+  return facet.criterionId;
+}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmInsightsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmInsightsPanel.tsx
@@ -4,14 +4,19 @@ import {
   EMPTY_USAGE_FILTER,
   chipKey,
   isSameSelection,
+  removeChipByKey,
   removeChipsByKeys,
   selectionChipsToAdd,
+  toggleChip,
   type InsightsSelection,
+  type UsageFilterChip,
   type UsageFilterState,
 } from "@/hooks/chatbox-usage-filters";
 import { useUsageInsights, type InsightsScope } from "@/hooks/useUsageInsights";
 import { ChatboxInsightsSankey } from "@/components/chatboxes/ChatboxInsightsSankey";
 import { ChatboxGoalOutcomeDrilldown } from "@/components/chatboxes/ChatboxGoalOutcomeDrilldown";
+import { CriterionFacetCards } from "@/components/swarms/CriterionFacetCards";
+import { X } from "lucide-react";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
 
 interface SwarmInsightsPanelProps {
@@ -98,6 +103,27 @@ export function SwarmInsightsPanel({
     [filter, flowSelection, flowOwnedKeys],
   );
 
+  // Criterion chips are ORDINARY filter chips, not flow-owned: they are the
+  // user's own narrowing, so they feed the breakdown query and narrow the
+  // sankey. Only the flow's self-generated chips are subtracted above.
+  const handleToggleChip = useCallback(
+    (chip: UsageFilterChip) => setFilter((prev) => toggleChip(prev, chip)),
+    [],
+  );
+  const handleClearChip = useCallback(
+    (key: string) => setFilter((prev) => removeChipByKey(prev, key)),
+    [],
+  );
+
+  // The chips shown as dismissible pills — everything EXCEPT the ones the flow
+  // put there. Those are already expressed by the selected path in the
+  // diagram, and offering a second way to remove them would let the pill and
+  // the diagram disagree about what is selected.
+  const dismissibleChips = useMemo(() => {
+    const owned = new Set(flowOwnedKeys);
+    return filter.chips.filter((chip) => !owned.has(chipKey(chip)));
+  }, [filter.chips, flowOwnedKeys]);
+
   const handleCloseFlow = useCallback(() => {
     setFilter((prev) => removeChipsByKeys(prev, flowOwnedKeys));
     setFlowSelection(null);
@@ -145,6 +171,33 @@ export function SwarmInsightsPanel({
         onRebuild={handleRebuild}
         rebuildBusy={rebuildBusy}
         stageTitles={{ goal: "Journey" }}
+      />
+      {dismissibleChips.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5 px-5 pb-2">
+          {dismissibleChips.map((chip) => {
+            const key = chipKey(chip);
+            const label =
+              chip.kind === "cluster"
+                ? (chip.label ?? "Cluster")
+                : (chip.label ?? `${chip.key}: ${chip.value}`);
+            return (
+              <button
+                key={key}
+                type="button"
+                onClick={() => handleClearChip(key)}
+                className="inline-flex items-center gap-1 rounded-full border bg-muted/50 px-2 py-0.5 text-xs hover:bg-muted"
+              >
+                <span>{label}</span>
+                <X className="size-3" />
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+      <CriterionFacetCards
+        facets={breakdown?.criterionBreakdown}
+        filter={filter}
+        onToggleChip={handleToggleChip}
       />
       <ChatboxGoalOutcomeDrilldown
         scope={scope}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -79,6 +79,7 @@ export {
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import { JudgesSection } from "@/components/evals/judges-section";
 import { JourneyRubricEditor } from "@/components/swarms/journey-rubric-editor";
+import { areAllChecksValid } from "@/components/evals/checks-section";
 import { RunScorecardSection } from "@/components/swarms/run-scorecard";
 import {
   serializeRubricForWire,
@@ -1471,6 +1472,7 @@ function NewJourneyButton({
   }, [open, goalSeed]);
   const setOpen = onOpenChange;
   const envPayload = buildEnvJourneyPayload(environmentIds, envList);
+  const rubricValid = areAllChecksValid(rubric.map((entry) => entry.predicate));
 
   if (!open) {
     return (
@@ -1609,7 +1611,12 @@ function NewJourneyButton({
             sessionsPerHost > 5 ||
             !Number.isInteger(maxTurns) ||
             maxTurns < 1 ||
-            maxTurns > 20
+            maxTurns > 20 ||
+            // A half-finished criterion (a freshly added row with a blank tool
+            // name, say) would be rejected by the backend validator and lose
+            // the whole journey. `ChecksSection` renders the per-row error, but
+            // that validity never reaches this form — so gate on it here.
+            !rubricValid
           }
           onClick={async () => {
             if (!envPayload) return;

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -57,6 +57,7 @@ import {
   SWARM_QUERIES,
   DEFAULT_PAGE_SIZE,
   type JourneyRun,
+  type GoalScoreRollup,
   type JourneySessionRow,
   type PersonaTrackRecord,
 } from "@/lib/swarm-api";
@@ -77,6 +78,12 @@ export {
 } from "@/components/shared/session-quality/session-goal-score-badge";
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import { JudgesSection } from "@/components/evals/judges-section";
+import { JourneyRubricEditor } from "@/components/swarms/journey-rubric-editor";
+import { RunScorecardSection } from "@/components/swarms/run-scorecard";
+import {
+  serializeRubricForWire,
+  type JourneyCriterion,
+} from "@/shared/journey-rubric";
 import { useAvailableModels } from "@/hooks/use-available-models";
 import type { GoalJudgeConfig } from "@/components/shared/session-quality/judge-config";
 import {
@@ -1162,6 +1169,8 @@ function RunDetailPanel({
       <div className="min-h-0 flex-1">
         <RunSessionsView
           personaRefId={journey.personaRefId}
+          runId={run._id}
+          goalScoreSummary={run.goalScoreSummary}
         />
       </div>
     </div>
@@ -1169,7 +1178,15 @@ function RunDetailPanel({
 }
 
 // ── live stream + session detail (per run; matrix lives in JourneyBlock) ────
-function RunSessionsView({ personaRefId }: { personaRefId: string }) {
+function RunSessionsView({
+  personaRefId,
+  runId: scorecardRunId,
+  goalScoreSummary,
+}: {
+  personaRefId: string;
+  runId: string;
+  goalScoreSummary?: GoalScoreRollup;
+}) {
   const runSessions = useRunSessionsContext();
   const [detailSession, setDetailSession] = useState<JourneySessionRow | null>(
     null
@@ -1220,6 +1237,11 @@ function RunSessionsView({ personaRefId }: { personaRefId: string }) {
           ) : null}
         </div>
       ) : null}
+
+      <RunScorecardSection
+        runId={scorecardRunId}
+        goalScoreSummary={goalScoreSummary}
+      />
 
       <div className="flex min-h-[24rem] flex-1 flex-col">
         <SwarmLiveStreamPane
@@ -1411,6 +1433,8 @@ function NewJourneyButton({
     environmentIds: string[];
     config: { sessionsPerHost: number; maxTurns: number };
     judgeConfig?: GoalJudgeConfig;
+    /** Deterministic criteria. Omitted when the author added none. */
+    rubric?: JourneyCriterion[];
   }) => Promise<void>;
   // Controlled by SwarmsTab so `ui_open_journey_form` can open + prefill it.
   open: boolean;
@@ -1428,6 +1452,10 @@ function NewJourneyButton({
   const [judgeConfig, setJudgeConfig] = useState<GoalJudgeConfig | undefined>(
     undefined
   );
+  // Deterministic criteria, authored beside the judge. Empty = ungraded, which
+  // is a different state from "graded and everything passed" — the form never
+  // sends an empty rubric.
+  const [rubric, setRubric] = useState<JourneyCriterion[]>([]);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const { availableModels } = useAvailableModels({ projectId });
   // Seed the goal from the agent prefill (or reset to "") whenever the form
@@ -1436,6 +1464,7 @@ function NewJourneyButton({
     if (open) {
       setGoal(goalSeed);
       setJudgeConfig(undefined);
+      setRubric([]);
       setAdvancedOpen(false);
       setEnvironmentIds([]);
     }
@@ -1550,6 +1579,12 @@ function NewJourneyButton({
               bareAutoGradeBlurb="Grade every session automatically against this journey's goal. Uses credits. You can also judge any session on demand from its detail view."
               bareAutoGradeAriaLabel="Auto-grade every session with LLM as Judge"
             />
+            {/* Deterministic criteria sit BESIDE the judge, not under it: they
+                answer a different question (did the run satisfy these specific
+                rules?) and cost nothing to run. */}
+            <div className="mt-3 border-t border-border/40 pt-3">
+              <JourneyRubricEditor value={rubric} onChange={setRubric} />
+            </div>
           </div>
         ) : null}
       </div>
@@ -1584,11 +1619,18 @@ function NewJourneyButton({
               environmentIds: envPayload.environmentIds,
               config: { sessionsPerHost, maxTurns },
               ...(judgeConfig ? { judgeConfig } : {}),
+              // Empty ⇒ omit. Sending `[]` would persist "rubric configured,
+              // zero rows", which reads as graded-with-nothing rather than
+              // ungraded.
+              ...(rubric.length > 0
+                ? { rubric: serializeRubricForWire(rubric) }
+                : {}),
             });
             setOpen(false);
             setGoal("");
             setEnvironmentIds([]);
             setJudgeConfig(undefined);
+            setRubric([]);
           }}
         >
           Create journey

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.criteria.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.criteria.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Criterion facet cards in the swarm Insights view.
+ *
+ * What these pin is the thing the shared components cannot: criterion chips
+ * are ORDINARY filter chips, not flow-owned, so clicking one DOES narrow the
+ * breakdown query. That is the opposite of a sankey selection, which is the
+ * diagram's own output and is deliberately withheld from the query that draws
+ * it — mixing the two up would either collapse the diagram or make the facet
+ * click do nothing.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SwarmInsightsPanel } from "../SwarmInsightsPanel";
+import { chipKey, type UsageFilterState } from "@/hooks/chatbox-usage-filters";
+import type { CriterionFacet } from "@/hooks/useUsageInsights";
+
+const { mockUseUsageInsights, mockUseGoalOutcomeDrilldown } = vi.hoisted(() => ({
+  mockUseUsageInsights: vi.fn(),
+  mockUseGoalOutcomeDrilldown: vi.fn(),
+}));
+
+vi.mock("@/hooks/useUsageInsights", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useUsageInsights: (...args: unknown[]) => mockUseUsageInsights(...args),
+    useGoalOutcomeDrilldown: (...args: unknown[]) =>
+      mockUseGoalOutcomeDrilldown(...args),
+  };
+});
+
+vi.mock("@/components/chatboxes/ChatboxInsightsSankey", () => ({
+  ChatboxInsightsSankey: () => <div data-testid="sankey" />,
+}));
+
+const FACETS: CriterionFacet[] = [
+  {
+    criterionId: "crit-quick",
+    label: "Quick resolution",
+    kind: "turnCountUnder",
+    passCount: 4,
+    failCount: 6,
+    ungradedCount: 2,
+  },
+  {
+    criterionId: "crit-search",
+    kind: "toolCalledAtLeastOnce",
+    passCount: 9,
+    failCount: 1,
+    ungradedCount: 0,
+  },
+];
+
+function withFacets(facets: CriterionFacet[] | undefined) {
+  mockUseUsageInsights.mockReturnValue({
+    threads: undefined,
+    breakdown: facets === undefined ? null : { criterionBreakdown: facets },
+    rebuild: vi.fn().mockResolvedValue({ alreadyRunning: false }),
+  });
+}
+
+function lastBreakdownFilters(): UsageFilterState {
+  return (mockUseUsageInsights.mock.calls.at(-1)?.[0] as { filters: UsageFilterState })
+    .filters;
+}
+
+beforeEach(() => {
+  mockUseUsageInsights.mockReset();
+  mockUseGoalOutcomeDrilldown
+    .mockReset()
+    .mockReturnValue({ drilldown: undefined, isLoading: false });
+  withFacets(FACETS);
+});
+
+describe("SwarmInsightsPanel — criterion facets", () => {
+  it("renders one card per criterion, named by label then by predicate kind", () => {
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    expect(screen.getByText("Quick resolution")).toBeInTheDocument();
+    // No author label ⇒ the predicate kind's label, never the raw uuid.
+    expect(screen.getByText("Tool was called at least once")).toBeInTheDocument();
+  });
+
+  it("reports ungraded separately instead of folding it into the fail count", () => {
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    // 6 failed out of the 10 GRADED — the 2 ungraded are named, not summed in.
+    expect(screen.getByText(/6\/10 sessions failed/)).toBeInTheDocument();
+    expect(screen.getByText(/2 not graded/)).toBeInTheDocument();
+  });
+
+  it("a fail click NARROWS the breakdown — criterion chips are not flow-owned", async () => {
+    const user = userEvent.setup();
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    expect(lastBreakdownFilters().chips).toEqual([]);
+
+    // The fail count is the primary affordance.
+    await user.click(screen.getByRole("button", { name: /6\s*failed/ }));
+
+    expect(lastBreakdownFilters().chips.map(chipKey)).toEqual([
+      "criterion:crit-quick:fail",
+    ]);
+  });
+
+  it("chips for two DIFFERENT criteria stack, so the cohort narrows", async () => {
+    const user = userEvent.setup();
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    await user.click(screen.getByRole("button", { name: /6\s*failed/ }));
+    await user.click(screen.getByRole("button", { name: /1\s*failed/ }));
+
+    expect(lastBreakdownFilters().chips.map(chipKey)).toEqual([
+      "criterion:crit-quick:fail",
+      "criterion:crit-search:fail",
+    ]);
+  });
+
+  it("clicking the same chip again removes it", async () => {
+    const user = userEvent.setup();
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    await user.click(screen.getByRole("button", { name: /6\s*failed/ }));
+    await user.click(screen.getByRole("button", { name: /6\s*failed/ }));
+    expect(lastBreakdownFilters().chips).toEqual([]);
+  });
+
+  it("renders nothing at all when no run in the window carried a rubric", () => {
+    withFacets([]);
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    expect(screen.queryByText("Pass criteria")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the server predates criterionBreakdown", () => {
+    withFacets(undefined);
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    expect(screen.queryByText("Pass criteria")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.criteria.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.criteria.test.tsx
@@ -94,7 +94,9 @@ describe("SwarmInsightsPanel — criterion facets", () => {
     expect(lastBreakdownFilters().chips).toEqual([]);
 
     // The fail count is the primary affordance.
-    await user.click(screen.getByRole("button", { name: /6\s*failed/ }));
+    await user.click(
+      screen.getByRole("button", { name: "Quick resolution: 6 failed" }),
+    );
 
     expect(lastBreakdownFilters().chips.map(chipKey)).toEqual([
       "criterion:crit-quick:fail",
@@ -104,8 +106,14 @@ describe("SwarmInsightsPanel — criterion facets", () => {
   it("chips for two DIFFERENT criteria stack, so the cohort narrows", async () => {
     const user = userEvent.setup();
     render(<SwarmInsightsPanel projectId="proj-1" />);
-    await user.click(screen.getByRole("button", { name: /6\s*failed/ }));
-    await user.click(screen.getByRole("button", { name: /1\s*failed/ }));
+    await user.click(
+      screen.getByRole("button", { name: "Quick resolution: 6 failed" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Tool was called at least once: 1 failed",
+      }),
+    );
 
     expect(lastBreakdownFilters().chips.map(chipKey)).toEqual([
       "criterion:crit-quick:fail",
@@ -116,9 +124,37 @@ describe("SwarmInsightsPanel — criterion facets", () => {
   it("clicking the same chip again removes it", async () => {
     const user = userEvent.setup();
     render(<SwarmInsightsPanel projectId="proj-1" />);
-    await user.click(screen.getByRole("button", { name: /6\s*failed/ }));
-    await user.click(screen.getByRole("button", { name: /6\s*failed/ }));
+    await user.click(
+      screen.getByRole("button", { name: "Quick resolution: 6 failed" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Quick resolution: 6 failed" }),
+    );
     expect(lastBreakdownFilters().chips).toEqual([]);
+  });
+
+  it("makes the ungraded count clickable — it is the question the number provokes", async () => {
+    const user = userEvent.setup();
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    await user.click(
+      screen.getByRole("button", { name: /Quick resolution: 2 not graded/ }),
+    );
+    expect(lastBreakdownFilters().chips.map(chipKey)).toEqual([
+      "criterion:crit-quick:ungraded",
+    ]);
+  });
+
+  it("names each button with its criterion so identical counts stay distinguishable", () => {
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    // Both cards would otherwise expose bare "N failed" / "N passed" names.
+    expect(
+      screen.getByRole("button", { name: "Quick resolution: 6 failed" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Tool was called at least once: 1 failed",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("renders nothing at all when no run in the window carried a rubric", () => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/journey-rubric-editor.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/journey-rubric-editor.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * The rubric editor's job is the id layer: `ChecksSection` is id-blind and
+ * hands back a bare `Predicate[]` on every edit, so this component is the only
+ * thing standing between "the author nudged a threshold" and "a brand-new
+ * criterion appeared, and the old one's results are orphaned".
+ *
+ * `ChecksSection` is stubbed to a pair of buttons — its own behavior has its
+ * own tests, and driving a Radix select in jsdom would test the select rather
+ * than the mapping.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { JourneyRubricEditor } from "../journey-rubric-editor";
+import type { JourneyCriterion } from "@/shared/journey-rubric";
+import type { Predicate } from "@/shared/eval-matching";
+
+const ADDED: Predicate = { type: "toolCalledAtLeastOnce", toolName: "search" };
+const EDITED: Predicate = { type: "turnCountUnder", turns: 5 };
+
+vi.mock("@/components/evals/checks-section", () => ({
+  ChecksSection: ({
+    value,
+    onChange,
+  }: {
+    value: Predicate[];
+    onChange: (next: Predicate[]) => void;
+  }) => (
+    <div>
+      <span data-testid="predicate-count">{value.length}</span>
+      <button type="button" onClick={() => onChange([...value, ADDED])}>
+        add check
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange(value.map((p, i) => (i === 0 ? EDITED : p)))}
+      >
+        edit first
+      </button>
+      <button type="button" onClick={() => onChange(value.slice(1))}>
+        remove first
+      </button>
+    </div>
+  ),
+}));
+
+function Harness({ initial = [] }: { initial?: JourneyCriterion[] }) {
+  const [rubric, setRubric] = useState<JourneyCriterion[]>(initial);
+  return (
+    <>
+      <JourneyRubricEditor value={rubric} onChange={setRubric} />
+      <span data-testid="ids">{rubric.map((e) => e.id).join(",")}</span>
+      <span data-testid="labels">
+        {rubric.map((e) => e.label ?? "-").join(",")}
+      </span>
+    </>
+  );
+}
+
+const ids = () => screen.getByTestId("ids").textContent ?? "";
+
+describe("JourneyRubricEditor", () => {
+  it("mints an id when a check is added", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    expect(ids()).toBe("");
+
+    await user.click(screen.getByRole("button", { name: "add check" }));
+
+    expect(ids().length).toBeGreaterThan(0);
+    expect(screen.getByTestId("predicate-count")).toHaveTextContent("1");
+  });
+
+  it("PRESERVES the id when a check is edited", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={[{ id: "keep-me", predicate: { type: "turnCountUnder", turns: 3 } }]} />);
+
+    await user.click(screen.getByRole("button", { name: "edit first" }));
+
+    expect(ids()).toBe("keep-me");
+  });
+
+  it("keeps survivors' ids when a check is removed", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initial={[
+          { id: "a", predicate: { type: "noToolErrors" } },
+          { id: "b", predicate: { type: "turnCountUnder", turns: 3 } },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "remove first" }));
+
+    expect(ids()).toBe("b");
+  });
+
+  it("keeps ids stable across add-then-edit", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "add check" }));
+    const minted = ids();
+
+    await user.click(screen.getByRole("button", { name: "edit first" }));
+
+    expect(ids()).toBe(minted);
+  });
+
+  it("edits a per-row label without disturbing the id", async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initial={[{ id: "a", predicate: { type: "turnCountUnder", turns: 3 } }]}
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", { name: /name for criterion 1/i }),
+      "Quick",
+    );
+
+    expect(screen.getByTestId("labels")).toHaveTextContent("Quick");
+    expect(ids()).toBe("a");
+  });
+
+  it("uses the formatted predicate as the label PLACEHOLDER, not a prefilled value", () => {
+    render(
+      <Harness
+        initial={[{ id: "a", predicate: { type: "turnCountUnder", turns: 3 } }]}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: /name for criterion 1/i });
+    // A derived label stored as a value would stop tracking the predicate the
+    // moment the author changed the threshold.
+    expect(input).toHaveValue("");
+    expect(input).toHaveAttribute("placeholder", "Fewer than 3 user turns");
+  });
+
+  it("renders no name inputs for an empty rubric", () => {
+    render(<Harness />);
+    expect(screen.queryByText("Names (optional)")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/journey-rubric-editor.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-rubric-editor.tsx
@@ -48,7 +48,11 @@ export function JourneyRubricEditor({
         }
         title="Pass criteria"
         description="Deterministic checks run against every session in this journey. Each one becomes its own pass/fail column on the run scorecard and its own filter in Insights."
-        readOnly={atCap}
+        // `hideAddButton`, NOT `readOnly`: `readOnly` disables per-row edit AND
+        // remove, which would make the "Remove one to add another" message
+        // below impossible to act on. At the cap, adding is what stops — the
+        // rows already there stay fully editable.
+        hideAddButton={atCap}
       />
       {atCap ? (
         <p className="text-[11px] text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/swarms/journey-rubric-editor.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-rubric-editor.tsx
@@ -1,0 +1,87 @@
+import type React from "react";
+import { useMemo } from "react";
+import { Input } from "@mcpjam/design-system/input";
+import { ChecksSection } from "@/components/evals/checks-section";
+import { formatCriterion } from "@/shared/predicate-kinds";
+import {
+  MAX_RUBRIC_CRITERIA,
+  reconcileRubricEntries,
+  type JourneyCriterion,
+} from "@/shared/journey-rubric";
+import type { Predicate } from "@/shared/eval-matching";
+
+/**
+ * Rubric authoring for a journey — the deterministic half of "how is this
+ * graded?", sitting beside the LLM judge in the form's Advanced block.
+ *
+ * Wraps the same `ChecksSection` the eval suite settings use, so the predicate
+ * vocabulary and every field editor stay identical across surfaces, and layers
+ * two things on top that only a rubric needs: a stable id per row, and an
+ * optional human label.
+ *
+ * The id never surfaces in the UI. It exists so a row survives being
+ * reordered, retuned, or renamed — see `reconcileRubricEntries`.
+ */
+export function JourneyRubricEditor({
+  value,
+  onChange,
+}: {
+  value: JourneyCriterion[];
+  onChange: (next: JourneyCriterion[]) => void;
+}) {
+  // Stable across renders as long as the entries are: `ChecksSection` compares
+  // by identity when the user edits a row, and a fresh array every render
+  // would defeat the identity pass of the reconciler.
+  const predicates = useMemo(
+    () => value.map((entry) => entry.predicate),
+    [value],
+  );
+
+  const atCap = value.length >= MAX_RUBRIC_CRITERIA;
+
+  return (
+    <div className="space-y-2">
+      <ChecksSection
+        value={predicates}
+        onChange={(next: Predicate[]) =>
+          onChange(reconcileRubricEntries(value, next))
+        }
+        title="Pass criteria"
+        description="Deterministic checks run against every session in this journey. Each one becomes its own pass/fail column on the run scorecard and its own filter in Insights."
+        readOnly={atCap}
+      />
+      {atCap ? (
+        <p className="text-[11px] text-muted-foreground">
+          A rubric holds at most {MAX_RUBRIC_CRITERIA} criteria. Remove one to
+          add another.
+        </p>
+      ) : null}
+      {value.length > 0 ? (
+        <div className="space-y-1.5 rounded-md border border-border/40 p-2">
+          <p className="text-[11px] font-medium text-muted-foreground">
+            Names (optional)
+          </p>
+          {value.map((entry, index) => (
+            <div key={entry.id} className="flex items-center gap-2">
+              <Input
+                value={entry.label ?? ""}
+                // The formatted predicate is the placeholder, not a prefilled
+                // value: it shows what the row will be CALLED if left blank,
+                // without turning a derived label into stored text that then
+                // stops tracking the predicate.
+                placeholder={formatCriterion({ predicate: entry.predicate })}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  const next = [...value];
+                  next[index] = { ...entry, label: e.target.value };
+                  onChange(next);
+                }}
+                className="h-8 text-xs"
+                aria-label={`Name for criterion ${index + 1}`}
+              />
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/journey-run-results.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import {
   swarmAttemptChatSessionId,
   type JourneySessionRow,
+  type SessionCriteria,
   type SessionGoalScore,
 } from "@/lib/swarm-api";
 import { SessionGoalScoreBadge } from "@/components/shared/session-quality/session-goal-score-badge";
@@ -101,6 +102,7 @@ export function SwarmHostCell({
   sessionIndex,
   outcome,
   goalScore,
+  criteria,
   selected,
   onSelect,
 }: {
@@ -108,6 +110,7 @@ export function SwarmHostCell({
   sessionIndex: number;
   outcome: SwarmMatrixCellOutcome;
   goalScore?: SessionGoalScore;
+  criteria?: SessionCriteria;
   selected: boolean;
   onSelect: () => void;
 }) {
@@ -134,7 +137,58 @@ export function SwarmHostCell({
       <span className={cn("size-1.5 rounded-full", meta.dot)} />
       <span className={cn("font-semibold", meta.text)}>{meta.label}</span>
       <SessionGoalScoreBadge goalScore={goalScore} />
+      <SessionCriteriaChip criteria={criteria} />
     </button>
+  );
+}
+
+/**
+ * Per-cell deterministic rubric verdict: `N/M` passed when graded, a subtle
+ * glyph while pending or after a grading failure, and NOTHING when the session
+ * carries no stamp.
+ *
+ * Rendering nothing for an absent stamp is the point. A `0/0` would claim the
+ * session was graded against an empty rubric; absence means the run had no
+ * rubric at all, which is a different thing and belongs in no denominator.
+ */
+function SessionCriteriaChip({ criteria }: { criteria?: SessionCriteria }) {
+  if (!criteria) return null;
+
+  if (criteria.status === "completed") {
+    const results = criteria.results ?? [];
+    if (results.length === 0) return null;
+    const passed = results.filter((r) => r.passed).length;
+    const allPassed = passed === results.length;
+    return (
+      <span
+        title={`${passed} of ${results.length} pass criteria met`}
+        className={cn(
+          "rounded px-1 font-mono text-[10px] tabular-nums",
+          allPassed
+            ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+            : "bg-destructive/10 text-destructive",
+        )}
+      >
+        {passed}/{results.length}
+      </span>
+    );
+  }
+
+  // Pending and failed-grading stay visually quiet — they say something about
+  // the GRADER, not about the session, and shouting them would read as a
+  // product failure.
+  const pending = criteria.status === "pending";
+  return (
+    <span
+      title={
+        pending
+          ? "Pass criteria still being graded"
+          : "Pass criteria could not be graded"
+      }
+      className="rounded px-1 font-mono text-[10px] text-muted-foreground"
+    >
+      {pending ? "…" : "—"}
+    </span>
   );
 }
 
@@ -249,6 +303,7 @@ export function SwarmSessionsMatrix({
                 sessionIndex={sessionIndex}
                 outcome={outcome}
                 goalScore={convexSession?.goalScore}
+                criteria={convexSession?.criteria}
                 selected={selected}
                 onSelect={() =>
                   onSelect({

--- a/mcpjam-inspector/client/src/components/swarms/run-scorecard.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/run-scorecard.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/swarm-api";
 import {
   PREDICATE_KIND_LABELS,
+  formatCriterion,
   type PredicateKind,
 } from "@/shared/predicate-kinds";
 
@@ -152,10 +153,12 @@ export function RunScorecardSection({
  * for it would be a guess.
  */
 function criterionRowName(row: RunScorecardCriterion): string {
-  const label = row.label?.trim();
-  if (label) return label;
+  // Delegate to the shared helper so the label rules (blank-label handling,
+  // predicate-kind fallback) stay defined once and cannot drift between the
+  // authoring form and this table. Only the unknown-kind escape hatch is
+  // local: `formatCriterion` has no id to fall back to.
   if (row.kind in PREDICATE_KIND_LABELS) {
-    return PREDICATE_KIND_LABELS[row.kind as PredicateKind];
+    return formatCriterion({ ...row, kind: row.kind as PredicateKind });
   }
-  return row.criterionId;
+  return row.label?.trim() || row.criterionId;
 }

--- a/mcpjam-inspector/client/src/components/swarms/run-scorecard.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/run-scorecard.tsx
@@ -1,0 +1,161 @@
+import { useQuery } from "convex/react";
+import { cn } from "@/lib/utils";
+import {
+  SWARM_QUERIES,
+  type GoalScoreRollup,
+  type RunScorecard,
+  type RunScorecardCriterion,
+} from "@/lib/swarm-api";
+import {
+  PREDICATE_KIND_LABELS,
+  type PredicateKind,
+} from "@/shared/predicate-kinds";
+
+/**
+ * Deterministic rubric scorecard for one run, with the advisory
+ * goal-completion judge as the final row.
+ *
+ * The judge is rendered LAST and visually separated on purpose. It answers a
+ * different question with different evidence — an LLM's opinion of whether the
+ * goal was met, versus a rule that either held or did not — and a table that
+ * interleaved them would invite reading a 0.6 judge score and a failed
+ * criterion as the same kind of fact.
+ *
+ * Four count columns, kept distinct. Folding `pending` (a runner still
+ * working, or one that died) or `grading failed` into the fail column would
+ * make an infrastructure hiccup read as a product regression.
+ */
+export function RunScorecardSection({
+  runId,
+  goalScoreSummary,
+}: {
+  runId: string;
+  goalScoreSummary?: GoalScoreRollup;
+}) {
+  const scorecard = useQuery(
+    SWARM_QUERIES.getRunScorecard as never,
+    { runId } as never,
+  ) as RunScorecard | null | undefined;
+
+  const hasJudge =
+    goalScoreSummary !== undefined &&
+    (goalScoreSummary.gradedCount > 0 ||
+      (goalScoreSummary.pendingCount ?? 0) > 0 ||
+      (goalScoreSummary.failedCount ?? 0) > 0);
+  const criteria = scorecard?.criteria ?? [];
+
+  // Nothing graded this run either way. A "Pass criteria" heading over an
+  // empty table would advertise a feature the journey never opted into.
+  if (criteria.length === 0 && !hasJudge) return null;
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-card/40 p-3">
+      <div className="mb-2 flex items-baseline justify-between gap-2">
+        <h3 className="text-xs font-medium">Scorecard</h3>
+        {scorecard ? (
+          <span className="text-[11px] text-muted-foreground">
+            {scorecard.sessionsGraded}/{scorecard.sessionsTotal} sessions graded
+          </span>
+        ) : null}
+      </div>
+
+      {criteria.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-[11px]">
+            <thead className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="py-1 pr-2 font-medium">Criterion</th>
+                <th className="py-1 px-2 text-right font-medium">Passed</th>
+                <th className="py-1 px-2 text-right font-medium">Failed</th>
+                <th className="py-1 px-2 text-right font-medium">Pending</th>
+                <th
+                  className="py-1 pl-2 text-right font-medium"
+                  title="Grading itself broke — not the same as failing the criterion"
+                >
+                  Not graded
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {criteria.map((row) => (
+                <tr key={row.criterionId} className="border-t border-border/30">
+                  <td
+                    className="max-w-[16rem] truncate py-1 pr-2"
+                    title={criterionRowName(row)}
+                  >
+                    {criterionRowName(row)}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">
+                    {row.passCount}
+                  </td>
+                  <td
+                    className={cn(
+                      "py-1 px-2 text-right tabular-nums",
+                      row.failCount > 0 && "font-semibold text-destructive",
+                    )}
+                  >
+                    {row.failCount}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums text-muted-foreground">
+                    {row.pendingCount}
+                  </td>
+                  <td className="py-1 pl-2 text-right tabular-nums text-muted-foreground">
+                    {row.failedGradingCount}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      {hasJudge ? (
+        <div
+          className={cn(
+            "flex flex-wrap items-baseline gap-x-3 gap-y-1 text-[11px] text-muted-foreground",
+            criteria.length > 0 && "mt-2 border-t border-border/30 pt-2",
+          )}
+        >
+          <span className="font-medium text-foreground/80">
+            Goal completion (LLM judge)
+          </span>
+          <span className="tabular-nums">
+            {goalScoreSummary!.passedCount}/{goalScoreSummary!.gradedCount}{" "}
+            passed
+          </span>
+          {goalScoreSummary!.avgScore !== null ? (
+            <span className="tabular-nums">
+              avg {goalScoreSummary!.avgScore.toFixed(2)}
+            </span>
+          ) : null}
+          {(goalScoreSummary!.pendingCount ?? 0) > 0 ? (
+            <span className="tabular-nums">
+              {goalScoreSummary!.pendingCount} pending
+            </span>
+          ) : null}
+          {(goalScoreSummary!.failedCount ?? 0) > 0 ? (
+            <span className="tabular-nums">
+              {goalScoreSummary!.failedCount} not graded
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The author's `label`, else the predicate kind's label, else the raw id.
+ *
+ * The raw-id fallback is deliberate: a row whose id no longer appears in the
+ * run snapshot is a real row with real counts, and inventing a friendly name
+ * for it would be a guess.
+ */
+function criterionRowName(row: RunScorecardCriterion): string {
+  const label = row.label?.trim();
+  if (label) return label;
+  if (row.kind in PREDICATE_KIND_LABELS) {
+    return PREDICATE_KIND_LABELS[row.kind as PredicateKind];
+  }
+  return row.criterionId;
+}

--- a/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-criterion.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-criterion.test.ts
@@ -91,7 +91,7 @@ describe("threadMatchesChip — criterion", () => {
     expect(threadMatchesChip(t, chip("b", "fail"))).toBe(true);
   });
 
-  it("treats pending, failed-grading, and absence alike as ungraded", () => {
+  it("treats pending and failed-grading as ungraded when the criterion is IN SCOPE", () => {
     const pending = thread({
       status: "pending",
       generation: 1,
@@ -102,12 +102,33 @@ describe("threadMatchesChip — criterion", () => {
       generation: 1,
       criterionIds: ["a"],
     });
-    const noRubric = thread();
-    for (const t of [pending, failed, noRubric]) {
+    for (const t of [pending, failed]) {
       expect(threadMatchesChip(t, chip("a", "ungraded"))).toBe(true);
       expect(threadMatchesChip(t, chip("a", "pass"))).toBe(false);
       expect(threadMatchesChip(t, chip("a", "fail"))).toBe(false);
     }
+  });
+
+  it("does NOT call a rubric-less thread ungraded — out of scope, not unverdicted", () => {
+    // The facet card offers this chip next to a count that EXCLUDES rubric-less
+    // sessions; matching them would make "2 not graded" open a list of two
+    // hundred.
+    expect(threadMatchesChip(thread(), chip("a", "ungraded"))).toBe(false);
+  });
+
+  it("does NOT call a thread ungraded for a criterion its run never carried", () => {
+    const other = thread({
+      status: "pending",
+      generation: 1,
+      criterionIds: ["b"],
+    });
+    expect(threadMatchesChip(other, chip("a", "ungraded"))).toBe(false);
+    expect(threadMatchesChip(other, chip("b", "ungraded"))).toBe(true);
+  });
+
+  it("treats a legacy stamp with no recorded scope as in scope", () => {
+    const legacy = thread({ status: "pending", generation: 1 });
+    expect(threadMatchesChip(legacy, chip("a", "ungraded"))).toBe(true);
   });
 
   it("matches NOTHING for an uninterpretable chip rather than widening", () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-criterion.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-criterion.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  criterionChipValue,
+  parseCriterionChipValue,
+  primaryBehaviorTag,
+  threadMatchesChip,
+  threadMatchesFilterState,
+  type UsageFilterChip,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+import type { SharedChatThread } from "@/hooks/useSharedChatThreads";
+
+/**
+ * The criterion dimension is the one filter key whose identity lives in the
+ * chip VALUE, so the grouping rule carries the whole feature: chips on
+ * DIFFERENT criteria must AND ("failed A and failed B"), while pass/fail on
+ * ONE criterion must OR.
+ *
+ * These mirror the backend's `criterionFilters.test.ts` case for case — a
+ * divergence would make a server-filtered page and a client-filtered list
+ * disagree about what the user selected.
+ */
+
+let counter = 0;
+
+function thread(criteria?: SharedChatThread["criteria"]): SharedChatThread {
+  counter += 1;
+  return {
+    _id: `t${counter}`,
+    sourceType: "swarm",
+    messageCount: 3,
+    startedAt: 0,
+    lastActivityAt: 0,
+    ...(criteria ? { criteria } : {}),
+  };
+}
+
+function graded(results: Array<[string, boolean]>): SharedChatThread {
+  return thread({
+    status: "completed",
+    generation: 1,
+    criterionIds: results.map(([id]) => id),
+    results: results.map(([criterionId, passed]) => ({ criterionId, passed })),
+    gradedAt: 1,
+  });
+}
+
+function chip(
+  criterionId: string,
+  verdict: "pass" | "fail" | "ungraded",
+): UsageFilterChip {
+  return {
+    kind: "dimension",
+    key: "criterion",
+    value: criterionChipValue(criterionId, verdict),
+  };
+}
+
+const ALL: UsageFilterState = { preset: "all", chips: [] };
+
+describe("parseCriterionChipValue", () => {
+  it("round-trips a value built by criterionChipValue", () => {
+    expect(parseCriterionChipValue(criterionChipValue("abc", "fail"))).toEqual({
+      criterionId: "abc",
+      verdict: "fail",
+    });
+  });
+
+  it("splits at the LAST colon so an id containing one still resolves", () => {
+    expect(parseCriterionChipValue("ns:abc:pass")).toEqual({
+      criterionId: "ns:abc",
+      verdict: "pass",
+    });
+  });
+
+  it("returns null for a missing separator, an empty id, or an unknown verdict", () => {
+    expect(parseCriterionChipValue("abc")).toBeNull();
+    expect(parseCriterionChipValue(":pass")).toBeNull();
+    expect(parseCriterionChipValue("abc:maybe")).toBeNull();
+  });
+});
+
+describe("threadMatchesChip — criterion", () => {
+  it("matches pass and fail against the completed verdict", () => {
+    const t = graded([
+      ["a", true],
+      ["b", false],
+    ]);
+    expect(threadMatchesChip(t, chip("a", "pass"))).toBe(true);
+    expect(threadMatchesChip(t, chip("a", "fail"))).toBe(false);
+    expect(threadMatchesChip(t, chip("b", "fail"))).toBe(true);
+  });
+
+  it("treats pending, failed-grading, and absence alike as ungraded", () => {
+    const pending = thread({
+      status: "pending",
+      generation: 1,
+      criterionIds: ["a"],
+    });
+    const failed = thread({
+      status: "failed",
+      generation: 1,
+      criterionIds: ["a"],
+    });
+    const noRubric = thread();
+    for (const t of [pending, failed, noRubric]) {
+      expect(threadMatchesChip(t, chip("a", "ungraded"))).toBe(true);
+      expect(threadMatchesChip(t, chip("a", "pass"))).toBe(false);
+      expect(threadMatchesChip(t, chip("a", "fail"))).toBe(false);
+    }
+  });
+
+  it("matches NOTHING for an uninterpretable chip rather than widening", () => {
+    const bad: UsageFilterChip = {
+      kind: "dimension",
+      key: "criterion",
+      value: "garbage",
+    };
+    expect(threadMatchesChip(graded([["a", true]]), bad)).toBe(false);
+  });
+});
+
+describe("threadMatchesFilterState — criterion grouping", () => {
+  const failsBoth = graded([
+    ["a", false],
+    ["b", false],
+  ]);
+  const failsAOnly = graded([
+    ["a", false],
+    ["b", true],
+  ]);
+
+  it("ANDs across DIFFERENT criteria — 'fail A + fail B' narrows", () => {
+    const filter = { ...ALL, chips: [chip("a", "fail"), chip("b", "fail")] };
+    expect(threadMatchesFilterState(failsBoth, filter)).toBe(true);
+    expect(threadMatchesFilterState(failsAOnly, filter)).toBe(false);
+  });
+
+  it("ORs within ONE criterion — 'pass A + fail A' selects everything graded on A", () => {
+    const filter = { ...ALL, chips: [chip("a", "pass"), chip("a", "fail")] };
+    expect(threadMatchesFilterState(failsBoth, filter)).toBe(true);
+    expect(threadMatchesFilterState(graded([["a", true]]), filter)).toBe(true);
+    expect(threadMatchesFilterState(graded([["b", true]]), filter)).toBe(false);
+  });
+});
+
+describe("primaryBehaviorTag", () => {
+  it("uses the PRIORITY order, not array order", () => {
+    // A session that both looped and retried is a looping session — the
+    // backend collapses it that way, and taking `[0]` would make the two
+    // sides select different cohorts for the same chip.
+    expect(primaryBehaviorTag(["retried", "looping"])).toBe("looping");
+    expect(primaryBehaviorTag(["single_call"])).toBe("single_call");
+  });
+
+  it("is null for no tags", () => {
+    expect(primaryBehaviorTag(undefined)).toBeNull();
+    expect(primaryBehaviorTag([])).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
+++ b/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
@@ -21,8 +21,64 @@ export type UsageDimensionKey =
   | "outcome"
   | "friction"
   | "behaviorTag"
+  // Equality against the single collapsed behavior value. Distinct from
+  // `behaviorTag` (array-contains) — this one was missing here while the
+  // server has had it, so a `primaryBehavior` chip round-tripped as an
+  // unknown key on this side.
+  | "primaryBehavior"
   | "sentiment"
-  | "pathKey";
+  | "pathKey"
+  // Deterministic rubric criteria. ONE static key for every criterion — the
+  // criterion's identity travels in the chip VALUE
+  // (`<criterionId>:pass|fail|ungraded`), because the key is a closed union
+  // and criterion ids are minted at authoring time. `chipGroupKey` re-splits
+  // them so each criterion behaves as its own boolean dimension.
+  | "criterion";
+
+/** Chip-value verdicts for the `criterion` dimension. */
+export const CRITERION_PASS = "pass";
+export const CRITERION_FAIL = "fail";
+export const CRITERION_UNGRADED = "ungraded";
+
+export type CriterionVerdict = "pass" | "fail" | "ungraded";
+
+/** Build a criterion chip value. Mirrors `criterionChipValue` on the server. */
+export function criterionChipValue(
+  criterionId: string,
+  verdict: CriterionVerdict,
+): string {
+  return `${criterionId}:${verdict}`;
+}
+
+/**
+ * Split a criterion chip value into `(criterionId, verdict)`.
+ *
+ * Splits at the LAST colon. Criterion ids are UUIDs today and carry none, but
+ * they are opaque client-minted strings by contract, so parsing defensively
+ * costs nothing. Returns `null` for an unparseable value; the matcher then
+ * matches nothing, which is the safe direction for a chip we cannot read.
+ *
+ * Mirrors `parseCriterionChipValue` in
+ * `convex/lib/usageInsights/filters.ts` — the two must agree exactly or a
+ * server-filtered page and a client-filtered list would disagree about what
+ * the user selected.
+ */
+export function parseCriterionChipValue(
+  value: string,
+): { criterionId: string; verdict: CriterionVerdict } | null {
+  const idx = value.lastIndexOf(":");
+  if (idx <= 0) return null;
+  const criterionId = value.slice(0, idx);
+  const verdict = value.slice(idx + 1);
+  if (
+    verdict !== CRITERION_PASS &&
+    verdict !== CRITERION_FAIL &&
+    verdict !== CRITERION_UNGRADED
+  ) {
+    return null;
+  }
+  return { criterionId, verdict };
+}
 
 /**
  * Mirrors `SESSION_OUTCOMES`. Closed list so the flow's columns are stable
@@ -37,6 +93,36 @@ export const SESSION_OUTCOMES = [
 ] as const;
 
 export type SessionOutcome = (typeof SESSION_OUTCOMES)[number];
+
+/**
+ * Priority order for collapsing the multi-label trajectory tags to the single
+ * value `primaryBehavior` compares against. Mirrors
+ * `PRIMARY_BEHAVIOR_PRIORITY` in `convex/lib/usageInsights/signalEnums.ts` —
+ * NOT array order: a session that both looped and retried is a looping
+ * session, and taking `behaviorTags[0]` would make the client and server
+ * disagree about which cohort a chip selects.
+ */
+const PRIMARY_BEHAVIOR_PRIORITY = [
+  "looping",
+  "errored_tool",
+  "retried",
+  "multi_tool",
+  "two_tool",
+  "single_call",
+  "long_conversation",
+  "no_tools",
+] as const;
+
+/** The single behavior value for a thread, or null when it has no tags. */
+export function primaryBehaviorTag(
+  tags: readonly string[] | undefined | null,
+): string | null {
+  if (!tags || tags.length === 0) return null;
+  for (const candidate of PRIMARY_BEHAVIOR_PRIORITY) {
+    if (tags.includes(candidate)) return candidate;
+  }
+  return null;
+}
 
 /** Mirrors `SESSION_SENTIMENTS` in `convex/lib/usageInsights/signalEnums.ts`. */
 export const SESSION_SENTIMENTS = [
@@ -178,8 +264,27 @@ export function threadMatchesChip(
     case "behaviorTag":
       // Array-contains, not equality: the one multi-valued dimension.
       return thread.behaviorTags?.includes(chip.value) ?? false;
+    case "primaryBehavior": {
+      const primary = primaryBehaviorTag(thread.behaviorTags);
+      if (chip.value === UNLABELED_VALUE) return primary === null;
+      return primary === chip.value;
+    }
     case "pathKey":
       return thread.pathKey === chip.value;
+    case "criterion": {
+      const parsed = parseCriterionChipValue(chip.value);
+      if (!parsed) return false;
+      const result = (
+        thread.criteria?.status === "completed"
+          ? thread.criteria.results
+          : undefined
+      )?.find((r) => r.criterionId === parsed.criterionId);
+      // `ungraded` = no completed verdict for this criterion, whatever the
+      // reason — pending, grading failed, or a run that never carried it.
+      if (parsed.verdict === CRITERION_UNGRADED) return result === undefined;
+      if (result === undefined) return false;
+      return result.passed === (parsed.verdict === CRITERION_PASS);
+    }
     default:
       return false;
   }
@@ -191,9 +296,17 @@ function chipGroupKey(chip: UsageFilterChip): string {
   // this goal AND this behavior — into "either", a strictly wider cohort than
   // the link that was clicked. Two themes on the SAME axis still OR, which is
   // right: a session has one theme per axis, so requiring both matches nothing.
-  return chip.kind === "cluster"
-    ? `cluster:${chip.dimension ?? "goal"}`
-    : chip.key;
+  if (chip.kind === "cluster") return `cluster:${chip.dimension ?? "goal"}`;
+  // Criterion chips group PER CRITERION, not all under one `criterion` key.
+  // Each criterion is an independent boolean fact about a session, so chips on
+  // DIFFERENT criteria must AND ("failed A and failed B" is the cohort worth
+  // looking at) while pass/fail on the SAME criterion must OR — a session
+  // cannot be both, and requiring both would match nothing.
+  if (chip.key === "criterion") {
+    const parsed = parseCriterionChipValue(chip.value);
+    return parsed ? `criterion:${parsed.criterionId}` : "criterion:__invalid__";
+  }
+  return chip.key;
 }
 
 export function threadMatchesFilterState(

--- a/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
+++ b/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
@@ -274,14 +274,21 @@ export function threadMatchesChip(
     case "criterion": {
       const parsed = parseCriterionChipValue(chip.value);
       if (!parsed) return false;
+      const stamp = thread.criteria;
       const result = (
-        thread.criteria?.status === "completed"
-          ? thread.criteria.results
-          : undefined
+        stamp?.status === "completed" ? stamp.results : undefined
       )?.find((r) => r.criterionId === parsed.criterionId);
-      // `ungraded` = no completed verdict for this criterion, whatever the
-      // reason — pending, grading failed, or a run that never carried it.
-      if (parsed.verdict === CRITERION_UNGRADED) return result === undefined;
+      if (parsed.verdict === CRITERION_UNGRADED) {
+        // IN SCOPE but unverdicted — pending, or grading failed. A session
+        // whose run carried no rubric is not "ungraded for this criterion",
+        // it has nothing to do with this criterion; selecting it would make
+        // the cohort disagree with the facet count that offers the chip.
+        if (!stamp) return false;
+        const inScope =
+          stamp.criterionIds === undefined ||
+          stamp.criterionIds.includes(parsed.criterionId);
+        return inScope && result === undefined;
+      }
       if (result === undefined) return false;
       return result.passed === (parsed.verdict === CRITERION_PASS);
     }

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -4,6 +4,9 @@ import type {
   EvalTraceWidgetRenderObservationView,
 } from "@/shared/eval-trace";
 import type { SessionReadiness } from "@/components/chatboxes/session-readiness";
+// Type-only import, so the SharedChatThread import on the other side is not a
+// runtime cycle. One declaration of the backend contract, not two.
+import type { SessionCriteria } from "@/lib/swarm-api";
 import type { SessionSentiment } from "@/hooks/chatbox-usage-filters";
 
 export type SharedChatSourceType = "chatbox" | "swarm";
@@ -121,14 +124,7 @@ export interface SharedChatThread {
    * Absent on chatbox threads and on swarm threads whose run carried no
    * rubric — those render no criterion chip rather than a misleading 0/0.
    */
-  criteria?: {
-    status: "pending" | "completed" | "failed";
-    generation: number;
-    criterionIds?: string[];
-    /** Present on `completed` only. */
-    results?: Array<{ criterionId: string; passed: boolean }>;
-    gradedAt?: number;
-  };
+  criteria?: SessionCriteria;
   /**
    * Goal-completion judge verdict for SWARM sessions — the compact
    * denormalized `chatSessions.goalScore` subset (see backend

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -117,6 +117,19 @@ export interface SharedChatThread {
    */
   readiness?: SessionReadiness;
   /**
+   * Compact deterministic rubric verdict (mirrors `chatSessions.criteria`).
+   * Absent on chatbox threads and on swarm threads whose run carried no
+   * rubric — those render no criterion chip rather than a misleading 0/0.
+   */
+  criteria?: {
+    status: "pending" | "completed" | "failed";
+    generation: number;
+    criterionIds?: string[];
+    /** Present on `completed` only. */
+    results?: Array<{ criterionId: string; passed: boolean }>;
+    gradedAt?: number;
+  };
+  /**
    * Goal-completion judge verdict for SWARM sessions — the compact
    * denormalized `chatSessions.goalScore` subset (see backend
    * `convex/swarmJudge.ts`). Absent on non-swarm sessions and before the

--- a/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
+++ b/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
@@ -158,6 +158,21 @@ export type UsageScanMeta = {
   windowStartAt: number | null;
 };
 
+/**
+ * One criterion's tally. The three counts are disjoint and sum to the
+ * criterion's denominator — sessions from runs with NO rubric are excluded
+ * upstream rather than counted as ungraded.
+ */
+export type CriterionFacet = {
+  criterionId: string;
+  label?: string;
+  kind?: string;
+  passCount: number;
+  failCount: number;
+  /** No completed verdict: grading pending or grading failed. NOT "failed it". */
+  ungradedCount: number;
+};
+
 export type UsageBreakdown = {
   themes: Array<{ clusterId: string; label: string; count: number }>;
   userBreakdown: FeedbackBucketCount[];
@@ -175,6 +190,18 @@ export type UsageBreakdown = {
   sankey?: InsightsSankey;
   labeledOutcomeCount: number;
   outcomeFeedbackCalibration: OutcomeFeedbackCalibration[];
+  /**
+   * Per-criterion pass/fail tallies across the scanned sessions. `[]` on the
+   * chatbox surface (no rubric exists there); optional so a response from a
+   * server predating it still renders the rest of the panel.
+   *
+   * `label` / `kind` are resolved server-side from the RUN SNAPSHOTS the
+   * scanned sessions belong to — the definitions they were actually graded
+   * against — so a criterion renamed after a run still reads as it did then.
+   * Both absent ⇒ no run in the window named this id; the UI falls back to the
+   * raw id, which is ugly but never wrong.
+   */
+  criterionBreakdown?: CriterionFacet[];
   totalSessions: number;
   /** Optional so a stale/older server response still renders. */
   scan?: UsageScanMeta;

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -31,6 +31,8 @@ export const SWARM_QUERIES = {
   /** Sessions-tab metric strip aggregates (project-wide or persona-scoped). */
   getSwarmSessionMetrics: "journeyRuns:getSwarmSessionMetrics",
   listRunningPersonaRefIds: "journeyRuns:listRunningPersonaRefIds",
+  /** Deterministic rubric scorecard for one run (run detail panel). */
+  getRunScorecard: "journeyRuns:getRunScorecard",
   /** Project environments picker (env-based journeys — flag-gated UI). */
   listEnvironments: "projectEnvironments:listEnvironments",
   /**
@@ -176,6 +178,43 @@ export interface JourneySessionRow {
   };
   /** Server-denormalized judge verdict subset (see `swarmJudge.ts` backend). */
   goalScore?: SessionGoalScore;
+  /**
+   * Compact deterministic rubric verdict (mirrors `chatSessions.criteria`).
+   * Absent ⇒ the run carried no rubric, or the session predates grading —
+   * the matrix renders no chip at all rather than a misleading 0/0.
+   */
+  criteria?: SessionCriteria;
+}
+
+/** Mirrors `chatSessions.criteria` in the backend schema. */
+export interface SessionCriteria {
+  status: "pending" | "completed" | "failed";
+  generation: number;
+  /** Criteria this session was CLAIMED against; present in all three states. */
+  criterionIds?: string[];
+  /** Present on `completed` only. */
+  results?: Array<{ criterionId: string; passed: boolean }>;
+  gradedAt?: number;
+}
+
+/** One row of the run scorecard — mirrors `journeyRuns.getRunScorecard`. */
+export interface RunScorecardCriterion {
+  criterionId: string;
+  label?: string;
+  /** Predicate discriminator — the fallback label when `label` is unset. */
+  kind: string;
+  passCount: number;
+  failCount: number;
+  /** Claimed but unfinished, including a runner that died mid-grade. */
+  pendingCount: number;
+  /** Sessions whose GRADING broke — not sessions that failed the criterion. */
+  failedGradingCount: number;
+}
+
+export interface RunScorecard {
+  criteria: RunScorecardCriterion[];
+  sessionsTotal: number;
+  sessionsGraded: number;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -282,6 +282,9 @@ export function journeySessionRowToThread(
     personaId: row.personaRefId,
     personaLabel: row.personaLabel ?? fallbackPersonaName,
     readiness: row.readiness as SharedChatThread["readiness"] | undefined,
+    // Without this the shared criterion matcher sees a graded swarm session as
+    // having no stamp at all and classifies it `ungraded`.
+    criteria: row.criteria,
     goalScore: row.goalScore,
   };
 }

--- a/mcpjam-inspector/server/routes/web/swarm-runs.ts
+++ b/mcpjam-inspector/server/routes/web/swarm-runs.ts
@@ -381,6 +381,11 @@ swarmRuns.post("/journeys/:journeyId/runs", async (c) =>
           personaSnapshot: snapshot.personaSnapshot,
           sessionsPerHost: snapshot.sessionsPerHost,
           maxTurns: snapshot.maxTurns,
+          // Whether this run is rubric-graded at all. The runner only needs
+          // the yes/no — the criteria themselves come back from the claim, so
+          // the authoritative list is always the backend's pinned copy and
+          // never a value that rode along in process memory.
+          hasRubric: (snapshot.rubric?.length ?? 0) > 0,
           convexHttpUrl,
           bearer: bearerToken,
           authHeader,

--- a/mcpjam-inspector/server/services/checks/__tests__/run-swarm-checks.test.ts
+++ b/mcpjam-inspector/server/services/checks/__tests__/run-swarm-checks.test.ts
@@ -187,6 +187,20 @@ describe("runSwarmChecks", () => {
     expect(payload.criterionResults[0].reason).toContain("unavailable");
   });
 
+  it("treats a `{ ok: false }` COMPLETE as a failure, not a persisted verdict", async () => {
+    // The route answers 200 with `{ ok: false }` on a rejected payload. If the
+    // wrapper swallowed that, the runner would report `completed` while the
+    // check row sat `pending` forever.
+    claimSwarmChecksMock.mockResolvedValue(
+      claimResult([{ role: "user", content: "hi" }]),
+    );
+    completeSwarmChecksMock.mockRejectedValue(
+      new Error("Invalid response from backend completeSwarmChecks: rejected"),
+    );
+
+    await expect(runSwarmChecks(ARGS)).rejects.toThrow(/completeSwarmChecks/);
+  });
+
   it("grades an EMPTY-transcript session rather than skipping it", async () => {
     // A failed attempt that never produced a turn is still a graded session:
     // "no tool errors" holds trivially and "called search" does not, and both

--- a/mcpjam-inspector/server/services/checks/__tests__/run-swarm-checks.test.ts
+++ b/mcpjam-inspector/server/services/checks/__tests__/run-swarm-checks.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const claimSwarmChecksMock = vi.hoisted(() => vi.fn());
+const completeSwarmChecksMock = vi.hoisted(() => vi.fn());
+const failSwarmChecksMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../swarm-agent.js", () => ({
+  claimSwarmChecks: claimSwarmChecksMock,
+  completeSwarmChecks: completeSwarmChecksMock,
+  failSwarmChecks: failSwarmChecksMock,
+}));
+
+import { runSwarmChecks } from "../run-swarm-checks";
+import type { Predicate } from "@/shared/eval-matching";
+
+type Criterion = { id: string; label?: string; predicate: Predicate };
+
+const ARGS = {
+  convexHttpUrl: "https://backend.test",
+  bearer: "tok",
+  projectId: "proj_1",
+  runId: "run_1",
+  chatSessionId: "sess-ext-1",
+};
+
+const CRITERIA: Criterion[] = [
+  {
+    id: "crit-search",
+    label: "Searched",
+    predicate: { type: "toolCalledAtLeastOnce" as const, toolName: "search" },
+  },
+  {
+    id: "crit-quick",
+    predicate: { type: "turnCountUnder" as const, turns: 3 },
+  },
+];
+
+function claimResult(
+  messages: Array<Record<string, unknown>> | null,
+  criteria: Criterion[] = CRITERIA,
+) {
+  return {
+    claimed: true as const,
+    generation: 1,
+    checkDocId: "check_1",
+    sessionDocId: "session_1",
+    criteria,
+    envelope: messages === null ? null : { messages },
+  };
+}
+
+describe("runSwarmChecks", () => {
+  beforeEach(() => {
+    claimSwarmChecksMock.mockReset();
+    completeSwarmChecksMock.mockReset().mockResolvedValue(undefined);
+    failSwarmChecksMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("evaluates the pinned criteria and correlates verdicts back by criterionId", async () => {
+    claimSwarmChecksMock.mockResolvedValue(
+      claimResult([
+        { role: "user", content: "help" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool-call", toolName: "search", input: { q: "refund" } },
+          ],
+        },
+        { role: "assistant", content: [{ type: "text", text: "done" }] },
+      ]),
+    );
+
+    const outcome = await runSwarmChecks(ARGS);
+
+    expect(outcome.status).toBe("completed");
+    const [, , payload] = completeSwarmChecksMock.mock.calls[0];
+    expect(payload.criterionResults).toEqual([
+      expect.objectContaining({ criterionId: "crit-search", passed: true }),
+      // One user turn, budget 3 ⇒ passes strictly under.
+      expect.objectContaining({ criterionId: "crit-quick", passed: true }),
+    ]);
+    // The generation from the claim is echoed back so a stale grade no-ops
+    // server-side.
+    expect(payload.generation).toBe(1);
+    expect(payload.checkDocId).toBe("check_1");
+  });
+
+  it("fails a criterion whose predicate is not satisfied — a normal COMPLETED verdict", async () => {
+    claimSwarmChecksMock.mockResolvedValue(
+      claimResult([
+        { role: "user", content: "one" },
+        { role: "user", content: "two" },
+        { role: "user", content: "three" },
+        { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      ]),
+    );
+
+    const outcome = await runSwarmChecks(ARGS);
+
+    expect(outcome.status).toBe("completed");
+    expect(failSwarmChecksMock).not.toHaveBeenCalled();
+    const [, , payload] = completeSwarmChecksMock.mock.calls[0];
+    // Never called `search`, and used exactly 3 turns against a strict `< 3`.
+    expect(payload.criterionResults.map((r: any) => r.passed)).toEqual([
+      false,
+      false,
+    ]);
+    // Reasons carry the evidence; the compact session stamp will not.
+    expect(payload.criterionResults[1].reason).toContain("3");
+  });
+
+  it("CLAIMS before it evaluates, so a crash mid-grade leaves a visible pending", async () => {
+    const order: string[] = [];
+    claimSwarmChecksMock.mockImplementation(async () => {
+      order.push("claim");
+      return claimResult([{ role: "user", content: "hi" }]);
+    });
+    completeSwarmChecksMock.mockImplementation(async () => {
+      order.push("complete");
+    });
+
+    await runSwarmChecks(ARGS);
+
+    expect(order).toEqual(["claim", "complete"]);
+  });
+
+  it("skips entirely when the run carries no rubric — nothing is stamped", async () => {
+    claimSwarmChecksMock.mockResolvedValue(null);
+
+    const outcome = await runSwarmChecks(ARGS);
+
+    expect(outcome).toEqual({ status: "skipped", reason: "no_rubric" });
+    expect(completeSwarmChecksMock).not.toHaveBeenCalled();
+    expect(failSwarmChecksMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a FAILED grade when the envelope has no readable messages", async () => {
+    claimSwarmChecksMock.mockResolvedValue(claimResult(null));
+
+    const outcome = await runSwarmChecks(ARGS);
+
+    expect(outcome).toEqual({
+      status: "failed",
+      error: "transcript envelope unreadable",
+    });
+    expect(failSwarmChecksMock).toHaveBeenCalledTimes(1);
+    expect(completeSwarmChecksMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows a secondary failure while reporting the primary one", async () => {
+    claimSwarmChecksMock.mockResolvedValue(claimResult(null));
+    failSwarmChecksMock.mockRejectedValue(new Error("network down"));
+
+    // The claim's `pending` stamp is the honest fallback; masking the real
+    // cause with a transport error would help nobody.
+    await expect(runSwarmChecks(ARGS)).resolves.toEqual({
+      status: "failed",
+      error: "transcript envelope unreadable",
+    });
+  });
+
+  it("propagates a CLAIM failure — nothing was stamped, so there is no half-state", async () => {
+    claimSwarmChecksMock.mockRejectedValue(new Error("403 forbidden"));
+
+    await expect(runSwarmChecks(ARGS)).rejects.toThrow("403 forbidden");
+    expect(completeSwarmChecksMock).not.toHaveBeenCalled();
+    expect(failSwarmChecksMock).not.toHaveBeenCalled();
+  });
+
+  it("fails tokenBudgetUnder closed — swarm envelopes carry no token accounting", async () => {
+    claimSwarmChecksMock.mockResolvedValue(
+      claimResult([{ role: "user", content: "hi" }], [
+        {
+          id: "crit-tokens",
+          predicate: { type: "tokenBudgetUnder" as const, tokens: 1_000_000 },
+        },
+      ]),
+    );
+
+    await runSwarmChecks(ARGS);
+
+    const [, , payload] = completeSwarmChecksMock.mock.calls[0];
+    expect(payload.criterionResults[0]).toMatchObject({
+      criterionId: "crit-tokens",
+      passed: false,
+    });
+    expect(payload.criterionResults[0].reason).toContain("unavailable");
+  });
+
+  it("grades an EMPTY-transcript session rather than skipping it", async () => {
+    // A failed attempt that never produced a turn is still a graded session:
+    // "no tool errors" holds trivially and "called search" does not, and both
+    // are facts worth having.
+    claimSwarmChecksMock.mockResolvedValue(claimResult([]));
+
+    const outcome = await runSwarmChecks(ARGS);
+
+    expect(outcome.status).toBe("completed");
+    const [, , payload] = completeSwarmChecksMock.mock.calls[0];
+    expect(payload.criterionResults).toHaveLength(2);
+    expect(payload.criterionResults[0].passed).toBe(false);
+    // Zero user turns is a real reading, not absence, so `< 3` passes.
+    expect(payload.criterionResults[1].passed).toBe(true);
+  });
+});

--- a/mcpjam-inspector/server/services/checks/run-predicates-on-chat-session.ts
+++ b/mcpjam-inspector/server/services/checks/run-predicates-on-chat-session.ts
@@ -83,7 +83,7 @@ export interface RunPredicatesOnChatSessionResult {
  * `messages` (for tool-call extraction + final-message derivation) and
  * `spans` (for tool-error classification via `extractToolErrors`).
  */
-interface ChatSessionEnvelope {
+export interface ChatSessionEnvelope {
   traceVersion?: number;
   messages: Array<{ role: string; content: unknown }>;
   spans?: Array<Record<string, unknown>>;
@@ -106,7 +106,7 @@ interface ChatSessionEnvelope {
  * here — the envelope is a persisted transcript, not a live run — so the
  * `steps` branch is omitted.
  */
-function extractToolCallsFromEnvelopeMessages(
+export function extractToolCallsFromEnvelopeMessages(
   messages: ChatSessionEnvelope["messages"],
 ): TranscriptToolCall[] {
   const toolsCalled: TranscriptToolCall[] = [];

--- a/mcpjam-inspector/server/services/checks/run-swarm-checks.ts
+++ b/mcpjam-inspector/server/services/checks/run-swarm-checks.ts
@@ -29,7 +29,10 @@ import {
   buildIterationTranscript,
   evaluatePredicates,
 } from "@/shared/eval-matching";
-import type { TranscriptToolCall } from "@/shared/eval-matching";
+import {
+  extractToolCallsFromEnvelopeMessages,
+  type ChatSessionEnvelope,
+} from "./run-predicates-on-chat-session.js";
 import {
   claimSwarmChecks,
   completeSwarmChecks,
@@ -53,81 +56,10 @@ export type RunSwarmChecksOutcome =
   | { status: "failed"; error: string };
 
 /**
- * A message as it comes off the persisted envelope. `role` is `string` (not a
- * narrowed union) because the envelope is data we read back, not data we
- * construct — an unrecognized role must flow through and be ignored, not
- * fail the type.
+ * A message as it comes off the persisted envelope. Borrowed from the on-demand
+ * checks path so both graders read the same shape.
  */
-type EnvelopeMessage = { role: string; content: unknown; toolCalls?: unknown };
-
-/**
- * Pull tool calls out of the persisted envelope in the order they appear.
- *
- * Mirrors `extractToolCallsFromEnvelopeMessages` in
- * `run-predicates-on-chat-session.ts`, INCLUDING its identity-based dedupe
- * (same tool + same args collapses to one entry). That dedupe is a known
- * limitation inherited from the eval path: a session that legitimately called
- * one tool twice with identical arguments reads as one call, so
- * `toolCalledWith` with `minCount > 1` can under-count. Reproducing the
- * behavior is deliberate — the two surfaces must agree on what a transcript
- * says, and fixing it in one place only would make the same session grade
- * differently depending on who asked.
- */
-function extractToolCalls(messages: EnvelopeMessage[]): TranscriptToolCall[] {
-  const toolsCalled: TranscriptToolCall[] = [];
-
-  const push = (name: string, argumentsValue: Record<string, unknown>) => {
-    const argsKey = JSON.stringify(argumentsValue);
-    const alreadyAdded = toolsCalled.some(
-      (call) =>
-        call.toolName === name && JSON.stringify(call.arguments) === argsKey,
-    );
-    if (!alreadyAdded) toolsCalled.push({ toolName: name, arguments: argumentsValue });
-  };
-
-  for (const msg of messages) {
-    if (!msg || msg.role !== "assistant") continue;
-
-    if (Array.isArray(msg.content)) {
-      for (const item of msg.content) {
-        if (
-          !item ||
-          typeof item !== "object" ||
-          (item as { type?: unknown }).type !== "tool-call"
-        ) {
-          continue;
-        }
-        const rec = item as Record<string, unknown>;
-        const name = (rec.toolName ?? rec.name) as string | undefined;
-        if (!name) continue;
-        push(
-          name,
-          (rec.input as Record<string, unknown> | undefined) ??
-            (rec.parameters as Record<string, unknown> | undefined) ??
-            (rec.args as Record<string, unknown> | undefined) ??
-            {},
-        );
-      }
-    }
-
-    if (Array.isArray(msg.toolCalls)) {
-      for (const call of msg.toolCalls) {
-        if (!call || typeof call !== "object") continue;
-        const rec = call as Record<string, unknown>;
-        const name = (rec.toolName ?? rec.name) as string | undefined;
-        if (!name) continue;
-        push(
-          name,
-          (rec.args as Record<string, unknown> | undefined) ??
-            (rec.input as Record<string, unknown> | undefined) ??
-            {},
-        );
-      }
-    }
-  }
-
-  return toolsCalled;
-}
+type EnvelopeMessage = ChatSessionEnvelope["messages"][number];
 
 /** User-role messages — the unit `turnCountUnder` grades against. */
 function countUserTurns(messages: EnvelopeMessage[]): number {
@@ -138,9 +70,14 @@ function countUserTurns(messages: EnvelopeMessage[]): number {
  * Grade one session against its run's pinned rubric.
  *
  * Returns an outcome rather than throwing for the expected cases (no rubric,
- * grading failed) so the caller's log line can say what happened. Throws only
- * when the CLAIM itself fails — at that point nothing was stamped, so there is
- * no half-state to report.
+ * grading failed) so the caller's log line can say what happened. Throws for
+ * transport failures at the two ENDS of the flow, and only there:
+ *
+ *   - the CLAIM — nothing was stamped yet, so there is no half-state to report;
+ *   - the COMPLETE — the claim's `pending` stamp stands, which is honest and
+ *     re-runnable, so there is nothing better to write.
+ *
+ * Everything between them is caught and reported as a `failed` grade.
  */
 export async function runSwarmChecks(
   args: RunSwarmChecksArgs,
@@ -198,7 +135,12 @@ export async function runSwarmChecks(
           ? { spans: claim.envelope.spans as never[] }
           : {}),
       },
-      toolCalls: extractToolCalls(messages),
+      // The SHARED walker, not a copy: two extractors would let an
+      // envelope-format or dedupe fix land on one grading path and not the
+      // other, so the same session could grade differently depending on who
+      // asked. (Its identity dedupe — same tool + same args collapses to one
+      // entry — is a known limitation, now a single known limitation.)
+      toolCalls: extractToolCallsFromEnvelopeMessages(messages),
       // Swarm sessions carry no per-iteration token accounting on the
       // persisted envelope, so `tokenBudgetUnder` fails closed here by design.
       usage: undefined,

--- a/mcpjam-inspector/server/services/checks/run-swarm-checks.ts
+++ b/mcpjam-inspector/server/services/checks/run-swarm-checks.ts
@@ -1,0 +1,240 @@
+/**
+ * Deterministic rubric grading for one swarm (journey) session.
+ *
+ * Why this lives inspector-side: Convex functions cannot import `@mcpjam/sdk`
+ * (the bundling isolation that also forces `convex/lib/predicates.ts` to
+ * hand-mirror the SDK's predicate union). The backend owns persistence and the
+ * generation guard; the evaluation itself has to run where the evaluator does.
+ *
+ * The shape of the flow is load-bearing:
+ *
+ *   1. CLAIM — durable `pending` state, plus the transcript envelope, in one
+ *      authorized round trip. Claiming FIRST is what makes a runner crash
+ *      mid-grade survivable: the session reads "pending" (visible, re-runnable)
+ *      instead of carrying no stamp, which downstream reads as "this run had
+ *      no rubric" and would silently shrink every denominator.
+ *   2. EVALUATE — the same `evaluatePredicates` the eval runner calls, over a
+ *      transcript built the same way `run-predicates-on-chat-session.ts`
+ *      builds one.
+ *   3. COMPLETE or FAIL — verdicts correlated back to `criterionId`
+ *      positionally, which is sound here and only here: `entries.map(…)` and
+ *      the result array come from a single call with order preserved by
+ *      contract. Nothing else in the system correlates by position.
+ *
+ * The caller (`swarm-runner.ts`) awaits this inside a try/catch. Grading is
+ * never allowed to affect the attempt it graded.
+ */
+
+import {
+  buildIterationTranscript,
+  evaluatePredicates,
+} from "@/shared/eval-matching";
+import type { TranscriptToolCall } from "@/shared/eval-matching";
+import {
+  claimSwarmChecks,
+  completeSwarmChecks,
+  failSwarmChecks,
+  type SwarmCriterionResult,
+} from "../swarm-agent.js";
+
+export interface RunSwarmChecksArgs {
+  convexHttpUrl: string;
+  bearer: string;
+  projectId: string;
+  runId: string;
+  /** The attempt's EXTERNAL session id; the backend resolves it within the run. */
+  chatSessionId: string;
+  signal?: AbortSignal;
+}
+
+export type RunSwarmChecksOutcome =
+  | { status: "skipped"; reason: "no_rubric" }
+  | { status: "completed"; results: SwarmCriterionResult[] }
+  | { status: "failed"; error: string };
+
+/**
+ * A message as it comes off the persisted envelope. `role` is `string` (not a
+ * narrowed union) because the envelope is data we read back, not data we
+ * construct — an unrecognized role must flow through and be ignored, not
+ * fail the type.
+ */
+type EnvelopeMessage = { role: string; content: unknown; toolCalls?: unknown };
+
+/**
+ * Pull tool calls out of the persisted envelope in the order they appear.
+ *
+ * Mirrors `extractToolCallsFromEnvelopeMessages` in
+ * `run-predicates-on-chat-session.ts`, INCLUDING its identity-based dedupe
+ * (same tool + same args collapses to one entry). That dedupe is a known
+ * limitation inherited from the eval path: a session that legitimately called
+ * one tool twice with identical arguments reads as one call, so
+ * `toolCalledWith` with `minCount > 1` can under-count. Reproducing the
+ * behavior is deliberate — the two surfaces must agree on what a transcript
+ * says, and fixing it in one place only would make the same session grade
+ * differently depending on who asked.
+ */
+function extractToolCalls(messages: EnvelopeMessage[]): TranscriptToolCall[] {
+  const toolsCalled: TranscriptToolCall[] = [];
+
+  const push = (name: string, argumentsValue: Record<string, unknown>) => {
+    const argsKey = JSON.stringify(argumentsValue);
+    const alreadyAdded = toolsCalled.some(
+      (call) =>
+        call.toolName === name && JSON.stringify(call.arguments) === argsKey,
+    );
+    if (!alreadyAdded) toolsCalled.push({ toolName: name, arguments: argumentsValue });
+  };
+
+  for (const msg of messages) {
+    if (!msg || msg.role !== "assistant") continue;
+
+    if (Array.isArray(msg.content)) {
+      for (const item of msg.content) {
+        if (
+          !item ||
+          typeof item !== "object" ||
+          (item as { type?: unknown }).type !== "tool-call"
+        ) {
+          continue;
+        }
+        const rec = item as Record<string, unknown>;
+        const name = (rec.toolName ?? rec.name) as string | undefined;
+        if (!name) continue;
+        push(
+          name,
+          (rec.input as Record<string, unknown> | undefined) ??
+            (rec.parameters as Record<string, unknown> | undefined) ??
+            (rec.args as Record<string, unknown> | undefined) ??
+            {},
+        );
+      }
+    }
+
+    if (Array.isArray(msg.toolCalls)) {
+      for (const call of msg.toolCalls) {
+        if (!call || typeof call !== "object") continue;
+        const rec = call as Record<string, unknown>;
+        const name = (rec.toolName ?? rec.name) as string | undefined;
+        if (!name) continue;
+        push(
+          name,
+          (rec.args as Record<string, unknown> | undefined) ??
+            (rec.input as Record<string, unknown> | undefined) ??
+            {},
+        );
+      }
+    }
+  }
+
+  return toolsCalled;
+}
+
+/** User-role messages — the unit `turnCountUnder` grades against. */
+function countUserTurns(messages: EnvelopeMessage[]): number {
+  return messages.filter((msg) => msg?.role === "user").length;
+}
+
+/**
+ * Grade one session against its run's pinned rubric.
+ *
+ * Returns an outcome rather than throwing for the expected cases (no rubric,
+ * grading failed) so the caller's log line can say what happened. Throws only
+ * when the CLAIM itself fails — at that point nothing was stamped, so there is
+ * no half-state to report.
+ */
+export async function runSwarmChecks(
+  args: RunSwarmChecksArgs,
+): Promise<RunSwarmChecksOutcome> {
+  const { convexHttpUrl, bearer, projectId, runId, chatSessionId, signal } =
+    args;
+
+  const claim = await claimSwarmChecks(
+    convexHttpUrl,
+    bearer,
+    { projectId, runId, chatSessionId },
+    signal,
+  );
+  // No rubric pinned on the run. Nothing was stamped, and nothing should be:
+  // absence of the stamp is the signal that keeps criterion denominators
+  // honest.
+  if (claim === null) return { status: "skipped", reason: "no_rubric" };
+
+  const reportFailure = async (error: string): Promise<RunSwarmChecksOutcome> => {
+    try {
+      await failSwarmChecks(
+        convexHttpUrl,
+        bearer,
+        {
+          projectId,
+          runId,
+          sessionDocId: claim.sessionDocId,
+          checkDocId: claim.checkDocId,
+          generation: claim.generation,
+          error,
+        },
+        signal,
+      );
+    } catch {
+      // The `pending` stamp already left by the claim is the honest fallback
+      // here, and it is re-runnable. Masking the real failure with a secondary
+      // transport error would help nobody.
+    }
+    return { status: "failed", error };
+  };
+
+  const messages = Array.isArray(claim.envelope?.messages)
+    ? (claim.envelope.messages as EnvelopeMessage[])
+    : null;
+  if (messages === null) {
+    return reportFailure("transcript envelope unreadable");
+  }
+
+  let criterionResults: SwarmCriterionResult[];
+  try {
+    const transcript = buildIterationTranscript({
+      trace: {
+        messages,
+        ...(claim.envelope?.spans
+          ? { spans: claim.envelope.spans as never[] }
+          : {}),
+      },
+      toolCalls: extractToolCalls(messages),
+      // Swarm sessions carry no per-iteration token accounting on the
+      // persisted envelope, so `tokenBudgetUnder` fails closed here by design.
+      usage: undefined,
+      turnCount: countUserTurns(messages),
+    });
+
+    const results = evaluatePredicates(
+      transcript,
+      claim.criteria.map((entry) => entry.predicate),
+    );
+    // Positional correlation — sound because both arrays come from the same
+    // `claim.criteria` in the same call, and `evaluatePredicates` preserves
+    // order by contract. Everything downstream is keyed by `criterionId`.
+    criterionResults = claim.criteria.map((entry, index) => ({
+      criterionId: entry.id,
+      passed: results[index]?.passed ?? false,
+      reason: results[index]?.reason ?? "evaluator returned no verdict",
+    }));
+  } catch (error) {
+    return reportFailure(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  await completeSwarmChecks(
+    convexHttpUrl,
+    bearer,
+    {
+      projectId,
+      runId,
+      sessionDocId: claim.sessionDocId,
+      checkDocId: claim.checkDocId,
+      generation: claim.generation,
+      criterionResults,
+    },
+    signal,
+  );
+  return { status: "completed", results: criterionResults };
+}

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.rubric.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.rubric.test.ts
@@ -174,9 +174,12 @@ describe("swarm runner — rubric grading hook", () => {
     );
 
     const running = startJourneyRun(baseOpts());
-    // Give the loop a chance to reach the grading call, then release it. If
-    // grading were fire-and-forget the run would already be over by now.
-    await new Promise((r) => setTimeout(r, 50));
+    // Wait for the grading call to actually happen rather than for a fixed
+    // delay: a loaded CI worker that took longer than the sleep would leave
+    // `resolveGrade` unset and hang `await running` forever.
+    await vi.waitFor(() => expect(runSwarmChecksMock).toHaveBeenCalledTimes(1));
+    // The run is parked on the deferred grade — proof it is awaited rather
+    // than fire-and-forget.
     expect(gradeSettled).toBe(false);
     resolveGrade?.();
     await running;

--- a/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.rubric.test.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/__tests__/swarm-runner.rubric.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The runner's rubric-grading hook.
+ *
+ * The contract worth protecting is not "grading works" — that lives in
+ * `run-swarm-checks.test.ts`. It is that grading is WIRED correctly:
+ *
+ *   - it fires for every terminal attempt that produced a session, INCLUDING
+ *     failed ones (that is where tool-error and turn-count criteria pay off);
+ *   - it is AWAITED, so a runner that dies mid-grade has already left a
+ *     durable `pending`;
+ *   - it can never take the attempt or the host loop down with it.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const reportAttemptMock = vi.fn();
+const swarmPersonaNextTurnMock = vi.fn();
+const heartbeatJourneyRunMock = vi.fn();
+const finalizePendingAttemptsMock = vi.fn();
+const fetchPinnedSkillMock = vi.fn();
+const runSyntheticHostSessionMock = vi.fn();
+const captureWidgetSnapshotsMock = vi.fn();
+const runSwarmChecksMock = vi.fn();
+
+vi.mock("../../swarm-agent.js", async () => {
+  const actual = await vi.importActual<typeof import("../../swarm-agent.js")>(
+    "../../swarm-agent.js",
+  );
+  return {
+    ...actual,
+    reportAttempt: (...args: unknown[]) => reportAttemptMock(...args),
+    swarmPersonaNextTurn: (...args: unknown[]) =>
+      swarmPersonaNextTurnMock(...args),
+    heartbeatJourneyRun: (...args: unknown[]) =>
+      heartbeatJourneyRunMock(...args),
+    finalizePendingAttempts: (...args: unknown[]) =>
+      finalizePendingAttemptsMock(...args),
+    fetchPinnedSkill: (...args: unknown[]) => fetchPinnedSkillMock(...args),
+  };
+});
+
+vi.mock("../runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../runner.js")>(
+    "../runner.js",
+  );
+  return {
+    ...actual,
+    runSyntheticHostSession: (...args: unknown[]) =>
+      runSyntheticHostSessionMock(...args),
+    captureAndPersistWidgetSnapshotsForSession: (...args: unknown[]) =>
+      captureWidgetSnapshotsMock(...args),
+  };
+});
+
+vi.mock("../../checks/run-swarm-checks.js", () => ({
+  runSwarmChecks: (...args: unknown[]) => runSwarmChecksMock(...args),
+}));
+
+import { startJourneyRun } from "../swarm-runner.js";
+import { __clearPinnedSkillCacheForTest } from "../pinned-skill-cache.js";
+
+const HOST = {
+  hostId: "host-1",
+  hostName: "Host One",
+  hostConfigId: "hc-1",
+  modelId: "anthropic/claude-haiku-4.5",
+  systemPrompt: "sys",
+  requireToolApproval: false,
+  serverIds: ["server-1"],
+};
+
+function baseOpts(overrides: Record<string, unknown> = {}) {
+  return {
+    runId: "run-1",
+    projectId: "proj-1",
+    hosts: [HOST],
+    personaSnapshot: {
+      personaId: "p1",
+      name: "Persona One",
+      role: "tester",
+      notes: "",
+    },
+    sessionsPerHost: 1,
+    maxTurns: 3,
+    hasRubric: true,
+    convexHttpUrl: "https://convex.site",
+    bearer: "token",
+    authHeader: "Bearer token",
+    managerFactory: async () => ({
+      manager: {} as never,
+      connectedServerIds: ["server-1"],
+      dispose: async () => {},
+    }),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  reportAttemptMock.mockReset().mockResolvedValue({ ok: true, applied: true });
+  swarmPersonaNextTurnMock.mockReset();
+  heartbeatJourneyRunMock.mockReset().mockResolvedValue(undefined);
+  finalizePendingAttemptsMock.mockReset().mockResolvedValue(undefined);
+  fetchPinnedSkillMock.mockReset();
+  runSyntheticHostSessionMock.mockReset().mockResolvedValue({
+    outcome: "succeeded",
+  });
+  runSwarmChecksMock
+    .mockReset()
+    .mockResolvedValue({ status: "completed", results: [] });
+  __clearPinnedSkillCacheForTest();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("swarm runner — rubric grading hook", () => {
+  it("grades a succeeded attempt with the session the attempt claimed", async () => {
+    await startJourneyRun(baseOpts());
+
+    expect(runSwarmChecksMock).toHaveBeenCalledTimes(1);
+    const call = runSwarmChecksMock.mock.calls[0][0];
+    expect(call).toMatchObject({ projectId: "proj-1", runId: "run-1" });
+    // The SAME deterministic session id the terminal reported — grading a
+    // different session would silently attribute the verdict to the wrong row.
+    const terminal = reportAttemptMock.mock.calls
+      .map((c) => c[2] as { status: string; chatSessionId?: string })
+      .find((a) => a.status === "succeeded");
+    expect(call.chatSessionId).toBe(terminal?.chatSessionId);
+  });
+
+  it("ALSO grades a failed attempt — that is where error criteria pay off", async () => {
+    runSyntheticHostSessionMock.mockResolvedValue({
+      outcome: "failed",
+      errorMessage: "tool blew up",
+    });
+
+    await startJourneyRun(baseOpts());
+
+    expect(runSwarmChecksMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT grade a rate-limited attempt — no session, no transcript", async () => {
+    runSyntheticHostSessionMock.mockResolvedValue({
+      outcome: "rate_limited",
+      errorMessage: "429 from provider",
+    });
+
+    await startJourneyRun(baseOpts());
+
+    expect(runSwarmChecksMock).not.toHaveBeenCalled();
+  });
+
+  it("does not call the grader at all when the run has no rubric", async () => {
+    await startJourneyRun(baseOpts({ hasRubric: false }));
+
+    expect(runSwarmChecksMock).not.toHaveBeenCalled();
+    // The attempt itself is unaffected.
+    expect(
+      reportAttemptMock.mock.calls.some((c) => (c[2] as any).status === "succeeded"),
+    ).toBe(true);
+  });
+
+  it("AWAITS grading — the run does not finish before the grade lands", async () => {
+    let resolveGrade: (() => void) | undefined;
+    let gradeSettled = false;
+    runSwarmChecksMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveGrade = () => {
+            gradeSettled = true;
+            resolve({ status: "completed", results: [] });
+          };
+        }),
+    );
+
+    const running = startJourneyRun(baseOpts());
+    // Give the loop a chance to reach the grading call, then release it. If
+    // grading were fire-and-forget the run would already be over by now.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(gradeSettled).toBe(false);
+    resolveGrade?.();
+    await running;
+
+    expect(gradeSettled).toBe(true);
+  });
+
+  it("ISOLATES a grading throw — the attempt and the host loop are untouched", async () => {
+    runSwarmChecksMock.mockRejectedValue(new Error("backend exploded"));
+
+    await expect(
+      startJourneyRun(baseOpts({ sessionsPerHost: 2 })),
+    ).resolves.toBeUndefined();
+
+    // Both sessions still ran and both reported their terminal.
+    expect(runSyntheticHostSessionMock).toHaveBeenCalledTimes(2);
+    const terminals = reportAttemptMock.mock.calls
+      .map((c) => c[2] as { status: string })
+      .filter((a) => a.status === "succeeded");
+    expect(terminals).toHaveLength(2);
+  });
+
+  it("grades AFTER the terminal is reported, so the transcript is durable first", async () => {
+    const order: string[] = [];
+    reportAttemptMock.mockImplementation(async (_url, _bearer, args: any) => {
+      order.push(`report:${args.status}`);
+      return { ok: true, applied: true };
+    });
+    runSwarmChecksMock.mockImplementation(async () => {
+      order.push("grade");
+      return { status: "completed", results: [] };
+    });
+
+    await startJourneyRun(baseOpts());
+
+    expect(order).toEqual(["report:running", "report:succeeded", "grade"]);
+  });
+});

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -1081,7 +1081,15 @@ async function runJourneyFanOut(
                 projectId,
                 runId,
                 chatSessionId,
-                signal: sessionSignal,
+                // DELIBERATELY not `sessionSignal`. That signal aborts on
+                // shutdown and on an org spend-cap trip anywhere in the run —
+                // both of which can already be set by the time this line is
+                // reached, since the session has finished and its terminal is
+                // reported. Passing it would abort the CLAIM, leaving no
+                // `pending` stamp at all, and a session with no stamp reads
+                // downstream as "this run had no rubric". Grading is bounded by
+                // its own per-request timeout, so an unsignalled call cannot
+                // hold shutdown open.
               });
               if (graded.status === "failed") {
                 logger.warn("[swarm.runner] rubric grading failed", {

--- a/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
+++ b/mcpjam-inspector/server/services/sessionSimulation/swarm-runner.ts
@@ -16,6 +16,7 @@ import {
   type PinnedSkillMeta,
   type SwarmAttemptStatus,
 } from "../swarm-agent.js";
+import { runSwarmChecks } from "../checks/run-swarm-checks.js";
 import { createBrowserArtifactOutbox } from "../browser-artifact-outbox.js";
 import {
   canProvisionSwarmSandboxes,
@@ -117,6 +118,12 @@ export interface StartJourneyRunOptions {
   personaSnapshot: PersonaSnapshot;
   sessionsPerHost: number;
   maxTurns: number;
+  /**
+   * True when the run's pinned snapshot carries a non-empty rubric. Only a
+   * gate — the criteria themselves come back from the claim, so the graded
+   * definition is always the backend's pinned copy.
+   */
+  hasRubric?: boolean;
   convexHttpUrl: string;
   /** Launching member's bearer TOKEN for `/journey-execution/*` calls. */
   bearer: string;
@@ -301,6 +308,7 @@ async function runJourneyFanOut(
     personaSnapshot,
     sessionsPerHost,
     maxTurns,
+    hasRubric,
     convexHttpUrl,
     bearer,
     authHeader,
@@ -1049,6 +1057,56 @@ async function runJourneyFanOut(
               status: terminal.status,
               error: err instanceof Error ? err.message : String(err),
             });
+          }
+
+          // Deterministic rubric grading, AWAITED and non-fatal.
+          //
+          // Awaited, not fire-and-forget: the claim has to be durable before
+          // this attempt's slot is reused, so a crash leaves a visible
+          // `pending` rather than nothing. Non-fatal: a grading failure is
+          // recorded on the session and never touches the attempt or the host
+          // loop — the run's job is producing sessions, not grading them.
+          //
+          // Runs for BOTH `succeeded` and `failed` terminals. A failed session
+          // is exactly where "no tool errors" and "fewer than N turns" earn
+          // their keep; grading only the happy path would blind the scorecard
+          // to the sessions worth looking at. Skipped only when the run has no
+          // rubric or when there is no session to read a transcript from —
+          // a `rate_limited` attempt never produced one.
+          if (hasRubric && terminal.status !== "rate_limited") {
+            try {
+              const graded = await runSwarmChecks({
+                convexHttpUrl,
+                bearer,
+                projectId,
+                runId,
+                chatSessionId,
+                signal: sessionSignal,
+              });
+              if (graded.status === "failed") {
+                logger.warn("[swarm.runner] rubric grading failed", {
+                  runId,
+                  hostId,
+                  targetId,
+                  sessionIdx,
+                  error: graded.error,
+                });
+              }
+            } catch (err) {
+              logEvent("attempt.checks_failed", {
+                runId,
+                hostId,
+                targetId,
+                sessionIdx,
+              });
+              logger.error("[swarm.runner] rubric grading threw", {
+                runId,
+                hostId,
+                targetId,
+                sessionIdx,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
           }
 
           logEvent("attempt.finish", {

--- a/mcpjam-inspector/server/services/swarm-agent.ts
+++ b/mcpjam-inspector/server/services/swarm-agent.ts
@@ -594,7 +594,14 @@ export async function claimSwarmChecks(
   };
 }
 
-/** Persist a finished rubric verdict. Generation-guarded backend-side. */
+/**
+ * Persist a finished rubric verdict. Generation-guarded backend-side.
+ *
+ * A 2xx is NOT enough: the route answers `{ ok: false, error }` on a rejected
+ * payload, and treating that as persisted would let the runner report
+ * `completed` while the check row sat `pending` forever. Same `ok !== true`
+ * guard `reportAttempt` and `heartbeatJourneyRun` use.
+ */
 export async function completeSwarmChecks(
   convexHttpUrl: string,
   bearer: string,
@@ -608,18 +615,28 @@ export async function completeSwarmChecks(
   },
   signal?: AbortSignal
 ): Promise<void> {
-  await postJson<{ ok?: boolean }>(
+  const data = await postJson<{ ok?: boolean; error?: string }>(
     `${convexHttpUrl}/journey-execution/runs/checks/complete`,
     bearer,
     args,
     NON_LLM_TIMEOUT_MS,
     signal
   );
+  if (data.ok !== true) {
+    throw new Error(
+      `Invalid response from backend completeSwarmChecks: ${
+        data.error ?? "unknown error"
+      }`
+    );
+  }
 }
 
 /**
  * Record that GRADING failed — an unreadable transcript, an evaluator throw.
  * Distinct from criteria failing, which is a completed verdict.
+ *
+ * Same `ok !== true` guard as `completeSwarmChecks`: a rejected payload must
+ * not read as "the failure was recorded".
  */
 export async function failSwarmChecks(
   convexHttpUrl: string,
@@ -634,13 +651,20 @@ export async function failSwarmChecks(
   },
   signal?: AbortSignal
 ): Promise<void> {
-  await postJson<{ ok?: boolean }>(
+  const data = await postJson<{ ok?: boolean; error?: string }>(
     `${convexHttpUrl}/journey-execution/runs/checks/fail`,
     bearer,
     args,
     NON_LLM_TIMEOUT_MS,
     signal
   );
+  if (data.ok !== true) {
+    throw new Error(
+      `Invalid response from backend failSwarmChecks: ${
+        data.error ?? "unknown error"
+      }`
+    );
+  }
 }
 
 export async function heartbeatJourneyRun(

--- a/mcpjam-inspector/server/services/swarm-agent.ts
+++ b/mcpjam-inspector/server/services/swarm-agent.ts
@@ -4,6 +4,7 @@ import type {
   McpToolResultImageRenderingPolicy,
   ModelVisibleMcpToolResults,
 } from "@mcpjam/sdk/host-config/internal";
+import type { Predicate } from "@mcpjam/sdk/predicates";
 import type { HostComputerResource } from "../utils/built-in-tools/registry.js";
 import type { PinnedSkillArtifact } from "../../shared/skill-types.js";
 
@@ -164,12 +165,30 @@ export interface PersonaSnapshot {
   notes: string;
 }
 
+/**
+ * One row of a journey's deterministic rubric, as pinned onto the run.
+ *
+ * `id` is an opaque client-minted string the backend stores verbatim — the
+ * runner correlates verdicts by it and must never parse or regenerate it.
+ */
+export interface JourneyCriterion {
+  id: string;
+  label?: string;
+  predicate: Predicate;
+}
+
 export interface JourneySnapshot {
   hosts: PinnedHostExecutionSpec[];
   personaSnapshot: PersonaSnapshot;
   goal?: string;
   sessionsPerHost: number;
   maxTurns: number;
+  /**
+   * Deterministic criteria frozen at launch. Absent or empty ⇒ the run is not
+   * rubric-graded and the runner skips grading entirely (which is what makes
+   * "no `criteria` stamp" mean "no rubric" downstream).
+   */
+  rubric?: JourneyCriterion[];
 }
 
 export interface CreateJourneyRunResult {
@@ -493,6 +512,135 @@ export async function reportAttempt(
   // no-op replay; anything else (incl. a defensively-absent field) is "applied"
   // so a missing field can never wrongly suppress a fresh claim's execution.
   return { ok: true, applied: data.applied !== false };
+}
+
+/**
+ * One graded criterion, sent back to the backend as the verdict's full
+ * evidence. Keyed by `criterionId` — never by position — so a re-ordered or
+ * partially-evaluated result set still lands on the right rows.
+ */
+export interface SwarmCriterionResult {
+  criterionId: string;
+  passed: boolean;
+  reason: string;
+  scope?: { kind: "turn"; promptIndex: number };
+}
+
+export interface SwarmChecksClaim {
+  claimed: true;
+  /** Freshness token the backend owns; echoed back on complete/fail. */
+  generation: number;
+  checkDocId: string;
+  sessionDocId: string;
+  criteria: JourneyCriterion[];
+  /** Persisted transcript envelope, or null when it could not be read. */
+  envelope: { messages?: unknown[]; spans?: unknown[] } | null;
+}
+
+/**
+ * Claim a session for rubric grading and receive the transcript to grade.
+ *
+ * The two are ONE call on purpose: the claim must be durable before evaluation
+ * starts, so a runner that dies mid-grade leaves a visible `pending` state
+ * rather than nothing at all. Returns `null` when the run carries no rubric —
+ * a normal outcome, not an error.
+ */
+export async function claimSwarmChecks(
+  convexHttpUrl: string,
+  bearer: string,
+  args: { projectId: string; runId: string; chatSessionId: string },
+  signal?: AbortSignal
+): Promise<SwarmChecksClaim | null> {
+  const data = await postJson<
+    { ok?: boolean; claimed?: boolean; error?: string } & Partial<
+      Omit<SwarmChecksClaim, "claimed">
+    >
+  >(
+    `${convexHttpUrl}/journey-execution/runs/checks/claim`,
+    bearer,
+    {
+      projectId: args.projectId,
+      runId: args.runId,
+      chatSessionId: args.chatSessionId,
+    },
+    NON_LLM_TIMEOUT_MS,
+    signal
+  );
+  if (data.ok !== true) {
+    throw new Error(
+      `Invalid response from backend claimSwarmChecks: ${
+        data.error ?? "unknown error"
+      }`
+    );
+  }
+  if (data.claimed !== true) return null;
+  if (
+    typeof data.generation !== "number" ||
+    typeof data.checkDocId !== "string" ||
+    typeof data.sessionDocId !== "string" ||
+    !Array.isArray(data.criteria)
+  ) {
+    throw new Error(
+      "Invalid response from backend claimSwarmChecks: malformed claim"
+    );
+  }
+  return {
+    claimed: true,
+    generation: data.generation,
+    checkDocId: data.checkDocId,
+    sessionDocId: data.sessionDocId,
+    criteria: data.criteria,
+    envelope: data.envelope ?? null,
+  };
+}
+
+/** Persist a finished rubric verdict. Generation-guarded backend-side. */
+export async function completeSwarmChecks(
+  convexHttpUrl: string,
+  bearer: string,
+  args: {
+    projectId: string;
+    runId: string;
+    sessionDocId: string;
+    checkDocId: string;
+    generation: number;
+    criterionResults: SwarmCriterionResult[];
+  },
+  signal?: AbortSignal
+): Promise<void> {
+  await postJson<{ ok?: boolean }>(
+    `${convexHttpUrl}/journey-execution/runs/checks/complete`,
+    bearer,
+    args,
+    NON_LLM_TIMEOUT_MS,
+    signal
+  );
+}
+
+/**
+ * Record that GRADING failed — an unreadable transcript, an evaluator throw.
+ * Distinct from criteria failing, which is a completed verdict.
+ */
+export async function failSwarmChecks(
+  convexHttpUrl: string,
+  bearer: string,
+  args: {
+    projectId: string;
+    runId: string;
+    sessionDocId: string;
+    checkDocId: string;
+    generation: number;
+    error: string;
+  },
+  signal?: AbortSignal
+): Promise<void> {
+  await postJson<{ ok?: boolean }>(
+    `${convexHttpUrl}/journey-execution/runs/checks/fail`,
+    bearer,
+    args,
+    NON_LLM_TIMEOUT_MS,
+    signal
+  );
 }
 
 export async function heartbeatJourneyRun(

--- a/mcpjam-inspector/shared/__tests__/journey-rubric.test.ts
+++ b/mcpjam-inspector/shared/__tests__/journey-rubric.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  reconcileRubricEntries,
+  serializeRubricForWire,
+  type JourneyCriterion,
+} from "../journey-rubric";
+import type { Predicate } from "@/shared/eval-matching";
+
+/**
+ * The reconciler is the whole reason criterion ids survive authoring.
+ *
+ * The predicate editor is list-shaped and id-blind, so every keystroke hands
+ * back a bare `Predicate[]`. If an edit minted a fresh id, a criterion whose
+ * threshold was nudged would look brand new — breaking its cross-run trend and
+ * orphaning every result already stamped against it.
+ */
+
+const search: Predicate = { type: "toolCalledAtLeastOnce", toolName: "search" };
+const quick: Predicate = { type: "turnCountUnder", turns: 3 };
+
+function entry(id: string, predicate: Predicate, label?: string): JourneyCriterion {
+  return { id, predicate, ...(label !== undefined ? { label } : {}) };
+}
+
+describe("reconcileRubricEntries", () => {
+  it("keeps ids for untouched rows", () => {
+    const prev = [entry("a", search), entry("b", quick)];
+    const next = reconcileRubricEntries(prev, [search, quick]);
+    expect(next.map((e) => e.id)).toEqual(["a", "b"]);
+    expect(next[0]).toBe(prev[0]);
+  });
+
+  it("KEEPS the id when a row's predicate is EDITED — the point of the whole thing", () => {
+    const prev = [entry("a", quick, "Quick resolution")];
+    const edited: Predicate = { type: "turnCountUnder", turns: 5 };
+    const next = reconcileRubricEntries(prev, [edited]);
+    expect(next).toEqual([
+      { id: "a", label: "Quick resolution", predicate: edited },
+    ]);
+  });
+
+  it("mints an id for a genuinely new row and leaves the others alone", () => {
+    const prev = [entry("a", search)];
+    const added: Predicate = { type: "noToolErrors" };
+    const next = reconcileRubricEntries(prev, [search, added]);
+    expect(next[0].id).toBe("a");
+    expect(next[1].id).not.toBe("a");
+    expect(next[1].id.length).toBeGreaterThan(0);
+    expect(next[1].predicate).toBe(added);
+  });
+
+  it("keeps survivors' ids when a row in the MIDDLE is removed", () => {
+    const middle: Predicate = { type: "noToolErrors" };
+    const prev = [entry("a", search), entry("b", middle), entry("c", quick)];
+    // Deleting shifts indices, so a purely positional match would hand `c`'s
+    // predicate the id `b`.
+    const next = reconcileRubricEntries(prev, [search, quick]);
+    expect(next.map((e) => e.id)).toEqual(["a", "c"]);
+  });
+
+  it("keeps ids across a REORDER", () => {
+    const prev = [entry("a", search), entry("b", quick)];
+    const next = reconcileRubricEntries(prev, [quick, search]);
+    expect(next.map((e) => e.id)).toEqual(["b", "a"]);
+  });
+
+  it("gives DUPLICATE predicates distinct ids — two rows, two trends", () => {
+    // Same predicate VALUE authored twice. They are different objects, so
+    // identity matching keeps them apart.
+    const first: Predicate = { type: "toolCalledAtLeastOnce", toolName: "search" };
+    const second: Predicate = { type: "toolCalledAtLeastOnce", toolName: "search" };
+    const next = reconcileRubricEntries([], [first, second]);
+    expect(next).toHaveLength(2);
+    expect(next[0].id).not.toBe(next[1].id);
+  });
+
+  it("keeps the id when a row is retyped as a DIFFERENT predicate kind", () => {
+    // Still the author editing THAT row. Dropping the id here would break
+    // exactly the trend continuity the id exists for.
+    const prev = [entry("a", quick, "Quick resolution")];
+    const next = reconcileRubricEntries(prev, [search]);
+    expect(next).toEqual([
+      { id: "a", label: "Quick resolution", predicate: search },
+    ]);
+  });
+
+  it("does NOT match positionally when the length changed", () => {
+    // A shorter list means something was removed; positions past the removal
+    // point are meaningless, so a survivor must not inherit a dead row's id.
+    // Identity already matched the survivor in pass 1, so `c` keeps `c`.
+    const middle: Predicate = { type: "noToolErrors" };
+    const prev = [entry("a", search), entry("b", middle), entry("c", quick)];
+    const next = reconcileRubricEntries(prev, [middle, quick]);
+    expect(next.map((e) => e.id)).toEqual(["b", "c"]);
+  });
+
+  it("returns [] for an emptied list", () => {
+    expect(reconcileRubricEntries([entry("a", search)], [])).toEqual([]);
+  });
+});
+
+describe("serializeRubricForWire", () => {
+  it("drops a blank label rather than sending an empty string", () => {
+    // `""` would persist as "named, with nothing", and the UI would render an
+    // empty chip instead of falling back to the formatted predicate.
+    expect(
+      serializeRubricForWire([entry("a", search, "   "), entry("b", quick, "Fast")]),
+    ).toEqual([
+      { id: "a", predicate: search },
+      { id: "b", label: "Fast", predicate: quick },
+    ]);
+  });
+
+  it("trims a label that survives", () => {
+    expect(serializeRubricForWire([entry("a", search, "  Named  ")])).toEqual([
+      { id: "a", label: "Named", predicate: search },
+    ]);
+  });
+});

--- a/mcpjam-inspector/shared/__tests__/journey-rubric.test.ts
+++ b/mcpjam-inspector/shared/__tests__/journey-rubric.test.ts
@@ -94,6 +94,17 @@ describe("reconcileRubricEntries", () => {
     expect(next.map((e) => e.id)).toEqual(["b", "c"]);
   });
 
+  it("keeps the FIRST row when two rows share one predicate reference", () => {
+    // A duplicated row can share the object. Keeping the last would hand row 0
+    // row 1's id and mint a fresh one for row 1 — silently swapping which
+    // stamped results belong to which row.
+    const shared: Predicate = { type: "noToolErrors" };
+    const prev = [entry("a", shared), entry("b", shared)];
+    const next = reconcileRubricEntries(prev, [shared, shared]);
+    expect(next[0].id).toBe("a");
+    expect(next[1].id).not.toBe("a");
+  });
+
   it("returns [] for an emptied list", () => {
     expect(reconcileRubricEntries([entry("a", search)], [])).toEqual([]);
   });

--- a/mcpjam-inspector/shared/journey-rubric.ts
+++ b/mcpjam-inspector/shared/journey-rubric.ts
@@ -67,8 +67,14 @@ export function reconcileRubricEntries(
   previous: readonly JourneyCriterion[],
   nextPredicates: readonly Predicate[],
 ): JourneyCriterion[] {
+  // Keep the FIRST row per predicate reference, not the last. Two rows can
+  // legitimately share one object (a duplicated criterion), and overwriting
+  // would hand row 0 row 1's id and mint a fresh one for row 1 — silently
+  // swapping which stamped results belong to which row.
   const byIdentity = new Map<Predicate, JourneyCriterion>();
-  for (const entry of previous) byIdentity.set(entry.predicate, entry);
+  for (const entry of previous) {
+    if (!byIdentity.has(entry.predicate)) byIdentity.set(entry.predicate, entry);
+  }
 
   const claimed = new Set<string>();
   const resolved: Array<JourneyCriterion | null> = nextPredicates.map(

--- a/mcpjam-inspector/shared/journey-rubric.ts
+++ b/mcpjam-inspector/shared/journey-rubric.ts
@@ -1,0 +1,117 @@
+/**
+ * Journey rubric shapes + the id-preserving reconciler the authoring form
+ * needs.
+ *
+ * A rubric row is `{ id, label?, predicate }`. The `id` is the row's identity
+ * and the predicate is its current definition — which is what makes "did
+ * *Quick resolution* get better over the last five runs?" answerable after
+ * someone renames the row or retunes its threshold. Mirrors
+ * `criterionValidator` in the backend's `convex/lib/gradingConfig.ts`.
+ */
+
+import type { Predicate } from "@/shared/eval-matching";
+
+export interface JourneyCriterion {
+  /** Opaque, client-minted, stable across edits. Never parsed. */
+  id: string;
+  /** Author's display name. Absent ⇒ the UI formats the predicate. */
+  label?: string;
+  predicate: Predicate;
+}
+
+/** Mirrors the backend cap in `convex/lib/gradingConfig.ts`. */
+export const MAX_RUBRIC_CRITERIA = 25;
+
+/**
+ * Mint a criterion id.
+ *
+ * `crypto.randomUUID` where available; the fallback exists for older
+ * embedded webviews and non-secure contexts, where `crypto.randomUUID` is
+ * undefined. Uniqueness only has to hold WITHIN one rubric (≤ 25 rows, all
+ * minted in one editing session) — the backend enforces exactly that — so the
+ * fallback's weaker guarantee is sufficient.
+ */
+export function mintCriterionId(): string {
+  const c = globalThis.crypto;
+  if (typeof c?.randomUUID === "function") return c.randomUUID();
+  return `crit-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Fold a fresh predicate list back onto the criteria that produced it,
+ * PRESERVING ids.
+ *
+ * The predicate editor is list-shaped and knows nothing about ids, so every
+ * edit hands back a bare `Predicate[]`. Losing ids here would be silent
+ * damage: a criterion whose threshold was nudged would look like a brand-new
+ * criterion, breaking its cross-run trend and orphaning every stamped result
+ * that referenced it.
+ *
+ * Three passes, in decreasing confidence:
+ *
+ *   1. OBJECT IDENTITY — a row the edit did not touch is the same object it
+ *      was. This is what makes add and remove safe: survivors are matched by
+ *      identity no matter how the indices shifted.
+ *   2. POSITION, but ONLY when the length is unchanged. An EDITED row is a
+ *      new object at the same index, and pass 1 has already consumed every
+ *      untouched row — so with the length equal, an unmatched index can only
+ *      be the row that was edited. When the length CHANGED, the list was
+ *      added to or removed from and positions past the change point mean
+ *      nothing; matching on them would hand a surviving row a dead row's id.
+ *      Deliberately no predicate-kind check: retyping a criterion as a
+ *      different kind is still the author editing THAT row, and dropping its
+ *      id would break exactly the trend continuity the id exists for.
+ *   3. MINT — anything still unmatched is genuinely new.
+ */
+export function reconcileRubricEntries(
+  previous: readonly JourneyCriterion[],
+  nextPredicates: readonly Predicate[],
+): JourneyCriterion[] {
+  const byIdentity = new Map<Predicate, JourneyCriterion>();
+  for (const entry of previous) byIdentity.set(entry.predicate, entry);
+
+  const claimed = new Set<string>();
+  const resolved: Array<JourneyCriterion | null> = nextPredicates.map(
+    (predicate) => {
+      const match = byIdentity.get(predicate);
+      if (!match || claimed.has(match.id)) return null;
+      claimed.add(match.id);
+      return match;
+    },
+  );
+
+  if (previous.length === nextPredicates.length) {
+    for (let i = 0; i < resolved.length; i += 1) {
+      if (resolved[i] !== null) continue;
+      const candidate = previous[i];
+      if (!candidate || claimed.has(candidate.id)) continue;
+      claimed.add(candidate.id);
+      resolved[i] = { ...candidate, predicate: nextPredicates[i] };
+    }
+  }
+
+  return resolved.map(
+    (entry, i) => entry ?? { id: mintCriterionId(), predicate: nextPredicates[i] },
+  );
+}
+
+/**
+ * Normalize a rubric for the wire.
+ *
+ * Blank labels are dropped rather than sent as `""`: an empty label is the
+ * author declining to name the row, which is exactly what "absent" means, and
+ * persisting `""` would make the UI render an empty chip instead of falling
+ * back to the formatted predicate.
+ */
+export function serializeRubricForWire(
+  entries: readonly JourneyCriterion[],
+): JourneyCriterion[] {
+  return entries.map((entry) => {
+    const label = entry.label?.trim();
+    return {
+      id: entry.id,
+      ...(label ? { label } : {}),
+      predicate: entry.predicate,
+    };
+  });
+}

--- a/mcpjam-inspector/shared/predicate-kinds.ts
+++ b/mcpjam-inspector/shared/predicate-kinds.ts
@@ -23,6 +23,10 @@ export const PREDICATE_KIND_LABELS: Record<PredicateKind, string> = {
   widgetRendered: "View rendered",
   widgetRenderLatencyUnder: "View rendered under N ms",
   widgetNoConsoleErrors: "No view console errors",
+  // "Fewer than", not "maximum": the comparator is a strict `<`, so
+  // `turnCountUnder: 3` passes at 2 turns and fails at 3. "Maximum 3" would
+  // read as inclusive and mislead every author who set it.
+  turnCountUnder: "Fewer than N user turns",
 };
 
 export const INLINE_ASSERT_LABELS: Partial<Record<PredicateKind, string>> = {
@@ -48,6 +52,7 @@ export const PREDICATE_KIND_ORDER: PredicateKind[] = [
   "noToolErrors",
   "finalAssistantMessageNonEmpty",
   "tokenBudgetUnder",
+  "turnCountUnder",
   "widgetRendered",
   "widgetRenderLatencyUnder",
   "widgetNoConsoleErrors",
@@ -153,12 +158,64 @@ export function blankPredicate(kind: PredicateKind): Predicate {
       return { type: "finalAssistantMessageNonEmpty" };
     case "tokenBudgetUnder":
       return { type: "tokenBudgetUnder", tokens: 1000 };
+    case "turnCountUnder":
+      return { type: "turnCountUnder", turns: 10 };
     case "widgetRendered":
       return { type: "widgetRendered" };
     case "widgetRenderLatencyUnder":
       return { type: "widgetRenderLatencyUnder", ms: 3000 };
     case "widgetNoConsoleErrors":
       return { type: "widgetNoConsoleErrors" };
+  }
+}
+
+/**
+ * Human label for one rubric criterion.
+ *
+ * `label` is the author's own words and always wins. When absent, the
+ * predicate itself is formatted with its distinguishing argument inlined —
+ * "Tool was called at least once" alone is useless on a scorecard with three
+ * such rows, so the tool name goes in the label.
+ *
+ * Accepts either a rubric entry or a bare predicate so the run scorecard
+ * (which receives `{label?, kind}` without the predicate) and the authoring
+ * form (which has the whole entry) can share one function.
+ */
+export function formatCriterion(
+  entry:
+    | { label?: string; predicate: Predicate }
+    | { label?: string; kind: PredicateKind },
+): string {
+  if (entry.label !== undefined && entry.label.trim().length > 0) {
+    return entry.label.trim();
+  }
+  if (!("predicate" in entry)) return PREDICATE_KIND_LABELS[entry.kind];
+
+  const predicate = entry.predicate;
+  const base = PREDICATE_KIND_LABELS[predicate.type];
+  switch (predicate.type) {
+    case "toolCalledWith":
+    case "toolCalledAtLeastOnce":
+    case "toolNeverCalled":
+    case "firstToolWas":
+      return predicate.toolName ? `${base} ${predicate.toolName}` : base;
+    case "responseContains":
+      return `Response contains "${predicate.needle}"`;
+    case "responseMatches":
+      return `Response matches /${predicate.pattern}/`;
+    case "tokenBudgetUnder":
+      return `Token budget under ${predicate.tokens}`;
+    case "turnCountUnder":
+      return `Fewer than ${predicate.turns} user turns`;
+    case "widgetRenderLatencyUnder":
+      return predicate.toolName
+        ? `${predicate.toolName} rendered under ${predicate.ms} ms`
+        : `View rendered under ${predicate.ms} ms`;
+    case "widgetRendered":
+    case "widgetNoConsoleErrors":
+      return predicate.toolName ? `${base} (${predicate.toolName})` : base;
+    default:
+      return base;
   }
 }
 

--- a/sdk/src/predicates/evaluate.ts
+++ b/sdk/src/predicates/evaluate.ts
@@ -89,7 +89,7 @@ function brief(value: unknown): string {
 
 function callsTo(
   transcript: IterationTranscript,
-  toolName: string,
+  toolName: string
 ): TranscriptToolCall[] {
   return (transcript.toolCalls ?? []).filter((c) => c.toolName === toolName);
 }
@@ -108,7 +108,7 @@ function resolveFinalMessage(transcript: IterationTranscript): string {
  */
 function renderScope(
   transcript: IterationTranscript,
-  toolName: string | undefined,
+  toolName: string | undefined
 ): RenderObservationSummary[] {
   const all = transcript.renderObservations ?? [];
   return toolName === undefined
@@ -134,7 +134,9 @@ function describeStatuses(scope: RenderObservationSummary[]): string {
   return `${shown}${more}`;
 }
 
-function resolveTotalTokens(transcript: IterationTranscript): number | undefined {
+function resolveTotalTokens(
+  transcript: IterationTranscript
+): number | undefined {
   const usage = transcript.usage;
   if (!usage) return undefined;
   const { inputTokens, outputTokens, totalTokens } = usage;
@@ -197,7 +199,7 @@ function fail(predicate: Predicate, reason: string): PredicateResult {
 /** Evaluate a single predicate against the iteration transcript. */
 export function evaluatePredicate(
   transcript: IterationTranscript,
-  predicate: Predicate,
+  predicate: Predicate
 ): PredicateResult {
   switch (predicate.type) {
     case "toolCalledWith": {
@@ -207,26 +209,30 @@ export function evaluatePredicate(
       if (!Number.isInteger(minCount) || minCount < 1) {
         return fail(
           predicate,
-          `invalid minCount ${String(predicate.minCount)}; expected a positive integer ≥ 1`,
+          `invalid minCount ${String(
+            predicate.minCount
+          )}; expected a positive integer ≥ 1`
         );
       }
       const calls = callsTo(transcript, predicate.toolName);
       const matching = calls.filter((c) =>
-        argMatch(predicate.args, c.arguments ?? {}),
+        argMatch(predicate.args, c.arguments ?? {})
       );
       const mode = predicate.args.argumentMatching ?? "partial";
       if (matching.length >= minCount) {
         return pass(
           predicate,
           `tool "${predicate.toolName}" called with matching args ` +
-            `(${matching.length}/${minCount} required; ${mode} match)`,
+            `(${matching.length}/${minCount} required; ${mode} match)`
         );
       }
       if (calls.length === 0) {
         return fail(
           predicate,
           `expected tool "${predicate.toolName}" called ≥${minCount}× with ` +
-            `${brief(predicate.args.args)} (${mode} match), but it was never called`,
+            `${brief(
+              predicate.args.args
+            )} (${mode} match), but it was never called`
         );
       }
       const shown = calls.slice(0, MAX_ITEMS_SHOWN);
@@ -238,15 +244,22 @@ export function evaluatePredicate(
       return fail(
         predicate,
         `expected tool "${predicate.toolName}" called ≥${minCount}× with ` +
-          `${brief(predicate.args.args)} (${mode} match); got ${calls.length} ` +
-          `call(s) with args [${actualArgs.join(", ")}${more}], ${matching.length} matching`,
+          `${brief(predicate.args.args)} (${mode} match); got ${
+            calls.length
+          } ` +
+          `call(s) with args [${actualArgs.join(", ")}${more}], ${
+            matching.length
+          } matching`
       );
     }
 
     case "toolCalledAtLeastOnce": {
       const calls = callsTo(transcript, predicate.toolName);
       return calls.length > 0
-        ? pass(predicate, `tool "${predicate.toolName}" called ${calls.length}×`)
+        ? pass(
+            predicate,
+            `tool "${predicate.toolName}" called ${calls.length}×`
+          )
         : fail(predicate, `tool "${predicate.toolName}" was never called`);
     }
 
@@ -263,18 +276,15 @@ export function evaluatePredicate(
       if (!first) {
         return fail(
           predicate,
-          `expected first tool "${predicate.toolName}" but no tools were called`,
+          `expected first tool "${predicate.toolName}" but no tools were called`
         );
       }
       // Hard Constraint 4 (plan): tool calls carry `.toolName`, not `.name`.
       return first.toolName === predicate.toolName
-        ? pass(
-            predicate,
-            `first tool call was "${predicate.toolName}"`,
-          )
+        ? pass(predicate, `first tool call was "${predicate.toolName}"`)
         : fail(
             predicate,
-            `expected first tool "${predicate.toolName}", got "${first.toolName}"`,
+            `expected first tool "${predicate.toolName}", got "${first.toolName}"`
           );
     }
 
@@ -292,7 +302,7 @@ export function evaluatePredicate(
         ? pass(predicate, `tool "${predicate.toolName}" was not called`)
         : fail(
             predicate,
-            `forbidden tool "${predicate.toolName}" was called ${calls.length}×`,
+            `forbidden tool "${predicate.toolName}" was called ${calls.length}×`
           );
     }
 
@@ -315,12 +325,12 @@ export function evaluatePredicate(
         ? pass(
             predicate,
             `final assistant message contains "${predicate.needle}"` +
-              (caseSensitive ? " (case-sensitive)" : ""),
+              (caseSensitive ? " (case-sensitive)" : "")
           )
         : fail(
             predicate,
             `final assistant message does not contain "${predicate.needle}"` +
-              (caseSensitive ? " (case-sensitive)" : ""),
+              (caseSensitive ? " (case-sensitive)" : "")
           );
     }
 
@@ -336,13 +346,13 @@ export function evaluatePredicate(
       ) {
         return fail(
           predicate,
-          `responseMatches requires a non-empty string pattern`,
+          `responseMatches requires a non-empty string pattern`
         );
       }
       if (NESTED_QUANTIFIER.test(predicate.pattern)) {
         return fail(
           predicate,
-          `regex pattern /${predicate.pattern}/ contains a nested quantifier; refusing to evaluate to avoid catastrophic backtracking`,
+          `regex pattern /${predicate.pattern}/ contains a nested quantifier; refusing to evaluate to avoid catastrophic backtracking`
         );
       }
       let regex: RegExp;
@@ -353,20 +363,23 @@ export function evaluatePredicate(
           predicate,
           `invalid regex pattern /${predicate.pattern}/: ${
             error instanceof Error ? error.message : String(error)
-          }`,
+          }`
         );
       }
       if (message.length > MAX_REGEX_INPUT_CHARS) {
         return fail(
           predicate,
-          `final assistant message exceeds ${MAX_REGEX_INPUT_CHARS} chars; refusing to evaluate /${predicate.pattern}/ safely`,
+          `final assistant message exceeds ${MAX_REGEX_INPUT_CHARS} chars; refusing to evaluate /${predicate.pattern}/ safely`
         );
       }
       return regex.test(message)
-        ? pass(predicate, `final assistant message matches /${predicate.pattern}/`)
+        ? pass(
+            predicate,
+            `final assistant message matches /${predicate.pattern}/`
+          )
         : fail(
             predicate,
-            `final assistant message does not match /${predicate.pattern}/`,
+            `final assistant message does not match /${predicate.pattern}/`
           );
     }
 
@@ -391,7 +404,7 @@ export function evaluatePredicate(
           : "";
       return fail(
         predicate,
-        `${errors.length} tool error(s): ${detail}${moreErrors}`,
+        `${errors.length} tool error(s): ${detail}${moreErrors}`
       );
     }
 
@@ -408,14 +421,36 @@ export function evaluatePredicate(
         // Fail closed: a gate that cannot measure usage must not silently pass.
         return fail(
           predicate,
-          `token usage unavailable; cannot verify budget < ${predicate.tokens}`,
+          `token usage unavailable; cannot verify budget < ${predicate.tokens}`
         );
       }
       return total < predicate.tokens
         ? pass(predicate, `token usage ${total} < ${predicate.tokens}`)
         : fail(
             predicate,
-            `token usage ${total} is not under budget ${predicate.tokens}`,
+            `token usage ${total} is not under budget ${predicate.tokens}`
+          );
+    }
+
+    case "turnCountUnder": {
+      const turns = transcript.turnCount;
+      if (turns === undefined) {
+        // Fail closed, same rule as `tokenBudgetUnder`: a budget nobody could
+        // measure is not a budget that was met.
+        return fail(
+          predicate,
+          `turn count unavailable; cannot verify fewer than ${predicate.turns} user turn(s)`
+        );
+      }
+      // STRICTLY fewer — `turnCountUnder: 3` means 2 turns pass and 3 fail.
+      return turns < predicate.turns
+        ? pass(
+            predicate,
+            `${turns} user turn(s), fewer than ${predicate.turns}`
+          )
+        : fail(
+            predicate,
+            `${turns} user turn(s) is not fewer than ${predicate.turns}`
           );
     }
 
@@ -428,12 +463,12 @@ export function evaluatePredicate(
       return rendered.length > 0
         ? pass(
             predicate,
-            `widget rendered (${rendered.length}/${scope.length} observation(s))`,
+            `widget rendered (${rendered.length}/${scope.length} observation(s))`
           )
         : fail(
             predicate,
             `no widget rendered across ${scope.length} observation(s); ` +
-              `statuses: ${describeStatuses(scope)}`,
+              `statuses: ${describeStatuses(scope)}`
           );
     }
 
@@ -443,14 +478,16 @@ export function evaluatePredicate(
       if (!Number.isInteger(predicate.ms) || predicate.ms < 1) {
         return fail(
           predicate,
-          `invalid ms ${String(predicate.ms)}; expected a positive integer ≥ 1`,
+          `invalid ms ${String(predicate.ms)}; expected a positive integer ≥ 1`
         );
       }
       const scope = renderScope(transcript, predicate.toolName);
       if (scope.length === 0) {
         return fail(
           predicate,
-          `${emptyScopeReason(predicate.toolName)}; cannot verify render latency < ${predicate.ms}ms`,
+          `${emptyScopeReason(
+            predicate.toolName
+          )}; cannot verify render latency < ${predicate.ms}ms`
         );
       }
       const rendered = scope.filter((o) => o.status === "rendered");
@@ -458,19 +495,21 @@ export function evaluatePredicate(
         return fail(
           predicate,
           `no widget rendered; cannot verify render latency < ${predicate.ms}ms; ` +
-            `statuses: ${describeStatuses(scope)}`,
+            `statuses: ${describeStatuses(scope)}`
         );
       }
       const slowest = Math.max(...rendered.map((o) => o.elapsedMs));
       return slowest < predicate.ms
         ? pass(
             predicate,
-            `all ${rendered.length} rendered widget(s) under ${predicate.ms}ms (slowest ${slowest}ms)`,
+            `all ${rendered.length} rendered widget(s) under ${predicate.ms}ms (slowest ${slowest}ms)`
           )
         : fail(
             predicate,
             `widget render took ${slowest}ms, not under ${predicate.ms}ms ` +
-              `(${rendered.filter((o) => o.elapsedMs >= predicate.ms).length}/${rendered.length} rendered widget(s) over budget)`,
+              `(${rendered.filter((o) => o.elapsedMs >= predicate.ms).length}/${
+                rendered.length
+              } rendered widget(s) over budget)`
           );
     }
 
@@ -479,31 +518,31 @@ export function evaluatePredicate(
       if (scope.length === 0) {
         return fail(
           predicate,
-          `${emptyScopeReason(predicate.toolName)}; cannot verify console errors`,
+          `${emptyScopeReason(
+            predicate.toolName
+          )}; cannot verify console errors`
         );
       }
-      const offenders = scope.filter(
-        (o) => (o.consoleErrors?.length ?? 0) > 0,
-      );
+      const offenders = scope.filter((o) => (o.consoleErrors?.length ?? 0) > 0);
       if (offenders.length === 0) {
         return pass(
           predicate,
-          `no console errors across ${scope.length} observation(s)`,
+          `no console errors across ${scope.length} observation(s)`
         );
       }
       const totalErrors = offenders.reduce(
         (sum, o) => sum + (o.consoleErrors?.length ?? 0),
-        0,
+        0
       );
       // Console error text is live-page-controlled data; truncate like tool
       // error messages.
       const first = truncate(
         offenders[0]?.consoleErrors?.[0] ?? "",
-        MAX_ERROR_MSG_CHARS,
+        MAX_ERROR_MSG_CHARS
       );
       return fail(
         predicate,
-        `${totalErrors} console error(s) across ${offenders.length}/${scope.length} observation(s); first: ${first}`,
+        `${totalErrors} console error(s) across ${offenders.length}/${scope.length} observation(s); first: ${first}`
       );
     }
 
@@ -522,7 +561,7 @@ export function evaluatePredicate(
 /** Evaluate every predicate, preserving order. */
 export function evaluatePredicates(
   transcript: IterationTranscript,
-  predicates: Predicate[] | undefined,
+  predicates: Predicate[] | undefined
 ): PredicateResult[] {
   return (predicates ?? []).map((p) => {
     try {
@@ -573,13 +612,13 @@ export interface TurnChecksInput {
  * one reaches it directly (a different write path, a test, a future caller).
  */
 export function evaluateTurnChecks(
-  turns: TurnChecksInput[],
+  turns: TurnChecksInput[]
 ): PredicateResult[] {
   const results: PredicateResult[] = [];
   for (const turn of turns) {
     if (!turn.checks || turn.checks.length === 0) continue;
     const turnScopable = turn.checks.filter((check) =>
-      isTurnScopablePredicateKind(check.type),
+      isTurnScopablePredicateKind(check.type)
     );
     for (const result of evaluatePredicates(turn.transcript, turnScopable)) {
       results.push({

--- a/sdk/src/predicates/evaluate.ts
+++ b/sdk/src/predicates/evaluate.ts
@@ -434,9 +434,12 @@ export function evaluatePredicate(
 
     case "turnCountUnder": {
       const turns = transcript.turnCount;
-      if (turns === undefined) {
-        // Fail closed, same rule as `tokenBudgetUnder`: a budget nobody could
-        // measure is not a budget that was met.
+      // Fail closed on absent OR nonsensical, same rule as `tokenBudgetUnder`:
+      // a budget nobody could measure is not a budget that was met. The
+      // validity check matters because callers may supply `turnCount`
+      // explicitly — a negative or fractional count would otherwise sail under
+      // any limit and report a pass nobody earned.
+      if (turns === undefined || !Number.isInteger(turns) || turns < 0) {
         return fail(
           predicate,
           `turn count unavailable; cannot verify fewer than ${predicate.turns} user turn(s)`

--- a/sdk/src/predicates/evaluate.ts
+++ b/sdk/src/predicates/evaluate.ts
@@ -440,9 +440,16 @@ export function evaluatePredicate(
       // explicitly — a negative or fractional count would otherwise sail under
       // any limit and report a pass nobody earned.
       if (turns === undefined || !Number.isInteger(turns) || turns < 0) {
+        // Distinguish the two cases: "unavailable" sends a reader hunting for
+        // a missing transcript, which is the wrong hunt when a caller passed a
+        // real but nonsensical value.
+        const why =
+          turns === undefined
+            ? "turn count unavailable"
+            : `turn count ${turns} is not a valid count`;
         return fail(
           predicate,
-          `turn count unavailable; cannot verify fewer than ${predicate.turns} user turn(s)`
+          `${why}; cannot verify fewer than ${predicate.turns} user turn(s)`
         );
       }
       // STRICTLY fewer — `turnCountUnder: 3` means 2 turns pass and 3 fail.

--- a/sdk/src/predicates/transcript.ts
+++ b/sdk/src/predicates/transcript.ts
@@ -24,7 +24,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 /** Text of the last assistant message in a message list, if any. */
 export function extractFinalAssistantMessage(
-  messages: unknown,
+  messages: unknown
 ): string | undefined {
   if (!Array.isArray(messages)) return undefined;
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -42,7 +42,7 @@ export function extractFinalAssistantMessage(
     if (Array.isArray(content)) {
       const text = content
         .map((part) =>
-          isRecord(part) && part.type === "text" ? String(part.text ?? "") : "",
+          isRecord(part) && part.type === "text" ? String(part.text ?? "") : ""
         )
         .join("");
       return text.trim() ? text : undefined;
@@ -57,6 +57,22 @@ function messagesOf(trace: EvalTraceInput | undefined): unknown {
   if (Array.isArray(trace)) return trace;
   if (isRecord(trace)) return trace.messages;
   return undefined;
+}
+
+/**
+ * Count user turns in a message list.
+ *
+ * Returns `undefined` — not 0 — when the trace carries no readable messages,
+ * so `turnCountUnder` can fail closed. Zero is a real reading (an iteration
+ * that never got a user message); "we could not look" is not.
+ */
+function countUserTurns(messages: unknown): number | undefined {
+  if (!Array.isArray(messages)) return undefined;
+  let count = 0;
+  for (const message of messages) {
+    if (isRecord(message) && message.role === "user") count += 1;
+  }
+  return count;
 }
 
 export interface BuildTranscriptInput {
@@ -74,6 +90,11 @@ export interface BuildTranscriptInput {
    * `noToolErrors` would pass falsely. Merged with trace-derived errors.
    */
   toolErrors?: ToolErrorRecord[];
+  /**
+   * User turns for the iteration, when the caller already counted them.
+   * Otherwise derived from the trace's user-role messages.
+   */
+  turnCount?: number;
 }
 
 /**
@@ -102,7 +123,7 @@ export interface TurnTranscriptInput {
  * "calls to X" all resolve to the turn, with no change to the evaluator core.
  */
 export function buildTurnTranscript(
-  input: TurnTranscriptInput,
+  input: TurnTranscriptInput
 ): IterationTranscript {
   return {
     toolCalls: input.toolCalls,
@@ -119,7 +140,7 @@ export function buildTurnTranscript(
 
 /** Assemble an {@link IterationTranscript} from runner per-iteration data. */
 export function buildIterationTranscript(
-  input: BuildTranscriptInput,
+  input: BuildTranscriptInput
 ): IterationTranscript {
   const finalAssistantMessage =
     input.finalAssistantMessage ??
@@ -128,6 +149,7 @@ export function buildIterationTranscript(
     ...extractToolErrors(input.trace),
     ...(input.toolErrors ?? []),
   ];
+  const turnCount = input.turnCount ?? countUserTurns(messagesOf(input.trace));
   return {
     toolCalls: input.toolCalls,
     toolErrors,
@@ -136,5 +158,6 @@ export function buildIterationTranscript(
     ...(input.renderObservations && input.renderObservations.length > 0
       ? { renderObservations: input.renderObservations }
       : {}),
+    ...(turnCount !== undefined ? { turnCount } : {}),
   };
 }

--- a/sdk/src/predicates/types.ts
+++ b/sdk/src/predicates/types.ts
@@ -52,7 +52,12 @@ export type ArgMatcher = {
  */
 export type Predicate =
   /** A call to `toolName` whose args satisfy `args` occurred at least `minCount` (default 1) times. */
-  | { type: "toolCalledWith"; toolName: string; args: ArgMatcher; minCount?: number }
+  | {
+      type: "toolCalledWith";
+      toolName: string;
+      args: ArgMatcher;
+      minCount?: number;
+    }
   /** `toolName` was called at least once (args irrelevant). */
   | { type: "toolCalledAtLeastOnce"; toolName: string }
   /** `toolName` was never called (forbidden tool). */
@@ -86,7 +91,17 @@ export type Predicate =
    * console errors. Fails closed when the iteration recorded no render
    * observations in scope.
    */
-  | { type: "widgetNoConsoleErrors"; toolName?: string };
+  | { type: "widgetNoConsoleErrors"; toolName?: string }
+  /**
+   * The iteration used STRICTLY FEWER than `turns` user turns.
+   *
+   * A "turn" is one user-role message in the transcript, so this expresses
+   * "resolved in under N turns" without conflating it with a run's `maxTurns`
+   * cap — that bounds the agent loop, this grades the outcome. Fails closed
+   * when the transcript carries no turn count: an unmeasured budget is not a
+   * met budget.
+   */
+  | { type: "turnCountUnder"; turns: number };
 
 /** The `type` discriminants of {@link Predicate}, for validators. */
 export type PredicateType = Predicate["type"];
@@ -94,8 +109,9 @@ export type PredicateType = Predicate["type"];
 /**
  * Predicate kinds that may be authored on an individual prompt turn (evaluated
  * against that turn's slice of the transcript). Every kind is turn-scopable
- * EXCEPT `tokenBudgetUnder`: per-turn token usage is not reliably captured, so
- * a token budget is a whole-iteration (case-level) concern.
+ * EXCEPT `tokenBudgetUnder` and `turnCountUnder`: per-turn token usage is not
+ * reliably captured, and a turn count evaluated against a single turn's slice
+ * is always 1 — both are whole-iteration (case-level) concerns.
  *
  * Mirrored in `mcpjam-backend/convex/lib/predicates.ts`
  * (`TURN_SCOPABLE_PREDICATE_KINDS`). Used by the per-turn "Add check" menu and
@@ -197,7 +213,7 @@ export const predicateSchema = z.discriminatedUnion("type", [
             return false;
           }
         },
-        { message: "Invalid regular expression" },
+        { message: "Invalid regular expression" }
       ),
   }),
   z.object({
@@ -222,6 +238,12 @@ export const predicateSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("widgetNoConsoleErrors"),
     toolName: z.string().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("turnCountUnder"),
+    // Positive: `< 0` and `< 1` with a zero floor can never be satisfied, so a
+    // non-positive budget is an authoring mistake, not a strict gate.
+    turns: z.number().int().positive(),
   }),
 ]);
 
@@ -334,6 +356,12 @@ export type IterationTranscript = {
    * the `widget*` predicates fail closed (no signal is not a pass).
    */
   renderObservations?: RenderObservationSummary[];
+  /**
+   * User turns observed over the iteration — user-role messages in the
+   * transcript. Absent ⇒ `turnCountUnder` fails closed, same rule as
+   * `usage` and `tokenBudgetUnder`.
+   */
+  turnCount?: number;
 };
 
 /**

--- a/sdk/tests/fixtures/predicates-parity-fixtures.json
+++ b/sdk/tests/fixtures/predicates-parity-fixtures.json
@@ -123,6 +123,14 @@
       "value": { "type": "tokenBudgetUnder", "tokens": 100000 }
     },
     {
+      "label": "turnCountUnder — tight budget (strictly fewer than 3 user turns)",
+      "value": { "type": "turnCountUnder", "turns": 3 }
+    },
+    {
+      "label": "turnCountUnder — loose budget",
+      "value": { "type": "turnCountUnder", "turns": 8 }
+    },
+    {
       "label": "widgetRendered — minimal (no toolName filter)",
       "value": { "type": "widgetRendered" }
     },
@@ -258,6 +266,26 @@
     {
       "label": "tokenBudgetUnder — tokens missing",
       "value": { "type": "tokenBudgetUnder" }
+    },
+    {
+      "label": "turnCountUnder — turns missing",
+      "value": { "type": "turnCountUnder" }
+    },
+    {
+      "label": "turnCountUnder — zero turns (must be positive; `< 0` can never pass)",
+      "value": { "type": "turnCountUnder", "turns": 0 }
+    },
+    {
+      "label": "turnCountUnder — negative turns",
+      "value": { "type": "turnCountUnder", "turns": -1 }
+    },
+    {
+      "label": "turnCountUnder — fractional turns",
+      "value": { "type": "turnCountUnder", "turns": 2.5 }
+    },
+    {
+      "label": "turnCountUnder — numeric string turns",
+      "value": { "type": "turnCountUnder", "turns": "8" }
     },
     {
       "label": "widgetRendered — empty toolName",

--- a/sdk/tests/predicate-evaluate.test.ts
+++ b/sdk/tests/predicate-evaluate.test.ts
@@ -481,14 +481,16 @@ describe("evaluatePredicate — table driven", () => {
       transcript: transcript({ turnCount: -1 }),
       predicate: { type: "turnCountUnder", turns: 1 },
       passed: false,
-      reasonIncludes: ["unavailable"],
+      // Says the count is INVALID, not "unavailable" — the latter would send a
+      // reader hunting for a missing transcript.
+      reasonIncludes: ["-1", "not a valid count"],
     },
     {
       name: "turnCountUnder: fractional turnCount fails closed",
       transcript: transcript({ turnCount: 1.5 }),
       predicate: { type: "turnCountUnder", turns: 3 },
       passed: false,
-      reasonIncludes: ["unavailable"],
+      reasonIncludes: ["not a valid count"],
     },
     {
       name: "turnCountUnder: reason reports actual vs limit",

--- a/sdk/tests/predicate-evaluate.test.ts
+++ b/sdk/tests/predicate-evaluate.test.ts
@@ -7,7 +7,9 @@ import {
 import type { IterationTranscript, Predicate } from "../src/predicates/types";
 
 /** Minimal transcript builder so each row states only what it exercises. */
-function transcript(over: Partial<IterationTranscript> = {}): IterationTranscript {
+function transcript(
+  over: Partial<IterationTranscript> = {}
+): IterationTranscript {
   return { toolCalls: [], ...over };
 }
 
@@ -26,9 +28,15 @@ describe("evaluatePredicate — table driven", () => {
     {
       name: "toolCalledWith: partial match passes despite extra args",
       transcript: transcript({
-        toolCalls: [{ toolName: "book_flight", arguments: { airline: "DL", seat: "1A" } }],
+        toolCalls: [
+          { toolName: "book_flight", arguments: { airline: "DL", seat: "1A" } },
+        ],
       }),
-      predicate: { type: "toolCalledWith", toolName: "book_flight", args: { args: { airline: "DL" } } },
+      predicate: {
+        type: "toolCalledWith",
+        toolName: "book_flight",
+        args: { args: { airline: "DL" } },
+      },
       passed: true,
     },
     {
@@ -48,14 +56,22 @@ describe("evaluatePredicate — table driven", () => {
       transcript: transcript({
         toolCalls: [{ toolName: "book_flight", arguments: { airline: "UA" } }],
       }),
-      predicate: { type: "toolCalledWith", toolName: "book_flight", args: { args: { airline: "DL" } } },
+      predicate: {
+        type: "toolCalledWith",
+        toolName: "book_flight",
+        args: { args: { airline: "DL" } },
+      },
       passed: false,
       reasonIncludes: ["book_flight", '"airline":"DL"', '"airline":"UA"'],
     },
     {
       name: "toolCalledWith: never called fails with 'never called' reason",
       transcript: transcript({ toolCalls: [] }),
-      predicate: { type: "toolCalledWith", toolName: "book_flight", args: { args: { airline: "DL" } } },
+      predicate: {
+        type: "toolCalledWith",
+        toolName: "book_flight",
+        args: { args: { airline: "DL" } },
+      },
       passed: false,
       reasonIncludes: ["never called"],
     },
@@ -64,7 +80,12 @@ describe("evaluatePredicate — table driven", () => {
       transcript: transcript({
         toolCalls: [{ toolName: "search", arguments: { q: "x" } }],
       }),
-      predicate: { type: "toolCalledWith", toolName: "search", args: { args: {} }, minCount: 2 },
+      predicate: {
+        type: "toolCalledWith",
+        toolName: "search",
+        args: { args: {} },
+        minCount: 2,
+      },
       passed: false,
       reasonIncludes: ["≥2×"],
     },
@@ -88,7 +109,12 @@ describe("evaluatePredicate — table driven", () => {
           { toolName: "search", arguments: { q: "y" } },
         ],
       }),
-      predicate: { type: "toolCalledWith", toolName: "search", args: { args: {} }, minCount: 2 },
+      predicate: {
+        type: "toolCalledWith",
+        toolName: "search",
+        args: { args: {} },
+        minCount: 2,
+      },
       passed: true,
     },
 
@@ -106,7 +132,9 @@ describe("evaluatePredicate — table driven", () => {
     },
     {
       name: "toolCalledAtLeastOnce: absent fails",
-      transcript: transcript({ toolCalls: [{ toolName: "search", arguments: {} }] }),
+      transcript: transcript({
+        toolCalls: [{ toolName: "search", arguments: {} }],
+      }),
       predicate: { type: "toolCalledAtLeastOnce", toolName: "book_flight" },
       passed: false,
       reasonIncludes: ["never called"],
@@ -157,7 +185,9 @@ describe("evaluatePredicate — table driven", () => {
     // ── toolNeverCalled ───────────────────────────────────────────────
     {
       name: "toolNeverCalled: forbidden tool absent passes",
-      transcript: transcript({ toolCalls: [{ toolName: "search", arguments: {} }] }),
+      transcript: transcript({
+        toolCalls: [{ toolName: "search", arguments: {} }],
+      }),
       predicate: { type: "toolNeverCalled", toolName: "delete_account" },
       passed: true,
     },
@@ -172,7 +202,9 @@ describe("evaluatePredicate — table driven", () => {
     },
     {
       name: "toolNeverCalled: missing toolName fails closed (not silently 'not called')",
-      transcript: transcript({ toolCalls: [{ toolName: "search", arguments: {} }] }),
+      transcript: transcript({
+        toolCalls: [{ toolName: "search", arguments: {} }],
+      }),
       predicate: { type: "toolNeverCalled" } as unknown as Predicate,
       passed: false,
       reasonIncludes: ["non-empty toolName"],
@@ -181,14 +213,22 @@ describe("evaluatePredicate — table driven", () => {
     // ── responseContains ──────────────────────────────────────────────
     {
       name: "responseContains: case-insensitive default passes",
-      transcript: transcript({ finalAssistantMessage: "Your Refund Issued today." }),
+      transcript: transcript({
+        finalAssistantMessage: "Your Refund Issued today.",
+      }),
       predicate: { type: "responseContains", needle: "refund issued" },
       passed: true,
     },
     {
       name: "responseContains: case-sensitive mismatch fails",
-      transcript: transcript({ finalAssistantMessage: "Your Refund Issued today." }),
-      predicate: { type: "responseContains", needle: "refund issued", caseSensitive: true },
+      transcript: transcript({
+        finalAssistantMessage: "Your Refund Issued today.",
+      }),
+      predicate: {
+        type: "responseContains",
+        needle: "refund issued",
+        caseSensitive: true,
+      },
       passed: false,
     },
     {
@@ -208,7 +248,9 @@ describe("evaluatePredicate — table driven", () => {
     // ── responseMatches ───────────────────────────────────────────────
     {
       name: "responseMatches: regex matches passes",
-      transcript: transcript({ finalAssistantMessage: "Order #4823 confirmed" }),
+      transcript: transcript({
+        finalAssistantMessage: "Order #4823 confirmed",
+      }),
       predicate: { type: "responseMatches", pattern: "#\\d{4} confirmed" },
       passed: true,
     },
@@ -290,14 +332,22 @@ describe("evaluatePredicate — table driven", () => {
     // ── noToolErrors (the isError vs JSON-RPC distinction) ─────────────
     {
       name: "noToolErrors: no errors passes",
-      transcript: transcript({ toolCalls: [{ toolName: "search", arguments: {} }] }),
+      transcript: transcript({
+        toolCalls: [{ toolName: "search", arguments: {} }],
+      }),
       predicate: { type: "noToolErrors" },
       passed: true,
     },
     {
       name: "noToolErrors: content-error (isError:true) fails and is labeled",
       transcript: transcript({
-        toolErrors: [{ toolName: "book_flight", kind: "content-error", message: "sold out" }],
+        toolErrors: [
+          {
+            toolName: "book_flight",
+            kind: "content-error",
+            message: "sold out",
+          },
+        ],
       }),
       predicate: { type: "noToolErrors" },
       passed: false,
@@ -306,7 +356,13 @@ describe("evaluatePredicate — table driven", () => {
     {
       name: "noToolErrors: protocol-error (JSON-RPC) fails and is labeled",
       transcript: transcript({
-        toolErrors: [{ toolName: "book_flight", kind: "protocol-error", message: "method not found" }],
+        toolErrors: [
+          {
+            toolName: "book_flight",
+            kind: "protocol-error",
+            message: "method not found",
+          },
+        ],
       }),
       predicate: { type: "noToolErrors" },
       passed: false,
@@ -366,7 +422,9 @@ describe("evaluatePredicate — table driven", () => {
     },
     {
       name: "tokenBudgetUnder: falls back to input+output sum",
-      transcript: transcript({ usage: { inputTokens: 400, outputTokens: 300 } }),
+      transcript: transcript({
+        usage: { inputTokens: 400, outputTokens: 300 },
+      }),
       predicate: { type: "tokenBudgetUnder", tokens: 1000 },
       passed: true,
     },
@@ -384,6 +442,46 @@ describe("evaluatePredicate — table driven", () => {
       predicate: { type: "tokenBudgetUnder", tokens: 1000 },
       passed: false,
       reasonIncludes: ["unavailable"],
+    },
+
+    // ── turnCountUnder ────────────────────────────────────────────────
+    {
+      name: "turnCountUnder: under budget passes",
+      transcript: transcript({ turnCount: 2 }),
+      predicate: { type: "turnCountUnder", turns: 3 },
+      passed: true,
+    },
+    {
+      name: "turnCountUnder: boundary (equal) fails (strict <)",
+      transcript: transcript({ turnCount: 3 }),
+      predicate: { type: "turnCountUnder", turns: 3 },
+      passed: false,
+    },
+    {
+      name: "turnCountUnder: over budget fails",
+      transcript: transcript({ turnCount: 9 }),
+      predicate: { type: "turnCountUnder", turns: 3 },
+      passed: false,
+    },
+    {
+      name: "turnCountUnder: zero turns passes (a real reading, not absence)",
+      transcript: transcript({ turnCount: 0 }),
+      predicate: { type: "turnCountUnder", turns: 1 },
+      passed: true,
+    },
+    {
+      name: "turnCountUnder: missing turnCount fails closed",
+      transcript: transcript({}),
+      predicate: { type: "turnCountUnder", turns: 3 },
+      passed: false,
+      reasonIncludes: ["unavailable"],
+    },
+    {
+      name: "turnCountUnder: reason reports actual vs limit",
+      transcript: transcript({ turnCount: 5 }),
+      predicate: { type: "turnCountUnder", turns: 3 },
+      passed: false,
+      reasonIncludes: ["5", "3"],
     },
 
     // ── widgetRendered ────────────────────────────────────────────────
@@ -624,7 +722,11 @@ describe("evaluatePredicates — aggregate verdict", () => {
 
   it("all predicates pass → aggregate passes", () => {
     const predicates: Predicate[] = [
-      { type: "toolCalledWith", toolName: "book_flight", args: { args: { airline: "DL" } } },
+      {
+        type: "toolCalledWith",
+        toolName: "book_flight",
+        args: { args: { airline: "DL" } },
+      },
       { type: "responseContains", needle: "refund issued" },
       { type: "noToolErrors" },
       { type: "tokenBudgetUnder", tokens: 1000 },
@@ -636,7 +738,11 @@ describe("evaluatePredicates — aggregate verdict", () => {
 
   it("one predicate fails → aggregate fails", () => {
     const predicates: Predicate[] = [
-      { type: "toolCalledWith", toolName: "book_flight", args: { args: { airline: "DL" } } },
+      {
+        type: "toolCalledWith",
+        toolName: "book_flight",
+        args: { args: { airline: "DL" } },
+      },
       { type: "responseContains", needle: "this text is absent" },
     ];
     const results = evaluatePredicates(baseTranscript, predicates);
@@ -668,11 +774,19 @@ describe("reason redaction + bounding (persisted to Convex metadata)", () => {
         toolCalls: [
           {
             toolName: "book_flight",
-            arguments: { airline: "UA", api_key: "sk-secret-abc123", token: "t-xyz" },
+            arguments: {
+              airline: "UA",
+              api_key: "sk-secret-abc123",
+              token: "t-xyz",
+            },
           },
         ],
       },
-      { type: "toolCalledWith", toolName: "book_flight", args: { args: { airline: "DL" } } },
+      {
+        type: "toolCalledWith",
+        toolName: "book_flight",
+        args: { args: { airline: "DL" } },
+      }
     );
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("«redacted»");
@@ -686,7 +800,11 @@ describe("reason redaction + bounding (persisted to Convex metadata)", () => {
     const huge = "x".repeat(5000);
     const result = evaluatePredicate(
       { toolCalls: [{ toolName: "search", arguments: { q: huge } }] },
-      { type: "toolCalledWith", toolName: "search", args: { args: { q: "needle" } } },
+      {
+        type: "toolCalledWith",
+        toolName: "search",
+        args: { args: { q: "needle" } },
+      }
     );
     expect(result.passed).toBe(false);
     expect(result.reason.length).toBeLessThanOrEqual(600);
@@ -696,8 +814,13 @@ describe("reason redaction + bounding (persisted to Convex metadata)", () => {
   it("truncates long tool error messages", () => {
     const longMsg = "boom ".repeat(500);
     const result = evaluatePredicate(
-      { toolCalls: [], toolErrors: [{ toolName: "t", kind: "protocol-error", message: longMsg }] },
-      { type: "noToolErrors" },
+      {
+        toolCalls: [],
+        toolErrors: [
+          { toolName: "t", kind: "protocol-error", message: longMsg },
+        ],
+      },
+      { type: "noToolErrors" }
     );
     expect(result.passed).toBe(false);
     expect(result.reason.length).toBeLessThanOrEqual(600);
@@ -711,7 +834,11 @@ describe("reason redaction + bounding (persisted to Convex metadata)", () => {
     }));
     const result = evaluatePredicate(
       { toolCalls: calls },
-      { type: "toolCalledWith", toolName: "search", args: { args: { found: true } } },
+      {
+        type: "toolCalledWith",
+        toolName: "search",
+        args: { args: { found: true } },
+      }
     );
     expect(result.passed).toBe(false);
     expect(result.reason).toContain("+2 more");
@@ -746,7 +873,7 @@ describe("reason redaction + bounding (persisted to Convex metadata)", () => {
             endpoint: "/v1/widgets",
           },
         },
-      },
+      }
     );
     expect(result.passed).toBe(true);
     const persisted = result.predicate;

--- a/sdk/tests/predicate-evaluate.test.ts
+++ b/sdk/tests/predicate-evaluate.test.ts
@@ -477,6 +477,20 @@ describe("evaluatePredicate — table driven", () => {
       reasonIncludes: ["unavailable"],
     },
     {
+      name: "turnCountUnder: NEGATIVE turnCount fails closed (would sail under any limit)",
+      transcript: transcript({ turnCount: -1 }),
+      predicate: { type: "turnCountUnder", turns: 1 },
+      passed: false,
+      reasonIncludes: ["unavailable"],
+    },
+    {
+      name: "turnCountUnder: fractional turnCount fails closed",
+      transcript: transcript({ turnCount: 1.5 }),
+      predicate: { type: "turnCountUnder", turns: 3 },
+      passed: false,
+      reasonIncludes: ["unavailable"],
+    },
+    {
       name: "turnCountUnder: reason reports actual vs limit",
       transcript: transcript({ turnCount: 5 }),
       predicate: { type: "turnCountUnder", turns: 3 },

--- a/sdk/tests/predicate-transcript.test.ts
+++ b/sdk/tests/predicate-transcript.test.ts
@@ -49,7 +49,9 @@ describe("extractToolErrors — classification", () => {
 
   it("returns [] for a clean trace and for absent traces", () => {
     expect(
-      extractToolErrors({ messages: [toolResult({ toolName: "ok", result: { isError: false } })] }),
+      extractToolErrors({
+        messages: [toolResult({ toolName: "ok", result: { isError: false } })],
+      })
     ).toEqual([]);
     expect(extractToolErrors(undefined)).toEqual([]);
   });
@@ -91,19 +93,81 @@ describe("buildIterationTranscript", () => {
     const transcript = buildIterationTranscript({
       trace: {
         messages: [
-          { role: "assistant", content: [{ type: "text", text: "let me check" }] },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "let me check" }],
+          },
           {
             role: "tool",
             content: [
-              { type: "tool-result", toolName: "search", output: { type: "json", value: {} } },
+              {
+                type: "tool-result",
+                toolName: "search",
+                output: { type: "json", value: {} },
+              },
             ],
           },
-          { role: "assistant", content: [{ type: "tool-call", toolName: "search", input: "{}" }] },
+          {
+            role: "assistant",
+            content: [{ type: "tool-call", toolName: "search", input: "{}" }],
+          },
         ],
       },
       toolCalls: [{ toolName: "search", arguments: {} }],
     });
     expect(transcript.finalAssistantMessage).toBeUndefined();
+  });
+
+  it("derives turnCount from user-role messages", () => {
+    const transcript = buildIterationTranscript({
+      trace: {
+        messages: [
+          { role: "user", content: "hi" },
+          { role: "assistant", content: [{ type: "text", text: "hello" }] },
+          { role: "user", content: "and again" },
+          { role: "system", content: "ignored" },
+          { role: "assistant", content: [{ type: "text", text: "done" }] },
+        ],
+      },
+      toolCalls: [],
+    });
+    expect(transcript.turnCount).toBe(2);
+  });
+
+  it("prefers an explicitly supplied turnCount over the derived one", () => {
+    const transcript = buildIterationTranscript({
+      trace: { messages: [{ role: "user", content: "hi" }] },
+      toolCalls: [],
+      turnCount: 7,
+    });
+    expect(transcript.turnCount).toBe(7);
+  });
+
+  it("leaves turnCount UNDEFINED when the trace has no readable messages", () => {
+    // Not 0 — `turnCountUnder` must fail closed on "we could not look",
+    // whereas 0 is a real reading it should evaluate normally.
+    expect(
+      buildIterationTranscript({ toolCalls: [] }).turnCount
+    ).toBeUndefined();
+    expect(
+      buildIterationTranscript({ trace: { messages: "nope" }, toolCalls: [] })
+        .turnCount
+    ).toBeUndefined();
+  });
+
+  it("reports 0 for a message list with no user turns", () => {
+    const transcript = buildIterationTranscript({
+      trace: {
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "unprompted" }],
+          },
+        ],
+      },
+      toolCalls: [],
+    });
+    expect(transcript.turnCount).toBe(0);
   });
 });
 
@@ -113,7 +177,7 @@ describe("finalizePassedForEval — predicate AND-combine", () => {
       finalizePassedForEval({
         matchPassed: true,
         predicateResults: [{ passed: true }, { passed: true }],
-      }),
+      })
     ).toBe(true);
   });
 
@@ -122,7 +186,7 @@ describe("finalizePassedForEval — predicate AND-combine", () => {
       finalizePassedForEval({
         matchPassed: true,
         predicateResults: [{ passed: true }, { passed: false }],
-      }),
+      })
     ).toBe(false);
   });
 
@@ -132,7 +196,7 @@ describe("finalizePassedForEval — predicate AND-combine", () => {
         matchPassed: true,
         failOnToolError: false,
         predicateResults: [{ passed: false }],
-      }),
+      })
     ).toBe(false);
   });
 
@@ -141,7 +205,7 @@ describe("finalizePassedForEval — predicate AND-combine", () => {
       finalizePassedForEval({
         matchPassed: false,
         predicateResults: [{ passed: true }],
-      }),
+      })
     ).toBe(false);
   });
 

--- a/sdk/tests/predicates-parity.test.ts
+++ b/sdk/tests/predicates-parity.test.ts
@@ -37,18 +37,13 @@ describe("predicate parity fixtures — Zod (@mcpjam/sdk side)", () => {
     expect(data.reject.length).toBeGreaterThan(0);
   });
 
-  it("covers each of the 9 predicate kinds with ≥2 accept examples", () => {
-    const kinds = [
-      "toolCalledWith",
-      "toolCalledAtLeastOnce",
-      "toolNeverCalled",
-      "firstToolWas",
-      "responseContains",
-      "responseMatches",
-      "noToolErrors",
-      "finalAssistantMessageNonEmpty",
-      "tokenBudgetUnder",
-    ];
+  // Derived from the Predicate union rather than hand-listed: the previous
+  // hardcoded list silently froze at 9 while the union grew to 13, so the
+  // widget and turn-count kinds shipped with no coverage assertion at all.
+  it("covers EVERY predicate kind with ≥2 accept examples", () => {
+    const kinds = predicateSchema.options.map(
+      (option) => option.shape.type.value,
+    );
     for (const kind of kinds) {
       const matching = data.accept.filter(
         (r) =>


### PR DESCRIPTION
Inspector half of the swarm rubric work (PR 2 of 2). **Depends on [MCPJam/mcpjam-backend#853](https://github.com/MCPJam/mcpjam-backend/pull/853) being deployed first** — the routes and schema it uses land there.

## Grading runs here, not in Convex

Convex functions cannot import `@mcpjam/sdk` (the bundling isolation that also forces `convex/lib/predicates.ts` to hand-mirror the SDK union), so the backend owns persistence and the generation guard while the evaluation happens where the evaluator does.

New `server/services/checks/run-swarm-checks.ts`:
1. **claim** — durable `pending`, plus the transcript envelope, in one authorized round trip;
2. **evaluate** — the same `evaluatePredicates` the eval runner calls, over a transcript built the way `run-predicates-on-chat-session.ts` builds one;
3. **complete / fail** — verdicts correlated back to `criterionId`.

Fusing claim and envelope-load into one call is deliberate: it makes claim-before-evaluate structurally impossible to get wrong. A runner that dies mid-grade has already left a visible `pending`, never a silent absence — and absence is load-bearing downstream, where it means "this run had no rubric".

## The runner hook

`swarm-runner.ts` awaits the grade inside a try/catch right after `reportAttempt`. **Awaited**, not fire-and-forget, so the claim is durable before the attempt slot is reused. **Non-fatal**, so a grading failure is recorded on the session and never touches the attempt or the host loop — the run's job is producing sessions, not grading them.

It runs for `failed` terminals as well as `succeeded`. A failed session is exactly where "no tool errors" and "fewer than N turns" earn their keep; grading only the happy path would blind the scorecard to the sessions worth looking at. Only `rate_limited` is skipped — that attempt never produced a session to read a transcript from.

## Authoring, and why criteria carry an id

The rubric editor wraps the same `ChecksSection` the eval suite settings use, so the predicate vocabulary and every field editor stay identical across surfaces, and adds the one thing a rubric needs on top: a stable id per row, plus an optional human label.

`ChecksSection` is id-blind and hands back a bare `Predicate[]` on every edit, so `reconcileRubricEntries` folds it back onto the criteria that produced it — object identity for untouched rows, position (only when the length is unchanged) for an in-place edit, mint for genuinely new ones. A threshold nudge keeps its id, which is the entire reason cross-run trends survive authoring.

Writing the test for this surfaced a real bug in the first cut: a predicate-kind guard in the positional pass meant retyping a criterion as a different kind silently minted a new id, breaking the continuity the id exists for. Length equality turned out to be the precise signal, and it needs no second-guessing of the author's intent.

## Criterion insights

Each criterion is its own boolean dimension. Facet cards stack: clicking fail on two **different** criteria narrows to the sessions that failed both, while pass and fail on the **same** criterion widen (a session cannot be both, so requiring both would match nothing).

These are **ordinary filter chips, not flow-owned** — they narrow the sankey and the drilldown like any other chip. That is the opposite of a sankey selection, which is the diagram's own output and is deliberately withheld from the query that draws it; mixing the two up would either collapse the diagram or make the facet click do nothing.

The chip value carries the identity (`<criterionId>:pass|fail|ungraded`) because the dimension key is a closed literal union and criterion ids are minted at authoring time; `chipGroupKey` re-splits per criterion. Both the matcher and the grouping mirror the backend exactly — a divergence would make a server-filtered page and a client-filtered list disagree about what the user selected.

While in there: `primaryBehavior` was missing from the client's `UsageDimensionKey`, so that chip round-tripped as an unknown key. Added, with the backend's **priority-order** collapse rather than `behaviorTags[0]` — a session that both looped and retried is a looping session, and taking the first element would have selected a different cohort than the server.

## Honest states in the UI

Pass / fail / pending / could-not-grade stay four distinct columns on the run scorecard, and the facet cards report ungraded separately instead of summing it into fail. Folding a crashed runner into the fail column would read as a product regression, and "grading broke" is not "the criterion failed".

A matrix cell whose session carries **no** stamp renders no chip at all — a `0/0` would claim the session was graded against an empty rubric, when in fact its run had no rubric to begin with.

The goal-completion judge is rendered last on the scorecard and visually separated. It answers a different question with different evidence, and a table that interleaved them would invite reading a 0.6 judge score and a failed criterion as the same kind of fact.

## Also

- SDK `turnCountUnder` — strictly fewer than N user turns, so "resolved in under 3 turns" is expressible without conflating it with a run's `maxTurns` cap. Fails closed when the transcript carries no turn count, same rule as `tokenBudgetUnder`. New `IterationTranscript.turnCount`, derived from user-role messages (and `undefined`, not `0`, when the trace is unreadable — zero turns is a real reading, "we could not look" is not).
- Fixed the parity test's hardcoded kind list. It had frozen at 9 while the union grew to 13, so the widget kinds shipped with no coverage assertion at all; it now derives from the schema.
- `formatCriterion` in `shared/predicate-kinds.ts` — the label fallback when an author names nothing, with the distinguishing argument inlined (three "Tool was called at least once" rows on one scorecard are useless).

## Known limitations (inherited, deliberately reproduced)

`tokenBudgetUnder` fails closed on swarm sessions — the persisted envelope carries no per-iteration token accounting. The tool-call extractor's identity dedupe is copied verbatim from `run-predicates-on-chat-session.ts`, so a session that called one tool twice with identical arguments reads as one call; fixing it in one place only would make the same session grade differently depending on who asked.

## Verification

- `npm run build` in `sdk/`, `npm run typecheck:client` — clean
- `npx tsc --noEmit -p server/tsconfig.json` — 0 errors in touched files (175 pre-existing elsewhere, unchanged)
- SDK: 3510 passed, 1 skipped (191 files)
- Inspector (client + server + shared): 2627 passed, 6 skipped, 0 failed (270 files)
- Per-file `eslint --fix` on every touched file — 0 new errors

New tests: `run-swarm-checks.test.ts` (9), `swarm-runner.rubric.test.ts` (7), `journey-rubric.test.ts` (11), `journey-rubric-editor.test.tsx` (7), `chatbox-usage-filters-criterion.test.ts` (10), `SwarmInsightsPanel.criteria.test.tsx` (7), plus SDK evaluate/transcript cases and 7 parity fixtures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJiQG8CadXv94xF7KEyafs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches swarm run lifecycle and grading persistence (depends on backend #853); grading is isolated as non-fatal, but incorrect claim/complete wiring could leave sessions stuck pending or mis-attribute verdicts.
> 
> **Overview**
> **Journey rubrics** can be authored in the swarm journey form (Advanced): deterministic pass criteria beside the LLM judge, serialized with stable criterion IDs via `reconcileRubricEntries`, omitted when empty, and blocked on invalid checks.
> 
> **Grading** runs in the inspector (`run-swarm-checks`: claim → evaluate → complete/fail) and is **awaited** from `swarm-runner` after each terminal attempt (including failed; skipped when `hasRubric` is false or `rate_limited`). The SDK adds **`turnCountUnder`** (strict `< N` user turns) and transcript **`turnCount`**.
> 
> **UI**: run **scorecard** (`getRunScorecard`), matrix **criterion chips**, **JourneyRubricEditor**, and Swarm **Insights** **criterion facet cards** that toggle ordinary filter chips (AND across criteria, OR within one). Client filters gain **`criterion`** and **`primaryBehavior`** dimensions aligned with the backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832a83bfa9faf065264578112295b6c005266b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds journey rubric authoring and deterministic grading for swarms, plus per-criterion insights and a run scorecard. This update fixes grading durability, tightens rubric authoring, and aligns filters and SDK behavior for reliable results.

- **Bug Fixes**
  - Rubric editor: cap hides Add instead of setting read-only; Create is gated on valid checks; `reconcileRubricEntries` preserves ids when rows share a predicate object.
  - Grading flow: `completeSwarmChecks`/`failSwarmChecks` require `{ ok: true }`; grading no longer runs under `sessionSignal` and is awaited but non-fatal.
  - SDK/UI: `turnCountUnder` in `@mcpjam/sdk` fails closed on missing/negative/fractional turn counts, reports the specific failure reason, and the compact label clarifies “fewer than N user turns.”
  - Insights/filters: criterion facet buttons include accessible names; ungraded counts are clickable (`:ungraded`) and scoped to sessions in that rubric; criterion chips behave as ordinary filters (AND across criteria, OR within one).
  - Data parity: unified tool-call extractor with `run-predicates-on-chat-session.ts`; `JourneySessionRow` criteria propagate to shared threads; scorecard rows use `formatCriterion`.

- **Migration**
  - Requires backend changes from MCPJam/mcpjam-backend#853 to be deployed first.
  - No additional steps; runs without a rubric show no criterion chips.

<sup>Written for commit accf241d7f067acc4ec45b2ad247530da07ecdd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

