### PR TITLE
feat(analytics): enable Web Analytics pageviews on caniuse.dev / score.mcpjam.com

### DIFF
--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -75,12 +75,40 @@ function sanitizeAnalyticsProperties(
   return properties;
 }
 
+// Public vanity landings (caniuse.dev host-compare, score.mcpjam.com score
+// runner) get real Web Analytics: $pageview on SPA route changes plus
+// $pageleave, which is what makes bounce rate and session duration exist in
+// PostHog's Web Analytics tab. The app proper keeps pageviews OFF — track()
+// events already cover it, and in-app route churn would be noise and event
+// cost. Mirrors the server-side landing-host defaults (CANIUSE_LANDING_HOSTS /
+// SCORE_LANDING_HOSTS in server/config.ts) — keep in sync when a vanity
+// domain is added.
+export const LANDING_ANALYTICS_HOSTS = new Set([
+  "caniuse.dev",
+  "www.caniuse.dev",
+  "score.mcpjam.com",
+  "www.score.mcpjam.com",
+]);
+
+export function getPageviewCaptureOptions(
+  hostname: string | undefined = typeof window === "undefined"
+    ? undefined
+    : window.location?.hostname
+) {
+  const isLandingHost =
+    !!hostname && LANDING_ANALYTICS_HOSTS.has(hostname.toLowerCase());
+  return {
+    capture_pageview: isLandingHost ? ("history_change" as const) : false,
+    capture_pageleave: isLandingHost,
+  };
+}
+
 export const options = {
   api_host: getPostHogApiHost(),
   // Toolbar/app links must point at PostHog itself once api_host is proxied.
   ui_host: "https://us.posthog.com",
   ...getPostHogBootstrap(),
-  capture_pageview: false,
+  ...getPageviewCaptureOptions(),
   person_profiles: "always" as const,
   sanitize_properties: sanitizeAnalyticsProperties,
 
@@ -120,7 +148,7 @@ export const getPostHogOptions = () =>
         api_host: getPostHogApiHost(),
         ui_host: "https://us.posthog.com",
         ...getPostHogBootstrap(),
-        capture_pageview: false,
+        ...getPageviewCaptureOptions(),
         person_profiles: "always" as const,
         // Disable event capture but keep /decide enabled for feature flag evaluation.
         // Must be `opt_out_capturing_by_default` — `opt_out_capturing` is a method,

--- a/mcpjam-inspector/client/src/lib/__tests__/posthog-utils.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/posthog-utils.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { isPostHogBooleanFlagOn, options } from "../PosthogUtils";
+import {
+  getPageviewCaptureOptions,
+  isPostHogBooleanFlagOn,
+  options,
+} from "../PosthogUtils";
 
 describe("PosthogUtils", () => {
   beforeEach(() => {
@@ -18,6 +22,7 @@ describe("PosthogUtils", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
     vi.resetModules();
   });
 
@@ -56,5 +61,66 @@ describe("PosthogUtils", () => {
     const opts = getPostHogOptions() as Record<string, unknown>;
 
     expect(opts.opt_out_capturing_by_default).toBeUndefined();
+  });
+
+  describe("landing-host pageview capture", () => {
+    it("enables SPA pageviews + pageleave on vanity landing hosts", () => {
+      for (const hostname of [
+        "caniuse.dev",
+        "www.caniuse.dev",
+        "score.mcpjam.com",
+        "www.score.mcpjam.com",
+        "CANIUSE.DEV",
+      ]) {
+        expect(getPageviewCaptureOptions(hostname)).toEqual({
+          capture_pageview: "history_change",
+          capture_pageleave: true,
+        });
+      }
+    });
+
+    it("keeps pageviews off everywhere else", () => {
+      for (const hostname of [
+        "app.mcpjam.com",
+        "localhost",
+        // Suffix look-alikes must not match.
+        "evil-caniuse.dev",
+        "caniuse.dev.example.com",
+        undefined,
+      ]) {
+        expect(getPageviewCaptureOptions(hostname)).toEqual({
+          capture_pageview: false,
+          capture_pageleave: false,
+        });
+      }
+    });
+
+    it("wires pageview capture off in the app default options", () => {
+      // jsdom test host is localhost — not a landing host.
+      expect(options.capture_pageview).toBe(false);
+      expect(options.capture_pageleave).toBe(false);
+    });
+
+    it("wires landing-host capture into both option branches", async () => {
+      vi.stubGlobal("location", {
+        hostname: "caniuse.dev",
+        origin: "https://caniuse.dev",
+      });
+
+      vi.resetModules();
+      const enabled = await import("../PosthogUtils");
+      expect(enabled.options.capture_pageview).toBe("history_change");
+      expect(enabled.options.capture_pageleave).toBe(true);
+
+      // The VITE_DISABLE_POSTHOG_LOCAL branch is an independent options
+      // literal — it must carry the same pageview fields or dev/opt-out
+      // builds silently diverge.
+      vi.stubEnv("VITE_DISABLE_POSTHOG_LOCAL", "true");
+      vi.resetModules();
+      const disabled = await import("../PosthogUtils");
+      const opts = disabled.getPostHogOptions() as Record<string, unknown>;
+      expect(opts.capture_pageview).toBe("history_change");
+      expect(opts.capture_pageleave).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Why

caniuse.dev has real traffic (~1,000 sessions since late June) but PostHog's Web Analytics tab shows nothing for it: `capture_pageview: false` is global, so the domain has zero `$pageview` events. That setting is right for the app itself — `track()` events cover it and in-app route churn would be noise/cost — but wrong for public landing pages, where it costs us the standard visitors/referrers/bounce-rate/duration dashboard.

## What

- `$pageview` capture in `history_change` mode (SPA-aware) and `$pageleave` (required for bounce rate + session duration), scoped to the vanity landing hostnames: `caniuse.dev`, `www.caniuse.dev`, `score.mcpjam.com`, `www.score.mcpjam.com`.
- Applied to **both** option literals in `PosthogUtils.ts` — the enabled branch and the `VITE_DISABLE_POSTHOG_LOCAL` opt-out branch are independent objects, so both get the same fields via a shared `getPageviewCaptureOptions()`.
- Host list is a client constant mirroring the `CANIUSE_LANDING_HOSTS` / `SCORE_LANDING_HOSTS` defaults in `server/config.ts` (the server sets live behind env vars the client can't read; the hostnames are stable).
- Every other host keeps pageviews off — no behavior change for app.mcpjam.com, local, or Electron.

Existing `sanitize_properties` already scrubs `/results/<token>` from `$current_url`/`$referrer`/`$pathname`, so score-result pageviews don't leak the bearer token.

## Tests

- Pure-function coverage of the host gate (incl. case-insensitivity and suffix look-alikes like `evil-caniuse.dev`).
- Module-level wiring tests: landing host → `history_change`/`true` in **both** branches; default test host → `false`/`false`.
- `npx vitest run client/src/lib/__tests__/posthog-utils.test.ts client/src/lib/__tests__/analytics.test.ts`: 10 passed.
- `npm run typecheck:client`: clean.

## Verification after deploy

Query PostHog for `$pageview` with `properties.$host = 'caniuse.dev'` — Web Analytics starts populating from deploy (no backfill possible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only, hostname-scoped PostHog init with tests for false-positive host matches; no auth, API, or data-path changes.
> 
> **Overview**
> Turns on PostHog **Web Analytics** (`$pageview` on SPA `history_change` and `$pageleave`) only for vanity landing hostnames (`caniuse.dev`, `score.mcpjam.com`, and their `www` variants). The main app and other hosts still use **`capture_pageview: false`** so in-app route churn stays off the bill.
> 
> Adds **`getPageviewCaptureOptions()`** and a **`LANDING_ANALYTICS_HOSTS`** allowlist (documented to mirror server landing-host defaults). Both PostHog init paths—the default **`options`** object and the **`VITE_DISABLE_POSTHOG_LOCAL`** branch—now spread that helper instead of hardcoding pageviews off.
> 
> Tests cover host matching (case-insensitive, no suffix look-alikes), default localhost wiring, and that both option branches get the same landing-host behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 688b9f1d0c2a1f1a9649b5507f898c128ab11ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable SPA-aware pageview and pageleave capture on `caniuse.dev` and `score.mcpjam.com` so PostHog Web Analytics shows visitors, referrers, bounce rate, and session duration. Pageviews stay off for the app and all other hosts.

- **New Features**
  - Added `LANDING_ANALYTICS_HOSTS` and `getPageviewCaptureOptions()` to gate `$pageview: "history_change"` and `$pageleave` to landing domains.
  - Applied to both PostHog options paths (default and `VITE_DISABLE_POSTHOG_LOCAL`) to keep behavior consistent.
  - Existing sanitization keeps score-result tokens out of `$current_url`, `$referrer`, and `$pathname`.

<sup>Written for commit 688b9f1d0c2a1f1a9649b5507f898c128ab11ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

