### PR TITLE
fix(evals): make check pass/fail legibility and failed-check detail impossible to miss

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/constants.ts
+++ b/mcpjam-inspector/client/src/components/evals/constants.ts
@@ -94,6 +94,23 @@ export const EVAL_FAIL_BAR_CLASS = "bg-destructive/50";
 export const EVAL_FAILED_BADGE_CLASS =
   "bg-destructive/50 text-foreground";
 
+/**
+ * High-contrast pass/fail badges for spots where a failure must be
+ * impossible to miss at a glance (e.g. the per-check gate in
+ * predicates-list.tsx). Deliberately NOT `EVAL_FAILED_BADGE_CLASS`'s
+ * pastel-surface + neutral-text pattern: at `/50` opacity `--success` and
+ * `--destructive` land within ~0.03 OKLCH lightness of each other, so a
+ * "1 failed" chip and an "N/N passed" chip read as near-identical washed-out
+ * pastel — worse still for red/green color-vision deficiency, where hue is
+ * the only differentiator left once lightness converges. Text color itself
+ * carries the hue here, mirroring the checks badge already used in
+ * iteration-row.tsx.
+ */
+export const EVAL_PASSED_BADGE_STRONG_CLASS =
+  "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300";
+export const EVAL_FAILED_BADGE_STRONG_CLASS =
+  "bg-red-500/15 text-red-700 dark:text-red-300";
+
 // UI configuration
 export const UI_CONFIG = {
   MAX_TITLE_LENGTH: 100,

--- a/mcpjam-inspector/client/src/components/evals/constants.ts
+++ b/mcpjam-inspector/client/src/components/evals/constants.ts
@@ -107,7 +107,7 @@ export const EVAL_FAILED_BADGE_CLASS =
  * iteration-row.tsx.
  */
 export const EVAL_PASSED_BADGE_STRONG_CLASS =
-  "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300";
+  "bg-green-500/15 text-green-700 dark:text-green-300";
 export const EVAL_FAILED_BADGE_STRONG_CLASS =
   "bg-red-500/15 text-red-700 dark:text-red-300";
 

--- a/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
@@ -211,16 +211,16 @@ function PredicateRow({
             )}
             {row.passed ? "PASS" : "FAIL"}
           </span>
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+          <span className="min-w-0 flex-1">
+            <span className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
               <span className="font-mono text-xs font-medium">
                 {row.predicate.type}
               </span>
               <span className="truncate text-[11px] text-muted-foreground">
                 {summarizePredicate(row.predicate)}
               </span>
-            </div>
-          </div>
+            </span>
+          </span>
           <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground group-open:hidden" />
           <ChevronDown className="mt-0.5 hidden h-3.5 w-3.5 shrink-0 text-muted-foreground group-open:block" />
         </summary>

--- a/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
+++ b/mcpjam-inspector/client/src/components/evals/predicates-list.tsx
@@ -1,6 +1,11 @@
+import { CheckCircle2, ChevronDown, ChevronRight, XCircle } from "lucide-react";
 import type { Predicate, PredicateResult } from "@/shared/eval-matching";
 import type { EvalTraceWidgetRenderObservationView } from "@/shared/eval-trace";
 import { RenderObservationCard } from "./browser-artifacts-view";
+import {
+  EVAL_FAILED_BADGE_STRONG_CLASS,
+  EVAL_PASSED_BADGE_STRONG_CLASS,
+} from "./constants";
 import type { EvalIteration } from "./types";
 
 /**
@@ -142,12 +147,15 @@ export function PredicatesList({
           Checks
         </div>
         <div
-          className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${
-            allPassed
-              ? "bg-success/50 text-foreground"
-              : "bg-destructive/50 text-foreground"
+          className={`flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold ${
+            allPassed ? EVAL_PASSED_BADGE_STRONG_CLASS : EVAL_FAILED_BADGE_STRONG_CLASS
           }`}
         >
+          {allPassed ? (
+            <CheckCircle2 className="h-3 w-3 shrink-0" aria-hidden />
+          ) : (
+            <XCircle className="h-3 w-3 shrink-0" aria-hidden />
+          )}
           {allPassed
             ? `${predicates.length} / ${predicates.length} checks passed`
             : `${passed} / ${predicates.length} checks passed`}
@@ -160,6 +168,17 @@ export function PredicatesList({
   );
 }
 
+/**
+ * A single check, rendered as a native `<details>` disclosure — clickable
+ * (and keyboard/screen-reader accessible for free, unlike a `div onClick`)
+ * regardless of predicate type. Previously only widget-render predicates got
+ * an expand affordance (for their evidence cards); every other predicate
+ * (`responseContains`, `toolCalledWith`, …) rendered as static, unclickable
+ * markup. Failed rows start expanded — the reason stays "impossible to
+ * miss" inline, per PUR-24 — while passed rows start collapsed to keep a
+ * long checks list scannable; either can be toggled by clicking anywhere on
+ * the summary row.
+ */
 function PredicateRow({
   row,
   observations,
@@ -170,49 +189,56 @@ function PredicateRow({
   const evidence = evidenceObservations(row.predicate, observations);
   return (
     <li
-      className={`rounded border p-2 ${
+      className={`rounded border ${
         row.passed
-          ? "border-success/50 bg-success/50"
-          : "border-destructive/50 bg-destructive/50"
+          ? "border-border/40 bg-background/40"
+          : "border-red-500/40 bg-red-500/5"
       }`}
     >
-      <div className="flex items-start gap-2">
-        <span
-          className={`mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${
-            row.passed
-              ? "bg-success/50 text-foreground"
-              : "bg-destructive/50 text-foreground"
-          }`}
-          aria-label={row.passed ? "passed" : "failed"}
-        >
-          {row.passed ? "PASS" : "FAIL"}
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-            <span className="font-mono text-xs font-medium">
-              {row.predicate.type}
-            </span>
-            <span className="truncate text-[11px] text-muted-foreground">
-              {summarizePredicate(row.predicate)}
-            </span>
+      <details className="group" open={!row.passed}>
+        <summary className="flex cursor-pointer list-none items-start gap-2 p-2 [&::-webkit-details-marker]:hidden">
+          <span
+            className={`mt-0.5 flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold ${
+              row.passed
+                ? EVAL_PASSED_BADGE_STRONG_CLASS
+                : EVAL_FAILED_BADGE_STRONG_CLASS
+            }`}
+          >
+            {row.passed ? (
+              <CheckCircle2 className="h-3 w-3" aria-hidden />
+            ) : (
+              <XCircle className="h-3 w-3" aria-hidden />
+            )}
+            {row.passed ? "PASS" : "FAIL"}
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              <span className="font-mono text-xs font-medium">
+                {row.predicate.type}
+              </span>
+              <span className="truncate text-[11px] text-muted-foreground">
+                {summarizePredicate(row.predicate)}
+              </span>
+            </div>
           </div>
+          <ChevronRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground group-open:hidden" />
+          <ChevronDown className="mt-0.5 hidden h-3.5 w-3.5 shrink-0 text-muted-foreground group-open:block" />
+        </summary>
+        <div className="space-y-1.5 px-2 pb-2 pl-[26px]">
           <div
-            className={`mt-1 whitespace-pre-wrap break-words text-[11px] leading-tight ${
-              row.passed ? "text-muted-foreground" : "text-foreground"
+            className={`whitespace-pre-wrap break-words text-[11px] leading-tight ${
+              row.passed ? "text-muted-foreground" : "text-red-600 dark:text-red-400"
             }`}
           >
             {row.reason}
           </div>
           {evidence.length > 0 ? (
-            <details
-              className="mt-1.5"
-              data-testid="predicate-render-evidence"
-            >
-              <summary className="cursor-pointer text-[11px] text-muted-foreground hover:text-foreground">
+            <div data-testid="predicate-render-evidence">
+              <div className="text-[11px] text-muted-foreground">
                 {evidence.length === 1
                   ? "Rendered widget"
                   : `${evidence.length} rendered widgets`}
-              </summary>
+              </div>
               <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
                 {evidence.map((obs) => (
                   <RenderObservationCard
@@ -221,10 +247,10 @@ function PredicateRow({
                   />
                 ))}
               </div>
-            </details>
+            </div>
           ) : null}
         </div>
-      </div>
+      </details>
     </li>
   );
 }


### PR DESCRIPTION
## What
Fixes PUR-24 — an eval run reporting a failure could visually read as a pass, and a failed assertion row wasn't clickable to inspect why.

## Root cause
`PredicatesList`/`PredicateRow` (`client/src/components/evals/predicates-list.tsx`) styled both PASS and FAIL badges as `bg-success/50`/`bg-destructive/50` with the same neutral `text-foreground`. At `/50` opacity those two design-system tokens land within ~0.03 OKLCH lightness of each other, so a "1 failed" badge reads as a near-identical washed-out pastel chip to an all-passed one — worse for red/green color-vision deficiency, where hue is the only differentiator left once lightness converges.

Separately, only `widgetRendered`-family checks got a `<details>` disclosure. Every other predicate (`responseContains`, `toolCalledWith`, ...) rendered as static markup with no click affordance at all.

## Fix
- Added `EVAL_PASSED_BADGE_STRONG_CLASS` / `EVAL_FAILED_BADGE_STRONG_CLASS` (solid-hue badge + icon, mirroring the pattern already shipped in `iteration-row.tsx`) for the summary badge and each row's PASS/FAIL chip.
- Unified every check row under one native `<details>`/`<summary>` disclosure (previously only widget-render types) — every row now has a real click affordance, including keyboard/screen-reader support for free (a `div`+`onClick` wouldn't get that).
- Failed rows start expanded so the reason is inline immediately, per the task's ask; passed rows start collapsed to keep a long checks list scannable. A failed row's reason text is now red-tinted instead of neutral foreground.

## Verification
- Existing `predicates-list` test suites pass unchanged (16/16).
- `tsc --noEmit -p client/tsconfig.typecheck.json` clean.
- Rendered the real component live (client dev server + built SDK) and screenshotted before/after in both light and dark theme, including the click-to-expand interaction actually working.

Each shot puts `main` and this branch side by side: pastel green/red rows with a neutral-text badge and no click affordance, versus solid-hue badge + icon, a chevron on every row, and the failed row auto-expanded with a red-tinted reason.

**Light theme**

![PUR-24 eval checks, before and after, light theme](https://raw.githubusercontent.com/olartgabo/inspector/34384b2d96c8179bd9d0de555d1e2dbdb8afe494/pur-24-eval-legibility/checks-gate-light.jpg)

**Dark theme**

![PUR-24 eval checks, before and after, dark theme](https://raw.githubusercontent.com/olartgabo/inspector/34384b2d96c8179bd9d0de555d1e2dbdb8afe494/pur-24-eval-legibility/checks-gate-dark.jpg)

<sub>Screenshots are hosted on a branch in the `olartgabo/inspector` fork — no image files are added to this repo or to this PR's diff.</sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves eval check clarity and clickability (PUR-24). Failures are now obvious at a glance, and every failed row can be expanded to see why.

- **Bug Fixes**
  - Replaced pastel PASS/FAIL chips with high-contrast badges + icons via `EVAL_PASSED_BADGE_STRONG_CLASS` and `EVAL_FAILED_BADGE_STRONG_CLASS`; standardized the PASS hue to `bg-green-500/15` to match `iteration-row.tsx`.
  - Made every check a native `<details>/<summary>` disclosure for real click/keyboard/screen-reader support; fixed `<summary>` content model by switching layout wrappers to `<span>`.
  - Failed rows open by default with red-tinted reasons; passed rows start collapsed to keep long lists scannable.

<sup>Written for commit 8e64c5207bda419842e79a0d22ed657cde0c4f75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


