### PR TITLE
ci(release): deploy the Slack app and Soundcheck as part of a release

### DIFF
--- a/.github/workflows/deploy-slack-app.yml
+++ b/.github/workflows/deploy-slack-app.yml
@@ -9,6 +9,9 @@ on:
       - "package-lock.json"
       - ".github/workflows/deploy-slack-app.yml"
   workflow_dispatch:
+  # Called from release.yml so a release redeploys the bot AFTER the inspector
+  # promote — the bot renders the server's envelope, so it follows the server.
+  workflow_call:
 
 concurrency:
   group: slack-app

--- a/.github/workflows/deploy-soundcheck.yml
+++ b/.github/workflows/deploy-soundcheck.yml
@@ -9,6 +9,9 @@ on:
       - "package-lock.json"
       - ".github/workflows/deploy-soundcheck.yml"
   workflow_dispatch:
+  # Called from release.yml so a release redeploys Soundcheck after the
+  # inspector promote (same reasoning as deploy-slack-app.yml).
+  workflow_call:
 
 concurrency:
   group: soundcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,12 +492,42 @@ jobs:
             -e "$RAILWAY_PRODUCTION_ENVIRONMENT" \
             -p "$PREVIOUS_DEPLOY_ID"
 
+  # The two Railway satellites. Their own workflows already redeploy on
+  # ordinary main pushes touching their paths; these jobs make a RELEASE
+  # redeploy them too, ordered AFTER the inspector promote — both render the
+  # server's contract, so they must never ship ahead of it. A same-SHA
+  # push-triggered run may queue behind these (per-service concurrency
+  # groups, cancel-in-progress: false); the duplicate deploy is idempotent.
+  deploy-slack-app:
+    needs:
+      - preflight
+      - promote-production
+    if: |
+      always() &&
+      fromJSON(inputs.promote_production) &&
+      needs.promote-production.result == 'success'
+    uses: ./.github/workflows/deploy-slack-app.yml
+    secrets: inherit
+
+  deploy-soundcheck:
+    needs:
+      - preflight
+      - promote-production
+    if: |
+      always() &&
+      fromJSON(inputs.promote_production) &&
+      needs.promote-production.result == 'success'
+    uses: ./.github/workflows/deploy-soundcheck.yml
+    secrets: inherit
+
   finalize:
     needs:
       - preflight
       - publish-packages
       - deploy-backend-prod
       - promote-production
+      - deploy-slack-app
+      - deploy-soundcheck
     if: |
       always() &&
       needs.preflight.result == 'success' &&


### PR DESCRIPTION
A release now deploys everything in dependency order — no more remembering which Railway services to poke afterwards.

- `deploy-slack-app.yml` and `deploy-soundcheck.yml` gain `workflow_call` (their push-path and manual-dispatch triggers are unchanged).
- `release.yml` chains both after `promote-production`, gated the same way promote is (`promote_production` input + promote succeeded): **backend → inspector → bot + soundcheck**, each visible as its own check. `finalize` now waits on them.
- Ordering rationale: both satellites render the server's contract (the bot consumes the agent envelope; soundcheck the public API), so they must never ship ahead of it in a release. Day-to-day merges keep the existing path-triggered deploys.
- A same-SHA push-triggered run can queue behind the release-called one (per-service concurrency groups, `cancel-in-progress: false`); the duplicate deploy is idempotent.

actionlint: only the pre-existing `fromJSON(bool-input)` style warnings; the two new gates copy the file's established pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production release ordering and gates finalize on two more Railway deploys; mis-gating could block releases or deploy satellites before inspector, though the pattern mirrors existing `promote_production` checks.
> 
> **Overview**
> Release workflows now **redeploy the Slack bot and Soundcheck on Railway** when production promotion runs, so a single release covers the full stack instead of manual follow-ups.
> 
> `deploy-slack-app.yml` and `deploy-soundcheck.yml` add **`workflow_call`** (push and `workflow_dispatch` behavior unchanged). **`release.yml`** invokes both **after `promote-production`**, using the same **`promote_production`** input and success gate as inspector promote. **`finalize`** now **depends on** those jobs so tagging/commit steps wait for satellite deploys.
> 
> Ordering is intentional: both services consume the inspector/server contract, so they must not ship before production promote. Path-triggered main deploys still exist; a release-triggered deploy may queue behind them per-service (**idempotent** duplicate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e3104053955a44e81547c851f0015a9629f483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release pipeline now redeploys the Slack bot and Soundcheck as part of a release, after the server promote, so satellites never ship ahead of the contract. This makes releases fully ordered: backend → inspector → bot + soundcheck.

- **New Features**
  - Added `workflow_call` to `deploy-slack-app.yml` and `deploy-soundcheck.yml`.
  - `release.yml` calls both after `promote-production`, gated by `promote_production` and a successful promote; each shows as its own check.
  - `finalize` waits on these deployments.
  - Normal path-based deploys for main pushes remain unchanged.
  - Per-service concurrency with `cancel-in-progress: false`; duplicate same-SHA deploys are safe and idempotent.

<sup>Written for commit 34e3104053955a44e81547c851f0015a9629f483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

