### PR TITLE
feat(oauth): golden-trace comparator, freshness, profile binding (HP-43 S6)

### DIFF
--- a/.changeset/oauth-golden-comparator.md
+++ b/.changeset/oauth-golden-comparator.md
@@ -1,0 +1,40 @@
+---
+"@mcpjam/sdk": minor
+---
+
+OAuth client emulation: golden-trace comparator, freshness reporting, and
+profile/golden binding (HP-43 step 6).
+
+- **`normalizeOAuthTrace`** projects a run's HTTP history into comparable
+  steps, neutralizing what differs on every execution — timestamps, CSRF
+  state, PKCE, authorization codes, tokens, server-generated client ids, and
+  the loopback callback port. Normalization replaces volatile **values** but
+  never removes **keys**, so a client that stops sending a parameter is a
+  visible difference rather than a silent one. Responses are excluded: a
+  golden describes the client, not the server under test.
+- **`compareOAuthEmulationTrace`** diffs a run against a real-client capture
+  across the whole dance (discovery → registration → authorize → token →
+  authenticated MCP request), reporting per-step method, URL, header, and body
+  differences plus requests present on only one side.
+- **Honest match claims.** The result carries `qualifiers` independent of the
+  diff: `partial_coverage` (any `not_modeled` field), `stale_capture`, and
+  `client_version_mismatch`. `isUnqualifiedMatch` is true only when the
+  requests lined up, nothing was substituted, coverage was complete, and the
+  capture is current — so a `not_modeled` field can never yield an unqualified
+  `matched`.
+- **Freshness.** Goldens carry a capture date and client version; older than
+  90 days (`GOLDEN_STALENESS_DAYS`) is reported as stale, never as current.
+  The threshold day itself is still current.
+- **Binding.** A golden may only be compared against a run of the same
+  profile: `compareOAuthEmulationTrace` requires the run's profile digest
+  alongside the capture and returns `not_compared` /
+  `golden_profile_mismatch` rather than diffing two different clients.
+  `computeOAuthProfileDigest` and `computeOAuthGoldenTraceDigest` content-
+  address both sides, and every preflight result now reports its `bindings`
+  (profile schema version, profile digest, golden digest, catalog revision).
+- `runEmulatedOAuthPreflight` gains `goldenComparison`, always emits its
+  normalized `trace`, and its `comparison` field is now the full result
+  object rather than a placeholder string.
+
+Real-client captures live in the private backend, like the profiles; this
+ships the engine only.

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -197,6 +197,7 @@ export {
   computeOAuthProfileDigest,
   GOLDEN_STALENESS_DAYS,
   isUnqualifiedMatch,
+  insertAuthorizationRedirectStep,
   normalizeAuthorizationRedirectStep,
   normalizeOAuthTrace,
   NORMALIZED_VALUE,

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -191,6 +191,28 @@ export {
   planCompletionSafeRedirects,
 } from "./oauth/emulation/redirects.js";
 export type { CompletionSafeRedirectPlan } from "./oauth/emulation/redirects.js";
+export {
+  compareOAuthEmulationTrace,
+  computeOAuthGoldenTraceDigest,
+  computeOAuthProfileDigest,
+  GOLDEN_STALENESS_DAYS,
+  isUnqualifiedMatch,
+  normalizeAuthorizationRedirectStep,
+  normalizeOAuthTrace,
+  NORMALIZED_VALUE,
+} from "./oauth/emulation/golden-trace.js";
+export type {
+  CompareOAuthEmulationTraceInput,
+  NormalizedTraceStep,
+  NormalizedTraceStepKind,
+  OAuthComparisonNotComparedReason,
+  OAuthComparisonQualifier,
+  OAuthComparisonStatus,
+  OAuthGoldenFreshness,
+  OAuthGoldenTrace,
+  OAuthTraceComparisonResult,
+  OAuthTraceDifference,
+} from "./oauth/emulation/golden-trace.js";
 // SSRF host classification (shared hardening): the browser executor re-validates
 // the FINAL response URL after redirects using the same RFC 6890 policy the
 // factory guard applies to the initial request URL.

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -343,6 +343,7 @@ export {
   computeOAuthProfileDigest,
   GOLDEN_STALENESS_DAYS,
   isUnqualifiedMatch,
+  insertAuthorizationRedirectStep,
   normalizeAuthorizationRedirectStep,
   normalizeOAuthTrace,
   NORMALIZED_VALUE,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -337,6 +337,28 @@ export {
   planCompletionSafeRedirects,
 } from "./oauth/emulation/redirects.js";
 export type { CompletionSafeRedirectPlan } from "./oauth/emulation/redirects.js";
+export {
+  compareOAuthEmulationTrace,
+  computeOAuthGoldenTraceDigest,
+  computeOAuthProfileDigest,
+  GOLDEN_STALENESS_DAYS,
+  isUnqualifiedMatch,
+  normalizeAuthorizationRedirectStep,
+  normalizeOAuthTrace,
+  NORMALIZED_VALUE,
+} from "./oauth/emulation/golden-trace.js";
+export type {
+  CompareOAuthEmulationTraceInput,
+  NormalizedTraceStep,
+  NormalizedTraceStepKind,
+  OAuthComparisonNotComparedReason,
+  OAuthComparisonQualifier,
+  OAuthComparisonStatus,
+  OAuthGoldenFreshness,
+  OAuthGoldenTrace,
+  OAuthTraceComparisonResult,
+  OAuthTraceDifference,
+} from "./oauth/emulation/golden-trace.js";
 // Node-only: runs the emulated ladder over the hardened OAuth networking path.
 export { runEmulatedOAuthPreflight } from "./oauth/emulation/preflight.js";
 export type {

--- a/sdk/src/oauth/emulation/golden-trace.ts
+++ b/sdk/src/oauth/emulation/golden-trace.ts
@@ -158,21 +158,50 @@ function normalizeBodyValue(value: unknown, key?: string): unknown {
   return value;
 }
 
+/**
+ * Parse a form-encoded body into an object, preserving repeated keys as
+ * arrays. Collapsing `scope=a&scope=b` to its last value would let a run with
+ * duplicated parameters compare equal to one without them — parity overstated
+ * by a parsing artifact.
+ */
+function parseFormBody(body: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of new URLSearchParams(body).entries()) {
+    const existing = out[key];
+    if (existing === undefined) {
+      out[key] = value;
+    } else if (Array.isArray(existing)) {
+      existing.push(value);
+    } else {
+      out[key] = [existing, value];
+    }
+  }
+  return out;
+}
+
 function normalizeBody(body: unknown): unknown {
   if (body === undefined || body === null) return undefined;
 
-  // Form-encoded bodies are compared as objects: the encoded string's
-  // parameter order is an artifact of how the request was built.
   if (typeof body === "string") {
-    if (/^[^=&\s]+=[^&]*(&[^=&\s]+=[^&]*)*$/u.test(body)) {
-      const params = new URLSearchParams(body);
-      return normalizeBodyValue(Object.fromEntries(params.entries()));
-    }
+    // JSON FIRST. A form-encoded body is never valid JSON, but a JSON body can
+    // easily look form-encoded — `{"redirect_uri":"http://x?a=b"}` has no
+    // spaces and contains `=`, so a shape test would misparse it and change
+    // the body before comparison. Only object/array results are accepted here
+    // so scalar strings keep their previous treatment.
     try {
-      return normalizeBodyValue(JSON.parse(body));
+      const parsed = JSON.parse(body);
+      if (parsed && typeof parsed === "object") {
+        return normalizeBodyValue(parsed);
+      }
     } catch {
-      return normalizeLoopbackPort(body);
+      // Not JSON — fall through to the form-encoded reading.
     }
+    // Form-encoded bodies are compared as objects: the encoded string's
+    // parameter order is an artifact of how the request was built.
+    if (/^[^=&\s]+=[^&]*(&[^=&\s]+=[^&]*)*$/u.test(body)) {
+      return normalizeBodyValue(parseFormBody(body));
+    }
+    return normalizeLoopbackPort(body);
   }
   return normalizeBodyValue(body);
 }
@@ -212,6 +241,26 @@ export function normalizeAuthorizationRedirectStep(
     url: normalizeUrl(authorizationUrl),
     headers: {},
   };
+}
+
+/**
+ * Place the authorization redirect at its point in the flow — after discovery
+ * and registration, BEFORE the code is exchanged.
+ *
+ * Comparison is index-based, so position is meaning: appending the redirect
+ * would put it after the token request on any run that completed, and no
+ * golden recorded in flow order could ever match. A run that stopped AT the
+ * redirect has no token request, so appending and inserting agree there.
+ */
+export function insertAuthorizationRedirectStep(
+  steps: NormalizedTraceStep[],
+  authorizationUrl: string | undefined
+): NormalizedTraceStep[] {
+  if (!authorizationUrl) return steps;
+  const redirect = normalizeAuthorizationRedirectStep(authorizationUrl);
+  const tokenIndex = steps.findIndex((step) => step.step === "token_request");
+  if (tokenIndex === -1) return [...steps, redirect];
+  return [...steps.slice(0, tokenIndex), redirect, ...steps.slice(tokenIndex)];
 }
 
 /** Content address of a profile — what binds a golden to the client it came from. */
@@ -353,8 +402,18 @@ function computeFreshness(
   expectedClientVersion: string | undefined,
   now: Date
 ): OAuthGoldenFreshness {
-  const captured = new Date(`${golden.capturedAt}T00:00:00Z`);
-  const ageMs = now.getTime() - captured.getTime();
+  // Strict round-trip, matching the canonicalizer's date rule: `Date` silently
+  // rolls an impossible calendar date forward (2026-02-31 → 2026-03-03), which
+  // would turn a malformed capture into a confident freshness claim. An
+  // unusable date yields NaN and lands in the stale path below.
+  const raw = golden.capturedAt;
+  const captured = /^\d{4}-\d{2}-\d{2}$/u.test(raw)
+    ? new Date(`${raw}T00:00:00Z`)
+    : new Date(Number.NaN);
+  const roundTrips =
+    !Number.isNaN(captured.getTime()) &&
+    captured.toISOString().slice(0, 10) === raw;
+  const ageMs = roundTrips ? now.getTime() - captured.getTime() : Number.NaN;
   const ageDays = Number.isNaN(ageMs)
     ? Number.NaN
     : Math.floor(ageMs / 86_400_000);

--- a/sdk/src/oauth/emulation/golden-trace.ts
+++ b/sdk/src/oauth/emulation/golden-trace.ts
@@ -83,10 +83,16 @@ export interface OAuthGoldenTrace {
   steps: NormalizedTraceStep[];
 }
 
-/** Normalize the loopback callback port — it is chosen per run. */
+/**
+ * Normalize the loopback callback port — it is chosen per run.
+ *
+ * The host-start guard is a lookbehind, not `\b`: a word boundary never
+ * matches before the `[` of a bracketed IPv6 literal (the preceding `/` and
+ * the `[` are both non-word), so `\b` silently excluded `[::1]` entirely.
+ */
 function normalizeLoopbackPort(value: string): string {
   return value.replace(
-    /\b(127\.0\.0\.1|localhost|\[::1\]):\d+/gu,
+    /(?<![\w.])(127\.0\.0\.1|localhost|\[::1\]):\d+/gu,
     "$1:<port>"
   );
 }
@@ -113,6 +119,10 @@ function normalizeUrl(rawUrl: string): string {
   params.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
 
   url.search = "";
+  // The fragment is cleared too. Leaving it would append the rebuilt query
+  // AFTER it (`/path#frag?a=b`), burying the query inside the fragment — and a
+  // fragment is never sent to the server, so it is not part of a wire trace.
+  url.hash = "";
   const query = params
     .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
     .join("&");
@@ -165,7 +175,10 @@ function normalizeBodyValue(value: unknown, key?: string): unknown {
  * by a parsing artifact.
  */
 function parseFormBody(body: string): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
+  // Null-prototype: on a plain object literal `out["__proto__"] = value` sets
+  // the prototype instead of defining a property, so a form parameter named
+  // `__proto__` would vanish from both the comparison and the digest.
+  const out: Record<string, unknown> = Object.create(null);
   for (const [key, value] of new URLSearchParams(body).entries()) {
     const existing = out[key];
     if (existing === undefined) {
@@ -372,8 +385,13 @@ function diffStep(
       actual: actual.url,
     });
   }
-  const expectedHeaders = JSON.stringify(expected.headers);
-  const actualHeaders = JSON.stringify(actual.headers);
+  // Both sides are re-normalized before serializing. A run's steps already are
+  // (they came from `normalizeOAuthTrace`), but a golden may be hand-authored
+  // or hand-edited, and then key order alone would manufacture a mismatch.
+  // Normalization is idempotent, so re-applying it to a captured golden is
+  // free.
+  const expectedHeaders = JSON.stringify(normalizeHeaders(expected.headers));
+  const actualHeaders = JSON.stringify(normalizeHeaders(actual.headers));
   if (expectedHeaders !== actualHeaders) {
     differences.push({
       index,
@@ -383,8 +401,8 @@ function diffStep(
       actual: actualHeaders,
     });
   }
-  const expectedBody = JSON.stringify(expected.body ?? null);
-  const actualBody = JSON.stringify(actual.body ?? null);
+  const expectedBody = JSON.stringify(normalizeBody(expected.body) ?? null);
+  const actualBody = JSON.stringify(normalizeBody(actual.body) ?? null);
   if (expectedBody !== actualBody) {
     differences.push({
       index,
@@ -420,7 +438,13 @@ function computeFreshness(
   return {
     capturedAt: golden.capturedAt,
     ageDays,
-    stale: Number.isNaN(ageDays) || ageDays > GOLDEN_STALENESS_DAYS,
+    // A future-dated capture is as unusable as an unparseable one — nothing
+    // was captured tomorrow — and a negative age would otherwise sail past
+    // the threshold check and be reported as current.
+    stale:
+      Number.isNaN(ageDays) ||
+      ageDays < 0 ||
+      ageDays > GOLDEN_STALENESS_DAYS,
     ...(golden.clientVersion ? { clientVersion: golden.clientVersion } : {}),
     ...(expectedClientVersion ? { expectedClientVersion } : {}),
   };

--- a/sdk/src/oauth/emulation/golden-trace.ts
+++ b/sdk/src/oauth/emulation/golden-trace.ts
@@ -1,0 +1,465 @@
+/**
+ * Golden-trace normalization and comparison (HP-43 step 6).
+ *
+ * A run and a real-client capture can only be compared after the values that
+ * differ on EVERY execution are neutralized: timestamps, CSRF state, PKCE,
+ * authorization codes, tokens, server-generated client ids, and the loopback
+ * callback port. What survives normalization is the shape of the dance — which
+ * requests, in which order, carrying which parameters and headers — which is
+ * exactly what "does this client behave like the real one" asks.
+ *
+ * Two rules keep the result honest:
+ *
+ *  - Normalization replaces volatile VALUES but never removes KEYS. A client
+ *    that stopped sending `code_challenge` altogether must show up as a
+ *    difference, not vanish into the placeholder.
+ *  - A comparison carries qualifiers, and a `matched` with any qualifier is
+ *    not an unqualified match. Partial coverage, a stale capture, or a
+ *    client-version mismatch each keep the claim honest without pretending the
+ *    diff itself failed.
+ *
+ * Real-client captures live in the private backend, like the profiles. This
+ * module is the engine only and names no client.
+ */
+
+import { canonicalizeOAuthProfile } from "../../host-config/canonicalize.js";
+import { sha256Hex } from "../../host-config/hash.js";
+import type { HostConfigOAuthProfile } from "../../host-config/types.js";
+import type {
+  HttpHistoryEntry,
+  OAuthFlowStep,
+} from "../state-machines/types.js";
+import type { OAuthEmulationDivergence } from "./types.js";
+
+/** Replaces any value that legitimately differs on every run. */
+export const NORMALIZED_VALUE = "<normalized>";
+
+/** A capture older than this is reported as stale, never as current. */
+export const GOLDEN_STALENESS_DAYS = 90;
+
+/**
+ * Parameters whose VALUE is per-run noise. The key is always preserved, so
+ * dropping a parameter entirely remains a visible difference.
+ */
+const VOLATILE_PARAMETERS = new Set([
+  "state",
+  "code",
+  "code_verifier",
+  "code_challenge",
+  "client_id",
+  "client_secret",
+  "access_token",
+  "refresh_token",
+  "nonce",
+]);
+
+/** Header values that are per-run noise. Knob-bearing headers are compared. */
+const VOLATILE_HEADERS = new Set(["authorization", "cookie", "set-cookie"]);
+
+/** Derived from the body, so it tracks normalization rather than the wire. */
+const DROPPED_HEADERS = new Set(["content-length", "date"]);
+
+export type NormalizedTraceStepKind = OAuthFlowStep | "authorization_redirect";
+
+export interface NormalizedTraceStep {
+  step: NormalizedTraceStepKind;
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+export interface OAuthGoldenTrace {
+  /**
+   * Digest of the profile this capture belongs to. A golden may only be
+   * compared against a run of the same profile — otherwise the diff measures
+   * two different clients.
+   */
+  profileDigest: string;
+  /** The client build the capture came from, when known. */
+  clientVersion?: string;
+  /** ISO calendar date (`YYYY-MM-DD`) of the capture. */
+  capturedAt: string;
+  steps: NormalizedTraceStep[];
+}
+
+/** Normalize the loopback callback port — it is chosen per run. */
+function normalizeLoopbackPort(value: string): string {
+  return value.replace(
+    /\b(127\.0\.0\.1|localhost|\[::1\]):\d+/gu,
+    "$1:<port>"
+  );
+}
+
+function normalizeUrl(rawUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return normalizeLoopbackPort(rawUrl);
+  }
+
+  const params = [...url.searchParams.entries()].map(
+    ([key, value]) =>
+      [
+        key,
+        VOLATILE_PARAMETERS.has(key.toLowerCase())
+          ? NORMALIZED_VALUE
+          : normalizeLoopbackPort(value),
+      ] as [string, string]
+  );
+  // Sorted so query ORDER — which no spec fixes and which varies harmlessly
+  // between HTTP clients — cannot manufacture a mismatch.
+  params.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  url.search = "";
+  const query = params
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join("&");
+  const base = normalizeLoopbackPort(url.toString().replace(/\?$/u, ""));
+  return query ? `${base}?${query}` : base;
+}
+
+function normalizeHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (DROPPED_HEADERS.has(lower)) continue;
+    out[lower] = VOLATILE_HEADERS.has(lower)
+      ? NORMALIZED_VALUE
+      : normalizeLoopbackPort(value);
+  }
+  // Header order carries no meaning on the wire.
+  return Object.fromEntries(
+    Object.entries(out).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+  );
+}
+
+function normalizeBodyValue(value: unknown, key?: string): unknown {
+  if (key && VOLATILE_PARAMETERS.has(key.toLowerCase())) {
+    return NORMALIZED_VALUE;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeBodyValue(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+        .map(([entryKey, entryValue]) => [
+          entryKey,
+          normalizeBodyValue(entryValue, entryKey),
+        ])
+    );
+  }
+  if (typeof value === "string") return normalizeLoopbackPort(value);
+  return value;
+}
+
+function normalizeBody(body: unknown): unknown {
+  if (body === undefined || body === null) return undefined;
+
+  // Form-encoded bodies are compared as objects: the encoded string's
+  // parameter order is an artifact of how the request was built.
+  if (typeof body === "string") {
+    if (/^[^=&\s]+=[^&]*(&[^=&\s]+=[^&]*)*$/u.test(body)) {
+      const params = new URLSearchParams(body);
+      return normalizeBodyValue(Object.fromEntries(params.entries()));
+    }
+    try {
+      return normalizeBodyValue(JSON.parse(body));
+    } catch {
+      return normalizeLoopbackPort(body);
+    }
+  }
+  return normalizeBodyValue(body);
+}
+
+/**
+ * Project a run's HTTP history into comparable steps. Responses are excluded
+ * deliberately: a golden describes what the CLIENT does, and a server's
+ * answers are the variable under test, not part of the client's behavior.
+ */
+export function normalizeOAuthTrace(
+  entries: readonly HttpHistoryEntry[]
+): NormalizedTraceStep[] {
+  return entries.map((entry) => {
+    const step: NormalizedTraceStep = {
+      step: entry.step,
+      method: entry.request.method.toUpperCase(),
+      url: normalizeUrl(entry.request.url),
+      headers: normalizeHeaders(entry.request.headers ?? {}),
+    };
+    const body = normalizeBody(entry.request.body);
+    if (body !== undefined) step.body = body;
+    return step;
+  });
+}
+
+/**
+ * The authorization redirect is a browser navigation rather than a request the
+ * client issues, but its URL carries the parameters an emulated client is
+ * judged on, so it is a comparable step in its own right.
+ */
+export function normalizeAuthorizationRedirectStep(
+  authorizationUrl: string
+): NormalizedTraceStep {
+  return {
+    step: "authorization_redirect",
+    method: "GET",
+    url: normalizeUrl(authorizationUrl),
+    headers: {},
+  };
+}
+
+/** Content address of a profile — what binds a golden to the client it came from. */
+export async function computeOAuthProfileDigest(
+  profile: HostConfigOAuthProfile
+): Promise<string> {
+  return sha256Hex(JSON.stringify(canonicalizeOAuthProfile(profile)));
+}
+
+/** Content address of a capture, so a run can name the exact golden it used. */
+export async function computeOAuthGoldenTraceDigest(
+  trace: Pick<OAuthGoldenTrace, "steps">
+): Promise<string> {
+  return sha256Hex(JSON.stringify(trace.steps));
+}
+
+export type OAuthComparisonStatus =
+  | "not_compared"
+  | "matched"
+  | "matched_with_declared_substitutions"
+  | "mismatched";
+
+export type OAuthComparisonNotComparedReason =
+  | "no_golden"
+  | "golden_profile_mismatch"
+  | "no_run_trace";
+
+/**
+ * A reason the match cannot be stated plainly. Independent of the diff: the
+ * requests may line up exactly and the claim still be qualified.
+ */
+export type OAuthComparisonQualifier =
+  | "partial_coverage"
+  | "stale_capture"
+  | "client_version_mismatch";
+
+export interface OAuthTraceDifference {
+  index: number;
+  kind: "missing_in_run" | "unexpected_in_run" | "step" | "method" | "url" | "headers" | "body";
+  detail: string;
+  expected?: string;
+  actual?: string;
+}
+
+export interface OAuthGoldenFreshness {
+  capturedAt: string;
+  ageDays: number;
+  stale: boolean;
+  clientVersion?: string;
+  expectedClientVersion?: string;
+}
+
+export interface OAuthTraceComparisonResult {
+  status: OAuthComparisonStatus;
+  /** Present only when `status` is `not_compared`. */
+  reason?: OAuthComparisonNotComparedReason;
+  qualifiers: OAuthComparisonQualifier[];
+  differences: OAuthTraceDifference[];
+  /** Divergences the run itself declared (appended callback, retry, …). */
+  declaredSubstitutions: OAuthEmulationDivergence[];
+  freshness?: OAuthGoldenFreshness;
+}
+
+export interface CompareOAuthEmulationTraceInput {
+  /** The run's normalized steps. */
+  trace: NormalizedTraceStep[];
+  golden: OAuthGoldenTrace;
+  /** Digest of the profile the run used. Must match the golden's. */
+  profileDigest: string;
+  /** `partial` forces the `partial_coverage` qualifier. */
+  coverageSummary: "complete" | "partial";
+  declaredSubstitutions?: OAuthEmulationDivergence[];
+  /** The client build being emulated, when the caller knows it. */
+  expectedClientVersion?: string;
+  /** Injected so staleness is deterministic; defaults to the current date. */
+  now?: Date;
+}
+
+function diffStep(
+  index: number,
+  expected: NormalizedTraceStep,
+  actual: NormalizedTraceStep
+): OAuthTraceDifference[] {
+  const differences: OAuthTraceDifference[] = [];
+  if (expected.step !== actual.step) {
+    differences.push({
+      index,
+      kind: "step",
+      detail: `expected the ${expected.step} step, ran ${actual.step}`,
+      expected: expected.step,
+      actual: actual.step,
+    });
+  }
+  if (expected.method !== actual.method) {
+    differences.push({
+      index,
+      kind: "method",
+      detail: `${expected.step}: method differs`,
+      expected: expected.method,
+      actual: actual.method,
+    });
+  }
+  if (expected.url !== actual.url) {
+    differences.push({
+      index,
+      kind: "url",
+      detail: `${expected.step}: request URL differs`,
+      expected: expected.url,
+      actual: actual.url,
+    });
+  }
+  const expectedHeaders = JSON.stringify(expected.headers);
+  const actualHeaders = JSON.stringify(actual.headers);
+  if (expectedHeaders !== actualHeaders) {
+    differences.push({
+      index,
+      kind: "headers",
+      detail: `${expected.step}: request headers differ`,
+      expected: expectedHeaders,
+      actual: actualHeaders,
+    });
+  }
+  const expectedBody = JSON.stringify(expected.body ?? null);
+  const actualBody = JSON.stringify(actual.body ?? null);
+  if (expectedBody !== actualBody) {
+    differences.push({
+      index,
+      kind: "body",
+      detail: `${expected.step}: request body differs`,
+      expected: expectedBody,
+      actual: actualBody,
+    });
+  }
+  return differences;
+}
+
+function computeFreshness(
+  golden: OAuthGoldenTrace,
+  expectedClientVersion: string | undefined,
+  now: Date
+): OAuthGoldenFreshness {
+  const captured = new Date(`${golden.capturedAt}T00:00:00Z`);
+  const ageMs = now.getTime() - captured.getTime();
+  const ageDays = Number.isNaN(ageMs)
+    ? Number.NaN
+    : Math.floor(ageMs / 86_400_000);
+  return {
+    capturedAt: golden.capturedAt,
+    ageDays,
+    stale: Number.isNaN(ageDays) || ageDays > GOLDEN_STALENESS_DAYS,
+    ...(golden.clientVersion ? { clientVersion: golden.clientVersion } : {}),
+    ...(expectedClientVersion ? { expectedClientVersion } : {}),
+  };
+}
+
+export function compareOAuthEmulationTrace(
+  input: CompareOAuthEmulationTraceInput
+): OAuthTraceComparisonResult {
+  const {
+    trace,
+    golden,
+    profileDigest,
+    coverageSummary,
+    declaredSubstitutions = [],
+    expectedClientVersion,
+    now = new Date(),
+  } = input;
+
+  // A golden captured from a different profile describes a different client.
+  // Diffing it would produce confident nonsense, so refuse rather than report.
+  if (golden.profileDigest !== profileDigest) {
+    return {
+      status: "not_compared",
+      reason: "golden_profile_mismatch",
+      qualifiers: [],
+      differences: [],
+      declaredSubstitutions,
+    };
+  }
+
+  if (trace.length === 0) {
+    return {
+      status: "not_compared",
+      reason: "no_run_trace",
+      qualifiers: [],
+      differences: [],
+      declaredSubstitutions,
+    };
+  }
+
+  const freshness = computeFreshness(golden, expectedClientVersion, now);
+  const qualifiers: OAuthComparisonQualifier[] = [];
+  // `not_modeled` fields mean part of the client was never enforced, so even
+  // an exact diff cannot be an unqualified match.
+  if (coverageSummary === "partial") qualifiers.push("partial_coverage");
+  if (freshness.stale) qualifiers.push("stale_capture");
+  if (
+    expectedClientVersion &&
+    golden.clientVersion &&
+    golden.clientVersion !== expectedClientVersion
+  ) {
+    qualifiers.push("client_version_mismatch");
+  }
+
+  const differences: OAuthTraceDifference[] = [];
+  const shared = Math.min(golden.steps.length, trace.length);
+  for (let index = 0; index < shared; index += 1) {
+    differences.push(...diffStep(index, golden.steps[index], trace[index]));
+  }
+  for (let index = shared; index < golden.steps.length; index += 1) {
+    differences.push({
+      index,
+      kind: "missing_in_run",
+      detail: `the real client sent a ${golden.steps[index].step} request the run never made`,
+      expected: golden.steps[index].url,
+    });
+  }
+  for (let index = shared; index < trace.length; index += 1) {
+    differences.push({
+      index,
+      kind: "unexpected_in_run",
+      detail: `the run made a ${trace[index].step} request the real client never made`,
+      actual: trace[index].url,
+    });
+  }
+
+  const status: OAuthComparisonStatus =
+    differences.length > 0
+      ? "mismatched"
+      : declaredSubstitutions.length > 0
+        ? "matched_with_declared_substitutions"
+        : "matched";
+
+  return {
+    status,
+    qualifiers,
+    differences,
+    declaredSubstitutions,
+    freshness,
+  };
+}
+
+/**
+ * The only shape that may be reported as plain parity: the requests lined up,
+ * nothing was substituted, coverage was complete, and the capture is current.
+ */
+export function isUnqualifiedMatch(
+  result: OAuthTraceComparisonResult
+): boolean {
+  return result.status === "matched" && result.qualifiers.length === 0;
+}

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -142,6 +142,13 @@ export interface EmulatedOAuthPreflightConfig {
   /** Recorded verbatim in `bindings`, for backend provenance. */
   catalogRevision?: string;
   profileSchemaVersion?: 1 | 2;
+  /**
+   * Digest of the profile this run used. Recorded in `bindings` so a
+   * capture-only run (one taken to BECOME a golden) is bound to its profile
+   * too. When `goldenComparison` is supplied, its digest is used if this is
+   * absent.
+   */
+  profileDigest?: string;
   /** Override the hardened default executor (tests, alternate transports). */
   requestExecutor?: OAuthRequestExecutor;
   allowLoopbackMetadataFetch?: boolean;
@@ -412,8 +419,18 @@ export async function runEmulatedOAuthPreflight(
   let outcome: EmulatedOAuthPreflightOutcome = "blocked";
   /** Reported to the caller: the run stopped here and needs a human. */
   let authorizationUrl: string | undefined;
-  /** Recorded in the trace: authorization happened, however the run ended. */
-  let traceAuthorizationUrl: string | undefined;
+  /**
+   * The authorization URL each attempt produced, keyed by its index in
+   * `attempts`. Kept per attempt so the redirect is placed inside the attempt
+   * that performed it, rather than relying on only one attempt ever
+   * authorizing.
+   */
+  const authorizationUrlByAttempt = new Map<number, string>();
+  /**
+   * Divergences THIS RUN introduced, as distinct from compile-time ones the
+   * profile already carried. Only these are substitutions in the trace.
+   */
+  const runtimeDivergences: OAuthEmulationDivergence[] = [];
   let credentials: EmulatedOAuthPreflightResult["credentials"];
   let error: { message: string } | undefined;
   let redirectDivergencesDeclared = false;
@@ -800,11 +817,13 @@ export async function runEmulatedOAuthPreflight(
           detail:
             "the emulated client prefers a static credential, but none was supplied",
         });
-        divergences.push({
+        const skipped: OAuthEmulationDivergence = {
           kind: "not-enforced",
           detail:
             "api-key rung skipped: no static credential was supplied, and the runner never invents one",
-        });
+        };
+        divergences.push(skipped);
+        runtimeDivergences.push(skipped);
         continue;
       }
 
@@ -878,9 +897,11 @@ export async function runEmulatedOAuthPreflight(
     // true once a registration actually ran.
     if (attemptOutput.registrations > 0 && !redirectDivergencesDeclared) {
       divergences.push(...redirectPlan.divergences);
+      runtimeDivergences.push(...redirectPlan.divergences);
       redirectDivergencesDeclared = true;
     }
     divergences.push(...attemptOutput.divergences);
+    runtimeDivergences.push(...attemptOutput.divergences);
 
     if (attemptOutput.outcome) outcome = attemptOutput.outcome;
     if (attemptOutput.authorizationUrl) {
@@ -894,7 +915,7 @@ export async function runEmulatedOAuthPreflight(
     const attemptAuthorizationUrl =
       attemptOutput.authorizationUrl ?? attemptOutput.state?.authorizationUrl;
     if (attemptAuthorizationUrl) {
-      traceAuthorizationUrl = attemptAuthorizationUrl;
+      authorizationUrlByAttempt.set(attempts.length - 1, attemptAuthorizationUrl);
     }
     if (attemptOutput.state) {
       const { accessToken, refreshToken, clientId, clientSecret } =
@@ -917,13 +938,14 @@ export async function runEmulatedOAuthPreflight(
   }
 
   // The run's own wire behavior, normalized: what a capture would record and
-  // what a comparison diffs. Built from every attempt in the order they ran,
-  // with the authorization redirect appended as its own step.
-  const trace: NormalizedTraceStep[] = insertAuthorizationRedirectStep(
-    attempts.flatMap((attempt) =>
-      normalizeOAuthTrace(attempt.httpHistory ?? [])
-    ),
-    traceAuthorizationUrl
+  // what a comparison diffs. Each attempt carries ITS OWN authorization URL,
+  // so the redirect lands at the authorization boundary of the attempt that
+  // performed it rather than depending on only one attempt ever authorizing.
+  const trace: NormalizedTraceStep[] = attempts.flatMap((attempt, index) =>
+    insertAuthorizationRedirectStep(
+      normalizeOAuthTrace(attempt.httpHistory ?? []),
+      authorizationUrlByAttempt.get(index)
+    )
   );
 
   const comparison: OAuthTraceComparisonResult = config.goldenComparison
@@ -932,7 +954,11 @@ export async function runEmulatedOAuthPreflight(
         golden: config.goldenComparison.golden,
         profileDigest: config.goldenComparison.profileDigest,
         coverageSummary: derived.coverageSummary,
-        declaredSubstitutions: divergences,
+        // Only what THIS RUN substituted. Compile-time divergences (a narrowed
+        // ladder version, an unenforced field) describe the profile, not the
+        // wire, and would otherwise downgrade a byte-exact match to
+        // "matched with declared substitutions". They stay in `divergences`.
+        declaredSubstitutions: runtimeDivergences,
         expectedClientVersion: config.goldenComparison.expectedClientVersion,
         now: config.goldenComparison.now,
       })
@@ -941,16 +967,18 @@ export async function runEmulatedOAuthPreflight(
         reason: "no_golden",
         qualifiers: [],
         differences: [],
-        declaredSubstitutions: divergences,
+        declaredSubstitutions: runtimeDivergences,
       };
 
+  // A capture-only run (no golden yet) still records which profile it came
+  // from — that binding is what makes the capture usable as a golden later.
+  const profileDigest =
+    config.profileDigest ?? config.goldenComparison?.profileDigest;
   const bindings: EmulatedOAuthPreflightResult["bindings"] = {
     ...(config.profileSchemaVersion
       ? { profileSchemaVersion: config.profileSchemaVersion }
       : {}),
-    ...(config.goldenComparison
-      ? { profileDigest: config.goldenComparison.profileDigest }
-      : {}),
+    ...(profileDigest ? { profileDigest } : {}),
     ...(config.goldenComparison
       ? {
           goldenTraceDigest: await computeOAuthGoldenTraceDigest(

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -146,7 +146,9 @@ export interface EmulatedOAuthPreflightConfig {
    * Digest of the profile this run used. Recorded in `bindings` so a
    * capture-only run (one taken to BECOME a golden) is bound to its profile
    * too. When `goldenComparison` is supplied, its digest is used if this is
-   * absent.
+   * absent — and supplying BOTH with different values is rejected, since a
+   * run has exactly one profile and a disagreement here would defeat the
+   * comparator's binding check.
    */
   profileDigest?: string;
   /** Override the hardened default executor (tests, alternate transports). */
@@ -403,6 +405,30 @@ export async function runEmulatedOAuthPreflight(
     allowLoopbackMetadataFetch,
     resourceIndicatorEnforcement = "warn",
   } = config;
+
+  // ONE digest per run, resolved before anything touches the network.
+  //
+  // Letting `profileDigest` and `goldenComparison.profileDigest` disagree does
+  // not just make the report inconsistent — it routes around the comparator's
+  // binding check. That check refuses when `golden.profileDigest` differs from
+  // the run's, precisely so a capture of one client is never diffed against a
+  // run of another; a caller supplying the golden's digest here while the run
+  // used a different profile would sail through it and get a confident match
+  // for two different clients. Contradictory input is rejected rather than
+  // silently resolved, and rejected BEFORE any client is registered.
+  if (
+    config.profileDigest &&
+    config.goldenComparison &&
+    config.profileDigest !== config.goldenComparison.profileDigest
+  ) {
+    throw new Error(
+      "runEmulatedOAuthPreflight: profileDigest and goldenComparison.profileDigest disagree " +
+        `("${config.profileDigest}" vs "${config.goldenComparison.profileDigest}"). ` +
+        "A run has one profile; supply one digest, or the same value twice."
+    );
+  }
+  const profileDigest =
+    config.profileDigest ?? config.goldenComparison?.profileDigest;
 
   const executor =
     config.requestExecutor ?? createHardenedExecutor(timeoutMs);
@@ -952,7 +978,9 @@ export async function runEmulatedOAuthPreflight(
     ? compareOAuthEmulationTrace({
         trace,
         golden: config.goldenComparison.golden,
-        profileDigest: config.goldenComparison.profileDigest,
+        // The single resolved digest — the guard above proved it equals
+        // `goldenComparison.profileDigest` whenever both were supplied.
+        profileDigest: profileDigest ?? config.goldenComparison.profileDigest,
         coverageSummary: derived.coverageSummary,
         // Only what THIS RUN substituted. Compile-time divergences (a narrowed
         // ladder version, an unenforced field) describe the profile, not the
@@ -970,10 +998,10 @@ export async function runEmulatedOAuthPreflight(
         declaredSubstitutions: runtimeDivergences,
       };
 
-  // A capture-only run (no golden yet) still records which profile it came
-  // from — that binding is what makes the capture usable as a golden later.
-  const profileDigest =
-    config.profileDigest ?? config.goldenComparison?.profileDigest;
+  // `profileDigest` (resolved at the top) is what BOTH the comparison and
+  // these bindings report, so provenance and comparison can never disagree.
+  // A capture-only run records it too — that binding is what makes the
+  // capture usable as a golden later.
   const bindings: EmulatedOAuthPreflightResult["bindings"] = {
     ...(config.profileSchemaVersion
       ? { profileSchemaVersion: config.profileSchemaVersion }

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -57,6 +57,15 @@ import {
   isInvalidRedirectUriRejection,
   planCompletionSafeRedirects,
 } from "./redirects.js";
+import {
+  compareOAuthEmulationTrace,
+  computeOAuthGoldenTraceDigest,
+  normalizeAuthorizationRedirectStep,
+  normalizeOAuthTrace,
+  type NormalizedTraceStep,
+  type OAuthGoldenTrace,
+  type OAuthTraceComparisonResult,
+} from "./golden-trace.js";
 import type {
   EmulatedAuthAttempt,
   EmulatedRegistrationPreference,
@@ -117,6 +126,22 @@ export interface EmulatedOAuthPreflightConfig {
     authorizationUrl: string;
     callbackUrl: string;
   }) => Promise<{ code: string }>;
+  /**
+   * Compare this run against a real-client capture. Both the golden and the
+   * digest of the profile the run used are required together: comparing
+   * without verifying the binding would diff two clients that only look alike.
+   * Captures live in the private backend — nothing here ships one.
+   */
+  goldenComparison?: {
+    golden: OAuthGoldenTrace;
+    profileDigest: string;
+    expectedClientVersion?: string;
+    /** Injected so staleness is deterministic; defaults to the current date. */
+    now?: Date;
+  };
+  /** Recorded verbatim in `bindings`, for backend provenance. */
+  catalogRevision?: string;
+  profileSchemaVersion?: 1 | 2;
   /** Override the hardened default executor (tests, alternate transports). */
   requestExecutor?: OAuthRequestExecutor;
   allowLoopbackMetadataFetch?: boolean;
@@ -166,10 +191,22 @@ export interface EmulatedOAuthPreflightResult {
   coverage: OAuthEmulationCoverage;
   coverageSummary: "complete" | "partial";
   /**
-   * Third, independent dimension. Golden-trace comparison is a later step; a
-   * run never claims a match on its own.
+   * Third, independent dimension. Absent a golden capture this stays
+   * `not_compared` — a run never claims a match on its own.
    */
-  comparison: "not_compared";
+  comparison: OAuthTraceComparisonResult;
+  /** The run's normalized steps, for capture or offline comparison. */
+  trace: NormalizedTraceStep[];
+  /**
+   * What this run is bound to, so a result can always be traced back to the
+   * exact profile and capture that produced it.
+   */
+  bindings: {
+    profileSchemaVersion?: 1 | 2;
+    profileDigest?: string;
+    goldenTraceDigest?: string;
+    catalogRevision?: string;
+  };
   attempts: EmulatedAuthAttemptResult[];
   authorizationUrl?: string;
   /** Compile-time divergences plus everything this run declared. */
@@ -866,13 +903,64 @@ export async function runEmulatedOAuthPreflight(
     if (attemptOutput.stop) break;
   }
 
+  // The run's own wire behavior, normalized: what a capture would record and
+  // what a comparison diffs. Built from every attempt in the order they ran,
+  // with the authorization redirect appended as its own step.
+  const trace: NormalizedTraceStep[] = [
+    ...attempts.flatMap((attempt) =>
+      normalizeOAuthTrace(attempt.httpHistory ?? [])
+    ),
+    ...(authorizationUrl
+      ? [normalizeAuthorizationRedirectStep(authorizationUrl)]
+      : []),
+  ];
+
+  const comparison: OAuthTraceComparisonResult = config.goldenComparison
+    ? compareOAuthEmulationTrace({
+        trace,
+        golden: config.goldenComparison.golden,
+        profileDigest: config.goldenComparison.profileDigest,
+        coverageSummary: derived.coverageSummary,
+        declaredSubstitutions: divergences,
+        expectedClientVersion: config.goldenComparison.expectedClientVersion,
+        now: config.goldenComparison.now,
+      })
+    : {
+        status: "not_compared",
+        reason: "no_golden",
+        qualifiers: [],
+        differences: [],
+        declaredSubstitutions: divergences,
+      };
+
+  const bindings: EmulatedOAuthPreflightResult["bindings"] = {
+    ...(config.profileSchemaVersion
+      ? { profileSchemaVersion: config.profileSchemaVersion }
+      : {}),
+    ...(config.goldenComparison
+      ? { profileDigest: config.goldenComparison.profileDigest }
+      : {}),
+    ...(config.goldenComparison
+      ? {
+          goldenTraceDigest: await computeOAuthGoldenTraceDigest(
+            config.goldenComparison.golden
+          ),
+        }
+      : {}),
+    ...(config.catalogRevision
+      ? { catalogRevision: config.catalogRevision }
+      : {}),
+  };
+
   return {
     serverUrl,
     protocolVersion,
     outcome,
     coverage: derived.coverage,
     coverageSummary: derived.coverageSummary,
-    comparison: "not_compared",
+    comparison,
+    trace,
+    bindings,
     attempts,
     ...(authorizationUrl ? { authorizationUrl } : {}),
     divergences,

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -416,8 +416,14 @@ export async function runEmulatedOAuthPreflight(
   // used a different profile would sail through it and get a confident match
   // for two different clients. Contradictory input is rejected rather than
   // silently resolved, and rejected BEFORE any client is registered.
+  //
+  // Presence, not truthiness: an explicitly supplied `""` is still a second
+  // digest, and a truthy check would wave it through to be resolved as `""`
+  // (`??` does not fall back on an empty string) — leaving the comparison
+  // holding `""` while `bindings` omits the digest entirely, which is the one
+  // disagreement this guard exists to prevent.
   if (
-    config.profileDigest &&
+    config.profileDigest !== undefined &&
     config.goldenComparison &&
     config.profileDigest !== config.goldenComparison.profileDigest
   ) {

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -60,7 +60,7 @@ import {
 import {
   compareOAuthEmulationTrace,
   computeOAuthGoldenTraceDigest,
-  normalizeAuthorizationRedirectStep,
+  insertAuthorizationRedirectStep,
   normalizeOAuthTrace,
   type NormalizedTraceStep,
   type OAuthGoldenTrace,
@@ -410,7 +410,10 @@ export async function runEmulatedOAuthPreflight(
   });
 
   let outcome: EmulatedOAuthPreflightOutcome = "blocked";
+  /** Reported to the caller: the run stopped here and needs a human. */
   let authorizationUrl: string | undefined;
+  /** Recorded in the trace: authorization happened, however the run ended. */
+  let traceAuthorizationUrl: string | undefined;
   let credentials: EmulatedOAuthPreflightResult["credentials"];
   let error: { message: string } | undefined;
   let redirectDivergencesDeclared = false;
@@ -883,6 +886,16 @@ export async function runEmulatedOAuthPreflight(
     if (attemptOutput.authorizationUrl) {
       authorizationUrl = attemptOutput.authorizationUrl;
     }
+    // A completed run authorized too; its URL simply never had to be handed
+    // back to a caller. The TRACE needs it either way, or a completed run
+    // would omit the authorize leg and mismatch every golden that records it.
+    // Kept separate from `authorizationUrl`, which means "stopped here, a
+    // human is required" and must not start appearing on completed runs.
+    const attemptAuthorizationUrl =
+      attemptOutput.authorizationUrl ?? attemptOutput.state?.authorizationUrl;
+    if (attemptAuthorizationUrl) {
+      traceAuthorizationUrl = attemptAuthorizationUrl;
+    }
     if (attemptOutput.state) {
       const { accessToken, refreshToken, clientId, clientSecret } =
         attemptOutput.state;
@@ -906,14 +919,12 @@ export async function runEmulatedOAuthPreflight(
   // The run's own wire behavior, normalized: what a capture would record and
   // what a comparison diffs. Built from every attempt in the order they ran,
   // with the authorization redirect appended as its own step.
-  const trace: NormalizedTraceStep[] = [
-    ...attempts.flatMap((attempt) =>
+  const trace: NormalizedTraceStep[] = insertAuthorizationRedirectStep(
+    attempts.flatMap((attempt) =>
       normalizeOAuthTrace(attempt.httpHistory ?? [])
     ),
-    ...(authorizationUrl
-      ? [normalizeAuthorizationRedirectStep(authorizationUrl)]
-      : []),
-  ];
+    traceAuthorizationUrl
+  );
 
   const comparison: OAuthTraceComparisonResult = config.goldenComparison
     ? compareOAuthEmulationTrace({

--- a/sdk/tests/oauth/emulation-golden-trace.test.ts
+++ b/sdk/tests/oauth/emulation-golden-trace.test.ts
@@ -73,6 +73,44 @@ describe("normalizeOAuthTrace", () => {
     });
   });
 
+  it("normalizes a bracketed IPv6 loopback callback too", () => {
+    // A `\b` guard never matches before `[`, so the IPv6 form was silently
+    // left un-normalized and its per-run port leaked into comparisons.
+    const ipv6Callback = "http://[::1]:41234/callback";
+    const [step] = normalizeOAuthTrace([
+      entry({
+        url: `https://as.example.com/authorize?redirect_uri=${encodeURIComponent(ipv6Callback)}`,
+        body: { redirect_uris: [ipv6Callback, "zed://oauth"] },
+      }),
+    ]);
+    expect(step.url).toContain(encodeURIComponent("[::1]:<port>"));
+    expect(step.body).toEqual({
+      redirect_uris: ["http://[::1]:<port>/callback", "zed://oauth"],
+    });
+  });
+
+  it("keeps a `__proto__` form parameter instead of losing it to the prototype", () => {
+    const [step] = normalizeOAuthTrace([
+      entry({ body: "__proto__=surprise&grant_type=authorization_code" }),
+    ]);
+    // The expectation is built with JSON.parse, not an object literal: writing
+    // `{ __proto__: "surprise" }` would hit the very trap under test and
+    // compare against an object with no such own property.
+    expect(JSON.parse(JSON.stringify(step.body))).toEqual(
+      JSON.parse(
+        '{"__proto__":"surprise","grant_type":"authorization_code"}'
+      )
+    );
+    expect(JSON.stringify(step.body)).toContain("__proto__");
+  });
+
+  it("puts the rebuilt query before any fragment, not inside it", () => {
+    const [step] = normalizeOAuthTrace([
+      entry({ url: "https://as.example.com/authorize?scope=x#frag" }),
+    ]);
+    expect(step.url).toBe("https://as.example.com/authorize?scope=x");
+  });
+
   it("compares form bodies as objects, ignoring parameter order", () => {
     const [a] = normalizeOAuthTrace([
       entry({ body: "grant_type=authorization_code&code=SECRET&resource=https%3A%2F%2Fx" }),
@@ -234,6 +272,33 @@ describe("compareOAuthEmulationTrace", () => {
     ]);
   });
 
+  it("a hand-authored golden is normalized before diffing, so key order is not a mismatch", () => {
+    // Goldens may be written or edited by hand; without re-normalizing, header
+    // key order alone would manufacture a difference.
+    const handAuthored: NormalizedTraceStep[] = steps.map((step, index) =>
+      index === 0
+        ? {
+            ...step,
+            headers: { "X-Zeta": "2", "Content-Type": "application/json" },
+          }
+        : step
+    );
+    const runSteps: NormalizedTraceStep[] = steps.map((step, index) =>
+      index === 0
+        ? {
+            ...step,
+            headers: { "content-type": "application/json", "x-zeta": "2" },
+          }
+        : step
+    );
+    const result = compare({
+      golden: golden({ steps: handAuthored }),
+      trace: runSteps,
+    });
+    expect(result.differences).toEqual([]);
+    expect(result.status).toBe("matched");
+  });
+
   it("refuses to compare a golden captured from a different profile", () => {
     const result = compare({ profileDigest: "digest-b" });
     expect(result.status).toBe("not_compared");
@@ -288,6 +353,16 @@ describe("compareOAuthEmulationTrace — freshness", () => {
     expect(Number.isNaN(result.freshness?.ageDays as number)).toBe(true);
     expect(result.freshness?.stale).toBe(true);
     expect(result.qualifiers).toContain("stale_capture");
+  });
+
+  it("a future-dated capture is stale — nothing was captured tomorrow", () => {
+    // A negative age would otherwise sail past the `> threshold` check and be
+    // reported as current.
+    const result = compareAged("2026-09-01");
+    expect(result.freshness?.ageDays).toBeLessThan(0);
+    expect(result.freshness?.stale).toBe(true);
+    expect(result.qualifiers).toContain("stale_capture");
+    expect(isUnqualifiedMatch(result)).toBe(false);
   });
 
   it("a malformed capturedAt is stale rather than current", () => {
@@ -511,6 +586,70 @@ describe("runEmulatedOAuthPreflight — comparison dimension", () => {
 
     expect(result.comparison.status).toBe("not_compared");
     expect(result.comparison.reason).toBe("golden_profile_mismatch");
+  });
+
+  it("a compile-time divergence does not count as a run substitution", async () => {
+    // A narrowed ladder version describes the PROFILE, not the wire. Counting
+    // it would downgrade a byte-exact match to "matched with substitutions".
+    const narrowed = deriveOAuthEmulation({
+      profileVersion: 2,
+      authModel: verified(["oauth2-dcr"]),
+      oauthSpecVersion: verified({
+        basis: "constant" as const,
+        revisions: ["2024-11-05"],
+      }),
+    });
+    expect(narrowed.divergences).toEqual([
+      expect.objectContaining({ kind: "version-narrowed" }),
+    ]);
+
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const first = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: narrowed,
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    const replay = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const second = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: narrowed,
+      callbackUrl: CALLBACK,
+      requestExecutor: replay.executor,
+      completeAuthorization: autoConsent,
+      goldenComparison: {
+        golden: { profileDigest: "d", capturedAt: "2026-08-01", steps: first.trace },
+        profileDigest: "d",
+        now: NOW,
+      },
+    });
+
+    expect(second.comparison.declaredSubstitutions).toEqual([]);
+    expect(second.comparison.status).toBe("matched");
+    // The compile-time divergence is still reported, just not as a substitution.
+    expect(second.divergences).toEqual([
+      expect.objectContaining({ kind: "version-narrowed" }),
+    ]);
+  });
+
+  it("a capture-only run is still bound to the profile it came from", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+      // No golden yet — this run exists to BECOME one.
+      profileDigest: "profile-under-capture",
+      profileSchemaVersion: 2,
+    });
+
+    expect(result.comparison.status).toBe("not_compared");
+    expect(result.bindings.profileDigest).toBe("profile-under-capture");
+    expect(result.bindings.goldenTraceDigest).toBeUndefined();
   });
 
   it("the run's trace carries no credential material", async () => {

--- a/sdk/tests/oauth/emulation-golden-trace.test.ts
+++ b/sdk/tests/oauth/emulation-golden-trace.test.ts
@@ -652,6 +652,69 @@ describe("runEmulatedOAuthPreflight — comparison dimension", () => {
     expect(result.bindings.goldenTraceDigest).toBeUndefined();
   });
 
+  it("rejects two disagreeing profile digests before touching the network", async () => {
+    // Allowing this would route around the comparator's binding check: the
+    // caller could pass the golden's digest for the comparison while the run
+    // actually used another profile, and get a confident match for two
+    // different clients — with bindings reporting the other one.
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    await expect(
+      runEmulatedOAuthPreflight({
+        serverUrl: SERVER_URL,
+        emulation: derive(),
+        callbackUrl: CALLBACK,
+        requestExecutor: mock.executor,
+        completeAuthorization: autoConsent,
+        profileDigest: "profile-actually-used",
+        goldenComparison: {
+          golden: {
+            profileDigest: "some-other-profile",
+            capturedAt: "2026-08-01",
+            steps: [],
+          },
+          profileDigest: "some-other-profile",
+          now: NOW,
+        },
+      })
+    ).rejects.toThrow(/disagree/);
+    // Rejected before any client was registered on the target server.
+    expect(mock.requests).toHaveLength(0);
+  });
+
+  it("comparison and bindings always report the same digest", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const first = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    const replay = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const second = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: replay.executor,
+      completeAuthorization: autoConsent,
+      // Both supplied, in agreement — the only accepted way to send two.
+      profileDigest: "agreed-digest",
+      goldenComparison: {
+        golden: {
+          profileDigest: "agreed-digest",
+          capturedAt: "2026-08-01",
+          steps: first.trace,
+        },
+        profileDigest: "agreed-digest",
+        now: NOW,
+      },
+    });
+
+    expect(second.bindings.profileDigest).toBe("agreed-digest");
+    expect(second.comparison.status).not.toBe("not_compared");
+  });
+
   it("the run's trace carries no credential material", async () => {
     const mock = createMockOAuthServer({
       serverUrl: SERVER_URL,

--- a/sdk/tests/oauth/emulation-golden-trace.test.ts
+++ b/sdk/tests/oauth/emulation-golden-trace.test.ts
@@ -681,6 +681,33 @@ describe("runEmulatedOAuthPreflight — comparison dimension", () => {
     expect(mock.requests).toHaveLength(0);
   });
 
+  it("rejects an explicitly empty digest against a golden's, too", async () => {
+    // `""` is a supplied value, not an absent one. Waving it through would
+    // resolve the run to `""` — comparison holding `""`, `bindings` omitting
+    // the digest — the exact disagreement the guard exists to prevent.
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    await expect(
+      runEmulatedOAuthPreflight({
+        serverUrl: SERVER_URL,
+        emulation: derive(),
+        callbackUrl: CALLBACK,
+        requestExecutor: mock.executor,
+        completeAuthorization: autoConsent,
+        profileDigest: "",
+        goldenComparison: {
+          golden: {
+            profileDigest: "some-other-profile",
+            capturedAt: "2026-08-01",
+            steps: [],
+          },
+          profileDigest: "some-other-profile",
+          now: NOW,
+        },
+      })
+    ).rejects.toThrow(/disagree/);
+    expect(mock.requests).toHaveLength(0);
+  });
+
   it("comparison and bindings always report the same digest", async () => {
     const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
     const first = await runEmulatedOAuthPreflight({

--- a/sdk/tests/oauth/emulation-golden-trace.test.ts
+++ b/sdk/tests/oauth/emulation-golden-trace.test.ts
@@ -6,6 +6,7 @@ import {
   computeOAuthGoldenTraceDigest,
   computeOAuthProfileDigest,
   GOLDEN_STALENESS_DAYS,
+  insertAuthorizationRedirectStep,
   isUnqualifiedMatch,
   normalizeAuthorizationRedirectStep,
   normalizeOAuthTrace,
@@ -111,6 +112,34 @@ describe("normalizeOAuthTrace", () => {
     } as HttpHistoryEntry;
     const [step] = normalizeOAuthTrace([withResponse]);
     expect(step).not.toHaveProperty("response");
+  });
+
+  it("keeps a JSON body containing `=` as JSON", () => {
+    // `{"redirect_uri":"http://x?a=b"}` has no spaces and contains `=`, so a
+    // shape test alone would misread it as form-encoded and reshape the body.
+    const [step] = normalizeOAuthTrace([
+      entry({ body: '{"redirect_uri":"http://x?a=b","client_name":"C"}' }),
+    ]);
+    expect(step.body).toEqual({
+      client_name: "C",
+      redirect_uri: "http://x?a=b",
+    });
+  });
+
+  it("preserves repeated form parameters instead of keeping only the last", () => {
+    // Collapsing these would let a run with duplicates compare equal to one
+    // without them — parity overstated by a parsing artifact.
+    const [withDuplicates] = normalizeOAuthTrace([
+      entry({ body: "scope=a&scope=b&grant_type=authorization_code" }),
+    ]);
+    const [withoutDuplicates] = normalizeOAuthTrace([
+      entry({ body: "scope=b&grant_type=authorization_code" }),
+    ]);
+    expect((withDuplicates.body as Record<string, unknown>).scope).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(withDuplicates.body).not.toEqual(withoutDuplicates.body);
   });
 
   it("normalizes the authorization redirect as its own step", () => {
@@ -252,6 +281,22 @@ describe("compareOAuthEmulationTrace — freshness", () => {
     expect(isUnqualifiedMatch(result)).toBe(false);
   });
 
+  it("an impossible calendar date is stale, not silently rolled forward", () => {
+    // `new Date("2026-02-31")` rolls to March 3, which would turn a malformed
+    // capture into a confident freshness claim.
+    const result = compareAged("2026-02-31");
+    expect(Number.isNaN(result.freshness?.ageDays as number)).toBe(true);
+    expect(result.freshness?.stale).toBe(true);
+    expect(result.qualifiers).toContain("stale_capture");
+  });
+
+  it("a malformed capturedAt is stale rather than current", () => {
+    for (const capturedAt of ["not-a-date", "2026-8-3", ""]) {
+      const result = compareAged(capturedAt);
+      expect(result.freshness?.stale).toBe(true);
+    }
+  });
+
   it("a client-version mismatch qualifies the match", () => {
     const result = compareOAuthEmulationTrace({
       trace: steps,
@@ -268,6 +313,40 @@ describe("compareOAuthEmulationTrace — freshness", () => {
     });
     expect(result.qualifiers).toContain("client_version_mismatch");
     expect(isUnqualifiedMatch(result)).toBe(false);
+  });
+});
+
+describe("insertAuthorizationRedirectStep", () => {
+  const steps = normalizeOAuthTrace([
+    entry({ step: "request_client_registration", url: "https://as.example.com/register" }),
+    entry({ step: "token_request" }),
+    entry({ step: "authenticated_mcp_request", url: SERVER_URL }),
+  ]);
+
+  it("places the redirect before the token exchange, where it happened", () => {
+    const withRedirect = insertAuthorizationRedirectStep(
+      steps,
+      "https://as.example.com/authorize?client_id=x"
+    );
+    expect(withRedirect.map((step) => step.step)).toEqual([
+      "request_client_registration",
+      "authorization_redirect",
+      "token_request",
+      "authenticated_mcp_request",
+    ]);
+  });
+
+  it("appends when the run stopped at the redirect and never exchanged", () => {
+    const stopped = steps.slice(0, 1);
+    expect(
+      insertAuthorizationRedirectStep(stopped, "https://as.example.com/authorize").map(
+        (step) => step.step
+      )
+    ).toEqual(["request_client_registration", "authorization_redirect"]);
+  });
+
+  it("is a no-op when authorization never happened", () => {
+    expect(insertAuthorizationRedirectStep(steps, undefined)).toBe(steps);
   });
 });
 
@@ -373,6 +452,42 @@ describe("runEmulatedOAuthPreflight — comparison dimension", () => {
       catalogRevision: "catalog-2026-08-03",
     });
     expect(second.bindings.goldenTraceDigest).toEqual(expect.any(String));
+  });
+
+  it("a completed run records the authorize leg, in flow order", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.outcome).toBe("completed");
+    const kinds = result.trace.map((step) => step.step);
+    expect(kinds).toContain("authorization_redirect");
+    // Position is meaning: comparison is index-based, so the redirect must sit
+    // where it happened — after registration, before the code is exchanged.
+    expect(kinds.indexOf("authorization_redirect")).toBeLessThan(
+      kinds.indexOf("token_request")
+    );
+    // `authorizationUrl` keeps meaning "stopped here, a human is required".
+    expect(result.authorizationUrl).toBeUndefined();
+  });
+
+  it("a run stopped at the redirect reports the URL and ends on that step", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+    });
+
+    expect(result.outcome).toBe("stopped_at_redirect");
+    expect(result.authorizationUrl).toContain("/authorize");
+    expect(result.trace.at(-1)?.step).toBe("authorization_redirect");
   });
 
   it("a golden from another profile is refused rather than diffed", async () => {

--- a/sdk/tests/oauth/emulation-golden-trace.test.ts
+++ b/sdk/tests/oauth/emulation-golden-trace.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Golden-trace normalization and comparison (HP-43 step 6).
+ */
+import {
+  compareOAuthEmulationTrace,
+  computeOAuthGoldenTraceDigest,
+  computeOAuthProfileDigest,
+  GOLDEN_STALENESS_DAYS,
+  isUnqualifiedMatch,
+  normalizeAuthorizationRedirectStep,
+  normalizeOAuthTrace,
+  NORMALIZED_VALUE,
+} from "../../src/oauth/emulation/golden-trace.js";
+import type {
+  NormalizedTraceStep,
+  OAuthGoldenTrace,
+} from "../../src/oauth/emulation/golden-trace.js";
+import { runEmulatedOAuthPreflight } from "../../src/oauth/emulation/preflight.js";
+import { deriveOAuthEmulation } from "../../src/oauth/emulation/derive.js";
+import type { HttpHistoryEntry } from "../../src/oauth/state-machines/types.js";
+import {
+  autoConsent,
+  createMockOAuthServer,
+} from "../support/mock-oauth-as.js";
+import { verified } from "../support/oauth-profiles.js";
+
+const SERVER_URL = "https://mcp-server.example.com/mcp";
+const CALLBACK = "http://127.0.0.1:41234/callback";
+const NOW = new Date("2026-08-03T00:00:00Z");
+
+const entry = (
+  overrides: Partial<HttpHistoryEntry["request"]> & { step?: string } = {}
+): HttpHistoryEntry =>
+  ({
+    step: (overrides.step ?? "token_request") as HttpHistoryEntry["step"],
+    timestamp: 1_700_000_000_000,
+    duration: 42,
+    request: {
+      method: overrides.method ?? "POST",
+      url: overrides.url ?? "https://as.example.com/token",
+      headers: overrides.headers ?? {},
+      body: overrides.body,
+    },
+  }) as HttpHistoryEntry;
+
+describe("normalizeOAuthTrace", () => {
+  it("neutralizes per-run values but keeps their keys", () => {
+    const [step] = normalizeOAuthTrace([
+      entry({
+        url: "https://as.example.com/authorize?state=abc123&code_challenge=xyz&scope=mcp%3Aread",
+      }),
+    ]);
+    // The volatile values are gone; the parameters themselves are not, so a
+    // client that STOPS sending one still shows up as a difference.
+    expect(step.url).toContain(`state=${encodeURIComponent(NORMALIZED_VALUE)}`);
+    expect(step.url).toContain(
+      `code_challenge=${encodeURIComponent(NORMALIZED_VALUE)}`
+    );
+    expect(step.url).toContain("scope=mcp%3Aread");
+  });
+
+  it("normalizes the loopback callback port everywhere it appears", () => {
+    const [step] = normalizeOAuthTrace([
+      entry({
+        url: `https://as.example.com/authorize?redirect_uri=${encodeURIComponent(CALLBACK)}`,
+        body: { redirect_uris: [CALLBACK, "zed://oauth"] },
+      }),
+    ]);
+    expect(step.url).toContain("127.0.0.1%3A%3Cport%3E");
+    expect(step.body).toEqual({
+      redirect_uris: ["http://127.0.0.1:<port>/callback", "zed://oauth"],
+    });
+  });
+
+  it("compares form bodies as objects, ignoring parameter order", () => {
+    const [a] = normalizeOAuthTrace([
+      entry({ body: "grant_type=authorization_code&code=SECRET&resource=https%3A%2F%2Fx" }),
+    ]);
+    const [b] = normalizeOAuthTrace([
+      entry({ body: "resource=https%3A%2F%2Fx&code=OTHER&grant_type=authorization_code" }),
+    ]);
+    expect(a.body).toEqual(b.body);
+    expect((a.body as Record<string, string>).code).toBe(NORMALIZED_VALUE);
+    expect((a.body as Record<string, string>).grant_type).toBe(
+      "authorization_code"
+    );
+  });
+
+  it("drops timestamps and derived headers, keeps knob-bearing ones", () => {
+    const [step] = normalizeOAuthTrace([
+      entry({
+        headers: {
+          "MCP-Protocol-Version": "2025-03-26",
+          "User-Agent": "RealClient/1.0",
+          Authorization: "Bearer super-secret",
+          "Content-Length": "123",
+        },
+      }),
+    ]);
+    expect(step).not.toHaveProperty("timestamp");
+    expect(step.headers["mcp-protocol-version"]).toBe("2025-03-26");
+    expect(step.headers["user-agent"]).toBe("RealClient/1.0");
+    expect(step.headers.authorization).toBe(NORMALIZED_VALUE);
+    expect(step.headers["content-length"]).toBeUndefined();
+  });
+
+  it("excludes responses — a golden describes the client, not the server", () => {
+    const withResponse = {
+      ...entry(),
+      response: { status: 200, statusText: "OK", headers: {}, body: { a: 1 } },
+    } as HttpHistoryEntry;
+    const [step] = normalizeOAuthTrace([withResponse]);
+    expect(step).not.toHaveProperty("response");
+  });
+
+  it("normalizes the authorization redirect as its own step", () => {
+    const step = normalizeAuthorizationRedirectStep(
+      "https://as.example.com/authorize?client_id=generated-42&state=zz"
+    );
+    expect(step.step).toBe("authorization_redirect");
+    expect(step.url).toContain(
+      `client_id=${encodeURIComponent(NORMALIZED_VALUE)}`
+    );
+  });
+});
+
+describe("compareOAuthEmulationTrace", () => {
+  const steps: NormalizedTraceStep[] = normalizeOAuthTrace([
+    entry({ step: "request_client_registration", url: "https://as.example.com/register", body: { client_name: "Real Client" } }),
+    entry({ step: "token_request", body: "grant_type=authorization_code&code=X" }),
+  ]);
+
+  const golden = (
+    overrides: Partial<OAuthGoldenTrace> = {}
+  ): OAuthGoldenTrace => ({
+    profileDigest: "digest-a",
+    capturedAt: "2026-07-20",
+    clientVersion: "1.2.3",
+    steps,
+    ...overrides,
+  });
+
+  const compare = (
+    overrides: Partial<Parameters<typeof compareOAuthEmulationTrace>[0]> = {}
+  ) =>
+    compareOAuthEmulationTrace({
+      trace: steps,
+      golden: golden(),
+      profileDigest: "digest-a",
+      coverageSummary: "complete",
+      now: NOW,
+      ...overrides,
+    });
+
+  it("an exact run with complete coverage and a fresh capture is an unqualified match", () => {
+    const result = compare();
+    expect(result.status).toBe("matched");
+    expect(result.qualifiers).toEqual([]);
+    expect(result.differences).toEqual([]);
+    expect(isUnqualifiedMatch(result)).toBe(true);
+  });
+
+  it("declared substitutions downgrade the status, not the diff", () => {
+    const result = compare({
+      declaredSubstitutions: [
+        { kind: "redirect-uri-appended", detail: "callback appended" },
+      ],
+    });
+    expect(result.status).toBe("matched_with_declared_substitutions");
+    expect(result.differences).toEqual([]);
+    expect(isUnqualifiedMatch(result)).toBe(false);
+  });
+
+  it("partial coverage can never be an unqualified match", () => {
+    const result = compare({ coverageSummary: "partial" });
+    expect(result.status).toBe("matched");
+    expect(result.qualifiers).toContain("partial_coverage");
+    expect(isUnqualifiedMatch(result)).toBe(false);
+  });
+
+  it("reports each differing field of a step", () => {
+    const drifted = normalizeOAuthTrace([
+      entry({ step: "request_client_registration", url: "https://as.example.com/register", body: { client_name: "Different Name" } }),
+      entry({ step: "token_request", body: "grant_type=authorization_code&code=X" }),
+    ]);
+    const result = compare({ trace: drifted });
+    expect(result.status).toBe("mismatched");
+    expect(result.differences).toEqual([
+      expect.objectContaining({ index: 0, kind: "body" }),
+    ]);
+    expect(isUnqualifiedMatch(result)).toBe(false);
+  });
+
+  it("reports a request the real client made that the run never did", () => {
+    const result = compare({ trace: [steps[0]] });
+    expect(result.differences).toEqual([
+      expect.objectContaining({ index: 1, kind: "missing_in_run" }),
+    ]);
+  });
+
+  it("reports a request the run made that the real client never did", () => {
+    const result = compare({ trace: [...steps, steps[1]] });
+    expect(result.differences).toEqual([
+      expect.objectContaining({ index: 2, kind: "unexpected_in_run" }),
+    ]);
+  });
+
+  it("refuses to compare a golden captured from a different profile", () => {
+    const result = compare({ profileDigest: "digest-b" });
+    expect(result.status).toBe("not_compared");
+    expect(result.reason).toBe("golden_profile_mismatch");
+    expect(result.differences).toEqual([]);
+  });
+
+  it("refuses to compare when the run produced no trace", () => {
+    const result = compare({ trace: [] });
+    expect(result.status).toBe("not_compared");
+    expect(result.reason).toBe("no_run_trace");
+  });
+});
+
+describe("compareOAuthEmulationTrace — freshness", () => {
+  const steps = normalizeOAuthTrace([entry()]);
+  const compareAged = (capturedAt: string, clientVersion?: string) =>
+    compareOAuthEmulationTrace({
+      trace: steps,
+      golden: {
+        profileDigest: "d",
+        capturedAt,
+        steps,
+        ...(clientVersion ? { clientVersion } : {}),
+      },
+      profileDigest: "d",
+      coverageSummary: "complete",
+      now: NOW,
+    });
+
+  it("a capture exactly at the threshold is still current", () => {
+    // NOW − 90 days.
+    const result = compareAged("2026-05-05");
+    expect(result.freshness?.ageDays).toBe(GOLDEN_STALENESS_DAYS);
+    expect(result.freshness?.stale).toBe(false);
+    expect(result.qualifiers).not.toContain("stale_capture");
+  });
+
+  it("a capture one day past the threshold is stale, never presented as current", () => {
+    const result = compareAged("2026-05-04");
+    expect(result.freshness?.ageDays).toBe(GOLDEN_STALENESS_DAYS + 1);
+    expect(result.freshness?.stale).toBe(true);
+    expect(result.qualifiers).toContain("stale_capture");
+    expect(result.status).toBe("matched");
+    expect(isUnqualifiedMatch(result)).toBe(false);
+  });
+
+  it("a client-version mismatch qualifies the match", () => {
+    const result = compareOAuthEmulationTrace({
+      trace: steps,
+      golden: {
+        profileDigest: "d",
+        capturedAt: "2026-08-01",
+        clientVersion: "1.0.0",
+        steps,
+      },
+      profileDigest: "d",
+      coverageSummary: "complete",
+      expectedClientVersion: "2.0.0",
+      now: NOW,
+    });
+    expect(result.qualifiers).toContain("client_version_mismatch");
+    expect(isUnqualifiedMatch(result)).toBe(false);
+  });
+});
+
+describe("digests bind a run to its profile and capture", () => {
+  it("the profile digest is canonical — key order cannot change it", async () => {
+    const a = await computeOAuthProfileDigest({
+      profileVersion: 2,
+      sendsResourceIndicator: verified(false),
+      authModel: verified(["oauth2-dcr"]),
+    });
+    const b = await computeOAuthProfileDigest({
+      profileVersion: 2,
+      authModel: verified(["oauth2-dcr"]),
+      sendsResourceIndicator: verified(false),
+    });
+    expect(a).toBe(b);
+  });
+
+  it("a different profile yields a different digest", async () => {
+    const a = await computeOAuthProfileDigest({
+      profileVersion: 2,
+      sendsResourceIndicator: verified(false),
+    });
+    const b = await computeOAuthProfileDigest({
+      profileVersion: 2,
+      sendsResourceIndicator: verified(true),
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("the golden digest addresses the captured steps", async () => {
+    const steps = normalizeOAuthTrace([entry()]);
+    const digest = await computeOAuthGoldenTraceDigest({ steps });
+    const other = await computeOAuthGoldenTraceDigest({
+      steps: normalizeOAuthTrace([entry({ method: "GET" })]),
+    });
+    expect(digest).not.toBe(other);
+  });
+});
+
+describe("runEmulatedOAuthPreflight — comparison dimension", () => {
+  const derive = () =>
+    deriveOAuthEmulation({
+      profileVersion: 2,
+      authModel: verified(["oauth2-dcr"]),
+    });
+
+  it("stays not_compared with no golden, and always emits a trace", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    expect(result.comparison.status).toBe("not_compared");
+    expect(result.comparison.reason).toBe("no_golden");
+    expect(result.trace.length).toBeGreaterThan(0);
+    // The three dimensions stay independent: a completed run says nothing
+    // about parity.
+    expect(result.outcome).toBe("completed");
+    expect(result.coverageSummary).toBe("partial");
+  });
+
+  it("matches its own trace, qualified by the partial coverage that produced it", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const first = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    const replay = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const second = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: replay.executor,
+      completeAuthorization: autoConsent,
+      profileSchemaVersion: 2,
+      catalogRevision: "catalog-2026-08-03",
+      goldenComparison: {
+        golden: {
+          profileDigest: "profile-digest",
+          capturedAt: "2026-08-01",
+          steps: first.trace,
+        },
+        profileDigest: "profile-digest",
+        now: NOW,
+      },
+    });
+
+    expect(second.comparison.differences).toEqual([]);
+    expect(second.comparison.qualifiers).toContain("partial_coverage");
+    expect(isUnqualifiedMatch(second.comparison)).toBe(false);
+    expect(second.bindings).toMatchObject({
+      profileSchemaVersion: 2,
+      profileDigest: "profile-digest",
+      catalogRevision: "catalog-2026-08-03",
+    });
+    expect(second.bindings.goldenTraceDigest).toEqual(expect.any(String));
+  });
+
+  it("a golden from another profile is refused rather than diffed", async () => {
+    const mock = createMockOAuthServer({ serverUrl: SERVER_URL });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+      goldenComparison: {
+        golden: {
+          profileDigest: "some-other-client",
+          capturedAt: "2026-08-01",
+          steps: [],
+        },
+        profileDigest: "this-client",
+        now: NOW,
+      },
+    });
+
+    expect(result.comparison.status).toBe("not_compared");
+    expect(result.comparison.reason).toBe("golden_profile_mismatch");
+  });
+
+  it("the run's trace carries no credential material", async () => {
+    const mock = createMockOAuthServer({
+      serverUrl: SERVER_URL,
+      issuedClientSecret: "registered-secret-value",
+    });
+    const result = await runEmulatedOAuthPreflight({
+      serverUrl: SERVER_URL,
+      emulation: derive(),
+      callbackUrl: CALLBACK,
+      requestExecutor: mock.executor,
+      completeAuthorization: autoConsent,
+    });
+
+    const serialized = JSON.stringify(result.trace);
+    expect(serialized).not.toContain("emulated-access-token");
+    expect(serialized).not.toContain("registered-secret-value");
+    expect(serialized).not.toContain("mock-authorization-code");
+  });
+});

--- a/sdk/tests/oauth/emulation-preflight.test.ts
+++ b/sdk/tests/oauth/emulation-preflight.test.ts
@@ -175,7 +175,7 @@ describe("runEmulatedOAuthPreflight — completion", () => {
       dcrRegistrations: 1,
       tokensIssued: 1,
     });
-    expect(result.comparison).toBe("not_compared");
+    expect(result.comparison.status).toBe("not_compared");
   });
 
   it("a token without a valid JSON-RPC result is NOT a completion", async () => {
@@ -779,6 +779,6 @@ describe("runEmulatedOAuthPreflight — coverage and parity", () => {
     expect(result.outcome).toBe("completed");
     expect(result.coverageSummary).toBe("partial");
     expect(result.coverage.scopeRequest).toBe("not_modeled");
-    expect(result.comparison).toBe("not_compared");
+    expect(result.comparison.status).toBe("not_compared");
   });
 });


### PR DESCRIPTION
Step 6 of the OAuth Client Emulation plan (v3), **stacked on #3677** (S5). Review that first — this PR's base is its branch. **Do not merge yet.**

## What

Compares an emulated run against a real-client capture, and refuses to overstate the result.

### Normalization
`normalizeOAuthTrace` projects a run's HTTP history into comparable steps, neutralizing what differs on every execution: timestamps, CSRF state, PKCE, authorization codes, tokens, server-generated client ids, and the loopback callback port.

Two deliberate rules:
- Volatile **values** are replaced; **keys** never are. A client that stops sending `code_challenge` must surface as a difference, not disappear into the placeholder.
- **Responses are excluded.** A golden describes what the *client* does; the server's answers are the variable under test, not part of the client's behavior.

Query-parameter and header ordering are sorted before comparison — no spec fixes them and they vary harmlessly between HTTP stacks, so comparing them would manufacture mismatches.

### Comparison
`compareOAuthEmulationTrace` diffs the whole dance (discovery → registration → authorize → token → authenticated MCP request), reporting per-step `method`/`url`/`headers`/`body` differences plus requests present on only one side.

### Honest match claims
The result carries **qualifiers independent of the diff**: `partial_coverage` (any `not_modeled` field), `stale_capture`, `client_version_mismatch`. `isUnqualifiedMatch` is true only when the requests lined up, nothing was substituted, coverage was complete, **and** the capture is current — so a `not_modeled` field can never yield an unqualified `matched`, exactly as the plan requires. Declared substitutions (appended callback, DCR retry) downgrade the *status*, not the diff.

### Freshness
Goldens carry a capture date and client version. Older than 90 days (`GOLDEN_STALENESS_DAYS`) is reported stale and never presented as current; the threshold day itself is still current (pinned by tests on both sides of the boundary).

### Binding
A golden may only be compared against a run of the **same profile**. The comparator requires the run's profile digest alongside the capture and returns `not_compared` / `golden_profile_mismatch` rather than diffing two clients that only look alike. `computeOAuthProfileDigest` and `computeOAuthGoldenTraceDigest` content-address both sides, and every preflight result now reports its `bindings` (profile schema version, profile digest, golden digest, catalog revision).

`runEmulatedOAuthPreflight` gains `goldenComparison`, always emits its normalized `trace`, and `comparison` is now the full result object rather than a placeholder string.

**Captures live in the private backend, like the profiles** — this ships the engine only and names no client.

## Tests

`emulation-golden-trace.test.ts` (24): value-vs-key normalization, loopback-port normalization, order-insensitive form bodies, header retention (knob-bearing) vs neutralization (credential-bearing), response exclusion; exact match, declared substitutions, partial coverage, per-field mismatch, missing/unexpected steps, profile-digest refusal, empty trace; the 90-day boundary on both sides, client-version mismatch; digest canonicality; and the preflight integration incl. a self-replay match, bindings, and a trace free of credential material.

Two S5 assertions updated for the richer `comparison` shape.

`tsc --noEmit` clean; full SDK suite green (**3617 passed**); browser-entry guards pass (the comparator is pure and browser-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a golden-trace comparator for OAuth emulation that normalizes and diffs client behavior against real-client captures, with freshness checks, profile binding, and one resolved profile digest per run. Implements HP-43 step 6 and keeps match claims honest.

- **New Features**
  - Normalization: `normalizeOAuthTrace` and `normalizeAuthorizationRedirectStep` replace volatile values (never keys), exclude responses, parse bodies JSON-first, keep repeated form params as arrays, drop URL fragments, preserve `__proto__` form keys, and normalize loopback callback ports (IPv4/IPv6); header order is ignored.
  - Flow order: `insertAuthorizationRedirectStep` places the authorization redirect before the token exchange; completed runs now record this leg, and the redirect is placed per attempt; `authorizationUrl` still only signals “stopped at redirect.”
  - Comparison: `compareOAuthEmulationTrace` re-normalizes both sides before diffing, reports per-step diffs and missing/unexpected requests; qualifiers (`partial_coverage`, `stale_capture`, `client_version_mismatch`) keep claims honest; `isUnqualifiedMatch` only when no substitutions, full coverage, and a current capture.
  - Freshness and binding: 90-day staleness with strict date round‑trip validation; future‑dated captures are stale. Goldens must match the run’s `profileDigest`. Added `computeOAuthProfileDigest` and `computeOAuthGoldenTraceDigest`. Preflight now emits normalized `trace`, full `comparison`, and `bindings` (profile schema version, profile digest—including capture‑only runs—golden digest, catalog revision). New APIs are exported from `@mcpjam/sdk` (index and browser), including `insertAuthorizationRedirectStep` and `NORMALIZED_VALUE`. Declared substitutions include only runtime divergences.

- **Migration**
  - `runEmulatedOAuthPreflight` result: `comparison` is now an object; code expecting a string should read `comparison.status`.
  - To compare against a golden, pass `goldenComparison` with `golden` and a matching `profileDigest`; optionally set `expectedClientVersion` and `now`. Provide exactly one profile digest per run: use top‑level `profileDigest` or `goldenComparison.profileDigest`. If both are supplied they must match or `runEmulatedOAuthPreflight` throws before any network call; an explicitly empty digest (`""`) counts as “supplied” and will be rejected if it disagrees. The single resolved digest is used for both `comparison` and `bindings`. Compile‑time divergences stay in `divergences` and no longer count as declared substitutions. Consumers can import comparison, normalization, insertion, match checks, digest helpers, and constants from `@mcpjam/sdk`.

<sup>Written for commit b9780eeba58768fdc68c0a847f85f8d44e678d5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

