### PR TITLE
feat(conformance): cover the Streamable HTTP transport MUSTs the protocol suite never exercised

### DIFF
--- a/.changeset/transport-must-checks.md
+++ b/.changeset/transport-must-checks.md
@@ -1,0 +1,36 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/cli": minor
+---
+
+Cover the Streamable HTTP transport MUSTs the protocol suite never exercised.
+
+Four new checks, each grounded in the spec text of the revisions it applies to:
+
+- `notification-post-accepted` — a POST carrying only a JSON-RPC notification
+  MUST be answered `202 Accepted` with no body (2025 revisions; removed wire
+  mechanics make it not-applicable on 2026-07-28).
+- `get-stream-or-405` — a GET MUST either open a `text/event-stream` response
+  or return `405 Method Not Allowed` (2025 revisions). The probe observes only
+  the status line and headers, so an accepted stream costs no timeout.
+- `session-id-visible-ascii` — a minted session id MUST contain only visible
+  ASCII (0x21–0x7E). Only the charset is judged: uniqueness and entropy are
+  SHOULD, and a server that mints no id is not-applicable, not failing.
+- `post-response-content-type` — the response to a JSON-RPC request MUST carry
+  `Content-Type: application/json` or `text/event-stream`, in every revision
+  including 2026-07-28. The choice between them is the server's and is never
+  judged.
+
+`localhost-host-rebinding-rejected` is now version-sensitive: 2025-11-25 added
+"servers MUST respond with HTTP 403 Forbidden" for a present-and-invalid
+Origin, so a 400 that passed under a 2025-06-18 pin fails under 2025-11-25.
+
+Two additions to the readiness (advice) channel, which never affects the
+verdict: `readiness-parse-error-handling` (no revision maps unparseable JSON
+to any response, so accepting it as success is advice, not a violation) and
+`readiness-session-termination` (session-termination DELETE is SHOULD/MAY on
+the 2025 revisions; 405-on-GET/DELETE is the 2026 backward-compat SHOULD).
+
+The CLI prints the readiness channel to stderr as an `Advice` section on
+`protocol conformance` / `conformance-suite` runs; exit codes are unchanged by
+advice.

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -2,6 +2,7 @@ import {
   conformanceExitCode,
   conformanceSuiteExitCode,
   reportIncomplete,
+  reportReadiness,
 } from "../lib/conformance-exit-code.js";
 import {
   isKnownProtocolVersion,
@@ -97,8 +98,10 @@ export function registerProtocolCommands(program: Command): void {
       const result = await new MCPConformanceTest(config).run();
 
       writeConformanceOutput(renderConformanceForCli(result, reporter, format));
-      // The JSON payload carries it too, but a human running this in a
-      // terminal must not have to dig for the reason a check never ran.
+      // The JSON payload carries both too, but a human running this in a
+      // terminal must not have to dig for the reason a check never ran or for
+      // the advice the run produced.
+      reportReadiness(result, command);
       reportIncomplete(result, command);
       const exitCode = conformanceExitCode(result);
       if (exitCode !== 0) {
@@ -125,6 +128,7 @@ export function registerProtocolCommands(program: Command): void {
       writeConformanceOutput(renderConformanceForCli(result, reporter, format));
       // Each run carries its own reason; a suite reports every incomplete one.
       for (const run of result.results) {
+        reportReadiness(run, command);
         reportIncomplete(run, command);
       }
       const exitCode = conformanceSuiteExitCode(result.results);

--- a/cli/src/lib/conformance-exit-code.ts
+++ b/cli/src/lib/conformance-exit-code.ts
@@ -36,6 +36,33 @@ export function conformanceSuiteExitCode(
  * Surface why a run established nothing. The JSON payload carries it too, but
  * a human in a terminal must not have to dig for the reason a check never ran.
  */
+/**
+ * Surface the readiness channel (SHOULD/RECOMMENDED/MAY advice) for a human.
+ * Advice lives beside the verdict, never inside it: it goes to stderr like
+ * {@link reportIncomplete}, affects no exit code, and is read structurally so
+ * an older `@mcpjam/sdk` (no `readiness`) simply prints nothing.
+ */
+export function reportReadiness(
+  result: {
+    readiness?: Array<{
+      specStrength: string;
+      title: string;
+      message: string;
+    }>;
+  },
+  command: { optsWithGlobals(): { quiet?: boolean } },
+): void {
+  const readiness = result.readiness ?? [];
+  if (readiness.length === 0) return;
+  if (command.optsWithGlobals().quiet) return;
+  process.stderr.write(`Advice (${readiness.length}):\n`);
+  for (const advice of readiness) {
+    process.stderr.write(
+      `  [${advice.specStrength}] ${advice.title}: ${advice.message}\n`,
+    );
+  }
+}
+
 export function reportIncomplete(
   result: { incompleteReason?: string },
   command: { optsWithGlobals(): { quiet?: boolean } },

--- a/cli/tests/conformance-exit-code.test.ts
+++ b/cli/tests/conformance-exit-code.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   conformanceExitCode,
   conformanceSuiteExitCode,
+  reportReadiness,
 } from "../src/lib/conformance-exit-code.js";
 
 test("incomplete gets its own exit code, distinct from a violation", () => {
@@ -38,4 +39,44 @@ test("a suite takes the worst of its runs, failure outranking incomplete", () =>
     conformanceSuiteExitCode([{ passed: true, outcome: "passed" }]),
     0,
   );
+});
+
+test("readiness advice goes to stderr, honors --quiet, and prints nothing for an older SDK", () => {
+  const lines: string[] = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = ((chunk: string) => {
+    lines.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const command = { optsWithGlobals: () => ({}) };
+    reportReadiness(
+      {
+        readiness: [
+          {
+            specStrength: "SHOULD",
+            title: "Explicit Session Termination",
+            message: "DELETE with the session id got HTTP 500",
+          },
+        ],
+      },
+      command,
+    );
+    assert.equal(lines.length, 2);
+    assert.match(lines[0], /Advice \(1\):/);
+    assert.match(lines[1], /\[SHOULD\] Explicit Session Termination: DELETE/);
+
+    lines.length = 0;
+    reportReadiness(
+      { readiness: [{ specStrength: "MAY", title: "x", message: "y" }] },
+      { optsWithGlobals: () => ({ quiet: true }) },
+    );
+    assert.equal(lines.length, 0);
+
+    // An older @mcpjam/sdk result has no readiness member at all.
+    reportReadiness({}, command);
+    assert.equal(lines.length, 0);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
 });

--- a/docs/sdk/reference/protocol-conformance.mdx
+++ b/docs/sdk/reference/protocol-conformance.mdx
@@ -146,6 +146,10 @@ Check ids:
 - `server-sse-polling-session`
 - `server-accepts-multiple-post-streams`
 - `server-sse-streams-functional`
+- `notification-post-accepted` (2025 revisions only)
+- `get-stream-or-405` (2025 revisions only)
+- `session-id-visible-ascii` (2025 revisions only)
+- `post-response-content-type`
 
 ## Result types
 

--- a/sdk/src/conformance-catalog.ts
+++ b/sdk/src/conformance-catalog.ts
@@ -98,6 +98,26 @@ export const PROTOCOL_CHECK_CATALOG = {
     title: "Functional SSE Streams",
     description: "Concurrent SSE streams remain readable.",
   },
+  "notification-post-accepted": {
+    title: "Notification POST Accepted",
+    description:
+      "A POST carrying only a JSON-RPC notification is answered with HTTP 202 Accepted and no body.",
+  },
+  "get-stream-or-405": {
+    title: "GET Opens SSE Or Returns 405",
+    description:
+      "A GET to the MCP endpoint either opens a text/event-stream response or returns HTTP 405 Method Not Allowed.",
+  },
+  "session-id-visible-ascii": {
+    title: "Session Id Visible ASCII",
+    description:
+      "A minted session id contains only visible ASCII characters (0x21 to 0x7E).",
+  },
+  "post-response-content-type": {
+    title: "POST Response Content-Type",
+    description:
+      "The response to a JSON-RPC request carries Content-Type application/json or text/event-stream.",
+  },
   "modern-client-handshake": {
     title: "Modern Client Handshake",
     description:

--- a/sdk/src/mcp-conformance/checks/security.ts
+++ b/sdk/src/mcp-conformance/checks/security.ts
@@ -223,7 +223,15 @@ export async function runSecurityChecks(
       // Origin header is present and invalid, servers MUST respond with HTTP
       // 403 Forbidden." The earlier revisions state the validation MUST but
       // name no status, so any 4xx satisfies them.
-      const requires403 = protocolVersion >= "2025-11-25";
+      //
+      // Gated on an EXPLICIT pin, not on the resolved version: `protocolVersion`
+      // falls back to 2025-11-25 to have something to put on the wire, and
+      // letting that fallback also decide the assertion would newly fail an
+      // unpinned run against a server that answers 400 — a run that asserted
+      // nothing about which revision it was judging.
+      const requires403 =
+        ctx.config.protocolVersion !== undefined &&
+        ctx.config.protocolVersion >= "2025-11-25";
       const rejected = requires403
         ? response.statusCode === 403
         : response.statusCode >= 400 && response.statusCode < 500;

--- a/sdk/src/mcp-conformance/checks/security.ts
+++ b/sdk/src/mcp-conformance/checks/security.ts
@@ -219,8 +219,14 @@ export async function runSecurityChecks(
         ctx.config.checkTimeout,
         protocolVersion,
       );
-      const rejected =
-        response.statusCode >= 400 && response.statusCode < 500;
+      // 2025-11-25 sharpened the requirement (changelog PR #1439): "If the
+      // Origin header is present and invalid, servers MUST respond with HTTP
+      // 403 Forbidden." The earlier revisions state the validation MUST but
+      // name no status, so any 4xx satisfies them.
+      const requires403 = protocolVersion >= "2025-11-25";
+      const rejected = requires403
+        ? response.statusCode === 403
+        : response.statusCode >= 400 && response.statusCode < 500;
       results.push(
         rejected
           ? passedResult(
@@ -234,7 +240,9 @@ export async function runSecurityChecks(
           : failedResult(
               SECURITY_CHECK_METADATA["localhost-host-rebinding-rejected"],
               Date.now() - startedAt,
-              `Expected a 4xx response for invalid Host/Origin headers, got ${response.statusCode}`,
+              requires403
+                ? `Expected HTTP 403 Forbidden for an invalid Origin header (required since 2025-11-25), got ${response.statusCode}`
+                : `Expected a 4xx response for invalid Host/Origin headers, got ${response.statusCode}`,
               {
                 statusCode: response.statusCode,
                 body: response.body as Record<string, unknown> | string | undefined,

--- a/sdk/src/mcp-conformance/checks/transport.ts
+++ b/sdk/src/mcp-conformance/checks/transport.ts
@@ -16,6 +16,9 @@ import {
   DEFAULT_LEGACY_PROTOCOL_VERSION,
   legacyHeaders,
   legacyInitialize,
+  modernHeaders,
+  modernRequestBody,
+  rawHeadersProbe,
   rawRequest,
   type RawHttpResult,
 } from "../raw-http.js";
@@ -43,12 +46,44 @@ export const TRANSPORT_CHECK_METADATA = {
     title: "Functional SSE Streams",
     description: "Concurrent SSE streams remain readable.",
   },
+  "notification-post-accepted": {
+    id: "notification-post-accepted",
+    category: "transport",
+    title: "Notification POST Accepted",
+    description:
+      "A POST carrying only a JSON-RPC notification is answered with HTTP 202 Accepted and no body.",
+  },
+  "get-stream-or-405": {
+    id: "get-stream-or-405",
+    category: "transport",
+    title: "GET Opens SSE Or Returns 405",
+    description:
+      "A GET to the MCP endpoint either opens a text/event-stream response or returns HTTP 405 Method Not Allowed.",
+  },
+  "session-id-visible-ascii": {
+    id: "session-id-visible-ascii",
+    category: "transport",
+    title: "Session Id Visible ASCII",
+    description:
+      "A minted session id contains only visible ASCII characters (0x21 to 0x7E).",
+  },
+  "post-response-content-type": {
+    id: "post-response-content-type",
+    category: "transport",
+    title: "POST Response Content-Type",
+    description:
+      "The response to a JSON-RPC request carries Content-Type application/json or text/event-stream.",
+  },
 } as const satisfies Record<
   Extract<
     MCPCheckId,
     | "server-sse-polling-session"
     | "server-accepts-multiple-post-streams"
     | "server-sse-streams-functional"
+    | "notification-post-accepted"
+    | "get-stream-or-405"
+    | "session-id-visible-ascii"
+    | "post-response-content-type"
   >,
   Pick<MCPCheckResult, "id" | "category" | "title" | "description">
 >;
@@ -65,11 +100,43 @@ function isOk(result: RawHttpResult): boolean {
   return result.status >= 200 && result.status < 300;
 }
 
+/**
+ * The transport MUST — identical in every revision, 2025-03-26 through
+ * 2026-07-28 — names exactly two permitted response content types for a
+ * JSON-RPC request. Matched on the media type so parameters (`; charset=…`)
+ * stay legal, and compared exactly so `text/html` cannot sneak through a
+ * substring test.
+ */
+function isAllowedPostResponseContentType(contentType: string): boolean {
+  const mediaType = (contentType.split(";")[0] ?? "").trim().toLowerCase();
+  return mediaType === "application/json" || mediaType === "text/event-stream";
+}
+
+/**
+ * "The session ID MUST only contain visible ASCII characters (ranging from
+ * 0x21 to 0x7E)" — every 2025 revision, verbatim. ONLY the charset is a MUST;
+ * uniqueness and cryptographic strength are SHOULD and are deliberately not
+ * judged here.
+ */
+function invalidSessionIdCharacters(sessionId: string): string[] {
+  const invalid = new Set<string>();
+  for (const char of sessionId) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code < 0x21 || code > 0x7e) {
+      invalid.add(
+        `U+${code.toString(16).toUpperCase().padStart(4, "0")}`,
+      );
+    }
+  }
+  return [...invalid];
+}
+
 async function initializeSession(ctx: RawHttpCheckContext): Promise<{
   ok: boolean;
   status: number;
   sessionId?: string;
   body: unknown;
+  contentType: string;
 }> {
   const { result, sessionId } = await legacyInitialize(ctx);
   return {
@@ -77,7 +144,72 @@ async function initializeSession(ctx: RawHttpCheckContext): Promise<{
     status: result.status,
     sessionId,
     body: result.json ?? (result.bodyText || undefined),
+    contentType: result.headers["content-type"] ?? "",
   };
+}
+
+function contentTypeCheckResult(
+  contentType: string,
+  durationMs: number,
+  details: Record<string, unknown>,
+): MCPCheckResult {
+  const metadata = TRANSPORT_CHECK_METADATA["post-response-content-type"];
+  return isAllowedPostResponseContentType(contentType)
+    ? passedResult(metadata, durationMs, { contentType, ...details })
+    : failedResult(
+        metadata,
+        durationMs,
+        `Expected the response to a JSON-RPC request to carry Content-Type application/json or text/event-stream, got "${contentType || "(no content-type)"}"`,
+        { contentType, ...details },
+      );
+}
+
+/**
+ * The modern half of `post-response-content-type`. The 2026 wire has no
+ * initialize prelude, so the probe is a self-contained `tools/list` carrying
+ * the full `_meta` envelope — an incomplete envelope would be rejected before
+ * the response whose framing this check judges is ever produced.
+ */
+async function modernPostResponseContentTypeCheck(
+  ctx: RawHttpCheckContext,
+): Promise<MCPCheckResult> {
+  const metadata = TRANSPORT_CHECK_METADATA["post-response-content-type"];
+  const startedAt = Date.now();
+  const version = ctx.config.protocolVersion ?? "2026-07-28";
+  try {
+    const result = await rawRequest(ctx, {
+      headers: modernHeaders({
+        protocolVersion: version,
+        method: "tools/list",
+      }),
+      body: modernRequestBody({
+        id: 1300,
+        method: "tools/list",
+        protocolVersion: version,
+      }),
+    });
+    if (!isOk(result)) {
+      // An error response's framing is not what the MUST names ("return
+      // Content-Type … to return one JSON object" describes the successful
+      // exchange), so judging a 4xx would overclaim. The obligation stays
+      // untested instead.
+      return couldNotRunResult(
+        metadata,
+        `tools/list failed with HTTP ${result.status}, so no successful request/response exchange was observed`,
+        { status: result.status },
+      );
+    }
+    return contentTypeCheckResult(
+      result.headers["content-type"] ?? "",
+      Date.now() - startedAt,
+      { method: "tools/list", status: result.status },
+    );
+  } catch (error) {
+    return couldNotRunResult(
+      metadata,
+      `tools/list request failed: ${errorMessage(error)}`,
+    );
+  }
 }
 
 async function terminateSession(
@@ -99,20 +231,23 @@ export async function runTransportChecks(
   selectedCheckIds: Set<MCPCheckId>,
 ): Promise<MCPCheckResult[]> {
   const results: MCPCheckResult[] = [];
+  // Membership in the metadata record, NOT a name-prefix test: a prefix
+  // predicate silently drops any new transport id that doesn't happen to match
+  // it, and that hazard has already bitten once.
   const requestedTransportChecks = [...selectedCheckIds].filter(
     (checkId): checkId is TransportCheckId =>
-      checkId.startsWith("server-sse") ||
-      checkId === "server-accepts-multiple-post-streams",
+      checkId in TRANSPORT_CHECK_METADATA,
   );
 
   if (requestedTransportChecks.length === 0) {
     return results;
   }
 
-  // Era gate: every transport check asserts 2025-era stateful-session / SSE
+  // Era gate: the session/SSE/notification/GET checks assert 2025-era wire
   // mechanics that do not exist in the sessionless 2026 era, so they are
   // legacy-only. On a modern run they are skipped up front — the skips fire
   // BEFORE `initializeSession` is ever called, so no handshake is attempted.
+  // `post-response-content-type` is the one both-era transport check.
   const applicableTransportChecks: TransportCheckId[] = [];
   for (const id of requestedTransportChecks) {
     if (CHECK_ERAS[id].includes(ctx.config.era)) {
@@ -131,16 +266,19 @@ export async function runTransportChecks(
     return results;
   }
 
+  if (ctx.config.era === "modern") {
+    // The era gate leaves only the both-era check standing on a modern run,
+    // and the 2026 wire has no initialize prelude to share — so it probes on
+    // its own and the legacy session flow below is never entered.
+    if (applicableTransportChecks.includes("post-response-content-type")) {
+      results.push(await modernPostResponseContentTypeCheck(ctx));
+    }
+    return results;
+  }
+
   const initializationStartedAt = Date.now();
   let sessionId: string | undefined;
-  let session:
-    | {
-        ok: boolean;
-        status: number;
-        sessionId?: string;
-        body: unknown;
-      }
-    | undefined;
+  let session: Awaited<ReturnType<typeof initializeSession>> | undefined;
 
   try {
     try {
@@ -161,6 +299,10 @@ export async function runTransportChecks(
       for (const id of [
         "server-accepts-multiple-post-streams",
         "server-sse-streams-functional",
+        "notification-post-accepted",
+        "get-stream-or-405",
+        "session-id-visible-ascii",
+        "post-response-content-type",
       ] as const) {
         if (selectedCheckIds.has(id)) {
           results.push(
@@ -210,10 +352,65 @@ export async function runTransportChecks(
       );
     }
 
+    if (selectedCheckIds.has("post-response-content-type")) {
+      results.push(
+        session.ok
+          ? contentTypeCheckResult(
+              session.contentType,
+              Date.now() - initializationStartedAt,
+              { method: "initialize", status: session.status },
+            )
+          : couldNotRunResult(
+              TRANSPORT_CHECK_METADATA["post-response-content-type"],
+              `Initialize failed with HTTP ${session.status}, so no successful request/response exchange was observed`,
+              { status: session.status },
+            ),
+      );
+    }
+
+    if (selectedCheckIds.has("session-id-visible-ascii")) {
+      if (!session.ok) {
+        results.push(
+          couldNotRunResult(
+            TRANSPORT_CHECK_METADATA["session-id-visible-ascii"],
+            `Initialize failed with HTTP ${session.status}, so no session id was observed`,
+            { status: session.status },
+          ),
+        );
+      } else if (!sessionId) {
+        // Assigning a session id at all is MAY, so a stateless legacy server
+        // leaves nothing for the charset MUST to bind to.
+        results.push(
+          notApplicableResult(
+            TRANSPORT_CHECK_METADATA["session-id-visible-ascii"],
+            "Server initialized without minting a session id (assigning one is MAY), so the charset requirement has no subject",
+          ),
+        );
+      } else {
+        const invalidCharacters = invalidSessionIdCharacters(sessionId);
+        results.push(
+          invalidCharacters.length === 0
+            ? passedResult(
+                TRANSPORT_CHECK_METADATA["session-id-visible-ascii"],
+                Date.now() - initializationStartedAt,
+                { sessionIdLength: sessionId.length },
+              )
+            : failedResult(
+                TRANSPORT_CHECK_METADATA["session-id-visible-ascii"],
+                Date.now() - initializationStartedAt,
+                `Session id contains characters outside visible ASCII (0x21–0x7E): ${invalidCharacters.join(", ")}`,
+                { invalidCharacters, sessionIdLength: sessionId.length },
+              ),
+        );
+      }
+    }
+
     if (!session.ok) {
       for (const id of [
         "server-accepts-multiple-post-streams",
         "server-sse-streams-functional",
+        "notification-post-accepted",
+        "get-stream-or-405",
       ] as const) {
         if (selectedCheckIds.has(id)) {
           results.push(
@@ -386,6 +583,93 @@ export async function runTransportChecks(
                 ),
           );
         }
+      }
+    }
+    if (selectedCheckIds.has("notification-post-accepted")) {
+      const startedAt = Date.now();
+      try {
+        const response = await rawRequest(ctx, {
+          headers: legacyHeaders({
+            protocolVersion:
+              ctx.config.protocolVersion ?? DEFAULT_LEGACY_PROTOCOL_VERSION,
+            sessionId,
+          }),
+          // `notifications/initialized` is the one notification every client
+          // sends, so "cannot accept" has no legitimate reading here.
+          body: { jsonrpc: "2.0", method: "notifications/initialized" },
+        });
+        const hasBody = response.bodyText !== "";
+        results.push(
+          response.status === 202 && !hasBody
+            ? passedResult(
+                TRANSPORT_CHECK_METADATA["notification-post-accepted"],
+                Date.now() - startedAt,
+                { status: response.status },
+              )
+            : failedResult(
+                TRANSPORT_CHECK_METADATA["notification-post-accepted"],
+                Date.now() - startedAt,
+                response.status === 202
+                  ? "Server answered a notification-only POST with HTTP 202 but included a body; the requirement is 202 Accepted with no body"
+                  : `Expected HTTP 202 Accepted with no body for a notification-only POST, got HTTP ${response.status}`,
+                {
+                  status: response.status,
+                  contentType: response.headers["content-type"] ?? "",
+                  bodyPreview: response.bodyText.slice(0, 200),
+                },
+              ),
+        );
+      } catch (error) {
+        results.push(
+          couldNotRunResult(
+            TRANSPORT_CHECK_METADATA["notification-post-accepted"],
+            `Notification POST could not be delivered: ${errorMessage(error)}`,
+          ),
+        );
+      }
+    }
+
+    if (selectedCheckIds.has("get-stream-or-405")) {
+      const startedAt = Date.now();
+      try {
+        // An accepted GET stream legitimately stays open forever, so only the
+        // status line and headers are observed — the verdict lives entirely
+        // there, and reading the body would burn the whole check timeout.
+        const response = await rawHeadersProbe(ctx, {
+          method: "GET",
+          headers: {
+            Accept: "text/event-stream",
+            "mcp-protocol-version":
+              ctx.config.protocolVersion ?? DEFAULT_LEGACY_PROTOCOL_VERSION,
+            ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+          },
+        });
+        const contentType = response.headers["content-type"] ?? "";
+        const opensStream =
+          response.status >= 200 &&
+          response.status < 300 &&
+          contentType.toLowerCase().includes("text/event-stream");
+        results.push(
+          opensStream || response.status === 405
+            ? passedResult(
+                TRANSPORT_CHECK_METADATA["get-stream-or-405"],
+                Date.now() - startedAt,
+                { status: response.status, contentType },
+              )
+            : failedResult(
+                TRANSPORT_CHECK_METADATA["get-stream-or-405"],
+                Date.now() - startedAt,
+                `Expected the GET to open a text/event-stream response or return HTTP 405 Method Not Allowed, got HTTP ${response.status} with Content-Type "${contentType || "(no content-type)"}"`,
+                { status: response.status, contentType },
+              ),
+        );
+      } catch (error) {
+        results.push(
+          couldNotRunResult(
+            TRANSPORT_CHECK_METADATA["get-stream-or-405"],
+            `GET request could not be delivered: ${errorMessage(error)}`,
+          ),
+        );
       }
     }
   } finally {

--- a/sdk/src/mcp-conformance/checks/transport.ts
+++ b/sdk/src/mcp-conformance/checks/transport.ts
@@ -14,6 +14,7 @@ import {
 } from "./helpers.js";
 import {
   DEFAULT_LEGACY_PROTOCOL_VERSION,
+  jsonRpcError,
   legacyHeaders,
   legacyInitialize,
   modernHeaders,
@@ -101,14 +102,24 @@ function isOk(result: RawHttpResult): boolean {
 }
 
 /**
+ * The bare media type, with parameters (`; charset=…`) and casing stripped.
+ *
+ * Every content-type verdict in this module goes through here so none of them
+ * can drift back to a substring test: `text/event-streamish` and
+ * `application/text/event-stream` both CONTAIN the required token without
+ * being it, and either would otherwise read as a conforming stream.
+ */
+function mediaTypeOf(contentType: string): string {
+  return (contentType.split(";")[0] ?? "").trim().toLowerCase();
+}
+
+/**
  * The transport MUST — identical in every revision, 2025-03-26 through
  * 2026-07-28 — names exactly two permitted response content types for a
- * JSON-RPC request. Matched on the media type so parameters (`; charset=…`)
- * stay legal, and compared exactly so `text/html` cannot sneak through a
- * substring test.
+ * JSON-RPC request.
  */
 function isAllowedPostResponseContentType(contentType: string): boolean {
-  const mediaType = (contentType.split(";")[0] ?? "").trim().toLowerCase();
+  const mediaType = mediaTypeOf(contentType);
   return mediaType === "application/json" || mediaType === "text/event-stream";
 }
 
@@ -137,6 +148,7 @@ async function initializeSession(ctx: RawHttpCheckContext): Promise<{
   sessionId?: string;
   body: unknown;
   contentType: string;
+  isMcpLayerResponse: boolean;
 }> {
   const { result, sessionId } = await legacyInitialize(ctx);
   return {
@@ -145,6 +157,11 @@ async function initializeSession(ctx: RawHttpCheckContext): Promise<{
     sessionId,
     body: result.json ?? (result.bodyText || undefined),
     contentType: result.headers["content-type"] ?? "",
+    // Whether the server answered at the MCP layer at all. A non-2xx carrying
+    // a JSON-RPC error IS the server's own response, so response-framing MUSTs
+    // still bind to it; a non-2xx without one came from something in front of
+    // the server (auth gateway, proxy) and binds to nothing here.
+    isMcpLayerResponse: isOk(result) || jsonRpcError(result) !== undefined,
   };
 }
 
@@ -188,14 +205,16 @@ async function modernPostResponseContentTypeCheck(
         protocolVersion: version,
       }),
     });
-    if (!isOk(result)) {
-      // An error response's framing is not what the MUST names ("return
-      // Content-Type … to return one JSON object" describes the successful
-      // exchange), so judging a 4xx would overclaim. The obligation stays
-      // untested instead.
+    if (!isOk(result) && jsonRpcError(result) === undefined) {
+      // A non-2xx that carries no JSON-RPC error is not an MCP-layer response
+      // at all — an OAuth gateway's 401 HTML page, a proxy 404, a load
+      // balancer 502. The server under test never framed it, so failing the
+      // content-type MUST on it would blame the wrong party. A non-2xx that
+      // DOES carry a JSON-RPC error is the server answering, and the MUST
+      // applies to it in full (falls through to the judgement below).
       return couldNotRunResult(
         metadata,
-        `tools/list failed with HTTP ${result.status}, so no successful request/response exchange was observed`,
+        `tools/list returned HTTP ${result.status} with no JSON-RPC error body, so no MCP-layer response was observed to judge`,
         { status: result.status },
       );
     }
@@ -354,7 +373,7 @@ export async function runTransportChecks(
 
     if (selectedCheckIds.has("post-response-content-type")) {
       results.push(
-        session.ok
+        session.isMcpLayerResponse
           ? contentTypeCheckResult(
               session.contentType,
               Date.now() - initializationStartedAt,
@@ -362,7 +381,7 @@ export async function runTransportChecks(
             )
           : couldNotRunResult(
               TRANSPORT_CHECK_METADATA["post-response-content-type"],
-              `Initialize failed with HTTP ${session.status}, so no successful request/response exchange was observed`,
+              `Initialize returned HTTP ${session.status} with no JSON-RPC error body, so no MCP-layer response was observed to judge`,
               { status: session.status },
             ),
       );
@@ -600,7 +619,17 @@ export async function runTransportChecks(
         });
         const hasBody = response.bodyText !== "";
         results.push(
-          response.status === 202 && !hasBody
+          // A body that could not be read to completion leaves the "no body"
+          // half of the requirement unestablished. Certifying a pass off a
+          // broken read would claim a fact the run never observed, and failing
+          // would blame the server for our own truncated read.
+          response.bodyError !== undefined
+            ? couldNotRunResult(
+                TRANSPORT_CHECK_METADATA["notification-post-accepted"],
+                `Response body could not be read to completion (${response.bodyError}), so "202 Accepted with no body" could not be confirmed`,
+                { status: response.status },
+              )
+            : response.status === 202 && !hasBody
             ? passedResult(
                 TRANSPORT_CHECK_METADATA["notification-post-accepted"],
                 Date.now() - startedAt,
@@ -648,7 +677,7 @@ export async function runTransportChecks(
         const opensStream =
           response.status >= 200 &&
           response.status < 300 &&
-          contentType.toLowerCase().includes("text/event-stream");
+          mediaTypeOf(contentType) === "text/event-stream";
         results.push(
           opensStream || response.status === 405
             ? passedResult(

--- a/sdk/src/mcp-conformance/raw-http.ts
+++ b/sdk/src/mcp-conformance/raw-http.ts
@@ -388,9 +388,16 @@ export async function rawRequest(
  */
 export async function rawHeadersProbe(
   ctx: RawHttpCheckContext,
-  options: Pick<RawHttpRequestOptions, "url" | "method" | "headers" | "timeoutMs"> = {}
+  options: Pick<
+    RawHttpRequestOptions,
+    "url" | "method" | "headers" | "timeoutMs" | "includeBaseHeaders"
+  > = {}
 ): Promise<{ status: number; statusText: string; headers: Record<string, string> }> {
-  const headers = new Headers(baseHeaders(ctx));
+  // Same base-header semantics as `rawRequest`, so a probe does not silently
+  // acquire auth it meant to omit just because it reads headers only.
+  const headers = new Headers(
+    options.includeBaseHeaders === false ? {} : baseHeaders(ctx)
+  );
   for (const [name, value] of Object.entries(options.headers ?? {})) {
     headers.set(name, value);
   }

--- a/sdk/src/mcp-conformance/raw-http.ts
+++ b/sdk/src/mcp-conformance/raw-http.ts
@@ -378,6 +378,50 @@ export async function rawRequest(
   };
 }
 
+/**
+ * Observe only the status line and response headers of an exchange, then
+ * abort. For probes whose verdict cannot depend on the body: an accepted GET
+ * stream legitimately never ends, so `rawRequest` — which reads the body to
+ * completion — would always burn its whole timeout on one. The streaming seam
+ * (`raw-listen.ts`) is the precedent for fetching outside the capture; this
+ * returns no body on purpose so it cannot become a second decode path.
+ */
+export async function rawHeadersProbe(
+  ctx: RawHttpCheckContext,
+  options: Pick<RawHttpRequestOptions, "url" | "method" | "headers" | "timeoutMs"> = {}
+): Promise<{ status: number; statusText: string; headers: Record<string, string> }> {
+  const headers = new Headers(baseHeaders(ctx));
+  for (const [name, value] of Object.entries(options.headers ?? {})) {
+    headers.set(name, value);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    options.timeoutMs ?? ctx.config.checkTimeout
+  );
+  try {
+    const response = await ctx.fetchFn(options.url ?? ctx.serverUrl, {
+      method: options.method ?? "GET",
+      headers,
+      signal: controller.signal,
+    });
+    const captured: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      captured[key.toLowerCase()] = value;
+    });
+    // The verdict is in hand; close the stream instead of reading it.
+    controller.abort();
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: captured,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 /** Every JSON-RPC message on the response, whether it arrived as JSON or SSE. */
 export function jsonRpcMessages(result: RawHttpResult): unknown[] {
   if (result.sse) {

--- a/sdk/src/mcp-conformance/raw-http.ts
+++ b/sdk/src/mcp-conformance/raw-http.ts
@@ -410,7 +410,12 @@ export async function rawHeadersProbe(
     response.headers.forEach((value, key) => {
       captured[key.toLowerCase()] = value;
     });
-    // The verdict is in hand; close the stream instead of reading it.
+    // The verdict is in hand, so release the stream instead of reading it: an
+    // accepted SSE stream never ends, and a probe that walks away without
+    // closing leaves the server under test writing into a socket nobody
+    // reads. Cancelling the body is the clean release; the abort also covers a
+    // response that carried no body at all.
+    await response.body?.cancel().catch(() => undefined);
     controller.abort();
     return {
       status: response.status,

--- a/sdk/src/mcp-conformance/readiness.ts
+++ b/sdk/src/mcp-conformance/readiness.ts
@@ -29,6 +29,7 @@ import {
   jsonRpcResult,
   legacyHeaders,
   legacyInitialize,
+  rawHeadersProbe,
   modernHeaders,
   modernRequestBody,
   rawRequest,
@@ -359,29 +360,48 @@ async function sessionTerminationWarning(
   ctx: RawHttpCheckContext
 ): Promise<MCPReadinessWarning | undefined> {
   if (ctx.config.era === "modern") {
-    const result = await rawRequest(ctx, {
-      method: "DELETE",
-      // The obligation is about "traffic from an older client", so the probe
-      // has to LOOK like one: a 2025 protocol pin and a session id, which the
-      // same clause tells a modern server to ignore. A bare DELETE would be
-      // neither era's traffic, and a header-validating server could answer 400
-      // for the missing version — which the advice would then misattribute to
-      // the 405 obligation.
-      headers: legacyHeaders({
-        protocolVersion: DEFAULT_LEGACY_PROTOCOL_VERSION,
-        sessionId: "mcpjam-conformance-legacy-probe",
-      }),
-      timeoutMs: Math.min(ctx.config.checkTimeout, 3_000),
+    // The obligation is about "traffic from an older client", so the probes
+    // have to LOOK like one: a 2025 protocol pin and a session id, which the
+    // same clause tells a modern server to ignore. A bare request would be
+    // neither era's traffic, and a header-validating server could answer 400
+    // for the missing version — which the advice would then misattribute to
+    // the 405 obligation.
+    const staleClientHeaders = legacyHeaders({
+      protocolVersion: DEFAULT_LEGACY_PROTOCOL_VERSION,
+      sessionId: "mcpjam-conformance-legacy-probe",
     });
-    if (result.status === 405) {
+    const timeoutMs = Math.min(ctx.config.checkTimeout, 3_000);
+    // The clause names GET *and* DELETE, so both are probed: a server that
+    // still opens a stream on GET is exactly the backward-compat trap this
+    // advice exists to name, and DELETE alone would never see it. The GET
+    // reads headers only — a stream it wrongly opens would never end.
+    const [get, del] = await Promise.all([
+      rawHeadersProbe(ctx, {
+        method: "GET",
+        headers: { ...staleClientHeaders, Accept: "text/event-stream" },
+        timeoutMs,
+      }),
+      rawRequest(ctx, {
+        method: "DELETE",
+        headers: staleClientHeaders,
+        timeoutMs,
+      }),
+    ]);
+    const offenders = [
+      ...(get.status === 405 ? [] : [`GET got HTTP ${get.status}`]),
+      ...(del.status === 405 ? [] : [`DELETE got HTTP ${del.status}`]),
+    ];
+    if (offenders.length === 0) {
       return undefined;
     }
     return warning(
       "readiness-session-termination",
       "Explicit Session Termination",
       "SHOULD",
-      `A 2026-07-28 server SHOULD answer stray GET/DELETE traffic from older clients with HTTP 405 Method Not Allowed; DELETE got HTTP ${result.status}`,
-      { status: result.status }
+      `A 2026-07-28 server SHOULD answer stray GET/DELETE traffic from older clients with HTTP 405 Method Not Allowed; ${offenders.join(
+        ", "
+      )}`,
+      { getStatus: get.status, deleteStatus: del.status }
     );
   }
 

--- a/sdk/src/mcp-conformance/readiness.ts
+++ b/sdk/src/mcp-conformance/readiness.ts
@@ -24,7 +24,11 @@ import type {
   RawHttpCheckContext,
 } from "./types.js";
 import {
+  DEFAULT_LEGACY_PROTOCOL_VERSION,
+  jsonRpcError,
   jsonRpcResult,
+  legacyHeaders,
+  legacyInitialize,
   modernHeaders,
   modernRequestBody,
   rawRequest,
@@ -305,6 +309,101 @@ async function xMcpHeaderDeclarationsWarning(
   );
 }
 
+/**
+ * No revision of the transports spec maps an unparseable POST body to ANY
+ * HTTP status or JSON-RPC error — the docs are silent in every version — so
+ * this can never be a check. JSON-RPC 2.0 itself names `-32700 Parse error`
+ * for exactly this, and a server that answers garbage with a SUCCESS status
+ * confuses every client on the far side of a proxy bug or truncated body.
+ * Advice therefore fires only when the server ACCEPTS the unparseable body
+ * without an in-band parse error.
+ */
+async function parseErrorHandlingWarning(
+  ctx: RawHttpCheckContext
+): Promise<MCPReadinessWarning | undefined> {
+  const result = await rawRequest(ctx, {
+    rawBody: '{"jsonrpc": "2.0",',
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    // A server that hangs on garbage instead of answering is not worth the
+    // full check timeout — this is advice, not a verdict.
+    timeoutMs: Math.min(ctx.config.checkTimeout, 3_000),
+  });
+  if (result.status >= 300) {
+    // Any rejection is unobjectionable: the spec never says which one.
+    return undefined;
+  }
+  if (jsonRpcError(result)?.code === -32700) {
+    return undefined;
+  }
+
+  return warning(
+    "readiness-parse-error-handling",
+    "Parse Error Handling",
+    "MAY",
+    `The server answered an unparseable JSON body with HTTP ${result.status} and no JSON-RPC -32700 Parse error. No MCP revision mandates a particular response here, but accepting garbage as success hides transport corruption from clients`,
+    { status: result.status }
+  );
+}
+
+/**
+ * Explicit session termination is advice on both sides of the era line: the
+ * 2025 revisions say clients SHOULD send a DELETE when abandoning a session
+ * and servers MAY answer 405, so no server response can violate a MUST; the
+ * 2026 revision says stray GET/DELETE traffic from older clients SHOULD get
+ * 405 Method Not Allowed.
+ */
+async function sessionTerminationWarning(
+  ctx: RawHttpCheckContext
+): Promise<MCPReadinessWarning | undefined> {
+  if (ctx.config.era === "modern") {
+    const result = await rawRequest(ctx, {
+      method: "DELETE",
+      timeoutMs: Math.min(ctx.config.checkTimeout, 3_000),
+    });
+    if (result.status === 405) {
+      return undefined;
+    }
+    return warning(
+      "readiness-session-termination",
+      "Explicit Session Termination",
+      "SHOULD",
+      `A 2026-07-28 server SHOULD answer stray GET/DELETE traffic from older clients with HTTP 405 Method Not Allowed; DELETE got HTTP ${result.status}`,
+      { status: result.status }
+    );
+  }
+
+  const { result, sessionId } = await legacyInitialize(ctx);
+  if (result.status < 200 || result.status >= 300 || !sessionId) {
+    // No session to terminate — nothing to advise on.
+    return undefined;
+  }
+  const deleteResult = await rawRequest(ctx, {
+    method: "DELETE",
+    headers: legacyHeaders({
+      protocolVersion:
+        ctx.config.protocolVersion ?? DEFAULT_LEGACY_PROTOCOL_VERSION,
+      sessionId,
+    }),
+    timeoutMs: Math.min(ctx.config.checkTimeout, 3_000),
+  });
+  if (deleteResult.status < 500) {
+    // 2xx terminated it, 405 declined to support termination (MAY), and any
+    // other 4xx is at worst odd — none of these earn advice.
+    return undefined;
+  }
+
+  return warning(
+    "readiness-session-termination",
+    "Explicit Session Termination",
+    "SHOULD",
+    `DELETE with the session id got HTTP ${deleteResult.status}. Clients SHOULD send this DELETE when abandoning a session (servers MAY answer 405 to decline), but a 5xx means the termination handler itself is broken`,
+    { status: deleteResult.status }
+  );
+}
+
 function metadataUrl(serverUrl: string, wellKnown: string): string {
   const url = new URL(serverUrl);
   return new URL(wellKnown, `${url.protocol}//${url.host}`).toString();
@@ -379,6 +478,8 @@ export async function collectRawReadiness(
     cacheTtlWarning(ctx),
     oauthIssWarning(ctx),
     xMcpHeaderDeclarationsWarning(ctx),
+    parseErrorHandlingWarning(ctx),
+    sessionTerminationWarning(ctx),
   ];
   const settled = await Promise.allSettled(probes);
   return settled.flatMap((outcome) =>

--- a/sdk/src/mcp-conformance/readiness.ts
+++ b/sdk/src/mcp-conformance/readiness.ts
@@ -375,7 +375,10 @@ async function sessionTerminationWarning(
     // still opens a stream on GET is exactly the backward-compat trap this
     // advice exists to name, and DELETE alone would never see it. The GET
     // reads headers only — a stream it wrongly opens would never end.
-    const [get, del] = await Promise.all([
+    // Settled per probe, not `Promise.all`: the two are independent
+    // observations, and one that times out must not discard what the other
+    // saw. A GET that hangs would otherwise bury a real DELETE violation.
+    const [getProbe, deleteProbe] = await Promise.allSettled([
       rawHeadersProbe(ctx, {
         method: "GET",
         headers: { ...staleClientHeaders, Accept: "text/event-stream" },
@@ -387,9 +390,12 @@ async function sessionTerminationWarning(
         timeoutMs,
       }),
     ]);
+    const get = getProbe.status === "fulfilled" ? getProbe.value : undefined;
+    const del =
+      deleteProbe.status === "fulfilled" ? deleteProbe.value : undefined;
     const offenders = [
-      ...(get.status === 405 ? [] : [`GET got HTTP ${get.status}`]),
-      ...(del.status === 405 ? [] : [`DELETE got HTTP ${del.status}`]),
+      ...(get && get.status !== 405 ? [`GET got HTTP ${get.status}`] : []),
+      ...(del && del.status !== 405 ? [`DELETE got HTTP ${del.status}`] : []),
     ];
     if (offenders.length === 0) {
       return undefined;
@@ -401,7 +407,9 @@ async function sessionTerminationWarning(
       `A 2026-07-28 server SHOULD answer stray GET/DELETE traffic from older clients with HTTP 405 Method Not Allowed; ${offenders.join(
         ", "
       )}`,
-      { getStatus: get.status, deleteStatus: del.status }
+      // A probe that never completed is reported as such rather than as a
+      // status, so the advice cannot read as though both were observed.
+      { getStatus: get?.status ?? "not observed", deleteStatus: del?.status ?? "not observed" }
     );
   }
 

--- a/sdk/src/mcp-conformance/readiness.ts
+++ b/sdk/src/mcp-conformance/readiness.ts
@@ -361,6 +361,16 @@ async function sessionTerminationWarning(
   if (ctx.config.era === "modern") {
     const result = await rawRequest(ctx, {
       method: "DELETE",
+      // The obligation is about "traffic from an older client", so the probe
+      // has to LOOK like one: a 2025 protocol pin and a session id, which the
+      // same clause tells a modern server to ignore. A bare DELETE would be
+      // neither era's traffic, and a header-validating server could answer 400
+      // for the missing version — which the advice would then misattribute to
+      // the 405 obligation.
+      headers: legacyHeaders({
+        protocolVersion: DEFAULT_LEGACY_PROTOCOL_VERSION,
+        sessionId: "mcpjam-conformance-legacy-probe",
+      }),
       timeoutMs: Math.min(ctx.config.checkTimeout, 3_000),
     });
     if (result.status === 405) {

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -66,6 +66,10 @@ const RAW_CHECK_CATEGORY_ENTRIES: ReadonlyArray<
   ["server-sse-polling-session", "transport"],
   ["server-accepts-multiple-post-streams", "transport"],
   ["server-sse-streams-functional", "transport"],
+  ["notification-post-accepted", "transport"],
+  ["get-stream-or-405", "transport"],
+  ["session-id-visible-ascii", "transport"],
+  ["post-response-content-type", "transport"],
   ...Object.values(MODERN_CHECK_METADATA).map(
     (check): readonly [MCPCheckId, MCPCheckCategory] => [
       check.id,

--- a/sdk/src/mcp-conformance/types.ts
+++ b/sdk/src/mcp-conformance/types.ts
@@ -43,6 +43,18 @@ export const MCP_CHECK_IDS = [
   "server-sse-polling-session",
   "server-accepts-multiple-post-streams",
   "server-sse-streams-functional",
+  // Streamable HTTP transport MUSTs stated verbatim by the 2025 revisions:
+  // a notification-only POST answers `202 Accepted` with no body, a GET either
+  // opens an SSE stream or answers 405, and a minted session id contains only
+  // visible ASCII (0x21–0x7E). All three mechanics were removed by 2026-07-28,
+  // so they are legacy-only.
+  "notification-post-accepted",
+  "get-stream-or-405",
+  "session-id-visible-ascii",
+  // Every revision, 2025-03-26 through 2026-07-28: the response to a JSON-RPC
+  // request MUST carry `Content-Type: application/json` or `text/event-stream`
+  // — the CHOICE between them is the server's, so this asserts membership only.
+  "post-response-content-type",
   // Phase 7 §15.3 — modern (2026-07-28) MUST checks. New ids rather than
   // reused legacy ones: each asserts a requirement that did not exist (or
   // changed materially) in the 2025 era, so a shared id would make a legacy
@@ -174,6 +186,15 @@ export const CHECK_ERAS: Record<MCPCheckId, MCPCheckEras> = {
   "server-sse-polling-session": ["legacy"],
   "server-accepts-multiple-post-streams": ["legacy"],
   "server-sse-streams-functional": ["legacy"],
+  // Client-to-server notifications, the GET stream endpoint, and sessions were
+  // all removed by 2026-07-28 (the revision even states that header
+  // requirements for a notification POST are undefined), so these three have
+  // nothing to assert on a modern run.
+  "notification-post-accepted": ["legacy"],
+  "get-stream-or-405": ["legacy"],
+  "session-id-visible-ascii": ["legacy"],
+  // The response-Content-Type MUST is stated identically by every revision.
+  "post-response-content-type": ["legacy", "modern"],
   "localhost-host-rebinding-rejected": ["legacy"],
   "localhost-host-valid-accepted": ["legacy"],
   "tools-list": ["legacy", "modern"],
@@ -311,6 +332,15 @@ export const MCP_READINESS_IDS = [
   "readiness-cache-ttl-useful",
   "readiness-oauth-iss-advertised",
   "readiness-x-mcp-header-declarations",
+  // No revision maps an unparseable POST body to any HTTP status or JSON-RPC
+  // error — the transports docs are silent — so answering garbage with a
+  // success status is ADVICE (JSON-RPC 2.0 names -32700 for it), never a
+  // violation.
+  "readiness-parse-error-handling",
+  // Explicit session termination is SHOULD (client-side) / MAY (server-side)
+  // on the 2025 revisions, and 405-on-GET/DELETE is the 2026 revision's
+  // backward-compat SHOULD; neither can fail a run.
+  "readiness-session-termination",
 ] as const;
 
 export type MCPReadinessId = (typeof MCP_READINESS_IDS)[number];

--- a/sdk/tests/mcp-conformance/checks.test.ts
+++ b/sdk/tests/mcp-conformance/checks.test.ts
@@ -223,6 +223,162 @@ describe("mcp conformance unit checks", () => {
     );
   });
 
+  it("passes the transport MUSTs for a server that speaks the 2025 wire correctly", async () => {
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "GET") {
+        return sseResponse(["data: hello\n\n"]);
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 200 });
+      }
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string };
+      if (body.method === "initialize") {
+        return jsonResponse(
+          { jsonrpc: "2.0", id: 1, result: {} },
+          { headers: { "mcp-session-id": "session-ok-1" } },
+        );
+      }
+      if (body.method === "notifications/initialized") {
+        return new Response(null, { status: 202 });
+      }
+      return jsonResponse({ jsonrpc: "2.0", id: 99, result: {} });
+    }) as typeof fetch;
+
+    const results = await runTransportChecks(
+      createTransportContext(fetchFn) as any,
+      new Set([
+        "notification-post-accepted",
+        "get-stream-or-405",
+        "session-id-visible-ascii",
+        "post-response-content-type",
+      ]),
+    );
+    const byId = Object.fromEntries(results.map((result) => [result.id, result]));
+
+    expect(byId["notification-post-accepted"].status).toBe("passed");
+    expect(byId["get-stream-or-405"].status).toBe("passed");
+    expect(byId["session-id-visible-ascii"].status).toBe("passed");
+    expect(byId["post-response-content-type"].status).toBe("passed");
+  });
+
+  it("fails the transport MUSTs a mis-framed server violates", async () => {
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "GET") {
+        // Neither an SSE stream nor a 405: an HTML landing page.
+        return new Response("<html>hi</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 405 });
+      }
+      const body = JSON.parse(String(init?.body ?? "{}")) as { method?: string };
+      if (body.method === "initialize") {
+        return jsonResponse(
+          { jsonrpc: "2.0", id: 1, result: {} },
+          // 0x20 (space) sits outside the visible-ASCII MUST.
+          { headers: { "mcp-session-id": "bad session id" } },
+        );
+      }
+      if (body.method === "notifications/initialized") {
+        // Accepted, but as a 200 with a body instead of a bare 202.
+        return jsonResponse({ ok: true }, { status: 200 });
+      }
+      return jsonResponse({ jsonrpc: "2.0", id: 99, result: {} });
+    }) as typeof fetch;
+
+    const results = await runTransportChecks(
+      createTransportContext(fetchFn) as any,
+      new Set([
+        "notification-post-accepted",
+        "get-stream-or-405",
+        "session-id-visible-ascii",
+      ]),
+    );
+    const byId = Object.fromEntries(results.map((result) => [result.id, result]));
+
+    expect(byId["notification-post-accepted"]).toMatchObject({
+      status: "failed",
+      error: { message: expect.stringContaining("202 Accepted") },
+    });
+    expect(byId["get-stream-or-405"]).toMatchObject({
+      status: "failed",
+      error: { message: expect.stringContaining("405") },
+    });
+    expect(byId["session-id-visible-ascii"]).toMatchObject({
+      status: "failed",
+      details: expect.objectContaining({ invalidCharacters: ["U+0020"] }),
+    });
+  });
+
+  it("judges the initialize response's content-type and rejects text/html", async () => {
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 405 });
+      }
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+        status: 200,
+        headers: { "content-type": "text/html", "mcp-session-id": "s-1" },
+      });
+    }) as typeof fetch;
+
+    const results = await runTransportChecks(
+      createTransportContext(fetchFn) as any,
+      new Set(["post-response-content-type"]),
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      id: "post-response-content-type",
+      status: "failed",
+      details: expect.objectContaining({ contentType: "text/html" }),
+    });
+  });
+
+  it("marks the session-id charset check not-applicable for a stateless legacy server", async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ jsonrpc: "2.0", id: 1, result: {} }),
+    ) as typeof fetch;
+
+    const results = await runTransportChecks(
+      createTransportContext(fetchFn) as any,
+      new Set(["session-id-visible-ascii"]),
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      id: "session-id-visible-ascii",
+      status: "skipped",
+      skipReason: "not-applicable",
+    });
+  });
+
+  it("reports could-not-run for the transport MUSTs when initialize itself fails", async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse(
+        { jsonrpc: "2.0", id: 1, error: { code: -32000, message: "nope" } },
+        { status: 500 },
+      ),
+    ) as typeof fetch;
+
+    const results = await runTransportChecks(
+      createTransportContext(fetchFn) as any,
+      new Set([
+        "notification-post-accepted",
+        "get-stream-or-405",
+        "session-id-visible-ascii",
+        "post-response-content-type",
+      ]),
+    );
+
+    expect(results).toHaveLength(4);
+    for (const result of results) {
+      expect(result.status).toBe("skipped");
+      expect(result.skipReason).toBe("could-not-run");
+    }
+  });
+
   it("returns structured transport failures instead of throwing on stream errors", async () => {
     let postCount = 0;
     const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/sdk/tests/mcp-conformance/checks.test.ts
+++ b/sdk/tests/mcp-conformance/checks.test.ts
@@ -371,12 +371,114 @@ describe("mcp conformance unit checks", () => {
         "post-response-content-type",
       ]),
     );
+    const byId = Object.fromEntries(results.map((result) => [result.id, result]));
 
     expect(results).toHaveLength(4);
-    for (const result of results) {
-      expect(result.status).toBe("skipped");
-      expect(result.skipReason).toBe("could-not-run");
+    for (const id of [
+      "notification-post-accepted",
+      "get-stream-or-405",
+      "session-id-visible-ascii",
+    ] as const) {
+      expect(byId[id].status).toBe("skipped");
+      expect(byId[id].skipReason).toBe("could-not-run");
     }
+    // The framing MUST still binds here: the server answered at the MCP layer
+    // with a JSON-RPC error, and it framed that answer as application/json.
+    expect(byId["post-response-content-type"].status).toBe("passed");
+  });
+
+  it("does not accept a content type that merely contains the SSE token", async () => {
+    // `text/event-streamish` contains the required token without being it, so
+    // a substring test would read this as a conforming stream.
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "GET") {
+        return new Response("", {
+          status: 200,
+          headers: { "content-type": "text/event-streamish" },
+        });
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 405 });
+      }
+      return jsonResponse(
+        { jsonrpc: "2.0", id: 1, result: {} },
+        { headers: { "mcp-session-id": "s-1" } },
+      );
+    }) as typeof fetch;
+
+    const results = await runTransportChecks(
+      createTransportContext(fetchFn) as any,
+      new Set(["get-stream-or-405"]),
+    );
+
+    expect(results[0]).toMatchObject({
+      id: "get-stream-or-405",
+      status: "failed",
+    });
+  });
+
+  it("accepts an SSE content type that carries parameters", async () => {
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "GET") {
+        return new Response("", {
+          status: 200,
+          headers: { "content-type": "text/event-stream; charset=utf-8" },
+        });
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 405 });
+      }
+      return jsonResponse(
+        { jsonrpc: "2.0", id: 1, result: {} },
+        { headers: { "mcp-session-id": "s-1" } },
+      );
+    }) as typeof fetch;
+
+    const results = await runTransportChecks(
+      createTransportContext(fetchFn) as any,
+      new Set(["get-stream-or-405"]),
+    );
+
+    expect(results[0].status).toBe("passed");
+  });
+
+  it("judges an MCP-layer error response's framing but not a gateway's", async () => {
+    // A non-2xx carrying a JSON-RPC error IS the server answering, so a
+    // mis-framed one is a violation...
+    const misframedError = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, error: { code: -32000, message: "no" } }),
+        { status: 400, headers: { "content-type": "text/html" } },
+      ),
+    ) as typeof fetch;
+
+    const failed = await runTransportChecks(
+      createTransportContext(misframedError) as any,
+      new Set(["post-response-content-type"]),
+    );
+    expect(failed[0]).toMatchObject({
+      status: "failed",
+      details: expect.objectContaining({ contentType: "text/html" }),
+    });
+
+    // ...while a non-2xx with no JSON-RPC body never reached the MCP server —
+    // an auth gateway or proxy produced it — so the run establishes nothing
+    // rather than blaming the server for someone else's framing.
+    const gateway = vi.fn(async () =>
+      new Response("<html>401</html>", {
+        status: 401,
+        headers: { "content-type": "text/html" },
+      }),
+    ) as typeof fetch;
+
+    const skipped = await runTransportChecks(
+      createTransportContext(gateway) as any,
+      new Set(["post-response-content-type"]),
+    );
+    expect(skipped[0]).toMatchObject({
+      status: "skipped",
+      skipReason: "could-not-run",
+    });
   });
 
   it("returns structured transport failures instead of throwing on stream errors", async () => {

--- a/sdk/tests/mcp-conformance/era.unit.test.ts
+++ b/sdk/tests/mcp-conformance/era.unit.test.ts
@@ -104,11 +104,15 @@ describe("CHECK_ERAS map", () => {
       "server-sse-polling-session",
       "server-accepts-multiple-post-streams",
       "server-sse-streams-functional",
+      "notification-post-accepted",
+      "get-stream-or-405",
+      "session-id-visible-ascii",
       "localhost-host-rebinding-rejected",
       "localhost-host-valid-accepted",
     ];
     const bothEras: MCPCheckId[] = [
       "capabilities-consistent",
+      "post-response-content-type",
       "tools-list",
       "tools-input-schemas-valid",
       "prompts-list",
@@ -377,6 +381,49 @@ describe("raw legacy-only checks are era-skipped on a modern run", () => {
       expect(result.status).toBe("skipped");
       expect(result.error?.message).toMatch(/Not applicable to the modern era/);
     }
+  });
+
+  it("legacy-only transport MUSTs era-skip on a modern run while the both-era content-type check probes", async () => {
+    const requests: string[] = [];
+    const fetchFn = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      requests.push(String(init?.method ?? "POST"));
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1300, result: { tools: [] } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const config = normalize({ fetchFn, protocolVersion: "2026-07-28" });
+    const selected = new Set<MCPCheckId>([
+      "notification-post-accepted",
+      "get-stream-or-405",
+      "session-id-visible-ascii",
+      "post-response-content-type",
+    ]);
+    const results = await runTransportChecks(
+      { config, serverUrl: SERVER_URL, fetchFn: config.fetchFn },
+      selected,
+    );
+
+    const byId = new Map(results.map((result) => [result.id, result]));
+    for (const id of [
+      "notification-post-accepted",
+      "get-stream-or-405",
+      "session-id-visible-ascii",
+    ] as const) {
+      expect(byId.get(id)?.status).toBe("skipped");
+      expect(byId.get(id)?.skipReason).toBe("not-applicable");
+      expect(byId.get(id)?.error?.message).toMatch(
+        /Not applicable to the modern era/,
+      );
+    }
+    expect(byId.get("post-response-content-type")?.status).toBe("passed");
+    // Exactly one exchange: the modern tools/list probe. No legacy initialize
+    // prelude is ever attempted on a modern run.
+    expect(requests).toEqual(["POST"]);
   });
 
   it("localhost security checks skip before any socket is opened", async () => {

--- a/sdk/tests/mcp-conformance/readiness.unit.test.ts
+++ b/sdk/tests/mcp-conformance/readiness.unit.test.ts
@@ -263,6 +263,100 @@ describe("raw readiness advice", () => {
     expect(await collectRawReadiness(rawContext(fetchFn))).toEqual([]);
   });
 
+  it("advises when unparseable JSON is accepted as success, and stays silent on any rejection", async () => {
+    const accepting = (async () =>
+      new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    const warnings = await collectRawReadiness(rawContext(accepting));
+    const parse = warnings.find(
+      (item) => item.id === "readiness-parse-error-handling"
+    );
+    expect(parse?.specStrength).toBe("MAY");
+    expect(parse?.message).toMatch(/-32700/);
+
+    const rejecting = (async () =>
+      new Response("Bad Request", { status: 400 })) as unknown as typeof fetch;
+    const silent = await collectRawReadiness(rawContext(rejecting));
+    expect(
+      silent.find((item) => item.id === "readiness-parse-error-handling")
+    ).toBeUndefined();
+  });
+
+  it("advises when the legacy session-termination DELETE answers 5xx, and accepts a 405 decline", async () => {
+    const brokenDelete = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "DELETE") {
+        return new Response("boom", { status: 500 });
+      }
+      const body = String(init?.body ?? "");
+      if (body.includes("initialize")) {
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "mcp-session-id": "session-1",
+          },
+        });
+      }
+      return new Response("Bad Request", { status: 400 });
+    }) as unknown as typeof fetch;
+
+    const warnings = await collectRawReadiness(rawContext(brokenDelete));
+    const termination = warnings.find(
+      (item) => item.id === "readiness-session-termination"
+    );
+    expect(termination?.specStrength).toBe("SHOULD");
+    expect(termination?.details).toMatchObject({ status: 500 });
+
+    const declining = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 405 });
+      }
+      const body = String(init?.body ?? "");
+      if (body.includes("initialize")) {
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "mcp-session-id": "session-1",
+          },
+        });
+      }
+      return new Response("Bad Request", { status: 400 });
+    }) as unknown as typeof fetch;
+
+    const silent = await collectRawReadiness(rawContext(declining));
+    expect(
+      silent.find((item) => item.id === "readiness-session-termination")
+    ).toBeUndefined();
+  });
+
+  it("advises a modern server whose DELETE is not answered 405", async () => {
+    const fetchFn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(_input).includes(".well-known")) {
+        return new Response("{}", { status: 404 });
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 8100, result: { tools: [], resultType: "complete" } }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    const warnings = await collectRawReadiness(
+      rawContext(fetchFn, "2026-07-28")
+    );
+    const termination = warnings.find(
+      (item) => item.id === "readiness-session-termination"
+    );
+    expect(termination?.specStrength).toBe("SHOULD");
+    expect(termination?.message).toMatch(/405/);
+  });
+
   it("swallows a probe that throws — advice never disturbs a run", async () => {
     const fetchFn = (async () => {
       throw new Error("network down");

--- a/sdk/tests/mcp-conformance/readiness.unit.test.ts
+++ b/sdk/tests/mcp-conformance/readiness.unit.test.ts
@@ -369,6 +369,40 @@ describe("raw readiness advice", () => {
     expect(deleteHeaders[0]["mcp-session-id"]).toBeTruthy();
   });
 
+  it("keeps the DELETE finding when the GET probe never completes", async () => {
+    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes(".well-known")) {
+        return new Response("{}", { status: 404 });
+      }
+      if (init?.method === "GET") {
+        throw new Error("GET timed out");
+      }
+      if (init?.method === "DELETE") {
+        return new Response(null, { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 8100,
+          result: { tools: [], resultType: "complete" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }) as unknown as typeof fetch;
+
+    const warnings = await collectRawReadiness(
+      rawContext(fetchFn, "2026-07-28")
+    );
+    const termination = warnings.find(
+      (item) => item.id === "readiness-session-termination"
+    );
+
+    // One probe failing must not bury what the other observed.
+    expect(termination?.message).toMatch(/DELETE got HTTP 200/);
+    expect(termination?.message).not.toMatch(/GET got HTTP/);
+    expect(termination?.details).toMatchObject({ getStatus: "not observed" });
+  });
+
   it("swallows a probe that throws — advice never disturbs a run", async () => {
     const fetchFn = (async () => {
       throw new Error("network down");

--- a/sdk/tests/mcp-conformance/readiness.unit.test.ts
+++ b/sdk/tests/mcp-conformance/readiness.unit.test.ts
@@ -333,12 +333,18 @@ describe("raw readiness advice", () => {
     ).toBeUndefined();
   });
 
-  it("advises a modern server whose DELETE is not answered 405", async () => {
+  it("advises a modern server whose DELETE is not answered 405, probing as an older client would", async () => {
+    const deleteHeaders: Array<Record<string, string>> = [];
     const fetchFn = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       if (String(_input).includes(".well-known")) {
         return new Response("{}", { status: 404 });
       }
       if (init?.method === "DELETE") {
+        const seen: Record<string, string> = {};
+        new Headers(init.headers).forEach((value, key) => {
+          seen[key.toLowerCase()] = value;
+        });
+        deleteHeaders.push(seen);
         return new Response(null, { status: 200 });
       }
       return new Response(
@@ -355,6 +361,12 @@ describe("raw readiness advice", () => {
     );
     expect(termination?.specStrength).toBe("SHOULD");
     expect(termination?.message).toMatch(/405/);
+    // The obligation covers traffic from an OLDER client, so the probe carries
+    // a 2025 pin and a session id rather than a bare DELETE a header-validating
+    // server could reject for the missing version.
+    expect(deleteHeaders).toHaveLength(1);
+    expect(deleteHeaders[0]["mcp-protocol-version"]).toBe("2025-11-25");
+    expect(deleteHeaders[0]["mcp-session-id"]).toBeTruthy();
   });
 
   it("swallows a probe that throws — advice never disturbs a run", async () => {

--- a/sdk/tests/mcp-conformance/runner.test.ts
+++ b/sdk/tests/mcp-conformance/runner.test.ts
@@ -39,7 +39,7 @@ describe("MCPConformanceTest", () => {
       expect(result.categorySummary.prompts.passed).toBe(1);
       expect(result.categorySummary.resources.passed).toBe(1);
       expect(result.categorySummary.security.passed).toBe(2);
-      expect(result.categorySummary.transport.passed).toBe(3);
+      expect(result.categorySummary.transport.passed).toBe(7);
     } finally {
       await mockServer.stop();
     }

--- a/sdk/tests/mcp-conformance/security-origin.integration.test.ts
+++ b/sdk/tests/mcp-conformance/security-origin.integration.test.ts
@@ -21,7 +21,11 @@ async function serveStatus(
 ): Promise<{ url: string; stop: () => Promise<void> }> {
   const server = http.createServer((req, res) => {
     const host = req.headers.host ?? "";
-    if (host.includes("evil.example.com")) {
+    const origin = req.headers.origin ?? "";
+    // Keyed on the ORIGIN as well as the Host: the requirement under test is
+    // about a present-and-invalid `Origin`, so a fixture that rejected on Host
+    // alone would stay green even if the probe stopped sending Origin at all.
+    if (host.includes("evil.example.com") && origin === "http://evil.example.com") {
       res.writeHead(status, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "rejected" }));
       return;
@@ -80,6 +84,29 @@ describe("Origin rejection status by protocol version", () => {
       expect(results).toHaveLength(1);
       expect(results[0].status).toBe("failed");
       expect(results[0].error?.message).toMatch(/403 Forbidden/);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("accepts any 4xx when the run pinned no version at all", async () => {
+    // The resolved version falls back to 2025-11-25 so the probe has something
+    // to put on the wire, but an unpinned run asserted nothing about which
+    // revision it judges — demanding 403 from it would newly fail servers that
+    // passed before the requirement was sharpened.
+    const server = await serveStatus(400);
+    try {
+      const config = normalizeMCPConformanceConfig({
+        serverUrl: server.url,
+        checkTimeout: 3_000,
+      });
+      expect(config.protocolVersion).toBeUndefined();
+      const results = await runSecurityChecks(
+        { config, serverUrl: server.url, fetchFn: config.fetchFn },
+        SELECTED,
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("passed");
     } finally {
       await server.stop();
     }

--- a/sdk/tests/mcp-conformance/security-origin.integration.test.ts
+++ b/sdk/tests/mcp-conformance/security-origin.integration.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Version sensitivity of `localhost-host-rebinding-rejected`.
+ *
+ * 2025-03-26 and 2025-06-18 state the Origin-validation MUST but name no
+ * status, so any 4xx rejection satisfies them. 2025-11-25 added (changelog PR
+ * #1439): "If the Origin header is present and invalid, servers MUST respond
+ * with HTTP 403 Forbidden." The same 400-rejecting server therefore passes
+ * under a 2025-06-18 pin and fails under a 2025-11-25 pin.
+ *
+ * A real listener is required: the security probes forge the Host header via
+ * `node:http`, which `fetch` forbids, so there is no fetchFn to stub.
+ */
+
+import http from "node:http";
+import { runSecurityChecks } from "../../src/mcp-conformance/checks/security.js";
+import type { MCPCheckId } from "../../src/mcp-conformance/types.js";
+import { normalizeMCPConformanceConfig } from "../../src/mcp-conformance/validation.js";
+
+async function serveStatus(
+  status: number,
+): Promise<{ url: string; stop: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    const host = req.headers.host ?? "";
+    if (host.includes("evil.example.com")) {
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "rejected" }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Server did not bind to a port");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    stop: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  };
+}
+
+const SELECTED = new Set<MCPCheckId>(["localhost-host-rebinding-rejected"]);
+
+describe("Origin rejection status by protocol version", () => {
+  it("accepts any 4xx under a 2025-06-18 pin", async () => {
+    const server = await serveStatus(400);
+    try {
+      const config = normalizeMCPConformanceConfig({
+        serverUrl: server.url,
+        protocolVersion: "2025-06-18",
+        checkTimeout: 3_000,
+      });
+      const results = await runSecurityChecks(
+        { config, serverUrl: server.url, fetchFn: config.fetchFn },
+        SELECTED,
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("passed");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("requires exactly 403 under a 2025-11-25 pin", async () => {
+    const server = await serveStatus(400);
+    try {
+      const config = normalizeMCPConformanceConfig({
+        serverUrl: server.url,
+        protocolVersion: "2025-11-25",
+        checkTimeout: 3_000,
+      });
+      const results = await runSecurityChecks(
+        { config, serverUrl: server.url, fetchFn: config.fetchFn },
+        SELECTED,
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("failed");
+      expect(results[0].error?.message).toMatch(/403 Forbidden/);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("passes a 403-rejecting server under a 2025-11-25 pin", async () => {
+    const server = await serveStatus(403);
+    try {
+      const config = normalizeMCPConformanceConfig({
+        serverUrl: server.url,
+        protocolVersion: "2025-11-25",
+        checkTimeout: 3_000,
+      });
+      const results = await runSecurityChecks(
+        { config, serverUrl: server.url, fetchFn: config.fetchFn },
+        SELECTED,
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe("passed");
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/sdk/tests/mcp-conformance/server-discover-identity.test.ts
+++ b/sdk/tests/mcp-conformance/server-discover-identity.test.ts
@@ -30,7 +30,22 @@ async function serveDiscover(result: Record<string, unknown>): Promise<string> {
     let body = "";
     req.on("data", (chunk) => (body += chunk));
     req.on("end", () => {
-      const id = (JSON.parse(body || "{}") as { id?: unknown }).id ?? 1;
+      // The readiness pass probes with a deliberately unparseable body; a
+      // fixture that throws on it would hang that request forever.
+      let id: unknown = 1;
+      try {
+        id = (JSON.parse(body || "{}") as { id?: unknown }).id ?? 1;
+      } catch {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32700, message: "Parse error" },
+          })
+        );
+        return;
+      }
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ jsonrpc: "2.0", id, result }));
     });

--- a/sdk/tests/mock-servers/conformance-mcp-server.ts
+++ b/sdk/tests/mock-servers/conformance-mcp-server.ts
@@ -936,6 +936,12 @@ export async function startConformanceMockServer(
 
       await new Promise<void>((resolve) => {
         httpServer.close(() => resolve());
+        // `close()` alone waits out every socket the transport still holds —
+        // a standalone GET SSE stream is never "idle", so teardown blocked for
+        // undici's full keep-alive window and pushed the suite past its
+        // timeout. The transports above are already closed; anything still
+        // attached is a socket nobody will end, so drop it.
+        httpServer.closeAllConnections();
       });
     },
   };


### PR DESCRIPTION
Widens the protocol suite's Streamable HTTP transport coverage. A server could previously pass the full suite while answering a notification POST with `200 + body`, answering GET with an HTML page, or minting a session id with invalid bytes — all verbatim MUSTs in the transports spec that no check exercised. Landing this **before** the score PR so the applicable-check set is stable when scoring ships.

Every requirement below was verified against the spec text of each revision (`<version>/basic/transports.mdx`, and `2026-07-28/basic/transports/streamable-http.mdx`), and each check's era scope follows from where that text actually exists.

## Four new MUST checks (`transport` category)

- **`notification-post-accepted`** — *"If the server accepts the input, the server MUST return HTTP status code 202 Accepted with no body."* Probes with `notifications/initialized`, the one notification every client sends, so the "cannot accept" escape hatch has no legitimate reading. Legacy-only: 2026-07-28 defines no core client-to-server notification over Streamable HTTP and explicitly leaves notification-POST header requirements undefined.
- **`get-stream-or-405`** — *"The server MUST either return `Content-Type: text/event-stream` … or else return HTTP 405 Method Not Allowed."* Catches the server that answers GET with something that is neither stream nor refusal (the existing `server-sse-*` checks only test that SSE works when offered). Legacy-only: the GET endpoint is removed in 2026-07-28, where 405 is a backward-compat SHOULD (covered by the new advice item instead).
- **`session-id-visible-ascii`** — *"The session ID MUST only contain visible ASCII characters (ranging from 0x21 to 0x7E)."* Only the charset is judged — uniqueness/entropy are SHOULD and deliberately not checked. No session id ⇒ not-applicable (minting one is MAY).
- **`post-response-content-type`** — the one both-era check: every revision, 2025-03-26 through 2026-07-28, states the response to a JSON-RPC request MUST carry `application/json` or `text/event-stream`. The server's *choice* between them is unconstrained and never flagged. On legacy it judges the initialize response; on modern it sends a self-contained enveloped `tools/list`.

All four classify honestly under the skip taxonomy from #3680: a broken initialize ⇒ `could-not-run` (run reports `incomplete`), an era mismatch or missing session id ⇒ `not-applicable`.

## One check sharpened, version-sensitively

`localhost-host-rebinding-rejected` accepted any 4xx. 2025-11-25 added (changelog PR #1439): *"If the `Origin` header is present and invalid, servers MUST respond with HTTP 403 Forbidden."* The check now requires exactly 403 under a 2025-11-25 pin and keeps any-4xx for 2025-03-26/06-18, where no status is named. It stays localhost-gated: the validation MUST is textually unscoped, but "invalid" is undecidable for a remote server whose allowed-origin set we don't know — only against localhost is `evil.example.com` definitively invalid, and failing remote servers would manufacture violations the spec text doesn't support.

## Two additions to the readiness (advice) channel

Both are things a grader might be tempted to fail servers on, where the spec doesn't:

- **`readiness-parse-error-handling`** — no revision maps an unparseable POST body to *any* HTTP status or JSON-RPC error; the transports docs are silent in all four. So this can never be a check. JSON-RPC 2.0 itself names `-32700`, and answering garbage with a success status hides transport corruption — advice fires only when the server accepts the garbage as success (`MAY` strength).
- **`readiness-session-termination`** — the 2025 session-termination DELETE is SHOULD (client-side) / MAY-answer-405 (server-side), so a 405 is fully conformant and produces nothing; only a 5xx earns advice. On modern, stray GET/DELETE not answered 405 earns the 2026 backward-compat SHOULD advice.

## The CLI benefits

- Both new check ids and the sharpened one flow through `--check-id` / `--category` and the reporters automatically (all data-driven off `MCP_CHECK_IDS`).
- The readiness channel — previously computed but rendered nowhere — now prints as an `Advice` section on stderr for `protocol conformance` and `conformance-suite`, mirroring `reportIncomplete`: visible to a human, invisible to JSON consumers and exit codes, silent under `--quiet`, and a no-op against an older SDK.

## Harness note

The GET probe uses a new `rawHeadersProbe` in the raw harness: an accepted GET stream legitimately never ends, so `rawRequest` (which reads bodies to completion) would burn its entire timeout on a *conforming* server. The probe observes the status line and headers, then aborts — same seam `raw-listen.ts` already uses for live streams. This also removes the flake where header arrival raced a fixed cut-off under load.

The transport runner now selects checks by membership in `TRANSPORT_CHECK_METADATA` instead of a `startsWith("server-sse")` prefix test — the prefix predicate would have silently dropped any id that didn't match it.

## Verification

- SDK: **3505 passed**, 1 skipped, 192 files — including a new e2e pass of all four checks against the official-SDK mock server, unit fixtures for each failure mode, and a 3-case integration test proving the 400-rejecting server passes under 2025-06-18 and fails under 2025-11-25
- CLI: **551 passed** (550 + new Advice test), CLI tsc clean
- Root `npm run typecheck` (all six releasable packages) clean
- Era invariants: the three legacy-only checks era-skip on a modern run before any HTTP; `post-response-content-type` probes with exactly one exchange

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands default conformance coverage and tightens Origin rejection for pinned 2025-11-25+ runs; behavior is era-gated and unpinned runs stay backward compatible, but CI against legacy servers may see new failures or advice.
> 
> **Overview**
> Adds **four transport conformance checks** for Streamable HTTP behavior that was previously untested: notification POST must return **202 with no body** (2025 only), GET must open **SSE or 405** (2025 only), minted session ids must be **visible ASCII** (2025 only), and JSON-RPC responses must use **`application/json` or `text/event-stream`** on every protocol revision. Legacy runs share an initialize session; modern runs probe **`tools/list`** for content-type only.
> 
> **`localhost-host-rebinding-rejected`** now requires **HTTP 403** only when the run **explicitly** pins **2025-11-25+**; unpinned runs and older pins still accept any 4xx.
> 
> The raw harness gains **`rawHeadersProbe`** (headers-only GET, body cancelled) so conforming SSE streams do not time out. Transport check selection uses **`TRANSPORT_CHECK_METADATA` membership** instead of an `server-sse` prefix.
> 
> **Readiness advice** adds parse-error handling (MAY) and session termination (SHOULD), including modern **GET/DELETE as a legacy client**. The CLI prints an **`Advice`** section on stderr for `protocol conformance` / `conformance-suite` (no exit-code change; respects `--quiet`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e1ff18567885994112403cc3b102d61a88d6368. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the conformance suite to cover Streamable HTTP transport MUSTs that were previously untested and surfaces readiness advice in the CLI. Adds four transport checks, version-aware Origin rejection, exact media-type handling, and more robust modern 405 advice.

- **New Features**
  - Transport checks:
    - `notification-post-accepted` (2025 only): notification POST must be 202 with no body.
    - `get-stream-or-405` (2025 only): GET must return SSE or 405.
    - `session-id-visible-ascii` (2025 only): session id chars limited to 0x21–0x7E.
    - `post-response-content-type` (all eras): response must be exactly `application/json` or `text/event-stream`.
  - Readiness advice: parse-error handling (MAY) and session termination (SHOULD). Printed to stderr by `@mcpjam/cli`; ignored by JSON output and exit codes.

- **Bug Fixes**
  - Origin check: 403 is required only under an explicit 2025-11-25+ pin; unpinned runs still accept any 4xx.
  - Content-Type: media type is parsed exactly (no substring matches); MCP-layer error responses are judged; gateway non-JSON responses are treated as could-not-run.
  - Modern 405 advice: probes GET and DELETE as an older client (2025 pin + session id) and settles each probe independently; a timeout on one no longer hides the other and is reported as “not observed.”
  - GET probe: observes headers only and cancels the body to release accepted SSE streams; test fixture drops leftover sockets to avoid timeouts.
  - Notification POST: unreadable response body yields could-not-run instead of a pass.

<sup>Written for commit 2e1ff18567885994112403cc3b102d61a88d6368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Review round

Eight findings from the automated reviewers, all addressed. Two I implemented differently from the suggestion, with reasoning:

**Unpinned runs no longer demand 403** (the one with real blast radius). The sharpened Origin check keyed its "must be 403" decision off the *resolved* protocol version — which falls back to `2025-11-25` purely so the probe has something to put on the wire. An **unpinned** run therefore started requiring 403 from servers that legitimately answer 400, even though such a run asserts nothing about which revision it is judging. Now gated on an explicit pin.

**Media-type comparison is exact everywhere.** The POST check parsed the media type properly but the GET check used a substring test, so `text/event-streamish` and `application/text/event-stream` both read as conforming streams. Every content-type verdict now goes through one parse that strips parameters (`; charset=utf-8` stays legal) and compares exactly.

**Response framing is judged on any MCP-layer response, not only 2xx.** Writing every non-2xx off as `could-not-run` let a real violation escape. But failing *every* non-2xx would falsely fail an OAuth gateway's 401 HTML page or a proxy 502 — responses the server under test never framed. The line drawn: a non-2xx **carrying a JSON-RPC error** is the server answering, so the framing MUST binds in full; without one, nothing MCP-layer was observed and the check stays `could-not-run`.

**A notification response whose body could not be read is `could-not-run`.** It was passing as "202 with no body", certifying a fact the run never established. Failing it instead would blame the server for our truncated read.

**The modern 405 advisory probes GET as well as DELETE**, since the clause names both and the modern GET path was otherwise unprobed. Both probes now carry a 2025 pin and a session id — the obligation is explicitly about *"traffic from an older client"*, and the same clause tells a modern server to ignore a stray session id. (A suggestion to send `MCP-Protocol-Version: 2026-07-28` instead was not taken: that would make the probe modern-client traffic, which never includes a GET or DELETE at all, so it would no longer exercise the obligation.)

**`rawHeadersProbe` honors `includeBaseHeaders`** like `rawRequest`, so a header-only probe cannot silently acquire auth it meant to omit.

**The Origin fixture keys on the forged Origin, not Host alone**, so a regression that dropped the `Origin` header can no longer stay green.

Four new tests, and I verified the two behavior-fix guards (`text/event-streamish`, unpinned-400) fail against the pre-fix code rather than passing either way. SDK **3509 passing**, CLI 551, root typecheck clean.
