### PR TITLE
fix(oauth-conformance): version-faithful resource_metadata discovery + the shared verdict

### DIFF
--- a/.changeset/oauth-fidelity.md
+++ b/.changeset/oauth-fidelity.md
@@ -1,0 +1,27 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": patch
+"@mcpjam/cli": patch
+---
+
+Make the OAuth conformance verdict honest, per protocol version.
+
+The resource-metadata check is now version-sensitive the way the spec is:
+2025-06-18 states a flat MUST for the WWW-Authenticate `resource_metadata`
+parameter, so its omission still fails there — but 2025-11-25 and 2026-07-28
+name TWO sanctioned discovery mechanisms, so on those revisions the check
+probes the RFC 9728 well-known URIs (path-scoped first, then root) before
+judging, and a server publishing metadata there passes with a note instead of
+failing. A well-known 200 must actually BE protected-resource metadata
+(carry the RFC 9728 `resource` member): an SPA answering every path with its
+index page does not count. A present-but-relative `resource_metadata` stays
+a violation everywhere the mechanism exists.
+
+The OAuth runner also adopts the shared verdict vocabulary, closing the last
+suite where "nothing failed" could read as "passed" over steps that could
+not run: `OAuthRunOutcome` gains `"incomplete"` (with `incompleteReason`),
+the CLI exits 3 for it like every other suite, the human formatter prints
+INCOMPLETE/INC, suite `passed` requires every flow to pass or be
+inapplicable, and the inspector badges it amber. Skipped steps without a
+could-not-run reason keep their existing verdicts, so current flows are
+unaffected.

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -502,7 +502,12 @@ export function registerOAuthCommands(program: Command): void {
       }
       // Worst-of the flows, matching the shared ordering: a violation (1)
       // outranks an unestablished run (3); not-applicable flows are neither.
-      const flowOutcomes = result.results.map((run) => run.outcome);
+      // A run without an outcome (older serialized data) falls back to
+      // `passed`, so a failure can never read as exit 0.
+      const flowOutcomes = result.results.map(
+        (run) =>
+          run.outcome ?? ((run as { passed?: boolean }).passed ? "passed" : "failed"),
+      );
       if (flowOutcomes.includes("failed")) {
         setProcessExitCode(1);
       } else if (flowOutcomes.includes("incomplete")) {

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -1,4 +1,7 @@
-import { reportScore } from "../lib/conformance-exit-code.js";
+import {
+  reportIncomplete,
+  reportScore,
+} from "../lib/conformance-exit-code.js";
 import {
   type OAuthConformanceConfig,
   type OAuthConformanceSuiteResult,
@@ -406,9 +409,15 @@ export function registerOAuthCommands(program: Command): void {
       // OPTIONAL, so a server that requires none has nothing to score.
       reportScore(scoreFromOAuthResult(result), command);
       // A not-applicable run is not a failure: authorization is OPTIONAL, so
-      // a server that requires none has no obligations to violate.
+      // a server that requires none has no obligations to violate. An
+      // incomplete run gets the same third exit code as every other suite —
+      // "we never established anything" is a different failure from "the
+      // server violated the spec", and a human must not have to dig for why.
+      reportIncomplete(result, command);
       if (result.outcome === "failed") {
         setProcessExitCode(1);
+      } else if (result.outcome === "incomplete") {
+        setProcessExitCode(3);
       }
     });
 
@@ -489,10 +498,15 @@ export function registerOAuthCommands(program: Command): void {
       }
       for (const run of result.results) {
         reportScore(scoreFromOAuthResult(run), command, run.label);
+        reportIncomplete(run, command);
       }
-      // Suite `passed` already treats a not-applicable flow as non-failing.
-      if (!result.passed) {
+      // Worst-of the flows, matching the shared ordering: a violation (1)
+      // outranks an unestablished run (3); not-applicable flows are neither.
+      const flowOutcomes = result.results.map((run) => run.outcome);
+      if (flowOutcomes.includes("failed")) {
         setProcessExitCode(1);
+      } else if (flowOutcomes.includes("incomplete")) {
+        setProcessExitCode(3);
       }
     });
 

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -211,7 +211,15 @@ function oauthStateFromResult(
   return {
     status: "done",
     result,
-    verdict: result.passed ? "passed" : "failed",
+    // OAuth now reports the same three-value verdict as the other suites
+    // (plus its own not-applicable, handled above), so an incomplete flow is
+    // badged amber rather than flattened to failed.
+    verdict:
+      result.outcome === "incomplete"
+        ? "incomplete"
+        : result.passed
+          ? "passed"
+          : "failed",
   };
 }
 

