### PR TITLE
fix(score): a server that requires OAuth reported a raw error instead of prompting

### DIFF
--- a/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
+++ b/mcpjam-inspector/client/src/components/score/ScoreRunnerPage.tsx
@@ -95,6 +95,7 @@ export function ScoreRunnerPage({
   const createServerIfMissing = useMutation(
     "servers:createServerIfMissing" as any
   );
+  const updateServer = useMutation("servers:updateServer" as any);
 
   const [urlInput, setUrlInput] = useState("");
   const [phase, setPhase] = useState<Phase>("form");
@@ -284,9 +285,33 @@ export function ScoreRunnerPage({
           enabled: true,
           transportType: "http",
           url: normalizedUrl,
+          // "Figure out what this server needs" — the only honest setting for a
+          // URL somebody pasted, and load-bearing rather than cosmetic. A row
+          // with no authMethod resolves through the legacy branch of
+          // `resolveEffectiveAuthMethod` to "none", and ONLY the "discover"
+          // mode converts a live 401 into the tagged `oauthRequired` error the
+          // OAuth branch below detects. Without it a server that requires
+          // authorization reports its raw transport failure and the visitor is
+          // never offered the flow that would have let them in.
+          authMethod: "auto",
         } as any);
 
-        await waitForServerId(name);
+        const createdServerId = await waitForServerId(name);
+        // `createServerIfMissing` is idempotent: a row from an earlier scan is
+        // returned untouched, authMethod and all. Rows minted before that field
+        // was set here would stay permanently un-escalatable — and the name is
+        // derived from the URL, so a retry finds the same stale row rather than
+        // a fresh one. Reconcile it instead of leaving the visitor stuck.
+        try {
+          await updateServer({
+            serverId: createdServerId,
+            authMethod: "auto",
+          } as any);
+        } catch {
+          // Best effort. A new row already has the right value, so this only
+          // matters for pre-existing ones, and failing here must not abort a
+          // scan that is otherwise fine.
+        }
 
         const nextServer: ServerWithName = {
           name,
@@ -318,7 +343,7 @@ export function ScoreRunnerPage({
         setPhase("form");
       }
     },
-    [createServerIfMissing, projectId, waitForServerId]
+    [createServerIfMissing, updateServer, projectId, waitForServerId]
   );
 
   // `runAll` needs the hook to have re-keyed onto the new server first — it

--- a/mcpjam-inspector/client/src/components/score/__tests__/score-auth-method.test.ts
+++ b/mcpjam-inspector/client/src/components/score/__tests__/score-auth-method.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { resolveEffectiveAuthMethod } from "../../../../../server/utils/effective-auth";
+
+/**
+ * Why a client-side concern is pinned against the SERVER's resolver.
+ *
+ * The score page creates a server row for a pasted URL and then relies on the
+ * hosted connect path to tell it "this server wants authorization". That signal
+ * is not a guess: the route converts a live 401 into a tagged `oauthRequired`
+ * error, but ONLY when the row resolves to the `discover` auth mode. Any other
+ * mode leaves the 401 as a plain transport failure, the score page's OAuth
+ * branch never fires, and a visitor scanning an auth-required server just sees
+ * a raw connect error with no way forward.
+ *
+ * The row shipped without `authMethod` at first, which lands in the legacy
+ * branch below and resolves to `"none"` — so every OAuth server failed this
+ * way. The value is one field on a create call, invisible in every unit test
+ * that mocked the mutation, and the failure only appears against a real server
+ * that actually demands auth. Hence this test, against the real resolver: it
+ * fails if either side of the contract moves.
+ */
+
+describe("the score page's server row resolves to the discover ladder", () => {
+  it("resolves authMethod 'auto' to discover, which is what tags a 401", () => {
+    // Exactly the shape the score page creates.
+    expect(
+      resolveEffectiveAuthMethod({
+        authMethod: "auto",
+        transportType: "http",
+      } as any)
+    ).toBe("discover");
+  });
+
+  it("resolves an authMethod-less row to 'none' — the bug this guards", () => {
+    // The original create call. `none` never escalates, so an auth-required
+    // server reports a raw transport error and the visitor is stuck.
+    expect(
+      resolveEffectiveAuthMethod({ transportType: "http" } as any)
+    ).toBe("none");
+  });
+
+  it("does not select XAA for a plain pasted URL", () => {
+    // `auto` picks XAA when the row carries XAA configuration. A score row
+    // never does, so it must land on the discover ladder instead.
+    expect(
+      resolveEffectiveAuthMethod({
+        authMethod: "auto",
+        transportType: "http",
+        url: "https://mcp.example.com/mcp",
+      } as any)
+    ).toBe("discover");
+  });
+});


### PR DESCRIPTION
Found by scanning `https://bart.vanshaj.dev/mcp` on the live site. It showed the raw transport failure — *"the server requires authorization (HTTP 401)"* — and stopped. The visitor was never offered the authorization flow that exists for exactly this case, so **every auth-requiring server was unscannable** through the public page, while working fine in the product.

## Root cause

The score page creates a row for the pasted URL, then relies on the hosted connect path to say "this one wants authorization." That signal isn't a guess — the route converts a live 401 into a tagged `oauthRequired` error (`server/routes/web/auth.ts:1388`), which the page detects and turns into the redirect.

But that conversion only runs when the row resolves to the **`discover`** auth mode, and the create call set **no `authMethod` at all**. That lands in the legacy branch of `resolveEffectiveAuthMethod` and resolves to `"none"`:

```ts
if (sc.useXaa === true && sc.useOAuth !== true) return "xaa";
if (sc.useOAuth === true) return "oauth";
return "none";   // ← the score page's row landed here
```

So nothing escalated, because as far as the server was concerned nothing was supposed to. My detection logic was correct; the tag genuinely wasn't there.

## Fix

`authMethod: "auto"` — the honest setting for a URL somebody pasted: *figure out what this server needs*. For a plain row it resolves to `discover`, the ladder that probes, sees the 401, and tags it.

**Existing rows are reconciled, not left behind.** `createServerIfMissing` returns an earlier row untouched, and the row name is derived from the URL — so anyone who hit the broken version would keep finding the same un-escalatable row on every retry, and this fix would look like it hadn't worked. The follow-up `updateServer` is best-effort: a new row already has the right value, and failing to patch an old one must not abort an otherwise healthy scan.

## Test

Asserted against the **real server-side resolver**, not a mock, and it pins the old behavior too so the regression is named.

That choice is the point: this was one field on a create call, invisible to every test that mocked the mutation, and only observable against a server that genuinely demands auth. A mock would have re-encoded the bug and passed. This is the same category as the two OAuth bugs in #3715 — all three lived in the gap between "the pieces are unit tested" and "the round trip works."

## Still not covered

The redirect round trip itself. This fix gets the visitor *to* the authorization prompt; whether the full return-and-resume works still needs one manual run against a real auth-required server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted scan auth setup and server row updates; behavior change is narrow but affects how all auth-required public scans connect.
> 
> **Overview**
> Fixes the public **Score** flow so servers that return HTTP 401 are offered authorization instead of a raw connect error.
> 
> When a visitor pastes a URL, the page now creates the server row with **`authMethod: "auto"`**, which resolves to **discover** on the hosted connect path so a 401 becomes the tagged **`oauthRequired`** error the UI already handles. Rows created earlier without that field are **best-effort patched** via **`updateServer`** after **`createServerIfMissing`**, since idempotent create by URL would otherwise leave stale **`none`** auth forever.
> 
> Adds **`score-auth-method.test.ts`**, asserting against the real **`resolveEffectiveAuthMethod`** that **`auto`** maps to **`discover`** and documents the old authMethod-less **`none`** behavior as the regression guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ba1757f7621443b91e7031a7271ebb19227e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the score page so scanning an OAuth-required server prompts for authorization instead of showing a raw 401 error. Sets server rows to auto-detect auth needs and reconciles stale rows so public scans work again.

- **Bug Fixes**
  - Set `authMethod: "auto"` on new server rows so they resolve to `discover` and convert a 401 into `oauthRequired`.
  - Reconcile existing rows after `servers:createServerIfMissing` with `servers:updateServer` to set `authMethod: "auto"`; ignore update failures to avoid aborting scans.
  - Added a regression test to verify `resolveEffectiveAuthMethod` returns `discover` for `auto` and `none` when missing, pinning the contract.

<sup>Written for commit 65ba1757f7621443b91e7031a7271ebb19227e0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

