### PR TITLE
hosts: model verified ChatGPT probe behavior

### DIFF
--- a/.changeset/chatgpt-probe-profile.md
+++ b/.changeset/chatgpt-probe-profile.md
@@ -1,0 +1,11 @@
+---
+"@mcpjam/sdk": minor
+"@mcpjam/inspector": minor
+---
+
+Model ChatGPT's verified MCP and MCP Apps behavior in the built-in host profile.
+
+The profile now records normal tool-call cancellation, MRTR modes, detailed CSP
+probe results, resource-cache reuse, and container growth evidence. Unknown
+ChatGPT results stay omitted, while the runtime applies the verified
+cancellation and MRTR behavior.

--- a/cli/src/lib/host-resolve.ts
+++ b/cli/src/lib/host-resolve.ts
@@ -27,7 +27,7 @@ export interface ResolvedHost {
 export function resolveHostConnection(hostId: string): ResolvedHost {
   if (!(HOST_TEMPLATE_IDS as readonly string[]).includes(hostId)) {
     throw usageError(
-      `Unknown host "${hostId}". Valid hosts: ${HOST_TEMPLATE_IDS.join(", ")}.`,
+      `Unknown host "${hostId}". Valid hosts: ${HOST_TEMPLATE_IDS.join(", ")}.`
     );
   }
   const id = hostId as HostTemplateId;
@@ -51,7 +51,7 @@ export function resolveHostFromOptions(options: {
   if (!options.host) return undefined;
   if (options.clientCapabilities !== undefined) {
     throw usageError(
-      "--host advertises the host's client capabilities; pass --host or --client-capabilities, not both.",
+      "--host advertises the host's client capabilities; pass --host or --client-capabilities, not both."
     );
   }
   return resolveHostConnection(options.host);
@@ -60,7 +60,7 @@ export function resolveHostFromOptions(options: {
 /** Merge a host's connection pins onto a parsed server config. */
 export function applyHostToConfig(
   config: MCPServerConfig,
-  host: HostConnectionProfile,
+  host: HostConnectionProfile
 ): MCPServerConfig {
   const identity = {
     ...(host.clientInfo ? { clientInfo: host.clientInfo } : {}),
@@ -94,6 +94,10 @@ export function applyHostToConfig(
   const conformance = {
     ...(host.firstPageOnly ? { firstPageOnly: true } : {}),
     ...(host.supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(host.toolCallCancellation === false
+      ? { toolCallCancellation: false }
+      : {}),
+    ...(host.mrtrModes ? { mrtrModes: host.mrtrModes } : {}),
   };
   return {
     ...config,
@@ -113,7 +117,7 @@ export function applyHostVisibility(
   tools: Array<Record<string, unknown>>,
   manager: MCPClientManager,
   serverId: string,
-  policy: HostExecutionPolicy,
+  policy: HostExecutionPolicy
 ): { tools: Array<Record<string, unknown>>; toolsDroppedVisibility: number } {
   const record: Record<string, Record<string, unknown>> = {};
   for (const tool of tools) {
@@ -122,10 +126,13 @@ export function applyHostVisibility(
   const signals = applyVisibilityPolicyAndCountSignals(
     record,
     manager as unknown as ToolMetadataSource,
-    policy,
+    policy
   );
   const visible = tools.filter((tool) => String(tool.name) in record);
-  return { tools: visible, toolsDroppedVisibility: signals.toolsDroppedVisibility };
+  return {
+    tools: visible,
+    toolsDroppedVisibility: signals.toolsDroppedVisibility,
+  };
 }
 
 // Bound the tools pagination so a pathological server can't loop forever.
@@ -144,7 +151,7 @@ export async function assertToolVisibleToHost(
   manager: MCPClientManager,
   serverId: string,
   toolName: string,
-  host: ResolvedHost,
+  host: ResolvedHost
 ): Promise<void> {
   if (host.policy.respectToolVisibility === false) return;
   const seenCursors = new Set<string>();
@@ -152,15 +159,15 @@ export async function assertToolVisibleToHost(
   for (let page = 0; page < TOOLS_PAGE_CAP; page++) {
     const result = await manager.listTools(
       serverId,
-      cursor ? { cursor } : undefined,
+      cursor ? { cursor } : undefined
     );
     const tool = (result.tools ?? []).find(
-      (t) => (t as { name?: unknown }).name === toolName,
+      (t) => (t as { name?: unknown }).name === toolName
     ) as { _meta?: Record<string, unknown> } | undefined;
     if (tool) {
       if (isAppOnlyTool(tool._meta)) {
         throw usageError(
-          `Tool "${toolName}" is app-only — not visible to host "${host.id}"'s model. Omit --host to call it as an operator.`,
+          `Tool "${toolName}" is app-only — not visible to host "${host.id}"'s model. Omit --host to call it as an operator.`
         );
       }
       return; // found and model-visible
@@ -175,6 +182,6 @@ export async function assertToolVisibleToHost(
   // Couldn't page through the full tool list (page cap or cursor loop) and the
   // tool hasn't appeared — can't confirm it's model-visible, so fail CLOSED.
   throw usageError(
-    `Could not verify "${toolName}" is visible to host "${host.id}" — the server's tool list is too long to page through. Omit --host to call it as an operator.`,
+    `Could not verify "${toolName}" is visible to host "${host.id}" — the server's tool list is too long to page through. Omit --host to call it as an operator.`
   );
 }

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2968,6 +2968,11 @@ export default function App() {
         : undefined;
     const supportsMrtr =
       activeMcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
+    const toolCallCancellation =
+      activeMcpProfile?.toolCallCancellation === false
+        ? (false as const)
+        : undefined;
+    const mrtrModes = activeMcpProfile?.mrtrModes;
 
     return {
       clientInfo,
@@ -2979,6 +2984,8 @@ export default function App() {
       mirrorToolParamHeaders,
       firstPageOnly,
       supportsMrtr,
+      toolCallCancellation,
+      mrtrModes,
       xaaPolicy,
     };
   }, [
@@ -3002,6 +3009,8 @@ export default function App() {
     mirrorToolParamHeaders: hostedMcpProfilePins.mirrorToolParamHeaders,
     firstPageOnly: hostedMcpProfilePins.firstPageOnly,
     supportsMrtr: hostedMcpProfilePins.supportsMrtr,
+    toolCallCancellation: hostedMcpProfilePins.toolCallCancellation,
+    mrtrModes: hostedMcpProfilePins.mrtrModes,
     xaaPolicy: hostedMcpProfilePins.xaaPolicy,
     clientConfigSyncPending:
       isClientConfigSyncPending || isProjectServerConfigLoading,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -931,7 +931,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(vendorOnly).toEqual({});
   });
 
-  it("flips advertised hostCapabilities when host style switches to chatgpt", async () => {
+  it("advertises the probed ChatGPT hostCapabilities", async () => {
     render(
       <ChatboxHostStyleProvider value="chatgpt">
         <ChatboxHostThemeProvider value="dark">
@@ -947,13 +947,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(appBridgeArgsRef.current?.hostCapabilities).toEqual(
       expect.objectContaining(getHostCapabilitiesForStyle("chatgpt"))
     );
-    // Sanity: profiles differ — switching is observable. Use a
-    // distinguishing key (Claude advertises serverResources / logging;
-    // ChatGPT doesn't) rather than full-blob inequality, which would
-    // false-positive on shared keys.
+    // The current ChatGPT probe advertises both proxy surfaces. Behavioral
+    // differences from Claude (request teardown and CSP enforcement) live in
+    // the matrix rather than this ui/initialize advertisement blob.
     const advertised = appBridgeArgsRef.current?.hostCapabilities;
-    expect(advertised).not.toHaveProperty("serverResources");
-    expect(advertised).not.toHaveProperty("logging");
+    expect(advertised).toHaveProperty("serverResources");
+    expect(advertised).toHaveProperty("logging");
   });
 
   it("passes the same effectiveHostCapabilities to the modal as the inline AppBridge advertises", async () => {

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/caniuse-capability-catalog.test.ts
@@ -12,21 +12,34 @@ import { hostConfigField } from "@/lib/host-config-field-schema";
 describe("caniuse capability catalog", () => {
   it("includes stable public capability slugs", () => {
     expect(getCaniuseCapabilityBySlug("sampling")?.field.id).toBe(
-      "capabilities.sampling",
+      "capabilities.sampling"
     );
     expect(getCaniuseCapabilityBySlug("elicitation")?.field.id).toBe(
-      "capabilities.elicitation",
+      "capabilities.elicitation"
     );
     expect(getCaniuseCapabilityBySlug("roots")?.field.id).toBe(
-      "capabilities.roots",
+      "capabilities.roots"
     );
     expect(
-      getCaniuseCapabilityBySlug("mcp-apps-available-display-modes")?.field.id,
+      getCaniuseCapabilityBySlug("mcp-apps-available-display-modes")?.field.id
     ).toBe("appsCap.availableDisplayModes");
     expect(
       getCaniuseCapabilityForField(hostConfigField("capabilities.elicitation"))
-        ?.slug,
+        ?.slug
     ).toBe("elicitation");
+    expect(
+      getCaniuseCapabilityBySlug("regular-mcp-tool-call-cancellation")?.field.id
+    ).toBe("toolCallCancellation");
+    expect(
+      getCaniuseCapabilityBySlug("mcp-apps-connect-domains-fetch")?.field.id
+    ).toBe("appsCap.cspConnectDomains.fetch");
+    expect(
+      getCaniuseCapabilityBySlug("mcp-apps-container-width")?.field.id
+    ).toBe("appsCap.containerSizing.width");
+  });
+
+  it("keeps the public field mirror at 69 capability rows", () => {
+    expect(PUBLIC_CAN_I_USE_FIELDS).toHaveLength(69);
   });
 
   it("excludes config-only fields from public capability pages", () => {
@@ -43,10 +56,10 @@ describe("caniuse capability catalog", () => {
     const slugs = CANIUSE_CAPABILITIES.map((capability) => capability.slug);
     expect(new Set(slugs).size).toBe(slugs.length);
     expect(slugs.every((slug) => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug))).toBe(
-      true,
+      true
     );
     expect(buildCaniuseCapabilityPath("sampling")).toBe(
-      "/capabilities/sampling",
+      "/capabilities/sampling"
     );
   });
 

--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
@@ -342,7 +342,9 @@ describe("HostConfigComparisonMatrix", () => {
           makeSubject("h_missing_a", "Missing A", { clientCapabilities: {} }),
           makeSubject("h_missing_b", "Missing B", { clientCapabilities: {} }),
         ]}
-        searchQuery="sampling"
+        // Avoid the separate "MRTR sampling" row: this case is specifically
+        // about the initialize client-capability row below.
+        searchQuery="server initiated llm"
         supportFilter="missing"
       />
     );

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/AppsExtensionTab.tsx
@@ -68,8 +68,7 @@ interface AppsExtensionTabProps {
 
 const SEGMENT_ACTIVE_CLASSES =
   "border-primary-foreground/40 bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground";
-const SEGMENT_BUTTON_CLASSES =
-  "border-l border-border first:border-l-0";
+const SEGMENT_BUTTON_CLASSES = "border-l border-border first:border-l-0";
 
 /**
  * User-facing JSON document. The `sandbox` block configures the proxy
@@ -518,6 +517,70 @@ export function applyJsonToDraft(
       const value = incoming[key];
       if (typeof value === "boolean") {
         (out as Record<string, unknown>)[key] = value;
+      }
+    }
+    const readBooleanProbeRecord = <K extends string>(
+      value: unknown,
+      keys: readonly K[]
+    ): Partial<Record<K, boolean>> | undefined => {
+      if (!isPlainObject(value)) return undefined;
+      const result: Partial<Record<K, boolean>> = {};
+      for (const key of keys) {
+        if (typeof value[key] === "boolean") result[key] = value[key];
+      }
+      return Object.keys(result).length > 0 ? result : undefined;
+    };
+    const cspConnectDomains = readBooleanProbeRecord(
+      incoming.cspConnectDomains,
+      ["fetch", "xhr", "websocket"] as const
+    );
+    if (cspConnectDomains) out.cspConnectDomains = cspConnectDomains;
+    const cspResourceDomains = readBooleanProbeRecord(
+      incoming.cspResourceDomains,
+      ["script", "stylesheet", "image", "font", "media"] as const
+    );
+    if (cspResourceDomains) out.cspResourceDomains = cspResourceDomains;
+    if (typeof incoming.resourceCacheTtl === "boolean") {
+      out.resourceCacheTtl = incoming.resourceCacheTtl;
+    }
+    if (isPlainObject(incoming.containerSizing)) {
+      const sizing = incoming.containerSizing;
+      const validRequiredNumbers =
+        typeof sizing.defaultWidth === "number" &&
+        Number.isFinite(sizing.defaultWidth) &&
+        sizing.defaultWidth > 0 &&
+        typeof sizing.defaultHeight === "number" &&
+        Number.isFinite(sizing.defaultHeight) &&
+        sizing.defaultHeight > 0;
+      const validOptionalNumbers =
+        (sizing.testedUpToWidth === undefined ||
+          (typeof sizing.testedUpToWidth === "number" &&
+            Number.isFinite(sizing.testedUpToWidth) &&
+            sizing.testedUpToWidth > 0)) &&
+        (sizing.testedUpToHeight === undefined ||
+          (typeof sizing.testedUpToHeight === "number" &&
+            Number.isFinite(sizing.testedUpToHeight) &&
+            sizing.testedUpToHeight > 0));
+      if (
+        validRequiredNumbers &&
+        validOptionalNumbers &&
+        (sizing.width === "fixed" || sizing.width === "grows") &&
+        (sizing.height === "fixed" || sizing.height === "grows") &&
+        typeof sizing.limitObserved === "boolean"
+      ) {
+        out.containerSizing = {
+          defaultWidth: sizing.defaultWidth as number,
+          defaultHeight: sizing.defaultHeight as number,
+          width: sizing.width,
+          height: sizing.height,
+          ...(typeof sizing.testedUpToWidth === "number"
+            ? { testedUpToWidth: sizing.testedUpToWidth }
+            : {}),
+          ...(typeof sizing.testedUpToHeight === "number"
+            ? { testedUpToHeight: sizing.testedUpToHeight }
+            : {}),
+          limitObserved: sizing.limitObserved,
+        };
       }
     }
     const modes = incoming.availableDisplayModes;
@@ -1389,7 +1452,7 @@ function McpAppsCapabilityMatrix({
 
   /** Set or clear a boolean dimension override. Pass `undefined` to revert to preset. */
   const setBooleanOverride = (
-    key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">,
+    key: McpAppsDimensionKey,
     nextEffective: boolean
   ) => {
     onDraftChange((prev) => {

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/ProtocolTab.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/lib/client-config-v2";
 import type {
   MrtrSupport,
+  MrtrModes,
   PaginationTraversalMode,
   ToolParamHeaderMirroring,
 } from "@mcpjam/sdk/browser";
@@ -172,6 +173,8 @@ type ProtocolDoc = {
    */
   paginationTraversal?: PaginationTraversalMode;
   mrtrSupport?: MrtrSupport;
+  toolCallCancellation?: boolean;
+  mrtrModes?: MrtrModes;
   capabilities?: Record<string, unknown>;
   /**
    * Host-level MCP profile extensions (`mcpProfile.extensions`) — freeform
@@ -242,6 +245,12 @@ export function protocolToJson(draft: HostConfigInputV2): ProtocolDoc {
   }
   if (draft.mcpProfile?.mrtrSupport !== undefined) {
     doc.mrtrSupport = draft.mcpProfile.mrtrSupport;
+  }
+  if (draft.mcpProfile?.toolCallCancellation !== undefined) {
+    doc.toolCallCancellation = draft.mcpProfile.toolCallCancellation;
+  }
+  if (draft.mcpProfile?.mrtrModes !== undefined) {
+    doc.mrtrModes = draft.mcpProfile.mrtrModes;
   }
 
   if (
@@ -488,6 +497,25 @@ export function applyJsonToDraft(
   const rawMrtr = parsed.mrtrSupport;
   const mrtrSupport: MrtrSupport | undefined =
     rawMrtr === "full" || rawMrtr === "none" ? rawMrtr : undefined;
+  const toolCallCancellation =
+    typeof parsed.toolCallCancellation === "boolean"
+      ? parsed.toolCallCancellation
+      : undefined;
+  let mrtrModes: MrtrModes | undefined;
+  if (isPlainObject(parsed.mrtrModes)) {
+    const nextModes: MrtrModes = {};
+    for (const key of [
+      "requestState",
+      "roots",
+      "sampling",
+      "elicitation",
+    ] as const) {
+      if (typeof parsed.mrtrModes[key] === "boolean") {
+        nextModes[key] = parsed.mrtrModes[key];
+      }
+    }
+    if (Object.keys(nextModes).length > 0) mrtrModes = nextModes;
+  }
 
   // capabilities — pass through verbatim as Record<string, unknown> only if
   // the user supplied an object. Absence vs `{}` is preserved: missing key
@@ -560,6 +588,8 @@ export function applyJsonToDraft(
       toolParamHeaderMirroring,
       paginationTraversal,
       mrtrSupport,
+      toolCallCancellation,
+      mrtrModes,
       extensions: profileExtensions,
     };
 
@@ -633,7 +663,7 @@ export function ProtocolTab({
   // canonical hash.
   const storedMirroring = draft.mcpProfile?.toolParamHeaderMirroring;
   const setToolParamHeaderMirroring = (
-    next: ToolParamHeaderMirroring | undefined,
+    next: ToolParamHeaderMirroring | undefined
   ) => {
     onDraftChange((prev) => {
       const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
@@ -657,7 +687,7 @@ export function ProtocolTab({
   const storedMrtrSupport = draft.mcpProfile?.mrtrSupport;
   const setConformanceKnob = <K extends "paginationTraversal" | "mrtrSupport">(
     key: K,
-    next: HostConfigMcpProfileV1[K] | undefined,
+    next: HostConfigMcpProfileV1[K] | undefined
   ) => {
     onDraftChange((prev) => {
       const base: HostConfigMcpProfileV1 = prev.mcpProfile ?? {
@@ -723,7 +753,7 @@ export function ProtocolTab({
     onDraftChange((prev) =>
       next === "default"
         ? clearTasksPolicy(prev)
-        : setTasksPolicy(prev, next === "on"),
+        : setTasksPolicy(prev, next === "on")
     );
   };
 
@@ -763,7 +793,10 @@ export function ProtocolTab({
             {/* The visible label is a plain <span>, not a <label>, so the
                 trigger needs its own accessible name — and there is now more
                 than one Select in this panel. */}
-            <SelectTrigger aria-label="MCP protocol version" className="h-9 text-xs">
+            <SelectTrigger
+              aria-label="MCP protocol version"
+              className="h-9 text-xs"
+            >
               <SelectValue placeholder="Automatic" />
             </SelectTrigger>
             <SelectContent>
@@ -804,9 +837,7 @@ export function ProtocolTab({
             onValueChange={(next) => {
               // "mirror" writes ABSENCE, not the literal: the conforming
               // default must keep hashing like a host that never opted in.
-              setToolParamHeaderMirroring(
-                next === "omit" ? "omit" : undefined,
-              );
+              setToolParamHeaderMirroring(next === "omit" ? "omit" : undefined);
             }}
             disabled={readOnly}
           >
@@ -842,7 +873,7 @@ export function ProtocolTab({
               // host that never opted in.
               setConformanceKnob(
                 "paginationTraversal",
-                next === "firstPageOnly" ? "firstPageOnly" : undefined,
+                next === "firstPageOnly" ? "firstPageOnly" : undefined
               );
             }}
             disabled={readOnly}
@@ -875,7 +906,7 @@ export function ProtocolTab({
             onValueChange={(next) => {
               setConformanceKnob(
                 "mrtrSupport",
-                next === "none" ? "none" : undefined,
+                next === "none" ? "none" : undefined
               );
             }}
             disabled={readOnly}
@@ -893,76 +924,78 @@ export function ProtocolTab({
           </Select>
         </div>
         {showPolicyToggle && (
-        <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
-          <div className="min-w-0">
-            <span className="text-[12px] font-medium">
-              Enterprise-managed authorization
-            </span>
-            <p className="text-[11px] leading-snug text-muted-foreground">
-              Route every HTTP server connection through your IdP (XAA) by
-              default. A server&apos;s explicit auth method overrides.
-              Servers without an XAA client registration fail to connect.
-              Applies on the next connect.
-            </p>
-            {policyInvalid ? (
-              <p className="text-[11px] leading-snug text-destructive">
-                This host&apos;s stored policy value is unsupported —
-                connections will fail until it is fixed. Toggling on repairs
-                it; toggling off removes it.
+          <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
+            <div className="min-w-0">
+              <span className="text-[12px] font-medium">
+                Enterprise-managed authorization
+              </span>
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                Route every HTTP server connection through your IdP (XAA) by
+                default. A server&apos;s explicit auth method overrides. Servers
+                without an XAA client registration fail to connect. Applies on
+                the next connect.
               </p>
-            ) : null}
+              {policyInvalid ? (
+                <p className="text-[11px] leading-snug text-destructive">
+                  This host&apos;s stored policy value is unsupported —
+                  connections will fail until it is fixed. Toggling on repairs
+                  it; toggling off removes it.
+                </p>
+              ) : null}
+            </div>
+            <Switch
+              checked={policyOn}
+              onCheckedChange={setPolicyOn}
+              disabled={readOnly}
+              aria-label="Enterprise-managed authorization"
+            />
           </div>
-          <Switch
-            checked={policyOn}
-            onCheckedChange={setPolicyOn}
-            disabled={readOnly}
-            aria-label="Enterprise-managed authorization"
-          />
-        </div>
         )}
         {showTasksPolicy && (
-        <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
-          <div className="min-w-0">
-            <span className="text-[12px] font-medium">
-              {fTasksPolicy.label}
-            </span>
-            <p className="text-[11px] leading-snug text-muted-foreground">
-              Whether chat, the agent and evals may run tools as MCP tasks on
-              servers that support them. Use default keeps today&apos;s
-              behavior: the Tools tab&apos;s own per-call controls, and nothing
-              else. Off removes every task affordance.
-            </p>
-            {tasksPolicyInvalid ? (
-              <p className="text-[11px] leading-snug text-destructive">
-                {describeInvalidTasksPolicy(draft) ??
-                  "This host's stored task policy is unsupported."}{" "}
-                Tasks stay disabled until it is fixed; any choice below repairs
-                it.
+          <div className="mt-2.5 flex items-center justify-between gap-3 border-t border-border/50 pt-2.5">
+            <div className="min-w-0">
+              <span className="text-[12px] font-medium">
+                {fTasksPolicy.label}
+              </span>
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                Whether chat, the agent and evals may run tools as MCP tasks on
+                servers that support them. Use default keeps today&apos;s
+                behavior: the Tools tab&apos;s own per-call controls, and
+                nothing else. Off removes every task affordance.
               </p>
-            ) : null}
-          </div>
-          <Select
-            value={tasksPolicyInvalid ? undefined : TASKS_POLICY_VALUE[tasksPolicy]}
-            onValueChange={(next) =>
-              setTasksPolicyChoice(next as TasksPolicyChoice)
-            }
-            disabled={readOnly}
-          >
-            <SelectTrigger className="h-9 w-[150px] shrink-0 text-xs">
-              {/* An invalid stored value shows the placeholder rather than
+              {tasksPolicyInvalid ? (
+                <p className="text-[11px] leading-snug text-destructive">
+                  {describeInvalidTasksPolicy(draft) ??
+                    "This host's stored task policy is unsupported."}{" "}
+                  Tasks stay disabled until it is fixed; any choice below
+                  repairs it.
+                </p>
+              ) : null}
+            </div>
+            <Select
+              value={
+                tasksPolicyInvalid ? undefined : TASKS_POLICY_VALUE[tasksPolicy]
+              }
+              onValueChange={(next) =>
+                setTasksPolicyChoice(next as TasksPolicyChoice)
+              }
+              disabled={readOnly}
+            >
+              <SelectTrigger className="h-9 w-[150px] shrink-0 text-xs">
+                {/* An invalid stored value shows the placeholder rather than
                   snapping to "Use default": pretending a broken config is the
                   default would hide the very thing the warning is about. */}
-              <SelectValue placeholder="Unsupported value" />
-            </SelectTrigger>
-            <SelectContent>
-              {TASKS_POLICY_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+                <SelectValue placeholder="Unsupported value" />
+              </SelectTrigger>
+              <SelectContent>
+                {TASKS_POLICY_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         )}
         <div className="mt-2.5 border-t border-border/50 pt-2.5">
           <div className="flex items-center justify-between gap-3">

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -58,7 +58,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
           permissions: { clipboardWrite: {}, microphone: {} },
         },
       },
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     expect(next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo).toEqual({
       connectDomains: ["https://api.openai.com"],
@@ -94,7 +94,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
           csp: { connectDomains: ["https://api.anthropic.com"] },
         },
       },
-      prev,
+      prev
     );
     expect(next?.mcpProfile?.apps?.sandbox?.csp?.mode).toBe("relaxed");
     expect(next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo).toEqual({
@@ -122,7 +122,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
     };
     const next = applyJsonToDraft({ hostContext: {} }, prev);
     expect(next?.mcpProfile?.apps?.sandbox).toEqual(
-      prev.mcpProfile.apps!.sandbox,
+      prev.mcpProfile.apps!.sandbox
     );
   });
 
@@ -151,7 +151,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
         hostContext: {},
         sandbox: {},
       },
-      prev,
+      prev
     );
     expect(next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo).toBeUndefined();
     expect(next?.mcpProfile?.apps?.sandbox?.csp?.mode).toBe("relaxed");
@@ -170,7 +170,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
           // microphone absent → not granted
         },
       },
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     expect(next?.mcpProfile?.apps?.sandbox?.permissions?.allow).toEqual({
       clipboardWrite: true,
@@ -189,7 +189,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
         hostContext: {},
         sandbox: { csp: { connectDomains: ["https://api.openai.com"] } },
       },
-      prev,
+      prev
     );
     expect(next?.mcpProfile?.initialize?.clientInfo).toEqual({
       name: "claude-ai",
@@ -213,11 +213,11 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
         hostCapabilities: preset,
         sandbox: { csp: { connectDomains: ["https://api.openai.com"] } },
       },
-      prev,
+      prev
     );
     expect(next?.hostCapabilitiesOverride).toBeUndefined();
     expect(
-      next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains,
+      next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains
     ).toEqual(["https://api.openai.com"]);
   });
 
@@ -238,7 +238,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
           sandbox: { csp: { connectDomains: ["https://leaked.example"] } },
         },
       },
-      prev,
+      prev
     );
     expect(next?.hostCapabilitiesOverride).toBeUndefined();
   });
@@ -258,7 +258,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
           },
         },
       },
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     expect(next?.mcpProfile?.apps?.sandbox?.csp?.cspDirectives).toEqual({
       "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
@@ -289,11 +289,11 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
           csp: { connectDomains: ["https://api.openai.com"] },
         },
       },
-      prev,
+      prev
     );
     expect(next?.mcpProfile?.apps?.sandbox?.csp?.cspDirectives).toBeUndefined();
     expect(
-      next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains,
+      next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains
     ).toEqual(["https://api.openai.com"]);
   });
 
@@ -309,7 +309,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
           permissionsPolicy: { fullscreen: "*" },
         },
       },
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     expect(next?.mcpProfile?.apps?.sandbox?.sandboxAttrs).toEqual([
       "allow-forms",
@@ -336,7 +336,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
           permissionsPolicy: {},
         },
       },
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     expect(next?.mcpProfile?.apps?.sandbox?.sandboxAttrs).toEqual([]);
     expect(next?.mcpProfile?.apps?.sandbox?.allowFeatures).toEqual({});
@@ -361,7 +361,7 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
     };
     const next = applyJsonToDraft({ hostContext: {} }, prev);
     expect(next?.mcpProfile?.apps?.sandbox).toEqual(
-      prev.mcpProfile.apps!.sandbox,
+      prev.mcpProfile.apps!.sandbox
     );
   });
 });
@@ -379,7 +379,7 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
           availableDisplayModes: ["fullscreen"],
         },
       },
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
       serverResources: false,
@@ -387,6 +387,63 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
       downloadFile: false,
       requestTeardown: true,
       availableDisplayModes: ["fullscreen"],
+    });
+  });
+
+  it("round-trips detailed CSP, cache, and container probe results", () => {
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        mcpAppsOverrides: {
+          cspConnectDomains: {
+            fetch: false,
+            xhr: false,
+            websocket: true,
+          },
+          cspResourceDomains: {
+            script: false,
+            stylesheet: false,
+            image: false,
+            font: false,
+            media: false,
+          },
+          resourceCacheTtl: true,
+          containerSizing: {
+            defaultWidth: 670,
+            defaultHeight: 398,
+            width: "grows",
+            height: "grows",
+            testedUpToWidth: 10000,
+            testedUpToHeight: 10000,
+            limitObserved: false,
+          },
+        },
+      },
+      emptyHostConfigInputV2()
+    );
+    expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
+      cspConnectDomains: {
+        fetch: false,
+        xhr: false,
+        websocket: true,
+      },
+      cspResourceDomains: {
+        script: false,
+        stylesheet: false,
+        image: false,
+        font: false,
+        media: false,
+      },
+      resourceCacheTtl: true,
+      containerSizing: {
+        defaultWidth: 670,
+        defaultHeight: 398,
+        width: "grows",
+        height: "grows",
+        testedUpToWidth: 10000,
+        testedUpToHeight: 10000,
+        limitObserved: false,
+      },
     });
   });
 