--- a/sdk/src/conformance-score.ts
+++ b/sdk/src/conformance-score.ts
@@ -299,10 +299,10 @@ export function scoreFromTasksResult(
  * which "a server without auth shouldn't deduct points" holds.
  *
  * Otherwise its steps adapt structurally (`step` → `id`) and are counted
- * directly — deliberately NOT trusting the suite's own `outcome`, which can
- * currently report "passed" over could-not-run steps. The score reads the
- * evidence, not the verdict. `teachableMoments` are explanations of failures
- * already costed at MUST weight, never advisories.
+ * directly: the score reads the evidence, not the verdict — even now that the
+ * runner derives its verdict from the same shared vocabulary, the score's
+ * arithmetic stays anchored to the steps themselves. `teachableMoments` are
+ * explanations of failures already costed at MUST weight, never advisories.
  */
 export function scoreFromOAuthResult(
   result: OAuthConformanceResult,

--- a/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
@@ -19,9 +19,14 @@ import type {
 // conformance suite where a violation is a hard FAIL against normative spec
 // text, not a readiness warning.
 //
-//   Finding 3 — the `WWW-Authenticate` challenge must carry an absolute
-//     `resource_metadata` URL (RFC 9728 §5.1). RFC 9728 entered the MCP spec
-//     at 2025-06-18, so this check skips on a 2025-03-26 target.
+//   Finding 3 — resource-metadata discovery must work. RFC 9728 entered the
+//     MCP spec at 2025-06-18 (this check skips on a 2025-03-26 target), where
+//     the WWW-Authenticate `resource_metadata` parameter is a flat MUST. From
+//     2025-11-25 the spec names TWO sanctioned mechanisms — the header, or
+//     protected-resource metadata at a well-known URI — so on those revisions
+//     a missing header only fails after both well-known URIs come up empty.
+//     A PRESENT-but-relative resource_metadata stays a violation everywhere
+//     the mechanism exists (RFC 9728 §5.1 requires an absolute URL).
 //   Finding 4 — an unauthenticated request must be answered with 401 + a Bearer
 //     challenge, never a 500 (RFC 6750 §3 / MCP authorization). A 2xx is not a
 //     violation — the spec permits anonymous `initialize` with authorization
@@ -399,14 +404,49 @@ export async function runResourceMetadataChallengeCheck(
   const resourceMetadata = extractResourceMetadata(wwwAuthenticate);
 
   if (!resourceMetadata) {
+    // Version-sensitive: 2025-06-18 states a flat MUST — "MCP servers MUST
+    // use the HTTP header WWW-Authenticate … to indicate the location of the
+    // resource server metadata URL" — so the omission is a violation there.
+    // 2025-11-25 (and 2026-07-28, verbatim) replaced it with "MCP servers
+    // MUST implement ONE of the following discovery mechanisms": the header,
+    // OR protected-resource metadata at a well-known URI (path-scoped first,
+    // then root). On those revisions the omission is only a violation when
+    // neither well-known URI serves the metadata either.
+    if (input.config.protocolVersion === "2025-06-18") {
+      return {
+        step: "oauth_resource_metadata_challenge",
+        status: "failed",
+        durationMs,
+        error: {
+          message:
+            "WWW-Authenticate Bearer challenge omitted the resource_metadata parameter; 2025-06-18 requires the header to indicate the resource metadata location (RFC 9728 §5.1)",
+          details: { wwwAuthenticate },
+        },
+      };
+    }
+
+    const wellKnown = await probeWellKnownResourceMetadata(input);
+    if (wellKnown.served) {
+      return {
+        step: "oauth_resource_metadata_challenge",
+        status: "passed",
+        durationMs: Date.now() - startedAt,
+        warnings: [
+          `The Bearer challenge omitted resource_metadata; discovery relies on the well-known URI (${wellKnown.url}), the second mechanism ${input.config.protocolVersion} sanctions`,
+        ],
+      };
+    }
+
     return {
       step: "oauth_resource_metadata_challenge",
       status: "failed",
-      durationMs,
+      durationMs: Date.now() - startedAt,
       error: {
-        message:
-          "WWW-Authenticate Bearer challenge omitted the resource_metadata parameter (RFC 9728 §5.1)",
-        details: { wwwAuthenticate },
+        message: `${input.config.protocolVersion} requires one of two discovery mechanisms, and the server provides neither: the WWW-Authenticate Bearer challenge omitted resource_metadata, and no well-known URI served protected-resource metadata`,
+        details: {
+          wwwAuthenticate,
+          wellKnownAttempts: wellKnown.attempts,
+        },
       },
     };
   }
@@ -428,6 +468,79 @@ export async function runResourceMetadataChallengeCheck(
     status: "passed",
     durationMs,
   };
+}
+
+/**
+ * RFC 9728 well-known probing, in the order 2025-11-25 lists: the path-scoped
+ * URI first (`/.well-known/oauth-protected-resource{endpoint-path}`), then the
+ * root. "Served" requires a 200 whose body is a JSON object carrying the
+ * RFC 9728 REQUIRED `resource` member — a bare 200 is not enough, or every
+ * SPA that answers unknown paths with its index page would count as
+ * publishing metadata.
+ */
+async function probeWellKnownResourceMetadata(
+  input: OAuthServerObligationInput,
+): Promise<{
+  served: boolean;
+  url?: string;
+  attempts: Array<{ url: string; status?: number; reason: string }>;
+}> {
+  const endpoint = new URL(input.config.serverUrl);
+  const origin = `${endpoint.protocol}//${endpoint.host}`;
+  const path = endpoint.pathname.replace(/\/$/, "");
+  const candidates = [
+    ...(path && path !== ""
+      ? [`${origin}/.well-known/oauth-protected-resource${path}`]
+      : []),
+    `${origin}/.well-known/oauth-protected-resource`,
+  ];
+
+  const attempts: Array<{ url: string; status?: number; reason: string }> = [];
+  for (const url of candidates) {
+    try {
+      const response = await input.trackedRequest({
+        method: "GET",
+        url,
+        headers: { Accept: "application/json" },
+      });
+      if (response.status !== 200) {
+        attempts.push({ url, status: response.status, reason: "non-200" });
+        continue;
+      }
+      const body =
+        typeof response.body === "string"
+          ? safeJsonParse(response.body)
+          : response.body;
+      if (
+        body !== null &&
+        typeof body === "object" &&
+        !Array.isArray(body) &&
+        typeof (body as Record<string, unknown>).resource === "string"
+      ) {
+        return { served: true, url, attempts };
+      }
+      attempts.push({
+        url,
+        status: response.status,
+        reason:
+          "200 but not RFC 9728 protected-resource metadata (no `resource` member)",
+      });
+    } catch (error) {
+      attempts.push({
+        url,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return { served: false, attempts };
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
 }
 
 // Unlike every other check, this request carries the REAL access token.

--- a/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-server-obligations.ts
@@ -403,7 +403,11 @@ export async function runResourceMetadataChallengeCheck(
 
   const resourceMetadata = extractResourceMetadata(wwwAuthenticate);
 
-  if (!resourceMetadata) {
+  // Strictly ABSENT, not falsy: `resource_metadata=""` is a present-but-empty
+  // parameter, and the absolute-URL branch below owns rejecting every present
+  // invalid value. Folding empty into "omitted" would let a valid well-known
+  // document launder a malformed challenge into a pass on 2025-11-25+.
+  if (resourceMetadata === undefined) {
     // Version-sensitive: 2025-06-18 states a flat MUST — "MCP servers MUST
     // use the HTTP header WWW-Authenticate … to indicate the location of the
     // resource server metadata URL" — so the omission is a violation there.
@@ -472,11 +476,21 @@ export async function runResourceMetadataChallengeCheck(
 
 /**
  * RFC 9728 well-known probing, in the order 2025-11-25 lists: the path-scoped
- * URI first (`/.well-known/oauth-protected-resource{endpoint-path}`), then the
- * root. "Served" requires a 200 whose body is a JSON object carrying the
- * RFC 9728 REQUIRED `resource` member — a bare 200 is not enough, or every
- * SPA that answers unknown paths with its index page would count as
- * publishing metadata.
+ * URI first (the well-known segment inserted before the endpoint's path AND
+ * query, per RFC 9728 §3), then the root. "Served" is held to what RFC 9728
+ * requires of a successful metadata response, or lookalikes would satisfy the
+ * one-of-two MUST:
+ *
+ *   - a 200 with an `application/json` media type (§3.2) — an SPA answering
+ *     unknown paths with its index page is not metadata;
+ *   - a JSON object whose REQUIRED `resource` member (§3.3) identifies the
+ *     resource actually under test — metadata published for a DIFFERENT
+ *     resource proves nothing about this one. Compared on normalized URLs so
+ *     cosmetic differences (default ports, trailing slash) don't false-fail.
+ *
+ * The probe carries the run's custom headers (a gateway bypass, a routing
+ * header) exactly like every other conformance request, minus any
+ * Authorization variant — discovery is defined unauthenticated.
  */
 async function probeWellKnownResourceMetadata(
   input: OAuthServerObligationInput,
@@ -487,13 +501,23 @@ async function probeWellKnownResourceMetadata(
 }> {
   const endpoint = new URL(input.config.serverUrl);
   const origin = `${endpoint.protocol}//${endpoint.host}`;
-  const path = endpoint.pathname.replace(/\/$/, "");
+  const pathAndQuery = `${endpoint.pathname.replace(/\/$/, "")}${endpoint.search}`;
   const candidates = [
-    ...(path && path !== ""
-      ? [`${origin}/.well-known/oauth-protected-resource${path}`]
+    ...(pathAndQuery
+      ? [`${origin}/.well-known/oauth-protected-resource${pathAndQuery}`]
       : []),
     `${origin}/.well-known/oauth-protected-resource`,
   ];
+
+  const headers: Record<string, string> = {
+    ...(input.config.customHeaders ?? {}),
+    Accept: "application/json",
+  };
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === "authorization") {
+      delete headers[key];
+    }
+  }
 
   const attempts: Array<{ url: string; status?: number; reason: string }> = [];
   for (const url of candidates) {
@@ -501,30 +525,48 @@ async function probeWellKnownResourceMetadata(
       const response = await input.trackedRequest({
         method: "GET",
         url,
-        headers: { Accept: "application/json" },
+        headers,
       });
       if (response.status !== 200) {
         attempts.push({ url, status: response.status, reason: "non-200" });
+        continue;
+      }
+      const contentType = getHeaderValue(response.headers, "content-type");
+      const mediaType = (contentType ?? "").split(";")[0]?.trim().toLowerCase();
+      if (mediaType !== "application/json") {
+        attempts.push({
+          url,
+          status: response.status,
+          reason: `200 but Content-Type "${contentType ?? "(none)"}" is not application/json (RFC 9728 §3.2)`,
+        });
         continue;
       }
       const body =
         typeof response.body === "string"
           ? safeJsonParse(response.body)
           : response.body;
-      if (
-        body !== null &&
-        typeof body === "object" &&
-        !Array.isArray(body) &&
-        typeof (body as Record<string, unknown>).resource === "string"
-      ) {
-        return { served: true, url, attempts };
+      const resource =
+        body !== null && typeof body === "object" && !Array.isArray(body)
+          ? (body as Record<string, unknown>).resource
+          : undefined;
+      if (typeof resource !== "string") {
+        attempts.push({
+          url,
+          status: response.status,
+          reason:
+            "200 but not RFC 9728 protected-resource metadata (no `resource` member)",
+        });
+        continue;
       }
-      attempts.push({
-        url,
-        status: response.status,
-        reason:
-          "200 but not RFC 9728 protected-resource metadata (no `resource` member)",
-      });
+      if (!urlsIdentify(resource, input.config.serverUrl)) {
+        attempts.push({
+          url,
+          status: response.status,
+          reason: `metadata identifies a different resource ("${resource}", not the server under test) — RFC 9728 §3.3 binds a document to its resource`,
+        });
+        continue;
+      }
+      return { served: true, url, attempts };
     } catch (error) {
       attempts.push({
         url,
@@ -533,6 +575,21 @@ async function probeWellKnownResourceMetadata(
     }
   }
   return { served: false, attempts };
+}
+
+/** URL identity on normalized form, so `https://a.example:443/mcp/` and
+ * `https://a.example/mcp` identify the same resource. */
+function urlsIdentify(left: string, right: string): boolean {
+  try {
+    const normalize = (value: string) => {
+      const url = new URL(value);
+      url.pathname = url.pathname.replace(/\/$/, "");
+      return url.href;
+    };
+    return normalize(left) === normalize(right);
+  } catch {
+    return false;
+  }
 }
 
 function safeJsonParse(text: string): unknown {

--- a/sdk/src/oauth-conformance/formatter.ts
+++ b/sdk/src/oauth-conformance/formatter.ts
@@ -270,9 +270,11 @@ function formatVerification(result: ConformanceResult): string[] {
   return lines;
 }
 
-/** A run that did not apply is neither PASSED nor FAILED. */
+/** A run that did not apply — or never exercised an applicable step — is
+ * neither PASSED nor FAILED. */
 function formatOutcome(outcome: ConformanceResult["outcome"]): string {
   if (outcome === "not-applicable") return "NOT APPLICABLE";
+  if (outcome === "incomplete") return "INCOMPLETE";
   return outcome === "passed" ? "PASSED" : "FAILED";
 }
 
@@ -305,7 +307,15 @@ export function formatOAuthConformanceSuiteHuman(
   result: OAuthConformanceSuiteResult,
 ): string {
   const lines = [
-    `OAuth conformance suite: ${result.passed ? "PASSED" : "FAILED"}`,
+    // Worst-of the flows, not a flattened boolean: a suite whose only
+    // non-passing flow is incomplete is unestablished, not violated.
+    `OAuth conformance suite: ${
+      result.results.some((flow) => flow.outcome === "failed")
+        ? "FAILED"
+        : result.results.some((flow) => flow.outcome === "incomplete")
+          ? "INCOMPLETE"
+          : "PASSED"
+    }`,
     `Suite: ${result.name}`,
     `Server: ${result.serverUrl}`,
     `Summary: ${result.summary}`,
@@ -317,9 +327,11 @@ export function formatOAuthConformanceSuiteHuman(
         `${
           flow.outcome === "not-applicable"
             ? "N/A "
-            : flow.outcome === "passed"
-              ? "PASS"
-              : "FAIL"
+            : flow.outcome === "incomplete"
+              ? "INC "
+              : flow.outcome === "passed"
+                ? "PASS"
+                : "FAIL"
         } ${flow.label}`,
     ),
   ];

--- a/sdk/src/oauth-conformance/runner.ts
+++ b/sdk/src/oauth-conformance/runner.ts
@@ -1,4 +1,5 @@
 import { randomInt } from "node:crypto";
+import { decideConformanceOutcome } from "../conformance-outcome.js";
 import {
   DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
   getConformanceAuthCodeDynamicRegistrationMetadata,
@@ -281,6 +282,46 @@ function buildSkippedStepResult(
   return { ...result, skipReason };
 }
 
+/**
+ * The run's verdict, from the shared vocabulary the other three suites use:
+ * "nothing failed" is not "passed" when an applicable step could not run.
+ * OAuth's own two states sit on top — a whole run the probe found
+ * inapplicable (authorization is OPTIONAL), and a flow that never reached
+ * completion, which is a failure regardless of per-step statuses. A skipped
+ * step WITHOUT a `"could-not-run"` reason counts as inapplicable, so the
+ * deliberate dedup-skips (a finding already owned by another check) and the
+ * strategy-gated steps keep their existing verdicts.
+ *
+ * Exported for direct testing: no natural flow can currently produce a
+ * could-not-run step while completing (the redirect URL always resolves), so
+ * the incomplete branch is proven here rather than through a contrived flow.
+ */
+export function deriveOAuthRunOutcome(input: {
+  steps: StepResult[];
+  flowComplete: boolean;
+  notApplicableReason?: string;
+}): { outcome: OAuthRunOutcome; incompleteReason?: string } {
+  if (input.notApplicableReason) {
+    return { outcome: "not-applicable" };
+  }
+  if (!input.flowComplete) {
+    return { outcome: "failed" };
+  }
+  const verdict = decideConformanceOutcome(
+    input.steps.map((step) => ({
+      id: step.step,
+      status: step.status,
+      ...(step.skipReason ? { skipReason: step.skipReason } : {}),
+      ...(step.error?.message
+        ? { error: { message: step.error.message } }
+        : {}),
+    })),
+  );
+  return verdict.outcome === "incomplete"
+    ? { outcome: "incomplete", incompleteReason: verdict.incompleteReason }
+    : { outcome: verdict.outcome };
+}
+
 function buildSummary(
   config: NormalizedOAuthConformanceConfig,
   steps: StepResult[],
@@ -292,6 +333,15 @@ function buildSummary(
 
   if (outcome === "passed") {
     return `OAuth conformance passed for ${config.serverUrl} (${config.protocolVersion}, ${config.registrationStrategy})`;
+  }
+
+  if (outcome === "incomplete") {
+    const unrun = steps.filter(
+      (step) => step.status === "skipped" && step.skipReason === "could-not-run",
+    );
+    return `OAuth conformance incomplete for ${config.serverUrl}: ${unrun.length} applicable step(s) could not run (${unrun
+      .map((step) => step.step)
+      .join(", ")}), so the run does not establish conformance`;
   }
 
   const failedSteps = steps.filter((step) => step.status === "failed");
@@ -926,12 +976,13 @@ export class OAuthConformanceTest {
       await interactiveSession?.stop().catch(() => undefined);
     }
 
-    let outcome: OAuthRunOutcome = notApplicableReason
-      ? "not-applicable"
-      : state.currentStep === "complete" &&
-          steps.every((step) => step.status !== "failed")
-        ? "passed"
-        : "failed";
+    const derived = deriveOAuthRunOutcome({
+      steps,
+      flowComplete: state.currentStep === "complete",
+      notApplicableReason,
+    });
+    let outcome: OAuthRunOutcome = derived.outcome;
+    let incompleteReason = derived.incompleteReason;
     let passed = outcome === "passed";
 
     // ── Post-auth verification ────────────────────────────────────────
@@ -1048,6 +1099,7 @@ export class OAuthConformanceTest {
     return {
       passed,
       outcome,
+      ...(incompleteReason ? { incompleteReason } : {}),
       protocolVersion: this.config.protocolVersion,
       registrationStrategy: this.config.registrationStrategy,
       serverUrl: this.config.serverUrl,

--- a/sdk/src/oauth-conformance/suite.ts
+++ b/sdk/src/oauth-conformance/suite.ts
@@ -34,11 +34,23 @@ function buildSuiteSummary(
     return `All ${total} flows passed for ${serverUrl}${suffix}`;
   }
 
-  // A not-applicable flow is not a failure — only genuine failures are named.
+  // A not-applicable flow is not a failure — only genuine failures are named,
+  // and incomplete flows are named as what they are: unestablished, not
+  // violated.
   const failures = results
     .filter((r) => r.outcome === "failed")
     .map((r) => r.label);
-  return `${passedCount}/${total} flows passed. Failed: ${failures.join(", ")}`;
+  const incomplete = results
+    .filter((r) => r.outcome === "incomplete")
+    .map((r) => r.label);
+  const parts = [`${passedCount}/${total} flows passed.`];
+  if (failures.length > 0) {
+    parts.push(`Failed: ${failures.join(", ")}`);
+  }
+  if (incomplete.length > 0) {
+    parts.push(`Incomplete: ${incomplete.join(", ")}`);
+  }
+  return parts.join(" ");
 }
 
 /**
@@ -82,8 +94,12 @@ export class OAuthConformanceSuite {
 
     const durationMs = Date.now() - startedAt;
     // A flow that did not apply cannot fail the suite: authorization is
-    // OPTIONAL, so a server that requires none has nothing to violate.
-    const passed = results.every((r) => r.outcome !== "failed");
+    // OPTIONAL, so a server that requires none has nothing to violate. An
+    // incomplete flow is not a pass either — it established nothing — so the
+    // suite is green only when every flow passed or was inapplicable.
+    const passed = results.every(
+      (r) => r.outcome === "passed" || r.outcome === "not-applicable",
+    );
 
     return {
       name: this.config.name ?? "OAuth Conformance Suite",

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -179,8 +179,20 @@ export type OAuthSkipReason = ConformanceSkipReason;
  * true ONLY for `"passed"` — but a `"not-applicable"` run is not a failure
  * either, which is exactly why a third value is needed: a public server used
  * to be reported as a hard OAuth failure.
+ *
+ * `"incomplete"` is the fourth value, aligning OAuth with the other three
+ * suites' {@link ConformanceRunOutcome}: a completed flow whose applicable
+ * steps include one that COULD NOT RUN established nothing about that
+ * obligation, and calling it "passed" is how a two-of-eight run once reported
+ * success elsewhere. OAuth keeps `"not-applicable"` on top because a whole
+ * RUN can be inapplicable (authorization is OPTIONAL), which no other suite
+ * expresses.
  */
-export type OAuthRunOutcome = "passed" | "failed" | "not-applicable";
+export type OAuthRunOutcome =
+  | "passed"
+  | "failed"
+  | "incomplete"
+  | "not-applicable";
 
 export interface StepResult {
   step: ConformanceStepId;
@@ -208,6 +220,11 @@ export interface ConformanceResult {
   /** True only when `outcome` is `"passed"`. */
   passed: boolean;
   outcome: OAuthRunOutcome;
+  /**
+   * Present when `outcome` is `"incomplete"`: which steps never ran and what
+   * has to change for them to run.
+   */
+  incompleteReason?: string;
   protocolVersion: OAuthProtocolVersion;
   registrationStrategy: OAuthRegistrationStrategy;
   serverUrl: string;

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -831,6 +831,148 @@ describe("oauth server obligation checks", () => {
       });
     });
 
+    it("fails an EMPTY resource_metadata as present-but-invalid, even with valid well-known metadata", async () => {
+      const trackedRequest = jest.fn().mockImplementation(async (request) => {
+        if (request.url.includes("/.well-known/")) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
+            body: { resource: "https://mcp.example.com" },
+          };
+        }
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": 'Bearer resource_metadata=""' },
+          body: undefined,
+        };
+      });
+
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest,
+      });
+
+      // A present-but-empty parameter is a malformed challenge, not an
+      // omission — the well-known fallback must not launder it into a pass.
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "failed",
+        error: {
+          message: expect.stringContaining("must be an absolute http(s) URL"),
+        },
+      });
+    });
+
+    it("holds a well-known 200 to RFC 9728: JSON media type and a resource that identifies the server under test", async () => {
+      const requested: Array<{ url: string; headers: Record<string, string> }> = [];
+      const trackedRequest = jest.fn().mockImplementation(async (request) => {
+        requested.push({ url: request.url, headers: request.headers });
+        if (request.url.endsWith("/.well-known/oauth-protected-resource/api/mcp")) {
+          // JSON-looking body under the wrong media type (§3.2).
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "text/html" },
+            body: '{"resource":"https://mcp.example.com/api/mcp"}',
+          };
+        }
+        if (request.url.endsWith("/.well-known/oauth-protected-resource")) {
+          // Right media type, but metadata for a DIFFERENT resource (§3.3).
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
+            body: { resource: "https://other.example.com/mcp" },
+          };
+        }
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": 'Bearer error="invalid_token"' },
+          body: undefined,
+        };
+      });
+
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        config: {
+          ...(baseObligationInput.config as any),
+          serverUrl: "https://mcp.example.com/api/mcp",
+          customHeaders: {
+            "x-gateway-key": "route-me",
+            Authorization: "Bearer must-not-leak",
+          },
+        },
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "failed",
+        error: { message: expect.stringContaining("provides neither") },
+      });
+      const details = (result as any).error?.details;
+      expect(JSON.stringify(details)).toContain("not application/json");
+      expect(JSON.stringify(details)).toContain("different resource");
+
+      // The probe carries the run's routing headers but never credentials.
+      const wellKnown = requested.filter((r) => r.url.includes("/.well-known/"));
+      expect(wellKnown.length).toBeGreaterThan(0);
+      for (const request of wellKnown) {
+        expect(request.headers["x-gateway-key"]).toBe("route-me");
+        expect(
+          Object.keys(request.headers).some(
+            (key) => key.toLowerCase() === "authorization",
+          ),
+        ).toBe(false);
+      }
+    });
+
+    it("inserts the well-known segment before both path and query", async () => {
+      const requested: string[] = [];
+      const trackedRequest = jest.fn().mockImplementation(async (request) => {
+        requested.push(request.url);
+        if (request.url.includes("/.well-known/")) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
+            body: { resource: "https://mcp.example.com/api/mcp?tenant=a" },
+          };
+        }
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": 'Bearer error="invalid_token"' },
+          body: undefined,
+        };
+      });
+
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        config: {
+          ...(baseObligationInput.config as any),
+          serverUrl: "https://mcp.example.com/api/mcp?tenant=a",
+        },
+        trackedRequest,
+      });
+
+      expect(result.status).toBe("passed");
+      // RFC 9728 §3: the well-known segment precedes path AND query.
+      expect(requested).toContain(
+        "https://mcp.example.com/.well-known/oauth-protected-resource/api/mcp?tenant=a",
+      );
+    });
+
     it("skips on 2025-03-26, which predates RFC 9728, without probing", async () => {
       const trackedRequest = jest.fn();
       const result = await runResourceMetadataChallengeCheck({

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -650,22 +650,115 @@ describe("oauth server obligation checks", () => {
       });
     });
 
-    it("fails when the challenge omits resource_metadata", async () => {
+    it("fails an omitted resource_metadata outright on 2025-06-18, where the header is a flat MUST", async () => {
+      const trackedRequest = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        headers: { "www-authenticate": 'Bearer error="invalid_token"' },
+        body: undefined,
+      });
       const result = await runResourceMetadataChallengeCheck({
         ...(baseObligationInput as any),
-        trackedRequest: jest.fn().mockResolvedValue({
-          ok: false,
-          status: 401,
-          statusText: "Unauthorized",
-          headers: { "www-authenticate": 'Bearer error="invalid_token"' },
-          body: undefined,
-        }),
+        config: {
+          ...(baseObligationInput.config as any),
+          protocolVersion: "2025-06-18",
+        },
+        trackedRequest,
       });
 
       expect(result).toMatchObject({
         step: "oauth_resource_metadata_challenge",
         status: "failed",
-        error: { message: expect.stringContaining("omitted the resource_metadata parameter") },
+        error: {
+          message: expect.stringContaining("2025-06-18 requires the header"),
+        },
+      });
+      // The flat MUST needs no fallback probing: one request, no well-known.
+      expect(trackedRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes an omitted resource_metadata on 2025-11-25 when a well-known URI serves the metadata, path-scoped first", async () => {
+      const requested: string[] = [];
+      const trackedRequest = jest.fn().mockImplementation(async (request) => {
+        requested.push(request.url);
+        if (request.url.includes("/.well-known/oauth-protected-resource")) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
+            body: {
+              resource: "https://mcp.example.com/api/mcp",
+              authorization_servers: ["https://as.example.com"],
+            },
+          };
+        }
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": 'Bearer error="invalid_token"' },
+          body: undefined,
+        };
+      });
+
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        config: {
+          ...(baseObligationInput.config as any),
+          serverUrl: "https://mcp.example.com/api/mcp",
+        },
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "passed",
+        warnings: [expect.stringContaining("well-known URI")],
+      });
+      // 2025-11-25 lists the path-scoped URI before the root.
+      const wellKnownRequests = requested.filter((url) =>
+        url.includes("/.well-known/"),
+      );
+      expect(wellKnownRequests[0]).toBe(
+        "https://mcp.example.com/.well-known/oauth-protected-resource/api/mcp",
+      );
+    });
+
+    it("fails on 2025-11-25 when the header is omitted and no well-known URI serves real metadata", async () => {
+      // A 200 that is NOT protected-resource metadata (an SPA index page)
+      // must not count as the second mechanism.
+      const trackedRequest = jest.fn().mockImplementation(async (request) => {
+        if (request.url.includes("/.well-known/")) {
+          return {
+            ok: true,
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "text/html" },
+            body: "<html>app shell</html>",
+          };
+        }
+        return {
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          headers: { "www-authenticate": 'Bearer error="invalid_token"' },
+          body: undefined,
+        };
+      });
+
+      const result = await runResourceMetadataChallengeCheck({
+        ...(baseObligationInput as any),
+        trackedRequest,
+      });
+
+      expect(result).toMatchObject({
+        step: "oauth_resource_metadata_challenge",
+        status: "failed",
+        error: {
+          message: expect.stringContaining("provides neither"),
+        },
       });
     });
 
