### PR TITLE
fix(connect): honor a server's own request timeout over the host default

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -2048,6 +2048,60 @@ describe("useServerState OAuth callback failures", () => {
     },
   );
 
+  // The initial connect probe resolves its config through the SAME precedence
+  // as a reconnect. It used to lose the per-server override: callers applied
+  // `withProjectConnectionDefaults` without a serverId (they only know the
+  // display name), so the `serverConnectionOverrides` lookup was skipped and
+  // the override only took effect on the *second* connection.
+  it.each([
+    [
+      "http",
+      {
+        name: "demo-server",
+        type: "http",
+        url: "https://example.com/mcp",
+      },
+    ],
+    [
+      "stdio",
+      {
+        name: "demo-server",
+        type: "stdio",
+        command: "node",
+        args: ["server.js"],
+      },
+    ],
+  ])(
+    "applies a %s server's requestTimeoutOverride on the initial connect probe",
+    async (_transport, formData) => {
+      testConnectionMock.mockResolvedValueOnce({
+        success: true,
+        initInfo: null,
+      });
+      const dispatch = vi.fn();
+      const { result } = renderUseServerState(dispatch, createAppState(), {
+        activeHostConfig: {
+          id: "host-id",
+          schemaVersion: 2,
+          connectionDefaults: { headers: {}, requestTimeout: 10000 },
+          clientCapabilities: {},
+          hostContext: {},
+          serverConnectionOverrides: {
+            srv_demo: { requestTimeoutOverride: 45000 },
+          },
+        },
+      });
+
+      await act(async () => {
+        await result.current.handleConnect(formData as any);
+      });
+
+      expect(testConnectionMock.mock.calls[0]?.[0]).toEqual(
+        expect.objectContaining({ timeout: 45000 }),
+      );
+    },
+  );
+
   it("treats a superseded client-switch reconnect as in-progress, not a failure", async () => {
     // Repro of the client-switch toast bug: when the user switches clients
     // faster than a reconnect completes, the in-flight reconnect's op token

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -1932,6 +1932,60 @@ describe("useServerState OAuth callback failures", () => {
     });
   });
 
