### PR TITLE
fix(github-checks): drop the egress lockdown, keep the platform baseline

### DIFF
--- a/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/github-checks-worker.test.ts
@@ -146,7 +146,6 @@ function harness(
         return {};
       },
     },
-    updateNetwork: async () => {},
     kill: async () => {},
   } as unknown as CheckSandbox;
 

--- a/mcpjam-inspector/server/services/github-checks-worker.ts
+++ b/mcpjam-inspector/server/services/github-checks-worker.ts
@@ -1156,7 +1156,7 @@ export async function executeClaimedCheck(
     // Runs the deterministic ladder against the checkout, then executes the
     // BACKEND'S candidates in the BACKEND'S order, reporting every phase, and
     // leaves the accepted box running a verified server. Provisioning, cloning,
-    // building, egress lockdown, the probe and the listener-identity check all
+    // building, the probe and the listener-identity check all
     // live in there, because the fresh-box-per-candidate policy is only
     // expressible where the boxes are made.
     const resolved = await deps.resolveAndStart(

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -840,7 +840,7 @@ describe("resolveAndStart — runtime verification", () => {
     }
   });
 
-  it("maps an infrastructure failure inside the build to `sandbox_error`", async () => {
+  it("maps a build/start infrastructure failure to `sandbox_error`", async () => {
     // Not `build_failed`: nothing about the PR's build is established by E2B
     // falling over, and the backend aborts on the infrastructure kinds rather
     // than burning the remaining candidates.
@@ -851,7 +851,7 @@ describe("resolveAndStart — runtime verification", () => {
       attempt: () => {
         throw new CheckStepError(
           "infra_error",
-          "sandbox provision failed: e2b 503"
+          "sandbox start failed: e2b 503"
         );
       },
     });

--- a/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/resolve-and-start.test.ts
@@ -202,7 +202,6 @@ function fakes(options: {
         sandboxId: `sb_${provisioned}`,
         getHost: (port: number) => `${port}-sb_${provisioned}.e2b.app`,
         commands: { run: async () => ({}) },
-        updateNetwork: async () => {},
         kill: async () => {},
       } as unknown as CheckSandbox;
       boxes.push(box);
@@ -842,9 +841,9 @@ describe("resolveAndStart — runtime verification", () => {
   });
 
   it("maps an infrastructure failure inside the build to `sandbox_error`", async () => {
-    // Not `build_failed`: nothing about the PR's build is established by our
-    // egress lockdown or E2B falling over, and the backend aborts on the
-    // infrastructure kinds rather than burning the remaining candidates.
+    // Not `build_failed`: nothing about the PR's build is established by E2B
+    // falling over, and the backend aborts on the infrastructure kinds rather
+    // than burning the remaining candidates.
     const session = fakeSession();
     const f = fakes({
       session,
@@ -852,7 +851,7 @@ describe("resolveAndStart — runtime verification", () => {
       attempt: () => {
         throw new CheckStepError(
           "infra_error",
-          "failed to disable sandbox egress before starting PR code"
+          "sandbox provision failed: e2b 503"
         );
       },
     });

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox-inspect.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox-inspect.test.ts
@@ -32,7 +32,6 @@ function boxRunning(
         return { exitCode: 0, stdout: result.stdout ?? "", stderr: "" };
       },
     },
-    updateNetwork: async () => {},
     kill: async () => {},
   } as unknown as CheckSandbox;
   return { sandbox, commands };

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox-provision.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox-provision.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { Sandbox } from "e2b";
+import {
+  GITHUB_CHECKS_EGRESS_DENY_CIDRS,
+  provisionCheckSandbox,
+} from "../sandbox";
+
+vi.mock("e2b", async () => {
+  const actual = await vi.importActual<typeof import("e2b")>("e2b");
+  return { ...actual, Sandbox: { ...actual.Sandbox, create: vi.fn() } };
+});
+
+describe("provisionCheckSandbox", () => {
+  it("creates a public box with the backend's non-guest egress baseline", async () => {
+    const create = vi.mocked(Sandbox.create);
+    const sandbox = { sandboxId: "sb_test" } as never;
+    vi.stubEnv("E2B_API_KEY", "e2b_test_key");
+    vi.stubEnv("GITHUB_CHECKS_E2B_TEMPLATE_ID", "template-test");
+    create.mockResolvedValueOnce(sandbox);
+
+    try {
+      await expect(
+        provisionCheckSandbox({
+          triggerId: "trigger-1",
+          repoFullName: "acme/example",
+          prNumber: 7,
+        })
+      ).resolves.toBe(sandbox);
+
+      expect(create).toHaveBeenCalledWith(
+        "template-test",
+        expect.objectContaining({
+          network: {
+            allowPublicTraffic: true,
+            denyOut: [...GITHUB_CHECKS_EGRESS_DENY_CIDRS],
+          },
+        })
+      );
+    } finally {
+      create.mockReset();
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
+++ b/mcpjam-inspector/server/services/github-checks/__tests__/sandbox.test.ts
@@ -5,7 +5,6 @@ import {
   CheckStepError,
   clampOutput,
   cloneAndCheckout,
-  lockDownEgress,
   OUTPUT_CLAMP_CHARS,
   PROBE_MAX_RESPONSE_BYTES,
   waitForMcpInitialize,
@@ -17,8 +16,13 @@ import { listRecipeRepos, lookupRecipe, resolveCheckRecipe } from "../recipes";
 // around the two properties that make that safe rather than around happy-path
 // plumbing:
 //
-//   1. egress is revoked BEFORE the PR's server process starts, and a failed
-//      revoke aborts instead of degrading to "start it anyway";
+//   1. the box's NETWORK IS NEVER TOUCHED after provisioning. It keeps the
+//      platform baseline (public internet, private ranges denied) for its whole
+//      life, so a server whose tools call an external API behaves the same
+//      inside a check as anywhere else. The fake still EXPOSES `updateNetwork`
+//      even though `CheckSandbox` no longer declares it, precisely so a
+//      reintroduced lockdown would show up in the event log and fail a test
+//      rather than pass unnoticed;
 //   2. failures are attributed correctly — a broken build is the PR's
 //      (`build_failed`), an unreachable E2B is ours (`infra_error`) — because
 //      the attribution is what decides whether someone gets a red X.
@@ -41,7 +45,6 @@ function fakeSandbox(options?: {
   stdout?: Record<string, string>;
   stderr?: Record<string, string>;
   throwOn?: (command: string) => unknown;
-  networkFails?: boolean;
   /** Emitted on the background command's stderr the moment it is spawned. */
   stderrOnSpawn?: string[];
 }) {
@@ -54,7 +57,13 @@ function fakeSandbox(options?: {
     return Object.keys(table).find((key) => command.includes(key));
   };
 
-  const sandbox: CheckSandbox = {
+  // TRIPWIRE, not plumbing: `CheckSandbox` no longer declares `updateNetwork`,
+  // and production code has no way to call it. The fake keeps it so that if a
+  // future change ever puts a network mutation back into this module, it lands
+  // in `events` and the "never modifies the network" test goes red on purpose.
+  const sandbox: CheckSandbox & {
+    updateNetwork(network: Record<string, unknown>): Promise<void>;
+  } = {
     sandboxId: "sb_test",
     getHost: (port: number) => `${port}-sb_test.e2b.app`,
     commands: {
@@ -91,7 +100,6 @@ function fakeSandbox(options?: {
     },
     updateNetwork: async (network) => {
       events.push(`network:${JSON.stringify(network)}`);
-      if (options?.networkFails) throw new Error("e2b network 502");
     },
     kill: async () => {
       events.push("kill");
@@ -205,7 +213,7 @@ function discoverCapabilitiesFetch(
 }
 
 describe("buildAndStart", () => {
-  it("locks down egress AFTER the build and BEFORE the server starts", async () => {
+  it("builds BEFORE it starts the server", async () => {
     const box = fakeSandbox();
     const fetchImpl = vi.fn(async () =>
       okInitialize()
@@ -214,35 +222,29 @@ describe("buildAndStart", () => {
     const started = await buildAndStart(box.sandbox, RECIPE, { fetchImpl });
 
     const buildIndex = box.events.findIndex((e) => e.includes("npm run build"));
-    const networkIndex = box.events.findIndex((e) => e.startsWith("network:"));
     const spawnIndex = box.events.findIndex((e) => e.startsWith("spawn:"));
 
     expect(buildIndex).toBeGreaterThanOrEqual(0);
-    expect(networkIndex).toBeGreaterThan(buildIndex);
-    expect(spawnIndex).toBeGreaterThan(networkIndex);
-    // Egress off, inbound untouched.
-    expect(box.events[networkIndex]).toBe(
-      'network:{"allowInternetAccess":false}'
-    );
+    expect(spawnIndex).toBeGreaterThan(buildIndex);
     expect(started.url).toBe("https://3001-sb_test.e2b.app/mcp");
   });
 
-  it("never starts the PR’s server if the egress lockdown fails", async () => {
-    const box = fakeSandbox({ networkFails: true });
+  it("never modifies the sandbox's network", async () => {
+    // The box keeps the network it was PROVISIONED with — public internet,
+    // private ranges denied by the platform baseline — for its whole life.
+    // This replaces an earlier egress lockdown that ran between the build and
+    // the start. It protected nothing (no credentials in the box, public-repo
+    // clone) while breaking every MCP server that proxies an external API,
+    // often GREEN because shallow assertions cannot tell a working tool call
+    // from an erroring one. Reintroducing one has to fail this test first.
+    const box = fakeSandbox();
     const fetchImpl = vi.fn(async () =>
       okInitialize()
     ) as unknown as typeof fetch;
 
-    await expect(
-      buildAndStart(box.sandbox, RECIPE, { fetchImpl })
-    ).rejects.toMatchObject({
-      name: "CheckStepError",
-      outcome: "infra_error",
-    });
+    await buildAndStart(box.sandbox, RECIPE, { fetchImpl });
 
-    // The load-bearing assertion: no background process was ever spawned.
-    expect(box.events.some((e) => e.startsWith("spawn:"))).toBe(false);
-    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(box.events.filter((e) => e.startsWith("network:"))).toEqual([]);
   });
 
   it("attributes a non-zero build to the PR, with a clamped log tail", async () => {
@@ -621,21 +623,6 @@ describe("cloneAndCheckout", () => {
     // injected text stays inside nested quotes.
     expect(box.calls[0].command.startsWith("bash -lc '")).toBe(true);
     expect(box.calls[0].command).not.toMatch(/;\s*rm -rf \/\s*'?\s*&&/);
-  });
-});
-
-describe("lockDownEgress", () => {
-  it("disables outbound while leaving the inbound host bridge alone", async () => {
-    const box = fakeSandbox();
-    await lockDownEgress(box.sandbox);
-    expect(box.events).toEqual(['network:{"allowInternetAccess":false}']);
-  });
-
-  it("surfaces a failure as infra_error so the caller can abort", async () => {
-    const box = fakeSandbox({ networkFails: true });
-    await expect(lockDownEgress(box.sandbox)).rejects.toMatchObject({
-      outcome: "infra_error",
-    });
   });
 });
 

--- a/mcpjam-inspector/server/services/github-checks/check-plan.ts
+++ b/mcpjam-inspector/server/services/github-checks/check-plan.ts
@@ -16,9 +16,9 @@
  *                            local attribution mapping is gone — it reports a
  *                            `failureKind` and the backend derives the verdict.
  *   THE INSPECTOR KEPT       deterministic `mcpjam.yaml` parsing and detection;
- *                            clone/build/start/probe; E2B lifecycle; egress
- *                            lockdown; cleanup; `/proc` listener identity;
- *                            telemetry. All still in the open.
+ *                            clone/build/start/probe; E2B lifecycle; cleanup;
+ *                            `/proc` listener identity; telemetry. All still in
+ *                            the open.
  *
  * The accepted cost, named: a check now depends on this backend mid-flight, so
  * a self-hosted Inspector cannot run checks standalone. That is the moat
@@ -117,6 +117,12 @@ export const ATTEMPT_FAILURE_KINDS = [
   "listener_unknown",
   "provision_failed",
   "clone_failed",
+  // RETIRED, deliberately kept. Nothing sends this any more — the egress
+  // lockdown it described is gone (see `sandbox.ts`). It stays because the
+  // value is mirrored by hand in the backend's `checkAttempts.failureKind`
+  // union and already exists on historical corpus rows; dropping it here is
+  // safe (the backend still accepts it), dropping it THERE first would not be.
+  // Retiring it on both sides is a follow-up, in backend-first order.
   "lockdown_failed",
   "sandbox_error",
   "lease_lost",

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -30,9 +30,10 @@
  * A FRESH SANDBOX PER CANDIDATE. Candidate B never runs in candidate A's box,
  * and A's box is KILLED BEFORE B's is provisioned (not merely before B's build):
  *
- *   1. EGRESS IS ALREADY REVOKED. `buildAndStart` locks the box down between
- *      build and start, on purpose. B's build would run with no network and
- *      fail for a reason that has nothing to do with B.
+ *   1. EGRESS KEEPS THE PLATFORM BASELINE. The box is provisioned with public
+ *      internet and the backend's non-guest RFC1918 denylist. `buildAndStart`
+ *      never changes that policy, so B's build and server see the same network
+ *      behavior as A's.
  *   2. A's PROCESSES ARE STILL ALIVE. A's server may hold the port, and it is
  *      A's code — so B's probe would be answered by A, which is the exact
  *      wrong-process-answering-the-probe class the runtime check below exists

--- a/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
+++ b/mcpjam-inspector/server/services/github-checks/resolve-and-start.ts
@@ -179,7 +179,7 @@ function provenanceOf(recipe: ResolvedRecipe): RecipeProvenance {
  * A `CheckStepError` from the sandbox, as the phase and failure kind it should
  * be REPORTED at.
  *
- * `buildAndStart` is one call covering build → lockdown → start → probe, so the
+ * `buildAndStart` is one call covering build → start → probe, so the
  * phase is inferred from the outcome the sandbox module already decided:
  * `build_failed` happened at the build, `server_unhealthy` means it built and
  * started and then never answered `initialize`, and anything else is our
@@ -198,10 +198,10 @@ function reportableStepFailure(error: CheckStepError): {
   if (error.outcome === "server_unhealthy") {
     return { phase: "probe", failureKind: "probe_failed" };
   }
-  // `sandbox_error` rather than `lockdown_failed`: the lockdown lives inside
-  // `buildAndStart`, and guessing which of its infrastructure failures we hit
-  // from an error string would file a wrong row in the corpus. Both attribute
-  // to `infra_error`, so the honest, coarser kind is the right one.
+  // `sandbox_error` is the honest coarse kind for everything else
+  // `buildAndStart` can fail with: guessing which of its infrastructure
+  // failures we hit from an error string would file a wrong row in the corpus,
+  // and they all attribute to `infra_error` anyway.
   return { phase: "build", failureKind: "sandbox_error" };
 }
 

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -8,15 +8,23 @@
  *     no token), and nothing about MCPJam's own environment is passed in;
  *   - it runs a DEDICATED minimal template (`GITHUB_CHECKS_E2B_TEMPLATE_ID`:
  *     node + git, nothing else), never the shared computer template;
- *   - outbound network is DISABLED after the build and BEFORE the PR's server
- *     starts. The build needs egress (`npm ci`); the server does not, and the
- *     server is the part that runs for twenty minutes while an eval suite pokes
- *     at it. If the lockdown fails we treat it as `infra_error` and never start
- *     the server — an open-egress box running PR code is not an acceptable
- *     degraded mode;
- *   - inbound eval traffic still arrives through `getHost(port)`, which is why
- *     the box is created with `allowPublicTraffic: true`. That is a one-way
- *     door: we can reach in, the box cannot reach out.
+ *   - outbound network is whatever the PLATFORM baseline grants and nothing
+ *     more: full public internet, with private ranges (RFC1918 and friends)
+ *     denied at the provider. PR code therefore cannot reach anything internal,
+ *     and we do not narrow it further. An earlier revision revoked egress
+ *     entirely between the build and the start; that is deliberately gone. It
+ *     defended nothing (there is no secret in the box to exfiltrate, and the
+ *     clone is a public repo), it is stricter than every mainstream CI system
+ *     running untrusted PR code, and it BROKE the product: a large share of MCP
+ *     servers exist to proxy an external API, so their tools failed inside a
+ *     check — often GREEN, because shallow assertions like
+ *     `toolCalledAtLeastOnce` cannot tell a working call from an erroring one.
+ *     A silent false pass is worse than the risk being defended against. The
+ *     real bounds on abuse are the same ones CI uses: a short TTL and
+ *     concurrency caps;
+ *   - inbound eval traffic arrives through `getHost(port)`, which is why the box
+ *     is created with `allowPublicTraffic: true`;
+ *   - the box is ephemeral and killed after the check.
  *
  * Failure attribution matters as much as failure detection. A build that exits
  * non-zero is the PR's problem (`build_failed`); a server that never answers
@@ -53,7 +61,10 @@ export class CheckStepError extends Error {
 /**
  * Structural view of the sandbox this module needs. Narrow on purpose: the unit
  * tests drive the whole build/start/health sequence through a fake, and a fake
- * of four methods stays honest where a fake of the entire E2B surface would not.
+ * of three methods stays honest where a fake of the entire E2B surface would
+ * not. Note what is NOT here: `updateNetwork`. This module never changes the
+ * box's network after provisioning, and leaving the method off the interface is
+ * what makes that mechanical rather than a convention.
  */
 export interface CheckSandbox {
   readonly sandboxId: string;
@@ -71,10 +82,6 @@ export interface CheckSandbox {
       }
     ): Promise<unknown>;
   };
-  updateNetwork(network: {
-    allowInternetAccess?: boolean;
-    denyOut?: string[];
-  }): Promise<void>;
   kill(): Promise<void>;
 }
 
@@ -292,8 +299,9 @@ export async function provisionCheckSandbox(args: {
       // If this process dies mid-check, E2B kills the box rather than paying to
       // keep a snapshot of someone's PR build around.
       lifecycle: { onTimeout: "kill" },
-      // Inbound only — the eval run reaches the server through `getHost`.
-      // Egress is revoked separately, after the build.
+      // The eval run reaches the server through `getHost`. Outbound is left at
+      // the platform baseline (public internet, private ranges denied) and is
+      // never modified afterwards — see the module docblock.
       network: { allowPublicTraffic: true },
       metadata: {
         purpose: "github-checks",
@@ -470,33 +478,6 @@ export async function cloneAndCheckout(
 }
 
 /**
- * Revoke outbound network.
- *
- * Called between the build and the start, and its ordering is a security
- * property, not an optimization: `npm ci` needs the registry, the PR's server
- * does not, and the server is the long-lived process an attacker would use. A
- * failure here is `infra_error` and ABORTS — the caller must never fall back to
- * starting the server with egress still open.
- */
-export async function lockDownEgress(sandbox: CheckSandbox): Promise<void> {
-  try {
-    // Equivalent to `denyOut: ['0.0.0.0/0']`; inbound (`allowPublicTraffic`) is
-    // untouched, so the eval run can still reach the server.
-    await sandbox.updateNetwork({ allowInternetAccess: false });
-    logger.info("[github-checks] egress locked down", {
-      sandboxId: sandbox.sandboxId,
-    });
-  } catch (error) {
-    throw new CheckStepError(
-      "infra_error",
-      `failed to disable sandbox egress before starting PR code: ${errorMessage(
-        error
-      )}`
-    );
-  }
-}
-
-/**
  * WHO WE STARTED — captured by the SPAWN, never read back out of the box.
  *
  * This is the anchor the listener-identity check hangs off, and the whole
@@ -542,15 +523,19 @@ export type StartedServer = {
 };
 
 /**
- * Build, lock down egress, start, and wait for the server to speak MCP.
+ * Build, start, and wait for the server to speak MCP.
  *
  * The step ORDER is the contract this function exists to guarantee, so it is
  * one function rather than three the caller sequences:
  *
- *   1. build (egress available)
- *   2. lock down egress            ← must land before any PR process is long-lived
- *   3. start the server
- *   4. poll `initialize` until it answers
+ *   1. build
+ *   2. start the server
+ *   3. poll `initialize` until it answers
+ *
+ * The box's network is NOT touched anywhere in here. It keeps the platform
+ * baseline it was provisioned with — public internet, private ranges denied —
+ * for its whole life, so a server whose tools call an external API behaves the
+ * same inside a check as it does anywhere else.
  */
 export async function buildAndStart(
   sandbox: CheckSandbox,
@@ -594,8 +579,6 @@ export async function buildAndStart(
       clampOutput(await readLogTail(sandbox, BUILD_LOG_PATH))
     );
   }
-
-  await lockDownEgress(sandbox);
 
   let spawnHandle: unknown;
   try {

--- a/mcpjam-inspector/server/services/github-checks/sandbox.ts
+++ b/mcpjam-inspector/server/services/github-checks/sandbox.ts
@@ -8,10 +8,10 @@
  *     no token), and nothing about MCPJam's own environment is passed in;
  *   - it runs a DEDICATED minimal template (`GITHUB_CHECKS_E2B_TEMPLATE_ID`:
  *     node + git, nothing else), never the shared computer template;
- *   - outbound network is whatever the PLATFORM baseline grants and nothing
- *     more: full public internet, with private ranges (RFC1918 and friends)
- *     denied at the provider. PR code therefore cannot reach anything internal,
- *     and we do not narrow it further. An earlier revision revoked egress
+ *   - outbound network is the same NON-GUEST PLATFORM BASELINE used by the
+ *     backend: full public internet, with the three RFC1918 private ranges
+ *     denied at the provider. This module passes that policy at CREATE time;
+ *     the box is never narrowed afterwards. An earlier revision revoked egress
  *     entirely between the build and the start; that is deliberately gone. It
  *     defended nothing (there is no secret in the box to exfiltrate, and the
  *     clone is a public repo), it is stricter than every mainstream CI system
@@ -96,6 +96,20 @@ export const BUILD_TIMEOUT_MS = 10 * 60_000;
 export const CLONE_TIMEOUT_MS = 5 * 60_000;
 export const HEALTH_TIMEOUT_MS = 2 * 60_000;
 export const HEALTH_INTERVAL_MS = 2_000;
+
+/**
+ * The GitHub-checks box is non-guest, so its baseline must match the backend's
+ * `resolveEgressBaseline(false)` exactly. Keep this hand-mirrored list in sync
+ * with `convex/lib/computerProviders/e2b.ts`; omitting it here would silently
+ * fall back to E2B's allow-all default. Link-local is intentionally not part of
+ * this list because E2B uses that range for its own metadata service.
+ */
+export const GITHUB_CHECKS_EGRESS_DENY_CIDRS = [
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+] as const;
+
 /**
  * Per-attempt cap on the health probe, clamped to the remaining deadline. A
  * healthy server answers `initialize` in milliseconds, so 10s is generous; the
@@ -299,10 +313,13 @@ export async function provisionCheckSandbox(args: {
       // If this process dies mid-check, E2B kills the box rather than paying to
       // keep a snapshot of someone's PR build around.
       lifecycle: { onTimeout: "kill" },
-      // The eval run reaches the server through `getHost`. Outbound is left at
-      // the platform baseline (public internet, private ranges denied) and is
-      // never modified afterwards — see the module docblock.
-      network: { allowPublicTraffic: true },
+      // The eval run reaches the server through `getHost`. Keep public egress,
+      // but apply the backend's non-guest RFC1918 baseline at creation time.
+      // The network is never modified afterwards — see the module docblock.
+      network: {
+        allowPublicTraffic: true,
+        denyOut: [...GITHUB_CHECKS_EGRESS_DENY_CIDRS],
+      },
       metadata: {
         purpose: "github-checks",
         triggerId: args.triggerId,


### PR DESCRIPTION
**This reverses an earlier decision in this same feature.** The GitHub-checks sandbox used to revoke outbound network between the build and the server start (`lockDownEgress`). This removes it. The box now keeps the network it was provisioned with — public internet, private ranges denied — for its whole life.

### Why the original reasoning doesn't hold

- **There is nothing in the box to exfiltrate.** Zero credentials by design, and an anonymous clone of a *public* repo. Nothing in there isn't already public.
- **The platform baseline already blocks what actually matters.** `resolveEgressBaseline` (backend `convex/lib/computerProviders/e2b.ts:178`) gives non-guest sandboxes `denyOut: <private CIDRs>` — so PR code already cannot reach our internal network. The lockdown was extra restriction layered on a baseline that was already correct.
- **Fork PRs are already rejected.** Only someone with push access to an allowlisted repo can trigger a run — a far smaller trust surface than public CI, which runs anonymous contributions with full egress.
- **Every CI system allows this.** GitHub Actions, CircleCI, Vercel and friends run untrusted PR code with full network. Abuse is bounded by TTL and concurrency caps, not by cutting DNS.

### And it was actively harmful

A large share of MCP servers exist to proxy an external API — GitHub, Slack, Stripe, weather. With egress cut, their tools fail inside a check. Worse, with a shallow assertion like `toolCalledAtLeastOnce`, the check can go **green** while every tool call errors on DNS. A silent false pass is a worse outcome than the risk the lockdown was defending against.

### What the sandbox still guarantees

Zero credentials · no private-range access (platform baseline) · dedicated minimal image · ephemeral, killed after the check · fork PRs never executed.

### Notes

- `lockdown_failed` is **kept** in the failure-kind union, unused. The value is hand-mirrored in the backend's `checkAttempts.failureKind` and already exists on historical corpus rows; dropping it here is safe, dropping it *there* first would not be. Retiring it on both sides is a follow-up, backend-first.
- New guard test: `never modifies the sandbox's network` asserts zero `network:` events during `buildAndStart`, so reintroducing a lockdown has to fail a test deliberately.
- Comments and docblocks describing the build→lockdown→start ordering are updated rather than orphaned.

### Verification

All github-checks suites, run **unpiped**:

```
$ npx vitest run server/services/github-checks \
      server/services/__tests__/github-checks-worker.test.ts
  Test Files  10 passed (10)
       Tests  460 passed (460)
$ echo $?
0

$ npm run check:mcp-v1-runtime-imports   # workspace root
$ echo $?
0
```

`tsc --noEmit` reports zero errors under `server/services/github-checks` (the repo has pre-existing errors in unrelated client test files).

**Live E2B run** of `scripts/verify-listener-identity.ts` against the real `mcpjam-github-checks` template. This is the evidence that matters here: it exercises provision → build → start → probe → listener identity, exactly the path this change touches, and the live image has contradicted the unit-test fakes before. All four scenarios passed, exit code `0`:

```
happy       SpawnIdentity pid=1482 pgrp=1482
            {"processes":[{"pid":1482,"ppids":[317],"pgrp":1482}]}   -> {"status":"ok"}
squatter    detached process binds first
            {"processes":[{"pid":1464,"ppids":[],"pgrp":317}]}       -> {"status":"mismatch"}
doublefork  reparented, ancestry gone, group intact
            {"processes":[{"pid":1479,"ppids":[],"pgrp":1472}]}      -> {"status":"ok"}
ipv6        server bound :: only, still attributed
            {"processes":[{"pid":1519,"ppids":[317],"pgrp":1519}]}   -> {"status":"ok"}
```

The probe answered over the public host bridge in all four (`https://3001-<id>.e2b.app/mcp`), confirming inbound is unaffected, and every box was killed after its scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes untrusted PR execution networking (wider egress during server/eval) but aligns with CI norms and fixes false-green checks; risk is mainly product/security tradeoff rather than accidental breakage, mitigated by provision-time private-range denylist and regression tests.
> 
> **Overview**
> **Removes the post-build egress lockdown** for GitHub-checks E2B sandboxes. Sandboxes no longer call `lockDownEgress()` or `updateNetwork` between build and server start; the flow is **build → start → probe** with the network unchanged for the box’s lifetime.
> 
> **Provisioning now sets the non-guest egress baseline at create time**: public traffic plus `denyOut` for the three RFC1918 CIDRs (`GITHUB_CHECKS_EGRESS_DENY_CIDRS`, mirrored from the backend). `CheckSandbox` drops `updateNetwork` so runtime code cannot narrow egress.
> 
> **Tests and docs** replace lockdown ordering assertions with a guard that `buildAndStart` emits no `network:` events, add `sandbox-provision.test.ts` for create-time network options, and retire `lockdown_failed` usage while keeping the failure kind in the union for historical/backend compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e4d1cb84460de88d459cc42440124b2c408e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped the egress lockdown for GitHub-checks sandboxes and now apply the RFC1918 denylist at provisioning. Sandboxes keep the platform baseline (public internet, private ranges denied) for their whole life, fixing false-green checks and letting MCP servers that call external APIs work.

- **Refactors**
  - Removed `lockDownEgress()` and `updateNetwork` from `CheckSandbox`; no post-provision network changes.
  - Applied the RFC1918 baseline at create (`denyOut` via `GITHUB_CHECKS_EGRESS_DENY_CIDRS`, `allowPublicTraffic: true` in `e2b` `Sandbox.create`).
  - Tests: added a provision test to assert the baseline; guard test ensures zero `network:` events during `buildAndStart`.
  - Mapped infra failures to `sandbox_error`; kept `lockdown_failed` in `ATTEMPT_FAILURE_KINDS` as retired; updated docs to the build → start → probe flow.

- **Bug Fixes**
  - Checks no longer go green while tool calls fail on DNS.

<sup>Written for commit 19e4d1cb84460de88d459cc42440124b2c408e85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