@@ -730,10 +823,10 @@ describe("oauth server obligation checks", () => {
       expect(result).toMatchObject({
         step: "oauth_resource_metadata_challenge",
         status: "failed",
+        // A lookalike parameter is an omission; on 2025-11-25 that cascades
+        // into the well-known probe, and this mock serves neither mechanism.
         error: {
-          message: expect.stringContaining(
-            "omitted the resource_metadata parameter",
-          ),
+          message: expect.stringContaining("provides neither"),
         },
       });
     });

--- a/sdk/tests/oauth-conformance/formatter.test.ts
+++ b/sdk/tests/oauth-conformance/formatter.test.ts
@@ -331,6 +331,33 @@ describe("OAuth conformance suite human formatter", () => {
     expect(output.match(/^\[flow-/gm)).toHaveLength(1);
   });
 
+  it("labels a suite INCOMPLETE when its only non-passing flow is unestablished", () => {
+    const incompleteFlow: ConformanceResult = {
+      ...createPassingResult(),
+      passed: false,
+      outcome: "incomplete",
+      incompleteReason: "1 of 2 selected check(s) could not run",
+    };
+    const suite: OAuthConformanceSuiteResult = {
+      name: "Incomplete Suite",
+      serverUrl: "https://mcp.example.com/mcp",
+      passed: false,
+      results: [
+        { ...createPassingResult(), label: "flow-1" },
+        { ...incompleteFlow, label: "flow-2" },
+      ],
+      summary: "1/2 flows passed. Incomplete: flow-2",
+      durationMs: 100,
+    };
+
+    const output = formatOAuthConformanceSuiteHuman(suite);
+
+    // Unestablished, not violated: the header and the flow line both say so.
+    expect(output).toContain("OAuth conformance suite: INCOMPLETE");
+    expect(output).toContain("INC  flow-2");
+    expect(output).not.toContain("suite: FAILED");
+  });
+
   it("shows verification details for flows that fail only post-auth verification", () => {
     // Post-auth verification failure: the runner downgrades BOTH `passed` and
     // `outcome`, so the fixture goes through the builder to stay consistent.

--- a/sdk/tests/oauth-conformance/runner.test.ts
+++ b/sdk/tests/oauth-conformance/runner.test.ts
@@ -1,4 +1,5 @@
 import { OAuthConformanceTest } from "../../src/oauth-conformance/index.js";
+import { deriveOAuthRunOutcome } from "../../src/oauth-conformance/runner.js";
 import { DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL } from "../../src/oauth/client-identity.js";
 import { MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION } from "../../src/oauth/state-machines/shared/initialize.js";
 import * as operations from "../../src/operations.js";
@@ -27,6 +28,80 @@ function createMcpInitializeResponse(protocolVersion: string): Response {
     },
   });
 }
