### PR TITLE
feat(swarms): Overview tab — runs grouped by journey with rubric findings

### DIFF
--- a/mcpjam-inspector/client/src/components/swarms/SwarmsSessionsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsSessionsPanel.tsx
@@ -37,6 +37,13 @@ import {
 } from "@/lib/app-navigation";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
 
+/**
+ * How many extra pages the deep-link walk may pull looking for its target.
+ * The flat project feed is unbounded, so this is what stops a link naming a
+ * session outside this list (or one that no longer exists) from paging forever.
+ */
+const MAX_DEEP_LINK_PAGE_PULLS = 10;
+
 export function SwarmsSessionsPanel({
   projectId,
   personas,
@@ -84,7 +91,7 @@ export function SwarmsSessionsPanel({
       if (r.hostId && !seen.has(r.hostId)) {
         seen.set(
           r.hostId,
-          hosts.find((h) => h.hostId === r.hostId)?.name ?? r.hostId.slice(0, 8),
+          hosts.find((h) => h.hostId === r.hostId)?.name ?? r.hostId.slice(0, 8)
         );
       }
     }
@@ -93,11 +100,11 @@ export function SwarmsSessionsPanel({
   const rows = useMemo(
     () =>
       hostFilter ? allRows.filter((r) => r.hostId === hostFilter) : allRows,
-    [allRows, hostFilter],
+    [allRows, hostFilter]
   );
 
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(
-    initialThreadId ?? null,
+    initialThreadId ?? null
   );
   const [sessionToPromote, setSessionToPromote] =
     useState<JourneySessionRow | null>(null);
@@ -125,6 +132,16 @@ export function SwarmsSessionsPanel({
 
   // Apply deep-link once the matching row appears (may need Load more).
   const appliedInitialRef = useRef(false);
+  const initialPagesPulledRef = useRef(0);
+  // A NEW target (an Overview finding drilling into a second session while the
+  // panel stays mounted) re-arms both the claim and the page budget — without
+  // this the walk below would be spent and the second link would never apply.
+  const prevInitialThreadRef = useRef(initialThreadId);
+  if (prevInitialThreadRef.current !== initialThreadId) {
+    prevInitialThreadRef.current = initialThreadId;
+    appliedInitialRef.current = false;
+    initialPagesPulledRef.current = 0;
+  }
   useEffect(() => {
     if (appliedInitialRef.current || !initialThreadId) return;
     if (rows.some((r) => r.id === initialThreadId)) {
@@ -133,14 +150,33 @@ export function SwarmsSessionsPanel({
     }
   }, [initialThreadId, rows]);
 
+  // The effect above only searches LOADED rows, so a target past the first
+  // page never applies and the viewer lands on a session list that ignored
+  // their click. Pull pages until it turns up or the budget runs out — same
+  // shape as the run-detail deep-link walk in `run-sessions-context.tsx`.
+  //
+  // BOUNDED on purpose: the project feed is unbounded, so an unlimited walk
+  // over a large project would page forever for a session that (after a host
+  // filter, say) is not in this list at all.
+  useEffect(() => {
+    if (appliedInitialRef.current || !initialThreadId) return;
+    if (status !== "CanLoadMore") return;
+    if (initialPagesPulledRef.current >= MAX_DEEP_LINK_PAGE_PULLS) return;
+    initialPagesPulledRef.current += 1;
+    loadMore(DEFAULT_PAGE_SIZE);
+    // `rows` is a dependency so each landed page re-evaluates: the effect above
+    // runs first on that commit and sets the applied ref when the target is
+    // present, which stops the walk without an extra query.
+  }, [initialThreadId, rows, status, loadMore]);
+
   const threads = useMemo(
     () => rows.map((r) => journeySessionRowToThread(r, personaName)),
-    [rows, personaName],
+    [rows, personaName]
   );
 
   const selectedRow = useMemo(
     () => rows.find((r) => r.id === selectedThreadId) ?? null,
-    [rows, selectedThreadId],
+    [rows, selectedThreadId]
   );
 
   const linkPersonaRefId =
@@ -161,19 +197,22 @@ export function SwarmsSessionsPanel({
   const emptyListCopy = hostFilter
     ? "No loaded sessions for this client"
     : filtered
-      ? "No sessions for this persona yet"
-      : "No swarm sessions yet";
+    ? "No sessions for this persona yet"
+    : "No swarm sessions yet";
 
   return (
-    <div className="flex h-full min-h-0 flex-col" data-testid="swarms-sessions-panel">
+    <div
+      className="flex h-full min-h-0 flex-col"
+      data-testid="swarms-sessions-panel"
+    >
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/40 px-4 py-2.5">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <p className="shrink-0 truncate text-xs text-muted-foreground">
             {status === "LoadingFirstPage"
               ? "Loading sessions…"
-              : `${threads.length}${status === "CanLoadMore" ? "+" : ""} session${
-                  threads.length === 1 ? "" : "s"
-                }`}
+              : `${threads.length}${
+                  status === "CanLoadMore" ? "+" : ""
+                } session${threads.length === 1 ? "" : "s"}`}
           </p>
           <Select
             value={personaRefId ?? "all"}
@@ -312,7 +351,7 @@ export function SwarmsSessionsPanel({
               type: "test-edit",
               suiteId,
               testId: testCaseId,
-            }),
+            })
           );
         }}
       />

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -5,10 +5,14 @@
  * journeys live at the project level; a journey targets one-or-more hosts and,
  * when run, fans out one single-host session per (host × sessionsPerHost).
  *
- * Top-level views (ViewModeSelector):
+ * Top-level views (ViewModeSelector). Overview is the landing tab; a deep link
+ * naming a session or a run overrides it, because those name a place:
+ *   - Overview — outcome metrics, recent runs grouped by journey, and the
+ *     failing rubric criteria on each journey's latest run
  *   - Personas — persona sidebar, journey cards, run matrix / live stream
- *   - Journeys — flat chatSessions browser with top-bar persona filter
+ *   - Sessions — flat chatSessions browser with top-bar persona filter
  *     (`listSessionsByPersona` + shared ShareUsageThreadList/Detail)
+ *   - Insights — session-flow sankey over the project's swarm sessions
  *
  * Consumes the project-scoped backend: personas:*, journeys:*, journeyRuns:*.
  *
@@ -97,8 +101,12 @@ import { getShareableAppOrigin } from "@/lib/chatbox-session";
 import { ConvertSwarmSessionDialog } from "@/components/swarms/convert-swarm-session-dialog";
 import { SwarmsSessionsPanel } from "@/components/swarms/SwarmsSessionsPanel";
 import { SwarmInsightsPanel } from "@/components/swarms/SwarmInsightsPanel";
+import { SwarmOverviewPanel } from "@/components/swarms/swarm-overview-panel";
 import { SwarmLiveStreamPane } from "@/components/swarms/journey-run-results";
-import { RunSessionsProvider, useRunSessionsContext } from "@/components/swarms/run-sessions-context";
+import {
+  RunSessionsProvider,
+  useRunSessionsContext,
+} from "@/components/swarms/run-sessions-context";
 import {
   JourneyList,
   type JourneyListJourney,
@@ -254,17 +262,21 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
     () => parseSwarmSessionParams(window.location.search),
     []
   );
-  type SwarmViewMode = "journeys" | "sessions" | "insights";
+  type SwarmViewMode = "overview" | "journeys" | "sessions" | "insights";
   const SWARM_VIEW_OPTIONS = [
+    { value: "overview" as const, label: "Overview" },
     { value: "journeys" as const, label: "Personas" },
     { value: "sessions" as const, label: "Sessions" },
     { value: "insights" as const, label: "Insights" },
   ];
-  // Session deep-links open the flat Sessions browser; run-only links stay on
-  // Journeys so the matrix / live stream can restore.
-  const [viewMode, setViewMode] = useState<SwarmViewMode>(() =>
-    deepLink.threadId ? "sessions" : "journeys"
-  );
+  // Session deep-links open the flat Sessions browser; a run-only link needs
+  // the Journeys matrix / live stream, so it lands there. Everything else
+  // starts on the Overview.
+  const [viewMode, setViewMode] = useState<SwarmViewMode>(() => {
+    if (deepLink.threadId) return "sessions";
+    if (deepLink.runId || deepLink.personaRefId) return "journeys";
+    return "overview";
+  });
   const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(
     () => deepLink.personaRefId ?? null
   );
@@ -274,13 +286,15 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   // still restore their persona filter.
   const [sessionsPersonaFilter, setSessionsPersonaFilter] = useState<
     string | null
-  >(() => (deepLink.threadId ? (deepLink.personaRefId ?? null) : null));
-  // Session opened from the Insights drill-down. Carried into the Sessions
-  // browser as its initial selection when the view flips; wins over the URL
-  // deep-link because it is the more recent intent.
-  const [insightsThreadId, setInsightsThreadId] = useState<string | null>(null);
+  >(() => (deepLink.threadId ? deepLink.personaRefId ?? null : null));
+  // Session opened from a drill-down (Insights, or an Overview finding).
+  // Carried into the Sessions browser as its initial selection when the view
+  // flips; wins over the URL deep-link because it is the more recent intent.
+  const [drilldownThreadId, setDrilldownThreadId] = useState<string | null>(
+    null
+  );
   const handleOpenSessionFromInsights = useCallback((sessionId: string) => {
-    setInsightsThreadId(sessionId);
+    setDrilldownThreadId(sessionId);
     setViewMode("sessions");
   }, []);
   const journeys = useJourneys(selectedPersonaId);
@@ -774,7 +788,19 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
         </div>
       </div>
       <div className="flex min-h-0 flex-1">
-        {viewMode === "journeys" ? (
+        {viewMode === "overview" ? (
+          <main className="min-w-0 flex-1 overflow-hidden">
+            <SwarmOverviewPanel
+              projectId={effectiveProjectId}
+              hasPersonas={
+                personas === undefined ? undefined : personas.length > 0
+              }
+              onCreatePersona={() => void handleCreatePersona()}
+              onOpenSession={handleOpenSessionFromInsights}
+              onLaunchJourney={launchJourney}
+            />
+          </main>
+        ) : viewMode === "journeys" ? (
           <>
             {/* Personas sidebar — Personas tab only */}
             <aside className="flex w-72 shrink-0 flex-col border-r">
@@ -918,9 +944,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                       <PersonaDetailHeader
                         persona={selectedPersona}
                         running={runningSet.has(selectedPersona._id)}
-                        autoEditName={
-                          personaAutoEditId === selectedPersona._id
-                        }
+                        autoEditName={personaAutoEditId === selectedPersona._id}
                         onSave={(patch) =>
                           savePersonaField(selectedPersona._id, patch)
                         }
@@ -1054,7 +1078,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
               hosts={hosts ?? []}
               personaRefId={sessionsPersonaFilter}
               onPersonaRefIdChange={setSessionsPersonaFilter}
-              initialThreadId={insightsThreadId ?? deepLink.threadId}
+              initialThreadId={drilldownThreadId ?? deepLink.threadId}
             />
           </main>
         ) : (

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -293,7 +293,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
   const [drilldownThreadId, setDrilldownThreadId] = useState<string | null>(
     null
   );
-  const handleOpenSessionFromInsights = useCallback((sessionId: string) => {
+  const handleOpenSessionDrilldown = useCallback((sessionId: string) => {
     setDrilldownThreadId(sessionId);
     setViewMode("sessions");
   }, []);
@@ -360,10 +360,18 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
     [personas, selectedPersonaId]
   );
 
-  // Personas tab: always land on someone — pick the first list entry when none
-  // is selected or the current id no longer exists (deleted / stale deep link).
+  // Always land on someone — pick the first list entry when none is selected or
+  // the current id no longer exists (deleted / stale deep link).
+  //
+  // Deliberately NOT gated on `viewMode`. It used to be, back when Personas was
+  // the landing tab and the gate was a no-op; with Overview landing instead, a
+  // gate would leave `selectedPersonaId` null on a fresh visit — and the agent
+  // bridge's `ui_launch_swarm_run` resolves journeys through `selectedPersona`,
+  // so it would answer "Select a persona first" for journeys the user can see
+  // listed in front of them. The Sessions tab is unaffected either way: its
+  // persona filter is separate state (`sessionsPersonaFilter`) precisely so
+  // this auto-select cannot narrow the flat browser.
   useEffect(() => {
-    if (viewMode !== "journeys") return;
     if (personas === undefined || personas.length === 0) return;
     const currentValid =
       selectedPersonaId !== null &&
@@ -371,7 +379,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
     if (!currentValid) {
       setSelectedPersonaId(personas[0]._id);
     }
-  }, [viewMode, personas, selectedPersonaId]);
+  }, [personas, selectedPersonaId]);
   // Gate on the VALIDATED persona, not the raw URL-derived id: a copied
   // /swarms?persona=... deep link opened while signed out (or with a stale id)
   // must not subscribe getPersonaTrackRecord before the allowed persona list
@@ -796,7 +804,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
                 personas === undefined ? undefined : personas.length > 0
               }
               onCreatePersona={() => void handleCreatePersona()}
-              onOpenSession={handleOpenSessionFromInsights}
+              onOpenSession={handleOpenSessionDrilldown}
               onLaunchJourney={launchJourney}
             />
           </main>
@@ -1085,7 +1093,7 @@ export function SwarmsTab({ projectId, isAuthenticated }: SwarmsTabProps) {
           <main className="min-w-0 flex-1 overflow-hidden">
             <SwarmInsightsPanel
               projectId={effectiveProjectId}
-              onOpenSession={handleOpenSessionFromInsights}
+              onOpenSession={handleOpenSessionDrilldown}
             />
           </main>
         )}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.agent.test.tsx
@@ -8,7 +8,13 @@
  * REST call are mocked; the persona is selected via the UI so the handlers see
  * the same query data the buttons do.
  */
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // NewJourneyButton's Advanced → Judge section pulls the model catalog via
@@ -187,12 +193,15 @@ describe("SwarmsTab — agent bridge handlers", () => {
 
     expect(response).toMatchObject({
       status: "success",
-      result: { status: "form_opened", prefilledGoal: "Book a flight to Tokyo" },
+      result: {
+        status: "form_opened",
+        prefilledGoal: "Book a flight to Tokyo",
+      },
     });
     // The form is now open with the goal seeded for the user to finish.
     await waitFor(() => {
       expect(
-        screen.getByDisplayValue("Book a flight to Tokyo"),
+        screen.getByDisplayValue("Book a flight to Tokyo")
       ).toBeInTheDocument();
     });
   });
@@ -212,6 +221,26 @@ describe("SwarmsTab — agent bridge handlers", () => {
     });
   });
 
+  it("launchSwarmRun works from the LANDING tab, with no persona ever clicked", async () => {
+    // Swarms lands on Overview, whose surface has no persona sidebar. The
+    // bridge resolves a journey through the selected persona, so if persona
+    // auto-selection were gated on being ON the Personas tab, this would answer
+    // "Select a persona first" for a journey the user can see listed in the
+    // Overview in front of them.
+    launchJourneyRunMock.mockResolvedValue({ runId: "run-1" });
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+
+    const response = await dispatch({
+      type: "launchSwarmRun",
+      payload: { journey: "Book a flight" },
+    });
+
+    expect(response).toMatchObject({
+      status: "success",
+      result: { status: "run_requested", journeyId: "journey-1" },
+    });
+  });
+
   it("launchSwarmRun routes through launchJourneyRun with a launch key and reports the run id", async () => {
     launchJourneyRunMock.mockResolvedValue({ runId: "run-1" });
     await renderAndSelectPersona();
@@ -223,7 +252,11 @@ describe("SwarmsTab — agent bridge handlers", () => {
 
     expect(response).toMatchObject({
       status: "success",
-      result: { status: "run_requested", journeyId: "journey-1", runId: "run-1" },
+      result: {
+        status: "run_requested",
+        journeyId: "journey-1",
+        runId: "run-1",
+      },
     });
     expect(launchJourneyRunMock).toHaveBeenCalledTimes(1);
     const arg = launchJourneyRunMock.mock.calls[0]![0] as {
@@ -239,7 +272,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
 
   it("launchSwarmRun maps a 402 to a billing/quota execution_failed error", async () => {
     launchJourneyRunMock.mockRejectedValue(
-      new LaunchJourneyRunError(402, "Swarm run limit reached"),
+      new LaunchJourneyRunError(402, "Swarm run limit reached")
     );
     await renderAndSelectPersona();
 
@@ -279,15 +312,16 @@ describe("SwarmsTab — agent bridge handlers", () => {
     // First attempt fails — the key must be RETAINED for the retry so the
     // backend dedupes rather than creating a second run.
     launchJourneyRunMock.mockRejectedValueOnce(
-      new LaunchJourneyRunError(500, "upstream unavailable"),
+      new LaunchJourneyRunError(500, "upstream unavailable")
     );
     const first = await dispatch({
       type: "launchSwarmRun",
       payload: { journey: "Book a flight" },
     });
     expect(first).toMatchObject({ status: "error" });
-    const firstKey = (launchJourneyRunMock.mock.calls[0]![0] as { launchKey: string })
-      .launchKey;
+    const firstKey = (
+      launchJourneyRunMock.mock.calls[0]![0] as { launchKey: string }
+    ).launchKey;
 
     // Retry succeeds with the SAME key.
     launchJourneyRunMock.mockResolvedValueOnce({ runId: "run-1" });
@@ -295,8 +329,9 @@ describe("SwarmsTab — agent bridge handlers", () => {
       type: "launchSwarmRun",
       payload: { journey: "Book a flight" },
     });
-    const retryKey = (launchJourneyRunMock.mock.calls[1]![0] as { launchKey: string })
-      .launchKey;
+    const retryKey = (
+      launchJourneyRunMock.mock.calls[1]![0] as { launchKey: string }
+    ).launchKey;
     expect(retryKey).toBe(firstKey);
 
     // After the confirmed 2xx, a subsequent launch mints a FRESH key.
@@ -305,8 +340,9 @@ describe("SwarmsTab — agent bridge handlers", () => {
       type: "launchSwarmRun",
       payload: { journey: "Book a flight" },
     });
-    const nextKey = (launchJourneyRunMock.mock.calls[2]![0] as { launchKey: string })
-      .launchKey;
+    const nextKey = (
+      launchJourneyRunMock.mock.calls[2]![0] as { launchKey: string }
+    ).launchKey;
     expect(nextKey).not.toBe(firstKey);
   });
 
@@ -332,7 +368,11 @@ describe("SwarmsTab — agent bridge handlers", () => {
     expect(snapshot).toMatchObject({
       ok: true,
       data: {
-        selectedPersona: { id: "persona-1", name: "Persona One", role: "tester" },
+        selectedPersona: {
+          id: "persona-1",
+          name: "Persona One",
+          role: "tester",
+        },
         personaCount: 1,
         personas: [{ id: "persona-1", name: "Persona One" }],
         journeys: [

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.agent.test.tsx
@@ -107,6 +107,7 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 import { SwarmsTab } from "../SwarmsTab";
+import { openPersonasTab } from "./swarms-tab-test-helpers";
 import { LaunchJourneyRunError } from "@/lib/swarm-api";
 
 let commandSeq = 0;
@@ -126,6 +127,7 @@ async function dispatch(command: Omit<InspectorCommand, "id">) {
 
 async function renderAndSelectPersona() {
   render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+  openPersonasTab();
   await waitFor(() => {
     expect(screen.getByLabelText("Notes / personality")).toBeTruthy();
   });
@@ -140,6 +142,7 @@ beforeEach(() => {
 describe("SwarmsTab — agent bridge handlers", () => {
   it("createPersona commits directly through the persona mutation and selects it", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     const response = await dispatch({
       type: "createPersona",
@@ -160,6 +163,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
 
   it("createPersona rejects a missing role without touching the mutation", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     const response = await dispatch({
       type: "createPersona",
@@ -195,6 +199,7 @@ describe("SwarmsTab — agent bridge handlers", () => {
 
   it("openJourneyForm rejects an unknown persona as invalid_request", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     const response = await dispatch({
       type: "openJourneyForm",

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.envJourneyForm.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.envJourneyForm.test.tsx
@@ -121,6 +121,7 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 import { SwarmsTab } from "../SwarmsTab";
+import { openPersonasTab } from "./swarms-tab-test-helpers";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -141,6 +142,7 @@ async function pickEnvironment(name: string | RegExp) {
 describe("SwarmsTab — new journey form env mode", () => {
   it("gates Create on ≥1 environment", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     openForm();
 
     fireEvent.change(screen.getByLabelText("Goal"), {
@@ -155,6 +157,7 @@ describe("SwarmsTab — new journey form env mode", () => {
 
   it("env submit: environmentIds in selection order + compat hostIds deduped in order, NO serverAttachmentId", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     openForm();
 
     fireEvent.change(screen.getByLabelText("Goal"), {
@@ -190,6 +193,7 @@ describe("SwarmsTab — new journey form env mode", () => {
 
   it("shows the environments picker (no clients / server-group affordances)", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     openForm();
 
     expect(
@@ -206,6 +210,7 @@ describe("SwarmsTab — new journey form env mode", () => {
   it("keeps Create disabled when the project has no environments", async () => {
     environmentList = [];
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     openForm();
 
     fireEvent.change(screen.getByLabelText("Goal"), {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.generate.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.generate.test.tsx
@@ -126,6 +126,7 @@ vi.mock("@/lib/toast", () => ({ toast: toastMock }));
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
 import { SwarmsTab } from "../SwarmsTab";
+import { openPersonasTab } from "./swarms-tab-test-helpers";
 import { GenerateSwarmDialog } from "../GenerateSwarmDialog";
 import { SwarmGenerateError } from "@/lib/swarm-api";
 
@@ -142,6 +143,7 @@ beforeEach(() => {
 
 function openGeneratePersona() {
   render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+  openPersonasTab();
   fireEvent.click(
     screen.getByRole("button", { name: /generate persona with ai/i })
   );
@@ -387,6 +389,7 @@ describe("SwarmsTab — generate journeys", () => {
     });
 
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     // SwarmsTab auto-selects the first persona, so the journeys panel (and its
     // Generate button) is already mounted.
     fireEvent.click(
@@ -433,6 +436,7 @@ describe("SwarmsTab — generate journeys", () => {
     createJourneyMutation.mockRejectedValue(new Error("Goal is required"));
 
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     // SwarmsTab auto-selects the first persona, so the journeys panel (and its
     // Generate button) is already mounted.
     fireEvent.click(

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.generateEnv.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.generateEnv.test.tsx
@@ -141,6 +141,7 @@ vi.mock("@/lib/toast", () => ({ toast: toastMock }));
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
 import { SwarmsTab } from "../SwarmsTab";
+import { openPersonasTab } from "./swarms-tab-test-helpers";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -155,6 +156,7 @@ beforeEach(() => {
 
 function openGeneratePersona() {
   render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+  openPersonasTab();
   fireEvent.click(
     screen.getByRole("button", { name: /generate persona with ai/i })
   );

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.journeyForm.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.journeyForm.test.tsx
@@ -114,6 +114,7 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 import { SwarmsTab } from "../SwarmsTab";
+import { openPersonasTab } from "./swarms-tab-test-helpers";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -128,6 +129,7 @@ async function pickEnvironment(name: string | RegExp) {
 describe("SwarmsTab — new journey form", () => {
   it("keeps Create disabled until an environment is picked", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
     fireEvent.click(screen.getByRole("button", { name: /new journey/i }));
 
@@ -145,6 +147,7 @@ describe("SwarmsTab — new journey form", () => {
 
   it("passes environmentIds into createJourney", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
     fireEvent.click(screen.getByRole("button", { name: /new journey/i }));
 
@@ -173,6 +176,7 @@ describe("SwarmsTab — new journey form", () => {
 
   it("lets you toggle multiple environments without closing the picker", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
     fireEvent.click(screen.getByRole("button", { name: /new journey/i }));
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.launch.test.tsx
@@ -77,10 +77,12 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 import { SwarmsTab } from "../SwarmsTab";
+import { openPersonasTab } from "./swarms-tab-test-helpers";
 import { LaunchJourneyRunError } from "@/lib/swarm-api";
 
 function selectPersonaAndRun() {
   render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+  openPersonasTab();
   fireEvent.click(screen.getAllByText("Persona One")[0]);
   return screen.getByRole("button", { name: "Run" });
 }

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.overview.test.tsx
@@ -32,6 +32,11 @@ vi.mock("@/hooks/use-available-models", () => ({
   useAvailableModels: () => ({ availableModels: [] }),
 }));
 
+/** Real day-start boundaries, so the sparkline's date labels are meaningful. */
+const DAY_MS = 86_400_000;
+const DAY_2 = Math.floor(Date.now() / DAY_MS) * DAY_MS;
+const DAY_1 = DAY_2 - DAY_MS;
+
 const persona = {
   _id: "persona-1",
   personaId: "p1",
@@ -110,8 +115,8 @@ const overview: SwarmOverview = {
     passRate: 0.5,
     runsWithGrades: 1,
     trend: [
-      { dayStartMs: 1, gradedCount: 2, passedCount: 1, passRate: 0.5 },
-      { dayStartMs: 2, gradedCount: 4, passedCount: 2, passRate: 0.5 },
+      { dayStartMs: DAY_1, gradedCount: 2, passedCount: 1, passRate: 0.5 },
+      { dayStartMs: DAY_2, gradedCount: 4, passedCount: 4, passRate: 1 },
     ],
   },
 };
@@ -130,7 +135,28 @@ const metrics: SwarmSessionMetrics = {
   latencyP95Ms: 4800,
   avgTokensPerSession: 5400,
   tokenSampleCount: 30,
-  trend: [],
+  trend: [
+    {
+      dayStartMs: DAY_1,
+      sessionCount: 12,
+      toolErrorRate: 0.02,
+      avgToolCallsPerSession: 3,
+      // A day with no latency sample at all — the series coalesces it rather
+      // than dropping the point, which keeps it aligned with its date label.
+      latencyP50Ms: null,
+      latencyP95Ms: null,
+      avgTokensPerSession: 4800,
+    },
+    {
+      dayStartMs: DAY_2,
+      sessionCount: 18,
+      toolErrorRate: 0.04,
+      avgToolCallsPerSession: 5,
+      latencyP50Ms: 1200,
+      latencyP95Ms: 4800,
+      avgTokensPerSession: 5800,
+    },
+  ],
 };
 
 /** Two graded sessions on run-2: one failed `crit-quick`, one passed it. */
@@ -203,6 +229,8 @@ const paginatedCalls: Array<{ name: string; args: unknown }> = [];
 /** Flipped per-test to exercise the pre-deploy `undefined` shell. */
 let overviewData: SwarmOverview | undefined = overview;
 let personasData: unknown = [persona];
+/** Flipped per-test to exercise the pre-deploy THROWING shell (undeployed query). */
+let overviewThrows = false;
 
 vi.mock("convex/react", () => ({
   useQuery: (name: string, args: unknown) => {
@@ -214,6 +242,9 @@ vi.mock("convex/react", () => ({
       case "hosts:listHosts":
         return [{ hostId: "host-1", name: "Host One" }];
       case "journeyRuns:getSwarmOverview":
+        if (overviewThrows) {
+          throw new Error("Could not find public function getSwarmOverview");
+        }
         return overviewData;
       case "journeyRuns:getSwarmSessionMetrics":
         return metrics;
@@ -290,6 +321,7 @@ beforeEach(() => {
   paginatedCalls.length = 0;
   overviewData = overview;
   personasData = [persona];
+  overviewThrows = false;
   launchJourneyRunMock.mockReset();
 });
 
@@ -380,8 +412,9 @@ describe("Overview — findings", () => {
     // 4 of 6 ≥ half ⇒ blocking; 1 of 6 ⇒ degraded.
     expect(within(findings[0]).getByText("blocking")).toBeTruthy();
     expect(within(findings[1]).getByText("degraded")).toBeTruthy();
-    // A single-run streak renders no "· N runs" suffix at all.
-    expect(within(findings[1]).queryByText(/· 1 runs/)).toBeNull();
+    // A single-run streak renders the bare count — no "· N runs" suffix at all,
+    // in either the plural or the singular.
+    expect(within(findings[1]).getByText("1 of 6 sessions")).toBeTruthy();
   });
 
   it("falls back to the predicate-kind label when the criterion is unlabelled", async () => {
@@ -460,6 +493,11 @@ describe("Overview — finding drill-down", () => {
 
     await waitFor(() => expect(activeViewLabel()).toBe("Sessions"));
     expect(screen.getByTestId("swarms-sessions-panel")).toBeTruthy();
+    // Not just the shell: the viewer must open on the session that was clicked.
+    // Asserting only the tab flip would still pass if the id were dropped on
+    // the way through — including by the deep-link page walk.
+    const viewer = await screen.findByTestId("viewer");
+    expect(viewer.getAttribute("data-thread-id")).toBe("thread-fail");
   });
 });
 
@@ -481,6 +519,35 @@ describe("Overview — Run again", () => {
     expect(arg.projectId).toBe("proj-1");
     expect(typeof arg.launchKey).toBe("string");
     expect(arg.launchKey.length).toBeGreaterThan(0);
+  });
+
+  it("dedupes rapid clicks into ONE run while a launch is in flight", async () => {
+    // The coordinator's whole point: a double-click must not spawn (and bill)
+    // two runs. Hold the launch open so the second click lands mid-flight.
+    let release: (v: unknown) => void = () => {};
+    launchJourneyRunMock.mockImplementation(
+      () => new Promise((resolve) => (release = resolve))
+    );
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+
+    const button = within(journeyCard("journey-1")).getByRole("button", {
+      name: "Run again",
+    });
+    fireEvent.click(button);
+    await waitFor(() => expect(launchJourneyRunMock).toHaveBeenCalledTimes(1));
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    release({ runId: "run-3" });
+    await waitFor(() =>
+      expect(
+        within(journeyCard("journey-1")).getByRole("button", {
+          name: "Run again",
+        })
+      ).not.toBeDisabled()
+    );
+    expect(launchJourneyRunMock).toHaveBeenCalledTimes(1);
   });
 
   it("is DISABLED for an archived journey — relaunching one throws server-side", async () => {
@@ -531,6 +598,15 @@ describe("Overview — empty and loading states", () => {
     renderTab();
     expect(await screen.findByTestId("swarm-overview-loading")).toBeTruthy();
     expect(screen.queryByTestId("swarms-empty-hero")).toBeNull();
+  });
+
+  it("falls back to the empty state — not a blank tab — when the query THROWS", async () => {
+    // `useQuery` throws for a function the backend hasn't deployed yet, which
+    // is exactly the window between these two PRs. A `null` fallback would
+    // leave the DEFAULT tab blank; the empty state at least says what to do.
+    overviewThrows = true;
+    renderTab();
+    expect(await screen.findByTestId("swarm-overview-no-runs")).toBeTruthy();
   });
 
   it("renders a loading shell — not a crash — while the query is undefined", async () => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.overview.test.tsx
@@ -1,0 +1,545 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  JourneySessionRow,
+  SwarmOverview,
+  SwarmSessionMetrics,
+} from "@/lib/swarm-api";
+
+/**
+ * The Swarms OVERVIEW tab — the default landing view.
+ *
+ * Two things these tests are actually for:
+ *
+ *  1. The WIRE CONTRACT. The Overview read is string-keyed and cast through
+ *     `as any`, so nothing type-checks the call. Every query dispatch is
+ *     recorded and asserted by (name, args) — a renamed query or a renamed arg
+ *     would otherwise only show up as a blank tab in production.
+ *  2. The FIXTURE CONTRACT. The fixtures below are typed against the mirrored
+ *     `SwarmOverview` interfaces, so a backend field rename that reaches the
+ *     mirror forces an edit here. Untyped fixtures would keep rendering — as
+ *     `NaN%` and "undefined of undefined sessions".
+ */
+
+vi.mock("@/hooks/use-available-models", () => ({
+  useAvailableModels: () => ({ availableModels: [] }),
+}));
+
+const persona = {
+  _id: "persona-1",
+  personaId: "p1",
+  name: "Persona One",
+  role: "tester",
+  notes: "",
+};
+
+const overview: SwarmOverview = {
+  runs: [
+    {
+      runId: "run-2",
+      journeyRefId: "journey-1",
+      journeyName: "Refund flow",
+      journeyArchived: false,
+      personaName: "Persona One",
+      createdAt: Date.now() - 60_000,
+      status: "completed",
+      summary: { total: 15, succeeded: 15, failed: 0, rateLimited: 0 },
+      goalScoreSummary: {
+        gradedCount: 6,
+        passedCount: 3,
+        avgScore: 0.62,
+        pendingCount: 0,
+        failedCount: 0,
+      },
+      findings: [
+        {
+          criterionId: "crit-quick",
+          label: "Quick resolution",
+          kind: "turnCountUnder",
+          failCount: 4,
+          pendingCount: 9,
+          failedGradingCount: 0,
+          sessionsGraded: 6,
+          runStreak: 2,
+        },
+        {
+          criterionId: "crit-search",
+          kind: "toolCalledAtLeastOnce",
+          failCount: 1,
+          pendingCount: 0,
+          failedGradingCount: 0,
+          sessionsGraded: 6,
+          runStreak: 1,
+        },
+      ],
+    },
+    {
+      runId: "run-1",
+      journeyRefId: "journey-1",
+      journeyName: "Refund flow",
+      journeyArchived: false,
+      personaName: "Persona One",
+      createdAt: Date.now() - 7_200_000,
+      status: "partial",
+      summary: { total: 15, succeeded: 12, failed: 3, rateLimited: 0 },
+      findings: [],
+    },
+    {
+      runId: "run-old",
+      journeyRefId: "journey-archived",
+      journeyName: "Retired flow",
+      journeyArchived: true,
+      personaName: "Persona One",
+      createdAt: Date.now() - 90_000_000,
+      status: "completed",
+      summary: { total: 2, succeeded: 2, failed: 0, rateLimited: 0 },
+      findings: [],
+    },
+  ],
+  runsConsidered: 3,
+  goalCompletion: {
+    gradedCount: 6,
+    passedCount: 3,
+    passRate: 0.5,
+    runsWithGrades: 1,
+    trend: [
+      { dayStartMs: 1, gradedCount: 2, passedCount: 1, passRate: 0.5 },
+      { dayStartMs: 2, gradedCount: 4, passedCount: 2, passRate: 0.5 },
+    ],
+  },
+};
+
+const metrics: SwarmSessionMetrics = {
+  sessionCount: 30,
+  analyzedCount: 30,
+  truncated: false,
+  toolCallCount: 120,
+  toolErrorCount: 4,
+  toolErrorRate: 0.033,
+  sessionsWithToolErrors: 3,
+  topFailingTool: { toolName: "search", errorCount: 3 },
+  avgToolCallsPerSession: 4,
+  latencyP50Ms: 1200,
+  latencyP95Ms: 4800,
+  avgTokensPerSession: 5400,
+  tokenSampleCount: 30,
+  trend: [],
+};
+
+/** Two graded sessions on run-2: one failed `crit-quick`, one passed it. */
+const runSessions: JourneySessionRow[] = [
+  {
+    id: "thread-fail",
+    chatSessionId: "synth_run-2_host-1_0",
+    projectId: "proj-1",
+    hostId: "host-1",
+    personaRefId: "persona-1",
+    journeyRunId: "run-2",
+    journeyRefId: "journey-1",
+    startedAt: 1,
+    messageCount: 4,
+    firstMessagePreview: "I want my money back",
+    personaLabel: "Persona One",
+    criteria: {
+      status: "completed",
+      generation: 1,
+      results: [
+        { criterionId: "crit-quick", passed: false },
+        { criterionId: "crit-search", passed: true },
+      ],
+    },
+  },
+  {
+    id: "thread-pass",
+    chatSessionId: "synth_run-2_host-1_1",
+    projectId: "proj-1",
+    hostId: "host-1",
+    personaRefId: "persona-1",
+    journeyRunId: "run-2",
+    journeyRefId: "journey-1",
+    startedAt: 2,
+    messageCount: 3,
+    firstMessagePreview: "refund please",
+    personaLabel: "Persona One",
+    criteria: {
+      status: "completed",
+      generation: 1,
+      results: [
+        { criterionId: "crit-quick", passed: true },
+        { criterionId: "crit-search", passed: true },
+      ],
+    },
+  },
+  {
+    // Still grading: `results` is absent, so it must not be offered as an
+    // affected session even though it belongs to the run.
+    id: "thread-pending",
+    chatSessionId: "synth_run-2_host-1_2",
+    projectId: "proj-1",
+    hostId: "host-1",
+    journeyRunId: "run-2",
+    journeyRefId: "journey-1",
+    startedAt: 3,
+    messageCount: 2,
+    firstMessagePreview: "hello?",
+    criteria: {
+      status: "pending",
+      generation: 1,
+      criterionIds: ["crit-quick", "crit-search"],
+    },
+  },
+];
+
+const queryCalls: Array<{ name: string; args: unknown }> = [];
+const paginatedCalls: Array<{ name: string; args: unknown }> = [];
+
+/** Flipped per-test to exercise the pre-deploy `undefined` shell. */
+let overviewData: SwarmOverview | undefined = overview;
+let personasData: unknown = [persona];
+
+vi.mock("convex/react", () => ({
+  useQuery: (name: string, args: unknown) => {
+    if (args === "skip") return undefined;
+    queryCalls.push({ name, args });
+    switch (name) {
+      case "personas:listPersonas":
+        return personasData;
+      case "hosts:listHosts":
+        return [{ hostId: "host-1", name: "Host One" }];
+      case "journeyRuns:getSwarmOverview":
+        return overviewData;
+      case "journeyRuns:getSwarmSessionMetrics":
+        return metrics;
+      default:
+        return undefined;
+    }
+  },
+  useMutation: () => vi.fn(),
+  useAction: () => vi.fn(),
+  useConvexAuth: () => ({ isLoading: false, isAuthenticated: true }),
+  usePaginatedQuery: (name: string, args: unknown) => {
+    paginatedCalls.push({ name, args });
+    if (name === "journeyRuns:listSessionsByJourneyRun") {
+      return {
+        results: runSessions,
+        status: "Exhausted",
+        loadMore: vi.fn(),
+        isLoading: false,
+      };
+    }
+    return {
+      results: [],
+      status: "Exhausted",
+      loadMore: vi.fn(),
+      isLoading: false,
+    };
+  },
+}));
+
+const launchJourneyRunMock = vi.fn();
+vi.mock("@/lib/swarm-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/swarm-api")>();
+  return {
+    ...actual,
+    launchJourneyRun: (...args: unknown[]) => launchJourneyRunMock(...args),
+  };
+});
+
+vi.mock("@/components/connection/share-usage/ShareUsageThreadDetail", () => ({
+  ShareUsageThreadDetail: ({ threadId }: { threadId: string }) => (
+    <div data-testid="viewer" data-thread-id={threadId} />
+  ),
+}));
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServerAttachments: () => ({
+    serverAttachments: [],
+    isLoading: false,
+  }),
+  useDbUserReady: () => true,
+  useProjectServers: () => ({ servers: [], isLoading: false }),
+}));
+vi.mock("@/lib/chatbox-session", () => ({
+  getShareableAppOrigin: () => "https://app.test",
+}));
+vi.mock("@/lib/toast", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { SwarmsTab } from "../SwarmsTab";
+import { activeViewLabel } from "./swarms-tab-test-helpers";
+
+function renderTab() {
+  return render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+}
+
+function journeyCard(journeyRefId: string): HTMLElement {
+  const card = document.querySelector(`[data-journey-id="${journeyRefId}"]`);
+  if (!card) throw new Error(`no journey card for ${journeyRefId}`);
+  return card as HTMLElement;
+}
+
+beforeEach(() => {
+  queryCalls.length = 0;
+  paginatedCalls.length = 0;
+  overviewData = overview;
+  personasData = [persona];
+  launchJourneyRunMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Overview — wire contract", () => {
+  it("lands on Overview and subscribes getSwarmOverview with { projectId }", async () => {
+    renderTab();
+    expect(await screen.findByTestId("swarms-overview-panel")).toBeTruthy();
+    expect(activeViewLabel()).toBe("Overview");
+
+    const call = queryCalls.find(
+      (c) => c.name === "journeyRuns:getSwarmOverview"
+    );
+    expect(call).toBeTruthy();
+    expect(call!.args).toEqual({ projectId: "proj-1" });
+  });
+
+  it("reads the metric cards from getSwarmSessionMetrics, project-scoped", async () => {
+    renderTab();
+    await screen.findByTestId("swarm-overview-metric-cards");
+    const call = queryCalls.find(
+      (c) => c.name === "journeyRuns:getSwarmSessionMetrics"
+    );
+    expect(call!.args).toEqual({ projectId: "proj-1" });
+  });
+});
+
+describe("Overview — runs grouped by journey", () => {
+  it("groups runs under one journey header with the persona name", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+
+    const cards = screen.getAllByTestId("swarm-overview-journey");
+    expect(cards).toHaveLength(2); // journey-1 (2 runs) + journey-archived
+
+    const refundCard = journeyCard("journey-1");
+    expect(within(refundCard).getByText("Refund flow")).toBeTruthy();
+    expect(within(refundCard).getByText(/Persona One/)).toBeTruthy();
+    expect(
+      within(refundCard).getAllByTestId("swarm-overview-run")
+    ).toHaveLength(2);
+  });
+
+  it("scores each run from its judge rollup, and renders '—' when nothing was graded", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+
+    const rows = within(journeyCard("journey-1")).getAllByTestId(
+      "swarm-overview-run"
+    );
+    // run-2: 3 of 6 passed.
+    expect(within(rows[0]).getByText("50%")).toBeTruthy();
+    // run-1 has no goalScoreSummary at all — the judge never ran. A 0% here
+    // would read as "every session failed" instead of "nothing was graded".
+    expect(within(rows[1]).getByText("—")).toBeTruthy();
+  });
+
+  it("shows the goal-completion card with a sample-honest sub", async () => {
+    renderTab();
+    const cards = await screen.findByTestId("swarm-overview-metric-cards");
+    expect(within(cards).getByText("50%")).toBeTruthy();
+    expect(
+      within(cards).getByText("6 graded sessions across 1 run")
+    ).toBeTruthy();
+  });
+});
+
+describe("Overview — findings", () => {
+  it("renders findings for the LATEST run only, with the graded denominator and streak", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+
+    const findings = within(journeyCard("journey-1")).getAllByTestId(
+      "swarm-overview-finding"
+    );
+    expect(findings).toHaveLength(2);
+
+    // 6 (graded), NOT 15 (the run's session total) — nine verdicts are still
+    // in flight and have nothing to say about this criterion.
+    expect(
+      within(findings[0]).getByText(/4 of 6 sessions · 2 runs/)
+    ).toBeTruthy();
+    expect(within(findings[0]).getByText("Quick resolution")).toBeTruthy();
+    expect(within(findings[0]).getByText(/9 still grading/)).toBeTruthy();
+    // 4 of 6 ≥ half ⇒ blocking; 1 of 6 ⇒ degraded.
+    expect(within(findings[0]).getByText("blocking")).toBeTruthy();
+    expect(within(findings[1]).getByText("degraded")).toBeTruthy();
+    // A single-run streak renders no "· N runs" suffix at all.
+    expect(within(findings[1]).queryByText(/· 1 runs/)).toBeNull();
+  });
+
+  it("falls back to the predicate-kind label when the criterion is unlabelled", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+    const findings = within(journeyCard("journey-1")).getAllByTestId(
+      "swarm-overview-finding"
+    );
+    expect(
+      within(findings[1]).getByText("Tool was called at least once")
+    ).toBeTruthy();
+  });
+
+  it("states the honest Run again semantics", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+    expect(
+      screen.getByText(
+        "Run again launches this journey with its current configuration."
+      )
+    ).toBeTruthy();
+  });
+
+  it("renders no findings block for a journey whose latest run has none", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+    expect(
+      within(journeyCard("journey-archived")).queryByTestId(
+        "swarm-overview-findings"
+      )
+    ).toBeNull();
+  });
+});
+
+describe("Overview — finding drill-down", () => {
+  it("expands to the sessions that FAILED the criterion, paginating the run", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+
+    const finding = within(journeyCard("journey-1")).getAllByTestId(
+      "swarm-overview-finding"
+    )[0];
+    fireEvent.click(finding);
+
+    // CONTRACT: the existing run-sessions query, keyed `journeyRunId`.
+    await waitFor(() => {
+      const call = paginatedCalls.find(
+        (c) => c.name === "journeyRuns:listSessionsByJourneyRun"
+      );
+      expect(call).toBeTruthy();
+      expect(call!.args).toEqual({ journeyRunId: "run-2" });
+    });
+
+    const sessions = await screen.findAllByTestId(
+      "swarm-overview-finding-session"
+    );
+    // Only the failing one: the passing session and the still-grading session
+    // (no `results` at all) are both excluded.
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].getAttribute("data-session-id")).toBe("thread-fail");
+    expect(within(sessions[0]).getByText(/I want my money back/)).toBeTruthy();
+  });
+
+  it("opens the clicked session in the Sessions browser", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+
+    fireEvent.click(
+      within(journeyCard("journey-1")).getAllByTestId(
+        "swarm-overview-finding"
+      )[0]
+    );
+    fireEvent.click(
+      (await screen.findAllByTestId("swarm-overview-finding-session"))[0]
+    );
+
+    await waitFor(() => expect(activeViewLabel()).toBe("Sessions"));
+    expect(screen.getByTestId("swarms-sessions-panel")).toBeTruthy();
+  });
+});
+
+describe("Overview — Run again", () => {
+  it("dispatches through the shared launch coordinator with an idempotency key", async () => {
+    launchJourneyRunMock.mockResolvedValue({ runId: "run-3" });
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+
+    fireEvent.click(
+      within(journeyCard("journey-1")).getByRole("button", {
+        name: "Run again",
+      })
+    );
+
+    await waitFor(() => expect(launchJourneyRunMock).toHaveBeenCalledTimes(1));
+    const arg = launchJourneyRunMock.mock.calls[0]![0] as any;
+    expect(arg.journeyId).toBe("journey-1");
+    expect(arg.projectId).toBe("proj-1");
+    expect(typeof arg.launchKey).toBe("string");
+    expect(arg.launchKey.length).toBeGreaterThan(0);
+  });
+
+  it("is DISABLED for an archived journey — relaunching one throws server-side", async () => {
+    renderTab();
+    await screen.findByTestId("swarms-overview-panel");
+
+    const button = within(journeyCard("journey-archived")).getByRole("button", {
+      name: "Run again",
+    });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(launchJourneyRunMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("Overview — empty and loading states", () => {
+  it("renders the create-persona hero when the project has no personas", async () => {
+    personasData = [];
+    renderTab();
+    expect(await screen.findByTestId("swarms-empty-hero")).toBeTruthy();
+  });
+
+  it("renders a distinct no-runs state when personas exist but nothing ran", async () => {
+    overviewData = {
+      runs: [],
+      runsConsidered: 0,
+      goalCompletion: {
+        gradedCount: 0,
+        passedCount: 0,
+        passRate: null,
+        runsWithGrades: 0,
+        trend: [],
+      },
+    };
+    renderTab();
+    expect(await screen.findByTestId("swarm-overview-no-runs")).toBeTruthy();
+    expect(screen.queryByTestId("swarms-empty-hero")).toBeNull();
+    // The cards still render — with "—", not 0%.
+    const cards = screen.getByTestId("swarm-overview-metric-cards");
+    expect(within(cards).getByText("no sessions graded yet")).toBeTruthy();
+  });
+
+  it("shows the loading shell — NOT the hero — while the persona list is loading", async () => {
+    // `undefined` personas is "we don't know yet", not "you have none".
+    // Collapsing the two flashes create-your-first-persona at every existing
+    // user on every mount.
+    personasData = undefined;
+    renderTab();
+    expect(await screen.findByTestId("swarm-overview-loading")).toBeTruthy();
+    expect(screen.queryByTestId("swarms-empty-hero")).toBeNull();
+  });
+
+  it("renders a loading shell — not a crash — while the query is undefined", async () => {
+    // This is the pre-backend-deploy shape, and the shape every other
+    // SwarmsTab suite renders under. An ErrorBoundary does not catch
+    // `undefined.runs`, so the shell has to be explicit.
+    overviewData = undefined;
+    renderTab();
+    expect(await screen.findByTestId("swarm-overview-loading")).toBeTruthy();
+    expect(screen.getByTestId("swarms-overview-panel")).toBeTruthy();
+  });
+});

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.personas.test.tsx
@@ -90,6 +90,7 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 import { SwarmsTab } from "../SwarmsTab";
+import { openPersonasTab } from "./swarms-tab-test-helpers";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -103,6 +104,7 @@ beforeEach(() => {
 describe("SwarmsTab — persona create/edit", () => {
   it("preselects the first persona on the Personas tab", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     await waitFor(() => {
       expect(screen.getByLabelText("Notes / personality")).toBeTruthy();
@@ -124,6 +126,7 @@ describe("SwarmsTab — persona create/edit", () => {
     });
 
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     const aside = screen.getByRole("complementary");
     fireEvent.click(within(aside).getByRole("button", { name: /^new$/i }));
@@ -140,6 +143,7 @@ describe("SwarmsTab — persona create/edit", () => {
 
   it("saves personality notes on blur via updatePersona", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     const notes = await screen.findByLabelText("Notes / personality");
     expect((notes as HTMLTextAreaElement).value).toBe("curious and impatient");
@@ -157,6 +161,7 @@ describe("SwarmsTab — persona create/edit", () => {
 
   it("saves an inline name edit via updatePersona", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     const nameLabels = await screen.findAllByText("Persona One");
     fireEvent.click(nameLabels[nameLabels.length - 1]!);
@@ -174,6 +179,7 @@ describe("SwarmsTab — persona create/edit", () => {
 
   it("deletes a persona from the sidebar trash button", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     const aside = await screen.findByRole("complementary");
     fireEvent.click(
@@ -194,6 +200,7 @@ describe("SwarmsTab — persona create/edit", () => {
     const seeded = resolvePersonaPixelLook("persona-1");
 
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(await screen.findByTestId("persona-avatar-look-trigger"));
     fireEvent.click(screen.getByTestId("persona-avatar-next-shape"));
 
@@ -209,6 +216,7 @@ describe("SwarmsTab — persona create/edit", () => {
   it("lights the sidebar avatar when the persona has a running journey", async () => {
     runningPersonaRefIds.current = ["persona-1"];
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     await waitFor(() => {
       const aside = screen.getByRole("complementary");
@@ -222,6 +230,7 @@ describe("SwarmsTab — persona create/edit", () => {
   it("does not mark a selected idle persona as busy", async () => {
     runningPersonaRefIds.current = [];
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
 
     await waitFor(() => {
       const aside = screen.getByRole("complementary");

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.sessions.test.tsx
@@ -227,6 +227,7 @@ vi.mock("@/components/swarms/convert-swarm-session-dialog", () => ({
 }));
 
 import { SwarmsTab } from "../SwarmsTab";
+import { openPersonasTab } from "./swarms-tab-test-helpers";
 
 beforeEach(() => {
   paginatedCalls.length = 0;
@@ -285,6 +286,7 @@ async function selectPersonaFilter(name: string) {
 describe("SwarmsTab — sessions-by-run query contract", () => {
   it("queries listSessionsByJourneyRun with { journeyRunId } and opens the viewer on the row's `id`", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
 
     await expandJourneyAndOpenRunSessions();
@@ -316,6 +318,7 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
 
   it("opens the promote dialog with the selected session row", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
     await expandJourneyAndOpenRunSessions();
 
@@ -337,6 +340,7 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
 
   it("opens a specific run when its trend segment is clicked", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
 
     // Host One's strip has one segment per run; clicking the completed (run-1)
@@ -358,6 +362,7 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
 
   it("surfaces failed attempts that never persisted a session transcript", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
     await expandJourneyAndOpenRunSessions("partial");
     fireEvent.click(
@@ -377,6 +382,7 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
 
   it("maps sticky chat-session 'active' to 'done' once the run completed", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
     await expandJourneyAndOpenRunSessions();
 
@@ -395,6 +401,7 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
 
   it("shows playground-style Trace / Chat / Raw tabs in the live pane", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     fireEvent.click(screen.getAllByText("Persona One")[0]);
     await expandJourneyAndOpenRunSessions();
     await selectFirstDoneCell();
@@ -411,6 +418,7 @@ describe("SwarmsTab — sessions-by-run query contract", () => {
 describe("SwarmsTab — top-level Journeys view", () => {
   it("defaults to listSessionsByProject and opens the viewer on `id`", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     openSessionsTab();
 
     await waitFor(() => {
@@ -438,6 +446,7 @@ describe("SwarmsTab — top-level Journeys view", () => {
 
   it("filters the visible list by client (host) without changing the query", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     openSessionsTab();
 
     // Both hosts' sessions are listed before filtering.
@@ -472,6 +481,7 @@ describe("SwarmsTab — top-level Journeys view", () => {
 
   it("narrows to listSessionsByPersona when a persona is selected, and clears back to all", async () => {
     render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    openPersonasTab();
     openSessionsTab();
     await selectPersonaFilter("Persona One");
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarms-tab-test-helpers.ts
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarms-tab-test-helpers.ts
@@ -1,0 +1,44 @@
+import { fireEvent, screen, within } from "@testing-library/react";
+
+/**
+ * Shared SwarmsTab navigation helpers.
+ *
+ * SwarmsTab now lands on the OVERVIEW tab, so a suite that exercises the
+ * Personas / Sessions / Insights surfaces has to navigate there first. Doing
+ * that through the real view-mode nav (rather than a prop) is deliberate: the
+ * tab wiring is the thing most likely to break when a view mode is added, and
+ * a helper that reached past the nav would hide exactly that.
+ */
+function viewNav(): HTMLElement {
+  return screen.getByRole("navigation", { name: "Swarm view" });
+}
+
+function openTab(label: string): void {
+  fireEvent.click(within(viewNav()).getByRole("button", { name: label }));
+}
+
+/** Overview — the default landing tab. */
+export function openOverviewTab(): void {
+  openTab("Overview");
+}
+
+/** Personas — the journeys/runs authoring surface (was the old default). */
+export function openPersonasTab(): void {
+  openTab("Personas");
+}
+
+/** Sessions — the flat swarm-session browser. */
+export function openSessionsTab(): void {
+  openTab("Sessions");
+}
+
+/** Insights — the session-flow sankey. */
+export function openInsightsTab(): void {
+  openTab("Insights");
+}
+
+/** The view mode currently marked active in the nav, by its label. */
+export function activeViewLabel(): string | null {
+  const current = within(viewNav()).queryByRole("button", { current: "page" });
+  return current?.textContent?.trim() ?? null;
+}

--- a/mcpjam-inspector/client/src/components/swarms/swarm-overview-panel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-overview-panel.tsx
@@ -1,0 +1,683 @@
+/**
+ * Swarms Overview — the default landing view.
+ *
+ * Three outcome metric cards, then the project's recent runs GROUPED BY
+ * JOURNEY, and under each journey's latest run the "findings": the rubric
+ * criteria that are failing, with a fail count over the graded denominator and
+ * a cross-run streak. Clicking a finding expands the sessions it failed on;
+ * clicking one of those opens it in the Sessions browser.
+ *
+ * Two honesty rules run through the whole panel:
+ *
+ *   - Denominators are the GRADED counts, never the session totals. Rubric
+ *     grading is asynchronous, so "4 of 15" while eleven verdicts are still in
+ *     flight would overstate the sample and understate the failure.
+ *   - Absent is unknown. A missing `criterionSummary`, a missing
+ *     `goalScoreSummary`, a zero graded count — each renders as "—" or as
+ *     nothing at all, never as 0%.
+ *
+ * Undefined-safety is load-bearing rather than polish: this is the DEFAULT tab
+ * and its query is string-keyed, so it renders against `undefined` from both
+ * queries whenever the backend hasn't deployed `getSwarmOverview` yet (and in
+ * every SwarmsTab test that mocks convex/react to `undefined`). The
+ * ErrorBoundary below catches a THROWING query; it cannot catch
+ * `undefined.runs`, so the shells are explicit.
+ */
+import { useMemo, useState } from "react";
+import { useQuery, usePaginatedQuery } from "convex/react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { ScrollArea } from "@mcpjam/design-system/scroll-area";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { cn } from "@/lib/utils";
+import { toast } from "@/lib/toast";
+import { evalSurfaceCardClass } from "@/components/evals/eval-surface-chrome";
+import {
+  LatencyTrendMetric,
+  TrendMetric,
+} from "@/components/evals/metric-strip";
+import { EvalSparkline } from "@/components/evals/eval-sparkline";
+import {
+  MIN_TREND_POINTS,
+  formatCompactNumber,
+} from "@/components/evals/metric-strip-data";
+import { SwarmsEmptyHero } from "@/components/swarms/swarms-empty-hero";
+import {
+  formatJourneyRelativeTime,
+  runStatusChipClass,
+} from "@/components/swarms/journey-run-format";
+import {
+  DEFAULT_PAGE_SIZE,
+  SWARM_QUERIES,
+  type JourneySessionRow,
+  type SwarmOverview,
+  type SwarmOverviewFinding,
+  type SwarmOverviewRun,
+  type SwarmSessionMetrics,
+} from "@/lib/swarm-api";
+import {
+  PREDICATE_KIND_LABELS,
+  type PredicateKind,
+} from "@/shared/predicate-kinds";
+
+/** Short day label for sparkline points, e.g. "Jul 3". */
+function formatDay(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** One decimal below 10%, whole percent above. `rate` is a 0..1 fraction. */
+function formatPercent(rate: number): string {
+  const pct = rate * 100;
+  return `${pct >= 10 || pct === 0 ? Math.round(pct) : pct.toFixed(1)}%`;
+}
+
+/**
+ * Author label, else the predicate kind's label, else the raw criterion id.
+ *
+ * The raw-id fallback is deliberate — a finding whose criterion no longer
+ * appears in the run snapshot still has real counts, and inventing a friendly
+ * name for it would be a guess.
+ */
+export function findingName(finding: SwarmOverviewFinding): string {
+  const label = finding.label?.trim();
+  if (label) return label;
+  if (finding.kind && finding.kind in PREDICATE_KIND_LABELS) {
+    return PREDICATE_KIND_LABELS[finding.kind as PredicateKind];
+  }
+  return finding.criterionId;
+}
+
+/**
+ * Severity is DERIVED, not stored: `blocking` once at least half the graded
+ * sessions failed the criterion, `degraded` otherwise.
+ *
+ * Never derived from a zero denominator. `failCount > 0` with
+ * `sessionsGraded === 0` is a contradiction the backend cannot produce, but
+ * `0 >= 0/2` is true, so an unguarded comparison would flag an empty run as
+ * blocking on the one shape where we know nothing at all.
+ */
+export function findingSeverity(
+  finding: SwarmOverviewFinding
+): "blocking" | "degraded" {
+  if (finding.sessionsGraded <= 0) return "degraded";
+  return finding.failCount >= finding.sessionsGraded / 2
+    ? "blocking"
+    : "degraded";
+}
+
+/** "4 of 15 sessions · 2 runs" — the graded denominator, plus the streak. */
+export function findingCountLabel(finding: SwarmOverviewFinding): string {
+  const base = `${finding.failCount} of ${finding.sessionsGraded} session${
+    finding.sessionsGraded === 1 ? "" : "s"
+  }`;
+  if (finding.runStreak <= 1) return base;
+  return `${base} · ${finding.runStreak} runs`;
+}
+
+/** Run score = judge pass rate. `null` whenever nothing was graded. */
+export function runScoreRate(run: SwarmOverviewRun): number | null {
+  const summary = run.goalScoreSummary;
+  if (!summary || summary.gradedCount <= 0) return null;
+  return summary.passedCount / summary.gradedCount;
+}
+
+type JourneyGroup = {
+  journeyRefId: string;
+  journeyName: string;
+  journeyArchived: boolean;
+  personaName: string;
+  /** Newest-first. The FIRST entry is the journey's latest run. */
+  runs: SwarmOverviewRun[];
+};
+
+/**
+ * Group runs by journey, preserving the backend's newest-first order both
+ * across groups (a journey ranks by its most recent run) and within them.
+ */
+export function groupRunsByJourney(
+  runs: readonly SwarmOverviewRun[]
+): JourneyGroup[] {
+  const groups = new Map<string, JourneyGroup>();
+  for (const run of runs) {
+    const existing = groups.get(run.journeyRefId);
+    if (existing) {
+      existing.runs.push(run);
+      continue;
+    }
+    groups.set(run.journeyRefId, {
+      journeyRefId: run.journeyRefId,
+      journeyName: run.journeyName,
+      journeyArchived: run.journeyArchived,
+      personaName: run.personaName,
+      runs: [run],
+    });
+  }
+  return [...groups.values()];
+}
+
+export interface SwarmOverviewPanelProps {
+  /** `null` while signed out — both queries skip rather than firing unscoped. */
+  projectId: string | null;
+  /**
+   * Whether the project has any personas — drives which empty state shows.
+   * `undefined` while the persona list is still loading: without that third
+   * state the panel flashes the create-your-first-persona hero at every
+   * existing user on every mount.
+   */
+  hasPersonas: boolean | undefined;
+  onCreatePersona: () => void;
+  /** Open a session in the Sessions browser (the parent owns the tab flip). */
+  onOpenSession: (sessionId: string) => void;
+  /**
+   * The SHARED per-journey launch coordinator from SwarmsTab — idempotency
+   * keys and in-flight dedupe come with it, so a Run again click here and a
+   * Run click on the Personas tab collapse into one paid run.
+   */
+  onLaunchJourney: (
+    journeyRefId: string
+  ) => Promise<
+    { status: "launched"; runId?: string } | { status: "already_launching" }
+  >;
+}
+
+export function SwarmOverviewPanel(props: SwarmOverviewPanelProps) {
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col"
+      data-testid="swarms-overview-panel"
+    >
+      {/* An undeployed backend query THROWS from useQuery. The fallback is the
+          empty state rather than `null`, because a blank default tab is what a
+          user would be staring at pre-backend-deploy. */}
+      <ErrorBoundary
+        fallback={
+          props.hasPersonas === false ? (
+            <SwarmsEmptyHero onCreatePersona={props.onCreatePersona} />
+          ) : (
+            <NoRunsEmptyState />
+          )
+        }
+      >
+        <SwarmOverviewPanelBody {...props} />
+      </ErrorBoundary>
+    </div>
+  );
+}
+
+function SwarmOverviewPanelBody({
+  projectId,
+  hasPersonas,
+  onCreatePersona,
+  onOpenSession,
+  onLaunchJourney,
+}: SwarmOverviewPanelProps) {
+  const overview = useQuery(
+    SWARM_QUERIES.getSwarmOverview as any,
+    (projectId ? { projectId } : "skip") as any
+  ) as SwarmOverview | undefined;
+
+  const metrics = useQuery(
+    SWARM_QUERIES.getSwarmSessionMetrics as any,
+    (projectId ? { projectId } : "skip") as any
+  ) as SwarmSessionMetrics | undefined;
+
+  const groups = useMemo(
+    () => groupRunsByJourney(overview?.runs ?? []),
+    [overview]
+  );
+
+  // Confirmed-empty personas ⇒ the create-persona hero, verbatim. Checked
+  // before the overview shell: an account with nothing in it should never see
+  // a spinner for data that will come back empty.
+  if (hasPersonas === false) {
+    return <SwarmsEmptyHero onCreatePersona={onCreatePersona} />;
+  }
+
+  if (hasPersonas === undefined || overview === undefined) {
+    return <LoadingShell />;
+  }
+
+  return (
+    <ScrollArea className="min-h-0 flex-1">
+      <div className="flex flex-col gap-4 px-6 py-5">
+        <OverviewMetricCards overview={overview} metrics={metrics} />
+        {groups.length === 0 ? (
+          <NoRunsEmptyState />
+        ) : (
+          <div className="flex flex-col gap-3">
+            {groups.map((group) => (
+              <JourneyGroupCard
+                key={group.journeyRefId}
+                group={group}
+                onOpenSession={onOpenSession}
+                onLaunchJourney={onLaunchJourney}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}
+
+// ── metric cards ────────────────────────────────────────────────────────────
+
+function OverviewMetricCards({
+  overview,
+  metrics,
+}: {
+  overview: SwarmOverview;
+  metrics: SwarmSessionMetrics | undefined;
+}) {
+  const { goalCompletion } = overview;
+
+  const goalPointLabels = useMemo(
+    () => goalCompletion.trend.map((p) => formatDay(p.dayStartMs)),
+    [goalCompletion]
+  );
+  const goalSeries = useMemo(
+    () => goalCompletion.trend.map((p) => p.passRate * 100),
+    [goalCompletion]
+  );
+  const sessionPointLabels = useMemo(
+    () => (metrics?.trend ?? []).map((p) => formatDay(p.dayStartMs)),
+    [metrics]
+  );
+  const sessionSeries = useMemo(() => {
+    const trend = metrics?.trend ?? [];
+    return {
+      tokens: trend.map((p) => p.avgTokensPerSession ?? 0),
+      latencyP50: trend.map((p) => p.latencyP50Ms ?? 0),
+      latencyP95: trend.map((p) => p.latencyP95Ms ?? 0),
+    };
+  }, [metrics]);
+
+  const showGoalTrend = goalCompletion.trend.length >= MIN_TREND_POINTS;
+  const showSessionTrend = (metrics?.trend?.length ?? 0) >= MIN_TREND_POINTS;
+
+  // State the SAMPLE, not just the number. The goal-completion judge does not
+  // auto-run by default, so "0 graded" is the ordinary case and the sub is
+  // what tells a reader the headline "—" means unmeasured, not failing.
+  const goalSub =
+    goalCompletion.gradedCount > 0
+      ? `${goalCompletion.gradedCount} graded session${
+          goalCompletion.gradedCount === 1 ? "" : "s"
+        } across ${goalCompletion.runsWithGrades} run${
+          goalCompletion.runsWithGrades === 1 ? "" : "s"
+        }`
+      : "no sessions graded yet";
+
+  return (
+    <div
+      className={cn(
+        evalSurfaceCardClass,
+        "grid grid-cols-1 overflow-hidden sm:grid-cols-3"
+      )}
+      data-testid="swarm-overview-metric-cards"
+    >
+      <TrendMetric
+        divider={false}
+        label="Goal completion"
+        value={
+          goalCompletion.passRate != null
+            ? formatPercent(goalCompletion.passRate)
+            : "—"
+        }
+        sub={goalSub}
+        chart={
+          showGoalTrend ? (
+            <EvalSparkline
+              points={goalSeries}
+              pointLabels={goalPointLabels}
+              formatValue={(v) => `${v.toFixed(0)}%`}
+              testId="swarm-overview-sparkline-goal"
+            />
+          ) : undefined
+        }
+      />
+      <TrendMetric
+        label="Tokens per session"
+        value={
+          metrics?.avgTokensPerSession != null
+            ? formatCompactNumber(metrics.avgTokensPerSession)
+            : "—"
+        }
+        sub={
+          metrics && metrics.tokenSampleCount > 0
+            ? `${metrics.tokenSampleCount} of ${metrics.sessionCount} sessions`
+            : "per session"
+        }
+        chart={
+          showSessionTrend && (metrics?.tokenSampleCount ?? 0) > 0 ? (
+            <EvalSparkline
+              points={sessionSeries.tokens}
+              pointLabels={sessionPointLabels}
+              formatValue={formatCompactNumber}
+              testId="swarm-overview-sparkline-tokens"
+            />
+          ) : undefined
+        }
+      />
+      {/* Session latency, NOT tool-call latency: the data model carries only
+          per-session summed host-turn latency (`readiness.hostLatencyMs`).
+          Labelling this "Tool call P50" would misname what it measures. */}
+      <LatencyTrendMetric
+        p50={metrics?.latencyP50Ms ?? null}
+        p95={metrics?.latencyP95Ms ?? null}
+        p50Series={sessionSeries.latencyP50}
+        p95Series={sessionSeries.latencyP95}
+        pointLabels={sessionPointLabels}
+        showTrend={showSessionTrend}
+        subLabel="per session"
+      />
+    </div>
+  );
+}
+
+// ── journey group ───────────────────────────────────────────────────────────
+
+function JourneyGroupCard({
+  group,
+  onOpenSession,
+  onLaunchJourney,
+}: {
+  group: JourneyGroup;
+  onOpenSession: (sessionId: string) => void;
+  onLaunchJourney: SwarmOverviewPanelProps["onLaunchJourney"];
+}) {
+  const [launching, setLaunching] = useState(false);
+  const latest = group.runs[0];
+
+  const onRunAgain = async () => {
+    if (launching || group.journeyArchived) return;
+    setLaunching(true);
+    try {
+      const result = await onLaunchJourney(group.journeyRefId);
+      if (result.status === "already_launching") return;
+      toast.success("Journey run started");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to start run");
+    } finally {
+      setLaunching(false);
+    }
+  };
+
+  return (
+    <section
+      className="rounded-lg border border-border/60"
+      data-testid="swarm-overview-journey"
+      data-journey-id={group.journeyRefId}
+    >
+      <header className="flex items-start justify-between gap-3 border-b border-border/40 px-4 py-3">
+        <div className="min-w-0">
+          <h3
+            className="truncate text-sm font-semibold"
+            title={group.journeyName}
+          >
+            {group.journeyName}
+          </h3>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {group.personaName}
+            {group.journeyArchived ? " · archived" : ""}
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7 shrink-0 px-2.5 text-xs"
+          disabled={launching || group.journeyArchived}
+          title={
+            group.journeyArchived
+              ? "This journey is archived — restore it to run again."
+              : undefined
+          }
+          onClick={() => void onRunAgain()}
+        >
+          {launching ? "Starting…" : "Run again"}
+        </Button>
+      </header>
+
+      <ul className="divide-y divide-border/40">
+        {group.runs.map((run) => (
+          <RunRow key={run.runId} run={run} />
+        ))}
+      </ul>
+
+      {latest.findings.length > 0 ? (
+        <div
+          className="border-t border-border/40 px-4 py-3"
+          data-testid="swarm-overview-findings"
+        >
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Findings · latest run
+          </p>
+          <div className="flex flex-col gap-1.5">
+            {latest.findings.map((finding) => (
+              <FindingRow
+                key={finding.criterionId}
+                finding={finding}
+                runId={latest.runId}
+                onOpenSession={onOpenSession}
+              />
+            ))}
+          </div>
+          <p className="mt-2.5 text-[11px] text-muted-foreground">
+            Run again launches this journey with its current configuration.
+          </p>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function RunRow({ run }: { run: SwarmOverviewRun }) {
+  const rate = runScoreRate(run);
+  return (
+    <li
+      className="flex items-center justify-between gap-3 px-4 py-2"
+      data-testid="swarm-overview-run"
+      data-run-id={run.runId}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <span
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
+            runStatusChipClass(run.status)
+          )}
+        >
+          {run.status}
+        </span>
+        <span className="truncate text-xs text-muted-foreground">
+          {formatJourneyRelativeTime(run.createdAt)} · {run.summary.succeeded}/
+          {run.summary.total} sessions
+        </span>
+      </div>
+      {/* "—" rather than 0%: an ungraded run is unmeasured, not failing. */}
+      <span className="shrink-0 text-xs font-semibold tabular-nums">
+        {rate != null ? formatPercent(rate) : "—"}
+      </span>
+    </li>
+  );
+}
+
+// ── findings ────────────────────────────────────────────────────────────────
+
+function FindingRow({
+  finding,
+  runId,
+  onOpenSession,
+}: {
+  finding: SwarmOverviewFinding;
+  runId: string;
+  onOpenSession: (sessionId: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const severity = findingSeverity(finding);
+
+  return (
+    <div className="rounded-md border border-border/50">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-2.5 py-2 text-left"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+        data-testid="swarm-overview-finding"
+        data-criterion-id={finding.criterionId}
+      >
+        <span
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+            severity === "blocking"
+              ? "bg-red-500/10 text-red-700 dark:text-red-400"
+              : "bg-amber-500/10 text-amber-700 dark:text-amber-400"
+          )}
+        >
+          {severity}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-xs font-medium">
+          {findingName(finding)}
+        </span>
+        <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
+          {findingCountLabel(finding)}
+          {finding.pendingCount > 0
+            ? ` · ${finding.pendingCount} still grading`
+            : ""}
+        </span>
+      </button>
+      {expanded ? (
+        <FindingSessions
+          runId={runId}
+          criterionId={finding.criterionId}
+          onOpenSession={onOpenSession}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The sessions a criterion actually failed on.
+ *
+ * Filtered CLIENT-side from the run's session page: `criteria.results` exists
+ * only on a COMPLETED grade, which is exactly the set we want — a pending or
+ * broken grade asserts nothing about this criterion. A run is bounded at
+ * hosts × sessionsPerHost, so paginating it whole is cheap.
+ */
+function FindingSessions({
+  runId,
+  criterionId,
+  onOpenSession,
+}: {
+  runId: string;
+  criterionId: string;
+  onOpenSession: (sessionId: string) => void;
+}) {
+  const { results, status, loadMore } = usePaginatedQuery(
+    SWARM_QUERIES.listSessionsByJourneyRun as any,
+    { journeyRunId: runId } as any,
+    { initialNumItems: Math.max(DEFAULT_PAGE_SIZE, 25) }
+  );
+
+  const rows = (results ?? []) as JourneySessionRow[];
+  const failing = useMemo(
+    () =>
+      rows.filter((row) =>
+        (row.criteria?.results ?? []).some(
+          (r) => r.criterionId === criterionId && r.passed === false
+        )
+      ),
+    [rows, criterionId]
+  );
+
+  if (status === "LoadingFirstPage") {
+    return (
+      <div className="flex items-center gap-2 border-t border-border/40 px-2.5 py-2 text-[11px] text-muted-foreground">
+        <Loader2 className="size-3 animate-spin" />
+        Loading sessions…
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-border/40 px-2.5 py-1.5">
+      {failing.length === 0 ? (
+        <p className="py-1 text-[11px] text-muted-foreground">
+          No loaded session carries a failing verdict for this criterion.
+        </p>
+      ) : (
+        <ul className="flex flex-col">
+          {failing.map((row) => (
+            <li key={row.id}>
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 rounded px-1 py-1.5 text-left hover:bg-muted/60"
+                onClick={() => onOpenSession(row.id)}
+                data-testid="swarm-overview-finding-session"
+                data-session-id={row.id}
+              >
+                <span className="shrink-0 text-[11px] font-medium">
+                  {row.personaLabel ?? row.visitorDisplayName ?? "Session"}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground">
+                  {row.firstMessagePreview ?? ""}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {status === "CanLoadMore" ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-6 w-full text-[11px]"
+          onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
+        >
+          Load more sessions
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+// ── shells + empty states ───────────────────────────────────────────────────
+
+function LoadingShell() {
+  return (
+    <div
+      className="flex min-h-0 flex-1 items-center justify-center gap-2 text-sm text-muted-foreground"
+      data-testid="swarm-overview-loading"
+    >
+      <Loader2 className="size-4 animate-spin" />
+      Loading overview…
+    </div>
+  );
+}
+
+/**
+ * Personas exist but nothing has been run yet. Distinct from the
+ * create-persona hero: the next action is launching a journey, which lives on
+ * the Personas tab, so the copy points there rather than at a button this
+ * panel doesn't own.
+ */
+function NoRunsEmptyState() {
+  return (
+    <div
+      className="flex min-h-0 flex-1 items-center justify-center px-6 py-10"
+      data-testid="swarm-overview-no-runs"
+    >
+      <div className="max-w-sm text-center">
+        <h3 className="text-sm font-semibold text-foreground">No runs yet</h3>
+        <p className="mt-1.5 text-pretty text-xs text-muted-foreground">
+          Open Personas and run one of your journeys. Once a run finishes, its
+          outcomes and any failing rubric criteria show up here.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/swarm-overview-panel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-overview-panel.tsx
@@ -23,7 +23,7 @@
  * ErrorBoundary below catches a THROWING query; it cannot catch
  * `undefined.runs`, so the shells are explicit.
  */
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, usePaginatedQuery } from "convex/react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -59,6 +59,7 @@ import {
   PREDICATE_KIND_LABELS,
   type PredicateKind,
 } from "@/shared/predicate-kinds";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
 
 /** Short day label for sparkline points, e.g. "Jul 3". */
 function formatDay(ms: number): string {
@@ -81,7 +82,7 @@ function formatPercent(rate: number): string {
  * appears in the run snapshot still has real counts, and inventing a friendly
  * name for it would be a guess.
  */
-export function findingName(finding: SwarmOverviewFinding): string {
+function findingName(finding: SwarmOverviewFinding): string {
   const label = finding.label?.trim();
   if (label) return label;
   if (finding.kind && finding.kind in PREDICATE_KIND_LABELS) {
@@ -99,7 +100,7 @@ export function findingName(finding: SwarmOverviewFinding): string {
  * `0 >= 0/2` is true, so an unguarded comparison would flag an empty run as
  * blocking on the one shape where we know nothing at all.
  */
-export function findingSeverity(
+function findingSeverity(
   finding: SwarmOverviewFinding
 ): "blocking" | "degraded" {
   if (finding.sessionsGraded <= 0) return "degraded";
@@ -109,7 +110,7 @@ export function findingSeverity(
 }
 
 /** "4 of 15 sessions · 2 runs" — the graded denominator, plus the streak. */
-export function findingCountLabel(finding: SwarmOverviewFinding): string {
+function findingCountLabel(finding: SwarmOverviewFinding): string {
   const base = `${finding.failCount} of ${finding.sessionsGraded} session${
     finding.sessionsGraded === 1 ? "" : "s"
   }`;
@@ -118,7 +119,7 @@ export function findingCountLabel(finding: SwarmOverviewFinding): string {
 }
 
 /** Run score = judge pass rate. `null` whenever nothing was graded. */
-export function runScoreRate(run: SwarmOverviewRun): number | null {
+function runScoreRate(run: SwarmOverviewRun): number | null {
   const summary = run.goalScoreSummary;
   if (!summary || summary.gradedCount <= 0) return null;
   return summary.passedCount / summary.gradedCount;
@@ -137,9 +138,7 @@ type JourneyGroup = {
  * Group runs by journey, preserving the backend's newest-first order both
  * across groups (a journey ranks by its most recent run) and within them.
  */
-export function groupRunsByJourney(
-  runs: readonly SwarmOverviewRun[]
-): JourneyGroup[] {
+function groupRunsByJourney(runs: readonly SwarmOverviewRun[]): JourneyGroup[] {
   const groups = new Map<string, JourneyGroup>();
   for (const run of runs) {
     const existing = groups.get(run.journeyRefId);
@@ -214,14 +213,19 @@ function SwarmOverviewPanelBody({
   onOpenSession,
   onLaunchJourney,
 }: SwarmOverviewPanelProps) {
+  // `shouldQueryProjectId`, not a bare truthiness check: a local/placeholder or
+  // UUID project id mid-transition would 500 the Convex arg validator, and the
+  // panel would surface that as an ErrorBoundary fallback rather than staying
+  // unloaded. Same guard the sibling project-scoped swarm reads use.
+  const queryable = shouldQueryProjectId(projectId);
   const overview = useQuery(
     SWARM_QUERIES.getSwarmOverview as any,
-    (projectId ? { projectId } : "skip") as any
+    (queryable ? { projectId } : "skip") as any
   ) as SwarmOverview | undefined;
 
   const metrics = useQuery(
     SWARM_QUERIES.getSwarmSessionMetrics as any,
-    (projectId ? { projectId } : "skip") as any
+    (queryable ? { projectId } : "skip") as any
   ) as SwarmSessionMetrics | undefined;
 
   const groups = useMemo(
@@ -489,7 +493,7 @@ function RunRow({ run }: { run: SwarmOverviewRun }) {
             runStatusChipClass(run.status)
           )}
         >
-          {run.status}
+          {run.status.replace(/_/g, " ")}
         </span>
         <span className="truncate text-xs text-muted-foreground">
           {formatJourneyRelativeTime(run.createdAt)} · {run.summary.succeeded}/
@@ -562,10 +566,16 @@ function FindingRow({
 /**
  * The sessions a criterion actually failed on.
  *
- * Filtered CLIENT-side from the run's session page: `criteria.results` exists
- * only on a COMPLETED grade, which is exactly the set we want — a pending or
- * broken grade asserts nothing about this criterion. A run is bounded at
- * hosts × sessionsPerHost, so paginating it whole is cheap.
+ * Filtered CLIENT-side from the run's sessions: `criteria.results` exists only
+ * on a COMPLETED grade, which is exactly the set we want — a pending or broken
+ * grade asserts nothing about this criterion.
+ *
+ * The run is paginated to EXHAUSTION before the list is presented. A run is
+ * bounded at hosts × sessionsPerHost (≤50 rows), so that costs at most a page
+ * or two — and the alternative is worse than slow: the headline count is over
+ * every graded session in the run, so filtering one page would quietly show
+ * "2 sessions" under a finding that says 4, with nothing on screen admitting
+ * the list was partial.
  */
 function FindingSessions({
   runId,
@@ -582,6 +592,13 @@ function FindingSessions({
     { initialNumItems: Math.max(DEFAULT_PAGE_SIZE, 25) }
   );
 
+  // Walk to the end of the run. Bounded by the run's own size, and each call
+  // moves the status to `LoadingMore`, so this advances once per landed page
+  // rather than spinning.
+  useEffect(() => {
+    if (status === "CanLoadMore") loadMore(DEFAULT_PAGE_SIZE);
+  }, [status, loadMore]);
+
   const rows = (results ?? []) as JourneySessionRow[];
   const failing = useMemo(
     () =>
@@ -593,7 +610,10 @@ function FindingSessions({
     [rows, criterionId]
   );
 
-  if (status === "LoadingFirstPage") {
+  // Hold the spinner until the run is fully loaded. Rendering the partial list
+  // mid-walk would flash a shorter set of affected sessions than the finding's
+  // own count claims — which is the exact discrepancy the walk exists to avoid.
+  if (status !== "Exhausted") {
     return (
       <div className="flex items-center gap-2 border-t border-border/40 px-2.5 py-2 text-[11px] text-muted-foreground">
         <Loader2 className="size-3 animate-spin" />
@@ -606,7 +626,7 @@ function FindingSessions({
     <div className="border-t border-border/40 px-2.5 py-1.5">
       {failing.length === 0 ? (
         <p className="py-1 text-[11px] text-muted-foreground">
-          No loaded session carries a failing verdict for this criterion.
+          No session in this run carries a failing verdict for this criterion.
         </p>
       ) : (
         <ul className="flex flex-col">
@@ -630,17 +650,6 @@ function FindingSessions({
           ))}
         </ul>
       )}
-      {status === "CanLoadMore" ? (
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="h-6 w-full text-[11px]"
-          onClick={() => loadMore(DEFAULT_PAGE_SIZE)}
-        >
-          Load more sessions
-        </Button>
-      ) : null}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/lib/swarm-api.ts
+++ b/mcpjam-inspector/client/src/lib/swarm-api.ts
@@ -33,6 +33,8 @@ export const SWARM_QUERIES = {
   listRunningPersonaRefIds: "journeyRuns:listRunningPersonaRefIds",
   /** Deterministic rubric scorecard for one run (run detail panel). */
   getRunScorecard: "journeyRuns:getRunScorecard",
+  /** Overview tab: recent runs grouped by journey + rubric-derived findings. */
+  getSwarmOverview: "journeyRuns:getSwarmOverview",
   /** Project environments picker (env-based journeys — flag-gated UI). */
   listEnvironments: "projectEnvironments:listEnvironments",
   /**
@@ -215,6 +217,71 @@ export interface RunScorecard {
   criteria: RunScorecardCriterion[];
   sessionsTotal: number;
   sessionsGraded: number;
+}
+
+// ── Swarms Overview (`journeyRuns:getSwarmOverview`) ────────────────────────
+//
+// Hand-mirrored from the backend `SwarmOverview` DTO (two-repo layout). The
+// field list here IS the contract — the panel's tests type their fixtures
+// against these interfaces so a backend rename forces a fixture edit rather
+// than silently rendering `NaN%`.
+
+/**
+ * One failing rubric criterion on a journey's LATEST run.
+ *
+ * `failCount` is over `sessionsGraded`, never the run's session total: grading
+ * is asynchronous, so a run with 15 sessions and 4 graded reads "4 of 4", not
+ * "4 of 15". Severity is NOT a field — it is derived client-side from
+ * `failCount` vs `sessionsGraded`, and only when that denominator is nonzero.
+ */
+export interface SwarmOverviewFinding {
+  criterionId: string;
+  /** Author-supplied name from the run's PINNED rubric; absent ⇒ format `kind`. */
+  label?: string;
+  /** Predicate discriminator — the fallback label. */
+  kind?: string;
+  failCount: number;
+  pendingCount: number;
+  failedGradingCount: number;
+  /** Denominator: sessions carrying a completed rubric verdict. */
+  sessionsGraded: number;
+  /** Consecutive runs (latest included) failing this criterion. Always ≥ 1. */
+  runStreak: number;
+}
+
+export interface SwarmOverviewRun {
+  runId: string;
+  journeyRefId: string;
+  journeyName: string;
+  /** Relaunching an archived journey throws server-side — disable Run again. */
+  journeyArchived: boolean;
+  personaName: string;
+  createdAt: number;
+  status: string;
+  summary: JourneyRunSummary;
+  goalScoreSummary?: GoalScoreRollup;
+  /** Populated on each journey's LATEST run only; `[]` on older runs. */
+  findings: SwarmOverviewFinding[];
+}
+
+export interface SwarmOverviewTrendPoint {
+  dayStartMs: number;
+  gradedCount: number;
+  passedCount: number;
+  passRate: number;
+}
+
+export interface SwarmOverview {
+  runs: SwarmOverviewRun[];
+  runsConsidered: number;
+  goalCompletion: {
+    gradedCount: number;
+    passedCount: number;
+    /** `null` when nothing in the window is graded — render "—", never 0%. */
+    passRate: number | null;
+    runsWithGrades: number;
+    trend: SwarmOverviewTrendPoint[];
+  };
 }
 
 /**


### PR DESCRIPTION
PR 2 of 2 for the Swarms Overview. **Depends on MCPJam/mcpjam-backend#857** — merge and deploy that first, then run its backfill. Until then the read is string-keyed and this panel degrades to its empty state.

## What this adds

The Swarms Overview, and it becomes the landing tab:

- **Three metric cards** — Goal completion (from the new query, with a daily sparkline), Tokens per session and Session latency P50/P95 (from the existing `getSwarmSessionMetrics`).
- **Runs grouped by journey** — journey header (name · persona), rows newest-first with status, relative time, session count and a score, plus a **Run again** button.
- **Findings under each journey's latest run** — the failing rubric criteria, with a derived severity pill, the fail count over the graded denominator, the cross-run streak, and "N still grading" when relevant.
- **Finding → affected sessions → session** — expanding a finding lists the sessions whose completed grade failed that criterion; clicking one opens it in the Sessions browser.

## Decisions worth flagging

**The third card is "Session latency P50", not "Tool call P50".** Per-tool-call latency exists nowhere in the data model — only per-session summed host-turn latency (`readiness.hostLatencyMs`). Relabelled rather than misrepresented; the denormalization that would enable a true tool-call card is a follow-up.

**Run again launches the journey's *current* configuration.** Snapshot-replay semantics ("reuses the run's cast, clients and rubric") are not implemented in the backend — run creation always re-resolves the live journey. So the footer says exactly that instead of implying a replay. Findings stay comparable across config edits anyway, because criterion ids are stable.

**Severity is derived, not stored** — `blocking` once `failCount ≥ sessionsGraded / 2`, else `degraded`, and never derived from a zero denominator.

**Denominators are graded counts.** A finding reads "4 of 6 sessions", not "4 of 15": the nine ungraded sessions have no verdict to fail. Anything unmeasured renders "—", never 0% — a 0% goal-completion headline would read as "everything failed" when the judge simply never ran (autoRun is off by default).

## Two fixes that came with it

- **Run again reuses SwarmsTab's existing per-journey launch coordinator**, so its idempotency key and in-flight dedupe carry over — a Run again click here and a Run click on the Personas tab collapse into one paid run rather than two. Disabled for archived journeys, whose relaunch throws server-side.
- **Deep-link gap in `SwarmsSessionsPanel`.** It applied `initialThreadId` only if the row happened to be on a loaded page, so opening a session from a finding could land on a list that ignored the click. It now walks up to ten more pages looking for the target — bounded, because the project session feed is not.

## Undefined-safety

The panel renders a loading/empty shell on `undefined` from either query rather than leaning on the ErrorBoundary. An ErrorBoundary catches a *throwing* query (the pre-backend-deploy case, which is why the fallback is the empty state and not `null`) but it cannot catch `undefined.runs` — and this is now the default tab. `undefined` personas is treated as "still loading", not "you have none", so existing users don't flash the create-your-first-persona hero on every mount.

## Testing

- New `SwarmsTab.overview.test.tsx`, 17 cases. Query dispatches are recorded and asserted by (name, args) — that's what protects the string-keyed `as any` reads — and every fixture is typed against the mirrored `SwarmOverview` interfaces, so a backend field rename forces a fixture edit instead of silently rendering `NaN%`.
- Covered: grouping and scores, findings with streak text and the graded denominator, the drill-down filtering to failing sessions (excluding the still-grading one) and flipping to Sessions, Run again through the launch coordinator and disabled when archived, both empty states, and the `undefined` shells.
- The nine existing SwarmsTab suites now navigate to Personas through the **real** view-mode nav via a shared test helper, rather than reaching around it — the tab wiring is the thing most likely to break when a view mode is added.
- Swarms suites: 23 files / 166 tests passing. Full `npm test` green, `tsc --noEmit` clean, `npm run build` green.

Not yet clicked through against a deployed backend — that wants the backend PR on dev first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtU1m7RWrwPuYxu3Z9VtUB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtU1m7RWrwPuYxu3Z9VtUB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default Swarms navigation, string-keyed Convex reads, and launch/idempotency paths; backend deploy timing can leave Overview on empty/loading shells until `getSwarmOverview` exists.
> 
> **Overview**
> **Swarms now opens on Overview** instead of Personas. Session/run deep links still route to Sessions or Personas; everything else lands on the new tab.
> 
> The **Overview** surface (`SwarmOverviewPanel`) pulls `journeyRuns:getSwarmOverview` and existing `getSwarmSessionMetrics`, shows goal completion / tokens / per-session latency cards, lists recent runs grouped by journey, and surfaces **findings** (failing rubric criteria on each journey’s latest run) with drill-down to failing sessions and a jump into the Sessions browser. **Run again** goes through the same idempotent `launchJourney` coordinator as Personas; archived journeys stay disabled. Client types for `SwarmOverview` are mirrored in `swarm-api.ts`.
> 
> **Routing and state:** Overview is a fourth view mode; Insights/Overview drill-downs share `drilldownThreadId` (replacing insights-only session state). **Persona auto-select** no longer depends on being on the Personas tab so `ui_launch_swarm_run` works from Overview.
> 
> **Sessions deep links:** `SwarmsSessionsPanel` pages up to 10 extra times to resolve `initialThreadId` and resets that budget when the target changes.
> 
> **Tests:** New `SwarmsTab.overview.test.tsx`, shared `swarms-tab-test-helpers` for tab navigation, and existing suites updated to open Personas via the real nav; agent test covers launch from the landing tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4909c50be9ab979ced39b6bf6d2a3a44b95934e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Swarms Overview as the default landing tab with outcome metrics and recent runs grouped by journey, including rubric findings with drill-downs to failing sessions. Also hardens deep links, launch idempotency, and landing-tab persona selection.

- **New Features**
  - New Overview tab (default): metric cards — Goal completion (+ sparkline), Tokens/session, Session latency P50/P95 (per-session).
  - Recent runs grouped by journey with status, relative time, session totals, per-run goal score, and “Run again”.
  - Findings on each journey’s latest run with derived severity, graded denominator, streak, and “N still grading”.
  - Finding → failing sessions drill-down; clicking a session opens the Sessions browser.
  - View routing: session deep links open Sessions; run/persona links open Personas; otherwise Overview.
  - Reads `journeyRuns:getSwarmOverview` and `journeyRuns:getSwarmSessionMetrics`; until available, shows an empty state.

- **Bug Fixes**
  - Session deep link now walks up to 10 extra pages in `SwarmsSessionsPanel` and re-arms for subsequent drill-downs.
  - “Run again” uses the shared per-journey launch coordinator (idempotency + in-flight dedupe); disabled for archived journeys.
  - Overview renders explicit loading/empty shells and gates queries with `shouldQueryProjectId`.
  - Persona auto-select is no longer gated on the Personas tab, so agent-bridge launches work from the landing Overview.
  - Run status chip displays underscored states nicely (“rate limited”).
  - Finding drill-down paginates the run to exhaustion before listing sessions, avoiding partial lists.

<sup>Written for commit 4909c50be9ab979ced39b6bf6d2a3a44b95934e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

