### PR TITLE
Clarify swarm insights rail and fix environment list crash

### DIFF
--- a/mcpjam-inspector/client/src/components/swarms/CriterionScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/CriterionScorecard.tsx
@@ -13,19 +13,16 @@ import {
 } from "@/shared/predicate-kinds";
 
 /**
- * Aggregate rubric scorecard for the swarm Insights view — the same table
- * shape as the per-run scorecard, but tallied across every graded session in
- * the scanned window, with a headline score on top.
+ * Aggregate rubric scorecard for the swarm Insights view — tallied across
+ * every graded session in the scanned window.
+ *
+ * Paired with "Where sessions struggled" in the Insights rail: same card
+ * chrome and header shape. Leads with "N/M clean" (not a % billboard) so
+ * rubric checks cannot read as an overall run grade next to open patterns.
  *
  * Each criterion is its own boolean dimension, so each row is its own filter:
  * clicking two DIFFERENT criteria's fail counts narrows to the sessions that
- * failed both, which is the read worth having. Two verdicts on the SAME
- * criterion widen (a session cannot be both) — the grouping rule in
- * `chipGroupKey` handles that, and these are ordinary filter chips, so they
- * narrow the sankey and the drilldown like any other.
- *
- * Fail is the primary affordance. The reason people open this view is to find
- * what broke, and a row that led with the pass count would bury it.
+ * failed both. Fail is the primary affordance.
  */
 export function CriterionScorecard({
   facets,
@@ -53,141 +50,151 @@ export function CriterionScorecard({
     label,
   });
 
-  // The headline is verdict-weighted, not criterion-weighted: 100 sessions
-  // failing one check should read worse than 2 sessions failing another.
   const totalPass = facets.reduce((sum, f) => sum + f.passCount, 0);
   const totalFail = facets.reduce((sum, f) => sum + f.failCount, 0);
   const totalGraded = totalPass + totalFail;
-  const scorePct =
-    totalGraded === 0 ? null : Math.round((totalPass / totalGraded) * 100);
   const cleanCount = facets.filter(
     (f) => f.passCount + f.failCount > 0 && f.failCount === 0,
   ).length;
+  const allClean = totalGraded > 0 && totalFail === 0;
 
   return (
-    <div className="px-5 pb-4 pt-4">
-      <div className="mb-2 flex items-baseline gap-2">
-        <h3 className="text-xs font-medium">Scorecard</h3>
-        <span className="text-[11px] text-muted-foreground">
-          Pass rates across graded sessions
-        </span>
-      </div>
-      <div className="overflow-hidden rounded-lg border bg-card/40">
-        <div className="flex items-baseline justify-between gap-2 border-b bg-muted/50 px-3 py-2">
-          <span className="font-mono text-sm font-semibold uppercase tracking-wider">
-            {scorePct === null ? "Score —" : `Score ${scorePct}%`}
-          </span>
-          <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
-            Across runs
-          </span>
+    <div
+      className="flex h-full min-h-0 flex-col rounded-lg border border-border/60 bg-muted/20"
+      data-testid="criterion-scorecard"
+    >
+      <div className="flex items-baseline justify-between gap-2 px-3 py-2">
+        <div className="min-w-0">
+          <h3 className="text-xs font-medium">Rubric checks</h3>
+          <p className="truncate text-[11px] text-muted-foreground">
+            Pass/fail rules you configured
+          </p>
         </div>
-        <div className="divide-y divide-border/50">
-          {facets.map((facet) => {
-            const name = criterionDisplayName(facet);
-            // The DENOMINATOR is only the sessions whose run carried this
-            // criterion — sessions from rubric-less runs are excluded upstream,
-            // so this rate never depends on how many ungraded sessions happened
-            // to be in the scan window.
-            const graded = facet.passCount + facet.failCount;
-            const failChip = chipFor(
-              facet.criterionId,
-              "fail",
-              `${name}: failed`,
-            );
-            const passChip = chipFor(
-              facet.criterionId,
-              "pass",
-              `${name}: passed`,
-            );
-            const ungradedChip = chipFor(
-              facet.criterionId,
-              "ungraded",
-              `${name}: not graded`,
-            );
-            const failActive = activeKeys.has(chipKey(failChip));
-            const passActive = activeKeys.has(chipKey(passChip));
-            const ungradedActive = activeKeys.has(chipKey(ungradedChip));
+        {totalGraded > 0 ? (
+          <span
+            className="shrink-0 text-[11px] tabular-nums text-muted-foreground"
+            data-testid="criterion-scorecard-clean"
+          >
+            {cleanCount}/{facets.length} clean
+          </span>
+        ) : null}
+      </div>
 
-            return (
-              <div
-                key={facet.criterionId}
-                className="flex items-center gap-3 px-3 py-2"
+      <div className="min-h-0 flex-1 divide-y divide-border/40 overflow-y-auto">
+        {facets.map((facet) => {
+          const name = criterionDisplayName(facet);
+          // The DENOMINATOR is only the sessions whose run carried this
+          // criterion — sessions from rubric-less runs are excluded upstream,
+          // so this rate never depends on how many ungraded sessions happened
+          // to be in the scan window.
+          const graded = facet.passCount + facet.failCount;
+          const failChip = chipFor(
+            facet.criterionId,
+            "fail",
+            `${name}: failed`,
+          );
+          const passChip = chipFor(
+            facet.criterionId,
+            "pass",
+            `${name}: passed`,
+          );
+          const ungradedChip = chipFor(
+            facet.criterionId,
+            "ungraded",
+            `${name}: not graded`,
+          );
+          const failActive = activeKeys.has(chipKey(failChip));
+          const passActive = activeKeys.has(chipKey(passChip));
+          const ungradedActive = activeKeys.has(chipKey(ungradedChip));
+
+          return (
+            <div
+              key={facet.criterionId}
+              className="flex items-center gap-3 px-3 py-1.5"
+            >
+              <button
+                type="button"
+                onClick={() => onToggleChip(failChip)}
+                disabled={facet.failCount === 0}
+                aria-pressed={failActive}
+                // The criterion name lives in a sibling element, so without
+                // this two rows with the same count present identical
+                // accessible names ("6 failed").
+                aria-label={`${name}: ${facet.failCount} failed`}
+                className={cn(
+                  "flex h-6 min-w-7 shrink-0 items-center justify-center rounded border px-1 font-mono text-xs font-semibold tabular-nums transition-colors",
+                  "disabled:cursor-default",
+                  facet.failCount > 0
+                    ? failActive
+                      ? "border-destructive bg-destructive/20 text-destructive"
+                      : "border-destructive/50 bg-destructive/10 text-destructive hover:bg-destructive/20"
+                    : "border-border/50 bg-muted text-muted-foreground",
+                )}
               >
+                {facet.failCount}
+              </button>
+              <span
+                className="min-w-0 flex-1 truncate text-xs font-medium"
+                title={name}
+              >
+                {name}
+              </span>
+              <div className="flex shrink-0 flex-wrap items-baseline justify-end gap-x-2 text-[11px] text-muted-foreground">
+                {graded === 0 ? (
+                  <span className="tabular-nums">No completed grades yet</span>
+                ) : facet.failCount > 0 ? (
+                  <span className="tabular-nums">
+                    {facet.failCount}/{graded} failed
+                  </span>
+                ) : null}
                 <button
                   type="button"
-                  onClick={() => onToggleChip(failChip)}
-                  disabled={facet.failCount === 0}
-                  aria-pressed={failActive}
-                  // The criterion name lives in a sibling element, so without
-                  // this two rows with the same count present identical
-                  // accessible names ("6 failed").
-                  aria-label={`${name}: ${facet.failCount} failed`}
+                  onClick={() => onToggleChip(passChip)}
+                  disabled={facet.passCount === 0}
+                  aria-pressed={passActive}
+                  aria-label={`${name}: ${facet.passCount} passed`}
                   className={cn(
-                    "flex h-6 min-w-7 shrink-0 items-center justify-center rounded border px-1 font-mono text-xs font-semibold tabular-nums transition-colors",
-                    "disabled:cursor-default",
-                    facet.failCount > 0
-                      ? failActive
-                        ? "border-destructive bg-destructive/20 text-destructive"
-                        : "border-destructive/50 bg-destructive/10 text-destructive hover:bg-destructive/20"
-                      : "border-border/50 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+                    "rounded px-1 tabular-nums underline-offset-2 transition-colors hover:underline",
+                    "disabled:cursor-default disabled:no-underline disabled:opacity-50",
+                    passActive && "bg-muted font-medium text-foreground",
                   )}
                 >
-                  {facet.failCount}
+                  {facet.passCount} passed
                 </button>
-                <span
-                  className="min-w-0 flex-1 truncate text-xs font-medium"
-                  title={name}
-                >
-                  {name}
-                </span>
-                <div className="flex shrink-0 flex-wrap items-baseline justify-end gap-x-2 text-[11px] text-muted-foreground">
-                  <span className="tabular-nums">
-                    {graded === 0
-                      ? "No completed grades yet"
-                      : `${facet.failCount}/${graded} sessions failed`}
-                  </span>
+                {/* Ungraded is reported separately, never folded into the
+                    fail count — a crashed runner is not a product regression
+                    — and it is CLICKABLE, because "which sessions never got
+                    graded?" is exactly the question this number provokes. */}
+                {facet.ungradedCount > 0 ? (
                   <button
                     type="button"
-                    onClick={() => onToggleChip(passChip)}
-                    disabled={facet.passCount === 0}
-                    aria-pressed={passActive}
-                    aria-label={`${name}: ${facet.passCount} passed`}
+                    onClick={() => onToggleChip(ungradedChip)}
+                    aria-pressed={ungradedActive}
+                    aria-label={`${name}: ${facet.ungradedCount} not graded`}
                     className={cn(
-                      "rounded px-1 tabular-nums underline-offset-2 transition-colors hover:underline",
-                      "disabled:cursor-default disabled:no-underline disabled:opacity-50",
-                      passActive && "bg-muted font-medium text-foreground",
+                      "rounded px-1 underline-offset-2 transition-colors hover:underline",
+                      ungradedActive && "bg-muted font-medium text-foreground",
                     )}
                   >
-                    {facet.passCount} passed
+                    {facet.ungradedCount} not graded
                   </button>
-                  {/* Ungraded is reported separately, never folded into the
-                      fail count — a crashed runner is not a product regression
-                      — and it is CLICKABLE, because "which sessions never got
-                      graded?" is exactly the question this number provokes. */}
-                  {facet.ungradedCount > 0 ? (
-                    <button
-                      type="button"
-                      onClick={() => onToggleChip(ungradedChip)}
-                      aria-pressed={ungradedActive}
-                      aria-label={`${name}: ${facet.ungradedCount} not graded`}
-                      className={cn(
-                        "rounded px-1 underline-offset-2 transition-colors hover:underline",
-                        ungradedActive && "bg-muted font-medium text-foreground",
-                      )}
-                    >
-                      {facet.ungradedCount} not graded
-                    </button>
-                  ) : null}
-                </div>
+                ) : null}
               </div>
-            );
-          })}
-        </div>
-        <div className="border-t bg-muted/30 px-3 py-1.5 text-[11px] text-muted-foreground">
-          {totalGraded === 0
-            ? "No completed grades yet"
-            : `${cleanCount} / ${facets.length} criteria passing · ${totalFail}/${totalGraded} graded checks failed`}
-        </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="border-t border-border/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+        {totalGraded === 0 ? (
+          "No completed grades yet"
+        ) : allClean ? (
+          <span data-testid="criterion-scorecard-bridge">
+            Checks passed — separate from struggle patterns on the left
+          </span>
+        ) : (
+          `${totalFail}/${totalGraded} graded checks failed`
+        )}
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/swarms/SwarmInsightsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmInsightsPanel.tsx
@@ -372,7 +372,7 @@ export function SwarmInsightsPanel({
         data-testid="swarm-insights-panel"
       >
         <div
-          className="flex max-h-[40%] min-h-0 shrink-0 flex-col gap-3 overflow-y-auto sm:flex-row sm:items-stretch"
+          className="flex max-h-[45%] min-h-[11rem] shrink-0 flex-col gap-3 overflow-y-auto sm:flex-row sm:items-stretch"
           data-testid="swarm-insights-rail"
         >
           {selectionOpen ? (
@@ -382,11 +382,11 @@ export function SwarmInsightsPanel({
           ) : (
             <>
               {children ? (
-                <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+                <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
                   {children}
                 </div>
               ) : null}
-              <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+              <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
                 {scorecardBlock}
               </div>
             </>

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.criteria.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.criteria.test.tsx
@@ -85,21 +85,48 @@ describe("SwarmInsightsPanel — criterion scorecard", () => {
     expect(screen.getByText("Tool was called at least once")).toBeInTheDocument();
   });
 
-  it("headlines a verdict-weighted score across every graded session", () => {
+  it("leads with clean criteria count, not a percent billboard", () => {
     render(<SwarmInsightsPanel projectId="proj-1" />);
-    // 13 passed of 20 graded verdicts — the 2 ungraded are outside the
-    // denominator, and the score is per-verdict, not per-criterion.
-    expect(screen.getByText("Score 65%")).toBeInTheDocument();
+    expect(screen.getByText("Rubric checks")).toBeInTheDocument();
     // Neither criterion has a clean sheet (6 fails and 1 fail respectively).
-    expect(
-      screen.getByText(/0 \/ 2 criteria passing · 7\/20 graded checks failed/),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("criterion-scorecard-clean")).toHaveTextContent(
+      "0/2 clean",
+    );
+    expect(screen.getByText(/7\/20 graded checks failed/)).toBeInTheDocument();
+  });
+
+  it("bridges when every check is clean so 100% cannot read as an overall grade", () => {
+    withFacets([
+      {
+        criterionId: "crit-a",
+        label: "No tool errors",
+        kind: "noToolErrors",
+        passCount: 11,
+        failCount: 0,
+        ungradedCount: 0,
+      },
+      {
+        criterionId: "crit-b",
+        label: "Final message non-empty",
+        kind: "finalMessageNonEmpty",
+        passCount: 11,
+        failCount: 0,
+        ungradedCount: 0,
+      },
+    ]);
+    render(<SwarmInsightsPanel projectId="proj-1" />);
+    expect(screen.getByTestId("criterion-scorecard-clean")).toHaveTextContent(
+      "2/2 clean",
+    );
+    expect(screen.getByTestId("criterion-scorecard-bridge")).toHaveTextContent(
+      /separate from struggle patterns/i,
+    );
   });
 
   it("reports ungraded separately instead of folding it into the fail count", () => {
     render(<SwarmInsightsPanel projectId="proj-1" />);
     // 6 failed out of the 10 GRADED — the 2 ungraded are named, not summed in.
-    expect(screen.getByText(/6\/10 sessions failed/)).toBeInTheDocument();
+    expect(screen.getByText(/6\/10 failed/)).toBeInTheDocument();
     expect(screen.getByText(/2 not graded/)).toBeInTheDocument();
   });
 
@@ -175,12 +202,12 @@ describe("SwarmInsightsPanel — criterion scorecard", () => {
   it("renders nothing at all when no run in the window carried a rubric", () => {
     withFacets([]);
     render(<SwarmInsightsPanel projectId="proj-1" />);
-    expect(screen.queryByText("Scorecard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rubric checks")).not.toBeInTheDocument();
   });
 
   it("renders nothing when the server predates criterionBreakdown", () => {
     withFacets(undefined);
     render(<SwarmInsightsPanel projectId="proj-1" />);
-    expect(screen.queryByText("Scorecard")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rubric checks")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.test.tsx
@@ -167,7 +167,7 @@ describe("SwarmInsightsPanel", () => {
     const panel = screen.getByTestId("swarm-insights-panel");
     expect(panel.className).toContain("flex-col");
     const rail = screen.getByTestId("swarm-insights-rail");
-    expect(rail.className).toContain("max-h-[40%]");
+    expect(rail.className).toContain("max-h-[45%]");
     expect(rail.className).toContain("sm:flex-row");
     expect(screen.getByTestId("idle-footer")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "pick journey theme" }));

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-run-insights.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-run-insights.test.tsx
@@ -333,12 +333,13 @@ describe("generation lifecycle", () => {
       insights: null,
       discovery: null,
       errorCode: "spend_cap_exceeded",
-      errorMessage: "Spending cap reached — insights were not generated.",
+      errorMessage: "Explanation unavailable — spend cap.",
       updatedAt: 1,
     };
     renderInsights();
+    expect(screen.getByText("Where sessions struggled")).toBeInTheDocument();
     expect(screen.getByTestId("swarm-run-insights-error")).toHaveTextContent(
-      /spending cap/i,
+      /explanation unavailable — spend cap/i,
     );
     // The deterministic rows survive a failed generation.
     expect(screen.getByTestId("swarm-run-insight")).toBeInTheDocument();
@@ -376,6 +377,51 @@ describe("registry lifecycle", () => {
     expect(screen.getByTestId("swarm-run-insight-status")).toHaveTextContent(
       "Recurring ×3",
     );
+  });
+
+  it("hides resolved findings by default and reveals them on toggle", () => {
+    const open = signal({
+      subjectId: "j-open",
+      subjectLabel: "Open journey",
+    });
+    const resolved = signal({
+      subjectId: "j-resolved",
+      subjectLabel: "Resolved journey",
+      detector: "target_failures",
+      subjectKind: "host",
+    });
+    state.signals = signals({ candidates: [open, resolved] });
+    state.dto = completed();
+    state.findings = [
+      finding({
+        fingerprint: signalFingerprint(open),
+        status: "recurring",
+        subjectId: "j-open",
+      }),
+      finding({
+        findingId: "f-2",
+        fingerprint: signalFingerprint(resolved),
+        status: "resolved",
+        subjectId: "j-resolved",
+        subjectLabel: "Resolved journey",
+        dimension: "target_failures",
+        subjectKind: "host",
+        occurrenceCount: 2,
+      }),
+    ];
+    renderInsights();
+
+    expect(screen.getAllByTestId("swarm-run-insight")).toHaveLength(1);
+    expect(screen.getByTestId("swarm-run-insight-headline")).toHaveTextContent(
+      /Open journey/,
+    );
+    expect(
+      screen.queryByText(/Failures concentrate on Resolved journey/),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("swarm-run-insights-resolved-toggle"));
+    expect(screen.getAllByTestId("swarm-run-insight")).toHaveLength(2);
+    expect(screen.getByText("Resolved ×2")).toBeInTheDocument();
   });
 
   it("dismisses optimistically and reverts when the write fails", async () => {

--- a/mcpjam-inspector/client/src/components/swarms/swarm-run-insights.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-run-insights.tsx
@@ -172,6 +172,9 @@ export function SwarmRunInsights({
   ) as SwarmFinding[] | undefined;
 
   const [showAll, setShowAll] = useState(false);
+  // Resolved registry rows are history — default to open problems so the
+  // panel answers "what still matters" instead of replaying green chips.
+  const [showResolved, setShowResolved] = useState(false);
 
   const rows: Row[] = useMemo(() => {
     if (!signals) return [];
@@ -189,6 +192,13 @@ export function SwarmRunInsights({
       };
     });
   }, [signals, insights, findings]);
+
+  const resolvedCount = rows.filter(
+    (row) => row.finding?.status === "resolved",
+  ).length;
+  const filteredRows = showResolved
+    ? rows
+    : rows.filter((row) => row.finding?.status !== "resolved");
 
   // Loading, unknown run, or a backend without the feature: render nothing
   // rather than a broken block.
@@ -214,7 +224,9 @@ export function SwarmRunInsights({
     );
   }
 
-  const visible = showAll ? rows : rows.slice(0, VISIBLE_ROWS);
+  const visible = showAll
+    ? filteredRows
+    : filteredRows.slice(0, VISIBLE_ROWS);
   const caveats: string[] = [];
   if (signals.judgeCoverage.graded === 0 && signals.judgeCoverage.total > 0) {
     caveats.push("no judge verdicts — goal completion not assessed");
@@ -227,73 +239,107 @@ export function SwarmRunInsights({
 
   return (
     <section
-      className="rounded-lg border border-border/60 bg-muted/20"
+      className="flex h-full min-h-0 flex-col rounded-lg border border-border/60 bg-muted/20"
       data-testid="swarm-run-insights"
     >
-      {(insights?.summary || busy || error) && (
-        <div className="flex items-start gap-2 border-b border-border/40 px-3 py-2">
-          {busy ? (
-            <p
-              className="flex items-center gap-2 text-sm text-muted-foreground"
-              data-testid="swarm-run-insights-generating"
-            >
-              <Loader2 className="size-3.5 animate-spin" />
-              Working out what went wrong…
+      <div className="space-y-1 px-3 py-2">
+        <div className="flex items-baseline justify-between gap-2">
+          <div className="min-w-0">
+            <h3 className="text-xs font-medium">Where sessions struggled</h3>
+            <p className="truncate text-[11px] text-muted-foreground">
+              Patterns across this run
             </p>
-          ) : error ? (
-            <p
-              className="flex items-center gap-2 text-sm text-muted-foreground"
-              data-testid="swarm-run-insights-error"
-            >
-              {error}
-              <button
-                type="button"
-                className="font-medium text-primary hover:underline"
-                onClick={() => request(true)}
-                data-testid="swarm-run-insights-retry"
-              >
-                Try again
-              </button>
-            </p>
-          ) : (
-            <RunSummary summary={insights!.summary} />
-          )}
-          {!busy && !error && !unavailable ? (
+          </div>
+          {resolvedCount > 0 ? (
             <button
               type="button"
               className="shrink-0 text-[11px] text-muted-foreground hover:text-foreground"
-              onClick={() => request(true)}
-              data-testid="swarm-run-insights-regenerate"
+              onClick={() => setShowResolved((prev) => !prev)}
+              data-testid="swarm-run-insights-resolved-toggle"
             >
-              Redo
+              {showResolved
+                ? "Hide resolved"
+                : `Show resolved (${resolvedCount})`}
             </button>
           ) : null}
         </div>
-      )}
-
-      <div className="divide-y divide-border/40">
-        {visible.map((row) => (
-          <InsightRow
-            key={row.fingerprint}
-            row={row}
-            onOpenSession={onOpenSession}
-          />
-        ))}
+        {/* LLM status is enrichment only — never a competing banner over the
+            deterministic rows. */}
+        {busy || error || insights?.summary ? (
+          <div className="flex items-start gap-2">
+            {busy ? (
+              <p
+                className="flex min-w-0 flex-1 items-center gap-1.5 text-[11px] text-muted-foreground"
+                data-testid="swarm-run-insights-generating"
+              >
+                <Loader2 className="size-3 animate-spin" />
+                Explaining…
+              </p>
+            ) : error ? (
+              <p
+                className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-[11px] text-muted-foreground"
+                data-testid="swarm-run-insights-error"
+              >
+                <span>{error}</span>
+                <button
+                  type="button"
+                  className="font-medium text-foreground/80 hover:underline"
+                  onClick={() => request(true)}
+                  data-testid="swarm-run-insights-retry"
+                >
+                  Try again
+                </button>
+              </p>
+            ) : (
+              <RunSummary summary={insights!.summary} />
+            )}
+            {!busy && !error && !unavailable ? (
+              <button
+                type="button"
+                className="shrink-0 text-[11px] text-muted-foreground hover:text-foreground"
+                onClick={() => request(true)}
+                data-testid="swarm-run-insights-regenerate"
+              >
+                Redo
+              </button>
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
-      <div className="flex items-center justify-between gap-3 px-3 py-1.5">
+      <div className="min-h-0 flex-1 divide-y divide-border/40 overflow-y-auto">
+        {filteredRows.length === 0 ? (
+          <p
+            className="px-3 py-2 text-[11px] text-muted-foreground"
+            data-testid="swarm-run-insights-all-resolved"
+          >
+            No open problems
+            {resolvedCount > 0 ? ` · ${resolvedCount} resolved` : ""}
+          </p>
+        ) : (
+          visible.map((row) => (
+            <InsightRow
+              key={row.fingerprint}
+              row={row}
+              onOpenSession={onOpenSession}
+            />
+          ))
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-3 border-t border-border/40 px-3 py-1.5">
         <p className="truncate text-[11px] text-muted-foreground">
           {signals.sessionCount} sessions
           {caveats.length > 0 ? ` · ${caveats.join(" · ")}` : ""}
         </p>
-        {rows.length > VISIBLE_ROWS ? (
+        {filteredRows.length > VISIBLE_ROWS ? (
           <button
             type="button"
-            className="shrink-0 text-[11px] font-medium text-primary hover:underline"
+            className="shrink-0 text-[11px] text-muted-foreground hover:text-foreground"
             onClick={() => setShowAll((prev) => !prev)}
             data-testid="swarm-run-insights-toggle"
           >
-            {showAll ? "Show fewer" : `Show all ${rows.length}`}
+            {showAll ? "Show fewer" : `Show all ${filteredRows.length}`}
           </button>
         ) : null}
       </div>
@@ -311,7 +357,7 @@ function RunSummary({ summary }: { summary: string }) {
   const needsClamp = summary.length > SUMMARY_CLAMP_CHARS;
   return (
     <p
-      className="min-w-0 flex-1 text-sm text-foreground"
+      className="min-w-0 flex-1 text-[11px] text-muted-foreground"
       data-testid="swarm-run-insights-summary"
     >
       <span className={cn(!expanded && needsClamp && "line-clamp-2")}>
@@ -320,7 +366,7 @@ function RunSummary({ summary }: { summary: string }) {
       {needsClamp ? (
         <button
           type="button"
-          className="mt-0.5 block text-[11px] font-medium text-primary hover:underline"
+          className="mt-0.5 block text-[11px] font-medium text-foreground/80 hover:underline"
           onClick={() => setExpanded((prev) => !prev)}
           data-testid="swarm-run-insights-summary-toggle"
         >
@@ -368,7 +414,7 @@ function InsightRow({
 
   return (
     <div
-      className={cn("px-3 py-1.5", dismissed && "opacity-50")}
+      className={cn("group px-3 py-1.5", dismissed && "opacity-50")}
       data-testid="swarm-run-insight"
       data-detector={signal.detector}
       data-dismissed={dismissed ? "true" : "false"}
@@ -419,7 +465,14 @@ function InsightRow({
         {finding ? (
           <button
             type="button"
-            className="shrink-0 text-[11px] text-muted-foreground hover:text-foreground"
+            className={cn(
+              "shrink-0 text-[11px] text-muted-foreground transition-opacity hover:text-foreground",
+              // Hover/focus reveal keeps the row calm; Undo stays visible so
+              // a dismissed finding is always recoverable.
+              dismissed
+                ? "opacity-100"
+                : "opacity-0 focus-visible:opacity-100 group-hover:opacity-100",
+            )}
             onClick={toggleDismiss}
             data-testid="swarm-run-insight-dismiss"
           >

--- a/mcpjam-inspector/client/src/hooks/use-swarm-run-insights.ts
+++ b/mcpjam-inspector/client/src/hooks/use-swarm-run-insights.ts
@@ -176,7 +176,8 @@ export function useSwarmRunInsights(
   const serverError = useMemo(() => {
     if (!dto || dto.status !== "failed") return null;
     if (dto.errorCode === "spend_cap_exceeded") {
-      return "Spending cap reached — insights were not generated.";
+      // Soft copy: signals still render; only the LLM explanation failed.
+      return "Explanation unavailable — spend cap.";
     }
     if (dto.errorCode === "cancelled") return null;
     return dto.errorMessage || "Insights could not be generated.";

--- a/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectEnvironments.ts
@@ -114,9 +114,10 @@ export interface ProjectEnvironmentView {
  * the public `/v1` list correct during rollout, and this filter is what keeps
  * THIS client correct against a backend that ignores the argument.
  *
- * Note the argument is only SENT when opting in. A backend that predates the
- * split rejects unknown args with a validation error, so passing the default
- * explicitly would turn a harmless skew into a hard failure.
+ * Do NOT send `origin` until every deployed backend accepts it — Convex
+ * rejects unknown args and the whole surface crashes. When `includeAdhoc` is
+ * true against an older backend, ad-hoc rows simply won't appear in the
+ * response; the client-side filter below still applies once they do.
  */
 export function useProjectEnvironments(
   projectId: string | null,
@@ -137,7 +138,6 @@ export function useProjectEnvironments(
       ? ({
           projectId: normalizedProjectId,
           ...(options?.includeArchived ? { includeArchived: true } : {}),
-          ...(includeAdhoc ? { origin: "all" } : {}),
         } as any)
       : "skip"
   ) as ProjectEnvironmentView[] | undefined;


### PR DESCRIPTION
## Summary
- Redesign the Swarm run Insights top rail so struggle patterns and rubric checks read as two distinct questions, with matched minimal card chrome.
- Hide resolved signals by default, demote LLM status to a quiet enrichment line, and replace the scorecard billboard with an N/M clean summary plus a bridge when checks pass.
- Stop sending the unsupported `origin` argument to `projectEnvironments:listEnvironments`, which was crashing Swarm run detail against older Convex deploys.

## Test plan
- [x] `swarm-run-insights.test.tsx`, `SwarmInsightsPanel.criteria.test.tsx`, and `SwarmInsightsPanel.test.tsx` pass locally
- [ ] Open a Swarm run Insights tab and confirm left shows open problems only, right shows rubric checks without a misleading 100% headline
- [ ] Open Swarm run detail on a project whose backend lacks the `origin` arg and confirm the page loads without the Convex validation error

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Swarm run Insights rail for clearer signals and hides noise by default; also removes an unsupported `origin` arg to fix environment list crashes on older Convex backends.

- **New Features**
  - Split the rail into “Where sessions struggled” and “Rubric checks” with matching minimal cards.
  - Scorecard now shows N/M clean and fail counts (no percent headline), with a bridge message when all checks pass.
  - Resolved findings are hidden by default; added a toggle to show them.
  - LLM explanation is a quiet enrichment line with softer copy and retry/redo actions; layout tweaked for better scrolling (rail max height 45%).

- **Bug Fixes**
  - Stop sending `origin` to `projectEnvironments:listEnvironments`, preventing Convex validation crashes on older deployments.

<sup>Written for commit e17aab9e29af5bffe33f6cbe202f4aca65ed1644. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

