### PR TITLE
fix(playground): name Excalidraw in the send-hint copy (PUR-6)

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/HandDrawnSendHint.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/HandDrawnSendHint.tsx
@@ -3,7 +3,8 @@ import { getChatboxHostFamily } from "@/lib/chatbox-client-style";
 import { cn } from "@/lib/utils";
 import arrow8Svg from "./arrow-8.svg?raw";
 
-const HINT_LABEL = "Try this prompt with a demo MCP server";
+const HINT_LABEL =
+  "Try this prompt with Excalidraw to get started and compare across clients";
 
 const hintFontStyle = {
   fontFamily: "'Caveat', cursive",

--- a/mcpjam-inspector/client/src/components/ui-playground/HandDrawnSendHint.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/HandDrawnSendHint.tsx
@@ -76,7 +76,13 @@ export function HandDrawnSendHint({
 
         <p
           className={cn(
-            "mr-6 mt-2 max-w-none -translate-x-6 whitespace-nowrap text-right text-[19px] leading-snug select-none",
+            // Wraps at every width on purpose. This renders inside the device
+            // frame — a plain div with an inline pixel width in the same
+            // document — so a viewport breakpoint like `sm:` says nothing
+            // about the space actually available: a desktop browser on the
+            // 430px Mobile preset still matches `sm:`, and the shell is
+            // overflow-hidden, so a single long line would clip.
+            "mr-6 mt-2 max-w-[16rem] -translate-x-6 text-right text-[19px] leading-snug select-none",
             textColor,
           )}
           style={hintFontStyle}

--- a/mcpjam-inspector/client/src/components/ui-playground/HandDrawnSendHint.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/HandDrawnSendHint.tsx
@@ -3,8 +3,7 @@ import { getChatboxHostFamily } from "@/lib/chatbox-client-style";
 import { cn } from "@/lib/utils";
 import arrow8Svg from "./arrow-8.svg?raw";
 
-const HINT_LABEL =
-  "Try this prompt with Excalidraw to get started and compare across clients";
+const HINT_LABEL = "Try this prompt with Excalidraw and compare across clients";
 
 const hintFontStyle = {
   fontFamily: "'Caveat', cursive",

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/HandDrawnSendHint.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/HandDrawnSendHint.test.tsx
@@ -20,7 +20,7 @@ describe("HandDrawnSendHint", () => {
   it("renders the hint label", () => {
     render(<HandDrawnSendHint theme="light" />);
     expect(screen.getByTestId("playground-send-nux-hint")).toHaveTextContent(
-      "Try this prompt with a demo MCP server",
+      "Try this prompt with Excalidraw to get started and compare across clients",
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/HandDrawnSendHint.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/HandDrawnSendHint.test.tsx
@@ -20,7 +20,7 @@ describe("HandDrawnSendHint", () => {
   it("renders the hint label", () => {
     render(<HandDrawnSendHint theme="light" />);
     expect(screen.getByTestId("playground-send-nux-hint")).toHaveTextContent(
-      "Try this prompt with Excalidraw to get started and compare across clients",
+      "Try this prompt with Excalidraw and compare across clients",
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -1826,7 +1826,7 @@ describe("PlaygroundMain", () => {
       const hint = screen.getByTestId("playground-send-nux-hint");
       const chatInput = screen.getByTestId("chat-input");
       expect(hint).toHaveTextContent(
-        "Try this prompt with Excalidraw to get started and compare across clients",
+        "Try this prompt with Excalidraw and compare across clients",
       );
       expect(hint.closest('[data-testid="chat-input"]')).toBeNull();
       expect(
@@ -1851,7 +1851,7 @@ describe("PlaygroundMain", () => {
       );
 
       expect(screen.getByTestId("playground-send-nux-hint")).toHaveTextContent(
-        "Try this prompt with Excalidraw to get started and compare across clients",
+        "Try this prompt with Excalidraw and compare across clients",
       );
     });
 

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -1825,7 +1825,9 @@ describe("PlaygroundMain", () => {
 
       const hint = screen.getByTestId("playground-send-nux-hint");
       const chatInput = screen.getByTestId("chat-input");
-      expect(hint).toHaveTextContent("Try this prompt with a demo MCP server");
+      expect(hint).toHaveTextContent(
+        "Try this prompt with Excalidraw to get started and compare across clients",
+      );
       expect(hint.closest('[data-testid="chat-input"]')).toBeNull();
       expect(
         chatInput.compareDocumentPosition(hint) &
@@ -1849,7 +1851,7 @@ describe("PlaygroundMain", () => {
       );
 
       expect(screen.getByTestId("playground-send-nux-hint")).toHaveTextContent(
-        "Try this prompt with a demo MCP server",
+        "Try this prompt with Excalidraw to get started and compare across clients",
       );
     });
 


### PR DESCRIPTION
Small copy fix — Kestral task PUR-6.

**What:** The onboarding hand-drawn hint under the Playground composer said "Try this prompt with a demo MCP server", but it only ever works with Excalidraw. Renamed it to name Excalidraw specifically.

```diff
- Try this prompt with a demo MCP server
+ Try this prompt with Excalidraw and compare across clients
```

**How it renders** (Playground first run, prompt seeded, before Excalidraw connects):

| Light | Dark |
| --- | --- |
| <img width="520" alt="Send hint under the composer, light theme" src="https://raw.githubusercontent.com/olartgabo/inspector/4670acbc0f8677d833d81d9e468f68cf2bcfc92c/pur-6-playground-hint/hint-light.png"> | <img width="520" alt="Send hint under the composer, dark theme" src="https://raw.githubusercontent.com/olartgabo/inspector/4670acbc0f8677d833d81d9e468f68cf2bcfc92c/pur-6-playground-hint/hint-dark.png"> |

At the Phone preset (430×932) the hint is 280px inside a 398px frame — two lines, right-aligned under the arrow, nothing clipped:

<img width="420" alt="Send hint at the 430px Phone device preset" src="https://raw.githubusercontent.com/olartgabo/inspector/4670acbc0f8677d833d81d9e468f68cf2bcfc92c/pur-6-playground-hint/hint-phone-430.png">

**Checked, no change needed:**
- `PostConnectGuide.tsx` already names Excalidraw explicitly.
- `excalidraw-quick-connect.ts` confirms the demo server this onboarding flow drives toward is in fact Excalidraw.

Updated the two unit tests asserting the old string.

The string first landed as "…with Excalidraw to get started and compare across clients"; "to get started" was dropped in the third commit as filler the onboarding flow already conveys.

**Layout:** the longer string cannot sit on one line inside the playground's device frame, so the hint now wraps (capped at `16rem`) at every width. See the second commit for why a `sm:` viewport breakpoint is the wrong tool here — the frame is a plain div with an inline pixel width in the same document, so the viewport says nothing about the space available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Playground hand-drawn send hint to name Excalidraw so the onboarding prompt matches the demo MCP server (PUR-6). Updated unit tests.

- **Bug Fixes**
  - Always wrap the hint and cap its width at 16rem to prevent clipping inside the device frame.

<sup>Written for commit 114dba94e32f6ea09d49f4520efd3a3588b882d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



