### PR TITLE
feat(oauth): resolve client profiles from the catalog (HP-43 S3 completion)

### DIFF
--- a/.changeset/oauth-profile-resolution.md
+++ b/.changeset/oauth-profile-resolution.md
@@ -1,0 +1,36 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+---
+
+OAuth client emulation: profile catalog resolution (HP-43 step 3, completing
+the piece that was specified but not built).
+
+The emulator could compile a profile it was handed, but nothing could turn
+"emulate client X" into that profile. This adds the resolution path:
+
+- **`fetchOAuthProfile` / `fetchOAuthProfileCatalog`** resolve a client id into
+  an evidence-backed profile, ready for `deriveOAuthEmulation`.
+- **`GET /api/v1/oauth-profiles[/:clientId]`** proxies the backend catalog, so
+  the OSS SDK and CLI never learn a `*.convex.site` address.
+- **`docs/host-oauth-profiles/profile-catalog-contract.md`** specifies the wire
+  contract the private backend implements against.
+
+Two deliberate departures from the `/v1/host-catalog` proxy this mirrors:
+
+- **No bundled fallback, ever.** Bundling profiles would put client names in
+  public source. A failed fetch therefore means "this client cannot be
+  emulated right now" — never "something else was used instead", which would
+  silently invalidate the coverage and comparison claims of the run that
+  followed.
+- **Authenticated.** Host-compat data is public metadata; a per-client OAuth
+  evidence catalog is not, so the route sits behind bearer auth and is absent
+  from the guest allowlist.
+
+The SDK verifies rather than trusts what the catalog returns: the envelope
+schema version must match exactly, the profile must survive the same
+canonicalizer the backend uses, and `profileDigest` is **recomputed locally**
+and rejected on mismatch. That last check matters because the digest gates the
+golden-trace comparator's binding check — an asserted-but-wrong digest would
+let a capture of one client be diffed against a run of another and reported as
+a confident match.

--- a/docs/host-oauth-profiles/profile-catalog-contract.md
+++ b/docs/host-oauth-profiles/profile-catalog-contract.md
@@ -28,10 +28,13 @@ coverage summary for a client it never emulated.
 
 ## Endpoints
 
-Served by the backend, proxied by the inspector at `/api/v1/oauth-profiles*`
-so the OSS SDK and CLI never learn a `*.convex.site` address.
+Served by the backend at `/web/oauth-profiles*`, proxied by the inspector at
+`/api/v1/oauth-profiles*` so the OSS SDK and CLI never learn a `*.convex.site`
+address.
 
-Both require authentication. The plan's invariant is "not in public source,"
+Both require authentication — hence `/web/*` rather than the `/public/*`
+prefix the backend reserves for genuinely unauthenticated documents like the
+host-compat catalog. The plan's invariant is "not in public source,"
 not "secret at runtime" — but that concerns the *tested server* seeing a
 `client_name` on the wire, which is unavoidable. It does not require the
 catalog to be world-enumerable, so these routes sit behind bearer auth and are

--- a/docs/host-oauth-profiles/profile-catalog-contract.md
+++ b/docs/host-oauth-profiles/profile-catalog-contract.md
@@ -1,0 +1,117 @@
+# OAuth client profile catalog — wire contract
+
+The emulator (HP-43) runs an MCP server through the OAuth behavior of a
+specific real client. The *behavior* is generic machinery in this repo; the
+*client identities and their evidence* live only in the private backend. This
+document is the contract between the two, so the backend has something
+concrete to implement against.
+
+## Why there is no bundled fallback
+
+`host-catalog` — the closest analogue in this repo — always returns a document:
+if the upstream fetch fails, it serves a stale cache, and failing that a
+catalog bundled into the SDK. That is correct for host-compat, whose data is
+public.
+
+OAuth profiles cannot do this. Bundling them would place client names and
+per-client findings in public source, which is the one constraint the whole
+feature is organized around. So the failure mode is different, and deliberately
+worse:
+
+> A failed fetch means **"this client cannot be emulated right now."** It never
+> means "use a bundled copy," and it never silently degrades into emulating
+> something else.
+
+Callers must surface `unavailable` as a real failure. An emulated run that
+quietly fell back to a different profile would report a comparison and a
+coverage summary for a client it never emulated.
+
+## Endpoints
+
+Served by the backend, proxied by the inspector at `/api/v1/oauth-profiles*`
+so the OSS SDK and CLI never learn a `*.convex.site` address.
+
+Both require authentication. The plan's invariant is "not in public source,"
+not "secret at runtime" — but that concerns the *tested server* seeing a
+`client_name` on the wire, which is unavoidable. It does not require the
+catalog to be world-enumerable, so these routes sit behind bearer auth and are
+**not** on the guest allowlist.
+
+### `GET /oauth-profiles`
+
+Lists what can be emulated. Metadata only — no profile bodies.
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "catalogRevision": "2026-08-04T00:00:00Z",   // opaque; recorded in run bindings
+  "entries": [
+    {
+      "clientId": "example-desktop",            // opaque, stable, URL-safe
+      "label": "Example Desktop",               // optional, for display
+      "clientVersion": "1.2.3",                 // optional; build the profile describes
+      "profileDigest": "9f2b…",                 // sha256 of the canonical profile
+      "capturedAt": "2026-07-30"                // optional ISO date
+    }
+  ]
+}
+```
+
+### `GET /oauth-profiles/{clientId}`
+
+Returns one profile, ready to compile with `deriveOAuthEmulation`.
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "catalogRevision": "2026-08-04T00:00:00Z",
+  "clientId": "example-desktop",
+  "clientVersion": "1.2.3",
+  "profileDigest": "9f2b…",
+  "profile": {
+    "profileVersion": 2,
+    "authModel": {
+      "status": "verified",
+      "value": ["oauth2-dcr"],
+      "source": "https://…",
+      "capturedAt": "2026-07-30"
+    }
+    // … any HostConfigOAuthProfileV1 | V2
+  }
+}
+```
+
+`404` for an unknown `clientId`. `503` when the catalog is not seeded.
+
+## Rules the SDK enforces on arrival
+
+The SDK does not trust the envelope. `fetchOAuthProfile` rejects rather than
+returning a profile when any of these fail:
+
+1. **`schemaVersion` must equal the version this SDK understands.** A newer
+   catalog is refused, not partially interpreted.
+2. **The profile must canonicalize** through `canonicalizeOAuthProfile` — the
+   same function the backend uses. A profile that would not survive
+   canonicalization is a data bug, and half-enforcing it would silently
+   emulate a different client.
+3. **The digest must be *recomputed and match*.** The backend asserts
+   `profileDigest`; the SDK computes it from the canonicalized profile and
+   rejects on mismatch (`digest_mismatch`).
+
+That third rule is not ceremony. The digest gates the golden-trace comparator's
+binding check: a comparison is refused unless the golden's `profileDigest`
+equals the run's. A wrong digest — from a backend bug, a cache, or a
+man-in-the-middle — would let a capture of one client be diffed against a run
+of another and reported as a confident match. Verifying locally means the
+digest is only ever as trustworthy as the profile bytes it was computed from.
+
+## Backend responsibilities
+
+- Compute `profileDigest` as `sha256_hex(JSON.stringify(canonicalizeOAuthProfile(profile)))`,
+  using the SDK's canonicalizer (`@mcpjam/sdk/host-config/internal`) rather
+  than a hand-mirrored copy, so the digest agrees byte-for-byte.
+- Keep `clientId` stable across catalog revisions; it is what a CI job pins.
+- Bump `catalogRevision` on every publish. Runs record it, so a result can be
+  traced back to the exact catalog that produced it.
+- Store V1 rows as V1. The canonicalizer never rewrites them, and their
+  digests must not change.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "MCPJam API",
     "version": "1.0.0-preview",
-    "description": "Programmatic access to MCP servers saved in your MCPJam projects — live diagnostics (validate, inspect, export) and operations: call tools, render prompts, run eval suites asynchronously and poll their results, and import OAuth tokens.\n\n**The API is in preview**: the surface may change while we finish the design. Error `code` values are stable; error `message` strings are not. Write clients that ignore unknown response fields.",
+    "description": "Programmatic access to MCP servers saved in your MCPJam projects \u2014 live diagnostics (validate, inspect, export) and operations: call tools, render prompts, run eval suites asynchronously and poll their results, and import OAuth tokens.\n\n**The API is in preview**: the surface may change while we finish the design. Error `code` values are stable; error `message` strings are not. Write clients that ignore unknown response fields.",
     "contact": {
       "name": "MCPJam",
       "url": "https://github.com/MCPJam/inspector/issues"
@@ -82,7 +82,7 @@
           "Catalog"
         ],
         "summary": "Get the host-compat catalog",
-        "description": "The versioned host-compatibility catalog backing `mcpjam compat` verdicts. Public and unauthenticated: static host facts and creation config with no project or user scope. Always returns a catalog — `source` is `live` when the backend publish was reachable and `bundled` when serving the SDK's built-in fallback.",
+        "description": "The versioned host-compatibility catalog backing `mcpjam compat` verdicts. Public and unauthenticated: static host facts and creation config with no project or user scope. Always returns a catalog \u2014 `source` is `live` when the backend publish was reachable and `bundled` when serving the SDK's built-in fallback.",
         "security": [],
         "responses": {
           "200": {
@@ -197,6 +197,155 @@
         }
       }
     },
