### PR TITLE
feat(user-testing): address a scenario by its chatbox id, not its host

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1305,7 +1305,7 @@ export function ChatboxesRoute() {
   // `user-testing/new` route already keeps it out of `params.scenarioId`, but
   // reserving the word here means route-ordering can't quietly turn the create
   // page into a "Scenario not found".
-  const scenarioHostId =
+  const scenarioId =
     rawScenarioId && rawScenarioId !== "new" ? decodeParam(rawScenarioId) : null;
 
   return (
@@ -1313,7 +1313,7 @@ export function ChatboxesRoute() {
       key={convexProjectId ?? "no-project"}
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
-      scenarioHostId={scenarioHostId}
+      scenarioId={scenarioId}
       createOpen={isUserTestingCreatePath(getRouteFallbackPathname())}
     />
   );

--- a/mcpjam-inspector/client/src/__tests__/ChatboxesRoute.billing.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/ChatboxesRoute.billing.test.tsx
@@ -131,7 +131,7 @@ describe("ChatboxesRoute gates", () => {
       expect.objectContaining({
         projectId: "project-1",
         isAuthenticated: true,
-        scenarioHostId: null,
+        scenarioId: null,
       }),
     );
   });

--- a/mcpjam-inspector/client/src/components/UserTestingTab.tsx
+++ b/mcpjam-inspector/client/src/components/UserTestingTab.tsx
@@ -8,15 +8,11 @@ import { UserTestingOverviewPanel } from "@/components/chatboxes/UserTestingOver
 import { UserTestingScenarioDetail } from "@/components/chatboxes/UserTestingScenarioDetail";
 import { UserTestingCreateFlow } from "@/components/chatboxes/UserTestingCreateFlow";
 import {
-  useChatboxByHostId,
+  useChatbox,
   useChatboxList,
   useChatboxMutations,
 } from "@/hooks/useChatboxes";
-import {
-  useHostList,
-  useHostMutations,
-  type HostListItem,
-} from "@/hooks/useClients";
+import { useHostList, useHostMutations } from "@/hooks/useClients";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { useUsageInsights } from "@/hooks/useUsageInsights";
 import { EMPTY_USAGE_FILTER } from "@/hooks/chatbox-usage-filters";
@@ -42,9 +38,16 @@ import type {
  *   - `/user-testing/:scenarioId`   — one scenario: share band, then
  *                                     Sessions | Clusters
  *
- * `:scenarioId` is the scenario's HOST id. Chatboxes are 1:1 with hosts, the
- * chatbox query is keyed by host, and every link copied before this rename
- * carried `?host=` — using the host id keeps all three aligned.
+ * `:scenarioId` is the scenario's CHATBOX id. It used to be the host id, back
+ * when every scenario was a client and the two were 1:1. Environment-backed
+ * scenarios broke that: several can point at the same host, and the host-keyed
+ * query deliberately refuses to return them. The chatbox id is the one
+ * identity both kinds have, and the one everything downstream — sessions,
+ * clusters, insights, the share section — was already keyed by.
+ *
+ * Links minted under the old scheme still work: a param that matches a host
+ * instead of a chatbox is redirected to that host's scenario (see the
+ * resolution ladder below), as is the older `?host=` query form.
  *
  * The route param is the only view state: no in-page mode flags. The auth and
  * billing gates above this component unmount and remount it several times
@@ -59,7 +62,7 @@ interface UserTestingTabProps {
   projectId: string | null;
   isAuthenticated: boolean;
   /** From `/user-testing/:scenarioId`. Null on the list. */
-  scenarioHostId?: string | null;
+  scenarioId?: string | null;
   /** From `/user-testing/new`. */
   createOpen?: boolean;
 }
@@ -69,7 +72,7 @@ const AGENT_SNAPSHOT_MAX_SESSIONS = 30;
 export function UserTestingTab({
   projectId,
   isAuthenticated,
-  scenarioHostId = null,
+  scenarioId = null,
   createOpen = false,
 }: UserTestingTabProps) {
   const navigate = useNavigate();
@@ -77,134 +80,89 @@ export function UserTestingTab({
   const convexAuth = useConvexAuth();
   const effectiveAuth = isAuthenticated && convexAuth.isAuthenticated;
 
-  // The host list does double duty: it backs the agent's host resolution AND
-  // validates `:scenarioId`. Validation is not optional — `getChatboxByHostId`
-  // declares `v.id('hosts')`, so a hand-typed or stale id doesn't come back
-  // null, it throws out of `useQuery` and takes the screen with it.
-  // `useHostList`/`useChatboxList` report `isLoading` as "no data yet", which
+  // The scenario list validates `:scenarioId` before anything queries it.
+  // Validation is not optional — `getChatbox` declares `v.id('chatboxes')`, so
+  // a hand-typed or stale id doesn't come back null, it throws out of
+  // `useQuery` and takes the screen with it.
+  // `useChatboxList`/`useHostList` report `isLoading` as "no data yet", which
   // is also true for a SKIPPED query (signed out, or no project). Distinguish
   // them here or a deep-linked scenario spins forever instead of saying why.
   const queryable = effectiveAuth && shouldQueryProjectId(projectId);
+  const { chatboxes, isLoading: listQueryLoading } = useChatboxList({
+    isAuthenticated: effectiveAuth,
+    projectId,
+  });
+  const listLoading = queryable && listQueryLoading;
+  // Still needed for the agent's host-addressed publish tool (re-pointed at
+  // scenario identity in a follow-up) and for the Swarms dead-end below.
   const { hosts, isLoading: hostsQueryLoading } = useHostList({
     isAuthenticated: effectiveAuth,
     projectId,
   });
   const hostsLoading = queryable && hostsQueryLoading;
-  const { chatboxes, isLoading: listLoading } = useChatboxList({
-    isAuthenticated: effectiveAuth,
-    projectId,
-  });
 
-  const scenarioHost: HostListItem | null = scenarioHostId
-    ? hosts.find((h) => h.hostId === scenarioHostId) ?? null
+  // Resolution ladder. The param is a chatbox id; a param that matches a HOST
+  // is a link minted under the old scheme and gets redirected rather than
+  // 404'd.
+  const rows = chatboxes ?? [];
+  const scenarioRow = scenarioId
+    ? rows.find((c) => c.chatboxId === scenarioId) ?? null
     : null;
-  // Only query once the id is known-good; until the list resolves we know
-  // nothing, which is a spinner, not a 404.
-  const queryHostId = scenarioHost ? scenarioHost.hostId : null;
-  // A Journeys-owned host is standalone: it has no share surface and must
-  // never be back-minted one.
-  const isJourneysHost = scenarioHost?.ownerScope?.type === "journeys";
+  // `!environmentId` mirrors the backend's `getHostPublishChatbox`: an
+  // environment-backed row displays a host it does not belong to, and must
+  // never absorb that host's legacy links.
+  const legacyHostRow =
+    scenarioId && !scenarioRow
+      ? rows.find((c) => c.namedHostId === scenarioId && !c.environmentId) ??
+        null
+      : null;
+  // A Journeys-owned host is standalone — it has no chatbox at all, so an old
+  // link to one lands here with nothing to resolve. Worth naming precisely
+  // instead of "not found".
+  const isJourneysHost =
+    scenarioId && !scenarioRow && !legacyHostRow
+      ? hosts.find((h) => h.hostId === scenarioId)?.ownerScope?.type ===
+        "journeys"
+      : false;
 
-  const { chatbox, isLoading: chatboxLoading } = useChatboxByHostId({
+  useEffect(() => {
+    if (!legacyHostRow) return;
+    // Carry the WHOLE URL across — an old link may hold `tab`/`session`, and
+    // the hash is how the hosted chat surface addresses a thread.
+    const query = searchParams.toString();
+    const hash = typeof window === "undefined" ? "" : window.location.hash;
+    const base = buildUserTestingScenarioPath(legacyHostRow.chatboxId);
+    navigate(`${base}${query ? `?${query}` : ""}${hash}`, { replace: true });
+  }, [legacyHostRow, navigate, searchParams]);
+
+  const { chatbox, isLoading: chatboxQueryLoading } = useChatbox({
     isAuthenticated: effectiveAuth,
-    hostId: queryHostId,
+    // Only query once the id is known-good; until the list resolves we know
+    // nothing, which is a spinner, not a 404.
+    chatboxId: scenarioRow ? scenarioRow.chatboxId : null,
   });
+  const chatboxLoading = Boolean(scenarioRow) && chatboxQueryLoading;
 
-  // Backfill: hosts created before the 1:1 invariant landed have no chatbox.
-  // Opening such a scenario fires `ensureChatboxForHost` (idempotent on the
-  // host's `by_namedHost`) and the reactive query refetches with the new row.
+  // Provisioning a chatbox for a host that lacks one used to happen on MOUNT,
+  // behind three pieces of state (a per-host latch, a suppress set for
+  // intentional deletes, and a stuck-timer). All of it is gone: a scenario is
+  // now addressed by the chatbox that already exists, so there is nothing to
+  // back-mint on the way in. A host without a chatbox simply has no scenario.
+  //
+  // The mutation itself survives for ONE caller — the agent's host-addressed
+  // publish tool below, where provisioning is the explicit request rather than
+  // a side effect of looking at a URL.
   const ensureChatboxForHost = useMutation(
     "chatboxes:ensureChatboxForHost" as any,
   );
-  // Latched per host so a transient null plus concurrent queries can't fire
-  // duplicate mutations.
-  const ensureLatchRef = useRef<Set<string>>(new Set());
-  // Hosts whose chatbox was INTENTIONALLY deleted. The back-mint below reads a
-  // reactive `chatbox === null` as drift and re-provisions; a delete has to
-  // stay deleted, so suppress the remint for that host until a chatbox exists
-  // again (an explicit re-publish).
-  const suppressEnsureHostsRef = useRef<Set<string>>(new Set());
-  // Hosts where ensure RESOLVED but the query is still returning null. That is
-  // not provisioning latency — it's the backend dropping the chatbox for a
-  // reason the query didn't surface. Without this we'd spin forever.
-  const [ensureCompletedNullHosts, setEnsureCompletedNullHosts] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
-
-  useEffect(() => {
-    if (!effectiveAuth) return;
-    if (!queryHostId) return;
-    // Wait for both the host list (ownerScope) and the chatbox query. Firing
-    // while the host is unresolved would race a chatbox onto a standalone host.
-    if (hostsLoading || chatboxLoading) return;
-    if (isJourneysHost) return;
-    if (chatbox !== null) return;
-    if (suppressEnsureHostsRef.current.has(queryHostId)) return;
-    if (ensureLatchRef.current.has(queryHostId)) return;
-    ensureLatchRef.current.add(queryHostId);
-    const targetHostId = queryHostId;
-    let cancelled = false;
-    let stuckTimer: ReturnType<typeof setTimeout> | undefined;
-    void ensureChatboxForHost({ hostId: targetHostId } as any)
-      .then(() => {
-        // Convex takes a render or two to surface the new row, so flipping the
-        // stuck flag synchronously here would flash the failure UI between
-        // resolve and refetch. Grace window first; the effect below clears the
-        // flag the moment the chatbox actually arrives.
-        if (cancelled) return;
-        stuckTimer = setTimeout(() => {
-          setEnsureCompletedNullHosts((prev) => {
-            const next = new Set(prev);
-            next.add(targetHostId);
-            return next;
-          });
-        }, 1500);
-      })
-      .catch((err: unknown) => {
-        ensureLatchRef.current.delete(targetHostId);
-        toast.error(
-          err instanceof Error
-            ? err.message
-            : "Failed to provision this scenario",
-        );
-      });
-    return () => {
-      cancelled = true;
-      if (stuckTimer !== undefined) clearTimeout(stuckTimer);
-    };
-  }, [
-    chatbox,
-    chatboxLoading,
-    effectiveAuth,
-    ensureChatboxForHost,
-    hostsLoading,
-    isJourneysHost,
-    queryHostId,
-  ]);
-
-  // Once the chatbox shows up, clear the stuck flag AND the per-host latch, so
-  // a later drift (its chatbox deleted mid-session) re-arms the ensure instead
-  // of silently dropping it. Both cleanups live in one effect to stay in
-  // lockstep with "a chatbox is present".
-  useEffect(() => {
-    if (!queryHostId) return;
-    if (chatbox === null || chatbox === undefined) return;
-    ensureLatchRef.current.delete(queryHostId);
-    suppressEnsureHostsRef.current.delete(queryHostId);
-    setEnsureCompletedNullHosts((prev) => {
-      if (!prev.has(queryHostId)) return prev;
-      const next = new Set(prev);
-      next.delete(queryHostId);
-      return next;
-    });
-  }, [chatbox, queryHostId]);
 
   // Legacy deep links: `/chatboxes?host=X&session=Y` redirects here with its
   // query intact, so translate it into the scenario path. Every session link
-  // copied before the rename comes through this.
+  // copied before the rename comes through this — the ladder above then turns
+  // that host id into its chatbox id.
   const legacyHostParam = searchParams.get("host");
   useEffect(() => {
-    if (scenarioHostId) return;
+    if (scenarioId) return;
     if (!legacyHostParam) return;
     // Carry the WHOLE URL across, minus the `host` that became the path
     // segment. An old link may hold more than `session`, and the hash is how
@@ -216,7 +174,7 @@ export function UserTestingTab({
     const hash = typeof window === "undefined" ? "" : window.location.hash;
     const base = buildUserTestingScenarioPath(legacyHostParam);
     navigate(`${base}${query ? `?${query}` : ""}${hash}`, { replace: true });
-  }, [legacyHostParam, navigate, scenarioHostId, searchParams]);
+  }, [legacyHostParam, navigate, scenarioId, searchParams]);
 
   // --- Agent tool group (surface "chatboxes") ---------------------------
   //
@@ -275,11 +233,7 @@ export function UserTestingTab({
     );
   };
 
-  const activeView = createOpen
-    ? "create"
-    : scenarioHostId
-    ? "detail"
-    : "overview";
+  const activeView = createOpen ? "create" : scenarioId ? "detail" : "overview";
 
   useSurfaceAgentBridge({
     surfaceId: "chatboxes",
@@ -297,14 +251,20 @@ export function UserTestingTab({
             `"${target.name}" belongs to the Swarms surface and has no share surface. Manage its journeys and runs on the Swarms screen, or publish a different client.`,
           );
         }
-        // Explicit publish intent — lift any prior intentional-delete
-        // suppression so provisioning (and future drift-remint) works again.
-        suppressEnsureHostsRef.current.delete(target.hostId);
         try {
-          await ensureChatboxForHost({ hostId: target.hostId } as any);
-          navigate(buildUserTestingScenarioPath(target.hostId));
+          // The mutation is idempotent and returns the chatbox either way, so
+          // its id is what we navigate with — no round trip through the
+          // legacy host-id redirect.
+          const settings = (await ensureChatboxForHost({
+            hostId: target.hostId,
+          } as any)) as { chatboxId: string } | null;
+          if (!settings?.chatboxId) {
+            throw new Error("Publishing returned no scenario.");
+          }
+          navigate(buildUserTestingScenarioPath(settings.chatboxId));
           return {
             status: "chatbox_published",
+            scenarioId: settings.chatboxId,
             hostId: target.hostId,
             name: target.name,
             note: "The client's scenario is provisioned and open. Copying its share link is a human action — check ui_snapshot_app for whether a link exists.",
@@ -320,8 +280,11 @@ export function UserTestingTab({
         requireAgentOperable();
         const { payload } = command as DeleteChatboxInspectorCommand;
         const target = resolveAgentHost(payload?.host);
-        const match = (chatboxes ?? []).find(
-          (c) => c.namedHostId === target.hostId,
+        // Host-addressed, so it deletes the host's OWN publish surface — never
+        // an environment-backed row that merely displays this host (same rule
+        // as the backend's `getHostPublishChatbox`).
+        const match = rows.find(
+          (c) => c.namedHostId === target.hostId && !c.environmentId,
         );
         if (!match) {
           throw createInspectorCommandClientError(
@@ -329,22 +292,16 @@ export function UserTestingTab({
             `"${target.name}" has no scenario to delete.`,
           );
         }
-        // Suppress the auto-remint BEFORE the delete lands: the reactive query
-        // flipping to null must not trigger ensureChatboxForHost, or the tool
-        // would report chatbox_deleted while the surface immediately reminted.
-        suppressEnsureHostsRef.current.add(target.hostId);
-        ensureLatchRef.current.delete(target.hostId);
         try {
           await deleteChatbox({ chatboxId: match.chatboxId } as any);
           return {
             status: "chatbox_deleted",
+            scenarioId: match.chatboxId,
             hostId: target.hostId,
             chatboxId: match.chatboxId,
             name: target.name,
           };
         } catch (e) {
-          // Delete failed — the chatbox still exists, so allow provisioning.
-          suppressEnsureHostsRef.current.delete(target.hostId);
           throw createInspectorCommandClientError(
             "execution_failed",
             e instanceof Error ? e.message : "Failed to delete the scenario.",
@@ -363,11 +320,18 @@ export function UserTestingTab({
           reason: "Sign in and select a project to use the User Testing tools.",
         };
       }
-      const scenarios = (chatboxes ?? []).map((c) => ({
+      const scenarios = rows.map((c) => ({
+        // The id every scenario has, and the one `/user-testing/:scenarioId`
+        // now carries.
+        scenarioId: c.chatboxId,
         chatboxId: c.chatboxId,
         hostId: c.namedHostId,
         name: c.name,
         client: c.hostStyle,
+        environment: c.environmentName ?? null,
+        // Present only when the row can't resolve — absence is "healthy",
+        // not "unknown".
+        environmentError: c.environmentError?.code ?? null,
         serverCount: c.serverCount,
         hasPublishLink: Boolean(c.link?.token),
         uniqueTesterCount: c.uniqueTesterCount ?? null,
@@ -396,8 +360,11 @@ export function UserTestingTab({
         detailTab: parseUserTestingDetailTab(
           typeof window === "undefined" ? "" : window.location.search,
         ),
-        selectedHostId: scenarioHostId ?? null,
-        selectedHostName: scenarioHost?.name ?? null,
+        selectedScenarioId: scenarioId ?? null,
+        selectedHostId: chatbox?.namedHostId ?? null,
+        selectedHostName: chatbox?.namedHostName ?? null,
+        selectedEnvironment: chatbox?.environmentName ?? null,
+        selectedEnvironmentError: chatbox?.environmentError?.code ?? null,
         // A standalone Journeys host has no share surface (the dead-end).
         isStandaloneSwarmHost: isJourneysHost,
         published: Boolean(chatbox),
@@ -436,7 +403,9 @@ export function UserTestingTab({
         onCreateScenario={async ({ name, input, chatboxMode }) => {
           // The one write. `hosts.createHost` mints the host, its chatbox and
           // the access mode in a single mutation, so a half-created scenario
-          // isn't reachable.
+          // isn't reachable. It returns the host id; the route wants the
+          // chatbox id, and the ladder above resolves one to the other on the
+          // next render — the list has already refetched by then.
           const { hostId } = await createHost({
             projectId,
             name,
@@ -452,7 +421,7 @@ export function UserTestingTab({
   }
 
   // --- Scenario detail --------------------------------------------------
-  if (scenarioHostId) {
+  if (scenarioId) {
     // Nothing was ever queried — signed out, or no project selected yet.
     // "Not found" would be a lie: we never looked.
     if (!queryable) {
@@ -466,35 +435,42 @@ export function UserTestingTab({
       );
     }
 
-    if (hostsLoading) return <ScenarioSpinner label="Loading scenario…" />;
+    // The list is what validates the param, so nothing can be decided until
+    // it lands. The host list only gates the Swarms dead-end below.
+    if (listLoading || (!scenarioRow && !legacyHostRow && hostsLoading)) {
+      return <ScenarioSpinner label="Loading scenario…" />;
+    }
 
-    if (!scenarioHost) {
+    // The redirect effect is already in flight; rendering "not found" for a
+    // frame would flash a lie at someone following a working old link.
+    if (legacyHostRow) return <ScenarioSpinner label="Loading scenario…" />;
+
+    if (!scenarioRow) {
+      if (isJourneysHost) {
+        return (
+          <ScenarioNotice
+            icon={<Boxes className="size-8 text-muted-foreground/70" />}
+            title="Managed by Swarms"
+            body="This client belongs to the Swarms surface and has no share surface. Manage its journeys and runs there."
+            onBack={goOverview}
+            extraAction={
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate(routePaths.swarms)}
+              >
+                Go to Swarms
+              </Button>
+            }
+          />
+        );
+      }
       return (
         <ScenarioNotice
           icon={<Inbox className="size-8 text-muted-foreground/70" />}
           title="Scenario not found"
-          body="This scenario no longer exists, or isn't visible to you."
+          body="This scenario no longer exists, was never published, or isn't visible to you."
           onBack={goOverview}
-        />
-      );
-    }
-
-    if (isJourneysHost) {
-      return (
-        <ScenarioNotice
-          icon={<Boxes className="size-8 text-muted-foreground/70" />}
-          title="Managed by Swarms"
-          body="This client belongs to the Swarms surface and has no share surface. Manage its journeys and runs there."
-          onBack={goOverview}
-          extraAction={
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => navigate(routePaths.swarms)}
-            >
-              Go to Swarms
-            </Button>
-          }
         />
       );
     }
@@ -502,42 +478,23 @@ export function UserTestingTab({
     if (chatboxLoading) return <ScenarioSpinner label="Loading scenario…" />;
 
     if (!chatbox) {
-      // Deleted on purpose (by the agent, or from the detail screen) — the
-      // suppression latch is holding the remint off, so say so rather than
-      // spinning on a provisioning that will never come.
-      if (suppressEnsureHostsRef.current.has(scenarioHostId)) {
-        return (
-          <ScenarioNotice
-            icon={<Inbox className="size-8 text-muted-foreground/70" />}
-            title="Scenario deleted"
-            body={`"${scenarioHost.name}" is no longer published. Its client is still in Connect if you want to publish it again.`}
-            onBack={goOverview}
-          />
-        );
-      }
-      // Ensure returned but the query is still empty: a real failure, not
-      // latency.
-      if (ensureCompletedNullHosts.has(scenarioHostId)) {
-        return (
-          <ScenarioLoadFailure
-            title="Couldn't load this scenario"
-            body="The backfill mutation succeeded but the chatbox query still returned nothing. Check the Convex logs for getChatboxByHostId on this client."
-          />
-        );
-      }
-      return <ScenarioSpinner label="Provisioning this scenario…" />;
+      // The row is in the list but the detail query returns nothing — the
+      // scenario was deleted from under this view (another tab, the agent),
+      // or its environment stopped resolving hard enough that even the
+      // degraded read failed.
+      return (
+        <ScenarioLoadFailure
+          title="Couldn't load this scenario"
+          body="It may have just been deleted. Go back to User Testing to see the current list."
+        />
+      );
     }
 
     return (
       <UserTestingScenarioDetail
         chatbox={chatbox}
-        hostName={scenarioHost.name}
         onBack={goOverview}
-        onDeleted={() => {
-          suppressEnsureHostsRef.current.add(scenarioHostId);
-          ensureLatchRef.current.delete(scenarioHostId);
-          goOverview();
-        }}
+        onDeleted={goOverview}
       />
     );
   }
@@ -567,9 +524,7 @@ export function UserTestingTab({
         <UserTestingOverviewPanel
           chatboxes={chatboxes}
           isLoading={listLoading}
-          onOpenScenario={(hostId) =>
-            navigate(buildUserTestingScenarioPath(hostId))
-          }
+          onOpenScenario={(id) => navigate(buildUserTestingScenarioPath(id))}
           onCreateScenario={goCreate}
           createLabel="New scenario"
         />

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.agent.test.tsx
@@ -75,6 +75,12 @@ const hostCursorTwin: HostListItem = {
   updatedAt: 0,
 };
 
+/**
+ * Mutable per test: the post-delete case drops a row to prove the surface
+ * never re-provisions what an agent just deleted.
+ */
+let listRows: ChatboxListItem[] = [];
+
 const chatboxList: ChatboxListItem[] = [
   {
     chatboxId: "cb-1",
@@ -223,8 +229,8 @@ vi.mock("@/hooks/useClients", () => ({
 }));
 
 vi.mock("@/hooks/useChatboxes", () => ({
-  useChatboxByHostId: () => chatboxState,
-  useChatboxList: () => ({ chatboxes: chatboxList, isLoading: false }),
+  useChatbox: () => chatboxState,
+  useChatboxList: () => ({ chatboxes: listRows, isLoading: false }),
   useChatboxMutations: () => ({ deleteChatbox: deleteChatboxMock }),
 }));
 
@@ -270,13 +276,13 @@ function expectCommandError(
 function renderUserTesting(props?: {
   isAuthenticated?: boolean;
   projectId?: string | null;
-  scenarioHostId?: string | null;
+  scenarioId?: string | null;
 }) {
   return render(
     <UserTestingTab
       projectId={props?.projectId ?? "proj-1"}
       isAuthenticated={props?.isAuthenticated ?? true}
-      scenarioHostId={props?.scenarioHostId ?? null}
+      scenarioId={props?.scenarioId ?? null}
     />
   );
 }
@@ -285,10 +291,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   hostListState.hosts = [hostClaude, hostCursor, hostJourney];
   hostListState.isLoading = false;
+  listRows = chatboxList.map((row) => ({ ...row }));
   chatboxState.chatbox = { ...scenarioChatbox };
   chatboxState.isLoading = false;
   usageState.threads = sessionThreads;
-  ensureChatboxForHostMock.mockResolvedValue(undefined);
+  // The publish handler navigates with the id the mutation returns, so the
+  // mock has to behave like the real (idempotent) mutation and return a row.
+  ensureChatboxForHostMock.mockResolvedValue({ chatboxId: "cb-2" });
   deleteChatboxMock.mockResolvedValue(undefined);
 });
 
@@ -301,13 +310,19 @@ describe("UserTestingTab — agent bridge handlers", () => {
     });
     expect(response).toMatchObject({
       status: "success",
-      result: { status: "chatbox_published", hostId: "host-2", name: "Cursor" },
+      result: {
+        status: "chatbox_published",
+        scenarioId: "cb-2",
+        hostId: "host-2",
+        name: "Cursor",
+      },
     });
     expect(ensureChatboxForHostMock).toHaveBeenCalledWith({ hostId: "host-2" });
     // Selection is the ROUTE now (buildUserTestingScenarioPath), not in-page
     // state — a publish that ensured but never navigated leaves the agent
-    // reporting a scenario the user cannot see.
-    expect(navigateMock).toHaveBeenCalledWith("/user-testing/host-2");
+    // reporting a scenario the user cannot see. It navigates with the id the
+    // mutation returned rather than the host id, so there is no redirect hop.
+    expect(navigateMock).toHaveBeenCalledWith("/user-testing/cb-2");
   });
 
   it("publishChatbox HONORS the Swarms-owned dead-end without ensuring", async () => {
@@ -358,43 +373,42 @@ describe("UserTestingTab — agent bridge handlers", () => {
     });
     expect(response).toMatchObject({
       status: "success",
-      result: { status: "chatbox_deleted", chatboxId: "cb-2", name: "Cursor" },
+      result: {
+        status: "chatbox_deleted",
+        scenarioId: "cb-2",
+        chatboxId: "cb-2",
+        name: "Cursor",
+      },
     });
     expect(deleteChatboxMock).toHaveBeenCalledWith({ chatboxId: "cb-2" });
   });
 
-  it("keeps the OPEN scenario deleted — no auto-remint after delete", async () => {
-    // host-1 (Claude) is the scenario on screen and is currently published.
-    const { rerender } = renderUserTesting({ scenarioHostId: "host-1" });
+  it("keeps the OPEN scenario deleted — nothing re-provisions it", async () => {
+    // cb-1 (Claude) is the scenario on screen and is currently published.
+    const { rerender } = renderUserTesting({ scenarioId: "cb-1" });
     const response = await dispatch({
       type: "deleteChatbox",
       payload: { host: "Claude" },
     });
     expect(response).toMatchObject({
       status: "success",
-      result: { status: "chatbox_deleted", chatboxId: "cb-1" },
+      result: { status: "chatbox_deleted", scenarioId: "cb-1" },
     });
     expect(deleteChatboxMock).toHaveBeenCalledWith({ chatboxId: "cb-1" });
 
-    // The reactive query now reports null for the deleted host. Without the
-    // suppression latch, the back-mint effect would call ensureChatboxForHost
-    // and re-provision it — contradicting chatbox_deleted.
+    // The reactive queries now report the row gone. This used to need a
+    // suppression latch, because a back-mint effect read `chatbox === null` as
+    // drift and re-provisioned — contradicting chatbox_deleted. The surface no
+    // longer provisions anything, so the delete simply stands.
+    listRows = listRows.filter((row) => row.chatboxId !== "cb-1");
     chatboxState.chatbox = null;
     await act(async () => {
       rerender(
-        <UserTestingTab
-          projectId="proj-1"
-          isAuthenticated
-          scenarioHostId="host-1"
-        />
+        <UserTestingTab projectId="proj-1" isAuthenticated scenarioId="cb-1" />
       );
     });
-    expect(ensureChatboxForHostMock).not.toHaveBeenCalledWith({
-      hostId: "host-1",
-    });
-    // …and the screen says so instead of spinning on a provisioning that the
-    // latch is deliberately holding off.
-    expect(await screen.findByText(/Scenario deleted/i)).toBeInTheDocument();
+    expect(ensureChatboxForHostMock).not.toHaveBeenCalled();
+    expect(await screen.findByText(/Scenario not found/i)).toBeInTheDocument();
   });
 
   it("refuses every command as unsupported_in_mode when signed out", async () => {
@@ -412,7 +426,7 @@ describe("UserTestingTab — agent bridge handlers", () => {
   });
 
   it("snapshot reports redacted state and NEVER the token / transcript / PII", async () => {
-    renderUserTesting({ scenarioHostId: "host-1" });
+    renderUserTesting({ scenarioId: "cb-1" });
 
     const snapshot = await readSurfaceSnapshot("chatboxes");
     expect(snapshot).toMatchObject({

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.journeys.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.journeys.test.tsx
@@ -1,33 +1,44 @@
 /**
- * Guards the standalone-host must-fix and the `:scenarioId` validation gate.
+ * The `:scenarioId` resolution ladder, and the standalone-host must-fix.
  *
- * A Journeys-owned host has NO share surface, so the User Testing surface must
- * (a) never back-mint a chatbox for it and (b) render the "Managed by Swarms"
- * notice with a way out. The surrounding cases pin the decision inputs: it
- * back-mints for an untagged chatbox-less host, waits for the host list before
- * deciding anything, and treats a host that isn't in the list as not-found —
- * without ever putting that id on the wire.
+ * `:scenarioId` is a CHATBOX id. This suite pins the three things that ladder
+ * owes its callers: links minted under the old host-id scheme still land on
+ * the right scenario, an id that resolves to nothing says so without ever
+ * reaching the wire (`getChatbox` declares `v.id('chatboxes')` — an unknown id
+ * THROWS out of useQuery and takes the screen with it), and a Journeys-owned
+ * host — which has no share surface and therefore no chatbox at all — gets the
+ * "Managed by Swarms" dead-end instead of a bare not-found.
+ *
+ * The surface no longer provisions anything on mount: a host without a chatbox
+ * simply has no scenario. `ensureMock` is asserted-never here to keep it that
+ * way.
  */
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { HostListItem } from "@/hooks/useClients";
+import type { ChatboxListItem } from "@/hooks/useChatboxes";
 
 const {
   ensureMock,
   navigateMock,
   hostListState,
+  listState,
   chatboxState,
   chatboxQuerySpy,
 } = vi.hoisted(() => ({
   ensureMock: vi.fn().mockResolvedValue(undefined),
   navigateMock: vi.fn(),
   hostListState: { hosts: [] as HostListItem[], isLoading: false },
+  listState: {
+    chatboxes: [] as ChatboxListItem[] | undefined,
+    isLoading: false,
+  },
   chatboxState: { chatbox: null as unknown, isLoading: false },
   // A spy, not a plain factory: one case asserts on the ARGS the surface hands
   // the chatbox query.
   chatboxQuerySpy:
     vi.fn<
-      (args: { isAuthenticated: boolean; hostId: string | null }) => void
+      (args: { isAuthenticated: boolean; chatboxId: string | null }) => void
     >(),
 }));
 
@@ -50,14 +61,11 @@ vi.mock("@/hooks/useClients", () => ({
 }));
 
 vi.mock("@/hooks/useChatboxes", () => ({
-  useChatboxByHostId: (args: {
-    isAuthenticated: boolean;
-    hostId: string | null;
-  }) => {
+  useChatbox: (args: { isAuthenticated: boolean; chatboxId: string | null }) => {
     chatboxQuerySpy(args);
     return chatboxState;
   },
-  useChatboxList: () => ({ chatboxes: [], isLoading: false }),
+  useChatboxList: () => listState,
   useChatboxMutations: () => ({ deleteChatbox: vi.fn() }),
 }));
 
@@ -98,85 +106,118 @@ function hostFixture(overrides: Partial<HostListItem>): HostListItem {
   };
 }
 
-function renderScenario(scenarioHostId: string = SCENARIO_HOST_ID) {
+function rowFixture(overrides: Partial<ChatboxListItem>): ChatboxListItem {
+  return {
+    chatboxId: "cb-1",
+    projectId: "proj-1",
+    name: "Payments beta",
+    hostStyle: "cursor",
+    mode: "anyone_with_link",
+    allowGuestAccess: true,
+    serverCount: 0,
+    serverNames: [],
+    namedHostId: "host-real",
+    namedHostName: "Cursor",
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function renderScenario(scenarioId: string = SCENARIO_HOST_ID) {
   return render(
-    <UserTestingTab
-      projectId="proj-1"
-      isAuthenticated
-      scenarioHostId={scenarioHostId}
-    />
+    <UserTestingTab projectId="proj-1" isAuthenticated scenarioId={scenarioId} />
   );
 }
 
-describe("UserTestingTab — Journeys-owned (standalone) host", () => {
+describe("UserTestingTab — scenario resolution", () => {
   afterEach(() => {
     ensureMock.mockClear();
     navigateMock.mockClear();
     chatboxQuerySpy.mockClear();
     hostListState.hosts = [];
     hostListState.isLoading = false;
+    listState.chatboxes = [];
+    listState.isLoading = false;
     chatboxState.chatbox = null;
     chatboxState.isLoading = false;
   });
 
-  it("does NOT back-mint a chatbox and shows the notice + a way to Swarms", async () => {
+  it("shows the Swarms dead-end for a Journeys-owned host, and never provisions", async () => {
+    // A standalone host has no publish surface, so nothing in the scenario
+    // list points at it. Without this branch it would read as "not found",
+    // which hides the reason and the way out.
     hostListState.hosts = [hostFixture({ ownerScope: { type: "journeys" } })];
-    chatboxState.chatbox = null; // journeys host has no chatbox
+    listState.chatboxes = [];
 
     renderScenario();
 
     expect(await screen.findByText(/Managed by Swarms/i)).toBeInTheDocument();
-    // Recoverable: the notice offers the surface that actually owns this host.
     expect(
       screen.getByRole("button", { name: /Go to Swarms/i })
     ).toBeInTheDocument();
-    // Critically: the auto-ensure mutation is never fired for a journeys host.
     await waitFor(() => {
       expect(ensureMock).not.toHaveBeenCalled();
     });
   });
 
-  it("DOES back-mint for a chatbox-less untagged host (control)", async () => {
-    hostListState.hosts = [
-      hostFixture({ name: "Legacy Client", ownerScope: null }),
+  it("redirects a legacy host-id link onto its chatbox id", async () => {
+    // Every link copied before the identity change carries a host id.
+    listState.chatboxes = [
+      rowFixture({ chatboxId: "cb-42", namedHostId: "host-real" }),
     ];
-    chatboxState.chatbox = null;
 
-    renderScenario();
-
-    await waitFor(() => {
-      expect(ensureMock).toHaveBeenCalledWith({ hostId: SCENARIO_HOST_ID });
-    });
-    expect(screen.queryByText(/Managed by Swarms/i)).not.toBeInTheDocument();
-  });
-
-  it("waits for the host list to load before deciding (no ensure while loading)", async () => {
-    // The host list carries ownerScope; deciding before it lands would race a
-    // chatbox onto a standalone host.
-    hostListState.hosts = [];
-    hostListState.isLoading = true;
-    chatboxState.chatbox = null;
-
-    renderScenario();
+    renderScenario("host-real");
 
     await waitFor(() => {
-      expect(ensureMock).not.toHaveBeenCalled();
+      expect(navigateMock).toHaveBeenCalledWith("/user-testing/cb-42", {
+        replace: true,
+      });
     });
-    expect(screen.queryByText(/Managed by Swarms/i)).not.toBeInTheDocument();
+    // Not a 404 while the redirect is in flight.
     expect(screen.queryByText(/Scenario not found/i)).not.toBeInTheDocument();
   });
 
-  it("a RESOLVED-missing host renders not-found and never provisions", async () => {
-    // The list finished and this host is gone (deleted / not visible) —
-    // provisioning would just fail the mutation and strand the spinner.
-    hostListState.hosts = [];
-    hostListState.isLoading = false;
-    chatboxState.chatbox = null;
+  it("an environment-backed row never absorbs the host's legacy links", async () => {
+    // Environment-backed rows carry a `namedHostId` for DISPLAY only, and
+    // several can point at the same host. Matching on it would hand an old
+    // link to an unrelated scenario — the same rule the backend's
+    // `getHostPublishChatbox` enforces.
+    listState.chatboxes = [
+      rowFixture({
+        chatboxId: "cb-env",
+        namedHostId: "host-real",
+        environmentId: "env-1",
+      }),
+    ];
+
+    renderScenario("host-real");
+
+    expect(await screen.findByText(/Scenario not found/i)).toBeInTheDocument();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("waits for the list before deciding anything", async () => {
+    listState.chatboxes = undefined;
+    listState.isLoading = true;
+
+    renderScenario();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Scenario not found/i)).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Managed by Swarms/i)).not.toBeInTheDocument();
+  });
+
+  it("a host with no scenario is not-found — nothing is minted on the way in", async () => {
+    // This used to back-mint a chatbox on mount. A scenario is now something
+    // that already exists; a client without one simply isn't one.
+    hostListState.hosts = [hostFixture({ ownerScope: null })];
+    listState.chatboxes = [];
 
     renderScenario();
 
     expect(await screen.findByText(/Scenario not found/i)).toBeInTheDocument();
-    // Recoverable: a way back to the scenario list rather than a dead end.
     expect(
       screen.getByRole("button", { name: /Back to User Testing/i })
     ).toBeInTheDocument();
@@ -186,20 +227,19 @@ describe("UserTestingTab — Journeys-owned (standalone) host", () => {
   });
 
   it("never puts an unknown :scenarioId on the wire", async () => {
-    // `getChatboxByHostId` declares `v.id("hosts")`, so a hand-typed or stale
-    // id does not come back null — it THROWS out of useQuery and takes the
-    // screen with it. Validating against the loaded host list first is what
-    // keeps a bad URL from white-screening the app.
+    // `getChatbox` declares `v.id('chatboxes')`, so a hand-typed or stale id
+    // does not come back null — it THROWS out of useQuery and takes the screen
+    // with it. Validating against the loaded list first is what keeps a bad
+    // URL from white-screening the app.
     hostListState.hosts = [hostFixture({ hostId: "host-real" })];
-    hostListState.isLoading = false;
+    listState.chatboxes = [rowFixture({ chatboxId: "cb-1" })];
 
-    renderScenario("not-a-real-host-id");
+    renderScenario("not-a-real-id");
 
     expect(await screen.findByText(/Scenario not found/i)).toBeInTheDocument();
-    expect(ensureMock).not.toHaveBeenCalled();
     expect(chatboxQuerySpy).toHaveBeenCalled();
     for (const [args] of chatboxQuerySpy.mock.calls) {
-      expect(args.hostId).toBeNull();
+      expect(args.chatboxId).toBeNull();
     }
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -386,7 +386,7 @@ export function ChatboxUsagePanel({
                 <ShareUsageThreadDetail
                   threadId={selectedThreadId}
                   sessionLink={`${getShareableAppOrigin()}${buildUserTestingScenarioPath(
-                    chatbox.namedHostId,
+                    chatbox.chatboxId,
                     { session: selectedThreadId },
                   )}`}
                 />

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingOverviewPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingOverviewPanel.tsx
@@ -26,7 +26,8 @@ interface UserTestingOverviewPanelProps {
   /** Undefined while loading (Convex `useQuery` semantics). */
   chatboxes: ChatboxListItem[] | undefined;
   isLoading: boolean;
-  onOpenScenario: (hostId: string) => void;
+  /** Receives the scenario's chatbox id — the route's `:scenarioId`. */
+  onOpenScenario: (scenarioId: string) => void;
   onCreateScenario: () => void;
   createLabel: string;
 }
@@ -111,8 +112,9 @@ function OverviewBody({
             <button
               type="button"
               data-testid="user-testing-overview-row"
+              data-scenario-id={row.chatboxId}
               data-host-id={row.namedHostId}
-              onClick={() => onOpenScenario(row.namedHostId)}
+              onClick={() => onOpenScenario(row.chatboxId)}
               className={cn(
                 ROW_PAD,
                 ROW_COLS,
@@ -121,8 +123,20 @@ function OverviewBody({
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               )}
             >
-              <span className="min-w-0 truncate text-sm font-medium text-foreground">
-                {row.name}
+              <span className="flex min-w-0 items-center gap-1.5">
+                <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                  {row.name}
+                </span>
+                {row.environmentError ? (
+                  // The row is deliberately still here — its share link is
+                  // minted and only its owner can retire it — so say what's
+                  // wrong instead of rendering a confident, empty-looking row.
+                  <AlertTriangle
+                    data-testid="user-testing-overview-row-error"
+                    aria-label={row.environmentError.message}
+                    className="size-3.5 shrink-0 text-amber-600 dark:text-amber-500"
+                  />
+                ) : null}
               </span>
               <span className="flex min-w-0 items-center gap-2">
                 <span className="inline-flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-md border border-border/50 bg-background">

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import { useLocation, useNavigate } from "react-router";
-import { ArrowLeft, ExternalLink, Link2, Trash2 } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ExternalLink,
+  Layers,
+  Link2,
+  Trash2,
+} from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection";
@@ -35,9 +42,8 @@ import { cn } from "@/lib/utils";
  */
 interface UserTestingScenarioDetailProps {
   chatbox: ChatboxSettings;
-  hostName: string;
   onBack: () => void;
-  /** Parent sets its remint suppression and returns to the list. */
+  /** Parent returns to the list. */
   onDeleted: () => void;
 }
 
@@ -51,7 +57,6 @@ const TAB_OPTIONS: ReadonlyArray<{
 
 export function UserTestingScenarioDetail({
   chatbox,
-  hostName,
   onBack,
   onDeleted,
 }: UserTestingScenarioDetailProps) {
@@ -70,6 +75,13 @@ export function UserTestingScenarioDetail({
     "session",
   );
 
+  const environmentName = chatbox.environmentName ?? null;
+  // Present only when the environment can't resolve right now (archived, a
+  // pinned plugin disabled, its host gone). The scenario still opens: its
+  // sessions are history worth reading, and unpublishing it is the action
+  // this state calls for.
+  const environmentError = chatbox.environmentError ?? null;
+
   const publishLink = chatbox.link?.token
     ? buildChatboxLink(chatbox.link.token, chatbox.name)
     : null;
@@ -79,7 +91,7 @@ export function UserTestingScenarioDetail({
     // Replace, not push: flipping a sub-tab shouldn't put a stop on the back
     // button between the scenario and the list. Drops `?session=` — that
     // selection belongs to the Sessions tab.
-    navigate(buildUserTestingScenarioPath(chatbox.namedHostId, { tab: next }), {
+    navigate(buildUserTestingScenarioPath(chatbox.chatboxId, { tab: next }), {
       replace: true,
     });
   };
@@ -132,24 +144,38 @@ export function UserTestingScenarioDetail({
               {chatbox.name}
             </h1>
             <div className="mt-1.5 flex items-center gap-2 text-sm text-muted-foreground">
-              <span className="inline-flex size-5 items-center justify-center overflow-hidden rounded-sm border border-border/50 bg-background">
-                <img
-                  src={getChatboxHostLogo(
-                    chatbox.hostStyle,
-                    undefined,
-                    themeMode,
-                  )}
-                  alt=""
-                  className="size-3.5 object-contain"
-                />
-              </span>
-              <span className="font-medium text-foreground">
-                {getChatboxHostLabel(chatbox.hostStyle)}
-              </span>
-              <span aria-hidden="true" className="text-muted-foreground/40">
-                ·
-              </span>
-              <span className="truncate">{hostName}</span>
+              {environmentName ? (
+                // Environment-backed: the environment IS the scenario's
+                // identity. Its client is a detail of the environment, not a
+                // second name for the thing.
+                <>
+                  <Layers className="size-4 shrink-0" />
+                  <span className="truncate font-medium text-foreground">
+                    {environmentName}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <span className="inline-flex size-5 items-center justify-center overflow-hidden rounded-sm border border-border/50 bg-background">
+                    <img
+                      src={getChatboxHostLogo(
+                        chatbox.hostStyle,
+                        undefined,
+                        themeMode,
+                      )}
+                      alt=""
+                      className="size-3.5 object-contain"
+                    />
+                  </span>
+                  <span className="font-medium text-foreground">
+                    {getChatboxHostLabel(chatbox.hostStyle)}
+                  </span>
+                  <span aria-hidden="true" className="text-muted-foreground/40">
+                    ·
+                  </span>
+                  <span className="truncate">{chatbox.namedHostName}</span>
+                </>
+              )}
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
@@ -173,6 +199,25 @@ export function UserTestingScenarioDetail({
             </Button>
           </div>
         </div>
+
+        {environmentError ? (
+          <div
+            data-testid="user-testing-detail-environment-error"
+            className="mt-4 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+          >
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+            <div className="min-w-0 text-sm">
+              <p className="font-medium text-foreground">
+                {environmentError.code === "ENV_ARCHIVED"
+                  ? "This scenario's environment is archived — the share link no longer opens."
+                  : "This scenario's environment can't be loaded right now — the share link won't open."}
+              </p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {environmentError.message} Its sessions below are unaffected.
+              </p>
+            </div>
+          </div>
+        ) : null}
 
         <div className="mt-4 flex flex-col gap-3 rounded-md border border-primary/20 bg-primary/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-w-0">
@@ -229,7 +274,7 @@ export function UserTestingScenarioDetail({
               // Stash the target in the URL, then flip the tab — the same
               // reason the tab itself lives there.
               navigate(
-                buildUserTestingScenarioPath(chatbox.namedHostId, {
+                buildUserTestingScenarioPath(chatbox.chatboxId, {
                   session: threadId,
                 }),
                 { replace: true },

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingOverviewPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingOverviewPanel.test.tsx
@@ -87,19 +87,53 @@ describe("UserTestingOverviewPanel", () => {
     ).toHaveTextContent("0");
   });
 
-  it("opens a scenario by its host id", () => {
+  it("opens a scenario by its CHATBOX id, not the host it displays", () => {
     const onOpenScenario = vi.fn();
     render(
       <UserTestingOverviewPanel
         {...defaults}
         onOpenScenario={onOpenScenario}
-        chatboxes={[row({ namedHostId: "host-42" })]}
+        chatboxes={[row({ chatboxId: "cb-42", namedHostId: "host-42" })]}
       />,
     );
 
     fireEvent.click(screen.getByTestId("user-testing-overview-row"));
 
-    expect(onOpenScenario).toHaveBeenCalledWith("host-42");
+    // Several environment-backed scenarios can display the SAME host, so the
+    // host id doesn't address a row.
+    expect(onOpenScenario).toHaveBeenCalledWith("cb-42");
+  });
+
+  it("badges a row whose environment can't resolve, instead of hiding it", () => {
+    render(
+      <UserTestingOverviewPanel
+        {...defaults}
+        chatboxes={[
+          row({
+            environmentId: "env-1",
+            environmentError: {
+              code: "ENV_ARCHIVED",
+              message: "Environment “prod” is archived.",
+            },
+          }),
+        ]}
+      />,
+    );
+
+    // Its share link is still minted — the person who can retire it has to be
+    // able to see it.
+    expect(screen.getByTestId("user-testing-overview-row")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("user-testing-overview-row-error"),
+    ).toHaveAttribute("aria-label", "Environment “prod” is archived.");
+  });
+
+  it("shows no error badge on a healthy row", () => {
+    render(<UserTestingOverviewPanel {...defaults} chatboxes={[row()]} />);
+
+    expect(
+      screen.queryByTestId("user-testing-overview-row-error"),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the empty state, with the create action, when there are none", () => {

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -86,11 +86,10 @@ const chatbox = {
   link: { token: "tok", path: "/t/tok", url: "u", rotatedAt: 0, updatedAt: 0 },
 } as unknown as ChatboxSettings;
 
-const renderDetail = () =>
+const renderDetail = (over: Partial<ChatboxSettings> = {}) =>
   render(
     <UserTestingScenarioDetail
-      chatbox={chatbox}
-      hostName="Cursor"
+      chatbox={{ ...chatbox, ...over } as ChatboxSettings}
       onBack={vi.fn()}
       onDeleted={vi.fn()}
     />,
@@ -127,10 +126,44 @@ describe("UserTestingScenarioDetail", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Clusters" }));
 
+    // Addressed by chatbox id: the host it displays is not unique per
+    // scenario once environments are in play.
     expect(navigateMock).toHaveBeenCalledWith(
-      "/user-testing/host-1?tab=clusters",
+      "/user-testing/cb-1?tab=clusters",
       { replace: true },
     );
+  });
+
+  it("names the ENVIRONMENT on an environment-backed scenario", () => {
+    renderDetail({ environmentId: "env-1", environmentName: "Checkout flow" });
+
+    expect(screen.getByText("Checkout flow")).toBeInTheDocument();
+  });
+
+  it("warns when the environment can't resolve, and keeps the sessions", () => {
+    renderDetail({
+      environmentId: "env-1",
+      environmentName: "Checkout flow",
+      environmentError: {
+        code: "ENV_ARCHIVED",
+        message: "Environment “Checkout flow” is archived.",
+      },
+    });
+
+    expect(
+      screen.getByTestId("user-testing-detail-environment-error"),
+    ).toHaveTextContent(/archived/i);
+    // History is exactly what someone opens an archived scenario to read.
+    expect(screen.getByTestId("stub-usage-sessions")).toBeInTheDocument();
+  });
+
+  it("shows the client, not an environment, on a host-backed scenario", () => {
+    renderDetail();
+
+    expect(
+      screen.queryByTestId("user-testing-detail-environment-error"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Cursor")).toBeInTheDocument();
   });
 
   it("seeds the session pane from a deep-linked session", () => {

--- a/mcpjam-inspector/client/src/hooks/useChatboxes.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxes.ts
@@ -67,6 +67,16 @@ export interface ChatboxSettings {
   /** The named host this chatbox resolves through. */
   namedHostId: string;
   namedHostName: string;
+  /**
+   * Environment identity + resolution state, same contract as
+   * `ChatboxListItem`: non-null `environmentId` marks a live-follow row,
+   * `environmentError` says why it can't resolve. Every settings-returning
+   * mutation carries these too (mcpjam-backend #889), so state replaced from
+   * a `setChatboxMode` response keeps them.
+   */
+  environmentId?: string | null;
+  environmentName?: string | null;
+  environmentError?: { code: string | null; message: string } | null;
   link: {
     token: string;
     path: string;
@@ -117,6 +127,21 @@ export interface ChatboxListItem {
    * host-backed.
    */
   environmentId?: string | null;
+  /**
+   * The environment's name, resolved live (mcpjam-backend #889). Null on
+   * host-backed rows — absence means "not environment-backed", never
+   * "unnamed". Optional so a backend predating the field reads as absent.
+   */
+  environmentName?: string | null;
+  /**
+   * Why an environment-backed row can't resolve right now: its environment
+   * was archived, a pinned plugin was disabled, its host is gone. Null when
+   * healthy AND on host-backed rows. The row is still projected — a scenario
+   * whose share link is live must stay visible to the person who can retire
+   * it — so this is what tells the UI to badge it instead of rendering a
+   * confident-looking but empty row.
+   */
+  environmentError?: { code: string | null; message: string } | null;
   /** Shareable link (null until first publish mints one). */
   link?: { token: string; path: string; url: string } | null;
   /**

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -93,8 +93,11 @@ export type UserTestingDetailTab = "sessions" | "clusters";
 
 /**
  * Build a path to one User Testing scenario. `scenarioId` is the scenario's
- * HOST id (chatboxes are 1:1 with hosts). `session` opens straight into one
- * tester session, which is what a copied session link carries.
+ * CHATBOX id — the identity host-backed and environment-backed scenarios
+ * share. A HOST id is still accepted by the surface (links minted under the
+ * older scheme redirect onto the chatbox id), but new links should never be
+ * built with one. `session` opens straight into one tester session, which is
+ * what a copied session link carries.
  */
 export function buildUserTestingScenarioPath(
   scenarioId: string,


### PR DESCRIPTION
## Why

`/user-testing/:scenarioId` carried a **host** id, from when every scenario was a client and the two were 1:1. Environment-backed scenarios break that in both directions: several can point at the same host, and the host-keyed query (`getChatboxByHostId`) *deliberately* filters them out — so an environment-backed scenario had no addressable detail view at all.

The chatbox id is the identity both kinds share, and the one everything downstream — sessions, clusters, insights, the share section — was already keyed by. Three places were still minting links from `namedHostId`, including the session link the Sessions pane hands you to copy.

Backend groundwork for this shipped in mcpjam-backend #887 (publish contract), #889 (environment-aware projections) and #890 (guest ENV_* statuses).

## Old links keep working

A `:scenarioId` that matches a host instead of a chatbox redirects onto that host's scenario, preserving query **and** hash; the older `?host=` form still translates too.

That match ignores environment-backed rows. They carry a `namedHostId` for display only and several can share one, so matching on it would hand an old link to an unrelated scenario — the same rule the backend's `getHostPublishChatbox` enforces. There's a test for exactly this.

## What's deleted

The mount-time back-mint, and its three pieces of state: a per-host latch, a suppress set for intentional deletes, and a 1500 ms stuck-timer. It existed because opening a chatbox-less host had to provision one on the way in. A scenario is now something that already exists — a client without one simply isn't one, and says so.

The mutation itself survives for one caller: the agent's `ui_publish_chatbox`, where provisioning is the explicit request rather than a side effect of looking at a URL. That handler now navigates with the id the mutation returns instead of bouncing through the redirect.

## What's added

Detail and list read the environment fields from #889:
- an environment-backed scenario shows the **environment** as its identity, not client-logo + host name;
- a scenario whose environment can't resolve (archived, plugin disabled, host gone) gets a warning banner naming the reason, and its sessions stay readable — history is what you open an archived scenario for;
- the list badges such a row instead of hiding it. Its share link is still minted, and the person who can retire it has to be able to see it.

## Not in this PR

The create flow still writes a host (environment-first create + the list filter that drops auto-minted client rows is the next PR). It navigates with the host id and the ladder resolves it. The agent tools stay host-addressed; re-pointing them at scenario identity is its own PR.

## Tests

Rewrote `UserTestingTab.journeys.test.tsx` around the resolution ladder — the old file tested back-minting, which no longer exists. It now pins: legacy host-id link redirects; an environment-backed row never absorbs that host's links; unknown id is not-found and **never reaches the wire** (`getChatbox` declares `v.id('chatboxes')`, so an unknown id throws out of `useQuery` and white-screens the app); a Journeys host still gets the Swarms dead-end; nothing is provisioned on mount.

Also updated: overview panel (opens by chatbox id, badges an unresolvable row), detail (env identity, ENV_ARCHIVED state, chatbox-id nav), agent bridge, billing route.

```
npx vitest run client/src/components/chatboxes client/src/components/__tests__/UserTestingTab.*.test.tsx \
  client/src/__tests__/ChatboxesRoute.billing.test.tsx client/src/lib/__tests__
# 97 files, 1163 tests passed

vite build --config client/vite.config.ts    # ✓ built in 2m41s
```

Full `client/src` suite was re-run separately; result reported on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Routing and deep-link identity changed across User Testing with careful legacy handling; behavior is well-tested but affects bookmarks, agent navigation, and scenario resolution for mixed host/environment rows.
> 
> **Overview**
> **User Testing** now treats `/user-testing/:scenarioId` as a **chatbox id** (not a host id), so environment-backed scenarios get a real detail view. Validation runs against the chatbox list before `getChatbox` runs, avoiding invalid ids crashing `useQuery`.
> 
> **Legacy links** still work: a param that matches a host (non–environment-backed row only) redirects to that scenario’s chatbox id with query and hash preserved; `?host=` is still translated. Environment-backed rows never absorb a host’s old links.
> 
> **Removed** the mount-time `ensureChatboxForHost` back-mint and all related latch/suppress/stuck-timer state; hosts without a chatbox show not-found. **Agent** `publishChatbox` still provisions explicitly and navigates with the returned `chatboxId`; `deleteChatbox` targets the host’s own publish row (`!environmentId`).
> 
> **UI/types** add environment name and `environmentError` on list and detail (warning banner, list badge); navigation and session links use `chatboxId`. Docs and tests were updated for the resolution ladder and removed back-mint behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edec0b04469e028190e2d8e549f376f998628a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch User Testing routes to address scenarios by chatbox id instead of host id. Legacy links still work via redirect, and environment-backed scenarios now display their environment and warn when it can’t resolve.

- New Features
  - `/user-testing/:scenarioId` now takes a chatbox id. Host-id and `?host=` links redirect to the chatbox, preserving query and hash.
  - Environment-backed scenarios show the environment as their identity; a banner explains when the environment can’t resolve. The list badges these rows instead of hiding them.
  - Session/share links are built with the chatbox id.
  - Safer deep links: unknown ids are caught before querying; Journeys-owned hosts show a “Managed by Swarms” dead-end.

- Refactors
  - Removed mount-time back-minting. Scenarios must already exist; provisioning happens only via the agent’s `ui_publish_chatbox`, which now navigates to the returned chatbox id. Deletes no longer re-provision.
  - Replaced `scenarioHostId` with `scenarioId`, `useChatboxByHostId` with `useChatbox`, and updated navigation and tests. Overview row clicks and usage panel links now use chatbox ids.

<sup>Written for commit edec0b04469e028190e2d8e549f376f998628a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

