### PR TITLE
environments: groundwork for unnamed ad-hoc rows, and an actionable resolve error

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useConvex } from "convex/react";
 import { toast } from "sonner";
 import { track } from "@/lib/analytics";
@@ -235,6 +235,21 @@ export function useEvalHandlers({
   const projectEnvironmentsEnabled = useProjectEnvironmentsEnabled();
   const projectEnvironments = useProjectEnvironments(
     projectEnvironmentsEnabled ? projectId : null
+  );
+  // Narrowed to rows that actually carry a name, for the run-plan labels below.
+  const namedProjectEnvironments = useMemo(
+    () =>
+      projectEnvironments?.flatMap((environment) =>
+        environment.name === undefined
+          ? []
+          : [
+              {
+                environmentId: environment.environmentId,
+                name: environment.name,
+              },
+            ]
+      ),
+    [projectEnvironments]
   );
 
   // Action states
@@ -655,7 +670,13 @@ export function useEvalHandlers({
       // server resolves the environment's closed set at launch.
       const runPlans = buildSuiteRunPlans(
         suite,
-        projectEnvironments,
+        // NAMED rows only. A suite can only ever attach a named environment, so
+        // this drops nothing in practice — and for a stale pin at an id that no
+        // longer resolves to a name, `buildSuiteRunPlans` already degrades to
+        // showing the raw id, which is exactly today's behavior. Keeping the
+        // helper's parameter a plain `{environmentId, name}` keeps that pure
+        // module out of the label vocabulary.
+        namedProjectEnvironments,
         executionContext.suiteServers
       );
 

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundEnvironmentSection.tsx
@@ -3,6 +3,12 @@ import { AlertTriangle, Loader2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { track } from "@/lib/analytics";
 import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
+import { ErrorCard } from "@/components/ui/error-card";
+import {
+  describeEnvironmentError,
+  isNoServersError,
+} from "@/lib/environment-error";
+import { navigateApp, routePaths } from "@/lib/app-navigation";
 import { pluralize } from "@/components/chat-v2/shared/chat-helpers";
 import { PlaygroundPluginSelector } from "./PlaygroundPluginSelector";
 import type { PlaygroundEnvironmentState } from "@/hooks/use-playground-environment";
@@ -49,6 +55,7 @@ export function PlaygroundEnvironmentSection({
     hasExplicitPluginOverride,
     resetPluginsToEnvironment,
     setPluginVersionEnabled,
+    refreshPreview,
   } = environment;
 
   // Telemetry: an environment resolving is also a host becoming the presented
@@ -124,13 +131,26 @@ export function PlaygroundEnvironmentSection({
       ) : null}
 
       {isEnvironmentMode && previewError ? (
-        <div className="flex min-w-0 flex-col gap-1">
-          <p
-            className="text-[11px] text-destructive"
-            data-testid="playground-environment-error"
-          >
-            {previewError}
-          </p>
+        <div
+          className="flex min-w-0 flex-col gap-1"
+          data-testid="playground-environment-error"
+        >
+          <ErrorCard
+            error={describeEnvironmentError(previewError)}
+            variant="inline"
+            // Retry is pointless for a zero-servers failure — the resolve is
+            // deterministic and would fail identically. Offer the thing that
+            // actually fixes it instead. Note the preview FAILED, so there is
+            // no resolved host to deep-link to; Servers is where the fix lives.
+            {...(isNoServersError(previewError)
+              ? {
+                  action: {
+                    label: "Open Servers",
+                    onClick: () => navigateApp(routePaths.servers),
+                  },
+                }
+              : { onRetry: refreshPreview })}
+          />
           {/* The most common reason an environment refuses to resolve is a
               pinned plugin that is no longer runnable, and the failed preview
               cannot say which one. The probe reads the row's pins directly, so

--- a/mcpjam-inspector/client/src/components/playground/panes/EnvironmentToolsPane.tsx
+++ b/mcpjam-inspector/client/src/components/playground/panes/EnvironmentToolsPane.tsx
@@ -29,6 +29,12 @@ import {
 import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
 import { SchemaViewer } from "@/components/ui/schema-viewer";
 import { SearchInput } from "@/components/ui/search-input";
+import { ErrorCard } from "@/components/ui/error-card";
+import {
+  describeEnvironmentError,
+  isNoServersError,
+} from "@/lib/environment-error";
+import { navigateApp, routePaths } from "@/lib/app-navigation";
 import { cn } from "@/lib/utils";
 
 interface EnvironmentToolsPaneProps {
@@ -122,8 +128,21 @@ export function EnvironmentToolsPane({
 
       <div className="flex-1 min-h-0 overflow-auto px-2 pb-2">
         {error ? (
-          <div className="text-center py-8 px-4">
-            <p className="text-xs text-destructive">{error}</p>
+          <div className="py-6 px-2">
+            <ErrorCard
+              error={describeEnvironmentError(error)}
+              variant="inline"
+              // A zero-servers environment is not a transient failure, so Retry
+              // would only fail again. Send the user where the fix is instead.
+              {...(isNoServersError(error)
+                ? {
+                    action: {
+                      label: "Open Servers",
+                      onClick: () => navigateApp(routePaths.servers),
+                    },
+                  }
+                : { onRetry: refresh })}
+            />
           </div>
         ) : isLoading && !servers ? (
           <div className="flex flex-col items-center justify-center py-8 text-center">

--- a/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
@@ -93,7 +93,7 @@ export function ConnectEnvironmentsStrip({
   const saveAsEnvironment = () => {
     if (!normalizedProjectId) return;
     const previewedHostName = previewedHostId
-      ? labelContext.hostName(previewedHostId)
+      ? labelContext.hostName?.(previewedHostId)
       : undefined;
     saveEnvironmentDraftSeed(normalizedProjectId, {
       hostId: previewedHostId ?? null,

--- a/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ConnectEnvironmentsStrip.tsx
@@ -1,15 +1,13 @@
-import { useMemo } from "react";
 import { useConvexAuth } from "convex/react";
 import { ArrowRight, Layers, Plus } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
-import { useHostList } from "@/hooks/useClients";
 import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { usePreviewedEnvironmentId } from "@/hooks/use-previewed-environment-id";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
-import { useComputersEnabled } from "@/hooks/useComputersEnabled";
-import { useSandboxImages } from "@/hooks/useSandboxImages";
 import { shouldQueryProjectId, useProjectMembers } from "@/hooks/useProjects";
+import { EnvironmentSummaryLine } from "@/components/project-environments/EnvironmentSummaryLine";
+import { useEnvironmentLabelContext } from "@/components/project-environments/use-environment-label-context";
 import { saveEnvironmentDraftSeed } from "@/lib/environment-draft-seed";
 import { navigateApp, routePaths } from "@/lib/app-navigation";
 import { cn } from "@/lib/utils";
@@ -59,10 +57,6 @@ export function ConnectEnvironmentsStrip({
   const environments = useProjectEnvironments(
     enabled ? normalizedProjectId : null
   );
-  const { hosts } = useHostList({
-    isAuthenticated,
-    projectId: enabled ? normalizedProjectId : null,
-  });
   const [, setPreviewedEnvironmentId] =
     usePreviewedEnvironmentId(normalizedProjectId);
   const [previewedHostId] = usePreviewedHostId(normalizedProjectId);
@@ -82,31 +76,13 @@ export function ConnectEnvironmentsStrip({
         : null,
   });
 
-  const hostNamesById = useMemo(
-    () => new Map(hosts.map((host) => [host.hostId, host.name])),
-    [hosts]
-  );
-
-  // Sandbox-image names for the card chips. ONE project-wide list query (the
-  // documented row-data-only / no-N+1 budget) — the same resolve-by-find
-  // precedent the eval run detail uses.
-  //
-  // Skipped entirely unless a LOADED row actually carries a pin: the chip is the
-  // only consumer, so firing this for the empty/loading strip or a project whose
-  // environments pin nothing would add a project-wide request that can never
-  // render anything. Flag off skips it too. Once a pinned row appears the query
-  // starts, and the raw-id fallback below covers the frame before it resolves.
-  const computersEnabled = useComputersEnabled();
-  const hasPinnedImage = (environments ?? []).some(
-    (environment) => environment.computerEnvironmentId
-  );
-  const sandboxImages = useSandboxImages(
-    enabled && computersEnabled && hasPinnedImage ? normalizedProjectId : null
-  );
-  const imageNamesById = useMemo(
-    () =>
-      new Map((sandboxImages ?? []).map((img) => [img.environmentId, img.name])),
-    [sandboxImages]
+  // Host + sandbox-image names for the cards. Two project-wide list queries for
+  // the whole strip (the documented row-data-only / no-N+1 budget) — see
+  // `use-environment-label-context.ts`, which carries the full rationale and the
+  // skip-unless-pinned guard for the images query.
+  const labelContext = useEnvironmentLabelContext(
+    enabled ? normalizedProjectId : null,
+    environments
   );
 
   // "Save as environment": capture what Connect is currently pointed at into a
@@ -116,11 +92,12 @@ export function ConnectEnvironmentsStrip({
   // host is fine too: the editor's own "Pick a client" guard handles it.
   const saveAsEnvironment = () => {
     if (!normalizedProjectId) return;
+    const previewedHostName = previewedHostId
+      ? labelContext.hostName(previewedHostId)
+      : undefined;
     saveEnvironmentDraftSeed(normalizedProjectId, {
       hostId: previewedHostId ?? null,
-      ...(previewedHostId && hostNamesById.get(previewedHostId)
-        ? { name: hostNamesById.get(previewedHostId)! }
-        : {}),
+      ...(previewedHostName ? { name: previewedHostName } : {}),
       serverAttachmentId: null,
       skillSelection: null,
     });
@@ -214,44 +191,17 @@ export function ConnectEnvironmentsStrip({
       </div>
       <div className="flex gap-2 overflow-x-auto pb-0.5">
         {environments.map((environment) => {
-          const hostName =
-            hostNamesById.get(environment.hostId) ?? "Unknown client";
-          const pinnedSkillCount =
-            environment.skillSelection?.skillIds.length ?? 0;
-          const pluginPinCount = environment.pluginVersionIds?.length ?? 0;
           return (
             <div
               key={environment.environmentId}
               className="flex min-w-[240px] shrink-0 flex-col gap-1.5 rounded-md border border-border/40 bg-background/60 p-2.5"
               data-testid={`connect-environment-card-${environment.environmentId}`}
             >
-              <p className="truncate text-sm font-medium">{environment.name}</p>
-              <p className="truncate text-[11px] text-muted-foreground">
-                {hostName}
-              </p>
-              <p className="text-[11px] text-muted-foreground">
-                {environment.serverAttachmentId
-                  ? "Server group attached"
-                  : "Client's own servers"}
-                {" · "}
-                {pinnedSkillCount} skill pin{pinnedSkillCount === 1 ? "" : "s"}
-                {" · "}
-                {pluginPinCount} plugin pin{pluginPinCount === 1 ? "" : "s"}
-                {/* Image chip only when pinned AND the computers flag is on —
-                    absence is semantic (default image), so unpinned rows show
-                    nothing rather than a filler label. Deleted image ⇒
-                    truncated raw id, never a silent blank. */}
-                {computersEnabled && environment.computerEnvironmentId ? (
-                  <span
-                    title="Sandbox image for eval runs and published chatboxes in this environment — Playground and swarms don't use it yet."
-                    data-testid={`connect-environment-image-${environment.environmentId}`}
-                  >
-                    {" · "}
-                    {imageNamesById.get(environment.computerEnvironmentId) ??
-                      `image ${environment.computerEnvironmentId.slice(0, 8)}…`}
-                  </span>
-                ) : null}
-              </p>
+              <EnvironmentSummaryLine
+                environment={environment}
+                ctx={labelContext}
+                testIdPrefix="connect-environment-image"
+              />
               <Button
                 variant="outline"
                 size="sm"

--- a/mcpjam-inspector/client/src/components/project-environments/EnvironmentCanvasPanel.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/EnvironmentCanvasPanel.tsx
@@ -140,7 +140,7 @@ export function EnvironmentCanvasPanel({
   if (error !== null) {
     return (
       <FallbackCard>
-        <span className="block">{error}</span>
+        <span className="block">{error.message}</span>
         <Button
           type="button"
           size="sm"

--- a/mcpjam-inspector/client/src/components/project-environments/EnvironmentSummaryLine.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/EnvironmentSummaryLine.tsx
@@ -33,7 +33,10 @@ export function EnvironmentSummaryLine({
   testIdPrefix?: string;
 }) {
   const displayLabel = label ?? environmentLabel(environment, ctx);
-  const hostName = ctx.hostName(environment.hostId) ?? "Unknown client";
+  // Optional call: `hostName` is omitted on surfaces that don't list ad-hoc
+  // rows. Every caller of THIS component passes a real context, so the fallback
+  // is for type honesty rather than a case we expect to hit.
+  const hostName = ctx.hostName?.(environment.hostId) ?? "Unknown client";
   const { skillPins, pluginPins } = environmentPinCounts(environment);
   const imageLabel = environmentImageLabel(environment, ctx);
 

--- a/mcpjam-inspector/client/src/components/project-environments/EnvironmentSummaryLine.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/EnvironmentSummaryLine.tsx
@@ -1,0 +1,70 @@
+import {
+  describeServerScope,
+  environmentImageLabel,
+  environmentLabel,
+  environmentPinCounts,
+  type EnvironmentLabelContext,
+  type EnvironmentLabelRow,
+} from "@/lib/environment-label";
+
+/**
+ * The two-or-three line identity block for one environment: label, client, and
+ * the composition summary.
+ *
+ * Shared by the Connect strip, the Environments list, and the ad-hoc detail
+ * view so the vocabulary cannot drift between them. It renders the same content
+ * `environmentDetailLine` produces as a string — both compose the same helpers
+ * — but as JSX, so the sandbox-image chip can carry its tooltip.
+ *
+ * `label` is an override for callers that ran the list through
+ * `disambiguateLabels` and need the `#n`-suffixed form; omit it and the row
+ * labels itself.
+ */
+export function EnvironmentSummaryLine({
+  environment,
+  ctx,
+  label,
+  testIdPrefix,
+}: {
+  environment: EnvironmentLabelRow;
+  ctx: EnvironmentLabelContext;
+  label?: string;
+  /** Set to keep an existing surface's `data-testid` contract intact. */
+  testIdPrefix?: string;
+}) {
+  const displayLabel = label ?? environmentLabel(environment, ctx);
+  const hostName = ctx.hostName(environment.hostId) ?? "Unknown client";
+  const { skillPins, pluginPins } = environmentPinCounts(environment);
+  const imageLabel = environmentImageLabel(environment, ctx);
+
+  return (
+    <>
+      <p className="truncate text-sm font-medium">{displayLabel}</p>
+      <p className="truncate text-[11px] text-muted-foreground">{hostName}</p>
+      <p className="text-[11px] text-muted-foreground">
+        {describeServerScope(environment)}
+        {" · "}
+        {skillPins} skill pin{skillPins === 1 ? "" : "s"}
+        {" · "}
+        {pluginPins} plugin pin{pluginPins === 1 ? "" : "s"}
+        {/* Image chip only when pinned AND the computers flag is on — absence is
+            semantic (default image), so unpinned rows show nothing rather than a
+            filler label. Deleted image ⇒ truncated raw id, never a silent
+            blank. */}
+        {imageLabel ? (
+          <span
+            title="Sandbox image for eval runs and published chatboxes in this environment — Playground and swarms don't use it yet."
+            {...(testIdPrefix
+              ? {
+                  "data-testid": `${testIdPrefix}-${environment.environmentId}`,
+                }
+              : {})}
+          >
+            {" · "}
+            {imageLabel}
+          </span>
+        ) : null}
+      </p>
+    </>
+  );
+}

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
@@ -30,7 +30,11 @@ type EnvironmentDraft = {
 
 function draftFromEnvironment(env: ProjectEnvironmentView): EnvironmentDraft {
   return {
-    name: env.name,
+    // The editor only ever mounts for a NAMED row (ad-hoc rows get the
+    // read-only detail view instead), so the fallback is unreachable in
+    // practice — it exists so the draft type stays a plain `string` and the
+    // dirty check below can compare without threading `undefined` through it.
+    name: env.name ?? "",
     description: env.description ?? "",
     hostId: env.hostId,
     serverAttachmentId: env.serverAttachmentId ?? null,

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
@@ -12,6 +12,7 @@ import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { Badge } from "@mcpjam/design-system/badge";
 import { routePaths } from "@/lib/app-navigation";
+import { isNamedEnvironment } from "@/lib/environment-label";
 import { convexErrMessage } from "@/lib/convex-error";
 import { useProjectEnvironmentsEnabledState } from "@/hooks/useProjectEnvironmentsEnabled";
 import {
@@ -58,9 +59,12 @@ export function ProjectEnvironmentsRoute({
 }) {
   const flagEnabled = useProjectEnvironmentsEnabledState();
 
+  // The management surface is the ONE place that sees every kind of row:
+  // archived (to restore), and ad-hoc (to browse what has been run, and to
+  // name one). Every other surface takes the named-only default.
   const environments = useProjectEnvironments(
     flagEnabled === true ? projectId : null,
-    { includeArchived: true }
+    { includeArchived: true, includeAdhoc: true }
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -326,8 +330,20 @@ function EnvironmentList({
       </div>
     );
   }
-  const live = environments.filter((e) => !e.archivedAt);
-  const archived = environments.filter((e) => !!e.archivedAt);
+  // Three ways, not two. Ad-hoc rows get their own collapsed section so they
+  // never compete with the environments a human curated, and ARCHIVED stays
+  // named-only — an archived machine-minted row is noise nobody will restore.
+  // NAMED rows only, in both sections. Ad-hoc rows are fetched (so a later
+  // "From runs" section and the deep link can find them) but deliberately not
+  // listed yet — they would otherwise land in the main list, which is exactly
+  // the pollution this program removes. Archived stays named-only for good: an
+  // archived machine-minted row is noise nobody will restore.
+  const live = environments.filter(
+    (e) => !e.archivedAt && isNamedEnvironment(e)
+  );
+  const archived = environments.filter(
+    (e) => !!e.archivedAt && isNamedEnvironment(e)
+  );
 
   return (
     <div className="space-y-6">

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-canvas-panel.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-canvas-panel.test.tsx
@@ -253,7 +253,7 @@ describe("EnvironmentCanvasPanel — non-canvas states", () => {
     mockPreview.value = {
       preview: null,
       isLoading: false,
-      error: "This environment couldn't be resolved.",
+      error: { message: "This environment couldn't be resolved." },
     };
     const { container } = renderPanel();
 
@@ -271,7 +271,7 @@ describe("EnvironmentCanvasPanel — non-canvas states", () => {
     mockPreview.value = {
       preview: null,
       isLoading: true,
-      error: "This environment couldn't be resolved.",
+      error: { message: "This environment couldn't be resolved." },
     };
     renderPanel();
     expect(screen.getByRole("button", { name: /retry/i })).toBeDisabled();

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-picker.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-picker.test.tsx
@@ -183,3 +183,60 @@ describe("EnvironmentPicker — archived rows stay detach-only", () => {
     expect(onChange).toHaveBeenCalledWith([]);
   });
 });
+
+/**
+ * Ad-hoc rows are machine-minted from a swarm composition and carry no name.
+ * They are the reason the picker fetches them at all: a journey's
+ * `environmentIds` can point at one, so the trigger has to be able to NAME what
+ * is selected — while never letting anyone pick one.
+ */
+describe("EnvironmentPicker — ad-hoc rows", () => {
+  const adhoc = (id: string) =>
+    env(id, undefined as unknown as string, { origin: "adhoc" });
+
+  it("never offers an ad-hoc row for selection", () => {
+    mockEnvironments.value = [env("env_1", "Staging"), adhoc("env_adhoc")];
+    render(
+      <EnvironmentPicker projectId="p_1" value={[]} onChange={vi.fn()} multi />
+    );
+    fireEvent.click(screen.getByRole("button"));
+
+    // The named row is offerable…
+    expect(screen.getByLabelText("Staging")).toBeInTheDocument();
+    // …and the ad-hoc one is absent from the list entirely.
+    expect(screen.queryByLabelText("Automatic environment")).toBeNull();
+  });
+
+  it("still labels a SELECTED ad-hoc row rather than showing the orphan ellipsis", () => {
+    mockEnvironments.value = [env("env_1", "Staging"), adhoc("env_adhoc")];
+    render(
+      <EnvironmentPicker
+        projectId="p_1"
+        value={["env_adhoc"]}
+        onChange={vi.fn()}
+        multi
+        triggerTestId="picker"
+      />
+    );
+    // "…" is reserved for an id NO row resolves. An ad-hoc row resolves — it
+    // just has no name — so it must read as a real thing.
+    expect(screen.getByTestId("picker")).toHaveTextContent(
+      "Automatic environment"
+    );
+    expect(screen.getByTestId("picker")).not.toHaveTextContent("…");
+  });
+
+  it("treats a row with no origin and no name as ad-hoc, not as a blank label", () => {
+    // Skew: a backend mid-rollout may omit `origin`. Name-presence decides.
+    mockEnvironments.value = [
+      env("env_x", undefined as unknown as string),
+      env("env_1", "Staging"),
+    ];
+    render(
+      <EnvironmentPicker projectId="p_1" value={[]} onChange={vi.fn()} multi />
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByLabelText("Staging")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Automatic environment")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/environment-picker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/environment-picker.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from "@/lib/utils";
 import { navigateApp, routePaths } from "@/lib/app-navigation";
 import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
+import { environmentLabel, isNamedEnvironment } from "@/lib/environment-label";
 
 /** Backend cap on `suite.environmentIds` (and the journey fan-out list). */
 export const MAX_SUITE_ENVIRONMENTS = 10;
@@ -32,8 +33,20 @@ export const MAX_SUITE_ENVIRONMENTS = 10;
  *    moved out of the project) render the same way, for the same reason.
  *    `archivedSelected` cannot surface these, because it resolves ids THROUGH
  *    the row map, so a missing id filters away silently.
+ *  - AD-HOC rows (machine-minted from a composition, no name) are fetched but
+ *    never offered. A journey's `environmentIds` can point at one, and without
+ *    the row in `environmentsById` the trigger would label it "…" — so the
+ *    picker needs it present to LABEL, and excluded from `liveEnvironments` to
+ *    never OFFER. Same split as the two cases above.
  *
- * Neither is ever offered for new selection.
+ * None of the three is ever offered for new selection.
+ *
+ * `environmentLabel` is called WITHOUT a label context on purpose. The richer
+ * "client name" label for an ad-hoc row would cost two project-wide queries,
+ * and this component only ever labels an already-selected ad-hoc id — a rare
+ * edge. Paying for that here would also break the pure-presentation contract
+ * above, since it would make the picker fetch. The Environments page, which
+ * lists ad-hoc rows for real, supplies the context.
  */
 export function EnvironmentPicker({
   projectId,
@@ -73,10 +86,13 @@ export function EnvironmentPicker({
    */
   inModal?: boolean;
 }) {
-  // Include archived so a still-attached archived row can surface and be
-  // detached (see the doc block above).
+  // Include archived AND ad-hoc so a still-attached row of either kind can be
+  // labeled and detached (see the doc block above). Both are filtered out of
+  // the offerable list below — fetching them is what makes the trigger able to
+  // name what is already selected.
   const environments = useProjectEnvironments(projectId, {
     includeArchived: true,
+    includeAdhoc: true,
   });
 
   const [open, setOpen] = useState(false);
@@ -92,7 +108,10 @@ export function EnvironmentPicker({
     [environments]
   );
   const liveEnvironments = useMemo(
-    () => (environments ?? []).filter((e) => !e.archivedAt),
+    () =>
+      (environments ?? []).filter(
+        (e) => !e.archivedAt && isNamedEnvironment(e)
+      ),
     [environments]
   );
   const archivedSelected = useMemo(
@@ -140,7 +159,15 @@ export function EnvironmentPicker({
   const triggerLabel =
     selected.length === 0
       ? emptyLabel
-      : selected.map((id) => environmentsById.get(id)?.name ?? "…").join(", ");
+      : selected
+          .map((id) => {
+            const env = environmentsById.get(id);
+            // "…" is for an id no row resolves at all (the orphan case). A row
+            // that merely has no name — an ad-hoc one a journey points at —
+            // labels by its client instead.
+            return env ? environmentLabel(env) : "…";
+          })
+          .join(", ");
 
   return (
     <Popover open={open} onOpenChange={(next) => !inert && setOpen(next)}>
@@ -216,10 +243,13 @@ export function EnvironmentPicker({
                       toggle(env.environmentId, next === true)
                     }
                     disabled={capBlocked || inert}
-                    aria-label={env.name}
+                    aria-label={environmentLabel(env)}
                   />
                   <span className="min-w-0 flex-1 truncate font-normal">
-                    {env.name}
+                    {/* Offerable rows are named-only, so this IS the name —
+                        routed through the helper so the type stays honest and
+                        the vocabulary stays in one place. */}
+                    {environmentLabel(env)}
                   </span>
                   {multi && checked ? (
                     <span className="shrink-0 rounded-full bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
@@ -245,10 +275,10 @@ export function EnvironmentPicker({
                     checked
                     onCheckedChange={() => toggle(env.environmentId, false)}
                     disabled={inert}
-                    aria-label={`${env.name} (archived)`}
+                    aria-label={`${environmentLabel(env)} (archived)`}
                   />
                   <span className="min-w-0 flex-1 truncate font-normal">
-                    {env.name}
+                    {environmentLabel(env)}
                     <span className="ml-1 text-[10px] text-muted-foreground">
                       (archived)
                     </span>

--- a/mcpjam-inspector/client/src/components/project-environments/use-environment-label-context.ts
+++ b/mcpjam-inspector/client/src/components/project-environments/use-environment-label-context.ts
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import { useConvexAuth } from "convex/react";
+import { useHostList } from "@/hooks/useClients";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
+import { useSandboxImages } from "@/hooks/useSandboxImages";
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+import type { EnvironmentLabelContext } from "@/lib/environment-label";
+
+/**
+ * The name lookups `@/lib/environment-label` needs, fetched once per SURFACE.
+ *
+ * ## The budget this exists to protect
+ *
+ * Every field an environment card shows comes from the row that
+ * `projectEnvironments:listEnvironments` already returned, plus two project-wide
+ * lookups: host names and sandbox-image names. Nothing here triggers a runtime
+ * resolve, because a resolve is one round trip PER ENVIRONMENT — an N+1 on a
+ * list that re-renders on every visit.
+ *
+ * That is also why a card never shows a resolved server count. The row stores a
+ * `serverAttachmentId` (a scope), not a server set; the real set folds in the
+ * host's own picks and any plugin-contributed servers, both LIVE. Printing a
+ * number would mean either lying or paying the N+1. The honest count belongs in
+ * the Playground, where exactly one environment is resolved for real.
+ *
+ * ## Why `environments` is a parameter
+ *
+ * The sandbox-image query is skipped entirely unless a LOADED row actually pins
+ * an image. The image name is its only consumer, so firing it for an empty or
+ * still-loading list — or for a project whose environments pin nothing — would
+ * add a project-wide request that can never render anything. Once a pinned row
+ * appears the query starts, and `environmentImageLabel`'s truncated-id fallback
+ * covers the frame before it resolves.
+ */
+export function useEnvironmentLabelContext(
+  projectId: string | null,
+  environments: ProjectEnvironmentView[] | undefined
+): EnvironmentLabelContext {
+  const { isAuthenticated } = useConvexAuth();
+  // Normalize ONCE and feed every hook the same value: `useProjectEnvironments`
+  // trims internally, so a whitespace-padded id still renders rows while
+  // `useHostList` would key off the raw string and leave every row labeled
+  // "Unknown client".
+  const normalizedProjectId = projectId?.trim() || null;
+  const { hosts } = useHostList({
+    isAuthenticated,
+    projectId: normalizedProjectId,
+  });
+  const computersEnabled = useComputersEnabled();
+  const hasPinnedImage = (environments ?? []).some(
+    (environment) => environment.computerEnvironmentId
+  );
+  const sandboxImages = useSandboxImages(
+    computersEnabled && hasPinnedImage ? normalizedProjectId : null
+  );
+
+  const hostNamesById = useMemo(
+    () => new Map(hosts.map((host) => [host.hostId, host.name])),
+    [hosts]
+  );
+  const imageNamesById = useMemo(
+    () =>
+      new Map(
+        (sandboxImages ?? []).map((img) => [img.environmentId, img.name])
+      ),
+    [sandboxImages]
+  );
+
+  return useMemo(
+    () => ({
+      hostName: (hostId: string) => hostNamesById.get(hostId),
+      imageName: (imageId: string) => imageNamesById.get(imageId),
+      computersEnabled,
+    }),
+    [hostNamesById, imageNamesById, computersEnabled]
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmsTab.tsx
@@ -50,6 +50,7 @@ import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import { Textarea } from "@mcpjam/design-system/textarea";
 import { toast } from "@/lib/toast";
+import { isNamedEnvironment } from "@/lib/environment-label";
 import { cn } from "@/lib/utils";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { EditableTitle } from "@/components/evals/EditableTitle";
@@ -223,15 +224,31 @@ function useProjectHosts(projectId: string | null) {
     projectId ? ({ projectId } as any) : "skip"
   ) as HostItem[] | undefined;
 }
-/** Live project environments for swarm create/generate (environments-only). */
+/**
+ * Live project environments for swarm create/generate (environments-only).
+ *
+ * NOTE this is a RAW `useQuery`, deliberately not `useProjectEnvironments` —
+ * it predates that hook's auth/db-ready gate and feeds four consumers here. It
+ * is therefore the one list site an `includeAdhoc` option on the hook cannot
+ * protect, so the NAMED-only filter is applied explicitly below. Everything
+ * this feeds — the castle picker, the journey environments popover — offers
+ * environments a human chose to name; ad-hoc rows would flood them.
+ *
+ * The backend's own named-only default already covers this, and the filter is
+ * redundant with it on purpose: the two protect different failure modes.
+ */
 function useProjectEnvironmentsList(projectId: string | null) {
-  return useQuery(
+  const rows = useQuery(
     SWARM_QUERIES.listEnvironments as any,
     // `shouldQueryProjectId` (not a bare truthiness check): a local/placeholder
     // or UUID project id during a project transition would 500 the Convex arg
     // validator, so skip until the id is a real queryable project.
     shouldQueryProjectId(projectId) ? ({ projectId } as any) : "skip"
   ) as ProjectEnvironmentView[] | undefined;
+  return useMemo(
+    () => (rows === undefined ? undefined : rows.filter(isNamedEnvironment)),
+    [rows]
+  );
 }
 function usePersonaTrackRecord(personaRefId: string | null) {
   return useQuery(

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
@@ -88,6 +88,7 @@ import { toast } from "@/lib/toast";
 import { ClusterTuningControl } from "@/components/shared/usage-insights/ClusterTuningControl";
 import type { ClusterTuning } from "@/lib/cluster-tuning";
 import { environmentLabel } from "@/lib/environment-label";
+import { ErrorCard } from "@/components/ui/error-card";
 import { cn } from "@/lib/utils";
 
 const CREATE_STEPS = [
@@ -1469,14 +1470,12 @@ export function NewSwarmCreateFlow({
               </div>
             </section>
 
-            {errorMessage ? (
-              <p
-                role="alert"
-                className="text-sm leading-relaxed text-destructive"
-              >
-                {errorMessage}
-              </p>
-            ) : null}
+            {/* `errorMessage` is a bare string from a dozen call sites, most of
+                which are not environment failures — `ErrorCard` takes one and
+                runs it through `describeError`, so this still gains the
+                container, icon and details disclosure that make a long backend
+                sentence readable instead of a wall of red text. */}
+            {errorMessage ? <ErrorCard error={errorMessage} /> : null}
 
             <div className="flex flex-wrap items-center gap-3 border-t border-border/40 pt-4">
               <Button

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-create-flow.tsx
@@ -87,6 +87,7 @@ import { track } from "@/lib/analytics";
 import { toast } from "@/lib/toast";
 import { ClusterTuningControl } from "@/components/shared/usage-insights/ClusterTuningControl";
 import type { ClusterTuning } from "@/lib/cluster-tuning";
+import { environmentLabel } from "@/lib/environment-label";
 import { cn } from "@/lib/utils";
 
 const CREATE_STEPS = [
@@ -1134,11 +1135,11 @@ export function NewSwarmCreateFlow({
       return [
         {
           key: `environment:${environmentId}`,
-          label: env.name,
+          label: environmentLabel(env, { hostName: hostNameById }),
         },
       ];
     });
-  }, [envListForPayload, environmentIds]);
+  }, [envListForPayload, environmentIds, hostNameById]);
 
   const environmentLabels = useMemo(
     () =>
@@ -1146,9 +1147,14 @@ export function NewSwarmCreateFlow({
         const env = envListForPayload.find(
           (entry) => entry.environmentId === environmentId
         );
-        return env?.name ?? environmentId.slice(0, 8);
+        // `slice(0, 8)` stays for a row that isn't in the list AT ALL — a
+        // different failure from a row that merely has no name, which
+        // `environmentLabel` covers with the client name.
+        return env
+          ? environmentLabel(env, { hostName: hostNameById })
+          : environmentId.slice(0, 8);
       }),
-    [envListForPayload, environmentIds]
+    [envListForPayload, environmentIds, hostNameById]
   );
 
   const groundingEnvironmentId =

--- a/mcpjam-inspector/client/src/components/swarms/swarm-target-materialize.ts
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-target-materialize.ts
@@ -213,7 +213,9 @@ export async function materializeSwarmTargets(
   // Names the backend would reject. Seeded from the live rows this client can
   // see and grown with every row we create, so two clients in one batch can't
   // pick the same auto-name.
-  const takenNames = new Set(working.map((e) => e.name));
+  const takenNames = new Set(
+    working.flatMap((e) => (e.name === undefined ? [] : [e.name]))
+  );
   const environmentIds: string[] = [];
   const environments: ProjectEnvironmentView[] = [];
   const createdIds: string[] = [];
@@ -269,7 +271,7 @@ export async function materializeSwarmTargets(
       );
     }
     working.push(created);
-    takenNames.add(created.name);
+    if (created.name !== undefined) takenNames.add(created.name);
     environmentIds.push(created.environmentId);
     environments.push(created);
     createdIds.push(created.environmentId);

--- a/mcpjam-inspector/client/src/components/swarms/swarm-targets.ts
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-targets.ts
@@ -17,6 +17,11 @@ import type {
 import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
 import type { SwarmSessionTargetIdentity } from "@/shared/swarm-session-id";
 import { swarmAttemptChatSessionId } from "@/shared/swarm-session-id";
+import {
+  disambiguateLabels,
+  environmentLabel,
+  trimOrUndefined,
+} from "@/lib/environment-label";
 
 /** One matrix/list column. `key` is the canonical target key (D2); `identity`
  * feeds the shared session-id mint. */
@@ -48,19 +53,9 @@ export function summaryTargetKey(row: {
   return row.targetId;
 }
 
-/** Disambiguate duplicate labels with a stable `#n` suffix (collision groups
- * only; unique labels stay untouched). */
-function disambiguateLabels(columns: SwarmTargetColumn[]): SwarmTargetColumn[] {
-  const counts = new Map<string, number>();
-  for (const c of columns) counts.set(c.label, (counts.get(c.label) ?? 0) + 1);
-  const seen = new Map<string, number>();
-  return columns.map((c) => {
-    if ((counts.get(c.label) ?? 0) <= 1) return c;
-    const n = (seen.get(c.label) ?? 0) + 1;
-    seen.set(c.label, n);
-    return { ...c, label: `${c.label} #${n}` };
-  });
-}
+// `disambiguateLabels` moved to `@/lib/environment-label` — ad-hoc environments
+// derive their label from the client name, so label collisions became the norm
+// rather than the exception and the Environments surfaces need it too.
 
 /**
  * Build the run-detail matrix columns: one per `hostSummaries` row (run order),
@@ -85,8 +80,12 @@ export function buildSwarmRunTargets(args: {
         ? snapshotHosts?.find((h) => h.targetId === summary.targetId)
         : undefined) ?? snapshotHosts?.find((h) => h.hostId === summary.hostId);
     const environmentId = snap?.environmentRef?.environmentId;
+    // `trimOrUndefined`, NOT `??`. The backend types `environmentRef.name` as a
+    // required string (it is baked into two historical run-snapshot schemas), so
+    // an ad-hoc target can snapshot an EMPTY name rather than an absent one —
+    // and `??` would pass `""` straight through, blanking the column label.
     const label =
-      snap?.environmentRef?.name ??
+      trimOrUndefined(snap?.environmentRef?.name) ??
       hostName(summary.hostId) ??
       snap?.hostName ??
       summary.hostId.slice(0, 8);
@@ -126,7 +125,12 @@ export function buildUnrunJourneyTargets(args: {
         hostId,
         targetId: `environment:${environmentId}`,
         environmentId,
-        label: env?.name ?? environmentId.slice(0, 8),
+        // `slice(0, 8)` is for a row missing from the live list ENTIRELY (a
+        // deleted/archived id) — a different failure from a row that simply has
+        // no name, which `environmentLabel` covers with the client name.
+        label: env
+          ? environmentLabel(env, { hostName })
+          : environmentId.slice(0, 8),
         identity: { hostId, environmentId },
       } satisfies SwarmTargetColumn;
     });

--- a/mcpjam-inspector/client/src/components/ui/error-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui/error-card.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import {
   AlertTriangle,
+  ArrowRight,
   ChevronDown,
   ChevronRight,
   CircleAlert,
@@ -30,6 +31,16 @@ export type ErrorCardProps = {
   error: NormalizedError | WebApiError | Error | string | unknown;
   onRetry?: () => void;
   onDismiss?: () => void;
+  /**
+   * One affordance that actually FIXES this error, rendered beside Retry.
+   *
+   * Distinct from `onRetry` on purpose: retrying a deterministic failure —
+   * "this environment has no servers" — just fails again identically. What the
+   * user needs is a way to go add a server. Omit it when there is no such
+   * action; a button that only navigates somewhere vaguely related is worse
+   * than none.
+   */
+  action?: { label: string; onClick: () => void };
   variant?: "inline" | "banner" | "toast";
   /**
    * Uncontrolled initial state for the details disclosure. Ignored when
@@ -98,6 +109,7 @@ export function ErrorCard({
   error,
   onRetry,
   onDismiss,
+  action,
   variant = "inline",
   defaultOpen = false,
   open,
@@ -183,6 +195,17 @@ export function ErrorCard({
               >
                 <RefreshCw className="h-3 w-3" />
                 Retry
+              </button>
+            ) : null}
+            {action ? (
+              <button
+                type="button"
+                onClick={action.onClick}
+                className="inline-flex items-center gap-1 text-[11px] font-medium text-foreground/70 hover:text-foreground"
+                data-testid="error-card-action"
+              >
+                <ArrowRight className="h-3 w-3" />
+                {action.label}
               </button>
             ) : null}
           </div>

--- a/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
+++ b/mcpjam-inspector/client/src/hooks/use-environment-preview.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { authFetch } from "@/lib/session-token";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
+import {
+  readEnvironmentErrorPayload,
+  type EnvironmentErrorPayload,
+} from "@/lib/environment-error";
 
 /**
  * Client mirror of the server's `EnvironmentPreview`
@@ -75,25 +79,19 @@ export interface EnvironmentPreview {
 export interface UseEnvironmentPreviewResult {
   preview: EnvironmentPreview | null;
   isLoading: boolean;
-  /** Human-readable failure, or `null`. Never a thrown error — a Playground
-   *  that can't preview must still render its host-mode chrome. */
-  error: string | null;
+  /**
+   * Structured failure, or `null`. Never a thrown error — a Playground that
+   * can't preview must still render its host-mode chrome.
+   *
+   * Carries the backend's `ENV_*` code alongside the sentence. That code is
+   * what lets `describeEnvironmentError` turn "resolves to no servers" into a
+   * card with causes, next steps, and an action; without it every failure
+   * degrades to the same red sentence.
+   */
+  error: EnvironmentErrorPayload | null;
   refresh: () => void;
 }
 
-function readErrorMessage(payload: unknown, fallback: string): string {
-  if (payload && typeof payload === "object") {
-    const error = (payload as { error?: unknown }).error;
-    if (typeof error === "string" && error.length > 0) return error;
-    if (error && typeof error === "object") {
-      const message = (error as { message?: unknown }).message;
-      if (typeof message === "string" && message.length > 0) return message;
-    }
-    const message = (payload as { message?: unknown }).message;
-    if (typeof message === "string" && message.length > 0) return message;
-  }
-  return fallback;
-}
 
 /**
  * Read what an environment currently resolves to.
@@ -141,7 +139,7 @@ export function useEnvironmentPreview(
   const [committed, setCommitted] = useState<{
     key: string | null;
     preview: EnvironmentPreview | null;
-    error: string | null;
+    error: EnvironmentErrorPayload | null;
     isLoading: boolean;
   }>({ key: null, preview: null, error: null, isLoading: false });
   const [refreshToken, setRefreshToken] = useState(0);
@@ -191,7 +189,7 @@ export function useEnvironmentPreview(
           setCommitted({
             key: targetKey,
             preview: null,
-            error: readErrorMessage(
+            error: readEnvironmentErrorPayload(
               payload,
               "This environment couldn't be resolved."
             ),
@@ -210,10 +208,12 @@ export function useEnvironmentPreview(
         setCommitted({
           key: targetKey,
           preview: null,
-          error:
-            caught instanceof Error
-              ? caught.message
-              : "This environment couldn't be resolved.",
+          error: {
+            message:
+              caught instanceof Error
+                ? caught.message
+                : "This environment couldn't be resolved.",
+          },
           isLoading: false,
         });
       }

--- a/mcpjam-inspector/client/src/hooks/use-environment-tools.ts
+++ b/mcpjam-inspector/client/src/hooks/use-environment-tools.ts
@@ -3,6 +3,10 @@ import type { Tool } from "@modelcontextprotocol/client";
 import { authFetch } from "@/lib/session-token";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
 import type { EnvironmentPreviewServerSource } from "@/hooks/use-environment-preview";
+import {
+  readEnvironmentErrorPayload,
+  type EnvironmentErrorPayload,
+} from "@/lib/environment-error";
 
 /**
  * Client mirror of `GET /api/web/environments/:environmentId/tools` —
@@ -28,8 +32,15 @@ export interface EnvironmentServerTools {
 export interface UseEnvironmentToolsResult {
   servers: EnvironmentServerTools[] | null;
   isLoading: boolean;
-  /** Whole-route failure (auth, resolve). Per-server failures live on rows. */
-  error: string | null;
+  /**
+   * Whole-route failure (auth, resolve). Per-server failures live on rows.
+   *
+   * Structured like `use-environment-preview`'s: it carries the backend's
+   * `ENV_*` code so the rail can render an actionable card. Both routes resolve
+   * through the SAME backend query, so both see the same codes — keep the two
+   * shapes identical.
+   */
+  error: EnvironmentErrorPayload | null;
   refresh: () => void;
 }
 
@@ -48,7 +59,7 @@ export function useEnvironmentTools(
   const [committed, setCommitted] = useState<{
     key: string | null;
     servers: EnvironmentServerTools[] | null;
-    error: string | null;
+    error: EnvironmentErrorPayload | null;
     isLoading: boolean;
   }>({ key: null, servers: null, error: null, isLoading: false });
   const [refreshToken, setRefreshToken] = useState(0);
@@ -84,25 +95,17 @@ export function useEnvironmentTools(
         );
         const payload = (await response.json().catch(() => null)) as {
           servers?: EnvironmentServerTools[];
-          error?: { message?: string } | string;
-          message?: string;
         } | null;
         if (!active || seq !== requestSeqRef.current) return;
         if (!response.ok || !Array.isArray(payload?.servers)) {
-          // Same probe order as `use-environment-preview`: `error` (string or
-          // {message}) first, then a top-level `message` — some route error
-          // envelopes carry only the latter, and dropping it would flatten an
-          // actionable resolve/auth failure into the generic fallback.
-          const message =
-            typeof payload?.error === "string"
-              ? payload.error
-              : payload?.error?.message ||
-                payload?.message ||
-                "Couldn't load this environment's tools.";
           setCommitted({
             key: targetKey,
             servers: null,
-            error: message,
+            // Shared with `use-environment-preview` — same routes, same codes.
+            error: readEnvironmentErrorPayload(
+              payload,
+              "Couldn't load this environment's tools."
+            ),
             isLoading: false,
           });
           return;
@@ -118,10 +121,12 @@ export function useEnvironmentTools(
         setCommitted({
           key: targetKey,
           servers: null,
-          error:
-            caught instanceof Error
-              ? caught.message
-              : "Couldn't load this environment's tools.",
+          error: {
+            message:
+              caught instanceof Error
+                ? caught.message
+                : "Couldn't load this environment's tools.",
+          },
           isLoading: false,
         });
       }

--- a/mcpjam-inspector/client/src/hooks/use-playground-environment.ts
+++ b/mcpjam-inspector/client/src/hooks/use-playground-environment.ts
@@ -10,6 +10,7 @@ import {
   type EnvironmentPreviewPlugin,
   type EnvironmentPreviewServer,
 } from "@/hooks/use-environment-preview";
+import type { EnvironmentErrorPayload } from "@/lib/environment-error";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
 
@@ -65,7 +66,12 @@ export interface PlaygroundEnvironmentState {
   environmentId: string | null;
   preview: EnvironmentPreview | null;
   isPreviewLoading: boolean;
-  previewError: string | null;
+  /**
+   * Structured, so the surface can render an actionable card rather than a red
+   * sentence — it carries the backend's `ENV_*` code alongside the message.
+   * Pass it to `describeEnvironmentError` rather than reading `.message`.
+   */
+  previewError: EnvironmentErrorPayload | null;
   /**
    * True while an environment is selected but has not yet resolved to a usable
    * preview (initial resolve, or the gap after switching to a different one).

--- a/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
@@ -1,6 +1,14 @@
+import { useMemo } from "react";
 import { useMutation, useQuery, useConvexAuth } from "convex/react";
 import { useDbUserReady } from "@/contexts/db-user-ready-context";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
+import {
+  isNamedEnvironment,
+  type ProjectEnvironmentOrigin,
+} from "@/lib/environment-label";
+// NOTE the import direction: `environment-label` imports ONLY a type from this
+// module (`import type`, erased at build), so this value import does not create
+// a runtime cycle. Keep it that way — a value import back this way would.
 
 /**
  * Client hooks for **Project environments** (mcpjam-backend
@@ -33,7 +41,32 @@ export type ProjectEnvironmentSkillSelection = {
 export interface ProjectEnvironmentView {
   environmentId: string;
   projectId: string;
-  name: string;
+  /**
+   * ABSENT on ad-hoc rows, which have no name by construction.
+   *
+   * Never render this directly — call `environmentLabel()` from
+   * `@/lib/environment-label`, which derives a label from row data when the
+   * name is missing. Rendering it raw is how a nameless row becomes a blank
+   * cell or an `Archive "undefined"?` confirmation.
+   */
+  name?: string;
+  /**
+   * Which KIND of row this is — see `@/lib/environment-label`.
+   *
+   * OPTIONAL for deploy skew: a backend that predates the split omits it, and
+   * every row it returns is named. Read it through `environmentOrigin()`, which
+   * falls back to name-presence, rather than testing this field directly.
+   */
+  origin?: ProjectEnvironmentOrigin;
+  /** Backend content fingerprint; the ad-hoc dedupe key. Ad-hoc rows only. */
+  fingerprint?: string;
+  /**
+   * Denormalized usage counters, bumped by `ensureAdhocEnvironment`. ABSENT is
+   * NOT zero — an older backend omits them, and a surface must render nothing
+   * rather than "0 runs" when it cannot tell the difference.
+   */
+  lastUsedAt?: number;
+  runCount?: number;
   description?: string;
   /** Exactly one host per environment. */
   hostId: string;
@@ -67,10 +100,27 @@ export interface ProjectEnvironmentView {
  * Environments for a project. The management route passes
  * `includeArchived: true`; suite/journey pickers use the live-only default.
  * `undefined` while loading or when the query is skipped.
+ *
+ * ## Ad-hoc rows are excluded by default
+ *
+ * Most surfaces — every picker, the Connect strip, the schedule editor — offer
+ * environments a human chose to name. Ad-hoc rows are machine-minted and would
+ * flood them, so `includeAdhoc` is opt-in and this hook filters them out
+ * otherwise.
+ *
+ * That filter is deliberately REDUNDANT with the backend's own default (which
+ * also returns named-only). Belt and braces, because the two protect different
+ * failure modes: the backend default is what keeps already-deployed clients and
+ * the public `/v1` list correct during rollout, and this filter is what keeps
+ * THIS client correct against a backend that ignores the argument.
+ *
+ * Note the argument is only SENT when opting in. A backend that predates the
+ * split rejects unknown args with a validation error, so passing the default
+ * explicitly would turn a harmless skew into a hard failure.
  */
 export function useProjectEnvironments(
   projectId: string | null,
-  options?: { includeArchived?: boolean }
+  options?: { includeArchived?: boolean; includeAdhoc?: boolean }
 ): ProjectEnvironmentView[] | undefined {
   const { isAuthenticated } = useConvexAuth();
   const isUserReady = useDbUserReady();
@@ -80,15 +130,22 @@ export function useProjectEnvironments(
   const normalizedProjectId = projectId?.trim() || null;
   const enableQuery =
     isAuthenticated && isUserReady && shouldQueryProjectId(normalizedProjectId);
-  return useQuery(
+  const includeAdhoc = options?.includeAdhoc ?? false;
+  const rows = useQuery(
     "projectEnvironments:listEnvironments" as any,
     enableQuery
       ? ({
           projectId: normalizedProjectId,
           ...(options?.includeArchived ? { includeArchived: true } : {}),
+          ...(includeAdhoc ? { origin: "all" } : {}),
         } as any)
       : "skip"
   ) as ProjectEnvironmentView[] | undefined;
+  return useMemo(() => {
+    if (rows === undefined) return undefined;
+    if (includeAdhoc) return rows;
+    return rows.filter(isNamedEnvironment);
+  }, [rows, includeAdhoc]);
 }
 
 /**
@@ -143,6 +200,98 @@ export function useCreateProjectEnvironment(): (args: {
   computerEnvironmentId?: string;
 }) => Promise<ProjectEnvironmentView> {
   return useMutation("projectEnvironments:createEnvironment" as any) as never;
+}
+
+/**
+ * Get-or-create the AD-HOC environment for a composition, in one transaction.
+ *
+ * `name` is absent from the argument list on purpose: an ad-hoc row cannot
+ * carry one, and accepting-then-ignoring a name would let a caller believe it
+ * had named something. Naming is {@link usePromoteProjectEnvironment}.
+ *
+ * The backend fingerprints the composition and returns an existing row when one
+ * matches, so this is idempotent — running the same stack fifty times yields one
+ * row. The fingerprint is computed server-side and never crosses the wire,
+ * which is what makes a client/server canonicalizer drift impossible.
+ *
+ * MEMBER-gated, unlike `createEnvironment`'s admin escalation for plugin pins —
+ * except that pinning plugins escalates here too, for the same reason it does
+ * there: pinning a version is plugin-lifecycle authority, and this must not
+ * become a side door into it.
+ *
+ * `created` distinguishes a mint from a match. A backend that omits it reads as
+ * a reuse, which only costs a word in a toast.
+ */
+export function useEnsureAdhocEnvironment(): (args: {
+  projectId: string;
+  hostId: string;
+  serverAttachmentId?: string | null;
+  skillSelection?: ProjectEnvironmentSkillSelection | null;
+  computerEnvironmentId?: string;
+}) => Promise<{ environment: ProjectEnvironmentView; created?: boolean }> {
+  return useMutation(
+    "projectEnvironments:ensureAdhocEnvironment" as any
+  ) as never;
+}
+
+/**
+ * Batch form: get-or-create one ad-hoc environment per composition, atomically.
+ *
+ * Preferred over N sequential {@link useEnsureAdhocEnvironment} calls on the
+ * launch path. A swarm fans out to up to `MAX_ENVIRONMENTS_PER_JOURNEY` clients,
+ * and the per-call loop it replaces could fail midway and leave orphan rows
+ * behind. One transaction makes materialization all-or-nothing, and two
+ * identical stacks in one batch resolve to one row naturally (the second lookup
+ * sees the first insert).
+ *
+ * Results are returned in input order.
+ */
+export function useEnsureAdhocEnvironments(): (args: {
+  projectId: string;
+  stacks: Array<{
+    hostId: string;
+    serverAttachmentId?: string | null;
+    skillSelection?: ProjectEnvironmentSkillSelection | null;
+    computerEnvironmentId?: string;
+  }>;
+}) => Promise<
+  Array<{ environment: ProjectEnvironmentView; created?: boolean }>
+> {
+  return useMutation(
+    "projectEnvironments:ensureAdhocEnvironments" as any
+  ) as never;
+}
+
+/**
+ * Promote an ad-hoc row to a named environment, IN PLACE.
+ *
+ * The returned row keeps the SAME `environmentId`. That is not an
+ * implementation detail — synthetic swarm session ids are derived from it
+ * (`shared/swarm-session-id.ts`: `synth_<runId>_env_<environmentId>_<idx>`), so
+ * an implementation that inserted a new row and archived the old one would make
+ * every historical run's session cells unresolvable. Any change here must keep
+ * the id stable.
+ *
+ * MEMBER-gated, matching `createEnvironment`. Promotion touches only the name,
+ * description, and kind — by construction it cannot change what any existing
+ * suite or journey resolves to, which is what the admin gate on the MUTATING
+ * operations actually protects. Note the direction of travel: it moves a row
+ * from member-writable to admin-only, so it REDUCES the promoter's own power
+ * over it.
+ *
+ * Takes `expectedRevision` like every other environment write. Ad-hoc rows are
+ * immutable so the revision is always 1, which makes it look like ceremony — it
+ * is not: it closes the race where two people promote the same row from the same
+ * screen and the second silently clobbers the first's name.
+ */
+export function usePromoteProjectEnvironment(): (args: {
+  projectId: string;
+  environmentId: string;
+  expectedRevision: number;
+  name: string;
+  description?: string;
+}) => Promise<ProjectEnvironmentView> {
+  return useMutation("projectEnvironments:nameEnvironment" as any) as never;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/__tests__/environment-error.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/environment-error.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeEnvironmentError,
+  isNoServersError,
+  readEnvironmentErrorPayload,
+} from "@/lib/environment-error";
+
+const NO_SERVERS_SENTENCE =
+  'Environment "Billing · ChatGPT" resolves to no servers. Pick at least one server before launching.';
+
+describe("readEnvironmentErrorPayload", () => {
+  // The whole point of the change: the DOMAIN code lives in `details`, and it
+  // used to be thrown away, which is why every failure rendered identically.
+  it("prefers the domain code in details over the transport code", () => {
+    const payload = readEnvironmentErrorPayload(
+      {
+        code: "conflict",
+        message: NO_SERVERS_SENTENCE,
+        details: { code: "ENV_NO_SERVERS", environmentId: "env_1" },
+      },
+      "fallback"
+    );
+    expect(payload.code).toBe("ENV_NO_SERVERS");
+    expect(payload.message).toBe(NO_SERVERS_SENTENCE);
+    expect(payload.details).toEqual({
+      code: "ENV_NO_SERVERS",
+      environmentId: "env_1",
+    });
+  });
+
+  it("falls back to the transport code when there is no details code", () => {
+    expect(
+      readEnvironmentErrorPayload({ code: "not_found", message: "Gone" }, "f")
+        .code
+    ).toBe("not_found");
+  });
+
+  // Some route envelopes carry only one of these shapes; dropping either would
+  // flatten an actionable failure into the generic fallback.
+  it.each([
+    [{ error: "from error string" }, "from error string"],
+    [{ error: { message: "from error object" } }, "from error object"],
+    [{ message: "from top-level message" }, "from top-level message"],
+  ])("reads the message from %o", (body, expected) => {
+    expect(readEnvironmentErrorPayload(body, "fallback").message).toBe(
+      expected
+    );
+  });
+
+  it.each([[null], [undefined], ["a string body"], [{}]])(
+    "falls back for an unusable body (%o)",
+    (body) => {
+      expect(readEnvironmentErrorPayload(body, "fallback").message).toBe(
+        "fallback"
+      );
+    }
+  );
+
+  it("omits code entirely rather than emitting undefined", () => {
+    expect("code" in readEnvironmentErrorPayload({ message: "x" }, "f")).toBe(
+      false
+    );
+  });
+});
+
+describe("describeEnvironmentError", () => {
+  it("turns ENV_NO_SERVERS into an actionable warning", () => {
+    const normalized = describeEnvironmentError({
+      message: NO_SERVERS_SENTENCE,
+      code: "ENV_NO_SERVERS",
+    });
+    expect(normalized.title).toBe("This environment has no servers");
+    expect(normalized.severity).toBe("warning");
+    // The backend's own sentence survives verbatim — it names the specific
+    // environment, which no client-side copy can do.
+    expect(normalized.oneLine).toBe(NO_SERVERS_SENTENCE);
+    expect(normalized.rawCode).toBe("ENV_NO_SERVERS");
+    expect(normalized.likelyCauses.length).toBeGreaterThan(0);
+    expect(normalized.nextSteps.length).toBeGreaterThan(0);
+  });
+
+  // An ENV_ code we have no bespoke copy for still beats describeError: it
+  // keeps the backend prose and surfaces the code in the details block.
+  it("keeps the message and code for an unrecognized ENV_ code", () => {
+    const normalized = describeEnvironmentError({
+      message: "Something environment-shaped went wrong.",
+      code: "ENV_SOMETHING_NEW",
+    });
+    expect(normalized.oneLine).toBe("Something environment-shaped went wrong.");
+    expect(normalized.rawCode).toBe("ENV_SOMETHING_NEW");
+    expect(normalized.nextSteps.length).toBeGreaterThan(0);
+  });
+
+  it("gives ENV_ARCHIVED and ENV_HOST_MISSING their own titles", () => {
+    expect(
+      describeEnvironmentError({ message: "m", code: "ENV_ARCHIVED" }).title
+    ).toBe("This environment is archived");
+    expect(
+      describeEnvironmentError({ message: "m", code: "ENV_HOST_MISSING" }).title
+    ).toBe("This environment's client no longer exists");
+  });
+
+  // Non-environment failures must not be dressed up as environment ones.
+  it("delegates a non-ENV payload to describeError", () => {
+    const normalized = describeEnvironmentError({
+      message: "socket hang up",
+      code: "internal_error",
+    });
+    expect(normalized.slug.startsWith("environment/")).toBe(false);
+  });
+
+  it("delegates a thrown Error to describeError", () => {
+    const normalized = describeEnvironmentError(new Error("boom"));
+    expect(normalized.slug.startsWith("environment/")).toBe(false);
+    expect(typeof normalized.title).toBe("string");
+  });
+});
+
+describe("isNoServersError", () => {
+  it("matches only the zero-servers code", () => {
+    expect(isNoServersError({ message: "m", code: "ENV_NO_SERVERS" })).toBe(
+      true
+    );
+    expect(isNoServersError({ message: "m", code: "ENV_ARCHIVED" })).toBe(
+      false
+    );
+    expect(isNoServersError({ message: "m" })).toBe(false);
+    expect(isNoServersError(null)).toBe(false);
+    expect(isNoServersError("ENV_NO_SERVERS")).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/environment-label.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/environment-label.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import {
+  disambiguateLabels,
+  environmentDetailLine,
+  environmentImageLabel,
+  environmentLabel,
+  environmentOrigin,
+  isAdhocEnvironment,
+  isNamedEnvironment,
+  trimOrUndefined,
+  type EnvironmentLabelContext,
+  type EnvironmentLabelRow,
+} from "@/lib/environment-label";
+
+const HOSTS: Record<string, string> = {
+  h_claude: "Claude",
+  h_chatgpt: "ChatGPT",
+};
+
+const ctx: EnvironmentLabelContext = {
+  hostName: (hostId) => HOSTS[hostId],
+  imageName: (imageId) => (imageId === "img_ok" ? "ubuntu-24" : undefined),
+  computersEnabled: true,
+};
+
+function row(
+  overrides: Partial<EnvironmentLabelRow> = {}
+): EnvironmentLabelRow {
+  return {
+    environmentId: "env_1",
+    hostId: "h_claude",
+    ...overrides,
+  };
+}
+
+describe("environmentOrigin", () => {
+  it("uses the explicit origin when the backend sends one", () => {
+    expect(environmentOrigin(row({ origin: "adhoc", name: "leftover" }))).toBe(
+      "adhoc"
+    );
+    expect(environmentOrigin(row({ origin: "named" }))).toBe("named");
+  });
+
+  // Deploy skew: a backend that predates the split omits `origin` entirely, and
+  // every row it returns is one a human named.
+  it("reads a named row from a pre-origin backend as named", () => {
+    expect(environmentOrigin(row({ name: "Billing" }))).toBe("named");
+    expect(isNamedEnvironment(row({ name: "Billing" }))).toBe(true);
+  });
+
+  it("reads a nameless row with no origin as adhoc rather than blank", () => {
+    expect(environmentOrigin(row())).toBe("adhoc");
+    expect(isAdhocEnvironment(row())).toBe(true);
+  });
+
+  // A whitespace-only name is not a name.
+  it("treats a blank name as absent", () => {
+    expect(environmentOrigin(row({ name: "   " }))).toBe("adhoc");
+  });
+});
+
+describe("environmentLabel", () => {
+  it("labels a named row with its name", () => {
+    expect(environmentLabel(row({ name: "Billing" }), ctx)).toBe("Billing");
+  });
+
+  it("labels an adhoc row with its client name", () => {
+    expect(environmentLabel(row({ origin: "adhoc" }), ctx)).toBe("Claude");
+  });
+
+  // The `.trim() ||` vs `??` distinction. An empty name must fall THROUGH to the
+  // client name; `??` would pass it straight to the UI as a blank cell.
+  it("falls through an empty-string name to the client name", () => {
+    expect(environmentLabel(row({ name: "" }), ctx)).toBe("Claude");
+  });
+
+  it("falls back when the host is gone from the project", () => {
+    expect(environmentLabel(row({ hostId: "h_deleted" }), ctx)).toBe(
+      "Unknown client"
+    );
+  });
+});
+
+describe("environmentDetailLine", () => {
+  it("describes the client's own servers with zero pins", () => {
+    expect(environmentDetailLine(row(), ctx)).toBe(
+      "Client's own servers · 0 skill pins · 0 plugin pins"
+    );
+  });
+
+  it("singularizes a single pin and names an attached group", () => {
+    const line = environmentDetailLine(
+      row({
+        serverAttachmentId: "sa_1",
+        skillSelection: { mode: "explicit", skillIds: ["s1"] },
+        pluginVersionIds: ["pv1"],
+      }),
+      ctx
+    );
+    expect(line).toBe("Server group attached · 1 skill pin · 1 plugin pin");
+  });
+
+  it("appends the image name when one is pinned", () => {
+    const line = environmentDetailLine(
+      row({ computerEnvironmentId: "img_ok" }),
+      ctx
+    );
+    expect(line.endsWith(" · ubuntu-24")).toBe(true);
+  });
+});
+
+describe("environmentImageLabel", () => {
+  // Absence is semantic — an unpinned row means "provider default image" and
+  // must render nothing rather than a filler label.
+  it("returns undefined when nothing is pinned", () => {
+    expect(environmentImageLabel(row(), ctx)).toBeUndefined();
+  });
+
+  it("returns undefined when the computers flag is off, even if pinned", () => {
+    expect(
+      environmentImageLabel(row({ computerEnvironmentId: "img_ok" }), {
+        ...ctx,
+        computersEnabled: false,
+      })
+    ).toBeUndefined();
+  });
+
+  // A deleted or not-yet-loaded image degrades to a truncated id, never a blank.
+  it("degrades an unresolvable image to a truncated id", () => {
+    expect(
+      environmentImageLabel(
+        row({ computerEnvironmentId: "img_gone_1234" }),
+        ctx
+      )
+    ).toBe("image img_gone…");
+  });
+});
+
+describe("disambiguateLabels", () => {
+  it("leaves unique labels untouched", () => {
+    const out = disambiguateLabels([{ label: "Claude" }, { label: "ChatGPT" }]);
+    expect(out.map((o) => o.label)).toEqual(["Claude", "ChatGPT"]);
+  });
+
+  // Adhoc rows label by client name, so this is the COMMON case, not an edge.
+  it("suffixes colliding labels in stable order", () => {
+    const out = disambiguateLabels([
+      { label: "Claude" },
+      { label: "ChatGPT" },
+      { label: "Claude" },
+      { label: "Claude" },
+    ]);
+    expect(out.map((o) => o.label)).toEqual([
+      "Claude #1",
+      "ChatGPT",
+      "Claude #2",
+      "Claude #3",
+    ]);
+  });
+
+  it("preserves the other fields on each item", () => {
+    const out = disambiguateLabels([
+      { label: "Claude", environmentId: "a" },
+      { label: "Claude", environmentId: "b" },
+    ]);
+    expect(out.map((o) => o.environmentId)).toEqual(["a", "b"]);
+  });
+});
+
+describe("trimOrUndefined", () => {
+  it.each([
+    ["Billing", "Billing"],
+    ["  Billing  ", "Billing"],
+    ["", undefined],
+    ["   ", undefined],
+    [undefined, undefined],
+  ])("%o → %o", (input, expected) => {
+    expect(trimOrUndefined(input as string | undefined)).toBe(expected);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/environment-label.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/environment-label.test.ts
@@ -178,3 +178,28 @@ describe("trimOrUndefined", () => {
     expect(trimOrUndefined(input as string | undefined)).toBe(expected);
   });
 });
+
+describe("environmentLabel without a client-name lookup", () => {
+  // Surfaces that never LIST ad-hoc rows (the shared picker) omit the lookup
+  // rather than pay two project-wide queries to label a rare selected row.
+  it("labels an adhoc row generically when no hostName is supplied", () => {
+    expect(environmentLabel(row({ origin: "adhoc" }), {})).toBe(
+      "Automatic environment"
+    );
+    expect(environmentLabel(row({ origin: "adhoc" }))).toBe(
+      "Automatic environment"
+    );
+  });
+
+  // "Unknown client" specifically means "the host was deleted" — a claim we
+  // cannot make without a lookup, so it must not leak into the no-context path.
+  it("does not claim the client is unknown when it simply wasn't looked up", () => {
+    expect(environmentLabel(row({ origin: "adhoc" }), {})).not.toBe(
+      "Unknown client"
+    );
+  });
+
+  it("still prefers a real name over the generic label", () => {
+    expect(environmentLabel(row({ name: "Billing" }), {})).toBe("Billing");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/environment-error.ts
+++ b/mcpjam-inspector/client/src/lib/environment-error.ts
@@ -1,0 +1,179 @@
+import { describeError, type NormalizedError } from "@mcpjam/sdk/browser";
+
+/**
+ * Turn an environment-resolution failure into a card the user can act on.
+ *
+ * ## Why this exists
+ *
+ * The backend raises a structured `ENV_*` code and a sentence, and the route
+ * layer forwards BOTH — the sentence as `message`, the code in `details.code`
+ * (see `server/services/environments/runtime.ts`). Until now the client threw
+ * the code away and rendered the bare sentence as red text, which is why an
+ * environment with no servers produced a wall of prose with nothing to click.
+ *
+ * The remedy is deliberately client-side. The backend sentence stays the
+ * `oneLine` verbatim — it is the accurate statement of what went wrong — while
+ * the likely causes and next steps are authored HERE, because they depend on
+ * which surface is asking and the backend has no idea whether it is talking to
+ * the Playground, a swarm launch, or an eval. No backend copy change needed.
+ */
+
+export interface EnvironmentErrorPayload {
+  /** The backend's own sentence. Rendered verbatim as the card's one-liner. */
+  message: string;
+  /** `details.code` from the 409 — e.g. `ENV_NO_SERVERS`. */
+  code?: string;
+  details?: Record<string, unknown>;
+}
+
+const DOCS_ANCHOR = "/troubleshooting/error-codes";
+
+/**
+ * Pull the message AND the machine code out of a web-route error body.
+ *
+ * The body is `{ code, message, details?: { code? } }` (`webError`). The
+ * environment routes put the TRANSPORT code (`conflict`) at the top level and
+ * the DOMAIN code (`ENV_NO_SERVERS`) inside `details` — callers branch on the
+ * domain one, so it wins.
+ *
+ * The message probe order — `error` (string or `{message}`), then a top-level
+ * `message` — is deliberate: some route envelopes carry only the latter, and
+ * dropping it would flatten an actionable resolve failure into the generic
+ * fallback.
+ *
+ * Shared by the preview and tools hooks. Both hit routes that resolve through
+ * the SAME backend query, so both see the same codes; two copies of this would
+ * drift.
+ */
+export function readEnvironmentErrorPayload(
+  payload: unknown,
+  fallback: string
+): EnvironmentErrorPayload {
+  if (!payload || typeof payload !== "object") return { message: fallback };
+  const record = payload as {
+    error?: unknown;
+    message?: unknown;
+    code?: unknown;
+    details?: unknown;
+  };
+  const details =
+    record.details && typeof record.details === "object"
+      ? (record.details as Record<string, unknown>)
+      : undefined;
+  const domainCode =
+    details && typeof details.code === "string" ? details.code : undefined;
+  const topCode = typeof record.code === "string" ? record.code : undefined;
+
+  let message: string | undefined;
+  if (typeof record.error === "string" && record.error.length > 0) {
+    message = record.error;
+  } else if (record.error && typeof record.error === "object") {
+    const nested = (record.error as { message?: unknown }).message;
+    if (typeof nested === "string" && nested.length > 0) message = nested;
+  }
+  if (!message && typeof record.message === "string" && record.message) {
+    message = record.message;
+  }
+
+  const code = domainCode ?? topCode;
+  return {
+    message: message ?? fallback,
+    ...(code ? { code } : {}),
+    ...(details ? { details } : {}),
+  };
+}
+
+export function isEnvironmentErrorPayload(
+  value: unknown
+): value is EnvironmentErrorPayload {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    typeof (value as { message?: unknown }).message === "string"
+  );
+}
+
+/**
+ * Per-code copy. Only codes whose remedy is genuinely different get an entry;
+ * everything else falls through to the generic `ENV_*` shape below, which still
+ * beats `describeError` because it keeps the backend's sentence and code.
+ */
+const ENV_COPY: Record<
+  string,
+  Pick<NormalizedError, "title" | "likelyCauses" | "nextSteps" | "severity">
+> = {
+  ENV_NO_SERVERS: {
+    title: "This environment has no servers",
+    severity: "warning",
+    likelyCauses: [
+      "The client this environment points at has no servers connected",
+      "The attached server group is empty",
+      "Every server contributed by a pinned plugin has been removed",
+    ],
+    nextSteps: [
+      "Connect a server to the client, or attach a server group",
+      "Check the environment's pinned plugins if it relied on one for servers",
+    ],
+  },
+  ENV_ARCHIVED: {
+    title: "This environment is archived",
+    severity: "warning",
+    likelyCauses: ["Someone archived it after this was configured"],
+    nextSteps: [
+      "Restore it from the Environments list, or pick a different one",
+    ],
+  },
+  ENV_HOST_MISSING: {
+    title: "This environment's client no longer exists",
+    severity: "error",
+    likelyCauses: ["The client was deleted after the environment was created"],
+    nextSteps: ["Point the environment at a different client, or recreate it"],
+  },
+  ENV_ATTACHMENT_MISSING: {
+    title: "This environment's server group is gone",
+    severity: "error",
+    likelyCauses: ["The attached server group was deleted"],
+    nextSteps: ["Attach a different server group, or clear the attachment"],
+  },
+};
+
+/**
+ * `NormalizedError` for an environment failure.
+ *
+ * Anything that is not a recognizable environment error — a network blip, an
+ * auth failure, a thrown `Error` — delegates to `describeError`, which already
+ * classifies those well and always returns a complete result.
+ */
+export function describeEnvironmentError(input: unknown): NormalizedError {
+  if (!isEnvironmentErrorPayload(input)) return describeError(input);
+  const { message, code } = input;
+  if (!code || !code.startsWith("ENV_")) return describeError(message);
+
+  const copy = ENV_COPY[code];
+  return {
+    slug: `environment/${code.toLowerCase()}`,
+    title: copy?.title ?? "This environment can't run right now",
+    // The backend's sentence, verbatim. It names the specific environment and
+    // is the most accurate one-line statement available.
+    oneLine: message,
+    likelyCauses: copy?.likelyCauses ?? [],
+    nextSteps: copy?.nextSteps ?? [
+      "Open the environment and check its client, servers, and pins",
+    ],
+    docsAnchor: DOCS_ANCHOR,
+    severity: copy?.severity ?? "error",
+    rawMessage: message,
+    rawCode: code,
+  };
+}
+
+/**
+ * True when the failure is specifically "resolves to zero servers".
+ *
+ * Surfaces use this to offer the one action that actually fixes it — opening
+ * the client's servers — rather than a generic retry, which would just fail
+ * again identically.
+ */
+export function isNoServersError(input: unknown): boolean {
+  return isEnvironmentErrorPayload(input) && input.code === "ENV_NO_SERVERS";
+}

--- a/mcpjam-inspector/client/src/lib/environment-label.ts
+++ b/mcpjam-inspector/client/src/lib/environment-label.ts
@@ -1,0 +1,217 @@
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+
+/**
+ * THE display vocabulary for project environments.
+ *
+ * An environment row comes in two kinds. A NAMED row is one a human named: it
+ * appears in the Environments list, it is editable, and its `name` is the label.
+ * An AD-HOC row was materialized from a composition someone ran without picking
+ * a saved environment — it has NO name by construction, is immutable, and is
+ * deduped by a backend content fingerprint.
+ *
+ * Because half the rows have no name, `environment.name` must never be rendered
+ * directly. Every surface calls {@link environmentLabel} instead, so a nameless
+ * row degrades in ONE place rather than at each of the ~15 sites that used to
+ * write `env.name ?? env.environmentId.slice(0, 8)` by hand.
+ *
+ * This module is deliberately pure and React-free: `swarm-targets.ts`,
+ * `journey-environments.ts`, and `evals/helpers.ts` all need it and none of them
+ * is a component. The React side of the same job — fetching the host and image
+ * name maps without an N+1 — lives in `use-environment-label-context.ts`.
+ */
+
+export type ProjectEnvironmentOrigin = "named" | "adhoc";
+
+/**
+ * The row fields the label vocabulary reads. Structural rather than the full
+ * {@link ProjectEnvironmentView} so callers holding a projection (a run
+ * snapshot's target, a partially-selected row) can pass what they have.
+ */
+export type EnvironmentLabelRow = Pick<
+  ProjectEnvironmentView,
+  "environmentId" | "hostId"
+> &
+  Partial<
+    Pick<
+      ProjectEnvironmentView,
+      | "name"
+      | "origin"
+      | "serverAttachmentId"
+      | "skillSelection"
+      | "pluginVersionIds"
+      | "computerEnvironmentId"
+    >
+  >;
+
+export interface EnvironmentLabelContext {
+  /**
+   * `undefined` for a host that is no longer in the project. The fallback chain
+   * depends on that distinction, exactly like `buildSwarmRunTargets` — do not
+   * coalesce to a placeholder inside the lookup.
+   */
+  hostName: (hostId: string) => string | undefined;
+  /** Absent when the computers flag is off or no loaded row pins an image. */
+  imageName?: (imageId: string) => string | undefined;
+  computersEnabled?: boolean;
+}
+
+/** Shown when a row's host has been deleted out from under it. */
+const UNKNOWN_HOST_LABEL = "Unknown client";
+
+/**
+ * Trim, and treat whitespace-only as absent.
+ *
+ * Used instead of `??` everywhere a name is consumed. The distinction is
+ * load-bearing at the run-snapshot boundary: `environmentRef.name` is typed as a
+ * required string on the backend (it is baked into two historical run-snapshot
+ * schemas), so an ad-hoc target may arrive carrying `""` rather than an absent
+ * field. With `??` an empty string passes straight through and every matrix
+ * column renders blank; with this, it falls through to the host name.
+ */
+export function trimOrUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Which kind of row this is.
+ *
+ * Falls back to name-presence rather than assuming, so this is correct in both
+ * skew directions: a backend that predates `origin` returns named rows with no
+ * `origin` field (⇒ "named", which they are), and a row that somehow arrives
+ * nameless without an origin still reads as ad-hoc rather than rendering blank.
+ */
+export function environmentOrigin(
+  environment: EnvironmentLabelRow
+): ProjectEnvironmentOrigin {
+  if (environment.origin === "named" || environment.origin === "adhoc") {
+    return environment.origin;
+  }
+  return trimOrUndefined(environment.name) ? "named" : "adhoc";
+}
+
+export function isNamedEnvironment(environment: EnvironmentLabelRow): boolean {
+  return environmentOrigin(environment) === "named";
+}
+
+export function isAdhocEnvironment(environment: EnvironmentLabelRow): boolean {
+  return environmentOrigin(environment) === "adhoc";
+}
+
+/**
+ * The ONE display label for an environment.
+ *
+ * Named rows label as their name. Ad-hoc rows label as their client's name,
+ * because that is the only human-meaningful thing a composition carries — which
+ * means ad-hoc labels COLLIDE by design (every ad-hoc row on one client reads
+ * the same). Any surface listing more than one must run the result through
+ * {@link disambiguateLabels}.
+ */
+export function environmentLabel(
+  environment: EnvironmentLabelRow,
+  ctx: EnvironmentLabelContext
+): string {
+  const name = trimOrUndefined(environment.name);
+  if (name) return name;
+  return (
+    trimOrUndefined(ctx.hostName(environment.hostId)) ?? UNKNOWN_HOST_LABEL
+  );
+}
+
+/** `"Server group attached"` vs `"Client's own servers"`. */
+export function describeServerScope(environment: EnvironmentLabelRow): string {
+  return environment.serverAttachmentId
+    ? "Server group attached"
+    : "Client's own servers";
+}
+
+/**
+ * Pinned skill / plugin counts.
+ *
+ * These are honest row data — `skillSelection.skillIds` is the explicit pinned
+ * selection and `pluginVersionIds` are pinned version ids, both stored and
+ * exact. They are labeled as PINS, never as totals, because the host and plugin
+ * channels contribute more skills at resolve time.
+ */
+export function environmentPinCounts(environment: EnvironmentLabelRow): {
+  skillPins: number;
+  pluginPins: number;
+} {
+  return {
+    skillPins: environment.skillSelection?.skillIds.length ?? 0,
+    pluginPins: environment.pluginVersionIds?.length ?? 0,
+  };
+}
+
+/**
+ * The sandbox-image chip text, or `undefined` when no chip should render.
+ *
+ * Absence is semantic (the provider default image), so an unpinned row shows
+ * nothing rather than a filler label. A pinned image the images query hasn't
+ * resolved — or one that was deleted — degrades to a truncated raw id, never a
+ * silent blank.
+ */
+export function environmentImageLabel(
+  environment: EnvironmentLabelRow,
+  ctx: EnvironmentLabelContext
+): string | undefined {
+  if (!ctx.computersEnabled) return undefined;
+  const imageId = environment.computerEnvironmentId;
+  if (!imageId) return undefined;
+  return (
+    trimOrUndefined(ctx.imageName?.(imageId)) ?? `image ${imageId.slice(0, 8)}…`
+  );
+}
+
+/**
+ * The composition line as a plain string — server scope, pin counts, and the
+ * image chip, joined with the same ` · ` separator the cards use.
+ *
+ * Note what is NOT here: a resolved server count. The row stores a
+ * `serverAttachmentId` (a scope), not a server set; the real set folds in the
+ * host's own picks and any plugin-contributed servers, both LIVE. Printing a
+ * number would mean either lying or paying one resolve round trip PER ROW — an
+ * N+1 on a list that renders on every visit. The count belongs in the
+ * Playground, where exactly one environment is resolved for real.
+ *
+ * `EnvironmentSummaryLine` renders the same content as JSX (so the image chip
+ * can carry its tooltip); both compose the helpers above so they cannot drift.
+ */
+export function environmentDetailLine(
+  environment: EnvironmentLabelRow,
+  ctx: EnvironmentLabelContext
+): string {
+  const { skillPins, pluginPins } = environmentPinCounts(environment);
+  const parts = [
+    describeServerScope(environment),
+    `${skillPins} skill pin${skillPins === 1 ? "" : "s"}`,
+    `${pluginPins} plugin pin${pluginPins === 1 ? "" : "s"}`,
+  ];
+  const imageLabel = environmentImageLabel(environment, ctx);
+  if (imageLabel) parts.push(imageLabel);
+  return parts.join(" · ");
+}
+
+/**
+ * Suffix duplicate labels with a stable `#n` (collision groups only; unique
+ * labels are returned untouched).
+ *
+ * Moved here from `swarm-targets.ts`, where it was module-private, because
+ * ad-hoc rows make collisions the NORM rather than the exception: every ad-hoc
+ * row on one client derives the same label.
+ */
+export function disambiguateLabels<T extends { label: string }>(
+  items: readonly T[]
+): T[] {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    counts.set(item.label, (counts.get(item.label) ?? 0) + 1);
+  }
+  const seen = new Map<string, number>();
+  return items.map((item) => {
+    if ((counts.get(item.label) ?? 0) <= 1) return item;
+    const n = (seen.get(item.label) ?? 0) + 1;
+    seen.set(item.label, n);
+    return { ...item, label: `${item.label} #${n}` };
+  });
+}

--- a/mcpjam-inspector/client/src/lib/environment-label.ts
+++ b/mcpjam-inspector/client/src/lib/environment-label.ts
@@ -45,11 +45,17 @@ export type EnvironmentLabelRow = Pick<
 
 export interface EnvironmentLabelContext {
   /**
-   * `undefined` for a host that is no longer in the project. The fallback chain
-   * depends on that distinction, exactly like `buildSwarmRunTargets` — do not
-   * coalesce to a placeholder inside the lookup.
+   * Client-name lookup. `undefined` for a host that is no longer in the
+   * project — the fallback chain depends on that distinction, exactly like
+   * `buildSwarmRunTargets`, so do not coalesce to a placeholder inside it.
+   *
+   * OMIT the whole function on surfaces that never need it. A picker that only
+   * labels an already-selected ad-hoc row — and never offers one — should not
+   * pay two project-wide queries for a rare edge case; it passes `{}` and gets
+   * the generic label below. `useEnvironmentLabelContext` supplies the real
+   * lookup on surfaces that list ad-hoc rows for real.
    */
-  hostName: (hostId: string) => string | undefined;
+  hostName?: (hostId: string) => string | undefined;
   /** Absent when the computers flag is off or no loaded row pins an image. */
   imageName?: (imageId: string) => string | undefined;
   computersEnabled?: boolean;
@@ -57,6 +63,9 @@ export interface EnvironmentLabelContext {
 
 /** Shown when a row's host has been deleted out from under it. */
 const UNKNOWN_HOST_LABEL = "Unknown client";
+
+/** Ad-hoc label where no client-name lookup is available. */
+const GENERIC_ADHOC_LABEL = "Automatic environment";
 
 /**
  * Trim, and treat whitespace-only as absent.
@@ -109,10 +118,14 @@ export function isAdhocEnvironment(environment: EnvironmentLabelRow): boolean {
  */
 export function environmentLabel(
   environment: EnvironmentLabelRow,
-  ctx: EnvironmentLabelContext
+  ctx: EnvironmentLabelContext = {}
 ): string {
   const name = trimOrUndefined(environment.name);
   if (name) return name;
+  // No lookup supplied ⇒ this surface doesn't list ad-hoc rows and shouldn't
+  // pay for the host query. "Unknown client" would be a lie there; it means
+  // "the host was deleted", which we cannot know without the lookup.
+  if (!ctx.hostName) return GENERIC_ADHOC_LABEL;
   return (
     trimOrUndefined(ctx.hostName(environment.hostId)) ?? UNKNOWN_HOST_LABEL
   );

--- a/mcpjam-inspector/server/routes/v1/environments.ts
+++ b/mcpjam-inspector/server/routes/v1/environments.ts
@@ -50,10 +50,29 @@ const environments = new Hono();
 // ── Convex row shapes (hand-mirrored from convex/projectEnvironments.ts) ─────
 type SkillSelection = { mode: "explicit"; skillIds: string[] };
 
+/**
+ * A row this API is willing to emit.
+ *
+ * Mirrors the client's `environmentOrigin`: trust `origin` when the backend
+ * sends it, and fall back to name-presence when it doesn't, so a deployment
+ * that predates the split reads every row as named — which they all are.
+ */
+function isNamedEnvironmentRow(row: {
+  name?: string;
+  origin?: "named" | "adhoc";
+}): boolean {
+  if (row.origin === "named") return true;
+  if (row.origin === "adhoc") return false;
+  return typeof row.name === "string" && row.name.trim().length > 0;
+}
+
 type EnvironmentRow = {
   environmentId: string;
   projectId: string;
-  name: string;
+  /** Absent on ad-hoc rows, which `/v1` never emits — see `isNamedEnvironmentRow`. */
+  name?: string;
+  /** Absent from a backend that predates the named/ad-hoc split ⇒ named. */
+  origin?: "named" | "adhoc";
   description?: string;
   hostId: string;
   serverAttachmentId?: string;
@@ -408,6 +427,15 @@ const revisionBodySchema = z.strictObject({
 // GET /v1/projects/:projectId/environments — list a project's environments.
 // Archived rows are excluded unless `?includeArchived=true`; without it there
 // is no way to find an archived environment to restore.
+//
+// AD-HOC rows are excluded unconditionally — not even opt-in. `/v1` is the
+// NAMED-environments API: `PlatformEnvironment.name` is a required field in the
+// published SDK type, so emitting a nameless DTO here would be a breaking
+// change for every external consumer. Ad-hoc rows are an internal
+// run-provenance concept; the browser surfaces read them through Convex.
+//
+// The backend's own default is already named-only, so this filter is belt and
+// braces against a backend that widens that default later.
 environments.get("/projects/:projectId/environments", async (c) => {
   const projectId = c.req.param("projectId");
   const includeArchived = c.req.query("includeArchived") === "true";
@@ -421,7 +449,10 @@ environments.get("/projects/:projectId/environments", async (c) => {
   } catch (error) {
     throw translateConvexError(error);
   }
-  return v1PageJson(c, (rows ?? []).map(toEnvironmentDto));
+  return v1PageJson(
+    c,
+    (rows ?? []).filter(isNamedEnvironmentRow).map(toEnvironmentDto)
+  );
 });
 
 // GET /v1/projects/:projectId/environments/:environmentId


### PR DESCRIPTION
## Why

Swarms auto-creates a project environment per selected client at launch and names it
`${describeParagraph} · ${clientName}`, clamped to 100 chars. Two things go wrong:

1. **The Environments list fills with junk.** Someone pasted a server's description into the
   Describe box and permanently created rows named *"Atlan is an active metadata and data
   governance platform designed to connect data teams, a · ChatGPT"*, sitting next to the two
   environments a human actually curated.
2. **A name can fail a launch.** The name is truncated *before* uniqueness is checked, so two
   Describe paragraphs sharing a prefix collide, get ` (2)`/` (3)` suffixes, and past 20
   attempts `uniqueEnvironmentName` throws outright — on a field the user never typed.

The intent behind auto-creation is right and stays: a dev must **not** be forced to
pre-create an environment to run a swarm. The fix is to stop *naming* those rows, not to stop
tracking them — which means ~15 surfaces have to render a row that has no name.

This PR is the **inspector-side groundwork**. No ad-hoc rows exist yet (they need the backend
mutations), so nothing here changes behavior except the error card in commit 2.

## What's in it

Three self-contained commits, reviewable in order.

**1. `refactor(environments): one label vocabulary`** — `ProjectEnvironmentView.name` becomes
optional; the row gains `origin`, `fingerprint`, and `lastUsedAt`/`runCount`, all optional so
an older backend still reads correctly. `client/src/lib/environment-label.ts` becomes the one
place a row turns into a display string.

`useCreateProjectEnvironment` deliberately keeps `name` **required** — that is what held the
type cascade to four call sites instead of fifteen, since ad-hoc rows will only ever come from
`ensureAdhocEnvironment`.

Two details worth a look:
- `trimOrUndefined` rather than `??` at the run-snapshot boundary. The backend types
  `environmentRef.name` as a required string, so an ad-hoc target can snapshot an **empty**
  name; `??` would pass `""` through and blank the run-matrix column label.
- `environmentOrigin` falls back to name-presence instead of trusting the field, so a backend
  that predates the split (no `origin`, all rows named) reads correctly.

`disambiguateLabels` moves out of `swarm-targets.ts` (it was module-private) because ad-hoc
labels derive from the client name, making collisions the norm. The Connect strip's card
summary is extracted to `EnvironmentSummaryLine` — **its 17 existing tests passing untouched
is what proves that extraction**.

**2. `fix(environments): stop discarding the resolution error code`** — independent of the
rest, and the only user-visible change here.

An environment resolving to zero servers renders as a wall of red text in three places, twice
in the Playground alone, with nothing to click. The backend was never the problem: it raises
`ENV_NO_SERVERS` and the route forwards both the sentence and the code in `details.code`. The
client threw the code away.

`readEnvironmentErrorPayload` now keeps it (preferring the domain code in `details` over the
transport code), shared by the preview and tools hooks since both resolve through the same
backend query. `describeEnvironmentError` turns it into a real card — title, likely causes,
next steps. The backend's sentence stays the one-liner verbatim because it names the specific
environment; everything else is authored client-side, which is why **this needs no backend
change**.

The three raw `<p className="text-destructive">` renders become `ErrorCard`. For a
zero-servers failure they offer **"Open Servers"** instead of Retry, via a new optional
`action` prop — the resolve is deterministic, so retrying fails identically.

**3. `feat(environments): exclude ad-hoc rows from every surface that offers one`** — a no-op
today; it puts the filter in place before the rows exist.

The site most likely to be missed is the one an option on `useProjectEnvironments` cannot
reach: `SwarmsTab`'s `useProjectEnvironmentsList` is a raw `useQuery` feeding the castle
picker, the journey popover, NewJourneyButton and GenerateSwarmDialog. It gets the filter
explicitly, with a comment saying why it can't inherit one.

The picker is the subtle case. It must **fetch** ad-hoc rows — a journey's `environmentIds`
can point at one, and without the row present the trigger labels it `"…"`, which is reserved
for an id that resolves to nothing — while never **offering** one. Same label-vs-offer split
its archived and orphan handling already uses.

`/v1` excludes them unconditionally, not even opt-in: `PlatformEnvironment.name` is required
in the published SDK type, so a nameless DTO would break external consumers.

## A wrong turn worth flagging

I first had the picker call `useEnvironmentLabelContext`, which broke all nine of its tests by
dragging Convex auth into a component documented as **pure presentation**. It only ever labels
an already-selected ad-hoc row, never offers one — so `environmentLabel`'s context is now
optional and the picker passes none, getting `"Automatic environment"`. No queries, contract
intact. The richer client-name label is for surfaces that list ad-hoc rows for real.

## Testing

- `npm run typecheck:client` — clean (exit 0). This is what finds the `.name` sites a grep misses.
- `npm test` — full suite green.
- `npm run build:inspector` — verified, since only the bundler walks the module graph.
- New: `environment-label.test.ts` (25), `environment-error.test.ts` (16), and three
  label-vs-offer cases in `environment-picker.test.tsx`.

## What this does NOT do

Stated so nobody assumes otherwise:

- **No ad-hoc rows are created.** That needs the backend's `ensureAdhocEnvironment`, the
  `swarm-target-materialize` rewrite, the "From runs" section, and promote — all follow-ups.
- **The zero-servers check still only fires at resolve time.** Moving it to save/compose time
  is the remaining half of that fix.
- The junk rows already in the list are untouched; they need the backend migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7b93a930d39072cf75667bb291e32ebb795e3940. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lays groundwork for unnamed ad‑hoc environments and makes environment resolve failures actionable. No ad‑hoc rows are created yet; the only user‑visible change is the new error card.

- **New Features**
  - Centralized label vocabulary in `@/lib/environment-label` with derived labels for nameless rows, `disambiguateLabels`, and composition summary; `ProjectEnvironmentView.name` is now optional.
  - Exclude ad‑hoc rows from pickers and list surfaces by default via `useProjectEnvironments({ includeAdhoc })`; `SwarmsTab` applies a named‑only filter; `/v1` environments API now emits named‑only rows.
  - Added `EnvironmentSummaryLine` and `useEnvironmentLabelContext` to avoid N+1 lookups; introduced hooks for ad‑hoc lifecycle (`useEnsureAdhocEnvironment`, `useEnsureAdhocEnvironments`, `usePromoteProjectEnvironment`) for future use.

- **Bug Fixes**
  - Preserved backend `ENV_*` codes with `readEnvironmentErrorPayload` and rendered actionable `ErrorCard` via `describeEnvironmentError`; `ENV_NO_SERVERS` now offers “Open Servers” instead of retry in Playground and Tools.
  - Standardized error handling across preview/tools; replaced raw red text with structured cards and optional actions.

<sup>Written for commit 7b93a930d39072cf75667bb291e32ebb795e3940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

