### PR TITLE
feat(environments): embed the read-only Connect canvas in the detail view

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1346,6 +1346,7 @@ export function EnvironmentsRoute() {
     <ProjectEnvironmentsRoute
       projectId={convexProjectId ?? null}
       canManage={canManage}
+      isAuthenticated={isAuthenticated}
     />
   );
 }

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/__tests__/RedesignedHostCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/__tests__/RedesignedHostCanvas.test.tsx
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { render, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, within } from "@testing-library/react";
 import { ReactFlowProvider, type Edge } from "@xyflow/react";
 import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
 import {
+  ADD_SERVER_NODE_ID,
   BUILTIN_TOOLS_NODE_ID,
   COMPUTER_NODE_ID,
   HOST_MATRIX_NODE_ID,
@@ -273,6 +274,109 @@ describe("RedesignedHostCanvas", () => {
     expect(
       within(computer as HTMLElement).getByText("+ Computer"),
     ).toBeInTheDocument();
+  });
+});
+
+/**
+ * Read-only mode — the surface the chatbox and environment canvas embeds ride
+ * on. Rendered identically to the editable canvas but inert: no add affordance,
+ * and every click is a single "take me to a writable editor" gesture rather
+ * than a selection.
+ */
+describe("read-only mode", () => {
+  function renderReadOnly(opts: {
+    readOnly?: boolean;
+    onRequestEdit?: () => void;
+    onSelectNode?: (id: string) => void;
+    onClearSelection?: () => void;
+  }) {
+    const viewModel = buildRedesignedHostCanvas(
+      {
+        hostName: "Test host",
+        draft: emptyHostConfigInputV2(),
+        savedSnapshotId: "snap",
+        isDirty: false,
+        projectServers: [{ id: "s1", name: "bench", url: "https://x.test" }],
+      },
+      [],
+    );
+    return render(
+      <ReactFlowProvider>
+        <div style={{ width: 900, height: 700 }}>
+          <RedesignedHostCanvas
+            viewModel={viewModel}
+            selectedNodeId={null}
+            onSelectNode={opts.onSelectNode ?? (() => {})}
+            onClearSelection={opts.onClearSelection ?? (() => {})}
+            onAddServer={() => {}}
+            readOnly={opts.readOnly ?? true}
+            onRequestEdit={opts.onRequestEdit}
+          />
+        </div>
+      </ReactFlowProvider>,
+    );
+  }
+
+  it("filters the add-server pill out of the view model", () => {
+    const { container } = renderReadOnly({});
+    expect(
+      container.querySelector(
+        `.react-flow__node[data-id="${ADD_SERVER_NODE_ID}"]`,
+      ),
+    ).toBeNull();
+    // The rest of the graph still renders — this is a summary, not a stub.
+    expect(
+      container.querySelector(`.react-flow__node[data-id="server-card:s1"]`),
+    ).not.toBeNull();
+  });
+
+  it("keeps the add-server pill when NOT read-only (the control)", () => {
+    const { container } = renderReadOnly({ readOnly: false });
+    expect(
+      container.querySelector(
+        `.react-flow__node[data-id="${ADD_SERVER_NODE_ID}"]`,
+      ),
+    ).not.toBeNull();
+  });
+
+  it("routes a node click to onRequestEdit instead of onSelectNode", () => {
+    const onRequestEdit = vi.fn();
+    const onSelectNode = vi.fn();
+    const { container } = renderReadOnly({ onRequestEdit, onSelectNode });
+
+    const card = container.querySelector(
+      `.react-flow__node[data-id="server-card:s1"]`,
+    ) as HTMLElement;
+    fireEvent.click(card);
+
+    expect(onRequestEdit).toHaveBeenCalledTimes(1);
+    expect(onSelectNode).not.toHaveBeenCalled();
+  });
+
+  it("routes a pane click to onRequestEdit instead of onClearSelection", () => {
+    const onRequestEdit = vi.fn();
+    const onClearSelection = vi.fn();
+    const { container } = renderReadOnly({ onRequestEdit, onClearSelection });
+
+    fireEvent.click(container.querySelector(".react-flow__pane") as HTMLElement);
+
+    expect(onRequestEdit).toHaveBeenCalledTimes(1);
+    expect(onClearSelection).not.toHaveBeenCalled();
+  });
+
+  it("still clears selection on a pane click when NOT read-only (the control)", () => {
+    const onRequestEdit = vi.fn();
+    const onClearSelection = vi.fn();
+    const { container } = renderReadOnly({
+      readOnly: false,
+      onRequestEdit,
+      onClearSelection,
+    });
+
+    fireEvent.click(container.querySelector(".react-flow__pane") as HTMLElement);
+
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+    expect(onRequestEdit).not.toHaveBeenCalled();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/project-environments/EnvironmentCanvasPanel.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/EnvironmentCanvasPanel.tsx
@@ -1,0 +1,208 @@
+import { useMemo, type ReactNode } from "react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { useHost } from "@/hooks/useClients";
+import { useProjectServers, type RemoteServer } from "@/hooks/useProjects";
+import {
+  useEnvironmentPreview,
+  type EnvironmentPreviewServer,
+} from "@/hooks/use-environment-preview";
+import { RedesignedHostCanvas } from "@/components/hosts/redesigned/canvas/RedesignedHostCanvas";
+import { buildRedesignedHostCanvas } from "@/components/hosts/redesigned/canvas/canvasBuilder";
+import type { HostRedesignContext } from "@/components/hosts/redesigned/types";
+import {
+  emptyHostConfigInputV2,
+  hostConfigDtoToInput,
+  type HostConfigDtoV2,
+} from "@/lib/client-config-v2";
+import { buildHostsPath, useAppNavigate } from "@/lib/app-navigation";
+
+/**
+ * Read-only embedding of the Connect "Host" graph for an environment's
+ * RESOLVED bundle. Mirrors `ChatboxHostCanvasPanel` — pure data →
+ * `buildRedesignedHostCanvas` → `<RedesignedHostCanvas readOnly>` — with one
+ * difference that drives the whole file: the server set is not the host's own
+ * picks, it is whatever the backend resolver says this environment currently
+ * resolves to (group-vs-host pick, plus plugin-contributed servers). Clicking
+ * anywhere routes to Connect, which owns every field the matrix displays.
+ */
+
+/**
+ * Builder context for an environment's canvas. Exported (and pure) so the
+ * preview→canvas contract is unit-testable without mounting ReactFlow.
+ */
+export function buildEnvironmentCanvasContext(args: {
+  hostName: string;
+  /** `host.config` from `useHost`; null while the host is missing/loading. */
+  hostConfig: HostConfigDtoV2 | null;
+  /** `preview.servers` — the resolver's answer, never re-derived here. */
+  previewServers: EnvironmentPreviewServer[];
+  /** `useProjectServers().servers`, consulted for the url join ONLY. */
+  projectServers: RemoteServer[] | undefined;
+}): HostRedesignContext {
+  const { hostName, hostConfig, previewServers, projectServers } = args;
+
+  // `hostConfigDtoToInput` requires a non-null DTO; the chatbox precedent
+  // guards the same way so a dangling host still renders host-less chrome.
+  const base = hostConfig
+    ? hostConfigDtoToInput(hostConfig)
+    : emptyHostConfigInputV2();
+
+  const byId = new Map((projectServers ?? []).map((s) => [s._id, s]));
+
+  return {
+    hostName,
+    // An environment's server set is CLOSED: everything the resolver returned
+    // is required/solid, and nothing else exists. No dashed "optional" cards.
+    draft: {
+      ...base,
+      serverIds: previewServers.map((s) => s.serverId),
+      optionalServerIds: [],
+    },
+    // LOAD-BEARING: the builder draws one card per entry of `projectServers`,
+    // so the closed-set rendering rests on this list being built FROM the
+    // preview. Never pass the project's full server list here — a non-member
+    // project server would surface as a card on an environment that does not
+    // include it.
+    projectServers: previewServers.map((s) => ({
+      id: s.serverId,
+      name: s.name,
+      // url join only; plugin/unjoinable servers render name-only.
+      url: byId.get(s.serverId)?.url ?? undefined,
+      // No `connectionStatus`: the builder defaults to "unknown" (neutral
+      // dot). Environment servers are connected backend-side per turn, so any
+      // dot here would imply a liveness this surface cannot know.
+    })),
+    savedSnapshotId: hostConfig?.id ?? "",
+    isDirty: false,
+  };
+}
+
+type EnvironmentCanvasPanelProps = {
+  projectId: string;
+  environmentId: string;
+  hostId: string;
+  /** The selected row's `revision` — refetches the preview after a Save. */
+  revision: number;
+  isArchived: boolean;
+  isAuthenticated: boolean;
+};
+
+export function EnvironmentCanvasPanel({
+  projectId,
+  environmentId,
+  hostId,
+  revision,
+  isArchived,
+  isAuthenticated,
+}: EnvironmentCanvasPanelProps) {
+  const navigate = useAppNavigate();
+  // Archived environments are keyed off the ROW, never off a parsed error: the
+  // preview endpoint 409s on them (`ENV_ARCHIVED`), so passing `null` keeps the
+  // doomed fetch — including the hook's focus-return refetch — from ever firing.
+  const { preview, isLoading, error, refresh } = useEnvironmentPreview(
+    projectId,
+    isArchived ? null : environmentId,
+    revision
+  );
+  const { host, isLoading: hostLoading } = useHost({ isAuthenticated, hostId });
+  const { servers } = useProjectServers({ projectId, isAuthenticated });
+
+  const viewModel = useMemo(() => {
+    if (!preview || !host) return null;
+    return buildRedesignedHostCanvas(
+      buildEnvironmentCanvasContext({
+        hostName: host.name ?? preview.host.hostName ?? "",
+        hostConfig: host.config ?? null,
+        previewServers: preview.servers,
+        projectServers: servers,
+      }),
+      []
+    );
+  }, [preview, host, servers]);
+
+  const handleRequestEdit = () => {
+    navigate(buildHostsPath(hostId));
+  };
+
+  if (isArchived) {
+    return (
+      <FallbackCard>
+        Archived — this environment no longer resolves to a live canvas.
+      </FallbackCard>
+    );
+  }
+
+  if (error !== null) {
+    return (
+      <FallbackCard>
+        <span className="block">{error}</span>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="mt-3 h-7 text-xs"
+          // The hook keeps the stale `error` across a same-key refetch, so the
+          // button itself has to carry the feedback for the click.
+          disabled={isLoading}
+          onClick={() => refresh()}
+        >
+          {isLoading ? (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+          ) : null}
+          Retry
+        </Button>
+      </FallbackCard>
+    );
+  }
+
+  if (!preview) {
+    return <SpinnerRow label="Resolving environment…" />;
+  }
+
+  if (!host) {
+    return hostLoading ? (
+      <SpinnerRow label="Loading client…" />
+    ) : (
+      <FallbackCard>
+        The client behind this environment is no longer available.
+      </FallbackCard>
+    );
+  }
+
+  return (
+    <div className="h-full min-h-0 p-3">
+      <ReactFlowProvider>
+        <RedesignedHostCanvas
+          viewModel={viewModel!}
+          selectedNodeId={null}
+          onSelectNode={() => {}}
+          onClearSelection={() => {}}
+          onAddServer={() => {}}
+          readOnly
+          onRequestEdit={handleRequestEdit}
+        />
+      </ReactFlowProvider>
+    </div>
+  );
+}
+
+function SpinnerRow({ label }: { label: string }) {
+  return (
+    <div className="flex h-full items-center justify-center text-muted-foreground">
+      <Loader2 className="mr-2 size-4 animate-spin" />
+      <span className="text-sm">{label}</span>
+    </div>
+  );
+}
+
+function FallbackCard({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-sm rounded-md border bg-muted/30 p-4 text-center text-xs text-muted-foreground">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/project-environments/EnvironmentCanvasPanel.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/EnvironmentCanvasPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useCallback, useMemo, type ReactNode } from "react";
 import { ReactFlowProvider } from "@xyflow/react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -122,9 +122,12 @@ export function EnvironmentCanvasPanel({
     );
   }, [preview, host, servers]);
 
-  const handleRequestEdit = () => {
+  // Stable across renders: the canvas memoizes its matrix context on
+  // `onRequestEdit`, so a fresh closure would re-render the matrix subtree
+  // through that context on every parent render.
+  const handleRequestEdit = useCallback(() => {
     navigate(buildHostsPath(hostId));
-  };
+  }, [navigate, hostId]);
 
   if (isArchived) {
     return (
@@ -161,7 +164,10 @@ export function EnvironmentCanvasPanel({
     return <SpinnerRow label="Resolving environment…" />;
   }
 
-  if (!host) {
+  // `!viewModel` is unreachable given the memo's own guard, but narrowing on the
+  // value keeps the compiler — not a comment — as the invariant's enforcer, so a
+  // later reorder of these guards can't silently hand ReactFlow a null model.
+  if (!host || !viewModel) {
     return hostLoading ? (
       <SpinnerRow label="Loading client…" />
     ) : (
@@ -175,7 +181,7 @@ export function EnvironmentCanvasPanel({
     <div className="h-full min-h-0 p-3">
       <ReactFlowProvider>
         <RedesignedHostCanvas
-          viewModel={viewModel!}
+          viewModel={viewModel}
           selectedNodeId={null}
           onSelectNode={() => {}}
           onClearSelection={() => {}}

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
@@ -20,7 +20,13 @@ import {
   useRestoreProjectEnvironment,
   type ProjectEnvironmentView,
 } from "@/hooks/useProjectEnvironments";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
 import { ProjectEnvironmentEditor } from "./ProjectEnvironmentEditor";
+import { EnvironmentCanvasPanel } from "./EnvironmentCanvasPanel";
 import { useProjectEnvironmentConsumers } from "./use-project-environment-consumers";
 import {
   takeEnvironmentDraftSeed,
@@ -36,10 +42,13 @@ import {
 export function ProjectEnvironmentsRoute({
   projectId,
   canManage,
+  isAuthenticated,
 }: {
   projectId: string | null;
   /** Admin-gated writes; members browse read-only. */
   canManage: boolean;
+  /** Threaded to the detail canvas's host/server reads. */
+  isAuthenticated: boolean;
 }) {
   const flagEnabled = useProjectEnvironmentsEnabledState();
 
@@ -145,6 +154,22 @@ export function ProjectEnvironmentsRoute({
     );
   }
 
+  // Detail mode is the ONE mode that escapes the centered `max-w-2xl` column:
+  // it owns the full width so the read-only Connect canvas can sit beside the
+  // editor. List and create modes keep the narrow shell verbatim.
+  if (!creating && selected) {
+    return (
+      <EnvironmentDetail
+        key={`${selected.environmentId}:${selected.archivedAt ?? "live"}`}
+        projectId={projectId}
+        environment={selected}
+        canManage={canManage}
+        isAuthenticated={isAuthenticated}
+        onBack={() => setSelectedId(null)}
+      />
+    );
+  }
+
   return (
     <div className="h-full overflow-y-auto">
       <div className="mx-auto max-w-2xl px-6 py-8">
@@ -188,14 +213,6 @@ export function ProjectEnvironmentsRoute({
               }}
             />
           </div>
-        ) : selected ? (
-          <EnvironmentDetail
-            key={`${selected.environmentId}:${selected.archivedAt ?? "live"}`}
-            projectId={projectId}
-            environment={selected}
-            canManage={canManage}
-            onBack={() => setSelectedId(null)}
-          />
         ) : (
           <EnvironmentList
             environments={environments}
@@ -335,11 +352,13 @@ function EnvironmentDetail({
   projectId,
   environment,
   canManage,
+  isAuthenticated,
   onBack,
 }: {
   projectId: string;
   environment: ProjectEnvironmentView;
   canManage: boolean;
+  isAuthenticated: boolean;
   onBack: () => void;
 }) {
   const archiveEnvironment = useArchiveProjectEnvironment();
@@ -412,89 +431,112 @@ function EnvironmentDetail({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between gap-3">
-        <BackLink label="All environments" onClick={onBack} />
-        <span className="flex items-center gap-2">
-          {isArchived ? <Badge variant="outline">Archived</Badge> : null}
-          <span className="font-mono text-[10px] text-muted-foreground">
-            rev {environment.revision}
-          </span>
-        </span>
-      </div>
+    <div className="h-full min-h-0 overflow-hidden">
+      <ResizablePanelGroup direction="horizontal" className="h-full">
+        <ResizablePanel defaultSize={45} minSize={32}>
+          {/* Editor column owns the scroll; the canvas column owns the height
+              (ReactFlow measures its container, so it must not scroll). */}
+          <div className="h-full overflow-y-auto px-6 py-8">
+            <div className="mx-auto max-w-2xl space-y-4">
+              <div className="flex items-center justify-between gap-3">
+                <BackLink label="All environments" onClick={onBack} />
+                <span className="flex items-center gap-2">
+                  {isArchived ? (
+                    <Badge variant="outline">Archived</Badge>
+                  ) : null}
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    rev {environment.revision}
+                  </span>
+                </span>
+              </div>
 
-      {isArchived ? (
-        <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 p-3">
-          <p className="text-xs text-muted-foreground">
-            Archived — hidden from pickers; suites and journeys still
-            referencing it fail fast at their next launch.
-          </p>
-          {canManage ? (
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="h-7 shrink-0 text-xs"
-              disabled={busy}
-              onClick={() => void onRestore()}
-            >
-              <ArchiveRestore className="mr-1.5 size-3.5" /> Restore
-            </Button>
-          ) : null}
-        </div>
-      ) : null}
+              {isArchived ? (
+                <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 p-3">
+                  <p className="text-xs text-muted-foreground">
+                    Archived — hidden from pickers; suites and journeys still
+                    referencing it fail fast at their next launch.
+                  </p>
+                  {canManage ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="h-7 shrink-0 text-xs"
+                      disabled={busy}
+                      onClick={() => void onRestore()}
+                    >
+                      <ArchiveRestore className="mr-1.5 size-3.5" /> Restore
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
 
-      <ProjectEnvironmentEditor
-        projectId={projectId}
-        environment={environment}
-        canManage={canManage && !isArchived}
-      />
+              <ProjectEnvironmentEditor
+                projectId={projectId}
+                environment={environment}
+                canManage={canManage && !isArchived}
+              />
 
-      {canManage && !isArchived ? (
-        <div className="flex items-center justify-between border-t pt-4">
-          {confirmingArchive ? (
-            <span className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-              <span>
-                Archive “{environment.name}”? {referenceSummary} Referencing
-                runs fail fast at their next launch.
-              </span>
-              <Button
-                type="button"
-                size="sm"
-                variant="destructive"
-                className="h-7 text-xs"
-                disabled={busy}
-                onClick={() => void onArchive()}
-              >
-                {busy ? (
-                  <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                ) : null}
-                Archive
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                className="h-7 text-xs"
-                disabled={busy}
-                onClick={() => setConfirmingArchive(false)}
-              >
-                Cancel
-              </Button>
-            </span>
-          ) : (
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              className="text-destructive hover:text-destructive"
-              onClick={() => setConfirmingArchive(true)}
-            >
-              <Archive className="mr-1.5 size-3.5" /> Archive
-            </Button>
-          )}
-        </div>
-      ) : null}
+              {canManage && !isArchived ? (
+                <div className="flex items-center justify-between border-t pt-4">
+                  {confirmingArchive ? (
+                    <span className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      <span>
+                        Archive “{environment.name}”? {referenceSummary}{" "}
+                        Referencing runs fail fast at their next launch.
+                      </span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="destructive"
+                        className="h-7 text-xs"
+                        disabled={busy}
+                        onClick={() => void onArchive()}
+                      >
+                        {busy ? (
+                          <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                        ) : null}
+                        Archive
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 text-xs"
+                        disabled={busy}
+                        onClick={() => setConfirmingArchive(false)}
+                      >
+                        Cancel
+                      </Button>
+                    </span>
+                  ) : (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => setConfirmingArchive(true)}
+                    >
+                      <Archive className="mr-1.5 size-3.5" /> Archive
+                    </Button>
+                  )}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel defaultSize={55} minSize={30}>
+          <EnvironmentCanvasPanel
+            projectId={projectId}
+            environmentId={environment.environmentId}
+            hostId={environment.hostId}
+            revision={environment.revision}
+            isArchived={isArchived}
+            isAuthenticated={isAuthenticated}
+          />
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/archive-consumer-counts.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/archive-consumer-counts.test.tsx
@@ -36,6 +36,12 @@ vi.mock("../ProjectEnvironmentEditor", () => ({
 vi.mock("../use-project-environment-consumers", () => ({
   useProjectEnvironmentConsumers: () => mockConsumers.value,
 }));
+// Every case here clicks a row into DETAIL mode, which now mounts the
+// read-only Connect canvas. The real panel reads Convex (`useHost`), and this
+// suite has no ConvexProvider — stub it out; the consumer copy is the subject.
+vi.mock("../EnvironmentCanvasPanel", () => ({
+  EnvironmentCanvasPanel: () => <div data-testid="stub-env-canvas" />,
+}));
 
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";
 
@@ -55,7 +61,13 @@ function renderAndOpenArchiveConfirm() {
       <Routes>
         <Route
           path="/environments"
-          element={<ProjectEnvironmentsRoute projectId="proj-1" canManage />}
+          element={
+            <ProjectEnvironmentsRoute
+              isAuthenticated
+              projectId="proj-1"
+              canManage
+            />
+          }
         />
       </Routes>
     </MemoryRouter>

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-canvas-panel.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-canvas-panel.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * EnvironmentCanvasPanel — the read-only Connect canvas embedded in the
+ * environment detail view.
+ *
+ * The contract under test: the RESOLVED preview (not a client-side re-derivation
+ * of the environment's picks) is what the canvas draws, the set it draws is
+ * CLOSED (a project server outside the preview never gets a card), project
+ * servers are consulted for the url join only, and every non-canvas state
+ * (archived / error / loading / dangling host) keeps ReactFlow unmounted.
+ *
+ * The canvas + builder are the REAL modules here — both are pure and jsdom-safe,
+ * as the existing `RedesignedHostCanvas` suite already proves. Only the data
+ * hooks (network + Convex) are mocked.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
+import type { EnvironmentPreview } from "@/hooks/use-environment-preview";
+
+const {
+  mockPreview,
+  mockRefresh,
+  mockHost,
+  mockProjectServers,
+  mockNavigate,
+  mockPreviewArgs,
+} = vi.hoisted(() => ({
+  mockPreview: {
+    value: {
+      preview: null as unknown,
+      isLoading: false,
+      error: null as string | null,
+    },
+  },
+  mockRefresh: vi.fn(),
+  mockHost: {
+    value: { host: null as unknown, isLoading: false },
+  },
+  mockProjectServers: { value: [] as unknown[] },
+  mockNavigate: vi.fn(),
+  mockPreviewArgs: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-environment-preview", () => ({
+  useEnvironmentPreview: (
+    projectId: string | null,
+    environmentId: string | null,
+    revision?: number | null
+  ) => {
+    mockPreviewArgs({ projectId, environmentId, revision });
+    return { ...mockPreview.value, refresh: mockRefresh };
+  },
+}));
+vi.mock("@/hooks/useClients", () => ({
+  useHost: () => mockHost.value,
+}));
+vi.mock("@/hooks/useProjects", () => ({
+  useProjectServers: () => ({ servers: mockProjectServers.value }),
+}));
+vi.mock("@/lib/app-navigation", () => ({
+  useAppNavigate: () => mockNavigate,
+  buildHostsPath: (hostId: string) => `/hosts/${hostId}`,
+}));
+
+import {
+  EnvironmentCanvasPanel,
+  buildEnvironmentCanvasContext,
+} from "../EnvironmentCanvasPanel";
+
+const HOST_CONFIG = {
+  ...emptyHostConfigInputV2(),
+  id: "hc_1",
+  schemaVersion: 2,
+} as never;
+
+const HOST = { hostId: "host-1", name: "Claude Code", config: HOST_CONFIG };
+
+function previewWith(
+  servers: Array<{ serverId: string; name: string; source: string | null }>
+): EnvironmentPreview {
+  return {
+    specVersion: 1,
+    environment: { environmentId: "env-1", name: "Prod-like", revision: 3 },
+    host: {
+      hostId: "host-1",
+      hostName: "Claude Code",
+      hostConfigId: "hc_1",
+      modelId: null,
+      hostStyle: null,
+      harness: null,
+    },
+    servers,
+    skills: [],
+    plugins: [],
+    capabilities: {
+      requireToolApproval: null,
+      respectToolVisibility: null,
+      progressiveToolDiscovery: null,
+      builtInToolIds: [],
+      hasComputer: false,
+      serverCount: servers.length,
+      skillCount: 0,
+      skillDelivery: "emulated",
+      pluginCount: 0,
+      serversOverridden: false,
+    },
+  } as EnvironmentPreview;
+}
+
+function renderPanel(overrides: Partial<{ isArchived: boolean }> = {}) {
+  return render(
+    <div style={{ width: 900, height: 700 }}>
+      <EnvironmentCanvasPanel
+        projectId="proj-1"
+        environmentId="env-1"
+        hostId="host-1"
+        revision={3}
+        isArchived={overrides.isArchived ?? false}
+        isAuthenticated
+      />
+    </div>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPreview.value = { preview: null, isLoading: false, error: null };
+  mockHost.value = { host: HOST, isLoading: false };
+  mockProjectServers.value = [];
+});
+
+describe("EnvironmentCanvasPanel — preview → canvas wiring", () => {
+  it("draws a card per RESOLVED server and joins urls from the project list", () => {
+    mockPreview.value = {
+      preview: previewWith([
+        { serverId: "s1", name: "bench", source: "host_or_group" },
+        { serverId: "p1", name: "plugin-server", source: "plugin" },
+      ]),
+      isLoading: false,
+      error: null,
+    };
+    // The project list knows `s1` only — `p1` is plugin-contributed and has no
+    // project row to join against.
+    mockProjectServers.value = [
+      { _id: "s1", name: "bench", url: "https://bench.example.com" },
+    ];
+
+    const { container } = renderPanel();
+
+    const joined = container.querySelector(
+      `.react-flow__node[data-id="server-card:s1"]`
+    ) as HTMLElement | null;
+    expect(joined).not.toBeNull();
+    expect(joined!.textContent).toContain("https://bench.example.com");
+
+    const nameOnly = container.querySelector(
+      `.react-flow__node[data-id="server-card:p1"]`
+    ) as HTMLElement | null;
+    expect(nameOnly).not.toBeNull();
+    expect(nameOnly!.textContent).toContain("plugin-server");
+    expect(nameOnly!.textContent).not.toContain("https://");
+  });
+
+  it("renders a CLOSED set — a project server outside the preview gets no card", () => {
+    mockPreview.value = {
+      preview: previewWith([
+        { serverId: "s1", name: "bench", source: "host_or_group" },
+      ]),
+      isLoading: false,
+      error: null,
+    };
+    mockProjectServers.value = [
+      { _id: "s1", name: "bench", url: "https://bench.example.com" },
+      { _id: "s9", name: "not-a-member", url: "https://nope.example.com" },
+    ];
+
+    const { container } = renderPanel();
+
+    expect(
+      container.querySelector(`.react-flow__node[data-id="server-card:s1"]`)
+    ).not.toBeNull();
+    expect(
+      container.querySelector(`.react-flow__node[data-id="server-card:s9"]`)
+    ).toBeNull();
+  });
+
+  it("routes any canvas click to the host's Connect view", () => {
+    mockPreview.value = {
+      preview: previewWith([]),
+      isLoading: false,
+      error: null,
+    };
+    const { container } = renderPanel();
+
+    const pane = container.querySelector(".react-flow__pane") as HTMLElement;
+    fireEvent.click(pane);
+    expect(mockNavigate).toHaveBeenCalledWith("/hosts/host-1");
+  });
+});
+
+describe("buildEnvironmentCanvasContext", () => {
+  it("makes every preview server required and implies no liveness", () => {
+    const context = buildEnvironmentCanvasContext({
+      hostName: "Claude Code",
+      hostConfig: HOST_CONFIG,
+      previewServers: [
+        { serverId: "s1", name: "bench", source: "host_or_group" },
+        { serverId: "p1", name: "plugin-server", source: "plugin" },
+      ],
+      projectServers: [
+        { _id: "s1", name: "bench", url: "https://bench.example.com" },
+        { _id: "s9", name: "not-a-member", url: "https://nope.example.com" },
+      ] as never,
+    });
+
+    expect(context.draft.serverIds).toEqual(["s1", "p1"]);
+    expect(context.draft.optionalServerIds).toEqual([]);
+    // Closed set: built FROM the preview, never from the project list.
+    expect(context.projectServers.map((s) => s.id)).toEqual(["s1", "p1"]);
+    expect(context.projectServers[0].url).toBe("https://bench.example.com");
+    expect(context.projectServers[1].url).toBeUndefined();
+    // No liveness dot, no Computers islands.
+    for (const server of context.projectServers) {
+      expect(server.connectionStatus).toBeUndefined();
+    }
+    expect(context.computersEnabled).toBeUndefined();
+    expect(context.isDirty).toBe(false);
+    expect(context.savedSnapshotId).toBe("hc_1");
+  });
+
+  it("falls back to an empty host config when the host is gone", () => {
+    const context = buildEnvironmentCanvasContext({
+      hostName: "",
+      hostConfig: null,
+      previewServers: [],
+      projectServers: undefined,
+    });
+    expect(context.savedSnapshotId).toBe("");
+    expect(context.draft.serverIds).toEqual([]);
+  });
+});
+
+describe("EnvironmentCanvasPanel — non-canvas states", () => {
+  it("shows a spinner and mounts no ReactFlow while the preview resolves", () => {
+    mockPreview.value = { preview: null, isLoading: true, error: null };
+    const { container } = renderPanel();
+
+    expect(screen.getByText(/resolving environment/i)).toBeInTheDocument();
+    expect(container.querySelector(".react-flow")).toBeNull();
+  });
+
+  it("offers a Retry that calls the hook's refresh on an error", () => {
+    mockPreview.value = {
+      preview: null,
+      isLoading: false,
+      error: "This environment couldn't be resolved.",
+    };
+    const { container } = renderPanel();
+
+    expect(
+      screen.getByText("This environment couldn't be resolved.")
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(".react-flow")).toBeNull();
+  });
+
+  it("disables Retry while the same-key refetch is in flight", () => {
+    // The hook keeps the stale `error` across a refetch, so the button is the
+    // only place the click can show feedback.
+    mockPreview.value = {
+      preview: null,
+      isLoading: true,
+      error: "This environment couldn't be resolved.",
+    };
+    renderPanel();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDisabled();
+  });
+
+  it("shows archived copy off the ROW and never fires the doomed fetch", () => {
+    // The preview endpoint 409s on archived environments; the copy is keyed on
+    // the row, and the hook is passed a null environmentId so it stays idle.
+    mockPreview.value = { preview: null, isLoading: false, error: null };
+    const { container } = renderPanel({ isArchived: true });
+
+    expect(screen.getByText(/archived/i)).toBeInTheDocument();
+    expect(container.querySelector(".react-flow")).toBeNull();
+    expect(mockPreviewArgs).toHaveBeenCalledWith(
+      expect.objectContaining({ environmentId: null })
+    );
+  });
+
+  it("reports a dangling host instead of spinning forever", () => {
+    mockPreview.value = {
+      preview: previewWith([]),
+      isLoading: false,
+      error: null,
+    };
+    mockHost.value = { host: null, isLoading: false };
+    const { container } = renderPanel();
+
+    expect(
+      screen.getByText(/client behind this environment is no longer available/i)
+    ).toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).toBeNull();
+    expect(container.querySelector(".react-flow")).toBeNull();
+  });
+
+  it("spins while the host query is still loading", () => {
+    mockPreview.value = {
+      preview: previewWith([]),
+      isLoading: false,
+      error: null,
+    };
+    mockHost.value = { host: null, isLoading: true };
+    const { container } = renderPanel();
+
+    expect(screen.getByText(/loading client/i)).toBeInTheDocument();
+    expect(container.querySelector(".react-flow")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.flag-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.flag-gate.test.tsx
@@ -28,6 +28,9 @@ vi.mock("../use-project-environment-consumers", () => ({
     journeyCount: null,
   }),
 }));
+vi.mock("../EnvironmentCanvasPanel", () => ({
+  EnvironmentCanvasPanel: () => <div data-testid="stub-env-canvas" />,
+}));
 
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";
 
@@ -37,7 +40,13 @@ function renderAtEnvironments(projectId = "proj-1") {
       <Routes>
         <Route
           path="/environments"
-          element={<ProjectEnvironmentsRoute projectId={projectId} canManage />}
+          element={
+            <ProjectEnvironmentsRoute
+              isAuthenticated
+              projectId={projectId}
+              canManage
+            />
+          }
         />
         <Route path="/servers" element={<div>Servers Screen</div>} />
       </Routes>
@@ -100,7 +109,13 @@ describe("ProjectEnvironmentsRoute project switch", () => {
         <Routes>
           <Route
             path="/environments"
-            element={<ProjectEnvironmentsRoute projectId="proj-2" canManage />}
+            element={
+              <ProjectEnvironmentsRoute
+                isAuthenticated
+                projectId="proj-2"
+                canManage
+              />
+            }
           />
           <Route path="/servers" element={<div>Servers Screen</div>} />
         </Routes>
@@ -111,5 +126,32 @@ describe("ProjectEnvironmentsRoute project switch", () => {
     expect(
       screen.getByRole("heading", { name: "Environments" })
     ).toBeInTheDocument();
+  });
+});
+
+describe("ProjectEnvironmentsRoute detail mode", () => {
+  beforeEach(() => {
+    mockFlagValue.value = true;
+    mockListEnvironments.mockClear().mockReturnValue([
+      {
+        environmentId: "env-1",
+        projectId: "proj-1",
+        name: "Prod-like",
+        hostId: "host-1",
+        revision: 3,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ]);
+  });
+
+  it("renders the editor beside the read-only Connect canvas", () => {
+    // Detail mode is a split view now: the editor column keeps its centered
+    // max-w-2xl body, and the right panel embeds the environment's canvas.
+    renderAtEnvironments();
+    fireEvent.click(screen.getByText("Prod-like"));
+
+    expect(screen.getByText("Environment Editor")).toBeInTheDocument();
+    expect(screen.getByTestId("stub-env-canvas")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.seed.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.seed.test.tsx
@@ -40,6 +40,11 @@ vi.mock("../ProjectEnvironmentEditor", async () => {
 vi.mock("../use-project-environment-consumers", () => ({
   useProjectEnvironmentConsumers: () => ({ consumers: [], loading: false }),
 }));
+// Hygiene: keeps xyflow's module graph out of a suite that mocks react-router
+// down to `{ Navigate }`.
+vi.mock("../EnvironmentCanvasPanel", () => ({
+  EnvironmentCanvasPanel: () => <div data-testid="stub-env-canvas" />,
+}));
 vi.mock("@/lib/toast", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock("react-router", () => ({
   Navigate: () => <div data-testid="redirect" />,
@@ -62,7 +67,9 @@ describe("ProjectEnvironmentsRoute — seed consumption", () => {
       serverAttachmentId: null,
       skillSelection: null,
     });
-    render(<ProjectEnvironmentsRoute projectId="proj_1" canManage />);
+    render(
+      <ProjectEnvironmentsRoute isAuthenticated projectId="proj_1" canManage />
+    );
 
     await waitFor(() => expect(screen.getByTestId("editor")).toBeVisible());
     expect(screen.getByText("New environment")).toBeInTheDocument();
@@ -87,7 +94,7 @@ describe("ProjectEnvironmentsRoute — seed consumption", () => {
     });
     mockFlagValue.value = undefined;
     const { rerender, container } = render(
-      <ProjectEnvironmentsRoute projectId="proj_1" canManage />
+      <ProjectEnvironmentsRoute isAuthenticated projectId="proj_1" canManage />
     );
     // Hydrating: route renders nothing, seed untouched.
     expect(container).toBeEmptyDOMElement();
@@ -96,7 +103,9 @@ describe("ProjectEnvironmentsRoute — seed consumption", () => {
     );
 
     mockFlagValue.value = true;
-    rerender(<ProjectEnvironmentsRoute projectId="proj_1" canManage />);
+    rerender(
+      <ProjectEnvironmentsRoute isAuthenticated projectId="proj_1" canManage />
+    );
     await waitFor(() => expect(screen.getByTestId("editor")).toBeVisible());
     expect(screen.getByText("New environment")).toBeInTheDocument();
   });
@@ -116,7 +125,7 @@ describe("ProjectEnvironmentsRoute — seed consumption", () => {
     });
 
     const { rerender } = render(
-      <ProjectEnvironmentsRoute projectId="proj_a" canManage />
+      <ProjectEnvironmentsRoute isAuthenticated projectId="proj_a" canManage />
     );
     await waitFor(() => expect(screen.getByTestId("editor")).toBeVisible());
     expect(
@@ -129,7 +138,9 @@ describe("ProjectEnvironmentsRoute — seed consumption", () => {
 
     // Straight from one seeded create form to another: the remount key must
     // change, or React reuses the instance and B's already-deleted seed is lost.
-    rerender(<ProjectEnvironmentsRoute projectId="proj_b" canManage />);
+    rerender(
+      <ProjectEnvironmentsRoute isAuthenticated projectId="proj_b" canManage />
+    );
     await waitFor(() => {
       const props = mockEditorProps.mock.calls.at(-1)![0] as {
         capturedInitialDraft?: { hostId: string };
@@ -147,7 +158,13 @@ describe("ProjectEnvironmentsRoute — seed consumption", () => {
       serverAttachmentId: null,
       skillSelection: null,
     });
-    render(<ProjectEnvironmentsRoute projectId="  proj_1  " canManage />);
+    render(
+      <ProjectEnvironmentsRoute
+        isAuthenticated
+        projectId="  proj_1  "
+        canManage
+      />
+    );
     await waitFor(() => expect(screen.getByTestId("editor")).toBeVisible());
     expect(
       (
@@ -159,7 +176,9 @@ describe("ProjectEnvironmentsRoute — seed consumption", () => {
   });
 
   it("no seed ⇒ lands on the list, not create mode", () => {
-    render(<ProjectEnvironmentsRoute projectId="proj_1" canManage />);
+    render(
+      <ProjectEnvironmentsRoute isAuthenticated projectId="proj_1" canManage />
+    );
     // The list ALSO renders a "New environment" button — the editor testid is
     // the unambiguous create-mode signal.
     expect(screen.queryByTestId("editor")).not.toBeInTheDocument();
@@ -171,7 +190,9 @@ describe("ProjectEnvironmentsRoute — seed consumption", () => {
       serverAttachmentId: null,
       skillSelection: null,
     });
-    render(<ProjectEnvironmentsRoute projectId="proj_1" canManage />);
+    render(
+      <ProjectEnvironmentsRoute isAuthenticated projectId="proj_1" canManage />
+    );
     expect(screen.queryByTestId("editor")).not.toBeInTheDocument();
     // The other project's seed stays for its own route visit.
     expect(sessionStorage.getItem("mcp-environment-draft-seed")).toContain(


### PR DESCRIPTION
## What

Environments launched with a plain narrow form. The detail view now carries the product's visual signature by **reusing** the Connect host canvas exactly as the chatbox publish view does — pure data → `buildRedesignedHostCanvas` → `<RedesignedHostCanvas readOnly onRequestEdit>`.

**Client only — no backend changes.** Ships under the existing `project-environments-enabled` route gate; no new flag.

## How

### `EnvironmentCanvasPanel.tsx` (new)

A mirror of `ChatboxHostCanvasPanel.tsx`, with one difference that drives the whole file: it renders what the environment **resolves to**, not a client-side re-derivation of its picks.

- **Server set = canonical resolution.** `useEnvironmentPreview` runs the backend resolver, so `preview.servers` already folds in the group-vs-host pick *and* plugin-contributed servers. Never re-derived here.
- **The set is CLOSED.** Every preview server is required/solid (`draft.serverIds` = preview ids, `optionalServerIds: []`) — an environment's server set has no "optional" members. This rests on the builder's `projectServers` list being constructed **from the preview**, since the builder draws one card per entry; a comment in the code says so, and a test pins it.
- **`useProjectServers` is a url join only.** Plugin/unjoinable servers render name-only.
- **No liveness implied.** `connectionStatus` is omitted, so the builder defaults to `"unknown"` (neutral dot). Environment servers are connected backend-side per turn — a dot here would imply liveness this surface cannot know.
- **Click-through = Connect.** In readOnly mode every node/pane click fires `onRequestEdit` → `navigate(buildHostsPath(hostId))`. The matrix shows Connect-owned client config, so Connect is where it's edited.
- **v1 renders the SAVED row.** The preview hook refetches on `revision` change, so the canvas updates right after Save.

A pure `buildEnvironmentCanvasContext()` helper is exported so the preview→canvas contract is testable without mounting ReactFlow.

Render states are ordered so ReactFlow never mounts hidden or before data:

| State | Render |
|---|---|
| archived | Fallback card, keyed off the **row** — the preview endpoint 409s on archived envs, so `environmentId: null` goes into the hook and the doomed fetch (incl. its focus-return refetch) never fires |
| error | Error string + outline **Retry** calling `refresh()`, disabled/spinning off `isLoading` (the hook keeps the stale error during a same-key refetch, so the button carries the feedback) |
| loading | Spinner row |
| dangling host | "The client behind this environment is no longer available." — not an infinite spinner |
| otherwise | The canvas |

### Layout

Detail mode is the **one** mode that escapes `max-w-2xl`: a `ResizablePanelGroup` split, editor left (45%) / canvas right (55%), mirroring the chatbox publish view. The editor column owns the scroll; the canvas column owns the height (ReactFlow measures its container). List and create modes keep the centered narrow shell verbatim.

`isAuthenticated` is threaded from `App.tsx` → `ProjectEnvironmentsRoute` → `EnvironmentDetail` → the panel's Convex reads.

## Testing

`npm test -- --project client src/components/project-environments src/components/hosts/redesigned/canvas` → **13 files, 147 tests, exit 0**. `npm run typecheck:client` → exit 0.

- **New `environment-canvas-panel.test.tsx`** (11 cases) — renders the *real* canvas + builder (both pure and jsdom-safe), mocking only the data hooks. Covers the preview→builder wiring and url join (`s1` joined, plugin `p1` name-only), the closed set (a non-member project server `s9` gets no card), click-through to `/hosts/:hostId`, a direct unit test of `buildEnvironmentCanvasContext`, and each non-canvas state.
- **`RedesignedHostCanvas.test.tsx`** gains a `read-only mode` block — this surface was previously untested despite the chatbox already shipping on it. Covers the add-server pill being filtered, node click → `onRequestEdit` (not `onSelectNode`), pane click → `onRequestEdit` (not `onClearSelection`), each with a not-read-only control.
- **Three existing route suites** stub the panel and pass the new prop. `archive-consumer-counts.test.tsx` matters most: all 6 cases click into detail mode, so without the stub the real panel's `useHost` would hit `useQuery` with no ConvexProvider. `flag-gate` also gains a detail-mode case asserting the editor and the canvas render side by side.

## Out of scope (follow-ups)

- Live-draft morphing (canvas reacting to *unsaved* editor edits) — needs draft lifting from the editor.
- Stacked mobile layout for the split view (matches Connect/Chatbox behavior today).
- Canvas for archived environments — needs a backend resolver change to serve archived rows.
- The `"Project server"` url-fallback label is mildly wrong for plugin-sourced servers — cosmetic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnBF6xJvLciPwJEtAEjanu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI behind the existing environments flag; no backend or auth logic changes beyond threading `isAuthenticated` for reads.
> 
> **Overview**
> **Environment detail** now uses a full-width **resizable split**: editor on the left (~45%) and a new **`EnvironmentCanvasPanel`** on the right (~55%), matching the chatbox publish pattern. List and create modes stay in the narrow `max-w-2xl` column.
> 
> The panel shows the **resolved** environment bundle via `useEnvironmentPreview` (not client-side re-derivation of picks). **`buildEnvironmentCanvasContext`** maps preview servers to a **closed** server set on the host graph—required IDs only, `projectServers` built from preview for cards, project list used only for URL joins—and renders **`RedesignedHostCanvas`** in **`readOnly`** with clicks navigating to Connect (`/hosts/:hostId`). It handles archived (skips preview fetch), error + retry, loading, and missing host without mounting ReactFlow.
> 
> **`isAuthenticated`** flows from `App` → `ProjectEnvironmentsRoute` → detail → the panel for Convex host/server reads.
> 
> **Tests:** new `environment-canvas-panel` suite; **`read-only mode`** block on `RedesignedHostCanvas` (add-server hidden, `onRequestEdit` vs selection); route tests stub the panel and pass `isAuthenticated`, plus a detail split-view assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a87d3b9ae82780eb798a54fff7f3b7e8e45132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed the read-only Connect host canvas into the `/environments` detail view so users can see the resolved server graph beside the editor. Uses the backend‑resolved, closed server set and routes clicks to the editable Connect host.

- **New Features**
  - Added `EnvironmentCanvasPanel` that builds the canvas from `useEnvironmentPreview` (resolved servers only), joins URLs from project servers, omits liveness, and navigates to the host on click.
  - Detail view switches to a split `ResizablePanelGroup` (editor left, canvas right). List and create views stay the same. `isAuthenticated` is threaded for host/server reads. Client-only behind `project-environments-enabled`.
  - Clear states: archived fallback (skips fetch), error with Retry, loading spinners, and a “dangling host” message. ReactFlow only mounts when data is ready.
  - Tests: new panel suite; added read‑only coverage for `RedesignedHostCanvas`; updated route suites to stub the panel and pass `isAuthenticated`.

- **Refactors**
  - Made `onRequestEdit` `useCallback`-stable to avoid unnecessary matrix re-renders, and narrowed on `viewModel` instead of asserting to keep the render invariant explicit.

<sup>Written for commit a2a87d3b9ae82780eb798a54fff7f3b7e8e45132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

