### PR TITLE
feat(user-testing): create a scenario from a route, and give Swarms the same

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1301,7 +1301,12 @@ export function ChatboxesRoute() {
   // router invariant on the no-router path.
   const rawScenarioId =
     params.scenarioId ?? scenarioIdFromPathname(getRouteFallbackPathname());
-  const scenarioHostId = rawScenarioId ? decodeParam(rawScenarioId) : null;
+  // `new` is the create route, never a scenario id. The dedicated
+  // `user-testing/new` route already keeps it out of `params.scenarioId`, but
+  // reserving the word here means route-ordering can't quietly turn the create
+  // page into a "Scenario not found".
+  const scenarioHostId =
+    rawScenarioId && rawScenarioId !== "new" ? decodeParam(rawScenarioId) : null;
 
   return (
     <UserTestingTab

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1309,8 +1309,13 @@ export function ChatboxesRoute() {
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
       scenarioHostId={scenarioHostId}
+      createOpen={isUserTestingCreatePath(getRouteFallbackPathname())}
     />
   );
+}
+
+function isUserTestingCreatePath(pathname: string): boolean {
+  return pathname.replace(/\/+$/, "") === "/user-testing/new";
 }
 
 function getRouteFallbackPathname(): string {
@@ -1430,7 +1435,7 @@ export function SwarmsRoute() {
     }
   }
 
-  const routeSwarmId =
+  const rawRouteSwarmId =
     params.swarmId ??
     (typeof window !== "undefined" &&
     window.location.pathname.startsWith(`${routePaths.swarms}/`)
@@ -1438,6 +1443,11 @@ export function SwarmsRoute() {
           .slice(`${routePaths.swarms}/`.length)
           .split("/")[0]
       : null);
+  // `/swarms/new` is the create route, not a run. The pathname fallback above
+  // can't tell them apart on its own, and treating "new" as a swarmId would
+  // render a not-found run detail instead of the create flow.
+  const createFlow = rawRouteSwarmId === "new";
+  const routeSwarmId = createFlow ? null : rawRouteSwarmId;
   let swarmId: string | null = null;
   if (routeSwarmId) {
     try {
@@ -1453,6 +1463,7 @@ export function SwarmsRoute() {
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
       swarmId={swarmId}
+      createFlow={createFlow}
     />
   );
 }

--- a/mcpjam-inspector/client/src/__tests__/SwarmsRoute.guest-gate.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/SwarmsRoute.guest-gate.test.tsx
@@ -199,6 +199,7 @@ describe("SwarmsRoute member-only gate", () => {
       projectId: "project-1",
       isAuthenticated: true,
       swarmId: null,
+      createFlow: false,
     });
   });
 
@@ -215,6 +216,7 @@ describe("SwarmsRoute member-only gate", () => {
       projectId: "project-1",
       isAuthenticated: true,
       swarmId: null,
+      createFlow: false,
     });
   });
 