+    "/oauth-profiles": {
+      "get": {
+        "operationId": "listOAuthClientProfiles",
+        "tags": [
+          "Catalog"
+        ],
+        "summary": "List emulatable OAuth client profiles",
+        "description": "Metadata for every OAuth client profile the emulator can run as (HP-43). Returns summaries only \u2014 never profile bodies. Authenticated: unlike the host-compat catalog this is per-client OAuth evidence, not public metadata. There is no bundled fallback, so an unreachable catalog is reported as `SERVER_UNREACHABLE` rather than degraded to some other data.",
+        "responses": {
+          "200": {
+            "description": "The catalog listing.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "schemaVersion",
+                    "catalogRevision",
+                    "entries"
+                  ],
+                  "properties": {
+                    "schemaVersion": {
+                      "type": "integer",
+                      "description": "Profile envelope schema version (currently 1)."
+                    },
+                    "catalogRevision": {
+                      "type": "string",
+                      "description": "Opaque publish revision; recorded in run bindings."
+                    },
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "clientId",
+                          "profileDigest"
+                        ],
+                        "properties": {
+                          "clientId": {
+                            "type": "string",
+                            "description": "Opaque, stable, URL-safe catalog id."
+                          },
+                          "label": {
+                            "type": "string",
+                            "description": "Human-readable display name."
+                          },
+                          "clientVersion": {
+                            "type": "string",
+                            "description": "Client build the profile describes."
+                          },
+                          "profileDigest": {
+                            "type": "string",
+                            "description": "sha256 of the canonical profile."
+                          },
+                          "capturedAt": {
+                            "type": "string",
+                            "description": "ISO date (YYYY-MM-DD) the evidence was captured."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "502": {
+            "description": "The profile catalog could not be reached."
+          }
+        }
+      }
+    },
+    "/oauth-profiles/{clientId}": {
+      "get": {
+        "operationId": "getOAuthClientProfile",
+        "tags": [
+          "Catalog"
+        ],
+        "summary": "Get one OAuth client profile",
+        "description": "The evidence-backed OAuth profile for one client, ready to compile with `deriveOAuthEmulation`. Consumers must recompute `profileDigest` from the returned profile and reject a mismatch: the digest gates the golden-trace comparator's binding check, so trusting an asserted value would allow a capture of one client to be compared against a run of another.",
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Opaque catalog id from the listing."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The profile envelope.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "schemaVersion",
+                    "catalogRevision",
+                    "clientId",
+                    "profileDigest",
+                    "profile"
+                  ],
+                  "properties": {
+                    "schemaVersion": {
+                      "type": "integer",
+                      "description": "Profile envelope schema version (currently 1)."
+                    },
+                    "catalogRevision": {
+                      "type": "string",
+                      "description": "Opaque publish revision; recorded in run bindings."
+                    },
+                    "clientId": {
+                      "type": "string"
+                    },
+                    "clientVersion": {
+                      "type": "string",
+                      "description": "Client build the profile describes."
+                    },
+                    "profileDigest": {
+                      "type": "string",
+                      "description": "sha256 of the canonical profile; verify locally."
+                    },
+                    "profile": {
+                      "type": "object",
+                      "description": "A HostConfigOAuthProfile (profileVersion 1 or 2)."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "description": "No profile with that client id."
+          },
+          "502": {
+            "description": "The profile catalog could not be reached."
+          }
+        }
+      }
+    },
     "/harness/{harnessId}/builtin-tools": {
       "get": {
         "operationId": "listHarnessBuiltinTools",
@@ -204,7 +353,7 @@
           "Harness"
         ],
         "summary": "List a harness's native built-in tools",
-        "description": "The native tools an agent harness (e.g. `claude-code`) runs INSIDE its sandbox — Bash, Read, Edit, Glob, Grep, WebSearch, and the like. Display-only: these execute via the harness's own agent loop and are NOT callable through MCPJam. Static published-package metadata; no project scope.",
+        "description": "The native tools an agent harness (e.g. `claude-code`) runs INSIDE its sandbox \u2014 Bash, Read, Edit, Glob, Grep, WebSearch, and the like. Display-only: these execute via the harness's own agent loop and are NOT callable through MCPJam. Static published-package metadata; no project scope.",
         "parameters": [
           {
             "name": "harnessId",
@@ -288,7 +437,7 @@
           "Sandbox images"
         ],
         "summary": "List a project's sandbox images",
-        "description": "The custom Computer images (digest-pinned Dockerfiles built into immutable images) saved in the project — your own personal drafts plus the project-shared ones.",
+        "description": "The custom Computer images (digest-pinned Dockerfiles built into immutable images) saved in the project \u2014 your own personal drafts plus the project-shared ones.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -501,7 +650,7 @@
           "Sandbox images"
         ],
         "summary": "Delete a sandbox image",
-        "description": "Permanently delete a sandbox image. Computers booted from it fall back to the base image. Deleting a project-shared image requires project admin. Bodyless — any field is rejected. Guest callers are denied (a write).",
+        "description": "Permanently delete a sandbox image. Computers booted from it fall back to the base image. Deleting a project-shared image requires project admin. Bodyless \u2014 any field is rejected. Guest callers are denied (a write).",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -600,7 +749,7 @@
           "Sandbox images"
         ],
         "summary": "Build a sandbox image",
-        "description": "Trigger a build of the sandbox image's image and respond `202`. The build runs asynchronously — poll the builds list for status. Bodyless. Guest callers are denied (a write).",
+        "description": "Trigger a build of the sandbox image's image and respond `202`. The build runs asynchronously \u2014 poll the builds list for status. Bodyless. Guest callers are denied (a write).",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -813,7 +962,7 @@
           "Hosts"
         ],
         "summary": "List a project's hosts",
-        "description": "The hosts saved in the project — the named model + capability profiles you attach to chats and eval suites. Returns the `id`s the host detail/update/delete routes take.",
+        "description": "The hosts saved in the project \u2014 the named model + capability profiles you attach to chats and eval suites. Returns the `id`s the host detail/update/delete routes take.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1151,7 +1300,7 @@
           "Server diagnostics"
         ],
         "summary": "Run the doctor",
-        "description": "Runs the full doctor workflow — probe → connect → initialize → capabilities → primitives — and returns a step-by-step report. The richest signal for \"is this server healthy, and why not.\"",
+        "description": "Runs the full doctor workflow \u2014 probe \u2192 connect \u2192 initialize \u2192 capabilities \u2192 primitives \u2014 and returns a step-by-step report. The richest signal for \"is this server healthy, and why not.\"",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1536,7 +1685,7 @@
           "Export"
         ],
         "summary": "Export a server snapshot",
-        "description": "Lists tools, resources, and prompts in one call and returns a single JSON snapshot — handy for diffing a server's surface over time in CI.",
+        "description": "Lists tools, resources, and prompts in one call and returns a single JSON snapshot \u2014 handy for diffing a server's surface over time in CI.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1593,7 +1742,7 @@
           "Execution"
         ],
         "summary": "Call a tool",
-        "description": "Executes a tool on the server and returns the MCP `CallToolResult` directly. Tool-level failures (`isError: true` in the result) are **successful calls** — the server answered; only transport/auth errors use the error envelope.",
+        "description": "Executes a tool on the server and returns the MCP `CallToolResult` directly. Tool-level failures (`isError: true` in the result) are **successful calls** \u2014 the server answered; only transport/auth errors use the error envelope.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -1946,7 +2095,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "description": "Page size, 1–200. Defaults to 50.",
+            "description": "Page size, 1\u2013200. Defaults to 50.",
             "schema": {
               "type": "integer",
               "minimum": 1,
@@ -2000,7 +2149,7 @@
           "Eval runs"
         ],
         "summary": "Get an iteration trace",
-        "description": "Full trace envelope for one iteration: conversation messages, expected-vs-actual tool call analysis, and spans. The shape is rich and may evolve — treat it as an open document. Returns `404` with `details.reason: \"TRACE_NOT_AVAILABLE\"` when the iteration finished without a stored trace.",
+        "description": "Full trace envelope for one iteration: conversation messages, expected-vs-actual tool call analysis, and spans. The shape is rich and may evolve \u2014 treat it as an open document. Returns `404` with `details.reason: \"TRACE_NOT_AVAILABLE\"` when the iteration finished without a stored trace.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2050,7 +2199,7 @@
           "Eval runs"
         ],
         "summary": "Get an iteration's step results",
-        "description": "One row per authored test step, in order, with `status` (`ok`/`fail`/`skipped`/`pending`), a `reason`, and any `evidence` (screenshots, replay-video offset, widget tool calls). The fastest way to see which step failed and why. Unlike `/trace`, a missing trace is not a `404` — step verdicts still return, just without evidence.",
+        "description": "One row per authored test step, in order, with `status` (`ok`/`fail`/`skipped`/`pending`), a `reason`, and any `evidence` (screenshots, replay-video offset, widget tool calls). The fastest way to see which step failed and why. Unlike `/trace`, a missing trace is not a `404` \u2014 step verdicts still return, just without evidence.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2218,7 +2367,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "description": "Maximum runs to return, 1–100. Defaults to 25.",
+            "description": "Maximum runs to return, 1\u2013100. Defaults to 25.",
             "schema": {
               "type": "integer",
               "minimum": 1,
@@ -2263,7 +2412,7 @@
           "OAuth"
         ],
         "summary": "Import OAuth tokens",
-        "description": "Stores OAuth tokens you obtained yourself (e.g. via the SDK's `runOAuthLogin` — interactive loopback, headless, or client-credentials) for this server, scoped to your user, project, and server. Subsequent API calls against the server inject the stored access token automatically, and `401`s from the server trigger a server-side refresh — no further caller involvement.\n\nThis closes the loop after an `OAUTH_REQUIRED` error.",
+        "description": "Stores OAuth tokens you obtained yourself (e.g. via the SDK's `runOAuthLogin` \u2014 interactive loopback, headless, or client-credentials) for this server, scoped to your user, project, and server. Subsequent API calls against the server inject the stored access token automatically, and `401`s from the server trigger a server-side refresh \u2014 no further caller involvement.\n\nThis closes the loop after an `OAUTH_REQUIRED` error.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2285,8 +2434,8 @@
                   "clientId": "client_123"
                 },
                 "tokens": {
-                  "access_token": "at_…",
-                  "refresh_token": "rt_…",
+                  "access_token": "at_\u2026",
+                  "refresh_token": "rt_\u2026",
                   "expires_in": 3600
                 }
               }
@@ -2427,7 +2576,7 @@
           "Catalog"
         ],
         "summary": "List a project's servers",
-        "description": "The MCP servers saved in the project — the `serverId`s every other route takes. STDIO command/args/env and raw headers are never exposed.",
+        "description": "The MCP servers saved in the project \u2014 the `serverId`s every other route takes. STDIO command/args/env and raw headers are never exposed.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2472,7 +2621,7 @@
           "Catalog"
         ],
         "summary": "List a project's eval suites",
-        "description": "Eval suites in the project with latest-run summaries and pass-rate trends — the `suiteId`s the eval-run routes take.",
+        "description": "Eval suites in the project with latest-run summaries and pass-rate trends \u2014 the `suiteId`s the eval-run routes take.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2515,7 +2664,7 @@
           "Eval runs"
         ],
         "summary": "Create an eval suite (author-only, does not run)",
