### PR TITLE
SDK parity: CLI bindings + ratchet, one error translator, and docs that match 3.0

### DIFF
--- a/cli/src/commands/chat.ts
+++ b/cli/src/commands/chat.ts
@@ -1,0 +1,185 @@
+/**
+ * Read-only views of the conversational surfaces: published chatboxes and the
+ * chat sessions they (and the in-app Playground) produced.
+ *
+ * These operations shipped in the SDK and the MCP catalog but had no CLI
+ * binding, which made them unreachable from a script — you could ask an agent
+ * about your chatboxes but not `grep` them in CI. Reads only: publishing,
+ * rotating a share link and managing members stay in the app, where the
+ * confirmation flows live.
+ */
+import type { Command } from "commander";
+import {
+  getChatboxOperation,
+  listChatSessionsOperation,
+  listChatboxesOperation,
+  PlatformApiError,
+  type PlatformOperation,
+} from "@mcpjam/sdk/platform";
+import { writeResult } from "../lib/output.js";
+import { buildPlatformClient, toCliError } from "../lib/platform-client.js";
+import { getGlobalOptions } from "../lib/server-config.js";
+
+type PlatformOptions = {
+  apiKey?: string;
+  apiUrl?: string;
+};
+
+function addPlatformOptions(command: Command): Command {
+  return command
+    .option("--api-key <key>", "MCPJam sk_ API key (overrides MCPJAM_API_KEY)")
+    .option(
+      "--api-url <url>",
+      "MCPJam API base URL (defaults to https://app.mcpjam.com/api/v1)",
+    );
+}
+
+async function runPlatformCommand<TOutput>(
+  options: PlatformOptions,
+  timeoutMs: number,
+  execute: (context: {
+    client: ReturnType<typeof buildPlatformClient>["client"];
+    signal: AbortSignal;
+  }) => Promise<TOutput>,
+): Promise<TOutput> {
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => {
+    controller.abort(
+      new PlatformApiError(
+        `Request timed out after ${timeoutMs}ms`,
+        "TIMEOUT",
+        {
+          status: 0,
+        },
+      ),
+    );
+  }, timeoutMs);
+  timeoutHandle.unref?.();
+
+  try {
+    const { client } = buildPlatformClient({ ...options, timeoutMs });
+    return await execute({ client, signal: controller.signal });
+  } catch (error) {
+    // When OUR deadline fired, surface the armed TIMEOUT error rather than the
+    // bare AbortError some fetch implementations reject with.
+    if (
+      controller.signal.aborted &&
+      controller.signal.reason instanceof PlatformApiError
+    ) {
+      throw toCliError(controller.signal.reason);
+    }
+    throw toCliError(error);
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+/** Validate against the operation's own schema so bad flags fail before the call. */
+function validateOpInput<TInput>(
+  op: PlatformOperation<TInput, unknown>,
+  raw: unknown,
+): TInput {
+  const parsed = op.inputSchema.safeParse(raw);
+  if (!parsed.success) {
+    const detail = parsed.error.issues
+      .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+      .join("; ");
+    const error = new Error(`Invalid input: ${detail}`);
+    (error as { exitCode?: number }).exitCode = 2;
+    throw error;
+  }
+  return parsed.data;
+}
+
+async function executeOp<TInput, TOutput>(
+  op: PlatformOperation<TInput, TOutput>,
+  input: TInput,
+  options: PlatformOptions,
+  command: Command,
+): Promise<void> {
+  const globalOptions = getGlobalOptions(command);
+  const result = await runPlatformCommand(
+    options,
+    globalOptions.timeout,
+    ({ client, signal }) => op.execute(input, { client, signal }),
+  );
+  writeResult(result, globalOptions.format);
+}
+
+export function registerChatCommands(program: Command): void {
+  const chatboxes = program
+    .command("chatboxes")
+    .description("Inspect the chatboxes published from a hosted project");
+
+  addPlatformOptions(
+    chatboxes
+      .command("list")
+      .description("List the chatboxes published from a project")
+      .option(
+        "--project <id-or-name>",
+        "Project name or ID (defaults to the most recently updated project)",
+      ),
+  ).action(async (options: PlatformOptions & { project?: string }, command) => {
+    const input = validateOpInput(listChatboxesOperation, {
+      ...(options.project === undefined ? {} : { project: options.project }),
+    });
+    await executeOp(listChatboxesOperation, input, options, command);
+  });
+
+  addPlatformOptions(
+    chatboxes
+      .command("get")
+      .description(
+        "Show one chatbox: access mode, attached servers, share link",
+      )
+      .requiredOption("--chatbox <id-or-name>", "Chatbox name or ID")
+      .option(
+        "--project <id-or-name>",
+        "Project name or ID (defaults to the most recently updated project)",
+      ),
+  ).action(
+    async (
+      options: PlatformOptions & { chatbox: string; project?: string },
+      command,
+    ) => {
+      const input = validateOpInput(getChatboxOperation, {
+        chatbox: options.chatbox,
+        ...(options.project === undefined ? {} : { project: options.project }),
+      });
+      await executeOp(getChatboxOperation, input, options, command);
+    },
+  );
+
+  const sessions = program
+    .command("chat-sessions")
+    .description("Inspect saved chat sessions");
+
+  addPlatformOptions(
+    sessions
+      .command("list")
+      .description(
+        "List chat sessions, newest first (all accessible projects unless --project is given)",
+      )
+      .option("--project <id-or-name>", "Restrict to one project")
+      .option("--status <status>", "Filter by session status")
+      .option("--limit <n>", "Maximum sessions to return (1-200)", (value) =>
+        Number.parseInt(value, 10),
+      ),
+  ).action(
+    async (
+      options: PlatformOptions & {
+        project?: string;
+        status?: string;
+        limit?: number;
+      },
+      command,
+    ) => {
+      const input = validateOpInput(listChatSessionsOperation, {
+        ...(options.project === undefined ? {} : { project: options.project }),
+        ...(options.status === undefined ? {} : { status: options.status }),
+        ...(options.limit === undefined ? {} : { limit: options.limit }),
+      });
+      await executeOp(listChatSessionsOperation, input, options, command);
+    },
+  );
+}

--- a/cli/src/commands/eval.ts
+++ b/cli/src/commands/eval.ts
@@ -21,6 +21,7 @@ import {
   getEvalSuiteOperation,
   listEvalCasesOperation,
   listEvalRunIterationsOperation,
+  listEvalSuiteRunsOperation,
   listEvalSuitesOperation,
   PlatformApiError,
   runEvalCaseOperation,
@@ -488,6 +489,38 @@ export function registerEvalCommands(program: Command): void {
     );
     writeResult(result, globalOptions.format);
   });
