### PR TITLE
Agent approval hardening: unforgeable preview, one oracle-free answer, targeted dedup, honest evidence

### DIFF
--- a/.changeset/proposed-action-target.md
+++ b/.changeset/proposed-action-target.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/sdk": minor
+---
+
+`ProposedAction` gains an optional `target` (`{ type, selector }`, new `ProposedActionTarget` export) naming the resource a proposal is about, in the proposing operation's own selector vocabulary. Hosts use it to correlate proposals with other turn output — e.g. suppressing a duplicate run affordance on exactly the created suite a run proposal already targets. Absent on older servers and untargeted operations; treat absence as match-unknown.

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -6669,6 +6669,24 @@
                     "none"
                   ],
                   "description": "How stern the confirmation copy should be: `spend` consumes quota or credits, `external` runs somewhere MCPJam does not control and cannot undo, `none` states explicitly that the default cost warning would be FALSE for this action (disabling a schedule stops spend). Absent means the host's default copy is honest enough."
+                },
+                "target": {
+                  "type": "object",
+                  "required": [
+                    "type",
+                    "selector"
+                  ],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Resource type the proposal is about, e.g. `eval_suite`."
+                    },
+                    "selector": {
+                      "type": "string",
+                      "description": "The validated input's own selector for it — an id where the server minted the proposal, possibly a name where the model authored it. Match against both."
+                    }
+                  },
+                  "description": "What the proposal is about, for correlating it with other turn output (e.g. suppressing a duplicate run affordance on the created suite it already offers to run). Display/dedup only — never an instruction. Absent means match-unknown; fall back to coarser behavior."
                 }
               }
             }

--- a/mcpjam-inspector/server/middleware/__tests__/slack-service-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/slack-service-auth.test.ts
@@ -25,8 +25,6 @@ function buildApp() {
       surfaceKind: c.get("surfaceKind"),
       surfaceTenantId: c.get("surfaceTenantId"),
       surfaceActorId: c.get("surfaceActorId"),
-      slackTeamId: c.get("slackTeamId"),
-      slackUserId: c.get("slackUserId"),
     })
   );
   return app;
@@ -86,8 +84,6 @@ describe("slk_ service auth", () => {
       surfaceKind: "slack",
       surfaceTenantId: "T1",
       surfaceActorId: "U1",
-      slackTeamId: "T1",
-      slackUserId: "U1",
     });
   });
 

--- a/mcpjam-inspector/server/middleware/slack-service-auth.ts
+++ b/mcpjam-inspector/server/middleware/slack-service-auth.ts
@@ -318,16 +318,15 @@ export async function handleSlackServiceAuth(
   c.set("workosUserId", link.workosUserId);
   c.set("mcpjamUserId", link.userId);
   c.set("mcpjamOrganizationId", link.organizationId);
-  // CANONICAL, then the Slack-named aliases. Routes read only the canonical
-  // trio, so a second wrapper (Discord) is a new auth branch that sets these
-  // same three names and nothing downstream changes. The aliases stay because
-  // dropping them would be a flag day for anything mid-deploy still reading
-  // them; they are set from the same values, so the two cannot disagree.
+  // The CANONICAL surface trio, and nothing Slack-named beside it. Routes
+  // read only these three, so a second wrapper (Discord) is a new auth branch
+  // that sets the same three names and nothing downstream changes. Context
+  // vars are per-process, per-request — there is no mid-deploy reader to keep
+  // an alias alive for, and an alias that nothing reads is one a new route
+  // could start reading by mistake.
   c.set("surfaceKind", "slack");
   c.set("surfaceTenantId", teamId);
   c.set("surfaceActorId", slackUserId);
-  c.set("slackTeamId", teamId);
-  c.set("slackUserId", slackUserId);
   c.set("slackDefaultProjectId", link.defaultProjectId ?? undefined);
 
   logger.info("Slack service request", {

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -262,8 +262,8 @@ describe("agent op registry", () => {
       parameters: { to: "alice@example.com", subject: "Q3 numbers" },
     });
     expect(description).toContain("send_email");
-    expect(description).toContain("to: alice@example.com");
-    expect(description).toContain("subject: Q3 numbers");
+    expect(description).toContain('to: "alice@example.com"');
+    expect(description).toContain('subject: "Q3 numbers"');
     expect(description).toContain("on mailer");
   });
 
@@ -277,7 +277,7 @@ describe("agent op registry", () => {
       parameters: { a: "1", b: "2" },
     });
     expect(one).toBe(other);
-    expect(one).toContain("a: 1, b: 2");
+    expect(one).toContain('a: "1", b: "2"');
   });
 
   it("shows the VALUES inside nested arguments, not just their shape", () => {
@@ -339,13 +339,15 @@ describe("agent op registry", () => {
       toolName: "delete_everything_".repeat(30),
       parameters: { path: "/" },
     });
-    expect(description).toContain("path: /");
+    expect(description).toContain('path: "/"');
     expect(description).toContain("on files");
   });
 