+  it.each([
+    [
+      "http",
+      { type: "http", url: "https://example.com/mcp", timeout: 120000 },
+    ],
+    [
+      "stdio",
+      { type: "stdio", command: "node", args: ["server.js"], timeout: 120000 },
+    ],
+  ])(
+    "prefers a %s server's own timeout over the host-wide connection default",
+    async (_transport, serverConfig) => {
+      const { reconnectServer } = await import("@/state/mcp-api");
+      const { ensureAuthorizedForReconnect } = await import(
+        "@/state/oauth-orchestrator"
+      );
+      vi.mocked(reconnectServer).mockResolvedValue({
+        success: true,
+        initInfo: { clientCapabilities: {} },
+      } as any);
+
+      const appState = createAppState();
+      appState.projects.default.servers["demo-server"].config =
+        serverConfig as any;
+      appState.servers["demo-server"].config = serverConfig as any;
+
+      const dispatch = vi.fn();
+      const { result } = renderUseServerState(dispatch, appState, {
+        activeHostConfig: {
+          id: "host-id",
+          schemaVersion: 2,
+          connectionDefaults: { headers: {}, requestTimeout: 10000 },
+          clientCapabilities: {},
+          hostContext: {},
+        },
+      });
+      vi.mocked(ensureAuthorizedForReconnect).mockResolvedValue({
+        kind: "ready",
+        serverConfig: appState.projects.default.servers["demo-server"].config,
+        tokens: undefined,
+      } as any);
+
+      await result.current.handleReconnect("demo-server");
+
+      await waitFor(() => {
+        expect(vi.mocked(reconnectServer)).toHaveBeenCalled();
+      });
+
+      const [, effectiveConfig] =
+        vi.mocked(reconnectServer).mock.calls.at(-1) ?? [];
+      expect(effectiveConfig).toMatchObject({ timeout: 120000 });
+    },
+  );
+
   it("treats a superseded client-switch reconnect as in-progress, not a failure", async () => {
     // Repro of the client-switch toast bug: when the user switches clients
     // faster than a reconnect completes, the in-flight reconnect's op token

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -1986,6 +1986,68 @@ describe("useServerState OAuth callback failures", () => {
     },
   );
 
+  // Third distinct value on purpose: 45000 is neither the server row's 120000
+  // nor the host's 10000, so this fails if the override lookup is dropped OR
+  // if either lower-precedence value leaks through.
+  it.each([
+    [
+      "http",
+      { type: "http", url: "https://example.com/mcp", timeout: 120000 },
+    ],
+    [
+      "stdio",
+      { type: "stdio", command: "node", args: ["server.js"], timeout: 120000 },
+    ],
+  ])(
+    "prefers a %s server's requestTimeoutOverride over its own timeout",
+    async (_transport, serverConfig) => {
+      const { reconnectServer } = await import("@/state/mcp-api");
+      const { ensureAuthorizedForReconnect } = await import(
+        "@/state/oauth-orchestrator"
+      );
+      vi.mocked(reconnectServer).mockResolvedValue({
+        success: true,
+        initInfo: { clientCapabilities: {} },
+      } as any);
+
+      const appState = createAppState();
+      appState.projects.default.servers["demo-server"].config =
+        serverConfig as any;
+      appState.servers["demo-server"].config = serverConfig as any;
+
+      const dispatch = vi.fn();
+      const { result } = renderUseServerState(dispatch, appState, {
+        activeHostConfig: {
+          id: "host-id",
+          schemaVersion: 2,
+          connectionDefaults: { headers: {}, requestTimeout: 10000 },
+          clientCapabilities: {},
+          hostContext: {},
+          // Keyed by the Convex serverId `tryResolveProjectServer` returns,
+          // not the display name.
+          serverConnectionOverrides: {
+            srv_demo: { requestTimeoutOverride: 45000 },
+          },
+        },
+      });
+      vi.mocked(ensureAuthorizedForReconnect).mockResolvedValue({
+        kind: "ready",
+        serverConfig: appState.projects.default.servers["demo-server"].config,
+        tokens: undefined,
+      } as any);
+
+      await result.current.handleReconnect("demo-server");
+
+      await waitFor(() => {
+        expect(vi.mocked(reconnectServer)).toHaveBeenCalled();
+      });
+
+      const [, effectiveConfig] =
+        vi.mocked(reconnectServer).mock.calls.at(-1) ?? [];
+      expect(effectiveConfig).toMatchObject({ timeout: 45000 });
+    },
+  );
+
   it("treats a superseded client-switch reconnect as in-progress, not a failure", async () => {
     // Repro of the client-switch toast bug: when the user switches clients
     // faster than a reconnect completes, the in-flight reconnect's op token

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1166,6 +1166,15 @@ export function useServerState({
             serverConfig,
           });
 
+      // Hoisted above the transport split: the per-server override applies to
+      // stdio too. Its only field that means anything off HTTP is the timeout,
+      // but that one does apply — a slow stdio server needs the same escape
+      // hatch as a slow HTTP one.
+      const perServerOverride =
+        serverId && activeHostConfig
+          ? activeHostConfig.serverConnectionOverrides?.[serverId]
+          : undefined;
+
       let nextRequestInit = serverConfig.requestInit;
       if ("url" in serverConfig) {
         let mergedHeaders: Record<string, string>;
@@ -1177,9 +1186,6 @@ export function useServerState({
             headers: extractRequestHeaders(serverConfig.requestInit),
             timeout: serverConfig.timeout,
           };
-          const perServerOverride = serverId
-            ? activeHostConfig.serverConnectionOverrides?.[serverId]
-            : undefined;
           const resolved = resolveServerConnectionSettings(
             serverBase,
             activeHostConfig.connectionDefaults,
@@ -1212,12 +1218,17 @@ export function useServerState({
         } as MCPServerConfig;
       }
 
+      // stdio. Same precedence rule as the HTTP branch above, via the same
+      // helper — an inline copy of the ladder is what let the two transports
+      // drift apart in the first place (issue #3671).
       return {
         ...serverConfig,
         timeout: activeHostConfig
-          ? activeHostConfig.connectionDefaults.requestTimeout ??
-            serverConfig.timeout ??
-            projectConnectionDefaults.requestTimeout
+          ? resolveServerConnectionSettings(
+              { timeout: serverConfig.timeout },
+              activeHostConfig.connectionDefaults,
+              perServerOverride
+            ).timeout
           : serverConfig.timeout ?? projectConnectionDefaults.requestTimeout,
         capabilities: effectiveClientCapabilities,
         clientCapabilities: effectiveClientCapabilities,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1509,7 +1509,18 @@ export function useServerState({
       // resolver context is available so existing test mocks keep matching.
       const resolved = tryResolveProjectServer(serverName);
       if (resolved) {
-        return testConnection(serverConfig, resolved.serverId, {
+        // Re-resolve WITH the Convex serverId. Callers already applied
+        // `withProjectConnectionDefaults`, but they only know the display
+        // name, so the `serverConnectionOverrides[serverId]` layer was skipped
+        // and a per-server timeout override landed only on the NEXT connect.
+        // `guardedReconnectServer` re-resolves the same way for the same
+        // reason — which is why reconnects honored it and first connects did
+        // not. Applying it here makes the two paths agree.
+        const configWithDefaults = withProjectConnectionDefaults(
+          serverConfig,
+          resolved.serverId
+        );
+        return testConnection(configWithDefaults, resolved.serverId, {
           projectId: resolved.projectId,
           serverName,
           // Forward the active mcpProfile so the resolver path pins
@@ -1517,7 +1528,7 @@ export function useServerState({
           // Undefined preserves SDK defaults — no behavior change for
           // users without an mcpProfile.
           connectionDefaults: buildResolverConnectionDefaults(
-            serverConfig,
+            configWithDefaults,
             activeMcpProfile,
             resolved.serverId,
             serverName,
@@ -1530,6 +1541,7 @@ export function useServerState({
     [
       assertClientConfigSynced,
       buildResolverConnectionDefaults,
+      withProjectConnectionDefaults,
       activeMcpProfile,
     ]
   );

--- a/mcpjam-inspector/client/src/lib/__tests__/client-connection-resolve.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-connection-resolve.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { resolveServerConnectionSettings } from "@/lib/client-connection-resolve";
+import type { HostConfigConnectionDefaults } from "@/lib/client-config-v2";
+
+/**
+ * `connectionDefaults.requestTimeout` is a REQUIRED number on the host config,
+ * so it is never nullish. Any precedence rule that reads it before the server's
+ * own timeout makes that server timeout unreachable — which is exactly how
+ * issue #3671 escaped: the per-server "Connection overrides" timeout was stored,
+ * echoed back in the form, and then silently discarded on every connect.
+ */
+const HOST_DEFAULTS: HostConfigConnectionDefaults = {
+  headers: {},
+  requestTimeout: 10_000,
+};
+
+describe("resolveServerConnectionSettings — timeout precedence", () => {
+  it("prefers the server's own timeout over the host-wide default", () => {
+    const resolved = resolveServerConnectionSettings(
+      { timeout: 120_000 },
+      HOST_DEFAULTS,
+      undefined,
+    );
+
+    expect(resolved.timeout).toBe(120_000);
+  });
+
+  it("prefers a per-server requestTimeoutOverride over the server's own timeout", () => {
+    const resolved = resolveServerConnectionSettings(
+      { timeout: 120_000 },
+      HOST_DEFAULTS,
+      { requestTimeoutOverride: 45_000 },
+    );
+
+    expect(resolved.timeout).toBe(45_000);
+  });
+
+  it("falls back to the host-wide default when the server sets no timeout", () => {
+    const resolved = resolveServerConnectionSettings(
+      {},
+      { headers: {}, requestTimeout: 30_000 },
+      undefined,
+    );
+
+    expect(resolved.timeout).toBe(30_000);
+  });
+});
+
+describe("resolveServerConnectionSettings — header precedence", () => {
+  it("layers server headers under host defaults under the per-server override", () => {
+    const resolved = resolveServerConnectionSettings(
+      { headers: { "X-Server": "server", "X-Shared": "server" } },
+      { headers: { "X-Host": "host", "X-Shared": "host" }, requestTimeout: 10_000 },
+      { headersOverride: { "X-Override": "override", "X-Shared": "override" } },
+    );
+
+    expect(resolved.headers).toEqual({
+      "X-Server": "server",
+      "X-Host": "host",
+      "X-Override": "override",
+      "X-Shared": "override",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/client-connection-resolve.ts
+++ b/mcpjam-inspector/client/src/lib/client-connection-resolve.ts
@@ -3,10 +3,24 @@ import type { HostConfigConnectionDefaults } from "./client-config-v2";
 /**
  * Resolve the effective connection settings for a single server within a host.
  *
- * Merge order (lowest → highest priority):
- *   1. serverBase   — the server row's own headers/timeout
+ * Headers MERGE, lowest → highest priority:
+ *   1. serverBase   — the server row's own headers
  *   2. hostDefaults — host-wide connectionDefaults
  *   3. override     — per-host-server override from hostConfigServerRefs
+ *
+ * A header overlay is a SET, so a host-wide entry legitimately applies on top
+ * of every server ("send this header everywhere").
+ *
+ * The timeout is a SCALAR — exactly one value can win — so it resolves most-
+ * specific-first instead, highest → lowest priority:
+ *   1. override.requestTimeoutOverride — this server, in this host
+ *   2. serverBase.timeout              — the server row's "Connection overrides"
+ *   3. hostDefaults.requestTimeout     — the host-wide default
+ *
+ * `hostDefaults.requestTimeout` is a REQUIRED number, never nullish. Reading it
+ * before `serverBase.timeout` therefore made the server's own timeout dead code:
+ * a user could set it, see it echoed back in the form, and watch every connect
+ * silently discard it (issue #3671). Keep the host default LAST.
  *
  * The `requestTimeoutOverride` wire name maps to the `timeout` field used by
  * MCPServerConfig.
@@ -27,7 +41,7 @@ export function resolveServerConnectionSettings(
     },
     timeout:
       override?.requestTimeoutOverride ??
-      hostDefaults.requestTimeout ??
-      serverBase.timeout,
+      serverBase.timeout ??
+      hostDefaults.requestTimeout,
   };
 }

--- a/slack-app/listeners/actions/run-evidence.js
+++ b/slack-app/listeners/actions/run-evidence.js
@@ -45,11 +45,7 @@ const ITERATIONS_PAGE = 25;
  * @param {Record<string, any>} iteration
  */
 function isFailedIteration(iteration) {
-  return (
-    iteration?.status === 'failed' ||
-    iteration?.status === 'timed_out' ||
-    iteration?.result === 'failed'
-  );
+  return iteration?.status === 'failed' || iteration?.status === 'timed_out' || iteration?.result === 'failed';
 }
 
 /** Per-image download budget. Signed artifact URLs are fast or they are broken. */

--- a/slack-app/listeners/actions/run-watcher.js
+++ b/slack-app/listeners/actions/run-watcher.js
@@ -58,10 +58,7 @@ export function formatRunOutcome(run, url, userId) {
  * @param {{ status: string, result: string | null }} run
  */
 export function isFailedOutcome(run) {
-  return (
-    run?.status === 'failed' ||
-    (run?.status === 'completed' && run?.result === 'failed')
-  );
+  return run?.status === 'failed' || (run?.status === 'completed' && run?.result === 'failed');
 }
 
 /**

--- a/slack-app/listeners/events/run-and-reply.js
+++ b/slack-app/listeners/events/run-and-reply.js
@@ -144,8 +144,7 @@ export async function runAndReply(args) {
             // is the hazard, but so is zero, which is what an unconditional
             // drop would produce against a server that predates the offer.
             ...buildCreatedResourceBlocks(result.createdResources, {
-              suiteAccessory: (resource) =>
-                !rendersRunProposalFor(result.proposedActions, resource),
+              suiteAccessory: (resource) => !rendersRunProposalFor(result.proposedActions, resource),
             }),
             ...buildProposalBlocks(result.proposedActions),
             ...buildFeedbackBlocks(),
@@ -172,8 +171,7 @@ export async function runAndReply(args) {
               },
             },
             ...buildCreatedResourceBlocks(envelope.createdResources, {
-              suiteAccessory: (resource) =>
-                !rendersRunProposalFor(envelope.proposedActions, resource),
+              suiteAccessory: (resource) => !rendersRunProposalFor(envelope.proposedActions, resource),
             }),
             // Proposals replay too. They are still `proposed` server-side — the
             // approval never happened — so re-offering them is the difference
@@ -224,8 +222,7 @@ export async function runAndReply(args) {
             ],
           },
           ...buildCreatedResourceBlocks(envelope.createdResources ?? [], {
-            suiteAccessory: (resource) =>
-                !rendersRunProposalFor(envelope.proposedActions, resource),
+            suiteAccessory: (resource) => !rendersRunProposalFor(envelope.proposedActions, resource),
           }),
           ...buildProposalBlocks(envelope.proposedActions ?? []),
         ],

--- a/slack-app/listeners/views/agent-reply-builder.js
+++ b/slack-app/listeners/views/agent-reply-builder.js
@@ -132,9 +132,7 @@ export function buildCreatedResourceBlocks(createdResources, opts = {}) {
 
   /** @param {{ type: string, id: string, name?: string, url: string }} resource */
   const accessoryFor = (resource) =>
-    typeof opts.suiteAccessory === 'function'
-      ? opts.suiteAccessory(resource) !== false
-      : opts.suiteAccessory !== false;
+    typeof opts.suiteAccessory === 'function' ? opts.suiteAccessory(resource) !== false : opts.suiteAccessory !== false;
   const shown = resources.slice(0, MAX_SUITE_BLOCKS);
   /** @type {Array<Record<string, unknown>>} */
   const blocks = [];

--- a/slack-app/tests/listeners/actions/run-watcher.test.js
+++ b/slack-app/tests/listeners/actions/run-watcher.test.js
@@ -1,11 +1,7 @@
 import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 
-import {
-  announceAndWatchRun,
-  isFailedOutcome,
-  watchRunUntilDone,
-} from '../../../listeners/actions/run-watcher.js';
+import { announceAndWatchRun, isFailedOutcome, watchRunUntilDone } from '../../../listeners/actions/run-watcher.js';
 
 const POLL_INTERVAL_MS = 10_000;
 


### PR DESCRIPTION
Fixes #3671

## The bug

Setting a timeout in a server's **Connection overrides** had no effect. It was stored and echoed back in the form, but every connect discarded it and used the host-wide default instead — so a tool call that ran longer than 10s died with `Request timed out after 10000ms of server time`.

Not the MCP SDK's default (that's 60s). The 10000 is our own `connectionDefaults.requestTimeout`, and it was winning because of one precedence ladder:

```ts
override?.requestTimeoutOverride ??
hostDefaults.requestTimeout ??   // required number — never nullish
serverBase.timeout,              // therefore unreachable
```

`HostConfigConnectionDefaults.requestTimeout` is a required `number`, so `??` never falls through. The per-server timeout was dead code.

## The fix

Timeouts resolve **most-specific-first**: per-server override → server row → host default. Headers still merge lowest-to-highest — a header overlay is a set, so a host-wide entry legitimately applies on top of every server, whereas a timeout is a scalar where exactly one value must win.

The `stdio` branch of `withProjectConnectionDefaults` carried its own inline copy of the ladder with the same inversion, and ignored `serverConnectionOverrides` entirely — so a slow local server had no per-server escape hatch at all. It now calls the shared helper, removing the duplication that let the two transports drift apart.

## Tests

`resolveServerConnectionSettings` had no test file. Added one covering all three precedence levels plus header layering, and a parameterized hook test that drives a real reconnect for both `http` and `stdio` and asserts the outgoing config.

All three new assertions were confirmed failing with `10000` before the fix. Full inspector suite: 12452 passing (the 2 failures on `local-stdio.desktop` and `repoFiles` reproduce on a clean tree and are unrelated). `typecheck:client` clean.

Also verified by hand in the running inspector: with a host default of 5000 and a per-server timeout of 120000, a 20s tool call fails at 5s before the change and completes after; clearing the per-server field correctly falls back to the host default.

## Note for reviewers

This commits to reading the host-wide `requestTimeout` as a **default** (any server may override it) rather than a **policy** (binds every server). That matches the UI wording and the no-host-config branch, which already resolved it this way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3671: honors per‑server timeout overrides over the host default across HTTP and `stdio`, on both initial connect and reconnect. Also formats Slack app files to satisfy Biome (no behavior change).

- **Bug Fixes**
  - Timeout precedence is now per‑server override → server row timeout → host default; both transports use the shared resolver.
  - Initial connect probe now resolves with the serverId so a per‑server `requestTimeoutOverride` applies on the first connect.
  - Header behavior unchanged: server < host defaults < per‑server override.
  - Added tests for timeout precedence, header layering, and both initial connect and reconnect paths for HTTP and `stdio`.

- **Refactors**
  - Biome formatting on five Slack app files to unblock CI; no behavior change.

<sup>Written for commit 74ddcb2796c414e9ae8be546ba79fc5cd728b7b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

