### PR TITLE
fix(slack-link): offer the user's actual projects on the success page

### DIFF
--- a/mcpjam-inspector/server/routes/slack-link/index.ts
+++ b/mcpjam-inspector/server/routes/slack-link/index.ts
@@ -47,6 +47,7 @@ import {
 } from "../../services/authkit-jwt.js";
 import { isValidSlackServiceToken } from "../../middleware/slack-service-auth.js";
 import { resolveUserByExternalId } from "../../services/identity.js";
+import { getConvexBearerForDelegation } from "../../utils/v1-convex-token.js";
 import {
   consumeSlackLinkSession,
   createSlackLinkSession,
@@ -781,12 +782,48 @@ slackLink.get("/workos/callback", async (c) => {
   }
   if (!result.ok) return linkFailed(c);
 
+  // The person is fully identified at this point, so the page can offer
+  // their ACTUAL projects instead of asking them to go find an id. Fetched
+  // with a delegated token for exactly the org the link landed in;
+  // best-effort — an empty list degrades to the paste field, never to a
+  // failed page (the LINK already succeeded, and this is decoration on it).
+  let projects: Array<{ id: string; name: string }> = [];
+  try {
+    const convexHttpUrl = (process.env.CONVEX_HTTP_URL ?? "").replace(
+      /\/+$/,
+      ""
+    );
+    if (convexHttpUrl) {
+      const jwt = await getConvexBearerForDelegation(
+        workosUserId,
+        organizationId
+      );
+      const { ok, body } = await fetchJsonWithDeadline<{
+        items?: Array<{ id?: unknown; name?: unknown }>;
+        data?: Array<{ id?: unknown; name?: unknown }>;
+      }>(`${convexHttpUrl}/v1/projects`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      });
+      const rows = ok ? (body.items ?? body.data ?? []) : [];
+      projects = rows
+        .filter((row) => typeof row?.id === "string")
+        .map((row) => ({
+          id: String(row.id),
+          name: typeof row.name === "string" && row.name ? row.name : String(row.id),
+        }));
+    }
+  } catch (error) {
+    logger.warn("[slack-link] could not list projects for the picker", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
   // Keep the cookie: the default-project picker below needs the session id,
   // and the session is now `consumed`, so it can no longer authorize a link.
   return page(c, {
     title: "Slack is connected",
     body: "MCPJam will now act as you when you talk to it in Slack. Pick the project your Slack work should land in — you can change this any time from the app’s Home tab.",
-    extraHtml: renderProjectPicker(),
+    extraHtml: renderProjectPicker(projects),
   });
 });
 
@@ -860,11 +897,51 @@ function decodeJwtClaims(jwt: string): Record<string, unknown> | null {
   }
 }
 
-function renderProjectPicker(): string {
+function renderProjectPicker(
+  projects: Array<{ id: string; name: string }>
+): string {
   // Inline, dependency-free: this page is served once, to one person, right
   // after an auth flow — pulling in the SPA would be strictly worse.
-  return `
-<form id="pick" class="muted">
+  //
+  // With a project list, each project is ONE BUTTON and a click saves it —
+  // nobody should have to know what a project id looks like. The paste field
+  // survives only as the fallback for the (rare) case the list could not be
+  // fetched.
+  const buttons = projects
+    .slice(0, 50)
+    .map(
+      (project) =>
+        `<button type="button" class="proj" data-id="${escapeHtml(project.id)}" style="display:block;width:100%;text-align:left;font:inherit;padding:.6rem .9rem;margin:.35rem 0;border-radius:.6rem;border:1px solid color-mix(in srgb, CanvasText 25%, transparent);background:color-mix(in srgb, CanvasText 6%, transparent);cursor:pointer">${escapeHtml(project.name)}</button>`
+    )
+    .join("");
+
+  const listHtml =
+    projects.length > 0
+      ? `<div id="projects" style="max-width:24rem">${buttons}</div>
+<p id="msg" class="muted"></p>
+<script>
+document.querySelectorAll('.proj').forEach((button) => {
+  button.addEventListener('click', async () => {
+    const msg = document.getElementById('msg');
+    msg.textContent = 'Saving…';
+    document.querySelectorAll('.proj').forEach((b) => { b.disabled = true; });
+    const response = await fetch('/api/slack/link/default-project', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: button.dataset.id }),
+    });
+    const body = await response.json().catch(() => ({}));
+    if (body.ok) {
+      msg.textContent = 'Saved — head back to Slack and say hi.';
+      button.style.borderColor = 'currentColor';
+    } else {
+      msg.textContent = body.message || 'Could not save that project.';
+      document.querySelectorAll('.proj').forEach((b) => { b.disabled = false; });
+    }
+  });
+});
+</script>`
+      : `<form id="pick" class="muted">
   <label for="projectId">Default project id</label><br>
   <input id="projectId" name="projectId" placeholder="Paste a project id" style="font:inherit;padding:.5rem .75rem;border-radius:.5rem;border:1px solid color-mix(in srgb, CanvasText 25%, transparent);min-width:18rem">
   <button type="submit">Save</button>
@@ -884,6 +961,8 @@ document.getElementById('pick').addEventListener('submit', async (event) => {
   msg.textContent = body.ok ? 'Saved. You can close this tab.' : (body.message || 'Could not save that project.');
 });
 </script>`;
+
+  return `\n${listHtml}`;
 }
 
 export default slackLink;


### PR DESCRIPTION
Follow-up to the live link-flow dogfood: the success page asked the freshly-linked user to *paste a project id*. The person is fully identified at that point, so the page now mints a delegated token for the org the link landed in, fetches `GET /v1/projects`, and renders each project as a single click-to-save button. The paste field remains only as the fallback when the list can't be fetched (the link itself already succeeded — the picker must degrade, never error).

Project names are escaped through the page's existing `escapeHtml`; the list is capped at 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds server-side delegated JWT minting and a Convex projects fetch on the post-link page; scope is limited to the already-verified user/org and failures degrade to the legacy picker without affecting link completion.
> 
> **Overview**
> After Slack account linking completes, the success page no longer asks users to **paste a project id** by default. It **mints an org-scoped delegated bearer** for the authenticated WorkOS user, calls **`GET /v1/projects`**, and shows up to **50 named projects** as one-click buttons that POST to the existing **`/default-project`** endpoint.
> 
> If **`CONVEX_HTTP_URL`** is unset, the request fails, or the list is empty, the UI **falls back** to the original paste form so linking still succeeds and the picker never blocks the page. Project **names and ids** are passed through **`escapeHtml`** in the button markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906534ae1a5680921cedfa8672ac1fbc4cbf1f08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Slack link success page now lists the user’s projects from their org and lets them set a default with one click. If the list can’t be fetched, it falls back to the paste field so the flow never errors.

- **New Features**
  - Fetch projects with a delegated token scoped to the linked org via `/v1/projects` (max 50).
  - Render each project as a click-to-save button; POST to `/api/slack/link/default-project`.
  - Escape project names; show id when name is missing.
  - Graceful fallback to the existing paste field; warn on fetch failure without breaking the page.

<sup>Written for commit 906534ae1a5680921cedfa8672ac1fbc4cbf1f08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

