### PR TITLE
feat(conformance): the score — one number, 0–100, advice included

### DIFF
--- a/.changeset/conformance-score.md
+++ b/.changeset/conformance-score.md
@@ -1,0 +1,26 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+"@mcpjam/cli": minor
+---
+
+One number for conformance: a 0–100 score with advice included.
+
+`computeConformanceScore` and per-suite adapters, grounded in the spec's own
+doctrine: conformance is defined by RFC 2119 MUSTs, so MUSTs own 95 of the
+100 points; SEP-2484 makes SHOULD-level findings warnings rather than
+failures, so advice owns the last 5 (SHOULD/RECOMMENDED −2, MAY −1, capped).
+`not-applicable` checks leave the denominator entirely — a server without
+auth loses nothing — while `could-not-run` checks stay in it as unearned
+points. The 95–100 band is reserved for MUST-clean, complete runs, and 100
+means every applicable check passed with nothing left to advise. The number
+always ships with its denominator and protocol version.
+
+Surfaces: a pooled headline card and per-suite score chips in the
+inspector's Conformance panel (readiness warnings are now rendered — they
+cost points, so they must be visible), a `Score:` stderr line on all four
+CLI conformance commands, `score` on every `ConformanceReport`
+(json-summary), and a JUnit `<properties>` block. Also fixes
+`ConformanceReport.outcome`/`incompleteReason`, which were declared but
+never assigned, so json-summary can finally tell a failed run from an
+incomplete one.

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -2,6 +2,7 @@ import {
   conformanceExitCode,
   conformanceSuiteExitCode,
   reportIncomplete,
+  reportScore,
 } from "../lib/conformance-exit-code.js";
 import { Command } from "commander";
 import {
@@ -14,6 +15,7 @@ import {
   type MCPAppsCheckId,
   type MCPAppsConformanceConfig,
   type McpProtocolVersion,
+  scoreFromAppsResult,
 } from "@mcpjam/sdk";
 import { loadAppsSuiteConfig } from "../lib/config-file.js";
 import {
@@ -213,8 +215,10 @@ export function registerAppsCommands(program: Command): void {
     writeConformanceOutput(
       renderConformanceForCli(outputResult, reporter, globalOptions.format),
     );
-    // The JSON payload carries it too, but a human running this in a terminal
-    // must not have to dig for the reason a check never ran.
+    // The JSON payload carries both too, but a human running this in a
+    // terminal must not have to dig for the number or the reason a check
+    // never ran.
+    reportScore(scoreFromAppsResult(result), command);
     reportIncomplete(result, command);
     const exitCode = conformanceExitCode(result);
     if (exitCode !== 0) {
@@ -554,8 +558,9 @@ export function registerAppsCommands(program: Command): void {
       writeConformanceOutput(
         renderConformanceForCli(outputResult, reporter, globalOptions.format),
       );
-      // Each run carries its own reason; a suite reports every incomplete one.
+      // Each run carries its own score and reason.
       for (const run of result.results) {
+        reportScore(scoreFromAppsResult(run), command, run.label);
         reportIncomplete(run, command);
       }
       const exitCode = conformanceSuiteExitCode(result.results);

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -3,9 +3,11 @@ import {
   conformanceSuiteExitCode,
   reportIncomplete,
   reportReadiness,
+  reportScore,
 } from "../lib/conformance-exit-code.js";
 import {
   isKnownProtocolVersion,
+  scoreFromProtocolResult,
   MCP_CHECK_CATEGORIES,
   MCP_CHECK_IDS,
   MCP_PROTOCOL_VERSIONS,
@@ -98,9 +100,10 @@ export function registerProtocolCommands(program: Command): void {
       const result = await new MCPConformanceTest(config).run();
 
       writeConformanceOutput(renderConformanceForCli(result, reporter, format));
-      // The JSON payload carries both too, but a human running this in a
-      // terminal must not have to dig for the reason a check never ran or for
-      // the advice the run produced.
+      // The JSON payload carries all three too, but a human running this in a
+      // terminal must not have to dig for the number, the reason a check
+      // never ran, or the advice the run produced.
+      reportScore(scoreFromProtocolResult(result), command);
       reportReadiness(result, command);
       reportIncomplete(result, command);
       const exitCode = conformanceExitCode(result);
@@ -126,8 +129,10 @@ export function registerProtocolCommands(program: Command): void {
       const result = await new MCPConformanceSuite(config).run();
 
       writeConformanceOutput(renderConformanceForCli(result, reporter, format));
-      // Each run carries its own reason; a suite reports every incomplete one.
+      // Each run carries its own score and reasons — a suite's runs usually
+      // pin different revisions, so per-run lines are the actionable ones.
       for (const run of result.results) {
+        reportScore(scoreFromProtocolResult(run), command, run.label);
         reportReadiness(run, command);
         reportIncomplete(run, command);
       }

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -1,3 +1,4 @@
+import { reportScore } from "../lib/conformance-exit-code.js";
 import {
   type OAuthConformanceConfig,
   type OAuthConformanceSuiteResult,
@@ -10,6 +11,7 @@ import {
   fetchOAuthMetadata,
   OAuthProxyError,
   runOAuthLogin,
+  scoreFromOAuthResult,
 } from "@mcpjam/sdk";
 import { Command } from "commander";
 import {
@@ -400,6 +402,9 @@ export function registerOAuthCommands(program: Command): void {
       if (credentialsFileError) {
         throw credentialsFileError;
       }
+      // A not-applicable run yields no number at all: authorization is
+      // OPTIONAL, so a server that requires none has nothing to score.
+      reportScore(scoreFromOAuthResult(result), command);
       // A not-applicable run is not a failure: authorization is OPTIONAL, so
       // a server that requires none has no obligations to violate.
       if (result.outcome === "failed") {
@@ -481,6 +486,9 @@ export function registerOAuthCommands(program: Command): void {
       );
       if (credentialsFileError) {
         throw credentialsFileError;
+      }
+      for (const run of result.results) {
+        reportScore(scoreFromOAuthResult(run), command, run.label);
       }
       // Suite `passed` already treats a not-applicable flow as non-failing.
       if (!result.passed) {

--- a/cli/src/commands/tasks.ts
+++ b/cli/src/commands/tasks.ts
@@ -1,5 +1,6 @@
 import { conformanceExitCode } from "../lib/conformance-exit-code.js";
 import { Command } from "commander";
+import { reportScore } from "../lib/conformance-exit-code.js";
 import {
   MCP_TASKS_CHECK_CATEGORIES,
   MCP_TASKS_CHECK_IDS,
@@ -11,6 +12,7 @@ import {
   type MCPTasksCheckId,
   type MCPTasksConformanceConfig,
   type TasksSupport,
+  scoreFromTasksResult,
 } from "@mcpjam/sdk";
 import {
   renderConformanceForCli,
@@ -756,6 +758,7 @@ export function registerTasksCommands(program: Command): void {
     const output = renderConformanceForCli(outputResult, reporter, format);
     process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 
+    reportScore(scoreFromTasksResult(result), command);
     const incompleteReason = (result as { incompleteReason?: string })
       .incompleteReason;
     if (incompleteReason && !globalOptions.quiet) {

--- a/cli/src/lib/conformance-exit-code.ts
+++ b/cli/src/lib/conformance-exit-code.ts
@@ -1,3 +1,8 @@
+import {
+  describeConformanceScore,
+  type ConformanceScore,
+} from "@mcpjam/sdk";
+
 /**
  * Exit code for a finished conformance run, shared by every suite.
  *
@@ -36,6 +41,23 @@ export function conformanceSuiteExitCode(
  * Surface why a run established nothing. The JSON payload carries it too, but
  * a human in a terminal must not have to dig for the reason a check never ran.
  */
+/**
+ * The score line, one per run. Same channel discipline as its siblings:
+ * stderr so JSON stdout stays parseable, suppressed by `--quiet`, and no
+ * effect on exit codes — the score annotates the verdict, it does not
+ * replace it.
+ */
+export function reportScore(
+  score: ConformanceScore,
+  command: { optsWithGlobals(): { quiet?: boolean } },
+  label?: string,
+): void {
+  if (command.optsWithGlobals().quiet) return;
+  process.stderr.write(
+    `Score${label ? ` [${label}]` : ""}: ${describeConformanceScore(score)}\n`,
+  );
+}
+
 /**
  * Surface the readiness channel (SHOULD/RECOMMENDED/MAY advice) for a human.
  * Advice lives beside the verdict, never inside it: it goes to stderr like

--- a/cli/src/lib/conformance-exit-code.ts
+++ b/cli/src/lib/conformance-exit-code.ts
@@ -38,20 +38,19 @@ export function conformanceSuiteExitCode(
 }
 
 /**
- * Surface why a run established nothing. The JSON payload carries it too, but
- * a human in a terminal must not have to dig for the reason a check never ran.
- */
-/**
  * The score line, one per run. Same channel discipline as its siblings:
  * stderr so JSON stdout stays parseable, suppressed by `--quiet`, and no
  * effect on exit codes — the score annotates the verdict, it does not
- * replace it.
+ * replace it. A scoreless run (nothing applicable — e.g. OAuth against a
+ * server without auth) prints nothing: the run's own summary already says
+ * why, and absence is the honest rendering of "no number".
  */
 export function reportScore(
   score: ConformanceScore,
   command: { optsWithGlobals(): { quiet?: boolean } },
   label?: string,
 ): void {
+  if (score.score === null) return;
   if (command.optsWithGlobals().quiet) return;
   process.stderr.write(
     `Score${label ? ` [${label}]` : ""}: ${describeConformanceScore(score)}\n`,
@@ -85,6 +84,10 @@ export function reportReadiness(
   }
 }
 
+/**
+ * Surface why a run established nothing. The JSON payload carries it too, but
+ * a human in a terminal must not have to dig for the reason a check never ran.
+ */
 export function reportIncomplete(
   result: { incompleteReason?: string },
   command: { optsWithGlobals(): { quiet?: boolean } },

--- a/cli/tests/conformance-exit-code.test.ts
+++ b/cli/tests/conformance-exit-code.test.ts
@@ -4,7 +4,9 @@ import {
   conformanceExitCode,
   conformanceSuiteExitCode,
   reportReadiness,
+  reportScore,
 } from "../src/lib/conformance-exit-code.js";
+import { computeConformanceScore } from "@mcpjam/sdk";
 
 test("incomplete gets its own exit code, distinct from a violation", () => {
   // "The server violated the spec" and "we never established anything" are
@@ -75,6 +77,41 @@ test("readiness advice goes to stderr, honors --quiet, and prints nothing for an
 
     // An older @mcpjam/sdk result has no readiness member at all.
     reportReadiness({}, command);
+    assert.equal(lines.length, 0);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+});
+
+test("the score line goes to stderr with denominator and version, and honors --quiet", () => {
+  const lines: string[] = [];
+  const originalWrite = process.stderr.write;
+  process.stderr.write = ((chunk: string) => {
+    lines.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const score = computeConformanceScore(
+      [
+        { id: "a", status: "passed" },
+        { id: "b", status: "failed" },
+      ],
+      [{ id: "advice", tier: "should" }],
+      "2025-11-25",
+    );
+    reportScore(score, { optsWithGlobals: () => ({}) });
+    assert.equal(lines.length, 1);
+    assert.equal(
+      lines[0],
+      "Score: 51/100 — 1/2 applicable checks passed, 1 failed, 1 advisory (−2) [2025-11-25]\n",
+    );
+
+    lines.length = 0;
+    reportScore(score, { optsWithGlobals: () => ({}) }, "run-1");
+    assert.match(lines[0], /^Score \[run-1\]: /);
+
+    lines.length = 0;
+    reportScore(score, { optsWithGlobals: () => ({ quiet: true }) });
     assert.equal(lines.length, 0);
   } finally {
     process.stderr.write = originalWrite;

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -36,13 +36,20 @@ import {
   canRunConformance,
   CHECK_ERAS,
   CONFORMANCE_CHECK_METADATA,
+  describeConformanceScore,
   MCP_APPS_CHECK_IDS,
   MCP_CHECK_IDS,
   MCP_PROTOCOL_VERSIONS,
   MCP_TASKS_CHECK_IDS,
+  pooledConformanceScore,
   PROTOCOL_CHECK_CATALOG,
   PROTOCOL_VERSION_ERAS,
+  scoreFromAppsResult,
+  scoreFromOAuthResult,
+  scoreFromProtocolResult,
+  scoreFromTasksResult,
   TASKS_CHECK_CATALOG,
+  type ConformanceScore,
   type McpProtocolVersion,
   type OAuthConformanceCheckId,
 } from "@mcpjam/sdk/browser";
@@ -196,6 +203,9 @@ function oauthStateFromResult(
     return {
       status: "unavailable",
       unavailableReason: result.summary,
+      // Kept so the score pool can see the run: a not-applicable OAuth run
+      // contributes its "nothing to score here" tally instead of vanishing.
+      result,
     };
   }
   return {
@@ -470,6 +480,7 @@ function SuiteSection({
   catalog,
   catalogNote,
   hasResult,
+  score,
   children,
 }: {
   title: string;
@@ -478,6 +489,8 @@ function SuiteSection({
   catalog: CatalogEntry[];
   catalogNote?: string;
   hasResult: boolean;
+  /** This suite's score chip, rendered beside the verdict badge. */
+  score?: ConformanceScore;
   children?: React.ReactNode;
 }) {
   // `null` follows the suite: one that is running or finished opens itself, an
@@ -538,7 +551,14 @@ function SuiteSection({
             ))}
           <span className="text-sm font-medium truncate">{title}</span>
         </span>
-        {badge}
+        <span className="flex items-center gap-2">
+          {score && score.score !== null && (
+            <span className="text-[10px] font-semibold tabular-nums text-foreground">
+              {score.score}/100
+            </span>
+          )}
+          {badge}
+        </span>
       </button>
       <div className="px-2 py-1">
         {state.status === "unavailable" && state.unavailableReason && (
@@ -944,6 +964,34 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
     [versionPin],
   );
 
+  // Scores are derived, never stored: each finished suite contributes, and
+  // the headline pools their COUNTS (not an average of suite scores), so a
+  // 0-for-9 OAuth run stays visible inside 30 protocol passes.
+  const protocolScore = useMemo(
+    () => (protocol.result ? scoreFromProtocolResult(protocol.result) : undefined),
+    [protocol.result],
+  );
+  const appsScore = useMemo(
+    () => (apps.result ? scoreFromAppsResult(apps.result) : undefined),
+    [apps.result],
+  );
+  const tasksScore = useMemo(
+    () => (tasks.result ? scoreFromTasksResult(tasks.result) : undefined),
+    [tasks.result],
+  );
+  const oauthScore = useMemo(
+    () => (oauth.result ? scoreFromOAuthResult(oauth.result) : undefined),
+    [oauth.result],
+  );
+  const pooledScore = useMemo(() => {
+    const parts = [protocolScore, appsScore, tasksScore, oauthScore].filter(
+      (part): part is ConformanceScore => part !== undefined,
+    );
+    return parts.length > 0 ? pooledConformanceScore(parts) : undefined;
+  }, [protocolScore, appsScore, tasksScore, oauthScore]);
+  const oauthNotScored =
+    oauthScore !== undefined && oauthScore.score === null;
+
   const isRunning =
     protocol.status === "running" ||
     apps.status === "running" ||
@@ -958,6 +1006,47 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           Run Protocol, Apps, Tasks, and OAuth checks against {server.name}.
         </p>
       </div>
+
+      {/* No card at all when nothing was applicable: a "—/100" over a run
+          with nothing to score would be noise dressed as a number. */}
+      {pooledScore && pooledScore.score !== null && (
+        <div className="mt-4 flex items-center gap-4 rounded-md border border-border/50 bg-muted/30 px-4 py-3">
+          <div className="text-3xl font-semibold tabular-nums leading-none">
+            {pooledScore.score}
+            <span className="ml-0.5 text-sm font-normal text-muted-foreground">
+              /100
+            </span>
+          </div>
+          <div className="min-w-0 space-y-0.5">
+            <div
+              className={`text-xs font-medium ${
+                pooledScore.outcome === "failed"
+                  ? "text-red-400"
+                  : pooledScore.outcome === "incomplete"
+                    ? "text-amber-500"
+                    : "text-green-500"
+              }`}
+            >
+              {pooledScore.outcome === "failed"
+                ? "Not conformant"
+                : pooledScore.outcome === "incomplete"
+                  ? "Incomplete run"
+                  : pooledScore.advisories.length > 0
+                    ? "Conformant, with advice"
+                    : "Fully conformant"}
+            </div>
+            {/* The denominator and version travel with the number, always —
+                "100 of 11 applicable" and "100 of 38" are different servers. */}
+            <div className="truncate text-[11px] text-muted-foreground">
+              {describeConformanceScore(pooledScore)}
+              {pooledScore.notApplicable > 0
+                ? ` · ${pooledScore.notApplicable} not applicable`
+                : ""}
+              {oauthNotScored ? " · OAuth not applicable (no auth) — not scored" : ""}
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="mt-4 flex items-center justify-between gap-2">
         <Button size="sm" onClick={runAll} disabled={isRunning}>
@@ -1005,6 +1094,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           key={`${runVersion}-protocol`}
           title="Protocol"
           state={protocol}
+          score={protocolScore}
           catalog={protocolChecks}
           catalogNote={
             versionPin === "auto"
@@ -1018,6 +1108,25 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
               <div className="px-1 py-1 text-[10px] text-muted-foreground">
                 {protocol.result.summary}
               </div>
+              {(protocol.result.readiness ?? []).length > 0 && (
+                <div className="mx-1 my-1 space-y-1 rounded-sm border border-amber-500/50 px-2 py-1.5">
+                  {(protocol.result.readiness ?? []).map((warning) => (
+                    <div
+                      key={warning.id}
+                      className="flex items-start gap-1.5 text-[11px]"
+                    >
+                      <AlertTriangle className="mt-0.5 h-3 w-3 flex-shrink-0 text-amber-500" />
+                      <span className="min-w-0">
+                        <span className="font-medium">{warning.title}</span>{" "}
+                        <span className="text-muted-foreground">
+                          ({warning.specStrength})
+                        </span>{" "}
+                        — {warning.message}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
               {protocol.result.checks.map((check) => (
                 <CheckRow key={`${runVersion}-${check.id}`} check={check} />
               ))}
@@ -1029,6 +1138,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           key={`${runVersion}-apps`}
           title="Apps"
           state={apps}
+          score={appsScore}
           catalog={APPS_CATALOG}
           hasResult={Boolean(apps.result)}
         >
@@ -1048,6 +1158,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           key={`${runVersion}-tasks`}
           title="Tasks"
           state={tasks}
+          score={tasksScore}
           catalog={TASKS_CATALOG}
           hasResult={Boolean(tasks.result)}
         >
@@ -1067,6 +1178,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           key={`${runVersion}-oauth`}
           title="OAuth"
           state={oauth}
+          score={oauthScore}
           catalog={OAUTH_CATALOG}
           catalogNote="The authorization flow steps are recorded as the run proceeds."
           hasResult={Boolean(oauth.result) || Boolean(oauth.waitingForAuth)}

--- a/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/__tests__/ConformancePanel.test.tsx
@@ -198,6 +198,118 @@ beforeEach(() => {
 });
 
 describe("ConformanceTab", () => {
+  it("shows a pooled score headline with denominator, and readiness advice that costs points", async () => {
+    setupSuccessfulRunMocks({
+      protocol: createProtocolResult({
+        checks: [
+          {
+            id: "ping",
+            category: "core",
+            title: "Ping",
+            description: "Ping.",
+            status: "passed",
+            durationMs: 1,
+          },
+          {
+            id: "tools-list",
+            category: "tools",
+            title: "Tools List",
+            description: "List tools.",
+            status: "skipped",
+            skipReason: "not-applicable",
+            durationMs: 0,
+          },
+        ],
+        protocolVersion: "2025-11-25",
+        readiness: [
+          {
+            id: "readiness-metadata-quality",
+            title: "Metadata Quality",
+            severity: "warning",
+            specStrength: "SHOULD",
+            message: "2 tool(s) have no description",
+          },
+        ],
+      } as Partial<MCPConformanceResult>),
+      apps: createAppsResult({
+        checks: [
+          {
+            id: "ui-tools-present",
+            category: "tools",
+            title: "UI Tools Present",
+            description: "ui",
+            status: "passed",
+            durationMs: 1,
+          },
+        ],
+      }),
+      oauth: createOAuthResult({
+        steps: [
+          {
+            step: "request_without_token",
+            title: "Initial MCP Request",
+            summary: "first",
+            status: "passed",
+            durationMs: 1,
+            logs: [],
+            httpAttempts: [],
+          },
+        ],
+      }),
+    });
+    mockRunTasks.mockResolvedValue({
+      success: true,
+      result: createTasksResult({
+        checks: [
+          {
+            id: "tasks-wire-resolvable",
+            category: "dispatch",
+            title: "Tasks Wire Resolvable",
+            description: "wire",
+            status: "passed",
+            durationMs: 1,
+          },
+        ],
+      }),
+    });
+
+    render(<ConformanceTab server={createHttpServer()} />);
+    fireEvent.click(screen.getByRole("button", { name: /run available checks/i }));
+
+    // Pooled: 4/4 applicable across the suites, one SHOULD advisory (-2)
+    // from protocol readiness = 98. The number appears twice: the pooled
+    // headline and the Protocol suite chip (the clean suites' chips read
+    // 100/100).
+    // The headline's own text node is the bare number (the /100 is a child
+    // span); the Protocol suite chip renders the combined "98/100".
+    await waitFor(() => expect(screen.getByText("98")).toBeInTheDocument());
+    expect(screen.getByText("98/100")).toBeInTheDocument();
+    expect(screen.getByText("Conformant, with advice")).toBeInTheDocument();
+    // The denominator travels with the number.
+    expect(
+      screen.getByText(/4\/4 applicable checks passed/),
+    ).toBeInTheDocument();
+
+    // The advisory that deducted is visible, tier and all.
+    expect(screen.getByText("Metadata Quality")).toBeInTheDocument();
+    expect(screen.getByText("(SHOULD)")).toBeInTheDocument();
+
+  });
+
+  it("renders no score card when nothing was applicable", async () => {
+    setupSuccessfulRunMocks();
+
+    render(<ConformanceTab server={createHttpServer()} />);
+    fireEvent.click(screen.getByRole("button", { name: /run available checks/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Protocol summary")).toBeInTheDocument(),
+    );
+    // Empty fixtures leave zero applicable checks everywhere: a "—/100" card
+    // would be noise dressed as a number, so no card renders at all.
+    expect(screen.queryByText("/100")).not.toBeInTheDocument();
+  });
+
   it("renders the tab title for an HTTP server", () => {
     render(<ConformanceTab server={createHttpServer()} />);
 

--- a/sdk/src/apps-conformance/runner.ts
+++ b/sdk/src/apps-conformance/runner.ts
@@ -1010,6 +1010,13 @@ export class MCPAppsConformanceTest {
           // A check that COULD NOT RUN is neither a violation nor a pass: the
           // obligation went untested, so the run is `incomplete`.
           const verdict = decideConformanceOutcome(checks);
+          // The negotiated revision, so the score label is data. Only the
+          // success path can state one — a failed connection established none.
+          // Optional-called: this is best-effort metadata for a LABEL, and a
+          // partial manager (tests stub only what their check needs) must
+          // yield "no version", never a failed run.
+          const negotiatedProtocolVersion =
+            manager.getInitializationInfo?.(serverId)?.protocolVersion;
 
           return {
             passed: verdict.outcome === "passed",
@@ -1018,6 +1025,9 @@ export class MCPAppsConformanceTest {
               ? { incompleteReason: verdict.incompleteReason }
               : {}),
             target: this.config.target,
+            ...(negotiatedProtocolVersion !== undefined
+              ? { protocolVersion: negotiatedProtocolVersion }
+              : {}),
             checks,
             summary: buildSummary(checks),
             durationMs: Date.now() - startedAt,

--- a/sdk/src/apps-conformance/types.ts
+++ b/sdk/src/apps-conformance/types.ts
@@ -91,6 +91,12 @@ export interface MCPAppsConformanceResult {
    */
   incompleteReason?: string;
   target: string;
+  /**
+   * The revision the run's connection negotiated (or the caller pinned).
+   * Absent when the connection never succeeded — the run established no
+   * version, and a score label must not invent one.
+   */
+  protocolVersion?: string;
   checks: MCPAppsCheckResult[];
   summary: string;
   durationMs: number;

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -386,6 +386,35 @@ export type { MCPTasksCheckId } from "./tasks-conformance/types.js";
 export { CONFORMANCE_CHECK_METADATA } from "./oauth-conformance/types.js";
 export type { OAuthConformanceCheckId } from "./oauth-conformance/types.js";
 
+// The shared verdict vocabulary and the score built on it. Both are pure data
+// reasoning (no MCP client, no transport, no Node built-ins) — the score's
+// suite adapters reach the result types through `import type` only.
+export {
+  buildOutcomeSummary,
+  decideConformanceOutcome,
+  isInapplicableCheck,
+  isUnrunCheck,
+} from "./conformance-outcome.js";
+export type {
+  ConformanceRunOutcome,
+  ConformanceSkipReason,
+  OutcomeCheckLike,
+} from "./conformance-outcome.js";
+export {
+  computeConformanceScore,
+  describeConformanceScore,
+  pooledConformanceScore,
+  scoreFromAppsResult,
+  scoreFromOAuthResult,
+  scoreFromProtocolResult,
+  scoreFromTasksResult,
+} from "./conformance-score.js";
+export type {
+  ConformanceAdvisoryTier,
+  ConformanceScore,
+  ScoredAdvisory,
+} from "./conformance-score.js";
+
 // Each check's title and one-line description, kept byte-identical to the
 // strings on the check implementations by `tests/conformance-catalog.test.ts`.
 export {

--- a/sdk/src/conformance-reporting.ts
+++ b/sdk/src/conformance-reporting.ts
@@ -275,7 +275,16 @@ function suiteOutcomeFields(
   }>,
 ): Pick<ConformanceReport, "outcome" | "incompleteReason"> {
   const outcomes = results.map(
-    (entry) => outcomeFields(entry).outcome ?? (entry.passed ? "passed" : "failed"),
+    (entry) =>
+      outcomeFields(entry).outcome ??
+      // OAuth's not-applicable flows carry `passed: false` (they are not
+      // passes) but they are not failures either — authorization is OPTIONAL,
+      // so a no-auth flow must not drag a suite's verdict to "failed".
+      (entry.outcome === "not-applicable"
+        ? "passed"
+        : entry.passed
+          ? "passed"
+          : "failed"),
   );
   if (outcomes.includes("failed")) {
     return { outcome: "failed" };
@@ -591,7 +600,10 @@ function renderConformanceTestCase(
   return `    <testcase name="${name}" classname="${escapedClassname}" time="${time}"/>`;
 }
 
-function renderConformanceTestSuite(group: ConformanceReportGroup): string {
+function renderConformanceTestSuite(
+  group: ConformanceReportGroup,
+  score: ConformanceScore | undefined,
+): string {
   const name = escapeXml(group.title);
   const tests = group.cases.length;
   const failures = group.cases.filter((entry) => entry.status === "failed").length;
@@ -599,11 +611,23 @@ function renderConformanceTestSuite(group: ConformanceReportGroup): string {
   const time = (group.durationMs / 1000).toFixed(3);
   const classname = group.target || `mcpjam.${sanitizeToken(group.id)}`;
 
+  // JUnit's XSDs put <properties> under <testsuite>, never under the
+  // <testsuites> root — a root-level block is schema-invalid to Jenkins and
+  // friends. The score is REPORT-level (pooled for suites), so every
+  // testsuite carries the same values; the property names say so.
+  const properties = score
+    ? `    <properties>\n      <property name="mcpjam.conformance.score" value="${
+        score.score === null ? "not-scored" : String(score.score)
+      }"/>\n      <property name="mcpjam.conformance.summary" value="${escapeXml(
+        describeConformanceScore(score),
+      )}"/>\n    </properties>\n`
+    : "";
+
   const cases = group.cases
     .map((entry) => renderConformanceTestCase(entry, classname))
     .join("\n");
 
-  return `  <testsuite name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${cases}\n  </testsuite>`;
+  return `  <testsuite name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${properties}${cases}\n  </testsuite>`;
 }
 
 export function renderConformanceReportJUnitXml(
@@ -627,19 +651,9 @@ export function renderConformanceReportJUnitXml(
   const time = (redactedReport.durationMs / 1000).toFixed(3);
   const name = escapeXml(redactedReport.name);
 
-  const suites = redactedReport.groups.map(renderConformanceTestSuite).join("\n");
+  const suites = redactedReport.groups
+    .map((group) => renderConformanceTestSuite(group, redactedReport.score))
+    .join("\n");
 
-  // JUnit has no score slot of its own, so the score rides in a top-level
-  // <properties> block — the schema-sanctioned extension point — leaving the
-  // test/failure/skip counts untouched for consumers that only read those.
-  const score = redactedReport.score;
-  const properties = score
-    ? `  <properties>\n    <property name="mcpjam.conformance.score" value="${
-        score.score === null ? "not-scored" : String(score.score)
-      }"/>\n    <property name="mcpjam.conformance.summary" value="${escapeXml(
-        describeConformanceScore(score),
-      )}"/>\n  </properties>\n`
-    : "";
-
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${properties}${suites}\n</testsuites>\n`;
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${suites}\n</testsuites>\n`;
 }

--- a/sdk/src/conformance-reporting.ts
+++ b/sdk/src/conformance-reporting.ts
@@ -2,6 +2,15 @@ import type {
   ConformanceRunOutcome,
   ConformanceSkipReason,
 } from "./conformance-outcome.js";
+import {
+  describeConformanceScore,
+  pooledConformanceScore,
+  scoreFromAppsResult,
+  scoreFromOAuthResult,
+  scoreFromProtocolResult,
+  scoreFromTasksResult,
+  type ConformanceScore,
+} from "./conformance-score.js";
 import { redactSensitiveValue } from "./redaction.js";
 import type {
   MCPConformanceResult,
@@ -71,6 +80,12 @@ export interface ConformanceReport {
    */
   outcome?: ConformanceRunOutcome;
   incompleteReason?: string;
+  /**
+   * The 0–100 conformance score (see `conformance-score.ts`). For a suite,
+   * the pooled score over its runs. `score.score` is null when nothing was
+   * applicable — e.g. OAuth against a server that serves without auth.
+   */
+  score?: ConformanceScore;
   durationMs: number;
   groups: ConformanceReportGroup[];
 }
@@ -403,6 +418,7 @@ function createProtocolReport(
       name: result.name,
       passed: result.passed,
       ...suiteOutcomeFields(result.results),
+      score: pooledConformanceScore(result.results.map(scoreFromProtocolResult)),
       durationMs: result.durationMs,
       groups: result.results.map((entry, index) =>
         mcpGroupFromResult(entry, entry.label, index),
@@ -416,6 +432,7 @@ function createProtocolReport(
     name: "MCP Protocol Conformance",
     passed: result.passed,
     ...outcomeFields(result),
+    score: scoreFromProtocolResult(result),
     durationMs: result.durationMs,
     groups: [mcpGroupFromResult(result, "MCP Protocol Conformance", 0)],
   };
@@ -431,6 +448,7 @@ function createAppsReport(
       name: result.name,
       passed: result.passed,
       ...suiteOutcomeFields(result.results),
+      score: pooledConformanceScore(result.results.map(scoreFromAppsResult)),
       durationMs: result.durationMs,
       groups: result.results.map((entry, index) =>
         appsGroupFromResult(entry, entry.label, index),
@@ -444,6 +462,7 @@ function createAppsReport(
     name: "MCP Apps Conformance",
     passed: result.passed,
     ...outcomeFields(result),
+    score: scoreFromAppsResult(result),
     durationMs: result.durationMs,
     groups: [appsGroupFromResult(result, "MCP Apps Conformance", 0)],
   };
@@ -459,6 +478,7 @@ function createOAuthReport(
       name: result.name,
       passed: result.passed,
       ...suiteOutcomeFields(result.results),
+      score: pooledConformanceScore(result.results.map(scoreFromOAuthResult)),
       durationMs: result.durationMs,
       groups: result.results.map((entry, index) =>
         oauthGroupFromResult(entry, entry.label, index),
@@ -472,6 +492,7 @@ function createOAuthReport(
     name: "OAuth Conformance",
     passed: result.passed,
     ...outcomeFields(result),
+    score: scoreFromOAuthResult(result),
     durationMs: result.durationMs,
     groups: [
       oauthGroupFromResult(
@@ -521,6 +542,7 @@ export function toConformanceReport(
       name: "MCP Tasks Conformance",
       passed: result.passed,
       ...outcomeFields(result),
+      score: scoreFromTasksResult(result),
       durationMs: result.durationMs,
       groups: [appsGroupFromResult(result, "MCP Tasks Conformance", 0, "tasks")],
     };
@@ -607,5 +629,17 @@ export function renderConformanceReportJUnitXml(
 
   const suites = redactedReport.groups.map(renderConformanceTestSuite).join("\n");
 
-  return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${suites}\n</testsuites>\n`;
+  // JUnit has no score slot of its own, so the score rides in a top-level
+  // <properties> block — the schema-sanctioned extension point — leaving the
+  // test/failure/skip counts untouched for consumers that only read those.
+  const score = redactedReport.score;
+  const properties = score
+    ? `  <properties>\n    <property name="mcpjam.conformance.score" value="${
+        score.score === null ? "not-scored" : String(score.score)
+      }"/>\n    <property name="mcpjam.conformance.summary" value="${escapeXml(
+        describeConformanceScore(score),
+      )}"/>\n  </properties>\n`
+    : "";
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites name="${name}" tests="${tests}" failures="${failures}" skipped="${skipped}" time="${time}">\n${properties}${suites}\n</testsuites>\n`;
 }

--- a/sdk/src/conformance-reporting.ts
+++ b/sdk/src/conformance-reporting.ts
@@ -221,6 +221,64 @@ function reportCaseFromOAuthStep(
   };
 }
 
+/**
+ * The three-value verdict for a single-run report. Declared on
+ * `ConformanceReport` since the skip-taxonomy change but never assigned by any
+ * builder, so `json-summary` could not tell a failed run from an incomplete
+ * one — exactly the distinction the field exists to carry.
+ *
+ * OAuth's own outcome union also contains `"not-applicable"`, which the
+ * report's three-value union does not; that value is omitted here, and
+ * consumers keep the documented fallback (`passed ? "passed" : "failed"`).
+ */
+function outcomeFields(result: {
+  outcome?: string;
+  incompleteReason?: string;
+}): Pick<ConformanceReport, "outcome" | "incompleteReason"> {
+  const outcome = result.outcome;
+  if (outcome !== "passed" && outcome !== "failed" && outcome !== "incomplete") {
+    return {};
+  }
+  return {
+    outcome,
+    ...(result.incompleteReason
+      ? { incompleteReason: result.incompleteReason }
+      : {}),
+  };
+}
+
+/**
+ * A suite's verdict is the worst of its runs — a failure outranks an
+ * incomplete, the same ordering the CLI exit codes use — and the first
+ * incomplete run's reason speaks for the suite.
+ */
+function suiteOutcomeFields(
+  results: ReadonlyArray<{
+    passed: boolean;
+    outcome?: string;
+    incompleteReason?: string;
+  }>,
+): Pick<ConformanceReport, "outcome" | "incompleteReason"> {
+  const outcomes = results.map(
+    (entry) => outcomeFields(entry).outcome ?? (entry.passed ? "passed" : "failed"),
+  );
+  if (outcomes.includes("failed")) {
+    return { outcome: "failed" };
+  }
+  if (outcomes.includes("incomplete")) {
+    const first = results.find(
+      (entry) => outcomeFields(entry).outcome === "incomplete",
+    );
+    return {
+      outcome: "incomplete",
+      ...(first?.incompleteReason
+        ? { incompleteReason: first.incompleteReason }
+        : {}),
+    };
+  }
+  return { outcome: "passed" };
+}
+
 function mcpGroupFromResult(
   result: MCPConformanceResult,
   title: string,
@@ -344,6 +402,7 @@ function createProtocolReport(
       kind: "protocol-conformance",
       name: result.name,
       passed: result.passed,
+      ...suiteOutcomeFields(result.results),
       durationMs: result.durationMs,
       groups: result.results.map((entry, index) =>
         mcpGroupFromResult(entry, entry.label, index),
@@ -356,6 +415,7 @@ function createProtocolReport(
     kind: "protocol-conformance",
     name: "MCP Protocol Conformance",
     passed: result.passed,
+    ...outcomeFields(result),
     durationMs: result.durationMs,
     groups: [mcpGroupFromResult(result, "MCP Protocol Conformance", 0)],
   };
@@ -370,6 +430,7 @@ function createAppsReport(
       kind: "apps-conformance",
       name: result.name,
       passed: result.passed,
+      ...suiteOutcomeFields(result.results),
       durationMs: result.durationMs,
       groups: result.results.map((entry, index) =>
         appsGroupFromResult(entry, entry.label, index),
@@ -382,6 +443,7 @@ function createAppsReport(
     kind: "apps-conformance",
     name: "MCP Apps Conformance",
     passed: result.passed,
+    ...outcomeFields(result),
     durationMs: result.durationMs,
     groups: [appsGroupFromResult(result, "MCP Apps Conformance", 0)],
   };
@@ -396,6 +458,7 @@ function createOAuthReport(
       kind: "oauth-conformance",
       name: result.name,
       passed: result.passed,
+      ...suiteOutcomeFields(result.results),
       durationMs: result.durationMs,
       groups: result.results.map((entry, index) =>
         oauthGroupFromResult(entry, entry.label, index),
@@ -408,6 +471,7 @@ function createOAuthReport(
     kind: "oauth-conformance",
     name: "OAuth Conformance",
     passed: result.passed,
+    ...outcomeFields(result),
     durationMs: result.durationMs,
     groups: [
       oauthGroupFromResult(
@@ -456,6 +520,7 @@ export function toConformanceReport(
       kind: "tasks-conformance",
       name: "MCP Tasks Conformance",
       passed: result.passed,
+      ...outcomeFields(result),
       durationMs: result.durationMs,
       groups: [appsGroupFromResult(result, "MCP Tasks Conformance", 0, "tasks")],
     };

--- a/sdk/src/conformance-score.ts
+++ b/sdk/src/conformance-score.ts
@@ -238,9 +238,11 @@ export function describeConformanceScore(score: ConformanceScore): string {
 export function scoreFromProtocolResult(
   result: MCPConformanceResult,
 ): ConformanceScore {
+  // `?? []`: a serialized result from an SDK that predates the readiness
+  // channel scores fine — it just has no advice to deduct.
   return computeConformanceScore(
     result.checks,
-    result.readiness.map((warning) => ({
+    (result.readiness ?? []).map((warning) => ({
       id: warning.id,
       tier: warning.specStrength === "MAY" ? "may" : "should",
     })),

--- a/sdk/src/conformance-score.ts
+++ b/sdk/src/conformance-score.ts
@@ -1,0 +1,325 @@
+/**
+ * The conformance score: one number, 0–100, computable for any suite and for
+ * all of them pooled.
+ *
+ * The shape is grounded in the spec's own doctrine rather than invented:
+ *
+ *   - The spec (every version's `basic/index.mdx`) defines requirement levels
+ *     via BCP 14 / RFC 2119 and has no conformance clause beyond them —
+ *     conformance IS the MUSTs. So MUSTs own 95 of the 100 points.
+ *   - SEP-2484 (Final): "Checks for SHOULD-level requirements report as
+ *     warnings rather than failures. MAY requirements do not need rows."
+ *     Advice therefore factors into the number — the last 5 points — but can
+ *     never masquerade as a failure: a MUST-clean server scores ≥95 no matter
+ *     how much advice fired.
+ *   - SEP-1730 sets tier lines at 100% and 80%; the 95/5 split keeps advice
+ *     from ever demoting a MUST-clean server across either line. The 95–100
+ *     band is reserved for runs that are MUST-clean and complete (a failed or
+ *     incomplete run caps at 94), so a violating server can never outrank a
+ *     clean-but-advised one and reading ≥95 always means the same thing.
+ *   - RFC 2119 makes RECOMMENDED the SHOULD tier ("SHOULD — this word, or the
+ *     adjective RECOMMENDED") and MAY the weakest, hence −2 / −1.
+ *
+ * The denominator rules come from `conformance-outcome.ts` and are what make
+ * the score honest:
+ *
+ *   - `not-applicable` checks leave the denominator entirely — a server
+ *     without auth, a stdio server's HTTP checks, a legacy pin's modern
+ *     checks: none of them cost points.
+ *   - `could-not-run` checks stay IN the denominator as unearned points, so
+ *     an incomplete run can never display 100.
+ *
+ * 100 therefore means exactly one thing: every applicable check ran and
+ * passed, and nothing was left to advise.
+ *
+ * Pure data reasoning — no MCP client, no transport, no Node built-ins — so
+ * it is exported from the browser entry alongside the catalog.
+ */
+
+import {
+  decideConformanceOutcome,
+  isInapplicableCheck,
+  isUnrunCheck,
+  type ConformanceRunOutcome,
+  type OutcomeCheckLike,
+} from "./conformance-outcome.js";
+import type { MCPConformanceResult } from "./mcp-conformance/types.js";
+import type {
+  MCPAppsConformanceResult,
+} from "./apps-conformance/types.js";
+import type {
+  MCPTasksConformanceResult,
+} from "./tasks-conformance/types.js";
+import type {
+  ConformanceResult as OAuthConformanceResult,
+} from "./oauth-conformance/types.js";
+
+/** MUSTs own this many of the 100 points; advice owns the remainder. */
+const MUST_POINTS = 95;
+const ADVICE_POINTS = 100 - MUST_POINTS;
+/** Per RFC 2119, RECOMMENDED is the SHOULD tier; MAY is the weakest. */
+const DEDUCTION_BY_TIER = { should: 2, may: 1 } as const;
+
+export type ConformanceAdvisoryTier = keyof typeof DEDUCTION_BY_TIER;
+
+/** One piece of advice that costs points: a readiness warning, a check warning. */
+export interface ScoredAdvisory {
+  id: string;
+  tier: ConformanceAdvisoryTier;
+}
+
+export interface ConformanceScore {
+  /**
+   * 0–100, or null when nothing was applicable — a server with no applicable
+   * checks has nothing to claim a number ABOUT, and inventing one would let a
+   * vacuous run outrank a real one.
+   */
+  score: number | null;
+  outcome: ConformanceRunOutcome;
+  /** The denominator: passed + failed + couldNotRun. Always display it. */
+  applicable: number;
+  passed: number;
+  failed: number;
+  couldNotRun: number;
+  notApplicable: number;
+  advisories: ScoredAdvisory[];
+  /** Points the advisories cost, after the cap. */
+  advicePointsLost: number;
+  /** The revision the score was judged against. Always display it. */
+  protocolVersion?: string;
+}
+
+function adviceDeduction(advisories: ScoredAdvisory[]): number {
+  const raw = advisories.reduce(
+    (sum, advisory) => sum + DEDUCTION_BY_TIER[advisory.tier],
+    0,
+  );
+  return Math.min(raw, ADVICE_POINTS);
+}
+
+function scoreFromCounts(
+  counts: Pick<
+    ConformanceScore,
+    "passed" | "failed" | "couldNotRun" | "notApplicable"
+  >,
+  advisories: ScoredAdvisory[],
+  outcome: ConformanceRunOutcome,
+  protocolVersion?: string,
+): ConformanceScore {
+  const applicable = counts.passed + counts.failed + counts.couldNotRun;
+  const advicePointsLost = adviceDeduction(advisories);
+
+  let score: number | null = null;
+  if (applicable > 0) {
+    const mustPoints = (MUST_POINTS * counts.passed) / applicable;
+    const advicePoints = ADVICE_POINTS - advicePointsLost;
+    score = Math.round(mustPoints + advicePoints);
+    // The bands must mean something, so two caps guard them:
+    //
+    //   - 95–100 is reserved for runs that are MUST-clean AND complete. With
+    //     a large enough denominator, one failure costs less than the 5-point
+    //     advice budget (95·25/26 + 5 ≈ 96), which would rank a violating
+    //     server above a clean-but-advised one. A failed or incomplete run
+    //     therefore caps at 94: reading ≥95 always means every applicable
+    //     MUST passed and was exercised.
+    //   - 100 is reserved for the run with nothing left to say. Rounding
+    //     alone would print 100 from 95·(n−1)/n + 5 once n ≈ 190.
+    if (outcome !== "passed") {
+      score = Math.min(score, MUST_POINTS - 1);
+    } else if (advisories.length > 0) {
+      score = Math.min(score, 99);
+    }
+  }
+
+  return {
+    score,
+    outcome,
+    applicable,
+    ...counts,
+    advisories,
+    advicePointsLost,
+    ...(protocolVersion !== undefined ? { protocolVersion } : {}),
+  };
+}
+
+/**
+ * Score one suite's checks. `advisories` is whatever advice channel the suite
+ * has (readiness warnings, per-check warnings) — pass an empty array for a
+ * suite without one.
+ */
+export function computeConformanceScore(
+  checks: OutcomeCheckLike[],
+  advisories: ScoredAdvisory[] = [],
+  protocolVersion?: string,
+): ConformanceScore {
+  const counts = {
+    passed: checks.filter((check) => check.status === "passed").length,
+    failed: checks.filter((check) => check.status === "failed").length,
+    couldNotRun: checks.filter(isUnrunCheck).length,
+    notApplicable: checks.filter(isInapplicableCheck).length,
+  };
+  // The outcome word comes from the shared verdict logic, never from the
+  // arithmetic — the score annotates the verdict, it does not override it.
+  const { outcome } = decideConformanceOutcome(checks);
+  return scoreFromCounts(counts, advisories, outcome, protocolVersion);
+}
+
+/**
+ * One number across suites. Counts are summed and the score re-derived, so a
+ * suite with many checks cannot drown one with few through averaging — and a
+ * 0-for-9 OAuth run stays visible inside 30 protocol passes.
+ *
+ * Parts with nothing applicable (score null — e.g. OAuth against a public
+ * server) contribute only their `notApplicable` tally: they are excluded from
+ * the denominator by construction, not by filtering.
+ */
+export function pooledConformanceScore(
+  parts: ConformanceScore[],
+): ConformanceScore {
+  const counts = {
+    passed: sum(parts, (part) => part.passed),
+    failed: sum(parts, (part) => part.failed),
+    couldNotRun: sum(parts, (part) => part.couldNotRun),
+    notApplicable: sum(parts, (part) => part.notApplicable),
+  };
+  const advisories = parts.flatMap((part) => part.advisories);
+
+  // Worst-of, failure outranking incomplete — the same ordering the CLI exit
+  // codes and suite reports use. Scoreless parts carry "passed" (nothing
+  // unverified) and so never drag the pool.
+  const outcomes = parts.map((part) => part.outcome);
+  const outcome: ConformanceRunOutcome = outcomes.includes("failed")
+    ? "failed"
+    : outcomes.includes("incomplete")
+      ? "incomplete"
+      : "passed";
+
+  const versions = new Set(
+    parts
+      .map((part) => part.protocolVersion)
+      .filter((version): version is string => version !== undefined),
+  );
+  const protocolVersion = versions.size === 1 ? [...versions][0] : undefined;
+
+  return scoreFromCounts(counts, advisories, outcome, protocolVersion);
+}
+
+function sum<T>(items: T[], select: (item: T) => number): number {
+  return items.reduce((total, item) => total + select(item), 0);
+}
+
+/** The one-line rendering every surface shares, so the wording cannot drift. */
+export function describeConformanceScore(score: ConformanceScore): string {
+  if (score.score === null) {
+    return `not scored — 0 applicable checks (${score.notApplicable} not applicable)`;
+  }
+  const parts = [
+    `${score.passed}/${score.applicable} applicable checks passed`,
+  ];
+  if (score.failed > 0) {
+    parts.push(`${score.failed} failed`);
+  }
+  if (score.couldNotRun > 0) {
+    parts.push(`${score.couldNotRun} could not run`);
+  }
+  if (score.advisories.length > 0) {
+    parts.push(
+      `${score.advisories.length} advisor${score.advisories.length === 1 ? "y" : "ies"} (−${score.advicePointsLost})`,
+    );
+  }
+  const version = score.protocolVersion ? ` [${score.protocolVersion}]` : "";
+  return `${score.score}/100 — ${parts.join(", ")}${version}`;
+}
+
+/**
+ * Protocol: checks verbatim; advice is the typed readiness channel, whose
+ * `specStrength` already names the RFC 2119 tier.
+ */
+export function scoreFromProtocolResult(
+  result: MCPConformanceResult,
+): ConformanceScore {
+  return computeConformanceScore(
+    result.checks,
+    result.readiness.map((warning) => ({
+      id: warning.id,
+      tier: warning.specStrength === "MAY" ? "may" : "should",
+    })),
+    result.protocolVersion,
+  );
+}
+
+/**
+ * Apps and Tasks share a check shape. Their advice channel is the per-check
+ * free-string `warnings` — untyped, so each entry counts at the WEAKEST tier:
+ * a string with no declared spec strength must not cost what a SHOULD does.
+ */
+function scoreFromWarningChecks(
+  checks: Array<OutcomeCheckLike & { warnings?: string[] }>,
+  protocolVersion?: string,
+): ConformanceScore {
+  return computeConformanceScore(
+    checks,
+    checks.flatMap((check) =>
+      (check.warnings ?? []).map((_, index) => ({
+        id: `${check.id}-warning-${index + 1}`,
+        tier: "may" as const,
+      })),
+    ),
+    protocolVersion,
+  );
+}
+
+export function scoreFromAppsResult(
+  result: MCPAppsConformanceResult,
+): ConformanceScore {
+  return scoreFromWarningChecks(result.checks);
+}
+
+export function scoreFromTasksResult(
+  result: MCPTasksConformanceResult,
+): ConformanceScore {
+  return scoreFromWarningChecks(
+    result.checks,
+    result.discovery.protocolVersion,
+  );
+}
+
+/**
+ * OAuth is the outlier twice over.
+ *
+ * Its `"not-applicable"` outcome (the server serves without auth, which the
+ * spec makes OPTIONAL) means the whole suite has nothing to score: null, zero
+ * applicable, every step tallied as not-applicable. That is the mechanism by
+ * which "a server without auth shouldn't deduct points" holds.
+ *
+ * Otherwise its steps adapt structurally (`step` → `id`) and are counted
+ * directly — deliberately NOT trusting the suite's own `outcome`, which can
+ * currently report "passed" over could-not-run steps. The score reads the
+ * evidence, not the verdict. `teachableMoments` are explanations of failures
+ * already costed at MUST weight, never advisories.
+ */
+export function scoreFromOAuthResult(
+  result: OAuthConformanceResult,
+): ConformanceScore {
+  if (result.outcome === "not-applicable") {
+    return scoreFromCounts(
+      {
+        passed: 0,
+        failed: 0,
+        couldNotRun: 0,
+        notApplicable: result.steps.length,
+      },
+      [],
+      "passed",
+      result.protocolVersion,
+    );
+  }
+
+  const checks: OutcomeCheckLike[] = result.steps.map((step) => ({
+    id: step.step,
+    status: step.status,
+    ...(step.skipReason ? { skipReason: step.skipReason } : {}),
+    ...(step.error?.message ? { error: { message: step.error.message } } : {}),
+  }));
+  return computeConformanceScore(checks, [], result.protocolVersion);
+}

--- a/sdk/src/conformance-score.ts
+++ b/sdk/src/conformance-score.ts
@@ -194,12 +194,16 @@ export function pooledConformanceScore(
       ? "incomplete"
       : "passed";
 
-  const versions = new Set(
-    parts
-      .map((part) => part.protocolVersion)
-      .filter((version): version is string => version !== undefined),
-  );
-  const protocolVersion = versions.size === 1 ? [...versions][0] : undefined;
+  // Strict: EVERY part must state the same version for the pool to claim one.
+  // A part without a version is a run that established none, and labeling the
+  // pool from the parts that did would overstate what was judged. Scoreless
+  // parts (nothing applicable) constrain nothing — they judged nothing.
+  const constraining = parts.filter((part) => part.applicable > 0);
+  const versions = new Set(constraining.map((part) => part.protocolVersion));
+  const protocolVersion =
+    constraining.length > 0 && versions.size === 1
+      ? [...versions][0]
+      : undefined;
 
   return scoreFromCounts(counts, advisories, outcome, protocolVersion);
 }
@@ -274,7 +278,7 @@ function scoreFromWarningChecks(
 export function scoreFromAppsResult(
   result: MCPAppsConformanceResult,
 ): ConformanceScore {
-  return scoreFromWarningChecks(result.checks);
+  return scoreFromWarningChecks(result.checks, result.protocolVersion);
 }
 
 export function scoreFromTasksResult(

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -298,6 +298,31 @@ export type {
   ConformanceReportKind,
   SupportedConformanceResult,
 } from "./conformance-reporting.js";
+export {
+  buildOutcomeSummary,
+  decideConformanceOutcome,
+  isInapplicableCheck,
+  isUnrunCheck,
+} from "./conformance-outcome.js";
+export type {
+  ConformanceRunOutcome,
+  ConformanceSkipReason,
+  OutcomeCheckLike,
+} from "./conformance-outcome.js";
+export {
+  computeConformanceScore,
+  describeConformanceScore,
+  pooledConformanceScore,
+  scoreFromAppsResult,
+  scoreFromOAuthResult,
+  scoreFromProtocolResult,
+  scoreFromTasksResult,
+} from "./conformance-score.js";
+export type {
+  ConformanceAdvisoryTier,
+  ConformanceScore,
+  ScoredAdvisory,
+} from "./conformance-score.js";
 export { runOAuthLogin } from "./oauth-login.js";
 export type {
   OAuthLoginConfig,

--- a/sdk/src/mcp-conformance/runner.ts
+++ b/sdk/src/mcp-conformance/runner.ts
@@ -508,6 +508,11 @@ export class MCPConformanceTest {
         ? { incompleteReason: verdict.incompleteReason }
         : {}),
       serverUrl: this.config.serverUrl,
+      // The EFFECTIVE version: the pin, or the negotiated upgrade when the
+      // run connected without one. Undefined for an unpinned raw-only run.
+      ...(clientRun.config.protocolVersion !== undefined
+        ? { protocolVersion: clientRun.config.protocolVersion }
+        : {}),
       checks,
       summary: buildSummary(checks),
       durationMs: Date.now() - startedAt,

--- a/sdk/src/mcp-conformance/types.ts
+++ b/sdk/src/mcp-conformance/types.ts
@@ -376,6 +376,13 @@ export interface MCPConformanceResult {
    */
   incompleteReason?: string;
   serverUrl: string;
+  /**
+   * The revision this run was judged against: the caller's pin, or the
+   * version the server negotiated when the run connected without one. Absent
+   * when an unpinned run never connected (raw-only selection) — the run
+   * established no version, and a score label must not invent one.
+   */
+  protocolVersion?: McpProtocolVersion;
   checks: MCPCheckResult[];
   summary: string;
   durationMs: number;

--- a/sdk/tests/conformance-reporting.test.ts
+++ b/sdk/tests/conformance-reporting.test.ts
@@ -326,7 +326,7 @@ describe("report score", () => {
     expect(suite.score?.failed).toBeGreaterThan(0);
   });
 
-  it("emits the score as JUnit properties without touching the counts", () => {
+  it("emits the score as properties inside each <testsuite>, never under the root", () => {
     const xml = renderConformanceReportJUnitXml(
       toConformanceReport(createAppsResult()),
     );
@@ -334,6 +334,27 @@ describe("report score", () => {
     expect(xml).toContain('<property name="mcpjam.conformance.score" value="100"/>');
     expect(xml).toContain('name="mcpjam.conformance.summary"');
     expect(xml).toContain('tests="1" failures="0" skipped="0"');
+    // JUnit XSDs (Jenkins, Ant, Surefire) place <properties> under
+    // <testsuite>; a root-level block is schema-invalid.
+    expect(xml).toMatch(/<testsuite [^>]*>\n    <properties>/);
+    expect(xml).not.toMatch(/<testsuites [^>]*>\n\s*<properties>/);
+  });
+
+  it("does not fail an OAuth suite whose only non-passing flow is not-applicable", () => {
+    const suite = createOAuthSuiteResult();
+    suite.passed = true;
+    suite.results = [
+      { ...createOAuthResult({ passed: true, outcome: "passed", steps: [] }), label: "dcr" },
+      {
+        ...createOAuthResult({ passed: false, outcome: "not-applicable", steps: [] }),
+        label: "no-auth",
+      },
+    ];
+
+    const report = toConformanceReport(suite);
+    // A no-auth flow is not a pass, but authorization is OPTIONAL — it must
+    // not drag the suite verdict to failed.
+    expect(report.outcome).toBe("passed");
   });
 
   it("reports not-scored for an OAuth run against a server without auth", () => {

--- a/sdk/tests/conformance-reporting.test.ts
+++ b/sdk/tests/conformance-reporting.test.ts
@@ -47,6 +47,7 @@ function createProtocolResult(
     ],
     summary: "0/2 checks passed, 1 failed, 1 skipped",
     durationMs: 25,
+    readiness: [],
     categorySummary: {
       core: { total: 1, passed: 0, failed: 1, skipped: 0 },
       protocol: { total: 0, passed: 0, failed: 0, skipped: 0 },
@@ -287,6 +288,64 @@ describe("report outcome fields", () => {
     // Consumers keep the documented fallback: passed ? "passed" : "failed".
     expect(report.outcome).toBeUndefined();
     expect(report.passed).toBe(true);
+  });
+});
+
+describe("report score", () => {
+  it("scores every report kind, pooling suites over their runs", () => {
+    const single = toConformanceReport(
+      createProtocolResult({
+        checks: [
+          {
+            id: "ping",
+            category: "core",
+            title: "Ping",
+            description: "Ping.",
+            status: "passed",
+            durationMs: 1,
+          },
+        ],
+        readiness: [
+          {
+            id: "readiness-metadata-quality",
+            title: "Metadata Quality",
+            severity: "warning",
+            specStrength: "SHOULD",
+            message: "…",
+          },
+        ],
+      } as Partial<MCPConformanceResult>),
+    );
+
+    // 1/1 applicable passed, one SHOULD advisory: 95 + (5 − 2) = 98.
+    expect(single.score?.score).toBe(98);
+    expect(single.score?.applicable).toBe(1);
+
+    const suite = toConformanceReport(createProtocolSuiteResult());
+    expect(suite.score).toBeDefined();
+    expect(suite.score?.failed).toBeGreaterThan(0);
+  });
+
+  it("emits the score as JUnit properties without touching the counts", () => {
+    const xml = renderConformanceReportJUnitXml(
+      toConformanceReport(createAppsResult()),
+    );
+
+    expect(xml).toContain('<property name="mcpjam.conformance.score" value="100"/>');
+    expect(xml).toContain('name="mcpjam.conformance.summary"');
+    expect(xml).toContain('tests="1" failures="0" skipped="0"');
+  });
+
+  it("reports not-scored for an OAuth run against a server without auth", () => {
+    const report = toConformanceReport(
+      createOAuthResult({ passed: true, outcome: "not-applicable" }),
+    );
+    expect(report.score?.score).toBeNull();
+
+    const xml = renderConformanceReportJUnitXml(report);
+    expect(xml).toContain(
+      '<property name="mcpjam.conformance.score" value="not-scored"/>',
+    );
   });
 });
 

--- a/sdk/tests/conformance-reporting.test.ts
+++ b/sdk/tests/conformance-reporting.test.ts
@@ -231,6 +231,65 @@ describe("toConformanceReport", () => {
   });
 });
 
+describe("report outcome fields", () => {
+  it("carries a single run's outcome and incompleteReason through", () => {
+    const incomplete = toConformanceReport(
+      createProtocolResult({
+        passed: false,
+        outcome: "incomplete",
+        incompleteReason: "1 of 2 selected check(s) could not run",
+      }),
+    );
+
+    expect(incomplete.outcome).toBe("incomplete");
+    expect(incomplete.incompleteReason).toMatch(/could not run/);
+
+    const failed = toConformanceReport(
+      createProtocolResult({ passed: false, outcome: "failed" }),
+    );
+    expect(failed.outcome).toBe("failed");
+    expect(failed.incompleteReason).toBeUndefined();
+  });
+
+  it("derives a suite outcome as the worst of its runs, failure outranking incomplete", () => {
+    const suite = createProtocolSuiteResult();
+    suite.results = [
+      {
+        ...createProtocolResult({ passed: true, checks: [], outcome: "passed" }),
+        label: "Run 1",
+      },
+      {
+        ...createProtocolResult({
+          passed: false,
+          outcome: "incomplete",
+          incompleteReason: "probe unavailable",
+        }),
+        label: "Run 2",
+      },
+    ];
+
+    const incompleteSuite = toConformanceReport(suite);
+    expect(incompleteSuite.outcome).toBe("incomplete");
+    expect(incompleteSuite.incompleteReason).toBe("probe unavailable");
+
+    suite.results.push({
+      ...createProtocolResult({ passed: false, outcome: "failed" }),
+      label: "Run 3",
+    });
+    expect(toConformanceReport(suite).outcome).toBe("failed");
+  });
+
+  it("omits outcome for OAuth's not-applicable, which the report union does not carry", () => {
+    const report = toConformanceReport(
+      createOAuthResult({ passed: true, outcome: "not-applicable" }),
+    );
+
+    // Consumers keep the documented fallback: passed ? "passed" : "failed".
+    expect(report.outcome).toBeUndefined();
+    expect(report.passed).toBe(true);
+  });
+});
+
 describe("renderConformanceReportJson", () => {
   it("redacts sensitive values", () => {
     const report = toConformanceReport(createOAuthResult());

--- a/sdk/tests/conformance-score.test.ts
+++ b/sdk/tests/conformance-score.test.ts
@@ -216,13 +216,27 @@ describe("pooledConformanceScore", () => {
     expect(pooled.notApplicable).toBe(5);
   });
 
-  it("keeps the version label only when every part agrees on it", () => {
+  it("labels the pool only when every scoring part states the same version", () => {
     const a = computeConformanceScore(passing(2), [], "2025-11-25");
     const b = computeConformanceScore(passing(2), [], "2025-11-25");
     expect(pooledConformanceScore([a, b]).protocolVersion).toBe("2025-11-25");
 
     const c = computeConformanceScore(passing(2), [], "2026-07-28");
     expect(pooledConformanceScore([a, c]).protocolVersion).toBeUndefined();
+
+    // A part that judged checks WITHOUT establishing a version bars the label:
+    // claiming 2025-11-25 for a pool containing versionless judgements would
+    // overstate what was judged against.
+    const versionless = computeConformanceScore(passing(2));
+    expect(pooledConformanceScore([a, versionless]).protocolVersion).toBeUndefined();
+
+    // A scoreless part constrains nothing — it judged nothing.
+    const scoreless = computeConformanceScore([
+      check("na", "skipped", "not-applicable"),
+    ]);
+    expect(pooledConformanceScore([a, scoreless]).protocolVersion).toBe(
+      "2025-11-25",
+    );
   });
 
   it("takes the worst outcome, failure outranking incomplete", () => {

--- a/sdk/tests/conformance-score.test.ts
+++ b/sdk/tests/conformance-score.test.ts
@@ -1,0 +1,456 @@
+/**
+ * The conformance score: MUSTs own 95 points, advice owns 5, and the
+ * denominator rules from `conformance-outcome.ts` keep the number honest.
+ * Every property asserted here is one a caller will quote to a server author,
+ * so each has a test: not-applicable costs nothing, could-not-run caps below
+ * 100, advice can never breach the 95-point MUST floor, and 100 means
+ * "everything applicable passed and nothing was left to advise".
+ */
+
+import {
+  computeConformanceScore,
+  describeConformanceScore,
+  pooledConformanceScore,
+  scoreFromAppsResult,
+  scoreFromOAuthResult,
+  scoreFromProtocolResult,
+  scoreFromTasksResult,
+  type ConformanceScore,
+} from "../src/conformance-score.js";
+import type { OutcomeCheckLike } from "../src/conformance-outcome.js";
+import type { MCPConformanceResult } from "../src/mcp-conformance/types.js";
+import type { ConformanceResult as OAuthConformanceResult } from "../src/oauth-conformance/types.js";
+
+function check(
+  id: string,
+  status: OutcomeCheckLike["status"],
+  skipReason?: "not-applicable" | "could-not-run",
+): OutcomeCheckLike {
+  return {
+    id,
+    status,
+    ...(skipReason ? { skipReason } : {}),
+    ...(skipReason === "could-not-run"
+      ? { error: { message: `${id} could not run` } }
+      : {}),
+  };
+}
+
+function passing(count: number): OutcomeCheckLike[] {
+  return Array.from({ length: count }, (_, index) =>
+    check(`check-${index + 1}`, "passed"),
+  );
+}
+
+describe("computeConformanceScore", () => {
+  it("scores 100 only when every applicable check passed and no advice fired", () => {
+    const clean = computeConformanceScore(passing(26));
+    expect(clean.score).toBe(100);
+    expect(clean.outcome).toBe("passed");
+
+    const withAdvice = computeConformanceScore(passing(26), [
+      { id: "readiness-metadata-quality", tier: "should" },
+    ]);
+    expect(withAdvice.score).toBe(98);
+    expect(withAdvice.outcome).toBe("passed");
+    expect(withAdvice.advicePointsLost).toBe(2);
+  });
+
+  it("leaves not-applicable checks out of the denominator entirely — the no-auth case", () => {
+    const checks = [
+      ...passing(11),
+      ...Array.from({ length: 9 }, (_, index) =>
+        check(`oauth-${index + 1}`, "skipped", "not-applicable"),
+      ),
+    ];
+    const score = computeConformanceScore(checks);
+
+    expect(score.applicable).toBe(11);
+    expect(score.notApplicable).toBe(9);
+    expect(score.score).toBe(100);
+  });
+
+  it("keeps could-not-run in the denominator, so an incomplete run cannot reach 100", () => {
+    const score = computeConformanceScore([
+      ...passing(25),
+      check("unrun", "skipped", "could-not-run"),
+    ]);
+
+    expect(score.outcome).toBe("incomplete");
+    expect(score.applicable).toBe(26);
+    // 95 × 25/26 + 5 = 96.3 — but an incomplete run is barred from the
+    // MUST-clean band, so it reads 94 at most.
+    expect(score.score).toBe(94);
+  });
+
+  it("reserves the 95–100 band for MUST-clean, complete runs", () => {
+    // With a large denominator one failure costs less than the 5-point advice
+    // budget (95 × 199/200 + 5 = 99.5), which would rank a violating server
+    // above a clean-but-advised one. The band cap prevents exactly that.
+    const failedOne = computeConformanceScore([
+      ...passing(199),
+      check("failed-one", "failed"),
+    ]);
+    expect(failedOne.score).toBe(94);
+    expect(failedOne.outcome).toBe("failed");
+
+    const unrunOne = computeConformanceScore([
+      ...passing(199),
+      check("unrun-one", "skipped", "could-not-run"),
+    ]);
+    expect(unrunOne.score).toBe(94);
+
+    // A MUST-clean run with advice stays in the band but below 100 — rounding
+    // alone would have printed 100 here.
+    const advisedOnly = computeConformanceScore(passing(200), [
+      { id: "advice", tier: "may" },
+    ]);
+    expect(advisedOnly.score).toBe(99);
+    expect(advisedOnly.outcome).toBe("passed");
+  });
+
+  it("keeps a MUST-clean server at or above 95 no matter how much advice fired", () => {
+    const advisories = Array.from({ length: 40 }, (_, index) => ({
+      id: `advice-${index + 1}`,
+      tier: "should" as const,
+    }));
+    const score = computeConformanceScore(passing(10), advisories);
+
+    // SEP-2484: SHOULD-level findings are warnings, not failures. The advice
+    // deduction floors at the 5-point advice budget, so no volume of advice
+    // can demote a MUST-clean server across SEP-1730's 80/100 tier lines.
+    expect(score.score).toBe(95);
+    expect(score.advicePointsLost).toBe(5);
+    expect(score.outcome).toBe("passed");
+  });
+
+  it("weights SHOULD/RECOMMENDED advice at 2 points and MAY at 1", () => {
+    const should = computeConformanceScore(passing(10), [
+      { id: "a", tier: "should" },
+    ]);
+    const may = computeConformanceScore(passing(10), [{ id: "a", tier: "may" }]);
+
+    expect(should.score).toBe(98);
+    expect(may.score).toBe(99);
+  });
+
+  it("never ranks a violating server above a MUST-clean one", () => {
+    // The ordering property the bands guarantee: any failed run scores below
+    // the floor (95) of any MUST-clean run, whatever the denominators.
+    const oneFailure = computeConformanceScore([
+      ...passing(25),
+      check("failed", "failed"),
+    ]);
+    const maxAdvice = computeConformanceScore(
+      passing(26),
+      Array.from({ length: 10 }, (_, index) => ({
+        id: `advice-${index}`,
+        tier: "should" as const,
+      })),
+    );
+
+    expect(oneFailure.score).toBeLessThan(maxAdvice.score!);
+    expect(maxAdvice.score).toBe(95);
+    expect(oneFailure.score).toBe(94);
+  });
+
+  it("returns null when nothing was applicable — no number over a vacuous run", () => {
+    const score = computeConformanceScore([
+      check("a", "skipped", "not-applicable"),
+      check("b", "skipped", "not-applicable"),
+    ]);
+
+    expect(score.score).toBeNull();
+    expect(score.applicable).toBe(0);
+    expect(score.notApplicable).toBe(2);
+  });
+
+  it("takes the outcome word from the shared verdict logic, never the arithmetic", () => {
+    const failed = computeConformanceScore([
+      ...passing(3),
+      check("bad", "failed"),
+    ]);
+    expect(failed.outcome).toBe("failed");
+    // 95 × 3/4 + 5 = 76.25 → 76, under the band cap.
+    expect(failed.score).toBe(76);
+  });
+});
+
+describe("pooledConformanceScore", () => {
+  it("sums counts so a small suite cannot drown inside a large one", () => {
+    const protocol = computeConformanceScore(passing(30));
+    const oauth = computeConformanceScore(
+      Array.from({ length: 9 }, (_, index) => check(`o-${index}`, "failed")),
+    );
+
+    const pooled = pooledConformanceScore([protocol, oauth]);
+
+    expect(pooled.applicable).toBe(39);
+    expect(pooled.passed).toBe(30);
+    expect(pooled.failed).toBe(9);
+    // 95 × 30/39 + 5 = 78 — an average of suite scores (≈ (100+5)/2 = 52 or
+    // a naive mean of 100 and 5) would say something different; summing is
+    // what keeps the 0-for-9 OAuth run visible.
+    expect(pooled.score).toBe(78);
+    expect(pooled.outcome).toBe("failed");
+  });
+
+  it("lets a scoreless part contribute only its not-applicable tally", () => {
+    const protocol = computeConformanceScore(passing(20));
+    const oauthNotApplicable: ConformanceScore = {
+      score: null,
+      outcome: "passed",
+      applicable: 0,
+      passed: 0,
+      failed: 0,
+      couldNotRun: 0,
+      notApplicable: 5,
+      advisories: [],
+      advicePointsLost: 0,
+    };
+
+    const pooled = pooledConformanceScore([protocol, oauthNotApplicable]);
+
+    expect(pooled.score).toBe(100);
+    expect(pooled.applicable).toBe(20);
+    expect(pooled.notApplicable).toBe(5);
+  });
+
+  it("keeps the version label only when every part agrees on it", () => {
+    const a = computeConformanceScore(passing(2), [], "2025-11-25");
+    const b = computeConformanceScore(passing(2), [], "2025-11-25");
+    expect(pooledConformanceScore([a, b]).protocolVersion).toBe("2025-11-25");
+
+    const c = computeConformanceScore(passing(2), [], "2026-07-28");
+    expect(pooledConformanceScore([a, c]).protocolVersion).toBeUndefined();
+  });
+
+  it("takes the worst outcome, failure outranking incomplete", () => {
+    const incomplete = computeConformanceScore([
+      check("u", "skipped", "could-not-run"),
+    ]);
+    const failed = computeConformanceScore([check("f", "failed")]);
+    const passed = computeConformanceScore(passing(1));
+
+    expect(pooledConformanceScore([passed, incomplete]).outcome).toBe(
+      "incomplete",
+    );
+    expect(pooledConformanceScore([passed, incomplete, failed]).outcome).toBe(
+      "failed",
+    );
+  });
+});
+
+describe("describeConformanceScore", () => {
+  it("always shows the number, the denominator, and the version", () => {
+    const line = describeConformanceScore(
+      computeConformanceScore(
+        [...passing(24), check("f1", "failed"), check("f2", "failed")],
+        [{ id: "advice", tier: "should" }],
+        "2025-11-25",
+      ),
+    );
+
+    expect(line).toBe(
+      "91/100 — 24/26 applicable checks passed, 2 failed, 1 advisory (−2) [2025-11-25]",
+    );
+  });
+
+  it("says why there is no number instead of inventing one", () => {
+    const line = describeConformanceScore(
+      computeConformanceScore([check("a", "skipped", "not-applicable")]),
+    );
+    expect(line).toBe("not scored — 0 applicable checks (1 not applicable)");
+  });
+});
+
+describe("suite adapters", () => {
+  function protocolResult(
+    overrides: Partial<MCPConformanceResult> = {},
+  ): MCPConformanceResult {
+    return {
+      passed: true,
+      outcome: "passed",
+      serverUrl: "https://mcp.example.com/mcp",
+      protocolVersion: "2025-11-25",
+      checks: [
+        {
+          id: "ping",
+          category: "core",
+          title: "Ping",
+          description: "Ping.",
+          status: "passed",
+          durationMs: 1,
+        },
+        {
+          id: "tools-list",
+          category: "tools",
+          title: "Tools List",
+          description: "List tools.",
+          status: "skipped",
+          skipReason: "not-applicable",
+          durationMs: 0,
+        },
+      ],
+      summary: "",
+      durationMs: 1,
+      categorySummary: {} as MCPConformanceResult["categorySummary"],
+      readiness: [
+        {
+          id: "readiness-metadata-quality",
+          title: "Metadata Quality",
+          severity: "warning",
+          specStrength: "SHOULD",
+          message: "…",
+        },
+        {
+          id: "readiness-parse-error-handling",
+          title: "Parse Error Handling",
+          severity: "warning",
+          specStrength: "MAY",
+          message: "…",
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  it("maps protocol readiness onto tiers by spec strength, RECOMMENDED folding into SHOULD", () => {
+    const score = scoreFromProtocolResult(
+      protocolResult({
+        readiness: [
+          {
+            id: "readiness-oauth-iss-advertised",
+            title: "iss",
+            severity: "warning",
+            specStrength: "RECOMMENDED",
+            message: "…",
+          },
+        ],
+      }),
+    );
+
+    expect(score.advisories).toEqual([
+      { id: "readiness-oauth-iss-advertised", tier: "should" },
+    ]);
+    expect(score.score).toBe(98);
+    expect(score.protocolVersion).toBe("2025-11-25");
+  });
+
+  it("scores protocol checks with the readiness deduction applied", () => {
+    const score = scoreFromProtocolResult(protocolResult());
+    // 1/1 applicable passed; SHOULD (−2) + MAY (−1) advice → 97.
+    expect(score.score).toBe(97);
+    expect(score.notApplicable).toBe(1);
+  });
+
+  it("counts untyped apps/tasks check warnings at the weakest tier", () => {
+    const base = {
+      passed: true,
+      outcome: "passed" as const,
+      target: "node server.js",
+      summary: "",
+      durationMs: 1,
+      categorySummary: {},
+      checks: [
+        {
+          id: "ui-tools-present",
+          category: "tools",
+          title: "UI Tools Present",
+          description: "…",
+          status: "passed" as const,
+          durationMs: 1,
+          warnings: ["tool foo has no description", "tool bar has no title"],
+        },
+      ],
+    };
+
+    const apps = scoreFromAppsResult({
+      ...base,
+      discovery: {
+        toolCount: 1,
+        uiToolCount: 1,
+        listedResourceCount: 0,
+        listedUiResourceCount: 0,
+        checkedUiResourceCount: 0,
+      },
+    } as never);
+
+    expect(apps.advisories).toHaveLength(2);
+    expect(apps.advisories.every((advisory) => advisory.tier === "may")).toBe(
+      true,
+    );
+    expect(apps.score).toBe(98);
+
+    const tasks = scoreFromTasksResult({
+      ...base,
+      discovery: {
+        protocolVersion: "2025-11-25",
+        wire: "extension",
+        toolCount: 1,
+        taskCapableToolCount: 1,
+      },
+    } as never);
+    expect(tasks.protocolVersion).toBe("2025-11-25");
+  });
+
+  function oauthResult(
+    overrides: Partial<OAuthConformanceResult> = {},
+  ): OAuthConformanceResult {
+    return {
+      passed: true,
+      outcome: "passed",
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      serverUrl: "https://mcp.example.com/mcp",
+      steps: [
+        {
+          step: "request_without_token",
+          title: "Initial MCP Request",
+          summary: "…",
+          status: "passed",
+          durationMs: 1,
+          logs: [],
+          httpAttempts: [],
+        },
+        {
+          step: "verify_list_tools",
+          title: "List Tools",
+          summary: "…",
+          status: "skipped",
+          skipReason: "could-not-run",
+          durationMs: 0,
+          logs: [],
+          httpAttempts: [],
+          error: { message: "verification never ran" },
+        },
+      ],
+      summary: "",
+      durationMs: 2,
+      ...overrides,
+    };
+  }
+
+  it("scores OAuth from the step evidence, not the suite's own verdict", () => {
+    // The runner can currently stamp outcome "passed" over could-not-run
+    // steps; the score must not inherit that. 1 passed + 1 unrun of 2
+    // applicable → 95 × 1/2 + 5 = 52.5 → 53, outcome incomplete.
+    const score = scoreFromOAuthResult(oauthResult());
+
+    expect(score.outcome).toBe("incomplete");
+    expect(score.applicable).toBe(2);
+    expect(score.couldNotRun).toBe(1);
+    expect(score.score).toBe(53);
+  });
+
+  it("returns a scoreless result for a server without auth — OPTIONAL costs nothing", () => {
+    const score = scoreFromOAuthResult(
+      oauthResult({ outcome: "not-applicable" }),
+    );
+
+    expect(score.score).toBeNull();
+    expect(score.applicable).toBe(0);
+    expect(score.notApplicable).toBe(2);
+    expect(score.outcome).toBe("passed");
+  });
+});


### PR DESCRIPTION
The conformance score: **one number, 0–100, with advice included in it** — the followup the skip taxonomy (#3680), honest OAuth no-auth handling (#3675), and the transport MUSTs (#3687) existed to make possible.

## The formula, grounded in the spec's own doctrine

```
applicable   = passed + failed + couldNotRun          # not-applicable excluded entirely
score        = 95 × passed/applicable  +  (5 − advice deductions, floored at 0)
```

- **MUSTs own 95 points.** The spec has no conformance clause beyond its RFC 2119 requirement levels — conformance *is* the MUSTs (every version's `basic/index.mdx` incorporates BCP 14 by reference and nothing else defines conformance).
- **Advice owns 5.** SEP-2484 (Final): *"Checks for SHOULD-level requirements report as warnings rather than failures. MAY requirements do not need rows."* Advice therefore moves the number — SHOULD/RECOMMENDED −2, MAY −1, capped at the 5-point budget — but can never masquerade as a failure. RECOMMENDED folds into the SHOULD tier per RFC 2119's own definition.
- **`not-applicable` leaves the denominator.** A server without auth (authorization is OPTIONAL), a stdio server's HTTP checks, a legacy pin's modern checks: none cost a point. This is the mechanism, not a special case.
- **`could-not-run` stays in the denominator** as unearned points, so an incomplete run cannot claim a number it never established.
- **The 95–100 band is reserved for MUST-clean, complete runs.** With a large denominator, one failure costs less than the advice budget (95·25/26 + 5 ≈ 96), which would rank a violating server above a clean-but-advised one — so failed/incomplete runs cap at 94, and reading ≥95 always means every applicable MUST passed. **100** means one thing: everything applicable passed and nothing was left to advise.
- **The number always ships with its denominator and version** — "100 of 11 applicable" and "100 of 38" are different servers, and only the label says which revision was judged.

Pooling sums **counts**, never averages suite scores, so a 0-for-9 OAuth run stays visible inside 30 protocol passes. SEP-1730's percentage badges ("90% MCP Compliant", tiers at 100/80) are the upstream precedent for the number itself.

## Where it lives

All in the SDK (`sdk/src/conformance-score.ts`, pure and browser-safe like the catalog), so every surface reports the same number:

- **Inspector**: pooled headline card (number, verdict word, denominator + version) and per-suite score chips. **Readiness warnings are now rendered** — advice costs points, and an invisible deduction is indistinguishable from a bug. A not-applicable OAuth run is labelled and pooled without deducting; when *nothing* was applicable, no card renders at all rather than a dash pretending to be a number.
- **CLI**: a `Score:` stderr line on all four conformance commands (and per-run in suites), beside the existing incomplete/advice lines. Exit codes untouched. Live against the Excalidraw server:
  `Score: 98/100 — 13/13 applicable checks passed, 1 advisory (−2) [2025-11-25]`
- **Reporters**: `score` on every `ConformanceReport` (pooled for suites); JUnit carries it in a `<properties>` block with counts untouched.
- **Hosted routes**: zero changes — they return SDK results verbatim.

Two supporting changes:
- `MCPConformanceResult.protocolVersion` (additive): the effective revision — pin or negotiated — so the score label is data, not caller memory.
- **Bugfix (own commit):** `ConformanceReport.outcome`/`incompleteReason` were declared but never assigned by any builder, so json-summary could not tell a failed run from an incomplete one. Singles copy their run's verdict; suites take the worst of their runs (failure outranks incomplete, matching the exit-code ordering).

Deliberate judgment calls, called out for review:
- **OAuth is scored from step evidence, not the suite's own verdict** — the runner can currently stamp `passed` over could-not-run steps; the score refuses to inherit that. (Fixing the runner itself is noted as a follow-up.)
- Apps/tasks free-string check `warnings` count at the **weakest tier** (MAY): a string with no declared spec strength must not cost what a SHOULD does. OAuth `teachableMoments` are never advisories — they explain failures already costed at MUST weight.

## Verification

- SDK: **3656 passed** across 196 files, including 20 formula/adapter tests; **13 of the 20 fail against a naive `passed/(passed+failed)`** implementation (verified by swapping it in), so the guards constrain the formula rather than decorate it
- CLI: **552 passed**; inspector panel: **27 passed**; client CI typecheck clean; root `npm run typecheck` clean across all six packages
- Browser guards green — the score module and outcome vocabulary are exported from `@mcpjam/sdk/browser`
- Live: the Excalidraw endpoint scores 98/100 with the deducting advisory (Metadata Quality, SHOULD) named beneath the number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches conformance verdict reporting and a new scoring formula used in CI/reporters; behavior is heavily tested but wrong weighting or pooling would mislead users comparing servers.
> 
> **Overview**
> Introduces a **shared 0–100 conformance score** (`computeConformanceScore`, suite adapters, `pooledConformanceScore`, `describeConformanceScore`) in the SDK: MUST checks drive 95 points, capped advisory deductions (SHOULD/MAY) drive the last 5, `not-applicable` drops out of the denominator, and `could-not-run` stays in so incomplete runs cannot read as perfect.
> 
> **Surfaces:** Inspector pooled headline + per-suite chips, visible protocol **readiness** warnings (they deduct points); CLI `Score:` on stderr for protocol/apps/tasks/oauth (and per-run in suites), respecting `--quiet`; `ConformanceReport.score` for json-summary; JUnit `<properties>` for score and summary. Runners now attach **`protocolVersion`** on protocol/apps results for score labels.
> 
> **Bugfix:** Report builders finally set **`outcome` / `incompleteReason`** (suite worst-of, OAuth `not-applicable` does not fail the suite). OAuth scoring uses step evidence, not the suite verdict; scoreless when auth is not applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62d2db84b3db1282cf374e3c446bcff88682dc1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single 0–100 conformance score (MUSTs = 95 pts; capped advisory deductions = 5 pts) and surfaces it across the SDK, CLI, reports, and Inspector for a clear, comparable number. Recent changes refine suite outcomes, strict version labeling, JUnit placement, and not-applicable OAuth handling.

- **New Features**
  - SDK: `computeConformanceScore`, suite adapters, `pooledConformanceScore`, and `describeConformanceScore` exported from `@mcpjam/sdk` and browser entry.
    - Rules: SHOULD/RECOMMENDED −2, MAY −1 (capped at 5); `not-applicable` excluded; `could-not-run` included; failed/incomplete cap at 94; 100 only with zero advice.
  - Inspector: pooled headline score card, per‑suite score chips, and visible readiness warnings; OAuth “no auth” runs are labeled and not scored.
  - CLI: prints `Score:` to stderr for each run; prints nothing for not‑scored runs; honors `--quiet`; exit codes unchanged.
  - Reports: `score` on every `ConformanceReport` (suites pool counts); JUnit adds score and summary in a `<properties>` block under each `<testsuite>` with test counts untouched.
  - Data: `MCPConformanceResult.protocolVersion` and `MCPAppsConformanceResult.protocolVersion` added so score labels use the effective revision.

- **Bug Fixes**
  - `ConformanceReport.outcome` and `incompleteReason` now set; suites take the worst run (failure outranks incomplete) and OAuth `not-applicable` runs do not fail a suite.
  - Strict pooled version label: shown only when all scoring parts state the same version; versionless judgments suppress it; scoreless parts don’t constrain the label.

<sup>Written for commit 62d2db84b3db1282cf374e3c446bcff88682dc1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