@@ -402,7 +459,7 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
           availableDisplayModes: ["inline", "weirdmode", "pip"],
         },
       },
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
       serverResources: false,
@@ -421,7 +478,7 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
           availableDisplayModes: ["weirdmode"],
         },
       },
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
   });
@@ -465,7 +522,7 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
         hostCapabilities: effectiveHostCapabilities,
         mcpAppsOverrides: { serverResources: false, logging: false },
       },
-      prev,
+      prev
     );
     // Matrix preserved; legacy override NOT created.
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
@@ -509,7 +566,7 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
         hostCapabilities: stalehostCapabilities,
         // mcpAppsOverrides removed — the only deliberate user action
       },
-      prev,
+      prev
     );
     // Matrix cleared.
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
@@ -541,7 +598,7 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
         hostContext: {},
         hostCapabilities: deliberate,
       },
-      prev,
+      prev
     );
     expect(next?.hostCapabilitiesOverride).toEqual(deliberate);
   });
@@ -568,7 +625,7 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
         uiInitialize: { hostInfo: { name: "fakehost", version: "1.0" } },
         mcpAppsOverrides: { logging: false },
       },
-      prev,
+      prev
     );
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
       logging: false,

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/focus/__tests__/ProtocolTab.conformanceKnobs.test.tsx
@@ -93,18 +93,18 @@ describe("ProtocolTab client-conformance controls", () => {
             mrtrSupport: "none",
           },
         }}
-      />,
+      />
     );
 
     await user.click(paginationCombo());
     await user.click(
-      screen.getByRole("option", { name: "Walk every page (default)" }),
+      screen.getByRole("option", { name: "Walk every page (default)" })
     );
     expect(screen.getByTestId("pagination").textContent).toBe("<undefined>");
 
     await user.click(mrtrCombo());
     await user.click(
-      screen.getByRole("option", { name: "Supported (default)" }),
+      screen.getByRole("option", { name: "Supported (default)" })
     );
     expect(screen.getByTestId("mrtr").textContent).toBe("<undefined>");
     // Nothing left in the profile ⇒ it collapses, so the host hashes exactly
@@ -127,12 +127,12 @@ describe("ProtocolTab client-conformance controls", () => {
             mrtrSupport: "none",
           },
         }}
-      />,
+      />
     );
 
     await user.click(paginationCombo());
     await user.click(
-      screen.getByRole("option", { name: "Walk every page (default)" }),
+      screen.getByRole("option", { name: "Walk every page (default)" })
     );
 
     expect(screen.getByTestId("pagination").textContent).toBe("<undefined>");