-        "description": "Creates a runnable eval suite — the suite record plus its test cases — and responds `201` **synchronously**, WITHOUT executing anything. Use this to author a suite, then run it later with `POST /eval-runs` (passing the returned `suiteId`).\n\nThis is distinct from `POST /eval-runs`, which creates a run and **detaches execution**, responding `202` with a `runId`. There is no concurrency cap here (no run is started).\n\nThe body uses an ergonomic authoring shape: a suite-level default `model` (and optional `provider`) applies to every test unless the test overrides it; `provider` is derived from a `provider/model` id when neither is supplied. Each test's case body is an ordered `steps` array (prompt / toolCall / interact / assert).\n\nGuest callers are denied (suite creation is a write).",
+        "description": "Creates a runnable eval suite \u2014 the suite record plus its test cases \u2014 and responds `201` **synchronously**, WITHOUT executing anything. Use this to author a suite, then run it later with `POST /eval-runs` (passing the returned `suiteId`).\n\nThis is distinct from `POST /eval-runs`, which creates a run and **detaches execution**, responding `202` with a `runId`. There is no concurrency cap here (no run is started).\n\nThe body uses an ergonomic authoring shape: a suite-level default `model` (and optional `provider`) applies to every test unless the test overrides it; `provider` is derived from a `provider/model` id when neither is supplied. Each test's case body is an ordered `steps` array (prompt / toolCall / interact / assert).\n\nGuest callers are denied (suite creation is a write).",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2632,7 +2781,7 @@
             "name": "limit",
             "in": "query",
             "required": false,
-            "description": "Page size, 1–200. Defaults to 50.",
+            "description": "Page size, 1\u2013200. Defaults to 50.",
             "schema": {
               "type": "integer",
               "minimum": 1,
@@ -2686,7 +2835,7 @@
           "Chatboxes"
         ],
         "summary": "List a project's chatboxes",
-        "description": "The chatboxes published from this project — name, access mode, attached servers, and share link. Read-only.",
+        "description": "The chatboxes published from this project \u2014 name, access mode, attached servers, and share link. Read-only.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2785,7 +2934,7 @@
           "Tunnels"
         ],
         "summary": "Create (or revive) a relay tunnel for a named project server",
-        "description": "Registers a server record named `name` if missing, mints a relay tunnel grant for it, and **persists the tunnel bearer URL (including the plaintext `?k=` secret) onto the server record's `url`** so evals and chatboxes can target the tunnel like any remote server. The plaintext persistence is a deliberate trade-off of the current tunnel MVP — the backend otherwise stores only a hash of the secret — mitigated by rotation: **every call rotates the secret, revokes the previous grant at the edge (disconnecting any live tunnel session for the server), and updates the stored URL**, so re-calling this route is also the rotation/recovery path.\n\nThe caller hosts the tunnel itself: connect a WebSocket to `relayWsUrl` (subprotocol `mcpjam-tunnel.v1`, `Authorization: Bearer <connectToken>`) and serve the relayed requests — this is what `mcpjam tunnel` does. When the host disconnects, the server record stays and calls to the public URL fail fast at the edge.",
+        "description": "Registers a server record named `name` if missing, mints a relay tunnel grant for it, and **persists the tunnel bearer URL (including the plaintext `?k=` secret) onto the server record's `url`** so evals and chatboxes can target the tunnel like any remote server. The plaintext persistence is a deliberate trade-off of the current tunnel MVP \u2014 the backend otherwise stores only a hash of the secret \u2014 mitigated by rotation: **every call rotates the secret, revokes the previous grant at the edge (disconnecting any live tunnel session for the server), and updates the stored URL**, so re-calling this route is also the rotation/recovery path.\n\nThe caller hosts the tunnel itself: connect a WebSocket to `relayWsUrl` (subprotocol `mcpjam-tunnel.v1`, `Authorization: Bearer <connectToken>`) and serve the relayed requests \u2014 this is what `mcpjam tunnel` does. When the host disconnects, the server record stays and calls to the public URL fail fast at the edge.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2817,8 +2966,8 @@
                   "name": "everything",
                   "existed": false,
                   "slug": "calm-otter",
-                  "url": "https://calm-otter.tunnels.mcpjam.com/api/mcp/adapter-http/srv_abc123?k=…",
-                  "connectToken": "ct_…",
+                  "url": "https://calm-otter.tunnels.mcpjam.com/api/mcp/adapter-http/srv_abc123?k=\u2026",
+                  "connectToken": "ct_\u2026",
                   "connectTokenExpiresAt": 1767225600000,
                   "relayWsUrl": "wss://tunnels.mcpjam.com/agent",
                   "secretVersion": 3
@@ -2857,7 +3006,7 @@
           "Tunnels"
         ],
         "summary": "Revoke a tunnel's live grant",
-        "description": "Revokes the grant at the control plane and edge: the public URL stops working immediately and any live tunnel session is disconnected. The server record — including its now-dead `url` — is intentionally left untouched, so the next create revives the tunnel with the same slug.",
+        "description": "Revokes the grant at the control plane and edge: the public URL stops working immediately and any live tunnel session is disconnected. The server record \u2014 including its now-dead `url` \u2014 is intentionally left untouched, so the next create revives the tunnel with the same slug.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -2909,7 +3058,7 @@
           "Environments"
         ],
         "summary": "List a project's environments",
-        "description": "The project environments saved in the project. Archived environments are excluded unless `includeArchived=true` — you need that to find one to restore.",
+        "description": "The project environments saved in the project. Archived environments are excluded unless `includeArchived=true` \u2014 you need that to find one to restore.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3069,7 +3218,7 @@
           "Environments"
         ],
         "summary": "Update an environment",
-        "description": "Edit an environment. Only the fields you send change; send `null` for `serverAttachmentId`, `skillSelection`, or `pluginVersionIds` to clear them. Requires `expectedRevision` — the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
+        "description": "Edit an environment. Only the fields you send change; send `null` for `serverAttachmentId`, `skillSelection`, or `pluginVersionIds` to clear them. Requires `expectedRevision` \u2014 the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3133,7 +3282,7 @@
           "Environments"
         ],
         "summary": "Preview what an environment resolves to",
-        "description": "Resolve an environment to the exact execution inputs a run would use right now: the host's current config, the closed server set (including servers contributed by pinned plugin versions), and the resolved plugin versions. Returns 409 when the environment cannot currently produce a runnable configuration — for example a pinned plugin was disabled or deleted; `details.code` carries the specific reason (`ENV_PLUGIN_UNAVAILABLE`, `ENV_NO_SERVERS`, `ENV_HOST_MISSING`, …).",
+        "description": "Resolve an environment to the exact execution inputs a run would use right now: the host's current config, the closed server set (including servers contributed by pinned plugin versions), and the resolved plugin versions. Returns 409 when the environment cannot currently produce a runnable configuration \u2014 for example a pinned plugin was disabled or deleted; `details.code` carries the specific reason (`ENV_PLUGIN_UNAVAILABLE`, `ENV_NO_SERVERS`, `ENV_HOST_MISSING`, \u2026).",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3184,7 +3333,7 @@
           "Environments"
         ],
         "summary": "Archive an environment",
-        "description": "Archive an environment. It stops being selectable for runs and frees its name for a new one, but the row is kept and can be restored — this is why archive is a sub-action rather than a DELETE. Requires `expectedRevision` — the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
+        "description": "Archive an environment. It stops being selectable for runs and frees its name for a new one, but the row is kept and can be restored \u2014 this is why archive is a sub-action rather than a DELETE. Requires `expectedRevision` \u2014 the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3248,7 +3397,7 @@
           "Environments"
         ],
         "summary": "Restore an archived environment",
-        "description": "Restore an archived environment. Returns 409 if another live environment took its name in the meantime. Plugin pins whose version row no longer exists at all are dropped on the way back to live — compare the returned `pluginVersionIds` against what you archived to detect that. Requires `expectedRevision` — the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
+        "description": "Restore an archived environment. Returns 409 if another live environment took its name in the meantime. Plugin pins whose version row no longer exists at all are dropped on the way back to live \u2014 compare the returned `pluginVersionIds` against what you archived to detect that. Requires `expectedRevision` \u2014 the revision you last read. If the environment changed since, the write is rejected with 409 rather than overwriting the concurrent edit. Requires project admin.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3373,7 +3522,7 @@
           "Agent"
         ],
         "summary": "Run one headless agent turn",
-        "description": "Runs ONE assistant turn over the supplied message history and responds synchronously with the final assistant text, the operations it invoked, and references to any resources it created (currently eval suites).\n\nThe caller owns conversation state: resend the full history each turn. The model is pinned server-side (hosted catalog) and billed to the project. Tools available to the turn are read operations plus atomic `create_eval_suite`; run/cancel and generation operations are deliberately excluded — starting a run stays an explicit caller action via `POST /eval-runs`.\n\nEvery tool invocation is hard-clamped to the path `projectId`. Turns are capped at 4 concurrent per organization (`429 RATE_LIMITED`; enforced per server instance) and ~90s wall clock (`504 TIMEOUT`). Guest callers are denied. Requires a hosted MCPJam deployment (`422 FEATURE_NOT_SUPPORTED` otherwise).\n\nWhen a turn fails or times out AFTER a create operation already persisted a resource, the error body's `details.createdResources` carries the created references — check it before retrying, or a retry will create duplicates.\n\n**Retry policy:** this operation is NOT idempotent — a turn may persist resources (eval suites) even when the response is lost, and there is no idempotency key yet. Do not blind-retry: deduplicate on your own trigger identity (e.g. the Slack event id) and, when a retry is unavoidable, first list suites to check whether the previous attempt already created one.",
+        "description": "Runs ONE assistant turn over the supplied message history and responds synchronously with the final assistant text, the operations it invoked, and references to any resources it created (currently eval suites).\n\nThe caller owns conversation state: resend the full history each turn. The model is pinned server-side (hosted catalog) and billed to the project. Tools available to the turn are read operations plus atomic `create_eval_suite`; run/cancel and generation operations are deliberately excluded \u2014 starting a run stays an explicit caller action via `POST /eval-runs`.\n\nEvery tool invocation is hard-clamped to the path `projectId`. Turns are capped at 4 concurrent per organization (`429 RATE_LIMITED`; enforced per server instance) and ~90s wall clock (`504 TIMEOUT`). Guest callers are denied. Requires a hosted MCPJam deployment (`422 FEATURE_NOT_SUPPORTED` otherwise).\n\nWhen a turn fails or times out AFTER a create operation already persisted a resource, the error body's `details.createdResources` carries the created references \u2014 check it before retrying, or a retry will create duplicates.\n\n**Retry policy:** this operation is NOT idempotent \u2014 a turn may persist resources (eval suites) even when the response is lost, and there is no idempotency key yet. Do not blind-retry: deduplicate on your own trigger identity (e.g. the Slack event id) and, when a retry is unavoidable, first list suites to check whether the previous attempt already created one.",
         "parameters": [
           {
             "$ref": "#/components/parameters/projectId"
@@ -3458,7 +3607,7 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer",
-        "description": "MCPJam API key (`sk_…`). Create one at [Settings → API keys](https://app.mcpjam.com/settings/api-keys). Guest sessions cannot use the API, and API keys cannot manage other API keys."
+        "description": "MCPJam API key (`sk_\u2026`). Create one at [Settings \u2192 API keys](https://app.mcpjam.com/settings/api-keys). Guest sessions cannot use the API, and API keys cannot manage other API keys."
       }
     },
     "parameters": {
@@ -3604,7 +3753,7 @@
           },
           "message": {
             "type": "string",
-            "description": "Human-readable description. May change between releases — don't match on it."
+            "description": "Human-readable description. May change between releases \u2014 don't match on it."
           },
           "details": {
             "type": "object",
@@ -3640,7 +3789,7 @@
       },
       "DoctorReport": {
         "type": "object",
-        "description": "Step-by-step health report from the probe → connect → initialize → capabilities workflow.",
+        "description": "Step-by-step health report from the probe \u2192 connect \u2192 initialize \u2192 capabilities workflow.",
         "required": [
           "generatedAt",
           "status",
@@ -4025,7 +4174,7 @@
           },
           "isError": {
             "type": "boolean",
-            "description": "`true` when the **tool** reported a failure. The HTTP call still succeeds — the server answered."
+            "description": "`true` when the **tool** reported a failure. The HTTP call still succeeds \u2014 the server answered."
           }
         },
         "additionalProperties": true
