### PR TITLE
fix: refresh 2026 protocol release labels

### DIFF
--- a/.changeset/fresh-protocol-labels.md
+++ b/.changeset/fresh-protocol-labels.md
@@ -1,0 +1,8 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Label MCP 2026-07-28 as the latest stable protocol revision across OAuth
+configuration surfaces, and stop presenting 2025-11-25 as latest. Refresh the
+active protocol and error-code documentation for the final 2026-07-28 release.

--- a/cli/src/lib/mrtr-input.ts
+++ b/cli/src/lib/mrtr-input.ts
@@ -673,7 +673,7 @@ function coerceFieldValueRaw(
 /**
  * Terminal handler for an ordinary server-to-client `elicitation/create`.
  *
- * MRTR replaced server-initiated requests in the 2026-07-28 draft ("Servers
+ * MRTR replaced server-initiated requests in the 2026-07-28 revision ("Servers
  * MUST send server-to-client requests using the MRTR pattern"), but every
  * earlier version a user can still connect to — 2025-06-18 and 2025-11-25 —
  * delivers elicitation as a real inbound request. Declaring the `elicitation`

--- a/docs/contributing/oauth-architecture.mdx
+++ b/docs/contributing/oauth-architecture.mdx
@@ -218,7 +218,7 @@ graph LR
 
 ## Protocol Versions
 
-The OAuth debugger supports three MCP OAuth protocol versions:
+The OAuth debugger supports four MCP OAuth protocol versions:
 
 ### 2025-03-26 (Original)
 
@@ -235,11 +235,18 @@ The OAuth debugger supports three MCP OAuth protocol versions:
 - PKCE recommended but not strictly enforced
 - Registration: DCR (SHOULD) or pre-registered
 
-### 2025-11-25 (Latest)
+### 2025-11-25
 
 - Client ID Metadata Documents (CIMD) support
 - RFC8414 or OIDC discovery without root fallback
 - PKCE strictly required and enforced
+- Registration: CIMD (SHOULD), DCR, or pre-registered
+
+### 2026-07-28 (Latest)
+
+- Uses 2025-11-25 discovery, CIMD, and strict PKCE behavior
+- Sends OIDC `application_type` during Dynamic Client Registration
+- Validates a returned RFC 9207 `iss` against the discovered issuer
 - Registration: CIMD (SHOULD), DCR, or pre-registered
 
 ## Key Components
@@ -272,7 +279,7 @@ Step metadata is defined in `sdk/src/oauth/state-machines/shared/step-metadata.t
 Modal dialog for configuring OAuth test profiles:
 
 - Server name and URL configuration
-- Protocol version selection (2025-03-26, 2025-06-18, 2025-11-25)
+- Protocol version selection (2025-03-26, 2025-06-18, 2025-11-25, 2026-07-28)
 - Registration strategy selection (CIMD, DCR, Pre-registered)
 - Advanced settings accordion for optional configuration
 - Custom headers management with add/remove functionality

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -67,7 +67,7 @@ MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps
     [First MCP App →](/guides/first-mcp-app) · [First ChatGPT App in React →](/guides/first-chatgpt-app-react)
   </Accordion>
   <Accordion title="Validate OAuth conformance across protocol versions" icon="shield-check">
-    Step through every stage of the MCP authorization flow against protocol versions 03-26, 06-18, 11-25, and 2026-07-28 (Draft), with DCR, pre-registration, and CIMD coverage.
+    Step through every stage of the MCP authorization flow against protocol versions 03-26, 06-18, 11-25, and 2026-07-28 (Latest), with DCR, pre-registration, and CIMD coverage.
 
     [Guided OAuth →](/inspector/guided-oauth) · [CLI OAuth conformance →](/cli/oauth-conformance)
   </Accordion>
@@ -93,7 +93,7 @@ MCPJam is the development platform for **MCP servers, MCP apps, and ChatGPT apps
 | Capability | Description |
 | --- | --- |
 | Playground | IDE-style workspace combining chat, manual tool calls, widget rendering, Chat/Trace/Raw views, and multi-model and multi-host compare. OpenAI Apps SDK and MCP App UIs, text tools, Chrome DevTools-style widget emulator. [Read more](/inspector/playground) |
-| OAuth Debugger | Guided MCP OAuth conformance checks: protocol versions 03-26, 06-18, 11-25, 2026-07-28 (Draft); DCR, client pre-registration, CIMD. [Read more](/inspector/guided-oauth) |
+| OAuth Debugger | Guided MCP OAuth conformance checks: protocol versions 03-26, 06-18, 11-25, 2026-07-28 (Latest); DCR, client pre-registration, CIMD. [Read more](/inspector/guided-oauth) |
 | MCP Server Debugging | Manually run tools, resources, templates, and elicitation; full JSON-RPC logs. |
 | Skills | Skills in the Playground; local filesystem only. [Read more](/inspector/skills) |
 | Projects | Shared server groups with real-time team sync. [Read more](/inspector/projects) |

--- a/docs/inspector/guided-oauth.mdx
+++ b/docs/inspector/guided-oauth.mdx
@@ -20,7 +20,7 @@ The OAuth Debugger provides a visual, step-by-step interface for testing and deb
 The OAuth Debugger includes:
 
 - **Visual Step-by-Step Guide** - Interactive flow guide with detailed explanations for each OAuth step
-- **Multi-Protocol Support** - Test against OAuth spec versions 03-26, 06-18, 11-25, and 2026-07-28 (Draft)
+- **Multi-Protocol Support** - Test against OAuth spec versions 03-26, 06-18, 11-25, and 2026-07-28 (Latest)
 - **Full Registration Methods** - Support for client pre-registration, Dynamic Client Registration (DCR), and Client ID Metadata Documents (CIMD)
 - **Network Inspection** - View all HTTP requests and responses with headers and body content
 - **Educational Context** - Built-in teachable moments and tips for common OAuth issues
@@ -59,7 +59,7 @@ The setting is stored per server and applies to both the OAuth Debugger and the 
 
 When the authorization server returns an `iss` parameter on the callback that does not match the issuer recorded from its metadata, Inspector's behavior depends on the protocol version selected for the flow:
 
-- **2026-07-28 (Draft)** — The flow is blocked before the authorization code is redeemed. The error names both the recorded issuer and the one returned on the callback so you can compare them directly.
+- **2026-07-28 (Latest)** — The flow is blocked before the authorization code is redeemed. The error names both the recorded issuer and the one returned on the callback so you can compare them directly.
 - **2025-11-25 and earlier** — The flow continues and a warning toast is shown naming both issuers. These protocol versions do not mention `iss` or RFC 9207 issuer validation, so blocking would enforce a rule the selected version does not contain.
 
 In both cases the mismatch is recorded on the OAuth trace at the `received_authorization_code` step, visible in the **Last OAuth Trace** panel.

--- a/docs/inspector/protocol-versions.mdx
+++ b/docs/inspector/protocol-versions.mdx
@@ -149,5 +149,5 @@ If you need to talk to a mix of servers on different versions in the same Client
 Background on the 2026-07-28 release and the stateless protocol:
 
 - [MCP Is Growing Up](https://aaif.io/blog/mcp-is-growing-up/) — AAIF's overview of what the 2026-07-28 revision means for teams building agentic systems.
-- [2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) — the official blog post walking through what the RC changes and why.
+- [Preview of the 2026-07-28 release](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) — a historical overview of the changes that shipped in the final release.
 - [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28) — the stable specification targeted by the inspector's 2026 client.

--- a/docs/inspector/protocol-versions.mdx
+++ b/docs/inspector/protocol-versions.mdx
@@ -1,14 +1,14 @@
 ---
 title: "MCP protocol versions"
-description: "Pin the inspector to a specific MCP protocol version — including the 2026-07-28 stateless RC — to test how your server behaves across versions."
+description: "Pin the inspector to a specific MCP protocol version — including the latest 2026-07-28 stateless release — to test how your server behaves across versions."
 icon: "git-branch"
 tag: "Preview"
 ---
 
-The inspector can speak more than one version of the MCP protocol. By default (**Automatic**), unpinned connections probe `server/discover` for 2026 support and fall back to the legacy `initialize` negotiation — on both HTTP and stdio. You can also pin a specific version when you want to test an exact revision — including the **2026-07-28 stateless RC** or any earlier stable release.
+The inspector can speak more than one version of the MCP protocol. By default (**Automatic**), unpinned connections probe `server/discover` for 2026 support and fall back to the legacy `initialize` negotiation — on both HTTP and stdio. You can also pin a specific version when you want to test an exact revision — including the latest **2026-07-28 stateless release** or any earlier stable release.
 
 <Warning>
-  **Migration required if you used the old Draft version.** The previous `DRAFT-2026-v1` placeholder has been retired and replaced with the upstream RC literal `2026-07-28`. If you had any servers pinned to `DRAFT-2026-v1`, you must re-select the protocol version in the inspector UI. Stored `DRAFT-2026-v1` pins are rejected by spec-conforming servers with a `-32004 UnsupportedProtocolVersionError`.
+  **Migration required if you used the old Draft version.** The previous `DRAFT-2026-v1` placeholder has been retired and replaced with the date-stamped literal `2026-07-28`. If you had any servers pinned to `DRAFT-2026-v1`, you must re-select the protocol version in the inspector UI. Stored `DRAFT-2026-v1` pins are rejected by spec-conforming servers with a `-32022 UnsupportedProtocolVersion` error.
 </Warning>
 
 ## Where the setting lives
@@ -40,7 +40,7 @@ When Automatic falls back to the legacy `initialize` handshake, it uses the MCP 
 
 **Latest** is derived, not hardcoded: it always labels the newest version in the SDK's known-version list. **November** labels the `2025-11-25` stateful release.
 
-The 2026 RC applies the stateless model across transports. MCPJam's initial preview client is narrower: it currently supports the RC over Streamable HTTP POST. The per-server dropdown hides the RC option for STDIO and legacy SSE servers; if a host-level RC default reaches a non-HTTP server, the inspector fails the connection with a clear transport error instead of silently attempting the wrong protocol.
+The 2026 release applies the stateless model across transports. MCPJam's preview client is narrower: it currently supports the revision over Streamable HTTP POST. The per-server dropdown hides the 2026 option for STDIO and legacy SSE servers; if a host-level 2026 default reaches a non-HTTP server, the inspector fails the connection with a clear transport error instead of silently attempting the wrong protocol.
 
 ## Setting the host default
 
@@ -71,7 +71,7 @@ You can set the per-server protocol version either when adding a server or when 
 
 ### At add time (shared projects)
 
-When adding a server to a shared project, the **Connection overrides** section of the Add Server modal includes a **Protocol version** picker. The 2026 RC option is only shown for HTTP servers.
+When adding a server to a shared project, the **Connection overrides** section of the Add Server modal includes a **Protocol version** picker. The 2026 option is only shown for HTTP servers.
 
 1. Click **Add server** in the **Servers** tab.
 2. Fill in the server details.
@@ -102,7 +102,7 @@ When you add or edit an HTTP server with **OAuth 2.0** authentication, the **Aut
 3. The version freshly detected or negotiated with the MCP server.
 4. `2025-11-25` when a `401` requires OAuth before the server can provide protocol evidence.
 
-The last case is an authentication-gated compatibility fallback, not version detection. If you know an auth-gated server requires the 2026 draft behavior, select `2026-07-28` explicitly.
+The last case is an authentication-gated compatibility fallback, not version detection. If you know an auth-gated server requires the 2026 behavior, select `2026-07-28` explicitly.
 
 OAuth callback security follows the concrete version recorded for that flow. Every version validates `state`. The 2026-07-28 flow also validates a returned RFC 9207 `iss` against the discovered authorization-server issuer; 2025 flows retain compatibility and ignore callback `iss`.
 
@@ -112,25 +112,25 @@ If your server already speaks `2026-07-28`, you mostly won't notice. A few thing
 
 - **No `initialize` handshake.** The inspector connects, immediately fires `server/discover`, and uses the result to populate the server card's name, version, capabilities, and instructions.
 - **Per-request metadata.** Every request the inspector sends carries `MCP-Protocol-Version: 2026-07-28` as an HTTP header and the same value inside `params._meta["io.modelcontextprotocol/protocolVersion"]`. `clientInfo` and `clientCapabilities` ride along on every request too.
-- **No session IDs.** The inspector never sends an `mcp-session-id`. If your server returns one, the inspector discards it and surfaces a warning — your server isn't conforming to the stateless RC.
+- **No session IDs.** The inspector never sends an `mcp-session-id`. If your server returns one, the inspector discards it and surfaces a warning — your server isn't conforming to the stateless revision.
 - **Cancellation is closing the stream.** For SSE responses, the inspector closes the response stream to cancel; your server should treat that as a cancel signal.
 
 ### What the inspector tells you
 
-- If your server doesn't speak `2026-07-28`, `server/discover` returns `-32004 UnsupportedProtocolVersionError` and the connection fails with the supported-versions list visible in the Activity log.
-- If your server is missing a capability the inspector needs for a request, you'll get `-32003 MissingRequiredClientCapability` back from your server — surface those in the Activity log to confirm they reach you.
+- If your server doesn't speak `2026-07-28`, `server/discover` returns `-32022 UnsupportedProtocolVersion` and the connection fails with the supported-versions list visible in the Activity log.
+- If your server is missing a capability the inspector needs for a request, you'll get `-32021 MissingRequiredClientCapability` back from your server — surface those in the Activity log to confirm they reach you.
 - The **Activity** log (server card → **Activity**) is the source of truth — every request and response, success or error, lands there so you can verify headers and `_meta` content.
 
-### Not yet supported in the RC client
+### Not yet supported in the preview client
 
-The 2026 RC client is a **preview**. A handful of pieces from the SEP family aren't wired up yet — if you try them, the inspector throws a labeled error instead of silently no-op'ing:
+MCPJam's 2026 client is a **preview**. A handful of pieces from the SEP family aren't wired up yet — if you try them, the inspector throws a labeled error instead of silently no-op'ing:
 
 - `subscriptions/listen` (long-lived notification stream)
 - Server-initiated requests via MRTR / `InputRequiredResult` for sampling and listRoots embedded in responses (elicitation via `input_required` is supported — see [Multi-round input](#multi-round-input-mcp-2026-07-28-input_required))
 - Resumption tokens
 - Automatic detection (HTTP and stdio) falls back to the legacy `initialize` handshake. An explicit 2026 pin remains exact and does not fall back.
 
-For everything else — `tools/list`, `tools/call`, `resources/*`, `prompts/*`, OAuth refresh, custom headers, progress notifications — the RC client behaves like the legacy one.
+For everything else — `tools/list`, `tools/call`, `resources/*`, `prompts/*`, OAuth refresh, custom headers, progress notifications — the preview client behaves like the legacy one.
 
 ## Recommended testing flow
 
@@ -139,15 +139,15 @@ For everything else — `tools/list`, `tools/call`, `resources/*`, `prompts/*`, 
 3. Connect — confirm the server card shows the server info populated from `server/discover` (name, version, capabilities, instructions).
 4. Run a `tools/list` and a `tools/call` from the **Tools** tab.
 5. Watch the **Activity** log for the request `_meta` and the `MCP-Protocol-Version` header.
-6. Try an unsupported version on a second test server to confirm your `-32004` error envelope looks right.
+6. Try an unsupported version on a second test server to confirm your `-32022` error envelope looks right.
 7. Once your server is happy on Latest, keep one Client on **Automatic** (or pinned to **November (2025-11-25)**) so you can flip between versions without rewriting settings.
 
-If you need to talk to a mix of servers on different versions in the same Client, use per-server overrides — the RC server stays pinned to `2026-07-28`, the rest fall back to the host default.
+If you need to talk to a mix of servers on different versions in the same Client, use per-server overrides — the 2026 server stays pinned to `2026-07-28`, the rest fall back to the host default.
 
 ## Recommended reading
 
-Background on the 2026-07-28 RC and the stateless direction the protocol is moving in:
+Background on the 2026-07-28 release and the stateless protocol:
 
-- [MCP Is Growing Up](https://aaif.io/blog/mcp-is-growing-up/) — AAIF's overview of what the 2026-07-28 RC means for teams building agentic systems.
+- [MCP Is Growing Up](https://aaif.io/blog/mcp-is-growing-up/) — AAIF's overview of what the 2026-07-28 revision means for teams building agentic systems.
 - [2026-07-28 release candidate announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) — the official blog post walking through what the RC changes and why.
-- [MCP specification (draft)](https://modelcontextprotocol.io/specification/draft) — the in-progress spec text the inspector's RC client targets.
+- [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28) — the stable specification targeted by the inspector's 2026 client.

--- a/docs/troubleshooting/error-codes.mdx
+++ b/docs/troubleshooting/error-codes.mdx
@@ -20,8 +20,10 @@ These come from the MCP transport itself. Numeric codes are defined by the [JSON
 | `-32602` | [Invalid params](#invalid-params) |
 | `-32603` | [Internal error](#internal-error) |
 | `-32000` | [Connection closed](#connection-closed) |
-| `-32001` | [Request timed out](#request-timeout) / [Header mismatch](#header-mismatch) |
-| `-32004` | [Unsupported protocol version](#unsupported-protocol-version) |
+| `-32001` | [Request timed out](#request-timeout) |
+| `-32020` | [Header mismatch](#header-mismatch) |
+| `-32021` | [Missing required client capability](#missing-required-client-capability) |
+| `-32022` | [Unsupported protocol version](#unsupported-protocol-version) |
 | `-32042` | [URL elicitation required](#url-elicitation-required) |
 
 ### Parse error
@@ -131,12 +133,12 @@ The server did not respond within the configured request timeout.
 
 ### Header mismatch
 
-`-32001 — jsonrpc/header_mismatch`
+`-32020 — jsonrpc/header_mismatch`
 
-The server rejected the request because an HTTP header disagreed with the JSON-RPC body — for example, `Mcp-Protocol-Version` does not match the version negotiated at `initialize`, or `Mcp-Name` does not match the tool name in the request body.
+The server rejected the request because an HTTP header disagreed with the JSON-RPC body — for example, `MCP-Protocol-Version` does not match the version in the request metadata, or `Mcp-Name` does not match the tool name in the request body.
 
 **Likely causes**
-- Server is enforcing a different protocol version than the one negotiated at `initialize`.
+- Server is enforcing a different protocol version than the request declares.
 - A proxy stripped or rewrote an `Mcp-*` header.
 - A routing header (`Mcp-Name`, `Mcp-Method`) was set to a value that disagrees with the request body.
 
@@ -146,21 +148,37 @@ The server rejected the request because an HTTP header disagreed with the JSON-R
 - Verify the server's protocol-version pinning in the connection settings.
 - If you set an explicit protocol version per server, ensure it matches what the server advertises.
 
-> The `-32001` code is overloaded between `request_timeout` and `header_mismatch`. The inspector disambiguates by message; check the raw message in the ErrorCard's details panel.
+> Older 2026 preview builds used `-32001` for this error. The inspector still recognizes that transitional code by its message, while conforming 2026-07-28 implementations use `-32020`.
+
+### Missing required client capability
+
+`-32021 — jsonrpc/missing_required_client_capability`
+
+The server refused the request because the client did not advertise a capability required by the operation.
+
+**Likely causes**
+- A server-initiated input request needs an elicitation or sampling capability the client did not declare.
+- The connection advertised a capability set the server considers insufficient for the operation.
+
+**Next steps**
+- Enable the required capability in the connection's Client settings.
+- Check the server's documentation for the capabilities it requires.
 
 ### Unsupported protocol version
 
-`-32004 — jsonrpc/unsupported_protocol_version`
+`-32022 — jsonrpc/unsupported_protocol_version`
 
 The server does not support any protocol version this inspector offered.
 
 **Likely causes**
-- Server pinned to a newer MCP draft your inspector build does not understand.
+- Server pinned to a newer MCP revision your inspector build does not understand.
 - Server pinned to a legacy version this build dropped support for.
 
 **Next steps**
 - Update the inspector to a newer build.
-- Check the supported versions list in the server's `initialize` response.
+- Check the supported versions list in the server's `server/discover` result (modern) or `initialize` response (legacy).
+
+> Older 2026 preview builds used `-32004` for this error. The inspector accepts that transitional code, while conforming 2026-07-28 implementations use `-32022`.
 
 ### URL elicitation required
 

--- a/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/AddServerModal.tsx
@@ -50,7 +50,7 @@ interface AddServerModalProps {
 }
 
 // normalizeOauthProtocolMode / ServerFormOAuthProtocolMode are single-sourced
-// in shared/types (the normalizer preserves the 2026-07-28 draft era).
+// in shared/types (the normalizer preserves the 2026-07-28 era).
 
 // Single-sourced in the SDK's registration vocabulary (accepts the legacy
 // pre_registered alias; unknown → undefined so callers apply defaults).

--- a/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/AuthenticationSection.test.tsx
@@ -803,7 +803,7 @@ describe("AuthenticationSection", () => {
         screen.getByRole("button", { name: /advanced settings/i })
       );
 
-    it("offers the 2026-07-28 (Draft) option in the Protocol dropdown", () => {
+    it("labels 2026-07-28 as the latest protocol in the dropdown", () => {
       render(
         <AuthenticationSection
           {...protocolBaseProps}
@@ -811,9 +811,8 @@ describe("AuthenticationSection", () => {
         />
       );
       openAdvanced();
-      // Radix Select renders the selected item's label in the trigger; the
-      // 2026 draft option resolving to a label proves it is in PROTOCOL_OPTIONS.
-      expect(screen.getByText("2026-07-28 (Draft)")).toBeInTheDocument();
+      expect(screen.getByText("2026-07-28 (Latest)")).toBeInTheDocument();
+      expect(screen.queryByText("2026-07-28 (Draft)")).not.toBeInTheDocument();
     });
 
     it("keeps Auto visible when the wire pin is 2026-07-28", () => {
@@ -827,7 +826,7 @@ describe("AuthenticationSection", () => {
       openAdvanced();
       expect(screen.getByText("Auto")).toBeInTheDocument();
       expect(
-        screen.queryByText("2026-07-28 (Draft)")
+        screen.queryByText("2026-07-28 (Latest)")
       ).not.toBeInTheDocument();
     });
 
@@ -842,7 +841,7 @@ describe("AuthenticationSection", () => {
       openAdvanced();
       expect(screen.getByText("Auto")).toBeInTheDocument();
       expect(
-        screen.queryByText("2026-07-28 (Draft)")
+        screen.queryByText("2026-07-28 (Latest)")
       ).not.toBeInTheDocument();
     });
 
@@ -861,7 +860,7 @@ describe("AuthenticationSection", () => {
       openAdvanced();
       expect(screen.getByText("Auto")).toBeInTheDocument();
       expect(
-        screen.queryByText("2025-11-25 (Latest)")
+        screen.queryByText("2025-11-25")
       ).not.toBeInTheDocument();
     });
 
@@ -890,7 +889,7 @@ describe("AuthenticationSection", () => {
       openAdvanced();
       expect(screen.getByText("2025-06-18")).toBeInTheDocument();
       expect(
-        screen.queryByText("2026-07-28 (Draft)")
+        screen.queryByText("2026-07-28 (Latest)")
       ).not.toBeInTheDocument();
     });
   });

--- a/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
+++ b/mcpjam-inspector/client/src/components/connection/hooks/use-server-form.ts
@@ -67,7 +67,7 @@ interface HeaderEntry {
 }
 
 // normalizeOauthProtocolMode is single-sourced in shared/types (preserves the
-// 2026-07-28 draft era; unknown/"auto" → 2025-11-25 default).
+// 2026-07-28 era; unknown/"auto" → 2025-11-25 default).
 
 // Single-sourced in the SDK's registration vocabulary (accepts the legacy
 // pre_registered alias; unknown → undefined so callers apply defaults).

--- a/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AuthenticationSection.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import {
+  PROTOCOL_VERSION_INFO,
   readXaaEnterprisePolicy,
   resolveAuthorizationPlan,
   type McpProtocolVersion,
@@ -127,10 +128,10 @@ const PROTOCOL_OPTIONS: Array<{
   label: string;
 }> = [
   { value: "auto", label: "Auto" },
-  { value: "2026-07-28", label: "2026-07-28 (Draft)" },
-  { value: "2025-11-25", label: "2025-11-25 (Latest)" },
-  { value: "2025-06-18", label: "2025-06-18" },
-  { value: "2025-03-26", label: "2025-03-26 (Legacy)" },
+  { value: "2026-07-28", label: PROTOCOL_VERSION_INFO["2026-07-28"].label },
+  { value: "2025-11-25", label: PROTOCOL_VERSION_INFO["2025-11-25"].label },
+  { value: "2025-06-18", label: PROTOCOL_VERSION_INFO["2025-06-18"].label },
+  { value: "2025-03-26", label: PROTOCOL_VERSION_INFO["2025-03-26"].label },
 ];
 
 // Options come from the shared registration-vocabulary label module, so the

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -19,6 +19,7 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { Label } from "@mcpjam/design-system/label";
 import {
+  PROTOCOL_VERSION_INFO,
   getDefaultRegistrationStrategy,
   getSupportedRegistrationStrategies,
   type OAuthProtocolVersion,
@@ -392,16 +393,16 @@ export function OAuthProfileModal({
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="2025-03-26" className="text-xs">
-                        2025-03-26
+                        {PROTOCOL_VERSION_INFO["2025-03-26"].label}
                       </SelectItem>
                       <SelectItem value="2025-06-18" className="text-xs">
-                        2025-06-18
+                        {PROTOCOL_VERSION_INFO["2025-06-18"].label}
                       </SelectItem>
                       <SelectItem value="2025-11-25" className="text-xs">
-                        2025-11-25 (Latest)
+                        {PROTOCOL_VERSION_INFO["2025-11-25"].label}
                       </SelectItem>
                       <SelectItem value="2026-07-28" className="text-xs">
-                        2026-07-28 (Draft)
+                        {PROTOCOL_VERSION_INFO["2026-07-28"].label}
                       </SelectItem>
                     </SelectContent>
                   </Select>

--- a/mcpjam-inspector/client/src/components/oauth/ProtocolVersionSelector.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/ProtocolVersionSelector.tsx
@@ -42,6 +42,12 @@ interface ProtocolVersionSelectorProps {
   showDetails?: boolean;
 }
 
+const SELECTABLE_PROTOCOL_VERSIONS: OAuthProtocolVersion[] = [
+  "2025-06-18",
+  "2025-11-25",
+  "2026-07-28",
+];
+
 export function ProtocolVersionSelector({
   value,
   onChange,
@@ -65,24 +71,15 @@ export function ProtocolVersionSelector({
           <div>
             <CardTitle className="text-lg">OAuth Protocol Version</CardTitle>
             <CardDescription>
-              Choose between stable and draft specifications
+              Choose an MCP OAuth specification version
             </CardDescription>
           </div>
-          {value === "2026-07-28" && (
-            <Badge variant="default" className="ml-2">
-              Draft
-            </Badge>
-          )}
-          {value === "2025-11-25" && (
-            <Badge variant="secondary" className="ml-2">
-              Latest
-            </Badge>
-          )}
-          {value === "2025-06-18" && (
-            <Badge variant="secondary" className="ml-2">
-              Stable
-            </Badge>
-          )}
+          <Badge
+            variant={currentInfo.status === "Latest" ? "default" : "secondary"}
+            className="ml-2"
+          >
+            {currentInfo.status}
+          </Badge>
         </div>
       </CardHeader>
 
@@ -95,30 +92,24 @@ export function ProtocolVersionSelector({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="2025-06-18">
-                <div className="flex items-center gap-2">
-                  <span>2025-06-18</span>
-                  <Badge variant="secondary" className="text-xs">
-                    Stable
-                  </Badge>
-                </div>
-              </SelectItem>
-              <SelectItem value="2025-11-25">
-                <div className="flex items-center gap-2">
-                  <span>2025-11-25</span>
-                  <Badge variant="secondary" className="text-xs">
-                    Latest
-                  </Badge>
-                </div>
-              </SelectItem>
-              <SelectItem value="2026-07-28">
-                <div className="flex items-center gap-2">
-                  <span>2026-07-28</span>
-                  <Badge variant="default" className="text-xs">
-                    Draft
-                  </Badge>
-                </div>
-              </SelectItem>
+              {SELECTABLE_PROTOCOL_VERSIONS.map((version) => {
+                const info = PROTOCOL_VERSION_INFO[version];
+                return (
+                  <SelectItem key={version} value={version}>
+                    <div className="flex items-center gap-2">
+                      <span>{version}</span>
+                      <Badge
+                        variant={
+                          info.status === "Latest" ? "default" : "secondary"
+                        }
+                        className="text-xs"
+                      >
+                        {info.status}
+                      </Badge>
+                    </div>
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
         </div>
@@ -271,21 +262,12 @@ export function ProtocolVersionBadge({
       title={currentInfo.description}
     >
       <span className="text-xs font-mono">{value}</span>
-      {value === "2026-07-28" && (
-        <Badge variant="default" className="text-xs px-1.5 py-0">
-          Draft
-        </Badge>
-      )}
-      {value === "2025-11-25" && (
-        <Badge variant="secondary" className="text-xs px-1.5 py-0">
-          Latest
-        </Badge>
-      )}
-      {value === "2025-06-18" && (
-        <Badge variant="secondary" className="text-xs px-1.5 py-0">
-          Stable
-        </Badge>
-      )}
+      <Badge
+        variant={currentInfo.status === "Latest" ? "default" : "secondary"}
+        className="text-xs px-1.5 py-0"
+      >
+        {currentInfo.status}
+      </Badge>
     </Button>
   );
 }

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -137,6 +137,25 @@ describe("OAuthProfileModal", () => {
     expect(payload.profile.protocolVersion).toBe("2026-07-28");
   });
 
+  it("shows the stable 2026 release as latest instead of draft", () => {
+    const server = createServer("oauth-flow-target");
+    (server as any).oauthFlowProfile = {
+      serverUrl: "https://existing.example.com/mcp",
+      clientId: "",
+      clientSecret: "",
+      scopes: "",
+      customHeaders: [],
+      protocolVersion: "2026-07-28",
+    };
+
+    renderModal({ server, existingServerNames: ["oauth-flow-target"] });
+
+    expect(
+      screen.getAllByText("2026-07-28 (Latest)").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("2026-07-28 (Draft)")).not.toBeInTheDocument();
+  });
+
   it("blocks a second submit while the first save is still in flight", async () => {
     // Awaiting onSave keeps the modal open, which opened a resubmit window the
     // old fire-and-forget close never had.

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/ProtocolVersionSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/ProtocolVersionSelector.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ProtocolVersionBadge,
+  ProtocolVersionSelector,
+} from "../ProtocolVersionSelector";
+
+describe("ProtocolVersionSelector release status", () => {
+  it("marks 2026-07-28 as latest", () => {
+    render(<ProtocolVersionSelector value="2026-07-28" onChange={vi.fn()} />);
+
+    expect(screen.getAllByText("Latest").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Draft")).not.toBeInTheDocument();
+  });
+
+  it("marks 2025-11-25 as stable", () => {
+    render(<ProtocolVersionBadge value="2025-11-25" />);
+
+    expect(screen.getByText("Stable")).toBeInTheDocument();
+    expect(screen.queryByText("Latest")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/project-serialization.test.ts
@@ -526,7 +526,7 @@ describe("OAuth test-profile round-trip (protocol version + registration strateg
     expect(servers.auto.oauthFlowProfile?.protocolVersion).toBe("2026-07-28");
   });
 
-  it("survives a 2026-07-28 draft-era protocol version through the round-trip", () => {
+  it("survives a 2026-07-28 protocol version through the round-trip", () => {
     const servers = deserializeServersFromConvex([
       {
         name: "draft-2026",

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -1754,7 +1754,7 @@ describe("mcp-oauth", () => {
 
     it("warns but still exchanges on a 2025 issuer mismatch", async () => {
       // `MUST validate a present iss` is SEP-2468, introduced in the
-      // 2026-07-28 draft. 2025-11-25 never mentions `iss`, so blocking here
+      // 2026-07-28 revision. 2025-11-25 never mentions `iss`, so blocking here
       // would enforce a rule the selected version does not contain.
       await seedPendingOAuth(
         undefined,
@@ -1813,7 +1813,7 @@ describe("mcp-oauth", () => {
         callbackIss: "https://different.example.com",
       });
 
-      // An unrecoverable version is treated as pre-draft, matching how the
+      // An unrecoverable version is treated as pre-2026, matching how the
       // reject-on-absence row already handles a missing version.
       expect(result.success).toBe(true);
       expect(mockExchangeAuthorization).toHaveBeenCalledTimes(1);
@@ -3548,9 +3548,9 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
     "warns but does not reject a mismatched iss on a %s flow",
     async (protocolVersion) => {
       // `MUST validate a present iss` is introduced by SEP-2468 in the
-      // 2026-07-28 draft. Pre-draft specs never mention `iss` at all, so
+      // 2026-07-28 revision. Pre-2026 specs never mention `iss` at all, so
       // rejecting there would enforce a rule the selected version does not
-      // contain. An unknown version is treated as pre-draft, matching how the
+      // contain. An unknown version is treated as pre-2026, matching how the
       // reject-on-absence row already handles `undefined`.
       const { evaluateCallbackSecurity } = await import("../mcp-oauth");
       const result = evaluateCallbackSecurity({
@@ -3578,7 +3578,7 @@ describe("evaluateCallbackSecurity (2R-iss callback gate)", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("a matching iss carries no warning on a pre-draft flow", async () => {
+  it("a matching iss carries no warning on a pre-2026 flow", async () => {
     const { evaluateCallbackSecurity } = await import("../mcp-oauth");
     expect(
       evaluateCallbackSecurity({ ...base, protocolVersion: "2025-11-25" })

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -3484,14 +3484,15 @@ export async function completeHostedOAuthCallback(
  *   we treat it as mandatory whenever this flow issued one).
  * - A PRESENT `iss` is compared against the recorded issuer on every version,
  *   but only the modern era REJECTS on a mismatch. SEP-2468 introduces
- *   `MUST validate a present iss` in the 2026-07-28 draft; 2025-11-25 and
+ *   `MUST validate a present iss` in the 2026-07-28 revision; 2025-11-25 and
  *   earlier never mention `iss`, RFC 9207, or issuer identification at all, so
  *   enforcing there would apply a rule the selected version does not contain.
- *   Pre-draft eras surface the mismatch as a `warning` and let the flow finish.
+ *   Pre-2026 eras surface the mismatch as a `warning` and let the flow finish.
  * - Rejecting an ABSENT `iss` that the AS advertised support for is likewise
- *   the rule the draft introduces, so it too fires on the modern era only.
+ *   the rule the 2026 revision introduces, so it too fires on the modern era
+ *   only.
  *
- * Warning-not-blocking on pre-draft eras is a deliberate, narrow concession:
+ * Warning-not-blocking on pre-2026 eras is a deliberate, narrow concession:
  * PKCE S256 is already mandatory there and defeats code injection, the token
  * endpoint always comes from the RECORDED metadata (never from the callback,
  * so a hostile `iss` cannot redirect the code), and tokens are persisted

--- a/mcpjam-inspector/shared/__tests__/types.test.ts
+++ b/mcpjam-inspector/shared/__tests__/types.test.ts
@@ -130,7 +130,7 @@ describe("MCPJam-provided model classification", () => {
 describe("normalizeOauthProtocolMode (connect-form OAuth protocol)", () => {
   // Single source for the Add and Edit connect forms — both previously kept
   // private copies that had to preserve 2026-07-28 in lockstep.
-  it("preserves every concrete protocol era, including the 2026-07-28 draft", () => {
+  it("preserves every concrete protocol era, including 2026-07-28", () => {
     expect(normalizeOauthProtocolMode("2025-03-26")).toBe("2025-03-26");
     expect(normalizeOauthProtocolMode("2025-06-18")).toBe("2025-06-18");
     expect(normalizeOauthProtocolMode("2025-11-25")).toBe("2025-11-25");

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -739,7 +739,7 @@ export function isServerFormOAuthProtocolMode(
 
 /**
  * Coerce an arbitrary stored/prefilled protocol string to a connect-form OAuth
- * protocol mode, preserving both the 2026-07-28 draft era AND the deferred
+ * protocol mode, preserving both the 2026-07-28 era AND the deferred
  * "auto" sentinel. "auto" is a valid {@link ServerFormOAuthProtocolMode} that
  * the wire-pin bridge resolves later, so it MUST survive hydration — coercing
  * it to a concrete era here drops the sentinel and makes the bridge unreachable

--- a/mcpjam-inspector/test-servers/stateless-mcp-server.ts
+++ b/mcpjam-inspector/test-servers/stateless-mcp-server.ts
@@ -1,5 +1,5 @@
 /**
- * Fixture HTTP server for the 2026-07-28 stateless transport (RC).
+ * Fixture HTTP server for the 2026-07-28 stateless transport.
  * Stands up a minimal "spec-conforming enough" target so unit + integration
  * tests can exercise `StatelessMcpHttpPreviewClient` without an
  * external dependency.

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -203,7 +203,7 @@ export {
 } from "./oauth/ssrf-guard.js";
 // RFC 9207 authorization-response `iss` validation. The comparison itself is
 // era-agnostic, but REJECTING on a mismatch is a 2026-07-28 (SEP-2468) rule —
-// callers pass `enforcePresentIssMismatch` so pre-draft flows warn instead.
+// callers pass `enforcePresentIssMismatch` so pre-2026 flows warn instead.
 export {
   validateAuthorizationResponseIssuer,
   type AuthorizationResponseIssuerCheck,

--- a/sdk/src/error-describer/catalog.ts
+++ b/sdk/src/error-describer/catalog.ts
@@ -168,7 +168,7 @@ export const ERROR_CATALOG: Record<string, ErrorCatalogEntry> = {
     "Unsupported protocol version (-32022)",
     "The server does not support any protocol version this inspector offered.",
     [
-      "Server pinned to a newer MCP draft your inspector build does not understand.",
+      "Server pinned to a newer MCP revision your inspector build does not understand.",
       "Server pinned to a legacy version this build dropped support for.",
     ],
     [

--- a/sdk/src/mcp-client-manager/mcp-error-codes.ts
+++ b/sdk/src/mcp-client-manager/mcp-error-codes.ts
@@ -4,7 +4,8 @@
  *
  * Why this module exists (and why the values look duplicated):
  *
- * The 2026-07-28 draft renumbered its new protocol codes late in review
+ * The 2026-07-28 release candidate renumbered its new protocol codes late in
+ * review
  * (HeaderMismatch `-32001`→`-32020`, MissingRequiredClientCapability
  * `-32003`→`-32021`, UnsupportedProtocolVersion `-32004`→`-32022`) and folded
  * resource-not-found into InvalidParams (`-32002`→`-32602`). The installed SDK

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -1,5 +1,5 @@
 /**
- * OAuth 2.0 State Machine for MCP - 2025-11-25 Protocol (Draft)
+ * OAuth 2.0 State Machine for MCP - 2025-11-25 Protocol
  *
  * This implementation follows the 2025-11-25 MCP OAuth specification:
  * - Registration priority: CIMD (SHOULD) > Pre-registered > DCR (MAY)

--- a/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2026-07-28.ts
@@ -1,5 +1,5 @@
 /**
- * OAuth 2.0 State Machine for MCP - 2026-07-28 Protocol (Draft)
+ * OAuth 2.0 State Machine for MCP - 2026-07-28 Protocol
  *
  * This implementation follows the 2026-07-28 MCP OAuth specification:
  * - Registration priority: CIMD (SHOULD) > Pre-registered > DCR (MAY)
@@ -737,7 +737,7 @@ export function evaluatePathScopedIssuer(input: {
  * rejection actionable. It is still attacker-controlled, hence `quoteUntrusted`.
  *
  * `enforcePresentIssMismatch` scopes row 2 to the era that actually mandates it.
- * SEP-2468 introduces `MUST validate a present iss` in the 2026-07-28 draft;
+ * SEP-2468 introduces `MUST validate a present iss` in the 2026-07-28 revision;
  * 2025-11-25 and earlier never mention `iss`, so a caller on those versions
  * passes `false` to downgrade row 2 to a `warning` and let the flow continue.
  * Defaults to enforcing: an omitted flag must fail closed, and the value that

--- a/sdk/src/oauth/state-machines/factory.ts
+++ b/sdk/src/oauth/state-machines/factory.ts
@@ -200,6 +200,7 @@ export function getSupportedRegistrationStrategies(
 export const PROTOCOL_VERSION_INFO = {
   "2025-03-26": {
     label: "2025-03-26 (Legacy)",
+    status: "Legacy",
     description: "Original MCP OAuth specification with direct discovery",
     features: [
       "Dynamic Client Registration (DCR) SHOULD be supported",
@@ -211,7 +212,8 @@ export const PROTOCOL_VERSION_INFO = {
   },
   "2025-06-18": {
     label: "2025-06-18",
-    description: "Current MCP OAuth specification with resource metadata",
+    status: "Stable",
+    description: "June 2025 MCP OAuth specification with resource metadata",
     features: [
       "Dynamic Client Registration (DCR) SHOULD be supported",
       "Protected Resource Metadata (RFC9728) required",
@@ -220,8 +222,9 @@ export const PROTOCOL_VERSION_INFO = {
     ],
   },
   "2025-11-25": {
-    label: "2025-11-25 (Latest)",
-    description: "Proposed MCP OAuth specification with CIMD support",
+    label: "2025-11-25",
+    status: "Stable",
+    description: "November 2025 MCP OAuth specification with CIMD support",
     features: [
       "Client ID Metadata Documents (CIMD) SHOULD be supported",
       "Protected Resource Metadata (RFC9728) required",
@@ -231,9 +234,10 @@ export const PROTOCOL_VERSION_INFO = {
     ],
   },
   "2026-07-28": {
-    label: "2026-07-28 (Draft)",
+    label: "2026-07-28 (Latest)",
+    status: "Latest",
     description:
-      "Draft MCP OAuth specification: 2025-11-25 discovery plus OIDC application_type",
+      "Latest MCP OAuth specification: 2025-11-25 discovery plus OIDC application_type",
     features: [
       "Client ID Metadata Documents (CIMD) SHOULD be supported",
       "Protected Resource Metadata (RFC9728) required",

--- a/sdk/tests/browser-entry.test.ts
+++ b/sdk/tests/browser-entry.test.ts
@@ -92,7 +92,14 @@ describe("browser entrypoint", () => {
     expect(browser.EMPTY_OAUTH_FLOW_STATE.currentStep).toBe("idle");
     expect(typeof browser.createOAuthStateMachine).toBe("function");
     expect(typeof browser.buildOAuthSequenceActions).toBe("function");
-    expect(browser.PROTOCOL_VERSION_INFO["2025-11-25"]).toBeDefined();
+    expect(browser.PROTOCOL_VERSION_INFO["2025-11-25"]).toMatchObject({
+      label: "2025-11-25",
+      status: "Stable",
+    });
+    expect(browser.PROTOCOL_VERSION_INFO["2026-07-28"]).toMatchObject({
+      label: "2026-07-28 (Latest)",
+      status: "Latest",
+    });
     expect(browser.getDefaultRegistrationStrategy("2025-11-25")).toBe("cimd");
     expect(browser.getSupportedRegistrationStrategies("2025-06-18")).toEqual([
       "dcr",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Marks MCP OAuth 2026-07-28 as the Latest protocol across `@mcpjam/inspector` and `@mcpjam/sdk`, removing all “Draft”/RC wording. Updates error codes and UI labels to the final 2026 release.

- **Refactors**
  - Centralized protocol labels and status via `PROTOCOL_VERSION_INFO`; UI badges/selectors now derive status: “2026-07-28 (Latest)”, “2025-11-25 (Stable)”, “2025-06-18 (Stable)”, “2025-03-26 (Legacy)”.
  - Updated ProtocolVersionSelector and OAuthProfileModal to use the map; added tests to assert “Latest”/“Stable” labeling.
  - Adopted final codes: `-32020` header_mismatch, `-32021` missing_required_client_capability, `-32022` unsupported_protocol_version; maintain compatibility with older preview codes.
  - Docs refreshed to the stable 2026 release (links to spec, issuer-validation behavior, transport scope); removed “Draft”/“RC” language and aligned terminology.

- **Migration**
  - If you pinned `DRAFT-2026-v1`, re-select `2026-07-28`; old pins are rejected with `-32022`.
  - 2026 remains HTTP-only; stdio/SSE continue on legacy versions.
  - No other changes required; existing flows continue with updated labels and codes.

<sup>Written for commit d20f7c66c006e1bedbfda71c60151c8fdd9555a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