@@ -252,6 +254,7 @@ describe("SwarmsRoute member-only gate", () => {
       projectId: null,
       isAuthenticated: false,
       swarmId: null,
+      createFlow: false,
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/UserTestingTab.tsx
+++ b/mcpjam-inspector/client/src/components/UserTestingTab.tsx
@@ -12,7 +12,12 @@ import {
   useChatboxList,
   useChatboxMutations,
 } from "@/hooks/useChatboxes";
-import { useHostList, useHostMutations, type HostListItem } from "@/hooks/useClients";
+import {
+  useHostList,
+  useHostMutations,
+  type HostListItem,
+} from "@/hooks/useClients";
+import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { useUsageInsights } from "@/hooks/useUsageInsights";
 import { EMPTY_USAGE_FILTER } from "@/hooks/chatbox-usage-filters";
 import {
@@ -76,10 +81,15 @@ export function UserTestingTab({
   // validates `:scenarioId`. Validation is not optional — `getChatboxByHostId`
   // declares `v.id('hosts')`, so a hand-typed or stale id doesn't come back
   // null, it throws out of `useQuery` and takes the screen with it.
-  const { hosts, isLoading: hostsLoading } = useHostList({
+  // `useHostList`/`useChatboxList` report `isLoading` as "no data yet", which
+  // is also true for a SKIPPED query (signed out, or no project). Distinguish
+  // them here or a deep-linked scenario spins forever instead of saying why.
+  const queryable = effectiveAuth && shouldQueryProjectId(projectId);
+  const { hosts, isLoading: hostsQueryLoading } = useHostList({
     isAuthenticated: effectiveAuth,
     projectId,
   });
+  const hostsLoading = queryable && hostsQueryLoading;
   const { chatboxes, isLoading: listLoading } = useChatboxList({
     isAuthenticated: effectiveAuth,
     projectId,
@@ -196,13 +206,16 @@ export function UserTestingTab({
   useEffect(() => {
     if (scenarioHostId) return;
     if (!legacyHostParam) return;
-    const session = searchParams.get("session");
-    navigate(
-      buildUserTestingScenarioPath(legacyHostParam, {
-        ...(session ? { session } : {}),
-      }),
-      { replace: true },
-    );
+    // Carry the WHOLE URL across, minus the `host` that became the path
+    // segment. An old link may hold more than `session`, and the hash is how
+    // the hosted chat surface addresses a thread — dropping either turns a
+    // working bookmark into a landing page.
+    const rest = new URLSearchParams(searchParams);
+    rest.delete("host");
+    const query = rest.toString();
+    const hash = typeof window === "undefined" ? "" : window.location.hash;
+    const base = buildUserTestingScenarioPath(legacyHostParam);
+    navigate(`${base}${query ? `?${query}` : ""}${hash}`, { replace: true });
   }, [legacyHostParam, navigate, scenarioHostId, searchParams]);
 
   // --- Agent tool group (surface "chatboxes") ---------------------------
@@ -211,7 +224,10 @@ export function UserTestingTab({
   // scenario. Publish/delete resolve a host by name or id against the live
   // list and honor the Swarms-owned dead-end. The snapshot is REDACTED state
   // only — never transcript text, the share token, or visitor PII.
-  const agentOperable = effectiveAuth && Boolean(projectId);
+  // A truthy-but-not-yet-queryable project id (a local placeholder during
+  // hydration) would advertise the tools before any query can run, so the
+  // agent would get an empty snapshot and failing commands.
+  const agentOperable = effectiveAuth && shouldQueryProjectId(projectId);
   const { deleteChatbox } = useChatboxMutations();
   const { createHost } = useHostMutations();
   // Session rows for the snapshot only — the same list query the Sessions view
@@ -437,6 +453,19 @@ export function UserTestingTab({
 
   // --- Scenario detail --------------------------------------------------
   if (scenarioHostId) {
+    // Nothing was ever queried — signed out, or no project selected yet.
+    // "Not found" would be a lie: we never looked.
+    if (!queryable) {
+      return (
+        <ScenarioNotice
+          icon={<Inbox className="size-8 text-muted-foreground/70" />}
+          title="Sign in to open this scenario"
+          body="Scenarios live in a project. Sign in and select the project this link belongs to."
+          onBack={goOverview}
+        />
+      );
+    }
+
     if (hostsLoading) return <ScenarioSpinner label="Loading scenario…" />;
 
     if (!scenarioHost) {

--- a/mcpjam-inspector/client/src/components/UserTestingTab.tsx
+++ b/mcpjam-inspector/client/src/components/UserTestingTab.tsx
@@ -6,19 +6,20 @@ import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { UserTestingOverviewPanel } from "@/components/chatboxes/UserTestingOverviewPanel";
 import { UserTestingScenarioDetail } from "@/components/chatboxes/UserTestingScenarioDetail";
+import { UserTestingCreateFlow } from "@/components/chatboxes/UserTestingCreateFlow";
 import {
   useChatboxByHostId,
   useChatboxList,
   useChatboxMutations,
 } from "@/hooks/useChatboxes";
-import { useHostList, type HostListItem } from "@/hooks/useClients";
+import { useHostList, useHostMutations, type HostListItem } from "@/hooks/useClients";
 import { useUsageInsights } from "@/hooks/useUsageInsights";
 import { EMPTY_USAGE_FILTER } from "@/hooks/chatbox-usage-filters";
 import {
-  buildHostsPath,
   buildUserTestingScenarioPath,
   parseUserTestingDetailTab,
   routePaths,
+  userTestingCreatePath,
 } from "@/lib/app-navigation";
 import { useSurfaceAgentBridge } from "@/lib/webmcp/use-surface-agent-bridge";
 import { createInspectorCommandClientError } from "@/lib/inspector-command-handlers";
@@ -54,7 +55,7 @@ interface UserTestingTabProps {
   isAuthenticated: boolean;
   /** From `/user-testing/:scenarioId`. Null on the list. */
   scenarioHostId?: string | null;
-  /** `/user-testing/new`. Wired in the create-flow PR; inert here. */
+  /** From `/user-testing/new`. */
   createOpen?: boolean;
 }
 
@@ -212,6 +213,7 @@ export function UserTestingTab({
   // only — never transcript text, the share token, or visitor PII.
   const agentOperable = effectiveAuth && Boolean(projectId);
   const { deleteChatbox } = useChatboxMutations();
+  const { createHost } = useHostMutations();
   // Session rows for the snapshot only — the same list query the Sessions view
   // reads, unfiltered, redacted at read time.
   const { threads: agentSessionThreads } = useUsageInsights({
@@ -396,6 +398,42 @@ export function UserTestingTab({
   });
 
   const goOverview = () => navigate(routePaths.userTesting);
+  const goCreate = () => navigate(userTestingCreatePath);
+
+  // --- Create -----------------------------------------------------------
+  if (createOpen) {
+    if (!projectId) {
+      return (
+        <ScenarioNotice
+          icon={<Inbox className="size-8 text-muted-foreground/70" />}
+          title="Select a project first"
+          body="Scenarios belong to a project — pick one, then create a scenario in it."
+          onBack={goOverview}
+        />
+      );
+    }
+    return (
+      <UserTestingCreateFlow
+        projectId={projectId}
+        isAuthenticated={effectiveAuth}
+        onCancel={goOverview}
+        onCreateScenario={async ({ name, input, chatboxMode }) => {
+          // The one write. `hosts.createHost` mints the host, its chatbox and
+          // the access mode in a single mutation, so a half-created scenario
+          // isn't reachable.
+          const { hostId } = await createHost({
+            projectId,
+            name,
+            input,
+            chatboxMode,
+          });
+          toast.success("Scenario created");
+          navigate(buildUserTestingScenarioPath(hostId), { replace: true });
+          return { hostId };
+        }}
+      />
+    );
+  }
 
   // --- Scenario detail --------------------------------------------------
   if (scenarioHostId) {
@@ -486,11 +524,9 @@ export function UserTestingTab({
           <h1 className="text-xl font-bold tracking-tight text-foreground">
             User Testing
           </h1>
-          {/* Until the create flow lands, scenarios come from Connect — every
-              client there is auto-published as one. */}
-          <Button size="sm" onClick={() => navigate(buildHostsPath())}>
+          <Button size="sm" onClick={goCreate}>
             <Plus className="mr-1.5 size-4" />
-            New client
+            New scenario
           </Button>
         </div>
         <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
@@ -505,8 +541,8 @@ export function UserTestingTab({
           onOpenScenario={(hostId) =>
             navigate(buildUserTestingScenarioPath(hostId))
           }
-          onCreateScenario={() => navigate(buildHostsPath())}
-          createLabel="New client"
+          onCreateScenario={goCreate}
+          createLabel="New scenario"
         />
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.agent.test.tsx
@@ -217,6 +217,9 @@ vi.mock("convex/react", () => ({
 // separate host query to seed.
 vi.mock("@/hooks/useClients", () => ({
   useHostList: () => hostListState,
+  // The tab holds `createHost` for the create route; these suites never reach
+  // it, but an absent export fails module resolution.
+  useHostMutations: () => ({ createHost: vi.fn() }),
 }));
 
 vi.mock("@/hooks/useChatboxes", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.journeys.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.journeys.test.tsx
@@ -44,6 +44,9 @@ vi.mock("react-router", () => ({
 
 vi.mock("@/hooks/useClients", () => ({
   useHostList: () => hostListState,
+  // The tab holds `createHost` for the create route; these suites never reach
+  // it, but an absent export fails module resolution.
+  useHostMutations: () => ({ createHost: vi.fn() }),
 }));
 
 vi.mock("@/hooks/useChatboxes", () => ({

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxDeleteConfirmDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxDeleteConfirmDialog.tsx
@@ -17,6 +17,12 @@ import { cn } from "@/lib/utils";
 export const CHATBOX_DELETE_CONFIRM_PHRASE = "delete";
 
 export interface ChatboxDeleteConfirmDialogProps {
+  /**
+   * What the user thinks they are deleting. A destructive confirmation that
+   * names the wrong thing is worse than a generic one, and this dialog is
+   * shared by surfaces that call the same row different names.
+   */
+  entityLabel?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   chatboxName: string;
@@ -25,6 +31,7 @@ export interface ChatboxDeleteConfirmDialogProps {
 }
 
 export function ChatboxDeleteConfirmDialog({
+  entityLabel = "swarm",
   open,
   onOpenChange,
   chatboxName,
@@ -62,16 +69,17 @@ export function ChatboxDeleteConfirmDialog({
         className="gap-4 sm:max-w-md"
       >
         <DialogHeader className="gap-2 text-left">
-          <DialogTitle className="text-foreground">Delete swarm?</DialogTitle>
+          <DialogTitle className="text-foreground">
+            Delete {entityLabel}?
+          </DialogTitle>
           <DialogDescription asChild>
             <div className="space-y-2 text-sm text-muted-foreground">
               <p>
                 <span className="font-medium text-foreground">
-                  {chatboxName || "This swarm"}
+                  {chatboxName || `This ${entityLabel}`}
                 </span>{" "}
                 will be removed from this project. The hosted link will stop
-                working and saved usage history for this swarm will be
-                cleared.
+                working and saved usage history for it will be cleared.
               </p>
               <p>You cannot undo this.</p>
             </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingCreateFlow.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingCreateFlow.tsx
@@ -1,0 +1,396 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft, ChevronDown, Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import { useProjectServers } from "@/hooks/useViews";
+import { useClaudeCodeHostEnabled } from "@/hooks/useClaudeCodeHostEnabled";
+import { useCodexHostEnabled } from "@/hooks/useCodexHostEnabled";
+import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
+import { filterHostsByFeatureFlags } from "@/lib/host-compat/feature-visibility";
+import {
+  getCatalogHost,
+  getCatalogHosts,
+  getCatalogTemplate,
+} from "@mcpjam/sdk/host-compat";
+import {
+  DEFAULT_CATALOG_HOST_ID,
+  getHostLogoSrc,
+} from "@/lib/host-ui-metadata";
+import {
+  cloneHostTemplateInput,
+  type HostConfigInputV2,
+} from "@/lib/client-config-v2";
+import {
+  settingsFromChatboxAccessPreset,
+  type ChatboxAccessPreset,
+} from "@/lib/chatbox-access-presets";
+import type { ChatboxMode } from "@/hooks/useChatboxes";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+
+/**
+ * `/user-testing/new` — create a scenario: pick the server, pick the client the
+ * tester will see, decide who can open it, save.
+ *
+ * **Nothing is written until Save.** Every choice is local state; the single
+ * write is `onCreateScenario`, injected by the parent (the same inversion
+ * `new-swarm-create-flow` uses). This matters more than it looks: the version
+ * of this screen we replaced minted a draft host on mount, so every abandoned
+ * visit left an orphaned host and chatbox in the project, and they showed up in
+ * the list as real scenarios.
+ *
+ * There is no preview pane for the same reason — before Save there is nothing
+ * to preview.
+ */
+interface UserTestingCreateFlowProps {
+  projectId: string;
+  isAuthenticated: boolean;
+  onCancel: () => void;
+  /**
+   * The ONLY write path. Creates the host, its chatbox and the access mode in
+   * one mutation; resolves to the new scenario's host id.
+   */
+  onCreateScenario: (draft: {
+    name: string;
+    input: HostConfigInputV2;
+    chatboxMode: ChatboxMode;
+  }) => Promise<{ hostId: string }>;
+}
+
+const ACCESS_OPTIONS: ReadonlyArray<{
+  value: ChatboxAccessPreset;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "invited_only",
+    label: "Invited users only",
+    description: "Only people you invite by email can open this scenario.",
+  },
+  {
+    value: "link_guests",
+    label: "Anyone with the link",
+    description:
+      "Anyone with the link can open it, including guests without an account. Guest usage runs on your organization's credits.",
+  },
+  {
+    value: "project",
+    label: "Project members",
+    description:
+      "Signed-in members of this project can open it with the link. Guests cannot.",
+  },
+];
+
+export function UserTestingCreateFlow({
+  projectId,
+  isAuthenticated,
+  onCancel,
+  onCreateScenario,
+}: UserTestingCreateFlowProps) {
+  const themeMode = usePreferencesStore((s) => s.themeMode);
+  const catalogState = useHostCatalog();
+  const claudeCodeEnabled = useClaudeCodeHostEnabled();
+  const codexEnabled = useCodexHostEnabled();
+  const { servers } = useProjectServers({ isAuthenticated, projectId });
+
+  const visibleCatalogHosts = useMemo(
+    () =>
+      catalogState.status === "live"
+        ? filterHostsByFeatureFlags(getCatalogHosts(catalogState.catalog), {
+            claudeCode: claudeCodeEnabled,
+            codex: codexEnabled,
+          }).sort((a, b) => a.label.localeCompare(b.label))
+        : [],
+    [catalogState, claudeCodeEnabled, codexEnabled],
+  );
+  const defaultTemplateId =
+    visibleCatalogHosts.find((h) => h.id === DEFAULT_CATALOG_HOST_ID)?.id ??
+    visibleCatalogHosts[0]?.id ??
+    DEFAULT_CATALOG_HOST_ID;
+
+  const [name, setName] = useState("");
+  // Set once the user hand-types a name, so the template-label default below
+  // stops overwriting it. A ref rather than state derived inside the setter:
+  // mutating during an updater is impure and StrictMode's double-invoke made
+  // the older version of that trick misread a defaulted name as user-typed.
+  const userEditedNameRef = useRef(false);
+  const [templateId, setTemplateId] = useState(defaultTemplateId);
+  const [serverId, setServerId] = useState<string | null>(null);
+  const [accessPreset, setAccessPreset] =
+    useState<ChatboxAccessPreset>("invited_only");
+  const [isSaving, setIsSaving] = useState(false);
+  // Synchronous guard: a double-click must not create two scenarios before
+  // React commits `isSaving`.
+  const savingRef = useRef(false);
+
+  const templateLabel =
+    catalogState.status === "live"
+      ? getCatalogHost(catalogState.catalog, templateId)?.label ?? ""
+      : "";
+  const templateInput =
+    catalogState.status === "live"
+      ? getCatalogTemplate(catalogState.catalog, templateId)
+      : undefined;
+
+  // Keep the selection inside the visible set — a flag can hide the client
+  // that was picked.
+  useEffect(() => {
+    if (visibleCatalogHosts.length === 0) return;
+    if (!visibleCatalogHosts.some((h) => h.id === templateId)) {
+      setTemplateId(defaultTemplateId);
+    }
+  }, [visibleCatalogHosts, templateId, defaultTemplateId]);
+
+  useEffect(() => {
+    if (userEditedNameRef.current) return;
+    setName(templateLabel);
+  }, [templateLabel]);
+
+  useEffect(() => {
+    if (serverId) return;
+    if (servers && servers.length > 0) setServerId(servers[0]._id);
+  }, [servers, serverId]);
+
+  const selectedServer = servers?.find((s) => s._id === serverId);
+  const canSave =
+    Boolean(name.trim()) && Boolean(templateInput) && !isSaving && !!projectId;
+
+  const handleSave = async () => {
+    if (!canSave || !templateInput || savingRef.current) return;
+    savingRef.current = true;
+    setIsSaving(true);
+    try {
+      const seed = cloneHostTemplateInput(templateInput, { themeMode });
+      await onCreateScenario({
+        name: name.trim(),
+        input: { ...seed, serverIds: serverId ? [serverId] : [] },
+        chatboxMode: settingsFromChatboxAccessPreset(accessPreset)
+          .mode as ChatboxMode,
+      });
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create the scenario",
+      );
+      savingRef.current = false;
+      setIsSaving(false);
+    }
+    // On success the parent navigates away; leaving the latch set keeps the
+    // button inert through the unmount.
+  };
+
+  const catalogUnavailable =
+    catalogState.status !== "live"
+      ? catalogState.status === "loading"
+        ? "Loading client templates…"
+        : "Could not load client templates. Try again in a moment."
+      : null;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="shrink-0 border-b border-border/40 px-6 py-4 sm:px-8">
+        <button
+          type="button"
+          onClick={onCancel}
+          data-testid="user-testing-create-back"
+          className={cn(
+            "inline-flex items-center gap-1 rounded-sm text-sm font-medium text-primary",
+            "hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          <ArrowLeft className="size-3.5" />
+          User Testing
+        </button>
+        <h1 className="mt-2 text-xl font-semibold tracking-tight">
+          New scenario
+        </h1>
+        <p className="mt-1 max-w-xl text-sm text-muted-foreground">
+          One of your servers, seen through the client a tester already uses.
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-6 sm:px-8">
+        <div className="mx-auto flex max-w-xl flex-col gap-6">
+          <div className="space-y-2">
+            <Label htmlFor="scenario-name">Scenario name</Label>
+            <Input
+              id="scenario-name"
+              value={name}
+              onChange={(e) => {
+                userEditedNameRef.current = e.target.value.trim().length > 0;
+                setName(e.target.value);
+              }}
+              placeholder="e.g. Payments API public beta"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Server</Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="user-testing-create-server"
+                  className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  <span className="flex-1 truncate text-left">
+                    {selectedServer
+                      ? selectedServer.name
+                      : servers === undefined
+                      ? "Loading servers…"
+                      : "No server"}
+                  </span>
+                  <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                className="w-[--radix-dropdown-menu-trigger-width]"
+              >
+                <DropdownMenuRadioGroup
+                  value={serverId ?? ""}
+                  onValueChange={setServerId}
+                >
+                  {(servers ?? []).map((s) => (
+                    <DropdownMenuRadioItem key={s._id} value={s._id}>
+                      {s.name}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {servers && servers.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                Connect a server first — a scenario with nothing attached gives
+                a tester nothing to try.
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Client the tester will see</Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="user-testing-create-client"
+                  className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  <img
+                    src={getHostLogoSrc(templateId, themeMode)}
+                    alt=""
+                    className="size-4 shrink-0 object-contain"
+                  />
+                  <span className="flex-1 truncate text-left">
+                    {templateLabel || "Select a client"}
+                  </span>
+                  <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                className="w-[--radix-dropdown-menu-trigger-width]"
+              >
+                <DropdownMenuRadioGroup
+                  value={templateId}
+                  onValueChange={setTemplateId}
+                >
+                  {visibleCatalogHosts.map((h) => (
+                    <DropdownMenuRadioItem
+                      key={h.id}
+                      value={h.id}
+                      className="gap-2"
+                    >
+                      <img
+                        src={getHostLogoSrc(h.id, themeMode)}
+                        alt=""
+                        className="size-4 object-contain"
+                      />
+                      {h.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {catalogUnavailable ? (
+              <p className="text-xs text-muted-foreground">
+                {catalogUnavailable}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Who can open it</Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="user-testing-create-access"
+                  className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                >
+                  <span className="flex-1 truncate text-left">
+                    {
+                      ACCESS_OPTIONS.find((o) => o.value === accessPreset)
+                        ?.label
+                    }
+                  </span>
+                  <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                className="w-[--radix-dropdown-menu-trigger-width]"
+              >
+                <DropdownMenuRadioGroup
+                  value={accessPreset}
+                  onValueChange={(v) =>
+                    setAccessPreset(v as ChatboxAccessPreset)
+                  }
+                >
+                  {ACCESS_OPTIONS.map((option) => (
+                    <DropdownMenuRadioItem
+                      key={option.value}
+                      value={option.value}
+                      className="items-start"
+                    >
+                      <div>
+                        <div className="font-medium">{option.label}</div>
+                        <p className="text-xs font-normal text-muted-foreground">
+                          {option.description}
+                        </p>
+                      </div>
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          <div className="flex items-center justify-end gap-2 border-t border-border/40 pt-5">
+            <Button variant="ghost" onClick={onCancel} disabled={isSaving}>
+              Cancel
+            </Button>
+            <Button
+              data-testid="user-testing-create-save"
+              disabled={!canSave}
+              onClick={() => void handleSave()}
+            >
+              {isSaving ? (
+                <Loader2 className="mr-1.5 size-4 animate-spin" />
+              ) : null}
+              Create scenario
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingOverviewPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingOverviewPanel.tsx
@@ -1,5 +1,5 @@
 import { formatDistanceToNow } from "date-fns";
-import { Inbox, Plus } from "lucide-react";
+import { AlertTriangle, Inbox, Plus } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import type { ChatboxListItem } from "@/hooks/useChatboxes";
@@ -38,13 +38,14 @@ const ROW_COLS =
 
 export function UserTestingOverviewPanel(props: UserTestingOverviewPanelProps) {
   return (
-    // A Convex query against a backend that hasn't deployed the counters yet
-    // THROWS out of `useQuery` rather than returning undefined, and an
-    // uncaught throw here takes the whole screen. Falling back to the empty
-    // state keeps the create path reachable.
+    // Catches a render failure in the rows — a row shaped differently than
+    // this component expects. It does NOT cover the list query: that runs in
+    // the parent, above this boundary. The fallback says the list failed
+    // rather than reusing the empty state, because "we couldn't show your
+    // scenarios" and "you have no scenarios" send a user to different places.
     <ErrorBoundary
       fallback={
-        <EmptyState
+        <LoadFailureState
           onCreateScenario={props.onCreateScenario}
           createLabel={props.createLabel}
         />
@@ -64,7 +65,7 @@ function OverviewBody({
 }: UserTestingOverviewPanelProps) {
   const themeMode = usePreferencesStore((s) => s.themeMode);
 
-  if (isLoading || chatboxes === undefined) {
+  if (isLoading) {
     return (
       <div className="space-y-2" data-testid="user-testing-overview-loading">
         {Array.from({ length: 3 }).map((_, i) => (
@@ -77,7 +78,10 @@ function OverviewBody({
     );
   }
 
-  if (chatboxes.length === 0) {
+  // Not loading and no rows — including the skipped-query case, where the hook
+  // reports `isLoading: false` with no data because there is no project or no
+  // auth to query with. Treating that as "still loading" would spin forever.
+  if (!chatboxes || chatboxes.length === 0) {
     return (
       <EmptyState
         onCreateScenario={onCreateScenario}
@@ -159,8 +163,39 @@ function OverviewBody({
 }
 
 function serverLabel(row: ChatboxListItem): string {
-  if (row.serverNames.length > 0) return row.serverNames[0];
+  // Tolerate a row without the array: a version skew should cost this cell,
+  // not the whole list.
+  const names = row.serverNames ?? [];
+  if (names.length > 0) return names[0];
   return row.serverCount > 0 ? `${row.serverCount} servers` : "—";
+}
+
+function LoadFailureState({
+  onCreateScenario,
+  createLabel,
+}: {
+  onCreateScenario: () => void;
+  createLabel: string;
+}) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center px-6 py-16 text-center"
+      data-testid="user-testing-overview-error"
+    >
+      <AlertTriangle className="size-8 text-amber-500" />
+      <h2 className="mt-4 text-base font-semibold">
+        Couldn&apos;t show your scenarios
+      </h2>
+      <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+        The list failed to render. Reload the page — this doesn&apos;t mean
+        anything happened to your scenarios.
+      </p>
+      <Button variant="outline" className="mt-5" onClick={onCreateScenario}>
+        <Plus className="mr-1.5 size-4" />
+        {createLabel}
+      </Button>
+    </div>
+  );
 }
 
 function EmptyState({

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -102,6 +102,10 @@ export function UserTestingScenarioDetail({
       toast.error(
         err instanceof Error ? err.message : "Failed to delete the scenario",
       );
+      // Rethrow: the dialog closes itself when `onConfirm` RESOLVES, so
+      // swallowing here would dismiss the confirmation on a delete that
+      // didn't happen and leave the user believing it did.
+      throw err;
     } finally {
       setIsDeleting(false);
     }
@@ -236,6 +240,7 @@ export function UserTestingScenarioDetail({
       </div>
 
       <ChatboxDeleteConfirmDialog
+        entityLabel="scenario"
         open={deleteOpen}
         onOpenChange={setDeleteOpen}
         chatboxName={chatbox.name}

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingCreateFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingCreateFlow.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * The one thing this flow must guarantee: **nothing is written until Save.**
+ *
+ * The version of this screen we replaced minted a draft host on mount, so every
+ * abandoned visit left an orphaned host and its chatbox in the project — and
+ * they appeared in the scenario list as real scenarios. These tests exercise
+ * every control and assert the write path stays untouched until the user
+ * commits.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { catalogState, serversState, cloneMock } = vi.hoisted(() => ({
+  catalogState: { status: "live" as string },
+  serversState: {
+    servers: [{ _id: "srv-1", name: "acme-payments" }] as
+      | Array<{ _id: string; name: string }>
+      | undefined,
+  },
+  cloneMock: vi.fn(() => ({ hostStyle: "cursor", serverIds: [] })),
+}));
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: () => "light",
+}));
+vi.mock("@/lib/toast", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServers: () => ({ servers: serversState.servers }),
+}));
+vi.mock("@/hooks/useClaudeCodeHostEnabled", () => ({
+  useClaudeCodeHostEnabled: () => true,
+}));
+vi.mock("@/hooks/useCodexHostEnabled", () => ({
+  useCodexHostEnabled: () => true,
+}));
+vi.mock("@/lib/host-compat/use-host-catalog", () => ({
+  useHostCatalog: () => ({ status: catalogState.status, catalog: {} }),
+}));
+vi.mock("@/lib/host-compat/feature-visibility", () => ({
+  filterHostsByFeatureFlags: (hosts: unknown) => hosts,
+}));
+vi.mock("@mcpjam/sdk/host-compat", () => ({
+  getCatalogHosts: () => [
+    { id: "cursor", label: "Cursor" },
+    { id: "claude", label: "Claude" },
+  ],
+  getCatalogHost: (_c: unknown, id: string) => ({
+    id,
+    label: id === "cursor" ? "Cursor" : "Claude",
+  }),
+  getCatalogTemplate: (_c: unknown, id: string) => ({ templateFor: id }),
+}));
+vi.mock("@/lib/host-ui-metadata", () => ({
+  DEFAULT_CATALOG_HOST_ID: "cursor",
+  getHostLogoSrc: () => "logo.png",
+}));
+vi.mock("@/lib/client-config-v2", () => ({
+  cloneHostTemplateInput: (...args: unknown[]) => cloneMock(...(args as [])),
+}));
+
+import { UserTestingCreateFlow } from "../UserTestingCreateFlow";
+
+const renderFlow = (
+  onCreateScenario = vi.fn().mockResolvedValue({ hostId: "h1" }),
+) => {
+  const onCancel = vi.fn();
+  render(
+    <UserTestingCreateFlow
+      projectId="proj-1"
+      isAuthenticated
+      onCancel={onCancel}
+      onCreateScenario={onCreateScenario}
+    />,
+  );
+  return { onCreateScenario, onCancel };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  catalogState.status = "live";
+  serversState.servers = [{ _id: "srv-1", name: "acme-payments" }];
+});
+
+describe("UserTestingCreateFlow", () => {
+  it("writes nothing while the user fills the form", () => {
+    const { onCreateScenario } = renderFlow();
+
+    fireEvent.change(screen.getByLabelText("Scenario name"), {
+      target: { value: "Payments beta" },
+    });
+    fireEvent.click(screen.getByTestId("user-testing-create-client"));
+    fireEvent.click(screen.getByTestId("user-testing-create-server"));
+    fireEvent.click(screen.getByTestId("user-testing-create-access"));
+
+    expect(onCreateScenario).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when the user backs out", () => {
+    const { onCreateScenario, onCancel } = renderFlow();
+
+    fireEvent.change(screen.getByLabelText("Scenario name"), {
+      target: { value: "Abandoned" },
+    });
+    fireEvent.click(screen.getByTestId("user-testing-create-back"));
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onCreateScenario).not.toHaveBeenCalled();
+  });
+
+  it("saves the name, the attached server and the access mode in one call", async () => {
+    const { onCreateScenario } = renderFlow();
+
+    fireEvent.change(screen.getByLabelText("Scenario name"), {
+      target: { value: "Payments beta" },
+    });
+    fireEvent.click(screen.getByTestId("user-testing-create-save"));
+
+    await waitFor(() => expect(onCreateScenario).toHaveBeenCalledTimes(1));
+    expect(onCreateScenario).toHaveBeenCalledWith({
+      name: "Payments beta",
+      input: expect.objectContaining({ serverIds: ["srv-1"] }),
+      // The default preset: a scenario is invite-only until its author widens
+      // it, so an accidental Save can't publish to the world.
+      chatboxMode: "invited_only",
+    });
+  });
+
+  it("creates one scenario on a double-click, not two", async () => {
+    let resolveSave: (v: { hostId: string }) => void = () => {};
+    const onCreateScenario = vi.fn(
+      () => new Promise<{ hostId: string }>((r) => (resolveSave = r)),
+    );
+    renderFlow(onCreateScenario);
+
+    fireEvent.change(screen.getByLabelText("Scenario name"), {
+      target: { value: "Payments beta" },
+    });
+    const save = screen.getByTestId("user-testing-create-save");
+    fireEvent.click(save);
+    fireEvent.click(save);
+
+    await waitFor(() => expect(onCreateScenario).toHaveBeenCalledTimes(1));
+    resolveSave({ hostId: "h1" });
+  });
+
+  it("cannot save an unnamed scenario", () => {
+    const { onCreateScenario } = renderFlow();
+
+    fireEvent.change(screen.getByLabelText("Scenario name"), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByTestId("user-testing-create-save"));
+
+    expect(onCreateScenario).not.toHaveBeenCalled();
+  });
+
+  it("cannot save before the client catalog resolves", () => {
+    catalogState.status = "loading";
+    const { onCreateScenario } = renderFlow();
+
+    fireEvent.change(screen.getByLabelText("Scenario name"), {
+      target: { value: "Payments beta" },
+    });
+    fireEvent.click(screen.getByTestId("user-testing-create-save"));
+
+    expect(onCreateScenario).not.toHaveBeenCalled();
+  });
+
+  it("says so when the project has no server to point at", () => {
+    serversState.servers = [];
+    renderFlow();
+
+    expect(screen.getByText(/Connect a server first/i)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingOverviewPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingOverviewPanel.test.tsx
@@ -12,7 +12,12 @@ vi.mock("@/stores/preferences/preferences-provider", () => ({
 }));
 
 vi.mock("@/lib/chatbox-client-style", () => ({
-  getChatboxHostLabel: (style: string) => `Label:${style}`,
+  getChatboxHostLabel: (style: string) => {
+    // A row can only blow up the render through one of these helpers now that
+    // the field reads are guarded; this is the lever the failure test pulls.
+    if (style === "explode") throw new TypeError("bad row");
+    return `Label:${style}`;
+  },
   getChatboxHostLogo: () => "logo.png",
 }));
 
@@ -131,20 +136,65 @@ describe("UserTestingOverviewPanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  // This is the landing screen. A row shaped differently than expected — an
-  // older or newer backend — must cost the list, not the whole page, and must
-  // leave the create action reachable.
-  it("falls back to the empty state when a row blows up the render", () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
-    const malformed = { ...row(), serverNames: undefined } as ChatboxListItem;
+  // A backend that stops sending a field must cost that CELL, not the row and
+  // not the screen.
+  it("still renders a row that is missing its server list", () => {
+    const malformed = {
+      ...row(),
+      serverNames: undefined,
+      serverCount: 2,
+    } as unknown as ChatboxListItem;
 
     render(<UserTestingOverviewPanel {...defaults} chatboxes={[malformed]} />);
 
+    expect(screen.getByText("Payments beta")).toBeInTheDocument();
+    expect(screen.getByText("2 servers")).toBeInTheDocument();
+  });
+
+  // When the list genuinely can't render, say so. Reusing the empty state here
+  // would tell a user with scenarios that they have none — and send them off
+  // to create a duplicate.
+  it("shows a failure notice, not an empty state, when a row throws", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <UserTestingOverviewPanel
+        {...defaults}
+        chatboxes={[
+          row({ hostStyle: "explode" as ChatboxListItem["hostStyle"] }),
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("user-testing-overview-error"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("user-testing-overview-empty"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/No scenarios yet/i)).not.toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  // The list hook reports `isLoading: false` with no data when the query is
+  // skipped (signed out, no project). Spinning on that forever is the failure
+  // mode this guards.
+  it("does not spin forever when the query was never issued", () => {
+    render(
+      <UserTestingOverviewPanel
+        {...defaults}
+        isLoading={false}
+        chatboxes={undefined}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("user-testing-overview-loading"),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByTestId("user-testing-overview-empty"),
     ).toBeInTheDocument();
-    consoleError.mockRestore();
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -47,7 +47,11 @@ import { ChatboxSurfaceProvider } from "@/contexts/chatbox-surface-context";
 import { WebManagedServersProvider } from "@/contexts/web-managed-servers-context";
 import { ChatboxHostOnboardingOverlays } from "@/components/hosted/ChatboxHostOnboardingOverlays";
 import { useChatboxHostIntroGate } from "@/components/hosted/useChatboxHostIntroGate";
-import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
+import {
+  getChatboxHostLabel,
+  getChatboxHostLogo,
+  getChatboxShellStyle,
+} from "@/lib/chatbox-client-style";
 
 interface ChatboxChatPageProps {
   pathToken?: string | null;
@@ -813,6 +817,8 @@ export function ChatboxChatPage({
   const hostStyle = session?.payload.hostStyle ?? "claude";
   const chatUiOverride = session?.payload.chatUiOverride;
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode, chatUiOverride);
+  const clientLabel = getChatboxHostLabel(hostStyle, chatUiOverride);
+  const clientLogoSrc = getChatboxHostLogo(hostStyle, chatUiOverride, themeMode);
   const oauthPending = pendingOAuthServers.length > 0;
   const welcomeAvailable =
     (session?.payload.chatUi?.surfaces?.welcome?.enabled ?? true) &&
@@ -962,10 +968,21 @@ export function ChatboxChatPage({
                     style={shellStyle}
                   >
                     <header className="border-b border-border/50 bg-background/95 backdrop-blur">
-                      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-2.5">
-                        <h1 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
-                          {session?.payload.name || "\u00A0"}
-                        </h1>
+                      <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-3 px-4 py-2.5">
+                        {/* Name the client, not the scenario. A tester arrives
+                            here to try something in "Cursor" or "ChatGPT";
+                            the scenario's internal name is the author's
+                            label for it and means nothing to them. */}
+                        <div className="flex min-w-0 flex-1 items-center gap-2">
+                          <img
+                            src={clientLogoSrc}
+                            alt=""
+                            className="size-5 shrink-0 object-contain"
+                          />
+                          <h1 className="min-w-0 truncate text-sm font-semibold text-foreground">
+                            {clientLabel}
+                          </h1>
+                        </div>
                         <button
                           onClick={handleOpenMcpJam}
                           className="cursor-pointer flex-shrink-0 border-none bg-transparent p-0"

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -221,9 +221,6 @@ export const navigationSections: NavSection[] = [
         icon: Users,
         featureFlag: "sandboxes-enabled",
         billingFeature: "chatboxes",
-        // The tab id stayed `chatboxes`; without this the item never
-        // highlights on its own route.
-        matchTabs: ["chatboxes"],
       },
       {
         title: "Swarms",

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -104,6 +104,7 @@ import {
   navigateApp,
   parseSwarmSessionParams,
   routePaths,
+  swarmsCreatePath,
   useAppNavigate,
 } from "@/lib/app-navigation";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
@@ -202,6 +203,12 @@ interface SwarmsTabProps {
    * router.
    */
   swarmId?: string | null;
+  /**
+   * When true (from `/swarms/new`), render the full-page create flow. A route
+   * rather than in-page state so the flow is linkable and the browser back
+   * button leaves it — the same durable-path shape User Testing uses.
+   */
+  createFlow?: boolean;
 }
 
 // ── hooks ─────────────────────────────────────────────────────────────────
@@ -268,6 +275,7 @@ export function SwarmsTab({
   projectId,
   isAuthenticated,
   swarmId: swarmIdProp = null,
+  createFlow = false,
 }: SwarmsTabProps) {
   // Don't subscribe to project-scoped Convex reads until auth is ready — a
   // signed-out/loading mount with a persisted project would otherwise surface
@@ -299,6 +307,10 @@ export function SwarmsTab({
   const [viewMode, setViewMode] = useState<SwarmViewMode>(() => {
     if (deepLink.threadId) return "sessions";
     if (deepLink.runId || deepLink.personaRefId) return "journeys";
+    // `?view=` is how leaving the create flow names its landing view, so a
+    // reload of that URL lands in the same place.
+    const requested = new URLSearchParams(window.location.search).get("view");
+    if (requested === "sessions" || requested === "journeys") return requested;
     return "overview";
   });
   const [selectedPersonaId, setSelectedPersonaId] = useState<string | null>(
@@ -339,8 +351,7 @@ export function SwarmsTab({
     [hosts]
   );
 
-  // Full-page New swarm create flow (Describe → Confirm personas).
-  const [createFlowOpen, setCreateFlowOpen] = useState(false);
+  // The create flow is route-driven (`createFlow`), not state.
   // Human labels for the runs the create flow just launched, so the sessions
   // view groups them under "Persona · Journey" instead of a run id suffix.
   // Empty for every run this session didn't launch — those keep the id label.
@@ -350,7 +361,7 @@ export function SwarmsTab({
 
   // AI generation ("Generate persona" / "Generate journeys"). Both write real
   // rows through the mutations above; running them stays a separate click.
-  // New swarm uses `createFlowOpen`; this dialog remains for Personas sidebar
+  // New swarm has its own route; this dialog remains for Personas sidebar
   // Generate and "Generate journeys".
   const [generateMode, setGenerateMode] = useState<
     "persona" | "journeys" | null
@@ -882,7 +893,7 @@ export function SwarmsTab({
     );
   }
 
-  if (createFlowOpen && projectId) {
+  if (createFlow && projectId) {
     return (
       <div className="flex h-full min-h-0 flex-col">
         <ErrorBoundary fallback={null}>
@@ -925,16 +936,21 @@ export function SwarmsTab({
             await updateJourney({ journeyRefId, ...patch } as any);
           }}
           launchJourney={launchJourney}
-          onCancel={() => setCreateFlowOpen(false)}
+          onCancel={() => navigate(routePaths.swarms)}
           onDone={(runLabels) => {
+            // Labels are component state and `/swarms/new` → `/swarms` swaps
+            // sibling routes without remounting this component, so they
+            // survive. `?view=sessions` carries the landing view in the URL
+            // regardless, so a remount (or a reload) still lands correctly —
+            // it just falls back to run-id labels.
             setSwarmRunLabels(runLabels);
-            setCreateFlowOpen(false);
             setViewMode("sessions");
+            navigate(`${routePaths.swarms}?view=sessions`);
           }}
           onEditExistingPersona={(personaRefId) => {
-            setCreateFlowOpen(false);
             setSelectedPersonaId(personaRefId);
             setViewMode("journeys");
+            navigate(`${routePaths.swarms}?persona=${encodeURIComponent(personaRefId)}`);
           }}
           onSetInsightsTuning={async (tuning) => {
             await setInsightsTuning({ projectId, tuning } as any);
@@ -979,7 +995,7 @@ export function SwarmsTab({
         viewOptions={SWARM_VIEW_OPTIONS}
         onViewModeChange={setViewMode}
         creatingSwarm={creatingPersona}
-        onNewSwarm={() => setCreateFlowOpen(true)}
+        onNewSwarm={() => navigate(swarmsCreatePath)}
       />
       <div className="flex min-h-0 flex-1">
         {viewMode === "overview" ? (
@@ -989,7 +1005,7 @@ export function SwarmsTab({
               hasPersonas={
                 personas === undefined ? undefined : personas.length > 0
               }
-              onNewSwarm={() => setCreateFlowOpen(true)}
+              onNewSwarm={() => navigate(swarmsCreatePath)}
               onOpenSwarm={handleOpenSwarm}
             />
           </main>
@@ -1126,7 +1142,7 @@ export function SwarmsTab({
                 </div>
               ) : personas.length === 0 ? (
                 <SwarmsEmptyHero
-                  onNewSwarm={() => setCreateFlowOpen(true)}
+                  onNewSwarm={() => navigate(swarmsCreatePath)}
                 />
               ) : !selectedPersona ? (
                 <JourneyNetworkBackdrop />

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.createFlow.test.tsx
@@ -10,6 +10,7 @@
  * predicate editor would test `ChecksSection`, which has its own tests.
  */
 import {
+  cleanup,
   fireEvent,
   render,
   screen,
@@ -203,6 +204,15 @@ vi.mock("@/lib/chatbox-session", () => ({
   getShareableAppOrigin: () => "https://app.test",
 }));
 
+const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }));
+// The create flow is entered and left by NAVIGATION now (`/swarms/new`), not
+// by in-page state, so the entry/exit assertions need the navigate call.
+vi.mock("@/lib/app-navigation", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/app-navigation")>();
+  return { ...actual, useAppNavigate: () => navigateMock };
+});
+
 vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
 
 vi.mock("@/lib/toast", () => ({
@@ -278,14 +288,8 @@ const updateJourneyMock = vi.fn();
 import { SwarmsTab } from "../SwarmsTab";
 
 function openDescribe() {
-  render(<SwarmsTab projectId="proj-1" isAuthenticated />);
-  // Header + empty-hero both expose "New swarm"; prefer the header chrome.
-  fireEvent.click(
-    within(screen.getByTestId("swarms-tab-header-chrome")).getByRole(
-      "button",
-      { name: /^new swarm$/i }
-    )
-  );
+  // `/swarms/new` is what opens the flow — mount it the way the router does.
+  render(<SwarmsTab projectId="proj-1" isAuthenticated createFlow />);
 }
 
 function submitLaunchEnabled() {
@@ -361,7 +365,24 @@ beforeEach(() => {
 });
 
 describe("SwarmsTab — New swarm create flow", () => {
-  it("opens Describe from New swarm and Cancel returns to the tab", () => {
+  it("reaches the create flow by its own route, and Cancel leaves it", () => {
+    // A linkable route rather than in-page state, so the browser back button
+    // exits the flow and a reload doesn't drop the user back on the list.
+    render(<SwarmsTab projectId="proj-1" isAuthenticated />);
+    fireEvent.click(
+      within(screen.getByTestId("swarms-tab-header-chrome")).getByRole(
+        "button",
+        { name: /^new swarm$/i }
+      )
+    );
+    expect(navigateMock).toHaveBeenCalledWith("/swarms/new");
+    // Still on the list: navigation is what swaps the view, not a state flip.
+    expect(
+      screen.queryByTestId("new-swarm-create-flow")
+    ).not.toBeInTheDocument();
+
+    cleanup();
+    navigateMock.mockClear();
     openDescribe();
 
     expect(screen.getByTestId("new-swarm-create-flow")).toBeInTheDocument();
@@ -376,10 +397,7 @@ describe("SwarmsTab — New swarm create flow", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
 
-    expect(
-      screen.queryByTestId("new-swarm-create-flow")
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("swarms-tab-header-chrome")).toBeInTheDocument();
+    expect(navigateMock).toHaveBeenCalledWith("/swarms");
   });
 
   it("keeps the action disabled until there is something to act on, and says why", () => {
@@ -522,15 +540,9 @@ describe("SwarmsTab — New swarm create flow", () => {
 
     fireEvent.click(within(detail).getByTestId("new-swarm-goal-edit"));
 
-    expect(
-      screen.queryByTestId("new-swarm-create-flow")
-    ).not.toBeInTheDocument();
-    expect(
-      within(screen.getByLabelText("Swarm view")).getByRole("button", {
-        name: /^personas$/i,
-      })
-    ).toHaveAttribute("aria-current", "page");
-    expect(screen.getAllByText("Ana").length).toBeGreaterThan(0);
+    // Leaving the flow is a route change now; the persona lands in the URL so
+    // the Personas view restores its selection even on a cold load.
+    expect(navigateMock).toHaveBeenCalledWith("/swarms?persona=p-1");
   });
 
   it("summarizes the combined result when both doors are used", () => {
@@ -653,11 +665,15 @@ describe("SwarmsTab — New swarm create flow", () => {
       (call) => call[0].launchKey
     );
     expect(new Set(keys).size).toBe(2);
-    // Launch stays in the wizard on the live matrix; Leave hands off to Overview.
+    // Launch stays in the wizard on the live matrix; Leave hands the user off
+    // to the Sessions view. That handoff is a route change now, and `?view=`
+    // carries the landing view so reloading that URL lands there too.
     await screen.findByTestId("new-swarm-running-step");
     expect(screen.getByText(/Refund Chaser/)).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("new-swarm-running-stop"));
-    await screen.findByTestId("sessions-panel");
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith("/swarms?view=sessions"),
+    );
   });
 
   it("removing a persona on Confirm drops its journeys from the launch", async () => {

--- a/mcpjam-inspector/client/src/hooks/useChatboxes.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxes.ts
@@ -124,10 +124,11 @@ export interface ChatboxListItem {
    * chatbox row (mcpjam-backend). Optional so a deployment predating them
    * renders "—" rather than a confident zero — the two are different claims.
    * Excludes preview and synthetic sessions: a tester is someone who opened
-   * the share link.
+   * the share link. (The backend also returns `sessionCount`; it is left out
+   * here until a column reads it, so the type can't advertise a value the UI
+   * ignores.)
    */
   uniqueTesterCount?: number;
-  sessionCount?: number;
   lastSessionAt?: number | null;
   createdAt: number;
   updatedAt: number;

--- a/mcpjam-inspector/client/src/hooks/useClients.ts
+++ b/mcpjam-inspector/client/src/hooks/useClients.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from "convex/react";
 import type { HostConfigDtoV2, HostConfigInputV2 } from "@/lib/client-config-v2";
+import type { ChatboxMode } from "./useChatboxes";
 import { shouldQueryProjectId } from "./useProjects";
 
 /**
@@ -95,6 +96,10 @@ export function useHostMutations() {
     // `'journeys'` → mint a standalone (chatbox-less) host owned by the Swarm
     // surface. Absent → legacy behavior (a chatbox is minted).
     owner?: "journeys";
+    // Access mode for the auto-minted chatbox. Absent → 'project_members'.
+    // Set here rather than with a follow-up setChatboxMode so a scenario is
+    // never briefly readable by the wrong audience. Ignored for journeys hosts.
+    chatboxMode?: ChatboxMode;
   }) => Promise<{ hostId: string; hostConfigId: string; chatboxId: string | null }>;
 
   const updateHost = useMutation("hosts:updateHost" as any) as unknown as (args: {

--- a/mcpjam-inspector/client/src/lib/__tests__/agent-bridge-modules.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/agent-bridge-modules.ts
@@ -28,7 +28,7 @@ export const BRIDGE_MODULES: Record<string, string> = {
   // availability + daily-cap gates the buttons use are in scope. Not a shared
   // hook, so the "computer" group can't be mis-scoped.
   computer: "client/src/components/computer/ComputerView.tsx",
-  // ChatboxesTab owns the previewed host's chatbox + the publish/generate/delete
+  // UserTestingTab owns the project's scenarios + the publish/delete
   // flows (ensureChatboxForHost, the Generate-with-AI endpoints, deleteChatbox)
   // and the host list a publish/delete call resolves against. It honors the
   // Swarms-owned dead-end there. Not a shared hook (SwarmsTab is a separate

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -85,6 +85,9 @@ export function buildHostComparePath(
 }
 
 
+/** The create route. A static segment, so it outranks `:scenarioId`. */
+export const userTestingCreatePath = `${routePaths.userTesting}/new`;
+
 /** Sub-tabs on `/user-testing/:scenarioId`. Sessions is the landing tab. */
 export type UserTestingDetailTab = "sessions" | "clusters";
 
@@ -113,6 +116,9 @@ export function parseUserTestingDetailTab(
     ? "clusters"
     : "sessions";
 }
+
+/** The Swarms create route. Static, so it outranks `:swarmId`. */
+export const swarmsCreatePath = `${routePaths.swarms}/new`;
 
 /** Detail tabs on `/swarms/:swarmId`. Insights is the default landing tab. */
 export type SwarmDetailTab = "insights" | "sessions";

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -90,6 +90,7 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
     note: "Legacy deep link; redirects to /playground so old bookmarks land there rather than the catch-all.",
   },
   { path: "user-testing", kind: "screen", surfaceId: "chatboxes" },
+  { path: "user-testing/new", kind: "screen", surfaceId: "chatboxes" },
   // `:scenarioId` is the scenario's HOST id — chatboxes are 1:1 with hosts,
   // and every existing deep link (and the agent's publish tool) already
   // speaks hostId.
@@ -100,6 +101,7 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
     note: "Legacy: the Chatbox surface is now User Testing. Redirects to /user-testing, preserving search + hash so old ?host=&session= links keep working.",
   },
   { path: "swarms", kind: "screen", surfaceId: "swarms" },
+  { path: "swarms/new", kind: "screen", surfaceId: "swarms" },
   { path: "swarms/:swarmId", kind: "screen", surfaceId: "swarms" },
   {
     path: "environments",

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/chatboxes.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/chatboxes.ts
@@ -30,7 +30,7 @@ import { asOptionalString, errorResult, fromActionResult } from "./shared";
 const HOST_PROPERTY = {
   type: "string",
   description:
-    "Client (host) as the client picker shows it: its name (e.g. 'Claude') or its host id. Chatboxes are 1:1 with clients.",
+    "Client (host) as the scenario list shows it: its name (e.g. 'Claude') or its host id. Scenarios are 1:1 with clients.",
 } as const;
 
 export function buildChatboxesUiTools(): UiToolDefinition[] {
@@ -38,7 +38,7 @@ export function buildChatboxesUiTools(): UiToolDefinition[] {
     {
       name: "ui_publish_chatbox",
       description:
-        "Publish the chatbox for a client on the Chatboxes screen — provision its shareable chat surface if it doesn't have one yet, and select that client so the publish surface follows. Idempotent: a client that already has a chatbox just gets selected. A client that belongs to the Swarms surface has NO publish surface and is refused (use Swarms for it instead). Copying the resulting share link is a human action — check ui_snapshot_app for whether a link exists.",
+        "Publish a client's scenario on the User Testing screen — provision its shareable chat surface if it doesn't have one yet, and open that scenario. Idempotent: a client that already has a scenario just gets opened. A client that belongs to the Swarms surface has NO share surface and is refused (use Swarms for it instead). Copying the resulting share link is a human action — check ui_snapshot_app for whether a link exists.",
       inputSchema: {
         type: "object",
         properties: { host: HOST_PROPERTY },
@@ -70,7 +70,7 @@ export function buildChatboxesUiTools(): UiToolDefinition[] {
     {
       name: "ui_delete_chatbox",
       description:
-        "Permanently delete a client's chatbox on the Chatboxes screen — its hosted share link stops working and its saved session/usage history is cleared. Irreversible; be sure the user wants this exact client's chatbox gone. Addressed by client name or id, exactly as the client picker shows it.",
+        "Permanently delete a client's scenario on the User Testing screen — its share link stops working and its saved tester-session history is cleared. Irreversible; be sure the user wants this exact client's scenario gone. Addressed by client name or id, exactly as the scenario list shows it.",
       inputSchema: {
         type: "object",
         properties: { host: HOST_PROPERTY },

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -111,6 +111,8 @@ const ROUTE_ELEMENTS: Record<
   // route param is what selects the view, so a deep-linked scenario survives
   // the auth-gate remounts a cold boot puts it through.
   "user-testing": { element: <ChatboxesRoute /> },
+  // Static segment, so it outranks `:scenarioId` in React Router's matcher.
+  "user-testing/new": { element: <ChatboxesRoute /> },
   "user-testing/:scenarioId": { element: <ChatboxesRoute /> },
   // Old bookmarks and every session link copied before the rename. Search and
   // hash come along: `/chatboxes?host=X&session=Y` has to land on that
@@ -125,6 +127,8 @@ const ROUTE_ELEMENTS: Record<
   // with Journeys + Sessions views. Same billing feature as chatboxes.
   // `/swarms/:swarmId` — one Swarm Run (wave) detail; same surface element.
   swarms: { element: <SwarmsRoute /> },
+  // Static segment, so it outranks `:swarmId`.
+  "swarms/new": { element: <SwarmsRoute /> },
   "swarms/:swarmId": { element: <SwarmsRoute /> },
   // `/environments` — project environments management. The route component
   // enforces the `project-environments-enabled` flag itself (redirects when

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -234,12 +234,17 @@ export const APP_SURFACES = [
     // URL changed.
     id: "chatboxes",
     canonicalPath: "/user-testing",
-    routePatterns: ["user-testing", "user-testing/:scenarioId"],
+    routePatterns: [
+      "user-testing",
+      "user-testing/new",
+      "user-testing/:scenarioId",
+    ],
     navSegments: ["chatboxes"],
     title: "User Testing",
     purpose:
       "Share a scenario — one client, one server — with real people, then review the sessions they had with it.",
     userActivities: [
+      "Create a scenario (pick a server, a client, and who can open it)",
       "Browse the project's user-testing scenarios and how many testers each has had",
       "Open a scenario to copy its share link or invite testers by email",
       "Review a scenario's tester sessions (trace, chat, raw)",
@@ -253,7 +258,7 @@ export const APP_SURFACES = [
   {
     id: "swarms",
     canonicalPath: "/swarms",
-    routePatterns: ["swarms", "swarms/:swarmId"],
+    routePatterns: ["swarms", "swarms/new", "swarms/:swarmId"],
     navSegments: ["swarms"],
     title: "Swarms",
     purpose:


### PR DESCRIPTION
**Stacked on #3748** (review that first — this diff is against its branch). Completes the User Testing rebuild by adding the create flow, and brings the Swarms create flow onto the same route-driven shape.

## `/user-testing/new`

Pick a server, pick the client the tester will see, decide who can open it, save.

**Nothing is written until Save.** Every choice is local state; the single write is `hosts.createHost`, which mints the host, its chatbox *and* the access mode in one mutation (the `chatboxMode` passthrough from mcpjam-backend#882), so a scenario is never briefly readable by an audience its author didn't pick.

That constraint is the reason this screen looks plainer than the design it came from. The version in #3691 minted a draft host on mount to power a live preview pane, which meant every abandoned visit to the create page left an orphaned host and chatbox in the project — and they appeared in the scenario list as real scenarios. There is no preview pane here for the same reason: before Save there is nothing to preview.

Access defaults to **invited-only**, so an accidental Save can't publish to the world. Widening to "anyone with the link" says in the picker that guest usage runs on the organization's credits.

## Swarms: `createFlowOpen` → `/swarms/new`

Per the direction to put both surfaces on the durable path. The flow component itself is untouched — only how you enter and leave it.

Two things worth a look in review:

- **SwarmsRoute has to recognise `new` explicitly.** The static segment outranks `:swarmId` in the matcher, but SwarmsRoute also recovers a swarmId from `window.location.pathname` for the no-router render path, and that fallback would read `"new"` as a run id and render a not-found run detail instead of the create flow.
- **`?view=sessions` on the done-handoff is not redundant with the state setters.** `/swarms/new` → `/swarms` swaps sibling routes rendering the same element, so React preserves the component and `setViewMode`/`setSwarmRunLabels` do land today. The URL keeps the handoff correct if that ever changes, or if the user reloads — it just falls back to run-id labels rather than the friendly ones.

## Also

The public chat page header names the **client** (logo + label) instead of the scenario. A tester arrives to try something in Cursor or ChatGPT; the scenario's name is the author's label for it and means nothing to them.

## Verification

- `npx vitest run` — 1112 files / 12950 tests, 0 failures
- `npm run typecheck:client -w @mcpjam/inspector` clean; `npm run build:inspector` succeeds
- New `UserTestingCreateFlow.test.tsx` (7): writes nothing while filling the form, writes nothing on back-out, one call carrying name + attached server + access mode, double-click creates one scenario not two, can't save unnamed, can't save before the catalog resolves, and says so when the project has no server
- `SwarmsTab.createFlow.test.tsx` (41) migrated: the flow's own behaviour tests are unchanged; the three entry/exit tests now assert the navigation (`/swarms/new`, `/swarms`, `/swarms?view=sessions`, `/swarms?persona=…`) instead of a state flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Rebased onto main + review fixes

#3748 was squash-merged, so this branch was rebuilt: it now carries only its own commit on top of current `main`. A `-X ours` merge would have been wrong — #3745 (Integrations) also touched App.tsx / app-routes.ts / router.tsx / app-surfaces.ts and landed before #3748, so taking the branch side wholesale would have dropped it. Cherry-picking applied cleanly and both surfaces are intact.

A second commit addresses the nine cubic/CodeRabbit findings left on #3748. The ones that were real bugs:

- **A failed delete looked like it succeeded.** The confirm dialog closes when `onConfirm` resolves, and the detail swallowed the rejection — so a failed delete dismissed the confirmation. Now rethrows. (The shared dialog also said "Delete swarm?" on this surface; the noun is a prop now.)
- **Two screens could spin forever.** `isLoading` is also true for a *skipped* query (signed out / no project), so a deep-linked scenario and the list both read that as in-flight. Now distinguished — and a deep link opened without a project says to sign in rather than claiming the scenario doesn't exist.
- **The list could tell a user with scenarios that they have none.** An unguarded `serverNames` read threw into the error boundary, whose fallback was the empty state. Field read guarded; the boundary now renders a distinct failure notice. Its doc comment also claimed to protect the list query — it never did, that query runs in the parent, above the boundary.
- **Old deep links lost state.** The legacy `?host=` translation kept only `session`, dropping every other param and the hash.
- **The agent quoted the old product name** in both `ui_*` tool descriptions — the strings the model reads back to users.

Plus: `shouldQueryProjectId` for the agent-tool gate, `new` reserved as a path segment, redundant `matchTabs` dropped, unused `sessionCount` dropped from the client type, stale fixture comment fixed.

**Left open on purpose:** an intentional delete is still suppressed only per-mount, so a reload can let the legacy back-mint recreate the scenario. That predates this work and needs a backend answer (distinguishing "deleted" from "never had one"), not another ref.

Re-verified after both changes: 1116 files / 12980 tests green, typecheck clean, `build:inspector` succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scenario creation (access mode at mint time), shared routing for User Testing and Swarms, and several user-visible error/loading paths; scope is broad but mostly UI and navigation with targeted tests.
> 
> **Overview**
> Adds a **linkable User Testing create flow** at `/user-testing/new`: pick server, client template, and access preset, then **one `hosts.createHost` write** (with `chatboxMode`) on Save—no draft hosts on mount. The list/overview **"New scenario"** path goes there instead of Connect.
> 
> **Swarms** drops in-page `createFlowOpen` for **`/swarms/new`** (`createFlow` from the route). Cancel/done/edit-existing persona navigate to `/swarms`, `/swarms?view=sessions`, or `/swarms?persona=…`.
> 
> **Routing** treats `new` as create, not an id (`scenarioHostId` / `routeSwarmId`), including pathname fallbacks when there is no router.
> 
> **UX / correctness fixes:** distinguish skipped vs loading queries (`shouldQueryProjectId`); sign-in prompt vs false "not found"; overview **load failure** vs empty state; legacy `/chatboxes?host=` keeps remaining query + hash; delete confirm **rethrows** on failure and uses **`entityLabel`**; hosted chat header shows **client** logo/label; agent tool copy says User Testing/scenarios.
> 
> **Routes/surfaces:** register `user-testing/new` and `swarms/new` in router, `app-routes`, and `app-surfaces`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d91bfe3d2e4eb462423650d7902fa8307242bf4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->