### PR TITLE
fix(settings): treat an unresolvable GitHub Checks availability as unavailable

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1745,7 +1745,24 @@ export function ApiKeysSettingsRoute() {
 
 export function GithubChecksSettingsRoute() {
   const { activeOrganizationId } = useAppRouteContext();
-  return <GithubChecksRoute activeOrganizationId={activeOrganizationId} />;
+  // The page's queries THROW rather than resolve when the backend cannot answer
+  // — the function is not deployed yet, or the caller is not a member of the
+  // active org (the backend throws there on purpose; `disabled` would confirm
+  // the org exists). Without a boundary that unmounts the whole app.
+  //
+  // Redirecting matches what an explicit `disabled` already does: a gated
+  // surface that cannot confirm it is available is not available. The error is
+  // logged rather than swallowed, so a genuine render bug is still visible.
+  return (
+    <ErrorBoundary
+      onError={(error) =>
+        console.error("[settings/github-checks] unavailable:", error)
+      }
+      fallback={<Navigate to="/settings" replace />}
+    >
+      <GithubChecksRoute activeOrganizationId={activeOrganizationId} />
+    </ErrorBoundary>
+  );
 }
 
 export function SupportRoute() {

--- a/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useGithubChecksAvailability } from "@/hooks/useGithubChecksSettings";
 
 export type SettingsNavSection =
@@ -17,6 +18,87 @@ interface SettingsNavProps {
   activeOrganizationId?: string | null;
 }
 
+interface TabDescriptor {
+  id: SettingsNavSection;
+  label: string;
+  path: string;
+}
+
+const GITHUB_CHECKS_TAB: TabDescriptor = {
+  id: "github-checks",
+  label: "GitHub Checks",
+  path: "/settings/github-checks",
+};
+
+function SettingsNavTab({
+  tab,
+  active,
+  onSelect,
+}: {
+  tab: TabDescriptor;
+  active: SettingsNavSection;
+  onSelect: (path: string) => void;
+}) {
+  const isActive = active === tab.id;
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (!isActive) onSelect(tab.path);
+      }}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "-mb-px shrink-0 border-b-2 px-3 py-2 text-sm font-medium transition-colors",
+        isActive
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground"
+      )}
+    >
+      {tab.label}
+    </button>
+  );
+}
+
+/**
+ * The GitHub Checks tab, isolated behind its own boundary.
+ *
+ * `useQuery` THROWS when its query errors, and this one errors in two ordinary
+ * situations — neither of them exotic:
+ *
+ *  - **The backend function is not deployed yet.** The Inspector and the Convex
+ *    backend release independently, so there is always a window where this
+ *    client is newer than the deployment it talks to.
+ *  - **The caller is not a member of the active organization.** The backend
+ *    throws there deliberately rather than answering `disabled`, because
+ *    `disabled` would confirm the org exists. A stale active-org id in local
+ *    storage is enough to land on it.
+ *
+ * Unhandled, either one blanks EVERY settings page, because this nav renders on
+ * all of them. So an error means exactly what an explicit `disabled` means: not
+ * available. That is the same fail-closed rule the backend's own flag helper
+ * applies to `undefined` and to a throw — a surface that cannot confirm it is
+ * available is not available.
+ */
+function GithubChecksNavTab({
+  activeOrganizationId,
+  active,
+  onSelect,
+}: {
+  activeOrganizationId?: string | null;
+  active: SettingsNavSection;
+  onSelect: (path: string) => void;
+}) {
+  const availability = useGithubChecksAvailability(activeOrganizationId);
+  if (availability?.state !== "enabled") return null;
+  return (
+    <SettingsNavTab
+      tab={GITHUB_CHECKS_TAB}
+      active={active}
+      onSelect={onSelect}
+    />
+  );
+}
+
 /**
  * Top-level Settings sections, shared across `/settings`,
  * `/settings/api-keys`, and the organization page so they read as one
@@ -28,43 +110,26 @@ export function SettingsNav({
 }: SettingsNavProps) {
   const appNavigate = useAppNavigate();
 
-  // Resolved HERE rather than passed in by each caller. This nav is shared by
-  // every settings page, so a prop would have to be threaded through all of
-  // them — miss one and the tab silently vanishes from that page, which is the
-  // reachability bug that costs you the whole surface. The backend is still the
-  // only authority; this just asks it in one place instead of N.
+  // Availability is resolved HERE rather than passed in by each caller. This
+  // nav is shared by every settings page, so a prop would have to be threaded
+  // through all of them — miss one and the tab silently vanishes from that
+  // page, which is the reachability bug that costs you the whole surface. The
+  // backend is still the only authority; this just asks it in one place.
   //
   // Omitted rather than disabled when unavailable, like the Organization tab: a
   // disabled tab advertises a surface the viewer cannot reach.
-  const githubChecksAvailable =
-    useGithubChecksAvailability(activeOrganizationId)?.state === "enabled";
-
-  const tabs: Array<{
-    id: SettingsNavSection;
-    label: string;
-    path: string;
-  }> = [
+  const tabs: TabDescriptor[] = [
     { id: "general", label: "General", path: "/settings" },
     { id: "api-keys", label: "API Keys", path: "/settings/api-keys" },
-    ...(githubChecksAvailable
-      ? [
-          {
-            id: "github-checks" as const,
-            label: "GitHub Checks",
-            path: "/settings/github-checks",
-          },
-        ]
-      : []),
-    ...(activeOrganizationId
-      ? [
-          {
-            id: "organization" as const,
-            label: "Organization",
-            path: buildOrganizationPath(activeOrganizationId),
-          },
-        ]
-      : []),
   ];
+
+  const organizationTab: TabDescriptor | null = activeOrganizationId
+    ? {
+        id: "organization",
+        label: "Organization",
+        path: buildOrganizationPath(activeOrganizationId),
+      }
+    : null;
 
   return (
     <nav
@@ -72,23 +137,34 @@ export function SettingsNav({
       className="flex items-end gap-1 border-b border-border/60"
     >
       {tabs.map((tab) => (
-        <button
+        <SettingsNavTab
           key={tab.id}
-          type="button"
-          onClick={() => {
-            if (tab.id !== active) appNavigate(tab.path);
-          }}
-          aria-current={active === tab.id ? "page" : undefined}
-          className={cn(
-            "-mb-px shrink-0 border-b-2 px-3 py-2 text-sm font-medium transition-colors",
-            active === tab.id
-              ? "border-primary text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground"
-          )}
-        >
-          {tab.label}
-        </button>
+          tab={tab}
+          active={active}
+          onSelect={appNavigate}
+        />
       ))}
+
+      {/*
+       * `fallback={null}` is the documented "hide this on error" contract of
+       * the boundary primitive. The always-present tabs render outside it, so
+       * Settings stays navigable even when availability cannot be resolved.
+       */}
+      <ErrorBoundary fallback={null}>
+        <GithubChecksNavTab
+          activeOrganizationId={activeOrganizationId}
+          active={active}
+          onSelect={appNavigate}
+        />
+      </ErrorBoundary>
+
+      {organizationTab ? (
+        <SettingsNavTab
+          tab={organizationTab}
+          active={active}
+          onSelect={appNavigate}
+        />
+      ) : null}
     </nav>
   );
 }

