### PR TITLE
feat(oauth): flag-gated `oauth emulate` CLI rollout (HP-43 S7)

### DIFF
--- a/.changeset/oauth-emulation-cli.md
+++ b/.changeset/oauth-emulation-cli.md
@@ -1,0 +1,33 @@
+---
+"@mcpjam/cli": minor
+"@mcpjam/sdk": minor
+---
+
+OAuth client emulation: flag-gated CLI rollout (HP-43 step 7).
+
+`mcpjam oauth emulate` runs an emulated client's OAuth ladder against an MCP
+server, headless and CI-ready, on the existing `oauth` command group — no new
+surface.
+
+- **Feature-flagged.** `MCPJAM_OAUTH_EMULATION=1` is required; without it the
+  command refuses with a message naming what it would do. An emulated run
+  registers a client and may obtain a token on the target server, so it is
+  opted into deliberately.
+- **Profiles are data, never names.** `--profile <path>` takes a JSON profile
+  the private backend produces, canonicalized on load through the same SDK
+  canonicalizer the backend uses. The CLI ships no client catalog.
+- **Comparison and capture.** `--golden <path>` compares the run against a
+  real-client capture (refused unless its `profileDigest` matches the run's);
+  `--trace-out <path>` writes this run's normalized trace already bound to its
+  profile, ready to become a golden.
+- **Exit codes** join the shared conformance vocabulary: `0` pass, `1` failed
+  (including a mismatched comparison — the finding the emulator exists to
+  produce), `2` usage, `3` incomplete. Stopping at the consent leg is
+  incomplete, not a pass: nothing was established.
+- `--auth-mode headless` crosses the consent leg against an auto-consenting
+  authorization server; the default stops and reports the URL.
+
+SDK: `completeHeadlessAuthorization` is now exported, and
+`runEmulatedOAuthPreflight`'s `completeAuthorization` callback receives the
+run's own executor so a headless completer uses the same hardened transport
+(SSRF guard, timeouts) as the flow rather than building its own.

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -5,10 +5,14 @@ import {
   type OAuthVerificationConfig,
   OAuthConformanceTest,
   OAuthConformanceSuite,
+  completeHeadlessAuthorization,
+  computeOAuthProfileDigest,
+  deriveOAuthEmulation,
   executeDebugOAuthProxy,
   executeOAuthProxy,
   fetchOAuthMetadata,
   OAuthProxyError,
+  runEmulatedOAuthPreflight,
   runOAuthLogin,
 } from "@mcpjam/sdk";
 import { Command } from "commander";
@@ -52,6 +56,15 @@ import {
   redactCredentialsFromResult,
   writeCredentialsFile,
 } from "../lib/credentials-file.js";
+import {
+  assertOAuthEmulationEnabled,
+  emulationExitCode,
+  loadOAuthGoldenFile,
+  loadOAuthProfileFile,
+  parseStaticCredential,
+  renderEmulationResult,
+  writeEmulationTraceFile,
+} from "../lib/oauth-emulation.js";
 import {
   createCliRpcLogCollector,
 } from "../lib/rpc-logs.js";
@@ -405,6 +418,195 @@ export function registerOAuthCommands(program: Command): void {
       if (result.outcome === "failed") {
         setProcessExitCode(1);
       }
+    });
+
+  oauth
+    .command("emulate")
+    .description(
+      "Run an emulated client's OAuth ladder against an MCP server (feature-flagged)",
+    )
+    .requiredOption("--url <url>", "MCP server URL")
+    .requiredOption(
+      "--profile <path>",
+      "Path to a JSON OAuth client profile (HostConfigOAuthProfile). Profiles are data — this CLI ships no client catalog.",
+    )
+    .option(
+      "--golden <path>",
+      "Path to a JSON golden trace to compare this run against",
+    )
+    .option(
+      "--profile-digest <digest>",
+      "Digest binding this run to its profile. Computed from --profile when omitted.",
+    )
+    .option(
+      "--expected-client-version <version>",
+      "Client build being emulated; a golden captured from another build is reported as a qualified match",
+    )
+    .option("--catalog-revision <revision>", "Recorded in the run's bindings")
+    .option(
+      "--callback-url <url>",
+      "Callback MCPJam controls; authorization and token legs always use it",
+      "http://127.0.0.1:41234/callback",
+    )
+    .option("--client-id <id>", "Pre-registered OAuth client ID")
+    .option("--client-secret <secret>", "Pre-registered OAuth client secret")
+    .option(
+      "--client-metadata-url <url>",
+      "MCPJam-controlled client metadata URL for CIMD attempts",
+    )
+    .option(
+      "--static-credential <header>",
+      'Static credential for an api-key rung, in "Header-Name: value" format',
+    )
+    .option(
+      "--header <header>",
+      'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
+      (value: string, previous: string[] = []) => [...previous, value],
+      [],
+    )
+    .option("--scopes <scopes>", "Space-separated scope string")
+    .option(
+      "--auth-mode <mode>",
+      "How the consent leg is crossed: headless (auto-consenting AS) or stop (report the URL and stop)",
+      "stop",
+    )
+    .option(
+      "--step-timeout <ms>",
+      "Per-step timeout in milliseconds",
+      (value: string) => parsePositiveInteger(value, "Step timeout"),
+      30_000,
+    )
+    .option(
+      "--trace-out <path>",
+      "Write this run's normalized trace to <path>, ready to become a golden",
+    )
+    .option(
+      "--credentials-out <path>",
+      "Write OAuth credentials to <path> (mode 0600)",
+    )
+    .action(async (options, command) => {
+      assertOAuthEmulationEnabled();
+
+      const authMode = options.authMode as string;
+      if (authMode !== "headless" && authMode !== "stop") {
+        throw usageError(
+          `Invalid --auth-mode "${authMode}". Expected headless or stop.`,
+        );
+      }
+
+      const profile = loadOAuthProfileFile(options.profile as string);
+      const emulation = deriveOAuthEmulation(profile);
+      const golden = options.golden
+        ? loadOAuthGoldenFile(options.golden as string)
+        : undefined;
+      const profileDigest =
+        (options.profileDigest as string | undefined) ??
+        (await computeOAuthProfileDigest(profile));
+
+      const result = await runEmulatedOAuthPreflight({
+        serverUrl: options.url as string,
+        emulation,
+        callbackUrl: options.callbackUrl as string,
+        profileDigest,
+        profileSchemaVersion: profile.profileVersion,
+        ...(options.catalogRevision
+          ? { catalogRevision: options.catalogRevision as string }
+          : {}),
+        ...(options.clientId
+          ? {
+              preregistered: {
+                clientId: options.clientId as string,
+                ...(options.clientSecret
+                  ? { clientSecret: options.clientSecret as string }
+                  : {}),
+              },
+            }
+          : {}),
+        ...(options.clientMetadataUrl
+          ? { clientIdMetadataUrl: options.clientMetadataUrl as string }
+          : {}),
+        ...(options.staticCredential
+          ? {
+              staticCredential: parseStaticCredential(
+                options.staticCredential as string,
+              ),
+            }
+          : {}),
+        ...(options.header && (options.header as string[]).length > 0
+          ? { customHeaders: parseHeadersOption(options.header as string[]) }
+          : {}),
+        ...(options.scopes ? { customScopes: options.scopes as string } : {}),
+        timeoutMs: options.stepTimeout as number,
+        ...(golden
+          ? {
+              goldenComparison: {
+                golden,
+                profileDigest,
+                ...(options.expectedClientVersion
+                  ? {
+                      expectedClientVersion:
+                        options.expectedClientVersion as string,
+                    }
+                  : {}),
+              },
+            }
+          : {}),
+        ...(authMode === "headless"
+          ? {
+              completeAuthorization: ({
+                authorizationUrl,
+                callbackUrl,
+                request,
+              }) =>
+                completeHeadlessAuthorization({
+                  authorizationUrl,
+                  redirectUrl: callbackUrl,
+                  request,
+                }),
+            }
+          : {}),
+      });
+
+      if (options.traceOut) {
+        await writeEmulationTraceFile(
+          options.traceOut as string,
+          result,
+          profileDigest,
+        );
+      }
+
+      let credentialsFilePath: string | undefined;
+      let credentialsFileError: unknown;
+      if (options.credentialsOut && result.credentials?.accessToken) {
+        try {
+          credentialsFilePath = await writeCredentialsFile(
+            options.credentialsOut as string,
+            {
+              serverUrl: result.serverUrl,
+              protocolVersion: result.protocolVersion,
+              credentials: result.credentials,
+            },
+          );
+        } catch (error) {
+          credentialsFileError = error;
+        }
+      }
+
+      // Same format resolution every other oauth subcommand uses.
+      const format = getOAuthConformanceFormat(command, undefined);
+      if (format === "json") {
+        writeResult(result);
+      } else {
+        writeOAuthOutput(renderEmulationResult(result));
+        if (credentialsFilePath) {
+          writeOAuthOutput(`\nCredentials written to ${credentialsFilePath}`);
+        }
+      }
+
+      if (credentialsFileError) {
+        throw credentialsFileError;
+      }
+      setProcessExitCode(emulationExitCode(result));
     });
 
   oauth

