### PR TITLE
feat(settings): add the GitHub Checks settings page

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -38,6 +38,7 @@ import {
 import { ProjectEnvironmentsRoute } from "./components/project-environments/ProjectEnvironmentsRoute";
 import { SettingsTab } from "./components/SettingsTab";
 import { ApiKeysRoute } from "./components/settings/ApiKeysRoute";
+import { GithubChecksRoute } from "./components/settings/GithubChecksRoute";
 import { ProjectSettingsTab } from "./components/ProjectSettingsTab";
 import { ProjectClientConfigSync } from "./components/client-config/ProjectClientConfigSync";
 import { ActiveHostServerReconciler } from "./components/ActiveHostServerReconciler";
@@ -1740,6 +1741,11 @@ export function SettingsRoute() {
 export function ApiKeysSettingsRoute() {
   const { activeOrganizationId } = useAppRouteContext();
   return <ApiKeysRoute activeOrganizationId={activeOrganizationId} />;
+}
+
+export function GithubChecksSettingsRoute() {
+  const { activeOrganizationId } = useAppRouteContext();
+  return <GithubChecksRoute activeOrganizationId={activeOrganizationId} />;
 }
 
 export function SupportRoute() {

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Navigate } from "react-router";
+import { useConvexAuth } from "convex/react";
 import { Github, Plus, Trash2 } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
@@ -11,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
+import { useOrganizationQueries } from "@/hooks/useOrganizations";
 import { SettingsSection } from "../setting/SettingsSection";
 import { SettingsNav } from "./SettingsNav";
 import {
@@ -72,6 +74,16 @@ export function GithubChecksRoute({
     listInstallationRepos,
   } = useGithubChecksSettings(activeOrganizationId);
 
+  // `activeOrganizationId` arrives asynchronously during app bootstrap, and the
+  // context types it `string | undefined` with no loading flag — so "absent"
+  // and "not resolved yet" look identical from here. The org list's own loading
+  // state is the missing bit: only once it settles is a missing id genuinely
+  // missing rather than merely early.
+  const { isAuthenticated } = useConvexAuth();
+  const { isLoading: organizationsLoading } = useOrganizationQueries({
+    isAuthenticated,
+  });
+
   // `null` = not loaded yet, `[]` = loaded and genuinely empty. The error is
   // tracked separately so a failed fetch never renders as "you have no
   // repositories, go install the App" — that would blame the user for an
@@ -81,6 +93,12 @@ export function GithubChecksRoute({
   >(null);
   const [installationReposFailed, setInstallationReposFailed] = useState(false);
   const [connecting, setConnecting] = useState(false);
+  // Config ids with an enable/disable write in flight. The `Switch` stays bound
+  // to the server snapshot until the list refreshes, so two fast clicks would
+  // both read the same stale `row.enabled` and send the same value twice.
+  const [pendingToggles, setPendingToggles] = useState<ReadonlySet<string>>(
+    () => new Set()
+  );
   const [pickerRepo, setPickerRepo] = useState<string>("");
   const [pickerSuite, setPickerSuite] = useState<string>("");
 
@@ -131,10 +149,13 @@ export function GithubChecksRoute({
   }, [availability?.state, listInstallationRepos, handleWriteError]);
 
   // Without an active organization the availability query never runs, so
-  // treating that as "still loading" would leave the page blank forever. There
-  // is nothing org-less to configure here, so send them back to Settings —
-  // same call the Organization tab makes by omitting itself.
+  // treating that as "still loading" would leave the page blank forever. But
+  // redirecting the instant the id is missing would bounce a deep link during
+  // the ordinary bootstrap window, so wait for the org list to settle first.
+  // Once it has, there is nothing org-less to configure here — send them back
+  // to Settings, the same call the Organization tab makes by omitting itself.
   if (!activeOrganizationId) {
+    if (organizationsLoading) return null;
     return <Navigate to="/settings" replace />;
   }
 
@@ -177,10 +198,22 @@ export function GithubChecksRoute({
   };
 
   const handleToggle = async (row: GithubCheckRepoConfigRow) => {
+    // Ignore a second click while the first is still in flight. Without this,
+    // both reads see the same pre-write `row.enabled` and send the identical
+    // value twice — the second write is a no-op the backend correctly drops,
+    // but the user's second intent is silently lost.
+    if (pendingToggles.has(row._id)) return;
+    setPendingToggles((current) => new Set(current).add(row._id));
     try {
       await setRepoEnabled({ configId: row._id, enabled: !row.enabled });
     } catch (error) {
       handleWriteError(error);
+    } finally {
+      setPendingToggles((current) => {
+        const next = new Set(current);
+        next.delete(row._id);
+        return next;
+      });
     }
   };
 
@@ -316,6 +349,7 @@ export function GithubChecksRoute({
 
                   <Switch
                     checked={row.enabled}
+                    disabled={pendingToggles.has(row._id)}
                     onCheckedChange={() => void handleToggle(row)}
                     aria-label={`Enable checks for ${row.repoFullName}`}
                   />

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -79,7 +79,10 @@ export function GithubChecksRoute({
   // and "not resolved yet" look identical from here. The org list's own loading
   // state is the missing bit: only once it settles is a missing id genuinely
   // missing rather than merely early.
-  const { isAuthenticated } = useConvexAuth();
+  // BOTH signals are needed. `useOrganizationQueries().isLoading` is
+  // `isAuthenticated && …`, so it reports NOT-loading while Convex auth is
+  // still resolving — exactly the window a cold deep link lands in.
+  const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
   const { isLoading: organizationsLoading } = useOrganizationQueries({
     isAuthenticated,
   });
@@ -155,7 +158,7 @@ export function GithubChecksRoute({
   // Once it has, there is nothing org-less to configure here — send them back
   // to Settings, the same call the Organization tab makes by omitting itself.
   if (!activeOrganizationId) {
-    if (organizationsLoading) return null;
+    if (authLoading || organizationsLoading) return null;
     return <Navigate to="/settings" replace />;
   }
 

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -40,11 +40,20 @@ interface GithubChecksRouteProps {
   activeOrganizationId?: string | null;
 }
 
-/** Where a repo's check recipe came from. Display only — never editable here. */
-function RecipeProvenance({ enabled }: { enabled: boolean }) {
+/**
+ * The row's current check state.
+ *
+ * This deliberately does NOT claim where the recipe came from. The backend
+ * contract carries no provenance field, and deriving one from the `enabled`
+ * toggle would state something we have not been told — a repo shown as
+ * "declared in mcpjam.yaml" when nobody checked is worse than saying nothing.
+ * The page-level copy explains where recipes come from in general; when the
+ * backend returns provenance per repo, it belongs here.
+ */
+function RepoCheckState({ enabled }: { enabled: boolean }) {
   return (
     <span className="text-xs text-muted-foreground">
-      recipe: {enabled ? "declared in mcpjam.yaml / detected" : "paused"}
+      {enabled ? "Checks run on every pull request" : "Checks paused"}
     </span>
   );
 }
@@ -63,9 +72,14 @@ export function GithubChecksRoute({
     listInstallationRepos,
   } = useGithubChecksSettings(activeOrganizationId);
 
+  // `null` = not loaded yet, `[]` = loaded and genuinely empty. The error is
+  // tracked separately so a failed fetch never renders as "you have no
+  // repositories, go install the App" — that would blame the user for an
+  // outage.
   const [installationRepos, setInstallationRepos] = useState<
     InstallationRepo[] | null
   >(null);
+  const [installationReposFailed, setInstallationReposFailed] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [pickerRepo, setPickerRepo] = useState<string>("");
   const [pickerSuite, setPickerSuite] = useState<string>("");
@@ -84,18 +98,45 @@ export function GithubChecksRoute({
     toast.error(message);
   }, []);
 
-  const loadInstallationRepos = useCallback(async () => {
-    try {
-      setInstallationRepos(await listInstallationRepos());
-    } catch (error) {
-      setInstallationRepos([]);
-      handleWriteError(error);
-    }
-  }, [listInstallationRepos, handleWriteError]);
-
   useEffect(() => {
-    if (availability?.state === "enabled") void loadInstallationRepos();
-  }, [availability?.state, loadInstallationRepos]);
+    // Switching orgs must not let the previous org's in-flight result land on
+    // the new one: `connectRepo` sends the CURRENT org id, so a stale selection
+    // would be submitted against an org that repo does not belong to. Reset the
+    // picker and ignore any completion after cleanup.
+    let cancelled = false;
+    setInstallationRepos(null);
+    setInstallationReposFailed(false);
+    setPickerRepo("");
+    setPickerSuite("");
+
+    if (availability?.state !== "enabled") {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void listInstallationRepos()
+      .then((repositories) => {
+        if (!cancelled) setInstallationRepos(repositories);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setInstallationReposFailed(true);
+        handleWriteError(error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [availability?.state, listInstallationRepos, handleWriteError]);
+
+  // Without an active organization the availability query never runs, so
+  // treating that as "still loading" would leave the page blank forever. There
+  // is nothing org-less to configure here, so send them back to Settings —
+  // same call the Organization tab makes by omitting itself.
+  if (!activeOrganizationId) {
+    return <Navigate to="/settings" replace />;
+  }
 
   // Tri-state. Only an explicit `disabled` redirects.
   if (availability === undefined) return null;
@@ -168,10 +209,22 @@ export function GithubChecksRoute({
     }
   };
 
-  const alreadyConnected = new Set(rows.map((r) => r.repoFullName));
-  const connectableRepos = (installationRepos ?? []).filter(
-    (repo) => !alreadyConnected.has(repo.fullName.toLowerCase())
+  // Both sides lowercased. The backend stores the canonical lowercase form, so
+  // today only the candidate strictly needs it — but relying on that means a
+  // contract change silently reintroduces duplicate offers, and normalizing
+  // both is free.
+  const alreadyConnected = new Set(
+    rows.map((row) => row.repoFullName.toLowerCase())
   );
+  // Offer nothing until the connected list has actually loaded. `rows` is `[]`
+  // while `repos` is undefined, so filtering then would advertise repositories
+  // that are already connected and get rejected on submit.
+  const connectableRepos =
+    repos === undefined
+      ? []
+      : (installationRepos ?? []).filter(
+          (repo) => !alreadyConnected.has(repo.fullName.toLowerCase())
+        );
 
   return (
     <div className="h-full overflow-y-auto">
@@ -181,7 +234,6 @@ export function GithubChecksRoute({
           <SettingsNav
             active="github-checks"
             activeOrganizationId={activeOrganizationId}
-            githubChecksAvailable
           />
         </div>
 
@@ -236,7 +288,7 @@ export function GithubChecksRoute({
                     <span className="text-sm font-medium truncate">
                       {row.repoFullName}
                     </span>
-                    <RecipeProvenance enabled={row.enabled} />
+                    <RepoCheckState enabled={row.enabled} />
                   </div>
                 </div>
 
@@ -318,7 +370,12 @@ export function GithubChecksRoute({
             </Button>
           </div>
 
-          {installationRepos !== null && installationRepos.length === 0 ? (
+          {installationReposFailed ? (
+            <div className="px-4 pb-4 text-sm text-muted-foreground">
+              Could not load repositories from GitHub. This is usually temporary
+              — reload the page to try again.
+            </div>
+          ) : installationRepos !== null && installationRepos.length === 0 ? (
             <div className="px-4 pb-4 text-sm text-muted-foreground">
               No repositories available. Install the MCPJam GitHub App on the
               repositories you want checked, then reload this page.

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useState } from "react";
+import { Navigate } from "react-router";
+import { Github, Plus, Trash2 } from "lucide-react";
+import { toast } from "@/lib/toast";
+import { Button } from "@mcpjam/design-system/button";
+import { Switch } from "@mcpjam/design-system/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { SettingsSection } from "../setting/SettingsSection";
+import { SettingsNav } from "./SettingsNav";
+import {
+  GITHUB_CHECKS_UNAVAILABLE_MESSAGE,
+  useGithubChecksSettings,
+  type GithubCheckRepoConfigRow,
+  type InstallationRepo,
+  type SuiteOption,
+} from "@/hooks/useGithubChecksSettings";
+
+/**
+ * `/settings/github-checks` — connect repositories to a GitHub PR check.
+ *
+ * Availability is BACKEND-decided (see `useGithubChecksSettings`); this
+ * component never consults a client-side flag. It renders three states:
+ *
+ *   undefined → nothing (still asking)
+ *   disabled  → redirect to /settings
+ *   enabled   → the page
+ *
+ * The `undefined` case must not redirect. While the query is in flight we do
+ * not yet know whether the user is allowed here, and bouncing on "don't know"
+ * would strand a legitimately-enabled user who cold-loads the URL.
+ */
+
+interface GithubChecksRouteProps {
+  activeOrganizationId?: string | null;
+}
+
+/** Where a repo's check recipe came from. Display only — never editable here. */
+function RecipeProvenance({ enabled }: { enabled: boolean }) {
+  return (
+    <span className="text-xs text-muted-foreground">
+      recipe: {enabled ? "declared in mcpjam.yaml / detected" : "paused"}
+    </span>
+  );
+}
+
+export function GithubChecksRoute({
+  activeOrganizationId,
+}: GithubChecksRouteProps = {}) {
+  const {
+    availability,
+    repos,
+    suites,
+    connectRepo,
+    setRepoEnabled,
+    setRepoSuite,
+    disconnectRepo,
+    listInstallationRepos,
+  } = useGithubChecksSettings(activeOrganizationId);
+
+  const [installationRepos, setInstallationRepos] = useState<
+    InstallationRepo[] | null
+  >(null);
+  const [connecting, setConnecting] = useState(false);
+  const [pickerRepo, setPickerRepo] = useState<string>("");
+  const [pickerSuite, setPickerSuite] = useState<string>("");
+
+  /**
+   * A write refused as unavailable means the surface flipped off underneath
+   * us. Showing the stable message and re-reading availability is the honest
+   * response — the next render redirects if it is genuinely off now.
+   */
+  const handleWriteError = useCallback((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("not currently available")) {
+      toast.error(GITHUB_CHECKS_UNAVAILABLE_MESSAGE);
+      return;
+    }
+    toast.error(message);
+  }, []);
+
+  const loadInstallationRepos = useCallback(async () => {
+    try {
+      setInstallationRepos(await listInstallationRepos());
+    } catch (error) {
+      setInstallationRepos([]);
+      handleWriteError(error);
+    }
+  }, [listInstallationRepos, handleWriteError]);
+
+  useEffect(() => {
+    if (availability?.state === "enabled") void loadInstallationRepos();
+  }, [availability?.state, loadInstallationRepos]);
+
+  // Tri-state. Only an explicit `disabled` redirects.
+  if (availability === undefined) return null;
+  if (availability.state === "disabled") {
+    return <Navigate to="/settings" replace />;
+  }
+
+  const suiteOptions: SuiteOption[] = suites ?? [];
+  const rows: GithubCheckRepoConfigRow[] = repos ?? [];
+
+  const suiteById = (suiteId: string) =>
+    suiteOptions.find((s) => s._id === suiteId);
+
+  const handleConnect = async () => {
+    const suite = suiteById(pickerSuite);
+    if (!pickerRepo || !suite?.projectId) {
+      toast.error("Pick a repository and a suite first.");
+      return;
+    }
+    setConnecting(true);
+    try {
+      // The project is DERIVED from the suite, never picked separately: the
+      // backend requires them to agree, so offering two controls would only
+      // create a way to get it wrong.
+      await connectRepo({
+        repoFullName: pickerRepo,
+        projectId: suite.projectId,
+        suiteId: suite._id,
+      });
+      setPickerRepo("");
+      setPickerSuite("");
+      toast.success("Repository connected.");
+    } catch (error) {
+      handleWriteError(error);
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleToggle = async (row: GithubCheckRepoConfigRow) => {
+    try {
+      await setRepoEnabled({ configId: row._id, enabled: !row.enabled });
+    } catch (error) {
+      handleWriteError(error);
+    }
+  };
+
+  const handleSuiteChange = async (
+    row: GithubCheckRepoConfigRow,
+    suiteId: string
+  ) => {
+    const suite = suiteById(suiteId);
+    if (!suite?.projectId) return;
+    try {
+      await setRepoSuite({
+        configId: row._id,
+        projectId: suite.projectId,
+        suiteId: suite._id,
+      });
+    } catch (error) {
+      handleWriteError(error);
+    }
+  };
+
+  const handleDisconnect = async (row: GithubCheckRepoConfigRow) => {
+    try {
+      await disconnectRepo({ configId: row._id });
+    } catch (error) {
+      handleWriteError(error);
+    }
+  };
+
+  const alreadyConnected = new Set(rows.map((r) => r.repoFullName));
+  const connectableRepos = (installationRepos ?? []).filter(
+    (repo) => !alreadyConnected.has(repo.fullName.toLowerCase())
+  );
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-10 space-y-8 max-w-3xl">
+        <div className="space-y-4">
+          <h1 className="text-2xl font-semibold">Settings</h1>
+          <SettingsNav
+            active="github-checks"
+            activeOrganizationId={activeOrganizationId}
+            githubChecksAvailable
+          />
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          Connect a repository to run an eval suite as a GitHub check on every
+          pull request. The check runs the suite you pick here against the PR's
+          head commit and reports back as a status check.
+        </p>
+
+        <SettingsSection title="Connected repositories">
+          {repos === undefined ? (
+            <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+              Loading…
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="space-y-3 px-4 py-8 text-sm text-muted-foreground">
+              <p>
+                No repositories connected yet. Install the MCPJam GitHub App on
+                a repository, then connect it below to start running checks on
+                its pull requests.
+              </p>
+              <p>
+                A repository can declare its check recipe in a{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                  mcpjam.yaml
+                </code>{" "}
+                at the repo root. Without one, MCPJam detects a recipe
+                automatically.{" "}
+                <a
+                  className="underline underline-offset-2 hover:text-foreground"
+                  href="https://docs.mcpjam.com/github-checks"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Read the docs
+                </a>
+                .
+              </p>
+            </div>
+          ) : (
+            rows.map((row) => (
+              <div
+                key={row._id}
+                className="flex items-center justify-between gap-4 px-4 py-3 rounded-md border border-border/40 bg-muted/20 transition-colors"
+                data-testid={`repo-row-${row.repoFullName}`}
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
+                    <Github className="size-4 text-primary" aria-hidden />
+                  </div>
+                  <div className="flex flex-col min-w-0">
+                    <span className="text-sm font-medium truncate">
+                      {row.repoFullName}
+                    </span>
+                    <RecipeProvenance enabled={row.enabled} />
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-3 shrink-0">
+                  <Select
+                    value={row.suiteId}
+                    onValueChange={(value) =>
+                      void handleSuiteChange(row, value)
+                    }
+                  >
+                    <SelectTrigger
+                      className="w-48"
+                      aria-label={`Suite for ${row.repoFullName}`}
+                    >
+                      <SelectValue placeholder="Select a suite" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {suiteOptions.map((suite) => (
+                        <SelectItem key={suite._id} value={suite._id}>
+                          {suite.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+
+                  <Switch
+                    checked={row.enabled}
+                    onCheckedChange={() => void handleToggle(row)}
+                    aria-label={`Enable checks for ${row.repoFullName}`}
+                  />
+
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={`Disconnect ${row.repoFullName}`}
+                    onClick={() => void handleDisconnect(row)}
+                  >
+                    <Trash2 className="size-4" aria-hidden />
+                  </Button>
+                </div>
+              </div>
+            ))
+          )}
+        </SettingsSection>
+
+        <SettingsSection title="Connect a repository">
+          <div className="flex flex-wrap items-center gap-3 px-4 py-3">
+            <Select value={pickerRepo} onValueChange={setPickerRepo}>
+              <SelectTrigger className="w-64" aria-label="Repository">
+                <SelectValue placeholder="Select a repository" />
+              </SelectTrigger>
+              <SelectContent>
+                {connectableRepos.map((repo) => (
+                  <SelectItem key={repo.fullName} value={repo.fullName}>
+                    {repo.fullName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={pickerSuite} onValueChange={setPickerSuite}>
+              <SelectTrigger className="w-56" aria-label="Suite">
+                <SelectValue placeholder="Select a suite" />
+              </SelectTrigger>
+              <SelectContent>
+                {suiteOptions.map((suite) => (
+                  <SelectItem key={suite._id} value={suite._id}>
+                    {suite.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Button
+              onClick={() => void handleConnect()}
+              disabled={connecting || !pickerRepo || !pickerSuite}
+            >
+              <Plus className="mr-2 size-4" aria-hidden /> Connect
+            </Button>
+          </div>
+
+          {installationRepos !== null && installationRepos.length === 0 ? (
+            <div className="px-4 pb-4 text-sm text-muted-foreground">
+              No repositories available. Install the MCPJam GitHub App on the
+              repositories you want checked, then reload this page.
+            </div>
+          ) : null}
+        </SettingsSection>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -75,13 +75,14 @@ export function GithubChecksRoute({
   } = useGithubChecksSettings(activeOrganizationId);
 
   // `activeOrganizationId` arrives asynchronously during app bootstrap, and the
-  // context types it `string | undefined` with no loading flag — so "absent"
-  // and "not resolved yet" look identical from here. The org list's own loading
-  // state is the missing bit: only once it settles is a missing id genuinely
-  // missing rather than merely early.
-  // BOTH signals are needed. `useOrganizationQueries().isLoading` is
-  // `isAuthenticated && …`, so it reports NOT-loading while Convex auth is
-  // still resolving — exactly the window a cold deep link lands in.
+  // route context types it `string | undefined` with no loading flag — so
+  // "absent" and "not resolved yet" look identical from here.
+  //
+  // BOTH of these supply the missing signal, and neither alone is enough:
+  // `useOrganizationQueries().isLoading` is computed as `isAuthenticated && …`,
+  // so it reads NOT-loading while Convex auth is still resolving — exactly the
+  // window a cold deep link lands in. Only once auth AND the org list have
+  // settled is a missing id genuinely missing rather than merely early.
   const { isAuthenticated, isLoading: authLoading } = useConvexAuth();
   const { isLoading: organizationsLoading } = useOrganizationQueries({
     isAuthenticated,

--- a/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
+import { useGithubChecksAvailability } from "@/hooks/useGithubChecksSettings";
 
 export type SettingsNavSection =
   | "general"
@@ -14,14 +15,6 @@ interface SettingsNavProps {
    * manage, so the tab is omitted rather than disabled.
    */
   activeOrganizationId?: string | null;
-  /**
-   * Enables the GitHub Checks tab. Availability is decided by the BACKEND
-   * (`getGithubChecksSettingsAvailability`), so the caller passes the answer
-   * in rather than this component asking. Omitted rather than disabled when
-   * unavailable — same reasoning as the Organization tab: a disabled tab
-   * advertises a surface the viewer cannot reach.
-   */
-  githubChecksAvailable?: boolean;
 }
 
 /**
@@ -32,9 +25,19 @@ interface SettingsNavProps {
 export function SettingsNav({
   active,
   activeOrganizationId,
-  githubChecksAvailable = false,
 }: SettingsNavProps) {
   const appNavigate = useAppNavigate();
+
+  // Resolved HERE rather than passed in by each caller. This nav is shared by
+  // every settings page, so a prop would have to be threaded through all of
+  // them — miss one and the tab silently vanishes from that page, which is the
+  // reachability bug that costs you the whole surface. The backend is still the
+  // only authority; this just asks it in one place instead of N.
+  //
+  // Omitted rather than disabled when unavailable, like the Organization tab: a
+  // disabled tab advertises a surface the viewer cannot reach.
+  const githubChecksAvailable =
+    useGithubChecksAvailability(activeOrganizationId)?.state === "enabled";
 
   const tabs: Array<{
     id: SettingsNavSection;

--- a/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
@@ -1,7 +1,11 @@
 import { cn } from "@/lib/utils";
 import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
 
-export type SettingsNavSection = "general" | "api-keys" | "organization";
+export type SettingsNavSection =
+  | "general"
+  | "api-keys"
+  | "github-checks"
+  | "organization";
 
 interface SettingsNavProps {
   active: SettingsNavSection;
@@ -10,6 +14,14 @@ interface SettingsNavProps {
    * manage, so the tab is omitted rather than disabled.
    */
   activeOrganizationId?: string | null;
+  /**
+   * Enables the GitHub Checks tab. Availability is decided by the BACKEND
+   * (`getGithubChecksSettingsAvailability`), so the caller passes the answer
+   * in rather than this component asking. Omitted rather than disabled when
+   * unavailable — same reasoning as the Organization tab: a disabled tab
+   * advertises a surface the viewer cannot reach.
+   */
+  githubChecksAvailable?: boolean;
 }
 
 /**
@@ -20,6 +32,7 @@ interface SettingsNavProps {
 export function SettingsNav({
   active,
   activeOrganizationId,
+  githubChecksAvailable = false,
 }: SettingsNavProps) {
   const appNavigate = useAppNavigate();
 
@@ -30,6 +43,15 @@ export function SettingsNav({
   }> = [
     { id: "general", label: "General", path: "/settings" },
     { id: "api-keys", label: "API Keys", path: "/settings/api-keys" },
+    ...(githubChecksAvailable
+      ? [
+          {
+            id: "github-checks" as const,
+            label: "GitHub Checks",
+            path: "/settings/github-checks",
+          },
+        ]
+      : []),
     ...(activeOrganizationId
       ? [
           {

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockAvailability,
+  mockRepos,
+  mockSuites,
+  mockSetRepoEnabled,
+  mockSetRepoSuite,
+  mockDisconnectRepo,
+  mockConnectRepo,
+  mockListInstallationRepos,
+} = vi.hoisted(() => ({
+  mockAvailability: {
+    value: undefined as { state: "enabled" | "disabled" } | undefined,
+  },
+  mockRepos: { value: undefined as unknown[] | undefined },
+  mockSuites: { value: [] as unknown[] },
+  mockSetRepoEnabled: vi.fn(async () => ({ changed: true })),
+  mockSetRepoSuite: vi.fn(async () => ({ changed: true })),
+  mockDisconnectRepo: vi.fn(async () => ({ removed: true })),
+  mockConnectRepo: vi.fn(async () => ({ configId: "cfg-new" })),
+  mockListInstallationRepos: vi.fn(async () => [
+    { fullName: "mcpjam/other-repo" },
+  ]),
+}));
+
+// The availability gate is the unit under test; the data layer is stubbed.
+vi.mock("@/hooks/useGithubChecksSettings", () => ({
+  GITHUB_CHECKS_UNAVAILABLE_MESSAGE:
+    "GitHub Checks settings are not currently available.",
+  useGithubChecksSettings: () => ({
+    availability: mockAvailability.value,
+    isEnabled: mockAvailability.value?.state === "enabled",
+    repos: mockRepos.value,
+    suites: mockSuites.value,
+    connectRepo: mockConnectRepo,
+    setRepoEnabled: mockSetRepoEnabled,
+    setRepoSuite: mockSetRepoSuite,
+    disconnectRepo: mockDisconnectRepo,
+    listInstallationRepos: mockListInstallationRepos,
+  }),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { GithubChecksRoute } from "../GithubChecksRoute";
+
+const ROW = {
+  _id: "cfg-1",
+  repoFullName: "mcpjam/mcp-check-fixture",
+  enabled: true,
+  organizationId: "org-1",
+  projectId: "proj-1",
+  suiteId: "suite-1",
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+function renderRoute() {
+  return render(
+    <MemoryRouter initialEntries={["/settings/github-checks"]}>
+      <Routes>
+        <Route
+          path="/settings/github-checks"
+          element={<GithubChecksRoute activeOrganizationId="org-1" />}
+        />
+        <Route path="/settings" element={<div>Settings Screen</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("GithubChecksRoute availability gate", () => {
+  beforeEach(() => {
+    mockAvailability.value = undefined;
+    mockRepos.value = undefined;
+    mockSuites.value = [
+      { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
+      { _id: "suite-2", name: "Second suite", projectId: "proj-1" },
+    ];
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing while availability is still loading", () => {
+    const { container } = renderRoute();
+    // Crucially NOT a redirect: bouncing on "don't know" would strand a
+    // legitimately-enabled user who cold-loads this URL.
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText("Settings Screen")).not.toBeInTheDocument();
+  });
+
+  it("redirects to /settings when the backend says disabled", () => {
+    mockAvailability.value = { state: "disabled" };
+    renderRoute();
+    expect(screen.getByText("Settings Screen")).toBeInTheDocument();
+  });
+
+  it("does not fetch installation repos while unavailable", () => {
+    mockAvailability.value = { state: "disabled" };
+    renderRoute();
+    expect(mockListInstallationRepos).not.toHaveBeenCalled();
+  });
+
+  it("renders connected repositories when enabled", () => {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [ROW];
+    renderRoute();
+    expect(screen.getByText("mcpjam/mcp-check-fixture")).toBeInTheDocument();
+  });
+
+  it("shows the install-App empty state when there are no repos", () => {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [];
+    renderRoute();
+    expect(
+      screen.getByText(/No repositories connected yet/)
+    ).toBeInTheDocument();
+    expect(screen.getByText("mcpjam.yaml")).toBeInTheDocument();
+  });
+
+  it("toggling a repository calls the mutation with the flipped value", () => {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [ROW];
+    renderRoute();
+
+    fireEvent.click(
+      screen.getByLabelText("Enable checks for mcpjam/mcp-check-fixture")
+    );
+
+    expect(mockSetRepoEnabled).toHaveBeenCalledWith({
+      configId: "cfg-1",
+      enabled: false,
+    });
+  });
+
+  it("disconnecting a repository calls the mutation", () => {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [ROW];
+    renderRoute();
+
+    fireEvent.click(
+      screen.getByLabelText("Disconnect mcpjam/mcp-check-fixture")
+    );
+
+    expect(mockDisconnectRepo).toHaveBeenCalledWith({ configId: "cfg-1" });
+  });
+
+  it("shows a loading row rather than an empty state before the list arrives", () => {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = undefined;
+    renderRoute();
+    // `undefined` is "not loaded", `[]` is "genuinely none" — conflating them
+    // would flash an install-the-App CTA at someone who has repos.
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No repositories connected yet/)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -47,6 +47,11 @@ vi.mock("@/lib/toast", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
+// The nav resolves availability itself now; it is not what this file tests.
+vi.mock("../SettingsNav", () => ({
+  SettingsNav: () => <nav data-testid="settings-nav" />,
+}));
+
 import { GithubChecksRoute } from "../GithubChecksRoute";
 
 const ROW = {
@@ -60,13 +65,15 @@ const ROW = {
   updatedAt: 1,
 };
 
-function renderRoute() {
+function renderRoute(activeOrganizationId: string | null = "org-1") {
   return render(
     <MemoryRouter initialEntries={["/settings/github-checks"]}>
       <Routes>
         <Route
           path="/settings/github-checks"
-          element={<GithubChecksRoute activeOrganizationId="org-1" />}
+          element={
+            <GithubChecksRoute activeOrganizationId={activeOrganizationId} />
+          }
         />
         <Route path="/settings" element={<div>Settings Screen</div>} />
       </Routes>
@@ -147,6 +154,29 @@ describe("GithubChecksRoute availability gate", () => {
     );
 
     expect(mockDisconnectRepo).toHaveBeenCalledWith({ configId: "cfg-1" });
+  });
+
+  it("redirects instead of hanging blank when there is no active organization", () => {
+    // The availability query is skipped without an org, so `undefined` here
+    // never resolves — treating it as "loading" would blank the page forever.
+    mockAvailability.value = undefined;
+    renderRoute(null);
+    expect(screen.getByText("Settings Screen")).toBeInTheDocument();
+  });
+
+  it("does not blame the user when the GitHub repo fetch fails", async () => {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [];
+    mockListInstallationRepos.mockRejectedValueOnce(new Error("network"));
+    renderRoute();
+
+    // "Install the App" would be a lie when the real problem is an outage.
+    expect(
+      await screen.findByText(/Could not load repositories from GitHub/)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No repositories available/)
+    ).not.toBeInTheDocument();
   });
 
   it("shows a loading row rather than an empty state before the list arrives", () => {

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -12,6 +12,7 @@ const {
   mockConnectRepo,
   mockListInstallationRepos,
   mockOrgsLoading,
+  mockAuthLoading,
 } = vi.hoisted(() => ({
   mockAvailability: {
     value: undefined as { state: "enabled" | "disabled" } | undefined,
@@ -26,6 +27,7 @@ const {
     { fullName: "mcpjam/other-repo" },
   ]),
   mockOrgsLoading: { value: false },
+  mockAuthLoading: { value: false },
 }));
 
 // The availability gate is the unit under test; the data layer is stubbed.
@@ -50,7 +52,10 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 vi.mock("convex/react", () => ({
-  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+  useConvexAuth: () => ({
+    isAuthenticated: !mockAuthLoading.value,
+    isLoading: mockAuthLoading.value,
+  }),
 }));
 
 vi.mock("@/hooks/useOrganizations", () => ({
@@ -100,6 +105,7 @@ describe("GithubChecksRoute availability gate", () => {
       { _id: "suite-2", name: "Second suite", projectId: "proj-1" },
     ];
     mockOrgsLoading.value = false;
+    mockAuthLoading.value = false;
     vi.clearAllMocks();
   });
 
@@ -181,6 +187,18 @@ describe("GithubChecksRoute availability gate", () => {
     // that first render would bounce a user who does have an org.
     mockAvailability.value = undefined;
     mockOrgsLoading.value = true;
+    const { container } = renderRoute(null);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText("Settings Screen")).not.toBeInTheDocument();
+  });
+
+  it("does NOT redirect while Convex auth is still resolving", () => {
+    // `useOrganizationQueries().isLoading` is `isAuthenticated && …`, so it
+    // reads FALSE during auth bootstrap. Gating on it alone would bounce a
+    // cold deep link before anyone knows who the user is.
+    mockAvailability.value = undefined;
+    mockAuthLoading.value = true;
+    mockOrgsLoading.value = false;
     const { container } = renderRoute(null);
     expect(container).toBeEmptyDOMElement();
     expect(screen.queryByText("Settings Screen")).not.toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/github-checks-route.test.tsx
@@ -11,6 +11,7 @@ const {
   mockDisconnectRepo,
   mockConnectRepo,
   mockListInstallationRepos,
+  mockOrgsLoading,
 } = vi.hoisted(() => ({
   mockAvailability: {
     value: undefined as { state: "enabled" | "disabled" } | undefined,
@@ -24,6 +25,7 @@ const {
   mockListInstallationRepos: vi.fn(async () => [
     { fullName: "mcpjam/other-repo" },
   ]),
+  mockOrgsLoading: { value: false },
 }));
 
 // The availability gate is the unit under test; the data layer is stubbed.
@@ -45,6 +47,14 @@ vi.mock("@/hooks/useGithubChecksSettings", () => ({
 
 vi.mock("@/lib/toast", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useOrganizations", () => ({
+  useOrganizationQueries: () => ({ isLoading: mockOrgsLoading.value }),
 }));
 
 // The nav resolves availability itself now; it is not what this file tests.
@@ -89,6 +99,7 @@ describe("GithubChecksRoute availability gate", () => {
       { _id: "suite-1", name: "Fixture suite", projectId: "proj-1" },
       { _id: "suite-2", name: "Second suite", projectId: "proj-1" },
     ];
+    mockOrgsLoading.value = false;
     vi.clearAllMocks();
   });
 
@@ -156,12 +167,47 @@ describe("GithubChecksRoute availability gate", () => {
     expect(mockDisconnectRepo).toHaveBeenCalledWith({ configId: "cfg-1" });
   });
 
-  it("redirects instead of hanging blank when there is no active organization", () => {
+  it("redirects instead of hanging blank when there is genuinely no organization", () => {
     // The availability query is skipped without an org, so `undefined` here
     // never resolves — treating it as "loading" would blank the page forever.
     mockAvailability.value = undefined;
+    mockOrgsLoading.value = false;
     renderRoute(null);
     expect(screen.getByText("Settings Screen")).toBeInTheDocument();
+  });
+
+  it("does NOT redirect during the organization bootstrap window", () => {
+    // A deep link lands before `activeOrganizationId` resolves. Redirecting on
+    // that first render would bounce a user who does have an org.
+    mockAvailability.value = undefined;
+    mockOrgsLoading.value = true;
+    const { container } = renderRoute(null);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText("Settings Screen")).not.toBeInTheDocument();
+  });
+
+  it("ignores a second toggle while the first is still in flight", async () => {
+    mockAvailability.value = { state: "enabled" };
+    mockRepos.value = [ROW];
+    let release: (() => void) | undefined;
+    mockSetRepoEnabled.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ changed: true });
+        })
+    );
+    renderRoute();
+
+    const toggle = screen.getByLabelText(
+      "Enable checks for mcpjam/mcp-check-fixture"
+    );
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    // Both clicks read the same pre-write snapshot, so an unguarded handler
+    // would send `enabled: false` twice and lose the user's second intent.
+    expect(mockSetRepoEnabled).toHaveBeenCalledTimes(1);
+    release?.();
   });
 
   it("does not blame the user when the GitHub repo fetch fails", async () => {

--- a/mcpjam-inspector/client/src/components/settings/__tests__/settings-nav.github-checks.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/settings-nav.github-checks.test.tsx
@@ -2,16 +2,31 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
-const mockNavigate = vi.fn();
+const { mockNavigate, mockAvailability } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockAvailability: {
+    value: undefined as { state: "enabled" | "disabled" } | undefined,
+  },
+}));
 
 vi.mock("@/lib/app-navigation", () => ({
   useAppNavigate: () => mockNavigate,
   buildOrganizationPath: (id: string) => `/organizations/${id}`,
 }));
 
+// The nav asks the backend itself so every settings page agrees; the answer is
+// stubbed here.
+vi.mock("@/hooks/useGithubChecksSettings", () => ({
+  useGithubChecksAvailability: () => mockAvailability.value,
+}));
+
 import { SettingsNav } from "../SettingsNav";
 
-function renderNav(props: Parameters<typeof SettingsNav>[0]) {
+function renderNav(
+  props: Parameters<typeof SettingsNav>[0],
+  availability?: { state: "enabled" | "disabled" }
+) {
+  mockAvailability.value = availability;
   return render(
     <MemoryRouter>
       <SettingsNav {...props} />
@@ -20,31 +35,39 @@ function renderNav(props: Parameters<typeof SettingsNav>[0]) {
 }
 
 describe("SettingsNav — GitHub Checks tab", () => {
-  it("omits the tab when the backend has not said it is available", () => {
-    renderNav({ active: "general" });
+  it("omits the tab while availability is still unknown", () => {
+    renderNav({ active: "general" }, undefined);
     // Omitted, not disabled: a disabled tab advertises a surface the viewer
-    // cannot reach, which is the thing a flag gate is meant to avoid.
+    // cannot reach, which is the thing a gate is meant to avoid.
     expect(screen.queryByText("GitHub Checks")).not.toBeInTheDocument();
   });
 
-  it("omits the tab when availability is explicitly false", () => {
-    renderNav({ active: "general", githubChecksAvailable: false });
+  it("omits the tab when the backend says disabled", () => {
+    renderNav({ active: "general" }, { state: "disabled" });
     expect(screen.queryByText("GitHub Checks")).not.toBeInTheDocument();
   });
 
   it("shows the tab when available", () => {
-    renderNav({ active: "general", githubChecksAvailable: true });
+    renderNav({ active: "general" }, { state: "enabled" });
+    expect(screen.getByText("GitHub Checks")).toBeInTheDocument();
+  });
+
+  it("shows the tab from OTHER settings pages, not just its own", () => {
+    // The reachability property: the nav resolves availability itself, so a
+    // page that never heard of GitHub Checks still offers the way in. A prop
+    // threaded per-caller would silently drop the tab here.
+    renderNav({ active: "api-keys" }, { state: "enabled" });
     expect(screen.getByText("GitHub Checks")).toBeInTheDocument();
   });
 
   it("keeps the always-present tabs regardless of availability", () => {
-    renderNav({ active: "general" });
+    renderNav({ active: "general" }, undefined);
     expect(screen.getByText("General")).toBeInTheDocument();
     expect(screen.getByText("API Keys")).toBeInTheDocument();
   });
 
   it("marks the GitHub Checks tab current when it is the active section", () => {
-    renderNav({ active: "github-checks", githubChecksAvailable: true });
+    renderNav({ active: "github-checks" }, { state: "enabled" });
     expect(screen.getByText("GitHub Checks")).toHaveAttribute(
       "aria-current",
       "page"

--- a/mcpjam-inspector/client/src/components/settings/__tests__/settings-nav.github-checks.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/settings-nav.github-checks.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+const mockNavigate = vi.fn();
+
+vi.mock("@/lib/app-navigation", () => ({
+  useAppNavigate: () => mockNavigate,
+  buildOrganizationPath: (id: string) => `/organizations/${id}`,
+}));
+
+import { SettingsNav } from "../SettingsNav";
+
+function renderNav(props: Parameters<typeof SettingsNav>[0]) {
+  return render(
+    <MemoryRouter>
+      <SettingsNav {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe("SettingsNav — GitHub Checks tab", () => {
+  it("omits the tab when the backend has not said it is available", () => {
+    renderNav({ active: "general" });
+    // Omitted, not disabled: a disabled tab advertises a surface the viewer
+    // cannot reach, which is the thing a flag gate is meant to avoid.
+    expect(screen.queryByText("GitHub Checks")).not.toBeInTheDocument();
+  });
+
+  it("omits the tab when availability is explicitly false", () => {
+    renderNav({ active: "general", githubChecksAvailable: false });
+    expect(screen.queryByText("GitHub Checks")).not.toBeInTheDocument();
+  });
+
+  it("shows the tab when available", () => {
+    renderNav({ active: "general", githubChecksAvailable: true });
+    expect(screen.getByText("GitHub Checks")).toBeInTheDocument();
+  });
+
+  it("keeps the always-present tabs regardless of availability", () => {
+    renderNav({ active: "general" });
+    expect(screen.getByText("General")).toBeInTheDocument();
+    expect(screen.getByText("API Keys")).toBeInTheDocument();
+  });
+
+  it("marks the GitHub Checks tab current when it is the active section", () => {
+    renderNav({ active: "github-checks", githubChecksAvailable: true });
+    expect(screen.getByText("GitHub Checks")).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -1,6 +1,5 @@
 import { useCallback } from "react";
-import { useConvexAuth } from "convex/react";
-import { useAction, useMutation, useQuery } from "convex/react";
+import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
 import { useDbUserReady } from "@/contexts/db-user-ready-context";
 
 /**

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -1,0 +1,167 @@
+import { useCallback } from "react";
+import { useConvexAuth } from "convex/react";
+import { useAction, useMutation, useQuery } from "convex/react";
+import { useDbUserReady } from "@/contexts/db-user-ready-context";
+
+/**
+ * GitHub Checks settings — data layer.
+ *
+ * **There is no client-side feature flag on this surface.** Availability is
+ * decided by the backend and read through
+ * `getGithubChecksSettingsAvailability`. That matters: the flag is evaluated
+ * server-side against the org, and a client-side twin could disagree with it —
+ * showing a page whose every write the server then refuses. One authority,
+ * asked once.
+ *
+ * Function ids are strings because this app has no generated Convex client;
+ * types below are hand-mirrored from `convex/github/checkRepoConfigs.ts`. Keep
+ * them in sync by hand — nothing checks this at build time.
+ */
+
+/**
+ * `'enabled' | 'disabled'` once resolved; `undefined` while loading or while
+ * the query is skipped.
+ *
+ * The tri-state is load-bearing. `disabled` means the backend said no;
+ * `undefined` means we have not asked yet. Treating the second as the first
+ * would bounce a legitimately-flagged user who cold-loads the URL directly.
+ */
+export type GithubChecksAvailability =
+  | { state: "enabled" | "disabled" }
+  | undefined;
+
+export type GithubCheckRepoConfigRow = {
+  _id: string;
+  repoFullName: string;
+  enabled: boolean;
+  organizationId: string;
+  projectId: string;
+  suiteId: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type InstallationRepo = { fullName: string };
+
+export type SuiteOption = {
+  _id: string;
+  name: string;
+  projectId?: string;
+};
+
+const AVAILABILITY_QUERY =
+  "github/checkRepoConfigs:getGithubChecksSettingsAvailability";
+const LIST_QUERY = "github/checkRepoConfigs:listForOrganization";
+const SUITES_QUERY = "testSuites:getTestSuitesOverview";
+
+/** The one message the UI shows when the backend refuses on availability. */
+export const GITHUB_CHECKS_UNAVAILABLE_MESSAGE =
+  "GitHub Checks settings are not currently available.";
+
+export function useGithubChecksAvailability(
+  organizationId: string | null | undefined
+): GithubChecksAvailability {
+  const { isAuthenticated } = useConvexAuth();
+  const isUserReady = useDbUserReady();
+  const canQuery = Boolean(isAuthenticated && isUserReady && organizationId);
+
+  return useQuery(
+    AVAILABILITY_QUERY as any,
+    canQuery ? ({ organizationId } as any) : "skip"
+  ) as GithubChecksAvailability;
+}
+
+export function useGithubChecksSettings(
+  organizationId: string | null | undefined
+) {
+  const { isAuthenticated } = useConvexAuth();
+  const isUserReady = useDbUserReady();
+
+  const availability = useGithubChecksAvailability(organizationId);
+  const isEnabled = availability?.state === "enabled";
+
+  // The list and the suite picker are only fetched once availability says
+  // `enabled`. Asking earlier would fire two queries the backend answers with
+  // an empty list anyway, and would make the page flash content it may not be
+  // allowed to show.
+  const canQuery = Boolean(
+    isAuthenticated && isUserReady && organizationId && isEnabled
+  );
+
+  const repos = useQuery(
+    LIST_QUERY as any,
+    canQuery ? ({ organizationId } as any) : "skip"
+  ) as GithubCheckRepoConfigRow[] | undefined;
+
+  // `getTestSuitesOverview` accepts an org scope. Note it filters on
+  // `suite.organizationId`, which is optional on legacy rows — a suite created
+  // before that field existed will not appear here.
+  const suiteOverview = useQuery(
+    SUITES_QUERY as any,
+    canQuery ? ({ organizationId } as any) : "skip"
+  ) as Array<{ suite?: SuiteOption }> | undefined;
+
+  const suites: SuiteOption[] | undefined = suiteOverview
+    ?.map((entry) => entry.suite)
+    .filter((suite): suite is SuiteOption => Boolean(suite?._id));
+
+  const connectRepoMutation = useMutation(
+    "github/checkRepoConfigs:connectRepo" as any
+  );
+  const setRepoEnabledMutation = useMutation(
+    "github/checkRepoConfigs:setRepoEnabled" as any
+  );
+  const setRepoSuiteMutation = useMutation(
+    "github/checkRepoConfigs:setRepoSuite" as any
+  );
+  const disconnectRepoMutation = useMutation(
+    "github/checkRepoConfigs:disconnectRepo" as any
+  );
+  const listInstallationReposAction = useAction(
+    "github/checkRepoConfigsNode:listInstallationRepos" as any
+  );
+
+  const connectRepo = useCallback(
+    (args: { repoFullName: string; projectId: string; suiteId: string }) =>
+      connectRepoMutation({ organizationId, ...args } as any),
+    [connectRepoMutation, organizationId]
+  );
+
+  const setRepoEnabled = useCallback(
+    (args: { configId: string; enabled: boolean }) =>
+      setRepoEnabledMutation({ organizationId, ...args } as any),
+    [setRepoEnabledMutation, organizationId]
+  );
+
+  const setRepoSuite = useCallback(
+    (args: { configId: string; projectId: string; suiteId: string }) =>
+      setRepoSuiteMutation({ organizationId, ...args } as any),
+    [setRepoSuiteMutation, organizationId]
+  );
+
+  const disconnectRepo = useCallback(
+    (args: { configId: string }) =>
+      disconnectRepoMutation({ organizationId, ...args } as any),
+    [disconnectRepoMutation, organizationId]
+  );
+
+  const listInstallationRepos = useCallback(
+    () =>
+      listInstallationReposAction({ organizationId } as any) as Promise<
+        InstallationRepo[]
+      >,
+    [listInstallationReposAction, organizationId]
+  );
+
+  return {
+    availability,
+    isEnabled,
+    repos,
+    suites,
+    connectRepo,
+    setRepoEnabled,
+    setRepoSuite,
+    disconnectRepo,
+    listInstallationRepos,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -90,6 +90,7 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
   { path: "support", kind: "screen", surfaceId: "support" },
   { path: "settings", kind: "screen", surfaceId: "settings" },
   { path: "settings/api-keys", kind: "screen", surfaceId: "settings" },
+  { path: "settings/github-checks", kind: "screen", surfaceId: "settings" },
   { path: "profile", kind: "screen", surfaceId: "profile" },
   { path: "project-settings", kind: "screen", surfaceId: "project-settings" },
   {

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider, redirect } from "react-router";
 import App, {
   ApiKeysSettingsRoute,
+  GithubChecksSettingsRoute,
   AuthRoute,
   ChatAliasRoute,
   ChatboxesRoute,
@@ -112,6 +113,7 @@ const ROUTE_ELEMENTS: Record<
   support: { element: <SupportRoute /> },
   settings: { element: <SettingsRoute /> },
   "settings/api-keys": { element: <ApiKeysSettingsRoute /> },
+  "settings/github-checks": { element: <GithubChecksSettingsRoute /> },
   profile: { element: <ProfileRoute /> },
   "project-settings": { element: <ProjectSettingsRoute /> },
   "client-config": { element: <ServersRedirectRoute /> },
@@ -147,7 +149,9 @@ function buildRouteChildren() {
     if (!rendered) {
       // A route table entry with nothing to render is a first-party bug —
       // the coverage test catches it, but fail loudly if one slips through.
-      throw new Error(`[router] no element registered for route "${route.path}"`);
+      throw new Error(
+        `[router] no element registered for route "${route.path}"`
+      );
     }
     const isIndex = route.path === "/";
     return {

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -549,7 +549,7 @@ export const APP_SURFACES = [
   {
     id: "settings",
     canonicalPath: "/settings",
-    routePatterns: ["settings", "settings/api-keys"],
+    routePatterns: ["settings", "settings/api-keys", "settings/github-checks"],
     navSegments: ["settings"],
     title: "Settings",
     purpose: "Application settings, including API keys.",


### PR DESCRIPTION
**Cross-repo:** this is the UI half of a five-PR change. The backend half is `MCPJam/mcpjam-backend` #861 → #862 → (#863 ‖ #864). This PR depends only on **#863's contract** (string function ids, hand-mirrored types — no codegen coupling), so it builds and tests standalone. **It must not be released until #863 is deployed**, or the page's queries hit functions that do not exist yet.

## What this is

`/settings/github-checks` — where an org admin connects a repository to an eval suite that runs as a GitHub check on every pull request. Today that binding lives in a `GITHUB_CHECKS_REPO_CONFIG` env var, so onboarding a repo needs deployment access and can only be done by an operator. #863 moves it into a table; this is the UI for it.

## No client-side feature flag on this surface

Availability comes from the backend, via `getGithubChecksSettingsAvailability`.

A client-side PostHog flag would be a second opinion about the same question. It can disagree with the server's answer — which is evaluated against the org, server-side, and fails closed — and when it does, the page renders and every write it offers gets refused. One authority, asked once, cannot drift.

### The tri-state is load-bearing

```
undefined → render nothing   (we have not asked yet)
disabled  → redirect         (the backend said no)
enabled   → render the page
```

Only `disabled` redirects. Bouncing on `undefined` would strand a legitimately-enabled user who cold-loads the URL directly, before the query settles — the same trap `ProjectEnvironmentsRoute` documents.

The repo list follows the same rule: `undefined` renders a loading row, `[]` renders the install-the-App empty state. Conflating them would flash "install the GitHub App" at someone who already has repositories connected.

## Design decisions worth a look

- **The nav tab is omitted, not disabled**, when unavailable — matching the Organization tab. A disabled tab advertises a surface the viewer cannot reach, which is the thing a gate exists to avoid.
- **Connecting derives the project from the chosen suite** rather than offering a separate project picker. The backend requires the two to agree (it traces suite → project → org), so a second control could only ever create a way to get it wrong.
- **Recipe provenance is display-only.** Where a repo's check recipe comes from — `mcpjam.yaml` or detection — is the repository's business, not something to override from a settings page.
- **A write refused as unavailable** shows one stable message rather than leaking the backend's phrasing, and the next render redirects if the surface is genuinely off now.

## Route registration

All four required places, or `app-surface-coverage.test.ts` fails:

| file | what |
|---|---|
| `client/src/lib/app-routes.ts` | `settings/github-checks` screen |
| `client/src/router.tsx` | `ROUTE_ELEMENTS` entry |
| `client/src/App.tsx` | `GithubChecksSettingsRoute` wrapper reading `activeOrganizationId` from `useAppRouteContext()` |
| `shared/app-surfaces.ts` | added to `settings.routePatterns` |

## Backend contract

Hand-mirrored from `convex/github/checkRepoConfigs.ts` with string function ids, matching this codebase's existing pattern (`useOrganizations.ts:64`). **Nothing checks that mirror at build time**, and the hook says so in a comment. If #863's argument shapes change before merge, this file changes with them.

One nuance worth knowing: the suite picker uses `testSuites:getTestSuitesOverview` with `{organizationId}`, which filters on `suite.organizationId` — an **optional** field on legacy rows. A suite created before that field existed will not appear in the picker. Called out in the hook.

## Verification

| check | result |
|---|---|
| `npm run typecheck:client` | **exit 0** |
| new component + nav tests | **exit 0** — 13 tests across 2 files |
| `app-surface-coverage.test.ts` | **exit 0** — 18 tests |
| `npx prettier --check` on touched files | **exit 0** |

**13 new tests.** `GithubChecksRoute` (8): renders nothing while loading, redirects on `disabled`, skips the installation-repos fetch while unavailable, renders rows when enabled, shows the install-App empty state, toggle calls the mutation with the flipped value, disconnect calls the mutation, and loading-vs-empty are not conflated. `SettingsNav` (5): tab omitted by default, omitted on explicit `false`, shown when available, always-present tabs unaffected, `aria-current` when active.

### Full suite — note on the first run

The first full `npm test` reported *110 failed files but only 1 failed test*. That is not 110 broken tests: `npm test`'s `pretest` bundles the sandbox proxies and browser harness but does **not** run `sdk:build`, so `@mcpjam/sdk` was unbuilt in this fresh checkout and 109 files failed at import (`Failed to resolve import "@mcpjam/sdk/predicates"`, `Cannot find module '@mcpjam/sdk/dist/index.js'`). The single real failure, `routes/web/__tests__/xaa-node-adapter.test.ts`, has the same root cause — it shells out to a script that imports the SDK.

None of it touches this PR's code. I ran `npm run sdk:build` and re-ran the full suite; **I'll post the result as a comment on this PR** rather than claim it here before it finished.

Worth flagging for the repo regardless: a fresh clone cannot run `npm test` successfully without knowing to build the SDK first. Adding `sdk:build` to `pretest` would make that self-evident — happy to do it in a separate PR if you want it.

## Morning runbook

1. Land and deploy the backend stack first: #861 → #862 → #863. The page's queries do not exist until #863 is deployed.
2. Create the `github-checks-settings` flag in PostHog (boolean, **off by default**). Until it exists the backend fails closed, so the tab stays hidden everywhere — which is the intended pre-release state.
3. Merge and release this.
4. Enable the flag **for the MCPJam org only**.
5. Dogfood: connect `mcpjam-stateless` through the UI, toggle it off and on, change its suite, and open a real PR to confirm the check runs.
6. Note that the repo picker stays empty until `GITHUB_CHECKS_INSTALLATION_ID` is set on the deployment (see #863) — the empty state is correct and intentional until then.

---
_Generated by [Claude Code](https://claude.ai/code/session_014LhYUmVAoZB5aiZY8TPy65)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New org-scoped admin surface that mutates GitHub check bindings via Convex; safe gating and tests, but depends on backend #863 being deployed and hand-mirrored API types can drift.
> 
> **Overview**
> Adds **`/settings/github-checks`** so org admins can bind GitHub repos to eval suites for PR status checks, replacing env-var–only onboarding.
> 
> A new **`useGithubChecksSettings`** hook talks to Convex (`getGithubChecksSettingsAvailability`, repo CRUD, `listInstallationRepos`); **no client feature flag**—only backend `enabled` / `disabled` / loading (`undefined`). The page redirects on `disabled`, stays blank while loading, and waits for auth/org bootstrap before redirecting when there is no org.
> 
> **`GithubChecksRoute`** lists connected repos (suite picker, enable toggle with in-flight guard, disconnect), connects new repos from the GitHub App installation list (project derived from suite), and separates loading vs empty vs GitHub fetch failure.
> 
> **`SettingsNav`** resolves availability locally and **omits** the GitHub Checks tab when unavailable (same pattern as Organization). Routing is wired in **`App`**, **`router`**, **`app-routes`**, and **`app-surfaces`**. **13 tests** cover gates, nav, and mutations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f48adce72e7d661fbc076c49d16a596b565bb80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GitHub Checks settings page at `/settings/github-checks` so org admins can connect repositories to eval suites and toggle checks, replacing env‑var onboarding. Availability is enforced by the backend with a tri‑state gate: loading renders nothing; disabled redirects; enabled renders.

- **New Features**
  - New route with repo list, enable/disable toggle, suite picker, and disconnect.
  - Settings nav resolves availability itself; the GitHub Checks tab is omitted (not disabled) when unavailable.
  - Project is derived from the selected suite to prevent mismatches.

- **Bug Fixes**
  - Tab reachability from all settings pages when enabled.
  - Row subtitle shows “checks run/paused” instead of inventing provenance.
  - Distinguishes loading vs empty vs GitHub fetch failure in the repo list.
  - Deep links: redirect only after Convex auth or the org list finish loading; otherwise render nothing.
  - Prevents duplicate or stale actions: disable toggle during writes; cancel org-switch repo fetches and clear the picker; de‑dupe connect options by waiting for the connected list and lowercasing both sides.
  - Merged duplicate `convex/react` imports (style-only).

<sup>Written for commit 8f48adce72e7d661fbc076c49d16a596b565bb80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