--- a/mcpjam-inspector/client/src/components/settings/__tests__/settings-nav.github-checks.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/settings-nav.github-checks.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockNavigate, mockAvailability } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockAvailability: {
     value: undefined as { state: "enabled" | "disabled" } | undefined,
+    /** When set, the hook throws — what `useQuery` does on a query error. */
+    error: null as Error | null,
   },
 }));
 
@@ -17,7 +19,10 @@ vi.mock("@/lib/app-navigation", () => ({
 // The nav asks the backend itself so every settings page agrees; the answer is
 // stubbed here.
 vi.mock("@/hooks/useGithubChecksSettings", () => ({
-  useGithubChecksAvailability: () => mockAvailability.value,
+  useGithubChecksAvailability: () => {
+    if (mockAvailability.error) throw mockAvailability.error;
+    return mockAvailability.value;
+  },
 }));
 
 import { SettingsNav } from "../SettingsNav";
@@ -27,6 +32,20 @@ function renderNav(
   availability?: { state: "enabled" | "disabled" }
 ) {
   mockAvailability.value = availability;
+  mockAvailability.error = null;
+  return render(
+    <MemoryRouter>
+      <SettingsNav {...props} />
+    </MemoryRouter>
+  );
+}
+
+/** Render with the availability query throwing, as `useQuery` does on error. */
+function renderNavWithQueryError(props: Parameters<typeof SettingsNav>[0]) {
+  mockAvailability.value = undefined;
+  mockAvailability.error = new Error(
+    "Could not find function for 'github/checkRepoConfigs:getGithubChecksSettingsAvailability'"
+  );
   return render(
     <MemoryRouter>
       <SettingsNav {...props} />
@@ -64,6 +83,43 @@ describe("SettingsNav — GitHub Checks tab", () => {
     renderNav({ active: "general" }, undefined);
     expect(screen.getByText("General")).toBeInTheDocument();
     expect(screen.getByText("API Keys")).toBeInTheDocument();
+  });
+
+  describe("when the availability query throws", () => {
+    // `useQuery` re-throws query errors during render. Two ordinary cases hit
+    // this: the backend function is not deployed yet (the repos release
+    // independently), and a non-member of the active org (the backend throws
+    // there on purpose). This nav renders on EVERY settings page, so an
+    // unhandled throw here blanks all of them.
+    let consoleError: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // React logs the caught error; silence it so the suite output stays real.
+      consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleError.mockRestore();
+    });
+
+    it("keeps the rest of Settings navigable instead of crashing", () => {
+      renderNavWithQueryError({ active: "general" });
+      expect(screen.getByText("General")).toBeInTheDocument();
+      expect(screen.getByText("API Keys")).toBeInTheDocument();
+    });
+
+    it("omits the GitHub Checks tab, like an explicit disabled", () => {
+      renderNavWithQueryError({ active: "general" });
+      expect(screen.queryByText("GitHub Checks")).not.toBeInTheDocument();
+    });
+
+    it("still renders the Organization tab", () => {
+      renderNavWithQueryError({
+        active: "general",
+        activeOrganizationId: "org-1",
+      });
+      expect(screen.getByText("Organization")).toBeInTheDocument();
+    });
   });
 
   it("marks the GitHub Checks tab current when it is the active section", () => {

--- a/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
+++ b/mcpjam-inspector/client/src/hooks/useGithubChecksSettings.ts
@@ -15,6 +15,14 @@ import { useDbUserReady } from "@/contexts/db-user-ready-context";
  * Function ids are strings because this app has no generated Convex client;
  * types below are hand-mirrored from `convex/github/checkRepoConfigs.ts`. Keep
  * them in sync by hand — nothing checks this at build time.
+ *
+ * **These hooks can throw, and callers must treat a throw as "unavailable".**
+ * `useQuery` re-throws query errors during render, and two ordinary cases
+ * produce one here: the backend function is not deployed yet (the two repos
+ * release independently), and a caller who is not a member of the active
+ * organization (the backend throws there deliberately — answering `disabled`
+ * would confirm the org exists). Both callers wrap these in an `ErrorBoundary`
+ * for exactly that reason; see `SettingsNav` and `GithubChecksSettingsRoute`.
  */
 
 /**


### PR DESCRIPTION
Settings currently blanks the whole app when the GitHub Checks availability query cannot be answered. This makes an unanswerable query mean "unavailable" instead of "crash".

## The bug

`useQuery` re-throws query errors during render:

```js
// node_modules/convex/dist/esm/react/client.js
if (result instanceof Error) { throw result; }
```

`SettingsNav` calls `useGithubChecksAvailability`, and that nav renders on **every** settings page. There is no error boundary above the settings routes and no router `errorElement` — the only two boundaries in the app wrap the OAuth and XAA debuggers. So the throw unmounts the tree: `/settings`, `/settings/api-keys` and `/settings/github-checks` all go blank for any signed-in user with an active org.

Two ordinary situations produce that throw:

1. **The backend function is not deployed yet.** The Inspector and the Convex backend release independently, so a newer client always precedes its deployment for some window. This was live: #3710 merged while the backend stack was still open, and prod answered `Could not find function for 'github/checkRepoConfigs:getGithubChecksSettingsAvailability'`.
2. **The caller is not a member of the active organization.** `getGithubChecksSettingsAvailability` throws there **deliberately** — answering `disabled` would confirm the org exists. A stale active-org id in local storage is enough to hit it, and that path does not go away once the backend ships.

The second reason is why this is a real fix rather than a deploy-order workaround.

## The change

An unresolvable answer now means exactly what an explicit `disabled` means: the surface is unavailable. Same fail-closed rule the backend's own flag helper applies to `undefined` and to a throw.

- **`SettingsNav`** — the GitHub Checks tab moved into its own `<ErrorBoundary fallback={null}>`. `fallback={null}` is the primitive's documented "hide this on error" contract. The always-present tabs render *outside* the boundary, so Settings stays navigable when availability cannot be resolved. Extracted a `SettingsNavTab` presentational component so the boundary-wrapped tab and the plain tabs share one implementation.
- **`GithubChecksSettingsRoute`** (App.tsx) — wrapped so the page redirects to `/settings` instead of unmounting the app. The error is logged via `onError` rather than swallowed, so a genuine render bug is still visible in the console.
- **`useGithubChecksSettings`** — documents that these hooks can throw and that callers must treat a throw as unavailable.

## Verification

By exit code, unpiped:

| check | result |
|---|---|
| settings suites + `app-surface-coverage.test.ts` | **exit 0** — 40 tests |
| `npm run typecheck:client` | **exit 0** |
| `npx prettier --check` on touched files | **exit 0** |

Three new tests cover the throwing query — the existing tests mocked the hook to *return* a value, so none of them exercised a throw. They assert the rest of Settings stays navigable, the tab is omitted, and the Organization tab still renders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only error handling around settings navigation; no auth, billing, or data mutation changes.
> 
> **Overview**
> Fixes Settings going blank when **`useGithubChecksAvailability`** errors during render (undeployed Convex function or non-member of the active org — same cases **`useQuery`** re-throws).
> 
> **`SettingsNav`** moves the GitHub Checks tab into **`GithubChecksNavTab`** behind **`ErrorBoundary`** with **`fallback={null}`**, so General/API Keys/Organization stay usable; shared **`SettingsNavTab`** replaces inline tab buttons.
> 
> **`GithubChecksSettingsRoute`** wraps **`GithubChecksRoute`** in **`ErrorBoundary`** that logs via **`onError`** and **`Navigate`**s to **`/settings`** on failure.
> 
> **`useGithubChecksSettings`** documents that hooks can throw and callers should treat that as unavailable. Tests add three cases for a throwing availability mock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7531dc5424adb278638d3f72ed516fe27e3680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat unresolvable GitHub Checks availability as unavailable to prevent Settings from blanking. The GitHub Checks tab is hidden on error, and the route redirects to `/settings` instead of crashing.

- **Bug Fixes**
  - Errors from `useGithubChecksAvailability` now mean “unavailable” (same as `disabled`).
  - Wrapped the GitHub Checks tab in an `ErrorBoundary` with `fallback={null}` so other tabs still render.
  - Wrapped the GitHub Checks settings route in an `ErrorBoundary` that logs and redirects to `/settings`.
  - Documented that these hooks can throw and must be handled with a boundary.
  - Added tests covering the throwing query path.

- **Refactors**
  - Extracted `SettingsNavTab` to share tab rendering.
  - Resolved availability inside `SettingsNav` to keep all settings pages consistent.

<sup>Written for commit 8b7531dc5424adb278638d3f72ed516fe27e3680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