@@ -4359,7 +4508,7 @@
       },
       "EvalRunCreateRequest": {
         "type": "object",
-        "description": "Three valid shapes: `suiteId` (rerun an existing suite, optionally upserting inline `tests` into it), `suiteName` + `tests` + `serverIds` (create a new suite and run it), or `suiteName` + `tests` + `environmentId` (create a new suite and run it against a project environment, which supplies the servers). Inline `tests` alone — without a `suiteId` or a `suiteName` — are rejected with `VALIDATION_ERROR`.",
+        "description": "Three valid shapes: `suiteId` (rerun an existing suite, optionally upserting inline `tests` into it), `suiteName` + `tests` + `serverIds` (create a new suite and run it), or `suiteName` + `tests` + `environmentId` (create a new suite and run it against a project environment, which supplies the servers). Inline `tests` alone \u2014 without a `suiteId` or a `suiteName` \u2014 are rejected with `VALIDATION_ERROR`.",
         "anyOf": [
           {
             "required": [
@@ -4414,14 +4563,14 @@
           "serverIds": {
             "type": "array",
             "minItems": 1,
-            "description": "Servers (by ID) the run connects to. Required when creating a new suite unless `environmentId` is given (the environment supplies the closed server set, and any `serverIds` sent alongside it are ignored); optional on reruns — when omitted, the run connects the suite's saved server selection (the set its snapshot references). A rerun of a suite with no saved selection is rejected with `VALIDATION_ERROR` (`details.reason: \"NO_SAVED_SERVER_SELECTION\"`).",
+            "description": "Servers (by ID) the run connects to. Required when creating a new suite unless `environmentId` is given (the environment supplies the closed server set, and any `serverIds` sent alongside it are ignored); optional on reruns \u2014 when omitted, the run connects the suite's saved server selection (the set its snapshot references). A rerun of a suite with no saved selection is rejected with `VALIDATION_ERROR` (`details.reason: \"NO_SAVED_SERVER_SELECTION\"`).",
             "items": {
               "type": "string"
             }
           },
           "modelApiKeys": {
             "type": "object",
-            "description": "Optional per-provider model API keys (e.g. `{ \"anthropic\": \"sk-ant-…\" }`). Falls back to your organization's configured providers when omitted.",
+            "description": "Optional per-provider model API keys (e.g. `{ \"anthropic\": \"sk-ant-\u2026\" }`). Falls back to your organization's configured providers when omitted.",
             "additionalProperties": {
               "type": "string"
             }
@@ -4445,7 +4594,7 @@
           },
           "environmentId": {
             "type": "string",
-            "description": "Run against a project environment. The environment supplies the closed server set (so `serverIds` is not required and is ignored if sent), and the run is pinned to the revision resolved at launch — if the environment changes in between, the run is rejected with 409 rather than executing against a different configuration."
+            "description": "Run against a project environment. The environment supplies the closed server set (so `serverIds` is not required and is ignored if sent), and the run is pinned to the revision resolved at launch \u2014 if the environment changes in between, the run is rejected with 409 rather than executing against a different configuration."
           }
         },
         "additionalProperties": true
@@ -4471,7 +4620,7 @@
           },
           "servers": {
             "type": "array",
-            "description": "The servers the run connects to — explicit or derived from the suite's saved selection. `name` is present when known (always, on the derived path).",
+            "description": "The servers the run connects to \u2014 explicit or derived from the suite's saved selection. `name` is present when known (always, on the derived path).",
             "items": {
               "type": "object",
               "required": [
@@ -4777,7 +4926,7 @@
           },
           "clientInformation": {
             "type": "object",
-            "description": "OAuth client used to obtain the tokens. Optional, but without it server-side refresh cannot run — always include it when you provide a `refresh_token`.",
+            "description": "OAuth client used to obtain the tokens. Optional, but without it server-side refresh cannot run \u2014 always include it when you provide a `refresh_token`.",
             "required": [
               "clientId"
             ],
@@ -6041,7 +6190,7 @@
       },
       "SandboxImageBuildStarted": {
         "type": "object",
-        "description": "A build was accepted (202). It runs in the background — poll the builds list for status.",
+        "description": "A build was accepted (202). It runs in the background \u2014 poll the builds list for status.",
         "required": [
           "id",
           "buildId",
@@ -6098,7 +6247,7 @@
       },
       "EnvironmentSkillSelection": {
         "type": "object",
-        "description": "An explicit pinned skill selection. Cannot be empty — clear the field instead (send `null` on update) to mean \"no pinned skills\".",
+        "description": "An explicit pinned skill selection. Cannot be empty \u2014 clear the field instead (send `null` on update) to mean \"no pinned skills\".",
         "required": [
           "mode",
           "skillIds"
@@ -6243,14 +6392,14 @@
           "sandboxImageId": {
             "type": "string",
             "minLength": 1,
-            "description": "Optional sandbox-image pin. Must be a project-shared image; personal drafts are rejected — promote them first.",
+            "description": "Optional sandbox-image pin. Must be a project-shared image; personal drafts are rejected \u2014 promote them first.",
             "pattern": ".*\\S.*"
           }
         }
       },
       "ProjectEnvironmentUpdateRequest": {
         "type": "object",
-        "description": "Only the fields you send change. `serverAttachmentId`, `skillSelection`, and `pluginVersionIds` are three-state: omit to leave unchanged, send `null` to CLEAR, send a value to set. An empty array is rejected — it is not a way to clear. Send at least one field besides `expectedRevision`. Unknown fields are rejected.",
+        "description": "Only the fields you send change. `serverAttachmentId`, `skillSelection`, and `pluginVersionIds` are three-state: omit to leave unchanged, send `null` to CLEAR, send a value to set. An empty array is rejected \u2014 it is not a way to clear. Send at least one field besides `expectedRevision`. Unknown fields are rejected.",
         "required": [
           "expectedRevision"
         ],
@@ -6323,7 +6472,7 @@
       },
       "ProjectEnvironmentResolved": {
         "type": "object",
-        "description": "What an environment resolves to right now — the same resolution an eval run performs.",
+        "description": "What an environment resolves to right now \u2014 the same resolution an eval run performs.",
         "required": [
           "environment",
           "hostId",
@@ -6363,7 +6512,7 @@
           },
           "hostConfigId": {
             "type": "string",
-            "description": "The host's config at resolve time — hosts rotate configs live, so this can change without the environment's `revision` changing."
+            "description": "The host's config at resolve time \u2014 hosts rotate configs live, so this can change without the environment's `revision` changing."
           },
           "serverAttachmentId": {
             "type": "string"
@@ -6386,7 +6535,7 @@
             "items": {
               "type": "string"
             },
-            "description": "`selectedServerIds` plus the servers contributed by pinned plugin versions — the set a run actually connects. Identical to `selectedServerIds` when no plugins are pinned."
+            "description": "`selectedServerIds` plus the servers contributed by pinned plugin versions \u2014 the set a run actually connects. Identical to `selectedServerIds` when no plugins are pinned."
           },
           "pluginVersions": {
             "type": "array",
@@ -6451,7 +6600,7 @@
       },
       "SandboxImageBlueprintValidateResult": {
         "type": "object",
-        "description": "Lint result. `ok: true` carries the resolved base digest; `ok: false` carries structured errors. Always returned with HTTP 200 — an invalid blueprint is a successful lint.",
+        "description": "Lint result. `ok: true` carries the resolved base digest; `ok: false` carries structured errors. Always returned with HTTP 200 \u2014 an invalid blueprint is a successful lint.",
         "required": [
           "ok"
         ],
@@ -6648,7 +6797,7 @@
         }
       },
       "Unauthorized": {
-        "description": "Missing, invalid, revoked, or orphaned key (`UNAUTHORIZED`) — or the **target MCP server** needs an OAuth grant (`OAUTH_REQUIRED`), which is a property of the server, not your key.",
+        "description": "Missing, invalid, revoked, or orphaned key (`UNAUTHORIZED`) \u2014 or the **target MCP server** needs an OAuth grant (`OAUTH_REQUIRED`), which is a property of the server, not your key.",
         "content": {
           "application/json": {
             "schema": {
@@ -6766,7 +6915,7 @@
         }
       },
       "Conflict": {
-        "description": "The resource is not in a state that accepts this write — a stale `expectedRevision`, a duplicate name, or an environment that cannot currently be launched. The request was well-formed; re-read the resource and retry.",
+        "description": "The resource is not in a state that accepts this write \u2014 a stale `expectedRevision`, a duplicate name, or an environment that cannot currently be launched. The request was well-formed; re-read the resource and retry.",
         "content": {
           "application/json": {
             "schema": {

--- a/mcpjam-inspector/server/routes/v1/__tests__/oauth-profiles.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/oauth-profiles.test.ts
@@ -71,7 +71,7 @@ describe("/api/v1/oauth-profiles", () => {
     expect(await response.json()).toEqual(profileEnvelope);
     const requestedUrl = String(fetchMock.mock.calls[0][0]);
     expect(requestedUrl).toBe(
-      "https://convex-http.example.com/public/oauth-profiles/example-desktop",
+      "https://convex-http.example.com/web/oauth-profiles/example-desktop",
     );
     // Per-account authorized: never cacheable by a shared cache.
     expect(response.headers.get("Cache-Control")).toContain("private");
@@ -83,7 +83,7 @@ describe("/api/v1/oauth-profiles", () => {
     await makeApp().request("/api/v1/oauth-profiles/a%2Fb", { headers: AUTH });
 
     expect(String(fetchMock.mock.calls[0][0])).toBe(
-      "https://convex-http.example.com/public/oauth-profiles/a%2Fb",
+      "https://convex-http.example.com/web/oauth-profiles/a%2Fb",
     );
   });
 
@@ -151,7 +151,7 @@ describe("/api/v1/oauth-profiles", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(listing);
     expect(String(fetchMock.mock.calls[0][0])).toBe(
-      "https://convex-http.example.com/public/oauth-profiles",
+      "https://convex-http.example.com/web/oauth-profiles",
     );
   });
 });

--- a/mcpjam-inspector/server/routes/v1/__tests__/oauth-profiles.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/oauth-profiles.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Covers the /api/v1/oauth-profiles proxy seam. Two properties matter more
+// here than for the host-catalog proxy this mirrors: the route is
+// AUTHENTICATED (a per-client OAuth evidence catalog is not public metadata),
+// and it has NO fallback — an upstream failure is reported, never papered over
+// with some other client's profile. The Convex side is covered separately.
+
+import v1Routes from "../index.js";
+import { logger } from "../../../utils/logger.js";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const AUTH = { authorization: "Bearer test-token" };
+
+const profileEnvelope = {
+  schemaVersion: 1,
+  catalogRevision: "2026-08-04T00:00:00Z",
+  clientId: "example-desktop",
+  profileDigest: "abc123",
+  profile: { profileVersion: 2 },
+};
+
+describe("/api/v1/oauth-profiles", () => {
+  const originalEnv = process.env.CONVEX_HTTP_URL;
+  const originalFetch = global.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://convex-http.example.com";
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.env.CONVEX_HTTP_URL = originalEnv;
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("rejects an unauthenticated caller — the catalog is not public", async () => {
+    const response = await makeApp().request("/api/v1/oauth-profiles");
+    expect(response.status).toBe(401);
+    // No upstream call is attempted for an anonymous caller.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("proxies a profile without exposing the convex host", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(profileEnvelope));
+
+    const response = await makeApp().request(
+      "/api/v1/oauth-profiles/example-desktop",
+      { headers: AUTH },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(profileEnvelope);
+    const requestedUrl = String(fetchMock.mock.calls[0][0]);
+    expect(requestedUrl).toBe(
+      "https://convex-http.example.com/public/oauth-profiles/example-desktop",
+    );
+    // Per-account authorized: never cacheable by a shared cache.
+    expect(response.headers.get("Cache-Control")).toContain("private");
+  });
+
+  it("path-encodes the client id it forwards", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(profileEnvelope));
+
+    await makeApp().request("/api/v1/oauth-profiles/a%2Fb", { headers: AUTH });
+
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      "https://convex-http.example.com/public/oauth-profiles/a%2Fb",
+    );
+  });
+
+  it("maps an unknown client to NOT_FOUND", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 404));
+
+    const response = await makeApp().request("/api/v1/oauth-profiles/nope", {
+      headers: AUTH,
+    });
+
+    expect(response.status).toBe(404);
+    expect((await response.json()).code).toBe("NOT_FOUND");
+  });
+
+  it("reports an unreachable catalog instead of falling back", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const response = await makeApp().request("/api/v1/oauth-profiles", {
+      headers: AUTH,
+    });
+
+    // There is no bundled copy to serve: emulating a different client than
+    // the caller asked for would invalidate every claim the run then makes.
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.code).toBe("SERVER_UNREACHABLE");
+    expect(body).not.toHaveProperty("profile");
+  });
+
+  it("reports an upstream 5xx as unreachable", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 503));
+
+    const response = await makeApp().request("/api/v1/oauth-profiles", {
+      headers: AUTH,
+    });
+
+    expect(response.status).toBe(502);
+    expect((await response.json()).code).toBe("SERVER_UNREACHABLE");
+  });
+
+  it("reports a misconfigured deployment rather than silently serving nothing", async () => {
+    delete process.env.CONVEX_HTTP_URL;
+
+    const response = await makeApp().request("/api/v1/oauth-profiles", {
+      headers: AUTH,
+    });
+
+    expect(response.status).toBe(500);
+    expect((await response.json()).code).toBe("INTERNAL_ERROR");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("lists the catalog for an authenticated caller", async () => {
+    const listing = {
+      schemaVersion: 1,
+      catalogRevision: "rev-1",
+      entries: [{ clientId: "example-desktop", profileDigest: "abc" }],
+    };
+    fetchMock.mockResolvedValue(jsonResponse(listing));
+
+    const response = await makeApp().request("/api/v1/oauth-profiles", {
+      headers: AUTH,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(listing);
+    expect(String(fetchMock.mock.calls[0][0])).toBe(
+      "https://convex-http.example.com/public/oauth-profiles",
+    );
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -27,6 +27,7 @@ import evalIngest from "./eval-ingest.js";
 import agent from "./agent.js";
 import proposedActionsRoutes from "./proposed-actions.js";
 import oauth from "./oauth.js";
+import oauthProfiles from "./oauth-profiles.js";
 import catalog from "./catalog.js";
 import hostCatalog from "./host-catalog.js";
 import tunnels from "./tunnels.js";
@@ -44,6 +45,12 @@ v1.route("/", hostCatalog);
 // Every v1 live-op route requires bearer auth + guest rate limiting, matching
 // the /api/web/* MCP operation routes.
 v1.use("*", bearerAuthMiddleware, guestRateLimitMiddleware);
+
+// OAuth client profile catalog (HP-43). Mounted AFTER the auth middleware and
+// deliberately NOT on the guest allowlist: unlike the host-compat catalog this
+// is per-client OAuth evidence, not public metadata, so anonymous callers must
+// not be able to enumerate it.
+v1.route("/", oauthProfiles);
 
 // Guests get a NARROW allowlist of v1 routes — exactly the platform MCP tool
 // surface the worker drives (see mcp/src/tools/platformTools.ts

--- a/mcpjam-inspector/server/routes/v1/oauth-profiles.ts
+++ b/mcpjam-inspector/server/routes/v1/oauth-profiles.ts
@@ -1,0 +1,151 @@
+/**
+ * `GET /api/v1/oauth-profiles` and `/api/v1/oauth-profiles/:clientId` — the
+ * stable public URLs for the OAuth client profile catalog (HP-43).
+ *
+ * The OSS SDK/CLI never learn a `*.convex.site` address: this route is the one
+ * public host, proxying the backend's profile catalog.
+ *
+ * Two deliberate differences from `/v1/host-catalog`, the closest analogue:
+ *
+ *   - **Authenticated.** Host-compat data is public metadata; a per-client
+ *     OAuth evidence catalog is not. This mounts AFTER the bearer middleware
+ *     and is deliberately absent from the guest allowlist, so anonymous
+ *     callers cannot enumerate the catalog.
+ *   - **No bundled fallback, no serve-stale.** There is no bundled copy to
+ *     degrade to — bundling profiles would put client names in public source.
+ *     An upstream failure is reported as a failure, because "emulate some
+ *     other client than the one you asked for" is never an acceptable
+ *     degradation: it would silently invalidate every coverage and comparison
+ *     claim the run goes on to make.
+ *
+ * See docs/host-oauth-profiles/profile-catalog-contract.md.
+ */
+import { Hono, type Context } from "hono";
+import { assertBearerToken } from "../web/errors.js";
+import {
+  buildConvexAuthHeaders,
+  callerContextFromHono,
+} from "../web/auth.js";
+import { logger } from "../../utils/logger.js";
+import { v1Error } from "./envelope.js";
+
+const oauthProfiles = new Hono();
+
+const UPSTREAM_TIMEOUT_MS = 6_500;
+
+type ProxyFailure = {
+  code: "NOT_FOUND" | "FORBIDDEN" | "SERVER_UNREACHABLE" | "INTERNAL_ERROR";
+  message: string;
+};
+
+/**
+ * Proxy one upstream GET. Returns the parsed body, or a typed failure the
+ * caller maps onto a v1 error — never a silent fallback.
+ */
+async function proxyUpstream(
+  c: Context,
+  upstreamPath: string
+): Promise<{ ok: true; body: unknown } | { ok: false; failure: ProxyFailure }> {
+  const convexUrl = process.env.CONVEX_HTTP_URL?.trim();
+  if (!convexUrl) {
+    return {
+      ok: false,
+      failure: {
+        code: "INTERNAL_ERROR",
+        message:
+          "The OAuth profile catalog is not configured for this deployment (CONVEX_HTTP_URL is unset).",
+      },
+    };
+  }
+
+  const bearerToken = assertBearerToken(c);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);
+  try {
+    const response = await fetch(new URL(upstreamPath, convexUrl), {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        ...buildConvexAuthHeaders(callerContextFromHono(c), bearerToken),
+      },
+      signal: controller.signal,
+    });
+
+    if (response.status === 404) {
+      return {
+        ok: false,
+        failure: {
+          code: "NOT_FOUND",
+          message: "No OAuth client profile with that id.",
+        },
+      };
+    }
+    if (response.status === 401 || response.status === 403) {
+      return {
+        ok: false,
+        failure: {
+          code: "FORBIDDEN",
+          message: "Not authorized to read the OAuth profile catalog.",
+        },
+      };
+    }
+    if (!response.ok) {
+      logger.warn("[oauth-profiles] upstream returned non-2xx", {
+        status: response.status,
+        upstreamPath,
+      });
+      return {
+        ok: false,
+        failure: {
+          code: "SERVER_UNREACHABLE",
+          message: "The OAuth profile catalog is temporarily unavailable.",
+        },
+      };
+    }
+
+    return { ok: true, body: await response.json() };
+  } catch (error) {
+    logger.warn("[oauth-profiles] upstream fetch failed", {
+      error: error instanceof Error ? error.name : typeof error,
+      upstreamPath,
+    });
+    return {
+      ok: false,
+      failure: {
+        code: "SERVER_UNREACHABLE",
+        message: "The OAuth profile catalog could not be reached.",
+      },
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+oauthProfiles.get("/oauth-profiles", async (c) => {
+  const result = await proxyUpstream(c, "/public/oauth-profiles");
+  if (!result.ok) {
+    return v1Error(c, result.failure.code, result.failure.message);
+  }
+  // Contents change on publish, not per request — but they are per-account
+  // authorized, so never let a shared cache hold them.
+  c.header("Cache-Control", "private, max-age=60");
+  return c.json(result.body as Record<string, unknown>);
+});
+
+oauthProfiles.get("/oauth-profiles/:clientId", async (c) => {
+  const clientId = c.req.param("clientId");
+  if (!clientId?.trim()) {
+    return v1Error(c, "VALIDATION_ERROR", "clientId is required.");
+  }
+  const result = await proxyUpstream(
+    c,
+    `/public/oauth-profiles/${encodeURIComponent(clientId)}`
+  );
+  if (!result.ok) {
+    return v1Error(c, result.failure.code, result.failure.message);
+  }
+  c.header("Cache-Control", "private, max-age=60");
+  return c.json(result.body as Record<string, unknown>);
+});
+
+export default oauthProfiles;

--- a/mcpjam-inspector/server/routes/v1/oauth-profiles.ts
+++ b/mcpjam-inspector/server/routes/v1/oauth-profiles.ts
@@ -122,7 +122,7 @@ async function proxyUpstream(
 }
 
 oauthProfiles.get("/oauth-profiles", async (c) => {
-  const result = await proxyUpstream(c, "/public/oauth-profiles");
+  const result = await proxyUpstream(c, "/web/oauth-profiles");
   if (!result.ok) {
     return v1Error(c, result.failure.code, result.failure.message);
   }
@@ -139,7 +139,7 @@ oauthProfiles.get("/oauth-profiles/:clientId", async (c) => {
   }
   const result = await proxyUpstream(
     c,
-    `/public/oauth-profiles/${encodeURIComponent(clientId)}`
+    `/web/oauth-profiles/${encodeURIComponent(clientId)}`
   );
   if (!result.ok) {
     return v1Error(c, result.failure.code, result.failure.message);

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -181,6 +181,27 @@ export type {
   OAuthEmulationFieldStatus,
 } from "./oauth/emulation/types.js";
 export { OAUTH_EMULATION_FIELDS } from "./oauth/emulation/types.js";
+export {
+  computeOAuthProfileDigest,
+  oauthProfileEnvelopeSchema,
+  oauthProfileListEnvelopeSchema,
+  SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION,
+} from "./oauth/emulation/profile-catalog.js";
+export type {
+  OAuthProfileEnvelope,
+  OAuthProfileListEnvelope,
+  OAuthProfileSummary,
+} from "./oauth/emulation/profile-catalog.js";
+export {
+  fetchOAuthProfile,
+  fetchOAuthProfileCatalog,
+} from "./oauth/emulation/profile-fetch.js";
+export type {
+  FetchOAuthProfileOptions,
+  FetchOAuthProfileResult,
+  FetchOAuthProfileCatalogResult,
+  FetchOAuthProfileFailureReason,
+} from "./oauth/emulation/profile-fetch.js";
 export type {
   EmulatedAuthAttempt,
   EmulatedRegistrationPreference,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -328,6 +328,27 @@ export type {
   OAuthEmulationFieldStatus,
 } from "./oauth/emulation/types.js";
 export { OAUTH_EMULATION_FIELDS } from "./oauth/emulation/types.js";
+export {
+  computeOAuthProfileDigest,
+  oauthProfileEnvelopeSchema,
+  oauthProfileListEnvelopeSchema,
+  SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION,
+} from "./oauth/emulation/profile-catalog.js";
+export type {
+  OAuthProfileEnvelope,
+  OAuthProfileListEnvelope,
+  OAuthProfileSummary,
+} from "./oauth/emulation/profile-catalog.js";
+export {
+  fetchOAuthProfile,
+  fetchOAuthProfileCatalog,
+} from "./oauth/emulation/profile-fetch.js";
+export type {
+  FetchOAuthProfileOptions,
+  FetchOAuthProfileResult,
+  FetchOAuthProfileCatalogResult,
+  FetchOAuthProfileFailureReason,
+} from "./oauth/emulation/profile-fetch.js";
 export type {
   EmulatedAuthAttempt,
   EmulatedRegistrationPreference,

--- a/sdk/src/oauth/emulation/profile-catalog.ts
+++ b/sdk/src/oauth/emulation/profile-catalog.ts
@@ -1,0 +1,78 @@
+/**
+ * OAuth client profile catalog — wire schema and digest (HP-43 step 3).
+ *
+ * The emulation engine is public; the client identities it emulates are not.
+ * This module is the seam: the envelope shape the private backend serves, and
+ * the validation the SDK applies before trusting any of it.
+ *
+ * See docs/host-oauth-profiles/profile-catalog-contract.md for the contract
+ * this implements, including why there is deliberately no bundled fallback.
+ */
+
+import { z } from "zod";
+import { canonicalizeOAuthProfile } from "../../host-config/canonicalize.js";
+import { sha256Hex } from "../../host-config/hash.js";
+import type { HostConfigOAuthProfile } from "../../host-config/types.js";
+
+/**
+ * The envelope version this SDK understands. Unlike the host-compat catalog,
+ * an unknown version is NOT absorbed: there is no bundled fallback to degrade
+ * to, so a profile this SDK cannot correctly interpret must fail rather than
+ * be partially applied to a client emulation.
+ */
+export const SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION = 1;
+
+/** Catalog listing entry — metadata only, never a profile body. */
+export const oauthProfileSummarySchema = z.object({
+  clientId: z.string().min(1),
+  label: z.string().min(1).optional(),
+  clientVersion: z.string().min(1).optional(),
+  profileDigest: z.string().min(1),
+  capturedAt: z.string().min(1).optional(),
+});
+
+export type OAuthProfileSummary = z.infer<typeof oauthProfileSummarySchema>;
+
+export const oauthProfileListEnvelopeSchema = z.object({
+  schemaVersion: z.literal(SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION),
+  catalogRevision: z.string().min(1),
+  entries: z.array(oauthProfileSummarySchema),
+});
+
+export type OAuthProfileListEnvelope = z.infer<
+  typeof oauthProfileListEnvelopeSchema
+>;
+
+/**
+ * Single-profile envelope. `profile` is validated structurally here and
+ * canonicalized by the fetch layer — this schema only asserts it is an object,
+ * because `canonicalizeOAuthProfile` is the authority on what a valid profile
+ * is and duplicating its rules in Zod would create two sources of truth.
+ */
+export const oauthProfileEnvelopeSchema = z.object({
+  schemaVersion: z.literal(SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION),
+  catalogRevision: z.string().min(1),
+  clientId: z.string().min(1),
+  clientVersion: z.string().min(1).optional(),
+  profileDigest: z.string().min(1),
+  profile: z.record(z.string(), z.unknown()),
+});
+
+export type OAuthProfileEnvelope = Omit<
+  z.infer<typeof oauthProfileEnvelopeSchema>,
+  "profile"
+> & { profile: HostConfigOAuthProfile };
+
+/**
+ * Content address of a profile: the sha256 of its canonical JSON.
+ *
+ * This is what binds a run to a profile and what the golden-trace comparator
+ * checks a capture against, so it must be computed from the CANONICAL form —
+ * two profiles that differ only in key order are the same profile and must
+ * digest identically.
+ */
+export async function computeOAuthProfileDigest(
+  profile: HostConfigOAuthProfile
+): Promise<string> {
+  return sha256Hex(JSON.stringify(canonicalizeOAuthProfile(profile)));
+}

--- a/sdk/src/oauth/emulation/profile-fetch.ts
+++ b/sdk/src/oauth/emulation/profile-fetch.ts
@@ -1,0 +1,268 @@
+/**
+ * Resolve an OAuth client profile from the catalog (HP-43 step 3).
+ *
+ * This is the piece that turns "emulate client X" into a profile the engine
+ * can compile. The catalog itself lives in the private backend; the inspector
+ * proxies it at `/api/v1/oauth-profiles*` so the OSS SDK and CLI never learn a
+ * `*.convex.site` address.
+ *
+ * Two properties, both deliberate:
+ *
+ *  1. **Never throws.** Every failure collapses to `{ok: false, reason}` so a
+ *     caller can report it rather than crash mid-run.
+ *  2. **No fallback.** Unlike the host-compat catalog there is no bundled copy
+ *     to degrade to — bundling profiles would put client names in public
+ *     source. `ok: false` therefore means "this client cannot be emulated
+ *     right now", never "something else was used instead". Callers must
+ *     surface it; silently continuing would report a coverage summary and a
+ *     comparison for a client that was never emulated.
+ */
+
+import { DEFAULT_PLATFORM_API_BASE_URL } from "../../platform/client.js";
+import { canonicalizeOAuthProfile } from "../../host-config/canonicalize.js";
+import type { HostConfigOAuthProfile } from "../../host-config/types.js";
+import {
+  computeOAuthProfileDigest,
+  oauthProfileEnvelopeSchema,
+  oauthProfileListEnvelopeSchema,
+  SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION,
+  type OAuthProfileSummary,
+} from "./profile-catalog.js";
+
+export interface FetchOAuthProfileOptions {
+  /** API origin + version prefix. Defaults to the hosted production API. */
+  baseUrl?: string;
+  /** Bearer token. These routes are authenticated — the catalog is not public. */
+  authToken?: string;
+  /** Abort the whole exchange after this long. Default 5000ms. */
+  timeoutMs?: number;
+  /** Injectable for tests / non-global-fetch runtimes. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Why a profile could not be resolved.
+ *
+ *   `network`        — the request failed outright.
+ *   `timeout`        — aborted at `timeoutMs`.
+ *   `unauthorized`   — 401/403; the catalog requires credentials.
+ *   `not_found`      — no such client in the catalog.
+ *   `unavailable`    — any other non-2xx (e.g. 503 catalog-not-seeded).
+ *   `invalid`        — body was not a parseable envelope, or the profile did
+ *                      not survive canonicalization.
+ *   `digest_mismatch`— the profile bytes do not hash to the digest the catalog
+ *                      asserted. See the contract doc: a wrong digest would
+ *                      let a capture of one client be compared against a run
+ *                      of another and reported as a match.
+ */
+export type FetchOAuthProfileFailureReason =
+  | "network"
+  | "timeout"
+  | "unauthorized"
+  | "not_found"
+  | "unavailable"
+  | "invalid"
+  | "digest_mismatch";
+
+export type FetchOAuthProfileResult =
+  | {
+      ok: true;
+      clientId: string;
+      clientVersion?: string;
+      /** Canonicalized — ready for `deriveOAuthEmulation`. */
+      profile: HostConfigOAuthProfile;
+      /** Verified locally, not merely echoed from the catalog. */
+      profileDigest: string;
+      catalogRevision: string;
+    }
+  | { ok: false; reason: FetchOAuthProfileFailureReason; detail?: string };
+
+export type FetchOAuthProfileCatalogResult =
+  | {
+      ok: true;
+      entries: OAuthProfileSummary[];
+      catalogRevision: string;
+    }
+  | { ok: false; reason: FetchOAuthProfileFailureReason; detail?: string };
+
+interface RawFetch {
+  status: number;
+  body: unknown;
+}
+
+/** Perform the request, mapping every failure onto a reason. Never throws. */
+async function requestCatalog(
+  path: string,
+  options: FetchOAuthProfileOptions | undefined
+): Promise<
+  { ok: true; response: RawFetch } | { ok: false; reason: FetchOAuthProfileFailureReason }
+> {
+  const baseUrl = (options?.baseUrl ?? DEFAULT_PLATFORM_API_BASE_URL).replace(
+    /\/+$/u,
+    ""
+  );
+  const timeoutMs = options?.timeoutMs ?? 5000;
+  // Read through `globalThis` so a runtime without a fetch binding yields
+  // undefined rather than throwing outside the try — the never-throws contract
+  // must hold everywhere. Bind it too: a detached `fetch` throws "Illegal
+  // invocation" in browsers and workers.
+  const fetchImpl = options?.fetchImpl ?? globalThis.fetch?.bind(globalThis);
+  if (typeof fetchImpl !== "function") {
+    return { ok: false, reason: "network" };
+  }
+
+  // The deadline must cover the body read: `fetch` resolves on headers, so
+  // clearing the timer early would leave a stalled body free to hang.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(`${baseUrl}${path}`, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        ...(options?.authToken
+          ? { authorization: `Bearer ${options.authToken}` }
+          : {}),
+      },
+      signal: controller.signal,
+    });
+
+    if (response.status === 401 || response.status === 403) {
+      return { ok: false, reason: "unauthorized" };
+    }
+    if (response.status === 404) {
+      return { ok: false, reason: "not_found" };
+    }
+    if (!response.ok) {
+      return { ok: false, reason: "unavailable" };
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      // A body that aborts past the deadline is a timeout, not malformed JSON.
+      if (controller.signal.aborted) return { ok: false, reason: "timeout" };
+      return { ok: false, reason: "invalid" };
+    }
+    return { ok: true, response: { status: response.status, body } };
+  } catch {
+    return {
+      ok: false,
+      reason: controller.signal.aborted ? "timeout" : "network",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function schemaVersionDetail(body: unknown): string | undefined {
+  const version =
+    body !== null && typeof body === "object" && !Array.isArray(body)
+      ? (body as { schemaVersion?: unknown }).schemaVersion
+      : undefined;
+  return typeof version === "number" &&
+    version !== SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION
+    ? `catalog schema version ${version} is not supported by this SDK (expected ${SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION})`
+    : undefined;
+}
+
+/** List what can be emulated. Metadata only — no profile bodies. */
+export async function fetchOAuthProfileCatalog(
+  options?: FetchOAuthProfileOptions
+): Promise<FetchOAuthProfileCatalogResult> {
+  const raw = await requestCatalog("/oauth-profiles", options);
+  if (!raw.ok) return raw;
+
+  const parsed = oauthProfileListEnvelopeSchema.safeParse(raw.response.body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: "invalid",
+      ...(schemaVersionDetail(raw.response.body)
+        ? { detail: schemaVersionDetail(raw.response.body) }
+        : {}),
+    };
+  }
+
+  return {
+    ok: true,
+    entries: parsed.data.entries,
+    catalogRevision: parsed.data.catalogRevision,
+  };
+}
+
+/**
+ * Resolve one client's profile, canonicalized and digest-verified.
+ *
+ * `clientId` is path-encoded: it is catalog data, and letting it interpolate
+ * raw would let a crafted id reach a different route.
+ */
+export async function fetchOAuthProfile(
+  clientId: string,
+  options?: FetchOAuthProfileOptions
+): Promise<FetchOAuthProfileResult> {
+  if (!clientId.trim()) {
+    return { ok: false, reason: "invalid", detail: "clientId is required" };
+  }
+
+  const raw = await requestCatalog(
+    `/oauth-profiles/${encodeURIComponent(clientId)}`,
+    options
+  );
+  if (!raw.ok) return raw;
+
+  const parsed = oauthProfileEnvelopeSchema.safeParse(raw.response.body);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      reason: "invalid",
+      ...(schemaVersionDetail(raw.response.body)
+        ? { detail: schemaVersionDetail(raw.response.body) }
+        : {}),
+    };
+  }
+
+  // Canonicalize through the SAME function the backend used. A profile that
+  // would not survive canonicalization is a data bug, and half-enforcing it
+  // would emulate a client that does not exist.
+  let profile: HostConfigOAuthProfile;
+  try {
+    const canonical = canonicalizeOAuthProfile(
+      parsed.data.profile as HostConfigOAuthProfile
+    );
+    if (!canonical) {
+      return { ok: false, reason: "invalid", detail: "profile was empty" };
+    }
+    profile = canonical;
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "invalid",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  // Recompute rather than trust. The digest gates the golden-trace
+  // comparator's binding check, so accepting an asserted one would let a
+  // capture of one client be diffed against a run of another.
+  const digest = await computeOAuthProfileDigest(profile);
+  if (digest !== parsed.data.profileDigest) {
+    return {
+      ok: false,
+      reason: "digest_mismatch",
+      detail: `catalog asserted ${parsed.data.profileDigest}, profile hashes to ${digest}`,
+    };
+  }
+
+  return {
+    ok: true,
+    clientId: parsed.data.clientId,
+    ...(parsed.data.clientVersion
+      ? { clientVersion: parsed.data.clientVersion }
+      : {}),
+    profile,
+    profileDigest: digest,
+    catalogRevision: parsed.data.catalogRevision,
+  };
+}

--- a/sdk/tests/oauth/emulation-profile-fetch.test.ts
+++ b/sdk/tests/oauth/emulation-profile-fetch.test.ts
@@ -1,0 +1,293 @@
+/**
+ * OAuth profile catalog resolution (HP-43 step 3).
+ */
+import {
+  fetchOAuthProfile,
+  fetchOAuthProfileCatalog,
+} from "../../src/oauth/emulation/profile-fetch.js";
+import {
+  computeOAuthProfileDigest,
+  SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION,
+} from "../../src/oauth/emulation/profile-catalog.js";
+import { deriveOAuthEmulation } from "../../src/oauth/emulation/derive.js";
+import type { HostConfigOAuthProfile } from "../../src/host-config/internal";
+import { verified } from "../support/oauth-profiles.js";
+
+const BASE_URL = "https://api.example.test/v1";
+
+const PROFILE: HostConfigOAuthProfile = {
+  profileVersion: 2,
+  authModel: verified(["oauth2-dcr"]),
+  sendsResourceIndicator: verified(false),
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function envelope(
+  overrides: Record<string, unknown> = {}
+): Promise<Record<string, unknown>> {
+  return {
+    schemaVersion: SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION,
+    catalogRevision: "2026-08-04T00:00:00Z",
+    clientId: "example-desktop",
+    clientVersion: "1.2.3",
+    profileDigest: await computeOAuthProfileDigest(PROFILE),
+    profile: PROFILE,
+    ...overrides,
+  };
+}
+
+describe("fetchOAuthProfile — success", () => {
+  it("returns a canonicalized profile ready to compile", async () => {
+    const fetchImpl = jest.fn(async () =>
+      jsonResponse(200, await envelope())
+    ) as unknown as typeof fetch;
+
+    const result = await fetchOAuthProfile("example-desktop", {
+      baseUrl: BASE_URL,
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.clientId).toBe("example-desktop");
+    expect(result.clientVersion).toBe("1.2.3");
+    expect(result.catalogRevision).toBe("2026-08-04T00:00:00Z");
+    // The resolved profile drives the engine with no further ceremony.
+    expect(deriveOAuthEmulation(result.profile).authAttempts).toEqual([
+      { kind: "oauth", registrationPreference: ["dcr"] },
+    ]);
+  });
+
+  it("sends the bearer token and path-encodes the client id", async () => {
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      calls.push([url, init]);
+      return jsonResponse(200, await envelope({ clientId: "a/b" }));
+    }) as unknown as typeof fetch;
+
+    await fetchOAuthProfile("a/b", {
+      baseUrl: BASE_URL,
+      authToken: "tok-123",
+      fetchImpl,
+    });
+
+    // Encoded, so a crafted id cannot reach a different route.
+    expect(calls[0][0]).toBe(`${BASE_URL}/oauth-profiles/a%2Fb`);
+    expect(
+      (calls[0][1]?.headers as Record<string, string>).authorization
+    ).toBe("Bearer tok-123");
+  });
+});
+
+describe("fetchOAuthProfile — verification, not trust", () => {
+  it("rejects a profile whose bytes do not hash to the asserted digest", async () => {
+    // The digest gates the golden comparator's binding check. Trusting an
+    // asserted one would let a capture of one client be diffed against a run
+    // of another and reported as a confident match.
+    const fetchImpl = (async () =>
+      jsonResponse(
+        200,
+        await envelope({ profileDigest: "0000deadbeef" })
+      )) as unknown as typeof fetch;
+
+    const result = await fetchOAuthProfile("example-desktop", {
+      baseUrl: BASE_URL,
+      fetchImpl,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "digest_mismatch" });
+    if (result.ok) return;
+    expect(result.detail).toMatch(/0000deadbeef/);
+  });
+
+  it("rejects a profile that would not survive canonicalization", async () => {
+    const fetchImpl = (async () =>
+      jsonResponse(
+        200,
+        await envelope({
+          profile: {
+            profileVersion: 2,
+            // Unverifiable evidence may not carry a value.
+            authModel: {
+              status: "unverifiable",
+              reason: "closed",
+              value: ["none"],
+            },
+          },
+        })
+      )) as unknown as typeof fetch;
+
+    const result = await fetchOAuthProfile("example-desktop", {
+      baseUrl: BASE_URL,
+      fetchImpl,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "invalid" });
+    if (result.ok) return;
+    expect(result.detail).toMatch(/value must be omitted/);
+  });
+
+  it("refuses a newer catalog schema instead of partially interpreting it", async () => {
+    const fetchImpl = (async () =>
+      jsonResponse(
+        200,
+        await envelope({ schemaVersion: SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION + 1 })
+      )) as unknown as typeof fetch;
+
+    const result = await fetchOAuthProfile("example-desktop", {
+      baseUrl: BASE_URL,
+      fetchImpl,
+    });
+
+    expect(result).toMatchObject({ ok: false, reason: "invalid" });
+    if (result.ok) return;
+    expect(result.detail).toMatch(/schema version/);
+  });
+});
+
+describe("fetchOAuthProfile — failures never throw and never fall back", () => {
+  const cases: Array<[string, () => Promise<Response>, string]> = [
+    ["a 404", async () => jsonResponse(404, {}), "not_found"],
+    ["a 401", async () => jsonResponse(401, {}), "unauthorized"],
+    ["a 403", async () => jsonResponse(403, {}), "unauthorized"],
+    ["a 503", async () => jsonResponse(503, {}), "unavailable"],
+    [
+      "a non-JSON body",
+      async () => new Response("not json", { status: 200 }),
+      "invalid",
+    ],
+  ];
+
+  for (const [label, respond, reason] of cases) {
+    it(`maps ${label} to ${reason}`, async () => {
+      const result = await fetchOAuthProfile("x", {
+        baseUrl: BASE_URL,
+        fetchImpl: respond as unknown as typeof fetch,
+      });
+      expect(result).toMatchObject({ ok: false, reason });
+    });
+  }
+
+  it("maps a thrown transport error to network, without throwing", async () => {
+    const result = await fetchOAuthProfile("x", {
+      baseUrl: BASE_URL,
+      fetchImpl: (async () => {
+        throw new Error("ECONNREFUSED");
+      }) as unknown as typeof fetch,
+    });
+    expect(result).toMatchObject({ ok: false, reason: "network" });
+  });
+
+  it("maps an aborted request to timeout", async () => {
+    const result = await fetchOAuthProfile("x", {
+      baseUrl: BASE_URL,
+      timeoutMs: 1,
+      fetchImpl: ((_url: string, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new Error("aborted"))
+          );
+        })) as unknown as typeof fetch,
+    });
+    expect(result).toMatchObject({ ok: false, reason: "timeout" });
+  });
+
+  it("rejects an empty clientId before making a request", async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch;
+    const result = await fetchOAuthProfile("  ", {
+      baseUrl: BASE_URL,
+      fetchImpl,
+    });
+    expect(result).toMatchObject({ ok: false, reason: "invalid" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("never returns a profile on failure — there is no bundled fallback", async () => {
+    const result = await fetchOAuthProfile("x", {
+      baseUrl: BASE_URL,
+      fetchImpl: (async () => jsonResponse(503, {})) as unknown as typeof fetch,
+    });
+    // A failure means "this client cannot be emulated right now", never
+    // "something else was used instead".
+    expect(result.ok).toBe(false);
+    expect(result).not.toHaveProperty("profile");
+  });
+});
+
+describe("fetchOAuthProfileCatalog", () => {
+  it("lists entries without profile bodies", async () => {
+    const fetchImpl = (async () =>
+      jsonResponse(200, {
+        schemaVersion: SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION,
+        catalogRevision: "rev-1",
+        entries: [
+          {
+            clientId: "example-desktop",
+            label: "Example Desktop",
+            profileDigest: "abc",
+          },
+        ],
+      })) as unknown as typeof fetch;
+
+    const result = await fetchOAuthProfileCatalog({
+      baseUrl: BASE_URL,
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.catalogRevision).toBe("rev-1");
+    expect(result.entries).toEqual([
+      {
+        clientId: "example-desktop",
+        label: "Example Desktop",
+        profileDigest: "abc",
+      },
+    ]);
+  });
+
+  it("refuses a malformed listing rather than returning a partial one", async () => {
+    const result = await fetchOAuthProfileCatalog({
+      baseUrl: BASE_URL,
+      fetchImpl: (async () =>
+        jsonResponse(200, {
+          schemaVersion: SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION,
+          catalogRevision: "rev-1",
+          entries: [{ label: "missing its clientId" }],
+        })) as unknown as typeof fetch,
+    });
+    expect(result).toMatchObject({ ok: false, reason: "invalid" });
+  });
+});
+
+describe("computeOAuthProfileDigest", () => {
+  it("is canonical — key order cannot change it", async () => {
+    const a = await computeOAuthProfileDigest({
+      profileVersion: 2,
+      authModel: verified(["oauth2-dcr"]),
+      sendsResourceIndicator: verified(false),
+    });
+    const b = await computeOAuthProfileDigest({
+      profileVersion: 2,
+      sendsResourceIndicator: verified(false),
+      authModel: verified(["oauth2-dcr"]),
+    });
+    expect(a).toBe(b);
+  });
+
+  it("distinguishes different profiles", async () => {
+    const a = await computeOAuthProfileDigest(PROFILE);
+    const b = await computeOAuthProfileDigest({
+      profileVersion: 2,
+      authModel: verified(["oauth2-cimd"]),
+      sendsResourceIndicator: verified(false),
+    });
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
Completes the piece of step 3 that was specified but never built. Branches from `main` (which already contains #3664/S3, #3666/S4, #3677/S5), so it is **independent of the open #3685 → #3689 stack**. **Do not merge yet.**

## The gap

Step 3's line item was "V2 profile validation, frozen-V1 compat tests, **private catalog resolution**, scope/token-auth fields." The first, second and fourth shipped in #3664; the third did not. Every consumer takes an *already-resolved* profile — the SDK an object, the CLI a `--profile <file>` — so nothing could turn "emulate client X" into that profile.

The catalog **data** correctly lives in the private backend. The **fetch path** belongs here, and that is what this adds.

## What

- **`fetchOAuthProfile` / `fetchOAuthProfileCatalog`** — resolve a client id into an evidence-backed profile, ready for `deriveOAuthEmulation`.
- **`GET /api/v1/oauth-profiles[/:clientId]`** — proxies the backend catalog, so the OSS SDK and CLI never learn a `*.convex.site` address.
- **`docs/host-oauth-profiles/profile-catalog-contract.md`** — the wire contract the private backend implements against (you asked for this spec'd).

## Two deliberate departures from the `/v1/host-catalog` proxy this mirrors

1. **No bundled fallback, and no serve-stale.** host-catalog always returns *something* (stale cache, then a catalog bundled into the SDK). Profiles cannot: bundling them would put client names in public source, which is the constraint the whole feature is organized around. So a failed fetch means **"this client cannot be emulated right now"** — never "something else was used instead", which would silently invalidate every coverage and comparison claim the run then makes.

2. **Authenticated.** Host-compat data is public metadata; a per-client OAuth evidence catalog is not. The route mounts *after* the bearer middleware and is deliberately absent from the guest allowlist, so anonymous callers cannot enumerate the catalog. (The plan's "not secret at runtime" concerns the *tested server* seeing a `client_name` on the wire — it does not require the catalog to be world-readable.)

## Verify, don't trust

The SDK rejects rather than accepts when any of these fail:
- the envelope `schemaVersion` must match **exactly** (no bundled copy to degrade to, so a newer catalog is refused rather than partially interpreted);
- the profile must survive **the same canonicalizer the backend uses**;
- **`profileDigest` is recomputed locally** and rejected on mismatch.

That third check is load-bearing, not ceremony: the digest gates the golden-trace comparator's binding check, so an asserted-but-wrong digest would let a capture of one client be diffed against a run of another and reported as a confident match — the same failure class as the digest fix in #3685.

## Tests

- `sdk/tests/oauth/emulation-profile-fetch.test.ts` (18): success + compile-through, bearer header, path-encoded client id, digest mismatch, canonicalization failure, newer schema refused, every failure reason (404/401/403/503/non-JSON/throw/abort), empty-id short-circuit, and an explicit "never returns a profile on failure".
- `mcpjam-inspector/server/routes/v1/__tests__/oauth-profiles.test.ts` (8): anonymous rejected with no upstream call, proxy passthrough without leaking the convex host, path encoding, NOT_FOUND, unreachable/5xx/misconfigured all reported rather than fallen back, `private` cache-control.
- Both routes documented in `docs/reference/openapi.json` — the repo's openapi-drift guard caught them, and I documented rather than baselined.

`tsc --noEmit` clean in both packages; SDK **3631 passed**, server **4485 passed**.

## Follow-ups (not in this PR)

- **`--client <id>` on `oauth emulate`** depends on #3689 (S7), so it lands after that.
- **`computeOAuthProfileDigest` now exists twice**: here (`profile-catalog.ts`) and in #3685's `golden-trace.ts`. Identical two-line function. When #3685 rebases onto main after this lands, its copy should re-export from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OAuth client profile resolution from the private catalog so you can emulate client X end-to-end (HP-43 step 3). The inspector now proxies authenticated `/web/oauth-profiles` and the SDK fetches, canonicalizes, and digest‑verifies profiles.

- **New Features**
  - Server (`@mcpjam/inspector`): `GET /api/v1/oauth-profiles` and `/api/v1/oauth-profiles/:clientId` proxy the backend `/web/oauth-profiles*`; behind bearer auth, not on the guest allowlist; no bundled fallback; path-encodes ids; adds `Cache-Control: private`.
  - SDK (`@mcpjam/sdk`): `fetchOAuthProfile` and `fetchOAuthProfileCatalog` resolve profiles; never throw and return typed failure reasons; re-canonicalize profiles and recompute `profileDigest`; reject newer `schemaVersion`.
  - SDK exports: `computeOAuthProfileDigest`, `oauthProfileEnvelopeSchema`, `oauthProfileListEnvelopeSchema`, `SUPPORTED_OAUTH_PROFILE_SCHEMA_VERSION`.
  - Docs/OpenAPI: added `docs/host-oauth-profiles/profile-catalog-contract.md`; expanded `docs/reference/openapi.json`.
  - Tests: route proxy behavior (auth, upstream `/web` path, path encoding, error mapping, cache-control); SDK success paths, digest mismatch, canonicalization failure, schema/version errors, and network/timeouts.

<sup>Written for commit c29ed2869726abe97c8484c3224313ca78cd84e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