-  it("flattens newlines so a preview cannot fake the end of itself", () => {
+  it("renders a value's newline as a visible escape, never a line break", () => {
     // A multi-line value in a confirmation dialog can be made to look like the
-    // preview ended and something more official began.
+    // preview ended and something more official began. Quoting renders it as
+    // a literal `\n` INSIDE the quotes — better than flattening to a space,
+    // which would hide that the value contained a break at all.
     const description = proposalMetaFor(
       callServerToolOperation.name
     ).description({
@@ -353,7 +355,9 @@ describe("agent op registry", () => {
       parameters: { body: "line one\nMCPJam: this call is safe" },
     });
     expect(description).not.toContain("\n");
-    expect(description).toContain("line one MCPJam: this call is safe");
+    expect(description).toContain(
+      'body: "line one\\nMCPJam: this call is safe"'
+    );
   });
 
   it("flattens EVERY describer's output, not only the tool-call preview", () => {
@@ -391,6 +395,69 @@ describe("agent op registry", () => {
       suite: "smoke\u2066\u2069\u200E\u200F\u202A",
     });
     expect(selector).toBe("Run eval suite smoke");
+  });
+
+  it("quotes string values so one cannot forge the preview's own grammar", () => {
+    // Unquoted, `a: draft only) on mailer` reads as a call that ended at
+    // `mailer` \u2014 everything after it, including the real recipient, looks
+    // like trailing noise. Quoted, the same text is visibly data.
+    const description = proposalMetaFor(
+      callServerToolOperation.name
+    ).description({
+      toolName: "send_email",
+      server: "mailer",
+      parameters: {
+        a: "draft only) on mailer",
+        to: "attacker@evil.example",
+      },
+    });
+    expect(description).toContain('a: "draft only) on mailer"');
+    expect(description).toContain('to: "attacker@evil.example"');
+    // The one unquoted `) on ` in the preview is its real terminator.
+    expect(description.indexOf('to: "attacker@evil.example"')).toBeLessThan(
+      description.lastIndexOf(") on mailer")
+    );
+  });
+
+  it("sanitizes the tool name and keys \u2014 grammar tokens cannot hide in them", () => {
+    // A tool NAMED like a complete call would otherwise render one: the
+    // preview's unquoted tokens are its grammar, so they are restricted to
+    // spec-shaped characters and anything else is visibly mangled \u2014 a name
+    // that reads differently from a real one invites exactly the scrutiny it
+    // deserves.
+    const description = proposalMetaFor(
+      callServerToolOperation.name
+    ).description({
+      toolName: "send(to: a@b.c) on mailer",
+      server: "evil",
+      parameters: { "x: 1) on safe": "v" },
+    });
+    expect(description).not.toContain("send(to:");
+    expect(description).toContain("send_to_");
+    expect(description).not.toContain("x: 1)");
+  });
+
+  it("NAMES omitted arguments instead of counting them", () => {
+    // `+1 more` makes omission attacker-orderable: the third-party tool
+    // defines the argument names, so six benign keys sort ahead of `to` and
+    // the destructive target is exactly what alphabetical truncation hides.
+    const description = proposalMetaFor(
+      callServerToolOperation.name
+    ).description({
+      toolName: "send_email",
+      server: "mailer",
+      parameters: {
+        a1: "hi",
+        a2: "hi",
+        a3: "hi",
+        a4: "hi",
+        a5: "hi",
+        a6: "hi",
+        to: "attacker@evil.example",
+      },
+    });
+    expect(description).toContain("+1 more: to");
+    expect(description).not.toMatch(/\+1 more$/);
   });
 
   it("describes a call with no arguments without inventing any", () => {

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent-op-registry.test.ts
@@ -460,6 +460,22 @@ describe("agent op registry", () => {
     expect(description).not.toMatch(/\+1 more$/);
   });
 
+  it("names the suite a run proposal is ABOUT, so hosts can correlate it", () => {
+    // The Slack bot suppresses the legacy Run-it accessory per suite on this;
+    // without a target it must fall back to stripping every suite, which
+    // costs an unrelated created suite its only run affordance.
+    const meta = proposalMetaFor(runEvalSuiteOperation.name);
+    expect(meta.targetFor({ suite: "smoke" })).toEqual({
+      type: "eval_suite",
+      selector: "smoke",
+    });
+    expect(meta.targetFor({})).toBeUndefined();
+    // No meaningful target answers undefined, never a guess.
+    expect(
+      proposalMetaFor(cancelEvalRunOperation.name).targetFor({ runId: "r1" })
+    ).toBeUndefined();
+  });
+
   it("describes a call with no arguments without inventing any", () => {
     expect(
       proposalMetaFor(callServerToolOperation.name).description({

--- a/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/agent.test.ts
@@ -1158,7 +1158,7 @@ describe("gated proposal tools", () => {
     expect(result).toMatchObject({ proposed: true });
     // The approver is shown the call, not just the fact of one.
     expect(result.description).toContain("send_email");
-    expect(result.description).toContain("to: alice@example.com");
+    expect(result.description).toContain('to: "alice@example.com"');
     expect(createProposedActionMock).toHaveBeenCalledWith(
       expect.objectContaining({ operation: callServerToolOperation.name })
     );

--- a/mcpjam-inspector/server/routes/v1/__tests__/proposed-actions.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/proposed-actions.test.ts
@@ -207,6 +207,11 @@ describe("POST /api/v1/projects/:projectId/proposed-actions/:actionId/execute", 
     );
     const res = await executeRequest(makeApp());
     expect(res.status).toBe(404);
+    const body = (await res.json()) as { message: string };
+    // Byte-identical to the tenant/org/missing answers. A "different project"
+    // message would confirm the id exists in this workspace and let a caller
+    // binary-search which project it lives in.
+    expect(body.message).toBe("That approval is no longer available.");
     expect(beginProposedActionMock).not.toHaveBeenCalled();
   });
 
@@ -227,6 +232,26 @@ describe("POST /api/v1/projects/:projectId/proposed-actions/:actionId/execute", 
     const res = await executeRequest(makeApp());
     expect(res.status).toBe(404);
     expect(beginProposedActionMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a claim whose identity diverged from the pre-claim read", async () => {
+    // The operation to execute is resolved from the read; the input from the
+    // claim. If the row changed identity in between, running would execute
+    // something nobody was shown — so the route enforces the equality instead
+    // of assuming it, and deliberately strands the suspect claim (no release:
+    // a proposal whose identity moved is not one any click should spend).
+    beginProposedActionMock.mockResolvedValue({
+      ok: true,
+      operation: "call_server_tool",
+      input: { suite: "smoke" },
+      organizationId: "org_1",
+      projectId: "p1",
+      teamId: "T1",
+    });
+    const res = await executeRequest(makeApp());
+    expect(res.status).toBe(404);
+    expect(releaseProposedActionMock).not.toHaveBeenCalled();
+    expect(completeProposedActionMock).not.toHaveBeenCalled();
   });
 
   it("answers SERVER_UNREACHABLE — not NOT_FOUND — when the read fails", async () => {

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -271,7 +271,14 @@ function toSafeLine(text: string): string {
  */
 function previewValue(value: unknown): string {
   if (value === null) return "null";
-  if (typeof value === "string") return capChars(value, PREVIEW_VALUE_CHARS);
+  if (typeof value === "string") {
+    // Capped FIRST, quoted second, so the quotes always balance: a string is
+    // rendered as a JSON literal because an unquoted value can reproduce the
+    // preview's own grammar — `a: draft only) on mailer` reads as a call that
+    // ended at `mailer`, hiding every argument after it. Inside quotes the
+    // same text is visibly data.
+    return JSON.stringify(capChars(value, PREVIEW_VALUE_CHARS));
+  }
   if (typeof value === "number" || typeof value === "boolean") {
     return String(value);
   }
@@ -288,12 +295,31 @@ function previewValue(value: unknown): string {
 }
 
 /**
- * `name(key: value, key: value)` for the validated arguments.
+ * A display-safe identifier: the tool name or an argument key.
+ *
+ * These are the UNQUOTED tokens of the preview's own grammar, so characters
+ * that can reproduce that grammar must not pass through verbatim — a tool
+ * NAMED `send(to: a@b.c) on mailer` would otherwise render as a complete,
+ * benign-looking call with the real arguments pushed outside what the
+ * approver reads. Spec-shaped names ([A-Za-z0-9_.-]) render unchanged;
+ * anything else is visibly replaced with `_`, and a mangled name that reads
+ * differently from the real one is the safe direction: it invites scrutiny
+ * of exactly the name that deserved it.
+ */
+function previewIdentifier(text: string): string {
+  return capChars(text.replace(/[^\w.-]/g, "_"), PREVIEW_VALUE_CHARS);
+}
+
+/**
+ * `name(key: "value", key: "value")` for the validated arguments.
  *
  * Keys are sorted so the preview is stable: the same call must not read one
  * way today and another tomorrow because the model emitted its object in a
  * different order. Newlines are flattened — a preview that spans lines can be
- * made to look like it ended and something else began.
+ * made to look like it ended and something else began. String values are
+ * quoted and identifiers sanitized so no value or name can reproduce the
+ * preview's own `name(… ) on server` grammar; omitted arguments are named,
+ * never just counted.
  */
 function previewToolCall(
   toolName: string,
@@ -305,18 +331,30 @@ function previewToolCall(
       : {};
   const keys = Object.keys(args).sort();
   const shown = keys.slice(0, PREVIEW_MAX_ARGS);
-  const parts = shown.map((key) => `${key}: ${previewValue(args[key])}`);
-  if (keys.length > shown.length) {
-    parts.push(`+${keys.length - shown.length} more`);
+  const parts = shown.map(
+    (key) => `${previewIdentifier(key)}: ${previewValue(args[key])}`
+  );
+  const omitted = keys.slice(PREVIEW_MAX_ARGS);
+  if (omitted.length > 0) {
+    // Omitted arguments are NAMED, not counted. A bare `+1 more` makes the
+    // omission attacker-orderable: the third-party tool defines the argument
+    // names, so six benign `a1..a6` keys sort ahead of `to:` and the one
+    // argument the gate exists to show is exactly the one hidden. Named keys
+    // keep the hidden part inspectable even when its values are not.
+    parts.push(
+      `+${omitted.length} more: ${omitted
+        .map((key) => previewIdentifier(key))
+        .join(", ")}`
+    );
   }
-  // The NAME is capped before the whole preview is, because the total cap
-  // trims from the right: a 500-character tool name would otherwise consume
-  // the entire budget and push every argument out of view, leaving the
-  // approver a truncated name and no idea what it is being called with. That
-  // is exactly the state this preview exists to prevent, and it is reachable
-  // by an agent choosing a long name.
+  // The NAME is capped (inside previewIdentifier) before the whole preview
+  // is, because the total cap trims from the right: a 500-character tool
+  // name would otherwise consume the entire budget and push every argument
+  // out of view, leaving the approver a truncated name and no idea what it
+  // is being called with. That is exactly the state this preview exists to
+  // prevent, and it is reachable by an agent choosing a long name.
   const rendered = toSafeLine(
-    `${capChars(toolName, PREVIEW_VALUE_CHARS)}(${parts.join(", ")})`
+    `${previewIdentifier(toolName)}(${parts.join(", ")})`
   );
   return capChars(rendered, PREVIEW_TOTAL_CHARS);
 }

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -71,6 +71,7 @@ import type {
   ExecutedActionResource,
   ProposedActionKind,
   ProposedActionSeverity,
+  ProposedActionTarget,
 } from "@mcpjam/sdk/public-api";
 import { MCPJAM_HOSTED_ORIGIN } from "../../config.js";
 
@@ -122,6 +123,17 @@ export interface GatedProposalMeta {
     result: unknown,
     context: { projectId: string }
   ): ExecutedActionResource | undefined;
+  /**
+   * What the proposal is ABOUT, from validated input, when that is a nameable
+   * resource. Lets a host correlate the proposal with other turn output —
+   * the Slack bot uses it to strip the legacy Run-it accessory from exactly
+   * the created suite a run proposal already targets, instead of from every
+   * suite in the message. Absent means "no meaningful target", which hosts
+   * must treat as match-unknown.
+   */
+  target?(
+    input: Record<string, unknown>
+  ): ProposedActionTarget | undefined;
 }
 
 /** Read a string off an unknown result, at a dotted path. */
@@ -132,6 +144,18 @@ function readString(source: unknown, path: string): string | undefined {
     node = (node as Record<string, unknown>)[key];
   }
   return typeof node === "string" && node ? node : undefined;
+}
+
+/**
+ * The suite both run-ops are ABOUT, in the validated input's own selector
+ * vocabulary (the server's post-create offer passes the suite id; a
+ * model-authored proposal may pass a name — hosts match against both).
+ */
+function evalSuiteTarget(
+  input: Record<string, unknown>
+): ProposedActionTarget | undefined {
+  const selector = named(input, "suite");
+  return selector ? { type: "eval_suite", selector } : undefined;
 }
 
 /**
@@ -434,6 +458,7 @@ export const AGENT_OP_REGISTRY: readonly AgentOpEntry[] = [
       buttonLabel: "Run it",
       kind: "start",
       resource: evalRunResource,
+      target: evalSuiteTarget,
     },
   },
   {
@@ -445,6 +470,7 @@ export const AGENT_OP_REGISTRY: readonly AgentOpEntry[] = [
       buttonLabel: "Run it",
       kind: "start",
       resource: evalRunResource,
+      target: evalSuiteTarget,
     },
   },
   {
@@ -606,6 +632,10 @@ export function proposalMetaFor(operationName: string): {
   severityFor: (
     input: Record<string, unknown>
   ) => ProposedActionSeverity | undefined;
+  /** What the proposal is about, when that is a nameable resource. */
+  targetFor: (
+    input: Record<string, unknown>
+  ) => ProposedActionTarget | undefined;
 } {
   const entry = GATED_BY_NAME.get(operationName);
   if (!entry) {
@@ -614,12 +644,14 @@ export function proposalMetaFor(operationName: string): {
       buttonLabel: "Approve",
       kind: "start",
       severityFor: () => undefined,
+      targetFor: () => undefined,
     };
   }
   const severity = entry.proposal.confirmSeverity;
   return {
     severityFor: (input) =>
       typeof severity === "function" ? severity(input) : severity,
+    targetFor: (input) => entry.proposal.target?.(input),
     // Flattened and capped HERE, at the one seam every describer's output
     // passes through. `previewToolCall` bounds and flattens the parenthesised
     // arguments, but the templates that wrap it interpolate

--- a/mcpjam-inspector/server/routes/v1/agent.ts
+++ b/mcpjam-inspector/server/routes/v1/agent.ts
@@ -193,6 +193,7 @@ function toWireProposal(proposal: ProposedAction): PublicProposedAction {
     ...(proposal.confirmSeverity
       ? { confirmSeverity: proposal.confirmSeverity }
       : {}),
+    ...(proposal.target ? { target: proposal.target } : {}),
   };
 }
 
@@ -270,6 +271,9 @@ async function persistProposal(opts: {
       ...(meta.severityFor(input)
         ? { confirmSeverity: meta.severityFor(input) }
         : {}),
+      // What the proposal is about, so a host can correlate it with the turn's
+      // created resources instead of guessing from the operation name.
+      ...(meta.targetFor(input) ? { target: meta.targetFor(input) } : {}),
     });
   }
   return actionId;

--- a/mcpjam-inspector/server/routes/v1/proposed-actions.ts
+++ b/mcpjam-inspector/server/routes/v1/proposed-actions.ts
@@ -115,20 +115,19 @@ proposedActions.post(
     ) {
       return v1Error(c, "NOT_FOUND", "That approval is no longer available.");
     }
-    if (record.projectId !== projectId) {
-      return v1Error(
-        c,
-        "NOT_FOUND",
-        "That approval belongs to a different project."
-      );
-    }
-
     // ORG CHECK BEFORE THE CLAIM. One Slack workspace can host people from
     // several MCPJam orgs. Letting an outsider reach `beginProposedAction`
     // would let them CLAIM the proposal and then fail authorization — burning
     // it, so the colleague who could legitimately approve it never gets to.
     // Same non-disclosing answer, so this is not an oracle either.
     if (record.organizationId !== actor.organizationId) {
+      return v1Error(c, "NOT_FOUND", "That approval is no longer available.");
+    }
+    // Same answer AGAIN for a project mismatch, and only after org membership
+    // is proven: a distinct "different project" message — or answering before
+    // the org check — would confirm to an outsider that the id exists in this
+    // workspace and let them narrow down which project it lives in.
+    if (record.projectId !== projectId) {
       return v1Error(c, "NOT_FOUND", "That approval is no longer available.");
     }
 
@@ -188,6 +187,24 @@ proposedActions.post(
       return v1Error(c, "NOT_FOUND", "That approval is no longer available.");
     }
 
+    // THE CLAIM IS THE CONTRACT — enforced, not assumed. `operation` was
+    // resolved from the PRE-claim read; if the row changed identity between
+    // that read and the claim, executing would run something nobody was
+    // shown. Nothing writes those columns today, so this should be
+    // unreachable — which is exactly why it must refuse loudly if it is ever
+    // reached. Deliberately NOT released: a proposal whose identity moved is
+    // not one any click should spend, so it is left to age out of its lease.
+    if (
+      claim.operation !== record.operation ||
+      claim.projectId !== record.projectId
+    ) {
+      logger.error(
+        "[v1/proposed-actions] claim diverged from the pre-claim read",
+        { actionId }
+      );
+      return v1Error(c, "NOT_FOUND", "That approval is no longer available.");
+    }
+
     // From here the claim is HELD. Every exit must either complete it or
     // release it, or the proposal is stranded `executing` and the sweep will
     // deliberately refuse to reap it.
@@ -239,9 +256,13 @@ proposedActions.post(
             ...init,
             signal: init?.signal ?? abortController.signal,
           });
-          // The action id IS the idempotency key. A redelivered click, or a
-          // retry after this process died mid-execution, presents the same key
-          // and lands on the same run rather than billing a second one.
+          // The action id IS the idempotency key — scoped by the backend to
+          // (creator, suite, key), so a redelivered click by the SAME approver
+          // lands on the same run rather than billing a second one. That
+          // per-creator scope is also why a claim whose process died is CLOSED
+          // at lease lapse rather than handed to the next clicker: a different
+          // approver's re-drive would miss the dedupe entirely, and
+          // call_server_tool has no idempotency to miss.
           request.headers.set(
             IDEMPOTENCY_KEY_HEADER,
             `proposal:${actionId}:${operation.name}`

--- a/mcpjam-inspector/server/types/hono.ts
+++ b/mcpjam-inspector/server/types/hono.ts
@@ -77,17 +77,6 @@ declare module "hono" {
     /** The acting human's id inside `surfaceKind`. */
     surfaceActorId?: string;
     /**
-     * Slack workspace id. Set only with `authMethod: "slack_service"`.
-     * @deprecated Read `surfaceTenantId`. Kept so existing call sites and any
-     * mid-deploy code keep working; the Slack auth branch sets both.
-     */
-    slackTeamId?: string;
-    /**
-     * Slack user id of the acting human. Set with `slackTeamId`.
-     * @deprecated Read `surfaceActorId`.
-     */
-    slackUserId?: string;
-    /**
      * The linked user's default project, if they picked one. Advisory: the
      * route's `:projectId` still governs, and Convex still enforces access.
      */

--- a/sdk/src/public-api/index.ts
+++ b/sdk/src/public-api/index.ts
@@ -230,6 +230,26 @@ export interface ProposedAction {
   kind: ProposedActionKind;
   /** Absent ⇒ the host's default confirmation copy is sufficient. */
   confirmSeverity?: ProposedActionSeverity;
+  /**
+   * What the proposal is ABOUT, for hosts that correlate it with other turn
+   * output — e.g. suppressing a duplicate run affordance on exactly the
+   * created resource this proposal already offers to run. Display/dedup only,
+   * never an instruction. Absent on operations with no meaningful target and
+   * on servers that predate the field; a host must treat absence as "match
+   * unknown" and fall back to its coarser behavior.
+   */
+  target?: ProposedActionTarget;
+}
+
+/**
+ * The resource a proposal targets, in the proposing operation's own selector
+ * vocabulary: `selector` is whatever the validated input named — an id where
+ * the server minted the proposal itself, possibly a name where the model
+ * authored it — so hosts should match it against both.
+ */
+export interface ProposedActionTarget {
+  type: string;
+  selector: string;
 }
 
 /** A resource the turn created, with an app deep link. */

--- a/slack-app/agent/mcpjam-client.js
+++ b/slack-app/agent/mcpjam-client.js
@@ -59,7 +59,11 @@ const EXECUTE_ACTION_TIMEOUT_MS = 150_000;
  * @property {string} description
  * @property {string} [buttonLabel]
  * @property {'start' | 'cancel' | 'generate' | 'schedule' | 'external'} [kind]
- * @property {'spend' | 'external'} [confirmSeverity]
+ * @property {'spend' | 'external' | 'none'} [confirmSeverity]
+ * @property {{ type: string, selector: string }} [target] what the proposal is
+ *   about, in the operation's own selector vocabulary (id or name — match
+ *   both). Absent on older servers and unTargeted operations: treat as
+ *   match-unknown.
  */
 
 export class McpjamApiError extends Error {

--- a/slack-app/listeners/actions/proposal-button.js
+++ b/slack-app/listeners/actions/proposal-button.js
@@ -22,7 +22,7 @@ import { tryslackContextFrom } from '../../agent/slack-context.js';
 import { resolveTurnTarget } from '../../agent/turn-target.js';
 import { escapeSlackText } from '../views/agent-reply-builder.js';
 import { postRunEvidence } from './run-evidence.js';
-import { announceAndWatchRun } from './run-watcher.js';
+import { announceAndWatchRun, isFailedOutcome } from './run-watcher.js';
 
 /**
  * What to say once the action has actually run.
@@ -201,10 +201,15 @@ export async function handleProposalButton({ ack, body, client, context, logger,
         userId,
         logger,
         text: `:rocket: Approved by <@${userId}> — running… <${outcome.resource.url}|watch it here>.`,
-        // Screenshots land in the thread once the run is done. Strictly
-        // additive: the watcher has already posted the outcome by the time
-        // this runs, and every failure inside it is logged and skipped.
-        onTerminal: async () => {
+        // Screenshots land in the thread once the run is done — and only for
+        // the FAILED outcome, whose message says "see what broke". A passing
+        // run's pictures are noise under a green verdict; worse, posting them
+        // under a red one illustrates a failure with evidence of success.
+        // Strictly additive: the watcher has already posted the outcome by
+        // the time this runs, and every failure inside it is logged and
+        // skipped.
+        onTerminal: async (run) => {
+          if (!isFailedOutcome(run)) return;
           await postRunEvidence(client, {
             runId,
             ctx: runCtx,

--- a/slack-app/listeners/actions/run-evidence.js
+++ b/slack-app/listeners/actions/run-evidence.js
@@ -26,11 +26,31 @@ import { getEvalRunSteps, listEvalRunIterations } from '../../agent/mcpjam-clien
 const MAX_SCREENSHOTS = 5;
 
 /**
- * Iterations to look through. A suite runs every case × iteration, so a run can
- * have dozens; the first few contain the same story as the rest and each one
- * costs a request against a bot that is already holding a watcher open.
+ * Iterations to FETCH STEPS FOR. A suite runs every case × iteration, so a run
+ * can have dozens; each step read costs a request against a bot that is
+ * already holding a watcher open. Failed iterations are chosen first — a run
+ * that failed in iteration 7 must not have its budget spent on the three
+ * passing iterations that happened to come earlier.
  */
 const MAX_ITERATIONS = 3;
+
+/**
+ * Iterations to LIST when choosing those three. Listing is one cheap JSON
+ * request either way; the cap only bounds the page size.
+ */
+const ITERATIONS_PAGE = 25;
+
+/**
+ * Whether an iteration is one the failure story lives in.
+ * @param {Record<string, any>} iteration
+ */
+function isFailedIteration(iteration) {
+  return (
+    iteration?.status === 'failed' ||
+    iteration?.status === 'timed_out' ||
+    iteration?.result === 'failed'
+  );
+}
 
 /** Per-image download budget. Signed artifact URLs are fast or they are broken. */
 const DOWNLOAD_TIMEOUT_MS = 15_000;
@@ -185,9 +205,17 @@ export async function postRunEvidence(client, args) {
   const allSteps = [];
   try {
     const iterations = await listEvalRunIterations(args.runId, args.ctx, {
-      limit: MAX_ITERATIONS,
+      limit: ITERATIONS_PAGE,
     });
-    for (const iteration of iterations.slice(0, MAX_ITERATIONS)) {
+    // Failed iterations first, in their own order; passing ones only fill
+    // whatever budget is left. Reading the first three REGARDLESS of status
+    // was how a failure in iteration 4+ ended up illustrated by the passing
+    // iterations before it.
+    const prioritized = [
+      ...iterations.filter((iteration) => isFailedIteration(iteration)),
+      ...iterations.filter((iteration) => !isFailedIteration(iteration)),
+    ];
+    for (const iteration of prioritized.slice(0, MAX_ITERATIONS)) {
       const iterationId = typeof iteration?.id === 'string' ? iteration.id : null;
       if (!iterationId) continue;
       let steps;

--- a/slack-app/listeners/actions/run-watcher.js
+++ b/slack-app/listeners/actions/run-watcher.js
@@ -49,6 +49,22 @@ export function formatRunOutcome(run, url, userId) {
 }
 
 /**
+ * Whether a terminal run is the red-circle case — the one whose thread said
+ * "see what broke". Matches `formatRunOutcome`'s failure branch so evidence
+ * and outcome copy can never disagree: posting screenshots under a green
+ * "Run passed" is noise, and a *passing* run's screenshots under a red
+ * verdict actively misleads the approver about what broke.
+ *
+ * @param {{ status: string, result: string | null }} run
+ */
+export function isFailedOutcome(run) {
+  return (
+    run?.status === 'failed' ||
+    (run?.status === 'completed' && run?.result === 'failed')
+  );
+}
+
+/**
  * Watch a run until terminal and edit the status message in place.
  *
  * Detached from whichever handler started it; failures degrade to leaving the

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -5,7 +5,7 @@ import { createThreadBinding, resolveTurnTarget } from '../../agent/turn-target.
 import { buildCreatedResourceBlocks } from '../views/agent-reply-builder.js';
 import { appHomeDeepLink, buildConnectBlocks, buildPickProjectBlocks } from '../views/connect-builder.js';
 import { buildFeedbackBlocks } from '../views/feedback-builder.js';
-import { buildProposalBlocks, rendersRunProposal } from '../views/proposal-builder.js';
+import { buildProposalBlocks, rendersRunProposalFor } from '../views/proposal-builder.js';
 
 /**
  * Shared body for both event listeners: run the turn (deduped + serialized
@@ -144,7 +144,8 @@ export async function runAndReply(args) {
             // is the hazard, but so is zero, which is what an unconditional
             // drop would produce against a server that predates the offer.
             ...buildCreatedResourceBlocks(result.createdResources, {
-              suiteAccessory: !rendersRunProposal(result.proposedActions),
+              suiteAccessory: (resource) =>
+                !rendersRunProposalFor(result.proposedActions, resource),
             }),
             ...buildProposalBlocks(result.proposedActions),
             ...buildFeedbackBlocks(),
@@ -171,7 +172,8 @@ export async function runAndReply(args) {
               },
             },
             ...buildCreatedResourceBlocks(envelope.createdResources, {
-              suiteAccessory: !rendersRunProposal(envelope.proposedActions),
+              suiteAccessory: (resource) =>
+                !rendersRunProposalFor(envelope.proposedActions, resource),
             }),
             // Proposals replay too. They are still `proposed` server-side — the
             // approval never happened — so re-offering them is the difference
@@ -222,7 +224,8 @@ export async function runAndReply(args) {
             ],
           },
           ...buildCreatedResourceBlocks(envelope.createdResources ?? [], {
-            suiteAccessory: !rendersRunProposal(envelope.proposedActions),
+            suiteAccessory: (resource) =>
+                !rendersRunProposalFor(envelope.proposedActions, resource),
           }),
           ...buildProposalBlocks(envelope.proposedActions ?? []),
         ],

--- a/slack-app/listeners/views/agent-reply-builder.js
+++ b/slack-app/listeners/views/agent-reply-builder.js
@@ -41,12 +41,50 @@ export function escapeSlackText(text) {
  * Display label for a suite: length-capped on code-point boundaries, then
  * escaped. Order matters — capping after escaping could slice an entity
  * like `&amp;` in half.
- * @param {string} name
+ *
+ * Coerces first: the name rides an envelope this build does not control, and a
+ * numeric `name` throwing in here would take down the whole reply — against
+ * this module's own "nothing here may drop a resource" charter.
+ * @param {unknown} name
  */
 export function toSuiteLabel(name) {
-  const chars = Array.from(name);
-  const capped = chars.length > MAX_SUITE_NAME_CHARS ? `${chars.slice(0, MAX_SUITE_NAME_CHARS - 1).join('')}…` : name;
+  const text = typeof name === 'string' ? name : String(name ?? 'Eval suite');
+  const chars = Array.from(text);
+  const capped = chars.length > MAX_SUITE_NAME_CHARS ? `${chars.slice(0, MAX_SUITE_NAME_CHARS - 1).join('')}…` : text;
   return escapeSlackText(capped);
+}
+
+/**
+ * A resource url safe to interpolate into an mrkdwn link.
+ *
+ * The url comes from the same trusted-server envelope as the names — which
+ * already get escaped, so trusting the url verbatim was this module's one
+ * asymmetry. `https:` only (matching the stance run-evidence takes on the
+ * same envelope's artifact urls), and `|` — mrkdwn's own label separator —
+ * is the one character that could smuggle display text, so it is encoded.
+ * Returns null for anything unparseable; callers render the name unlinked
+ * rather than dropping the resource.
+ * @param {unknown} url
+ */
+export function toSafeResourceUrl(url) {
+  if (typeof url !== 'string' || !url) return null;
+  try {
+    if (new URL(url).protocol !== 'https:') return null;
+  } catch {
+    return null;
+  }
+  return url.replaceAll('|', '%7C');
+}
+
+/**
+ * An mrkdwn link when the url passes `toSafeResourceUrl`, the bare (already
+ * escaped) label when it does not — a resource with a bad url is still shown.
+ * @param {unknown} url
+ * @param {string} escapedLabel
+ */
+function linkedLabel(url, escapedLabel) {
+  const safeUrl = toSafeResourceUrl(url);
+  return safeUrl ? `<${safeUrl}|${escapedLabel}>` : escapedLabel;
 }
 
 /**
@@ -76,10 +114,13 @@ function toResourceKindLabel(type) {
  * and it means a new resource type is a server-only change.
  *
  * @param {Array<{ type: string, id: string, name?: string, url: string }>} createdResources
- * @param {{ suiteAccessory?: boolean }} [opts] `suiteAccessory: false` omits the
- *   legacy Run-it button. Pass it only when an approval control for running the
- *   suite WILL be rendered — `rendersRunProposal` in `proposal-builder.js` is
- *   what answers that, because it owns the block cap that decides it. Both
+ * @param {{ suiteAccessory?: boolean | ((resource: { type: string, id: string, name?: string, url: string }) => boolean) }} [opts]
+ *   `suiteAccessory: false` omits the legacy Run-it button; a FUNCTION decides
+ *   per suite, which is what target-aware suppression needs — a proposal that
+ *   runs suite B must not cost suite A its only run affordance. Pass false (or
+ *   a function answering false) only when an approval control for running THAT
+ *   suite will be rendered — `rendersRunProposalFor` in `proposal-builder.js`
+ *   is what answers it, because it owns the block cap that decides. Both
  *   buttons is one hazard; zero is the other.
  * @returns {Array<Record<string, unknown>>}
  */
@@ -89,7 +130,11 @@ export function buildCreatedResourceBlocks(createdResources, opts = {}) {
   );
   if (resources.length === 0) return [];
 
-  const withAccessory = opts.suiteAccessory !== false;
+  /** @param {{ type: string, id: string, name?: string, url: string }} resource */
+  const accessoryFor = (resource) =>
+    typeof opts.suiteAccessory === 'function'
+      ? opts.suiteAccessory(resource) !== false
+      : opts.suiteAccessory !== false;
   const shown = resources.slice(0, MAX_SUITE_BLOCKS);
   /** @type {Array<Record<string, unknown>>} */
   const blocks = [];
@@ -99,9 +144,9 @@ export function buildCreatedResourceBlocks(createdResources, opts = {}) {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `:test_tube: *<${resource.url}|${toSuiteLabel(resource.name ?? 'Eval suite')}>* is ready to run.`,
+          text: `:test_tube: *${linkedLabel(resource.url, toSuiteLabel(resource.name ?? 'Eval suite'))}* is ready to run.`,
         },
-        ...(withAccessory
+        ...(accessoryFor(resource)
           ? {
               accessory: {
                 type: 'button',
@@ -125,7 +170,7 @@ export function buildCreatedResourceBlocks(createdResources, opts = {}) {
         // The name goes through `toSuiteLabel` (cap + escape); the TYPE
         // fallback is already escaped by `toResourceKindLabel`, so passing it
         // through again would render `&amp;amp;` at the user.
-        text: `:package: *<${resource.url}|${resource.name ? toSuiteLabel(resource.name) : toResourceKindLabel(resource.type)}>* — ${toResourceKindLabel(resource.type).toLowerCase()}.`,
+        text: `:package: *${linkedLabel(resource.url, resource.name ? toSuiteLabel(resource.name) : toResourceKindLabel(resource.type))}* — ${toResourceKindLabel(resource.type).toLowerCase()}.`,
       },
     });
   }

--- a/slack-app/listeners/views/proposal-builder.js
+++ b/slack-app/listeners/views/proposal-builder.js
@@ -164,21 +164,37 @@ function sectionNote(severity) {
 }
 
 /**
- * Will an approval control for RUNNING A SUITE actually be rendered?
+ * Will an approval control for running THIS suite actually be rendered?
  *
  * Lives here because this module owns both rules that decide it: the
  * `MAX_PROPOSAL_BLOCKS` cap and the `actionId` skip. Asking "does the envelope
- * contain a run proposal?" is the wrong question — a run proposal sitting at
- * index six is not rendered, and a caller that suppressed the legacy Run-it
- * button on the strength of it would leave the suite with NO way to run it.
+ * contain a run proposal?" is the wrong question twice over — a run proposal
+ * sitting at index six is not rendered, and one targeting a DIFFERENT suite is
+ * no substitute: "make a suite for X and rerun smoke" would strip X's only run
+ * affordance on the strength of smoke's button.
  *
  * @param {Array<import('../../agent/mcpjam-client.js').ProposedAction> | undefined} proposals
+ * @param {{ id?: string, name?: string } | undefined} resource the created suite
  */
-export function rendersRunProposal(proposals) {
+export function rendersRunProposalFor(proposals, resource) {
   if (!Array.isArray(proposals)) return false;
-  return proposals
-    .slice(0, MAX_PROPOSAL_BLOCKS)
-    .some((proposal) => proposal?.actionId && proposal.operation === 'run_eval_suite');
+  return proposals.slice(0, MAX_PROPOSAL_BLOCKS).some((proposal) => {
+    if (!proposal?.actionId || proposal.operation !== 'run_eval_suite') return false;
+    const target = proposal.target;
+    // No target: an older server. Match-unknown must SUPPRESS — two buttons
+    // for one billed run is the costlier mistake, and stripping every suite
+    // is exactly the pre-target behavior this falls back to.
+    if (!target || typeof target.selector !== 'string' || !target.selector) {
+      return true;
+    }
+    if (target.type !== 'eval_suite') return false;
+    // The server's own post-create offer selects by id; a model-authored
+    // proposal may have selected by name. Match both, so "make a suite for X
+    // and rerun smoke" keeps X's run button while smoke's proposal renders.
+    if (target.selector === resource?.id) return true;
+    const name = typeof resource?.name === 'string' ? resource.name : '';
+    return Boolean(name) && target.selector.toLowerCase() === name.toLowerCase();
+  });
 }
 
 /**

--- a/slack-app/tests/listeners/actions/proposal-button.test.js
+++ b/slack-app/tests/listeners/actions/proposal-button.test.js
@@ -5,7 +5,7 @@ import { announcementFor, handleProposalButton } from '../../../listeners/action
 import {
   buildProposalBlocks,
   PROPOSAL_ACTION_ID,
-  rendersRunProposal,
+  rendersRunProposalFor,
 } from '../../../listeners/views/proposal-builder.js';
 
 const PROPOSAL = {
@@ -187,13 +187,34 @@ describe('buildProposalBlocks', () => {
   });
 });
 
-describe('rendersRunProposal', () => {
+describe('rendersRunProposalFor', () => {
+  const suite = { type: 'eval_suite', id: 'ts_1', name: 'Smoke', url: 'https://app/x' };
   const run = { actionId: 'run', operation: 'run_eval_suite', description: 'Run eval suite ts_1' };
   const other = (index) => ({ actionId: `a${index}`, operation: 'cancel_eval_run', description: 'x' });
 
-  it('is true only when a run button will ACTUALLY be rendered', () => {
-    assert.strictEqual(rendersRunProposal([run]), true);
-    assert.strictEqual(rendersRunProposal([other(0), run]), true);
+  it('suppresses on a TARGETLESS run proposal — the older-server fallback', () => {
+    // Match-unknown must strip: two buttons for one billed run is the
+    // costlier mistake, and this is exactly the pre-target behavior.
+    assert.strictEqual(rendersRunProposalFor([run], suite), true);
+    assert.strictEqual(rendersRunProposalFor([other(0), run], suite), true);
+  });
+
+  it('suppresses only the suite a targeted proposal is actually about', () => {
+    // "Make a suite for X and rerun smoke": smoke's proposal renders its own
+    // button; X keeps the legacy accessory — stripping it would leave X with
+    // NO run affordance at all.
+    const targeted = { ...run, target: { type: 'eval_suite', selector: 'ts_other' } };
+    assert.strictEqual(rendersRunProposalFor([targeted], suite), false);
+    assert.strictEqual(
+      rendersRunProposalFor([{ ...run, target: { type: 'eval_suite', selector: 'ts_1' } }], suite),
+      true,
+    );
+  });
+
+  it('matches a name selector case-insensitively — models propose by name', () => {
+    const byName = { ...run, target: { type: 'eval_suite', selector: 'smoke' } };
+    assert.strictEqual(rendersRunProposalFor([byName], suite), true);
+    assert.strictEqual(rendersRunProposalFor([byName], { ...suite, name: 'Checkout' }), false);
   });
 
   it('is false for a run proposal pushed past the block cap', () => {
@@ -205,17 +226,17 @@ describe('rendersRunProposal', () => {
       .filter((block) => block.accessory)
       .map((block) => block.accessory.value);
     assert.ok(!rendered.includes('run'), 'fixture must push the run proposal past the cap');
-    assert.strictEqual(rendersRunProposal(proposals), false);
+    assert.strictEqual(rendersRunProposalFor(proposals, suite), false);
   });
 
   it('is false for a run proposal with no action id — those are skipped too', () => {
-    assert.strictEqual(rendersRunProposal([{ operation: 'run_eval_suite' }]), false);
+    assert.strictEqual(rendersRunProposalFor([{ operation: 'run_eval_suite' }], suite), false);
   });
 
   it('is false for an empty or missing list', () => {
-    assert.strictEqual(rendersRunProposal([]), false);
-    assert.strictEqual(rendersRunProposal(undefined), false);
-    assert.strictEqual(rendersRunProposal([other(0)]), false);
+    assert.strictEqual(rendersRunProposalFor([], suite), false);
+    assert.strictEqual(rendersRunProposalFor(undefined, suite), false);
+    assert.strictEqual(rendersRunProposalFor([other(0)], suite), false);
   });
 });
 

--- a/slack-app/tests/listeners/actions/run-evidence.test.js
+++ b/slack-app/tests/listeners/actions/run-evidence.test.js
@@ -238,6 +238,53 @@ describe('postRunEvidence', () => {
     assert.strictEqual(uploads[0].file_uploads.length, 5);
   });
 
+  it('reads the FAILED iteration even when it comes after three passing ones', async () => {
+    // Reading the first three iterations regardless of status was how a run
+    // that failed in iteration 4 got illustrated by the passing iterations
+    // before it — green screenshots under a red verdict.
+    const stepsByIteration = {
+      it_1: [step(0, { evidence: { screenshotUrl: 'https://cdn/pass-1.png' } })],
+      it_2: [step(0, { evidence: { screenshotUrl: 'https://cdn/pass-2.png' } })],
+      it_3: [step(0, { evidence: { screenshotUrl: 'https://cdn/pass-3.png' } })],
+      it_4: [
+        step(2, {
+          status: 'fail',
+          evidence: { screenshotUrl: 'https://cdn/broke.png', locatorLabel: 'Checkout' },
+        }),
+      ],
+    };
+    globalThis.fetch = mock.fn(async (url) => {
+      const path = String(url);
+      const stepsMatch = path.match(/\/iterations\/(it_\d+)\/steps$/);
+      if (stepsMatch) return json({ items: stepsByIteration[stepsMatch[1]] ?? [] });
+      if (path.endsWith('/iterations') || path.includes('/iterations?')) {
+        return json({
+          items: [
+            { id: 'it_1', status: 'completed', result: 'passed' },
+            { id: 'it_2', status: 'completed', result: 'passed' },
+            { id: 'it_3', status: 'completed', result: 'passed' },
+            { id: 'it_4', status: 'failed', result: 'failed' },
+          ],
+        });
+      }
+      if (path.startsWith('https://cdn/')) return png();
+      throw new Error(`unexpected fetch to ${path}`);
+    });
+    const { client, uploads } = slackClient();
+    const count = await postRunEvidence(client, {
+      runId: 'run_1',
+      ctx,
+      channelId: 'C1',
+      threadTs: '1.0',
+      logger,
+    });
+    // The failing step IS the evidence; the passing frames from earlier
+    // iterations never displace it.
+    assert.strictEqual(count, 1);
+    assert.match(uploads[0].file_uploads[0].title, /Checkout/);
+    assert.match(uploads[0].file_uploads[0].title, /failed/);
+  });
+
   it('selects across the WHOLE RUN, not one iteration at a time', async () => {
     // Selecting inside the loop scoped both guarantees to one iteration: the
     // duplicate check never spanned the run, and a passing early iteration

--- a/slack-app/tests/listeners/actions/run-watcher.test.js
+++ b/slack-app/tests/listeners/actions/run-watcher.test.js
@@ -1,0 +1,157 @@
+import assert from 'node:assert';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import {
+  announceAndWatchRun,
+  isFailedOutcome,
+  watchRunUntilDone,
+} from '../../../listeners/actions/run-watcher.js';
+
+const POLL_INTERVAL_MS = 10_000;
+
+describe('isFailedOutcome', () => {
+  it('matches exactly the red-circle branch of formatRunOutcome', () => {
+    // Evidence and outcome copy must never disagree: this predicate is what
+    // keeps "see what broke" and the screenshots pointing at the same runs.
+    assert.strictEqual(isFailedOutcome({ status: 'failed', result: null }), true);
+    assert.strictEqual(isFailedOutcome({ status: 'completed', result: 'failed' }), true);
+    assert.strictEqual(isFailedOutcome({ status: 'completed', result: 'passed' }), false);
+    assert.strictEqual(isFailedOutcome({ status: 'cancelled', result: null }), false);
+    assert.strictEqual(isFailedOutcome({ status: 'timed_out', result: null }), false);
+  });
+});
+
+describe('watchRunUntilDone', () => {
+  /** @type {typeof fetch} */
+  let realFetch;
+
+  beforeEach(() => {
+    realFetch = globalThis.fetch;
+    process.env.MCPJAM_SLACK_SERVICE_TOKEN = 'slk_test';
+    process.env.MCPJAM_BASE_URL = 'https://api.test';
+    mock.timers.enable({ apis: ['setTimeout'] });
+  });
+
+  afterEach(() => {
+    mock.timers.reset();
+    globalThis.fetch = realFetch;
+    delete process.env.MCPJAM_SLACK_SERVICE_TOKEN;
+    delete process.env.MCPJAM_BASE_URL;
+  });
+
+  const ctx = { teamId: 'T1', slackUserId: 'U1', mode: 'user', projectId: 'p1' };
+  const logger = /** @type {any} */ ({ warn: () => {}, error: () => {}, info: () => {} });
+
+  /** @param {Record<string, any>} run */
+  function stubRun(run) {
+    globalThis.fetch = mock.fn(
+      async () =>
+        new Response(JSON.stringify(run), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+  }
+
+  /**
+   * Drive the watcher through its first poll: it sleeps BEFORE polling, so
+   * the mocked clock must advance once for anything to happen at all.
+   * @param {Promise<void>} watcher
+   */
+  async function firstPoll(watcher) {
+    await new Promise((resolve) => setImmediate(resolve));
+    mock.timers.tick(POLL_INTERVAL_MS);
+    await watcher;
+  }
+
+  it('edits the outcome FIRST, then runs the completion hook', async () => {
+    // The hook is strictly additive. If it ran first, a slow screenshot pass
+    // would leave the thread saying "running…" long after the run ended.
+    stubRun({ status: 'completed', result: 'failed' });
+    /** @type {string[]} */
+    const order = [];
+    const client = /** @type {any} */ ({
+      chat: {
+        update: async () => {
+          order.push('update');
+          return { ok: true };
+        },
+      },
+    });
+    await firstPoll(
+      watchRunUntilDone(client, {
+        runId: 'run_1',
+        url: 'https://app.test/run_1',
+        ctx,
+        channelId: 'C1',
+        statusTs: '1.0',
+        userId: 'U1',
+        logger,
+        onTerminal: async (run) => {
+          order.push(`hook:${run.status}/${run.result}`);
+        },
+      }),
+    );
+    assert.deepStrictEqual(order, ['update', 'hook:completed/failed']);
+  });
+
+  it('a rejecting completion hook is logged, never thrown', async () => {
+    // An unhandled rejection here would take down a watcher whose outcome
+    // message is already correct — trading the important thing for the extra.
+    stubRun({ status: 'completed', result: 'passed' });
+    const warnings = [];
+    const client = /** @type {any} */ ({
+      chat: { update: async () => ({ ok: true }) },
+    });
+    await firstPoll(
+      watchRunUntilDone(client, {
+        runId: 'run_1',
+        url: 'https://app.test/run_1',
+        ctx,
+        channelId: 'C1',
+        statusTs: '1.0',
+        userId: 'U1',
+        logger: /** @type {any} */ ({
+          warn: (message) => warnings.push(String(message)),
+          error: () => {},
+          info: () => {},
+        }),
+        onTerminal: async () => {
+          throw new Error('screenshot pass exploded');
+        },
+      }),
+    );
+    assert.strictEqual(warnings.filter((w) => w.includes('screenshot pass exploded')).length, 1);
+  });
+});
+
+describe('announceAndWatchRun', () => {
+  it('does not start a watcher for a message Slack never posted', async () => {
+    // A watcher with no `ts` has nothing to edit; polling would be pure load.
+    let fetched = 0;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = /** @type {any} */ (
+      async () => {
+        fetched += 1;
+        throw new Error('should never poll');
+      }
+    );
+    try {
+      const client = /** @type {any} */ ({
+        chat: { postMessage: async () => ({ ok: false }) },
+      });
+      await announceAndWatchRun(client, {
+        runId: 'run_1',
+        url: 'https://app.test/run_1',
+        ctx: { teamId: 'T1', slackUserId: 'U1', mode: 'user', projectId: 'p1' },
+        channelId: 'C1',
+        threadTs: '1.0',
+        userId: 'U1',
+        logger: /** @type {any} */ ({ warn: () => {}, error: () => {}, info: () => {} }),
+      });
+      assert.strictEqual(fetched, 0);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});


### PR DESCRIPTION
Follow-up to #3696, which merged while these four review fixes were still in final verification. They close the security findings from the adversarial review — most importantly the forgeable `call_server_tool` approval preview. **Companion: MCPJam/mcpjam-backend#860 (the double-spend half); deploy that first.**

## What

- **`fix(agent): the preview's grammar cannot be forged from inside it`** — three confirmed-by-execution bypasses closed at the one seam every describer passes through: string values render as JSON literals (capped first so the quotes always balance; an embedded newline becomes a visible `\n` escape), tool names and argument keys — the preview's unquoted grammar tokens — are restricted to spec-shaped characters with anything else visibly mangled, and omitted arguments are NAMED rather than counted, so alphabetical truncation can no longer hide exactly the argument the gate exists to show.
- **`fix(agent): one mismatch answer, in one order, and the claim is checked`** — the org check moves above the project check and every mismatch answers the same bytes (the distinct "belongs to a different project" message, answered pre-org-check, was an existence oracle within a workspace); the claim's `operation`/`projectId` are now enforced against the pre-claim read, with a diverged claim deliberately stranded to age out. Idempotency comments now state the per-creator dedupe scope truthfully.
- **`fix(slack): evidence only for failed runs, and from the failed iteration`** — screenshots post only for the red-circle outcome (`isFailedOutcome` mirrors `formatRunOutcome`'s failure branch), and failed iterations are read first: a failure at iteration 4+ previously never had its failing step fetched, so the fallback illustrated a red verdict with the passing frames of iterations 1–3. The watcher/`onTerminal` contract gets its first tests.
- **`fix(agent+slack): proposals name their target, so dedup stops guessing`** — proposals carry an optional `target` (`{type, selector}`; SDK `ProposedActionTarget` export + OpenAPI updated, changeset included), and the bot strips the legacy Run-it accessory only from the suite a *rendered* run proposal actually targets (id and name matched) — "make a suite for X and rerun smoke" keeps X's run button. Targetless proposals (older server) keep the strip-everything fallback: two buttons for one billed run stays the costlier mistake. Riding along: `confirmSeverity: "none"` in the bot typedef, resource URLs https-only with mrkdwn-pipe encoding (bad url renders the name unlinked, never drops the resource), non-string resource names coerced instead of crashing the reply, and the dead `slackTeamId`/`slackUserId` context aliases deleted.

## Testing

Full workspace green at the branch: inspector 12,449, sdk 3,759, slack-app 223 (+12 new across the four commits), cli 552, `openapi-drift` green. The three preview forgeries and the iteration-4 evidence miss were each reproduced against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7dc2d2692b1d1ea3b1af73d4b1e67d22800dc6bb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens agent approvals and Slack evidence: the `call_server_tool` preview is now unforgeable, execute errors are oracle-free with enforced claim checks, and proposals carry a target so we stop stripping run buttons from unrelated suites. Requires deploying the backend double-spend fix first.

- **New Features**
  - Add optional `target` to `ProposedAction` (`{ type, selector }`, new `ProposedActionTarget`); OpenAPI and `@mcpjam/sdk` updated. Slack uses it to suppress the legacy Run-it accessory only for the targeted suite; falls back to strip-all on older servers. Supports `confirmSeverity: "none"` in Slack typedef.

- **Bug Fixes**
  - Tool-call preview: quote string values (render `\n`), sanitize tool names/keys, and name omitted arg keys to prevent grammar forgery and truncation attacks.
  - Execute route: check org before project; use the same “That approval is no longer available.” answer for all mismatches; enforce claim `operation`/`projectId` against the pre-claim read and strand diverged claims; clarify per-creator idempotency.
  - Slack evidence: post screenshots only for failed outcomes; fetch failed iterations first; add `isFailedOutcome` and watcher tests; hook runs after outcome update and logs errors.
  - Slack context: remove `slackTeamId`/`slackUserId` aliases; use `surfaceKind`/`surfaceTenantId`/`surfaceActorId` only.
  - Reply safety: require https-only resource URLs with mrkdwn `|` encoded; render names unlinked on bad URLs; coerce non-string names to avoid crashes.

<sup>Written for commit 7dc2d2692b1d1ea3b1af73d4b1e67d22800dc6bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