+
+  addPlatformOptions(
+    evals
+      .command("runs")
+      .description("List a suite's run history, newest first")
+      .requiredOption("--suite <id-or-name>", "Eval suite name or ID")
+      .option(
+        "--project <id-or-name>",
+        "Project name or ID (defaults to the most recently updated project)"
+      )
+      .option(
+        "--limit <n>",
+        "Maximum number of runs to return (1-100)",
+        (value) => Number.parseInt(value, 10)
+      )
+  ).action(
+    async (
+      options: PlatformOptions & {
+        suite: string;
+        project?: string;
+        limit?: number;
+      },
+      command
+    ) => {
+      const input = validateOpInput(listEvalSuiteRunsOperation, {
+        suite: options.suite,
+        ...(options.project === undefined ? {} : { project: options.project }),
+        ...(options.limit === undefined ? {} : { limit: options.limit }),
+      });
+      await executeOp(listEvalSuiteRunsOperation, input, options, command);
+    }
+  );
 
   addPlatformOptions(
     evals

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { registerAppsCommands } from "./commands/apps.js";
 import { registerAuthCommands } from "./commands/auth.js";
 import { registerCompatCommands } from "./commands/compat.js";
 import { registerImagesCommands } from "./commands/images.js";
+import { registerChatCommands } from "./commands/chat.js";
 import { registerEnvironmentsCommands } from "./commands/environments.js";
 import { registerEvalCommands } from "./commands/eval.js";
 import { registerHostsCommands } from "./commands/hosts.js";
@@ -88,6 +89,7 @@ export async function main(
   registerAuthCommands(program);
   registerProjectsCommands(program);
   registerEvalCommands(program);
+  registerChatCommands(program);
   registerHostsCommands(program);
   registerEnvironmentsCommands(program);
   registerImagesCommands(program);

--- a/cli/src/lib/op-bindings.ts
+++ b/cli/src/lib/op-bindings.ts
@@ -1,0 +1,157 @@
+/**
+ * Which platform operation each CLI command exposes — and, for the ones the CLI
+ * deliberately does not expose, why.
+ *
+ * The CLI was the last of the five operation surfaces with no drift check. The
+ * MCP catalog, the agent registry and the in-app chat toolset each partition
+ * `ALL_OPERATIONS` into "advertised" and "excluded, with a reason", enforced by
+ * a test that fails both when an operation is missed and when an exclusion goes
+ * stale. This is that partition for the CLI.
+ *
+ * The reason it matters here specifically: an operation with no CLI binding is
+ * invisible from a shell script, and nothing about adding an SDK operation
+ * prompts anyone to notice. `list_eval_suite_runs` sat unreachable for exactly
+ * that reason — the operation, the route and the MCP tool all existed.
+ *
+ * A binding names the command path a user would type. The test resolves each
+ * one against the real Commander tree, so an entry claiming a command that was
+ * never registered (or was later renamed) fails rather than quietly asserting
+ * coverage that does not exist.
+ */
+
+/** A command path (`"eval runs"`), or a documented reason for having none. */
+export type CliBinding = { command: string } | { excluded: string };
+
+export const CLI_BINDINGS: Readonly<Record<string, CliBinding>> = {
+  // ── Projects and servers ────────────────────────────────────────────────
+  list_projects: { command: "projects list" },
+  create_project: { command: "projects create" },
+  update_project: { command: "projects update" },
+  delete_project: { command: "projects delete" },
+  list_project_servers: { command: "projects servers" },
+  create_project_server: { command: "projects server add" },
+  get_project_server: { command: "projects server get" },
+  update_project_server: { command: "projects server update" },
+  delete_project_server: { command: "projects server remove" },
+  show_servers: { command: "projects status" },
+
+  // ── Evals ───────────────────────────────────────────────────────────────
+  list_eval_suites: { command: "eval list" },
+  create_eval_suite: { command: "eval create" },
+  get_eval_suite: { command: "eval get" },
+  update_eval_suite: { command: "eval update" },
+  delete_eval_suite: { command: "eval delete" },
+  set_eval_suite_schedule: { command: "eval schedule" },
+  set_eval_suite_environments: { command: "eval environments set" },
+  list_eval_suite_runs: { command: "eval runs" },
+  run_eval_suite: { command: "eval run" },
+  cancel_eval_run: { command: "eval cancel" },
+  get_eval_run: { command: "eval status" },
+  list_eval_run_iterations: { command: "eval iterations" },
+  get_eval_iteration_trace: { command: "eval trace" },
+  get_eval_run_steps: { command: "eval steps" },
+  list_eval_cases: { command: "eval cases list" },
+  get_eval_case: { command: "eval cases get" },
+  create_eval_case: { command: "eval cases create" },
+  update_eval_case: { command: "eval cases update" },
+  delete_eval_case: { command: "eval cases delete" },
+  generate_eval_cases: { command: "eval cases generate" },
+  run_eval_case: { command: "eval cases run" },
+
+  // ── Hosts, environments, images ─────────────────────────────────────────
+  list_hosts: { command: "hosts list" },
+  get_host: { command: "hosts get" },
+  create_host: { command: "hosts create" },
+  update_host: { command: "hosts update" },
+  delete_host: { command: "hosts delete" },
+  set_host_servers: { command: "hosts servers" },
+  duplicate_host: { command: "hosts duplicate" },
+  list_project_environments: { command: "environments list" },
+  get_project_environment: { command: "environments get" },
+  resolve_project_environment: { command: "environments resolve" },
+  create_project_environment: { command: "environments create" },
+  update_project_environment: { command: "environments update" },
+  archive_project_environment: { command: "environments archive" },
+  restore_project_environment: { command: "environments restore" },
+  list_sandbox_images: { command: "images list" },
+  get_sandbox_image: { command: "images get" },
+  create_sandbox_image: { command: "images create" },
+  update_sandbox_image: { command: "images edit" },
+  validate_sandbox_image_blueprint: { command: "images validate" },
+  build_sandbox_image: { command: "images build" },
+  list_sandbox_image_builds: { command: "images logs" },
+  promote_sandbox_image: { command: "images promote" },
+  use_sandbox_image: { command: "images use" },
+  delete_sandbox_image: { command: "images delete" },
+  reset_computer: { command: "images reset" },
+
+  // ── Chat surfaces ───────────────────────────────────────────────────────
+  list_chatboxes: { command: "chatboxes list" },
+  get_chatbox: { command: "chatboxes get" },
+  list_chat_sessions: { command: "chat-sessions list" },
+
+  // ── Tunnels ─────────────────────────────────────────────────────────────
+  create_tunnel: { command: "tunnel" },
+  close_tunnel: {
+    excluded:
+      "The tunnel closes when `mcpjam tunnel` exits; a separate close command would only strand a session nobody is holding.",
+  },
+
+  // ── Deliberately local-first ────────────────────────────────────────────
+  // The CLI talks to MCP servers DIRECTLY (--url / config file) rather than
+  // through the platform, so a developer can inspect a server that is not
+  // saved in any project and without an API key. Routing these through the
+  // hosted operations would make the platform a prerequisite for the CLI's
+  // most common use. A hosted variant is a real feature request, not an
+  // oversight — it would need its own `--project` mode.
+  list_server_tools: {
+    excluded:
+      "`tools list` connects to the server directly, so it works without a project or an API key.",
+  },
+  call_server_tool: {
+    excluded:
+      "`tools call` connects to the server directly, so it works without a project or an API key.",
+  },
+  list_server_prompts: {
+    excluded:
+      "`prompts list` connects to the server directly, so it works without a project or an API key.",
+  },
+  get_server_prompt: {
+    excluded:
+      "`prompts get` connects to the server directly, so it works without a project or an API key.",
+  },
+  list_server_resources: {
+    excluded:
+      "`resources list` connects to the server directly, so it works without a project or an API key.",
+  },
+  read_server_resource: {
+    excluded:
+      "`resources read` connects to the server directly, so it works without a project or an API key.",
+  },
+  diagnose_server: {
+    excluded:
+      "`server doctor` runs the same sweep locally; the hosted variant is reachable through `projects status`.",
+  },
+  validate_server: {
+    excluded:
+      "`server validate` runs locally against any reachable server, saved or not.",
+  },
+  export_server: {
+    excluded:
+      "`server export` writes a snapshot of any reachable server without needing it saved first.",
+  },
+  check_host_compatibility: {
+    excluded:
+      "`compat` evaluates the bundled catalog locally, so it stays fast and works offline.",
+  },
+
+  // ── Covered by the surrounding session, not a command ────────────────────
+  get_me: {
+    excluded:
+      "`auth whoami` already reports the signed-in identity for the stored credentials.",
+  },
+  list_models: {
+    excluded:
+      "Model choice belongs to whatever runs an eval; the CLI never picks one on the user's behalf.",
+  },
+};

--- a/cli/tests/op-bindings.test.ts
+++ b/cli/tests/op-bindings.test.ts
@@ -1,0 +1,117 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { Command } from "commander";
+import { ALL_OPERATIONS } from "@mcpjam/sdk/platform";
+import { CLI_BINDINGS } from "../src/lib/op-bindings.js";
+import { registerChatCommands } from "../src/commands/chat.js";
+import { registerEnvironmentsCommands } from "../src/commands/environments.js";
+import { registerEvalCommands } from "../src/commands/eval.js";
+import { registerHostsCommands } from "../src/commands/hosts.js";
+import { registerImagesCommands } from "../src/commands/images.js";
+import { registerProjectsCommands } from "../src/commands/projects.js";
+import { registerTunnelCommands } from "../src/commands/tunnel.js";
+
+/**
+ * The CLI's half of the operation-exposure ratchet.
+ *
+ * Two failure modes, both silent before this existed: an SDK operation ships
+ * with no CLI command and nobody notices (that is how `list_eval_suite_runs`
+ * became unreachable from a script), or a binding claims a command that was
+ * renamed or never written, so the map asserts coverage that does not exist.
+ */
+
+/** A program carrying every command group that binds platform operations. */
+function buildPlatformProgram(): Command {
+  const program = new Command().name("mcpjam").exitOverride();
+  registerProjectsCommands(program);
+  registerEvalCommands(program);
+  registerChatCommands(program);
+  registerHostsCommands(program);
+  registerEnvironmentsCommands(program);
+  registerImagesCommands(program);
+  registerTunnelCommands(program);
+  return program;
+}
+
+/** Walk a command path like "eval cases run" through the Commander tree. */
+function resolveCommandPath(program: Command, path: string): boolean {
+  let node: Command = program;
+  for (const segment of path.split(" ")) {
+    const next: Command | undefined = node.commands.find(
+      (candidate) =>
+        candidate.name() === segment || candidate.aliases().includes(segment),
+    );
+    if (!next) return false;
+    node = next;
+  }
+  return true;
+}
+
+describe("CLI operation bindings", () => {
+  const names = ALL_OPERATIONS.map((operation) => operation.name);
+
+  test("covers every SDK operation exactly once", () => {
+    const uncovered = names.filter((name) => !(name in CLI_BINDINGS)).sort();
+    assert.deepEqual(
+      uncovered,
+      [],
+      `SDK operations with no CLI_BINDINGS entry — add a command, or an { excluded } reason:\n  ${uncovered.join(
+        "\n  ",
+      )}`,
+    );
+  });
+
+  test("has no stale bindings", () => {
+    const known = new Set(names);
+    const stale = Object.keys(CLI_BINDINGS)
+      .filter((name) => !known.has(name))
+      .sort();
+    assert.deepEqual(
+      stale,
+      [],
+      `CLI_BINDINGS entries for operations that no longer exist — remove them:\n  ${stale.join(
+        "\n  ",
+      )}`,
+    );
+  });
+
+  test("every advertised command actually resolves in the CLI", () => {
+    // The point of the whole file. A map entry is a claim; this is the proof.
+    const program = buildPlatformProgram();
+    const missing: string[] = [];
+    for (const [name, binding] of Object.entries(CLI_BINDINGS)) {
+      if (!("command" in binding)) continue;
+      if (!resolveCommandPath(program, binding.command)) {
+        missing.push(`${name} -> "${binding.command}"`);
+      }
+    }
+    assert.deepEqual(
+      missing,
+      [],
+      `CLI_BINDINGS name commands that do not exist (renamed? never registered?):\n  ${missing.join(
+        "\n  ",
+      )}`,
+    );
+  });
+
+  test("every exclusion carries a substantive reason", () => {
+    for (const [name, binding] of Object.entries(CLI_BINDINGS)) {
+      if (!("excluded" in binding)) continue;
+      assert.ok(
+        binding.excluded.length > 20,
+        `${name} needs a real reason, not a placeholder`,
+      );
+    }
+    // One sentence copy-pasted across every entry is a derived map wearing a
+    // literal's clothes — the same failure the other surfaces' maps had.
+    const reasons = Object.values(CLI_BINDINGS)
+      .filter(
+        (binding): binding is { excluded: string } => "excluded" in binding,
+      )
+      .map((binding) => binding.excluded);
+    assert.ok(
+      new Set(reasons).size > reasons.length / 3,
+      "exclusion reasons are too repetitive to be a real review",
+    );
+  });
+});

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -126,12 +126,16 @@
       },
       {
         "tab": "SDK",
-        "tag": "v1",
+        "tag": "v3",
         "groups": [
           {
             "group": "Get Started",
             "icon": "rocket",
-            "pages": ["sdk/index", "sdk/quickstart"]
+            "pages": [
+              "sdk/index",
+              "sdk/quickstart",
+              "sdk/migrating-to-v3"
+            ]
           },
           {
             "group": "Concepts",

--- a/docs/sdk/migrating-to-v3.mdx
+++ b/docs/sdk/migrating-to-v3.mdx
@@ -1,0 +1,141 @@
+---
+title: "Migrating to SDK 3.0"
+description: "What changed, why a passing test can start failing, and how to upgrade."
+icon: "arrow-up-right"
+---
+
+SDK 3.0 makes code-first evals **enforce what they declare**. Three assertions the SDK accepted but never actually evaluated locally now gate every iteration, and two metrics stop returning a number that was not what their name promised.
+
+Most upgrades need no code changes. The exception is deliberate: a test that declared `expectedToolCalls` and never had them checked can start failing. That is the bug being fixed — the same run was already failing in the MCPJam dashboard, which recomputed the match server-side.
+
+## Why this changed
+
+Before 3.0, `expectedToolCalls` was upload metadata. The local verdict came from your `test` function alone; the platform then re-derived the tool-call match from the case snapshot. The two could disagree, and when they did the SDK was the one telling you what you wanted to hear:
+
+```typescript
+// SDK 2.x — both of these were true at once
+test.accuracy(); // 1.0  — every iteration "passed" locally
+// …while the run for those same iterations showed FAILED in MCPJam,
+// because the expected tool call was never made.
+```
+
+A verdict you cannot trust is worse than no verdict. 3.0 evaluates the expectation where the iteration runs, so local and hosted agree.
+
+## Breaking changes
+
+### `expectedToolCalls` is enforced locally
+
+If a test declares expected tool calls, they are matched during the run and a mismatch fails the iteration.
+
+```typescript
+const test = new EvalTest({
+  name: "books the venue",
+  expectedToolCalls: [{ toolName: "book_venue" }],
+  test: async (executor) => {
+    const r = await executor.run("Book Friday.");
+    return r.hasToolCall("book_venue");
+  },
+});
+```
+
+**If this newly fails**, pick whichever is true:
+
+<AccordionGroup>
+  <Accordion title="The expectation was wrong or stale">
+    Fix or delete it. The tool may have been renamed, or the agent legitimately solves the task another way now.
+  </Accordion>
+  <Accordion title="The expectation was over-specified">
+    Relax the matcher rather than the assertion:
+
+    ```typescript
+    matchOptions: { argumentMatching: "ignore" }   // names must match, arguments need not
+    matchOptions: { maxExtraToolCalls: null }      // extra calls are fine (the default)
+    ```
+  </Accordion>
+  <Accordion title="It was only ever documentation">
+    Remove `expectedToolCalls`. A test with no expectations behaves exactly as it did in 2.x — your `test` function is the whole verdict.
+  </Accordion>
+</AccordionGroup>
+
+<Note>
+  Tests that declare neither `expectedToolCalls` nor `predicates` are unaffected by this release.
+</Note>
+
+### `precision()` and `recall()` return real values
+
+In 2.x, `precision()`, `recall()` and `truePositiveRate()` all did `return this.accuracy()` — three names for the pass rate. They now compute genuine micro-averaged values from the tool-call matches, and **throw** when no test in the run declared `expectedToolCalls`, because there is nothing to compute them from.
+
+```typescript
+// 2.x: precision() === recall() === accuracy(), always
+// 3.0: real values, or a thrown error if there are no expectations
+test.accuracy(); // unchanged — the pass rate
+```
+
+If you were reading `precision()` as a stand-in for accuracy, call [`accuracy()`](/sdk/reference/eval-test#accuracy) directly.
+
+### `falsePositiveRate()` is deprecated
+
+It returned `failures / iterations` — the failure rate, not a false-positive rate. Use [`unexpectedToolCallRate()`](/sdk/reference/eval-test#unexpectedtoolcallrate), the fraction of expectation-bearing iterations that made a call nobody asked for. `falsePositiveRate()` still returns the legacy value for runs without expectations, so existing dashboards do not move.
+
+## New in 3.0
+
+### Predicates work code-first
+
+The deterministic check engine was hosted-only. It now runs in your test file, gating the iteration **and** reporting the same verdicts, so the dashboard's check chips and cross-run criterion trends light up for code-first runs.
+
+```typescript
+const test = new EvalTest({
+  name: "answers cleanly",
+  predicates: [
+    { type: "noToolErrors" },
+    { type: "responseContains", needle: "confirmed" },
+    { type: "turnCountUnder", max: 4 },
+  ],
+  test: async (executor) => {
+    const r = await executor.run("Book Friday and confirm.");
+    return r.text.length > 0;
+  },
+});
+```
+
+An iteration passes only if every predicate passes — independently of `failOnToolError`. See the [predicate gate](/sdk/reference/eval-reporting#predicate-gate) for the full list of types.
+
+<Warning>
+  The three widget predicates (`widgetRendered`, `widgetRenderLatencyUnder`, `widgetNoConsoleErrors`) read render observations that only a hosted run captures, and they fail closed. `EvalTest` rejects them **at construction** rather than failing every iteration with a confusing reason — move those cases to a hosted suite.
+</Warning>
+
+### `matchOptions`
+
+How `expectedToolCalls` is matched, layered suite → case and validated when the test is constructed:
+
+```typescript
+new EvalSuite({
+  name: "booking",
+  matchOptions: { toolCallOrder: "strict" }, // default for every test
+});
+```
+
+Full option table in the [`EvalTest` reference](/sdk/reference/eval-test#matchoptions).
+
+## Upgrade checklist
+
+<Steps>
+  <Step title="Bump the package">
+    ```bash
+    npm install @mcpjam/sdk@^3
+    ```
+  </Step>
+  <Step title="Run your suite">
+    Failures here are expectations that were never being checked. Work through them with the three options above.
+  </Step>
+  <Step title="Replace deprecated metric calls">
+    `falsePositiveRate()` → `unexpectedToolCallRate()`. If you read `precision()` or `recall()` expecting the pass rate, switch to `accuracy()`.
+  </Step>
+  <Step title="Optional: adopt predicates">
+    Anything your `test` function asserts about the transcript — a tool was called, the reply contains a phrase, no tool errored — is expressible as a predicate, which makes it visible in the dashboard instead of hidden inside a boolean.
+  </Step>
+</Steps>
+
+## Unchanged
+
+Connecting to servers, `HostRunner` / `HostRuntime`, prompt execution and multi-turn context threading, reporting configuration, and the run URL printed after an upload all behave as they did in 2.x.

--- a/docs/sdk/reference/eval-reporting.mdx
+++ b/docs/sdk/reference/eval-reporting.mdx
@@ -458,7 +458,13 @@ Advanced replay override. Most users should not construct this manually.
 
 Predicates add a deterministic, state-based assertion layer on top of tool-call matching. Each predicate is a pure function of the iteration transcript — same transcript, same verdict — which makes it suitable as a CI release gate.
 
-Predicates are authored on the suite or case (in the corpus JSON, or through the Inspector's per-case **Checks** editor). `EvalResultInput` has no predicate field. The runner evaluates them and persists per-predicate verdicts under [`metadata.predicates`](#predicate-results-in-metadata). A case passes the predicate gate iff **all** predicates pass. An absent or empty list means no predicate gate (the case is judged solely by tool-call matching and `failOnToolError`).
+Predicates can be authored two ways: on a hosted suite or case (in the corpus JSON, or through the Inspector's per-case **Checks** editor), or **code-first** from SDK 3.0 onward by passing `predicates` to [`EvalTest`](/sdk/reference/eval-test) or [`EvalSuite`](/sdk/reference/eval-suite). Either way the runner evaluates them and persists per-predicate verdicts under [`metadata.predicates`](#predicate-results-in-metadata). A case passes the predicate gate iff **all** predicates pass. An absent or empty list means no predicate gate (the case is judged solely by tool-call matching and `failOnToolError`).
+
+<Note>
+  Before SDK 3.0 the predicate engine was hosted-only: `EvalResultInput` had no predicate field, and a code-first run could not evaluate them. Code-first predicates now gate the iteration locally **and** report the same verdicts, so a suite reads identically whether it ran from your test file or from the platform.
+</Note>
+
+The three widget predicates — `widgetRendered`, `widgetRenderLatencyUnder`, `widgetNoConsoleErrors` — read render observations that only a hosted run captures, and they fail closed. `EvalTest` therefore **rejects them at construction** rather than failing every iteration with a confusing reason; move those cases to a hosted suite.
 
 #### Predicate types
 

--- a/docs/sdk/reference/eval-suite.mdx
+++ b/docs/sdk/reference/eval-suite.mdx
@@ -30,6 +30,11 @@ new EvalSuite(options?: EvalSuiteConfig)
 |----------|------|----------|-------------|
 | `name` | `string` | No | Name for the suite (defaults to `"EvalSuite"`) |
 | `mcpjam` | [`MCPJamReportingConfig`](/sdk/reference/eval-reporting) | No | Auto-save results to MCPJam when the suite completes |
+| `matchOptions` | [`EvalMatchOptions`](/sdk/reference/eval-test#matchoptions) | No | Default matcher policy for every test in the suite that declares `expectedToolCalls` |
+
+<Note>
+`matchOptions` is a **default**, not an override: a test that sets its own keeps it. This mirrors how the hosted product layers suite → case, so a suite behaves the same whether it runs from your test file or from the platform.
+</Note>
 
 <Note>
 When an API key is available — via `mcpjam.apiKey` or the `MCPJAM_API_KEY` environment variable — all test results are consolidated into a single run and saved to MCPJam after the suite completes. Individual `EvalTest` auto-saves are suppressed to avoid duplicate uploads. Set `mcpjam.enabled: false` to disable.
@@ -252,7 +257,7 @@ getResults(): EvalSuiteResult | null
 
 ### recall()
 
-Returns aggregate recall (same as accuracy in basic context).
+Aggregate recall across every test in the suite that declared `expectedToolCalls`.
 
 ```typescript
 recall(): number
@@ -262,17 +267,26 @@ recall(): number
 
 ### precision()
 
-Returns aggregate precision (same as accuracy in basic context).
+Aggregate precision across every test in the suite that declared `expectedToolCalls`.
 
 ```typescript
 precision(): number
 ```
 
+<Warning>
+  **Changed in 3.0.** These returned `accuracy()` — the suite's pass rate —
+  under all three names. They now aggregate real tool-call counts and **throw**
+  when no test in the suite declared `expectedToolCalls`. Tests without
+  expectations are skipped in the aggregate rather than counted as perfect. See
+  [`EvalTest.precision()`](/sdk/reference/eval-test#precision) for how the
+  counts are derived.
+</Warning>
+
 ---
 
 ### truePositiveRate()
 
-Returns aggregate true positive rate (same as recall).
+Aggregate true positive rate (same as recall).
 
 ```typescript
 truePositiveRate(): number
@@ -280,9 +294,24 @@ truePositiveRate(): number
 
 ---
 
+### unexpectedToolCallRate()
+
+The fraction of expectation-bearing iterations across the suite that made at least one tool call nobody asked for.
+
+```typescript
+unexpectedToolCallRate(): number
+```
+
+---
+
 ### falsePositiveRate()
 
-Returns aggregate false positive rate.
+<Warning>
+  **Deprecated in 3.0** — use [`unexpectedToolCallRate()`](#unexpectedtoolcallrate).
+  It returned `failures / iterations`, which is the failure rate. Suites with no
+  `expectedToolCalls` still get that legacy value; suites with expectations now
+  delegate to `unexpectedToolCallRate()`.
+</Warning>
 
 ```typescript
 falsePositiveRate(): number

--- a/docs/sdk/reference/eval-test.mdx
+++ b/docs/sdk/reference/eval-test.mdx
@@ -26,10 +26,58 @@ new EvalTest(options: EvalTestConfig)
 
 ### EvalTestConfig
 
-| Property | Type           | Required | Description                    |
-| -------- | -------------- | -------- | ------------------------------ |
-| `name`   | `string`       | Yes      | Unique identifier for the test |
-| `test`   | `TestFunction` | Yes      | The test function to run       |
+| Property            | Type                     | Required | Description                                                                    |
+| ------------------- | ------------------------ | -------- | ------------------------------------------------------------------------------ |
+| `name`              | `string`                 | Yes      | Unique identifier for the test                                                 |
+| `test`              | `TestFunction`           | Yes      | The test function to run                                                       |
+| `expectedToolCalls` | `EvalExpectedToolCall[]` | No       | Tool calls the iteration must make. **Enforced locally from 3.0** — see below. |
+| `matchOptions`      | `EvalMatchOptions`       | No       | How `expectedToolCalls` is matched (order, arguments, extras)                   |
+| `predicates`        | `Predicate[]`            | No       | Deterministic transcript checks that gate each iteration                        |
+
+<Warning>
+  **Changed in 3.0.** `expectedToolCalls` used to be reporting metadata only:
+  the local verdict came from your `test` function alone, while the dashboard
+  recomputed the match — so the same run could show `accuracy() === 1` locally
+  and fail in MCPJam. It is now enforced during the run, which means a test
+  whose expectations were never actually checked can start failing on upgrade.
+
+  If that happens, the expectation was wrong or over-specified. Fix it, relax it
+  with `matchOptions` (e.g. `{ argumentMatching: "ignore" }`), or drop
+  `expectedToolCalls` if it was only ever documentation. Tests that declare
+  neither `expectedToolCalls` nor `predicates` behave exactly as before.
+</Warning>
+
+#### matchOptions
+
+Layered suite → case, and validated when the test is constructed rather than mid-run.
+
+| Option              | Values                                | Default     | Meaning                                        |
+| ------------------- | ------------------------------------- | ----------- | ---------------------------------------------- |
+| `toolCallOrder`     | `"ignore"` \| `"strict"` \| `"superset"` | `"ignore"`  | Whether expected calls must appear in order    |
+| `argumentMatching`  | `"partial"` \| `"exact"` \| `"ignore"`   | `"partial"` | How strictly arguments must match              |
+| `maxExtraToolCalls` | `number` \| `null`                       | `null`      | Cap on unexpected calls (`null` = unlimited)   |
+
+#### predicates
+
+Deterministic, state-based checks evaluated against the iteration transcript — same transcript, same verdict, which is what makes them usable as a CI gate. An iteration passes only if **every** predicate passes, independently of `failOnToolError`. Verdicts are reported under `metadata.predicates`, so the dashboard's check chips work for code-first runs too. See [eval reporting](/sdk/reference/eval-reporting#predicate-gate) for the full list of predicate types.
+
+```typescript
+const test = new EvalTest({
+  name: "books the venue",
+  expectedToolCalls: [{ toolName: "book_venue" }],
+  matchOptions: { toolCallOrder: "strict" },
+  predicates: [
+    { type: "noToolErrors" },
+    { type: "responseContains", needle: "confirmed" },
+  ],
+  test: async (executor) => {
+    const r = await executor.run("Book the venue for Friday.");
+    return r.hasToolCall("book_venue");
+  },
+});
+```
+
+The widget predicates (`widgetRendered`, `widgetRenderLatencyUnder`, `widgetNoConsoleErrors`) need render observations only a hosted run captures, so `EvalTest` rejects them at construction instead of failing every iteration.
 
 ### TestFunction Type
 
@@ -145,7 +193,7 @@ console.log(`Accuracy: ${(test.accuracy() * 100).toFixed(1)}%`);
 
 ### precision()
 
-Returns the precision metric.
+Returns the precision metric, micro-averaged over the run's tool-call matches.
 
 ```typescript
 precision(): number
@@ -153,13 +201,24 @@ precision(): number
 
 #### Returns
 
-`number` - True positives / (True positives + False positives).
+`number` — True positives / (True positives + False positives).
+
+Counted per iteration from the expected/actual tool calls: a matched expectation is a true positive, an unexpected call is a false positive, a missing one is a false negative, and an argument mismatch counts as both.
+
+<Warning>
+  **Changed in 3.0.** `precision()`, `recall()` and `truePositiveRate()` all
+  used to `return this.accuracy()` — three names for one number. They now
+  compute real values, and **throw** when no test in the run declared
+  `expectedToolCalls`, because there is nothing to compute them from. If you
+  were reading `precision()` as a stand-in for accuracy, call
+  [`accuracy()`](#accuracy) directly.
+</Warning>
 
 ---
 
 ### recall()
 
-Returns the recall metric.
+Returns the recall metric, micro-averaged over the run's tool-call matches.
 
 ```typescript
 recall(): number
@@ -167,7 +226,9 @@ recall(): number
 
 #### Returns
 
-`number` - True positives / (True positives + False negatives).
+`number` — True positives / (True positives + False negatives).
+
+Throws when the run declared no `expectedToolCalls`.
 
 ---
 
@@ -181,17 +242,33 @@ truePositiveRate(): number
 
 ---
 
-### falsePositiveRate()
+### unexpectedToolCallRate()
 
-Returns the false positive rate.
+The fraction of expectation-bearing iterations that made at least one tool call nobody asked for.
 
 ```typescript
-falsePositiveRate(): number
+unexpectedToolCallRate(): number
 ```
 
 #### Returns
 
-`number` - False positives / (False positives + True negatives).
+`number` — Iterations with an extra call / iterations that had expectations. `0` when the run declared no expectations.
+
+---
+
+### falsePositiveRate()
+
+<Warning>
+  **Deprecated in 3.0** — use [`unexpectedToolCallRate()`](#unexpectedtoolcallrate).
+  The old implementation returned `failures / iterations`, which is the failure
+  rate, not a false-positive rate. For runs with no `expectedToolCalls` it still
+  returns that legacy value so existing dashboards do not change; for runs with
+  expectations it now delegates to `unexpectedToolCallRate()`.
+</Warning>
+
+```typescript
+falsePositiveRate(): number
+```
 
 ---
 

--- a/mcpjam-inspector/server/routes/v1/convex-errors.ts
+++ b/mcpjam-inspector/server/routes/v1/convex-errors.ts
@@ -59,6 +59,18 @@ export interface TranslateConvexWriteErrorOptions {
   notFoundMessage?: string;
   /** Copy for a 409 when the backend sent none. */
   conflictMessage?: string;
+  /**
+   * Whether an admin-gate failure may answer 403 (default) or must collapse
+   * into the same neutral 404 as everything else.
+   *
+   * Genuinely per-resource, not a style choice. Environments SURFACE the admin
+   * gate: you are already a member, so "requires admin" tells you something
+   * actionable and reveals nothing you could not see. Sandbox images HIDE it:
+   * their gate also guards shared environments, and there a 403 would confirm
+   * the resource exists to somebody who cannot otherwise see it. When in doubt
+   * leave it hidden.
+   */
+  adminFailureIsForbidden?: boolean;
 }
 
 export function translateConvexWriteError(
@@ -73,6 +85,7 @@ export function translateConvexWriteError(
     fallbackMessage = `${resource} write rejected by the platform`,
     notFoundMessage = `${resource} not found`,
     conflictMessage = `${resource} changed since you loaded it.`,
+    adminFailureIsForbidden = true,
   } = options;
 
   const data = convexErrorData(error);
@@ -98,7 +111,11 @@ export function translateConvexWriteError(
     return new WebRouteError(404, ErrorCode.NOT_FOUND, notFoundMessage);
   }
   if (code === "FORBIDDEN") {
-    if (structuredMessage && /admin/i.test(structuredMessage)) {
+    if (
+      adminFailureIsForbidden &&
+      structuredMessage &&
+      /admin/i.test(structuredMessage)
+    ) {
       return new WebRouteError(403, ErrorCode.FORBIDDEN, structuredMessage);
     }
     return new WebRouteError(404, ErrorCode.NOT_FOUND, notFoundMessage);
@@ -116,12 +133,14 @@ export function translateConvexWriteError(
   if (/not found|unauthorized|not a member/i.test(raw)) {
     return new WebRouteError(404, ErrorCode.NOT_FOUND, notFoundMessage);
   }
-  if (/requires admin|only .* admins|insufficient .* permissions/i.test(raw)) {
-    return new WebRouteError(
-      403,
-      ErrorCode.FORBIDDEN,
-      cleanConvexMessage(error)
-    );
+  if (
+    /requires admin|only .* admins|insufficient .* permissions|cannot manage/i.test(
+      raw
+    )
+  ) {
+    return adminFailureIsForbidden
+      ? new WebRouteError(403, ErrorCode.FORBIDDEN, cleanConvexMessage(error))
+      : new WebRouteError(404, ErrorCode.NOT_FOUND, notFoundMessage);
   }
   if (
     /timed out|timeout|fetch failed|network|ECONNRESET|ECONNREFUSED|ENOTFOUND|socket hang up/i.test(

--- a/mcpjam-inspector/server/routes/v1/environments.ts
+++ b/mcpjam-inspector/server/routes/v1/environments.ts
@@ -36,14 +36,10 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { z } from "zod";
 import { ConvexHttpClient } from "convex/browser";
-import {
-  parseWithSchema,
-  ErrorCode,
-  WebRouteError,
-  mapRuntimeError,
-} from "../web/errors.js";
+import { parseWithSchema, ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { v1PageJson, v1Resource } from "./envelope.js";
+import { translateConvexWriteError } from "./convex-errors.js";
 
 const environments = new Hono();
 
@@ -217,69 +213,18 @@ function translateConvexError(
   error: unknown,
   fallbackMessage = "Environment write rejected by the platform"
 ): WebRouteError {
-  if (error instanceof WebRouteError) return error;
-  const data = convexErrorData(error);
-  const code = typeof data?.code === "string" ? data.code : undefined;
-  const structuredMessage =
-    typeof data?.message === "string" ? data.message : undefined;
-
-  if (code === "CONFLICT") {
-    return new WebRouteError(
-      409,
-      ErrorCode.CONFLICT,
-      structuredMessage ?? "Environment changed since you loaded it."
-    );
-  }
-  if (code === "VALIDATION") {
-    return new WebRouteError(
-      400,
-      ErrorCode.VALIDATION_ERROR,
-      structuredMessage ?? fallbackMessage
-    );
-  }
-  if (code === "NOT_FOUND") {
-    return new WebRouteError(404, ErrorCode.NOT_FOUND, "Environment not found");
-  }
-  if (code === "FORBIDDEN") {
-    if (structuredMessage && /admin/i.test(structuredMessage)) {
-      return new WebRouteError(403, ErrorCode.FORBIDDEN, structuredMessage);
-    }
-    return new WebRouteError(
-      404,
-      ErrorCode.NOT_FOUND,
-      "Environment or project not found, or you do not have access to it."
-    );
-  }
-
-  const message = error instanceof Error ? error.message : String(error);
-  if (/not found|unauthorized|not a member/i.test(message)) {
-    return new WebRouteError(
-      404,
-      ErrorCode.NOT_FOUND,
-      "Environment or project not found, or you do not have access to it."
-    );
-  }
-  // Infrastructure failures (timeouts, connection resets) are 5xx, not a 400
-  // validation error — defer to the shared runtime classifier so a transient
-  // outage isn't reported to callers as bad input.
-  if (
-    /timed out|timeout|fetch failed|network|ECONNRESET|ECONNREFUSED|ENOTFOUND|socket hang up/i.test(
-      message
-    )
-  ) {
-    return mapRuntimeError(error);
-  }
-  const cleaned = message
-    .replace(/\[Request ID:[^\]]*\]\s*/g, "")
-    .replace(/^Server Error\s*/i, "")
-    .replace(/Uncaught (Error|ConvexError):\s*/i, "")
-    .split("\n")[0]!
-    .trim();
-  return new WebRouteError(
-    400,
-    ErrorCode.VALIDATION_ERROR,
-    cleaned || fallbackMessage
-  );
+  return translateConvexWriteError(error, {
+    resource: "Environment",
+    fallbackMessage,
+    // "Not a project member" must read the same as "no such project"; only the
+    // admin gate below is allowed to be specific.
+    notFoundMessage:
+      "Environment or project not found, or you do not have access to it.",
+    conflictMessage: "Environment changed since you loaded it.",
+    // The caller demonstrably CAN see the environment, so telling them the
+    // block is their role rather than a bad id reveals nothing new.
+    adminFailureIsForbidden: true,
+  });
 }
 
 /**

--- a/mcpjam-inspector/server/routes/v1/evals.ts
+++ b/mcpjam-inspector/server/routes/v1/evals.ts
@@ -71,6 +71,7 @@ import {
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { logger } from "../../utils/logger.js";
 import { v1Error, v1PageJson, v1Resource } from "./envelope.js";
+import { translateConvexWriteError as translateConvexError } from "./convex-errors.js";
 import { synthesizeServerBody } from "./adapter.js";
 import {
   getCanonicalModelId,
@@ -1567,24 +1568,14 @@ function buildCaseMutationArgs(
  * 400), not 500s.
  */
 function translateConvexWriteError(error: unknown): WebRouteError {
-  if (error instanceof WebRouteError) return error;
-  const message = error instanceof Error ? error.message : String(error);
-  if (isConvexNotVisibleError(error)) {
-    return new WebRouteError(404, ErrorCode.NOT_FOUND, "Resource not found");
-  }
-  // Strip Convex's "[Request ID: …] Server Error\nUncaught Error: " framing so
-  // the caller sees the human-readable invariant message.
-  const cleaned = message
-    .replace(/\[Request ID:[^\]]*\]\s*/g, "")
-    .replace(/^Server Error\s*/i, "")
-    .replace(/Uncaught (Error|ConvexError):\s*/i, "")
-    .split("\n")[0]!
-    .trim();
-  return new WebRouteError(
-    400,
-    ErrorCode.VALIDATION_ERROR,
-    cleaned || "Eval write rejected by the platform"
-  );
+  return translateConvexError(error, {
+    resource: "Resource",
+    // Eval writes span suites, cases, runs and schedules, and Convex collapses
+    // "missing" and "not visible to you" into one error — naming the specific
+    // resource would leak which link in that chain the caller cannot see.
+    notFoundMessage: "Resource not found",
+    fallbackMessage: "Eval write rejected by the platform",
+  });
 }
 
 /**

--- a/mcpjam-inspector/server/routes/v1/hosts.ts
+++ b/mcpjam-inspector/server/routes/v1/hosts.ts
@@ -26,6 +26,7 @@ import { parseWithSchema, ErrorCode, WebRouteError } from "../web/errors.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { logger } from "../../utils/logger.js";
 import { v1PageJson, v1Resource } from "./envelope.js";
+import { translateConvexWriteError as translateConvexError } from "./convex-errors.js";
 import { synthesizeServerBody } from "./adapter.js";
 
 const hosts = new Hono();
@@ -135,31 +136,17 @@ function createConvexClient(convexAuthToken: string): ConvexHttpClient {
 }
 
 function translateConvexWriteError(error: unknown): WebRouteError {
-  if (error instanceof WebRouteError) return error;
-  const message = error instanceof Error ? error.message : String(error);
-  if (/not found|unauthorized|not a member/i.test(message)) {
+  return translateConvexError(error, {
+    resource: "Host",
     // Convex collapses "project missing", "not a project member", and "host
     // missing" into the same generic error, and the v1 surface deliberately
     // doesn't leak which. Keep the message neutral rather than asserting
     // "Host not found" — the failure on the list/create paths is usually the
     // PROJECT (bad id or no membership), where a host-specific message misleads.
-    return new WebRouteError(
-      404,
-      ErrorCode.NOT_FOUND,
-      "Project or host not found, or you do not have access to it."
-    );
-  }
-  const cleaned = message
-    .replace(/\[Request ID:[^\]]*\]\s*/g, "")
-    .replace(/^Server Error\s*/i, "")
-    .replace(/Uncaught (Error|ConvexError):\s*/i, "")
-    .split("\n")[0]!
-    .trim();
-  return new WebRouteError(
-    400,
-    ErrorCode.VALIDATION_ERROR,
-    cleaned || "Host write rejected by the platform"
-  );
+    notFoundMessage:
+      "Project or host not found, or you do not have access to it.",
+    fallbackMessage: "Host write rejected by the platform",
+  });
 }
 
 async function readHostDetail(

--- a/mcpjam-inspector/server/routes/v1/images.ts
+++ b/mcpjam-inspector/server/routes/v1/images.ts
@@ -29,15 +29,11 @@ import { Hono } from "hono";
 import type { Context } from "hono";
 import { z } from "zod";
 import { ConvexHttpClient } from "convex/browser";
-import {
-  parseWithSchema,
-  ErrorCode,
-  WebRouteError,
-  mapRuntimeError,
-} from "../web/errors.js";
+import { parseWithSchema, ErrorCode, WebRouteError } from "../web/errors.js";
 import { createConvexClients } from "../shared/evals.js";
 import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
 import { v1PageJson, v1Resource } from "./envelope.js";
+import { translateConvexWriteError as translateConvexError } from "./convex-errors.js";
 
 const images = new Hono();
 
@@ -115,41 +111,18 @@ function createConvexReadClient(convexAuthToken: string): ConvexHttpClient {
 }
 
 function translateConvexWriteError(error: unknown): WebRouteError {
-  if (error instanceof WebRouteError) return error;
-  const message = error instanceof Error ? error.message : String(error);
-  if (
-    /not found|unauthorized|not a member|cannot manage|admin/i.test(message)
-  ) {
+  return translateConvexError(error, {
+    resource: "Environment",
     // Convex collapses "project missing", "not a member", "env missing", and
     // the shared-env admin gate into generic errors; keep the v1 message
     // neutral rather than leaking which.
-    return new WebRouteError(
-      404,
-      ErrorCode.NOT_FOUND,
-      "Environment or project not found, or you do not have access to it."
-    );
-  }
-  // Infrastructure failures (timeouts, connection resets) are 5xx, not a 400
-  // validation error — defer to the shared runtime classifier (504/502/…) so
-  // a transient outage isn't reported to callers as bad input.
-  if (
-    /timed out|timeout|fetch failed|network|ECONNRESET|ECONNREFUSED|ENOTFOUND|socket hang up/i.test(
-      message
-    )
-  ) {
-    return mapRuntimeError(error);
-  }
-  const cleaned = message
-    .replace(/\[Request ID:[^\]]*\]\s*/g, "")
-    .replace(/^Server Error\s*/i, "")
-    .replace(/Uncaught (Error|ConvexError):\s*/i, "")
-    .split("\n")[0]!
-    .trim();
-  return new WebRouteError(
-    400,
-    ErrorCode.VALIDATION_ERROR,
-    cleaned || "Environment write rejected by the platform"
-  );
+    notFoundMessage:
+      "Environment or project not found, or you do not have access to it.",
+    fallbackMessage: "Environment write rejected by the platform",
+    // The admin gate here also guards SHARED environments, so answering 403
+    // would confirm the resource exists to someone who cannot otherwise see it.
+    adminFailureIsForbidden: false,
+  });
 }
 
 /**


### PR DESCRIPTION
Finishes the SDK-parity backlog from the three audits, minus the enterprise design doc (deferred deliberately).

## The CLI gets its bindings — and the drift ratchet it never had

The CLI was the only one of the five operation surfaces with no partition check, and it showed: three operations had a route, an SDK op **and** an MCP tool, but no command — so they were unreachable from a shell script and nothing about adding an SDK operation prompted anyone to notice.

- `mcpjam eval runs --suite <s>` — a suite's run history. This is the one that stings: a CI job could start a run but not list what had already run.
- `mcpjam chatboxes list | get`, `mcpjam chat-sessions list` — reads only. Publishing, rotating a share link and managing members stay in the app, where the confirmation flows are.

`cli/src/lib/op-bindings.ts` is the partition: every operation names the command that exposes it, or carries a reason for having none. The 13 exclusions are one real policy stated per entry — the CLI talks to MCP servers **directly** (`--url` / config file), so `tools call`, `prompts get`, `resources read`, `server doctor|validate|export` and `compat` all work against a server that is not saved in any project and without an API key. Routing them through the hosted operations would make the platform a prerequisite for the CLI's most common use.

The test does what a map alone cannot: it walks each advertised command path through the **real Commander tree**, so an entry naming a renamed or never-registered command fails instead of asserting coverage that does not exist. Verified against three synthetic drifts before committing — bogus command path, operation with no entry, stale entry — each failing its own assertion and only that one.

Coverage: **47 → 60** of 73 operations bound.

## One Convex error translator, finally

The shared module landed in #3735 covering the two routers that PR introduced; the other four still had their own near-copies. All five now delegate.

Each copy's deliberate wording is preserved rather than flattened, because the differences were real product decisions:

- **hosts** keeps the neutral "Project or host not found" — on list/create the failure is usually the *project*, where a host-specific message misleads.
- **images** hides the admin distinction (new `adminFailureIsForbidden: false`): its gate also guards shared environments, so a 403 would confirm the resource exists to someone who cannot otherwise see it.
- **environments** surfaces it (403): the caller demonstrably *can* see the environment, so naming the role requirement reveals nothing new.
- **evals** stays generic across suites/cases/runs/schedules, so the response never leaks which link in the chain is invisible.

## Docs that contradicted the code

`eval-reporting.mdx` still said *"Predicates are authored on the suite or case… `EvalResultInput` has no predicate field"*, and `eval-test.mdx` never mentioned `predicates`, `matchOptions` or `expectedToolCalls`. Both became false when 3.0 shipped — and they were about to be the pages someone reads at the exact moment an upgrade starts failing their tests, with the migration note living only in a changeset.

Fixed across `eval-test`, `eval-suite` and `eval-reporting`, including the metrics: `precision()`/`recall()` stop claiming to be accuracy, `unexpectedToolCallRate()` is documented, and `falsePositiveRate()` is marked deprecated with its legacy behavior spelled out.

**New: `sdk/migrating-to-v3`** — why the change was made, the three honest responses to a newly-failing test, metric replacements, and what is unchanged.

## Docs stay latest-only (decision recorded)

We looked at adding an AI-SDK-style version dropdown. Mintlify's `versions` sits **above** tabs in the navigation hierarchy (confirmed against their live `docs.json` schema), so the dropdown would appear on the Inspector, CLI and API tabs too, and each version entry would duplicate the whole tab list.

The multi-surface tools MCPJam resembles — Stripe, Sentry, Supabase, Twilio — document latest plus a migration guide, and reserve version switchers for sites that *are* one library (AI SDK, LangChain, Prisma). A frozen doc tree has no owner: within a release or two nobody backports into it, and it becomes authoritative-looking and wrong.

Evidence it rots: the SDK tab's `tag` said `v1` while the package was `2.4.0` — a hand-maintained label that had already gone stale through an entire major. Set to `v3` to match what the pages describe; keeping it honest belongs on the release checklist.

## Verification

- 564 CLI tests pass; `tsc` clean in `cli/`.
- Inspector server `tsc`: error sets compared before/after — **identical**, zero new (the one apparent difference was the same pre-existing error shifting from line 3068 to 3059 as the translator bodies shrank).
- `docs.json` diff is 6 lines: the tag and the new page. Verified structurally byte-identical otherwise, every navigation page path resolves to a real file, and all four cross-links in the migration guide resolve including anchors.
- New CLI ratchet proven to fail on three synthetic drifts.

## Not in this PR

The enterprise design doc (ephemeral/TTL projects, service accounts) — deferred by request. It is the one blocked on a decision rather than typing: `sk_` keys always resolve to a human `users` row, so CI pipelines authenticate *as an employee* today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6wTEZitfeVMy9tVmyUF1Q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive CLI and documentation; API error mapping is a behavioral refinement on permission responses for sandbox images (403→404 for some admin failures), which is intentional and low blast radius.
> 
> **Overview**
> Closes the gap where several platform SDK operations had API/MCP exposure but **no shell command**, and adds the **CLI operation-binding ratchet** the other surfaces already had.
> 
> **CLI:** New read-only **`chatboxes list|get`** and **`chat-sessions list`** (wired to existing platform ops). **`mcpjam eval runs`** lists a suite’s run history (`list_eval_suite_runs`). **`CLI_BINDINGS`** maps every `ALL_OPERATIONS` entry to a command path or a documented exclusion (local-first tools, tunnel lifecycle, etc.), with tests that require full coverage, no stale keys, real Commander paths, and substantive exclusion reasons.
> 
> **API:** **`hosts`**, **`environments`**, **`evals`**, and **`images`** v1 write routes now call shared **`translateConvexWriteError`** instead of local copies. Per-resource behavior is preserved via options—especially **`adminFailureIsForbidden: false`** on **images** so admin-gate failures stay **404** (avoid confirming hidden shared resources), while **environments** still surfaces **403** for admin blocks.
> 
> **Docs:** SDK tab tag **`v1` → `v3`**, new **`sdk/migrating-to-v3`**, and reference updates for **3.0 eval behavior** (`expectedToolCalls` enforced locally, code-first **predicates**, **`matchOptions`**, real **`precision`/`recall`**, **`unexpectedToolCallRate`**, deprecated **`falsePositiveRate`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7fca314d121e17de2922c4be16b31c42a405a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing CLI bindings and a drift ratchet to reach SDK parity, unifies Convex error handling, and updates SDK docs to match 3.0 with a clear migration path.

- **New Features**
  - CLI commands: `mcpjam eval runs --suite <s>`, `mcpjam chatboxes list|get`, `mcpjam chat-sessions list` (read-only).
  - Ratchet: `cli/src/lib/op-bindings.ts` maps `@mcpjam/sdk/platform` operations to real Commander paths; test ensures no drift and lifts coverage 47 → 60 of 73.
  - Docs: adds `sdk/migrating-to-v3`; updates references for `predicates`, `matchOptions`, `expectedToolCalls`; corrects metrics; sets SDK tab tag to `v3`.
  - CLI stays local-first for tools/prompts/resources/server doctor|validate|export|compat, with documented exclusions.

- **Refactors**
  - One Convex error translator with resource-specific messaging:
    - Hosts: neutral “Project or host not found”.
    - Images: hide admin gate (`adminFailureIsForbidden: false`).
    - Environments: surface admin gate (403).
    - Evals: generic “Resource not found” across suites/cases/runs/schedules.

<sup>Written for commit c7fca314d121e17de2922c4be16b31c42a405a12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