+
+describe("deriveOAuthRunOutcome", () => {
+  const step = (
+    id: string,
+    status: "passed" | "failed" | "skipped",
+    skipReason?: "not-applicable" | "could-not-run",
+  ) =>
+    ({
+      step: id,
+      title: id,
+      summary: "",
+      status,
+      ...(skipReason ? { skipReason } : {}),
+      durationMs: 0,
+      logs: [],
+      httpAttempts: [],
+      ...(skipReason === "could-not-run"
+        ? { error: { message: `${id} could not run` } }
+        : {}),
+    }) as any;
+
+  it("reports incomplete, not passed, when an applicable step could not run", () => {
+    const derived = deriveOAuthRunOutcome({
+      steps: [
+        step("request_without_token", "passed"),
+        step("oauth_invalid_redirect", "skipped", "could-not-run"),
+      ],
+      flowComplete: true,
+    });
+
+    // The exact gap this closes: the old inline verdict called this "passed"
+    // because nothing FAILED, certifying an obligation the run never tested.
+    expect(derived.outcome).toBe("incomplete");
+    expect(derived.incompleteReason).toContain("oauth_invalid_redirect");
+  });
+
+  it("keeps reason-less and not-applicable skips as passes, preserving existing flows", () => {
+    const derived = deriveOAuthRunOutcome({
+      steps: [
+        step("request_without_token", "passed"),
+        step("generate_pkce_parameters", "skipped"),
+        step("oauth_resource_metadata_challenge", "skipped", "not-applicable"),
+      ],
+      flowComplete: true,
+    });
+
+    expect(derived.outcome).toBe("passed");
+  });
+
+  it("keeps OAuth's own states on top: incomplete never outranks not-applicable or an unfinished flow", () => {
+    const unrun = [step("x", "skipped", "could-not-run")];
+
+    expect(
+      deriveOAuthRunOutcome({
+        steps: unrun,
+        flowComplete: true,
+        notApplicableReason: "server serves without auth",
+      }).outcome,
+    ).toBe("not-applicable");
+
+    expect(
+      deriveOAuthRunOutcome({ steps: unrun, flowComplete: false }).outcome,
+    ).toBe("failed");
+  });
+
+  it("still fails on any failed step", () => {
+    expect(
+      deriveOAuthRunOutcome({
+        steps: [step("a", "passed"), step("b", "failed")],
+        flowComplete: true,
+      }).outcome,
+    ).toBe("failed");
+  });
+});
 
 describe("OAuthConformanceTest", () => {
   it("passes the 2025-11-25 CIMD flow with a stubbed headless authorization strategy", async () => {


### PR DESCRIPTION
The two OAuth fidelity gaps carried as follow-ups since #3675 and #3695 — both now score-relevant, since a wrong OAuth verdict also moves the conformance number.

## 1. `resource_metadata` is judged by the revision's own text

The check failed any Bearer challenge lacking `resource_metadata` (except on 2025-03-26, which predates RFC 9728). That matches **2025-06-18**, whose text is a flat MUST:

> *"MCP servers **MUST** use the HTTP header `WWW-Authenticate` when returning a 401 Unauthorized to indicate the location of the resource server metadata URL"*

But **2025-11-25** (and 2026-07-28, verbatim) replaced it:

> *"MCP servers **MUST** implement **one of** the following discovery mechanisms: 1. WWW-Authenticate Header … 2. Well-Known URI …"*

So on those revisions the check was manufacturing MUST failures for servers that lawfully chose mechanism 2. Now:

- **2025-06-18**: omission fails outright, one request, no probing — the flat MUST needs no fallback.
- **2025-11-25 / 2026-07-28**: omission triggers probes of the RFC 9728 well-known URIs in the spec's own order (path-scoped, then root). Metadata found ⇒ **pass**, with a warning noting discovery rides on the second mechanism. Neither ⇒ fail citing the one-of-two MUST, with the attempts as evidence.
- A well-known 200 must actually *be* protected-resource metadata — a JSON object carrying RFC 9728's REQUIRED `resource` member. Without that guard, every SPA that answers unknown paths with its index page would count as publishing metadata.
- A **present-but-relative** `resource_metadata` stays a violation everywhere the mechanism exists (RFC 9728 §5.1 requires an absolute URL) — the version sensitivity is about omission, not malformation.

## 2. The OAuth runner adopts the shared verdict

OAuth was the last suite deciding its verdict as "flow complete and nothing failed" — the exact formulation that let could-not-run steps hide inside green runs everywhere else (#3680). The score already refused to trust it, reading step evidence directly; now the runner itself is honest:

- `deriveOAuthRunOutcome` (exported, directly tested) runs the steps through `decideConformanceOutcome`. OAuth's own two states stay on top: a run the pre-flight probe found **not-applicable**, and a flow that never reached completion (failed regardless of per-step statuses).
- `OAuthRunOutcome` gains `"incomplete"` + `incompleteReason` — additive, aligning OAuth with the other three suites.
- **Deliberately behavior-preserving**: skipped steps without a `could-not-run` reason (strategy-gated steps, deliberate dedup-skips) count as inapplicable, so every existing flow keeps its verdict — all 17 pre-existing runner tests pass unmodified. No natural flow can currently produce a could-not-run step while completing (the redirect URL always resolves), which is why the helper is proven by direct tests rather than a contrived flow; the honesty matters for the reporting chain and for every future could-not-run site.
- Ripples: CLI exits **3** for incomplete (single and worst-of-flows for suites, matching the shared ordering) and prints the `Run incomplete:` reason; the human formatter says INCOMPLETE/INC; suite `passed` now requires every flow to pass or be inapplicable (previously an incomplete flow could not fail a suite); the suite summary names incomplete flows as what they are; the inspector badges incomplete amber. Hosted routes: zero changes.

## Verification

- SDK: **3664 passed** across 196 files — 8 new tests (4 verdict, 3 version-matrix obligation tests incl. path-scoped-first ordering and the SPA guard, 1 INCOMPLETE formatter) with all pre-existing OAuth tests passing unmodified except two whose pinned *message text* changed with the new one-of-two failure wording
- CLI: 552 passed, tsc clean; panel: 27 passed; root `npm run typecheck` clean across all six packages
- Spec quotes verified against the local spec repo per version (`basic/authorization.mdx`, `2026-07-28/basic/authorization/authorization-server-discovery.mdx`); 2025-03-26 contains no RFC 9728 references at all, so its existing skip stands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches normative OAuth conformance scoring and CLI exit semantics; behavior changes for newer protocol pins and any future could-not-run steps, but existing flows are intended to stay verdict-stable.
> 
> **Overview**
> Makes OAuth conformance **honest per MCP authorization revision** and aligns OAuth with the **shared passed / failed / incomplete** verdict used elsewhere.
> 
> **Resource metadata (`oauth_resource_metadata_challenge`)** is now version-sensitive: on **2025-06-18**, a missing `resource_metadata` on the Bearer challenge still fails immediately. On **2025-11-25** and **2026-07-28**, omission only fails after probing RFC 9728 well-known URIs (path-scoped first, then root). Valid JSON metadata whose `resource` matches the server under test can pass with a warning; SPA/HTML lookalikes and wrong-resource documents do not count. Present-but-invalid values (empty, relative URL) still fail without well-known laundering.
> 
> **OAuth run outcomes** use `deriveOAuthRunOutcome` and `decideConformanceOutcome`, adding **`incomplete`** plus `incompleteReason` when applicable steps were skipped with `could-not-run`. Deliberate skips without that reason stay as today. The **CLI** calls `reportIncomplete` and exits **3** for incomplete (suite worst-of: failed beats incomplete). **Human output** shows INCOMPLETE/INC; suite **`passed`** is true only when every flow is passed or not-applicable. The **inspector** badges incomplete OAuth runs amber instead of treating them as failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8f6d359741f73a9fc5998ebb9fad296c317c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns OAuth conformance with spec revisions and adopts the shared “incomplete” verdict. Newer revisions now accept RFC 9728 well‑known discovery, and runs with untestable steps no longer read as passed.

- **Bug Fixes**
  - `resource_metadata` is version-aware: 2025-06-18 still requires the header; 2025-11-25/2026-07-28 probe RFC 9728 well‑known URIs (path‑scoped first, then root, preserving query) and pass if valid metadata is found. Valid means a 200 `application/json` with a `resource` that identifies the server under test; SPA pages or mismatched resources are rejected. Empty or relative `resource_metadata` still fails. The probe uses custom headers but strips any Authorization. 2025-03-26 is skipped.
  - OAuth uses the shared outcome: adds “incomplete” for runs with could‑not‑run applicable steps. CLI exits 3 for incomplete (single runs and suites, with fallback for older serialized data), the human formatter shows INCOMPLETE/INC and can label the suite INCOMPLETE, the suite only passes if all flows pass or are N/A, and the inspector badges incomplete amber.

- **Migration**
  - Update CI to treat exit code 3 as “incomplete/unestablished” and to recognize INCOMPLETE/INC labels in output (including suite headers).

<sup>Written for commit cf8f6d359741f73a9fc5998ebb9fad296c317c00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