--- a/cli/src/lib/oauth-emulation.ts
+++ b/cli/src/lib/oauth-emulation.ts
@@ -1,0 +1,264 @@
+/**
+ * OAuth client emulation — CLI plumbing (HP-43 step 7).
+ *
+ * The emulator runs behind a feature flag while it rolls out: it registers
+ * clients and issues tokens on servers the user names, so it must be opted
+ * into deliberately rather than discovered by tab-completion.
+ *
+ * The CLI takes a PROFILE as data — a JSON file the private backend produces —
+ * and never a client name. There is no catalog here to name a client from, by
+ * design (see the emulation modules in `@mcpjam/sdk`).
+ */
+import { readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { canonicalizeOAuthProfile } from "@mcpjam/sdk/host-config/internal";
+import type { HostConfigOAuthProfile } from "@mcpjam/sdk/host-config/internal";
+import type {
+  OAuthGoldenTrace,
+  EmulatedOAuthPreflightResult,
+} from "@mcpjam/sdk";
+import { usageError } from "./output.js";
+
+export const OAUTH_EMULATION_FLAG = "MCPJAM_OAUTH_EMULATION";
+
+/**
+ * The rollout gate. Off by default: an emulated run performs Dynamic Client
+ * Registration and a token exchange against a third-party server, which is not
+ * something a user should trigger by accident.
+ */
+export function assertOAuthEmulationEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (env[OAUTH_EMULATION_FLAG] !== "1") {
+    throw usageError(
+      `OAuth client emulation is behind a feature flag while it rolls out. ` +
+        `Set ${OAUTH_EMULATION_FLAG}=1 to enable it. ` +
+        `Note that an emulated run registers a client and may obtain a token ` +
+        `on the target server.`,
+    );
+  }
+}
+
+function readJsonFile(filePath: string, label: string): unknown {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, "utf-8");
+  } catch (error) {
+    throw usageError(
+      `Cannot read ${label} "${filePath}": ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw usageError(`${label} "${filePath}" is not valid JSON`);
+  }
+}
+
+/**
+ * Load a profile and put it through the SDK canonicalizer — the same one the
+ * backend uses. A profile that would not survive canonicalization must fail
+ * here, loudly, rather than producing a half-enforced emulation.
+ */
+export function loadOAuthProfileFile(filePath: string): HostConfigOAuthProfile {
+  const parsed = readJsonFile(filePath, "OAuth profile");
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw usageError("OAuth profile must be a JSON object");
+  }
+  try {
+    const canonical = canonicalizeOAuthProfile(
+      parsed as HostConfigOAuthProfile,
+    );
+    if (!canonical) {
+      throw usageError("OAuth profile is empty");
+    }
+    return canonical;
+  } catch (error) {
+    if (error instanceof Error && "code" in error) throw error;
+    throw usageError(
+      `OAuth profile "${filePath}" is not valid: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+/** Load a golden capture. Structural validation only — the comparator owns
+ * the semantics, and a capture is opaque data produced elsewhere. */
+export function loadOAuthGoldenFile(filePath: string): OAuthGoldenTrace {
+  const parsed = readJsonFile(filePath, "golden trace");
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw usageError("Golden trace must be a JSON object");
+  }
+  const golden = parsed as Partial<OAuthGoldenTrace>;
+  if (typeof golden.profileDigest !== "string" || !golden.profileDigest.trim()) {
+    throw usageError(
+      "Golden trace must have a non-empty string \"profileDigest\" — a capture " +
+        "that names no profile cannot be safely compared against a run",
+    );
+  }
+  if (typeof golden.capturedAt !== "string" || !golden.capturedAt.trim()) {
+    throw usageError('Golden trace must have a string "capturedAt" date');
+  }
+  if (!Array.isArray(golden.steps)) {
+    throw usageError('Golden trace must have a "steps" array');
+  }
+  return golden as OAuthGoldenTrace;
+}
+
+/**
+ * Write a run's normalized trace in golden shape, so a capture taken today can
+ * be compared against tomorrow. `capturedAt` is stamped now — the comparator
+ * treats a future or malformed date as stale, so it must be a real one.
+ */
+export async function writeEmulationTraceFile(
+  outputPath: string,
+  result: Pick<EmulatedOAuthPreflightResult, "trace">,
+  profileDigest: string,
+  now: Date = new Date(),
+): Promise<string> {
+  const resolved = path.resolve(process.cwd(), outputPath);
+  const golden: OAuthGoldenTrace = {
+    profileDigest,
+    capturedAt: now.toISOString().slice(0, 10),
+    steps: result.trace,
+  };
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, `${JSON.stringify(golden, null, 2)}\n`, "utf-8");
+  return resolved;
+}
+
+/** `Header-Name: value`, the same shape `--header` already uses. */
+export function parseStaticCredential(
+  value: string,
+): { headerName: string; value: string } {
+  const separator = value.indexOf(":");
+  if (separator <= 0) {
+    throw usageError(
+      `Static credential must be in "Header-Name: value" format (got "${value}")`,
+    );
+  }
+  const headerName = value.slice(0, separator).trim();
+  const headerValue = value.slice(separator + 1).trim();
+  if (!headerName || !headerValue) {
+    throw usageError(
+      'Static credential must have a non-empty header name and value',
+    );
+  }
+  return { headerName, value: headerValue };
+}
+
+/**
+ * Map a run onto the CLI's shared exit-code vocabulary (0 pass / 1 failed /
+ * 2 usage / 3 incomplete).
+ *
+ * `stopped_at_redirect` is INCOMPLETE, not a pass: the human leg was never
+ * crossed, so the run established nothing about whether this client can
+ * actually connect. A mismatched comparison is a FAILURE — that is the
+ * emulator reporting the very thing it exists to detect.
+ */
+export function emulationExitCode(
+  result: Pick<EmulatedOAuthPreflightResult, "outcome" | "comparison">,
+): number {
+  if (result.comparison.status === "mismatched") return 1;
+  switch (result.outcome) {
+    case "completed":
+    case "static_credential_ok":
+    case "unauthenticated_ok":
+      return 0;
+    case "stopped_at_redirect":
+      return 3;
+    case "blocked":
+    case "error":
+      return 1;
+  }
+}
+
+/**
+ * Human-readable summary. Every line the emulator is allowed to claim is
+ * qualified here the same way the result object qualifies it: the three
+ * dimensions stay separate, and a qualified match never prints as parity.
+ */
+export function renderEmulationResult(
+  result: EmulatedOAuthPreflightResult,
+): string {
+  const lines: string[] = [];
+  lines.push(`Server:    ${result.serverUrl}`);
+  lines.push(`Ladder:    ${result.protocolVersion}`);
+  lines.push(`Outcome:   ${result.outcome}`);
+  lines.push(
+    `Coverage:  ${result.coverageSummary}` +
+      (result.coverageSummary === "partial"
+        ? ` (${Object.entries(result.coverage)
+            .filter(([, status]) => status === "not_modeled")
+            .map(([field]) => field)
+            .join(", ")} not modeled)`
+        : ""),
+  );
+
+  const comparison = result.comparison;
+  const qualifiers = comparison.qualifiers.length
+    ? ` [${comparison.qualifiers.join(", ")}]`
+    : "";
+  lines.push(
+    `Compared:  ${comparison.status}${
+      comparison.reason ? ` (${comparison.reason})` : ""
+    }${qualifiers}`,
+  );
+
+  lines.push("");
+  lines.push("Attempts:");
+  for (const attempt of result.attempts) {
+    lines.push(
+      `  - ${attempt.kind}: ${attempt.status}` +
+        (attempt.registrationStrategy
+          ? ` via ${attempt.registrationStrategy}`
+          : "") +
+        (attempt.detail ? ` — ${attempt.detail}` : ""),
+    );
+  }
+
+  if (comparison.differences.length > 0) {
+    lines.push("");
+    lines.push("Differences from the real client:");
+    for (const difference of comparison.differences) {
+      lines.push(`  - [${difference.index}] ${difference.kind}: ${difference.detail}`);
+      if (difference.expected !== undefined) {
+        lines.push(`      real client: ${difference.expected}`);
+      }
+      if (difference.actual !== undefined) {
+        lines.push(`      this run:    ${difference.actual}`);
+      }
+    }
+  }
+
+  if (result.divergences.length > 0) {
+    lines.push("");
+    lines.push("Declared divergences:");
+    for (const divergence of result.divergences) {
+      lines.push(`  - ${divergence.kind}: ${divergence.detail}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(
+    `Side effects: ${result.sideEffects.dcrRegistrations} client registration(s), ` +
+      `${result.sideEffects.tokensIssued} token(s) issued`,
+  );
+
+  if (result.authorizationUrl) {
+    lines.push("");
+    lines.push(`Authorization URL (a human must visit it):`);
+    lines.push(`  ${result.authorizationUrl}`);
+  }
+
+  if (result.error) {
+    lines.push("");
+    lines.push(`Error: ${result.error.message}`);
+  }
+
+  return lines.join("\n");
+}

--- a/cli/tests/oauth-emulation.test.ts
+++ b/cli/tests/oauth-emulation.test.ts
@@ -1,0 +1,276 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  assertOAuthEmulationEnabled,
+  emulationExitCode,
+  loadOAuthGoldenFile,
+  loadOAuthProfileFile,
+  OAUTH_EMULATION_FLAG,
+  parseStaticCredential,
+  renderEmulationResult,
+  writeEmulationTraceFile,
+} from "../src/lib/oauth-emulation.js";
+
+function tempFile(contents: string, name = "profile.json"): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "mcpjam-oauth-emulation-"));
+  const filePath = path.join(dir, name);
+  writeFileSync(filePath, contents, "utf-8");
+  return filePath;
+}
+
+const VERIFIED = {
+  status: "verified",
+  value: ["oauth2-dcr"],
+  source: "https://example.test/capture#L1",
+  capturedAt: "2026-07-30",
+};
+
+test("the emulator is off unless the rollout flag is set", () => {
+  assert.throws(
+    () => assertOAuthEmulationEnabled({}),
+    /behind a feature flag/,
+  );
+  // A truthy-but-wrong value must not enable it either.
+  assert.throws(
+    () => assertOAuthEmulationEnabled({ [OAUTH_EMULATION_FLAG]: "true" }),
+    /behind a feature flag/,
+  );
+  assert.doesNotThrow(() =>
+    assertOAuthEmulationEnabled({ [OAUTH_EMULATION_FLAG]: "1" }),
+  );
+});
+
+test("the flag message names the side effects it is guarding", () => {
+  try {
+    assertOAuthEmulationEnabled({});
+    assert.fail("expected a usage error");
+  } catch (error) {
+    const message = (error as Error).message;
+    assert.match(message, /registers a client/);
+    assert.match(message, /token/);
+  }
+});
+
+test("a profile is canonicalized on load, so an invalid one fails loudly", () => {
+  const valid = tempFile(
+    JSON.stringify({ profileVersion: 2, authModel: VERIFIED }),
+  );
+  const profile = loadOAuthProfileFile(valid);
+  assert.equal(profile.profileVersion, 2);
+
+  // Unverifiable evidence may not carry a value — the same rule the backend
+  // canonicalizer enforces, applied here rather than half-emulated later.
+  const invalid = tempFile(
+    JSON.stringify({
+      profileVersion: 2,
+      authModel: { status: "unverifiable", reason: "closed", value: ["none"] },
+    }),
+  );
+  assert.throws(() => loadOAuthProfileFile(invalid), /value must be omitted/);
+});
+
+test("profile loading rejects unreadable, non-JSON, and non-object inputs", () => {
+  assert.throws(
+    () => loadOAuthProfileFile("/definitely/not/here.json"),
+    /Cannot read OAuth profile/,
+  );
+  assert.throws(
+    () => loadOAuthProfileFile(tempFile("{not json")),
+    /is not valid JSON/,
+  );
+  assert.throws(
+    () => loadOAuthProfileFile(tempFile("[]")),
+    /must be a JSON object/,
+  );
+});
+
+test("a golden without a profile binding is refused before any run", () => {
+  const unbound = tempFile(
+    JSON.stringify({ capturedAt: "2026-08-01", steps: [] }),
+    "golden.json",
+  );
+  assert.throws(() => loadOAuthGoldenFile(unbound), /profileDigest/);
+
+  const bound = tempFile(
+    JSON.stringify({
+      profileDigest: "d",
+      capturedAt: "2026-08-01",
+      steps: [],
+    }),
+    "golden.json",
+  );
+  assert.equal(loadOAuthGoldenFile(bound).profileDigest, "d");
+});
+
+test("static credentials parse as Header-Name: value", () => {
+  assert.deepEqual(parseStaticCredential("X-Acme-Key: s3cret"), {
+    headerName: "X-Acme-Key",
+    value: "s3cret",
+  });
+  // A value containing a colon keeps it.
+  assert.deepEqual(parseStaticCredential("Authorization: Bearer a:b"), {
+    headerName: "Authorization",
+    value: "Bearer a:b",
+  });
+  assert.throws(() => parseStaticCredential("no-separator"), /format/);
+  assert.throws(() => parseStaticCredential(": value"), /format/);
+  assert.throws(() => parseStaticCredential("Header:  "), /non-empty/);
+});
+
+test("exit codes separate a pass, a finding, and an unestablished run", () => {
+  const notCompared = {
+    status: "not_compared" as const,
+    qualifiers: [],
+    differences: [],
+    declaredSubstitutions: [],
+  };
+  assert.equal(
+    emulationExitCode({ outcome: "completed", comparison: notCompared }),
+    0,
+  );
+  assert.equal(
+    emulationExitCode({ outcome: "static_credential_ok", comparison: notCompared }),
+    0,
+  );
+  assert.equal(
+    emulationExitCode({ outcome: "unauthenticated_ok", comparison: notCompared }),
+    0,
+  );
+  assert.equal(
+    emulationExitCode({ outcome: "blocked", comparison: notCompared }),
+    1,
+  );
+  assert.equal(
+    emulationExitCode({ outcome: "error", comparison: notCompared }),
+    1,
+  );
+  // Stopping at the human leg establishes nothing — it is not a pass.
+  assert.equal(
+    emulationExitCode({ outcome: "stopped_at_redirect", comparison: notCompared }),
+    3,
+  );
+});
+
+test("a mismatched comparison fails the run even when the dance completed", () => {
+  assert.equal(
+    emulationExitCode({
+      outcome: "completed",
+      comparison: {
+        status: "mismatched",
+        qualifiers: [],
+        differences: [
+          { index: 0, kind: "body", detail: "request body differs" },
+        ],
+        declaredSubstitutions: [],
+      },
+    }),
+    1,
+  );
+});
+
+test("the summary keeps the three dimensions separate and never hides a qualifier", () => {
+  const output = renderEmulationResult({
+    serverUrl: "https://mcp.example.com/mcp",
+    protocolVersion: "2025-11-25",
+    outcome: "completed",
+    coverage: {
+      sendsResourceIndicator: "modeled",
+      oauthSpecVersion: "modeled",
+      protocolVersionPinning: "not_modeled",
+      scopeRequest: "modeled",
+      dcrIdentity: "modeled",
+      tokenEndpointAuthMethod: "modeled",
+      authModel: "modeled",
+    },
+    coverageSummary: "partial",
+    comparison: {
+      status: "matched",
+      qualifiers: ["partial_coverage", "stale_capture"],
+      differences: [],
+      declaredSubstitutions: [],
+    },
+    trace: [],
+    bindings: {},
+    attempts: [
+      { kind: "oauth", status: "ok", registrationStrategy: "dcr" },
+    ],
+    divergences: [
+      { kind: "redirect-uri-appended", detail: "callback appended" },
+    ],
+    sideEffects: { dcrRegistrations: 1, tokensIssued: 1 },
+  });
+
+  assert.match(output, /Outcome:\s+completed/);
+  assert.match(output, /Coverage:\s+partial/);
+  // The unmodeled field is named, not just counted.
+  assert.match(output, /protocolVersionPinning/);
+  // A qualified match must never print as bare parity.
+  assert.match(output, /Compared:\s+matched \[partial_coverage, stale_capture\]/);
+  assert.match(output, /1 client registration\(s\), 1 token\(s\) issued/);
+  assert.match(output, /redirect-uri-appended/);
+});
+
+test("the summary prints the authorization URL when a human is required", () => {
+  const output = renderEmulationResult({
+    serverUrl: "https://mcp.example.com/mcp",
+    protocolVersion: "2025-11-25",
+    outcome: "stopped_at_redirect",
+    coverage: {
+      sendsResourceIndicator: "not_modeled",
+      oauthSpecVersion: "not_modeled",
+      protocolVersionPinning: "not_modeled",
+      scopeRequest: "not_modeled",
+      dcrIdentity: "not_modeled",
+      tokenEndpointAuthMethod: "not_modeled",
+      authModel: "not_modeled",
+    },
+    coverageSummary: "partial",
+    comparison: {
+      status: "not_compared",
+      reason: "no_golden",
+      qualifiers: [],
+      differences: [],
+      declaredSubstitutions: [],
+    },
+    trace: [],
+    bindings: {},
+    attempts: [{ kind: "oauth", status: "redirected" }],
+    divergences: [],
+    sideEffects: { dcrRegistrations: 1, tokensIssued: 0 },
+    authorizationUrl: "https://as.example.com/authorize?client_id=x",
+  });
+
+  assert.match(output, /Compared:\s+not_compared \(no_golden\)/);
+  assert.match(output, /a human must visit it/);
+  assert.match(output, /https:\/\/as\.example\.com\/authorize/);
+});
+
+test("a captured trace is written already bound to its profile", async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mcpjam-oauth-trace-"));
+  const outPath = path.join(dir, "nested", "golden.json");
+  const written = await writeEmulationTraceFile(
+    outPath,
+    {
+      trace: [
+        {
+          step: "token_request",
+          method: "POST",
+          url: "https://as.example.com/token",
+          headers: {},
+        },
+      ],
+    },
+    "profile-digest-abc",
+    new Date("2026-08-03T12:00:00Z"),
+  );
+
+  const golden = JSON.parse(readFileSync(written, "utf-8"));
+  assert.equal(golden.profileDigest, "profile-digest-abc");
+  assert.equal(golden.capturedAt, "2026-08-03");
+  assert.equal(golden.steps.length, 1);
+  // It must round-trip through the loader it will be read back with.
+  assert.equal(loadOAuthGoldenFile(written).profileDigest, "profile-digest-abc");
+});

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -306,6 +306,10 @@ export type {
 } from "./oauth-login.js";
 // Loopback authorization-code capture + PKCE primitives, reused by the CLI's
 // platform login (`mcpjam login`) in addition to OAuth conformance runs.
+// Headless consent completion: follows an auto-consenting AS's redirects to
+// the callback and extracts the code. Shared by the login flow and the
+// emulated preflight so neither reimplements redirect following.
+export { completeHeadlessAuthorization } from "./oauth-conformance/auth-strategies/headless.js";
 export {
   createInteractiveAuthorizationSession,
   openUrlInBrowser,

--- a/sdk/src/oauth/emulation/preflight.ts
+++ b/sdk/src/oauth/emulation/preflight.ts
@@ -125,6 +125,12 @@ export interface EmulatedOAuthPreflightConfig {
   completeAuthorization?: (input: {
     authorizationUrl: string;
     callbackUrl: string;
+    /**
+     * The run's own executor — hardened by default. A completer that follows
+     * the consent redirects uses the SAME transport as the flow, so it cannot
+     * accidentally bypass the SSRF guard or the timeouts.
+     */
+    request: OAuthRequestExecutor;
   }) => Promise<{ code: string }>;
   /**
    * Compare this run against a real-client capture. Both the golden and the
@@ -629,6 +635,7 @@ export async function runEmulatedOAuthPreflight(
             const { code } = await completeAuthorization({
               authorizationUrl: url,
               callbackUrl: redirectPlan.authorizationRedirectUri,
+              request: executor,
             });
             return {
               type: "authorization_code" as const,


### PR DESCRIPTION
Step 7 of the OAuth Client Emulation plan (v3), **stacked on #3685** (S6). Review that first — this PR's base is its branch. **Do not merge yet.**

This is the *run* surface from the plan's Surface Integration section: "OAuth conformance + CLI — a new conformance mode/flag 'run as client X', headless and CI-ready. V1 ships here behind a feature flag." The Debugger dropdown and Host Compare column remain **separate UI PRs**, as the plan specifies.

## What

`mcpjam oauth emulate` on the existing `oauth` command group — no new surface.

### Flag-gated
`MCPJAM_OAUTH_EMULATION=1` is required. An emulated run performs Dynamic Client Registration and may obtain a token **on the target server**, so it is opted into deliberately rather than discovered by tab-completion; the refusal message names those side effects. A truthy-but-wrong value (`true`) does not enable it.

### Profiles are data, never names
`--profile <path>` takes a JSON profile the private backend produces, and runs it through the **same SDK canonicalizer the backend uses** — a profile that would not survive canonicalization fails loudly here rather than emulating half a client. The CLI ships no catalog and names no client, consistent with S3–S6.

### Comparison and capture
- `--golden <path>` compares the run against a real-client capture. A golden with no `profileDigest` is refused before any network call.
- `--trace-out <path>` writes this run's normalized trace **already bound to its profile** — the capture workflow that makes a golden.
- `--profile-digest`, `--catalog-revision`, `--expected-client-version` feed the run's bindings and freshness qualifiers.

### CI-ready exit codes
Joins the shared conformance vocabulary: `0` pass, `1` failed, `2` usage, `3` incomplete.
- A **mismatched comparison is a failure** — that is the finding the emulator exists to produce.
- **Stopping at the consent leg is incomplete, not a pass**: the human leg was never crossed, so the run established nothing about whether this client can connect. Same reasoning as the existing `incomplete` code.

`--auth-mode headless` crosses the consent leg against an auto-consenting AS; the default stops and reports the URL.

## SDK changes

- `completeHeadlessAuthorization` is now exported (it was already a `runOAuthLogin` dependency) so the CLI reuses redirect-following instead of reimplementing it.
- `runEmulatedOAuthPreflight`'s `completeAuthorization` callback now receives the run's own executor, so a headless completer uses the **same hardened transport** (SSRF guard, timeouts, DNS pinning) as the flow rather than constructing a second one.

## Tests

`cli/tests/oauth-emulation.test.ts` (11): the flag gate incl. the truthy-but-wrong value and the side-effect wording; canonicalize-on-load incl. an invalid-evidence profile; unreadable/non-JSON/non-object inputs; golden refused without a profile binding; static-credential parsing incl. a colon-bearing value; every exit-code branch; mismatch-fails-a-completed-run; the summary keeping the three dimensions separate and never printing a qualified match as parity; and a captured trace round-tripping through the loader that will read it back.

Full CLI suite green (**561 passed**); full SDK suite green (**3653 passed**); `tsc --noEmit` clean in both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a flag-gated `mcpjam oauth emulate` command to run an emulated OAuth client against an MCP server, headless and CI-ready. Aligns with HP-43 S7 by shipping the CLI behind a rollout flag and supporting comparisons to real-client captures.

- **New Features**
  - `MCPJAM_OAUTH_EMULATION=1` required; refusal message names client registration and token side effects.
  - `--profile <path>` loads a JSON profile and canonicalizes it; no client catalog. `--profile-digest` is optional and computed from the profile when omitted.
  - `--golden <path>` compares against a real-client capture; refused if missing `profileDigest`. `--trace-out <path>` writes a normalized trace bound to the run’s profile; plus `--catalog-revision` and `--expected-client-version`.
  - Consent flow: `--auth-mode headless` (auto-consent) or `stop` (default); `--callback-url` controls redirect handling.
  - Optional inputs: `--client-id`/`--client-secret`, `--client-metadata-url`, `--static-credential`, `--header`, `--scopes`, `--step-timeout`.
  - Outputs: `--credentials-out <path>` writes OAuth credentials (0600). Exit codes: 0 pass, 1 failed (including mismatched comparison), 2 usage, 3 incomplete (stopped at consent).

- **Refactors**
  - Exported `completeHeadlessAuthorization` in `@mcpjam/sdk`.
  - `runEmulatedOAuthPreflight` now passes the run’s executor to `completeAuthorization`, so headless consent uses the same hardened transport.

<sup>Written for commit 01220f76a788863c3f6c0ade81359824f5918379. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