@@ -147,6 +147,8 @@ describe("ProtocolTab JSON round-trip for the conformance knobs", () => {
     const doc = protocolToJson(emptyHostConfigInputV2());
     expect("paginationTraversal" in doc).toBe(false);
     expect("mrtrSupport" in doc).toBe(false);
+    expect("toolCallCancellation" in doc).toBe(false);
+    expect("mrtrModes" in doc).toBe(false);
   });
 
   it("surfaces and re-applies stored values", () => {
@@ -156,16 +158,25 @@ describe("ProtocolTab JSON round-trip for the conformance knobs", () => {
         profileVersion: 1,
         paginationTraversal: "firstPageOnly",
         mrtrSupport: "none",
+        toolCallCancellation: false,
+        mrtrModes: { requestState: true, elicitation: false },
       },
     };
     const doc = protocolToJson(draft);
     expect(doc.paginationTraversal).toBe("firstPageOnly");
     expect(doc.mrtrSupport).toBe("none");
+    expect(doc.toolCallCancellation).toBe(false);
+    expect(doc.mrtrModes).toEqual({ requestState: true, elicitation: false });
 
     const applied = applyJsonToDraft(doc, emptyHostConfigInputV2());
     expect(applied).not.toBeNull();
     expect(applied!.mcpProfile?.paginationTraversal).toBe("firstPageOnly");
     expect(applied!.mcpProfile?.mrtrSupport).toBe("none");
+    expect(applied!.mcpProfile?.toolCallCancellation).toBe(false);
+    expect(applied!.mcpProfile?.mrtrModes).toEqual({
+      requestState: true,
+      elicitation: false,
+    });
   });
 
   it("collapses unknown literals to undefined instead of failing the save", () => {
@@ -178,7 +189,7 @@ describe("ProtocolTab JSON round-trip for the conformance knobs", () => {
         paginationTraversal: "everyOtherPage",
         mrtrSupport: "partial",
       } as ReturnType<typeof protocolToJson>,
-      emptyHostConfigInputV2(),
+      emptyHostConfigInputV2()
     );
     // Assert the save SURVIVED first: `applyJsonToDraft` returns null when it
     // rejects the document, and optional chaining below would read `undefined`

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -2,6 +2,7 @@ import { useLayoutEffect } from "react";
 import { setApiContext } from "@/lib/apis/web/context";
 import type {
   McpProtocolVersion,
+  MrtrModes,
   XaaEnterprisePolicy,
 } from "@mcpjam/sdk/browser";
 
@@ -18,6 +19,8 @@ interface UseApiContextOptions {
   // Sibling conformance knobs; only the non-default value is ever set.
   firstPageOnly?: true;
   supportsMrtr?: false;
+  toolCallCancellation?: false;
+  mrtrModes?: MrtrModes;
   // Active host's enterprise-managed authorization policy (validated `on`
   // value only) — rides ad-hoc chat/eval request bodies.
   xaaPolicy?: XaaEnterprisePolicy;
@@ -43,6 +46,8 @@ export function useApiContext({
   mirrorToolParamHeaders,
   firstPageOnly,
   supportsMrtr,
+  toolCallCancellation,
+  mrtrModes,
   xaaPolicy,
   clientConfigSyncPending,
   getAccessToken,
@@ -73,6 +78,8 @@ export function useApiContext({
       mirrorToolParamHeaders,
       firstPageOnly,
       supportsMrtr,
+      toolCallCancellation,
+      mrtrModes,
       xaaPolicy,
       clientConfigSyncPending,
       getAccessToken,
@@ -97,6 +104,8 @@ export function useApiContext({
     mirrorToolParamHeaders,
     firstPageOnly,
     supportsMrtr,
+    toolCallCancellation,
+    mrtrModes,
     xaaPolicy,
     clientConfigSyncPending,
     getAccessToken,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1409,6 +1409,12 @@ export function useServerState({
       if (mcpProfile?.mrtrSupport === "none") {
         defaults.supportsMrtr = false;
       }
+      if (mcpProfile?.toolCallCancellation === false) {
+        defaults.toolCallCancellation = false;
+      }
+      if (mcpProfile?.mrtrModes) {
+        defaults.mrtrModes = mcpProfile.mrtrModes;
+      }
       // Enterprise-managed authorization policy from the active host's
       // mcpProfile. Sent only when validly ON; an `invalid` stored policy
       // fails the connect client-side with an actionable message instead of

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -9,6 +9,7 @@ import {
 import {
   getDefaultClientCapabilities,
   type McpProtocolVersion,
+  type MrtrModes,
   type XaaEnterprisePolicy,
 } from "@mcpjam/sdk/browser";
 
@@ -48,6 +49,8 @@ export interface ApiContext {
    */
   firstPageOnly?: true;
   supportsMrtr?: false;
+  toolCallCancellation?: false;
+  mrtrModes?: MrtrModes;
   /**
    * The active host's enterprise-managed authorization policy (validated
    * `on` value only). Rides ad-hoc chat/eval bodies; ignored server-side
@@ -422,6 +425,8 @@ function conformanceWireFields(apiContext: ApiContext): {
   mirrorToolParamHeaders?: false;
   firstPageOnly?: true;
   supportsMrtr?: false;
+  toolCallCancellation?: false;
+  mrtrModes?: MrtrModes;
 } {
   return {
     ...(apiContext.mirrorToolParamHeaders === false
@@ -433,6 +438,10 @@ function conformanceWireFields(apiContext: ApiContext): {
     ...(apiContext.supportsMrtr === false
       ? { supportsMrtr: false as const }
       : {}),
+    ...(apiContext.toolCallCancellation === false
+      ? { toolCallCancellation: false as const }
+      : {}),
+    ...(apiContext.mrtrModes ? { mrtrModes: apiContext.mrtrModes } : {}),
   };
 }
 
@@ -500,6 +509,8 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   mirrorToolParamHeaders?: boolean;
   firstPageOnly?: true;
   supportsMrtr?: false;
+  toolCallCancellation?: false;
+  mrtrModes?: MrtrModes;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -577,6 +588,8 @@ export function buildResolvedServerBatchRequest(input: {
   mirrorToolParamHeaders?: boolean;
   firstPageOnly?: true;
   supportsMrtr?: false;
+  toolCallCancellation?: false;
+  mrtrModes?: MrtrModes;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -622,6 +635,8 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   mirrorToolParamHeaders?: boolean;
   firstPageOnly?: true;
   supportsMrtr?: false;
+  toolCallCancellation?: false;
+  mrtrModes?: MrtrModes;
   xaaPolicy?: XaaEnterprisePolicy;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -55,6 +55,8 @@ export type HostedServerValidateContext = {
    */
   firstPageOnly?: true;
   supportsMrtr?: false;
+  toolCallCancellation?: false;
+  mrtrModes?: import("@mcpjam/sdk/browser").MrtrModes;
 };
 
 export interface HostedServerValidateResponse {
@@ -128,6 +130,12 @@ export async function validateHostedServer(
           : {}),
         ...(hostedContext.supportsMrtr === false
           ? { supportsMrtr: false }
+          : {}),
+        ...(hostedContext.toolCallCancellation === false
+          ? { toolCallCancellation: false }
+          : {}),
+        ...(hostedContext.mrtrModes
+          ? { mrtrModes: hostedContext.mrtrModes }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/lib/apps-capability-dimensions.ts
+++ b/mcpjam-inspector/client/src/lib/apps-capability-dimensions.ts
@@ -15,7 +15,12 @@ import type {
 /** Boolean MCP Apps spec-bridge dimensions (excludes the two non-boolean fields). */
 export type McpAppsDimensionKey = Exclude<
   keyof McpAppsCapabilities,
-  "availableDisplayModes" | "widgetDisplayModeRequests"
+  | "availableDisplayModes"
+  | "widgetDisplayModeRequests"
+  | "cspConnectDomains"
+  | "cspResourceDomains"
+  | "resourceCacheTtl"
+  | "containerSizing"
 >;
 
 /** Per-dimension matrix metadata. Description is shown on row hover. */

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -639,6 +639,10 @@ export function mergeMcpAppsCapabilities(
     sandboxPermissions: override.sandboxPermissions ?? base.sandboxPermissions,
     cspFrameDomains: override.cspFrameDomains ?? base.cspFrameDomains,
     cspBaseUriDomains: override.cspBaseUriDomains ?? base.cspBaseUriDomains,
+    cspConnectDomains: override.cspConnectDomains ?? base.cspConnectDomains,
+    cspResourceDomains: override.cspResourceDomains ?? base.cspResourceDomains,
+    resourceCacheTtl: override.resourceCacheTtl ?? base.resourceCacheTtl,
+    containerSizing: override.containerSizing ?? base.containerSizing,
     resourcePrefersBorder:
       override.resourcePrefersBorder ?? base.resourcePrefersBorder,
     downloadFile: override.downloadFile ?? base.downloadFile,
@@ -760,6 +764,8 @@ export function isMcpProfileEmpty(profile: HostConfigMcpProfileV1): boolean {
     profile.toolParamHeaderMirroring === undefined &&
     profile.paginationTraversal === undefined &&
     profile.mrtrSupport === undefined &&
+    profile.toolCallCancellation === undefined &&
+    profile.mrtrModes === undefined &&
     !profile.apps &&
     !profile.extensions
   );

--- a/mcpjam-inspector/client/src/lib/client-styles/__tests__/registry.test.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/__tests__/registry.test.ts
@@ -140,12 +140,14 @@ describe("host-styles registry", () => {
       message: { text: {} },
       downloadFile: {},
     });
-    // ChatGPT drops serverResources / logging per its matrix; downloadFile
-    // is on for every FULL-surface preset (ChatGPT inherits MCP_APPS_FULL_SURFACE
-    // with serverResources / logging overridden off).
+    // The current ChatGPT probe advertises serverResources + logging.
+    // downloadFile remains the permissive renderer fallback because that
+    // path was not exercised by this probe.
     expect(getHostCapabilitiesForStyle("chatgpt")).toEqual({
       openLinks: {},
       serverTools: {},
+      serverResources: {},
+      logging: {},
       updateModelContext: { text: {} },
       message: { text: {} },
       downloadFile: {},
@@ -166,12 +168,14 @@ describe("host-styles registry", () => {
     );
   });
 
-  it("differentiates claude and chatgpt capability presets", () => {
-    // Two profiles MUST differ in at least one observable key — otherwise
-    // host-style switching is cosmetic only and provides no signal to
-    // widget authors testing cross-client.
-    expect(getHostCapabilitiesForStyle("claude")).not.toEqual(
-      getHostCapabilitiesForStyle("chatgpt")
+  it("differentiates claude and chatgpt behavior matrices", () => {
+    // Their advertised ui/initialize blobs currently match, but their
+    // observed behavior does not (for example request teardown and CSP).
+    expect(CLAUDE_HOST_STYLE.mcp.mcpAppsCapabilities).not.toEqual(
+      CHATGPT_HOST_STYLE.mcp.mcpAppsCapabilities
+    );
+    expect(CHATGPT_HOST_STYLE.mcp.mcpAppsCapabilities.requestTeardown).toBe(
+      false
     );
   });
 

--- a/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
@@ -91,6 +91,7 @@ import type {
 // local — the SDK catalog doesn't carry them.
 import {
   MCP_APPS_FULL,
+  MCP_APPS_CHATGPT,
   MCP_APPS_COPILOT,
   MCP_APPS_GOOSE,
   MCP_APPS_NO_CLAIMS,
@@ -314,15 +315,13 @@ export const CHATGPT_HOST_STYLE: HostStyleDefinition = {
     protocolOverride: UIType.OPENAI_SDK,
     platform: CHATGPT_PLATFORM,
     fontCss: CHATGPT_FONT_CSS,
-    // ChatGPT differs from Claude on the SDK surface: ChatGPT's Apps SDK
-    // historically focuses on tool calls rather than proxying server
-    // resources/logging, so those rows are off here. `updateModelContext`
-    // and `message` stay on. Adjust once verified against the current
-    // OpenAI Apps SDK documentation.
+    // Start from the permissive runtime baseline, then apply every behavior
+    // observed by the 2026-08-04/05 ChatGPT probe. Sparse keys in the SDK
+    // constant remain explicitly unknown in the market catalog; the renderer
+    // still needs a concrete fallback behavior for those untested paths.
     mcpAppsCapabilities: {
       ...MCP_APPS_FULL_SURFACE,
-      serverResources: false,
-      logging: false,
+      ...MCP_APPS_CHATGPT,
     },
     resolveStyleVariables: getChatGPTStyleVariables,
     // Real ChatGPT exposes the OpenAI Apps SDK `window.openai` surface
@@ -331,7 +330,10 @@ export const CHATGPT_HOST_STYLE: HostStyleDefinition = {
     // full surface (every method on, requestDisplayMode unconstrained).
     compatRuntime: {
       openaiApps: true,
-      openaiAppsCapabilities: OPENAI_APPS_FULL_SURFACE,
+      openaiAppsCapabilities: {
+        ...OPENAI_APPS_FULL_SURFACE,
+        notifyIntrinsicHeight: false,
+      },
     },
   },
   chatUi: {

--- a/mcpjam-inspector/client/src/lib/client-styles/types.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/types.ts
@@ -267,6 +267,28 @@ export type McpAppsCapabilities = {
   sandboxPermissions?: boolean;
   cspFrameDomains?: boolean;
   cspBaseUriDomains?: boolean;
+  cspConnectDomains?: {
+    fetch?: boolean;
+    xhr?: boolean;
+    websocket?: boolean;
+  };
+  cspResourceDomains?: {
+    script?: boolean;
+    stylesheet?: boolean;
+    image?: boolean;
+    font?: boolean;
+    media?: boolean;
+  };
+  resourceCacheTtl?: boolean;
+  containerSizing?: {
+    defaultWidth: number;
+    defaultHeight: number;
+    width: "fixed" | "grows";
+    height: "fixed" | "grows";
+    testedUpToWidth?: number;
+    testedUpToHeight?: number;
+    limitObserved: boolean;
+  };
   resourcePrefersBorder?: boolean;
   downloadFile?: boolean;
   requestTeardown?: boolean;
@@ -323,6 +345,11 @@ export type ResolvedMcpAppsCapabilities = {
   sandboxPermissions: boolean;
   cspFrameDomains: boolean;
   cspBaseUriDomains: boolean;
+  /** Sparse probe observations; omitted means the subtest is unknown. */
+  cspConnectDomains?: McpAppsCapabilities["cspConnectDomains"];
+  cspResourceDomains?: McpAppsCapabilities["cspResourceDomains"];
+  resourceCacheTtl?: boolean;
+  containerSizing?: McpAppsCapabilities["containerSizing"];
   resourcePrefersBorder: boolean;
   downloadFile: boolean;
   requestTeardown: boolean;

--- a/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-field-schema.ts
@@ -199,6 +199,134 @@ const TASKS_POLICY_SUPPORT: Readonly<Record<string, SupportLevel>> = {
   invalid: "unsupported",
 };
 
+const CONTAINER_GROWTH_SUPPORT: Readonly<Record<string, SupportLevel>> = {
+  grows: "supported",
+  fixed: "neutral",
+};
+
+const CSP_CONNECT_PROBE_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
+  ["fetch", "connectDomains.fetch", "Honor connectDomains for fetch()."],
+  ["xhr", "connectDomains.xhr", "Honor connectDomains for XMLHttpRequest."],
+  [
+    "websocket",
+    "connectDomains.websocket",
+    "Honor connectDomains for WebSocket connections.",
+  ],
+].map(([key, label, description]) => ({
+  id: `appsCap.cspConnectDomains.${key}`,
+  section: "apps",
+  subsection: "MCP Apps capabilities",
+  label,
+  path: `mcpProfile.apps.mcpAppsOverrides.cspConnectDomains.${key} (effective)`,
+  description,
+  kind: { kind: "boolean" },
+  read: (cfg) =>
+    effMcpApps(cfg).cspConnectDomains?.[
+      key as keyof NonNullable<ResolvedMcpAppsCapabilities["cspConnectDomains"]>
+    ],
+}));
+
+const CSP_RESOURCE_PROBE_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
+  ["script", "resourceDomains.script", "Honor resourceDomains for scripts."],
+  [
+    "stylesheet",
+    "resourceDomains.stylesheet",
+    "Honor resourceDomains for stylesheets.",
+  ],
+  ["image", "resourceDomains.image", "Honor resourceDomains for images."],
+  ["font", "resourceDomains.font", "Honor resourceDomains for fonts."],
+  ["media", "resourceDomains.media", "Honor resourceDomains for media."],
+].map(([key, label, description]) => ({
+  id: `appsCap.cspResourceDomains.${key}`,
+  section: "apps",
+  subsection: "MCP Apps capabilities",
+  label,
+  path: `mcpProfile.apps.mcpAppsOverrides.cspResourceDomains.${key} (effective)`,
+  description,
+  kind: { kind: "boolean" },
+  read: (cfg) =>
+    effMcpApps(cfg).cspResourceDomains?.[
+      key as keyof NonNullable<
+        ResolvedMcpAppsCapabilities["cspResourceDomains"]
+      >
+    ],
+}));
+
+const CONTAINER_SIZING_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
+  {
+    id: "appsCap.containerSizing.defaultWidth",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "container.defaultWidth",
+    path: "mcpProfile.apps.mcpAppsOverrides.containerSizing.defaultWidth (effective)",
+    description: "Default container width reported by the size probe.",
+    kind: { kind: "number" },
+    read: (cfg) => effMcpApps(cfg).containerSizing?.defaultWidth,
+  },
+  {
+    id: "appsCap.containerSizing.defaultHeight",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "container.defaultHeight",
+    path: "mcpProfile.apps.mcpAppsOverrides.containerSizing.defaultHeight (effective)",
+    description: "Default container height reported by the size probe.",
+    kind: { kind: "number" },
+    read: (cfg) => effMcpApps(cfg).containerSizing?.defaultHeight,
+  },
+  {
+    id: "appsCap.containerSizing.width",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "container.width",
+    path: "mcpProfile.apps.mcpAppsOverrides.containerSizing.width (effective)",
+    description: "Whether the host fixes the container width or lets it grow.",
+    kind: { kind: "enum", support: CONTAINER_GROWTH_SUPPORT },
+    read: (cfg) => effMcpApps(cfg).containerSizing?.width,
+  },
+  {
+    id: "appsCap.containerSizing.height",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "container.height",
+    path: "mcpProfile.apps.mcpAppsOverrides.containerSizing.height (effective)",
+    description: "Whether the host fixes the container height or lets it grow.",
+    kind: { kind: "enum", support: CONTAINER_GROWTH_SUPPORT },
+    read: (cfg) => effMcpApps(cfg).containerSizing?.height,
+  },
+  {
+    id: "appsCap.containerSizing.testedUpToWidth",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "container.testedUpToWidth",
+    path: "mcpProfile.apps.mcpAppsOverrides.containerSizing.testedUpToWidth (effective)",
+    description:
+      "Largest width reached by the size probe; not a claimed maximum.",
+    kind: { kind: "number" },
+    read: (cfg) => effMcpApps(cfg).containerSizing?.testedUpToWidth,
+  },
+  {
+    id: "appsCap.containerSizing.testedUpToHeight",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "container.testedUpToHeight",
+    path: "mcpProfile.apps.mcpAppsOverrides.containerSizing.testedUpToHeight (effective)",
+    description:
+      "Largest height reached by the size probe; not a claimed maximum.",
+    kind: { kind: "number" },
+    read: (cfg) => effMcpApps(cfg).containerSizing?.testedUpToHeight,
+  },
+  {
+    id: "appsCap.containerSizing.limitObserved",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "container.limitObserved",
+    path: "mcpProfile.apps.mcpAppsOverrides.containerSizing.limitObserved (effective)",
+    description: "Whether the size probe reached a host-imposed limit.",
+    kind: { kind: "boolean" },
+    read: (cfg) => effMcpApps(cfg).containerSizing?.limitObserved,
+  },
+];
+
 /** "MCP Apps capabilities" subsection — effective SEP-1865 spec-bridge matrix. */
 const APPS_MCP_CAP_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
   {
@@ -222,7 +350,43 @@ const APPS_MCP_CAP_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
     kind: { kind: "enum", support: DISPLAY_MODE_SUPPORT },
     read: (cfg) => effMcpApps(cfg).widgetDisplayModeRequests,
   },
-  ...MCP_APPS_DIMENSIONS.map(
+  ...CSP_CONNECT_PROBE_FIELDS,
+  ...CSP_RESOURCE_PROBE_FIELDS,
+  {
+    id: "appsCap.cspFrameDomains",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "frameDomains.iframe",
+    path: "mcpProfile.apps.mcpAppsOverrides.cspFrameDomains (effective)",
+    description: "Honor frameDomains for nested iframes.",
+    kind: { kind: "boolean" },
+    read: (cfg) => effMcpApps(cfg).cspFrameDomains,
+  },
+  {
+    id: "appsCap.cspBaseUriDomains",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "baseUriDomains.baseUri",
+    path: "mcpProfile.apps.mcpAppsOverrides.cspBaseUriDomains (effective)",
+    description: "Honor baseUriDomains for <base href>.",
+    kind: { kind: "boolean" },
+    read: (cfg) => effMcpApps(cfg).cspBaseUriDomains,
+  },
+  {
+    id: "appsCap.resourceCacheTtl",
+    section: "apps",
+    subsection: "MCP Apps capabilities",
+    label: "resourceCacheTtl",
+    path: "mcpProfile.apps.mcpAppsOverrides.resourceCacheTtl (effective)",
+    description:
+      "Reuse a fetched app resource within the probe's 60-second window.",
+    kind: { kind: "boolean" },
+    read: (cfg) => effMcpApps(cfg).resourceCacheTtl,
+  },
+  ...CONTAINER_SIZING_FIELDS,
+  ...MCP_APPS_DIMENSIONS.filter(
+    ({ key }) => key !== "cspFrameDomains" && key !== "cspBaseUriDomains"
+  ).map(
     ({ key, description }): HostConfigFieldDef => ({
       id: `appsCap.${key}`,
       section: "apps",
@@ -588,6 +752,32 @@ export const HOST_CONFIG_FIELDS: ReadonlyArray<HostConfigFieldDef> = [
           | undefined
       )?.[MCP_SKILLS_EXTENSION_ID],
   },
+
+  // ============================================================
+  // Protocol · Observed host behavior
+  // ============================================================
+  {
+    id: "toolCallCancellation",
+    section: "protocol",
+    subsection: "Observed host behavior",
+    label: "Regular MCP tool-call cancellation",
+    path: "mcpProfile.toolCallCancellation",
+    description: "Cancel an in-flight normal MCP tools/call request.",
+    kind: { kind: "boolean" },
+    read: (cfg) => mcpProfile(cfg)?.toolCallCancellation,
+  },
+  ...(["requestState", "roots", "sampling", "elicitation"] as const).map(
+    (key): HostConfigFieldDef => ({
+      id: `mrtrModes.${key}`,
+      section: "protocol",
+      subsection: "Observed host behavior",
+      label: `MRTR ${key}`,
+      path: `mcpProfile.mrtrModes.${key}`,
+      description: `Support the MRTR ${key} probe mode.`,
+      kind: { kind: "boolean" },
+      read: (cfg) => mcpProfile(cfg)?.mrtrModes?.[key],
+    })
+  ),
 
   // ============================================================
   // Protocol · Host policy

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -62,7 +62,7 @@ function buildHostedValidationContext(
     projectId?: string;
     serverName?: string;
     connectionDefaults?: ConnectionDefaults;
-  },
+  }
 ): HostedServerValidateContext | undefined {
   if (!options?.projectId) return undefined;
 
@@ -112,13 +112,19 @@ function buildHostedValidationContext(
     ...(options.connectionDefaults?.supportsMrtr === false
       ? { supportsMrtr: false }
       : {}),
+    ...(options.connectionDefaults?.toolCallCancellation === false
+      ? { toolCallCancellation: false }
+      : {}),
+    ...(options.connectionDefaults?.mrtrModes
+      ? { mrtrModes: options.connectionDefaults.mrtrModes }
+      : {}),
   };
 }
 
 async function safeValidateHostedServer(
   serverId: string,
   serverConfig: MCPServerConfig,
-  hostedContext?: HostedServerValidateContext,
+  hostedContext?: HostedServerValidateContext
 ): Promise<
   HostedServerValidateResponse & {
     error?: string;
@@ -133,9 +139,9 @@ async function safeValidateHostedServer(
         serverId,
         oauthToken,
         serverConfig.capabilities as Record<string, unknown> | undefined,
-        hostedContext,
+        hostedContext
       ),
-      HOSTED_VALIDATE_TIMEOUT_MS,
+      HOSTED_VALIDATE_TIMEOUT_MS
     );
   } catch (error) {
     // Preserve the server-attached `normalized` block when the wrapped
@@ -148,8 +154,7 @@ async function safeValidateHostedServer(
     // path can detect "needs interactive OAuth" structurally, matching the
     // local envelope's top-level `oauthRequired`.
     const oauthRequired =
-      error instanceof WebApiError &&
-      error.details?.oauthRequired === true;
+      error instanceof WebApiError && error.details?.oauthRequired === true;
     return {
       success: false,
       error: normalizeHostedValidationError(error),
@@ -163,7 +168,7 @@ async function safeValidateHostedServer(
 async function authFetchWithTimeout(
   url: string,
   options: RequestInit,
-  timeoutMs: number = 10000,
+  timeoutMs: number = 10000
 ) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -181,7 +186,7 @@ async function authFetchWithTimeout(
       throw new Error(
         `Connection attempt timed out after ${
           timeoutMs / 1000
-        } seconds. The server may not exist or is not responding.`,
+        } seconds. The server may not exist or is not responding.`
       );
     }
     throw error;
@@ -190,7 +195,7 @@ async function authFetchWithTimeout(
 
 async function withTimeout<T>(
   promise: Promise<T>,
-  timeoutMs: number,
+  timeoutMs: number
 ): Promise<T> {
   return await new Promise<T>((resolve, reject) => {
     const timeoutId = window.setTimeout(() => {
@@ -198,8 +203,8 @@ async function withTimeout<T>(
         new Error(
           `Connection attempt timed out after ${
             timeoutMs / 1000
-          } seconds. The server may not exist or is not responding.`,
-        ),
+          } seconds. The server may not exist or is not responding.`
+        )
       );
     }, timeoutMs);
 
@@ -211,7 +216,7 @@ async function withTimeout<T>(
       (error) => {
         window.clearTimeout(timeoutId);
         reject(error);
-      },
+      }
     );
   });
 }
@@ -222,7 +227,7 @@ function buildResolverBody(
     projectId: string;
     serverName?: string;
     connectionDefaults?: ConnectionDefaults;
-  },
+  }
 ): Record<string, unknown> {
   return {
     projectId: options.projectId,
@@ -241,19 +246,19 @@ export async function testConnection(
     projectId?: string;
     serverName?: string;
     connectionDefaults?: ConnectionDefaults;
-  },
+  }
 ) {
   if (HOSTED_MODE) {
     return safeValidateHostedServer(
       serverId,
       serverConfig,
-      buildHostedValidationContext(serverId, options),
+      buildHostedValidationContext(serverId, options)
     );
   }
 
   if (!options?.projectId) {
     throw new Error(
-      "projectId is required for testConnection in local mode (server must be synced to Convex first)",
+      "projectId is required for testConnection in local mode (server must be synced to Convex first)"
     );
   }
 
@@ -270,7 +275,7 @@ export async function testConnection(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     },
-    20000, // 20 second timeout
+    20000 // 20 second timeout
   );
   return res.json();
 }
@@ -285,7 +290,7 @@ export async function deleteServer(serverId: string) {
     `/api/mcp/servers/${encodeURIComponent(serverId)}`,
     {
       method: "DELETE",
-    },
+    }
   );
   return res.json();
 }
@@ -304,20 +309,17 @@ export async function disconnectAllRuntimeServers() {
     id?: unknown;
     name?: unknown;
   }>;
-  const serverIds: string[] = listedServers.reduce(
-    (ids: string[], server) => {
-      if (typeof server.id === "string" && server.id) {
-        ids.push(server.id);
-      } else if (typeof server.name === "string" && server.name) {
-        ids.push(server.name);
-      }
-      return ids;
-    },
-    [] as string[],
-  );
+  const serverIds: string[] = listedServers.reduce((ids: string[], server) => {
+    if (typeof server.id === "string" && server.id) {
+      ids.push(server.id);
+    } else if (typeof server.name === "string" && server.name) {
+      ids.push(server.name);
+    }
+    return ids;
+  }, [] as string[]);
 
   const disconnectResults = await Promise.allSettled(
-    serverIds.map((serverId) => deleteServer(serverId)),
+    serverIds.map((serverId) => deleteServer(serverId))
   );
   const failures = disconnectResults.filter((disconnectResult) => {
     if (disconnectResult.status === "rejected") {
@@ -351,19 +353,19 @@ export async function reconnectServer(
     projectId?: string;
     serverName?: string;
     connectionDefaults?: ConnectionDefaults;
-  },
+  }
 ) {
   if (HOSTED_MODE) {
     return safeValidateHostedServer(
       serverId,
       serverConfig,
-      buildHostedValidationContext(serverId, options),
+      buildHostedValidationContext(serverId, options)
     );
   }
 
   if (!options?.projectId) {
     throw new Error(
-      "projectId is required for reconnectServer in local mode (server must be synced to Convex first)",
+      "projectId is required for reconnectServer in local mode (server must be synced to Convex first)"
     );
   }
 
@@ -380,7 +382,7 @@ export async function reconnectServer(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     },
-    20000, // 20 second timeout
+    20000 // 20 second timeout
   );
   return res.json();
 }
@@ -393,7 +395,7 @@ export async function getInitializationInfo(serverId: string) {
   }
 
   const res = await authFetch(
-    `/api/mcp/servers/init-info/${encodeURIComponent(serverId)}`,
+    `/api/mcp/servers/init-info/${encodeURIComponent(serverId)}`
   );
   return res.json();
 }
@@ -403,7 +405,7 @@ export async function setServerLoggingLevel(
   // `null` opts out of the modern per-request mechanism (absent `_meta` key
   // on the wire). Not meaningful for the legacy `logging/setLevel`
   // mechanism — the server route rejects it there.
-  level: LoggingLevel | null,
+  level: LoggingLevel | null
 ) {
   if (HOSTED_MODE) {
     void serverId;

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -84,6 +84,20 @@ const mcpProtocolVersionEnum = z.enum([
   "2025-11-25",
   "2026-07-28",
 ]);
+type MrtrModes = {
+  requestState?: boolean;
+  roots?: boolean;
+  sampling?: boolean;
+  elicitation?: boolean;
+};
+const mrtrModesSchema = z
+  .object({
+    requestState: z.boolean().optional(),
+    roots: z.boolean().optional(),
+    sampling: z.boolean().optional(),
+    elicitation: z.boolean().optional(),
+  })
+  .strict();
 
 function hasNonEmptyStringRecord(value: unknown): boolean {
   return (
@@ -153,6 +167,8 @@ export const projectServerSchema = z.object({
   // as a fully conforming client. Only the non-default value is ever sent.
   firstPageOnly: z.boolean().optional(),
   supportsMrtr: z.boolean().optional(),
+  toolCallCancellation: z.boolean().optional(),
+  mrtrModes: mrtrModesSchema.optional(),
   // Host enterprise-managed authorization policy, resolved client-side from
   // `hostConfig.mcpProfile.extensions`. Declared here (like the pins above)
   // so the wire contract documents it, but VALIDATED by
@@ -201,10 +217,7 @@ export const taskGetSchema = projectServerSchema.extend({
 });
 
 export const taskGetBatchSchema = projectServerSchema.extend({
-  taskIds: z
-    .array(z.string().min(1))
-    .min(1)
-    .max(HOSTED_TASK_BATCH_MAX_SHARED),
+  taskIds: z.array(z.string().min(1)).min(1).max(HOSTED_TASK_BATCH_MAX_SHARED),
 });
 
 export const taskListSchema = projectServerSchema.extend({
@@ -796,6 +809,8 @@ export function toHttpConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    toolCallCancellation?: boolean;
+    mrtrModes?: MrtrModes;
   }
 ): HttpServerConfig {
   if (authResponse.serverConfig.transportType !== "http") {
@@ -862,6 +877,12 @@ export function toHttpConfig(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(initializePins?.toolCallCancellation === false
+      ? { toolCallCancellation: false }
+      : {}),
+    ...(initializePins?.mrtrModes
+      ? { mrtrModes: initializePins.mrtrModes }
+      : {}),
   };
 }
 
@@ -882,6 +903,8 @@ function resolveEffectiveInitializePinsForServer(
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    toolCallCancellation?: boolean;
+    mrtrModes?: MrtrModes;
   },
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>
 ):
@@ -893,6 +916,10 @@ function resolveEffectiveInitializePinsForServer(
       supportedProtocolVersions?: string[];
       mcpProtocolVersion?: McpProtocolVersion;
       mirrorToolParamHeaders?: boolean;
+      firstPageOnly?: boolean;
+      supportsMrtr?: boolean;
+      toolCallCancellation?: boolean;
+      mrtrModes?: MrtrModes;
     }
   | undefined {
   const perServerPin = mcpProtocolVersionsByServerId?.[serverId];
@@ -926,6 +953,12 @@ function resolveEffectiveInitializePinsForServer(
     // resolve against.
     ...(initializePins?.firstPageOnly === true ? { firstPageOnly: true } : {}),
     ...(initializePins?.supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(initializePins?.toolCallCancellation === false
+      ? { toolCallCancellation: false }
+      : {}),
+    ...(initializePins?.mrtrModes
+      ? { mrtrModes: initializePins.mrtrModes }
+      : {}),
   };
 
   return Object.keys(resolved).length > 0 ? resolved : undefined;
@@ -1059,7 +1092,7 @@ export async function createAuthorizedManager(
      * `server/utils/mrtr-hosted-collector.ts`).
      */
     mrtrInputCollectorForServer?: (
-      serverId: string,
+      serverId: string
     ) => MrtrInputCollector | undefined;
   }
 ): Promise<AuthorizedManagerResult> {
@@ -1593,6 +1626,8 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
     mirrorToolParamHeaders?: boolean;
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    toolCallCancellation?: boolean;
+    mrtrModes?: MrtrModes;
   };
   mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
 } {
@@ -1628,13 +1663,18 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
   // Same one-explicit-value rule for the sibling knobs.
   const truncatePagination = raw.firstPageOnly === true;
   const disableMrtr = raw.supportsMrtr === false;
+  const disableToolCallCancellation = raw.toolCallCancellation === false;
+  const parsedMrtrModes = mrtrModesSchema.safeParse(raw.mrtrModes);
+  const mrtrModes = parsedMrtrModes.success ? parsedMrtrModes.data : undefined;
   const initializePins =
     initializeClientInfo ||
     initializeSupportedVersions ||
     initializeWireMode ||
     suppressParamMirroring ||
     truncatePagination ||
-    disableMrtr
+    disableMrtr ||
+    disableToolCallCancellation ||
+    mrtrModes
       ? {
           ...(initializeClientInfo ? { clientInfo: initializeClientInfo } : {}),
           ...(initializeSupportedVersions
@@ -1645,9 +1685,11 @@ export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
             : {}),
           ...(truncatePagination ? { firstPageOnly: true } : {}),
           ...(disableMrtr ? { supportsMrtr: false } : {}),
-          ...(suppressParamMirroring
-            ? { mirrorToolParamHeaders: false }
+          ...(disableToolCallCancellation
+            ? { toolCallCancellation: false }
             : {}),
+          ...(mrtrModes ? { mrtrModes } : {}),
+          ...(suppressParamMirroring ? { mirrorToolParamHeaders: false } : {}),
         }
       : undefined;
 
@@ -1769,7 +1811,7 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
      * connection on today's non-MRTR path.
      */
     mrtrInputCollectorForServer?: (
-      serverId: string,
+      serverId: string
     ) => MrtrInputCollector | undefined;
   }
 ): Promise<{
@@ -1917,7 +1959,7 @@ export async function createManualHostedConnection<S extends z.ZodTypeAny>(
  */
 function forwardLogMessagesInto(
   manager: InstanceType<typeof MCPClientManager>,
-  rpcCollector: ReturnType<typeof createHostedRpcLogCollector> | undefined,
+  rpcCollector: ReturnType<typeof createHostedRpcLogCollector> | undefined
 ) {
   return (serverId: string) => {
     if (!rpcCollector) return;

--- a/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/effective-auth.test.ts
@@ -236,8 +236,15 @@ describe("conformanceKnobsFromMcpProfile", () => {
       conformanceKnobsFromMcpProfile({
         paginationTraversal: "firstPageOnly",
         mrtrSupport: "none",
+        toolCallCancellation: false,
+        mrtrModes: { requestState: true, elicitation: false },
       })
-    ).toEqual({ firstPageOnly: true, supportsMrtr: false });
+    ).toEqual({
+      firstPageOnly: true,
+      supportsMrtr: false,
+      toolCallCancellation: false,
+      mrtrModes: { requestState: true, elicitation: false },
+    });
   });
 
   it("collapses the default literals, an absent profile and junk to undefined", () => {
@@ -253,6 +260,8 @@ describe("conformanceKnobsFromMcpProfile", () => {
       expect(conformanceKnobsFromMcpProfile(profile)).toEqual({
         firstPageOnly: undefined,
         supportsMrtr: undefined,
+        toolCallCancellation: undefined,
+        mrtrModes: undefined,
       });
     }
   });
@@ -274,6 +283,20 @@ describe("applyHostConformanceKnobs", () => {
         { firstPageOnly: true, supportsMrtr: undefined }
       )
     ).toEqual({ protocolVersion: "2026-07-28", firstPageOnly: true });
+  });
+
+  it("applies normal cancellation and sparse MRTR mode behavior", () => {
+    expect(
+      applyHostConformanceKnobs(undefined, {
+        firstPageOnly: undefined,
+        supportsMrtr: undefined,
+        toolCallCancellation: false,
+        mrtrModes: { requestState: true, elicitation: false },
+      })
+    ).toEqual({
+      toolCallCancellation: false,
+      mrtrModes: { requestState: true, elicitation: false },
+    });
   });
 
   it("strips caller pins when the host wants the full behavior", () => {

--- a/mcpjam-inspector/server/utils/effective-auth.ts
+++ b/mcpjam-inspector/server/utils/effective-auth.ts
@@ -238,18 +238,42 @@ export function applyHostParamMirroring<
 export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
   firstPageOnly: true | undefined;
   supportsMrtr: false | undefined;
+  toolCallCancellation: false | undefined;
+  mrtrModes:
+    | {
+        requestState?: boolean;
+        roots?: boolean;
+        sampling?: boolean;
+        elicitation?: boolean;
+      }
+    | undefined;
 } {
   const profile =
     mcpProfile !== null && typeof mcpProfile === "object"
       ? (mcpProfile as {
           paginationTraversal?: unknown;
           mrtrSupport?: unknown;
+          toolCallCancellation?: unknown;
+          mrtrModes?: unknown;
         })
       : undefined;
   return {
     firstPageOnly:
       profile?.paginationTraversal === "firstPageOnly" ? true : undefined,
     supportsMrtr: profile?.mrtrSupport === "none" ? false : undefined,
+    toolCallCancellation:
+      profile?.toolCallCancellation === false ? false : undefined,
+    mrtrModes:
+      profile?.mrtrModes !== null &&
+      typeof profile?.mrtrModes === "object" &&
+      !Array.isArray(profile.mrtrModes)
+        ? (profile.mrtrModes as {
+            requestState?: boolean;
+            roots?: boolean;
+            sampling?: boolean;
+            elicitation?: boolean;
+          })
+        : undefined,
   };
 }
 
@@ -270,10 +294,20 @@ export function conformanceKnobsFromMcpProfile(mcpProfile: unknown): {
  * unless the host actually asks for a non-default knob.
  */
 export function applyHostConformanceKnobs<
-  T extends { firstPageOnly?: boolean; supportsMrtr?: boolean }
+  T extends {
+    firstPageOnly?: boolean;
+    supportsMrtr?: boolean;
+    toolCallCancellation?: boolean;
+    mrtrModes?: Record<string, boolean>;
+  }
 >(
   pins: T | undefined,
-  host: { firstPageOnly: true | undefined; supportsMrtr: false | undefined }
+  host: {
+    firstPageOnly: true | undefined;
+    supportsMrtr: false | undefined;
+    toolCallCancellation?: false;
+    mrtrModes?: Record<string, boolean>;
+  }
 ): T | undefined {
   let next = pins;
   if (host.firstPageOnly === true) {
@@ -286,6 +320,18 @@ export function applyHostConformanceKnobs<
     next = { ...((next ?? {}) as T), supportsMrtr: false };
   } else if (next?.supportsMrtr !== undefined) {
     const { supportsMrtr: _hostOverrides, ...rest } = next;
+    next = rest as T;
+  }
+  if (host.toolCallCancellation === false) {
+    next = { ...((next ?? {}) as T), toolCallCancellation: false };
+  } else if (next?.toolCallCancellation !== undefined) {
+    const { toolCallCancellation: _hostOverrides, ...rest } = next;
+    next = rest as T;
+  }
+  if (host.mrtrModes !== undefined) {
+    next = { ...((next ?? {}) as T), mrtrModes: host.mrtrModes };
+  } else if (next?.mrtrModes !== undefined) {
+    const { mrtrModes: _hostOverrides, ...rest } = next;
     next = rest as T;
   }
   return next;

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -423,6 +423,29 @@ export function parseConnectionDefaults(
   if (input.supportsMrtr === false) {
     out.supportsMrtr = false;
   }
+  if (input.toolCallCancellation === false) {
+    out.toolCallCancellation = false;
+  }
+  if (
+    input.mrtrModes &&
+    typeof input.mrtrModes === "object" &&
+    !Array.isArray(input.mrtrModes)
+  ) {
+    const modes: NonNullable<ConnectionDefaults["mrtrModes"]> = {};
+    for (const key of [
+      "requestState",
+      "roots",
+      "sampling",
+      "elicitation",
+    ] as const) {
+      if (
+        typeof (input.mrtrModes as Record<string, unknown>)[key] === "boolean"
+      ) {
+        modes[key] = (input.mrtrModes as Record<string, boolean>)[key];
+      }
+    }
+    if (Object.keys(modes).length > 0) out.mrtrModes = modes;
+  }
 
   // Enterprise-managed authorization policy. UNLIKE every field above, this
   // one is enforcement, not advisory: silently dropping a malformed value
@@ -564,6 +587,8 @@ export function toMCPServerConfig(
      */
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
+    toolCallCancellation?: boolean;
+    mrtrModes?: import("@mcpjam/sdk").MrtrModes;
     /**
      * The host's enterprise-managed authorization policy (validated `on`
      * value). Present ⇒ the EMA extension is advertised on EVERY server of
@@ -635,6 +660,9 @@ export function toMCPServerConfig(
     // unlike the mirroring flag they are forwarded here as well as on HTTP.
     if (options?.firstPageOnly === true) stdio.firstPageOnly = true;
     if (options?.supportsMrtr === false) stdio.supportsMrtr = false;
+    if (options?.toolCallCancellation === false)
+      stdio.toolCallCancellation = false;
+    if (options?.mrtrModes) stdio.mrtrModes = options.mrtrModes;
     return stdio as MCPServerConfig;
   }
 
@@ -698,6 +726,9 @@ export function toMCPServerConfig(
     http.mirrorToolParamHeaders = false;
   if (options?.firstPageOnly === true) http.firstPageOnly = true;
   if (options?.supportsMrtr === false) http.supportsMrtr = false;
+  if (options?.toolCallCancellation === false)
+    http.toolCallCancellation = false;
+  if (options?.mrtrModes) http.mrtrModes = options.mrtrModes;
 
   // Attach the SDK's 401-recovery hook only when this is a hosted-OAuth
   // server (we have a token from `authorize-batch-local`) AND the caller
@@ -1063,6 +1094,8 @@ export async function resolveLocalServerForConnect(
     // Same path again for the sibling conformance knobs.
     firstPageOnly: options?.defaults?.firstPageOnly,
     supportsMrtr: options?.defaults?.supportsMrtr,
+    toolCallCancellation: options?.defaults?.toolCallCancellation,
+    mrtrModes: options?.defaults?.mrtrModes,
     oauthAccessToken: resolvedOauthAccessToken,
     refreshContext: {
       bearerToken,
@@ -1435,7 +1468,9 @@ export async function executeLocalServerConnect(
  * attribution). Same bearer the authorize call used — plugin reads are
  * project-scoped and re-authorized backend-side on every query.
  */
-function createPluginRuntimeConvexClient(bearerToken: string): ConvexHttpClient {
+function createPluginRuntimeConvexClient(
+  bearerToken: string
+): ConvexHttpClient {
   const { convexUrl } = getInspectorClientRuntimeConfig();
   if (!convexUrl) {
     throw new WebRouteError(

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -87,6 +87,8 @@ export type ConnectionDefaults = {
    */
   firstPageOnly?: true;
   supportsMrtr?: false;
+  toolCallCancellation?: false;
+  mrtrModes?: import("@mcpjam/sdk/browser").MrtrModes;
   /**
    * The host's enterprise-managed authorization policy, resolved client-side
    * via `readXaaEnterprisePolicy(hostConfig.mcpProfile)`. Present only when

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -544,6 +544,7 @@ export type {
   ToolParamHeaderMirroring,
   PaginationTraversalMode,
   MrtrSupport,
+  MrtrModes,
 } from "./host-config/index.js";
 
 // Shared task lifecycle engine. Browser-safe by construction: it performs no

--- a/sdk/src/host-compat/capabilities.ts
+++ b/sdk/src/host-compat/capabilities.ts
@@ -19,6 +19,9 @@ function frozen(matrix: McpAppsCapabilities): McpAppsCapabilities {
   if (Array.isArray(matrix.availableDisplayModes)) {
     Object.freeze(matrix.availableDisplayModes);
   }
+  if (matrix.cspConnectDomains) Object.freeze(matrix.cspConnectDomains);
+  if (matrix.cspResourceDomains) Object.freeze(matrix.cspResourceDomains);
+  if (matrix.containerSizing) Object.freeze(matrix.containerSizing);
   return Object.freeze(matrix);
 }
 
@@ -45,10 +48,40 @@ export const MCP_APPS_FULL: McpAppsCapabilities = frozen({
   widgetDisplayModeRequests: "accept",
 });
 
-/** ChatGPT — full surface minus downloadFile. */
+/** ChatGPT — probe-observed 2026-08-04/05 surface; omitted keys are unknown. */
 export const MCP_APPS_CHATGPT: McpAppsCapabilities = frozen({
-  ...MCP_APPS_FULL,
-  downloadFile: false,
+  availableDisplayModes: ["inline", "fullscreen", "pip"],
+  hostContextChanged: true,
+  toolInfo: true,
+  openLinks: true,
+  serverTools: true,
+  serverResources: true,
+  logging: true,
+  updateModelContext: true,
+  message: true,
+  sandboxPermissions: true,
+  cspFrameDomains: true,
+  cspBaseUriDomains: true,
+  cspConnectDomains: { fetch: false, xhr: false, websocket: true },
+  cspResourceDomains: {
+    script: false,
+    stylesheet: false,
+    image: false,
+    font: false,
+    media: false,
+  },
+  resourceCacheTtl: true,
+  containerSizing: {
+    defaultWidth: 670,
+    defaultHeight: 398,
+    width: "grows",
+    height: "grows",
+    testedUpToWidth: 10000,
+    testedUpToHeight: 10000,
+    limitObserved: false,
+  },
+  requestTeardown: false,
+  widgetDisplayModeRequests: "accept",
 });
 
 /** Mistral Le Chat — Apps-side `ui/initialize` evidence (no pip / download / teardown). */

--- a/sdk/src/host-compat/catalog-schema.ts
+++ b/sdk/src/host-compat/catalog-schema.ts
@@ -38,6 +38,30 @@ const availableDisplayModesSchema = z.preprocess(
   z.array(z.enum(DISPLAY_MODES)).optional()
 );
 
+const cspConnectDomainsSchema = z.object({
+  fetch: z.boolean().optional(),
+  xhr: z.boolean().optional(),
+  websocket: z.boolean().optional(),
+});
+
+const cspResourceDomainsSchema = z.object({
+  script: z.boolean().optional(),
+  stylesheet: z.boolean().optional(),
+  image: z.boolean().optional(),
+  font: z.boolean().optional(),
+  media: z.boolean().optional(),
+});
+
+const containerSizingSchema = z.object({
+  defaultWidth: z.number().positive(),
+  defaultHeight: z.number().positive(),
+  width: z.enum(["fixed", "grows"]),
+  height: z.enum(["fixed", "grows"]),
+  testedUpToWidth: z.number().positive().optional(),
+  testedUpToHeight: z.number().positive().optional(),
+  limitObserved: z.boolean(),
+});
+
 export const mcpAppsCapabilitiesSchema = z.object({
   availableDisplayModes: availableDisplayModesSchema,
   toolInputPartial: z.boolean().optional(),
@@ -54,6 +78,10 @@ export const mcpAppsCapabilitiesSchema = z.object({
   sandboxPermissions: z.boolean().optional(),
   cspFrameDomains: z.boolean().optional(),
   cspBaseUriDomains: z.boolean().optional(),
+  cspConnectDomains: cspConnectDomainsSchema.optional(),
+  cspResourceDomains: cspResourceDomainsSchema.optional(),
+  resourceCacheTtl: z.boolean().optional(),
+  containerSizing: containerSizingSchema.optional(),
   resourcePrefersBorder: z.boolean().optional(),
   downloadFile: z.boolean().optional(),
   requestTeardown: z.boolean().optional(),

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -691,11 +691,10 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             mimeTypes: ["text/html;profile=mcp-app"],
           },
         },
-        elicitation: {
-          form: {},
-        },
-        roots: {
-          listChanged: false,
+        experimental: {
+          "openai/visibility": {
+            enabled: true,
+          },
         },
       },
       hostContext: {
@@ -732,7 +731,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
         initialize: {
           supportedProtocolVersions: ["2025-11-25"],
           clientInfo: {
-            name: "cursor-vscode",
+            name: "openai-mcp",
             version: "1.0.0",
           },
         },

--- a/sdk/src/host-compat/catalog.generated.ts
+++ b/sdk/src/host-compat/catalog.generated.ts
@@ -69,6 +69,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             mimeTypes: ["text/html;profile=mcp-app"],
           },
           "io.modelcontextprotocol/enterprise-managed-authorization": {},
+          "io.modelcontextprotocol/skills": {},
         },
       },
       hostContext: {
@@ -635,9 +636,10 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
     chatgpt: {
       id: "chatgpt",
       label: "ChatGPT",
-      provenance: "vendor-doc",
+      provenance: "probe",
       rendersMcpApps: true,
-      verifiedAt: 1784764800000,
+      supportedProtocolVersions: ["2025-11-25"],
+      verifiedAt: 1785888000000,
       modelVisibleMcpToolResults: {
         directContent: {
           image: true,
@@ -689,10 +691,11 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             mimeTypes: ["text/html;profile=mcp-app"],
           },
         },
-        experimental: {
-          "openai/visibility": {
-            enabled: true,
-          },
+        elicitation: {
+          form: {},
+        },
+        roots: {
+          listChanged: false,
         },
       },
       hostContext: {
@@ -701,7 +704,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
         availableDisplayModes: ["inline", "fullscreen", "pip"],
         containerDimensions: {
           height: 400,
-          maxWidth: 768,
+          maxWidth: 528,
         },
         locale: "en-US",
         timeZone: "America/Los_Angeles",
@@ -720,9 +723,16 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
       },
       mcpProfile: {
         profileVersion: 1,
+        mcpProtocolVersion: "2025-11-25",
+        toolCallCancellation: false,
+        mrtrModes: {
+          requestState: true,
+          elicitation: false,
+        },
         initialize: {
+          supportedProtocolVersions: ["2025-11-25"],
           clientInfo: {
-            name: "openai-mcp",
+            name: "cursor-vscode",
             version: "1.0.0",
           },
         },
@@ -735,6 +745,21 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
           },
           compatRuntime: {
             openaiApps: true,
+            openaiAppsOverrides: {
+              callTool: true,
+              sendFollowUpMessage: true,
+              setWidgetState: true,
+              requestDisplayMode: "all",
+              notifyIntrinsicHeight: false,
+              openExternal: true,
+              setOpenInAppUrl: true,
+              requestModal: true,
+              uploadFile: true,
+              selectFiles: true,
+              getFileDownloadUrl: true,
+              requestCheckout: true,
+              requestClose: true,
+            },
           },
           sandbox: {
             csp: {
@@ -758,10 +783,7 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
           },
           mcpAppsOverrides: {
             availableDisplayModes: ["inline", "fullscreen", "pip"],
-            toolInputPartial: true,
-            toolCancelled: true,
             hostContextChanged: true,
-            resourceTeardown: true,
             toolInfo: true,
             openLinks: true,
             serverTools: true,
@@ -772,9 +794,29 @@ export const BUNDLED_HOST_COMPAT_CATALOG = {
             sandboxPermissions: true,
             cspFrameDomains: true,
             cspBaseUriDomains: true,
-            resourcePrefersBorder: true,
-            downloadFile: false,
-            requestTeardown: true,
+            cspConnectDomains: {
+              fetch: false,
+              xhr: false,
+              websocket: true,
+            },
+            cspResourceDomains: {
+              script: false,
+              stylesheet: false,
+              image: false,
+              font: false,
+              media: false,
+            },
+            resourceCacheTtl: true,
+            containerSizing: {
+              defaultWidth: 670,
+              defaultHeight: 398,
+              width: "grows",
+              height: "grows",
+              testedUpToWidth: 10000,
+              testedUpToHeight: 10000,
+              limitObserved: false,
+            },
+            requestTeardown: false,
             widgetDisplayModeRequests: "accept",
           },
         },

--- a/sdk/src/host-compat/catalog.ts
+++ b/sdk/src/host-compat/catalog.ts
@@ -245,6 +245,15 @@ function cloneProfile(p: HostCompatProfile): HostCompatProfile {
           availableDisplayModes: p.capabilities.availableDisplayModes
             ? [...p.capabilities.availableDisplayModes]
             : undefined,
+          cspConnectDomains: p.capabilities.cspConnectDomains
+            ? { ...p.capabilities.cspConnectDomains }
+            : undefined,
+          cspResourceDomains: p.capabilities.cspResourceDomains
+            ? { ...p.capabilities.cspResourceDomains }
+            : undefined,
+          containerSizing: p.capabilities.containerSizing
+            ? { ...p.capabilities.containerSizing }
+            : undefined,
         }
       : undefined,
     sandboxPermissionAllow: p.sandboxPermissionAllow

--- a/sdk/src/host-config/canonicalize.ts
+++ b/sdk/src/host-config/canonicalize.ts
@@ -102,6 +102,10 @@ const MCP_APPS_CAPABILITY_KEYS = [
   "sandboxPermissions",
   "cspFrameDomains",
   "cspBaseUriDomains",
+  "cspConnectDomains",
+  "cspResourceDomains",
+  "resourceCacheTtl",
+  "containerSizing",
   "resourcePrefersBorder",
   "downloadFile",
   "requestTeardown",
@@ -122,6 +126,22 @@ const MCP_APPS_WIDGET_DISPLAY_MODE_REQUEST_VALUES = [
 const MCP_APPS_DISPLAY_MODE_VALUE_SET: ReadonlySet<string> = new Set(
   MCP_APPS_DISPLAY_MODE_VALUES
 );
+
+const MRTR_MODE_KEYS = [
+  "requestState",
+  "roots",
+  "sampling",
+  "elicitation",
+] as const;
+
+const CSP_CONNECT_DOMAIN_KEYS = ["fetch", "xhr", "websocket"] as const;
+const CSP_RESOURCE_DOMAIN_KEYS = [
+  "script",
+  "stylesheet",
+  "image",
+  "font",
+  "media",
+] as const;
 
 function sortStringKeys<T extends Record<string, unknown>>(input: T): T {
   const out: Record<string, unknown> = {};
@@ -746,6 +766,45 @@ function canonicalizeMcpProfile(
     (out as Record<string, unknown>)[key] = value;
   }
 
+  if (input.toolCallCancellation !== undefined) {
+    if (typeof input.toolCallCancellation !== "boolean") {
+      throw new Error(
+        "hostConfigV2: mcpProfile.toolCallCancellation must be a boolean"
+      );
+    }
+    out.toolCallCancellation = input.toolCallCancellation;
+  }
+
+  if (input.mrtrModes !== undefined) {
+    if (!isPlainObject(input.mrtrModes)) {
+      throw new Error(
+        "hostConfigV2: mcpProfile.mrtrModes must be a plain object"
+      );
+    }
+    const modesOut: NonNullable<HostConfigMcpProfileV1["mrtrModes"]> = {};
+    for (const key of Object.keys(input.mrtrModes)) {
+      if (!(MRTR_MODE_KEYS as readonly string[]).includes(key)) {
+        throw new Error(
+          `hostConfigV2: mcpProfile.mrtrModes has unknown key "${key}"`
+        );
+      }
+      const value = (input.mrtrModes as Record<string, unknown>)[key];
+      if (typeof value !== "boolean") {
+        throw new Error(
+          `hostConfigV2: mcpProfile.mrtrModes.${key} must be a boolean`
+        );
+      }
+      (modesOut as Record<string, unknown>)[key] = value;
+    }
+    if (Object.keys(modesOut).length > 0) {
+      const sortedModes = {} as typeof modesOut;
+      for (const key of MRTR_MODE_KEYS) {
+        if (modesOut[key] !== undefined) sortedModes[key] = modesOut[key];
+      }
+      out.mrtrModes = sortedModes;
+    }
+  }
+
   if (input.initialize !== undefined) {
     if (!isPlainObject(input.initialize)) {
       throw new Error(
@@ -1203,6 +1262,110 @@ function canonicalizeMcpProfile(
           }
           mcpAppsOverridesOut.widgetDisplayModeRequests =
             value as McpAppsCapabilities["widgetDisplayModeRequests"];
+        } else if (
+          key === "cspConnectDomains" ||
+          key === "cspResourceDomains"
+        ) {
+          if (!isPlainObject(value)) {
+            throw new Error(
+              `hostConfigV2: mcpProfile.apps.mcpAppsOverrides.${key} must be a plain object`
+            );
+          }
+          const allowedKeys =
+            key === "cspConnectDomains"
+              ? CSP_CONNECT_DOMAIN_KEYS
+              : CSP_RESOURCE_DOMAIN_KEYS;
+          const nestedOut: Record<string, boolean> = {};
+          for (const nestedKey of Object.keys(value)) {
+            if (!(allowedKeys as readonly string[]).includes(nestedKey)) {
+              throw new Error(
+                `hostConfigV2: mcpProfile.apps.mcpAppsOverrides.${key} has unknown key "${nestedKey}"`
+              );
+            }
+            const nestedValue = value[nestedKey];
+            if (typeof nestedValue !== "boolean") {
+              throw new Error(
+                `hostConfigV2: mcpProfile.apps.mcpAppsOverrides.${key}.${nestedKey} must be a boolean`
+              );
+            }
+            nestedOut[nestedKey] = nestedValue;
+          }
+          if (Object.keys(nestedOut).length > 0) {
+            (mcpAppsOverridesOut as Record<string, unknown>)[key] =
+              Object.fromEntries(
+                allowedKeys
+                  .filter((nestedKey) => nestedOut[nestedKey] !== undefined)
+                  .map((nestedKey) => [nestedKey, nestedOut[nestedKey]])
+              );
+          }
+        } else if (key === "containerSizing") {
+          if (!isPlainObject(value)) {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.mcpAppsOverrides.containerSizing must be a plain object"
+            );
+          }
+          const allowedKeys = new Set([
+            "defaultWidth",
+            "defaultHeight",
+            "width",
+            "height",
+            "testedUpToWidth",
+            "testedUpToHeight",
+            "limitObserved",
+          ]);
+          for (const nestedKey of Object.keys(value)) {
+            if (!allowedKeys.has(nestedKey)) {
+              throw new Error(
+                `hostConfigV2: mcpProfile.apps.mcpAppsOverrides.containerSizing has unknown key "${nestedKey}"`
+              );
+            }
+          }
+          const numericKeys = [
+            "defaultWidth",
+            "defaultHeight",
+            "testedUpToWidth",
+            "testedUpToHeight",
+          ] as const;
+          for (const nestedKey of numericKeys) {
+            const nestedValue = value[nestedKey];
+            if (
+              (nestedKey === "defaultWidth" ||
+                nestedKey === "defaultHeight" ||
+                nestedValue !== undefined) &&
+              (typeof nestedValue !== "number" ||
+                !Number.isFinite(nestedValue) ||
+                nestedValue <= 0)
+            ) {
+              throw new Error(
+                `hostConfigV2: mcpProfile.apps.mcpAppsOverrides.containerSizing.${nestedKey} must be a positive finite number`
+              );
+            }
+          }
+          for (const nestedKey of ["width", "height"] as const) {
+            if (value[nestedKey] !== "fixed" && value[nestedKey] !== "grows") {
+              throw new Error(
+                `hostConfigV2: mcpProfile.apps.mcpAppsOverrides.containerSizing.${nestedKey} must be "fixed" | "grows"`
+              );
+            }
+          }
+          if (typeof value.limitObserved !== "boolean") {
+            throw new Error(
+              "hostConfigV2: mcpProfile.apps.mcpAppsOverrides.containerSizing.limitObserved must be a boolean"
+            );
+          }
+          mcpAppsOverridesOut.containerSizing = {
+            defaultWidth: value.defaultWidth as number,
+            defaultHeight: value.defaultHeight as number,
+            width: value.width as "fixed" | "grows",
+            height: value.height as "fixed" | "grows",
+            ...(value.testedUpToWidth !== undefined
+              ? { testedUpToWidth: value.testedUpToWidth as number }
+              : {}),
+            ...(value.testedUpToHeight !== undefined
+              ? { testedUpToHeight: value.testedUpToHeight as number }
+              : {}),
+            limitObserved: value.limitObserved,
+          };
         } else {
           if (typeof value !== "boolean") {
             throw new Error(
@@ -1542,7 +1705,9 @@ function readOAuthAuthModelValue(
   for (const [i, entry] of raw.entries()) {
     if (typeof entry !== "string" || !OAUTH_AUTH_MODEL_SET.has(entry)) {
       throw new Error(
-        `hostConfigV2: ${fieldName}[${i}] must be one of ${OAUTH_AUTH_MODELS.join(", ")}`
+        `hostConfigV2: ${fieldName}[${i}] must be one of ${OAUTH_AUTH_MODELS.join(
+          ", "
+        )}`
       );
     }
     // Reject rather than dedupe: a repeat makes the precedence list ambiguous,
@@ -1745,10 +1910,7 @@ function readOAuthScopeRequestValue(
     );
   }
   const mode = raw.mode;
-  if (
-    typeof mode !== "string" ||
-    !OAUTH_SCOPE_REQUEST_MODE_SET.has(mode)
-  ) {
+  if (typeof mode !== "string" || !OAUTH_SCOPE_REQUEST_MODE_SET.has(mode)) {
     throw new Error(
       `hostConfigV2: ${fieldName}.mode must be one of ${OAUTH_SCOPE_REQUEST_MODES.join(
         ", "
@@ -1790,7 +1952,11 @@ function readOAuthScopeRequestValue(
           `hostConfigV2: ${fieldName}.scopes is only valid when mode is "fixed"`
         );
       }
-      assertOnlyKnownKeys(raw, OAUTH_SCOPE_REQUEST_MODE_ONLY_KEY_SET, fieldName);
+      assertOnlyKnownKeys(
+        raw,
+        OAUTH_SCOPE_REQUEST_MODE_ONLY_KEY_SET,
+        fieldName
+      );
       return { mode: mode as "omit" | "challenge" | "all-supported" };
     }
     default: {
@@ -2187,7 +2353,9 @@ export function canonicalizeHostConfigV2(
   // normalizer.
   if (input.harness !== undefined && !isHarness(input.harness)) {
     throw new Error(
-      `hostConfigV2: harness must be one of ${HARNESS_IDS.map((h) => `"${h}"`).join(", ")} when set`
+      `hostConfigV2: harness must be one of ${HARNESS_IDS.map(
+        (h) => `"${h}"`
+      ).join(", ")} when set`
     );
   }
   const serverIds = sortUniqueServerIds(input.serverIds);

--- a/sdk/src/host-config/host-connection.ts
+++ b/sdk/src/host-config/host-connection.ts
@@ -1,4 +1,5 @@
 import { extractHostExecutionPolicy } from "./host-policy.js";
+import type { MrtrModes } from "./types.js";
 
 /**
  * The MCP connection facts a host advertises — what to send in the `initialize`
@@ -42,6 +43,10 @@ export interface HostConnectionProfile {
    * the profile → wire mapping in one place.
    */
   supportsMrtr?: false;
+  /** false means a caller abort does not cancel the in-flight tools/call. */
+  toolCallCancellation?: false;
+  /** Sparse per-mode MRTR behavior; omitted keys remain unknown. */
+  mrtrModes?: MrtrModes;
   /** undefined = spec default (filter app-only tools); false = host opts out. */
   respectToolVisibility: boolean | undefined;
 }
@@ -61,7 +66,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * (Not the public `Host.toJSON()` shape, which uses `mcp.protocolVersion` etc.)
  */
 export function hostConnectionProfile(
-  hostConfig: Record<string, unknown>,
+  hostConfig: Record<string, unknown>
 ): HostConnectionProfile {
   const mcpProfile = isRecord(hostConfig.mcpProfile)
     ? hostConfig.mcpProfile
@@ -79,10 +84,10 @@ export function hostConnectionProfile(
     : undefined;
 
   const supportedProtocolVersions = Array.isArray(
-    initialize?.supportedProtocolVersions,
+    initialize?.supportedProtocolVersions
   )
     ? (initialize.supportedProtocolVersions as unknown[]).filter(
-        (v): v is string => typeof v === "string",
+        (v): v is string => typeof v === "string"
       )
     : undefined;
 
@@ -106,6 +111,11 @@ export function hostConnectionProfile(
       : undefined;
   const supportsMrtr =
     mcpProfile?.mrtrSupport === "none" ? (false as const) : undefined;
+  const toolCallCancellation =
+    mcpProfile?.toolCallCancellation === false ? (false as const) : undefined;
+  const mrtrModes = isRecord(mcpProfile?.mrtrModes)
+    ? (mcpProfile.mrtrModes as MrtrModes)
+    : undefined;
 
   const clientCapabilities = isRecord(hostConfig.clientCapabilities)
     ? hostConfig.clientCapabilities
@@ -125,6 +135,8 @@ export function hostConnectionProfile(
       : {}),
     ...(firstPageOnly ? { firstPageOnly } : {}),
     ...(supportsMrtr === false ? { supportsMrtr: false } : {}),
+    ...(toolCallCancellation === false ? { toolCallCancellation: false } : {}),
+    ...(mrtrModes ? { mrtrModes } : {}),
     respectToolVisibility,
   };
 }

--- a/sdk/src/host-config/index.ts
+++ b/sdk/src/host-config/index.ts
@@ -52,6 +52,7 @@ export type {
   ToolParamHeaderMirroring,
   PaginationTraversalMode,
   MrtrSupport,
+  MrtrModes,
 } from "./public-types.js";
 
 // Tasks PRODUCT policy (`com.mcpjam/tasks`). Kept apart from the wire
@@ -67,8 +68,4 @@ export {
   taskModeForSurface,
   surfaceMayDeclareTasks,
 } from "./tasks-policy.js";
-export type {
-  TasksPolicy,
-  TaskMode,
-  TaskSurface,
-} from "./tasks-policy.js";
+export type { TasksPolicy, TaskMode, TaskSurface } from "./tasks-policy.js";

--- a/sdk/src/host-config/public-types.ts
+++ b/sdk/src/host-config/public-types.ts
@@ -32,6 +32,7 @@ import type {
   ToolParamHeaderMirroring,
   PaginationTraversalMode,
   MrtrSupport,
+  MrtrModes,
 } from "./types.js";
 
 export type {
@@ -49,6 +50,7 @@ export type {
   ToolParamHeaderMirroring,
   PaginationTraversalMode,
   MrtrSupport,
+  MrtrModes,
 };
 
 /**

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -791,14 +791,16 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         requireToolApproval: false,
       });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
-      // Real ChatGPT advertises an `experimental.openai/visibility` flag on top
-      // of the SDK-default MCP UI extension. Keep the default extension block
-      // (mime types) intact; only add the openai-specific experimental key.
+      // Verbatim from the 2026-08-04 ChatGPT host probe. Keep this separate
+      // from Apps-side ui/initialize capabilities below.
       base.clientCapabilities = {
-        ...base.clientCapabilities,
-        experimental: {
-          "openai/visibility": { enabled: true },
+        extensions: {
+          [MCP_UI_EXTENSION_ID]: {
+            mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE],
+          },
         },
+        elicitation: { form: {} },
+        roots: { listChanged: false },
       };
       // Override the preset advertise to match what real ChatGPT publishes in
       // ui/initialize. `sandbox` is intentionally omitted — host-config-v2's
@@ -823,7 +825,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         theme,
         displayMode: "inline",
         availableDisplayModes: ["inline", "fullscreen", "pip"],
-        containerDimensions: { height: 400, maxWidth: 768 },
+        containerDimensions: { height: 400, maxWidth: 528 },
         locale: "en-US",
         timeZone: "America/Los_Angeles",
         userAgent: "chatgpt",
@@ -834,17 +836,23 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         },
         safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
       };
-      // Host-level MCP profile: identify as openai-mcp during MCP
-      // initialize, and lock the iframe CSP down to the same connect/resource
-      // domain set real ChatGPT publishes. `mode: "declared"` keeps each
-      // resource's own CSP authoritative; `restrictTo` intersects on top so
-      // an MCP app can never reach a domain ChatGPT itself wouldn't allow.
+      // Host-level MCP profile captured from ChatGPT on 2026-08-05. Base MCP
+      // and MCP Apps are separate protocol layers: clientInfo below is what
+      // the server receives, while apps.uiInitialize.hostInfo is what a View
+      // receives. Sparse probe facts stay omitted when they were not tested.
       base.mcpProfile = {
         profileVersion: 1,
+        mcpProtocolVersion: "2025-11-25",
+        toolCallCancellation: false,
+        mrtrModes: {
+          requestState: true,
+          elicitation: false,
+        },
         initialize: {
+          supportedProtocolVersions: ["2025-11-25"],
           // Base MCP protocol: clientInfo sent to MCP servers during
           // `initialize`. Matches what real ChatGPT publishes.
-          clientInfo: { name: "openai-mcp", version: "1.0.0" },
+          clientInfo: { name: "cursor-vscode", version: "1.0.0" },
         },
         apps: {
           // MCP Apps extension: hostInfo sent to the View iframe in
@@ -861,7 +869,62 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
           // JSON editor surfaces the field on day one — without this,
           // the field would only appear after a manual edit and the
           // injected-globals chip would read "(from preset)".
-          compatRuntime: { openaiApps: true },
+          compatRuntime: {
+            openaiApps: true,
+            openaiAppsOverrides: {
+              callTool: true,
+              sendFollowUpMessage: true,
+              setWidgetState: true,
+              requestDisplayMode: "all",
+              notifyIntrinsicHeight: false,
+              openExternal: true,
+              setOpenInAppUrl: true,
+              requestModal: true,
+              uploadFile: true,
+              selectFiles: true,
+              getFileDownloadUrl: true,
+              requestCheckout: true,
+              requestClose: true,
+            },
+          },
+          mcpAppsOverrides: {
+            availableDisplayModes: ["inline", "fullscreen", "pip"],
+            hostContextChanged: true,
+            toolInfo: true,
+            openLinks: true,
+            serverTools: true,
+            serverResources: true,
+            logging: true,
+            updateModelContext: true,
+            message: true,
+            sandboxPermissions: true,
+            cspFrameDomains: true,
+            cspBaseUriDomains: true,
+            cspConnectDomains: {
+              fetch: false,
+              xhr: false,
+              websocket: true,
+            },
+            cspResourceDomains: {
+              script: false,
+              stylesheet: false,
+              image: false,
+              font: false,
+              media: false,
+            },
+            resourceCacheTtl: true,
+            containerSizing: {
+              defaultWidth: 670,
+              defaultHeight: 398,
+              width: "grows",
+              height: "grows",
+              testedUpToWidth: 10000,
+              testedUpToHeight: 10000,
+              limitObserved: false,
+            },
+            requestTeardown: false,
+            widgetDisplayModeRequests: "accept",
+          },
           sandbox: {
             csp: {
               // No host-side `restrictTo` — see the Claude template for

--- a/sdk/src/host-config/templates/seed-host-template.ts
+++ b/sdk/src/host-config/templates/seed-host-template.ts
@@ -791,16 +791,14 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         requireToolApproval: false,
       });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
-      // Verbatim from the 2026-08-04 ChatGPT host probe. Keep this separate
-      // from Apps-side ui/initialize capabilities below.
+      // ChatGPT advertises an `experimental.openai/visibility` flag on top
+      // of the SDK-default MCP UI extension. Keep the default extension block
+      // (mime types) intact; only add the OpenAI-specific experimental key.
       base.clientCapabilities = {
-        extensions: {
-          [MCP_UI_EXTENSION_ID]: {
-            mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE],
-          },
+        ...base.clientCapabilities,
+        experimental: {
+          "openai/visibility": { enabled: true },
         },
-        elicitation: { form: {} },
-        roots: { listChanged: false },
       };
       // Override the preset advertise to match what real ChatGPT publishes in
       // ui/initialize. `sandbox` is intentionally omitted — host-config-v2's
@@ -851,8 +849,8 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         initialize: {
           supportedProtocolVersions: ["2025-11-25"],
           // Base MCP protocol: clientInfo sent to MCP servers during
-          // `initialize`. Matches what real ChatGPT publishes.
-          clientInfo: { name: "cursor-vscode", version: "1.0.0" },
+          // `initialize`. Matches ChatGPT's established identity.
+          clientInfo: { name: "openai-mcp", version: "1.0.0" },
         },
         apps: {
           // MCP Apps extension: hostInfo sent to the View iframe in

--- a/sdk/src/host-config/types.ts
+++ b/sdk/src/host-config/types.ts
@@ -235,6 +235,14 @@ export const PAGINATION_TRAVERSAL_MODES = [
  */
 export type MrtrSupport = "full" | "none";
 
+/** Probe-observed MRTR behaviors. Omitted keys are untested, not false. */
+export type MrtrModes = {
+  requestState?: boolean;
+  roots?: boolean;
+  sampling?: boolean;
+  elicitation?: boolean;
+};
+
 /** The permitted {@link MrtrSupport} literals, for validation. */
 export const MRTR_SUPPORT_MODES = [
   "full",
@@ -251,6 +259,8 @@ export const MRTR_SUPPORT_MODES = [
 export const CONFORMANCE_PROFILE_KEYS = [
   "paginationTraversal",
   "mrtrSupport",
+  "toolCallCancellation",
+  "mrtrModes",
 ] as const;
 
 export type CspDomainSet = {
@@ -284,6 +294,12 @@ export type HostConfigMcpProfileV1 = {
   // Whether the client drives MRTR retry rounds at all. WHICH elicitation
   // modes it fulfills stays in `clientCapabilities.elicitation`.
   mrtrSupport?: MrtrSupport;
+  // Whether cancelling a normal, in-flight tools/call reaches the server.
+  // Omitted means untested; false is an observed lack of cancellation.
+  toolCallCancellation?: boolean;
+  // Per-mode results from the 2026-07-28 MRTR probe. Sparse by design:
+  // omitted modes remain unknown instead of being collapsed to false.
+  mrtrModes?: MrtrModes;
   initialize?: {
     // Order is semantic. The first entry is sent in
     // `initialize.params.protocolVersion`; all entries form the
@@ -389,6 +405,35 @@ export type McpAppsCapabilities = {
   sandboxPermissions?: boolean;
   cspFrameDomains?: boolean;
   cspBaseUriDomains?: boolean;
+  // Probe-observed enforcement of resource-declared connectDomains. Sparse:
+  // an omitted method was not tested.
+  cspConnectDomains?: {
+    fetch?: boolean;
+    xhr?: boolean;
+    websocket?: boolean;
+  };
+  // Probe-observed enforcement of resource-declared resourceDomains. Sparse:
+  // an omitted resource kind was not tested.
+  cspResourceDomains?: {
+    script?: boolean;
+    stylesheet?: boolean;
+    image?: boolean;
+    font?: boolean;
+    media?: boolean;
+  };
+  // Whether a resource fetched once was reused within the probe's 60s window.
+  resourceCacheTtl?: boolean;
+  // Dedicated container-size probe result. `limitObserved: false` means only
+  // that no limit was seen through the recorded testedUpTo* dimensions.
+  containerSizing?: {
+    defaultWidth: number;
+    defaultHeight: number;
+    width: "fixed" | "grows";
+    height: "fixed" | "grows";
+    testedUpToWidth?: number;
+    testedUpToHeight?: number;
+    limitObserved: boolean;
+  };
   resourcePrefersBorder?: boolean;
   downloadFile?: boolean;
   requestTeardown?: boolean;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -937,6 +937,7 @@ export type {
   ToolParamHeaderMirroring,
   PaginationTraversalMode,
   MrtrSupport,
+  MrtrModes,
 } from "./host-config/index.js";
 
 // MCPJam's Tasks **product policy** (`com.mcpjam/tasks`) — never a wire

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -138,10 +138,7 @@ import {
   updateTaskExt,
   withTasksExtensionDeclaration,
 } from "./tasks-ext.js";
-import {
-  resolveSkillsSupport,
-  type SkillsSupport,
-} from "./skills-dispatch.js";
+import { resolveSkillsSupport, type SkillsSupport } from "./skills-dispatch.js";
 import {
   getSkillExt,
   listSkillsExt,
@@ -170,10 +167,7 @@ import {
   convertMCPToolsToVercelTools,
   type ToolSchemaOverrides,
 } from "./tool-converters.js";
-import {
-  runToolTaskSeam,
-  type ToolTaskSeamOptions,
-} from "./tool-task-seam.js";
+import { runToolTaskSeam, type ToolTaskSeamOptions } from "./tool-task-seam.js";
 import { extensionTaskToObservation } from "./task-lifecycle-adapters.js";
 import { MCP_ERROR_CODES } from "./mcp-error-codes.js";
 import {
@@ -210,7 +204,6 @@ import {
   type MrtrInputCollector,
   type MrtrLegSender,
 } from "./mrtr-driver.js";
-
 
 /**
  * Manages multiple MCP server connections with support for tools, resources,
@@ -346,7 +339,8 @@ export class MCPClientManager {
    * it on the final complete result. Fail-open on an unknown dialect, matching
    * upstream's tool-output behavior (see `DialectAwareJsonSchemaValidator`).
    */
-  private readonly mrtrToolOutputValidator = new DialectAwareJsonSchemaValidator();
+  private readonly mrtrToolOutputValidator =
+    new DialectAwareJsonSchemaValidator();
 
   // Default options
   private readonly defaultClientName: string | undefined;
@@ -690,8 +684,8 @@ export class MCPClientManager {
         negotiation === undefined
           ? "legacy"
           : negotiation.mode === "auto"
-            ? "auto"
-            : "modern-pin";
+          ? "auto"
+          : "modern-pin";
 
       let negotiatedEra: "legacy" | "modern" | undefined;
       let negotiatedProtocolVersion: string | undefined;
@@ -915,8 +909,8 @@ export class MCPClientManager {
     const ids = Array.isArray(serverIds)
       ? serverIds
       : serverIds
-        ? [serverIds]
-        : this.listServers();
+      ? [serverIds]
+      : this.listServers();
 
     const perServerTools = await Promise.all(
       ids.map(async (id) => {
@@ -1036,7 +1030,22 @@ export class MCPClientManager {
     options?: ClientRequestOptions | ExecuteToolRequest,
     taskOptions?: TaskOptions
   ) {
-    const request = this.normalizeExecuteToolRequest(options, taskOptions);
+    let request = this.normalizeExecuteToolRequest(options, taskOptions);
+    if (
+      this.registeredServers.get(serverId)?.config.toolCallCancellation ===
+        false &&
+      request.request?.signal
+    ) {
+      const { signal: _ignoredSignal, ...requestWithoutSignal } =
+        request.request;
+      request = {
+        ...request,
+        request:
+          Object.keys(requestWithoutSignal).length > 0
+            ? requestWithoutSignal
+            : undefined,
+      };
+    }
 
     // Modern multi-round-trip: when a collector is registered and this is not a
     // task-augmented call, drive the manual `input_required` loop. A complete
@@ -1063,10 +1072,14 @@ export class MCPClientManager {
       await this.ensureConnected(serverId, signal);
       const client = this.getClientOrThrow(serverId);
       const mergedOptions = this.withProgressHandler(serverId, request.request);
-      const callParams = this.withTaskEligibilityDeclaration(serverId, request, {
-        name: toolName,
-        arguments: args,
-      });
+      const callParams = this.withTaskEligibilityDeclaration(
+        serverId,
+        request,
+        {
+          name: toolName,
+          arguments: args,
+        }
+      );
 
       if (request.task !== undefined) {
         this.assertLegacyTasksWire(serverId);
@@ -2390,7 +2403,7 @@ export class MCPClientManager {
         () => this.perRequestLogLevels.get(serverId),
         this.traceContextProvider
           ? () => this.traceContextProvider?.(serverId)
-          : undefined,
+          : undefined
       );
       client = managedClient;
 
@@ -2598,7 +2611,6 @@ export class MCPClientManager {
       config.requestInit
     );
     const preferSSE = config.preferSSE ?? url.pathname.endsWith("/sse");
-
 
     let streamableError: unknown;
 
@@ -3155,7 +3167,7 @@ export class MCPClientManager {
         this.elicitationManager.hasPendingForServer(
           serverId,
           this.elicitationTimeoutExtensionMs,
-          pendingSequenceAtStart,
+          pendingSequenceAtStart
         ),
     });
 
@@ -3347,15 +3359,22 @@ export class MCPClientManager {
     serverId: string
   ): () => readonly ElicitationMode[] {
     return () => {
+      if (
+        this.registeredServers.get(serverId)?.config.mrtrModes?.elicitation ===
+        false
+      ) {
+        return [];
+      }
       const declared = this.negotiatedElicitationCapability(
         this.liveClientStates.get(serverId)
       );
       // No declaration on record: mirror the inbound path, which allows form
       // (the legacy default) and rejects url absent an explicit declaration.
       if (declared === undefined) return ["form"];
-      const { supportsFormMode, supportsUrlMode } = getSupportedElicitationModes(
-        declared as Parameters<typeof getSupportedElicitationModes>[0]
-      );
+      const { supportsFormMode, supportsUrlMode } =
+        getSupportedElicitationModes(
+          declared as Parameters<typeof getSupportedElicitationModes>[0]
+        );
       const modes: ElicitationMode[] = [];
       if (supportsFormMode) modes.push("form");
       if (supportsUrlMode) modes.push("url");
@@ -3416,9 +3435,7 @@ export class MCPClientManager {
   ): typeof fetch {
     const httpLogger = this.resolveHttpLogger(config);
     return wrapFetchForTaskRouting(
-      httpLogger
-        ? wrapFetchForHttpLogging(serverId, httpLogger)
-        : undefined
+      httpLogger ? wrapFetchForHttpLogging(serverId, httpLogger) : undefined
     );
   }
 
@@ -3444,8 +3461,8 @@ export class MCPClientManager {
   ): value is ExecuteToolRequest {
     return Boolean(
       value &&
-      typeof value === "object" &&
-      ("request" in value || "retry" in value || "allowTaskResult" in value)
+        typeof value === "object" &&
+        ("request" in value || "retry" in value || "allowTaskResult" in value)
     );
   }
 
@@ -3579,8 +3596,7 @@ export class MCPClientManager {
       sender,
       collectInput: collect,
       validateContent: this.mrtrElicitationContentValidator,
-      supportedElicitationModes:
-        this.mrtrSupportedElicitationModes(serverId),
+      supportedElicitationModes: this.mrtrSupportedElicitationModes(serverId),
       validateResponse: (result) =>
         this.validateToolOutputSchema(serverId, callParams.name, result),
       requestOptions: baseOptions,
@@ -3596,11 +3612,14 @@ export class MCPClientManager {
     collect: MrtrInputCollector
   ): Promise<ReadResourceResult> {
     const sender: MrtrLegSender<ReadResourceResult> = (req) =>
-      this.runRetryableReadOperation(serverId, options, (client) =>
-        client.readResource(req.params as ReadResourceParams, {
-          ...this.withProgressHandler(serverId, options),
-          allowInputRequired: true,
-        }) as Promise<ReadResourceResult | InputRequiredResult>
+      this.runRetryableReadOperation(
+        serverId,
+        options,
+        (client) =>
+          client.readResource(req.params as ReadResourceParams, {
+            ...this.withProgressHandler(serverId, options),
+            allowInputRequired: true,
+          }) as Promise<ReadResourceResult | InputRequiredResult>
       );
 
     return runInputRequiredOperation<ReadResourceResult>({
@@ -3609,8 +3628,7 @@ export class MCPClientManager {
       sender,
       collectInput: collect,
       validateContent: this.mrtrElicitationContentValidator,
-      supportedElicitationModes:
-        this.mrtrSupportedElicitationModes(serverId),
+      supportedElicitationModes: this.mrtrSupportedElicitationModes(serverId),
       requestOptions: options,
       maxRounds: this.mrtrMaxRounds,
       signal: options?.signal,
@@ -3628,15 +3646,18 @@ export class MCPClientManager {
     // also exercises the modern per-request log-level `_meta` injection end to
     // end at the manager level.
     const sender: MrtrLegSender<GetPromptResult> = (req) =>
-      this.runRetryableReadOperation(serverId, options, (client) =>
-        client.requestWithSchema(
-          req as Request,
-          withInputRequired(defaultResultSchemaForMethod("prompts/get")),
-          {
-            ...this.withProgressHandler(serverId, options),
-            allowInputRequired: true,
-          }
-        ) as Promise<GetPromptResult | InputRequiredResult>
+      this.runRetryableReadOperation(
+        serverId,
+        options,
+        (client) =>
+          client.requestWithSchema(
+            req as Request,
+            withInputRequired(defaultResultSchemaForMethod("prompts/get")),
+            {
+              ...this.withProgressHandler(serverId, options),
+              allowInputRequired: true,
+            }
+          ) as Promise<GetPromptResult | InputRequiredResult>
       );
 
     return runInputRequiredOperation<GetPromptResult>({
@@ -3645,8 +3666,7 @@ export class MCPClientManager {
       sender,
       collectInput: collect,
       validateContent: this.mrtrElicitationContentValidator,
-      supportedElicitationModes:
-        this.mrtrSupportedElicitationModes(serverId),
+      supportedElicitationModes: this.mrtrSupportedElicitationModes(serverId),
       requestOptions: options,
       maxRounds: this.mrtrMaxRounds,
       signal: options?.signal,
@@ -3931,9 +3951,9 @@ export class MCPClientManager {
       await this.ensureConnected(serverId);
       const client = this.getClientOrThrow(serverId);
       const list = await client.listTools();
-      const tool = list.tools.find((candidate) => candidate.name === toolName) as
-        | { outputSchema?: unknown }
-        | undefined;
+      const tool = list.tools.find(
+        (candidate) => candidate.name === toolName
+      ) as { outputSchema?: unknown } | undefined;
       outputSchema = tool?.outputSchema;
     } catch {
       return;

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -25,6 +25,7 @@ import type { RefreshTokenOAuthProvider } from "./refresh-token-auth-provider.js
 import type { TraceContextProvider } from "./trace-context.js";
 import type { HttpExchangeLogger } from "./http-exchange-log.js";
 import type { ToolSet } from "ai";
+import type { MrtrModes } from "../host-config/types.js";
 
 // Re-export ElicitResult for convenience
 export type { ElicitResult };
@@ -322,6 +323,10 @@ export type BaseServerConfig = {
    * separate, already-modeled fact (`clientCapabilities.elicitation`).
    */
   supportsMrtr?: boolean;
+  /** Per-mode MRTR behavior observed for the emulated host. */
+  mrtrModes?: MrtrModes;
+  /** Whether aborting a normal tools/call reaches the MCP server. */
+  toolCallCancellation?: boolean;
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */
@@ -484,9 +489,7 @@ export interface BaseClientState {
  * Retained for compatibility with external type consumers.
  */
 export interface ManagedClientState extends BaseClientState {
-  promise?: Promise<
-    import("./managed-mcp-client.js").ManagedMcpClient
-  >;
+  promise?: Promise<import("./managed-mcp-client.js").ManagedMcpClient>;
 }
 
 /**
@@ -502,12 +505,8 @@ export interface RegisteredServerState {
  */
 export interface LiveClientState extends BaseClientState {
   stdioStderrCleanup?: () => void;
-  connectPromise?: Promise<
-    import("./managed-mcp-client.js").ManagedMcpClient
-  >;
-  retryPromise?: Promise<
-    import("./managed-mcp-client.js").ManagedMcpClient
-  >;
+  connectPromise?: Promise<import("./managed-mcp-client.js").ManagedMcpClient>;
+  retryPromise?: Promise<import("./managed-mcp-client.js").ManagedMcpClient>;
   initializedClientCapabilities?: ClientCapabilityOptions;
 }
 

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -86,10 +86,8 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "builtInToolIds": [],
     "chatUiOverride": undefined,
     "clientCapabilities": {
-      "experimental": {
-        "openai/visibility": {
-          "enabled": true,
-        },
+      "elicitation": {
+        "form": {},
       },
       "extensions": {
         "io.modelcontextprotocol/ui": {
@@ -97,6 +95,9 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "text/html;profile=mcp-app",
           ],
         },
+      },
+      "roots": {
+        "listChanged": false,
       },
     },
     "computer": undefined,
@@ -121,7 +122,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       ],
       "containerDimensions": {
         "height": 400,
-        "maxWidth": 768,
+        "maxWidth": 528,
       },
       "deviceCapabilities": {
         "hover": true,
@@ -145,6 +146,63 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       "apps": {
         "compatRuntime": {
           "openaiApps": true,
+          "openaiAppsOverrides": {
+            "callTool": true,
+            "getFileDownloadUrl": true,
+            "notifyIntrinsicHeight": false,
+            "openExternal": true,
+            "requestCheckout": true,
+            "requestClose": true,
+            "requestDisplayMode": "all",
+            "requestModal": true,
+            "selectFiles": true,
+            "sendFollowUpMessage": true,
+            "setOpenInAppUrl": true,
+            "setWidgetState": true,
+            "uploadFile": true,
+          },
+        },
+        "mcpAppsOverrides": {
+          "availableDisplayModes": [
+            "inline",
+            "fullscreen",
+            "pip",
+          ],
+          "containerSizing": {
+            "defaultHeight": 398,
+            "defaultWidth": 670,
+            "height": "grows",
+            "limitObserved": false,
+            "testedUpToHeight": 10000,
+            "testedUpToWidth": 10000,
+            "width": "grows",
+          },
+          "cspBaseUriDomains": true,
+          "cspConnectDomains": {
+            "fetch": false,
+            "websocket": true,
+            "xhr": false,
+          },
+          "cspFrameDomains": true,
+          "cspResourceDomains": {
+            "font": false,
+            "image": false,
+            "media": false,
+            "script": false,
+            "stylesheet": false,
+          },
+          "hostContextChanged": true,
+          "logging": true,
+          "message": true,
+          "openLinks": true,
+          "requestTeardown": false,
+          "resourceCacheTtl": true,
+          "sandboxPermissions": true,
+          "serverResources": true,
+          "serverTools": true,
+          "toolInfo": true,
+          "updateModelContext": true,
+          "widgetDisplayModeRequests": "accept",
         },
         "sandbox": {
           "csp": {
@@ -180,11 +238,20 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "initialize": {
         "clientInfo": {
-          "name": "openai-mcp",
+          "name": "cursor-vscode",
           "version": "1.0.0",
         },
+        "supportedProtocolVersions": [
+          "2025-11-25",
+        ],
+      },
+      "mcpProtocolVersion": "2025-11-25",
+      "mrtrModes": {
+        "elicitation": false,
+        "requestState": true,
       },
       "profileVersion": 1,
+      "toolCallCancellation": false,
     },
     "modelId": "openai/gpt-5-nano",
     "optionalServerIds": [],
@@ -200,10 +267,8 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "builtInToolIds": [],
     "chatUiOverride": undefined,
     "clientCapabilities": {
-      "experimental": {
-        "openai/visibility": {
-          "enabled": true,
-        },
+      "elicitation": {
+        "form": {},
       },
       "extensions": {
         "io.modelcontextprotocol/ui": {
@@ -211,6 +276,9 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "text/html;profile=mcp-app",
           ],
         },
+      },
+      "roots": {
+        "listChanged": false,
       },
     },
     "computer": undefined,
@@ -235,7 +303,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       ],
       "containerDimensions": {
         "height": 400,
-        "maxWidth": 768,
+        "maxWidth": 528,
       },
       "deviceCapabilities": {
         "hover": true,
@@ -259,6 +327,63 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       "apps": {
         "compatRuntime": {
           "openaiApps": true,
+          "openaiAppsOverrides": {
+            "callTool": true,
+            "getFileDownloadUrl": true,
+            "notifyIntrinsicHeight": false,
+            "openExternal": true,
+            "requestCheckout": true,
+            "requestClose": true,
+            "requestDisplayMode": "all",
+            "requestModal": true,
+            "selectFiles": true,
+            "sendFollowUpMessage": true,
+            "setOpenInAppUrl": true,
+            "setWidgetState": true,
+            "uploadFile": true,
+          },
+        },
+        "mcpAppsOverrides": {
+          "availableDisplayModes": [
+            "inline",
+            "fullscreen",
+            "pip",
+          ],
+          "containerSizing": {
+            "defaultHeight": 398,
+            "defaultWidth": 670,
+            "height": "grows",
+            "limitObserved": false,
+            "testedUpToHeight": 10000,
+            "testedUpToWidth": 10000,
+            "width": "grows",
+          },
+          "cspBaseUriDomains": true,
+          "cspConnectDomains": {
+            "fetch": false,
+            "websocket": true,
+            "xhr": false,
+          },
+          "cspFrameDomains": true,
+          "cspResourceDomains": {
+            "font": false,
+            "image": false,
+            "media": false,
+            "script": false,
+            "stylesheet": false,
+          },
+          "hostContextChanged": true,
+          "logging": true,
+          "message": true,
+          "openLinks": true,
+          "requestTeardown": false,
+          "resourceCacheTtl": true,
+          "sandboxPermissions": true,
+          "serverResources": true,
+          "serverTools": true,
+          "toolInfo": true,
+          "updateModelContext": true,
+          "widgetDisplayModeRequests": "accept",
         },
         "sandbox": {
           "csp": {
@@ -294,11 +419,20 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "initialize": {
         "clientInfo": {
-          "name": "openai-mcp",
+          "name": "cursor-vscode",
           "version": "1.0.0",
         },
+        "supportedProtocolVersions": [
+          "2025-11-25",
+        ],
+      },
+      "mcpProtocolVersion": "2025-11-25",
+      "mrtrModes": {
+        "elicitation": false,
+        "requestState": true,
       },
       "profileVersion": 1,
+      "toolCallCancellation": false,
     },
     "modelId": "openai/gpt-5-nano",
     "optionalServerIds": [],

--- a/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
+++ b/sdk/tests/__snapshots__/host-config-seed-host-template.test.ts.snap
@@ -86,8 +86,10 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "builtInToolIds": [],
     "chatUiOverride": undefined,
     "clientCapabilities": {
-      "elicitation": {
-        "form": {},
+      "experimental": {
+        "openai/visibility": {
+          "enabled": true,
+        },
       },
       "extensions": {
         "io.modelcontextprotocol/ui": {
@@ -95,9 +97,6 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "text/html;profile=mcp-app",
           ],
         },
-      },
-      "roots": {
-        "listChanged": false,
       },
     },
     "computer": undefined,
@@ -238,7 +237,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "initialize": {
         "clientInfo": {
-          "name": "cursor-vscode",
+          "name": "openai-mcp",
           "version": "1.0.0",
         },
         "supportedProtocolVersions": [
@@ -267,8 +266,10 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
     "builtInToolIds": [],
     "chatUiOverride": undefined,
     "clientCapabilities": {
-      "elicitation": {
-        "form": {},
+      "experimental": {
+        "openai/visibility": {
+          "enabled": true,
+        },
       },
       "extensions": {
         "io.modelcontextprotocol/ui": {
@@ -276,9 +277,6 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
             "text/html;profile=mcp-app",
           ],
         },
-      },
-      "roots": {
-        "listChanged": false,
       },
     },
     "computer": undefined,
@@ -419,7 +417,7 @@ exports[`seedHostTemplate > seed output matches the committed golden snapshot 1`
       },
       "initialize": {
         "clientInfo": {
-          "name": "cursor-vscode",
+          "name": "openai-mcp",
           "version": "1.0.0",
         },
         "supportedProtocolVersions": [

--- a/sdk/tests/host-compat-market-hosts.test.ts
+++ b/sdk/tests/host-compat-market-hosts.test.ts
@@ -60,8 +60,31 @@ describe("buildMarketHostProfiles", () => {
     expect(profileFor("chatgpt")?.capabilities).toMatchObject({
       serverResources: true,
       logging: true,
-      downloadFile: false,
+      requestTeardown: false,
+      cspConnectDomains: {
+        fetch: false,
+        xhr: false,
+        websocket: true,
+      },
+      cspResourceDomains: {
+        script: false,
+        stylesheet: false,
+        image: false,
+        font: false,
+        media: false,
+      },
+      resourceCacheTtl: true,
+      containerSizing: {
+        defaultWidth: 670,
+        defaultHeight: 398,
+        testedUpToWidth: 10000,
+        testedUpToHeight: 10000,
+        limitObserved: false,
+      },
     });
+    expect(profileFor("chatgpt")?.capabilities).not.toHaveProperty(
+      "toolCancelled"
+    );
   });
 
   it("carries each host's advertised protocol versions (or none)", () => {

--- a/sdk/tests/host-config-canonicalize.test.ts
+++ b/sdk/tests/host-config-canonicalize.test.ts
@@ -456,7 +456,9 @@ describe("canonicalizeHostConfigV2 — toolParamHeaderMirroring", () => {
   it("round-trips both literals", () => {
     for (const mode of ["mirror", "omit"] as const) {
       const c = canonicalizeHostConfigV2(
-        base({ mcpProfile: { profileVersion: 1, toolParamHeaderMirroring: mode } })
+        base({
+          mcpProfile: { profileVersion: 1, toolParamHeaderMirroring: mode },
+        })
       );
       expect(c.mcpProfile?.toolParamHeaderMirroring).toBe(mode);
     }
@@ -474,9 +476,17 @@ describe("canonicalizeHostConfigV2 — toolParamHeaderMirroring", () => {
 
   it("does not collide with an untouched profile's hash", async () => {
     expect(
-      await hash(base({ mcpProfile: { profileVersion: 1, toolParamHeaderMirroring: "omit" } }))
+      await hash(
+        base({
+          mcpProfile: { profileVersion: 1, toolParamHeaderMirroring: "omit" },
+        })
+      )
     ).not.toBe(
-      await hash(base({ mcpProfile: { profileVersion: 1, toolParamHeaderMirroring: "mirror" } }))
+      await hash(
+        base({
+          mcpProfile: { profileVersion: 1, toolParamHeaderMirroring: "mirror" },
+        })
+      )
     );
   });
 
@@ -486,8 +496,7 @@ describe("canonicalizeHostConfigV2 — toolParamHeaderMirroring", () => {
         base({
           mcpProfile: {
             profileVersion: 1,
-            toolParamHeaderMirroring:
-              "corrupt" as unknown as "mirror",
+            toolParamHeaderMirroring: "corrupt" as unknown as "mirror",
           },
         })
       )
@@ -564,6 +573,85 @@ describe("canonicalizeHostConfigV2 — client-conformance knobs", () => {
       "paginationTraversal",
       "toolParamHeaderMirroring",
     ]);
+  });
+});
+
+describe("canonicalizeHostConfigV2 — probe-observed host behaviors", () => {
+  it("round-trips sparse cancellation and MRTR mode results", () => {
+    const c = canonicalizeHostConfigV2(
+      base({
+        mcpProfile: {
+          profileVersion: 1,
+          toolCallCancellation: false,
+          mrtrModes: { elicitation: false, requestState: true },
+        },
+      })
+    );
+    expect(c.mcpProfile?.toolCallCancellation).toBe(false);
+    expect(c.mcpProfile?.mrtrModes).toEqual({
+      requestState: true,
+      elicitation: false,
+    });
+  });
+
+  it("validates and canonicalizes the detailed CSP/cache/container results", () => {
+    const c = canonicalizeHostConfigV2(
+      base({
+        mcpProfile: {
+          profileVersion: 1,
+          apps: {
+            mcpAppsOverrides: {
+              cspConnectDomains: {
+                websocket: true,
+                fetch: false,
+                xhr: false,
+              },
+              cspResourceDomains: {
+                media: false,
+                script: false,
+              },
+              resourceCacheTtl: true,
+              containerSizing: {
+                defaultWidth: 670,
+                defaultHeight: 398,
+                width: "grows",
+                height: "grows",
+                testedUpToWidth: 10000,
+                testedUpToHeight: 10000,
+                limitObserved: false,
+              },
+            },
+          },
+        },
+      })
+    );
+    expect(c.mcpProfile?.apps?.mcpAppsOverrides).toMatchObject({
+      cspConnectDomains: { fetch: false, xhr: false, websocket: true },
+      cspResourceDomains: { script: false, media: false },
+      resourceCacheTtl: true,
+      containerSizing: {
+        defaultWidth: 670,
+        defaultHeight: 398,
+        width: "grows",
+        height: "grows",
+        testedUpToWidth: 10000,
+        testedUpToHeight: 10000,
+        limitObserved: false,
+      },
+    });
+  });
+
+  it("rejects unknown probe subkeys", () => {
+    expect(() =>
+      canonicalizeHostConfigV2(
+        base({
+          mcpProfile: {
+            profileVersion: 1,
+            mrtrModes: { magic: true } as never,
+          },
+        })
+      )
+    ).toThrow(/mrtrModes has unknown key "magic"/);
   });
 });
 
@@ -789,7 +877,10 @@ describe("canonicalizeHostConfigV2 — skillSelection", () => {
   it("dedupes and sorts explicit skillIds deterministically (order-insensitive)", async () => {
     const c = canonicalizeHostConfigV2(
       base({
-        skillSelection: { mode: "explicit", skillIds: ["sk-b", "sk-a", "sk-b"] },
+        skillSelection: {
+          mode: "explicit",
+          skillIds: ["sk-b", "sk-a", "sk-b"],
+        },
       })
     );
     expect(c.skillSelection).toEqual({
@@ -798,7 +889,9 @@ describe("canonicalizeHostConfigV2 — skillSelection", () => {
     });
     expect(
       await hash(
-        base({ skillSelection: { mode: "explicit", skillIds: ["sk-a", "sk-b"] } })
+        base({
+          skillSelection: { mode: "explicit", skillIds: ["sk-a", "sk-b"] },
+        })
       )
     ).toBe(
       await hash(

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -156,8 +156,9 @@ describe("seedHostTemplate", () => {
           mimeTypes: ["text/html;profile=mcp-app"],
         },
       },
-      elicitation: { form: {} },
-      roots: { listChanged: false },
+      experimental: {
+        "openai/visibility": { enabled: true },
+      },
     });
     expect(profile).toMatchObject({
       mcpProtocolVersion: "2025-11-25",
@@ -165,7 +166,7 @@ describe("seedHostTemplate", () => {
       mrtrModes: { requestState: true, elicitation: false },
       initialize: {
         supportedProtocolVersions: ["2025-11-25"],
-        clientInfo: { name: "cursor-vscode", version: "1.0.0" },
+        clientInfo: { name: "openai-mcp", version: "1.0.0" },
       },
       apps: {
         compatRuntime: {

--- a/sdk/tests/host-config-seed-host-template.test.ts
+++ b/sdk/tests/host-config-seed-host-template.test.ts
@@ -143,12 +143,61 @@ describe("seedHostTemplate", () => {
 
   it("keeps ChatGPT raw host capabilities faithful to the probe", () => {
     const config = seedHostTemplate("chatgpt", { theme: "dark" });
+    const profile = config.mcpProfile;
 
     expect(config.hostCapabilitiesOverride).toMatchObject({
       serverResources: {},
       logging: {},
     });
     expect(config.hostCapabilitiesOverride).not.toHaveProperty("downloadFile");
+    expect(config.clientCapabilities).toEqual({
+      extensions: {
+        "io.modelcontextprotocol/ui": {
+          mimeTypes: ["text/html;profile=mcp-app"],
+        },
+      },
+      elicitation: { form: {} },
+      roots: { listChanged: false },
+    });
+    expect(profile).toMatchObject({
+      mcpProtocolVersion: "2025-11-25",
+      toolCallCancellation: false,
+      mrtrModes: { requestState: true, elicitation: false },
+      initialize: {
+        supportedProtocolVersions: ["2025-11-25"],
+        clientInfo: { name: "cursor-vscode", version: "1.0.0" },
+      },
+      apps: {
+        compatRuntime: {
+          openaiAppsOverrides: { notifyIntrinsicHeight: false },
+        },
+        mcpAppsOverrides: {
+          requestTeardown: false,
+          cspConnectDomains: {
+            fetch: false,
+            xhr: false,
+            websocket: true,
+          },
+          cspResourceDomains: {
+            script: false,
+            stylesheet: false,
+            image: false,
+            font: false,
+            media: false,
+          },
+          resourceCacheTtl: true,
+          containerSizing: {
+            defaultWidth: 670,
+            defaultHeight: 398,
+            width: "grows",
+            height: "grows",
+            testedUpToWidth: 10000,
+            testedUpToHeight: 10000,
+            limitObserved: false,
+          },
+        },
+      },
+    });
   });
 
   it("labels and persists the Copilot documented runtime surface", () => {

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -7,7 +7,7 @@ import {
 
 const profileFor = (id: HostTemplateId) =>
   hostConnectionProfile(
-    seedHostTemplate(id) as unknown as Record<string, unknown>,
+    seedHostTemplate(id) as unknown as Record<string, unknown>
   );
 
 const extensions = (caps: Record<string, unknown> | undefined) =>
@@ -17,14 +17,16 @@ describe("hostConnectionProfile", () => {
   it("derives Claude's identity + the MCP Apps UI capability", () => {
     const p = profileFor("claude");
     expect(p.clientInfo?.name).toBe("claude-ai");
-    expect(extensions(p.clientCapabilities)["io.modelcontextprotocol/ui"]).toBeDefined();
+    expect(
+      extensions(p.clientCapabilities)["io.modelcontextprotocol/ui"]
+    ).toBeDefined();
     // Claude's model filters app-only tools (default visibility policy).
     expect(p.respectToolVisibility).not.toBe(false);
   });
 
   it("pins Goose's advertised protocol version", () => {
     expect(profileFor("goose").supportedProtocolVersions).toContain(
-      "2025-03-26",
+      "2025-03-26"
     );
   });
 
@@ -32,10 +34,18 @@ describe("hostConnectionProfile", () => {
     expect(profileFor("cursor").respectToolVisibility).toBe(false);
   });
 
-  it("ChatGPT advertises its experimental openai/visibility capability", () => {
-    const experimental = (profileFor("chatgpt").clientCapabilities
-      ?.experimental ?? {}) as Record<string, { enabled?: boolean }>;
-    expect(experimental["openai/visibility"]?.enabled).toBe(true);
+  it("keeps ChatGPT's probed identity, protocol, and client behaviors", () => {
+    const p = profileFor("chatgpt");
+    expect(p.clientInfo).toEqual({ name: "cursor-vscode", version: "1.0.0" });
+    expect(p.supportedProtocolVersions).toEqual(["2025-11-25"]);
+    expect(p.mcpProtocolVersion).toBe("2025-11-25");
+    expect(p.toolCallCancellation).toBe(false);
+    expect(p.mrtrModes).toEqual({ requestState: true, elicitation: false });
+    expect(p.clientCapabilities).toMatchObject({
+      roots: { listChanged: false },
+      elicitation: { form: {} },
+    });
+    expect(p.clientCapabilities).not.toHaveProperty("experimental");
   });
 
   it("returns respectToolVisibility undefined for a config with no host fields", () => {
@@ -54,7 +64,7 @@ describe("hostConnectionProfile", () => {
     expect(
       hostConnectionProfile({
         mcpProfile: { initialize: { mcpProtocolVersion: "2026-07-28" } },
-      }).mcpProtocolVersion,
+      }).mcpProtocolVersion
     ).toBeUndefined();
   });
 

--- a/sdk/tests/host-connection.test.ts
+++ b/sdk/tests/host-connection.test.ts
@@ -34,18 +34,16 @@ describe("hostConnectionProfile", () => {
     expect(profileFor("cursor").respectToolVisibility).toBe(false);
   });
 
-  it("keeps ChatGPT's probed identity, protocol, and client behaviors", () => {
+  it("keeps ChatGPT's identity and verified protocol behaviors", () => {
     const p = profileFor("chatgpt");
-    expect(p.clientInfo).toEqual({ name: "cursor-vscode", version: "1.0.0" });
+    expect(p.clientInfo).toEqual({ name: "openai-mcp", version: "1.0.0" });
     expect(p.supportedProtocolVersions).toEqual(["2025-11-25"]);
     expect(p.mcpProtocolVersion).toBe("2025-11-25");
     expect(p.toolCallCancellation).toBe(false);
     expect(p.mrtrModes).toEqual({ requestState: true, elicitation: false });
     expect(p.clientCapabilities).toMatchObject({
-      roots: { listChanged: false },
-      elicitation: { form: {} },
+      experimental: { "openai/visibility": { enabled: true } },
     });
-    expect(p.clientCapabilities).not.toHaveProperty("experimental");
   });
 
   it("returns respectToolVisibility undefined for a config with no host fields", () => {

--- a/sdk/tests/modern-evidence.integration.test.ts
+++ b/sdk/tests/modern-evidence.integration.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { MCPClientManager } from "../src/mcp-client-manager/index.js";
 import { withEphemeralClient } from "../src/operations.js";
-import { serveMultiPageFixtureOnPort, type ServedMultiPageFixture } from "./support/multi-page-fixture.js";
+import {
+  serveMultiPageFixtureOnPort,
+  type ServedMultiPageFixture,
+} from "./support/multi-page-fixture.js";
 import { getWireField } from "./support/raw-capture.js";
 
 /**
@@ -26,13 +29,16 @@ describe("modern-era (2026-07-28) wire evidence", () => {
     manager = undefined;
   });
 
-  async function connectModern() {
+  async function connectModern(
+    overrides: { toolCallCancellation?: false } = {}
+  ) {
     served = await serveMultiPageFixtureOnPort();
     manager = new MCPClientManager();
     await manager.connectToServer("fixture", {
       url: served.url,
       mcpProtocolVersion: "2026-07-28",
       timeout: 10_000,
+      ...overrides,
     });
     return { served, manager };
   }
@@ -155,15 +161,15 @@ describe("modern-era (2026-07-28) wire evidence", () => {
     expect(
       await manager.mrtrToolParamHeaders("fixture", "tool-0", {
         message: "hi",
-      }),
+      })
     ).toEqual({ "Mcp-Param-Message": "hi" });
   });
 
   it("mrtrToolParamHeaders returns {} for a tool that declares nothing", async () => {
     const { manager } = await connectModern();
-    expect(
-      await manager.mrtrToolParamHeaders("fixture", "tool-1", {}),
-    ).toEqual({});
+    expect(await manager.mrtrToolParamHeaders("fixture", "tool-1", {})).toEqual(
+      {}
+    );
   });
 
   it("a caller Mcp-Param-* is OVERWRITTEN while mirroring is on", async () => {
@@ -177,7 +183,7 @@ describe("modern-era (2026-07-28) wire evidence", () => {
       "fixture",
       "tool-0",
       { message: "hi" },
-      { headers: { "Mcp-Param-Message": "deliberately-wrong" } },
+      { headers: { "Mcp-Param-Message": "deliberately-wrong" } }
     );
 
     const headers = byMethod("tools/call")[0]!.request.headers;
@@ -227,6 +233,25 @@ describe("modern-era (2026-07-28) wire evidence", () => {
     // stream itself — there must be no explicit notifications/cancelled
     // POST alongside it.
     expect(byMethod("notifications/cancelled")).toHaveLength(0);
+  });
+
+  it("ignores caller cancellation when the host profile records no regular tool-call cancellation", async () => {
+    const { manager } = await connectModern({ toolCallCancellation: false });
+    const controller = new AbortController();
+    const callPromise = manager.executeTool(
+      "fixture",
+      "slow-tool",
+      { delayMs: 100 },
+      { signal: controller.signal }
+    );
+
+    await served!.waitForToolCall("slow-tool");
+    controller.abort();
+
+    const result = (await callPromise) as {
+      content: Array<{ text?: string }>;
+    };
+    expect(result.content[0]?.text).toBe("slow-tool finished");
   });
 });
 
@@ -426,7 +451,7 @@ describe("SEP-2243 mirroring disabled (mirrorToolParamHeaders: false)", () => {
     expect(
       await manager.mrtrToolParamHeaders("fixture", "tool-0", {
         message: "hi",
-      }),
+      })
     ).toEqual({});
   });
 
@@ -448,7 +473,7 @@ describe("SEP-2243 mirroring disabled (mirrorToolParamHeaders: false)", () => {
     expect(listed.tools.map((t) => t.name)).not.toContain("tool-0");
 
     await expect(
-      manager.executeTool("fixture", "tool-0", { message: "hi" }),
+      manager.executeTool("fixture", "tool-0", { message: "hi" })
     ).rejects.toThrow(/Mcp-Param-Message header is absent/);
 
     // Exactly one attempt, with no mirrored header: suppression held and the
@@ -476,7 +501,7 @@ describe("SEP-2243 mirroring disabled (mirrorToolParamHeaders: false)", () => {
       timeout: 10_000,
     });
     await expect(
-      manager.executeTool("fixture", "tool-0", { message: "hi" }),
+      manager.executeTool("fixture", "tool-0", { message: "hi" })
     ).rejects.toThrow();
     expect(toolCalls().length).toBeGreaterThan(1);
   });
@@ -491,7 +516,7 @@ describe("SEP-2243 mirroring disabled (mirrorToolParamHeaders: false)", () => {
       "fixture",
       "tool-0",
       { message: "hi" },
-      { headers: { "Mcp-Param-Message": "deliberately-wrong" } },
+      { headers: { "Mcp-Param-Message": "deliberately-wrong" } }
     );
 
     const headers = toolCalls()[0]!.request.headers;

--- a/sdk/tests/mrtr-manager.integration.test.ts
+++ b/sdk/tests/mrtr-manager.integration.test.ts
@@ -30,11 +30,14 @@ interface ServedFixture {
 async function serveFixture(): Promise<ServedFixture> {
   const handler = createMrtrFixtureHandler();
   const httpServer = http.createServer(toNodeHandler(handler));
-  await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+  await new Promise<void>((resolve) =>
+    httpServer.listen(0, "127.0.0.1", resolve)
+  );
   const address = httpServer.address() as AddressInfo;
   return {
     url: `http://127.0.0.1:${address.port}/mcp`,
-    close: () => new Promise<void>((resolve) => httpServer.close(() => resolve())),
+    close: () =>
+      new Promise<void>((resolve) => httpServer.close(() => resolve())),
   };
 }
 
@@ -95,6 +98,19 @@ describe("MCPClientManager × modern MRTR fixture over HTTP", () => {
     expect(collect).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects embedded elicitation when the host profile records no MRTR elicitation", async () => {
+    await manager.connectToServer("fixture", {
+      url: served.url,
+      mcpProtocolVersion: "2026-07-28",
+      timeout: 10_000,
+      mrtrModes: { elicitation: false },
+    });
+
+    await expect(
+      manager.executeTool("fixture", "confirm", { topic: "fruit" })
+    ).rejects.toMatchObject({ name: "MrtrUnsupportedElicitationModeError" });
+  });
+
   it("reconstructs tool output-schema validation on the final result", async () => {
     manager.setMrtrInputCollector("fixture", acceptAllCollector("typed-ok"));
     await connect();
@@ -135,10 +151,13 @@ describe("MCPClientManager × modern MRTR fixture over HTTP", () => {
     await connect();
     const error = await manager
       .executeTool("fixture", "confirm", { topic: "x" })
-      .then(() => undefined, (e: unknown) => e);
+      .then(
+        () => undefined,
+        (e: unknown) => e
+      );
     expect((error as { code?: number })?.code).toBe(-32021);
     expect((error as { message?: string })?.message).toMatch(
-      /client capabilities do not declare/i,
+      /client capabilities do not declare/i
     );
   });
 });
@@ -195,7 +214,10 @@ describe("post-negotiation capability re-resolution (eraCapabilities.modern)", (
     });
     const error = await manager
       .executeTool("fixture", "confirm-url", { topic: "x" })
-      .then(() => undefined, (e: unknown) => e);
+      .then(
+        () => undefined,
+        (e: unknown) => e
+      );
     expect((error as { code?: number })?.code).toBe(-32021);
   });
 
@@ -216,7 +238,10 @@ describe("post-negotiation capability re-resolution (eraCapabilities.modern)", (
 
     const error = await manager
       .executeTool("fixture", "confirm-url", { topic: "x" })
-      .then(() => undefined, (e: unknown) => e);
+      .then(
+        () => undefined,
+        (e: unknown) => e
+      );
     expect((error as { code?: number })?.code).toBe(-32021);
   });
 
@@ -340,7 +365,10 @@ describe("supportsMrtr: false — a client that never implemented MRTR", () => {
 
     const error = await manager
       .executeTool("fixture", "confirm", { topic: "x" })
-      .then(() => undefined, (e: unknown) => e);
+      .then(
+        () => undefined,
+        (e: unknown) => e
+      );
 
     // The server refuses to embed the elicitation because the client never
     // declared the capability — same failure a genuinely non-MRTR client


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Models verified ChatGPT MCP and MCP Apps behavior and applies it to the built-in ChatGPT host profile. Adds runtime support for tool-call cancellation, MRTR modes, and detailed Apps CSP/container evidence across `@mcpjam/sdk` and `@mcpjam/inspector`. Also fixes preserving ChatGPT’s client identity in the seed/template.

- **New Features**
  - Catalog and templates: ChatGPT profile switched to probe provenance with supported protocol `2025-11-25`; `MCP_APPS_CHATGPT` now includes observed CSP connect/resource behavior, resource cache TTL, container sizing, and `requestTeardown: false`; unknowns remain omitted.
  - Host profile fields: added `toolCallCancellation?: false` and `mrtrModes?: { requestState?: boolean; roots?: boolean; sampling?: boolean; elicitation?: boolean }` to profile/connection defaults; included in canonicalization and exports.
  - Client manager: enforces `toolCallCancellation: false` for normal tools/call and gates MRTR by `mrtrModes` (e.g., rejects embedded elicitation when not supported).
  - Inspector: Protocol tab and API context can pin `toolCallCancellation` and `mrtrModes`; Apps capability matrix adds CSP connect/resource toggles, resource cache TTL, and container growth; ChatGPT host style now advertises `serverResources` and `logging`.
  - Server (inspector): validation schema, effective-auth, and local resolver parse and forward new conformance knobs.
  - Seed/template: ChatGPT client capabilities now include MCP UI extension, `experimental openai/visibility`, `elicitation.form`, and `roots.listChanged`; container width updated (max 528px).
  - Tests: updated snapshots and assertions for new ChatGPT profile, MRTR gating, wire evidence, and CSP/container fields.

- **Bug Fixes**
  - Seed/template: keep ChatGPT client identity in `initialize.clientInfo` to avoid regressions when generating connection profiles.

<sup>Written for commit c5f73b6311cd6bbf97e55760025060c0d70a2c7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

