### PR TITLE
score.mcpjam.com — public conformance score runner

### DIFF
--- a/.changeset/hosted-conformance-egress-guard.md
+++ b/.changeset/hosted-conformance-egress-guard.md
@@ -21,6 +21,19 @@ resolves to a private address is refused too. The whole guard is gated on
 product. Only the target is judged — the protocol suite's deliberate
 rebinding-style `Host` headers are untouched.
 
+Redirects are checked too. Validating only the URL a caller named guards
+against a typo, not against an attacker: a target that passes every check can
+answer `302 Location: http://169.254.169.254/` and reach the address the check
+exists to refuse, without the caller ever naming it. Both suites now dial
+through a fetch that follows redirects by hand and re-checks each hop, so the
+number of checks matches the number of addresses actually dialed. This matters
+most for the OAuth suite, which dials authorization, token, registration and
+metadata endpoints discovered from the target's own documents. Redirect
+semantics follow the Fetch standard, and a request that asked for
+`redirect: "manual"` still gets its 3xx back — the OAuth suite grades
+redirects, so following one would erase the evidence. The check-vs-connect
+window remains open; closing it needs connection-level IP pinning.
+
 Closes a bypass in the host check itself along the way: `new URL()` rewrites
 `[::ffff:169.254.169.254]` to `[::ffff:a9fe:a9fe]`, and only the dotted
 spelling was recognized, so the hex form of any blocked address passed. The
@@ -29,4 +42,5 @@ browser harness shares this check and is fixed by the same change.
 Hosted conformance runs also carry a per-IP ceiling (30 per 10 minutes)
 alongside the existing 60/min per-guest limit — guest identities are free to
 mint, so only the IP bounds how much outbound traffic one actor can aim at a
-third party.
+third party. That window lives in a single replica's memory, so the effective
+ceiling scales with the replica count.

--- a/.changeset/hosted-conformance-egress-guard.md
+++ b/.changeset/hosted-conformance-egress-guard.md
@@ -31,8 +31,14 @@ most for the OAuth suite, which dials authorization, token, registration and
 metadata endpoints discovered from the target's own documents. Redirect
 semantics follow the Fetch standard, and a request that asked for
 `redirect: "manual"` still gets its 3xx back — the OAuth suite grades
-redirects, so following one would erase the evidence. The check-vs-connect
-window remains open; closing it needs connection-level IP pinning.
+redirects, so following one would erase the evidence.
+
+Two gaps stay open and are documented where they live. The MCP client
+connection the protocol suite opens goes through the client manager's own
+transport fetch, which this does not reach, so a redirect returned by the MCP
+endpoint itself is still followed unchecked — closing that means threading a
+base fetch through a connection path shared by every protocol version and
+surface. And the check-vs-connect window needs connection-level IP pinning.
 
 Closes a bypass in the host check itself along the way: `new URL()` rewrites
 `[::ffff:169.254.169.254]` to `[::ffff:a9fe:a9fe]`, and only the dotted

--- a/.changeset/hosted-conformance-egress-guard.md
+++ b/.changeset/hosted-conformance-egress-guard.md
@@ -1,0 +1,32 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Guard the target URL on hosted conformance runs.
+
+`/api/web/conformance/*` performed no validation on where it was about to
+connect. Two inputs reach the dialer — the URL Convex resolved for the
+authorized server row, and `oauthProfile.serverUrl`, which the OAuth suite
+lets a caller supply outright and which overrides the resolved one. Since
+guests can already run these suites, an anonymous caller could name
+`http://169.254.169.254/` and have the hosted backend fetch cloud-metadata
+credentials on their behalf. Authorizing the server row proves who is
+asking, not where we are about to connect.
+
+Both inputs now pass through one shared helper (`hosted-egress-guard`),
+which blocks cloud-metadata, link-local, loopback, RFC-1918, CGNAT and IPv6
+ULA targets and adds a DNS-resolution pass so a public hostname that
+resolves to a private address is refused too. The whole guard is gated on
+`HOSTED_MODE`: local and desktop runs keep dialing `localhost`, which is the
+product. Only the target is judged — the protocol suite's deliberate
+rebinding-style `Host` headers are untouched.
+
+Closes a bypass in the host check itself along the way: `new URL()` rewrites
+`[::ffff:169.254.169.254]` to `[::ffff:a9fe:a9fe]`, and only the dotted
+spelling was recognized, so the hex form of any blocked address passed. The
+browser harness shares this check and is fixed by the same change.
+
+Hosted conformance runs also carry a per-IP ceiling (30 per 10 minutes)
+alongside the existing 60/min per-guest limit — guest identities are free to
+mint, so only the IP bounds how much outbound traffic one actor can aim at a
+third party.

--- a/.changeset/score-mcpjam-com.md
+++ b/.changeset/score-mcpjam-com.md
@@ -1,0 +1,39 @@
+---
+"@mcpjam/inspector": minor
+---
+
+score.mcpjam.com — paste an MCP server URL, get a conformance score.
+
+A public, sign-in-free surface: paste a URL, we run all four conformance
+suites against it and return one 0–100 number with a private shareable
+`/results/<token>` link. The scoring engine is the one already in the
+product, so the number means exactly what it means inside MCPJam.
+
+It rides the existing Railway service as a vanity domain (the caniuse.dev
+pattern): `SCORE_LANDING_HOSTS` sends `score.mcpjam.com/` to the chrome-less
+`/embed/score` route, and `/results/<token>` deep links pass through
+untouched. No new deploy.
+
+The runner is a guest-backed product surface rather than a raw-URL API: a
+visitor mints a guest session, the pasted server becomes a real row in that
+guest's project, and the existing hosted conformance routes run unchanged.
+That makes the funnel free — "Debug these failures in MCPJam" hands over a
+one-shot guest promotion proof, so signing in on app.mcpjam.com absorbs the
+guest project and its server into the new account. (A bare link would not:
+the guest cookie is host-only, so the proof has to be carried explicitly.)
+
+Connect-OAuth (authorizing a server so the suites can run at all) reuses the
+product's redirect gate under a new `"score"` surface. The surface is not
+cosmetic: `"project"` would rewrite the return path to `/servers` and lose
+the run, and `"chatbox"` demands a chatbox id that does not exist here. The
+OAuth conformance _suite_ keeps its own popup flow and is opt-in — declining
+it shows as _not scored_, never a deduction.
+
+Results are private by link: no directory, no listing, and the read route
+takes no bearer at all, so a shared result opens in an incognito window.
+Submissions are per-IP rate limited. Stated plainly: a v1 report is
+client-assembled and therefore forgeable, which is acceptable only because a
+run makes no third-party claim — a badge would need a server-verified re-run.
+
+Stdio and localhost servers can't be scored on the hosted runner and say so,
+pointing at `npx @mcpjam/inspector`.

--- a/.changeset/score-mcpjam-com.md
+++ b/.changeset/score-mcpjam-com.md
@@ -1,5 +1,6 @@
 ---
 "@mcpjam/inspector": minor
+"@mcpjam/sdk": minor
 ---
 
 score.mcpjam.com — paste an MCP server URL, get a conformance score.
@@ -17,21 +18,32 @@ untouched. No new deploy.
 The runner is a guest-backed product surface rather than a raw-URL API: a
 visitor mints a guest session, the pasted server becomes a real row in that
 guest's project, and the existing hosted conformance routes run unchanged.
-That makes the funnel free — "Debug these failures in MCPJam" hands over a
-one-shot guest promotion proof, so signing in on app.mcpjam.com absorbs the
-guest project and its server into the new account. (A bare link would not:
-the guest cookie is host-only, so the proof has to be carried explicitly.)
+"Debug these failures in MCPJam" is a plain link for now — carrying the
+scanned server into a new account needs a one-shot exchange endpoint, because
+the guest cookie is host-only and the promotion proof is a credential that
+does not belong in a URL.
 
 Connect-OAuth (authorizing a server so the suites can run at all) reuses the
 product's redirect gate under a new `"score"` surface. The surface is not
 cosmetic: `"project"` would rewrite the return path to `/servers` and lose
 the run, and `"chatbox"` demands a chatbox id that does not exist here. The
-OAuth conformance _suite_ keeps its own popup flow and is opt-in — declining
-it shows as _not scored_, never a deduction.
+surface owns its own pending sentinel and its own OAuth callback origin —
+both are per-origin state, so a callback that lands on the app cannot see
+them. Adding `score.mcpjam.com` to the redirect allowlist mints a new
+`redirect_uri`: dynamic registration carries it per flow, but Client ID
+Metadata Document flows only accept URIs listed in the document, so the host
+must be added there before CIMD servers will authorize. The OAuth conformance
+_suite_ keeps its own popup flow and is opt-in — declining it shows as _not
+scored_, never a deduction.
 
 Results are private by link: no directory, no listing, and the read route
 takes no bearer at all, so a shared result opens in an incognito window.
-Submissions are per-IP rate limited. Stated plainly: a v1 report is
+Anything stored is redacted first (`redactConformanceReportForSharing`, new
+in the SDK and browser-safe): a completed OAuth run holds a live access
+token, a refresh token and the client secret, and a link that exists to be
+forwarded must not carry them. Raw HTTP evidence is dropped rather than
+scrubbed, and every field a result page renders survives. Submissions are
+per-IP rate limited, per replica. Stated plainly: a v1 report is
 client-assembled and therefore forgeable, which is acceptable only because a
 run makes no third-party claim — a badge would need a server-verified re-run.
 

--- a/.changeset/shared-conformance-run-hook.md
+++ b/.changeset/shared-conformance-run-hook.md
@@ -1,0 +1,24 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Move the conformance run loop into a shared `useConformanceRun` hook.
+
+`ConformancePanel` owned all of it inline: per-suite run state, the four
+route calls, the OAuth-conformance popup and its postMessage/BroadcastChannel
+callback, per-suite score derivation, and the pooled headline. A second
+surface (score.mcpjam.com) runs the same four suites, and a second copy would
+drift on exactly the parts that must not — what "done" means per suite, which
+transports can run which suite, and how the headline pools counts rather than
+averaging suite scores.
+
+Behavior-preserving for the panel, which is now the hook's first consumer;
+its 27 tests pass unchanged. Rendering did not move.
+
+One new option comes with it, inert until something sets it:
+`deferOAuthAuthorization` parks a run at the OAuth authorization step
+(`status: "needs-authorization"`) instead of opening the popup, leaving the
+caller to decide via `authorizeOAuth()`. The panel passes false — an operator
+who pressed "Run" asked for the whole run — but an unrequested popup on a
+public landing page is a different thing, so the score surface will make
+OAuth an explicit opt-in.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1936,11 +1936,20 @@ export default function App() {
   // so a visitor lands on the thing they came for. `router.tsx` alone is not
   // enough — without this branch the score page would render inside the app
   // shell, behind the NUX redirect a guest has never seen.
+  //
+  // Compared with the trailing slash normalized away: the router matches
+  // `/embed/score/` as happily as `/embed/score`, so an exact compare would let
+  // a hand-typed or link-appended slash render this guest surface inside the
+  // full shell — with the onboarding redirect live.
+  const barePathname =
+    window.location.pathname.length > 1
+      ? window.location.pathname.replace(/\/+$/, "")
+      : window.location.pathname;
   const isBareCaniuseRoute =
-    window.location.pathname === routePaths.embedHostCompare ||
-    window.location.pathname === routePaths.embedScore ||
-    window.location.pathname.startsWith(`${routePaths.scoreResults}/`) ||
-    window.location.pathname.startsWith(`${routePaths.capabilities}/`);
+    barePathname === routePaths.embedHostCompare ||
+    barePathname === routePaths.embedScore ||
+    barePathname.startsWith(`${routePaths.scoreResults}/`) ||
+    barePathname.startsWith(`${routePaths.capabilities}/`);
 
   useEffect(() => {
     setEvaluateRunsFlagsLoaded(posthog.featureFlags?.hasLoadedFlags === true);

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -490,6 +490,9 @@ function AppChromeHeader({ hidden, ...props }: AppChromeHeaderProps) {
   return <Header {...props} />;
 }
 
+import { ScoreRunnerPage } from "@/components/score/ScoreRunnerPage";
+import { ScoreResultsPage } from "@/components/score/ScoreResultsPage";
+
 type AppRouteContext = Record<string, any>;
 
 const AppRouteReactContext = createContext<AppRouteContext | null>(null);
@@ -932,6 +935,25 @@ function buildHostVerifyLandingPath(
   if (!tabParam) return path;
   const params = new URLSearchParams({ [HOST_VERIFY_TAB_PARAM]: tabParam });
   return `${path}?${params.toString()}`;
+}
+
+/**
+ * score.mcpjam.com's runner. Chrome-less and guest-first: the visitor mints a
+ * guest session automatically, the server row lands in that guest's project,
+ * and the whole thing is reachable with no sign-in.
+ */
+export function ScoreRunnerRoute() {
+  const { convexProjectId } = useAppRouteContext();
+  return <ScoreRunnerPage convexProjectId={convexProjectId ?? null} />;
+}
+
+/**
+ * One stored run, addressable only by its secret link token. Reads through an
+ * unauthenticated GET on purpose — a shared result must open in an incognito
+ * window with no session, no guest cookie, and no project.
+ */
+export function ScoreResultsRoute() {
+  return <ScoreResultsPage />;
 }
 
 export function HostCompareRoute({ bare = false }: { bare?: boolean } = {}) {
@@ -1909,10 +1931,15 @@ export default function App() {
   const isChatboxChatRoute =
     !exitedChatboxChat && hostedRouteKind === "chatbox";
 
-  // Chrome-less caniuse.dev surfaces: render full-bleed without the
-  // sidebar/header, and suppress first-run onboarding so guests land directly.
+  // Chrome-less vanity surfaces (caniuse.dev, score.mcpjam.com): render
+  // full-bleed without the sidebar/header, and suppress first-run onboarding
+  // so a visitor lands on the thing they came for. `router.tsx` alone is not
+  // enough — without this branch the score page would render inside the app
+  // shell, behind the NUX redirect a guest has never seen.
   const isBareCaniuseRoute =
     window.location.pathname === routePaths.embedHostCompare ||
+    window.location.pathname === routePaths.embedScore ||
+    window.location.pathname.startsWith(`${routePaths.scoreResults}/`) ||
     window.location.pathname.startsWith(`${routePaths.capabilities}/`);
 
   useEffect(() => {
@@ -2039,20 +2066,32 @@ export default function App() {
       !isAuthenticated &&
       !!callbackContext.chatboxId &&
       !!callbackContext.sessionId;
+    // score.mcpjam.com: a guest authorizing a server in their OWN guest
+    // project. There is no chatbox here, so the chatbox branch above can never
+    // match — but the completion is otherwise identical, and without this the
+    // callback would fall through to the legacy client-side token exchange,
+    // which has no hosted server context to exchange against.
+    const isGuestScoreCallback =
+      !isAuthenticated &&
+      callbackContext.surface === "score" &&
+      hasHostedServerContext;
     const shouldUseHostedCompletion =
       hasHostedServerContext &&
-      (isAuthenticated || isGuestChatboxSessionCallback);
+      (isAuthenticated ||
+        isGuestChatboxSessionCallback ||
+        isGuestScoreCallback);
 
     const completeCallback = shouldUseHostedCompletion
       ? (async () => {
           let authorizationHeader: string | undefined;
-          if (isGuestChatboxSessionCallback) {
+          if (isGuestChatboxSessionCallback || isGuestScoreCallback) {
             const guestBearerToken = await getGuestBearerToken();
             if (!guestBearerToken) {
               return {
                 success: false,
-                error:
-                  "Your guest session expired. Reopen the swarm link and try again.",
+                error: isGuestScoreCallback
+                  ? "Your session expired while you were authorizing. Start the scan again."
+                  : "Your guest session expired. Reopen the swarm link and try again.",
               };
             }
             authorizationHeader = `Bearer ${guestBearerToken}`;

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
@@ -23,6 +23,11 @@ vi.mock("@workos-inc/authkit-react", () => ({
 
 vi.mock("convex/react", () => ({
   useConvexAuth: (...args: unknown[]) => mockUseConvexAuth(...args),
+  // `SettingsNav` reaches `useGithubChecksAvailability`, which queries Convex.
+  // Without this the mock is missing an export the tree now needs.
+  useQuery: () => undefined,
+  useMutation: () => vi.fn(),
+  useAction: () => vi.fn(),
 }));
 
 vi.mock("posthog-js/react", () => ({
@@ -287,10 +292,10 @@ describe("OrganizationsTab member management", () => {
 
     expect(screen.getByText("Members")).toBeInTheDocument();
     expect(
-      screen.queryByText("change-role-member@example.com"),
+      screen.queryByText("change-role-member@example.com")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText("transfer-member@example.com"),
+      screen.queryByText("transfer-member@example.com")
     ).not.toBeInTheDocument();
   });
 
@@ -355,11 +360,11 @@ describe("OrganizationsTab member management", () => {
     expect(screen.getByText("Access restricted")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "You don't have permission to view organization settings. Contact an admin or owner for access.",
-      ),
+        "You don't have permission to view organization settings. Contact an admin or owner for access."
+      )
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Go to Servers" }),
+      screen.getByRole("button", { name: "Go to Servers" })
     ).toBeInTheDocument();
   });
 
@@ -405,7 +410,7 @@ describe("OrganizationsTab member management", () => {
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
     expect(
-      screen.getByText("Sign in to manage organizations"),
+      screen.getByText("Sign in to manage organizations")
     ).toBeInTheDocument();
     expect(mockUseOrganizationBilling).not.toHaveBeenCalled();
 
@@ -482,12 +487,12 @@ describe("OrganizationsTab member management", () => {
     render(<OrganizationsTab organizationId="org-1" />);
 
     expect(screen.getByTestId("pending-seat-payment-notice")).toHaveTextContent(
-      "Finish payment to add new@example.com",
+      "Finish payment to add new@example.com"
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Finish payment" }));
     await waitFor(() =>
-      expect(finishSeatPayment).toHaveBeenCalledWith(undefined),
+      expect(finishSeatPayment).toHaveBeenCalledWith(undefined)
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
@@ -561,7 +566,9 @@ describe("OrganizationsTab member management", () => {
 
     render(<OrganizationsTab organizationId="org-1" />);
 
-    expect(screen.getByRole("button", { name: "Finish payment" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Finish payment" })
+    ).toBeDisabled();
     const cancelButton = screen.getByRole("button", { name: "Cancel" });
     expect(cancelButton).toBeEnabled();
 

--- a/mcpjam-inspector/client/src/components/__tests__/SettingsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SettingsTab.test.tsx
@@ -4,6 +4,16 @@ import { SettingsTab } from "../SettingsTab";
 
 vi.stubGlobal("__APP_VERSION__", "0.0.0-test");
 
+// `SettingsNav` reaches `useGithubChecksAvailability`, which calls
+// `useConvexAuth`/`useQuery`. This suite renders without a ConvexProvider, so
+// the real hooks throw on "no ConvexProviderWithAuth ancestor".
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: false, isLoading: false }),
+  useQuery: () => undefined,
+  useMutation: () => vi.fn(),
+  useAction: () => vi.fn(),
+}));
+
 const { mockSetThemeMode, mockUpdateThemeMode } = vi.hoisted(() => ({
   mockSetThemeMode: vi.fn(),
   mockUpdateThemeMode: vi.fn(),
@@ -68,7 +78,7 @@ describe("SettingsTab", () => {
     render(<SettingsTab />);
 
     expect(
-      screen.getByRole("heading", { name: "Settings" }),
+      screen.getByRole("heading", { name: "Settings" })
     ).toBeInTheDocument();
     expect(screen.getByText("About")).toBeInTheDocument();
     expect(screen.getByText("Version")).toBeInTheDocument();
@@ -82,7 +92,7 @@ describe("SettingsTab", () => {
     expect(screen.getByText("Theme")).toBeInTheDocument();
     expect(screen.getByText("Light")).toBeInTheDocument();
     expect(
-      screen.getByRole("switch", { name: "Toggle dark mode" }),
+      screen.getByRole("switch", { name: "Toggle dark mode" })
     ).toBeInTheDocument();
     expect(screen.queryByText("LLM Providers")).not.toBeInTheDocument();
   });

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -32,7 +32,6 @@ import {
   APPS_CHECK_CATALOG,
   CHECK_ERAS,
   CONFORMANCE_CHECK_METADATA,
-  describeConformanceScore,
   MCP_APPS_CHECK_IDS,
   MCP_CHECK_IDS,
   MCP_PROTOCOL_VERSIONS,
@@ -43,6 +42,7 @@ import {
   type ConformanceScore,
   type OAuthConformanceCheckId,
 } from "@mcpjam/sdk/browser";
+import { ScoreHeadline } from "./ScoreHeadline";
 import {
   useConformanceRun,
   type ProtocolVersionPin,
@@ -519,48 +519,9 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
         </p>
       </div>
 
-      {/* No card at all when nothing was applicable: a "—/100" over a run
-          with nothing to score would be noise dressed as a number. */}
-      {pooledScore && pooledScore.score !== null && (
-        <div className="mt-4 flex items-center gap-4 rounded-md border border-border/50 bg-muted/30 px-4 py-3">
-          <div className="text-3xl font-semibold tabular-nums leading-none">
-            {pooledScore.score}
-            <span className="ml-0.5 text-sm font-normal text-muted-foreground">
-              /100
-            </span>
-          </div>
-          <div className="min-w-0 space-y-0.5">
-            <div
-              className={`text-xs font-medium ${
-                pooledScore.outcome === "failed"
-                  ? "text-red-400"
-                  : pooledScore.outcome === "incomplete"
-                  ? "text-amber-500"
-                  : "text-green-500"
-              }`}
-            >
-              {pooledScore.outcome === "failed"
-                ? "Not conformant"
-                : pooledScore.outcome === "incomplete"
-                ? "Incomplete run"
-                : pooledScore.advisories.length > 0
-                ? "Conformant, with advice"
-                : "Fully conformant"}
-            </div>
-            {/* The denominator and version travel with the number, always —
-                "100 of 11 applicable" and "100 of 38" are different servers. */}
-            <div className="truncate text-[11px] text-muted-foreground">
-              {describeConformanceScore(pooledScore)}
-              {pooledScore.notApplicable > 0
-                ? ` · ${pooledScore.notApplicable} not applicable`
-                : ""}
-              {oauthNotScored
-                ? " · OAuth not applicable (no auth) — not scored"
-                : ""}
-            </div>
-          </div>
-        </div>
-      )}
+      <div className="mt-4">
+        <ScoreHeadline score={pooledScore} oauthNotScored={oauthNotScored} />
+      </div>
 
       <div className="mt-4 flex items-center justify-between gap-2">
         <Button size="sm" onClick={runAll} disabled={isRunning}>

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo, useRef } from "react";
+import { useState, useMemo } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Select,
@@ -20,11 +20,8 @@ import {
 } from "lucide-react";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import type {
-  MCPConformanceResult,
-  MCPAppsConformanceResult,
   MCPCheckResult,
   MCPAppsCheckResult,
-  MCPTasksConformanceResult,
   MCPTasksCheckResult,
   OAuthConformanceStepResult,
 } from "@mcpjam/sdk";
@@ -33,7 +30,6 @@ import type {
 // break the Vite browser bundle.
 import {
   APPS_CHECK_CATALOG,
-  canRunConformance,
   CHECK_ERAS,
   CONFORMANCE_CHECK_METADATA,
   describeConformanceScore,
@@ -41,33 +37,17 @@ import {
   MCP_CHECK_IDS,
   MCP_PROTOCOL_VERSIONS,
   MCP_TASKS_CHECK_IDS,
-  pooledConformanceScore,
   PROTOCOL_CHECK_CATALOG,
   PROTOCOL_VERSION_ERAS,
-  scoreFromAppsResult,
-  scoreFromOAuthResult,
-  scoreFromProtocolResult,
-  scoreFromTasksResult,
   TASKS_CHECK_CATALOG,
   type ConformanceScore,
-  type McpProtocolVersion,
   type OAuthConformanceCheckId,
 } from "@mcpjam/sdk/browser";
-import type { OAuthConformanceStartResult } from "@/lib/apis/mcp-conformance-api";
 import {
-  runProtocolConformance,
-  runAppsConformance,
-  runTasksConformance,
-  startOAuthConformance,
-  submitOAuthConformanceCode,
-  completeOAuthConformance,
-} from "@/lib/apis/mcp-conformance-api";
-import { deriveOAuthProfileFromServer } from "@/components/oauth/utils";
-
-type SuiteStatus = "idle" | "running" | "done" | "error" | "unavailable";
-
-/** "auto" ⇒ no pin: the run adopts whatever version the server negotiates. */
-type ProtocolVersionPin = "auto" | McpProtocolVersion;
+  useConformanceRun,
+  type ProtocolVersionPin,
+  type SuiteState,
+} from "@/hooks/use-conformance-run";
 
 /** One row in a suite's "what this will run" preview, before any run. */
 interface CatalogEntry {
@@ -123,105 +103,6 @@ const OAUTH_CATALOG: CatalogEntry[] = (
   title: CONFORMANCE_CHECK_METADATA[id].title,
   description: CONFORMANCE_CHECK_METADATA[id].summary,
 }));
-
-interface SuiteState {
-  status: SuiteStatus;
-  error?: string;
-  unavailableReason?: string;
-  /**
-   * The verdict of a finished run. "Done" only says the run ended — a suite
-   * that finished with failures must not read as green.
-   */
-  verdict?: "passed" | "failed" | "incomplete";
-}
-
-interface ProtocolSuiteState extends SuiteState {
-  result?: MCPConformanceResult;
-}
-
-interface AppsSuiteState extends SuiteState {
-  result?: MCPAppsConformanceResult;
-}
-
-interface TasksSuiteState extends SuiteState {
-  result?: MCPTasksConformanceResult;
-}
-
-interface OAuthSuiteState extends SuiteState {
-  result?: OAuthConformanceStartResult["result"];
-  sessionId?: string;
-  waitingForAuth?: boolean;
-}
-
-function isHttpServer(server: ServerWithName): boolean {
-  // `server.config` is typed required but can be undefined during hosted
-  // hydration — guard before using the `in` operator to avoid a TypeError.
-  return !!server.config && "url" in server.config;
-}
-
-function suiteState(
-  suite: "protocol" | "oauth" | "apps" | "tasks",
-  server: ServerWithName,
-): SuiteState {
-  // The SDK's `canRunConformance` is the source of truth for which suites
-  // support which transports. It handles null/undefined configs gracefully.
-  const support = canRunConformance(
-    suite,
-    server.config as Parameters<typeof canRunConformance>[1],
-  );
-  return support.supported
-    ? { status: "idle" }
-    : { status: "unavailable", unavailableReason: support.reason };
-}
-
-function createProtocolState(server: ServerWithName): ProtocolSuiteState {
-  return suiteState("protocol", server);
-}
-
-function createAppsState(server: ServerWithName): AppsSuiteState {
-  return suiteState("apps", server);
-}
-
-function createTasksState(server: ServerWithName): TasksSuiteState {
-  return suiteState("tasks", server);
-}
-
-function createOAuthState(server: ServerWithName): OAuthSuiteState {
-  return suiteState("oauth", server);
-}
-
-/**
- * A server that requires no authorization has no OAuth obligations to test —
- * authorization is OPTIONAL in every MCP revision — so the suite reports
- * `not-applicable`. That is not a result to render as red: it reuses the same
- * "unavailable" treatment as a transport that cannot run the suite.
- */
-function oauthStateFromResult(
-  result: NonNullable<OAuthConformanceStartResult["result"]>,
-): OAuthSuiteState {
-  if (result.outcome === "not-applicable") {
-    return {
-      status: "unavailable",
-      unavailableReason: result.summary,
-      // Kept so the score pool can see the run: a not-applicable OAuth run
-      // contributes its "nothing to score here" tally instead of vanishing.
-      result,
-    };
-  }
-  return {
-    status: "done",
-    result,
-    // OAuth now reports the same three-value verdict as the other suites
-    // (plus its own not-applicable, handled above), so an incomplete flow is
-    // badged amber rather than flattened to failed.
-    verdict:
-      result.outcome === "incomplete"
-        ? "incomplete"
-        : result.passed
-          ? "passed"
-          : "failed",
-  };
-}
 
 function StatusIcon({ status }: { status: string }) {
   if (status === "passed") {
@@ -532,9 +413,7 @@ function SuiteSection({
         return <span className="text-[10px] text-red-400">Failed</span>;
       }
       if (state.verdict === "incomplete") {
-        return (
-          <span className="text-[10px] text-amber-500">Incomplete</span>
-        );
+        return <span className="text-[10px] text-amber-500">Incomplete</span>;
       }
       return <span className="text-[10px] text-green-500">Passed</span>;
     }
@@ -605,406 +484,31 @@ function SuiteSection({
 }
 
 function ConformanceContent({ server }: { server: ServerWithName }) {
-  const httpServer = isHttpServer(server);
-  const [protocol, setProtocol] = useState<ProtocolSuiteState>(() =>
-    createProtocolState(server),
-  );
-  const [apps, setApps] = useState<AppsSuiteState>(() =>
-    createAppsState(server),
-  );
-  const [tasks, setTasks] = useState<TasksSuiteState>(() =>
-    createTasksState(server),
-  );
-  const [oauth, setOAuth] = useState<OAuthSuiteState>(() =>
-    createOAuthState(server),
-  );
-  const [versionPin, setVersionPin] = useState<ProtocolVersionPin>("auto");
-  const [runVersion, setRunVersion] = useState(0);
-
-  const activeServerNameRef = useRef(server.name);
-  const latestRunTokenRef = useRef(0);
-  const oauthListenerCleanupRef = useRef<(() => void) | null>(null);
-
-  const clearOAuthListeners = useCallback(() => {
-    oauthListenerCleanupRef.current?.();
-    oauthListenerCleanupRef.current = null;
-  }, []);
-
-  const beginRun = useCallback(() => {
-    latestRunTokenRef.current += 1;
-    clearOAuthListeners();
-    return latestRunTokenRef.current;
-  }, [clearOAuthListeners]);
-
-  const isRunActive = useCallback(
-    (runToken: number, serverName: string) =>
-      latestRunTokenRef.current === runToken &&
-      activeServerNameRef.current === serverName,
-    [],
-  );
-
-  const resetStates = useCallback(
-    (serverName?: string) => {
-      const effectiveServerName = serverName ?? activeServerNameRef.current;
-      latestRunTokenRef.current += 1;
-      clearOAuthListeners();
-      setRunVersion((value) => value + 1);
-      setProtocol(createProtocolState(server));
-      setApps(createAppsState(server));
-      setTasks(createTasksState(server));
-      setOAuth(createOAuthState(server));
-      activeServerNameRef.current = effectiveServerName;
-    },
-    [clearOAuthListeners, server],
-  );
-
-  useEffect(() => {
-    resetStates(server.name);
-  }, [server.name, resetStates]);
-
-  useEffect(
-    () => () => {
-      latestRunTokenRef.current += 1;
-      clearOAuthListeners();
-    },
-    [clearOAuthListeners],
-  );
-
-  const runProtocol = useCallback(
-    async (runToken: number, serverName: string) => {
-      if (!httpServer) return;
-      setProtocol({ status: "running" });
-      try {
-        const { result } = await runProtocolConformance(serverName, {
-          protocolVersion: versionPin === "auto" ? undefined : versionPin,
-        });
-        if (!isRunActive(runToken, serverName)) return;
-        setProtocol({
-          status: "done",
-          result,
-          // All four suites now report a three-value outcome, so an
-          // incomplete run is badged as such rather than flattened to failed.
-          verdict:
-            result.outcome === "incomplete"
-              ? "incomplete"
-              : result.passed
-                ? "passed"
-                : "failed",
-        });
-      } catch (err) {
-        if (!isRunActive(runToken, serverName)) return;
-        setProtocol({
-          status: "error",
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    },
-    [httpServer, isRunActive, versionPin],
-  );
-
-  const runApps = useCallback(
-    async (runToken: number, serverName: string) => {
-      setApps({ status: "running" });
-      try {
-        const { result } = await runAppsConformance(serverName);
-        if (!isRunActive(runToken, serverName)) return;
-        setApps({
-          status: "done",
-          result,
-          // All four suites now report a three-value outcome, so an
-          // incomplete run is badged as such rather than flattened to failed.
-          verdict:
-            result.outcome === "incomplete"
-              ? "incomplete"
-              : result.passed
-                ? "passed"
-                : "failed",
-        });
-      } catch (err) {
-        if (!isRunActive(runToken, serverName)) return;
-        setApps({
-          status: "error",
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    },
-    [isRunActive],
-  );
-
-  const runTasks = useCallback(
-    async (runToken: number, serverName: string) => {
-      setTasks({ status: "running" });
-      try {
-        const { result } = await runTasksConformance(serverName);
-        if (!isRunActive(runToken, serverName)) return;
-        setTasks({
-          status: "done",
-          result,
-          // The tasks suite reports a real third outcome: checks that apply but
-          // could not be exercised leave the run incomplete, never passing.
-          verdict:
-            result.outcome === "incomplete"
-              ? "incomplete"
-              : result.passed
-                ? "passed"
-                : "failed",
-        });
-      } catch (err) {
-        if (!isRunActive(runToken, serverName)) return;
-        setTasks({
-          status: "error",
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    },
-    [isRunActive],
-  );
-
-  const pollOAuthComplete = useCallback(
-    async (sessionId: string, runToken: number, serverName: string) => {
-      const MAX_POLLS = 10;
-      for (let i = 0; i < MAX_POLLS; i++) {
-        try {
-          const poll = await completeOAuthConformance(sessionId);
-          if (!isRunActive(runToken, serverName)) return;
-          if (poll.phase === "complete" && poll.result) {
-            setOAuth(oauthStateFromResult(poll.result));
-            return;
-          }
-        } catch (err) {
-          if (!isRunActive(runToken, serverName)) return;
-          setOAuth({
-            status: "error",
-            error: err instanceof Error ? err.message : String(err),
-          });
-          return;
-        }
-      }
-
-      if (!isRunActive(runToken, serverName)) return;
-      setOAuth({ status: "error", error: "OAuth conformance timed out" });
-    },
-    [isRunActive],
-  );
-
-  const handleOAuthCallback = useCallback(
-    async (
-      sessionId: string,
-      code: string,
-      runToken: number,
-      serverName: string,
-      state?: string,
-    ) => {
-      try {
-        await submitOAuthConformanceCode({ sessionId, code, state });
-        if (!isRunActive(runToken, serverName)) return;
-        setOAuth((prev) => ({
-          ...prev,
-          waitingForAuth: false,
-          status: "running",
-        }));
-        await pollOAuthComplete(sessionId, runToken, serverName);
-      } catch (err) {
-        if (!isRunActive(runToken, serverName)) return;
-        setOAuth({
-          status: "error",
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    },
-    [isRunActive, pollOAuthComplete],
-  );
-
-  const runOAuth = useCallback(
-    async (runToken: number, currentServer: ServerWithName) => {
-      if (!isHttpServer(currentServer)) return;
-
-      const serverName = currentServer.name;
-      setOAuth({ status: "running" });
-
-      try {
-        const profile = deriveOAuthProfileFromServer(currentServer);
-        // Always send callbackOrigin — both local and hosted modes redirect
-        // back to the inspector's own `/oauth/callback/debug` page so the
-        // server can surface the code back to the SDK runner.
-        const callbackOrigin = window.location.origin;
-
-        // A run-scoped version pin beats the stored OAuth-tab profile, and
-        // must be sent even when the profile is otherwise empty (the route
-        // falls back to its own default version when no profile arrives).
-        const pinnedVersion = versionPin === "auto" ? undefined : versionPin;
-        const baseProfile = profile.serverUrl
-          ? {
-              serverUrl: profile.serverUrl,
-              protocolVersion: profile.protocolVersion,
-              registrationStrategy: profile.registrationStrategy,
-              clientId: profile.clientId || undefined,
-              clientSecret: profile.clientSecret || undefined,
-              scopes: profile.scopes || undefined,
-              customHeaders: profile.customHeaders.length
-                ? profile.customHeaders
-                : undefined,
-            }
-          : undefined;
-
-        const startResult = await startOAuthConformance({
-          serverNameOrId: serverName,
-          oauthProfile: pinnedVersion
-            ? { ...baseProfile, protocolVersion: pinnedVersion }
-            : baseProfile,
-          callbackOrigin,
-        });
-
-        if (!isRunActive(runToken, serverName)) return;
-
-        if (startResult.phase === "complete" && startResult.result) {
-          setOAuth(oauthStateFromResult(startResult.result));
-          return;
-        }
-
-        if (
-          startResult.phase === "authorization_needed" &&
-          startResult.sessionId &&
-          startResult.authorizationUrl
-        ) {
-          const sessionId = startResult.sessionId;
-          setOAuth({
-            status: "running",
-            sessionId,
-            waitingForAuth: true,
-          });
-
-          window.open(
-            startResult.authorizationUrl,
-            "oauth_conformance_auth",
-            "width=600,height=700,scrollbars=yes",
-          );
-
-          const cleanupFns: Array<() => void> = [];
-          const cleanup = () => {
-            for (const fn of cleanupFns) fn();
-            if (oauthListenerCleanupRef.current === cleanup) {
-              oauthListenerCleanupRef.current = null;
-            }
-          };
-          oauthListenerCleanupRef.current = cleanup;
-
-          const handleMessage = (event: MessageEvent) => {
-            if (event.data?.type !== "OAUTH_CALLBACK" || !event.data?.code) {
-              return;
-            }
-            cleanup();
-            void handleOAuthCallback(
-              sessionId,
-              event.data.code,
-              runToken,
-              serverName,
-              event.data.state,
-            );
-          };
-
-          window.addEventListener("message", handleMessage);
-          cleanupFns.push(() =>
-            window.removeEventListener("message", handleMessage),
-          );
-
-          try {
-            const channel = new BroadcastChannel("oauth_callback_channel");
-            channel.onmessage = (event) => {
-              if (event.data?.type !== "OAUTH_CALLBACK" || !event.data?.code) {
-                return;
-              }
-              cleanup();
-              void handleOAuthCallback(
-                sessionId,
-                event.data.code,
-                runToken,
-                serverName,
-                event.data.state,
-              );
-            };
-            cleanupFns.push(() => channel.close());
-          } catch {
-            // BroadcastChannel not available
-          }
-
-          // Both local and hosted modes now rely on the `/oauth/authorize`
-          // endpoint to deliver the code; polling without a code submission
-          // would time out, so we defer all polling to `handleOAuthCallback`.
-        }
-      } catch (err) {
-        if (!isRunActive(runToken, currentServer.name)) return;
-        setOAuth({
-          status: "error",
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-    },
-    [handleOAuthCallback, isRunActive, pollOAuthComplete, versionPin],
-  );
-
-  const runAll = useCallback(async () => {
-    const runToken = beginRun();
-    const currentServer = server;
-    const httpServerNow = isHttpServer(currentServer);
-
-    setRunVersion((value) => value + 1);
-    setProtocol(createProtocolState(currentServer));
-    setApps(createAppsState(currentServer));
-    setTasks(createTasksState(currentServer));
-    setOAuth(createOAuthState(currentServer));
-
-    const promises: Promise<void>[] = [];
-    if (httpServerNow) {
-      promises.push(runProtocol(runToken, currentServer.name));
-    }
-    promises.push(runApps(runToken, currentServer.name));
-    promises.push(runTasks(runToken, currentServer.name));
-    if (httpServerNow) {
-      promises.push(runOAuth(runToken, currentServer));
-    }
-
-    await Promise.allSettled(promises);
-  }, [beginRun, runApps, runOAuth, runProtocol, runTasks, server]);
+  // Run state, per-suite scores and the pooled headline all live in the shared
+  // hook — score.mcpjam.com runs the same four suites and must pool them the
+  // same way. Rendering stays here.
+  const {
+    protocol,
+    apps,
+    tasks,
+    oauth,
+    versionPin,
+    setVersionPin,
+    runVersion,
+    runAll,
+    protocolScore,
+    appsScore,
+    tasksScore,
+    oauthScore,
+    pooledScore,
+    oauthNotScored,
+    isRunning,
+  } = useConformanceRun({ server });
 
   const protocolChecks = useMemo(
     () => protocolCatalog(versionPin),
-    [versionPin],
+    [versionPin]
   );
-
-  // Scores are derived, never stored: each finished suite contributes, and
-  // the headline pools their COUNTS (not an average of suite scores), so a
-  // 0-for-9 OAuth run stays visible inside 30 protocol passes.
-  const protocolScore = useMemo(
-    () => (protocol.result ? scoreFromProtocolResult(protocol.result) : undefined),
-    [protocol.result],
-  );
-  const appsScore = useMemo(
-    () => (apps.result ? scoreFromAppsResult(apps.result) : undefined),
-    [apps.result],
-  );
-  const tasksScore = useMemo(
-    () => (tasks.result ? scoreFromTasksResult(tasks.result) : undefined),
-    [tasks.result],
-  );
-  const oauthScore = useMemo(
-    () => (oauth.result ? scoreFromOAuthResult(oauth.result) : undefined),
-    [oauth.result],
-  );
-  const pooledScore = useMemo(() => {
-    const parts = [protocolScore, appsScore, tasksScore, oauthScore].filter(
-      (part): part is ConformanceScore => part !== undefined,
-    );
-    return parts.length > 0 ? pooledConformanceScore(parts) : undefined;
-  }, [protocolScore, appsScore, tasksScore, oauthScore]);
-  const oauthNotScored =
-    oauthScore !== undefined && oauthScore.score === null;
-
-  const isRunning =
-    protocol.status === "running" ||
-    apps.status === "running" ||
-    tasks.status === "running" ||
-    oauth.status === "running";
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -1031,17 +535,17 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
                 pooledScore.outcome === "failed"
                   ? "text-red-400"
                   : pooledScore.outcome === "incomplete"
-                    ? "text-amber-500"
-                    : "text-green-500"
+                  ? "text-amber-500"
+                  : "text-green-500"
               }`}
             >
               {pooledScore.outcome === "failed"
                 ? "Not conformant"
                 : pooledScore.outcome === "incomplete"
-                  ? "Incomplete run"
-                  : pooledScore.advisories.length > 0
-                    ? "Conformant, with advice"
-                    : "Fully conformant"}
+                ? "Incomplete run"
+                : pooledScore.advisories.length > 0
+                ? "Conformant, with advice"
+                : "Fully conformant"}
             </div>
             {/* The denominator and version travel with the number, always —
                 "100 of 11 applicable" and "100 of 38" are different servers. */}
@@ -1050,7 +554,9 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
               {pooledScore.notApplicable > 0
                 ? ` · ${pooledScore.notApplicable} not applicable`
                 : ""}
-              {oauthNotScored ? " · OAuth not applicable (no auth) — not scored" : ""}
+              {oauthNotScored
+                ? " · OAuth not applicable (no auth) — not scored"
+                : ""}
             </div>
           </div>
         </div>
@@ -1076,7 +582,9 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
           </label>
           <Select
             value={versionPin}
-            onValueChange={(value) => setVersionPin(value as ProtocolVersionPin)}
+            onValueChange={(value) =>
+              setVersionPin(value as ProtocolVersionPin)
+            }
             disabled={isRunning}
           >
             <SelectTrigger
@@ -1212,11 +720,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
   );
 }
 
-export function ConformanceTab({
-  server,
-}: {
-  server?: ServerWithName | null;
-}) {
+export function ConformanceTab({ server }: { server?: ServerWithName | null }) {
   // In hosted mode `selectedMCPConfig` can arrive as a stub with falsy name
   // and/or missing config while the project is still hydrating — treat any
   // non-connected shape as "no server selected" so the panel never runs

--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -519,9 +519,11 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
         </p>
       </div>
 
-      <div className="mt-4">
-        <ScoreHeadline score={pooledScore} oauthNotScored={oauthNotScored} />
-      </div>
+      {pooledScore && pooledScore.score !== null && (
+        <div className="mt-4">
+          <ScoreHeadline score={pooledScore} oauthNotScored={oauthNotScored} />
+        </div>
+      )}
 
       <div className="mt-4 flex items-center justify-between gap-2">
         <Button size="sm" onClick={runAll} disabled={isRunning}>

--- a/mcpjam-inspector/client/src/components/conformance/ScoreHeadline.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ScoreHeadline.tsx
@@ -1,0 +1,87 @@
+import {
+  describeConformanceScore,
+  type ConformanceScore,
+} from "@mcpjam/sdk/browser";
+
+/**
+ * The one big number, with everything that makes it honest attached to it.
+ *
+ * Shared by the in-product Conformance panel and score.mcpjam.com so the two
+ * cannot disagree about what a score means. Three rules are load-bearing:
+ *
+ *   - No card at all when nothing was applicable. A "—/100" over a run with
+ *     nothing to score is noise dressed as a number.
+ *   - The denominator and protocol version always travel with the score.
+ *     "100 of 11 applicable" and "100 of 38 applicable" are different servers.
+ *   - `notApplicable` and an unscored OAuth suite are stated, never silently
+ *     folded in. Not scored and scored zero are opposite claims.
+ */
+export function ScoreHeadline({
+  score,
+  oauthNotScored = false,
+  size = "compact",
+}: {
+  score: ConformanceScore | undefined;
+  /** OAuth produced a score object with nothing applicable in it. */
+  oauthNotScored?: boolean;
+  size?: "compact" | "hero";
+}) {
+  if (!score || score.score === null) return null;
+
+  const hero = size === "hero";
+  const toneClass =
+    score.outcome === "failed"
+      ? "text-red-400"
+      : score.outcome === "incomplete"
+      ? "text-amber-500"
+      : "text-green-500";
+
+  return (
+    <div
+      className={`flex items-center gap-4 rounded-md border border-border/50 bg-muted/30 ${
+        hero ? "px-6 py-5" : "px-4 py-3"
+      }`}
+    >
+      <div
+        className={`font-semibold tabular-nums leading-none ${
+          hero ? "text-6xl" : "text-3xl"
+        }`}
+      >
+        {score.score}
+        <span
+          className={`ml-0.5 font-normal text-muted-foreground ${
+            hero ? "text-lg" : "text-sm"
+          }`}
+        >
+          /100
+        </span>
+      </div>
+      <div className="min-w-0 space-y-0.5">
+        <div
+          className={`font-medium ${toneClass} ${hero ? "text-sm" : "text-xs"}`}
+        >
+          {score.outcome === "failed"
+            ? "Not conformant"
+            : score.outcome === "incomplete"
+            ? "Incomplete run"
+            : score.advisories.length > 0
+            ? "Conformant, with advice"
+            : "Fully conformant"}
+        </div>
+        <div
+          className={`truncate text-muted-foreground ${
+            hero ? "text-xs" : "text-[11px]"
+          }`}
+        >
+          {describeConformanceScore(score)}
+          {score.notApplicable > 0
+            ? ` · ${score.notApplicable} not applicable`
+            : ""}
+          {oauthNotScored
+            ? " · OAuth not applicable (no auth) — not scored"
+            : ""}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/score/ScoreResultsPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreResultsPage.tsx
@@ -69,9 +69,21 @@ interface ReportCheck {
   skipReason?: string;
 }
 
+/**
+ * Every suite's per-item breakdown, normalized.
+ *
+ * The OAuth suite names its items `steps`, not `checks` — reading only
+ * `checks` made every OAuth section claim "no individual checks" even after a
+ * full authorization run, quietly dropping the evidence behind its score.
+ */
 function collectChecks(suite: unknown): ReportCheck[] {
-  const checks = (suite as { checks?: unknown })?.checks;
-  return Array.isArray(checks) ? (checks as ReportCheck[]) : [];
+  const record = suite as { checks?: unknown; steps?: unknown } | undefined;
+  const items = Array.isArray(record?.checks)
+    ? record.checks
+    : Array.isArray(record?.steps)
+    ? record.steps
+    : [];
+  return items as ReportCheck[];
 }
 
 export function ScoreResultsPage() {
@@ -81,6 +93,11 @@ export function ScoreResultsPage() {
   const [notFound, setNotFound] = useState(false);
 
   useEffect(() => {
+    // Drop the previous result FIRST. Otherwise a token change (or a request
+    // that stalls) leaves the old score on screen under the new URL — the one
+    // thing a result page must never do is show a number for a server the
+    // reader did not ask about.
+    setRun(null);
     if (!runToken) return;
     let cancelled = false;
     setError(null);

--- a/mcpjam-inspector/client/src/components/score/ScoreResultsPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreResultsPage.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router";
+import { Button } from "@mcpjam/design-system/button";
+import { Loader2, CheckCircle2, XCircle, MinusCircle } from "lucide-react";
+import { routePaths } from "@/lib/app-navigation";
+import {
+  fetchScoreRun,
+  ScoreRunNotFoundError,
+  type ScoreSummary,
+  type StoredScoreRun,
+} from "@/lib/apis/score-api";
+
+const APP_ORIGIN = "https://app.mcpjam.com";
+
+const SUITE_TITLES: Record<string, string> = {
+  protocol: "Protocol",
+  apps: "Apps",
+  tasks: "Tasks",
+  oauth: "OAuth",
+};
+
+/**
+ * The same sentence the SDK's `describeConformanceScore` produces, rebuilt
+ * from the stored counts.
+ *
+ * The stored row carries `advisoryCount` rather than the advisory objects the
+ * SDK helper wants, and re-deriving the number here would be worse: the score
+ * was computed once, at run time, by the engine that owns the arithmetic. This
+ * only re-renders what was already decided.
+ */
+function describeStoredScore(summary: ScoreSummary): string {
+  if (summary.score === null) {
+    return `not scored — 0 applicable checks (${summary.notApplicable} not applicable)`;
+  }
+  const parts = [
+    `${summary.passed}/${summary.applicable} applicable checks passed`,
+  ];
+  if (summary.failed > 0) parts.push(`${summary.failed} failed`);
+  if (summary.couldNotRun > 0)
+    parts.push(`${summary.couldNotRun} could not run`);
+  if (summary.advisoryCount > 0) {
+    parts.push(
+      `${summary.advisoryCount} advisor${
+        summary.advisoryCount === 1 ? "y" : "ies"
+      }`
+    );
+  }
+  const version = summary.protocolVersion
+    ? ` [${summary.protocolVersion}]`
+    : "";
+  return `${summary.score}/100 — ${parts.join(", ")}${version}`;
+}
+
+function CheckIcon({ status }: { status: string }) {
+  if (status === "passed") {
+    return <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-500" />;
+  }
+  if (status === "failed") {
+    return <XCircle className="h-3.5 w-3.5 shrink-0 text-red-500" />;
+  }
+  return <MinusCircle className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />;
+}
+
+interface ReportCheck {
+  id?: string;
+  title?: string;
+  status?: string;
+  error?: { message?: string };
+  skipReason?: string;
+}
+
+function collectChecks(suite: unknown): ReportCheck[] {
+  const checks = (suite as { checks?: unknown })?.checks;
+  return Array.isArray(checks) ? (checks as ReportCheck[]) : [];
+}
+
+export function ScoreResultsPage() {
+  const { runToken } = useParams<{ runToken: string }>();
+  const [run, setRun] = useState<StoredScoreRun | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!runToken) return;
+    let cancelled = false;
+    setError(null);
+    setNotFound(false);
+    void fetchScoreRun(runToken)
+      .then((loaded) => {
+        if (!cancelled) setRun(loaded);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof ScoreRunNotFoundError) {
+          setNotFound(true);
+          return;
+        }
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runToken]);
+
+  const suites = useMemo(() => {
+    if (!run) return [];
+    return (["protocol", "apps", "tasks", "oauth"] as const)
+      .map((suiteId) => ({
+        suiteId,
+        summary: run.suiteSummaries.find((s) => s.suiteId === suiteId),
+        checks: collectChecks(run.report[suiteId]),
+      }))
+      .filter((entry) => entry.summary || entry.checks.length > 0);
+  }, [run]);
+
+  if (notFound) {
+    return (
+      <CenteredNotice
+        title="No result here"
+        body="That link isn't valid, or the run it pointed at no longer exists. Result links are private — check you copied the whole thing."
+      />
+    );
+  }
+
+  if (error) {
+    return <CenteredNotice title="Couldn't load this result" body={error} />;
+  }
+
+  if (!run) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const toneClass =
+    run.outcome === "failed"
+      ? "text-red-400"
+      : run.outcome === "incomplete"
+      ? "text-amber-500"
+      : "text-green-500";
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-3xl flex-col gap-6 overflow-y-auto px-6 py-10">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Conformance score</h1>
+        <p className="truncate text-sm text-muted-foreground">
+          {run.serverUrl}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Scanned {new Date(run.createdAt).toLocaleString()}
+        </p>
+      </header>
+
+      {run.score !== null && (
+        <div className="flex items-center gap-4 rounded-md border border-border/50 bg-muted/30 px-6 py-5">
+          <div className="text-6xl font-semibold leading-none tabular-nums">
+            {run.score}
+            <span className="ml-0.5 text-lg font-normal text-muted-foreground">
+              /100
+            </span>
+          </div>
+          <div className="min-w-0 space-y-0.5">
+            <div className={`text-sm font-medium ${toneClass}`}>
+              {run.outcome === "failed"
+                ? "Not conformant"
+                : run.outcome === "incomplete"
+                ? "Incomplete run"
+                : run.advisoryCount > 0
+                ? "Conformant, with advice"
+                : "Fully conformant"}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {describeStoredScore(run)}
+              {run.notApplicable > 0
+                ? ` · ${run.notApplicable} not applicable`
+                : ""}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {suites.map(({ suiteId, summary, checks }) => (
+          <section
+            key={suiteId}
+            className="overflow-hidden rounded-md border border-border/50"
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-border/40 bg-muted/20 px-4 py-2">
+              <div className="min-w-0">
+                <div className="text-sm font-medium">
+                  {SUITE_TITLES[suiteId]}
+                </div>
+                {summary && (
+                  <div className="truncate text-[11px] text-muted-foreground">
+                    {describeStoredScore(summary)}
+                  </div>
+                )}
+              </div>
+              {summary?.score !== null && summary?.score !== undefined && (
+                <span className="shrink-0 text-sm font-semibold tabular-nums">
+                  {summary.score}
+                  <span className="text-[10px] font-normal text-muted-foreground">
+                    /100
+                  </span>
+                </span>
+              )}
+            </div>
+            {checks.length > 0 ? (
+              <ul>
+                {checks.map((check, index) => (
+                  <li
+                    key={check.id ?? index}
+                    className="flex items-start gap-2 border-b border-border/30 px-4 py-2 last:border-b-0"
+                  >
+                    <CheckIcon status={check.status ?? "skipped"} />
+                    <div className="min-w-0">
+                      <div className="text-xs">
+                        {check.title ?? check.id ?? "check"}
+                      </div>
+                      {check.error?.message && (
+                        <div className="text-[11px] text-red-400">
+                          {check.error.message}
+                        </div>
+                      )}
+                      {!check.error?.message && check.skipReason && (
+                        <div className="text-[11px] text-muted-foreground">
+                          {check.skipReason}
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="px-4 py-3 text-[11px] text-muted-foreground">
+                This suite reported no individual checks.
+              </div>
+            )}
+          </section>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button asChild size="sm">
+          <a href={`${APP_ORIGIN}/servers`}>Debug these failures in MCPJam</a>
+        </Button>
+        <Button asChild size="sm" variant="outline">
+          <a href={routePaths.embedScore}>Run your own scan</a>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CenteredNotice({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="mx-auto flex h-full max-w-md flex-col items-center justify-center gap-3 px-6 text-center">
+      <h1 className="text-lg font-semibold">{title}</h1>
+      <p className="text-sm text-muted-foreground">{body}</p>
+      <Button asChild size="sm" variant="outline">
+        <a href={routePaths.embedScore}>Run your own scan</a>
+      </Button>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
@@ -328,6 +328,17 @@ export function ScoreRunnerPage({
    * what ran, and the one the visitor is holding always matches what they see.
    */
   const persistedOAuthStatusRef = useRef<string | null>(null);
+  /**
+   * The OAuth resave gets ONE attempt, ever.
+   *
+   * Without a cap, a failing save loops: `persistRun` ends in `setPhase("done")`
+   * whether it succeeded or not, which re-satisfies this effect's own
+   * condition, which saves again — the page oscillates between Saving and Done
+   * and hammers the endpoint until the per-IP limit cuts it off. "Retry on
+   * failure" and "no bound" are only safe apart.
+   */
+  const oauthResaveAttemptsRef = useRef(0);
+  const oauthResaveInFlightRef = useRef(false);
   useEffect(() => {
     // Deliberately NOT gated on an existing `resultToken`: if the first save
     // failed, a settled OAuth run is the visitor's second chance at getting a
@@ -340,10 +351,17 @@ export function ScoreRunnerPage({
     const settled = run.oauth.status === "done" && run.oauthScore !== undefined;
     if (!settled) return;
     if (persistedOAuthStatusRef.current === run.oauth.status) return;
+    if (oauthResaveInFlightRef.current) return;
+    // One attempt. Spending it leaves the visitor at a stable state — a score
+    // on screen, and either a link or a plain message saying the link could
+    // not be saved.
+    if (oauthResaveAttemptsRef.current >= 1) return;
+    oauthResaveAttemptsRef.current += 1;
+    oauthResaveInFlightRef.current = true;
     void persistRun(serverUrl).then((saved) => {
-      // The guard records a SUCCESSFUL save. Setting it up front would burn
-      // the one retry on a failure, leaving the visitor with a score on screen
-      // and permanently no link for it.
+      oauthResaveInFlightRef.current = false;
+      // The guard records a SUCCESSFUL save, so a later status change can
+      // still be saved — bounded by the attempt cap above.
       if (saved) persistedOAuthStatusRef.current = run.oauth.status;
     });
   }, [phase, run.oauth.status, run.oauthScore, server, persistRun]);
@@ -412,6 +430,8 @@ export function ScoreRunnerPage({
     clearScoreRunResume();
     persistedRunRef.current = null;
     persistedOAuthStatusRef.current = null;
+    oauthResaveAttemptsRef.current = 0;
+    oauthResaveInFlightRef.current = false;
     // Clearing the server re-keys `useConformanceRun`, which drops the prior
     // suite states. Without it the old server's score stays on screen through
     // "preparing" — and stays there permanently if setup fails and the phase

--- a/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
@@ -7,6 +7,7 @@ import { useConformanceRun } from "@/hooks/use-conformance-run";
 import { useHostedOAuthGate } from "@/hooks/hosted/use-hosted-oauth-gate";
 import { tryResolveProjectServer } from "@/lib/apis/web/context";
 import { validateHostedServer } from "@/lib/apis/web/servers-api";
+import { WebApiError } from "@/lib/apis/web/base";
 import { getGuestPromotionProof } from "@/lib/guest-session";
 import { routePaths } from "@/lib/app-navigation";
 import { ScoreHeadline } from "@/components/conformance/ScoreHeadline";
@@ -35,6 +36,15 @@ type Phase =
   | "running"
   | "saving"
   | "done";
+
+/** `oauthRequired` is carried on a thrown, tagged 401 — never on a return value. */
+function isOAuthRequiredError(error: unknown): boolean {
+  return (
+    error instanceof WebApiError &&
+    (error.details as { oauthRequired?: unknown } | undefined)
+      ?.oauthRequired === true
+  );
+}
 
 function normalizeUrlInput(raw: string): string | null {
   const trimmed = raw.trim();
@@ -103,11 +113,10 @@ export function ScoreRunnerPage({
   // Connect-OAuth (authorize the connection so protocol/apps/tasks can run at
   // all) is a DIFFERENT flow from the OAuth conformance suite above: it is a
   // full-page redirect, and it comes back through the "score" surface.
-  const oauthGate = useHostedOAuthGate({
-    surface: "score",
-    pendingKey: "mcp-hosted-oauth-pending",
-    projectId,
-    servers:
+  // Memoized: the gate synchronizes state from `servers` in an effect, so a
+  // fresh array every render would set state on every render and spin.
+  const oauthDescriptors = useMemo(
+    () =>
       server && serverId
         ? [
             {
@@ -121,6 +130,14 @@ export function ScoreRunnerPage({
             },
           ]
         : [],
+    [server, serverId]
+  );
+
+  const oauthGate = useHostedOAuthGate({
+    surface: "score",
+    pendingKey: "mcp-hosted-oauth-pending",
+    projectId,
+    servers: oauthDescriptors,
   });
 
   /** Poll `serverIdsByName` until bootstrap has the new row. */
@@ -138,51 +155,67 @@ export function ScoreRunnerPage({
     );
   }, []);
 
-  const persistRun = useCallback(
-    async (serverUrl: string) => {
-      if (!run.pooledScore) return;
-      setPhase("saving");
-      try {
-        const suiteSummaries: ScoreSuiteSummary[] = (
-          [
-            ["protocol", run.protocolScore],
-            ["apps", run.appsScore],
-            ["tasks", run.tasksScore],
-            ["oauth", run.oauthScore],
-          ] as const
-        )
-          .filter(([, score]) => score !== undefined)
-          .map(([suiteId, score]) => ({
-            suiteId: suiteId as ScoreSuiteId,
-            ...toScoreSummary(score!),
-          }));
+  /**
+   * The hook's latest output, readable from an async continuation.
+   *
+   * `persistRun` runs after `await runAll()`, and `runAll` reports results by
+   * setting state. A callback that closed over `run` would therefore be
+   * holding the snapshot from BEFORE the suites reported — `pooledScore`
+   * undefined, every result empty — and would silently save nothing. Reading
+   * through a ref is what makes the saved report the one the visitor is
+   * actually looking at.
+   */
+  const runRef = useRef(run);
+  runRef.current = run;
 
-        const { token } = await submitScoreRun({
-          serverUrl,
-          summary: toScoreSummary(run.pooledScore),
-          suiteSummaries,
-          report: {
-            protocol: run.protocol.result,
-            apps: run.apps.result,
-            tasks: run.tasks.result,
-            oauth: run.oauth.result,
-          },
-        });
-        setResultToken(token);
-      } catch (err) {
-        // A save failure must not hide the score the visitor already has on
-        // screen — they just don't get a link for it.
-        setError(
-          err instanceof Error
-            ? `Scan finished, but the shareable link could not be saved: ${err.message}`
-            : "Scan finished, but the shareable link could not be saved."
-        );
-      } finally {
-        setPhase("done");
-      }
-    },
-    [run]
-  );
+  const persistRun = useCallback(async (serverUrl: string) => {
+    const current = runRef.current;
+    if (!current.pooledScore) {
+      // Nothing applicable anywhere — there is no number to save, and no link
+      // worth handing out for it.
+      setPhase("done");
+      return;
+    }
+    setPhase("saving");
+    try {
+      const suiteSummaries: ScoreSuiteSummary[] = (
+        [
+          ["protocol", current.protocolScore],
+          ["apps", current.appsScore],
+          ["tasks", current.tasksScore],
+          ["oauth", current.oauthScore],
+        ] as const
+      )
+        .filter(([, score]) => score !== undefined)
+        .map(([suiteId, score]) => ({
+          suiteId: suiteId as ScoreSuiteId,
+          ...toScoreSummary(score!),
+        }));
+
+      const { token } = await submitScoreRun({
+        serverUrl,
+        summary: toScoreSummary(current.pooledScore),
+        suiteSummaries,
+        report: {
+          protocol: current.protocol.result,
+          apps: current.apps.result,
+          tasks: current.tasks.result,
+          oauth: current.oauth.result,
+        },
+      });
+      setResultToken(token);
+    } catch (err) {
+      // A save failure must not hide the score the visitor already has on
+      // screen — they just don't get a link for it.
+      setError(
+        err instanceof Error
+          ? `Scan finished, but the shareable link could not be saved: ${err.message}`
+          : "Scan finished, but the shareable link could not be saved."
+      );
+    } finally {
+      setPhase("done");
+    }
+  }, []);
 
   const startRun = useCallback(
     async (normalizedUrl: string) => {
@@ -219,15 +252,20 @@ export function ScoreRunnerPage({
         // Does this server need authorization before anything can run? The
         // suites would otherwise all come back with the same 401 and grade a
         // server we never actually reached.
-        const validation = await validateHostedServer(name);
-        if ((validation as { oauthRequired?: boolean }).oauthRequired) {
+        //
+        // The route SIGNALS this by throwing a tagged 401, not by returning a
+        // flag — `oauthRequired` rides `WebApiError.details` (see
+        // `local-server-resolver`). Reading it off the resolved value would
+        // never be true, and the throw would land in the generic catch below
+        // as "your scan failed", with no way to authorize.
+        await validateHostedServer(name);
+        setPhase("running");
+      } catch (err) {
+        if (isOAuthRequiredError(err)) {
           writeScoreRunResume({ serverUrl: normalizedUrl, serverName: name });
           setPhase("authorizing");
           return;
         }
-
-        setPhase("running");
-      } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
         setPhase("form");
       }
@@ -244,10 +282,40 @@ export function ScoreRunnerPage({
     if (startedForRef.current === server.name) return;
     startedForRef.current = server.name;
     const serverUrl = (server.config as { url?: string } | undefined)?.url;
-    void run.runAll().then(() => {
+    // Through the ref, not the closure: `run` is a fresh object every render,
+    // and the one captured here is the pre-run snapshot.
+    void runRef.current.runAll().then(() => {
       if (serverUrl) void persistRun(serverUrl);
     });
-  }, [phase, server, run, persistRun]);
+  }, [phase, server, persistRun]);
+
+  /**
+   * OAuth is opt-in and finishes AFTER the run settles, so the first save
+   * necessarily records a run without it. If the visitor then authorizes, the
+   * screen would show one score and the link a different, lower-information
+   * one. Save again and hand out the newer link: both saves are truthful about
+   * what ran, and the one the visitor is holding always matches what they see.
+   */
+  const persistedOAuthStatusRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (phase !== "done" || !resultToken) return;
+    const serverUrl = (server?.config as { url?: string } | undefined)?.url;
+    if (!serverUrl) return;
+    // Only a transition INTO a finished OAuth state re-saves; a repeat render
+    // of the same state must not.
+    const settled = run.oauth.status === "done" && run.oauthScore !== undefined;
+    if (!settled) return;
+    if (persistedOAuthStatusRef.current === run.oauth.status) return;
+    persistedOAuthStatusRef.current = run.oauth.status;
+    void persistRun(serverUrl);
+  }, [
+    phase,
+    resultToken,
+    run.oauth.status,
+    run.oauthScore,
+    server,
+    persistRun,
+  ]);
 
   // Coming back from a connect-OAuth redirect: the hosted marker restored the
   // server's authorization, but only this record knows a scan was in flight.
@@ -305,6 +373,7 @@ export function ScoreRunnerPage({
       return;
     }
     startedForRef.current = null;
+    persistedOAuthStatusRef.current = null;
     void startRun(normalized);
   };
 
@@ -436,9 +505,18 @@ export function ScoreRunnerPage({
                   size="sm"
                   variant="outline"
                   onClick={() => {
-                    void navigator.clipboard.writeText(resultUrl);
-                    setCopied(true);
-                    window.setTimeout(() => setCopied(false), 2000);
+                    // `writeText` rejects without focus or permission. Show the
+                    // check mark only once the write actually resolved — a tick
+                    // over an empty clipboard is worse than no tick.
+                    void navigator.clipboard
+                      .writeText(resultUrl)
+                      .then(() => {
+                        setCopied(true);
+                        window.setTimeout(() => setCopied(false), 2000);
+                      })
+                      .catch(() =>
+                        setError("Could not copy the link. Copy it manually.")
+                      );
                   }}
                 >
                   {copied ? (

--- a/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
@@ -1,0 +1,464 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import { Loader2, ArrowRight, ShieldCheck, Link2, Check } from "lucide-react";
+import { useMutation } from "convex/react";
+import { useAppReady, useAppReadyMessage } from "@/hooks/use-app-ready";
+import { useConformanceRun } from "@/hooks/use-conformance-run";
+import { useHostedOAuthGate } from "@/hooks/hosted/use-hosted-oauth-gate";
+import { tryResolveProjectServer } from "@/lib/apis/web/context";
+import { validateHostedServer } from "@/lib/apis/web/servers-api";
+import { getGuestPromotionProof } from "@/lib/guest-session";
+import { routePaths } from "@/lib/app-navigation";
+import { ScoreHeadline } from "@/components/conformance/ScoreHeadline";
+import type { ServerWithName } from "@/state/app-types";
+import {
+  submitScoreRun,
+  toScoreSummary,
+  type ScoreSuiteId,
+  type ScoreSuiteSummary,
+} from "@/lib/apis/score-api";
+import { deriveScoreServerName } from "./score-server-name";
+import {
+  clearScoreRunResume,
+  readScoreRunResume,
+  writeScoreRunResume,
+} from "./score-run-resume";
+import { ScoreSuiteBreakdown } from "./ScoreSuiteBreakdown";
+
+/** Where "Debug these failures in MCPJam" sends a visitor. */
+const APP_ORIGIN = "https://app.mcpjam.com";
+
+type Phase =
+  | "form"
+  | "preparing"
+  | "authorizing"
+  | "running"
+  | "saving"
+  | "done";
+
+function normalizeUrlInput(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  // A pasted host with no scheme is the single most common way this form gets
+  // filled. Assume https rather than rejecting it — http would be a downgrade
+  // nobody asked for.
+  const withScheme = /^https?:\/\//i.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`;
+  try {
+    const parsed = new URL(withScheme);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function ScoreRunnerPage({
+  convexProjectId,
+}: {
+  /** The guest's (or member's) project, from the app route context. */
+  convexProjectId: string | null;
+}) {
+  const appReady = useAppReady();
+  const appReadyMessage = useAppReadyMessage();
+  const createServerIfMissing = useMutation(
+    "servers:createServerIfMissing" as any
+  );
+
+  const [urlInput, setUrlInput] = useState("");
+  const [phase, setPhase] = useState<Phase>("form");
+  const [error, setError] = useState<string | null>(null);
+  const [server, setServer] = useState<ServerWithName | null>(null);
+  const [resultToken, setResultToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [ctaHref, setCtaHref] = useState(APP_ORIGIN);
+
+  const run = useConformanceRun({
+    // A placeholder keeps the hook's contract simple: it always has a server.
+    // Nothing runs until `runAll` is called, and that only happens once a real
+    // row exists.
+    server: server ?? {
+      name: "",
+      config: {} as ServerWithName["config"],
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+    },
+    // OAuth is opt-in here. A public landing page must not throw an
+    // unrequested popup at a visitor, and a skipped OAuth suite shows as
+    // *not scored* — never a deduction.
+    deferOAuthAuthorization: true,
+  });
+
+  // Resolved through the public accessor rather than the module-level context
+  // object: it returns null (instead of throwing BootstrapNotReadyError) while
+  // bootstrap is still catching up, which is the normal state on this page for
+  // the second or two after the row is created.
+  const resolved = server ? tryResolveProjectServer(server.name) : null;
+  const projectId = resolved?.projectId ?? convexProjectId;
+  const serverId = resolved?.serverId;
+
+  // Connect-OAuth (authorize the connection so protocol/apps/tasks can run at
+  // all) is a DIFFERENT flow from the OAuth conformance suite above: it is a
+  // full-page redirect, and it comes back through the "score" surface.
+  const oauthGate = useHostedOAuthGate({
+    surface: "score",
+    pendingKey: "mcp-hosted-oauth-pending",
+    projectId,
+    servers:
+      server && serverId
+        ? [
+            {
+              serverId,
+              serverName: server.name,
+              useOAuth: true,
+              serverUrl:
+                (server.config as { url?: string } | undefined)?.url ?? null,
+              clientId: null,
+              oauthScopes: null,
+            },
+          ]
+        : [],
+  });
+
+  /** Poll `serverIdsByName` until bootstrap has the new row. */
+  const waitForServerId = useCallback(async (name: string): Promise<string> => {
+    for (let attempt = 0; attempt < 60; attempt++) {
+      const id = tryResolveProjectServer(name)?.serverId;
+      if (id) return id;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    // `buildServerRequest` would otherwise throw BootstrapNotReadyError deep
+    // inside the first suite call, which reads as a mysterious failure of
+    // the scan rather than of setup.
+    throw new Error(
+      "Timed out preparing the workspace for this server. Reload and try again."
+    );
+  }, []);
+
+  const persistRun = useCallback(
+    async (serverUrl: string) => {
+      if (!run.pooledScore) return;
+      setPhase("saving");
+      try {
+        const suiteSummaries: ScoreSuiteSummary[] = (
+          [
+            ["protocol", run.protocolScore],
+            ["apps", run.appsScore],
+            ["tasks", run.tasksScore],
+            ["oauth", run.oauthScore],
+          ] as const
+        )
+          .filter(([, score]) => score !== undefined)
+          .map(([suiteId, score]) => ({
+            suiteId: suiteId as ScoreSuiteId,
+            ...toScoreSummary(score!),
+          }));
+
+        const { token } = await submitScoreRun({
+          serverUrl,
+          summary: toScoreSummary(run.pooledScore),
+          suiteSummaries,
+          report: {
+            protocol: run.protocol.result,
+            apps: run.apps.result,
+            tasks: run.tasks.result,
+            oauth: run.oauth.result,
+          },
+        });
+        setResultToken(token);
+      } catch (err) {
+        // A save failure must not hide the score the visitor already has on
+        // screen — they just don't get a link for it.
+        setError(
+          err instanceof Error
+            ? `Scan finished, but the shareable link could not be saved: ${err.message}`
+            : "Scan finished, but the shareable link could not be saved."
+        );
+      } finally {
+        setPhase("done");
+      }
+    },
+    [run]
+  );
+
+  const startRun = useCallback(
+    async (normalizedUrl: string) => {
+      setError(null);
+      setResultToken(null);
+      setPhase("preparing");
+
+      const name = deriveScoreServerName(normalizedUrl);
+      try {
+        if (!projectId) {
+          throw new Error(
+            "Still setting up your workspace. Give it a moment and try again."
+          );
+        }
+        await createServerIfMissing({
+          projectId,
+          name,
+          enabled: true,
+          transportType: "http",
+          url: normalizedUrl,
+        } as any);
+
+        await waitForServerId(name);
+
+        const nextServer: ServerWithName = {
+          name,
+          config: { url: normalizedUrl } as ServerWithName["config"],
+          lastConnectionTime: new Date(),
+          connectionStatus: "disconnected",
+          retryCount: 0,
+        };
+        setServer(nextServer);
+
+        // Does this server need authorization before anything can run? The
+        // suites would otherwise all come back with the same 401 and grade a
+        // server we never actually reached.
+        const validation = await validateHostedServer(name);
+        if ((validation as { oauthRequired?: boolean }).oauthRequired) {
+          writeScoreRunResume({ serverUrl: normalizedUrl, serverName: name });
+          setPhase("authorizing");
+          return;
+        }
+
+        setPhase("running");
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setPhase("form");
+      }
+    },
+    [createServerIfMissing, projectId, waitForServerId]
+  );
+
+  // `runAll` needs the hook to have re-keyed onto the new server first — it
+  // reads `server` from its own closure — so the run is kicked off by an
+  // effect once both the phase and the identity line up.
+  const startedForRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (phase !== "running" || !server) return;
+    if (startedForRef.current === server.name) return;
+    startedForRef.current = server.name;
+    const serverUrl = (server.config as { url?: string } | undefined)?.url;
+    void run.runAll().then(() => {
+      if (serverUrl) void persistRun(serverUrl);
+    });
+  }, [phase, server, run, persistRun]);
+
+  // Coming back from a connect-OAuth redirect: the hosted marker restored the
+  // server's authorization, but only this record knows a scan was in flight.
+  const resumedRef = useRef(false);
+  useEffect(() => {
+    if (resumedRef.current) return;
+    if (appReady.status !== "ready") return;
+    const resume = readScoreRunResume();
+    if (!resume) return;
+    resumedRef.current = true;
+    clearScoreRunResume();
+    setUrlInput(resume.serverUrl);
+    void startRun(resume.serverUrl);
+  }, [appReady.status, startRun]);
+
+  // The guest cookie is host-only, so a bare link to app.mcpjam.com would
+  // arrive with no guest identity and promote nothing. Carry a one-shot
+  // promotion proof in the CTA instead, so signing in there absorbs this
+  // guest project — server row and all — into the new account.
+  useEffect(() => {
+    if (phase !== "done") return;
+    let cancelled = false;
+    void getGuestPromotionProof().then((proof) => {
+      if (cancelled) return;
+      setCtaHref(
+        proof
+          ? `${APP_ORIGIN}/servers?guestProof=${encodeURIComponent(proof)}`
+          : `${APP_ORIGIN}/servers`
+      );
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [phase]);
+
+  const resultUrl = useMemo(
+    () =>
+      resultToken
+        ? `${window.location.origin}${routePaths.scoreResults}/${resultToken}`
+        : null,
+    [resultToken]
+  );
+
+  const busy =
+    phase === "preparing" ||
+    phase === "running" ||
+    phase === "saving" ||
+    run.isRunning;
+
+  const onSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    const normalized = normalizeUrlInput(urlInput);
+    if (!normalized) {
+      setError("Enter a valid http(s) MCP server URL.");
+      return;
+    }
+    startedForRef.current = null;
+    void startRun(normalized);
+  };
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-3xl flex-col gap-6 overflow-y-auto px-6 py-10">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Score your MCP server</h1>
+        <p className="text-sm text-muted-foreground">
+          Paste a server URL. We run the protocol, apps, tasks and OAuth
+          conformance suites against it and give you one number out of 100, with
+          every check we judged it on.
+        </p>
+      </header>
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-2 sm:flex-row">
+        <input
+          type="text"
+          inputMode="url"
+          autoComplete="off"
+          spellCheck={false}
+          value={urlInput}
+          onChange={(event) => setUrlInput(event.target.value)}
+          placeholder="https://mcp.example.com/mcp"
+          aria-label="MCP server URL"
+          disabled={busy}
+          className="h-10 min-w-0 flex-1 rounded-md border border-border/60 bg-background px-3 text-sm outline-none focus:border-foreground/30"
+        />
+        <Button type="submit" disabled={busy || appReady.status !== "ready"}>
+          {busy ? (
+            <>
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              {phase === "preparing"
+                ? "Preparing…"
+                : phase === "saving"
+                ? "Saving…"
+                : "Scanning…"}
+            </>
+          ) : (
+            <>
+              Score it
+              <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+            </>
+          )}
+        </Button>
+      </form>
+
+      {appReady.status !== "ready" && appReadyMessage && (
+        <p className="text-xs text-muted-foreground">{appReadyMessage}</p>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        Hosted scans reach your server over the public internet, so a stdio
+        server or one on localhost can&apos;t be scored here — run those locally
+        with{" "}
+        <code className="rounded bg-muted px-1 py-0.5">
+          npx @mcpjam/inspector
+        </code>
+        .
+      </p>
+
+      {error && (
+        <div className="rounded-md border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+          {error}
+        </div>
+      )}
+
+      {phase === "authorizing" && server && serverId && (
+        <div className="space-y-3 rounded-md border border-border/50 bg-muted/30 px-4 py-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <ShieldCheck className="h-4 w-4" />
+            This server requires authorization
+          </div>
+          <p className="text-xs text-muted-foreground">
+            We can&apos;t check what a server does for an authorized client
+            without being one. Authorizing sends you to the server&apos;s own
+            login and brings you straight back here to finish the scan.
+          </p>
+          <Button
+            size="sm"
+            onClick={() =>
+              void oauthGate.authorizeServer({
+                serverId,
+                serverName: server.name,
+                useOAuth: true,
+                serverUrl:
+                  (server.config as { url?: string } | undefined)?.url ?? null,
+                clientId: null,
+                oauthScopes: null,
+              })
+            }
+            disabled={oauthGate.hasBusyOAuth}
+          >
+            Authorize and continue
+          </Button>
+        </div>
+      )}
+
+      {(run.pooledScore || busy) && (
+        <div className="space-y-4">
+          <ScoreHeadline
+            score={run.pooledScore}
+            oauthNotScored={run.oauthNotScored}
+            size="hero"
+          />
+          <ScoreSuiteBreakdown
+            protocol={run.protocol}
+            apps={run.apps}
+            tasks={run.tasks}
+            oauth={run.oauth}
+            protocolScore={run.protocolScore}
+            appsScore={run.appsScore}
+            tasksScore={run.tasksScore}
+            oauthScore={run.oauthScore}
+            onAuthorizeOAuth={run.authorizeOAuth}
+          />
+        </div>
+      )}
+
+      {phase === "done" && (
+        <div className="space-y-3 rounded-md border border-border/50 px-4 py-3">
+          {resultUrl && (
+            <div className="space-y-1">
+              <div className="text-xs font-medium">Private result link</div>
+              <div className="flex items-center gap-2">
+                <code className="min-w-0 flex-1 truncate rounded bg-muted px-2 py-1 text-[11px]">
+                  {resultUrl}
+                </code>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    void navigator.clipboard.writeText(resultUrl);
+                    setCopied(true);
+                    window.setTimeout(() => setCopied(false), 2000);
+                  }}
+                >
+                  {copied ? (
+                    <Check className="h-3.5 w-3.5" />
+                  ) : (
+                    <Link2 className="h-3.5 w-3.5" />
+                  )}
+                </Button>
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                Anyone with this link can read the report. It is not listed
+                anywhere.
+              </p>
+            </div>
+          )}
+          <Button asChild size="sm">
+            <a href={ctaHref}>Debug these failures in MCPJam</a>
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
@@ -399,6 +399,11 @@ export function ScoreRunnerPage({
       return;
     }
     startedForRef.current = null;
+    // Drop any resume record from an abandoned run. `authorizing` leaves the
+    // form enabled, so a visitor can walk away from an OAuth prompt and paste
+    // a different URL — and a stale record would hijack the next reload back
+    // to the server they gave up on.
+    clearScoreRunResume();
     persistedRunRef.current = null;
     persistedOAuthStatusRef.current = null;
     void startRun(normalized);

--- a/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
@@ -34,6 +34,14 @@ type Phase =
   | "preparing"
   | "authorizing"
   | "running"
+  /**
+   * The suites have settled but their results may not have COMMITTED yet.
+   * `runAll` schedules React state updates and then resolves, so its promise
+   * continuation is a microtask that can run before the commit — persisting
+   * from there could still read a pre-run snapshot. This phase exists so the
+   * save is triggered by an effect, which React only runs after the commit.
+   */
+  | "run-complete"
   | "saving"
   | "done";
 
@@ -223,8 +231,11 @@ export function ScoreRunnerPage({
       setResultToken(null);
       setPhase("preparing");
 
-      const name = deriveScoreServerName(normalizedUrl);
+      // Declared outside the try: the catch needs it to write the resume
+      // record when the server turns out to require authorization.
+      let name = "";
       try {
+        name = await deriveScoreServerName(normalizedUrl);
         if (!projectId) {
           throw new Error(
             "Still setting up your workspace. Give it a moment and try again."
@@ -281,12 +292,26 @@ export function ScoreRunnerPage({
     if (phase !== "running" || !server) return;
     if (startedForRef.current === server.name) return;
     startedForRef.current = server.name;
-    const serverUrl = (server.config as { url?: string } | undefined)?.url;
     // Through the ref, not the closure: `run` is a fresh object every render,
-    // and the one captured here is the pre-run snapshot.
-    void runRef.current.runAll().then(() => {
-      if (serverUrl) void persistRun(serverUrl);
-    });
+    // and the one captured here is the pre-run snapshot. The continuation only
+    // advances the phase — the save itself happens in the effect below, after
+    // the results have actually committed.
+    void runRef.current.runAll().then(() => setPhase("run-complete"));
+  }, [phase, server]);
+
+  const persistedRunRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (phase !== "run-complete" || !server) return;
+    const serverUrl = (server.config as { url?: string } | undefined)?.url;
+    if (!serverUrl) {
+      setPhase("done");
+      return;
+    }
+    // Exactly once per run: an effect can re-fire, and a second save would
+    // hand out a second link for the same scan.
+    if (persistedRunRef.current === server.name) return;
+    persistedRunRef.current = server.name;
+    void persistRun(serverUrl);
   }, [phase, server, persistRun]);
 
   /**
@@ -362,6 +387,7 @@ export function ScoreRunnerPage({
   const busy =
     phase === "preparing" ||
     phase === "running" ||
+    phase === "run-complete" ||
     phase === "saving" ||
     run.isRunning;
 
@@ -373,6 +399,7 @@ export function ScoreRunnerPage({
       return;
     }
     startedForRef.current = null;
+    persistedRunRef.current = null;
     persistedOAuthStatusRef.current = null;
     void startRun(normalized);
   };
@@ -508,8 +535,14 @@ export function ScoreRunnerPage({
                     // `writeText` rejects without focus or permission. Show the
                     // check mark only once the write actually resolved — a tick
                     // over an empty clipboard is worse than no tick.
-                    void navigator.clipboard
-                      .writeText(resultUrl)
+                    const write = navigator.clipboard?.writeText?.(resultUrl);
+                    if (!write) {
+                      // No Clipboard API at all (insecure context, older
+                      // browser) — same outcome as a rejected write.
+                      setError("Could not copy the link. Copy it manually.");
+                      return;
+                    }
+                    void write
                       .then(() => {
                         setCopied(true);
                         window.setTimeout(() => setCopied(false), 2000);

--- a/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
@@ -8,7 +8,7 @@ import { useHostedOAuthGate } from "@/hooks/hosted/use-hosted-oauth-gate";
 import { tryResolveProjectServer } from "@/lib/apis/web/context";
 import { validateHostedServer } from "@/lib/apis/web/servers-api";
 import { WebApiError } from "@/lib/apis/web/base";
-import { getGuestPromotionProof } from "@/lib/guest-session";
+import { SCORE_OAUTH_PENDING_KEY } from "@/lib/hosted-oauth-callback";
 import { routePaths } from "@/lib/app-navigation";
 import { ScoreHeadline } from "@/components/conformance/ScoreHeadline";
 import type { ServerWithName } from "@/state/app-types";
@@ -26,8 +26,19 @@ import {
 } from "./score-run-resume";
 import { ScoreSuiteBreakdown } from "./ScoreSuiteBreakdown";
 
-/** Where "Debug these failures in MCPJam" sends a visitor. */
+/**
+ * Where "Debug these failures in MCPJam" sends a visitor.
+ *
+ * A plain link, deliberately. Carrying the guest project across would need the
+ * guest promotion proof, and that proof is a bearer credential that can claim a
+ * guest's projects — putting it in a URL leaks it to history, referrers and
+ * logs. The guest cookie is host-only, so it cannot travel from this origin to
+ * the app either. Handing the scanned server over needs a real one-shot
+ * exchange endpoint; until that exists, the honest CTA is a link, not a
+ * parameter that promotes nothing.
+ */
 const APP_ORIGIN = "https://app.mcpjam.com";
+const CTA_HREF = `${APP_ORIGIN}/servers`;
 
 type Phase =
   | "form"
@@ -91,7 +102,6 @@ export function ScoreRunnerPage({
   const [server, setServer] = useState<ServerWithName | null>(null);
   const [resultToken, setResultToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [ctaHref, setCtaHref] = useState(APP_ORIGIN);
 
   const run = useConformanceRun({
     // A placeholder keeps the hook's contract simple: it always has a server.
@@ -143,7 +153,10 @@ export function ScoreRunnerPage({
 
   const oauthGate = useHostedOAuthGate({
     surface: "score",
-    pendingKey: "mcp-hosted-oauth-pending",
+    // Its OWN sentinel. Naming the hosted marker's key here would overwrite the
+    // marker with `"true"` and dead-end the callback — see
+    // SCORE_OAUTH_PENDING_KEY.
+    pendingKey: SCORE_OAUTH_PENDING_KEY,
     projectId,
     servers: oauthDescriptors,
   });
@@ -175,6 +188,19 @@ export function ScoreRunnerPage({
    */
   const runRef = useRef(run);
   runRef.current = run;
+
+  /**
+   * Which settled OAuth status the last stored report already contained.
+   *
+   * Written by `persistRun` itself rather than by either caller, because the
+   * question it answers is "what did the payload we just sent include?" — and
+   * only the function that built the payload knows. Seeding it from the save
+   * is what stops the resave effect from storing a second, identical run when
+   * the OAuth suite happened to settle DURING `runAll` (the common case for a
+   * server that fails at discovery or registration, where the suite grades a
+   * failure without ever prompting anyone).
+   */
+  const persistedOAuthStatusRef = useRef<string | null>(null);
 
   const persistRun = useCallback(
     async (serverUrl: string): Promise<boolean> => {
@@ -214,6 +240,11 @@ export function ScoreRunnerPage({
           },
         });
         setResultToken(token);
+        // Record what this payload actually contained, so a resave only ever
+        // fires for an OAuth status the stored report does NOT already have.
+        if (current.oauth.status === "done" && current.oauthScore !== undefined) {
+          persistedOAuthStatusRef.current = current.oauth.status;
+        }
         return true;
       } catch (err) {
         // A save failure must not hide the score the visitor already has on
@@ -327,7 +358,6 @@ export function ScoreRunnerPage({
    * one. Save again and hand out the newer link: both saves are truthful about
    * what ran, and the one the visitor is holding always matches what they see.
    */
-  const persistedOAuthStatusRef = useRef<string | null>(null);
   /**
    * The OAuth resave gets ONE attempt, ever.
    *
@@ -358,11 +388,11 @@ export function ScoreRunnerPage({
     if (oauthResaveAttemptsRef.current >= 1) return;
     oauthResaveAttemptsRef.current += 1;
     oauthResaveInFlightRef.current = true;
-    void persistRun(serverUrl).then((saved) => {
+    void persistRun(serverUrl).then(() => {
       oauthResaveInFlightRef.current = false;
-      // The guard records a SUCCESSFUL save, so a later status change can
-      // still be saved — bounded by the attempt cap above.
-      if (saved) persistedOAuthStatusRef.current = run.oauth.status;
+      // `persistRun` records the status it actually stored, on success only —
+      // one owner for that fact, so a failed save can still be followed by a
+      // later status change (bounded by the attempt cap above).
     });
   }, [phase, run.oauth.status, run.oauthScore, server, persistRun]);
 
@@ -379,26 +409,6 @@ export function ScoreRunnerPage({
     setUrlInput(resume.serverUrl);
     void startRun(resume.serverUrl);
   }, [appReady.status, startRun]);
-
-  // The guest cookie is host-only, so a bare link to app.mcpjam.com would
-  // arrive with no guest identity and promote nothing. Carry a one-shot
-  // promotion proof in the CTA instead, so signing in there absorbs this
-  // guest project — server row and all — into the new account.
-  useEffect(() => {
-    if (phase !== "done") return;
-    let cancelled = false;
-    void getGuestPromotionProof().then((proof) => {
-      if (cancelled) return;
-      setCtaHref(
-        proof
-          ? `${APP_ORIGIN}/servers?guestProof=${encodeURIComponent(proof)}`
-          : `${APP_ORIGIN}/servers`
-      );
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [phase]);
 
   const resultUrl = useMemo(
     () =>
@@ -605,7 +615,7 @@ export function ScoreRunnerPage({
             </div>
           )}
           <Button asChild size="sm">
-            <a href={ctaHref}>Debug these failures in MCPJam</a>
+            <a href={CTA_HREF}>Debug these failures in MCPJam</a>
           </Button>
         </div>
       )}

--- a/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
@@ -176,54 +176,60 @@ export function ScoreRunnerPage({
   const runRef = useRef(run);
   runRef.current = run;
 
-  const persistRun = useCallback(async (serverUrl: string) => {
-    const current = runRef.current;
-    if (!current.pooledScore) {
-      // Nothing applicable anywhere — there is no number to save, and no link
-      // worth handing out for it.
-      setPhase("done");
-      return;
-    }
-    setPhase("saving");
-    try {
-      const suiteSummaries: ScoreSuiteSummary[] = (
-        [
-          ["protocol", current.protocolScore],
-          ["apps", current.appsScore],
-          ["tasks", current.tasksScore],
-          ["oauth", current.oauthScore],
-        ] as const
-      )
-        .filter(([, score]) => score !== undefined)
-        .map(([suiteId, score]) => ({
-          suiteId: suiteId as ScoreSuiteId,
-          ...toScoreSummary(score!),
-        }));
+  const persistRun = useCallback(
+    async (serverUrl: string): Promise<boolean> => {
+      const current = runRef.current;
+      if (!current.pooledScore) {
+        // Nothing applicable anywhere — there is no number to save, and no link
+        // worth handing out for it. (`pooledScore` is a ConformanceScore OBJECT,
+        // so a legitimate score of 0 is `{score: 0, …}` and stays truthy.)
+        setPhase("done");
+        return false;
+      }
+      setPhase("saving");
+      try {
+        const suiteSummaries: ScoreSuiteSummary[] = (
+          [
+            ["protocol", current.protocolScore],
+            ["apps", current.appsScore],
+            ["tasks", current.tasksScore],
+            ["oauth", current.oauthScore],
+          ] as const
+        )
+          .filter(([, score]) => score !== undefined)
+          .map(([suiteId, score]) => ({
+            suiteId: suiteId as ScoreSuiteId,
+            ...toScoreSummary(score!),
+          }));
 
-      const { token } = await submitScoreRun({
-        serverUrl,
-        summary: toScoreSummary(current.pooledScore),
-        suiteSummaries,
-        report: {
-          protocol: current.protocol.result,
-          apps: current.apps.result,
-          tasks: current.tasks.result,
-          oauth: current.oauth.result,
-        },
-      });
-      setResultToken(token);
-    } catch (err) {
-      // A save failure must not hide the score the visitor already has on
-      // screen — they just don't get a link for it.
-      setError(
-        err instanceof Error
-          ? `Scan finished, but the shareable link could not be saved: ${err.message}`
-          : "Scan finished, but the shareable link could not be saved."
-      );
-    } finally {
-      setPhase("done");
-    }
-  }, []);
+        const { token } = await submitScoreRun({
+          serverUrl,
+          summary: toScoreSummary(current.pooledScore),
+          suiteSummaries,
+          report: {
+            protocol: current.protocol.result,
+            apps: current.apps.result,
+            tasks: current.tasks.result,
+            oauth: current.oauth.result,
+          },
+        });
+        setResultToken(token);
+        return true;
+      } catch (err) {
+        // A save failure must not hide the score the visitor already has on
+        // screen — they just don't get a link for it.
+        setError(
+          err instanceof Error
+            ? `Scan finished, but the shareable link could not be saved: ${err.message}`
+            : "Scan finished, but the shareable link could not be saved."
+        );
+        return false;
+      } finally {
+        setPhase("done");
+      }
+    },
+    []
+  );
 
   const startRun = useCallback(
     async (normalizedUrl: string) => {
@@ -323,7 +329,10 @@ export function ScoreRunnerPage({
    */
   const persistedOAuthStatusRef = useRef<string | null>(null);
   useEffect(() => {
-    if (phase !== "done" || !resultToken) return;
+    // Deliberately NOT gated on an existing `resultToken`: if the first save
+    // failed, a settled OAuth run is the visitor's second chance at getting a
+    // link at all.
+    if (phase !== "done") return;
     const serverUrl = (server?.config as { url?: string } | undefined)?.url;
     if (!serverUrl) return;
     // Only a transition INTO a finished OAuth state re-saves; a repeat render
@@ -331,16 +340,13 @@ export function ScoreRunnerPage({
     const settled = run.oauth.status === "done" && run.oauthScore !== undefined;
     if (!settled) return;
     if (persistedOAuthStatusRef.current === run.oauth.status) return;
-    persistedOAuthStatusRef.current = run.oauth.status;
-    void persistRun(serverUrl);
-  }, [
-    phase,
-    resultToken,
-    run.oauth.status,
-    run.oauthScore,
-    server,
-    persistRun,
-  ]);
+    void persistRun(serverUrl).then((saved) => {
+      // The guard records a SUCCESSFUL save. Setting it up front would burn
+      // the one retry on a failure, leaving the visitor with a score on screen
+      // and permanently no link for it.
+      if (saved) persistedOAuthStatusRef.current = run.oauth.status;
+    });
+  }, [phase, run.oauth.status, run.oauthScore, server, persistRun]);
 
   // Coming back from a connect-OAuth redirect: the hosted marker restored the
   // server's authorization, but only this record knows a scan was in flight.
@@ -406,6 +412,11 @@ export function ScoreRunnerPage({
     clearScoreRunResume();
     persistedRunRef.current = null;
     persistedOAuthStatusRef.current = null;
+    // Clearing the server re-keys `useConformanceRun`, which drops the prior
+    // suite states. Without it the old server's score stays on screen through
+    // "preparing" — and stays there permanently if setup fails and the phase
+    // returns to "form" — labelled with the URL the visitor just typed.
+    setServer(null);
     void startRun(normalized);
   };
 
@@ -536,6 +547,9 @@ export function ScoreRunnerPage({
                 <Button
                   size="sm"
                   variant="outline"
+                  aria-label={
+                    copied ? "Copied result link" : "Copy result link"
+                  }
                   onClick={() => {
                     // `writeText` rejects without focus or permission. Show the
                     // check mark only once the write actually resolved — a tick

--- a/mcpjam-inspector/client/src/components/score/ScoreSuiteBreakdown.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreSuiteBreakdown.tsx
@@ -1,0 +1,135 @@
+import { Button } from "@mcpjam/design-system/button";
+import { Loader2 } from "lucide-react";
+import {
+  describeConformanceScore,
+  type ConformanceScore,
+} from "@mcpjam/sdk/browser";
+import type {
+  AppsSuiteState,
+  OAuthSuiteState,
+  ProtocolSuiteState,
+  SuiteState,
+  TasksSuiteState,
+} from "@/hooks/use-conformance-run";
+
+const SUITE_TITLES = {
+  protocol: "Protocol",
+  apps: "Apps",
+  tasks: "Tasks",
+  oauth: "OAuth",
+} as const;
+
+function SuiteRow({
+  title,
+  state,
+  score,
+  action,
+}: {
+  title: string;
+  state: SuiteState;
+  score?: ConformanceScore;
+  action?: React.ReactNode;
+}) {
+  const detail = (() => {
+    if (state.status === "running") return "Running…";
+    if (state.status === "needs-authorization") {
+      return "Not run — authorize to include it";
+    }
+    if (state.status === "unavailable") {
+      // A suite with nothing to judge is not a failure, and must never read
+      // as one. "Not scored" and "scored zero" are opposite claims.
+      return state.unavailableReason ?? "Not applicable — not scored";
+    }
+    if (state.status === "error") return state.error ?? "Could not run";
+    if (score) return describeConformanceScore(score);
+    return "Not run";
+  })();
+
+  const tone =
+    state.status === "error" || state.verdict === "failed"
+      ? "text-red-400"
+      : state.verdict === "incomplete"
+      ? "text-amber-500"
+      : state.verdict === "passed"
+      ? "text-green-500"
+      : "text-muted-foreground";
+
+  return (
+    <div className="flex items-start justify-between gap-3 border-b border-border/40 px-4 py-3 last:border-b-0">
+      <div className="min-w-0 space-y-0.5">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          {title}
+          {state.status === "running" && (
+            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+          )}
+        </div>
+        <div className={`text-[11px] ${tone}`}>{detail}</div>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {score && score.score !== null && (
+          <span className="text-sm font-semibold tabular-nums">
+            {score.score}
+            <span className="text-[10px] font-normal text-muted-foreground">
+              /100
+            </span>
+          </span>
+        )}
+        {action}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Per-suite breakdown under the headline number.
+ *
+ * The OAuth row carries the one interactive affordance on this page: a run
+ * that reached the authorization step waits here instead of opening a popup
+ * nobody asked for. Declining costs nothing — the suite reports "not scored",
+ * which is a different statement from a zero and is rendered as one.
+ */
+export function ScoreSuiteBreakdown({
+  protocol,
+  apps,
+  tasks,
+  oauth,
+  protocolScore,
+  appsScore,
+  tasksScore,
+  oauthScore,
+  onAuthorizeOAuth,
+}: {
+  protocol: ProtocolSuiteState;
+  apps: AppsSuiteState;
+  tasks: TasksSuiteState;
+  oauth: OAuthSuiteState;
+  protocolScore?: ConformanceScore;
+  appsScore?: ConformanceScore;
+  tasksScore?: ConformanceScore;
+  oauthScore?: ConformanceScore;
+  onAuthorizeOAuth?: () => void;
+}) {
+  return (
+    <div className="rounded-md border border-border/50">
+      <SuiteRow
+        title={SUITE_TITLES.protocol}
+        state={protocol}
+        score={protocolScore}
+      />
+      <SuiteRow title={SUITE_TITLES.apps} state={apps} score={appsScore} />
+      <SuiteRow title={SUITE_TITLES.tasks} state={tasks} score={tasksScore} />
+      <SuiteRow
+        title={SUITE_TITLES.oauth}
+        state={oauth}
+        score={oauthScore}
+        action={
+          oauth.status === "needs-authorization" && onAuthorizeOAuth ? (
+            <Button size="sm" variant="outline" onClick={onAuthorizeOAuth}>
+              Authorize to include OAuth
+            </Button>
+          ) : undefined
+        }
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/score/__tests__/score-server-name.test.ts
+++ b/mcpjam-inspector/client/src/components/score/__tests__/score-server-name.test.ts
@@ -8,55 +8,57 @@ import { deriveScoreServerName } from "../score-server-name";
  * guest's project.
  */
 describe("deriveScoreServerName", () => {
-  it("is stable for the same URL", () => {
-    expect(deriveScoreServerName("https://mcp.example.com/mcp")).toBe(
-      deriveScoreServerName("https://mcp.example.com/mcp")
+  it("is stable for the same URL", async () => {
+    expect(await deriveScoreServerName("https://mcp.example.com/mcp")).toBe(
+      await deriveScoreServerName("https://mcp.example.com/mcp")
     );
   });
 
-  it("ignores the universal /mcp and /sse endpoint suffixes", () => {
+  it("ignores the universal /mcp and /sse endpoint suffixes", async () => {
     // These say nothing about WHICH server this is.
     // The readable part drops the suffix; the digest still distinguishes them.
-    expect(deriveScoreServerName("https://mcp.example.com/mcp")).toMatch(
+    expect(await deriveScoreServerName("https://mcp.example.com/mcp")).toMatch(
       /^mcp-example-com-[a-z0-9]+$/
     );
-    expect(deriveScoreServerName("https://mcp.example.com/sse")).toMatch(
+    expect(await deriveScoreServerName("https://mcp.example.com/sse")).toMatch(
       /^mcp-example-com-/
     );
-    expect(deriveScoreServerName("https://mcp.example.com/mcp/")).toBe(
-      deriveScoreServerName("https://mcp.example.com/mcp")
+    expect(await deriveScoreServerName("https://mcp.example.com/mcp/")).toBe(
+      await deriveScoreServerName("https://mcp.example.com/mcp")
     );
   });
 
-  it("keeps a path that actually distinguishes two servers on one host", () => {
-    expect(deriveScoreServerName("https://example.com/team-a/mcp")).toMatch(
-      /^example-com-team-a-mcp-/
-    );
-    expect(deriveScoreServerName("https://example.com/team-a/mcp")).not.toBe(
-      deriveScoreServerName("https://example.com/team-b/mcp")
-    );
+  it("keeps a path that actually distinguishes two servers on one host", async () => {
+    expect(
+      await deriveScoreServerName("https://example.com/team-a/mcp")
+    ).toMatch(/^example-com-team-a-mcp-/);
+    expect(
+      await deriveScoreServerName("https://example.com/team-a/mcp")
+    ).not.toBe(await deriveScoreServerName("https://example.com/team-b/mcp"));
   });
 
-  it("drops a leading www so the label reads like the product", () => {
-    expect(deriveScoreServerName("https://www.example.com/mcp")).toMatch(
+  it("drops a leading www so the label reads like the product", async () => {
+    expect(await deriveScoreServerName("https://www.example.com/mcp")).toMatch(
       /^example-com-/
     );
   });
 
-  it("produces a safe slug from hostile input", () => {
-    const name = deriveScoreServerName("https://ex ample.com/a b/../c?x=1#y");
+  it("produces a safe slug from hostile input", async () => {
+    const name = await deriveScoreServerName(
+      "https://ex ample.com/a b/../c?x=1#y"
+    );
     // Matches the product's own `slugifyName` shape.
     expect(name).toMatch(/^[a-z0-9-]+$/);
     expect(name.startsWith("-")).toBe(false);
     expect(name.endsWith("-")).toBe(false);
   });
 
-  it("never returns an empty name", () => {
-    expect(deriveScoreServerName("")).toMatch(/^mcp-server-/);
-    expect(deriveScoreServerName("!!!").length).toBeGreaterThan(0);
+  it("never returns an empty name", async () => {
+    expect(await deriveScoreServerName("")).toMatch(/^mcp-server-/);
+    expect((await deriveScoreServerName("!!!")).length).toBeGreaterThan(0);
   });
 
-  it("keeps servers apart that the readable slug alone would merge", () => {
+  it("keeps servers apart that the readable slug alone would merge", async () => {
     // Each pair collides on the slug and must NOT collide on the name — a
     // merged name means the second scan silently grades the first server.
     const collidingPairs: Array<[string, string]> = [
@@ -73,14 +75,14 @@ describe("deriveScoreServerName", () => {
       ],
     ];
     for (const [left, right] of collidingPairs) {
-      expect(deriveScoreServerName(left)).not.toBe(
-        deriveScoreServerName(right)
+      expect(await deriveScoreServerName(left)).not.toBe(
+        await deriveScoreServerName(right)
       );
     }
   });
 
-  it("bounds the length so a pathological URL cannot become the label", () => {
-    const name = deriveScoreServerName(
+  it("bounds the length so a pathological URL cannot become the label", async () => {
+    const name = await deriveScoreServerName(
       `https://example.com/${"segment/".repeat(50)}mcp`
     );
     expect(name.length).toBeLessThanOrEqual(64);

--- a/mcpjam-inspector/client/src/components/score/__tests__/score-server-name.test.ts
+++ b/mcpjam-inspector/client/src/components/score/__tests__/score-server-name.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { deriveScoreServerName } from "../score-server-name";
+
+/**
+ * The derived name is what `buildServerRequest` resolves against
+ * `serverIdsByName`, so determinism is the whole requirement: the same URL
+ * twice must land on the same row instead of piling up duplicates in a
+ * guest's project.
+ */
+describe("deriveScoreServerName", () => {
+  it("is stable for the same URL", () => {
+    expect(deriveScoreServerName("https://mcp.example.com/mcp")).toBe(
+      deriveScoreServerName("https://mcp.example.com/mcp")
+    );
+  });
+
+  it("ignores the universal /mcp and /sse endpoint suffixes", () => {
+    // These say nothing about WHICH server this is.
+    expect(deriveScoreServerName("https://mcp.example.com/mcp")).toBe(
+      "mcp.example.com"
+    );
+    expect(deriveScoreServerName("https://mcp.example.com/sse")).toBe(
+      "mcp.example.com"
+    );
+    expect(deriveScoreServerName("https://mcp.example.com/mcp/")).toBe(
+      "mcp.example.com"
+    );
+  });
+
+  it("keeps a path that actually distinguishes two servers on one host", () => {
+    expect(deriveScoreServerName("https://example.com/team-a/mcp")).toBe(
+      "example.com-team-a-mcp"
+    );
+    expect(deriveScoreServerName("https://example.com/team-a/mcp")).not.toBe(
+      deriveScoreServerName("https://example.com/team-b/mcp")
+    );
+  });
+
+  it("drops a leading www so the label reads like the product", () => {
+    expect(deriveScoreServerName("https://www.example.com/mcp")).toBe(
+      "example.com"
+    );
+  });
+
+  it("produces a safe slug from hostile input", () => {
+    const name = deriveScoreServerName("https://ex ample.com/a b/../c?x=1#y");
+    expect(name).toMatch(/^[a-z0-9.-]+$/);
+    expect(name.startsWith("-")).toBe(false);
+    expect(name.endsWith("-")).toBe(false);
+  });
+
+  it("never returns an empty name", () => {
+    expect(deriveScoreServerName("")).toBe("mcp-server");
+    expect(deriveScoreServerName("!!!").length).toBeGreaterThan(0);
+  });
+
+  it("bounds the length so a pathological URL cannot become the label", () => {
+    const name = deriveScoreServerName(
+      `https://example.com/${"segment/".repeat(50)}mcp`
+    );
+    expect(name.length).toBeLessThanOrEqual(64);
+  });
+});

--- a/mcpjam-inspector/client/src/components/score/__tests__/score-server-name.test.ts
+++ b/mcpjam-inspector/client/src/components/score/__tests__/score-server-name.test.ts
@@ -16,20 +16,21 @@ describe("deriveScoreServerName", () => {
 
   it("ignores the universal /mcp and /sse endpoint suffixes", () => {
     // These say nothing about WHICH server this is.
-    expect(deriveScoreServerName("https://mcp.example.com/mcp")).toBe(
-      "mcp.example.com"
+    // The readable part drops the suffix; the digest still distinguishes them.
+    expect(deriveScoreServerName("https://mcp.example.com/mcp")).toMatch(
+      /^mcp-example-com-[a-z0-9]+$/
     );
-    expect(deriveScoreServerName("https://mcp.example.com/sse")).toBe(
-      "mcp.example.com"
+    expect(deriveScoreServerName("https://mcp.example.com/sse")).toMatch(
+      /^mcp-example-com-/
     );
     expect(deriveScoreServerName("https://mcp.example.com/mcp/")).toBe(
-      "mcp.example.com"
+      deriveScoreServerName("https://mcp.example.com/mcp")
     );
   });
 
   it("keeps a path that actually distinguishes two servers on one host", () => {
-    expect(deriveScoreServerName("https://example.com/team-a/mcp")).toBe(
-      "example.com-team-a-mcp"
+    expect(deriveScoreServerName("https://example.com/team-a/mcp")).toMatch(
+      /^example-com-team-a-mcp-/
     );
     expect(deriveScoreServerName("https://example.com/team-a/mcp")).not.toBe(
       deriveScoreServerName("https://example.com/team-b/mcp")
@@ -37,21 +38,45 @@ describe("deriveScoreServerName", () => {
   });
 
   it("drops a leading www so the label reads like the product", () => {
-    expect(deriveScoreServerName("https://www.example.com/mcp")).toBe(
-      "example.com"
+    expect(deriveScoreServerName("https://www.example.com/mcp")).toMatch(
+      /^example-com-/
     );
   });
 
   it("produces a safe slug from hostile input", () => {
     const name = deriveScoreServerName("https://ex ample.com/a b/../c?x=1#y");
-    expect(name).toMatch(/^[a-z0-9.-]+$/);
+    // Matches the product's own `slugifyName` shape.
+    expect(name).toMatch(/^[a-z0-9-]+$/);
     expect(name.startsWith("-")).toBe(false);
     expect(name.endsWith("-")).toBe(false);
   });
 
   it("never returns an empty name", () => {
-    expect(deriveScoreServerName("")).toBe("mcp-server");
+    expect(deriveScoreServerName("")).toMatch(/^mcp-server-/);
     expect(deriveScoreServerName("!!!").length).toBeGreaterThan(0);
+  });
+
+  it("keeps servers apart that the readable slug alone would merge", () => {
+    // Each pair collides on the slug and must NOT collide on the name — a
+    // merged name means the second scan silently grades the first server.
+    const collidingPairs: Array<[string, string]> = [
+      // Port is not part of the hostname.
+      ["https://mcp.example.com:8443/mcp", "https://mcp.example.com/mcp"],
+      // Punctuation collapses in the slug.
+      ["https://example.com/team a/mcp", "https://example.com/team-a/mcp"],
+      // Scheme alone.
+      ["https://mcp.example.com/mcp", "http://mcp.example.com/mcp"],
+      // Query string alone.
+      [
+        "https://mcp.example.com/mcp?tenant=a",
+        "https://mcp.example.com/mcp?tenant=b",
+      ],
+    ];
+    for (const [left, right] of collidingPairs) {
+      expect(deriveScoreServerName(left)).not.toBe(
+        deriveScoreServerName(right)
+      );
+    }
   });
 
   it("bounds the length so a pathological URL cannot become the label", () => {

--- a/mcpjam-inspector/client/src/components/score/score-run-resume.ts
+++ b/mcpjam-inspector/client/src/components/score/score-run-resume.ts
@@ -1,0 +1,73 @@
+/**
+ * The score page's own resume record.
+ *
+ * The hosted-OAuth pending marker restores the SERVER's authorization state —
+ * it knows nothing about a run being in flight. So when a visitor is bounced
+ * to an authorization server and comes back, the marker is enough to finish
+ * the connection and nothing more: the score run they started would simply be
+ * gone, and they would face an empty form again with no idea what happened.
+ *
+ * This record is the missing half: what they were scoring and that they meant
+ * to score it. sessionStorage, not localStorage — a run intent belongs to the
+ * tab that started it, and should not resurrect in a window opened tomorrow.
+ */
+
+const STORAGE_KEY = "mcpjam-score-run-resume";
+/** Long enough for a real authorization detour, short enough not to haunt. */
+const TTL_MS = 15 * 60_000;
+
+export interface ScoreRunResumeRecord {
+  serverUrl: string;
+  serverName: string;
+  startedAt: number;
+}
+
+export function writeScoreRunResume(
+  record: Omit<ScoreRunResumeRecord, "startedAt">
+): void {
+  try {
+    sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...record, startedAt: Date.now() })
+    );
+  } catch {
+    // Storage unavailable (private mode, quota). The run is simply not
+    // resumable — the form still works.
+  }
+}
+
+export function readScoreRunResume(): ScoreRunResumeRecord | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ScoreRunResumeRecord> | null;
+    if (
+      !parsed ||
+      typeof parsed.serverUrl !== "string" ||
+      typeof parsed.serverName !== "string" ||
+      typeof parsed.startedAt !== "number"
+    ) {
+      clearScoreRunResume();
+      return null;
+    }
+    if (Date.now() - parsed.startedAt > TTL_MS) {
+      clearScoreRunResume();
+      return null;
+    }
+    return {
+      serverUrl: parsed.serverUrl,
+      serverName: parsed.serverName,
+      startedAt: parsed.startedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearScoreRunResume(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}

--- a/mcpjam-inspector/client/src/components/score/score-server-name.ts
+++ b/mcpjam-inspector/client/src/components/score/score-server-name.ts
@@ -6,25 +6,29 @@
  * row rather than pile up duplicates in the guest's project.
  */
 /**
- * A short, stable digest of the canonical URL.
+ * A short, collision-RESISTANT digest of the canonical URL.
  *
  * The readable slug is lossy on purpose (punctuation collapses, length is
  * bounded), and `createServerIfMissing` returns the EXISTING row for a name it
- * already has. Without a digest, `https://mcp.example.com:8443/mcp` and
- * `https://mcp.example.com/mcp` derive the same name, the second scan silently
- * reuses the first row, and the visitor gets a score for a server we never
- * dialed — labelled with the URL they pasted. That is the one failure mode
- * this whole page cannot have.
+ * already has. So if two distinct URLs derive one name, the second scan
+ * silently reuses the first row and the visitor gets a score for a server we
+ * never dialed — labelled with the URL they pasted. That is the one failure
+ * mode this page cannot have.
+ *
+ * SHA-256 rather than a cheap 32-bit mixer: the input is user-supplied, and a
+ * short non-cryptographic hash is craftable. Truncated to 12 hex characters —
+ * 48 bits, which needs ~16M distinct URLs before a chance collision and offers
+ * no shortcut to a deliberate one.
  */
-function urlDigest(canonicalUrl: string): string {
-  let hash = 0;
-  for (const char of canonicalUrl) {
-    hash = (hash * 31 + char.charCodeAt(0)) | 0;
-  }
-  return (hash >>> 0).toString(36);
+async function urlDigest(canonicalUrl: string): Promise<string> {
+  const bytes = new TextEncoder().encode(canonicalUrl);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest).slice(0, 6))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }
 
-export function deriveScoreServerName(rawUrl: string): string {
+export async function deriveScoreServerName(rawUrl: string): Promise<string> {
   const trimmed = rawUrl.trim();
   let host = "";
   let path = "";
@@ -57,9 +61,10 @@ export function deriveScoreServerName(rawUrl: string): string {
     .replace(/-+/g, "-")
     .replace(/^-+|-+$/g, "");
 
-  const suffix = urlDigest(canonical);
-  // The slug is for humans; the suffix is what keeps two targets apart.
+  const suffix = await urlDigest(canonical);
+  // The slug is for humans; the suffix is what keeps two targets apart. The
+  // readable part is budgeted so the whole name still fits 64 characters.
   return slug
-    ? `${slug.slice(0, 56).replace(/-+$/, "")}-${suffix}`
+    ? `${slug.slice(0, 50).replace(/-+$/, "")}-${suffix}`
     : `mcp-server-${suffix}`;
 }

--- a/mcpjam-inspector/client/src/components/score/score-server-name.ts
+++ b/mcpjam-inspector/client/src/components/score/score-server-name.ts
@@ -15,15 +15,16 @@
  * never dialed — labelled with the URL they pasted. That is the one failure
  * mode this page cannot have.
  *
- * SHA-256 rather than a cheap 32-bit mixer: the input is user-supplied, and a
- * short non-cryptographic hash is craftable. Truncated to 12 hex characters —
- * 48 bits, which needs ~16M distinct URLs before a chance collision and offers
- * no shortcut to a deliberate one.
+ * SHA-256 rather than a cheap mixer: the input is user-supplied, and a short
+ * non-cryptographic hash is craftable. Truncated to 96 bits — a birthday
+ * search is ~2^48 work, which is out of reach for the payoff (mis-scoring a
+ * server inside your own guest project). 48 bits would have left that search
+ * at ~2^24, which is not a barrier at all.
  */
 async function urlDigest(canonicalUrl: string): Promise<string> {
   const bytes = new TextEncoder().encode(canonicalUrl);
   const digest = await crypto.subtle.digest("SHA-256", bytes);
-  return Array.from(new Uint8Array(digest).slice(0, 6))
+  return Array.from(new Uint8Array(digest).slice(0, 12))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
 }
@@ -63,8 +64,9 @@ export async function deriveScoreServerName(rawUrl: string): Promise<string> {
 
   const suffix = await urlDigest(canonical);
   // The slug is for humans; the suffix is what keeps two targets apart. The
-  // readable part is budgeted so the whole name still fits 64 characters.
+  // readable part is budgeted so the whole name still fits 64 characters
+  // (24 hex chars of digest + separator).
   return slug
-    ? `${slug.slice(0, 50).replace(/-+$/, "")}-${suffix}`
+    ? `${slug.slice(0, 39).replace(/-+$/, "")}-${suffix}`
     : `mcp-server-${suffix}`;
 }

--- a/mcpjam-inspector/client/src/components/score/score-server-name.ts
+++ b/mcpjam-inspector/client/src/components/score/score-server-name.ts
@@ -1,0 +1,32 @@
+/**
+ * Turn a pasted MCP server URL into a stable, human-readable server name.
+ *
+ * The name is what `buildServerRequest` resolves against `serverIdsByName`, so
+ * it has to be deterministic: pasting the same URL twice must find the same
+ * row rather than pile up duplicates in the guest's project.
+ */
+export function deriveScoreServerName(rawUrl: string): string {
+  let host = "";
+  let path = "";
+  try {
+    const parsed = new URL(rawUrl.trim());
+    host = parsed.hostname.replace(/^www\./, "");
+    path = parsed.pathname.replace(/\/+$/, "");
+  } catch {
+    host = rawUrl.trim();
+  }
+
+  // `/mcp` and `/sse` are near-universal endpoint suffixes and say nothing
+  // about WHICH server this is, so they earn no room in the label. Any other
+  // path does distinguish two servers on one host, and is kept.
+  const meaningfulPath =
+    path && !/^\/(mcp|sse)$/i.test(path) ? path.replace(/\//g, "-") : "";
+
+  const slug = `${host}${meaningfulPath}`
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "");
+
+  return slug ? slug.slice(0, 64) : "mcp-server";
+}

--- a/mcpjam-inspector/client/src/components/score/score-server-name.ts
+++ b/mcpjam-inspector/client/src/components/score/score-server-name.ts
@@ -5,15 +5,42 @@
  * it has to be deterministic: pasting the same URL twice must find the same
  * row rather than pile up duplicates in the guest's project.
  */
+/**
+ * A short, stable digest of the canonical URL.
+ *
+ * The readable slug is lossy on purpose (punctuation collapses, length is
+ * bounded), and `createServerIfMissing` returns the EXISTING row for a name it
+ * already has. Without a digest, `https://mcp.example.com:8443/mcp` and
+ * `https://mcp.example.com/mcp` derive the same name, the second scan silently
+ * reuses the first row, and the visitor gets a score for a server we never
+ * dialed — labelled with the URL they pasted. That is the one failure mode
+ * this whole page cannot have.
+ */
+function urlDigest(canonicalUrl: string): string {
+  let hash = 0;
+  for (const char of canonicalUrl) {
+    hash = (hash * 31 + char.charCodeAt(0)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
 export function deriveScoreServerName(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
   let host = "";
   let path = "";
+  let canonical = trimmed;
   try {
-    const parsed = new URL(rawUrl.trim());
+    const parsed = new URL(trimmed);
     host = parsed.hostname.replace(/^www\./, "");
+    // The port is part of a server's identity even though it never reads like
+    // part of its name.
+    if (parsed.port) host = `${host}-${parsed.port}`;
     path = parsed.pathname.replace(/\/+$/, "");
+    // Scheme and search included: two endpoints differing only there are two
+    // servers, and only the digest can still tell them apart.
+    canonical = `${parsed.protocol}//${parsed.host}${path}${parsed.search}`;
   } catch {
-    host = rawUrl.trim();
+    host = trimmed;
   }
 
   // `/mcp` and `/sse` are near-universal endpoint suffixes and say nothing
@@ -22,11 +49,17 @@ export function deriveScoreServerName(rawUrl: string): string {
   const meaningfulPath =
     path && !/^\/(mcp|sse)$/i.test(path) ? path.replace(/\//g, "-") : "";
 
+  // Alphanumeric + hyphen only, matching the `slugifyName` convention the
+  // product already uses when it creates server rows.
   const slug = `${host}${meaningfulPath}`
     .toLowerCase()
-    .replace(/[^a-z0-9.-]+/g, "-")
+    .replace(/[^a-z0-9]+/g, "-")
     .replace(/-+/g, "-")
-    .replace(/^[-.]+|[-.]+$/g, "");
+    .replace(/^-+|-+$/g, "");
 
-  return slug ? slug.slice(0, 64) : "mcp-server";
+  const suffix = urlDigest(canonical);
+  // The slug is for humans; the suffix is what keeps two targets apart.
+  return slug
+    ? `${slug.slice(0, 56).replace(/-+$/, "")}-${suffix}`
+    : `mcp-server-${suffix}`;
 }

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
@@ -11,6 +11,7 @@ import { getStoredTokens, initiateOAuth } from "@/lib/oauth/mcp-oauth";
 import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
 import {
+  HOSTED_OAUTH_PENDING_STORAGE_KEY,
   clearHostedOAuthPendingState,
   matchesHostedOAuthServerIdentity,
   writeHostedOAuthPendingMarker,
@@ -245,7 +246,13 @@ export function useHostedOAuthGate({
     () => servers.filter((server) => server.useOAuth),
     [servers]
   );
-  const isVaultBacked = isAuthenticated || !!chatboxId;
+  // Where does the token LAND? Vault-backed surfaces complete server-side, so
+  // nothing is written to localStorage and polling for it would only burn the
+  // resume window before reporting a token that was never missing. The score
+  // surface completes through `completeHostedOAuthCallback` with a guest
+  // bearer — server-side, exactly like a chatbox guest — so it belongs here
+  // even though it has neither a signed-in user nor a chatbox.
+  const isVaultBacked = isAuthenticated || !!chatboxId || surface === "score";
   const verifyVaultCredentialOnLoad = isAuthenticated;
   const [oauthStateByServerId, setOAuthStateByServerId] = useState<
     Record<string, HostedOAuthState>
@@ -466,7 +473,19 @@ export function useHostedOAuthGate({
         accessVersion: Number.isFinite(accessVersion) ? accessVersion : null,
         returnPath,
       });
-      localStorage.setItem(pendingKey, "true");
+      // The sentinel is a legacy boolean; the structured marker written just
+      // above is the real state. A caller that names the marker's own key would
+      // overwrite that JSON with `"true"`, and the marker reader — which
+      // requires an object — would clear it and strand the callback. Refuse the
+      // write rather than destroy the marker: the sentinel is redundant, the
+      // marker is not.
+      if (pendingKey === HOSTED_OAUTH_PENDING_STORAGE_KEY) {
+        console.error(
+          "useHostedOAuthGate: pendingKey must not be the hosted marker key; ignoring the sentinel write."
+        );
+      } else {
+        localStorage.setItem(pendingKey, "true");
+      }
       localStorage.setItem("mcp-oauth-return-hash", returnPath);
 
       const protocolSelection =

--- a/mcpjam-inspector/client/src/hooks/use-conformance-run.ts
+++ b/mcpjam-inspector/client/src/hooks/use-conformance-run.ts
@@ -1,0 +1,651 @@
+/**
+ * One conformance run — all four suites, their per-suite scores, and the
+ * pooled headline — as a hook.
+ *
+ * This logic grew up inside `ConformancePanel` and now has a second consumer
+ * (the score.mcpjam.com surface). Two copies would drift on exactly the parts
+ * that must not: what "done" means per suite, which suites a transport can
+ * run, and how the headline number is pooled. Rendering deliberately stays
+ * with the panel — this hook owns run state and nothing visual.
+ *
+ * Two OAuth flows exist in this codebase and they are NOT the same thing:
+ *
+ *   - The OAuth *conformance suite* (here) re-runs discovery/DCR/PKCE against
+ *     the target in order to GRADE it, and drives its own popup +
+ *     postMessage/BroadcastChannel callback.
+ *   - Connect-OAuth (`use-hosted-oauth-gate`) authorizes a connection so the
+ *     other three suites can run at all, via a full-page redirect.
+ *
+ * Only the first lives here.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  MCPConformanceResult,
+  MCPAppsConformanceResult,
+  MCPTasksConformanceResult,
+} from "@mcpjam/sdk";
+// Browser-safe SDK entry — the top-level `@mcpjam/sdk` pulls Node-only
+// transitive deps that break the Vite browser bundle.
+import {
+  canRunConformance,
+  pooledConformanceScore,
+  scoreFromAppsResult,
+  scoreFromOAuthResult,
+  scoreFromProtocolResult,
+  scoreFromTasksResult,
+  type ConformanceScore,
+  type McpProtocolVersion,
+} from "@mcpjam/sdk/browser";
+import type { ServerWithName } from "@/hooks/use-app-state";
+import type { OAuthConformanceStartResult } from "@/lib/apis/mcp-conformance-api";
+import {
+  completeOAuthConformance,
+  runAppsConformance,
+  runProtocolConformance,
+  runTasksConformance,
+  startOAuthConformance,
+  submitOAuthConformanceCode,
+} from "@/lib/apis/mcp-conformance-api";
+import { deriveOAuthProfileFromServer } from "@/components/oauth/utils";
+
+export type SuiteStatus =
+  | "idle"
+  | "running"
+  /**
+   * The OAuth suite reached the authorization step and is holding: it has a
+   * session and a URL, and is waiting for an explicit go-ahead. Only reachable
+   * under `deferOAuthAuthorization`.
+   */
+  | "needs-authorization"
+  | "done"
+  | "error"
+  | "unavailable";
+
+/** "auto" ⇒ no pin: the run adopts whatever version the server negotiates. */
+export type ProtocolVersionPin = "auto" | McpProtocolVersion;
+
+export interface SuiteState {
+  status: SuiteStatus;
+  error?: string;
+  unavailableReason?: string;
+  /**
+   * The verdict of a finished run. "Done" only says the run ended — a suite
+   * that finished with failures must not read as green.
+   */
+  verdict?: "passed" | "failed" | "incomplete";
+}
+
+export interface ProtocolSuiteState extends SuiteState {
+  result?: MCPConformanceResult;
+}
+
+export interface AppsSuiteState extends SuiteState {
+  result?: MCPAppsConformanceResult;
+}
+
+export interface TasksSuiteState extends SuiteState {
+  result?: MCPTasksConformanceResult;
+}
+
+export interface OAuthSuiteState extends SuiteState {
+  result?: OAuthConformanceStartResult["result"];
+  sessionId?: string;
+  waitingForAuth?: boolean;
+  /**
+   * Set only while `status === "needs-authorization"`: the URL the explicit
+   * authorize step will open.
+   */
+  authorizationUrl?: string;
+}
+
+export function isHttpServer(server: ServerWithName): boolean {
+  // `server.config` is typed required but can be undefined during hosted
+  // hydration — guard before using the `in` operator to avoid a TypeError.
+  return !!server.config && "url" in server.config;
+}
+
+function suiteState(
+  suite: "protocol" | "oauth" | "apps" | "tasks",
+  server: ServerWithName
+): SuiteState {
+  // The SDK's `canRunConformance` is the source of truth for which suites
+  // support which transports. It handles null/undefined configs gracefully.
+  const support = canRunConformance(
+    suite,
+    server.config as Parameters<typeof canRunConformance>[1]
+  );
+  return support.supported
+    ? { status: "idle" }
+    : { status: "unavailable", unavailableReason: support.reason };
+}
+
+export function createProtocolState(
+  server: ServerWithName
+): ProtocolSuiteState {
+  return suiteState("protocol", server);
+}
+
+export function createAppsState(server: ServerWithName): AppsSuiteState {
+  return suiteState("apps", server);
+}
+
+export function createTasksState(server: ServerWithName): TasksSuiteState {
+  return suiteState("tasks", server);
+}
+
+export function createOAuthState(server: ServerWithName): OAuthSuiteState {
+  return suiteState("oauth", server);
+}
+
+/** Every suite reports the same three-value outcome; render it, don't flatten it. */
+function verdictOf(result: {
+  outcome?: string;
+  passed?: boolean;
+}): "passed" | "failed" | "incomplete" {
+  if (result.outcome === "incomplete") return "incomplete";
+  return result.passed ? "passed" : "failed";
+}
+
+/**
+ * A server that requires no authorization has no OAuth obligations to test —
+ * authorization is OPTIONAL in every MCP revision — so the suite reports
+ * `not-applicable`. That is not a result to render as red: it reuses the same
+ * "unavailable" treatment as a transport that cannot run the suite.
+ */
+export function oauthStateFromResult(
+  result: NonNullable<OAuthConformanceStartResult["result"]>
+): OAuthSuiteState {
+  if (result.outcome === "not-applicable") {
+    return {
+      status: "unavailable",
+      unavailableReason: result.summary,
+      // Kept so the score pool can see the run: a not-applicable OAuth run
+      // contributes its "nothing to score here" tally instead of vanishing.
+      result,
+    };
+  }
+  return {
+    status: "done",
+    result,
+    // OAuth reports the same three-value verdict as the other suites (plus its
+    // own not-applicable, handled above), so an incomplete flow is badged
+    // amber rather than flattened to failed.
+    verdict: verdictOf(result),
+  };
+}
+
+export interface UseConformanceRunOptions {
+  server: ServerWithName;
+  /**
+   * When true, a run that reaches OAuth's authorization step PARKS at
+   * `needs-authorization` instead of opening the popup, and the caller decides
+   * when (or whether) to proceed via `authorizeOAuth`.
+   *
+   * The panel leaves this false: an operator who pressed "Run" in the product
+   * asked for the whole run, popup included. The score page turns it on,
+   * because an unrequested popup on a public landing page is a different
+   * thing entirely — there, OAuth is an opt-in "authorize to include OAuth in
+   * your score" step, and skipping it shows as *not scored*, never a
+   * deduction.
+   */
+  deferOAuthAuthorization?: boolean;
+}
+
+export interface UseConformanceRunResult {
+  protocol: ProtocolSuiteState;
+  apps: AppsSuiteState;
+  tasks: TasksSuiteState;
+  oauth: OAuthSuiteState;
+  versionPin: ProtocolVersionPin;
+  setVersionPin: (pin: ProtocolVersionPin) => void;
+  /** Bumped on every fresh run — a render key for per-suite disclosure state. */
+  runVersion: number;
+  runAll: () => Promise<void>;
+  /** Open the parked OAuth authorization popup. No-op unless parked. */
+  authorizeOAuth: () => void;
+  protocolScore?: ConformanceScore;
+  appsScore?: ConformanceScore;
+  tasksScore?: ConformanceScore;
+  oauthScore?: ConformanceScore;
+  pooledScore?: ConformanceScore;
+  /** True when OAuth produced a score object with nothing applicable in it. */
+  oauthNotScored: boolean;
+  isRunning: boolean;
+}
+
+export function useConformanceRun({
+  server,
+  deferOAuthAuthorization = false,
+}: UseConformanceRunOptions): UseConformanceRunResult {
+  const httpServer = isHttpServer(server);
+  const [protocol, setProtocol] = useState<ProtocolSuiteState>(() =>
+    createProtocolState(server)
+  );
+  const [apps, setApps] = useState<AppsSuiteState>(() =>
+    createAppsState(server)
+  );
+  const [tasks, setTasks] = useState<TasksSuiteState>(() =>
+    createTasksState(server)
+  );
+  const [oauth, setOAuth] = useState<OAuthSuiteState>(() =>
+    createOAuthState(server)
+  );
+  const [versionPin, setVersionPin] = useState<ProtocolVersionPin>("auto");
+  const [runVersion, setRunVersion] = useState(0);
+
+  const activeServerNameRef = useRef(server.name);
+  const latestRunTokenRef = useRef(0);
+  const oauthListenerCleanupRef = useRef<(() => void) | null>(null);
+  /** The parked authorization step, when `deferOAuthAuthorization` holds one. */
+  const pendingOAuthRef = useRef<{
+    sessionId: string;
+    authorizationUrl: string;
+    runToken: number;
+    serverName: string;
+  } | null>(null);
+
+  const clearOAuthListeners = useCallback(() => {
+    oauthListenerCleanupRef.current?.();
+    oauthListenerCleanupRef.current = null;
+  }, []);
+
+  const beginRun = useCallback(() => {
+    latestRunTokenRef.current += 1;
+    pendingOAuthRef.current = null;
+    clearOAuthListeners();
+    return latestRunTokenRef.current;
+  }, [clearOAuthListeners]);
+
+  const isRunActive = useCallback(
+    (runToken: number, serverName: string) =>
+      latestRunTokenRef.current === runToken &&
+      activeServerNameRef.current === serverName,
+    []
+  );
+
+  const resetStates = useCallback(
+    (serverName?: string) => {
+      const effectiveServerName = serverName ?? activeServerNameRef.current;
+      latestRunTokenRef.current += 1;
+      pendingOAuthRef.current = null;
+      clearOAuthListeners();
+      setRunVersion((value) => value + 1);
+      setProtocol(createProtocolState(server));
+      setApps(createAppsState(server));
+      setTasks(createTasksState(server));
+      setOAuth(createOAuthState(server));
+      activeServerNameRef.current = effectiveServerName;
+    },
+    [clearOAuthListeners, server]
+  );
+
+  useEffect(() => {
+    resetStates(server.name);
+  }, [server.name, resetStates]);
+
+  useEffect(
+    () => () => {
+      latestRunTokenRef.current += 1;
+      clearOAuthListeners();
+    },
+    [clearOAuthListeners]
+  );
+
+  const runProtocol = useCallback(
+    async (runToken: number, serverName: string) => {
+      if (!httpServer) return;
+      setProtocol({ status: "running" });
+      try {
+        const { result } = await runProtocolConformance(serverName, {
+          protocolVersion: versionPin === "auto" ? undefined : versionPin,
+        });
+        if (!isRunActive(runToken, serverName)) return;
+        setProtocol({ status: "done", result, verdict: verdictOf(result) });
+      } catch (err) {
+        if (!isRunActive(runToken, serverName)) return;
+        setProtocol({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [httpServer, isRunActive, versionPin]
+  );
+
+  const runApps = useCallback(
+    async (runToken: number, serverName: string) => {
+      setApps({ status: "running" });
+      try {
+        const { result } = await runAppsConformance(serverName);
+        if (!isRunActive(runToken, serverName)) return;
+        setApps({ status: "done", result, verdict: verdictOf(result) });
+      } catch (err) {
+        if (!isRunActive(runToken, serverName)) return;
+        setApps({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [isRunActive]
+  );
+
+  const runTasks = useCallback(
+    async (runToken: number, serverName: string) => {
+      setTasks({ status: "running" });
+      try {
+        const { result } = await runTasksConformance(serverName);
+        if (!isRunActive(runToken, serverName)) return;
+        // The tasks suite reports a real third outcome: checks that apply but
+        // could not be exercised leave the run incomplete, never passing.
+        setTasks({ status: "done", result, verdict: verdictOf(result) });
+      } catch (err) {
+        if (!isRunActive(runToken, serverName)) return;
+        setTasks({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [isRunActive]
+  );
+
+  const pollOAuthComplete = useCallback(
+    async (sessionId: string, runToken: number, serverName: string) => {
+      const MAX_POLLS = 10;
+      for (let i = 0; i < MAX_POLLS; i++) {
+        try {
+          const poll = await completeOAuthConformance(sessionId);
+          if (!isRunActive(runToken, serverName)) return;
+          if (poll.phase === "complete" && poll.result) {
+            setOAuth(oauthStateFromResult(poll.result));
+            return;
+          }
+        } catch (err) {
+          if (!isRunActive(runToken, serverName)) return;
+          setOAuth({
+            status: "error",
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return;
+        }
+      }
+
+      if (!isRunActive(runToken, serverName)) return;
+      setOAuth({ status: "error", error: "OAuth conformance timed out" });
+    },
+    [isRunActive]
+  );
+
+  const handleOAuthCallback = useCallback(
+    async (
+      sessionId: string,
+      code: string,
+      runToken: number,
+      serverName: string,
+      state?: string
+    ) => {
+      try {
+        await submitOAuthConformanceCode({ sessionId, code, state });
+        if (!isRunActive(runToken, serverName)) return;
+        setOAuth((prev) => ({
+          ...prev,
+          waitingForAuth: false,
+          status: "running",
+        }));
+        await pollOAuthComplete(sessionId, runToken, serverName);
+      } catch (err) {
+        if (!isRunActive(runToken, serverName)) return;
+        setOAuth({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [isRunActive, pollOAuthComplete]
+  );
+
+  /**
+   * Open the authorization popup and listen for the code coming back.
+   *
+   * Both local and hosted modes deliver the code through `/oauth/authorize`,
+   * so there is no polling here — `handleOAuthCallback` owns everything after
+   * the code arrives. Two channels are wired because a popup opened
+   * cross-origin may only be able to reach one of them.
+   */
+  const beginOAuthAuthorization = useCallback(
+    (
+      sessionId: string,
+      authorizationUrl: string,
+      runToken: number,
+      serverName: string
+    ) => {
+      setOAuth({ status: "running", sessionId, waitingForAuth: true });
+
+      window.open(
+        authorizationUrl,
+        "oauth_conformance_auth",
+        "width=600,height=700,scrollbars=yes"
+      );
+
+      const cleanupFns: Array<() => void> = [];
+      const cleanup = () => {
+        for (const fn of cleanupFns) fn();
+        if (oauthListenerCleanupRef.current === cleanup) {
+          oauthListenerCleanupRef.current = null;
+        }
+      };
+      oauthListenerCleanupRef.current = cleanup;
+
+      const onCode = (data: { code: string; state?: string }) => {
+        cleanup();
+        void handleOAuthCallback(
+          sessionId,
+          data.code,
+          runToken,
+          serverName,
+          data.state
+        );
+      };
+
+      const handleMessage = (event: MessageEvent) => {
+        if (event.data?.type !== "OAUTH_CALLBACK" || !event.data?.code) return;
+        onCode(event.data);
+      };
+
+      window.addEventListener("message", handleMessage);
+      cleanupFns.push(() =>
+        window.removeEventListener("message", handleMessage)
+      );
+
+      try {
+        const channel = new BroadcastChannel("oauth_callback_channel");
+        channel.onmessage = (event) => {
+          if (event.data?.type !== "OAUTH_CALLBACK" || !event.data?.code) {
+            return;
+          }
+          onCode(event.data);
+        };
+        cleanupFns.push(() => channel.close());
+      } catch {
+        // BroadcastChannel not available
+      }
+    },
+    [handleOAuthCallback]
+  );
+
+  const runOAuth = useCallback(
+    async (runToken: number, currentServer: ServerWithName) => {
+      if (!isHttpServer(currentServer)) return;
+
+      const serverName = currentServer.name;
+      setOAuth({ status: "running" });
+
+      try {
+        const profile = deriveOAuthProfileFromServer(currentServer);
+        // Always send callbackOrigin — both local and hosted modes redirect
+        // back to the inspector's own `/oauth/callback/debug` page so the
+        // server can surface the code back to the SDK runner.
+        const callbackOrigin = window.location.origin;
+
+        // A run-scoped version pin beats the stored OAuth-tab profile, and
+        // must be sent even when the profile is otherwise empty (the route
+        // falls back to its own default version when no profile arrives).
+        const pinnedVersion = versionPin === "auto" ? undefined : versionPin;
+        const baseProfile = profile.serverUrl
+          ? {
+              serverUrl: profile.serverUrl,
+              protocolVersion: profile.protocolVersion,
+              registrationStrategy: profile.registrationStrategy,
+              clientId: profile.clientId || undefined,
+              clientSecret: profile.clientSecret || undefined,
+              scopes: profile.scopes || undefined,
+              customHeaders: profile.customHeaders.length
+                ? profile.customHeaders
+                : undefined,
+            }
+          : undefined;
+
+        const startResult = await startOAuthConformance({
+          serverNameOrId: serverName,
+          oauthProfile: pinnedVersion
+            ? { ...baseProfile, protocolVersion: pinnedVersion }
+            : baseProfile,
+          callbackOrigin,
+        });
+
+        if (!isRunActive(runToken, serverName)) return;
+
+        if (startResult.phase === "complete" && startResult.result) {
+          setOAuth(oauthStateFromResult(startResult.result));
+          return;
+        }
+
+        if (
+          startResult.phase === "authorization_needed" &&
+          startResult.sessionId &&
+          startResult.authorizationUrl
+        ) {
+          const { sessionId, authorizationUrl } = startResult;
+          if (deferOAuthAuthorization) {
+            pendingOAuthRef.current = {
+              sessionId,
+              authorizationUrl,
+              runToken,
+              serverName,
+            };
+            setOAuth({
+              status: "needs-authorization",
+              sessionId,
+              authorizationUrl,
+            });
+            return;
+          }
+          beginOAuthAuthorization(
+            sessionId,
+            authorizationUrl,
+            runToken,
+            serverName
+          );
+        }
+      } catch (err) {
+        if (!isRunActive(runToken, currentServer.name)) return;
+        setOAuth({
+          status: "error",
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [beginOAuthAuthorization, deferOAuthAuthorization, isRunActive, versionPin]
+  );
+
+  const authorizeOAuth = useCallback(() => {
+    const pending = pendingOAuthRef.current;
+    if (!pending) return;
+    if (!isRunActive(pending.runToken, pending.serverName)) return;
+    pendingOAuthRef.current = null;
+    beginOAuthAuthorization(
+      pending.sessionId,
+      pending.authorizationUrl,
+      pending.runToken,
+      pending.serverName
+    );
+  }, [beginOAuthAuthorization, isRunActive]);
+
+  const runAll = useCallback(async () => {
+    const runToken = beginRun();
+    const currentServer = server;
+    const httpServerNow = isHttpServer(currentServer);
+
+    setRunVersion((value) => value + 1);
+    setProtocol(createProtocolState(currentServer));
+    setApps(createAppsState(currentServer));
+    setTasks(createTasksState(currentServer));
+    setOAuth(createOAuthState(currentServer));
+
+    const promises: Promise<void>[] = [];
+    if (httpServerNow) {
+      promises.push(runProtocol(runToken, currentServer.name));
+    }
+    promises.push(runApps(runToken, currentServer.name));
+    promises.push(runTasks(runToken, currentServer.name));
+    if (httpServerNow) {
+      promises.push(runOAuth(runToken, currentServer));
+    }
+
+    await Promise.allSettled(promises);
+  }, [beginRun, runApps, runOAuth, runProtocol, runTasks, server]);
+
+  // Scores are derived, never stored: each finished suite contributes, and
+  // the headline pools their COUNTS (not an average of suite scores), so a
+  // 0-for-9 OAuth run stays visible inside 30 protocol passes.
+  const protocolScore = useMemo(
+    () =>
+      protocol.result ? scoreFromProtocolResult(protocol.result) : undefined,
+    [protocol.result]
+  );
+  const appsScore = useMemo(
+    () => (apps.result ? scoreFromAppsResult(apps.result) : undefined),
+    [apps.result]
+  );
+  const tasksScore = useMemo(
+    () => (tasks.result ? scoreFromTasksResult(tasks.result) : undefined),
+    [tasks.result]
+  );
+  const oauthScore = useMemo(
+    () => (oauth.result ? scoreFromOAuthResult(oauth.result) : undefined),
+    [oauth.result]
+  );
+  const pooledScore = useMemo(() => {
+    const parts = [protocolScore, appsScore, tasksScore, oauthScore].filter(
+      (part): part is ConformanceScore => part !== undefined
+    );
+    return parts.length > 0 ? pooledConformanceScore(parts) : undefined;
+  }, [protocolScore, appsScore, tasksScore, oauthScore]);
+
+  const isRunning =
+    protocol.status === "running" ||
+    apps.status === "running" ||
+    tasks.status === "running" ||
+    oauth.status === "running";
+
+  return {
+    protocol,
+    apps,
+    tasks,
+    oauth,
+    versionPin,
+    setVersionPin,
+    runVersion,
+    runAll,
+    authorizeOAuth,
+    protocolScore,
+    appsScore,
+    tasksScore,
+    oauthScore,
+    pooledScore,
+    oauthNotScored: oauthScore !== undefined && oauthScore.score === null,
+    isRunning,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/use-conformance-run.ts
+++ b/mcpjam-inspector/client/src/hooks/use-conformance-run.ts
@@ -264,20 +264,33 @@ export function useConformanceRun({
     []
   );
 
+  /**
+   * The current server, read without making the reset depend on its OBJECT
+   * identity. `ServerWithName` carries mutable fields (`connectionStatus`,
+   * `lastConnectionTime`), so hosted hydration and reconnect polling hand down
+   * a fresh object for the same server mid-run. If `resetStates` changed
+   * identity with it, the effect below would re-run and discard the results of
+   * suites still in flight — the visitor would watch a finished run snap back
+   * to idle for no visible reason. Only a change of NAME is a different server.
+   */
+  const serverRef = useRef(server);
+  serverRef.current = server;
+
   const resetStates = useCallback(
     (serverName?: string) => {
       const effectiveServerName = serverName ?? activeServerNameRef.current;
+      const currentServer = serverRef.current;
       latestRunTokenRef.current += 1;
       pendingOAuthRef.current = null;
       clearOAuthListeners();
       setRunVersion((value) => value + 1);
-      setProtocol(createProtocolState(server));
-      setApps(createAppsState(server));
-      setTasks(createTasksState(server));
-      setOAuth(createOAuthState(server));
+      setProtocol(createProtocolState(currentServer));
+      setApps(createAppsState(currentServer));
+      setTasks(createTasksState(currentServer));
+      setOAuth(createOAuthState(currentServer));
       activeServerNameRef.current = effectiveServerName;
     },
-    [clearOAuthListeners, server]
+    [clearOAuthListeners]
   );
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/hooks/use-conformance-run.ts
+++ b/mcpjam-inspector/client/src/hooks/use-conformance-run.ts
@@ -293,9 +293,30 @@ export function useConformanceRun({
     [clearOAuthListeners]
   );
 
+  /**
+   * A stable key for "which target is this". Name alone is not enough: editing
+   * a server's URL or transport in place keeps the name and would leave the
+   * previous target's results — and its score — on screen. The OBJECT identity
+   * is too much (see `serverRef`); this is the middle ground that changes
+   * exactly when the thing being graded changes.
+   */
+  const serverConfigKey = useMemo(() => {
+    const config = server.config as
+      | { url?: unknown; command?: unknown; args?: unknown }
+      | undefined;
+    return JSON.stringify([
+      server.name,
+      typeof config?.url === "string" ? config.url : null,
+      typeof config?.command === "string" ? config.command : null,
+      Array.isArray(config?.args) ? config.args : null,
+    ]);
+  }, [server.name, server.config]);
+
   useEffect(() => {
     resetStates(server.name);
-  }, [server.name, resetStates]);
+    // `serverConfigKey` is the trigger; `server.name` is read through it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverConfigKey, resetStates]);
 
   useEffect(
     () => () => {

--- a/mcpjam-inspector/client/src/hooks/use-conformance-run.ts
+++ b/mcpjam-inspector/client/src/hooks/use-conformance-run.ts
@@ -306,7 +306,12 @@ export function useConformanceRun({
       | undefined;
     return JSON.stringify([
       server.name,
-      typeof config?.url === "string" ? config.url : null,
+      // Stringified, not type-narrowed: `url` is declared `string` but this
+      // codebase also builds configs with a `URL` instance (see
+      // `test/factories`). A `typeof === "string"` check maps every URL object
+      // to null, so editing the URL would not change the key and the previous
+      // target's score would stay on screen.
+      config?.url != null ? String(config.url) : null,
       typeof config?.command === "string" ? config.command : null,
       Array.isArray(config?.args) ? config.args : null,
     ]);

--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -51,6 +51,30 @@ function getPostHogBootstrap() {
     : {};
 }
 
+/**
+ * A score result link is a bearer credential — the token in `/results/<token>`
+ * is the only thing standing between a private run and anyone who has the URL.
+ * Autocapture attaches `$current_url` to every captured event, so a single
+ * click on that page would ship the credential to analytics, where it lands in
+ * logs and exports that no one thinks of as secret-bearing. Replace the token
+ * with a placeholder before anything leaves the browser; the path itself is
+ * still useful, and the token never was.
+ */
+export function scrubSensitiveUrl(value: string): string {
+  return value.replace(/(\/results\/)[^/?#]+/g, "$1[redacted]");
+}
+
+function sanitizeAnalyticsProperties(
+  properties: Record<string, any>
+): Record<string, any> {
+  for (const key of ["$current_url", "$referrer", "$pathname"]) {
+    if (typeof properties[key] === "string") {
+      properties[key] = scrubSensitiveUrl(properties[key]);
+    }
+  }
+  return properties;
+}
+
 export const options = {
   api_host: getPostHogApiHost(),
   // Toolbar/app links must point at PostHog itself once api_host is proxied.
@@ -58,6 +82,7 @@ export const options = {
   ...getPostHogBootstrap(),
   capture_pageview: false,
   person_profiles: "always" as const,
+  sanitize_properties: sanitizeAnalyticsProperties,
 
   // Optional: Set static super properties that never change
   loaded: (posthog: any) => {

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-score-surface.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-score-surface.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  HOSTED_OAUTH_PENDING_STORAGE_KEY,
+  SCORE_OAUTH_PENDING_KEY,
   clearHostedOAuthPendingMarker,
+  clearHostedOAuthPendingState,
   readHostedOAuthPendingMarker,
   resolveHostedOAuthReturnPath,
   writeHostedOAuthPendingMarker,
 } from "../hosted-oauth-callback";
+import { routePaths } from "../app-navigation";
 import {
   clearHostedOAuthResumeMarker,
   isHostedOAuthSurface,
@@ -105,5 +109,55 @@ describe("score OAuth surface", () => {
     );
     // Surface filtering still discriminates.
     expect(readHostedOAuthResumeMarker("project")).toBeNull();
+  });
+
+  /**
+   * The gate writes the structured marker and THEN writes a `"true"` sentinel
+   * to whatever `pendingKey` its caller named. Naming the marker's own key
+   * therefore destroys the marker — silently, because the reader treats an
+   * unparseable marker as "no authorization in flight" and clears it. The score
+   * page shipped with exactly that collision, and no unit test could see it
+   * because every test wrote markers directly.
+   */
+  describe("the pending sentinel and the marker are different keys", () => {
+    it("keeps the marker readable when the score sentinel is written", () => {
+      writeHostedOAuthPendingMarker({
+        surface: "score",
+        serverName: "mcp.example.com",
+        serverUrl: "https://mcp.example.com/mcp",
+        projectId: "p1",
+        serverId: "s1",
+        returnPath: routePaths.embedScore,
+      });
+      // What `authorizeServer` does immediately afterwards.
+      localStorage.setItem(SCORE_OAUTH_PENDING_KEY, "true");
+
+      const marker = readHostedOAuthPendingMarker();
+      expect(marker?.surface).toBe("score");
+      expect(marker?.serverId).toBe("s1");
+    });
+
+    it("is not the hosted marker key — writing the sentinel there erases it", () => {
+      expect(SCORE_OAUTH_PENDING_KEY).not.toBe(HOSTED_OAUTH_PENDING_STORAGE_KEY);
+
+      writeHostedOAuthPendingMarker({
+        surface: "score",
+        serverName: "mcp.example.com",
+        serverUrl: "https://mcp.example.com/mcp",
+        projectId: "p1",
+        serverId: "s1",
+        returnPath: routePaths.embedScore,
+      });
+      // The bug, reproduced: the sentinel lands on the marker's key.
+      localStorage.setItem(HOSTED_OAUTH_PENDING_STORAGE_KEY, "true");
+
+      expect(readHostedOAuthPendingMarker()).toBeNull();
+    });
+
+    it("clears the score sentinel along with the rest of the pending state", () => {
+      localStorage.setItem(SCORE_OAUTH_PENDING_KEY, "true");
+      clearHostedOAuthPendingState();
+      expect(localStorage.getItem(SCORE_OAUTH_PENDING_KEY)).toBeNull();
+    });
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-score-surface.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-score-surface.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearHostedOAuthPendingMarker,
+  readHostedOAuthPendingMarker,
+  resolveHostedOAuthReturnPath,
+  writeHostedOAuthPendingMarker,
+} from "../hosted-oauth-callback";
+import {
+  clearHostedOAuthResumeMarker,
+  isHostedOAuthSurface,
+  readHostedOAuthResumeMarker,
+  writeHostedOAuthResumeMarker,
+} from "../hosted-oauth-resume";
+
+/**
+ * The whole reason `"score"` exists as its own surface: neither of the other
+ * two can carry a score run through an OAuth redirect. "project" rewrites the
+ * return path to `/servers` (the segment is not an app tab), and "chatbox"
+ * expects a chatbox id there is none of.
+ */
+
+beforeEach(() => {
+  clearHostedOAuthPendingMarker();
+  clearHostedOAuthResumeMarker();
+});
+
+describe("score OAuth surface", () => {
+  it("is a recognized surface", () => {
+    expect(isHostedOAuthSurface("score")).toBe(true);
+    expect(isHostedOAuthSurface("project")).toBe(true);
+    expect(isHostedOAuthSurface("chatbox")).toBe(true);
+    expect(isHostedOAuthSurface("nope")).toBe(false);
+  });
+
+  it("round-trips a pending marker without collapsing /embed/score", () => {
+    writeHostedOAuthPendingMarker({
+      surface: "score",
+      serverName: "mcp.example.com",
+      serverUrl: "https://mcp.example.com/mcp",
+      projectId: "p1",
+      serverId: "s1",
+      returnPath: "/embed/score",
+    });
+
+    const marker = readHostedOAuthPendingMarker();
+    expect(marker?.surface).toBe("score");
+    expect(marker?.returnPath).toBe("/embed/score");
+  });
+
+  it("collapses the SAME path to /servers under the project surface", () => {
+    // The bug this surface exists to avoid, pinned so it cannot come back.
+    writeHostedOAuthPendingMarker({
+      surface: "project",
+      serverName: "mcp.example.com",
+      serverUrl: "https://mcp.example.com/mcp",
+      projectId: "p1",
+      serverId: "s1",
+      returnPath: "/embed/score",
+    });
+
+    expect(readHostedOAuthPendingMarker()?.returnPath).toBe("/servers");
+  });
+
+  it("returns the visitor to the runner, not to /servers", () => {
+    expect(
+      resolveHostedOAuthReturnPath({
+        surface: "score",
+        returnPath: "/embed/score",
+      })
+    ).toBe("/embed/score");
+  });
+
+  it("falls back to the runner when the return path went missing", () => {
+    expect(
+      resolveHostedOAuthReturnPath({ surface: "score", returnPath: null })
+    ).toBe("/embed/score");
+  });
+
+  it("still refuses a protocol-relative return path", () => {
+    // The carve-out is same-origin absolute paths only — never an escape
+    // hatch to another host.
+    writeHostedOAuthPendingMarker({
+      surface: "score",
+      serverName: "mcp.example.com",
+      serverUrl: "https://mcp.example.com/mcp",
+      projectId: "p1",
+      serverId: "s1",
+      returnPath: "//evil.example.com/steal",
+    });
+
+    expect(readHostedOAuthPendingMarker()?.returnPath).not.toContain(
+      "evil.example.com"
+    );
+  });
+
+  it("round-trips a resume marker on the score surface", () => {
+    writeHostedOAuthResumeMarker({
+      surface: "score",
+      serverName: "mcp.example.com",
+      serverUrl: "https://mcp.example.com/mcp",
+    });
+
+    expect(readHostedOAuthResumeMarker("score")?.serverName).toBe(
+      "mcp.example.com"
+    );
+    // Surface filtering still discriminates.
+    expect(readHostedOAuthResumeMarker("project")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/score-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/score-api.ts
@@ -1,0 +1,117 @@
+/**
+ * score.mcpjam.com persistence client.
+ *
+ * Deliberately a plain `fetch`, NOT `webPost`/`buildServerRequest`: those
+ * carry the hosted bootstrap machinery ({projectId, serverId} resolution,
+ * `BootstrapNotReadyError`) that a result page has no business needing. A
+ * `/results/<token>` visitor may have no session, no guest cookie, and no
+ * project — the token in the URL is the whole credential.
+ */
+
+import type { ConformanceScore } from "@mcpjam/sdk/browser";
+import type {
+  MCPConformanceResult,
+  MCPAppsConformanceResult,
+  MCPTasksConformanceResult,
+} from "@mcpjam/sdk";
+import type { OAuthConformanceStartResult } from "@/lib/apis/mcp-conformance-api";
+
+export type ScoreSuiteId = "protocol" | "apps" | "tasks" | "oauth";
+
+/** The flat headline stored on a run. Mirrors `ConformanceScore` minus advisories. */
+export interface ScoreSummary {
+  score: number | null;
+  outcome: "passed" | "failed" | "incomplete";
+  applicable: number;
+  passed: number;
+  failed: number;
+  couldNotRun: number;
+  notApplicable: number;
+  advisoryCount: number;
+  protocolVersion?: string;
+}
+
+export interface ScoreSuiteSummary extends ScoreSummary {
+  suiteId: ScoreSuiteId;
+}
+
+/** The full multi-suite report, stored as a blob and rendered on the result page. */
+export interface ScoreReport {
+  protocol?: MCPConformanceResult;
+  apps?: MCPAppsConformanceResult;
+  tasks?: MCPTasksConformanceResult;
+  oauth?: OAuthConformanceStartResult["result"];
+}
+
+export interface StoredScoreRun extends ScoreSummary {
+  serverUrl: string;
+  suiteSummaries: ScoreSuiteSummary[];
+  report: ScoreReport;
+  createdAt: number;
+}
+
+/** Drop the advisory bodies; the counts are what the stored row carries. */
+export function toScoreSummary(score: ConformanceScore): ScoreSummary {
+  return {
+    score: score.score,
+    outcome: score.outcome,
+    applicable: score.applicable,
+    passed: score.passed,
+    failed: score.failed,
+    couldNotRun: score.couldNotRun,
+    notApplicable: score.notApplicable,
+    advisoryCount: score.advisories.length,
+    ...(score.protocolVersion
+      ? { protocolVersion: score.protocolVersion }
+      : {}),
+  };
+}
+
+async function readError(response: Response, fallback: string) {
+  const body = (await response.json().catch(() => null)) as {
+    message?: string;
+    error?: string;
+  } | null;
+  return body?.message ?? body?.error ?? fallback;
+}
+
+export async function submitScoreRun(input: {
+  serverUrl: string;
+  summary: ScoreSummary;
+  suiteSummaries: ScoreSuiteSummary[];
+  report: ScoreReport;
+}): Promise<{ token: string }> {
+  const response = await fetch("/api/web/score/runs", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) {
+    throw new Error(await readError(response, "Could not save this run."));
+  }
+  const body = (await response.json()) as { token?: string };
+  if (!body.token) throw new Error("Could not save this run.");
+  return { token: body.token };
+}
+
+export class ScoreRunNotFoundError extends Error {}
+
+export async function fetchScoreRun(token: string): Promise<StoredScoreRun> {
+  const response = await fetch(
+    `/api/web/score/runs/${encodeURIComponent(token)}`
+  );
+  if (response.status === 404) {
+    throw new ScoreRunNotFoundError(
+      await readError(
+        response,
+        "That result link is not valid, or the run no longer exists."
+      )
+    );
+  }
+  if (!response.ok) {
+    throw new Error(await readError(response, "Could not load this result."));
+  }
+  const body = (await response.json()) as { run?: StoredScoreRun };
+  if (!body.run) throw new Error("Could not load this result.");
+  return body.run;
+}

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -25,6 +25,10 @@ export const routePaths = {
   hostCompare: "/host-compare",
   /** Chrome-less host-compare for vanity domains (caniuse.dev) — no sidebar/nav, bypasses NUX. */
   embedHostCompare: "/embed/host-compare",
+  /** Chrome-less conformance-score runner for score.mcpjam.com. */
+  embedScore: "/embed/score",
+  /** Result of one score run, addressable only by its secret link token. */
+  scoreResults: "/results",
   capabilities: "/capabilities",
   computer: "/computer",
   registry: "/registry",
@@ -86,7 +90,7 @@ export function buildChatboxSessionPath(
   // a Sessions tab over the same chatbox; the agent Swarm keeps links on
   // `/swarms` so a shared link doesn't bounce the recipient to the human
   // Chatbox surface.
-  basePath: string = routePaths.chatboxes,
+  basePath: string = routePaths.chatboxes
 ): string {
   const search = new URLSearchParams({ host: hostId, session: threadId });
   return `${basePath}?${search.toString()}`;

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -45,6 +45,16 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
     note: "Chrome-less vanity surface (caniuse.dev): no sidebar, no NUX.",
   },
   {
+    path: "embed/score",
+    kind: "special",
+    note: "Chrome-less vanity surface (score.mcpjam.com): the conformance-score runner. No sidebar, no NUX.",
+  },
+  {
+    path: "results/:runToken",
+    kind: "special",
+    note: "One score run's report. Public by link token — no session required to read it.",
+  },
+  {
     path: "capabilities/:capabilitySlug",
     kind: "screen",
     surfaceId: "host-compare",

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
@@ -32,6 +32,19 @@ export interface HostedOAuthCallbackContext extends HostedOAuthPendingMarker {}
 
 export const HOSTED_OAUTH_PENDING_STORAGE_KEY = "mcp-hosted-oauth-pending";
 
+/**
+ * The score surface's "an authorization is in flight" sentinel.
+ *
+ * It MUST be a different key from `HOSTED_OAUTH_PENDING_STORAGE_KEY`: the gate
+ * writes the structured marker to that key and then writes the literal string
+ * `"true"` to whichever `pendingKey` its caller named. Passing the marker's own
+ * key overwrites the marker with `"true"`, `readHostedOAuthPendingMarker` then
+ * fails to parse it as an object, clears it, and the whole callback round trip
+ * silently dead-ends. Chatbox has always used its own sentinel for the same
+ * reason; score needs one too.
+ */
+export const SCORE_OAUTH_PENDING_KEY = "mcp-oauth-score-pending";
+
 const HOSTED_OAUTH_PENDING_TTL_MS = 10 * 60 * 1000;
 
 export function normalizeHostedOAuthServerName(
@@ -198,6 +211,7 @@ export function clearHostedOAuthPendingMarker(): void {
 
 export function clearHostedOAuthLegacyPendingKeys(): void {
   localStorage.removeItem(CHATBOX_OAUTH_PENDING_KEY);
+  localStorage.removeItem(SCORE_OAUTH_PENDING_KEY);
 }
 
 export function clearHostedOAuthPendingState(): void {

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
@@ -1,4 +1,7 @@
-import type { HostedOAuthSurface } from "@/lib/hosted-oauth-resume";
+import {
+  isHostedOAuthSurface,
+  type HostedOAuthSurface,
+} from "@/lib/hosted-oauth-resume";
 import {
   readChatboxSession,
   CHATBOX_OAUTH_PENDING_KEY,
@@ -39,7 +42,7 @@ export function normalizeHostedOAuthServerName(
 
 function normalizeHostedOAuthReturnPath(
   returnTarget?: string | null,
-  surface?: HostedOAuthSurface,
+  surface?: HostedOAuthSurface
 ): string | null {
   const trimmed = returnTarget?.trim() ?? "";
   if (!trimmed) {
@@ -57,6 +60,20 @@ function normalizeHostedOAuthReturnPath(
 
   if (
     surface === "chatbox" &&
+    trimmed.startsWith("/") &&
+    !trimmed.startsWith("//")
+  ) {
+    return trimmed;
+  }
+
+  // score.mcpjam.com lives at `/embed/score`, which is not an app-tab segment,
+  // so `normalizeReturnTargetPath` would rewrite it to `/servers` and strand
+  // the visitor in an app they never asked for — losing the run they had
+  // started. Same carve-out as chatbox, and just as narrow: a same-origin
+  // absolute path only, never a protocol-relative `//host` that would leave
+  // the origin entirely.
+  if (
+    surface === "score" &&
     trimmed.startsWith("/") &&
     !trimmed.startsWith("//")
   ) {
@@ -103,7 +120,7 @@ export function writeHostedOAuthPendingMarker(
         accessVersion: marker.accessVersion ?? null,
         returnPath: normalizeHostedOAuthReturnPath(
           marker.returnPath,
-          marker.surface,
+          marker.surface
         ),
         startedAt: Date.now(),
       })
@@ -124,8 +141,7 @@ export function readHostedOAuthPendingMarker(): HostedOAuthPendingMarker | null 
     if (
       !parsed ||
       typeof parsed !== "object" ||
-      (parsed.surface !== "chatbox" &&
-        parsed.surface !== "project") ||
+      !isHostedOAuthSurface(parsed.surface) ||
       typeof parsed.serverName !== "string" ||
       typeof parsed.startedAt !== "number"
     ) {
@@ -154,8 +170,7 @@ export function readHostedOAuthPendingMarker(): HostedOAuthPendingMarker | null 
         parsed.accessScope === "chat_v2"
           ? parsed.accessScope
           : undefined,
-      chatboxId:
-        typeof parsed.chatboxId === "string" ? parsed.chatboxId : null,
+      chatboxId: typeof parsed.chatboxId === "string" ? parsed.chatboxId : null,
       accessVersion:
         typeof parsed.accessVersion === "number" &&
         Number.isFinite(parsed.accessVersion)
@@ -165,9 +180,9 @@ export function readHostedOAuthPendingMarker(): HostedOAuthPendingMarker | null 
         typeof parsed.returnPath === "string"
           ? parsed.returnPath
           : typeof parsed.returnHash === "string"
-            ? parsed.returnHash
-            : null,
-        parsed.surface,
+          ? parsed.returnHash
+          : null,
+        parsed.surface
       ),
       startedAt: parsed.startedAt,
     };
@@ -212,8 +227,8 @@ function inferHostedOAuthSurfaceFromSessions(
         serverName: server.serverName,
         serverUrl: server.serverUrl,
       },
-      { serverName, serverUrl },
-    ),
+      { serverName, serverUrl }
+    )
   );
 
   return chatboxMatch ? "chatbox" : null;
@@ -229,7 +244,10 @@ export function getHostedOAuthCallbackContext(): HostedOAuthCallbackContext | nu
   // would otherwise be misread here and pair with a stale mcp-oauth-pending
   // marker, producing a ghost "Finishing OAuth…" gate after sign-in.
   const pathname = window.location.pathname;
-  if (pathname !== "/oauth/callback" && !pathname.startsWith("/oauth/callback/")) {
+  if (
+    pathname !== "/oauth/callback" &&
+    !pathname.startsWith("/oauth/callback/")
+  ) {
     return null;
   }
 
@@ -289,6 +307,13 @@ export function resolveHostedOAuthReturnPath(
     return chatboxSession
       ? `/${slugify(chatboxSession.payload.name)}`
       : "/chatbox";
+  }
+
+  // A score visitor never asked to see the app. If the return path went
+  // missing, send them back to the runner rather than to `/servers`, which
+  // would drop them into a product they have not signed into.
+  if (context.surface === "score") {
+    return routePaths.embedScore;
   }
 
   return routePaths.servers;

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-resume.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-resume.ts
@@ -1,4 +1,27 @@
-export type HostedOAuthSurface = "chatbox" | "project";
+/**
+ * Which surface started a hosted OAuth redirect. This is not decoration: the
+ * value decides how the return path is normalized and which completion branch
+ * runs when the browser comes back.
+ *
+ *   - "project"  — the signed-in app. Return paths are normalized through the
+ *                  known app-tab segments.
+ *   - "chatbox"  — a published chatbox link. Guest completion is keyed on
+ *                  `chatboxId` + `sessionId`.
+ *   - "score"    — score.mcpjam.com. A guest with a `projectId`/`serverId` and
+ *                  no chatbox, returning to `/embed/score`. It needs its own
+ *                  value because neither of the others fits: "project" would
+ *                  collapse `/embed/score` to `/servers` (the segment isn't an
+ *                  app tab) and lose the run, and "chatbox" would demand a
+ *                  chatbox id it does not have.
+ */
+export type HostedOAuthSurface = "chatbox" | "project" | "score";
+
+/** Cheap guard so both marker validators agree on what a surface can be. */
+export function isHostedOAuthSurface(
+  value: unknown
+): value is HostedOAuthSurface {
+  return value === "chatbox" || value === "project" || value === "score";
+}
 
 export type HostedOAuthStatus =
   | "needs_auth"
@@ -27,7 +50,7 @@ export const HOSTED_OAUTH_RESUME_STORAGE_KEY = "mcp-hosted-oauth-resume";
 const HOSTED_OAUTH_RESUME_TTL_MS = 60_000;
 
 export function writeHostedOAuthResumeMarker(
-  marker: Omit<HostedOAuthResumeMarker, "completedAt">,
+  marker: Omit<HostedOAuthResumeMarker, "completedAt">
 ): void {
   try {
     localStorage.setItem(
@@ -37,7 +60,7 @@ export function writeHostedOAuthResumeMarker(
         serverUrl: marker.serverUrl ?? null,
         errorMessage: marker.errorMessage ?? null,
         completedAt: Date.now(),
-      }),
+      })
     );
   } catch {
     // Ignore storage failures.
@@ -45,7 +68,7 @@ export function writeHostedOAuthResumeMarker(
 }
 
 export function readHostedOAuthResumeMarker(
-  surface?: HostedOAuthSurface,
+  surface?: HostedOAuthSurface
 ): HostedOAuthResumeMarker | null {
   try {
     const raw = localStorage.getItem(HOSTED_OAUTH_RESUME_STORAGE_KEY);
@@ -55,7 +78,7 @@ export function readHostedOAuthResumeMarker(
     if (
       !parsed ||
       typeof parsed !== "object" ||
-      (parsed.surface !== "chatbox" && parsed.surface !== "project") ||
+      !isHostedOAuthSurface(parsed.surface) ||
       typeof parsed.serverName !== "string" ||
       typeof parsed.completedAt !== "number"
     ) {
@@ -98,14 +121,14 @@ export function isHostedOAuthBusy(status: HostedOAuthStatus): boolean {
 
 export function sanitizeHostedOAuthErrorMessage(
   error: unknown,
-  fallback: string,
+  fallback: string
 ): string {
   const message =
     typeof error === "string"
       ? error
       : error instanceof Error
-        ? error.message
-        : fallback;
+      ? error.message
+      : fallback;
 
   const normalized = message.replace(/\s+/g, " ").trim();
   if (!normalized) {
@@ -123,7 +146,7 @@ export function sanitizeHostedOAuthErrorMessage(
 
   if (
     /\b(cancelled|canceled)\b|user denied|denied the request|access_denied/i.test(
-      sanitized,
+      sanitized
     )
   ) {
     return "Authorization was cancelled. Try again.";
@@ -143,7 +166,7 @@ export function sanitizeHostedOAuthErrorMessage(
 
   if (
     /\b(401|403)\b|unauthorized|forbidden|authentication failed|invalid[_\s-]?token|expired token|token expired|non-200 status code|access denied/i.test(
-      sanitized,
+      sanitized
     )
   ) {
     return "Your authorization expired or was rejected. Authorize again to continue.";
@@ -151,7 +174,7 @@ export function sanitizeHostedOAuthErrorMessage(
 
   if (
     /sse error|failed to fetch|network ?error|timeout|timed out|socket hang up|econn/i.test(
-      sanitized,
+      sanitized
     )
   ) {
     return "We couldn't reach the authorization service. Try again.";

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/constants.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/constants.test.ts
@@ -41,6 +41,26 @@ describe("resolveBrowserOAuthRedirectOrigin", () => {
       )
     ).toBe(MCPJAM_HOSTED_APP_ORIGIN);
   });
+
+  /**
+   * score.mcpjam.com runs real authorizations, and every piece of state that
+   * carries one — the pending marker, the resume record, the guest cookie — is
+   * per-origin. Sending its callback to the app would land the visitor on a
+   * host that can read none of them, so the flow would dead-end and the scan
+   * would be lost. It has to keep its own callback.
+   */
+  it("keeps the current origin on the score domain", () => {
+    expect(
+      resolveBrowserOAuthRedirectOrigin(
+        new URL("https://score.mcpjam.com/embed/score")
+      )
+    ).toBe("https://score.mcpjam.com");
+    expect(
+      resolveBrowserOAuthRedirectOrigin(
+        new URL("https://www.score.mcpjam.com/embed/score")
+      )
+    ).toBe("https://www.score.mcpjam.com");
+  });
 });
 
 describe("getRedirectUri", () => {

--- a/mcpjam-inspector/client/src/lib/oauth/constants.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/constants.ts
@@ -4,9 +4,26 @@
 
 export const MCPJAM_HOSTED_APP_ORIGIN = "https://app.mcpjam.com";
 const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
+/**
+ * Hosts that receive their OWN OAuth callback rather than the app's.
+ *
+ * A host not listed here sends the browser back to `app.mcpjam.com`, which is
+ * correct for a vanity domain that only renders a page — but fatal for one that
+ * has to finish an authorization. The pending marker, the resume record and the
+ * guest cookie are all per-origin, so a callback that lands on a different host
+ * cannot see any of them: the flow dead-ends and the visitor loses their work.
+ * `score.mcpjam.com` runs authorizations, so it keeps its own callback.
+ *
+ * Adding a host here mints a new `redirect_uri`. Dynamic registration sends it
+ * per-flow and needs nothing else, but Client ID Metadata Document flows only
+ * accept URIs listed in the document at `MCPJAM_CLIENT_ID` — a new host must be
+ * added there too, or CIMD servers will reject the authorization.
+ */
 const HOSTED_REDIRECT_HOSTNAMES = new Set([
   "app.mcpjam.com",
   "staging.mcpjam.com",
+  "score.mcpjam.com",
+  "www.score.mcpjam.com",
 ]);
 
 /**

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -24,6 +24,8 @@ import App, {
   PromptsRoute,
   RegistryRoute,
   ResourcesRoute,
+  ScoreResultsRoute,
+  ScoreRunnerRoute,
   ServersRedirectRoute,
   ServersRoute,
   SettingsRoute,
@@ -73,6 +75,13 @@ const ROUTE_ELEMENTS: Record<
   // first-run onboarding redirect. `bare` forces the no-sub-nav render
   // even for signed-in users.
   "embed/host-compare": { element: <HostCompareRoute bare /> },
+  // score.mcpjam.com: paste a server URL, run the four conformance suites,
+  // get one 0-100 number on a private shareable link. Chrome-less like the
+  // caniuse surface above, and reachable by guests with no sign-in.
+  "embed/score": { element: <ScoreRunnerRoute /> },
+  // A stored run, addressable only by its secret token. Deliberately
+  // readable with no session at all — the link IS the credential.
+  "results/:runToken": { element: <ScoreResultsRoute /> },
   "capabilities/:capabilitySlug": { element: <CaniuseCapabilityRoute /> },
   computer: { element: <ComputerRoute /> },
   hosts: { element: <HostsRoute /> },

--- a/mcpjam-inspector/server/config.ts
+++ b/mcpjam-inspector/server/config.ts
@@ -32,7 +32,6 @@ export const NON_PROD_LOCKDOWN = process.env.MCPJAM_NONPROD_LOCKDOWN === "true";
 export const EVAL_WIDGET_MODEL_CONTEXT =
   process.env.MCPJAM_EVAL_WIDGET_MODEL_CONTEXT === "true";
 
-
 export const EMPLOYEE_EMAIL_DOMAINS = (
   process.env.MCPJAM_EMPLOYEE_EMAIL_DOMAINS ?? ""
 )
@@ -115,7 +114,8 @@ export const ELICITATION_SERVICE_ROUTE_TIMEOUT_MS = 10_000;
  * sequential elicitations. Slack over the longest single TTL so a form answered
  * at the last second still lands.
  */
-export const ELICITATION_TIMEOUT_EXTENSION_MS = ELICITATION_FORM_TTL_MS + 30_000;
+export const ELICITATION_TIMEOUT_EXTENSION_MS =
+  ELICITATION_FORM_TTL_MS + 30_000;
 
 // ── Hosted MRTR continuation transport (MCP 2026-07-28 §12.5) ────────────────
 //
@@ -187,5 +187,16 @@ export const CANIUSE_LANDING_HOSTS = new Set(
   (process.env.CANIUSE_LANDING_HOSTS ?? "caniuse.dev,www.caniuse.dev")
     .split(",")
     .map((h) => h.trim().toLowerCase())
-    .filter((h) => h.length > 0),
+    .filter((h) => h.length > 0)
+);
+
+// Vanity domains whose root path ("/") should land on the conformance-score
+// runner. score.mcpjam.com is this same service under another name — no
+// separate deploy — so the only thing it needs is a root redirect. Deep links
+// (`/results/<token>`) pass through untouched.
+export const SCORE_LANDING_HOSTS = new Set(
+  (process.env.SCORE_LANDING_HOSTS ?? "score.mcpjam.com,www.score.mcpjam.com")
+    .split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter((h) => h.length > 0)
 );

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -153,6 +153,7 @@ import {
   HOSTED_MODE,
   ALLOWED_HOSTS,
   CANIUSE_LANDING_HOSTS,
+  SCORE_LANDING_HOSTS,
 } from "./config";
 import "./types/hono"; // Type extensions
 import { initXAAIdpKeyPair, setXaaIdpLogger } from "@mcpjam/sdk";
@@ -577,6 +578,12 @@ if (process.env.NODE_ENV === "production") {
     const host = (c.req.header("Host") ?? "").toLowerCase().split(":")[0];
     if (CANIUSE_LANDING_HOSTS.has(host) && c.req.path === "/") {
       return c.redirect("/embed/host-compare", 302);
+    }
+    // score.mcpjam.com rides the same service: its root lands on the
+    // conformance-score runner. `/results/<token>` deep links fall through so
+    // a shared result opens directly.
+    if (SCORE_LANDING_HOSTS.has(host) && c.req.path === "/") {
+      return c.redirect("/embed/score", 302);
     }
     return next();
   });

--- a/mcpjam-inspector/server/middleware/__tests__/conformance-run-rate-limit.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/conformance-run-rate-limit.test.ts
@@ -79,15 +79,57 @@ describe("conformanceRunRateLimitMiddleware", () => {
     }
   });
 
-  it("bounds the window map against address churn", async () => {
+  it("bounds the window map against address churn WITHOUT resetting live buckets", async () => {
     const app = await appFor(true);
-    // Far more distinct addresses than the cap; every one must still be
-    // served, and memory must not track the churn one-for-one.
-    for (let i = 0; i < 2000; i++) {
-      expect((await hit(app, { "x-real-ip": `198.51.100.${i}` })).status).toBe(
-        200
-      );
+    const {
+      conformanceRunRateLimitWindowCountForTests,
+      CONFORMANCE_RUN_IP_WINDOW_MAX_ENTRIES,
+    } = await import("../conformance-run-rate-limit");
+
+    // Addresses spread across two octets so they are real IPv4 values rather
+    // than `198.51.100.900`.
+    const ipAt = (i: number) =>
+      `198.51.${Math.floor(i / 256) % 256}.${i % 256}`;
+
+    for (let i = 0; i < CONFORMANCE_RUN_IP_WINDOW_MAX_ENTRIES; i++) {
+      expect((await hit(app, { "x-real-ip": ipAt(i) })).status).toBe(200);
     }
+
+    // Past the cap the limiter FAILS CLOSED. The tempting alternative —
+    // evicting the oldest entry — would bound memory while handing that
+    // address a brand-new allowance, so a churner could reset their own
+    // exhausted bucket just by filling the map. Refusing the new key keeps
+    // both the memory bound and the enforcement.
+    expect(
+      (
+        await hit(app, {
+          "x-real-ip": ipAt(CONFORMANCE_RUN_IP_WINDOW_MAX_ENTRIES),
+        })
+      ).status
+    ).toBe(429);
+
+    expect(conformanceRunRateLimitWindowCountForTests()).toBeLessThanOrEqual(
+      CONFORMANCE_RUN_IP_WINDOW_MAX_ENTRIES
+    );
+  });
+
+  it("keeps serving an address that already has a window when the map is full", async () => {
+    // Fail-closed must not lock out callers who are already tracked and well
+    // inside their budget — only NEW keys are refused.
+    const app = await appFor(true);
+    const { CONFORMANCE_RUN_IP_WINDOW_MAX_ENTRIES } = await import(
+      "../conformance-run-rate-limit"
+    );
+    const known = { "x-real-ip": "203.0.113.42" };
+    expect((await hit(app, known)).status).toBe(200);
+
+    for (let i = 1; i < CONFORMANCE_RUN_IP_WINDOW_MAX_ENTRIES; i++) {
+      await hit(app, {
+        "x-real-ip": `198.51.${Math.floor(i / 256) % 256}.${i % 256}`,
+      });
+    }
+
+    expect((await hit(app, known)).status).toBe(200);
   });
 
   it("exposes a reset seam so suites cannot leak windows into each other", async () => {

--- a/mcpjam-inspector/server/middleware/__tests__/conformance-run-rate-limit.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/conformance-run-rate-limit.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+/**
+ * The per-IP ceiling on hosted conformance runs.
+ *
+ * The properties worth pinning are the ones a careless edit would quietly
+ * break: it must be a no-op locally (a laptop dialing its own server is the
+ * product), each address must get its own budget, and the map must not grow
+ * without bound — a limiter that can be turned into the attack is not one.
+ */
+
+const HOSTED_ENV = "VITE_MCPJAM_HOSTED_MODE";
+let savedHosted: string | undefined;
+
+beforeEach(() => {
+  savedHosted = process.env[HOSTED_ENV];
+});
+
+afterEach(() => {
+  if (savedHosted === undefined) delete process.env[HOSTED_ENV];
+  else process.env[HOSTED_ENV] = savedHosted;
+  vi.resetModules();
+});
+
+/** `HOSTED_MODE` is read at config import, so each mode needs a fresh registry. */
+async function appFor(hosted: boolean) {
+  process.env[HOSTED_ENV] = hosted ? "true" : "false";
+  vi.resetModules();
+  const { conformanceRunRateLimitMiddleware } = await import(
+    "../conformance-run-rate-limit"
+  );
+  const app = new Hono();
+  app.use("*", conformanceRunRateLimitMiddleware);
+  app.get("/run", (c) => c.json({ ok: true }));
+  return app;
+}
+
+const hit = (app: Hono, headers: Record<string, string> = {}) =>
+  app.request("/run", { headers });
+
+describe("conformanceRunRateLimitMiddleware", () => {
+  it("allows the budget and then 429s, per address", async () => {
+    const app = await appFor(true);
+    const ip = { "x-real-ip": "203.0.113.5" };
+
+    for (let i = 0; i < 30; i++) {
+      expect((await hit(app, ip)).status).toBe(200);
+    }
+    const blocked = await hit(app, ip);
+    expect(blocked.status).toBe(429);
+    expect((await blocked.json()).code).toBe("RATE_LIMITED");
+  });
+
+  it("gives each address its own budget", async () => {
+    const app = await appFor(true);
+    for (let i = 0; i < 30; i++) {
+      await hit(app, { "x-real-ip": "203.0.113.5" });
+    }
+    expect((await hit(app, { "x-real-ip": "203.0.113.5" })).status).toBe(429);
+    // A neighbour is untouched by the first address's exhausted window.
+    expect((await hit(app, { "x-real-ip": "203.0.113.6" })).status).toBe(200);
+  });
+
+  it("is a no-op outside hosted mode", async () => {
+    const app = await appFor(false);
+    const ip = { "x-real-ip": "203.0.113.5" };
+    for (let i = 0; i < 50; i++) {
+      expect((await hit(app, ip)).status).toBe(200);
+    }
+  });
+
+  it("does not collapse un-attributable callers into one shared bucket", async () => {
+    // No forwarding header and no socket peer: charging these to a single
+    // "unknown" key would let one such request starve every other.
+    const app = await appFor(true);
+    for (let i = 0; i < 50; i++) {
+      expect((await hit(app)).status).toBe(200);
+    }
+  });
+
+  it("bounds the window map against address churn", async () => {
+    const app = await appFor(true);
+    // Far more distinct addresses than the cap; every one must still be
+    // served, and memory must not track the churn one-for-one.
+    for (let i = 0; i < 2000; i++) {
+      expect((await hit(app, { "x-real-ip": `198.51.100.${i}` })).status).toBe(
+        200
+      );
+    }
+  });
+
+  it("exposes a reset seam so suites cannot leak windows into each other", async () => {
+    const app = await appFor(true);
+    const { resetConformanceRunRateLimitForTests } = await import(
+      "../conformance-run-rate-limit"
+    );
+    const ip = { "x-real-ip": "203.0.113.9" };
+    for (let i = 0; i < 30; i++) await hit(app, ip);
+    expect((await hit(app, ip)).status).toBe(429);
+
+    resetConformanceRunRateLimitForTests();
+    expect((await hit(app, ip)).status).toBe(200);
+  });
+});

--- a/mcpjam-inspector/server/middleware/conformance-run-rate-limit.ts
+++ b/mcpjam-inspector/server/middleware/conformance-run-rate-limit.ts
@@ -1,0 +1,82 @@
+import type { Context, Next } from "hono";
+import { ErrorCode } from "../routes/web/errors.js";
+import { getClientIp } from "../utils/client-ip.js";
+import { HOSTED_MODE } from "../config.js";
+
+/**
+ * Per-IP ceiling on hosted conformance runs, layered under the existing
+ * 60/min per-guest limiter.
+ *
+ * The per-guest limiter counts identities, and a guest identity is free to
+ * mint — so on its own it bounds one caller's politeness, not the fleet's
+ * outbound traffic. Since a run makes real requests to a caller-named third
+ * party (the protocol suite alone opens several connections; the tasks suite
+ * performs a real `tools/call`), the IP is the honest unit for "how much of
+ * our egress may one actor spend".
+ *
+ * Calibrated to parity, not paranoia: a guest can already run these suites in
+ * the product today, and a dev iterating on their own server legitimately runs
+ * the set repeatedly. 30 runs in 10 minutes leaves that comfortable and still
+ * bounds an abuser to a rate no one would call a flood.
+ *
+ * Local/desktop mode is exempt: the "fleet" there is one developer's laptop
+ * dialing their own server.
+ */
+
+const RUN_RATE_LIMIT = 30;
+const RUN_WINDOW_MS = 10 * 60_000;
+
+const ipWindows = new Map<string, { count: number; windowStart: number }>();
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of ipWindows) {
+    if (now - entry.windowStart > RUN_WINDOW_MS * 2) {
+      ipWindows.delete(ip);
+    }
+  }
+}, 5 * 60_000).unref();
+
+export function resetConformanceRunRateLimitForTests(): void {
+  ipWindows.clear();
+}
+
+export async function conformanceRunRateLimitMiddleware(
+  c: Context,
+  next: Next
+): Promise<Response | void> {
+  if (!HOSTED_MODE) return next();
+
+  const ip = getClientIp(c);
+  // No attributable IP means no bucket to charge. Falling through matches the
+  // per-guest limiter's posture (unknown identity ⇒ skip) rather than
+  // collapsing every such caller into one shared bucket, which would let one
+  // header-stripped request starve the rest.
+  if (!ip) return next();
+
+  const now = Date.now();
+  const entry = ipWindows.get(ip);
+
+  if (entry) {
+    if (now - entry.windowStart < RUN_WINDOW_MS) {
+      if (entry.count >= RUN_RATE_LIMIT) {
+        return c.json(
+          {
+            code: ErrorCode.RATE_LIMITED,
+            message:
+              "Too many conformance runs from this address. Try again in a few minutes.",
+          },
+          429
+        );
+      }
+      entry.count++;
+    } else {
+      entry.count = 1;
+      entry.windowStart = now;
+    }
+  } else {
+    ipWindows.set(ip, { count: 1, windowStart: now });
+  }
+
+  return next();
+}

--- a/mcpjam-inspector/server/middleware/conformance-run-rate-limit.ts
+++ b/mcpjam-inspector/server/middleware/conformance-run-rate-limit.ts
@@ -26,6 +26,13 @@ import { HOSTED_MODE } from "../config.js";
 const RUN_RATE_LIMIT = 30;
 const RUN_WINDOW_MS = 10 * 60_000;
 
+/**
+ * Bounded. Only expired windows are swept, and the key comes from a
+ * client-supplied forwarding header — so sustained IP churn would grow this
+ * map indefinitely and exhaust the replica long before any single bucket
+ * reached its limit. A limiter that can be turned into the attack is not one.
+ */
+const IP_WINDOW_MAX_ENTRIES = 10_000;
 const ipWindows = new Map<string, { count: number; windowStart: number }>();
 
 setInterval(() => {
@@ -75,6 +82,11 @@ export async function conformanceRunRateLimitMiddleware(
       entry.windowStart = now;
     }
   } else {
+    if (ipWindows.size >= IP_WINDOW_MAX_ENTRIES) {
+      // Oldest insertion first — Map preserves insertion order.
+      const oldest = ipWindows.keys().next();
+      if (!oldest.done) ipWindows.delete(oldest.value);
+    }
     ipWindows.set(ip, { count: 1, windowStart: now });
   }
 

--- a/mcpjam-inspector/server/middleware/conformance-run-rate-limit.ts
+++ b/mcpjam-inspector/server/middleware/conformance-run-rate-limit.ts
@@ -19,6 +19,14 @@ import { HOSTED_MODE } from "../config.js";
  * the set repeatedly. 30 runs in 10 minutes leaves that comfortable and still
  * bounds an abuser to a rate no one would call a flood.
  *
+ * PER PROCESS, not per fleet. The window lives in this replica's memory, so a
+ * horizontally scaled deployment enforces 30 runs per IP PER REPLICA — the real
+ * ceiling is that number times the replica count, and it moves when the
+ * deployment scales. That is a deliberate v1 trade (a shared counter means a
+ * round trip on every run, for a limit whose job is to blunt abuse rather than
+ * meter a product), but it must not be mistaken for a fleet-wide guarantee: if
+ * this ever needs to be exact, it needs shared state, not a smaller number.
+ *
  * Local/desktop mode is exempt: the "fleet" there is one developer's laptop
  * dialing their own server.
  */

--- a/mcpjam-inspector/server/middleware/conformance-run-rate-limit.ts
+++ b/mcpjam-inspector/server/middleware/conformance-run-rate-limit.ts
@@ -48,6 +48,13 @@ export function resetConformanceRunRateLimitForTests(): void {
   ipWindows.clear();
 }
 
+/** Test-only: the bound is only meaningful if a test can actually observe it. */
+export function conformanceRunRateLimitWindowCountForTests(): number {
+  return ipWindows.size;
+}
+
+export const CONFORMANCE_RUN_IP_WINDOW_MAX_ENTRIES = IP_WINDOW_MAX_ENTRIES;
+
 export async function conformanceRunRateLimitMiddleware(
   c: Context,
   next: Next
@@ -83,9 +90,19 @@ export async function conformanceRunRateLimitMiddleware(
     }
   } else {
     if (ipWindows.size >= IP_WINDOW_MAX_ENTRIES) {
-      // Oldest insertion first — Map preserves insertion order.
-      const oldest = ipWindows.keys().next();
-      if (!oldest.done) ipWindows.delete(oldest.value);
+      // FAIL CLOSED rather than evict. Evicting the oldest entry bounds memory
+      // but hands whoever owned it a fresh 30-run allowance — so a churner
+      // could reset their own exhausted bucket by filling the map, defeating
+      // the ceiling at exactly the scale it matters. Refusing the new key
+      // keeps both properties.
+      return c.json(
+        {
+          code: ErrorCode.RATE_LIMITED,
+          message:
+            "Too many conformance runs right now. Try again in a few minutes.",
+        },
+        429
+      );
     }
     ipWindows.set(ip, { count: 1, windowStart: now });
   }

--- a/mcpjam-inspector/server/routes/shared/conformance.ts
+++ b/mcpjam-inspector/server/routes/shared/conformance.ts
@@ -99,6 +99,14 @@ export async function runProtocolConformance(
     // addresses we end up dialing: a target can answer `302 Location:
     // http://169.254.169.254/`. This re-checks each hop. A no-op outside hosted
     // mode, where reaching localhost is the point.
+    //
+    // SCOPE, precisely: `fetchFn` is what the raw HTTP and SSE probes use. The
+    // one real MCP connection this suite opens goes through MCPClientManager's
+    // own transport fetch, which this does not reach — so a redirect returned by
+    // the MCP endpoint itself is still followed unchecked. Closing that means
+    // threading a base fetch through the client manager, which is a shared
+    // connection path for every protocol version and every surface, and does not
+    // belong in this change.
     fetchFn: createGuardedFetch(),
   };
   const test = new MCPConformanceTest(config);

--- a/mcpjam-inspector/server/routes/shared/conformance.ts
+++ b/mcpjam-inspector/server/routes/shared/conformance.ts
@@ -36,6 +36,7 @@ import {
   submitAuthorizationCode,
   type OAuthConformanceSession,
 } from "../../services/conformance-oauth-sessions.js";
+import { createGuardedFetch } from "../../utils/hosted-egress-guard.js";
 
 // ── Result shapes shared with clients ───────────────────────────────────
 
@@ -94,6 +95,11 @@ export async function runProtocolConformance(
     accessToken: input.accessToken,
     customHeaders: input.customHeaders,
     protocolVersion: input.protocolVersion,
+    // Checking the URL the caller named is not the same as checking the
+    // addresses we end up dialing: a target can answer `302 Location:
+    // http://169.254.169.254/`. This re-checks each hop. A no-op outside hosted
+    // mode, where reaching localhost is the point.
+    fetchFn: createGuardedFetch(),
   };
   const test = new MCPConformanceTest(config);
   const result = await test.run();
@@ -175,6 +181,13 @@ export async function startOAuthConformance(
     // verifying the server *rejects* bad input is half of OAuth conformance.
     // The runner only reaches them once the happy path passes end to end.
     oauthConformanceChecks: true,
+    // The OAuth suite dials URLs it DISCOVERS — authorization, token,
+    // registration and metadata endpoints all come out of the target's own
+    // documents — so the profile URL it was handed is the one address here that
+    // was ever checkable up front. Every request goes through the hop-checking
+    // fetch instead. Requests that ask for `redirect: "manual"` keep their 3xx:
+    // this suite grades redirects, and following one would erase the evidence.
+    fetchFn: createGuardedFetch(),
   };
 
   const test = new OAuthConformanceTest(oauthConfig, {

--- a/mcpjam-inspector/server/routes/web/__tests__/conformance-egress.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/conformance-egress.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The hosted conformance routes take a target URL from the request side and
+ * dial it from our cloud backend. Two inputs reach the dialer — the URL Convex
+ * resolved for the authorized server row, and `oauthProfile.serverUrl`, which
+ * the OAuth suite lets a caller supply outright — and neither was checked
+ * before. Authorizing the server row proves who is asking, not where we are
+ * about to connect.
+ *
+ * Local/desktop mode must keep dialing localhost: that is the product.
+ */
+
+const runProtocolConformanceMock = vi.hoisted(() => vi.fn());
+const startOAuthConformanceMock = vi.hoisted(() => vi.fn());
+const authorizeServerMock = vi.hoisted(() => vi.fn());
+const serverUrlRef = vi.hoisted(() => ({
+  current: "https://mcp.example.test/mcp",
+}));
+
+vi.mock("../auth.js", async () => {
+  const { z } = await import("zod");
+  return {
+    handleRoute: async (c: any, handler: () => Promise<any>) => {
+      try {
+        return c.json(await handler(), 200);
+      } catch (error: any) {
+        return c.json(
+          { code: error?.code ?? "INTERNAL_ERROR", message: error?.message },
+          error?.status ?? 500
+        );
+      }
+    },
+    projectServerSchema: z.object({}).passthrough(),
+    authorizeServer: authorizeServerMock,
+    toHttpConfig: (_auth: unknown, timeoutMs: number) => ({
+      url: serverUrlRef.current,
+      requestInit: { headers: {} },
+      timeout: timeoutMs,
+    }),
+  };
+});
+
+vi.mock("../../shared/conformance", () => ({
+  runProtocolConformance: runProtocolConformanceMock,
+  startOAuthConformance: startOAuthConformanceMock,
+  runTasksConformance: vi.fn(),
+  runAppsConformance: vi.fn(),
+  completeOAuthConformance: vi.fn(),
+  submitOAuthConformanceCode: vi.fn(),
+  UnsupportedTransportError: class extends Error {},
+  OAuthConformanceSessionNotFoundError: class extends Error {},
+  OAuthConformanceSessionFailedError: class extends Error {},
+}));
+
+async function post(path: string, body: Record<string, unknown>) {
+  const { default: conformanceWeb } = await import("../conformance.js");
+  return conformanceWeb.request(path, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: "Bearer test-token",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * `HOSTED_MODE` is read from the environment when `server/config` is first
+ * imported, so each mode needs a fresh module registry.
+ */
+async function withHostedMode<T>(hosted: boolean, run: () => Promise<T>) {
+  const previous = process.env.VITE_MCPJAM_HOSTED_MODE;
+  process.env.VITE_MCPJAM_HOSTED_MODE = hosted ? "true" : "false";
+  vi.resetModules();
+  try {
+    if (hosted) {
+      // Fabricated test hostnames resolve nowhere, and the guard fails closed
+      // on an unresolvable host. Answer for them so these cases exercise the
+      // address rules rather than the lookup branch.
+      const guard = await import("../../../utils/hosted-egress-guard.js");
+      guard.setEgressHostResolverForTests(async () => ["93.184.216.34"]);
+    }
+    return await run();
+  } finally {
+    if (previous === undefined) delete process.env.VITE_MCPJAM_HOSTED_MODE;
+    else process.env.VITE_MCPJAM_HOSTED_MODE = previous;
+    vi.resetModules();
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  serverUrlRef.current = "https://mcp.example.test/mcp";
+  authorizeServerMock.mockImplementation(async () => ({
+    serverConfig: { transportType: "http", url: serverUrlRef.current },
+  }));
+  runProtocolConformanceMock.mockResolvedValue({
+    result: { outcome: "passed", checks: [] },
+  });
+  startOAuthConformanceMock.mockResolvedValue({ phase: "complete" });
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("hosted conformance — resolved server URL", () => {
+  it("rejects a private target in hosted mode, before any run starts", async () => {
+    await withHostedMode(true, async () => {
+      for (const url of [
+        "http://169.254.169.254/mcp",
+        "http://127.0.0.1:3000/mcp",
+        "http://10.0.0.5/mcp",
+        "http://[::ffff:a9fe:a9fe]/mcp",
+      ]) {
+        serverUrlRef.current = url;
+        const res = await post("/protocol", {
+          projectId: "p1",
+          serverId: "s1",
+        });
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as { code: string; message: string };
+        expect(body.code).toBe("VALIDATION_ERROR");
+        expect(body.message).toMatch(/private or internal address/);
+      }
+      // Refused means refused — the suite never ran.
+      expect(runProtocolConformanceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("allows a public target in hosted mode", async () => {
+    await withHostedMode(true, async () => {
+      const res = await post("/protocol", { projectId: "p1", serverId: "s1" });
+      expect(res.status).toBe(200);
+      expect(runProtocolConformanceMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("allows localhost in local mode — testing a local server is the product", async () => {
+    await withHostedMode(false, async () => {
+      serverUrlRef.current = "http://localhost:3000/mcp";
+      const res = await post("/protocol", { projectId: "p1", serverId: "s1" });
+      expect(res.status).toBe(200);
+      expect(runProtocolConformanceMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe("hosted conformance — oauthProfile.serverUrl", () => {
+  const oauthBody = (serverUrl: string) => ({
+    projectId: "p1",
+    serverId: "s1",
+    callbackOrigin: "https://app.mcpjam.com",
+    oauthProfile: { serverUrl },
+  });
+
+  it("rejects a private override even though the server row is authorized", async () => {
+    await withHostedMode(true, async () => {
+      const res = await post(
+        "/oauth/start",
+        oauthBody("http://169.254.169.254/")
+      );
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string; message: string };
+      expect(body.code).toBe("VALIDATION_ERROR");
+      expect(body.message).toMatch(/OAuth profile server URL/);
+      expect(startOAuthConformanceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("allows a public override in hosted mode", async () => {
+    await withHostedMode(true, async () => {
+      const res = await post(
+        "/oauth/start",
+        oauthBody("https://auth.example.test/")
+      );
+      expect(res.status).toBe(200);
+      expect(startOAuthConformanceMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("allows a localhost override in local mode", async () => {
+    await withHostedMode(false, async () => {
+      const res = await post(
+        "/oauth/start",
+        oauthBody("http://localhost:9000/")
+      );
+      expect(res.status).toBe(200);
+      expect(startOAuthConformanceMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/score.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/score.test.ts
@@ -95,6 +95,75 @@ describe("POST /api/web/score/runs", () => {
     ).toBe("svc-tok");
   });
 
+  /**
+   * The submitted report is a debugging artifact; the STORED one is a shared
+   * document. A completed OAuth run carries a live access token, a refresh
+   * token and the client secret, and the link exists to be forwarded — so the
+   * relay is the last place that can stop those from becoming durable.
+   */
+  it("redacts credentials and raw HTTP evidence before anything is stored", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ ok: true, token: "tok_abc" }, { status: 200 })
+    );
+    global.fetch = fetchMock as any;
+
+    const app = await freshApp();
+    const res = await app.request("/api/web/score/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: submitBody({
+        serverUrl: "https://mcp.example.com/mcp?api_key=sk_live_secret",
+        report: {
+          oauth: {
+            outcome: "passed",
+            credentials: {
+              clientId: "client-abc",
+              clientSecret: "sh_secret",
+              accessToken: "at_live",
+              refreshToken: "rt_live",
+            },
+            steps: [
+              {
+                step: "exchanged_authorization_code",
+                title: "Exchange authorization code",
+                status: "passed",
+                httpAttempts: [
+                  {
+                    request: {
+                      url: "https://as.example.com/token",
+                      headers: { authorization: "Bearer at_live" },
+                      body: "code=ac_secret&client_secret=sh_secret",
+                    },
+                    response: { status: 200, body: { access_token: "at_live" } },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const stored = init.body as string;
+
+    for (const secret of ["at_live", "rt_live", "sh_secret", "ac_secret", "sk_live_secret"]) {
+      expect(stored).not.toContain(secret);
+    }
+
+    const parsed = JSON.parse(stored);
+    // What the result page renders must survive the scrub.
+    expect(parsed.report.oauth.steps[0].title).toBe(
+      "Exchange authorization code"
+    );
+    expect(parsed.report.oauth.steps[0].status).toBe("passed");
+    expect(parsed.report.oauth.steps[0].httpAttempts).toBeUndefined();
+    expect(parsed.report.oauth.credentials).toBeUndefined();
+    // The scanned URL is still recognisable, minus the key.
+    expect(parsed.serverUrl).toContain("mcp.example.com/mcp");
+  });
+
   it("400s a malformed summary without calling Convex", async () => {
     const fetchMock = vi.fn();
     global.fetch = fetchMock as any;

--- a/mcpjam-inspector/server/routes/web/__tests__/score.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/score.test.ts
@@ -147,6 +147,43 @@ describe("POST /api/web/score/runs", () => {
     expect((await submit()).status).toBe(429);
   });
 
+  it("keeps each IP on its own budget", async () => {
+    // Guards the failure where the key collapses to a constant (or to
+    // getClientIp's null fallback) and one busy client throttles everyone
+    // behind the same edge.
+    global.fetch = vi.fn(async () =>
+      Response.json({ ok: true, token: "tok" }, { status: 200 })
+    ) as any;
+
+    const app = await freshApp();
+    const submitFrom = (ip: string) =>
+      app.request("/api/web/score/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-real-ip": ip },
+        body: submitBody(),
+      });
+
+    for (let i = 0; i < 10; i++) {
+      expect((await submitFrom("198.51.100.1")).status).toBe(200);
+    }
+    expect((await submitFrom("198.51.100.1")).status).toBe(429);
+    // A different address is untouched by the first one's exhausted window.
+    expect((await submitFrom("198.51.100.2")).status).toBe(200);
+  });
+
+  it("400s a report that is not an object", async () => {
+    // A stored `null` would mint a working link to a page that throws on open.
+    const app = await freshApp();
+    for (const report of [null, "nope", 42, []]) {
+      const res = await app.request("/api/web/score/runs", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: submitBody({ report }),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
   it("503s when storage is not configured, rather than silently dropping a run", async () => {
     delete process.env.INSPECTOR_SERVICE_TOKEN;
     const app = await freshApp();
@@ -202,6 +239,41 @@ describe("GET /api/web/score/runs/:token", () => {
 
     expect(res.status).toBe(404);
     expect((await res.json()).message).toMatch(/not valid/);
+  });
+
+  it("charges only cache MISSES, and 429s a token guesser", async () => {
+    // A wrong token 404s and never populates the cache, so without a budget
+    // every guess is a free Convex round trip aimed at our own backend.
+    global.fetch = vi.fn(async () =>
+      Response.json({ ok: false }, { status: 404 })
+    ) as any;
+
+    const app = await freshApp();
+    const guess = (n: number) =>
+      app.request(`/api/web/score/runs/guess-${n}`, {
+        headers: { "x-real-ip": "203.0.113.77" },
+      });
+
+    for (let i = 0; i < 60; i++) {
+      expect((await guess(i)).status).toBe(404);
+    }
+    expect((await guess(999)).status).toBe(429);
+  });
+
+  it("does not charge a cached read against the budget", async () => {
+    global.fetch = vi.fn(async () =>
+      Response.json({ ok: true, run: { score: 82 } }, { status: 200 })
+    ) as any;
+
+    const app = await freshApp();
+    // One miss populates the cache; the rest are served from it, so a popular
+    // link can be opened far more often than the miss budget allows.
+    for (let i = 0; i < 100; i++) {
+      const res = await app.request("/api/web/score/runs/popular", {
+        headers: { "x-real-ip": "203.0.113.88" },
+      });
+      expect(res.status).toBe(200);
+    }
   });
 
   it("502s when Convex is unreachable", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/score.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/score.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+/**
+ * The score relay is the one place a result link is minted and redeemed.
+ *
+ * Two properties matter most and are asserted here: a submission is bounded
+ * and validated before it reaches Convex, and a READ works with no session
+ * whatsoever — a shared result must open in an incognito window, because the
+ * token in the URL is the entire credential.
+ */
+
+const SUMMARY = {
+  score: 82,
+  outcome: "failed" as const,
+  applicable: 40,
+  passed: 33,
+  failed: 6,
+  couldNotRun: 1,
+  notApplicable: 12,
+  advisoryCount: 2,
+  protocolVersion: "2025-06-18",
+};
+
+/**
+ * Fresh module per test: the rate-limit and result-cache maps are module
+ * state. `errors` is re-imported from the SAME reset registry — a
+ * `WebRouteError` thrown by the freshly-loaded route is not an instance of a
+ * stale registry's class, and every status would flatten to 500.
+ */
+async function freshApp() {
+  vi.resetModules();
+  const [{ default: scoreRoutes }, { mapRuntimeError, webError }] =
+    await Promise.all([import("../score"), import("../errors")]);
+
+  const app = new Hono();
+  app.route("/api/web/score", scoreRoutes);
+  app.onError((error, c) => {
+    const routeError = mapRuntimeError(error);
+    return webError(c, routeError.status, routeError.code, routeError.message);
+  });
+  return app;
+}
+
+function submitBody(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    serverUrl: "https://mcp.example.com/mcp",
+    summary: SUMMARY,
+    suiteSummaries: [{ suiteId: "protocol", ...SUMMARY }],
+    report: { protocol: { checks: [] } },
+    ...overrides,
+  });
+}
+
+const originalFetch = global.fetch;
+const originalConvexUrl = process.env.CONVEX_HTTP_URL;
+const originalServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+
+beforeEach(() => {
+  process.env.CONVEX_HTTP_URL = "https://convex.test";
+  process.env.INSPECTOR_SERVICE_TOKEN = "svc-tok";
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  if (originalConvexUrl === undefined) delete process.env.CONVEX_HTTP_URL;
+  else process.env.CONVEX_HTTP_URL = originalConvexUrl;
+  if (originalServiceToken === undefined)
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+  else process.env.INSPECTOR_SERVICE_TOKEN = originalServiceToken;
+  vi.restoreAllMocks();
+});
+
+describe("POST /api/web/score/runs", () => {
+  it("relays to Convex with the service token and returns the link token", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ ok: true, token: "tok_abc" }, { status: 200 })
+    );
+    global.fetch = fetchMock as any;
+
+    const app = await freshApp();
+    const res = await app.request("/api/web/score/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: submitBody(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, token: "tok_abc" });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://convex.test/internal/v1/score/runs");
+    expect(
+      (init.headers as Record<string, string>)["x-inspector-service-token"]
+    ).toBe("svc-tok");
+  });
+
+  it("400s a malformed summary without calling Convex", async () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as any;
+
+    const app = await freshApp();
+    const res = await app.request("/api/web/score/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: submitBody({ summary: { ...SUMMARY, outcome: "mostly-fine" } }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("400s more than four suite summaries", async () => {
+    const app = await freshApp();
+    const res = await app.request("/api/web/score/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: submitBody({
+        suiteSummaries: Array.from({ length: 5 }, () => ({
+          suiteId: "protocol",
+          ...SUMMARY,
+        })),
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("429s once the per-IP window is spent", async () => {
+    global.fetch = vi.fn(async () =>
+      Response.json({ ok: true, token: "tok" }, { status: 200 })
+    ) as any;
+
+    const app = await freshApp();
+    const submit = () =>
+      app.request("/api/web/score/runs", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-real-ip": "203.0.113.9",
+        },
+        body: submitBody(),
+      });
+
+    for (let i = 0; i < 10; i++) {
+      expect((await submit()).status).toBe(200);
+    }
+    expect((await submit()).status).toBe(429);
+  });
+
+  it("503s when storage is not configured, rather than silently dropping a run", async () => {
+    delete process.env.INSPECTOR_SERVICE_TOKEN;
+    const app = await freshApp();
+    const res = await app.request("/api/web/score/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: submitBody(),
+    });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("GET /api/web/score/runs/:token", () => {
+  it("reads a run with no session, cookie, or bearer of any kind", async () => {
+    global.fetch = vi.fn(async () =>
+      Response.json(
+        {
+          ok: true,
+          run: { serverUrl: "https://mcp.example.com/mcp", score: 82 },
+        },
+        { status: 200 }
+      )
+    ) as any;
+
+    const app = await freshApp();
+    // No Authorization header, no Cookie — an incognito visitor.
+    const res = await app.request("/api/web/score/runs/tok_abc");
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).run.score).toBe(82);
+  });
+
+  it("caches a repeat read instead of re-hitting Convex", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json({ ok: true, run: { score: 82 } }, { status: 200 })
+    );
+    global.fetch = fetchMock as any;
+
+    const app = await freshApp();
+    await app.request("/api/web/score/runs/tok_abc");
+    await app.request("/api/web/score/runs/tok_abc");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("404s an unknown token with a message a human can act on", async () => {
+    global.fetch = vi.fn(async () =>
+      Response.json({ ok: false }, { status: 404 })
+    ) as any;
+
+    const app = await freshApp();
+    const res = await app.request("/api/web/score/runs/nope");
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).message).toMatch(/not valid/);
+  });
+
+  it("502s when Convex is unreachable", async () => {
+    global.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as any;
+
+    const app = await freshApp();
+    expect((await app.request("/api/web/score/runs/tok")).status).toBe(502);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/conformance.ts
+++ b/mcpjam-inspector/server/routes/web/conformance.ts
@@ -5,10 +5,7 @@ import {
   oauthConformanceProfileSchema,
   type MCPServerConfig,
 } from "@mcpjam/sdk";
-import {
-  handleRoute,
-  projectServerSchema,
-} from "./auth.js";
+import { handleRoute, projectServerSchema } from "./auth.js";
 import {
   ErrorCode,
   WebRouteError,
@@ -29,10 +26,44 @@ import {
 } from "../shared/conformance";
 import { authorizeServer, toHttpConfig } from "./auth.js";
 import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
+import {
+  BlockedEgressTargetError,
+  assertAllowedHostedTargetUrl,
+} from "../../utils/hosted-egress-guard.js";
 
 const conformanceWeb = new Hono();
 
 // ── Helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Every URL these routes will dial passes through here.
+ *
+ * Hosted, a conformance run is an anonymous caller naming a target and our
+ * cloud backend connecting to it — an SSRF primitive unless the target is
+ * checked. Two inputs reach the dialer: the URL Convex resolved for the
+ * authorized server row, and `oauthProfile.serverUrl`, which the OAuth suite
+ * lets a caller supply directly. Neither was validated before.
+ *
+ * Local/desktop mode is exempt by construction (the guard no-ops outside
+ * `HOSTED_MODE`): testing a server on localhost is the inspector's whole job.
+ *
+ * Only the TARGET is judged, never the Host headers the protocol suite sends
+ * — its `localhost-host-rebinding-rejected` checks deliberately send
+ * rebinding-shaped Host values to grade the server's own defenses.
+ */
+async function assertConformanceTarget(
+  rawUrl: string,
+  label: string
+): Promise<void> {
+  try {
+    await assertAllowedHostedTargetUrl(rawUrl, label);
+  } catch (error) {
+    if (error instanceof BlockedEgressTargetError) {
+      throw new WebRouteError(400, ErrorCode.VALIDATION_ERROR, error.message);
+    }
+    throw error;
+  }
+}
 
 /** Resolve HTTP server URL and headers for conformance from authorized config. */
 async function resolveHostedHttpConfig(
@@ -84,6 +115,8 @@ async function resolveHostedHttpConfig(
     headers["Authorization"] = `Bearer ${oauthToken}`;
   }
 
+  await assertConformanceTarget(auth.serverConfig.url, "Server URL");
+
   return {
     serverUrl: auth.serverConfig.url,
     accessToken: undefined, // OAuth token goes in headers
@@ -118,6 +151,13 @@ async function resolveHostedServerConfig(
       : undefined,
     wsBody.clientCapabilities as Record<string, unknown> | undefined
   );
+
+  // Apps/Tasks accept any transport, so there may be no URL to judge (a stdio
+  // config never leaves the box). Guard the ones that do.
+  const url = (httpConfig as { url?: unknown }).url;
+  if (typeof url === "string" && url) {
+    await assertConformanceTarget(url, "Server URL");
+  }
 
   return httpConfig as MCPServerConfig;
 }
@@ -307,6 +347,16 @@ conformanceWeb.post("/oauth/start", async (c) =>
         400,
         ErrorCode.VALIDATION_ERROR,
         "callbackOrigin is required to run OAuth conformance"
+      );
+    }
+
+    // The profile's `serverUrl` OVERRIDES the Convex-resolved one inside the
+    // suite, so authorizing the server row is not enough — this string is
+    // caller-controlled and must clear the same bar.
+    if (parsed.oauthProfile?.serverUrl) {
+      await assertConformanceTarget(
+        parsed.oauthProfile.serverUrl,
+        "OAuth profile server URL"
       );
     }
 

--- a/mcpjam-inspector/server/routes/web/conformance.ts
+++ b/mcpjam-inspector/server/routes/web/conformance.ts
@@ -28,6 +28,7 @@ import { authorizeServer, toHttpConfig } from "./auth.js";
 import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
 import {
   BlockedEgressTargetError,
+  EgressResolutionError,
   assertAllowedHostedTargetUrl,
 } from "../../utils/hosted-egress-guard.js";
 
@@ -60,6 +61,11 @@ async function assertConformanceTarget(
   } catch (error) {
     if (error instanceof BlockedEgressTargetError) {
       throw new WebRouteError(400, ErrorCode.VALIDATION_ERROR, error.message);
+    }
+    // We could not reach a verdict. That is our outage, not a bad request —
+    // answer 503 so the caller knows it is worth trying again.
+    if (error instanceof EgressResolutionError) {
+      throw new WebRouteError(503, ErrorCode.SERVER_UNREACHABLE, error.message);
     }
     throw error;
   }

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -25,6 +25,7 @@ import guestSession from "./guest-session.js";
 import guestToken from "./guest-token.js";
 import chatHistory from "./chat-history.js";
 import conformanceWeb from "./conformance.js";
+import score from "./score.js";
 import checks from "./checks.js";
 import apiKeys from "./api-keys.js";
 import computers from "./computers.js";
@@ -130,6 +131,11 @@ web.route("/server-skills", serverSkills);
 // Public caniuse.dev correction reports. No bearer auth: the vanity compare
 // surface is intentionally anonymous.
 web.route("/caniuse", caniuse);
+// score.mcpjam.com run storage. Deliberately NOT under `bearerAuthMiddleware`:
+// a result link has to open for a visitor with no session at all, and the
+// secret token in the URL is the credential. Submission is per-IP rate
+// limited inside the router.
+web.route("/score", score);
 // `/api-keys` carries its own bearer-auth `.use()` because
 // `sessionAuthMiddleware` bypasses `/api/web/*` entirely. Nothing on this
 // sub-router is reachable without a session JWT (WorkOS `sk_…` keys are

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -60,15 +60,23 @@ web.use(
   guestRateLimitMiddleware
 );
 web.use("/chat-history/*", bearerAuthMiddleware, guestRateLimitMiddleware);
+web.use("/conformance/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // Conformance runs dial a caller-named third party, so they carry a per-IP
 // ceiling on top of the per-guest one — guest identities are free to mint, and
 // only the IP bounds how much of our egress a single actor can spend.
-web.use(
-  "/conformance/*",
-  bearerAuthMiddleware,
-  guestRateLimitMiddleware,
-  conformanceRunRateLimitMiddleware
-);
+//
+// Scoped to the routes that START work. `/oauth/authorize` and
+// `/oauth/complete` are the continuation of a run already paid for: charging
+// them would let `/oauth/start` spend the last slot and then 429 the callback,
+// stranding a session that can never finish. One run, one debit.
+for (const startsWork of [
+  "/conformance/protocol",
+  "/conformance/apps",
+  "/conformance/tasks",
+  "/conformance/oauth/start",
+]) {
+  web.use(startsWork, conformanceRunRateLimitMiddleware);
+}
 web.use("/checks/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // Hosted MRTR continuation resume/cancel (MCP 2026-07-28 §12.5). Bearer +
 // guest rate limit like every MCP-operation route; the resume path re-drives a

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { webError, mapRuntimeError } from "./errors.js";
 import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
 import { guestRateLimitMiddleware } from "../../middleware/guest-rate-limit.js";
+import { conformanceRunRateLimitMiddleware } from "../../middleware/conformance-run-rate-limit.js";
 import servers from "./servers.js";
 import tools from "./tools.js";
 import resources from "./resources.js";
@@ -58,7 +59,15 @@ web.use(
   guestRateLimitMiddleware
 );
 web.use("/chat-history/*", bearerAuthMiddleware, guestRateLimitMiddleware);
-web.use("/conformance/*", bearerAuthMiddleware, guestRateLimitMiddleware);
+// Conformance runs dial a caller-named third party, so they carry a per-IP
+// ceiling on top of the per-guest one — guest identities are free to mint, and
+// only the IP bounds how much of our egress a single actor can spend.
+web.use(
+  "/conformance/*",
+  bearerAuthMiddleware,
+  guestRateLimitMiddleware,
+  conformanceRunRateLimitMiddleware
+);
 web.use("/checks/*", bearerAuthMiddleware, guestRateLimitMiddleware);
 // Hosted MRTR continuation resume/cancel (MCP 2026-07-28 §12.5). Bearer +
 // guest rate limit like every MCP-operation route; the resume path re-drives a

--- a/mcpjam-inspector/server/routes/web/score.ts
+++ b/mcpjam-inspector/server/routes/web/score.ts
@@ -214,7 +214,13 @@ function backendConfig(): { convexUrl: string; serviceToken: string } {
     parsed.hostname === "127.0.0.1" ||
     parsed.hostname === "::1" ||
     parsed.hostname === "[::1]";
-  if (parsed.protocol !== "https:" && !isLoopback) {
+  // `http:` only for the loopback exemption — `ftp://localhost` is a
+  // misconfiguration, and letting it reach fetch reports it as an upstream
+  // 502 instead of the config error it is.
+  if (
+    parsed.protocol !== "https:" &&
+    !(parsed.protocol === "http:" && isLoopback)
+  ) {
     throw new WebRouteError(
       503,
       ErrorCode.INTERNAL_ERROR,
@@ -249,12 +255,26 @@ score.post("/runs", async (c) => {
       },
       body: JSON.stringify(parsed.data),
       signal: AbortSignal.timeout(BACKEND_TIMEOUT_MS),
+      // The scheme check above validates the CONFIGURED host. `fetch` follows
+      // redirects by default and replays headers to wherever it lands, so a
+      // 3xx could carry the service token to another host — over http, even.
+      // Refuse to follow; the credential stays confined to the host we vetted.
+      redirect: "manual",
     });
   } catch {
     throw new WebRouteError(
       502,
       ErrorCode.SERVER_UNREACHABLE,
       "Failed to store score run"
+    );
+  }
+
+  if (response.status >= 300 && response.status < 400) {
+    // `redirect: "manual"` surfaced a hop we refused to follow.
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "Score storage redirected; refusing to forward the service token"
     );
   }
 
@@ -301,6 +321,7 @@ score.get("/runs/:token", async (c) => {
         method: "GET",
         headers: { "x-inspector-service-token": serviceToken },
         signal: AbortSignal.timeout(BACKEND_TIMEOUT_MS),
+        redirect: "manual",
       }
     );
   } catch {
@@ -308,6 +329,14 @@ score.get("/runs/:token", async (c) => {
       502,
       ErrorCode.SERVER_UNREACHABLE,
       "Failed to load score run"
+    );
+  }
+
+  if (response.status >= 300 && response.status < 400) {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "Score storage redirected; refusing to forward the service token"
     );
   }
 

--- a/mcpjam-inspector/server/routes/web/score.ts
+++ b/mcpjam-inspector/server/routes/web/score.ts
@@ -32,29 +32,68 @@ const BACKEND_GET_PATH = "/internal/v1/score/runs/get";
 // Matches the caniuse report window rather than inventing a new number.
 const SUBMIT_RATE_LIMIT = 10;
 const SUBMIT_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+/**
+ * Bounded like `resultCache` below. Only EXPIRED windows are swept, and the
+ * key comes from a client-supplied forwarding header — so a caller rotating
+ * `x-forwarded-for` adds one live entry per request and none of them age out
+ * for ten minutes. A limiter that can be made to exhaust memory is a liability,
+ * not a defense.
+ */
+const SUBMIT_WINDOW_MAX_ENTRIES = 10_000;
 const submitWindows = new Map<string, { count: number; windowStart: number }>();
 
-function consumeSubmitRateLimit(clientKey: string, now: number) {
-  for (const [key, value] of submitWindows) {
+/** Read misses are cheap individually, so the budget is looser than submits'. */
+const READ_MISS_RATE_LIMIT = 60;
+const readWindows = new Map<string, { count: number; windowStart: number }>();
+
+function consumeWindow(
+  windows: Map<string, { count: number; windowStart: number }>,
+  clientKey: string,
+  now: number,
+  limit: number,
+  message: string
+) {
+  for (const [key, value] of windows) {
     if (now - value.windowStart >= SUBMIT_RATE_LIMIT_WINDOW_MS) {
-      submitWindows.delete(key);
+      windows.delete(key);
     }
   }
 
-  const rateWindow = submitWindows.get(clientKey);
+  const rateWindow = windows.get(clientKey);
   if (rateWindow) {
-    if (rateWindow.count >= SUBMIT_RATE_LIMIT) {
-      throw new WebRouteError(
-        429,
-        ErrorCode.RATE_LIMITED,
-        "Too many score submissions. Please try again later."
-      );
+    if (rateWindow.count >= limit) {
+      throw new WebRouteError(429, ErrorCode.RATE_LIMITED, message);
     }
     rateWindow.count++;
     return;
   }
 
-  submitWindows.set(clientKey, { count: 1, windowStart: now });
+  if (windows.size >= SUBMIT_WINDOW_MAX_ENTRIES) {
+    // Oldest insertion first — Map preserves insertion order.
+    const oldest = windows.keys().next();
+    if (!oldest.done) windows.delete(oldest.value);
+  }
+  windows.set(clientKey, { count: 1, windowStart: now });
+}
+
+function consumeReadRateLimit(clientKey: string, now: number) {
+  consumeWindow(
+    readWindows,
+    clientKey,
+    now,
+    READ_MISS_RATE_LIMIT,
+    "Too many result lookups. Please try again later."
+  );
+}
+
+function consumeSubmitRateLimit(clientKey: string, now: number) {
+  consumeWindow(
+    submitWindows,
+    clientKey,
+    now,
+    SUBMIT_RATE_LIMIT,
+    "Too many score submissions. Please try again later."
+  );
 }
 
 /**
@@ -107,12 +146,11 @@ const submitSchema = z.object({
       })
     )
     .max(4),
-  // The full multi-suite report. Shape is owned by the SDK's conformance
-  // result types and stored as an opaque blob, so it is not re-validated here
-  // — the backend caps the body size, which is the property that matters.
-  report: z.unknown().refine((value) => value !== undefined, {
-    message: "report is required",
-  }),
+  // The full multi-suite report. Suite CONTENTS are owned by the SDK's
+  // conformance result types and stored as an opaque blob — but the outer
+  // shape is checked, because the results page indexes into it. A stored
+  // `null` would mint a working link to a page that throws on open.
+  report: z.record(z.string(), z.unknown()),
 });
 
 function backendConfig(): { convexUrl: string; serviceToken: string } {
@@ -186,6 +224,12 @@ score.get("/runs/:token", async (c) => {
   if (cached) {
     return c.json({ success: true, run: cached });
   }
+
+  // Only MISSES are charged. A token is the whole credential, so a guesser
+  // gets 404s that never populate the cache — without a budget, every guess is
+  // a free Convex round trip and this public route becomes a load amplifier
+  // aimed at our own backend. Legitimate readers hit the cache and pay nothing.
+  consumeReadRateLimit(getClientIp(c) ?? "unknown", Date.now());
 
   const { convexUrl, serviceToken } = backendConfig();
 

--- a/mcpjam-inspector/server/routes/web/score.ts
+++ b/mcpjam-inspector/server/routes/web/score.ts
@@ -46,6 +46,25 @@ const submitWindows = new Map<string, { count: number; windowStart: number }>();
 const READ_MISS_RATE_LIMIT = 60;
 const readWindows = new Map<string, { count: number; windowStart: number }>();
 
+/**
+ * Expire windows on a timer, not on the request.
+ *
+ * Sweeping inside the handler is O(entries) on a PUBLIC path, so once a
+ * churner fills the map every subsequent request pays for the whole table —
+ * the limiter becomes the amplifier it was meant to prevent. The conformance
+ * middleware already ages its windows this way.
+ */
+setInterval(() => {
+  const now = Date.now();
+  for (const windows of [submitWindows, readWindows]) {
+    for (const [key, value] of windows) {
+      if (now - value.windowStart >= SUBMIT_RATE_LIMIT_WINDOW_MS) {
+        windows.delete(key);
+      }
+    }
+  }
+}, 60_000).unref();
+
 function consumeWindow(
   windows: Map<string, { count: number; windowStart: number }>,
   clientKey: string,
@@ -53,14 +72,15 @@ function consumeWindow(
   limit: number,
   message: string
 ) {
-  for (const [key, value] of windows) {
-    if (now - value.windowStart >= SUBMIT_RATE_LIMIT_WINDOW_MS) {
-      windows.delete(key);
-    }
-  }
-
   const rateWindow = windows.get(clientKey);
   if (rateWindow) {
+    if (now - rateWindow.windowStart >= SUBMIT_RATE_LIMIT_WINDOW_MS) {
+      // Expired in place. The timer above is a memory sweep, not the clock —
+      // correctness cannot depend on when it last ran.
+      rateWindow.count = 1;
+      rateWindow.windowStart = now;
+      return;
+    }
     if (rateWindow.count >= limit) {
       throw new WebRouteError(429, ErrorCode.RATE_LIMITED, message);
     }
@@ -69,9 +89,12 @@ function consumeWindow(
   }
 
   if (windows.size >= SUBMIT_WINDOW_MAX_ENTRIES) {
-    // Oldest insertion first — Map preserves insertion order.
-    const oldest = windows.keys().next();
-    if (!oldest.done) windows.delete(oldest.value);
+    // FAIL CLOSED rather than evict. Evicting the oldest entry would bound
+    // memory while handing whoever owned it a brand-new allowance — so a
+    // churner could reset their own exhausted bucket just by filling the map,
+    // which is precisely what this limiter exists to stop. Refusing the new
+    // key keeps both the memory cap and the enforcement.
+    throw new WebRouteError(429, ErrorCode.RATE_LIMITED, message);
   }
   windows.set(clientKey, { count: 1, windowStart: now });
 }
@@ -153,6 +176,14 @@ const submitSchema = z.object({
   report: z.record(z.string(), z.unknown()),
 });
 
+/**
+ * Bound every call to Convex. Without a deadline, a backend that accepts the
+ * connection and then goes quiet parks a PUBLIC request indefinitely — and
+ * this route takes no session, so there is nothing to stop someone collecting
+ * those.
+ */
+const BACKEND_TIMEOUT_MS = 10_000;
+
 function backendConfig(): { convexUrl: string; serviceToken: string } {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
@@ -163,6 +194,34 @@ function backendConfig(): { convexUrl: string; serviceToken: string } {
       "Score storage is not configured"
     );
   }
+
+  // These requests carry the service token — the credential that authenticates
+  // us AS the inspector. Sending it in cleartext to a remote host would put it
+  // on the wire for anyone on the path. Loopback is exempt because local dev
+  // legitimately runs Convex over http on 127.0.0.1.
+  let parsed: URL;
+  try {
+    parsed = new URL(convexUrl);
+  } catch {
+    throw new WebRouteError(
+      503,
+      ErrorCode.INTERNAL_ERROR,
+      "Score storage is misconfigured"
+    );
+  }
+  const isLoopback =
+    parsed.hostname === "localhost" ||
+    parsed.hostname === "127.0.0.1" ||
+    parsed.hostname === "::1" ||
+    parsed.hostname === "[::1]";
+  if (parsed.protocol !== "https:" && !isLoopback) {
+    throw new WebRouteError(
+      503,
+      ErrorCode.INTERNAL_ERROR,
+      "Score storage is misconfigured: refusing to send the service token over cleartext"
+    );
+  }
+
   return { convexUrl: convexUrl.replace(/\/$/, ""), serviceToken };
 }
 
@@ -189,6 +248,7 @@ score.post("/runs", async (c) => {
         "x-inspector-service-token": serviceToken,
       },
       body: JSON.stringify(parsed.data),
+      signal: AbortSignal.timeout(BACKEND_TIMEOUT_MS),
     });
   } catch {
     throw new WebRouteError(
@@ -240,6 +300,7 @@ score.get("/runs/:token", async (c) => {
       {
         method: "GET",
         headers: { "x-inspector-service-token": serviceToken },
+        signal: AbortSignal.timeout(BACKEND_TIMEOUT_MS),
       }
     );
   } catch {

--- a/mcpjam-inspector/server/routes/web/score.ts
+++ b/mcpjam-inspector/server/routes/web/score.ts
@@ -1,5 +1,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
+import {
+  redactConformanceReportForSharing,
+  redactSharedServerUrl,
+} from "@mcpjam/sdk";
 import { getClientIp } from "../../utils/client-ip.js";
 import { ErrorCode, WebRouteError, readJsonBody } from "./errors.js";
 
@@ -245,6 +249,21 @@ score.post("/runs", async (c) => {
 
   const { convexUrl, serviceToken } = backendConfig();
 
+  // Redact HERE, at the last gate before the report becomes durable and
+  // shareable — not in the browser that assembled it.
+  //
+  // A completed OAuth run carries a live access token, a refresh token, the
+  // client secret and the `Authorization` header of every request it made. The
+  // inspector shows all of that to the engineer who ran it, which is the point
+  // of a debugger; storing it behind a link that exists to be forwarded is a
+  // different act entirely. Doing it on the server means no client path — a
+  // future caller, a retry, a bug — can store the unredacted form by accident.
+  const storedPayload = {
+    ...parsed.data,
+    serverUrl: redactSharedServerUrl(parsed.data.serverUrl),
+    report: redactConformanceReportForSharing(parsed.data.report),
+  };
+
   let response: Response;
   try {
     response = await fetch(`${convexUrl}${BACKEND_CREATE_PATH}`, {
@@ -253,7 +272,7 @@ score.post("/runs", async (c) => {
         "Content-Type": "application/json",
         "x-inspector-service-token": serviceToken,
       },
-      body: JSON.stringify(parsed.data),
+      body: JSON.stringify(storedPayload),
       signal: AbortSignal.timeout(BACKEND_TIMEOUT_MS),
       // The scheme check above validates the CONFIGURED host. `fetch` follows
       // redirects by default and replays headers to wherever it lands, so a

--- a/mcpjam-inspector/server/routes/web/score.ts
+++ b/mcpjam-inspector/server/routes/web/score.ts
@@ -1,0 +1,234 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { getClientIp } from "../../utils/client-ip.js";
+import { ErrorCode, WebRouteError, readJsonBody } from "./errors.js";
+
+/**
+ * score.mcpjam.com persistence relay.
+ *
+ * The browser runs the suites (server-side, through `/api/web/conformance/*`)
+ * and assembles the report; this pair of routes stores it in Convex and reads
+ * it back. The inspector holds the service token, so the backend never has to
+ * open a `/public/*` surface and the link token never leaves our own edge.
+ *
+ * NO BEARER AUTH on either route, and that is the point rather than an
+ * oversight (the caniuse mounting precedent): a result link must open for
+ * someone with no session at all — a teammate, a maintainer, an incognito
+ * window. The token in the URL is the entire credential.
+ *
+ * Accepted v1 limitation, stated openly: the report is client-assembled, so a
+ * determined caller can store a fabricated one. That is tolerable ONLY because
+ * a run makes no third-party claim — no badge, no directory, no ranking — so
+ * the worst case is somebody lying to themselves via a link only they hold. A
+ * badge would require a server-verified re-run.
+ */
+
+const score = new Hono();
+
+const BACKEND_CREATE_PATH = "/internal/v1/score/runs";
+const BACKEND_GET_PATH = "/internal/v1/score/runs/get";
+
+// A full run takes a while and nobody legitimately stores dozens per minute.
+// Matches the caniuse report window rather than inventing a new number.
+const SUBMIT_RATE_LIMIT = 10;
+const SUBMIT_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const submitWindows = new Map<string, { count: number; windowStart: number }>();
+
+function consumeSubmitRateLimit(clientKey: string, now: number) {
+  for (const [key, value] of submitWindows) {
+    if (now - value.windowStart >= SUBMIT_RATE_LIMIT_WINDOW_MS) {
+      submitWindows.delete(key);
+    }
+  }
+
+  const rateWindow = submitWindows.get(clientKey);
+  if (rateWindow) {
+    if (rateWindow.count >= SUBMIT_RATE_LIMIT) {
+      throw new WebRouteError(
+        429,
+        ErrorCode.RATE_LIMITED,
+        "Too many score submissions. Please try again later."
+      );
+    }
+    rateWindow.count++;
+    return;
+  }
+
+  submitWindows.set(clientKey, { count: 1, windowStart: now });
+}
+
+/**
+ * Small, short-lived read cache. A shared result link gets opened repeatedly
+ * in a burst (a thread, a PR comment), and every hit is otherwise a Convex
+ * round trip for a document that can never change — runs are immutable.
+ */
+const RESULT_CACHE_TTL_MS = 60_000;
+const RESULT_CACHE_MAX_ENTRIES = 200;
+const resultCache = new Map<string, { at: number; payload: unknown }>();
+
+function readCachedResult(token: string): unknown | null {
+  const hit = resultCache.get(token);
+  if (!hit) return null;
+  if (Date.now() - hit.at > RESULT_CACHE_TTL_MS) {
+    resultCache.delete(token);
+    return null;
+  }
+  return hit.payload;
+}
+
+function cacheResult(token: string, payload: unknown) {
+  if (resultCache.size >= RESULT_CACHE_MAX_ENTRIES) {
+    // Oldest insertion first — Map preserves insertion order.
+    const oldest = resultCache.keys().next();
+    if (!oldest.done) resultCache.delete(oldest.value);
+  }
+  resultCache.set(token, { at: Date.now(), payload });
+}
+
+const summarySchema = z.object({
+  score: z.number().nullable(),
+  outcome: z.enum(["passed", "failed", "incomplete"]),
+  applicable: z.number().int().nonnegative(),
+  passed: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  couldNotRun: z.number().int().nonnegative(),
+  notApplicable: z.number().int().nonnegative(),
+  advisoryCount: z.number().int().nonnegative(),
+  protocolVersion: z.string().max(64).optional(),
+});
+
+const submitSchema = z.object({
+  serverUrl: z.string().trim().min(1).max(2048),
+  summary: summarySchema,
+  suiteSummaries: z
+    .array(
+      summarySchema.extend({
+        suiteId: z.enum(["protocol", "apps", "tasks", "oauth"]),
+      })
+    )
+    .max(4),
+  // The full multi-suite report. Shape is owned by the SDK's conformance
+  // result types and stored as an opaque blob, so it is not re-validated here
+  // — the backend caps the body size, which is the property that matters.
+  report: z.unknown().refine((value) => value !== undefined, {
+    message: "report is required",
+  }),
+});
+
+function backendConfig(): { convexUrl: string; serviceToken: string } {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!convexUrl || !serviceToken) {
+    throw new WebRouteError(
+      503,
+      ErrorCode.INTERNAL_ERROR,
+      "Score storage is not configured"
+    );
+  }
+  return { convexUrl: convexUrl.replace(/\/$/, ""), serviceToken };
+}
+
+score.post("/runs", async (c) => {
+  consumeSubmitRateLimit(getClientIp(c) ?? "unknown", Date.now());
+
+  const parsed = submitSchema.safeParse(await readJsonBody<unknown>(c));
+  if (!parsed.success) {
+    throw new WebRouteError(
+      400,
+      ErrorCode.VALIDATION_ERROR,
+      parsed.error.issues[0]?.message ?? "Invalid score run payload"
+    );
+  }
+
+  const { convexUrl, serviceToken } = backendConfig();
+
+  let response: Response;
+  try {
+    response = await fetch(`${convexUrl}${BACKEND_CREATE_PATH}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-inspector-service-token": serviceToken,
+      },
+      body: JSON.stringify(parsed.data),
+    });
+  } catch {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "Failed to store score run"
+    );
+  }
+
+  const body = (await response.json().catch(() => null)) as {
+    ok?: boolean;
+    token?: string;
+    error?: string;
+  } | null;
+  if (!response.ok || body?.ok !== true || !body.token) {
+    throw new WebRouteError(
+      response.status >= 400 ? response.status : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      body?.error ?? "Failed to store score run"
+    );
+  }
+
+  return c.json({ success: true, token: body.token });
+});
+
+score.get("/runs/:token", async (c) => {
+  const token = c.req.param("token");
+  if (!token) {
+    throw new WebRouteError(400, ErrorCode.VALIDATION_ERROR, "Missing token");
+  }
+
+  const cached = readCachedResult(token);
+  if (cached) {
+    return c.json({ success: true, run: cached });
+  }
+
+  const { convexUrl, serviceToken } = backendConfig();
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${convexUrl}${BACKEND_GET_PATH}?token=${encodeURIComponent(token)}`,
+      {
+        method: "GET",
+        headers: { "x-inspector-service-token": serviceToken },
+      }
+    );
+  } catch {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      "Failed to load score run"
+    );
+  }
+
+  if (response.status === 404) {
+    throw new WebRouteError(
+      404,
+      ErrorCode.NOT_FOUND,
+      "That result link is not valid, or the run no longer exists."
+    );
+  }
+
+  const body = (await response.json().catch(() => null)) as {
+    ok?: boolean;
+    run?: unknown;
+    error?: string;
+  } | null;
+  if (!response.ok || body?.ok !== true || !body.run) {
+    throw new WebRouteError(
+      response.status >= 400 ? response.status : 502,
+      ErrorCode.SERVER_UNREACHABLE,
+      body?.error ?? "Failed to load score run"
+    );
+  }
+
+  cacheResult(token, body.run);
+  return c.json({ success: true, run: body.run });
+});
+
+export default score;

--- a/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  BlockedEgressTargetError,
+  assertAllowedHostedTargetUrl,
+  type EgressHostResolver,
+} from "../hosted-egress-guard.js";
+
+/** Never consulted — reaching it means the literal check failed to short-circuit. */
+const exploding: EgressHostResolver = async () => {
+  throw new Error("resolver must not be called for an IP literal");
+};
+
+const resolvesTo =
+  (...ips: string[]): EgressHostResolver =>
+  async () =>
+    ips;
+
+async function assertBlocked(url: string, resolver?: EgressHostResolver) {
+  await expect(
+    assertAllowedHostedTargetUrl(url, "Server URL", {
+      hosted: true,
+      resolver: resolver ?? exploding,
+    })
+  ).rejects.toBeInstanceOf(BlockedEgressTargetError);
+}
+
+async function assertAllowed(url: string, resolver?: EgressHostResolver) {
+  await expect(
+    assertAllowedHostedTargetUrl(url, "Server URL", {
+      hosted: true,
+      resolver: resolver ?? exploding,
+    })
+  ).resolves.toBeUndefined();
+}
+
+describe("assertAllowedHostedTargetUrl — literal hosts", () => {
+  it("blocks cloud metadata, link-local and the unspecified address", async () => {
+    await assertBlocked("http://169.254.169.254/mcp");
+    await assertBlocked("http://169.254.0.1/mcp");
+    await assertBlocked("http://metadata.google.internal/mcp", resolvesTo());
+    await assertBlocked("http://0.0.0.0/mcp");
+    await assertBlocked("http://[::]/mcp");
+    await assertBlocked("http://[fe80::1]/mcp");
+  });
+
+  it("blocks loopback and `.localhost` when hosted", async () => {
+    await assertBlocked("http://127.0.0.1:3000/mcp");
+    await assertBlocked("http://127.9.9.9/mcp");
+    await assertBlocked("http://[::1]:3000/mcp");
+    await assertBlocked("http://localhost:3000/mcp", resolvesTo());
+    await assertBlocked("http://my-server.localhost/mcp", resolvesTo());
+  });
+
+  it("blocks RFC-1918, CGNAT and IPv6 ULA", async () => {
+    await assertBlocked("http://10.0.0.5/mcp");
+    await assertBlocked("http://192.168.1.1/mcp");
+    await assertBlocked("http://172.16.0.1/mcp");
+    await assertBlocked("http://172.31.255.254/mcp");
+    await assertBlocked("http://100.64.0.1/mcp");
+    await assertBlocked("http://[fc00::1]/mcp");
+    await assertBlocked("http://[fd12:3456::1]/mcp");
+  });
+
+  it("blocks IPv4-mapped IPv6 spellings of the same addresses", async () => {
+    await assertBlocked("http://[::ffff:169.254.169.254]/mcp");
+    await assertBlocked("http://[::ffff:127.0.0.1]/mcp");
+    await assertBlocked("http://[::ffff:10.0.0.5]/mcp");
+  });
+
+  it("blocks the hex spelling `new URL()` rewrites those into", async () => {
+    // `new URL("http://[::ffff:169.254.169.254]/").hostname` is
+    // `[::ffff:a9fe:a9fe]` — checking only the dotted form left the metadata
+    // endpoint reachable through any parsed URL.
+    expect(new URL("http://[::ffff:169.254.169.254]/").hostname).toBe(
+      "[::ffff:a9fe:a9fe]"
+    );
+    await assertBlocked("http://[::ffff:a9fe:a9fe]/mcp"); // 169.254.169.254
+    await assertBlocked("http://[::ffff:7f00:1]/mcp"); // 127.0.0.1
+    await assertBlocked("http://[::ffff:a00:5]/mcp"); // 10.0.0.5
+    await assertBlocked("http://[::ffff:c0a8:101]/mcp"); // 192.168.1.1
+    // …and the same spelling of a PUBLIC address still goes through.
+    await assertAllowed("http://[::ffff:808:808]/mcp"); // 8.8.8.8
+  });
+
+  it("allows public IP literals without touching DNS", async () => {
+    // `exploding` proves the literal path never resolves.
+    await assertAllowed("https://8.8.8.8/mcp");
+    await assertAllowed("https://172.32.0.1/mcp");
+    await assertAllowed("https://11.0.0.1/mcp");
+    await assertAllowed("https://[2606:4700::1111]/mcp");
+  });
+
+  it("rejects non-http(s) schemes and unparseable URLs", async () => {
+    await assertBlocked("file:///etc/passwd");
+    await assertBlocked("gopher://example.com/");
+    await assertBlocked("not a url");
+  });
+});
+
+describe("assertAllowedHostedTargetUrl — DNS rebinding", () => {
+  it("blocks a public hostname that resolves to a private address", async () => {
+    await assertBlocked(
+      "https://rebind.example.com/mcp",
+      resolvesTo("127.0.0.1")
+    );
+    await assertBlocked(
+      "https://rebind.example.com/mcp",
+      resolvesTo("169.254.169.254")
+    );
+    await assertBlocked("https://rebind.example.com/mcp", resolvesTo("::1"));
+  });
+
+  it("blocks when ANY resolved address is private, not just the first", async () => {
+    await assertBlocked(
+      "https://mixed.example.com/mcp",
+      resolvesTo("93.184.216.34", "10.0.0.5")
+    );
+  });
+
+  it("fails closed on an unresolvable hostname", async () => {
+    await expect(
+      assertAllowedHostedTargetUrl(
+        "https://nope.example.test/mcp",
+        "Server URL",
+        {
+          hosted: true,
+          resolver: resolvesTo(),
+        }
+      )
+    ).rejects.toThrow(/could not be resolved/);
+  });
+
+  it("reports a resolver failure as a lookup problem, not a verdict", async () => {
+    // A DNS blip must not read as "your server is blocked" — the wording is
+    // the only thing separating an infra hiccup from a real refusal.
+    await expect(
+      assertAllowedHostedTargetUrl(
+        "https://flaky.example.com/mcp",
+        "Server URL",
+        {
+          hosted: true,
+          resolver: async () => {
+            throw new Error("ESERVFAIL");
+          },
+        }
+      )
+    ).rejects.toThrow(/Could not check .* for a safe address: ESERVFAIL/);
+  });
+
+  it("allows a hostname that resolves entirely to public addresses", async () => {
+    await assertAllowed(
+      "https://mcp.example.com/mcp",
+      resolvesTo("93.184.216.34", "2606:2800:220:1::1")
+    );
+  });
+
+  it("allows a tunnel-backed server URL", async () => {
+    // Tunnels ride public `*.tunnels.mcpjam.com` hostnames, so they clear the
+    // guard like any other public target.
+    await assertAllowed(
+      "https://abc123.tunnels.mcpjam.com/mcp",
+      resolvesTo("104.18.0.1")
+    );
+  });
+});
+
+describe("assertAllowedHostedTargetUrl — local mode", () => {
+  it("is a no-op outside hosted mode, localhost very much included", async () => {
+    // Testing a server on localhost is the inspector's whole job locally.
+    for (const url of [
+      "http://localhost:3000/mcp",
+      "http://127.0.0.1:3000/mcp",
+      "http://192.168.1.50/mcp",
+      "http://169.254.169.254/mcp",
+    ]) {
+      await expect(
+        assertAllowedHostedTargetUrl(url, "Server URL", {
+          hosted: false,
+          resolver: exploding,
+        })
+      ).resolves.toBeUndefined();
+    }
+  });
+});
+
+describe("assertAllowedHostedTargetUrl — error text", () => {
+  it("names the field that was refused", async () => {
+    await expect(
+      assertAllowedHostedTargetUrl(
+        "http://10.0.0.5/mcp",
+        "OAuth profile server URL",
+        { hosted: true, resolver: exploding }
+      )
+    ).rejects.toThrow(/OAuth profile server URL/);
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
@@ -3,6 +3,7 @@ import {
   BlockedEgressTargetError,
   EgressResolutionError,
   assertAllowedHostedTargetUrl,
+  createGuardedFetch,
   type EgressHostResolver,
 } from "../hosted-egress-guard.js";
 
@@ -230,5 +231,166 @@ describe("assertAllowedHostedTargetUrl — error text", () => {
         { hosted: true, resolver: exploding }
       )
     ).rejects.toThrow(/OAuth profile server URL/);
+  });
+});
+
+describe("createGuardedFetch", () => {
+  /** A fetch that replays a scripted sequence and records what it was asked for. */
+  function scriptedFetch(responses: Array<() => Response>) {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    let index = 0;
+    const fn = (async (input: any, init: any) => {
+      calls.push({ url: String(input), init: init ?? {} });
+      const next = responses[Math.min(index, responses.length - 1)];
+      index += 1;
+      return next();
+    }) as unknown as typeof fetch;
+    return { fn, calls };
+  }
+
+  const redirectTo = (location: string, status = 302) => () =>
+    new Response(null, { status, headers: { location } });
+  const ok = (body = "ok") => () => new Response(body, { status: 200 });
+
+  /**
+   * The hole this exists to close: the caller names a host that passes every
+   * check, and that host points us at the metadata endpoint. Nothing about the
+   * request the caller made was refusable.
+   */
+  it("refuses a redirect into cloud metadata", async () => {
+    const { fn, calls } = scriptedFetch([
+      redirectTo("http://169.254.169.254/latest/meta-data/iam/"),
+      ok("IAM CREDENTIALS"),
+    ]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: resolvesTo("93.184.216.34"),
+    });
+
+    await expect(
+      guarded("https://redirector.example.com/go")
+    ).rejects.toThrow(BlockedEgressTargetError);
+    // The second hop was never dialed.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("refuses a redirect into the private network", async () => {
+    const { fn } = scriptedFetch([redirectTo("http://10.0.0.5/admin"), ok()]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: resolvesTo("93.184.216.34"),
+    });
+
+    await expect(guarded("https://redirector.example.com/go")).rejects.toThrow(
+      /private or internal/
+    );
+  });
+
+  it("follows an ordinary redirect and returns the final response", async () => {
+    const { fn, calls } = scriptedFetch([
+      redirectTo("https://elsewhere.example.com/mcp"),
+      ok("final"),
+    ]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: resolvesTo("93.184.216.34"),
+    });
+
+    const response = await guarded("https://start.example.com/mcp");
+    expect(await response.text()).toBe("final");
+    expect(calls.map((c) => c.url)).toEqual([
+      "https://start.example.com/mcp",
+      "https://elsewhere.example.com/mcp",
+    ]);
+  });
+
+  it("resolves a relative Location against the hop that sent it", async () => {
+    const { fn, calls } = scriptedFetch([redirectTo("/moved"), ok()]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: resolvesTo("93.184.216.34"),
+    });
+
+    await guarded("https://start.example.com/deep/path");
+    expect(calls[1].url).toBe("https://start.example.com/moved");
+  });
+
+  it("hands a 3xx straight back when the caller asked for manual redirects", async () => {
+    // The OAuth suite grades redirects; following one for it would destroy the
+    // evidence it is trying to collect.
+    const { fn, calls } = scriptedFetch([
+      redirectTo("http://169.254.169.254/"),
+      ok(),
+    ]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: resolvesTo("93.184.216.34"),
+    });
+
+    const response = await guarded("https://as.example.com/authorize", {
+      redirect: "manual",
+    });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("http://169.254.169.254/");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("turns a redirected POST into a GET without a body, per the Fetch standard", async () => {
+    const { fn, calls } = scriptedFetch([redirectTo("https://b.example.com/"), ok()]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: resolvesTo("93.184.216.34"),
+    });
+
+    await guarded("https://a.example.com/", {
+      method: "POST",
+      body: '{"jsonrpc":"2.0"}',
+      headers: { "content-type": "application/json" },
+    });
+    expect(calls[1].init.method).toBe("GET");
+    expect(calls[1].init.body).toBeUndefined();
+  });
+
+  it("preserves method and body across a 307", async () => {
+    const { fn, calls } = scriptedFetch([
+      redirectTo("https://b.example.com/", 307),
+      ok(),
+    ]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: resolvesTo("93.184.216.34"),
+    });
+
+    await guarded("https://a.example.com/", {
+      method: "POST",
+      body: '{"jsonrpc":"2.0"}',
+    });
+    expect(calls[1].init.method).toBe("POST");
+    expect(calls[1].init.body).toBe('{"jsonrpc":"2.0"}');
+  });
+
+  it("stops a redirect loop rather than spinning", async () => {
+    const { fn } = scriptedFetch([redirectTo("https://loop.example.com/")]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: resolvesTo("93.184.216.34"),
+    });
+
+    await expect(guarded("https://loop.example.com/")).rejects.toThrow(
+      /Too many redirects/
+    );
+  });
+
+  it("is the untouched fetch outside hosted mode", () => {
+    const { fn } = scriptedFetch([ok()]);
+    expect(createGuardedFetch({ hosted: false, baseFetch: fn })).toBe(fn);
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
@@ -469,6 +469,44 @@ describe("createGuardedFetch — credentials across a redirect", () => {
     expect(calls[1].init.method).toBe("HEAD");
   });
 
+  it("honors redirect: \"error\" instead of following", async () => {
+    const { fn, calls } = scriptedFetch([
+      redirectTo("https://b.example.com/"),
+      ok(),
+    ]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: publicResolver,
+    });
+
+    await expect(
+      guarded(new Request("https://a.example.com/", { redirect: "error" }))
+    ).rejects.toThrow(/refused redirects/);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("refuses a body-bearing Request rather than sending it empty", async () => {
+    // Copying every other field and dropping the body would send an empty POST
+    // and report the server's answer to THAT as its behavior.
+    const { fn, calls } = scriptedFetch([ok()]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: publicResolver,
+    });
+
+    await expect(
+      guarded(
+        new Request("https://a.example.com/", {
+          method: "POST",
+          body: '{"jsonrpc":"2.0"}',
+        })
+      )
+    ).rejects.toThrow(/cannot be dialed through the egress guard/);
+    expect(calls).toHaveLength(0);
+  });
+
   it("preserves a Request object's method and headers", async () => {
     const { fn, calls } = scriptedFetch([ok()]);
     const guarded = createGuardedFetch({

--- a/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
@@ -94,9 +94,16 @@ describe("assertAllowedHostedTargetUrl — literal hosts", () => {
   it("blocks reserved names spelled with a trailing DNS dot", async () => {
     // `localhost.` and `metadata.google.internal.` resolve identically to the
     // dotless forms, but are different strings to a literal comparison.
-    await assertBlocked("http://localhost./mcp", resolvesTo());
-    await assertBlocked("http://metadata.google.internal./mcp", resolvesTo());
-    await assertBlocked("http://my-server.localhost./mcp", resolvesTo());
+    //
+    // The resolver deliberately answers with a PUBLIC address: only the
+    // name-based check can reject these, so if the dot-strip regresses the
+    // target sails through and this test fails. An empty resolver would have
+    // blocked them via the unresolvable path and hidden the regression.
+    const publicAnswer = resolvesTo("93.184.216.34");
+    await assertBlocked("http://localhost./mcp", publicAnswer);
+    await assertBlocked("http://metadata.google.internal./mcp", publicAnswer);
+    await assertBlocked("http://my-server.localhost./mcp", publicAnswer);
+    await assertBlocked("http://metadata.goog./mcp", publicAnswer);
   });
 
   it("does not mistake a hex-looking hostname for an IPv6 literal", async () => {
@@ -104,7 +111,7 @@ describe("assertAllowedHostedTargetUrl — literal hosts", () => {
     // skip the DNS pass entirely and be dialed unresolved — the exact
     // rebinding hole the DNS pass exists to close.
     await assertBlocked("http://deadbeef/mcp", resolvesTo("10.0.0.5"));
-    await assertBlocked("http://cafe/mcp", resolvesTo());
+    await assertBlocked("http://cafe/mcp", resolvesTo("127.0.0.1"));
     await assertAllowed("http://f00d/mcp", resolvesTo("93.184.216.34"));
   });
 

--- a/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BlockedEgressTargetError,
+  EgressResolutionError,
   assertAllowedHostedTargetUrl,
   type EgressHostResolver,
 } from "../hosted-egress-guard.js";
@@ -90,6 +91,23 @@ describe("assertAllowedHostedTargetUrl — literal hosts", () => {
     await assertAllowed("https://[2606:4700::1111]/mcp");
   });
 
+  it("blocks reserved names spelled with a trailing DNS dot", async () => {
+    // `localhost.` and `metadata.google.internal.` resolve identically to the
+    // dotless forms, but are different strings to a literal comparison.
+    await assertBlocked("http://localhost./mcp", resolvesTo());
+    await assertBlocked("http://metadata.google.internal./mcp", resolvesTo());
+    await assertBlocked("http://my-server.localhost./mcp", resolvesTo());
+  });
+
+  it("does not mistake a hex-looking hostname for an IPv6 literal", async () => {
+    // `deadbeef` has no dots and no colon. Treated as an IP literal, it would
+    // skip the DNS pass entirely and be dialed unresolved — the exact
+    // rebinding hole the DNS pass exists to close.
+    await assertBlocked("http://deadbeef/mcp", resolvesTo("10.0.0.5"));
+    await assertBlocked("http://cafe/mcp", resolvesTo());
+    await assertAllowed("http://f00d/mcp", resolvesTo("93.184.216.34"));
+  });
+
   it("rejects non-http(s) schemes and unparseable URLs", async () => {
     await assertBlocked("file:///etc/passwd");
     await assertBlocked("gopher://example.com/");
@@ -131,8 +149,21 @@ describe("assertAllowedHostedTargetUrl — DNS rebinding", () => {
   });
 
   it("reports a resolver failure as a lookup problem, not a verdict", async () => {
-    // A DNS blip must not read as "your server is blocked" — the wording is
-    // the only thing separating an infra hiccup from a real refusal.
+    // A DNS blip must not read as "your server is blocked". The TYPE is what
+    // separates them: a blocked target is the caller's problem and permanent,
+    // a resolver outage is ours and retryable.
+    await expect(
+      assertAllowedHostedTargetUrl(
+        "https://flaky.example.com/mcp",
+        "Server URL",
+        {
+          hosted: true,
+          resolver: async () => {
+            throw new Error("ESERVFAIL");
+          },
+        }
+      )
+    ).rejects.toBeInstanceOf(EgressResolutionError);
     await expect(
       assertAllowedHostedTargetUrl(
         "https://flaky.example.com/mcp",

--- a/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-egress-guard.test.ts
@@ -394,3 +394,97 @@ describe("createGuardedFetch", () => {
     expect(createGuardedFetch({ hosted: false, baseFetch: fn })).toBe(fn);
   });
 });
+
+describe("createGuardedFetch — credentials across a redirect", () => {
+  function scriptedFetch(responses: Array<() => Response>) {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    let index = 0;
+    const fn = (async (input: any, init: any) => {
+      calls.push({ url: String(input), init: init ?? {} });
+      const next = responses[Math.min(index, responses.length - 1)];
+      index += 1;
+      return next();
+    }) as unknown as typeof fetch;
+    return { fn, calls };
+  }
+  const redirectTo = (location: string, status = 302) => () =>
+    new Response(null, { status, headers: { location } });
+  const ok = () => () => new Response("ok", { status: 200 });
+  const publicResolver: EgressHostResolver = async () => ["93.184.216.34"];
+
+  const headerOf = (init: RequestInit, name: string) =>
+    new Headers((init.headers as HeadersInit | undefined) ?? {}).get(name);
+
+  /**
+   * A server under test can harvest its caller's credentials by redirecting to
+   * a host it controls. `fetch` strips them on a cross-origin hop; following
+   * redirects by hand means inheriting that duty.
+   */
+  it("does not carry Authorization to a different origin", async () => {
+    const { fn, calls } = scriptedFetch([
+      redirectTo("https://attacker.example.com/collect"),
+      ok(),
+    ]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: publicResolver,
+    });
+
+    await guarded("https://mcp.example.com/mcp", {
+      headers: { authorization: "Bearer at_live", cookie: "sid=abc" },
+    });
+
+    expect(headerOf(calls[0].init, "authorization")).toBe("Bearer at_live");
+    expect(headerOf(calls[1].init, "authorization")).toBeNull();
+    expect(headerOf(calls[1].init, "cookie")).toBeNull();
+  });
+
+  it("keeps Authorization on a same-origin redirect", async () => {
+    // Same origin is the ordinary `/mcp` → `/mcp/` case; dropping the token
+    // there would break authenticated servers for no security gain.
+    const { fn, calls } = scriptedFetch([redirectTo("/mcp/v2"), ok()]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: publicResolver,
+    });
+
+    await guarded("https://mcp.example.com/mcp", {
+      headers: { authorization: "Bearer at_live" },
+    });
+
+    expect(headerOf(calls[1].init, "authorization")).toBe("Bearer at_live");
+  });
+
+  it("leaves a redirected HEAD as HEAD", async () => {
+    const { fn, calls } = scriptedFetch([redirectTo("https://b.example.com/", 303), ok()]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: publicResolver,
+    });
+
+    await guarded("https://a.example.com/", { method: "HEAD" });
+    expect(calls[1].init.method).toBe("HEAD");
+  });
+
+  it("preserves a Request object's method and headers", async () => {
+    const { fn, calls } = scriptedFetch([ok()]);
+    const guarded = createGuardedFetch({
+      hosted: true,
+      baseFetch: fn,
+      resolver: publicResolver,
+    });
+
+    await guarded(
+      new Request("https://mcp.example.com/mcp", {
+        method: "POST",
+        headers: { "x-custom": "kept" },
+      })
+    );
+
+    expect(calls[0].init.method).toBe("POST");
+    expect(headerOf(calls[0].init, "x-custom")).toBe("kept");
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/hosted-egress-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-egress-resolver.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `defaultEgressHostResolver` decides whether an empty DNS answer is a FACT
+ * ("this name has no records" — fail closed on it) or an OUTAGE ("our resolver
+ * broke" — retryable). Getting that wrong tells a user their server is
+ * forbidden during a DNS incident.
+ *
+ * These tests mock `node:dns` so the real classification runs. A test that
+ * stubbed the resolver itself would only be checking its own mock.
+ */
+
+const resolve4 = vi.hoisted(() => vi.fn());
+const resolve6 = vi.hoisted(() => vi.fn());
+
+vi.mock("node:dns", () => ({
+  promises: { resolve4, resolve6 },
+}));
+
+function dnsError(code: string) {
+  return Object.assign(new Error(code), { code });
+}
+
+async function resolver() {
+  vi.resetModules();
+  const { defaultEgressHostResolver } = await import("../hosted-egress-guard");
+  return defaultEgressHostResolver;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("defaultEgressHostResolver", () => {
+  it("merges both families when both answer", async () => {
+    resolve4.mockResolvedValue(["93.184.216.34"]);
+    resolve6.mockResolvedValue(["2606:2800:220:1::1"]);
+    expect(await (await resolver())("example.com")).toEqual([
+      "93.184.216.34",
+      "2606:2800:220:1::1",
+    ]);
+  });
+
+  it("keeps one family's answer when the other has no record", async () => {
+    // Ordinary: plenty of hosts are v4-only.
+    resolve4.mockResolvedValue(["93.184.216.34"]);
+    resolve6.mockRejectedValue(dnsError("ENODATA"));
+    expect(await (await resolver())("example.com")).toEqual(["93.184.216.34"]);
+  });
+
+  it("returns empty when BOTH families genuinely have no record", async () => {
+    // A fact, not an outage — the caller fails closed on it.
+    resolve4.mockRejectedValue(dnsError("ENOTFOUND"));
+    resolve6.mockRejectedValue(dnsError("ENOTFOUND"));
+    expect(await (await resolver())("nope.example.com")).toEqual([]);
+  });
+
+  it("throws when both families fail transiently", async () => {
+    resolve4.mockRejectedValue(dnsError("ESERVFAIL"));
+    resolve6.mockRejectedValue(dnsError("ESERVFAIL"));
+    await expect((await resolver())("flaky.example.com")).rejects.toThrow(
+      /ESERVFAIL/
+    );
+  });
+
+  it("throws on a MIXED no-record + outage answer", async () => {
+    // The subtle one. v4 says "no such record" (a fact), v6 SERVFAILs (an
+    // outage) — so we never learned whether an AAAA exists. Reporting
+    // "unresolvable" would be a claim we cannot support, and would answer 400
+    // "your server is forbidden" in the middle of a DNS incident.
+    resolve4.mockRejectedValue(dnsError("ENODATA"));
+    resolve6.mockRejectedValue(dnsError("ESERVFAIL"));
+    await expect((await resolver())("mixed.example.com")).rejects.toThrow(
+      /ESERVFAIL/
+    );
+  });
+
+  it("prefers a real answer over a sibling family's outage", async () => {
+    // If one family ANSWERED, we have addresses to judge — no need to fail.
+    resolve4.mockResolvedValue(["93.184.216.34"]);
+    resolve6.mockRejectedValue(dnsError("ESERVFAIL"));
+    expect(await (await resolver())("example.com")).toEqual(["93.184.216.34"]);
+  });
+});

--- a/mcpjam-inspector/server/utils/hosted-egress-guard.ts
+++ b/mcpjam-inspector/server/utils/hosted-egress-guard.ts
@@ -1,0 +1,244 @@
+/**
+ * The one place that decides whether the hosted inspector is allowed to dial a
+ * URL a caller handed it.
+ *
+ * Hosted, the inspector's backend sits on a shared cloud network, so any route
+ * that takes a target URL from a request is an SSRF primitive: point it at
+ * `http://169.254.169.254/` and the response is IAM credentials. Locally
+ * (CLI/desktop) the exact opposite is true — dialing `http://localhost:3000/mcp`
+ * IS the product — so every check here is gated on `HOSTED_MODE` and the
+ * host-tier distinction `isBlockedEgressHost` already draws:
+ *
+ *   - Always blocked: cloud-metadata addresses and their DNS aliases,
+ *     link-local, and the unspecified address. Never a legitimate target
+ *     anywhere, in any mode.
+ *   - Blocked only when hosted: loopback, `.localhost`, RFC-1918, CGNAT, and
+ *     IPv6 ULA.
+ *
+ * Two things this guard deliberately does NOT do:
+ *
+ *   - It judges the TARGET URL, never an outgoing `Host` header. The protocol
+ *     conformance suite sends rebinding-style Host headers on purpose (the
+ *     `localhost-host-rebinding-rejected` checks are how it grades a server's
+ *     own defenses); treating those as egress would break the suite it is
+ *     meant to protect.
+ *   - It does not close the check-vs-connect (TOCTOU) rebinding window: the
+ *     DNS answer is validated, then the HTTP client resolves again. Narrowing
+ *     that requires pinning the connection to the vetted IP, which belongs to
+ *     infra-level egress policy — the same punt documented on the harness
+ *     guard.
+ */
+
+import { promises as dns } from "node:dns";
+import { HOSTED_MODE } from "../config.js";
+
+/** Parse a dotted-quad IPv4 literal into octets, or null if not well-formed. */
+function parseIpv4Octets(
+  host: string
+): [number, number, number, number] | null {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!m) return null;
+  const o = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
+  if (o.some((n) => n > 255)) return null;
+  return [o[0], o[1], o[2], o[3]];
+}
+
+/**
+ * Is this hostname one the hosted inspector must refuse?
+ *
+ *   - ALWAYS blocked: cloud-metadata names, IPv4/IPv6 link-local (169.254/16,
+ *     fe80::/10), and the unspecified address (0.0.0.0/8, ::) — never a
+ *     legitimate target in any deployment.
+ *   - Blocked only when `blockPrivate` (hosted mode): loopback, RFC-1918
+ *     private, CGNAT (100.64/10), and IPv6 ULA (fc00::/7). Left reachable for
+ *     local dev, where the inspector legitimately talks to a localhost MCP
+ *     server and a widget legitimately renders against one.
+ *
+ * Matches on a literal hostname only; `assertAllowedHostedTargetUrl` is what
+ * adds the DNS-resolution pass on top.
+ *
+ * Two callers share this: the browser harness's egress route (a widget's
+ * declared CSP origins must not reach infrastructure only the harness HOST can
+ * see — most dangerously 169.254.169.254, whose IAM credentials would be a
+ * full account compromise) and the hosted conformance routes.
+ */
+export function isBlockedEgressHost(
+  hostname: string,
+  blockPrivate: boolean
+): boolean {
+  let host = hostname.trim().toLowerCase();
+  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
+  if (!host) return false;
+
+  // Cloud metadata DNS aliases (they resolve to link-local, but block the
+  // names too in case resolution is bypassed).
+  if (host === "metadata.google.internal" || host === "metadata.goog") {
+    return true;
+  }
+  if (host === "localhost" || host.endsWith(".localhost")) return blockPrivate;
+
+  const v4 = parseIpv4Octets(host);
+  if (v4) {
+    const [a, b] = v4;
+    if (a === 169 && b === 254) return true; // link-local incl. cloud metadata
+    if (a === 0) return true; // "this network" / unspecified
+    if (!blockPrivate) return false;
+    if (a === 127) return true; // loopback 127.0.0.0/8
+    if (a === 10) return true; // 10.0.0.0/8
+    if (a === 192 && b === 168) return true; // 192.168.0.0/16
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64.0.0/10
+    return false;
+  }
+
+  if (host.includes(":")) {
+    // IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) — judge the embedded v4.
+    const mapped = /(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/.exec(host);
+    if (mapped) return isBlockedEgressHost(mapped[1], blockPrivate);
+    // The SAME address in hex. `new URL()` rewrites the dotted spelling into
+    // this one (`[::ffff:169.254.169.254]` → `[::ffff:a9fe:a9fe]`), so a check
+    // that only knew the dotted form let the metadata endpoint through the
+    // moment the host came from a parsed URL rather than a raw string.
+    const mappedHex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(host);
+    if (mappedHex) {
+      const high = parseInt(mappedHex[1], 16);
+      const low = parseInt(mappedHex[2], 16);
+      return isBlockedEgressHost(
+        `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${
+          low & 0xff
+        }`,
+        blockPrivate
+      );
+    }
+    if (host === "::") return true; // unspecified
+    if (/^fe[89ab]/.test(host)) return true; // link-local fe80::/10
+    if (!blockPrivate) return false;
+    if (host === "::1") return true; // loopback
+    if (/^f[cd]/.test(host)) return true; // ULA fc00::/7
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Raised when a target is refused. Distinct from a transport failure so
+ * callers can map it to a 400 (you asked for something we won't dial) rather
+ * than a 502 (we tried and it didn't work).
+ */
+export class BlockedEgressTargetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BlockedEgressTargetError";
+  }
+}
+
+/**
+ * Resolve a hostname to IP strings. Injectable so tests can exercise the
+ * rebinding path without a network, and so hosted-route tests that use
+ * fabricated hostnames (`example.test`) can supply an answer instead of
+ * tripping the unresolvable-host branch.
+ */
+export type EgressHostResolver = (hostname: string) => Promise<string[]>;
+
+export const defaultEgressHostResolver: EgressHostResolver = async (
+  hostname
+) => {
+  const resolved: string[] = [];
+  // Both families are asked independently: a host with an A record and no
+  // AAAA (or vice versa) is ordinary, and one NXDOMAIN must not hide the
+  // other family's answer.
+  const [v4, v6] = await Promise.allSettled([
+    dns.resolve4(hostname),
+    dns.resolve6(hostname),
+  ]);
+  if (v4.status === "fulfilled") resolved.push(...v4.value);
+  if (v6.status === "fulfilled") resolved.push(...v6.value);
+  return resolved;
+};
+
+function isIpLiteral(host: string): boolean {
+  return /^[\d.]+$/.test(host) || /^[0-9a-f:]+$/i.test(host);
+}
+
+/**
+ * The resolver used when a caller passes none. Overridable so route-level
+ * tests can exercise the real guard against fabricated hostnames (the hosted
+ * conformance tests use `example.test`, which no real resolver will answer)
+ * instead of stubbing the guard out and testing nothing.
+ */
+let activeResolver: EgressHostResolver = defaultEgressHostResolver;
+
+export function setEgressHostResolverForTests(
+  resolver: EgressHostResolver | null
+): void {
+  activeResolver = resolver ?? defaultEgressHostResolver;
+}
+
+/**
+ * Throw unless the hosted inspector may dial `rawUrl`.
+ *
+ * No-op outside hosted mode. `label` names the field in the error so a user
+ * who pasted a bad URL learns WHICH url was refused — a run failure that says
+ * only "blocked" is indistinguishable from a bug in our runner.
+ */
+export async function assertAllowedHostedTargetUrl(
+  rawUrl: string,
+  label: string,
+  options: { resolver?: EgressHostResolver; hosted?: boolean } = {}
+): Promise<void> {
+  const hosted = options.hosted ?? HOSTED_MODE;
+  if (!hosted) return;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new BlockedEgressTargetError(`${label} is not a valid URL`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new BlockedEgressTargetError(
+      `${label} must be an http(s) URL (got "${parsed.protocol}")`
+    );
+  }
+
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (isBlockedEgressHost(host, true)) {
+    throw new BlockedEgressTargetError(
+      `${label} points at a private or internal address ("${host}") that the hosted inspector will not dial. Run this server locally in the inspector instead.`
+    );
+  }
+  // An IP literal has already been judged on its own terms; resolving it would
+  // only ask DNS to repeat the number back.
+  if (isIpLiteral(host)) return;
+
+  const resolver = options.resolver ?? activeResolver;
+  let resolvedIps: string[];
+  try {
+    resolvedIps = await resolver(host);
+  } catch (error) {
+    // A resolver that throws is infrastructure trouble, not a verdict about
+    // the target. Say so plainly rather than letting a DNS blip read as "your
+    // server is blocked".
+    throw new BlockedEgressTargetError(
+      `Could not check "${host}" for a safe address: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+  if (resolvedIps.length === 0) {
+    // Fail closed. Unresolvable means we cannot prove the target is external,
+    // and "we couldn't look it up" is a more useful thing to tell a user than
+    // a connection error thirty seconds later.
+    throw new BlockedEgressTargetError(
+      `${label} hostname "${host}" could not be resolved, so it cannot be checked for a safe address.`
+    );
+  }
+  for (const ip of resolvedIps) {
+    if (isBlockedEgressHost(ip, true)) {
+      throw new BlockedEgressTargetError(
+        `${label} hostname "${host}" resolves to a private or internal address (${ip}) that the hosted inspector will not dial.`
+      );
+    }
+  }
+}

--- a/mcpjam-inspector/server/utils/hosted-egress-guard.ts
+++ b/mcpjam-inspector/server/utils/hosted-egress-guard.ts
@@ -340,13 +340,29 @@ export function createGuardedFetch(
   if (!hosted) return baseFetch;
 
   const guardedFetch: typeof fetch = async (input, init) => {
-    let currentUrl =
-      typeof input === "string"
+    // A `Request` carries its own method, headers and body. Reading only its
+    // `url` and dropping the rest would silently turn an authenticated POST
+    // into an anonymous GET — a request the caller never made, whose response
+    // we would then report as the target's behavior.
+    const fromRequest =
+      typeof input !== "string" && !(input instanceof URL) ? input : undefined;
+    let currentUrl = fromRequest
+      ? fromRequest.url
+      : typeof input === "string"
         ? input
-        : input instanceof URL
-          ? input.toString()
-          : input.url;
-    let currentInit: RequestInit = { ...(init ?? {}) };
+        : input.toString();
+    let currentInit: RequestInit = fromRequest
+      ? {
+          method: fromRequest.method,
+          headers: new Headers(fromRequest.headers),
+          // A `Request` body is a stream; only a bodiless one can be replayed
+          // safely, and the 307/308 branch below refuses the rest explicitly.
+          body: fromRequest.bodyUsed ? undefined : (init?.body ?? undefined),
+          redirect: fromRequest.redirect,
+          signal: fromRequest.signal,
+          ...(init ?? {}),
+        }
+      : { ...(init ?? {}) };
 
     // A caller that wants the 3xx itself gets one request and one check.
     const wantsManual = currentInit.redirect === "manual";
@@ -378,8 +394,40 @@ export function createGuardedFetch(
       // that produced them, not the original request.
       const nextUrl = new URL(location, currentUrl).toString();
 
+      // CREDENTIALS DO NOT FOLLOW A REDIRECT ACROSS ORIGINS.
+      //
+      // Replaying the original headers on every hop hands the target's own
+      // `Authorization` — the access token a conformance run was given, or the
+      // bearer a user configured — to whatever host the redirect names. A
+      // server under test can therefore harvest its own caller's credentials by
+      // answering `302 Location: https://attacker.example/`. `fetch` strips
+      // these on a cross-origin redirect for exactly this reason, and following
+      // redirects by hand means inheriting that duty rather than the default.
+      if (new URL(nextUrl).origin !== new URL(currentUrl).origin) {
+        const headers = new Headers(
+          (currentInit.headers as HeadersInit | undefined) ?? {}
+        );
+        for (const name of [
+          "authorization",
+          "proxy-authorization",
+          "cookie",
+          "www-authenticate",
+        ]) {
+          headers.delete(name);
+        }
+        currentInit = { ...currentInit, headers };
+      }
+
       const method = (currentInit.method ?? "GET").toUpperCase();
-      if (response.status === 303 || ((response.status === 301 || response.status === 302) && method === "POST")) {
+      // Per the Fetch standard: 303 rewrites to GET, and 301/302 rewrite POST
+      // to GET. HEAD is exempt from both — it stays HEAD, because a caller that
+      // asked for headers only must not be handed a body.
+      const rewritesToGet =
+        method !== "HEAD" &&
+        (response.status === 303 ||
+          ((response.status === 301 || response.status === 302) &&
+            method === "POST"));
+      if (rewritesToGet) {
         currentInit = { ...currentInit, method: "GET", body: undefined };
         // A body-shaped content type on a bodiless GET confuses servers and is
         // no longer true of the request being sent.

--- a/mcpjam-inspector/server/utils/hosted-egress-guard.ts
+++ b/mcpjam-inspector/server/utils/hosted-egress-guard.ts
@@ -15,6 +15,12 @@
  *   - Blocked only when hosted: loopback, `.localhost`, RFC-1918, CGNAT, and
  *     IPv6 ULA.
  *
+ * Validating the URL a caller NAMED is not enough on its own, because a caller
+ * does not have to name the address they want reached — they can name a host
+ * they control and have it answer `302 Location: http://169.254.169.254/`. So
+ * `createGuardedFetch` re-checks every hop; a guard that only inspects the first
+ * URL is a guard against typos, not against an attacker.
+ *
  * Two things this guard deliberately does NOT do:
  *
  *   - It judges the TARGET URL, never an outgoing `Host` header. The protocol
@@ -297,4 +303,112 @@ export async function assertAllowedHostedTargetUrl(
       );
     }
   }
+}
+
+/**
+ * The redirect ceiling. Matches what `fetch` itself allows, so a legitimate
+ * chain that worked before this guard existed still works.
+ */
+const MAX_GUARDED_REDIRECTS = 20;
+
+/**
+ * A `fetch` that re-checks the target on every hop.
+ *
+ * Checking only the URL a caller named guards against a typo, not against an
+ * attacker: naming `https://redirector.example/` and having it answer
+ * `302 Location: http://169.254.169.254/latest/meta-data/iam/` reaches exactly
+ * the address the check was written to refuse, and the caller never had to say
+ * so. Following redirects by hand is what turns one check into a check per
+ * address actually dialed.
+ *
+ * Redirect semantics follow the Fetch standard rather than being invented here:
+ * 303 always becomes GET, 301 and 302 become GET from POST (what every real
+ * client does), 307 and 308 preserve method and body. A caller that asked for
+ * `redirect: "manual"` gets its 3xx back untouched — the OAuth suite inspects
+ * redirects as evidence, and following one on its behalf would destroy the very
+ * thing it is grading.
+ *
+ * Outside hosted mode this returns the underlying fetch unchanged: locally the
+ * inspector is supposed to reach localhost, and a redirect chain on a
+ * developer's laptop is not an egress decision.
+ */
+export function createGuardedFetch(
+  options: { resolver?: EgressHostResolver; hosted?: boolean; baseFetch?: typeof fetch } = {}
+): typeof fetch {
+  const hosted = options.hosted ?? HOSTED_MODE;
+  const baseFetch = options.baseFetch ?? fetch;
+  if (!hosted) return baseFetch;
+
+  const guardedFetch: typeof fetch = async (input, init) => {
+    let currentUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    let currentInit: RequestInit = { ...(init ?? {}) };
+
+    // A caller that wants the 3xx itself gets one request and one check.
+    const wantsManual = currentInit.redirect === "manual";
+
+    for (let hop = 0; hop <= MAX_GUARDED_REDIRECTS; hop++) {
+      await assertAllowedHostedTargetUrl(currentUrl, "Request URL", {
+        resolver: options.resolver,
+        hosted: true,
+      });
+
+      const response = await baseFetch(currentUrl, {
+        ...currentInit,
+        // Always manual under the hood: the point is to see each Location
+        // before anything is dialed. Auto-follow would hand the decision to the
+        // HTTP client, which is where the hole was.
+        redirect: "manual",
+      });
+
+      const isRedirect =
+        response.status >= 300 &&
+        response.status <= 399 &&
+        response.headers.has("location");
+      if (wantsManual || !isRedirect) {
+        return response;
+      }
+
+      const location = response.headers.get("location") as string;
+      // Relative Locations are the common case and must resolve against the hop
+      // that produced them, not the original request.
+      const nextUrl = new URL(location, currentUrl).toString();
+
+      const method = (currentInit.method ?? "GET").toUpperCase();
+      if (response.status === 303 || ((response.status === 301 || response.status === 302) && method === "POST")) {
+        currentInit = { ...currentInit, method: "GET", body: undefined };
+        // A body-shaped content type on a bodiless GET confuses servers and is
+        // no longer true of the request being sent.
+        if (currentInit.headers) {
+          const headers = new Headers(currentInit.headers as HeadersInit);
+          headers.delete("content-type");
+          headers.delete("content-length");
+          currentInit.headers = headers;
+        }
+      } else if (
+        currentInit.body !== undefined &&
+        currentInit.body !== null &&
+        typeof currentInit.body !== "string"
+      ) {
+        // 307/308 replay the body, and a stream cannot be replayed. Better to
+        // say so than to silently send an empty body and report whatever the
+        // server makes of it as the target's behavior.
+        throw new BlockedEgressTargetError(
+          `Redirect to "${nextUrl}" would need the request body replayed, which is not possible for a streamed body.`
+        );
+      }
+
+      currentUrl = nextUrl;
+    }
+
+    throw new BlockedEgressTargetError(
+      `Too many redirects (more than ${MAX_GUARDED_REDIRECTS}) starting from the request URL.`
+    );
+  };
+
+  return guardedFetch;
 }

--- a/mcpjam-inspector/server/utils/hosted-egress-guard.ts
+++ b/mcpjam-inspector/server/utils/hosted-egress-guard.ts
@@ -346,6 +346,16 @@ export function createGuardedFetch(
     // we would then report as the target's behavior.
     const fromRequest =
       typeof input !== "string" && !(input instanceof URL) ? input : undefined;
+    if (fromRequest?.body && init?.body === undefined) {
+      // A `Request` body is a one-shot stream. Copying every other field and
+      // leaving it behind would send an empty POST and report whatever the
+      // server made of THAT as the target's behavior — a wrong answer dressed
+      // as a real one. Refusing is the honest option; callers that need a body
+      // can pass it through `init`, which is replayable.
+      throw new BlockedEgressTargetError(
+        "A Request with a body cannot be dialed through the egress guard; pass the body via the init argument so it can be replayed across a redirect."
+      );
+    }
     let currentUrl = fromRequest
       ? fromRequest.url
       : typeof input === "string"
@@ -355,9 +365,6 @@ export function createGuardedFetch(
       ? {
           method: fromRequest.method,
           headers: new Headers(fromRequest.headers),
-          // A `Request` body is a stream; only a bodiless one can be replayed
-          // safely, and the 307/308 branch below refuses the rest explicitly.
-          body: fromRequest.bodyUsed ? undefined : (init?.body ?? undefined),
           redirect: fromRequest.redirect,
           signal: fromRequest.signal,
           ...(init ?? {}),
@@ -366,6 +373,10 @@ export function createGuardedFetch(
 
     // A caller that wants the 3xx itself gets one request and one check.
     const wantsManual = currentInit.redirect === "manual";
+    // `"error"` means "a redirect is a failure" — honoring it is not optional,
+    // and treating it as "follow" would silently do the one thing the caller
+    // ruled out.
+    const rejectsRedirect = currentInit.redirect === "error";
 
     for (let hop = 0; hop <= MAX_GUARDED_REDIRECTS; hop++) {
       await assertAllowedHostedTargetUrl(currentUrl, "Request URL", {
@@ -387,6 +398,11 @@ export function createGuardedFetch(
         response.headers.has("location");
       if (wantsManual || !isRedirect) {
         return response;
+      }
+      if (rejectsRedirect) {
+        throw new BlockedEgressTargetError(
+          `The request refused redirects (redirect: "error") but "${currentUrl}" answered ${response.status}.`
+        );
       }
 
       const location = response.headers.get("location") as string;

--- a/mcpjam-inspector/server/utils/hosted-egress-guard.ts
+++ b/mcpjam-inspector/server/utils/hosted-egress-guard.ts
@@ -68,6 +68,11 @@ export function isBlockedEgressHost(
 ): boolean {
   let host = hostname.trim().toLowerCase();
   if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
+  // A terminal dot is the same NAME to a resolver ("localhost." resolves to
+  // loopback), but it is a different STRING to every comparison below — so
+  // strip it before judging, or `http://metadata.google.internal./` walks past
+  // the alias check.
+  host = host.replace(/\.+$/, "");
   if (!host) return false;
 
   // Cloud metadata DNS aliases (they resolve to link-local, but block the
@@ -134,6 +139,20 @@ export class BlockedEgressTargetError extends Error {
 }
 
 /**
+ * We could not REACH a verdict — DNS itself failed. Distinct from
+ * `BlockedEgressTargetError`, which is a verdict, because the two deserve
+ * opposite answers: a blocked target is the caller's problem and permanent
+ * (4xx), while a resolver outage is ours and worth retrying (5xx). Collapsing
+ * them would tell a user their server is forbidden when our DNS hiccuped.
+ */
+export class EgressResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EgressResolutionError";
+  }
+}
+
+/**
  * Resolve a hostname to IP strings. Injectable so tests can exercise the
  * rebinding path without a network, and so hosted-route tests that use
  * fabricated hostnames (`example.test`) can supply an answer instead of
@@ -158,7 +177,15 @@ export const defaultEgressHostResolver: EgressHostResolver = async (
 };
 
 function isIpLiteral(host: string): boolean {
-  return /^[\d.]+$/.test(host) || /^[0-9a-f:]+$/i.test(host);
+  // The hex form REQUIRES a colon. Without that, a single-label hostname made
+  // of hex characters — `deadbeef`, `cafe`, `f00d` — reads as an IPv6 literal,
+  // is judged "not a blocked address", and then skips the DNS pass entirely.
+  // That is exactly the rebinding case the DNS pass exists to catch, handed a
+  // free pass by a regex. Every real IPv6 literal contains a colon; numeric
+  // hosts are normalized to dotted-quad by `new URL()` and caught above.
+  return (
+    /^[\d.]+$/.test(host) || (host.includes(":") && /^[0-9a-f:]+$/i.test(host))
+  );
 }
 
 /**
@@ -218,9 +245,9 @@ export async function assertAllowedHostedTargetUrl(
     resolvedIps = await resolver(host);
   } catch (error) {
     // A resolver that throws is infrastructure trouble, not a verdict about
-    // the target. Say so plainly rather than letting a DNS blip read as "your
-    // server is blocked".
-    throw new BlockedEgressTargetError(
+    // the target — so it gets its own type, and the route answers 5xx rather
+    // than telling the user their server is forbidden because our DNS blipped.
+    throw new EgressResolutionError(
       `Could not check "${host}" for a safe address: ${
         error instanceof Error ? error.message : String(error)
       }`

--- a/mcpjam-inspector/server/utils/hosted-egress-guard.ts
+++ b/mcpjam-inspector/server/utils/hosted-egress-guard.ts
@@ -160,6 +160,14 @@ export class EgressResolutionError extends Error {
  */
 export type EgressHostResolver = (hostname: string) => Promise<string[]>;
 
+/** Codes that mean "this name has no such record" — a fact, not an outage. */
+const NO_RECORD_CODES = new Set(["ENOTFOUND", "ENODATA", "NXDOMAIN"]);
+
+function isNoRecordError(reason: unknown): boolean {
+  const code = (reason as { code?: unknown } | undefined)?.code;
+  return typeof code === "string" && NO_RECORD_CODES.has(code);
+}
+
 export const defaultEgressHostResolver: EgressHostResolver = async (
   hostname
 ) => {
@@ -173,6 +181,22 @@ export const defaultEgressHostResolver: EgressHostResolver = async (
   ]);
   if (v4.status === "fulfilled") resolved.push(...v4.value);
   if (v6.status === "fulfilled") resolved.push(...v6.value);
+  if (resolved.length > 0) return resolved;
+
+  // Nothing came back. Distinguish "no such name" (a verdict — fail closed as
+  // unresolvable) from "the resolver broke" (an outage). Swallowing both would
+  // make the EgressResolutionError path unreachable and turn every SERVFAIL
+  // into a permanent 400 telling the user their server is forbidden.
+  const failures = [v4, v6].filter(
+    (settled): settled is PromiseRejectedResult => settled.status === "rejected"
+  );
+  const transient = failures.filter(
+    (settled) => !isNoRecordError(settled.reason)
+  );
+  if (transient.length > 0 && transient.length === failures.length) {
+    const reason = transient[0].reason;
+    throw reason instanceof Error ? reason : new Error(String(reason));
+  }
   return resolved;
 };
 

--- a/mcpjam-inspector/server/utils/hosted-egress-guard.ts
+++ b/mcpjam-inspector/server/utils/hosted-egress-guard.ts
@@ -193,7 +193,12 @@ export const defaultEgressHostResolver: EgressHostResolver = async (
   const transient = failures.filter(
     (settled) => !isNoRecordError(settled.reason)
   );
-  if (transient.length > 0 && transient.length === failures.length) {
+  // ANY transient failure, not only an all-transient one. A mixed result —
+  // v4 says ENODATA, v6 says SERVFAIL — means we never learned whether an
+  // AAAA exists, so "unresolvable" would be a claim we cannot make. Only when
+  // EVERY failure is a no-record answer do we actually know the name has
+  // nothing, and can fail closed on that fact.
+  if (transient.length > 0) {
     const reason = transient[0].reason;
     throw reason instanceof Error ? reason : new Error(String(reason));
   }

--- a/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
+++ b/mcpjam-inspector/server/utils/mcp-app-browser-harness.ts
@@ -48,6 +48,7 @@ import {
   isChromiumInstalled,
 } from "./browser-rendering-setup";
 import { HOSTED_MODE } from "../config";
+import { isBlockedEgressHost } from "./hosted-egress-guard";
 
 export { isChromiumInstalled };
 
@@ -356,80 +357,12 @@ export function cspSourceMatchesUrl(source: string, url: URL): boolean {
   return host === pattern;
 }
 
-/** Parse a dotted-quad IPv4 literal into octets, or null if not well-formed. */
-function parseIpv4Octets(
-  host: string
-): [number, number, number, number] | null {
-  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (!m) return null;
-  const o = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
-  if (o.some((n) => n > 255)) return null;
-  return [o[0], o[1], o[2], o[3]];
-}
-
-/**
- * SSRF guard for the egress route. A widget's declared CSP origins (and the
- * loopback shortcut) must never let it reach infrastructure only the harness
- * HOST can see — most dangerously the cloud metadata endpoint
- * (169.254.169.254), whose IAM credentials would be a full account compromise.
- * In production the same widget CSP runs in the END USER's browser, where these
- * addresses are harmless; in the eval harness it runs on our servers, so this
- * gate overrides the allowlist regardless of what the widget declared.
- *
- *   - ALWAYS blocked: cloud-metadata names, IPv4/IPv6 link-local (169.254/16,
- *     fe80::/10), and the unspecified address (0.0.0.0/8, ::) — never a
- *     legitimate widget target in any deployment.
- *   - Blocked only when `blockPrivate` (hosted mode): loopback, RFC-1918
- *     private, CGNAT (100.64/10), and IPv6 ULA (fc00::/7). Left reachable for
- *     local dev, where a widget legitimately talks to a localhost MCP server.
- *
- * Matches on the URL hostname (literal IPs range-checked); it does NOT resolve
- * DNS, so a name that resolves to an internal IP (DNS rebinding) is out of
- * scope here and must be covered by infra-level egress policy.
- */
-export function isBlockedEgressHost(
-  hostname: string,
-  blockPrivate: boolean
-): boolean {
-  let host = hostname.trim().toLowerCase();
-  if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
-  if (!host) return false;
-
-  // Cloud metadata DNS aliases (they resolve to link-local, but block the
-  // names too in case resolution is bypassed).
-  if (host === "metadata.google.internal" || host === "metadata.goog") {
-    return true;
-  }
-  if (host === "localhost" || host.endsWith(".localhost")) return blockPrivate;
-
-  const v4 = parseIpv4Octets(host);
-  if (v4) {
-    const [a, b] = v4;
-    if (a === 169 && b === 254) return true; // link-local incl. cloud metadata
-    if (a === 0) return true; // "this network" / unspecified
-    if (!blockPrivate) return false;
-    if (a === 127) return true; // loopback 127.0.0.0/8
-    if (a === 10) return true; // 10.0.0.0/8
-    if (a === 192 && b === 168) return true; // 192.168.0.0/16
-    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT 100.64.0.0/10
-    return false;
-  }
-
-  if (host.includes(":")) {
-    // IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) — judge the embedded v4.
-    const mapped = /(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/.exec(host);
-    if (mapped) return isBlockedEgressHost(mapped[1], blockPrivate);
-    if (host === "::") return true; // unspecified
-    if (/^fe[89ab]/.test(host)) return true; // link-local fe80::/10
-    if (!blockPrivate) return false;
-    if (host === "::1") return true; // loopback
-    if (/^f[cd]/.test(host)) return true; // ULA fc00::/7
-    return false;
-  }
-
-  return false;
-}
+// The SSRF host check lives in `hosted-egress-guard` — the harness is one of
+// two callers (the hosted conformance routes are the other), and that module
+// carries no Playwright/bundle dependencies, so a route can import the guard
+// without dragging the harness in. Re-exported here so existing callers and
+// tests keep their import path.
+export { isBlockedEgressHost };
 
 /**
  * Per-render cap on collected diagnostics. `consoleErrors` and

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -411,6 +411,15 @@ export type {
   ConformanceScore,
   ScoredAdvisory,
 } from "./conformance-score.js";
+// Redaction for reports that leave the machine that produced them (a stored,
+// shareable run). Structural drop of raw HTTP evidence plus a credential-shaped
+// key sweep — see the module header for why both layers exist.
+export {
+  REDACTED,
+  redactConformanceReportForSharing,
+  redactSharedServerUrl,
+  redactUrlSecrets,
+} from "./conformance-redaction.js";
 
 // Each check's title and one-line description, kept byte-identical to the
 // strings on the check implementations by `tests/conformance-catalog.test.ts`.

--- a/sdk/src/conformance-redaction.ts
+++ b/sdk/src/conformance-redaction.ts
@@ -117,6 +117,25 @@ function normalizeKey(key: string): string {
   return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
 }
 
+/**
+ * Is a key name — however it is spelled — one whose value is a credential?
+ *
+ * ONE predicate, used by the structural sweep and by every free-text matcher.
+ * They were separate before: the sweep consulted `SECRET_KEYS`, while the
+ * free-text patterns carried a hand-written alternation of `token|secret|…`.
+ * Two lists of the same thing drift, and this pair did — `code_verifier`,
+ * `proxy-authorization` and `x-api-key` were redacted as object fields but
+ * published as quoted JSON in an error string. A second list is a second thing
+ * to forget, so there is now only one.
+ */
+function isSecretKeyName(raw: string): boolean {
+  const normalized = normalizeKey(raw);
+  if (SECRET_KEYS.has(normalized)) return true;
+  // Suffix/substring shapes the explicit set cannot enumerate — vendor-prefixed
+  // names like `x_vendor_access_token` or `mytoken`.
+  return /(token|secret|password|apikey|signature|credential)/.test(normalized);
+}
+
 function looksSensitiveParam(name: string): boolean {
   const normalized = name.toLowerCase();
   if (SECRET_QUERY_PARAMS.has(normalized)) return true;
@@ -191,8 +210,13 @@ function redactInlineSecrets(value: string): string {
   return (
     value
       // `Authorization: Bearer …` and friends.
+      //
+      // `&` ends the value. Without it the match runs past the credential and
+      // swallows whatever follows in a form-encoded fragment — safe, but it
+      // deletes the diagnostic neighbours (`&grant_type=…`) that explain what
+      // the request was doing. No real credential contains a bare `&`.
       .replace(
-        /((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic|dpop)\s+)([^\s,;"']+)/gi,
+        /((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic|dpop)\s+)([^\s,;"'&]+)/gi,
         `$1${REDACTED}`
       )
       // A scheme + token with no header name in front — how tokens usually get
@@ -212,21 +236,25 @@ function redactInlineSecrets(value: string): string {
       // JSON fields: `"access_token": "…"`. The key stays legible, which is
       // the diagnostic half.
       //
-      // `authorization` and `cookie` are named explicitly: they are header
-      // names rather than `*token*`-shaped ones, so the suffix alternation
-      // below never matched them even though the structural sweep treats both
-      // as secrets. A quoted response body in an error string is exactly where
-      // they show up. Escaped quotes (`\"`) are matched too — a JSON document
-      // embedded in a JSON string is the normal shape of a logged response.
+      // Every quoted key is matched and then judged by `isSecretKeyName`, the
+      // same predicate the structural sweep uses — rather than by a second,
+      // hand-maintained alternation that could (and did) omit names the sweep
+      // already protects. Escaped quotes (`\"`) are matched too: a JSON document
+      // logged inside a JSON string is the normal shape of a captured response,
+      // not the exotic one.
       .replace(
-        /((?:\\?")(?:authorization|(?:set-)?cookie|[a-z_-]*(?:token|secret|password|apikey|api_key|signature)[a-z_-]*)(?:\\?")\s*:\s*(?:\\?"))((?:[^"\\]|\\.)*?)((?:\\?"))/gi,
-        `$1${REDACTED}$3`
+        /(\\?")([A-Za-z0-9_-]+)(\\?"\s*:\s*\\?")((?:[^"\\]|\\.)*?)(\\?")/g,
+        (match, openQuote, key, separator, _value, closeQuote) =>
+          isSecretKeyName(key)
+            ? `${openQuote}${key}${separator}${REDACTED}${closeQuote}`
+            : match
       )
       // Form-encoded / query-ish fragments that never parsed as a full URL:
-      // `client_secret=…&grant_type=…`.
+      // `client_secret=…&grant_type=…`. Judged by the same predicate.
       .replace(
-        /\b([a-z_-]*(?:token|secret|password|apikey|api_key|signature)[a-z_-]*)=([^\s&"';,]+)/gi,
-        `$1=${REDACTED}`
+        /\b([A-Za-z0-9_-]+)=([^\s&"';,]+)/g,
+        (match, key, _value) =>
+          isSecretKeyName(key) ? `${key}=${REDACTED}` : match
       )
   );
 }

--- a/sdk/src/conformance-redaction.ts
+++ b/sdk/src/conformance-redaction.ts
@@ -153,14 +153,68 @@ export function redactUrlSecrets(value: string): string {
     parsed.password = "";
     touched = true;
   }
+
+  // The FRAGMENT is not part of `searchParams`, and it is where the implicit
+  // OAuth flow puts `access_token` — the single most credential-dense place a
+  // URL can carry something. Same rule as the query: names kept, values gone.
+  if (parsed.hash.length > 1) {
+    const fragment = parsed.hash.slice(1);
+    // Only treat it as parameters when it actually looks like them; a plain
+    // `#section-2` anchor must survive untouched.
+    if (/^[^=&]+=[^&]*(?:&[^=&]+=[^&]*)*$/.test(fragment)) {
+      const params = new URLSearchParams(fragment);
+      let fragmentTouched = false;
+      for (const name of Array.from(params.keys())) {
+        if (!looksSensitiveParam(name)) continue;
+        params.set(name, REDACTED);
+        fragmentTouched = true;
+      }
+      if (fragmentTouched) {
+        parsed.hash = `#${params.toString()}`;
+        touched = true;
+      }
+    }
+  }
+
   return touched ? parsed.toString() : value;
 }
 
-/** `Authorization: Bearer …` and friends embedded in free text. */
+/**
+ * Credentials written into free text, where no object key marks them.
+ *
+ * The structural sweep only sees values under a key it recognizes. A summary
+ * or error string is unstructured by definition — "request failed: {"access_
+ * token":"ey…"}" carries a live credential under no key at all — so these
+ * patterns are the backstop for the shapes that actually show up in logs.
+ */
 function redactInlineSecrets(value: string): string {
-  return value.replace(
-    /((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic|dpop)\s+)([^\s,;"']+)/gi,
-    `$1${REDACTED}`
+  return (
+    value
+      // `Authorization: Bearer …` and friends.
+      .replace(
+        /((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic|dpop)\s+)([^\s,;"']+)/gi,
+        `$1${REDACTED}`
+      )
+      // A scheme + token with no header name in front — how tokens usually get
+      // pasted into a message.
+      .replace(
+        /\b(bearer|dpop)\s+([A-Za-z0-9._~+/-]{16,}=*)/gi,
+        `$1 ${REDACTED}`
+      )
+      // Cookie jars are credential stores; the whole line goes.
+      .replace(/((?:set-)?cookie\s*[:=]\s*)([^\n\r]+)/gi, `$1${REDACTED}`)
+      // JSON fields: `"access_token": "…"`. The key stays legible, which is
+      // the diagnostic half.
+      .replace(
+        /("(?:[a-z_-]*(?:token|secret|password|apikey|api_key|signature)[a-z_-]*)"\s*:\s*")([^"]*)(")/gi,
+        `$1${REDACTED}$3`
+      )
+      // Form-encoded / query-ish fragments that never parsed as a full URL:
+      // `client_secret=…&grant_type=…`.
+      .replace(
+        /\b([a-z_-]*(?:token|secret|password|apikey|api_key|signature)[a-z_-]*)=([^\s&"';,]+)/gi,
+        `$1=${REDACTED}`
+      )
   );
 }
 
@@ -175,11 +229,17 @@ function redactInlineSecrets(value: string): string {
  * URL at the end of a sentence still parses.
  */
 function redactEmbeddedUrls(value: string): string {
-  return value.replace(/https?:\/\/[^\s"'<>()[\]]+/gi, (match) => {
-    const trailing = match.match(/[.,;:!?]+$/)?.[0] ?? "";
-    const bare = trailing ? match.slice(0, -trailing.length) : match;
-    return `${redactUrlSecrets(bare)}${trailing}`;
-  });
+  // The bracket group admits an IPv6 authority (`http://[::1]:8080/…`) while
+  // the rest of the pattern still stops at a bracket, so a URL inside `[…]`
+  // prose does not swallow the closing bracket.
+  return value.replace(
+    /https?:\/\/(?:\[[0-9A-Fa-f:.]+\])?[^\s"'<>()[\]]*/gi,
+    (match) => {
+      const trailing = match.match(/[.,;:!?]+$/)?.[0] ?? "";
+      const bare = trailing ? match.slice(0, -trailing.length) : match;
+      return `${redactUrlSecrets(bare)}${trailing}`;
+    }
+  );
 }
 
 function redactString(value: string): string {

--- a/sdk/src/conformance-redaction.ts
+++ b/sdk/src/conformance-redaction.ts
@@ -197,16 +197,29 @@ function redactInlineSecrets(value: string): string {
       )
       // A scheme + token with no header name in front — how tokens usually get
       // pasted into a message.
+      //
+      // No length floor, and `basic` included. A short token is still a token:
+      // `Bearer at-123` opens the same door as a 200-character JWT, and
+      // `Basic dXNlcjpwYXNz` is a password in trivially reversible base64. The
+      // floor only ever protected prose ("bearer of this message"), which is
+      // not worth a credential.
       .replace(
-        /\b(bearer|dpop)\s+([A-Za-z0-9._~+/-]{16,}=*)/gi,
+        /\b(bearer|dpop|basic)\s+([A-Za-z0-9._~+/-]+=*)/gi,
         `$1 ${REDACTED}`
       )
       // Cookie jars are credential stores; the whole line goes.
       .replace(/((?:set-)?cookie\s*[:=]\s*)([^\n\r]+)/gi, `$1${REDACTED}`)
       // JSON fields: `"access_token": "…"`. The key stays legible, which is
       // the diagnostic half.
+      //
+      // `authorization` and `cookie` are named explicitly: they are header
+      // names rather than `*token*`-shaped ones, so the suffix alternation
+      // below never matched them even though the structural sweep treats both
+      // as secrets. A quoted response body in an error string is exactly where
+      // they show up. Escaped quotes (`\"`) are matched too — a JSON document
+      // embedded in a JSON string is the normal shape of a logged response.
       .replace(
-        /("(?:[a-z_-]*(?:token|secret|password|apikey|api_key|signature)[a-z_-]*)"\s*:\s*")([^"]*)(")/gi,
+        /((?:\\?")(?:authorization|(?:set-)?cookie|[a-z_-]*(?:token|secret|password|apikey|api_key|signature)[a-z_-]*)(?:\\?")\s*:\s*(?:\\?"))((?:[^"\\]|\\.)*?)((?:\\?"))/gi,
         `$1${REDACTED}$3`
       )
       // Form-encoded / query-ish fragments that never parsed as a full URL:

--- a/sdk/src/conformance-redaction.ts
+++ b/sdk/src/conformance-redaction.ts
@@ -1,0 +1,238 @@
+/**
+ * Make a conformance report safe to hand to somebody else.
+ *
+ * A conformance run is a debugging artifact first: it keeps the raw HTTP
+ * exchange so an engineer can see exactly what their server said. That is the
+ * right default in the inspector, where the data never leaves the tab of the
+ * person who produced it. It is the wrong default the moment a report is
+ * PERSISTED BEHIND A LINK, because the OAuth suite completes a real
+ * authorization — so the result carries a live access token, a refresh token,
+ * the client secret, the `Authorization` headers of every request it made, and
+ * the token-exchange bodies. Sharing that link would be sharing credentials for
+ * the server being scored.
+ *
+ * The formatter has always redacted these values on their way to a terminal
+ * (`redactSensitiveStrings`), which is the clearest possible statement that they
+ * are sensitive. This module is the same judgement applied one layer earlier, to
+ * the stored document itself: redaction at display time protects one reader,
+ * redaction at write time protects everyone the link ever reaches.
+ *
+ * Two layers, deliberately overlapping:
+ *
+ *  1. STRUCTURAL — whole containers whose entire purpose is raw protocol
+ *     evidence (`httpAttempts`, `http`, `logs`) and the typed credential bag
+ *     (`credentials`) are dropped, not scrubbed. A shared report is a summary:
+ *     it needs each check's id, title, status and failure message, and nothing
+ *     it drops here is rendered by any result page. Dropping also keeps the
+ *     document small, which matters against the 1MB storage bound.
+ *  2. KEY-NAME — everything that survives is walked and any value sitting under
+ *     a credential-shaped key is replaced, and any URL-shaped string has its
+ *     sensitive query parameters replaced. This is the backstop for shapes this
+ *     module does not know about, including ones added later.
+ *
+ * Layer 2 alone would be a blocklist, and a blocklist eventually misses. Layer 1
+ * is what makes that acceptable: the containers where unknown-shaped secrets
+ * actually accumulate are gone before layer 2 runs.
+ *
+ * Pure data reasoning — no MCP client, no transport, no Node built-ins — so it
+ * is exported from the browser entry alongside the scoring engine.
+ */
+
+export const REDACTED = "[REDACTED]";
+
+/**
+ * Containers dropped wholesale rather than scrubbed.
+ *
+ * `logs` carries an untyped `data` payload, and `httpAttempts` / `http` carry
+ * complete request and response pairs — headers and bodies both. There is no
+ * scrub of those that is easier to trust than their absence.
+ */
+const DROPPED_KEYS = new Set([
+  "httpattempts",
+  "http",
+  "logs",
+  "credentials",
+  "headers",
+  "rawheaders",
+  "customheaders",
+]);
+
+/**
+ * Keys whose value is a credential, however it is spelled.
+ *
+ * Compared after stripping non-alphanumerics and lowercasing, so `access_token`,
+ * `accessToken` and `Access-Token` are one entry. `tokentype` and `expiresin`
+ * are deliberately absent: they describe a token without being one.
+ */
+const SECRET_KEYS = new Set([
+  "accesstoken",
+  "refreshtoken",
+  "idtoken",
+  "clientsecret",
+  "codeverifier",
+  "authorization",
+  "proxyauthorization",
+  "cookie",
+  "setcookie",
+  "apikey",
+  "xapikey",
+  "secret",
+  "password",
+  "privatekey",
+  "assertion",
+  "clientassertion",
+  "registrationaccesstoken",
+  "token",
+  "bearertoken",
+]);
+
+/**
+ * `code` is an authorization code when it is a string and a JSON-RPC error
+ * number when it is not — and MCP results are full of the latter. Redacting the
+ * number would corrupt the very failures a report exists to explain, so this key
+ * is redacted only for string values.
+ */
+const STRING_ONLY_SECRET_KEYS = new Set(["code"]);
+
+/** Query parameters never worth carrying into a shared document. */
+const SECRET_QUERY_PARAMS = new Set([
+  "code",
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "token",
+  "client_secret",
+  "code_verifier",
+  "assertion",
+  "client_assertion",
+  "api_key",
+  "apikey",
+  "key",
+  "password",
+  "signature",
+  "sig",
+]);
+
+function normalizeKey(key: string): string {
+  return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function looksSensitiveParam(name: string): boolean {
+  const normalized = name.toLowerCase();
+  if (SECRET_QUERY_PARAMS.has(normalized)) return true;
+  return /(token|secret|password|apikey|api_key|auth|signature)/.test(
+    normalized
+  );
+}
+
+/**
+ * Replace sensitive query-parameter VALUES while keeping the parameter names.
+ *
+ * The names are diagnostic — "this endpoint was called with an api_key" is
+ * exactly the kind of thing a reader needs to know — and only the values are
+ * dangerous. Returns the input unchanged when it is not a URL, so this is safe
+ * to run over arbitrary strings.
+ */
+export function redactUrlSecrets(value: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return value;
+  }
+
+  let touched = false;
+  for (const name of Array.from(parsed.searchParams.keys())) {
+    if (!looksSensitiveParam(name)) continue;
+    parsed.searchParams.set(name, REDACTED);
+    touched = true;
+  }
+  // Userinfo is a credential in the URL itself (`https://user:pass@host/`).
+  if (parsed.username || parsed.password) {
+    parsed.username = "";
+    parsed.password = "";
+    touched = true;
+  }
+  return touched ? parsed.toString() : value;
+}
+
+/** `Authorization: Bearer …` and friends embedded in free text. */
+function redactInlineSecrets(value: string): string {
+  return value.replace(
+    /((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic|dpop)\s+)([^\s,;"']+)/gi,
+    `$1${REDACTED}`
+  );
+}
+
+/**
+ * Scrub every URL that appears INSIDE a string, not only strings that are
+ * entirely a URL.
+ *
+ * Summaries and error messages are where a redirect actually shows up —
+ * "Redirected to https://…?code=…" — and treating only whole-string URLs would
+ * walk straight past the single most likely place an authorization code is
+ * written down. Trailing sentence punctuation is left outside the match so a
+ * URL at the end of a sentence still parses.
+ */
+function redactEmbeddedUrls(value: string): string {
+  return value.replace(/https?:\/\/[^\s"'<>()[\]]+/gi, (match) => {
+    const trailing = match.match(/[.,;:!?]+$/)?.[0] ?? "";
+    const bare = trailing ? match.slice(0, -trailing.length) : match;
+    return `${redactUrlSecrets(bare)}${trailing}`;
+  });
+}
+
+function redactString(value: string): string {
+  return redactInlineSecrets(redactEmbeddedUrls(value));
+}
+
+/**
+ * The scanned server's own URL, as stored and displayed on a shared page.
+ *
+ * MCP servers are routinely addressed with a key in the query string, and the
+ * result page prints this back verbatim — so it gets the same treatment as any
+ * other URL in the document.
+ */
+export function redactSharedServerUrl(url: string): string {
+  return redactUrlSecrets(url);
+}
+
+function redactValue(value: unknown, depth: number): unknown {
+  // Reports are a handful of levels deep; anything beyond this is either
+  // pathological or cyclic, and neither belongs in stored evidence.
+  if (depth > 24) return REDACTED;
+
+  if (typeof value === "string") return redactString(value);
+  if (value === null || typeof value !== "object") return value;
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactValue(entry, depth + 1));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    const normalized = normalizeKey(key);
+    if (DROPPED_KEYS.has(normalized)) continue;
+    if (SECRET_KEYS.has(normalized)) {
+      if (entry !== undefined && entry !== null) out[key] = REDACTED;
+      continue;
+    }
+    if (STRING_ONLY_SECRET_KEYS.has(normalized) && typeof entry === "string") {
+      out[key] = REDACTED;
+      continue;
+    }
+    out[key] = redactValue(entry, depth + 1);
+  }
+  return out;
+}
+
+/**
+ * Redact a whole multi-suite report for storage behind a shareable link.
+ *
+ * Structure-preserving: suites keep their keys, checks keep their ids, titles,
+ * statuses and failure messages. What leaves is the raw protocol evidence and
+ * anything credential-shaped.
+ */
+export function redactConformanceReportForSharing<T>(report: T): T {
+  return redactValue(report, 0) as T;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -380,6 +380,15 @@ export type {
   ConformanceScore,
   ScoredAdvisory,
 } from "./conformance-score.js";
+// Redaction for reports that leave the machine that produced them (a stored,
+// shareable run). Structural drop of raw HTTP evidence plus a credential-shaped
+// key sweep — see the module header for why both layers exist.
+export {
+  REDACTED,
+  redactConformanceReportForSharing,
+  redactSharedServerUrl,
+  redactUrlSecrets,
+} from "./conformance-redaction.js";
 export { runOAuthLogin } from "./oauth-login.js";
 export type {
   OAuthLoginConfig,

--- a/sdk/tests/conformance-redaction.test.ts
+++ b/sdk/tests/conformance-redaction.test.ts
@@ -266,3 +266,59 @@ describe("credentials that survived the first pass", () => {
     expect(JSON.stringify(out)).toContain("https://example.com/docs]");
   });
 });
+
+describe("free-text credentials cubic flagged", () => {
+  it("redacts a SHORT bearer token, not just a long one", () => {
+    // A length floor only ever protected prose. `Bearer at-123` opens the same
+    // door as a 200-character JWT.
+    const out = redactConformanceReportForSharing({
+      protocol: { checks: [{ id: "c", summary: "sent Bearer at-123" }] },
+    }) as any;
+    expect(out.protocol.checks[0].summary).not.toContain("at-123");
+  });
+
+  it("redacts Basic credentials", () => {
+    const out = redactConformanceReportForSharing({
+      protocol: {
+        checks: [{ id: "c", summary: "retried with Basic dXNlcjpwYXNz" }],
+      },
+    }) as any;
+    expect(out.protocol.checks[0].summary).not.toContain("dXNlcjpwYXNz");
+  });
+
+  it("redacts authorization and cookie inside a quoted JSON body", () => {
+    const out = redactConformanceReportForSharing({
+      protocol: {
+        checks: [
+          {
+            id: "c",
+            error: {
+              message:
+                'upstream said {"authorization": "Bearer at_live", "set-cookie": "sid=abc123"}',
+            },
+          },
+        ],
+      },
+    }) as any;
+    const message = out.protocol.checks[0].error.message as string;
+    expect(message).not.toContain("at_live");
+    expect(message).not.toContain("sid=abc123");
+  });
+
+  it("redacts a token inside an ESCAPED JSON document", () => {
+    // A response body logged into a JSON string — the normal shape in a log.
+    const out = redactConformanceReportForSharing({
+      protocol: {
+        checks: [
+          { id: "c", summary: 'body was "{\\"access_token\\":\\"ey_live\\"}"' },
+        ],
+      },
+    }) as any;
+    expect(out.protocol.checks[0].summary).not.toContain("ey_live");
+  });
+
+  it("still leaves ordinary prose alone", () => {
+    const clean = { protocol: { checks: [{ id: "c", summary: "Server returned 401 Unauthorized" }] } };
+    expect(redactConformanceReportForSharing(clean)).toEqual(clean);
+  });
+});

--- a/sdk/tests/conformance-redaction.test.ts
+++ b/sdk/tests/conformance-redaction.test.ts
@@ -322,3 +322,53 @@ describe("free-text credentials cubic flagged", () => {
     expect(redactConformanceReportForSharing(clean)).toEqual(clean);
   });
 });
+
+describe("one credential predicate, not two lists", () => {
+  // These were redacted as OBJECT FIELDS but published verbatim when the same
+  // names appeared as quoted JSON in an error string — the free-text matcher
+  // carried its own shorter list. Both now consult the same predicate.
+  const cases: Array<[string, string]> = [
+    ["code_verifier", "cv_live_value"],
+    ["proxy-authorization", "Basic cHJveHk6cHc="],
+    ["x-api-key", "xak_live_value"],
+    ["registration_access_token", "rat_live_value"],
+    ["client_assertion", "ca_live_value"],
+    ["private_key", "pk_live_value"],
+  ];
+
+  for (const [key, secret] of cases) {
+    it(`redacts "${key}" inside a quoted JSON body`, () => {
+      const out = redactConformanceReportForSharing({
+        protocol: {
+          checks: [
+            { id: "c", summary: `upstream said {"${key}": "${secret}"}` },
+          ],
+        },
+      }) as any;
+      expect(out.protocol.checks[0].summary).not.toContain(secret);
+    });
+
+    it(`redacts "${key}" in a form-encoded fragment`, () => {
+      const out = redactConformanceReportForSharing({
+        protocol: {
+          checks: [{ id: "c", summary: `posted ${key}=${secret}&grant_type=x` }],
+        },
+      }) as any;
+      const summary = out.protocol.checks[0].summary as string;
+      expect(summary).not.toContain(secret);
+      // Non-secret neighbours survive — the scrub is targeted, not scorched.
+      expect(summary).toContain("grant_type=x");
+    });
+  }
+
+  it("does not redact innocuous fields that merely sit nearby", () => {
+    const clean = {
+      protocol: {
+        checks: [
+          { id: "c", summary: 'got {"grant_type": "authorization_code", "expires_in": "3600"}' },
+        ],
+      },
+    };
+    expect(redactConformanceReportForSharing(clean)).toEqual(clean);
+  });
+});

--- a/sdk/tests/conformance-redaction.test.ts
+++ b/sdk/tests/conformance-redaction.test.ts
@@ -197,3 +197,72 @@ describe("redactSharedServerUrl", () => {
     expect(redactUrlSecrets("not a url at all")).toBe("not a url at all");
   });
 });
+
+describe("credentials that survived the first pass", () => {
+  // Each of these was reachable before the gaps were closed: a shared report
+  // could carry a live credential through them.
+
+  it("redacts an access token in the URL FRAGMENT", () => {
+    // The implicit flow puts the token after `#`, which is not in
+    // `searchParams` — the densest credential spot a URL has.
+    const out = redactUrlSecrets(
+      "https://mcp.example.com/cb#access_token=ya29.live&token_type=bearer"
+    );
+    expect(out).not.toContain("ya29.live");
+    // The parameter NAME is diagnostic and stays.
+    expect(out).toContain("access_token=");
+  });
+
+  it("leaves a plain anchor alone", () => {
+    const url = "https://docs.example.com/guide#section-2";
+    expect(redactUrlSecrets(url)).toBe(url);
+  });
+
+  it("redacts a bare `Bearer <token>` with no header name", () => {
+    const out = redactConformanceReportForSharing({
+      summary: "retry failed, sent Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+    });
+    expect(JSON.stringify(out)).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+  });
+
+  it("redacts a Cookie header written into free text", () => {
+    const out = redactConformanceReportForSharing({
+      detail: "Cookie: session=abc123secret; other=1",
+    });
+    expect(JSON.stringify(out)).not.toContain("abc123secret");
+  });
+
+  it("redacts a token inside a JSON blob quoted in an error string", () => {
+    const out = redactConformanceReportForSharing({
+      error: 'token endpoint said {"access_token":"live-token-value","expires_in":3600}',
+    });
+    const text = JSON.stringify(out);
+    expect(text).not.toContain("live-token-value");
+    // Non-secret context survives, or the report stops being useful.
+    expect(text).toContain("expires_in");
+  });
+
+  it("redacts a form-encoded client_secret that never parsed as a URL", () => {
+    const out = redactConformanceReportForSharing({
+      detail: "body was grant_type=authorization_code&client_secret=s3cr3t-value",
+    });
+    const text = JSON.stringify(out);
+    expect(text).not.toContain("s3cr3t-value");
+    expect(text).toContain("grant_type=authorization_code");
+  });
+
+  it("redacts query secrets in an embedded IPv6 URL", () => {
+    // The bracketed authority previously ended the URL match at `[`.
+    const out = redactConformanceReportForSharing({
+      summary: "redirected to http://[::1]:8080/cb?code=auth-code-secret next",
+    });
+    expect(JSON.stringify(out)).not.toContain("auth-code-secret");
+  });
+
+  it("still does not swallow a closing bracket around a URL", () => {
+    const out = redactConformanceReportForSharing({
+      summary: "see [https://example.com/docs] for details",
+    });
+    expect(JSON.stringify(out)).toContain("https://example.com/docs]");
+  });
+});

--- a/sdk/tests/conformance-redaction.test.ts
+++ b/sdk/tests/conformance-redaction.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import {
+  REDACTED,
+  redactConformanceReportForSharing,
+  redactSharedServerUrl,
+  redactUrlSecrets,
+} from "../src/conformance-redaction.js";
+
+/**
+ * The shape these tests defend is the one a real OAuth conformance run
+ * produces: `credentials` from `buildCredentials`, and per-step `httpAttempts`
+ * whose requests carry an `Authorization` header and whose responses carry the
+ * token payload.
+ */
+function oauthResultLike() {
+  return {
+    passed: true,
+    outcome: "passed",
+    serverUrl: "https://mcp.example.com/mcp",
+    protocolVersion: "2025-11-25",
+    summary: "All steps passed",
+    credentials: {
+      clientId: "client-abc",
+      clientSecret: "sh_super_secret",
+      accessToken: "at_live_value",
+      refreshToken: "rt_live_value",
+      tokenType: "Bearer",
+      expiresIn: 3600,
+    },
+    steps: [
+      {
+        step: "exchanged_authorization_code",
+        title: "Exchange authorization code",
+        status: "passed",
+        logs: [{ label: "token", data: { access_token: "at_live_value" } }],
+        httpAttempts: [
+          {
+            request: {
+              method: "POST",
+              url: "https://as.example.com/token",
+              headers: { authorization: "Bearer at_live_value" },
+              body: "grant_type=authorization_code&code=ac_secret&client_secret=sh_super_secret",
+            },
+            response: {
+              status: 200,
+              body: { access_token: "at_live_value", token_type: "Bearer" },
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("redactConformanceReportForSharing", () => {
+  it("drops the credential bag a completed OAuth run leaves behind", () => {
+    const out = redactConformanceReportForSharing({
+      oauth: oauthResultLike(),
+    }) as any;
+
+    expect(out.oauth.credentials).toBeUndefined();
+    expect(JSON.stringify(out)).not.toContain("at_live_value");
+    expect(JSON.stringify(out)).not.toContain("rt_live_value");
+    expect(JSON.stringify(out)).not.toContain("sh_super_secret");
+  });
+
+  it("drops raw HTTP evidence and untyped logs entirely", () => {
+    const out = redactConformanceReportForSharing({
+      oauth: oauthResultLike(),
+    }) as any;
+
+    expect(out.oauth.steps[0].httpAttempts).toBeUndefined();
+    expect(out.oauth.steps[0].logs).toBeUndefined();
+    expect(JSON.stringify(out)).not.toContain("ac_secret");
+  });
+
+  it("keeps everything a result page renders", () => {
+    const out = redactConformanceReportForSharing({
+      oauth: oauthResultLike(),
+      protocol: {
+        checks: [
+          {
+            id: "initialize-negotiates-version",
+            title: "Initialize negotiates a protocol version",
+            status: "failed",
+            error: { message: "Server replied with an unknown version" },
+          },
+          { id: "skipped-one", status: "skipped", skipReason: "not-applicable" },
+        ],
+      },
+    }) as any;
+
+    expect(out.oauth.outcome).toBe("passed");
+    expect(out.oauth.protocolVersion).toBe("2025-11-25");
+    expect(out.oauth.steps[0].title).toBe("Exchange authorization code");
+    expect(out.oauth.steps[0].status).toBe("passed");
+    expect(out.protocol.checks[0].error.message).toBe(
+      "Server replied with an unknown version"
+    );
+    expect(out.protocol.checks[1].skipReason).toBe("not-applicable");
+  });
+
+  it("redacts credential-shaped keys wherever they survive", () => {
+    const out = redactConformanceReportForSharing({
+      protocol: {
+        checks: [
+          {
+            id: "some-check",
+            details: {
+              api_key: "ak_live",
+              nested: { refreshToken: "rt_live", tokenType: "Bearer" },
+            },
+          },
+        ],
+      },
+    }) as any;
+
+    const details = out.protocol.checks[0].details;
+    expect(details.api_key).toBe(REDACTED);
+    expect(details.nested.refreshToken).toBe(REDACTED);
+    // Describes a token without being one.
+    expect(details.nested.tokenType).toBe("Bearer");
+  });
+
+  it("redacts a string `code` but never a JSON-RPC numeric one", () => {
+    const out = redactConformanceReportForSharing({
+      protocol: {
+        checks: [
+          {
+            id: "error-shape",
+            // The exact thing a report exists to explain — must survive.
+            error: { code: -32601, message: "Method not found" },
+            details: { code: "ac_authorization_code" },
+          },
+        ],
+      },
+    }) as any;
+
+    expect(out.protocol.checks[0].error.code).toBe(-32601);
+    expect(out.protocol.checks[0].error.message).toBe("Method not found");
+    expect(out.protocol.checks[0].details.code).toBe(REDACTED);
+  });
+
+  it("scrubs secrets carried in URL strings", () => {
+    const out = redactConformanceReportForSharing({
+      protocol: {
+        checks: [
+          {
+            id: "redirected",
+            summary:
+              "Redirected to https://app.example.com/callback?code=ac_secret&state=xyz",
+          },
+        ],
+      },
+    }) as any;
+
+    const summary = out.protocol.checks[0].summary as string;
+    expect(summary).not.toContain("ac_secret");
+    expect(summary).toContain("state=xyz");
+  });
+
+  it("leaves a clean report byte-identical in the fields that matter", () => {
+    const clean = {
+      apps: { checks: [{ id: "a", title: "A", status: "passed" }] },
+      tasks: { checks: [{ id: "t", title: "T", status: "not-applicable" }] },
+    };
+    expect(redactConformanceReportForSharing(clean)).toEqual(clean);
+  });
+
+  it("survives a cyclic-depth payload without throwing", () => {
+    let deep: any = { id: "leaf" };
+    for (let i = 0; i < 60; i++) deep = { nested: deep };
+    expect(() => redactConformanceReportForSharing(deep)).not.toThrow();
+  });
+});
+
+describe("redactSharedServerUrl", () => {
+  it("strips an API key from the query while keeping the parameter name", () => {
+    const out = redactSharedServerUrl("https://mcp.example.com/mcp?api_key=sk_live_1");
+    expect(out).toContain("api_key=");
+    expect(out).not.toContain("sk_live_1");
+  });
+
+  it("strips URL userinfo", () => {
+    const out = redactSharedServerUrl("https://user:hunter2@mcp.example.com/mcp");
+    expect(out).not.toContain("hunter2");
+    expect(out).not.toContain("user:");
+    expect(out).toContain("mcp.example.com");
+  });
+
+  it("leaves an ordinary URL untouched", () => {
+    const url = "https://mcp.example.com/mcp";
+    expect(redactSharedServerUrl(url)).toBe(url);
+  });
+
+  it("returns non-URL strings unchanged", () => {
+    expect(redactUrlSecrets("not a url at all")).toBe("not a url at all");
+  });
+});


### PR DESCRIPTION
Paste an MCP server URL on a public page, we run the four conformance suites against it, and you get one 0–100 number back with a private shareable `/results/<token>` link. The mcpdebugger.dev product shape, powered by the scoring engine we already ship.

Backend counterpart: **MCPJam/mcpjam-backend#865** (the `conformanceScoreRuns` table + `/internal/v1/score/*`). That must deploy first — this PR's persistence calls it.

## A note on shape

The plan called for three separate inspector PRs (B → C → D), each merging before the next. This session could only push to one designated branch, so they are **three self-contained commits on one branch** instead. They are reviewable in order and each stands alone:

| Commit | What |
|---|---|
| `6c1534e` | **Security prereq** — SSRF/egress guard on the hosted conformance path. Independently valuable; fixes something reachable today. |
| `af478d5` | **Refactor** — extract the conformance run loop into a shared hook. Behavior-preserving. |
| `bf65053` | **Feature** — the score surface itself. |

If you'd rather land them separately, `6c1534e` and `af478d5` cherry-pick cleanly onto `main`.

---

## 1. Egress guard on hosted conformance (`6c1534e`)

`/api/web/conformance/*` performed **no validation on where it was about to connect**, and guests can already run these suites. Two inputs reach the dialer:

- the URL Convex resolved for the authorized server row, and
- `oauthProfile.serverUrl`, which the OAuth suite lets a caller supply outright — and which *overrides* the resolved one.

So an anonymous caller could name `http://169.254.169.254/` and have our hosted backend fetch cloud-metadata IAM credentials for them. Authorizing the server row proves *who is asking*, not *where we are about to connect*.

Both inputs now pass through one shared helper. `isBlockedEgressHost` moves out of the browser harness into `server/utils/hosted-egress-guard.ts` — the dependency has to point that way, since the harness module imports a generated Playwright bundle and a request route must not drag that in — and gains a DNS-resolution pass so a public hostname resolving to a private address is refused too.

Everything is gated on `HOSTED_MODE`: local and desktop keep dialing `localhost`, which is the product. **Only the target is judged**, never the protocol suite's deliberate rebinding-shaped `Host` headers — grading a server's own defenses has to keep working, and there's a test asserting the existing suite is unaffected.

**Bug found and fixed along the way:** `new URL()` rewrites `[::ffff:169.254.169.254]` to `[::ffff:a9fe:a9fe]`, and only the *dotted* spelling was recognized — so the hex form of any blocked address sailed through whenever the host came from a parsed URL. The harness shares the check and is fixed by the same change. Pinned with a regression test that asserts the normalization itself.

Also adds a per-IP ceiling (30 per 10 min) beside the existing 60/min per-guest limit: guest identities are free to mint, so only the IP bounds how much outbound traffic one actor can aim at a third party.

Two limits stated rather than hidden: the check-vs-connect (TOCTOU) rebinding window stays open (closing it needs connection-level IP pinning — infra egress policy's job), and an unresolvable hostname fails closed, which is why the resolver is injectable.

## 2. Shared conformance-run hook (`af478d5`)

`ConformancePanel` owned per-suite run state, the four route calls, the OAuth-conformance popup and its postMessage/BroadcastChannel callback, score derivation, and pooling — all inline. The score page runs the same four suites, and a second copy would drift on exactly the parts that must not: what "done" means per suite, which transports can run which suite, and that the headline pools **counts** rather than averaging suite scores.

A boundary shift, not a rewrite. The panel is the hook's first consumer and drops 1241 → 747 lines; its 27 tests pass unchanged, which is the claim being made.

One genuinely new thing, inert until set: `deferOAuthAuthorization` parks a run at the OAuth authorization step instead of opening the popup. The panel passes `false` and behaves exactly as before.

## 3. The score surface (`bf65053`)

**Vanity domain, no new deploy.** `SCORE_LANDING_HOSTS` sends `score.mcpjam.com/` → `/embed/score`; `/results/<token>` deep links pass through untouched.

**Guest-backed product surface, not a raw-URL API.** A visitor mints a guest session, the pasted URL becomes a real server row in that guest's project, and the existing hosted conformance routes run against it unchanged — no second code path to keep honest. It also makes the funnel free: the CTA carries a one-shot guest promotion proof, so signing in on app.mcpjam.com absorbs the guest project and its server. A bare link would silently promote nothing — the guest cookie is host-only.

**A new `"score"` OAuth surface, and it's load-bearing.** Connect-OAuth reuses `use-hosted-oauth-gate` as-is, but the surface union needed a third value: `"project"` runs the return path through the app-tab segments and would rewrite `/embed/score` → `/servers`, stranding the visitor and losing the run; `"chatbox"` demands a `chatboxId` that doesn't exist here. Both marker validators, the returnPath carve-out, and the App completion branch (guest + `projectId` + `serverId`, no chatbox) learn the new value. The hosted pending marker only restores the *server's* auth state and knows nothing about a run in flight, so the page keeps its own sessionStorage resume record and re-fires the scan on the way back.

**OAuth conformance is opt-in.** A public landing page shouldn't throw an unrequested popup at a visitor. Declining shows as *not scored*, never a deduction — those are opposite claims and the UI renders them as such.

**Private by link.** No directory, no listing, and the read route takes **no bearer at all** (mounted outside `bearerAuthMiddleware`, the caniuse precedent) so a shared result opens in an incognito window. Submissions are per-IP rate limited.

Stdio and localhost servers can't be scored on a hosted runner; the page says so and points at `npx @mcpjam/inspector` rather than failing obscurely.

## Accepted, stated for the record

- **A v1 report is client-assembled and therefore forgeable.** Acceptable only because a run makes no third-party claim — no badge, no ranking, no directory. A badge would need a server-verified re-run; not in this PR.
- No public directory, no README badge, no CLI `--publish`.
- Tasks-suite side effects (one real `tools/call`) and OAuth DCR registrations are unchanged from what the product already does for guests.

## Testing

`npm run typecheck`, `npm run typecheck:client`, and `npm run build:inspector` are all clean. New coverage:

- `server/utils/__tests__/hosted-egress-guard.test.ts` — 15 tests: RFC-1918 / loopback / CGNAT / ULA / link-local / metadata, IPv4-mapped IPv6 in **both** spellings, DNS-rebinding (including "any resolved address is private, not just the first"), fail-closed on unresolvable, resolver failure reported as a lookup problem rather than a verdict, tunnel URLs allowed, local mode a full no-op.
- `server/routes/web/__tests__/conformance-egress.test.ts` — 6 tests: private target and private `oauthProfile.serverUrl` rejected in HOSTED_MODE *before the suite runs*, public allowed, localhost allowed in local mode.
- `server/routes/web/__tests__/score.test.ts` — 9 tests: relay carries the service token, malformed payloads 400 without reaching Convex, per-IP 429, unconfigured storage 503, **read succeeds with no session/cookie/bearer**, repeat read is cached, 404 and 502 paths.
- `client/src/lib/__tests__/hosted-oauth-score-surface.test.ts` — 7 tests, including the pinned regression that the *same* path under `"project"` collapses to `/servers` (the bug the surface exists to avoid) and that the carve-out still refuses `//evil.example.com`.
- `client/src/components/score/__tests__/score-server-name.test.ts` — 7 tests on determinism and slug safety.

Existing suites pass unchanged: ConformancePanel (27), the browser-harness tests that share the moved egress check (19), and the hosted conformance route tests.

**Not yet exercised end-to-end against a live server** — the manual pass (paste the Excalidraw endpoint → suites run → open `/results/<token>` incognito → auth-required server round-trips through the `"score"` surface → CTA handoff → `Host: score.mcpjam.com` curl) still wants doing on a preview deploy, and needs mcpjam-backend#865 deployed first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjvLUx8BjPdwALRYeahLXY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes affect anonymous outbound connections (SSRF mitigation), public unauthenticated score APIs, and OAuth redirect/callback behavior on a new production domain; misconfiguration could block legitimate scans or leak credentials in stored reports if redaction fails.
> 
> **Overview**
> **score.mcpjam.com** is a chrome-less vanity surface: visitors paste an HTTP MCP URL, get a guest-backed server row, run the same four conformance suites as the product, and receive a pooled 0–100 score plus a private `/results/<token>` link (unauthenticated read). OAuth connect uses a new `"score"` hosted OAuth surface; OAuth conformance is opt-in via `deferOAuthAuthorization`. Reports are redacted server-side before Convex storage; PostHog scrubs result tokens from URLs.
> 
> **Hosted conformance security:** resolved server URLs and `oauthProfile.serverUrl` pass through `hosted-egress-guard` (private/metadata/link-local blocks + DNS rebinding checks, `HOSTED_MODE` only). Suites dial via redirect-following fetch that re-checks each hop. Adds per-IP rate limits (30 runs / 10 min) on conformance start routes alongside guest limits.
> 
> **Refactor:** `ConformancePanel` delegates run state, scoring, and OAuth popup flow to `useConformanceRun`; shared `ScoreHeadline` for consistent score display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c22c6cc3fbedf39e3cccbc974ab626f9a7ac098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Launches score.mcpjam.com: paste an MCP server URL, we run all four conformance suites, and you get a single 0–100 score with a private shareable `/results/<token>` link. Adds server-side redaction for stored reports, fixes the score‑domain OAuth round trip, hardens hosted egress with per‑hop checks and safe redirect handling, and tightens credential redaction and redirect semantics.

- New Features
  - Public runner at `score.mcpjam.com` (root → `/embed/score` via `SCORE_LANDING_HOSTS`); `/results/<token>` deep links open directly.
  - Runs Protocol, Apps, Tasks, and OAuth (OAuth is opt‑in) and shows a pooled score with applicability counts; results are private by link via an unauthenticated `/api/web/score/*` relay with per‑IP submit/read limits.
  - Guest‑backed flow with a dedicated `"score"` OAuth surface and a sessionStorage resume record; stdio/localhost targets are guided to `npx @mcpjam/inspector`; conformance logic moved into shared `useConformanceRun` (with `deferOAuthAuthorization`) and `ScoreHeadline` is shared.
  - Server‑side redaction: the relay drops raw HTTP evidence and credentials and scrubs URL secrets before storing; SDK exposes `redactConformanceReportForSharing`, `redactSharedServerUrl`, and `redactUrlSecrets` from `@mcpjam/sdk`/`@mcpjam/sdk/browser`; analytics scrubs result tokens from `$current_url`.

- Bug Fixes
  - Hosted SSRF/egress guard: blocks metadata, link‑local, loopback, RFC‑1918, CGNAT, and IPv6 ULA; resolves hostnames to catch rebinding; closes trailing‑dot and single‑label hex bypasses; DNS outages now return 503 (only all‑no‑record answers fail closed); and suites now use a guarded fetch that re‑checks every redirect hop, strips `Authorization` on cross‑origin redirects, preserves the original method/headers/body, and applies correct HEAD redirect rules. Scope is documented: hop checks cover OAuth and the protocol suite’s raw HTTP/SSE probes; the MCP connection path is unchanged for now.
  - Per‑IP limiters are bounded and fail‑closed at the cap; OAuth continuation is not double‑charged; sweeps moved to a timer to avoid per‑request scans.
  - Run persistence moved to a run‑complete effect so results save after commit; OAuth resave can recover from an initial save failure, is bounded to one retry with an in‑flight guard, and prevents duplicate saves when OAuth settles during the run.
  - Security hardening: Convex calls use `redirect: "manual"` so service tokens aren’t replayed on redirects (3xx yield 502); the service token is never sent over cleartext to non‑loopback hosts; loopback exemption narrowed to `http:` only.
  - OAuth flow: uses a separate pending sentinel, keeps callbacks on the score domain (allowlisted) and treats the score surface as vault‑backed so the round trip completes reliably; removed unused guest‑promotion proof from the CTA; resume records have a short TTL and are cleared on new submissions.
  - State/UX: starting a new scan clears previous server/suite state and drops stale resume records; results page resets on token change, validates report shape (incl. OAuth steps), rejects non‑object reports, and copies without `navigator.clipboard` with an accessible button name; server names include a widened 96‑bit SHA‑256 digest; config signatures stringify `URL` values; Convex calls carry a 10s deadline.
  - Redaction follow‑ups: scrub secrets in URL fragments; detect free‑text Bearer tokens (short forms) and `Basic` credentials, cookie jars, JSON `"*token"` as well as `"authorization"`/`"cookie"` fields (incl. escaped‑JSON cases), and form‑encoded `client_secret`; handle embedded bracketed IPv6 URLs during URL secret scrubbing.
  - Additional hardening: free‑text redaction now uses a single secret‑key predicate (covers `code_verifier`, `proxy-authorization`, `x-api-key`, `registration_access_token`, `client_assertion`, `private_key`, etc.); `Authorization:` matching no longer consumes trailing `&…` in form fragments; guarded fetch honors `Request.redirect === "error"` and refuses to replay one‑shot `Request` bodies across redirects.

<sup>Written for commit 3c22c6cc3fbedf39e3cccbc974ab626f9a7ac098. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

