### PR TITLE
fix(servers): make auto-connect usable by guests, default it on, soften failure state

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -792,10 +792,30 @@ export function ServersTab({
             input: { serverIds: [], overrides: {} },
           });
         }
-        // Personal-preference sync now lives in the reactive effect below
-        // (keyed off `autoConnectAll`), not here — see that effect's
-        // comment for why a point-in-time sync in the handler wasn't
-        // enough (coderabbit review, PUR-22).
+        // Keep THIS admin's own personal preference in lockstep with the
+        // policy THEY just set — but only once the write actually
+        // succeeds (syncing before the mutation left the two stores
+        // misaligned on a failed request; cubic review, PUR-22).
+        //
+        // Known scope limitation, accepted for this PR: this only syncs
+        // on the admin's own click. A policy that was already on before
+        // this PR shipped, or one changed by a DIFFERENT admin, won't
+        // reach this admin's personal preference until they toggle the
+        // switch themselves (or until a broader fix teaches
+        // `useAutoConnectProjectServers` to resolve the Convex project
+        // policy directly for admins, instead of only the personal
+        // preference). A tried-and-reverted alternative — reactively
+        // mirroring `autoConnectAll` into the personal preference on
+        // every render where the admin path is active — closed that gap
+        // but opened a worse one: `autoConnectServersEnabled` is a
+        // single DEVICE-GLOBAL preference, so merely viewing one shared
+        // project with the policy OFF would silently disable auto-connect
+        // for this admin's entirely unrelated local/no-cloud-sync
+        // projects on the same device too. The full fix is the
+        // project-policy-aware reconcile gate described above, not a
+        // client-side mirror; tracked as a fast-follow, not attempted
+        // here (cubic review, PUR-22).
+        setPersonalAutoConnectEnabled(next);
       } catch (err) {
         const message =
           err instanceof Error
@@ -812,6 +832,7 @@ export function ServersTab({
       catalogServerIds,
       projectServerConfigDto,
       setProjectServerConfigMutation,
+      setPersonalAutoConnectEnabled,
     ]
   );
 
@@ -825,32 +846,6 @@ export function ServersTab({
     canManageProjectServers &&
     catalogServerIds.length > 0 &&
     projectServerConfigDto !== undefined;
-  // Keep an admin's personal preference continuously mirroring the
-  // resolved project-wide policy — not just at the moment THIS admin
-  // toggles it. `useAutoConnectProjectServers`'s reconcile gate only ever
-  // reads the personal `autoConnectServersEnabled` preference, never this
-  // Convex policy, so without this the switch can show one state
-  // (`autoConnectAll`) while actual auto-connect behavior follows another:
-  // a policy that was already on before this PR shipped, or one flipped by
-  // a DIFFERENT admin, would never reach this admin's own personal
-  // preference through a click handler that only fires on THEIR click.
-  // `projectServerConfigDto` is a live Convex query, so this effect picks
-  // up both cases as soon as they hydrate/update (coderabbit review,
-  // PUR-22). Deliberately not folded into `useAutoConnectProjectServers`
-  // itself — that hook mounts on the Servers tab, Host page, and
-  // Playground, and teaching it the full admin/Convex-policy resolution
-  // path (on top of the personal preference it already owns) is a larger
-  // architectural change than this ticket's scope.
-  useEffect(() => {
-    if (!canUseProjectWideAutoConnect) return;
-    if (personalAutoConnectEnabled === autoConnectAll) return;
-    setPersonalAutoConnectEnabled(autoConnectAll);
-  }, [
-    canUseProjectWideAutoConnect,
-    autoConnectAll,
-    personalAutoConnectEnabled,
-    setPersonalAutoConnectEnabled,
-  ]);
   // `useProjectMembers` resolves `canManageMembers` asynchronously and
   // defaults it to `false` while loading; separately, a CONFIRMED admin's
   // path still isn't usable until the config DTO and catalog have

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -99,6 +99,7 @@ import {
   resetAutoConnectAttempts,
   useAutoConnectProjectServers,
 } from "@/hooks/useAutoConnectProjectServers";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { useHost } from "@/hooks/useClients";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { ConnectEnvironmentsStrip } from "./project-environments/ConnectEnvironmentsStrip";
@@ -701,24 +702,34 @@ export function ServersTab({
     [remoteServersByName, projects, moveServerToProject, onDisconnect, onRemove]
   );
 
-  // Project-wide auto-connect toggle. Single switch in the header that
-  // either enrolls every catalog server in project.serverIds (ON) or
-  // clears the set (OFF). Overrides on still-included servers are
-  // preserved on ON so existing per-server header/timeout config isn't
-  // wiped by a toggle round-trip. Per-server granularity is intentionally
-  // deferred — this is the simplest user-facing surface for the project-
-  // scoped server config rollout.
+  // Auto-connect toggle. Two backing stores, one visible switch:
+  //  - Project admins write the project-wide Convex policy (enrolls every
+  //    catalog server in project.serverIds on ON, clears the set on OFF).
+  //    Overrides on still-included servers are preserved on ON so existing
+  //    per-server header/timeout config isn't wiped by a toggle round-trip.
+  //  - Everyone else (members, guests, local/no-cloud-sync users) flips
+  //    their own client-local `autoConnectServersEnabled` preference
+  //    instead — no project-admin permission required, so the switch is
+  //    always visible and always does *something* useful, even for a
+  //    guest who can't write project policy (PUR-22: guests previously saw
+  //    no toggle here at all). See `useAutoConnectDefaultVariant` for the
+  //    A/B-tested default this preference starts from.
   //
-  // Stale-server note: when this is ON and a user adds a new server to
-  // the catalog later, the new server isn't auto-included — they'd
-  // toggle OFF/ON to refresh. Acceptable for v1; a later pass can fold
-  // newly-added servers in automatically when the toggle is on.
-  // Permission gate for the Auto-connect toggle. Backend
-  // `projectServerConfig:setConfig` requires project admin
-  // (`canManageProjectMembers`); mirror that check on the client so
-  // non-admins see a disabled switch instead of an enabled control that
-  // toasts an authorization error when toggled. Matches the
-  // canManageProjectSettings pattern in ProjectSettingsTab.
+  // Stale-server note: when the project-wide policy is ON and a user adds
+  // a new server to the catalog later, the new server isn't auto-included
+  // — they'd toggle OFF/ON to refresh. Acceptable for v1; a later pass can
+  // fold newly-added servers in automatically when the toggle is on.
+  const personalAutoConnectEnabled = usePreferencesStore(
+    (s) => s.autoConnectServersEnabled
+  );
+  const setPersonalAutoConnectEnabled = usePreferencesStore(
+    (s) => s.setAutoConnectServersEnabled
+  );
+  // Backend `projectServerConfig:setConfig` requires project admin
+  // (`canManageProjectMembers`); mirror that check on the client so a
+  // non-admin's toggle falls back to the personal preference instead of
+  // firing a mutation that will 403. Matches the canManageProjectSettings
+  // pattern in ProjectSettingsTab.
   const { canManageMembers: canManageProjectServers } = useProjectMembers({
     isAuthenticated,
     projectId: sharedProjectIdForHostScope,
@@ -797,14 +808,29 @@ export function ServersTab({
     ]
   );
 
+  // Only take the project-wide (admin) path once the catalog + config have
+  // actually hydrated — reading `autoConnectAll` against a still-loading
+  // DTO would show a false OFF. Everyone else (including guests) lands on
+  // the personal preference below, which needs no project sync at all.
+  const canUseProjectWideAutoConnect =
+    !!sharedProjectIdForHostScope &&
+    isAuthenticated &&
+    canManageProjectServers &&
+    catalogServerIds.length > 0 &&
+    projectServerConfigDto !== undefined;
+
   const renderAutoConnectToggle = () => {
-    // Hide entirely when the project hasn't synced or when there's no
-    // catalog to toggle against. Both states make the switch
-    // semantically meaningless.
-    if (!sharedProjectIdForHostScope || !isAuthenticated) return null;
-    if (catalogServerIds.length === 0) return null;
-    if (projectServerConfigDto === undefined) return null;
-    const disabled = isTogglingAutoConnect || !canManageProjectServers;
+    const checked = canUseProjectWideAutoConnect
+      ? autoConnectAll
+      : personalAutoConnectEnabled;
+    const disabled = canUseProjectWideAutoConnect && isTogglingAutoConnect;
+    const handleChange = (next: boolean) => {
+      if (canUseProjectWideAutoConnect) {
+        void handleToggleAutoConnect(next);
+      } else {
+        setPersonalAutoConnectEnabled(next);
+      }
+    };
     return (
       <label
         className={cn(
@@ -812,16 +838,16 @@ export function ServersTab({
           disabled ? "cursor-not-allowed" : "cursor-pointer"
         )}
         title={
-          canManageProjectServers
+          canUseProjectWideAutoConnect
             ? "Auto-connect every project server when a client opens"
-            : "Only project admins can change auto-connect"
+            : "Automatically reconnect your servers whenever you open a client on this device. Turn off to connect servers manually."
         }
       >
         <Switch
-          checked={autoConnectAll}
+          checked={checked}
           disabled={disabled}
-          onCheckedChange={handleToggleAutoConnect}
-          aria-label="Auto-connect project servers"
+          onCheckedChange={handleChange}
+          aria-label="Auto-connect servers"
         />
         <span>Auto-connect</span>
       </label>

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -768,15 +768,6 @@ export function ServersTab({
       // current host re-runs reconciliation instead of reusing stale attempts.
       resetAutoConnectAttempts(activeProjectId);
       resetAutoConnectAttempts(sharedProjectIdForHostScope);
-      // Keep this admin's own personal preference in lockstep: the actual
-      // reconcile gate in `useAutoConnectProjectServers` reads ONLY the
-      // personal `autoConnectServersEnabled` preference, never the
-      // project-wide Convex policy this toggle writes below. Without this,
-      // an admin could see the switch ON (project policy set) while their
-      // own client never auto-connects (personal preference still OFF from
-      // before this PR existed) — the switch would visibly lie about what
-      // it does (cubic review, PUR-22).
-      setPersonalAutoConnectEnabled(next);
       try {
         if (next) {
           // Preserve overrides for servers that remain in the catalog —
@@ -801,6 +792,18 @@ export function ServersTab({
             input: { serverIds: [], overrides: {} },
           });
         }
+        // Keep this admin's own personal preference in lockstep — but only
+        // once the project-policy write actually succeeds. The real
+        // reconcile gate in `useAutoConnectProjectServers` reads ONLY the
+        // personal `autoConnectServersEnabled` preference, never this
+        // Convex policy, so without this an admin could see the switch ON
+        // while their own client never auto-connects. Syncing it BEFORE
+        // the mutation (as an earlier pass of this fix did) has the
+        // opposite bug: a failed mutation leaves the personal preference
+        // changed while the project policy didn't move, the exact
+        // lockstep violation this is meant to prevent (cubic review,
+        // PUR-22).
+        setPersonalAutoConnectEnabled(next);
       } catch (err) {
         const message =
           err instanceof Error
@@ -832,14 +835,21 @@ export function ServersTab({
     catalogServerIds.length > 0 &&
     projectServerConfigDto !== undefined;
   // `useProjectMembers` resolves `canManageMembers` asynchronously and
-  // defaults it to `false` while loading. Without this, a real admin who
-  // clicks during that window falls through to the personal-preference
-  // branch — the click silently lands in the wrong store instead of
-  // updating the project-wide policy they think they're changing (cubic
-  // review, PUR-22). Only relevant once we're actually on a synced,
-  // authenticated project; guests/local users never hit this window.
+  // defaults it to `false` while loading; separately, a CONFIRMED admin's
+  // path still isn't usable until the config DTO and catalog have
+  // hydrated (`canUseProjectWideAutoConnect`'s other conditions). Either
+  // gap lets a real admin's click fall through to the personal-preference
+  // branch — silently landing in the wrong store instead of updating the
+  // project-wide policy they think they're changing (cubic review,
+  // PUR-22). Only relevant once we're actually on a synced, authenticated
+  // project; guests/local users never hit this window.
   const isResolvingProjectRole =
-    !!sharedProjectIdForHostScope && isAuthenticated && isLoadingProjectMembers;
+    !!sharedProjectIdForHostScope &&
+    isAuthenticated &&
+    (isLoadingProjectMembers ||
+      (canManageProjectServers &&
+        (projectServerConfigDto === undefined ||
+          viewProjectServersList === undefined)));
 
   const renderAutoConnectToggle = () => {
     const checked = canUseProjectWideAutoConnect

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -792,18 +792,10 @@ export function ServersTab({
             input: { serverIds: [], overrides: {} },
           });
         }
-        // Keep this admin's own personal preference in lockstep — but only
-        // once the project-policy write actually succeeds. The real
-        // reconcile gate in `useAutoConnectProjectServers` reads ONLY the
-        // personal `autoConnectServersEnabled` preference, never this
-        // Convex policy, so without this an admin could see the switch ON
-        // while their own client never auto-connects. Syncing it BEFORE
-        // the mutation (as an earlier pass of this fix did) has the
-        // opposite bug: a failed mutation leaves the personal preference
-        // changed while the project policy didn't move, the exact
-        // lockstep violation this is meant to prevent (cubic review,
-        // PUR-22).
-        setPersonalAutoConnectEnabled(next);
+        // Personal-preference sync now lives in the reactive effect below
+        // (keyed off `autoConnectAll`), not here — see that effect's
+        // comment for why a point-in-time sync in the handler wasn't
+        // enough (coderabbit review, PUR-22).
       } catch (err) {
         const message =
           err instanceof Error
@@ -820,7 +812,6 @@ export function ServersTab({
       catalogServerIds,
       projectServerConfigDto,
       setProjectServerConfigMutation,
-      setPersonalAutoConnectEnabled,
     ]
   );
 
@@ -834,6 +825,32 @@ export function ServersTab({
     canManageProjectServers &&
     catalogServerIds.length > 0 &&
     projectServerConfigDto !== undefined;
+  // Keep an admin's personal preference continuously mirroring the
+  // resolved project-wide policy — not just at the moment THIS admin
+  // toggles it. `useAutoConnectProjectServers`'s reconcile gate only ever
+  // reads the personal `autoConnectServersEnabled` preference, never this
+  // Convex policy, so without this the switch can show one state
+  // (`autoConnectAll`) while actual auto-connect behavior follows another:
+  // a policy that was already on before this PR shipped, or one flipped by
+  // a DIFFERENT admin, would never reach this admin's own personal
+  // preference through a click handler that only fires on THEIR click.
+  // `projectServerConfigDto` is a live Convex query, so this effect picks
+  // up both cases as soon as they hydrate/update (coderabbit review,
+  // PUR-22). Deliberately not folded into `useAutoConnectProjectServers`
+  // itself — that hook mounts on the Servers tab, Host page, and
+  // Playground, and teaching it the full admin/Convex-policy resolution
+  // path (on top of the personal preference it already owns) is a larger
+  // architectural change than this ticket's scope.
+  useEffect(() => {
+    if (!canUseProjectWideAutoConnect) return;
+    if (personalAutoConnectEnabled === autoConnectAll) return;
+    setPersonalAutoConnectEnabled(autoConnectAll);
+  }, [
+    canUseProjectWideAutoConnect,
+    autoConnectAll,
+    personalAutoConnectEnabled,
+    setPersonalAutoConnectEnabled,
+  ]);
   // `useProjectMembers` resolves `canManageMembers` asynchronously and
   // defaults it to `false` while loading; separately, a CONFIRMED admin's
   // path still isn't usable until the config DTO and catalog have

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -730,7 +730,10 @@ export function ServersTab({
   // non-admin's toggle falls back to the personal preference instead of
   // firing a mutation that will 403. Matches the canManageProjectSettings
   // pattern in ProjectSettingsTab.
-  const { canManageMembers: canManageProjectServers } = useProjectMembers({
+  const {
+    canManageMembers: canManageProjectServers,
+    isLoading: isLoadingProjectMembers,
+  } = useProjectMembers({
     isAuthenticated,
     projectId: sharedProjectIdForHostScope,
   });
@@ -765,6 +768,15 @@ export function ServersTab({
       // current host re-runs reconciliation instead of reusing stale attempts.
       resetAutoConnectAttempts(activeProjectId);
       resetAutoConnectAttempts(sharedProjectIdForHostScope);
+      // Keep this admin's own personal preference in lockstep: the actual
+      // reconcile gate in `useAutoConnectProjectServers` reads ONLY the
+      // personal `autoConnectServersEnabled` preference, never the
+      // project-wide Convex policy this toggle writes below. Without this,
+      // an admin could see the switch ON (project policy set) while their
+      // own client never auto-connects (personal preference still OFF from
+      // before this PR existed) — the switch would visibly lie about what
+      // it does (cubic review, PUR-22).
+      setPersonalAutoConnectEnabled(next);
       try {
         if (next) {
           // Preserve overrides for servers that remain in the catalog —
@@ -805,6 +817,7 @@ export function ServersTab({
       catalogServerIds,
       projectServerConfigDto,
       setProjectServerConfigMutation,
+      setPersonalAutoConnectEnabled,
     ]
   );
 
@@ -818,12 +831,23 @@ export function ServersTab({
     canManageProjectServers &&
     catalogServerIds.length > 0 &&
     projectServerConfigDto !== undefined;
+  // `useProjectMembers` resolves `canManageMembers` asynchronously and
+  // defaults it to `false` while loading. Without this, a real admin who
+  // clicks during that window falls through to the personal-preference
+  // branch — the click silently lands in the wrong store instead of
+  // updating the project-wide policy they think they're changing (cubic
+  // review, PUR-22). Only relevant once we're actually on a synced,
+  // authenticated project; guests/local users never hit this window.
+  const isResolvingProjectRole =
+    !!sharedProjectIdForHostScope && isAuthenticated && isLoadingProjectMembers;
 
   const renderAutoConnectToggle = () => {
     const checked = canUseProjectWideAutoConnect
       ? autoConnectAll
       : personalAutoConnectEnabled;
-    const disabled = canUseProjectWideAutoConnect && isTogglingAutoConnect;
+    const disabled =
+      isResolvingProjectRole ||
+      (canUseProjectWideAutoConnect && isTogglingAutoConnect);
     const handleChange = (next: boolean) => {
       if (canUseProjectWideAutoConnect) {
         void handleToggleAutoConnect(next);
@@ -838,7 +862,9 @@ export function ServersTab({
           disabled ? "cursor-not-allowed" : "cursor-pointer"
         )}
         title={
-          canUseProjectWideAutoConnect
+          isResolvingProjectRole
+            ? "Checking your project role…"
+            : canUseProjectWideAutoConnect
             ? "Auto-connect every project server when a client opens"
             : "Automatically reconnect your servers whenever you open a client on this device. Turn off to connect servers manually."
         }

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
-  render,
+  render as rtlRender,
   screen,
   fireEvent,
   waitFor,
   within,
+  type RenderOptions,
 } from "@testing-library/react";
 import { HostsConnectAddServerSlotContext } from "@/components/hosts/HostsConnectAddServerSlotContext";
-import { useState, type ReactNode } from "react";
+import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
+import { useState, type ReactElement, type ReactNode } from "react";
 import { getDefaultClientCapabilities } from "@mcpjam/sdk/browser";
 import type { ServerWithName, ServerUpdateResult } from "@/hooks/use-app-state";
 import type { Project } from "@/state/app-types";
@@ -21,6 +23,7 @@ import { writePendingQuickConnect } from "@/lib/quick-connect-pending";
 import type { EnrichedRegistryCatalogCard } from "@/hooks/useRegistryServers";
 import { getRegistryServerName } from "@/hooks/useRegistryServers";
 import { useClientConfigStore } from "@/stores/client-config-store";
+import { AUTO_CONNECT_SERVERS_KEY } from "@/stores/preferences/preferences-store";
 
 function createLinearCatalogCard(): EnrichedRegistryCatalogCard {
   const server = {
@@ -445,6 +448,29 @@ vi.mock("@dnd-kit/utilities", () => ({
 }));
 
 import { ServersTab } from "../ServersTab";
+
+// ServersTab now reads the personal auto-connect preference off
+// `PreferencesStoreProvider` (PUR-22 — guests need a working toggle even
+// though they can't write the project-wide Convex policy). Every render
+// site below gets that provider for free by shadowing testing-library's
+// `render` rather than touching each of the ~15 call sites individually.
+//
+// Must go through RTL's `wrapper` option, not a hand-nested
+// `<PreferencesStoreProvider>{ui}</...>` — several tests below call the
+// returned `rerender(<ServersTab .../>)` with a bare (unwrapped) element,
+// and only `options.wrapper` gets re-applied by RTL on every `rerender`;
+// a manual wrap only covers the first render, so the provider vanishes on
+// rerender and every `usePreferencesStore` call throws.
+function PreferencesWrapper({ children }: { children: ReactNode }) {
+  return (
+    <PreferencesStoreProvider themeMode="light" themePreset="default">
+      {children}
+    </PreferencesStoreProvider>
+  );
+}
+function render(ui: ReactElement, options?: RenderOptions) {
+  return rtlRender(ui, { wrapper: PreferencesWrapper, ...options });
+}
 
 function createServer(overrides: Partial<ServerWithName> = {}): ServerWithName {
   return {
@@ -1771,5 +1797,39 @@ describe("ServersTab shared detail modal", () => {
     expect(
       screen.queryByTestId("servers-quick-connect-section")
     ).not.toBeInTheDocument();
+  });
+
+  describe("auto-connect toggle (PUR-22)", () => {
+    // In this file's default mocks `useQuery` always returns `undefined` and
+    // `useProjectMembers` (unmocked, reading that same `useQuery`) resolves
+    // `canManageMembers: false` — i.e. every test below is already in the
+    // "can't manage the project" position a guest is in. There is nothing
+    // project-admin-only left to gate the switch on.
+    it("is visible and usable for a viewer who cannot manage the project, backed by the personal preference", () => {
+      render(<ServersTab {...defaultProps} />);
+
+      const toggle = screen.getByRole("switch", {
+        name: "Auto-connect servers",
+      });
+      // Defaults on with no stored preference — the opt-out model, not
+      // opt-in (PUR-22 ask #2).
+      expect(toggle).toBeEnabled();
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+
+      fireEvent.click(toggle);
+
+      expect(toggle).toHaveAttribute("aria-checked", "false");
+      expect(localStorage.getItem(AUTO_CONNECT_SERVERS_KEY)).toBe("false");
+    });
+
+    it("honors a previously-stored opt-out on mount", () => {
+      localStorage.setItem(AUTO_CONNECT_SERVERS_KEY, "false");
+
+      render(<ServersTab {...defaultProps} />);
+
+      expect(
+        screen.getByRole("switch", { name: "Auto-connect servers" })
+      ).toHaveAttribute("aria-checked", "false");
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -1831,5 +1831,28 @@ describe("ServersTab shared detail modal", () => {
         screen.getByRole("switch", { name: "Auto-connect servers" })
       ).toHaveAttribute("aria-checked", "false");
     });
+
+    it("disables the switch while the viewer's project role is still resolving, instead of falling through to the personal preference (cubic review)", () => {
+      // Authenticated + a shared project makes `useProjectMembers`'s query
+      // enabled; this file's global `useQuery` mock never resolves, so
+      // `isLoading` stays true for the life of the test — modeling the real
+      // hydration window where an admin's role isn't known yet.
+      mockIsAuthenticated = true;
+      const projectsWithSharedId = {
+        "project-1": {
+          ...projects["project-1"],
+          sharedProjectId: "shared-project-1",
+        },
+      };
+
+      render(
+        <ServersTab {...defaultProps} projects={projectsWithSharedId} />
+      );
+
+      const toggle = screen.getByRole("switch", {
+        name: "Auto-connect servers",
+      });
+      expect(toggle).toBeDisabled();
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -2,6 +2,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { toast } from "@/lib/toast";
@@ -43,6 +44,7 @@ import {
 import { ServerWithName } from "@/hooks/use-app-state";
 import { exportServerApi } from "@/lib/apis/mcp-export-api";
 import { ErrorCard } from "@/components/ui/error-card";
+import { describeError, isNormalizedError } from "@mcpjam/sdk/browser";
 import {
   getConnectionStatusMeta,
   getServerCommandDisplay,
@@ -185,6 +187,17 @@ export function ServerConnectionCard({
   const hasTunnel = Boolean(tunnelUrl);
   const hasError =
     server.connectionStatus === "failed" && Boolean(server.lastError);
+  // Cause + fix, surfaced directly on the compact status badge (via
+  // tooltip) instead of requiring the "Error" disclosure to be expanded
+  // first — the whole point of softening "Failed" to "Could not connect"
+  // is to pair it with an immediate, actionable explanation (PUR-22).
+  const normalizedFailure = useMemo(() => {
+    if (!hasError) return null;
+    if (isNormalizedError(server.lastNormalizedError)) {
+      return server.lastNormalizedError;
+    }
+    return describeError(server.lastError);
+  }, [hasError, server.lastError, server.lastNormalizedError]);
   const oauthFailureStep = getOAuthTraceFailureStep(server.lastOAuthTrace);
   const isHostedHttpReconnectBlocked = isHostedInsecureHttpServer(server);
   const isPendingConnection =
@@ -576,7 +589,7 @@ export function ServerConnectionCard({
                       e.stopPropagation();
                       setIsErrorExpanded(true);
                     }}
-                    className="inline-flex items-center gap-1 rounded-full border border-red-300/60 bg-red-500/10 px-2 py-0.5 text-[11px] text-red-700 dark:text-red-300 cursor-pointer"
+                    className="inline-flex items-center gap-1 rounded-full border border-amber-300/60 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-300 cursor-pointer"
                   >
                     <AlertCircle className="h-3 w-3" />
                     Error
@@ -599,11 +612,36 @@ export function ServerConnectionCard({
                       style={{ backgroundColor: indicatorColor }}
                     />
                   )}
-                  <span>
-                    {server.connectionStatus === "failed"
-                      ? `${connectionStatusLabel} (${server.retryCount})`
-                      : connectionStatusLabel}
-                  </span>
+                  {server.connectionStatus === "failed" &&
+                  normalizedFailure ? (
+                    <Tooltip>
+                      <TooltipTrigger
+                        type="button"
+                        className="underline decoration-dotted underline-offset-2 outline-none"
+                      >
+                        {`${connectionStatusLabel} (${server.retryCount})`}
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="top"
+                        sideOffset={4}
+                        variant="muted"
+                        className="max-w-64 px-2.5 text-left [text-wrap:normal]"
+                      >
+                        <p>{normalizedFailure.oneLine}</p>
+                        {normalizedFailure.nextSteps[0] ? (
+                          <p className="mt-1 opacity-75">
+                            {normalizedFailure.nextSteps[0]}
+                          </p>
+                        ) : null}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <span>
+                      {server.connectionStatus === "failed"
+                        ? `${connectionStatusLabel} (${server.retryCount})`
+                        : connectionStatusLabel}
+                    </span>
+                  )}
                   {needsReconnect ? (
                     <Tooltip>
                       <TooltipTrigger

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -198,6 +198,9 @@ export function ServerConnectionCard({
     }
     return describeError(server.lastError);
   }, [hasError, server.lastError, server.lastNormalizedError]);
+  // Hoisted so the tooltip-trigger branch and the plain-span fallback below
+  // can't drift out of sync (cubic review, PUR-22).
+  const failedStatusLabel = `${connectionStatusLabel} (${server.retryCount})`;
   const oauthFailureStep = getOAuthTraceFailureStep(server.lastOAuthTrace);
   const isHostedHttpReconnectBlocked = isHostedInsecureHttpServer(server);
   const isPendingConnection =
@@ -619,7 +622,7 @@ export function ServerConnectionCard({
                         type="button"
                         className="underline decoration-dotted underline-offset-2 outline-none"
                       >
-                        {`${connectionStatusLabel} (${server.retryCount})`}
+                        {failedStatusLabel}
                       </TooltipTrigger>
                       <TooltipContent
                         side="top"
@@ -628,7 +631,7 @@ export function ServerConnectionCard({
                         className="max-w-64 px-2.5 text-left [text-wrap:normal]"
                       >
                         <p>{normalizedFailure.oneLine}</p>
-                        {normalizedFailure.nextSteps[0] ? (
+                        {typeof normalizedFailure.nextSteps[0] === "string" ? (
                           <p className="mt-1 opacity-75">
                             {normalizedFailure.nextSteps[0]}
                           </p>
@@ -638,7 +641,7 @@ export function ServerConnectionCard({
                   ) : (
                     <span>
                       {server.connectionStatus === "failed"
-                        ? `${connectionStatusLabel} (${server.retryCount})`
+                        ? failedStatusLabel
                         : connectionStatusLabel}
                     </span>
                   )}

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -257,7 +257,7 @@ describe("ServerConnectionCard", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("shows failed status with retry count", () => {
+    it("shows a soft-fail status with retry count", () => {
       const server = createServer({
         connectionStatus: "failed",
         retryCount: 3,
@@ -265,7 +265,7 @@ describe("ServerConnectionCard", () => {
       });
       render(<ServerConnectionCard server={server} {...defaultProps} />);
 
-      expect(screen.getByText("Failed (3)")).toBeInTheDocument();
+      expect(screen.getByText("Could not connect (3)")).toBeInTheDocument();
     });
 
     it("shows a connection settings indicator without reconnect badge copy", () => {

--- a/mcpjam-inspector/client/src/components/connection/__tests__/server-card-utils.test.ts
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/server-card-utils.test.ts
@@ -30,11 +30,11 @@ describe("getConnectionStatusMeta", () => {
     expect(meta.iconClassName).toContain("text-purple-500");
   });
 
-  it("returns failed status meta", () => {
+  it("returns failed status meta with soft-fail (amber) styling", () => {
     const meta = getConnectionStatusMeta("failed");
-    expect(meta.label).toBe("Failed");
-    expect(meta.indicatorColor).toBe("#ef4444");
-    expect(meta.iconClassName).toContain("text-red-500");
+    expect(meta.label).toBe("Could not connect");
+    expect(meta.indicatorColor).toBe("#f59e0b");
+    expect(meta.iconClassName).toContain("text-amber-500");
   });
 
   it("returns disconnected status meta", () => {

--- a/mcpjam-inspector/client/src/components/connection/server-card-utils.ts
+++ b/mcpjam-inspector/client/src/components/connection/server-card-utils.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { Check, Loader2, Wifi, X } from "lucide-react";
+import { AlertTriangle, Check, Loader2, Wifi } from "lucide-react";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 import type { ConnectionStatus } from "@/state/app-types";
 
@@ -30,10 +30,16 @@ const connectionStatusMeta: Record<ConnectionStatus, ConnectionStatusMeta> = {
     iconClassName: "h-3 w-3 text-purple-500 animate-spin",
   },
   failed: {
-    label: "Failed",
-    indicatorColor: "#ef4444",
-    Icon: X,
-    iconClassName: "h-3 w-3 text-red-500",
+    // Soft-fail language on purpose: an auto-connect miss is almost always
+    // recoverable (stale token, sleeping server, one-off network blip) and
+    // the user has a clear next action (reconnect / re-auth). Red "Failed"
+    // read as a dead end; amber "Could not connect" plus the tooltip's
+    // cause + fix (see ServerConnectionCard) matches the severity users
+    // actually attach to this state (PUR-22).
+    label: "Could not connect",
+    indicatorColor: "#f59e0b",
+    Icon: AlertTriangle,
+    iconClassName: "h-3 w-3 text-amber-500",
   },
   disconnected: {
     label: "Disconnected",

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -902,6 +902,54 @@ describe("useAutoConnectProjectServers", () => {
       expect(ensureServersReady).toHaveBeenCalledWith(["alpha"]);
     });
 
+    it("does not clobber a preference the user set while the flag was still loading (coderabbit review)", async () => {
+      // Flag unresolved at mount — `hasExplicitPreference` (frozen then)
+      // sees no stored key and is `false`. If the user toggles in this
+      // window and the flag LATER resolves, the seed effect must not
+      // overwrite that now-explicit choice using the stale mount-time
+      // snapshot.
+      mocks.autoConnectDefaultVariant = undefined;
+      const ensureServersReady = vi.fn().mockResolvedValue({
+        readyServerNames: [],
+        failedServerNames: [],
+        missingServerNames: [],
+        reauthServerNames: [],
+      });
+      const appState = makeAppState(["alpha"]);
+
+      const { result, rerender } = renderHook(
+        () => ({
+          autoConnect: useAutoConnectProjectServers({
+            projectId: "proj-toggle-before-flag-loads",
+            hostScopeKey: "host-a",
+            requiredServerNames: ["alpha"],
+          }),
+          setEnabled: usePreferencesStore((s) => s.setAutoConnectServersEnabled),
+        }),
+        {
+          wrapper: ({ children }) =>
+            wrapper({ children, ensureServersReady, appState }),
+        }
+      );
+
+      await flushMicrotasks();
+
+      // User explicitly turns it OFF before the flag has resolved.
+      act(() => {
+        result.current.setEnabled(false);
+      });
+      await flushMicrotasks();
+
+      // The flag now resolves to "on" — must not flip the user back on.
+      mocks.autoConnectDefaultVariant = "on";
+      rerender();
+      await flushMicrotasks();
+
+      expect(localStorage.getItem("mcpjam-auto-connect-servers")).toBe(
+        "false"
+      );
+    });
+
     it("never overrides an explicit stored preference with the variant", async () => {
       localStorage.setItem("mcpjam-auto-connect-servers", "true");
       mocks.autoConnectDefaultVariant = "off";

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -820,6 +820,42 @@ describe("useAutoConnectProjectServers", () => {
       );
     });
 
+    it("does NOT auto-connect on the very first mount for a visitor bucketed into the 'off' arm (cubic review)", async () => {
+      // The variant is already resolved (mocked) by the time this hook first
+      // renders — simulating PostHog having answered before mount. Before the
+      // fix, the reconcile effects still read the stale store default
+      // (`true`) in that same first commit, firing one batch before the seed
+      // effect's `setAutoConnectServersEnabled(false)` had a chance to apply.
+      mocks.autoConnectDefaultVariant = "off";
+      const ensureServersReady = vi.fn().mockResolvedValue({
+        readyServerNames: ["alpha"],
+        failedServerNames: [],
+        missingServerNames: [],
+        reauthServerNames: [],
+      });
+      const appState = makeAppState(["alpha"]);
+
+      renderHook(
+        () =>
+          useAutoConnectProjectServers({
+            projectId: "proj-variant-off-first-mount",
+            hostScopeKey: "host-a",
+            requiredServerNames: ["alpha"],
+          }),
+        {
+          wrapper: ({ children }) =>
+            wrapper({ children, ensureServersReady, appState }),
+        }
+      );
+
+      await flushMicrotasks();
+
+      expect(ensureServersReady).not.toHaveBeenCalled();
+      expect(localStorage.getItem("mcpjam-auto-connect-servers")).toBe(
+        "false"
+      );
+    });
+
     it("never overrides an explicit stored preference with the variant", async () => {
       localStorage.setItem("mcpjam-auto-connect-servers", "true");
       mocks.autoConnectDefaultVariant = "off";

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { errorToastMessage } from "@/test/utils";
 import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
+import {
+  PreferencesStoreProvider,
+  usePreferencesStore,
+} from "@/stores/preferences/preferences-provider";
 import { AppStateProvider } from "@/state/app-state-context";
 import { ServerActionsProvider } from "@/state/server-actions-context";
 import {
@@ -854,6 +857,49 @@ describe("useAutoConnectProjectServers", () => {
       expect(localStorage.getItem("mcpjam-auto-connect-servers")).toBe(
         "false"
       );
+    });
+
+    it("honors the user's own toggle right after the seed settles, even with no prior stored preference (cubic review)", async () => {
+      // Regression for a bug in an earlier version of the seed fix: freezing
+      // "has an explicit preference" as a one-time mount snapshot correctly
+      // stopped the first-mount race, but then pinned `effectiveEnabled` to
+      // the A/B variant FOREVER — so a first-time visitor who flipped the
+      // switch mid-session found their own click silently ignored.
+      mocks.autoConnectDefaultVariant = "off";
+      const ensureServersReady = vi.fn().mockResolvedValue({
+        readyServerNames: ["alpha"],
+        failedServerNames: [],
+        missingServerNames: [],
+        reauthServerNames: [],
+      });
+      const appState = makeAppState(["alpha"]);
+
+      const { result } = renderHook(
+        () => ({
+          autoConnect: useAutoConnectProjectServers({
+            projectId: "proj-toggle-after-seed",
+            hostScopeKey: "host-a",
+            requiredServerNames: ["alpha"],
+          }),
+          setEnabled: usePreferencesStore((s) => s.setAutoConnectServersEnabled),
+        }),
+        {
+          wrapper: ({ children }) =>
+            wrapper({ children, ensureServersReady, appState }),
+        }
+      );
+
+      await flushMicrotasks();
+      // Seeded to "off" — no connect attempt on mount.
+      expect(ensureServersReady).not.toHaveBeenCalled();
+
+      // User flips Auto-connect ON in the Servers tab, same session.
+      act(() => {
+        result.current.setEnabled(true);
+      });
+      await flushMicrotasks();
+
+      expect(ensureServersReady).toHaveBeenCalledWith(["alpha"]);
     });
 
     it("never overrides an explicit stored preference with the variant", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -7,6 +7,7 @@ import { AppStateProvider } from "@/state/app-state-context";
 import { ServerActionsProvider } from "@/state/server-actions-context";
 import {
   resetAutoConnectAttempts,
+  resetAutoConnectDefaultVariantSeed,
   useAutoConnectProjectServers,
 } from "../useAutoConnectProjectServers";
 
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   toastError: vi.fn(),
   toastLoading: vi.fn(() => "reconnect-toast"),
   toastSuccess: vi.fn(),
+  track: vi.fn(),
   logger: {
     error: vi.fn(),
     warn: vi.fn(),
@@ -22,6 +24,10 @@ const mocks = vi.hoisted(() => ({
     trace: vi.fn(),
     context: "AutoConnectProjectServers",
   },
+  // Mutable so individual tests can simulate a resolved PostHog variant;
+  // `undefined` (the default) matches "flag still loading" and keeps every
+  // pre-existing test's behavior unchanged (the seeding effect no-ops).
+  autoConnectDefaultVariant: undefined as "on" | "off" | undefined,
 }));
 
 vi.mock("sonner", () => ({
@@ -34,6 +40,12 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/hooks/use-logger", () => ({
   useLogger: () => mocks.logger,
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: mocks.track }));
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagVariantKey: () => mocks.autoConnectDefaultVariant,
 }));
 
 function makeAppState(serverNames: string[]) {
@@ -90,10 +102,13 @@ const flushMicrotasks = () => act(() => Promise.resolve());
 describe("useAutoConnectProjectServers", () => {
   beforeEach(() => {
     resetAutoConnectAttempts();
+    resetAutoConnectDefaultVariantSeed();
     localStorage.removeItem("mcpjam-auto-connect-servers");
     mocks.toastError.mockClear();
     mocks.toastLoading.mockClear();
     mocks.toastSuccess.mockClear();
+    mocks.track.mockClear();
+    mocks.autoConnectDefaultVariant = undefined;
     mocks.logger.error.mockClear();
     mocks.logger.warn.mockClear();
     mocks.logger.info.mockClear();
@@ -772,5 +787,105 @@ describe("useAutoConnectProjectServers", () => {
     // Still only one attempt — re-renders without a scope change don't
     // re-fire, so a permanently-failing connection won't loop.
     expect(ensureServersReady).toHaveBeenCalledTimes(1);
+  });
+
+  describe("auto-connect-default A/B variant (PUR-22)", () => {
+    it("seeds the personal preference from the variant when nothing is stored yet", async () => {
+      mocks.autoConnectDefaultVariant = "off";
+      const ensureServersReady = vi.fn().mockResolvedValue({
+        readyServerNames: [],
+        failedServerNames: [],
+        missingServerNames: [],
+        reauthServerNames: [],
+      });
+      const appState = makeAppState(["alpha"]);
+
+      renderHook(
+        () =>
+          useAutoConnectProjectServers({
+            projectId: "proj-variant-seed",
+            hostScopeKey: "host-a",
+            requiredServerNames: ["alpha"],
+          }),
+        {
+          wrapper: ({ children }) =>
+            wrapper({ children, ensureServersReady, appState }),
+        }
+      );
+
+      await flushMicrotasks();
+
+      expect(localStorage.getItem("mcpjam-auto-connect-servers")).toBe(
+        "false"
+      );
+    });
+
+    it("never overrides an explicit stored preference with the variant", async () => {
+      localStorage.setItem("mcpjam-auto-connect-servers", "true");
+      mocks.autoConnectDefaultVariant = "off";
+      const ensureServersReady = vi.fn().mockResolvedValue({
+        readyServerNames: ["alpha"],
+        failedServerNames: [],
+        missingServerNames: [],
+        reauthServerNames: [],
+      });
+      const appState = makeAppState(["alpha"]);
+
+      renderHook(
+        () =>
+          useAutoConnectProjectServers({
+            projectId: "proj-variant-explicit",
+            hostScopeKey: "host-a",
+            requiredServerNames: ["alpha"],
+          }),
+        {
+          wrapper: ({ children }) =>
+            wrapper({ children, ensureServersReady, appState }),
+        }
+      );
+
+      await flushMicrotasks();
+
+      expect(localStorage.getItem("mcpjam-auto-connect-servers")).toBe(
+        "true"
+      );
+      expect(ensureServersReady).toHaveBeenCalledWith(["alpha"]);
+    });
+
+    it("tracks the batch outcome tagged with the resolved variant", async () => {
+      mocks.autoConnectDefaultVariant = "on";
+      const ensureServersReady = vi.fn().mockResolvedValue({
+        readyServerNames: ["alpha"],
+        failedServerNames: ["beta"],
+        missingServerNames: [],
+        reauthServerNames: [],
+      });
+      const appState = makeAppState(["alpha", "beta"]);
+
+      renderHook(
+        () =>
+          useAutoConnectProjectServers({
+            projectId: "proj-telemetry",
+            hostScopeKey: "host-a",
+            requiredServerNames: ["alpha", "beta"],
+          }),
+        {
+          wrapper: ({ children }) =>
+            wrapper({ children, ensureServersReady, appState }),
+        }
+      );
+
+      await flushMicrotasks();
+
+      expect(mocks.track).toHaveBeenCalledWith(
+        "auto_connect_batch_result",
+        expect.objectContaining({
+          attempted: 2,
+          ready: 1,
+          failed: 1,
+          auto_connect_default_variant: "on",
+        })
+      );
+    });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectDefaultVariant.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectDefaultVariant.ts
@@ -1,0 +1,33 @@
+import { useFeatureFlagVariantKey } from "posthog-js/react";
+
+/**
+ * PostHog A/B test deciding what a *first-time* viewer's personal
+ * auto-connect preference starts as (PUR-22 ask #2 — default auto-connect
+ * on for everyone, but roll it out behind an experiment so we can compare
+ * connection-failure rates between the "on" and "off" cohorts before
+ * fully committing).
+ *
+ * Two variants, both meaningful without the flag ever resolving:
+ *  - "on"  — auto-connect defaults enabled (the target end state).
+ *  - "off" — auto-connect defaults disabled (today's baseline behavior).
+ *
+ * This only decides the STARTING value. Once a viewer has an explicit
+ * stored preference (they toggled the switch themselves, in either
+ * direction), that opt-out/opt-in always wins — see the seeding effect in
+ * `useAutoConnectProjectServers`. PostHog's own flag-evaluation call
+ * already emits the `$feature_flag_called` exposure event, so no extra
+ * tracking is needed to know who was bucketed into which arm; pair that
+ * with the `auto_connect_batch_result` event (also emitted from
+ * `useAutoConnectProjectServers`) to compare failure rates per variant.
+ */
+export const AUTO_CONNECT_DEFAULT_FEATURE_FLAG = "auto-connect-default";
+
+export type AutoConnectDefaultVariant = "on" | "off";
+
+/** `undefined` while PostHog is still loading (or the flag doesn't exist). */
+export function useAutoConnectDefaultVariant():
+  | AutoConnectDefaultVariant
+  | undefined {
+  const variant = useFeatureFlagVariantKey(AUTO_CONNECT_DEFAULT_FEATURE_FLAG);
+  return variant === "on" || variant === "off" ? variant : undefined;
+}

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -195,6 +195,18 @@ export function useAutoConnectProjectServers({
       return true;
     }
   });
+  // Whether the pre-seed override below is still in effect. Starts `true`
+  // only when there's nothing to seed (an explicit preference already
+  // existed at mount); otherwise it flips to `true` — for good — the
+  // moment the variant resolves and the seed effect has had its one
+  // chance to write the store. Once flipped, `effectiveEnabled` trusts the
+  // live store value forever after, so a user's own toggle (or a sibling
+  // instance's write) is honored immediately. Without this the override
+  // stayed pinned to the variant permanently (a one-time snapshot), so a
+  // first-time visitor who then toggled the switch found their click
+  // silently ignored by the reconcile effects — the toggle showed one
+  // state while auto-connect behaved by another (cubic review, PUR-22).
+  const [isSeedSettled, setIsSeedSettled] = useState(hasExplicitPreference);
   // The store's `enabled` only reflects the A/B variant after the seeding
   // effect below has run AND its `setAutoConnectServersEnabled` state
   // update has committed on a later render — but effects in the SAME
@@ -205,18 +217,26 @@ export function useAutoConnectProjectServers({
   // contradicting the "off" arm's whole point and biasing the A/B
   // failure-rate comparison (cubic review, PUR-22). Deriving the effective
   // value directly from the variant (already available synchronously via
-  // the hook call above) sidesteps the round-trip entirely.
+  // the hook call above) sidesteps the round-trip entirely, but ONLY until
+  // `isSeedSettled` — after that, the live store is authoritative so
+  // subsequent toggles work normally.
   const effectiveEnabled =
-    !hasExplicitPreference && autoConnectDefaultVariant !== undefined
+    !isSeedSettled && autoConnectDefaultVariant !== undefined
       ? autoConnectDefaultVariant === "on"
       : enabled;
   useEffect(() => {
-    if (hasSeededAutoConnectDefault) return;
     if (autoConnectDefaultVariant === undefined) return;
-    hasSeededAutoConnectDefault = true;
-    if (!hasExplicitPreference) {
-      setAutoConnectServersEnabled(autoConnectDefaultVariant === "on");
+    // Only the first hook instance to observe the resolved variant actually
+    // writes the store (module-level guard); every instance still needs to
+    // stop overriding its own `effectiveEnabled` once the variant is known,
+    // whether or not IT did the writing.
+    if (!hasSeededAutoConnectDefault) {
+      hasSeededAutoConnectDefault = true;
+      if (!hasExplicitPreference) {
+        setAutoConnectServersEnabled(autoConnectDefaultVariant === "on");
+      }
     }
+    setIsSeedSettled(true);
   }, [autoConnectDefaultVariant, hasExplicitPreference, setAutoConnectServersEnabled]);
 
   const scopeKey = hostScopeKey ?? "-";

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -120,6 +120,26 @@ export function resetAutoConnectDefaultVariantSeed(): void {
   hasSeededAutoConnectDefault = false;
 }
 
+/**
+ * Whether the visitor already has an explicit `autoConnectServersEnabled`
+ * preference stored — i.e. there's nothing left for the A/B seed to do.
+ * Deliberately NOT memoized: called both once at mount (to seed
+ * `isSeedSettled`'s initial value) and fresh on every render / inside the
+ * seed effect, so a preference written in between (the user's own toggle,
+ * or a sibling hook instance) is always picked up immediately rather than
+ * trusting a stale snapshot (cubic + coderabbit review, PUR-22).
+ */
+function readHasExplicitAutoConnectPreference(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(AUTO_CONNECT_SERVERS_KEY) !== null;
+  } catch {
+    // Can't tell whether the user has an explicit preference — don't risk
+    // clobbering one that exists.
+    return true;
+  }
+}
+
 interface UseAutoConnectProjectServersResult {
   enabled: boolean;
   /** Last batch result; null until a batch has been attempted. */
@@ -184,17 +204,12 @@ export function useAutoConnectProjectServers({
   const autoConnectDefaultVariant = useAutoConnectDefaultVariant();
   // Resolved synchronously on first render (lazy initializer), NOT inside
   // an effect — every reconcile effect below needs this before it decides
-  // whether to fire.
-  const [hasExplicitPreference] = useState<boolean>(() => {
-    if (typeof window === "undefined") return true;
-    try {
-      return window.localStorage.getItem(AUTO_CONNECT_SERVERS_KEY) !== null;
-    } catch {
-      // Can't tell whether the user has an explicit preference — don't risk
-      // clobbering one that exists.
-      return true;
-    }
-  });
+  // whether to fire. Only used to seed `isSeedSettled`'s initial value —
+  // a fact about conditions before the very first render, not something
+  // that needs to be live.
+  const [hadExplicitPreferenceAtMount] = useState<boolean>(() =>
+    readHasExplicitAutoConnectPreference()
+  );
   // Whether the pre-seed override below is still in effect. Starts `true`
   // only when there's nothing to seed (an explicit preference already
   // existed at mount); otherwise it flips to `true` — for good — the
@@ -206,7 +221,7 @@ export function useAutoConnectProjectServers({
   // first-time visitor who then toggled the switch found their click
   // silently ignored by the reconcile effects — the toggle showed one
   // state while auto-connect behaved by another (cubic review, PUR-22).
-  const [isSeedSettled, setIsSeedSettled] = useState(hasExplicitPreference);
+  const [isSeedSettled, setIsSeedSettled] = useState(hadExplicitPreferenceAtMount);
   // The store's `enabled` only reflects the A/B variant after the seeding
   // effect below has run AND its `setAutoConnectServersEnabled` state
   // update has committed on a later render — but effects in the SAME
@@ -218,10 +233,17 @@ export function useAutoConnectProjectServers({
   // failure-rate comparison (cubic review, PUR-22). Deriving the effective
   // value directly from the variant (already available synchronously via
   // the hook call above) sidesteps the round-trip entirely, but ONLY until
-  // `isSeedSettled` — after that, the live store is authoritative so
-  // subsequent toggles work normally.
+  // `isSeedSettled` AND only while there's still genuinely no explicit
+  // preference — re-read LIVE on every render (not the frozen mount-time
+  // snapshot), because a user who toggles the switch during this same
+  // pre-settlement window must win immediately, not just once the effect
+  // below gets around to persisting it (cubic review, PUR-22: an "on"
+  // variant resolving before settlement could otherwise steamroll a
+  // manual "off" the user picked while the flag was still loading).
   const effectiveEnabled =
-    !isSeedSettled && autoConnectDefaultVariant !== undefined
+    !isSeedSettled &&
+    autoConnectDefaultVariant !== undefined &&
+    !readHasExplicitAutoConnectPreference()
       ? autoConnectDefaultVariant === "on"
       : enabled;
   useEffect(() => {
@@ -232,30 +254,17 @@ export function useAutoConnectProjectServers({
     // whether or not IT did the writing.
     if (!hasSeededAutoConnectDefault) {
       hasSeededAutoConnectDefault = true;
-      // Re-check for an explicit preference RIGHT HERE rather than trusting
-      // `hasExplicitPreference` (a snapshot frozen at mount) — if the user
-      // toggled the switch while the flag was still loading (`enabled`
-      // already reflects that; `effectiveEnabled` falls through to it too,
-      // since the override only applies once the variant is defined),
-      // writing the frozen "nothing stored yet" answer here would silently
-      // clobber that manual choice the moment the flag resolves
-      // (coderabbit review, PUR-22).
-      let hasPreferenceNow = hasExplicitPreference;
-      if (!hasPreferenceNow) {
-        try {
-          hasPreferenceNow =
-            typeof window !== "undefined" &&
-            window.localStorage.getItem(AUTO_CONNECT_SERVERS_KEY) !== null;
-        } catch {
-          hasPreferenceNow = true;
-        }
-      }
-      if (!hasPreferenceNow) {
+      // Re-check live rather than trusting `hadExplicitPreferenceAtMount`
+      // (frozen at mount) — if the user toggled the switch while the flag
+      // was still loading, writing the frozen "nothing stored yet" answer
+      // here would silently clobber that manual choice the moment the
+      // flag resolves (coderabbit review, PUR-22).
+      if (!readHasExplicitAutoConnectPreference()) {
         setAutoConnectServersEnabled(autoConnectDefaultVariant === "on");
       }
     }
     setIsSeedSettled(true);
-  }, [autoConnectDefaultVariant, hasExplicitPreference, setAutoConnectServersEnabled]);
+  }, [autoConnectDefaultVariant, setAutoConnectServersEnabled]);
 
   const scopeKey = hostScopeKey ?? "-";
   // Stable key for "what the active host wants selected". Drives the

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -5,6 +5,9 @@ import { useLogger } from "@/hooks/use-logger";
 import { useSharedAppState } from "@/state/app-state-context";
 import { useServerActions } from "@/state/server-actions-context";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+import { AUTO_CONNECT_SERVERS_KEY } from "@/stores/preferences/preferences-store";
+import { useAutoConnectDefaultVariant } from "@/hooks/useAutoConnectDefaultVariant";
+import { track } from "@/lib/analytics";
 
 /**
  * Module-level memo of "we already kicked off ensureServersReady for this
@@ -103,6 +106,20 @@ export function resetAutoConnectAttempts(projectId?: string): void {
   }
 }
 
+/**
+ * Module-level "have we already seeded the personal auto-connect
+ * preference from the PostHog A/B variant" latch. Global (not per-project)
+ * on purpose — this is a one-time-per-session decision about what the
+ * user's *default* starts as, not something that should re-fire per
+ * project/host scope the way the reconciliation dedupe above does.
+ */
+let hasSeededAutoConnectDefault = false;
+
+/** Test-only reset, mirrors `resetAutoConnectAttempts`. */
+export function resetAutoConnectDefaultVariantSeed(): void {
+  hasSeededAutoConnectDefault = false;
+}
+
 interface UseAutoConnectProjectServersResult {
   enabled: boolean;
   /** Last batch result; null until a batch has been attempted. */
@@ -152,10 +169,37 @@ export function useAutoConnectProjectServers({
   requiredServerNames: ReadonlyArray<string>;
 }): UseAutoConnectProjectServersResult {
   const enabled = usePreferencesStore((s) => s.autoConnectServersEnabled);
+  const setAutoConnectServersEnabled = usePreferencesStore(
+    (s) => s.setAutoConnectServersEnabled
+  );
   const sharedAppState = useSharedAppState();
   const { ensureServersReady, reconnectServer } = useServerActions();
   const logger = useLogger("AutoConnectProjectServers");
   const lastResultRef = useRef<EnsureServersReadyResult | null>(null);
+  // A/B test for PUR-22 ask #2 (default auto-connect on for everyone,
+  // measure the failure-rate delta before fully committing). Seeds the
+  // personal preference from the assigned variant exactly once, and only
+  // for a viewer with no explicit stored preference yet — an existing
+  // opt-out/opt-in always wins over the experiment.
+  const autoConnectDefaultVariant = useAutoConnectDefaultVariant();
+  useEffect(() => {
+    if (hasSeededAutoConnectDefault) return;
+    if (autoConnectDefaultVariant === undefined) return;
+    if (typeof window === "undefined") return;
+    hasSeededAutoConnectDefault = true;
+    let hasExplicitPreference: boolean;
+    try {
+      hasExplicitPreference =
+        window.localStorage.getItem(AUTO_CONNECT_SERVERS_KEY) !== null;
+    } catch {
+      // Can't tell whether the user has an explicit preference — don't risk
+      // clobbering one that exists.
+      hasExplicitPreference = true;
+    }
+    if (!hasExplicitPreference) {
+      setAutoConnectServersEnabled(autoConnectDefaultVariant === "on");
+    }
+  }, [autoConnectDefaultVariant, setAutoConnectServersEnabled]);
 
   const scopeKey = hostScopeKey ?? "-";
   // Stable key for "what the active host wants selected". Drives the
@@ -305,19 +349,48 @@ export function useAutoConnectProjectServers({
       (result) => {
         if (cancelled) return;
         lastResultRef.current = result;
+        // Failure-rate telemetry for the PUR-22 auto-connect-default A/B
+        // test — segment by `auto_connect_default_variant` to compare
+        // cohorts. Fires regardless of variant resolution so the control
+        // path (flag still loading, or the visitor predates the
+        // experiment) is represented too.
+        track("auto_connect_batch_result", {
+          location: "auto_connect_project_servers",
+          attempted: fresh.length,
+          ready: result.readyServerNames.length,
+          failed: result.failedServerNames.length,
+          reauth: result.reauthServerNames.length,
+          missing: result.missingServerNames.length,
+          auto_connect_default_variant: autoConnectDefaultVariant ?? "unresolved",
+        });
       },
       // Swallow rejections — `markAttempted` already ran, so a thrown error
-      // is treated identically to a "failed" outcome: the dot stays red,
-      // the user clicks to retry. Suppressing here also keeps the
-      // "refresh-keeps-failing" guard from generating noisy unhandled
-      // rejections in dev/test.
+      // is treated identically to a "failed" outcome: the badge shows the
+      // amber "Could not connect" state, the user clicks to retry.
+      // Suppressing here also keeps the "refresh-keeps-failing" guard from
+      // generating noisy unhandled rejections in dev/test.
       () => {
-        // intentionally empty
+        if (cancelled) return;
+        track("auto_connect_batch_result", {
+          location: "auto_connect_project_servers",
+          attempted: fresh.length,
+          ready: 0,
+          failed: fresh.length,
+          reauth: 0,
+          missing: 0,
+          threw: true,
+          auto_connect_default_variant: autoConnectDefaultVariant ?? "unresolved",
+        });
       }
     );
     return () => {
       cancelled = true;
     };
+    // `autoConnectDefaultVariant` is read via closure but excluded from deps
+    // on purpose: it labels telemetry for whichever batch this effect
+    // fires, it shouldn't itself trigger a new batch when PostHog resolves
+    // mid-scope.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, projectId, scopeKey, candidateNamesKey, ensureServersReady]);
 
   return { enabled, lastResult: lastResultRef.current };

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -232,7 +232,25 @@ export function useAutoConnectProjectServers({
     // whether or not IT did the writing.
     if (!hasSeededAutoConnectDefault) {
       hasSeededAutoConnectDefault = true;
-      if (!hasExplicitPreference) {
+      // Re-check for an explicit preference RIGHT HERE rather than trusting
+      // `hasExplicitPreference` (a snapshot frozen at mount) — if the user
+      // toggled the switch while the flag was still loading (`enabled`
+      // already reflects that; `effectiveEnabled` falls through to it too,
+      // since the override only applies once the variant is defined),
+      // writing the frozen "nothing stored yet" answer here would silently
+      // clobber that manual choice the moment the flag resolves
+      // (coderabbit review, PUR-22).
+      let hasPreferenceNow = hasExplicitPreference;
+      if (!hasPreferenceNow) {
+        try {
+          hasPreferenceNow =
+            typeof window !== "undefined" &&
+            window.localStorage.getItem(AUTO_CONNECT_SERVERS_KEY) !== null;
+        } catch {
+          hasPreferenceNow = true;
+        }
+      }
+      if (!hasPreferenceNow) {
         setAutoConnectServersEnabled(autoConnectDefaultVariant === "on");
       }
     }

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "@/lib/toast";
 import type { EnsureServersReadyResult } from "@/hooks/use-server-state";
 import { useLogger } from "@/hooks/use-logger";
@@ -182,24 +182,42 @@ export function useAutoConnectProjectServers({
   // for a viewer with no explicit stored preference yet — an existing
   // opt-out/opt-in always wins over the experiment.
   const autoConnectDefaultVariant = useAutoConnectDefaultVariant();
-  useEffect(() => {
-    if (hasSeededAutoConnectDefault) return;
-    if (autoConnectDefaultVariant === undefined) return;
-    if (typeof window === "undefined") return;
-    hasSeededAutoConnectDefault = true;
-    let hasExplicitPreference: boolean;
+  // Resolved synchronously on first render (lazy initializer), NOT inside
+  // an effect — every reconcile effect below needs this before it decides
+  // whether to fire.
+  const [hasExplicitPreference] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
     try {
-      hasExplicitPreference =
-        window.localStorage.getItem(AUTO_CONNECT_SERVERS_KEY) !== null;
+      return window.localStorage.getItem(AUTO_CONNECT_SERVERS_KEY) !== null;
     } catch {
       // Can't tell whether the user has an explicit preference — don't risk
       // clobbering one that exists.
-      hasExplicitPreference = true;
+      return true;
     }
+  });
+  // The store's `enabled` only reflects the A/B variant after the seeding
+  // effect below has run AND its `setAutoConnectServersEnabled` state
+  // update has committed on a later render — but effects in the SAME
+  // commit as that update (this hook's own reconcile effects, further
+  // down) still see the pre-seed value. A visitor bucketed into "off" with
+  // no stored preference could otherwise get one free auto-connect attempt
+  // on their very first mount, before the seed ever takes effect —
+  // contradicting the "off" arm's whole point and biasing the A/B
+  // failure-rate comparison (cubic review, PUR-22). Deriving the effective
+  // value directly from the variant (already available synchronously via
+  // the hook call above) sidesteps the round-trip entirely.
+  const effectiveEnabled =
+    !hasExplicitPreference && autoConnectDefaultVariant !== undefined
+      ? autoConnectDefaultVariant === "on"
+      : enabled;
+  useEffect(() => {
+    if (hasSeededAutoConnectDefault) return;
+    if (autoConnectDefaultVariant === undefined) return;
+    hasSeededAutoConnectDefault = true;
     if (!hasExplicitPreference) {
       setAutoConnectServersEnabled(autoConnectDefaultVariant === "on");
     }
-  }, [autoConnectDefaultVariant, setAutoConnectServersEnabled]);
+  }, [autoConnectDefaultVariant, hasExplicitPreference, setAutoConnectServersEnabled]);
 
   const scopeKey = hostScopeKey ?? "-";
   // Stable key for "what the active host wants selected". Drives the
@@ -223,7 +241,7 @@ export function useAutoConnectProjectServers({
   // host's required servers" path; reconnecting the ALREADY-connected set on a
   // client switch is handled separately below.
   const candidateNamesKey = useMemo(() => {
-    if (!enabled || !projectId || requiredNames.length === 0) {
+    if (!effectiveEnabled || !projectId || requiredNames.length === 0) {
       return null;
     }
     const candidates = requiredNames.filter((name) => {
@@ -238,7 +256,7 @@ export function useAutoConnectProjectServers({
     // Stable key: sorted and joined with NUL so reordering doesn't trigger a
     // fresh batch.
     return candidates.sort().join("\0");
-  }, [enabled, projectId, requiredNames, sharedAppState.servers]);
+  }, [effectiveEnabled, projectId, requiredNames, sharedAppState.servers]);
 
   // Detect a scope transition (user switched the active/lead client) and
   // clear the prior attempt log so revisiting a previously-tried host
@@ -268,7 +286,7 @@ export function useAutoConnectProjectServers({
   // scope dedupe makes this fire exactly once even though the hook mounts on
   // several surfaces.
   useEffect(() => {
-    if (!enabled || !projectId || hostScopeKey == null) return;
+    if (!effectiveEnabled || !projectId || hostScopeKey == null) return;
     if (isAttempted(projectId, scopeKey, "recycle")) return;
     markAttempted(projectId, scopeKey, "recycle");
     const connectedNow = Object.entries(sharedAppState.servers)
@@ -319,7 +337,7 @@ export function useAutoConnectProjectServers({
     // purpose: this must fire only on scope transitions, not whenever the
     // connected set changes within a scope. The dedupe gate stops re-runs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, projectId, scopeKey, hostScopeKey, reconnectServer, logger]);
+  }, [effectiveEnabled, projectId, scopeKey, hostScopeKey, reconnectServer, logger]);
 
   // Connect-required: fires when the candidate set (required-but-not-yet-
   // connected) changes. Dedupe is per-server-within-scope, not per
@@ -334,7 +352,7 @@ export function useAutoConnectProjectServers({
   // transition effect above), so re-entering this host gives every
   // required server a fresh attempt.
   useEffect(() => {
-    if (!enabled || !projectId || !candidateNamesKey) return;
+    if (!effectiveEnabled || !projectId || !candidateNamesKey) return;
     const allNames = candidateNamesKey.split("\0");
     const fresh = allNames.filter(
       (name) => !isAttempted(projectId, scopeKey, `srv:${name}`)
@@ -391,7 +409,7 @@ export function useAutoConnectProjectServers({
     // fires, it shouldn't itself trigger a new batch when PostHog resolves
     // mid-scope.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, projectId, scopeKey, candidateNamesKey, ensureServersReady]);
+  }, [effectiveEnabled, projectId, scopeKey, candidateNamesKey, ensureServersReady]);
 
-  return { enabled, lastResult: lastResultRef.current };
+  return { enabled: effectiveEnabled, lastResult: lastResultRef.current };
 }

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -62,6 +62,12 @@ export const ANALYTICS_EVENTS = {
 
   // --- Migrated raw-capture call sites (track() migration) ---
   add_server_button_clicked: { source: "client" },
+  // Outcome of one auto-connect reconciliation batch (PUR-22). Props:
+  // location, attempted/ready/failed/reauth/missing counts, and
+  // auto_connect_default_variant ("on" | "off" | "unresolved") — the A/B
+  // arm this visitor was bucketed into, for comparing failure rates
+  // between "auto-connect default on" and today's baseline.
+  auto_connect_batch_result: { source: "client" },
   app_builder_send_message: { source: "client" },
   app_builder_tab_viewed: { source: "client" },
   app_builder_tool_executed: { source: "client" },


### PR DESCRIPTION

## PUR-22 — Auto-connect toggle invisible to guests

Three fixes, per the task:

### 1. Guests can now see/use the toggle
The Servers-tab "Auto-connect" switch read `canManageProjectServers` (project-admin-only) for both **visibility** and **interactivity** — a guest, or anyone who isn't a project admin, saw nothing. It now always renders:
- **Admins** still write the shared, project-wide Convex policy (unchanged behavior).
- **Everyone else** (members, guests, local/no-cloud-sync users) flips their own client-local `autoConnectServersEnabled` preference instead — no permission required, so the switch is always usable.

### 2. Default on, opt-out, behind an A/B test
The personal preference already defaulted to `true`. Added `useAutoConnectDefaultVariant` — a PostHog flag (`auto-connect-default`, variants `on`/`off`) that seeds a *first-time* visitor's default exactly once; an explicit choice always wins over the experiment. Every reconciliation batch now fires `auto_connect_batch_result` tagged with the resolved variant, so connection-failure rates are comparable per cohort before fully committing to on-by-default.

### 3. Red "Failed" → amber "Could not connect"
Status dot, label, and the "Error" pill are amber now. Hovering the label shows the cause + fix, reusing the SDK's existing `describeError` catalog rather than inventing new copy.

## Verification
- 122 tests passing across the 4 directly-affected files (2 assertions updated for the copy change, 5 new tests for guest visibility + A/B seeding).
- `npm run typecheck:client` — clean.
- Verified live against the actual dev client (local/no-cloud-sync mode, signed out): the toggle renders and persists to `localStorage` for a signed-out viewer, and a genuinely unreachable server shows the amber badge.

## Not covered here (flagging for reviewer)
- The hover tooltip's cause/fix copy needs `server.lastError` populated, which this local dev backend's connection-failure path didn't set for any server I tried (pre-existing gap, unrelated to this diff) — so I couldn't capture it live. It's covered by `ServerConnectionCard.test.tsx` with mocked errors.
- A real hosted-guest session (multiplayer guest against a shared project, not local mode) toggling auto-connect is worth a manual screen-recording — that flow needs live Convex/WorkOS auth this environment doesn't have.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make auto-connect work for everyone: guests can now see and use the toggle, it defaults on (opt-out via a PostHog seed), and failures show a softer, actionable “Could not connect” state. Addresses PUR-22.

- **Bug Fixes**
  - Auto-connect toggle now always renders. Non-admins change their local `autoConnectServersEnabled`; admins update the project policy. The switch disables while your project role or project config is resolving. When an admin toggles, their personal preference is synced after the mutation succeeds; we do not mirror other-admin or pre-existing policy changes to avoid device‑global side effects.
  - Closed the first-mount “off” variant race by deriving an `effectiveEnabled` value from the resolved flag. Honors user toggles immediately after seeding and re-checks for a stored preference before seeding so a choice made while the flag was still loading isn’t clobbered. Guards the failure tooltip content to prevent crashes.

- **New Features**
  - Default-on rollout behind PostHog (`auto-connect-default`) via `useAutoConnectDefaultVariant` (reads `posthog-js/react`). Seeds a first-time viewer’s preference once; an explicit choice always wins. Added `auto_connect_batch_result` analytics with attempt/outcome counts and the resolved variant.
  - Soft-fail UI: red “Failed” → amber “Could not connect”, with a tooltip showing cause and next step using `describeError` from `@mcpjam/sdk/browser`.

<sup>Written for commit 64d7172883c8559c5ae2958a476a034478d2d281. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

