### PR TITLE
feat(evals): consolidate Evaluate + Runs into one surface under /evals

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -258,7 +258,6 @@ import type { HostFocusTabId } from "./components/hosts/redesigned/types";
 import {
   buildHostsPath,
   buildOrganizationPath,
-  buildEvalsPath,
   getInvalidOrganizationRouteNavigationTarget,
   getProjectSwitchNavigationTarget,
   isDebugOAuthCallbackPath,
@@ -272,6 +271,7 @@ import {
   useAppNavigate,
   useCurrentOrgRoute,
 } from "./lib/app-navigation";
+import { useEvalsMode, type EvalsMode } from "./lib/eval-route-url";
 import {
   Navigate,
   Outlet,
@@ -558,8 +558,6 @@ function NoRouterRouteBody({ activeTab }: { activeTab: string }) {
       return <OrganizationsRoute />;
     case "evals":
       return <EvalsRoute />;
-    case "ci-evals":
-      return <CiEvalsRoute />;
     case "home":
       return <HomeRoute />;
     case "servers":
@@ -1178,7 +1176,12 @@ export function ToolsRoute() {
   );
 }
 
-export function EvalsRoute() {
+/**
+ * Evaluate — one route, two lenses. Suites authors and runs eval suites;
+ * Runs reviews what CI already produced. Both gate on the same `evals`
+ * billing feature because they are one tab.
+ */
+export function EvalsRoute({ mode }: { mode?: EvalsMode } = {}) {
   const {
     billingUiEnabled,
     activeTabBillingLocked,
@@ -1188,9 +1191,23 @@ export function EvalsRoute() {
     handleContinueEvalInChat,
     handleConnect,
   } = useAppRouteContext();
+  // The route table passes `mode` explicitly. The no-Router fallback body
+  // (component tests) dispatches on the tab id alone, which is `evals` for
+  // both lenses, so resolve from the URL when the prop is absent.
+  const pathnameMode = useEvalsMode();
+  const activeMode = mode ?? pathnameMode;
 
   if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
     return <ActiveBillingUpsellGate />;
+  }
+
+  if (activeMode === "runs") {
+    return (
+      <CiEvalsTab
+        convexProjectId={convexProjectId}
+        ensureServersReady={ensureServersReady}
+      />
+    );
   }
 
   return (
@@ -1199,42 +1216,6 @@ export function EvalsRoute() {
       ensureServersReady={ensureServersReady}
       onContinueInChat={handleContinueEvalInChat}
       handleConnect={handleConnect}
-    />
-  );
-}
-
-export function CiEvalsRoute() {
-  const {
-    evaluateRunsFlagsLoaded,
-    evaluateRunsEnabled,
-    billingUiEnabled,
-    activeTabBillingLocked,
-    activeTabBillingFeature,
-    convexProjectId,
-    ensureServersReady,
-  } = useAppRouteContext();
-
-  if (!evaluateRunsFlagsLoaded) {
-    return (
-      <div className="flex h-full min-h-[320px] items-center justify-center">
-        <div className="text-center">
-          <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary" />
-          <p className="mt-4 text-sm text-muted-foreground">Loading Runs...</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (evaluateRunsEnabled !== true) return null;
-
-  if (billingUiEnabled && activeTabBillingLocked && activeTabBillingFeature) {
-    return <ActiveBillingUpsellGate />;
-  }
-
-  return (
-    <CiEvalsTab
-      convexProjectId={convexProjectId}
-      ensureServersReady={ensureServersReady}
     />
   );
 }
@@ -2026,9 +2007,6 @@ export default function App() {
   const [pendingCheckoutIntent, setPendingCheckoutIntent] =
     useState<CheckoutIntent | null>(() => getInitialPendingCheckoutIntent());
   const posthog = usePostHog();
-  const [evaluateRunsFlagsLoaded, setEvaluateRunsFlagsLoaded] = useState(
-    () => posthog.featureFlags?.hasLoadedFlags === true
-  );
   const billingEntitlementsUiEnabled = useFeatureFlagEnabled(
     "billing-entitlements-ui"
   );
@@ -2036,7 +2014,6 @@ export default function App() {
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
   const compatibilityEnabled = useFeatureFlagEnabled("mcpjam-compatibility");
-  const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
 
   // Per-tab "hide from this header" list for the OAuth / XAA debugger chip strip.
@@ -2114,13 +2091,6 @@ export default function App() {
     barePathname.startsWith(`${routePaths.scoreResults}/`) ||
     barePathname.startsWith(`${routePaths.capabilities}/`);
 
-  useEffect(() => {
-    setEvaluateRunsFlagsLoaded(posthog.featureFlags?.hasLoadedFlags === true);
-
-    return posthog.onFeatureFlags(() => {
-      setEvaluateRunsFlagsLoaded(posthog.featureFlags?.hasLoadedFlags === true);
-    });
-  }, [posthog]);
   const defaultHubRoute = useMemo((): "home" | "connect" | "servers" => {
     return "home";
   }, []);
@@ -2934,7 +2904,7 @@ export default function App() {
   });
   const sidebarGateDenied = useMemo(() => {
     const denied: Partial<Record<BillingFeatureName, boolean>> = {};
-    for (const key of ["evals", "chatboxes", "cicd"] as const) {
+    for (const key of ["evals", "chatboxes"] as const) {
       denied[key] = isGateAccessDenied(navPremiumness, key);
     }
     return denied;
@@ -3732,17 +3702,6 @@ export default function App() {
   ]);
 
   useEffect(() => {
-    if (activeTab === "ci-evals") {
-      if (!evaluateRunsFlagsLoaded) {
-        return;
-      }
-
-      if (evaluateRunsEnabled !== true) {
-        navigateApp(buildEvalsPath({ type: "list" }), { replace: true });
-        return;
-      }
-    }
-
     if (
       activeTabBillingLocked &&
       activeTabBillingFeature &&
@@ -3791,8 +3750,6 @@ export default function App() {
     defaultHubRoute,
     registryEnabled,
     learningEnabled,
-    evaluateRunsFlagsLoaded,
-    evaluateRunsEnabled,
     xaaEnabled,
     isAuthenticated,
     isAuthLoading,
@@ -4218,7 +4175,7 @@ export default function App() {
         }
       : undefined;
 
-  const isEvalsTab = activeTab === "evals" || activeTab === "ci-evals";
+  const isEvalsTab = activeTab === "evals";
   const globalHostBarProps =
     isAuthenticated &&
     convexProjectId &&
@@ -4308,8 +4265,6 @@ export default function App() {
     defaultHubRoute,
     ensureServersReady,
     evalChatHandoff,
-    evaluateRunsEnabled,
-    evaluateRunsFlagsLoaded,
     handleCheckoutIntentNavigationStarted,
     handleConnect,
     handleConnectWithTokensFromOAuthFlow,

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -2671,7 +2671,7 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByTestId("playground-tab")).not.toBeInTheDocument();
   });
 
-  it("keeps Playground available when evaluate-ci is disabled", async () => {
+  it("renders Suites mode on /evals", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
     window.history.replaceState({}, "", "/evals");
@@ -2690,92 +2690,27 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
   });
 
-  it("waits on ci-evals while the evaluate-ci flag is still loading", async () => {
+  it("renders Runs mode on /evals/runs with no flag gate", async () => {
+    // Runs used to sit behind `evaluate-ci` at its own /ci-evals tab. It is a
+    // mode under Evaluate now and ships to everyone, so there is no flag read,
+    // no "Loading Runs..." spinner, and no redirect back to Suites.
     clearHostedOAuthPendingState();
     clearChatboxSession();
-    window.history.replaceState({}, "", "/ci-evals");
+    window.history.replaceState({}, "", "/evals/runs");
     mockHandleOAuthCallback.mockReset();
-
-    const evaluateRunsState: { value: boolean | undefined } = {
-      value: undefined,
-    };
-    mockPosthogState.featureFlags.hasLoadedFlags = false;
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "evaluate-ci"
-        ? evaluateRunsState.value
-        : flag === "playground-enabled"
+    mockUseFeatureFlagEnabled.mockImplementation(
+      (flag: string) => flag === "playground-enabled" || flag === "evaluate-ui"
     );
 
     render(<App />);
-
-    expect(window.location.pathname).toBe("/ci-evals");
-    expect(screen.getByText("Loading Runs...")).toBeInTheDocument();
-    expect(screen.queryByTestId("evals-tab")).not.toBeInTheDocument();
-
-    act(() => {
-      mockPosthogState.featureFlags.hasLoadedFlags = true;
-      evaluateRunsState.value = true;
-      mockPosthogState.emitFeatureFlags();
-    });
 
     await waitFor(() => {
       expect(screen.getByTestId("ci-evals-tab")).toBeInTheDocument();
     });
 
-    expect(window.location.pathname).toBe("/ci-evals");
+    expect(window.location.pathname).toBe("/evals/runs");
     expect(screen.queryByText("Loading Runs...")).not.toBeInTheDocument();
-  });
-
-  it("redirects ci-evals to evals when evaluate-ci is disabled", async () => {
-    clearHostedOAuthPendingState();
-    clearChatboxSession();
-    window.history.replaceState({}, "", "/ci-evals");
-    mockHandleOAuthCallback.mockReset();
-
-    mockPosthogState.featureFlags.hasLoadedFlags = false;
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "evaluate-ci"
-        ? undefined
-        : flag === "playground-enabled" || flag === "evaluate-ui"
-    );
-
-    render(<App />);
-
-    expect(screen.getByText("Loading Runs...")).toBeInTheDocument();
-
-    act(() => {
-      mockPosthogState.featureFlags.hasLoadedFlags = true;
-      mockPosthogState.emitFeatureFlags();
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("evals-tab")).toBeInTheDocument();
-    });
-
-    expect(window.location.pathname).toBe("/evals");
-    expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
-  });
-
-  it("redirects nested ci-evals routes to evals when evaluate-ci is disabled", async () => {
-    clearHostedOAuthPendingState();
-    clearChatboxSession();
-    window.history.replaceState({}, "", "/ci-evals/suite/s_123?view=runs");
-    mockHandleOAuthCallback.mockReset();
-
-    mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
-      flag === "evaluate-ci"
-        ? undefined
-        : flag === "playground-enabled" || flag === "evaluate-ui"
-    );
-
-    render(<App />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId("evals-tab")).toBeInTheDocument();
-    });
-
-    expect(window.location.pathname).toBe("/evals");
-    expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("evals-tab")).not.toBeInTheDocument();
   });
 
   it("redirects conformance to home when the feature flag is disabled", async () => {
@@ -3013,10 +2948,12 @@ describe("App hosted OAuth callback handling", () => {
     });
   });
 
-  it("still applies the CI billing redirect when evaluate-ci is enabled", async () => {
+  it("applies the evals billing gate to Runs mode", async () => {
+    // Runs used to gate on `cicd` because it was its own tab. Both lenses are
+    // one tab now, so the tab-keyed gate is `evals` for both.
     clearHostedOAuthPendingState();
     clearChatboxSession();
-    window.history.replaceState({}, "", "/ci-evals");
+    window.history.replaceState({}, "", "/evals/runs");
     mockHandleOAuthCallback.mockReset();
     mockUseAppState.mockImplementation(() => ({
       ...createAppStateMock(),
@@ -3035,7 +2972,7 @@ describe("App hosted OAuth callback handling", () => {
     }));
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) =>
-        flag === "billing-entitlements-ui" || flag === "evaluate-ci"
+        flag === "billing-entitlements-ui"
     );
     mockUseQuery.mockImplementation((name: string) => {
       if (name === "users:getCurrentUser") {
@@ -3065,7 +3002,7 @@ describe("App hosted OAuth callback handling", () => {
           decisionRequired: false,
           gates: [
             {
-              gateKey: "cicd",
+              gateKey: "evals",
               kind: "feature",
               scope: "organization",
               canAccess: false,
@@ -3097,5 +3034,6 @@ describe("App hosted OAuth callback handling", () => {
 
     expect(window.location.pathname).toBe("/home");
     expect(screen.queryByTestId("evals-tab")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -25,12 +25,12 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { cn } from "@/lib/utils";
 import {
-  buildCiEvalsPath,
+  buildEvalsRunsPath,
   buildEvalsPath,
   navigateApp,
 } from "@/lib/app-navigation";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
-import { useCiEvalsRouteFromUrl } from "@/lib/eval-route-url";
+import { useEvalsRunsRouteFromUrl } from "@/lib/eval-route-url";
 import { useEvalTabContext } from "@/hooks/use-eval-tab-context";
 import {
   aggregateSuite,
@@ -50,6 +50,7 @@ import { CommitDetailView } from "./evals/commit-detail-view";
 import { ProjectRunsTable } from "./evals/project-runs-table";
 import { createCiSuiteNavigation } from "./evals/create-suite-navigation";
 import { EvalTabGate } from "./evals/EvalTabGate";
+import { EvalsHeader } from "./evals/evals-header";
 import { SuiteIterationsView } from "./evals/suite-iterations-view";
 import type { EvalSuite } from "./evals/types";
 import {
@@ -72,7 +73,7 @@ function navigateToCiEvalsPath(
   route: EvalRoute,
   options?: { replace?: boolean },
 ) {
-  navigateApp(buildCiEvalsPath(route), options);
+  navigateApp(buildEvalsRunsPath(route), options);
 }
 
 interface CiEvalsTabProps {
@@ -88,7 +89,7 @@ export function CiEvalsTab({
 }: CiEvalsTabProps) {
   const { isAuthenticated, isLoading } = useConvexAuth();
   const { user } = useAuth();
-  const route = useCiEvalsRouteFromUrl();
+  const route = useEvalsRunsRouteFromUrl();
   const mutations = useEvalMutations();
 
   const [deletingSuiteId, setDeletingSuiteId] = useState<string | null>(null);
@@ -382,7 +383,7 @@ export function CiEvalsTab({
         (entry) => entry.suite._id === suiteId,
       );
       navigateApp(
-        isCiVisible ? buildCiEvalsPath(target) : buildEvalsPath(target),
+        isCiVisible ? buildEvalsRunsPath(target) : buildEvalsPath(target)
       );
     },
     [visibleSuites],
@@ -502,7 +503,7 @@ export function CiEvalsTab({
   // would register under the wrong surface. Redacted STATE only: suite names,
   // commit SHAs, and pass/fail COUNTS — never a test's prompt or model output.
   useSurfaceAgentBridge({
-    surfaceId: "ci-evals",
+    surfaceId: "evals",
     snapshot: () =>
       buildCiEvalsSnapshot({
         routeType: route.type,
@@ -535,79 +536,79 @@ export function CiEvalsTab({
       isAuthenticated={isAuthenticated}
       user={user}
       projectId={convexProjectId}
-    >
-      <>
-        <div className="h-full flex flex-col overflow-hidden">
+      header={
+        <EvalsHeader mode="runs">
           {showCiSuiteDrilldownSidebar && selectedSuite ? (
-            <div className="shrink-0 border-b border-border/60 bg-muted/15 px-4 py-2.5 sm:px-6">
-              <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-                <Breadcrumb className="min-w-0 flex-1">
-                  <BreadcrumbList className="min-w-0 flex-nowrap">
-                    <BreadcrumbItem>
+            <Breadcrumb className="min-w-0 flex-1">
+              <BreadcrumbList className="min-w-0 flex-nowrap">
+                <BreadcrumbItem>
+                  <BreadcrumbLink asChild>
+                    <button
+                      type="button"
+                      onClick={handleCiBreadcrumbToSuiteList}
+                      className="inline-flex border-0 bg-transparent p-0 font-medium"
+                    >
+                      Suites
+                    </button>
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator />
+                {commitBreadcrumbContext ? (
+                  <>
+                    <BreadcrumbItem className="max-w-[min(120px,20vw)] min-w-0">
                       <BreadcrumbLink asChild>
                         <button
                           type="button"
-                          onClick={handleCiBreadcrumbToSuiteList}
-                          className="inline-flex border-0 bg-transparent p-0 font-medium"
+                          onClick={handleCiBreadcrumbToCommit}
+                          title="Back to commit"
+                          className="inline-flex max-w-full border-0 bg-transparent p-0 font-medium truncate"
                         >
-                          Suites
+                          {commitBreadcrumbContext.label}
                         </button>
                       </BreadcrumbLink>
                     </BreadcrumbItem>
                     <BreadcrumbSeparator />
-                    {commitBreadcrumbContext ? (
-                      <>
-                        <BreadcrumbItem className="max-w-[min(120px,20vw)] min-w-0">
-                          <BreadcrumbLink asChild>
-                            <button
-                              type="button"
-                              onClick={handleCiBreadcrumbToCommit}
-                              title="Back to commit"
-                              className="inline-flex max-w-full border-0 bg-transparent p-0 font-medium truncate"
-                            >
-                              {commitBreadcrumbContext.label}
-                            </button>
-                          </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                      </>
-                    ) : null}
-                    {route.type === "run-detail" ? (
-                      <>
-                        <BreadcrumbItem className="max-w-[min(200px,28vw)] min-w-0 sm:max-w-[240px]">
-                          <BreadcrumbLink asChild>
-                            <button
-                              type="button"
-                              onClick={handleCiBreadcrumbToSuiteOverview}
-                              title={selectedSuite.name}
-                              className="inline-flex max-w-full border-0 bg-transparent p-0 font-medium truncate"
-                            >
-                              {selectedSuite.name}
-                            </button>
-                          </BreadcrumbLink>
-                        </BreadcrumbItem>
-                        <BreadcrumbSeparator />
-                        <BreadcrumbItem>
-                          <BreadcrumbPage className="truncate font-medium">
-                            Run {formatRunId(route.runId)}
-                          </BreadcrumbPage>
-                        </BreadcrumbItem>
-                      </>
-                    ) : (
-                      <BreadcrumbItem className="max-w-[min(280px,50vw)] min-w-0">
-                        <BreadcrumbPage
-                          className="truncate font-medium"
+                  </>
+                ) : null}
+                {route.type === "run-detail" ? (
+                  <>
+                    <BreadcrumbItem className="max-w-[min(200px,28vw)] min-w-0 sm:max-w-[240px]">
+                      <BreadcrumbLink asChild>
+                        <button
+                          type="button"
+                          onClick={handleCiBreadcrumbToSuiteOverview}
                           title={selectedSuite.name}
+                          className="inline-flex max-w-full border-0 bg-transparent p-0 font-medium truncate"
                         >
                           {selectedSuite.name}
-                        </BreadcrumbPage>
-                      </BreadcrumbItem>
-                    )}
-                  </BreadcrumbList>
-                </Breadcrumb>
-              </div>
-            </div>
+                        </button>
+                      </BreadcrumbLink>
+                    </BreadcrumbItem>
+                    <BreadcrumbSeparator />
+                    <BreadcrumbItem>
+                      <BreadcrumbPage className="truncate font-medium">
+                        Run {formatRunId(route.runId)}
+                      </BreadcrumbPage>
+                    </BreadcrumbItem>
+                  </>
+                ) : (
+                  <BreadcrumbItem className="max-w-[min(280px,50vw)] min-w-0">
+                    <BreadcrumbPage
+                      className="truncate font-medium"
+                      title={selectedSuite.name}
+                    >
+                      {selectedSuite.name}
+                    </BreadcrumbPage>
+                  </BreadcrumbItem>
+                )}
+              </BreadcrumbList>
+            </Breadcrumb>
           ) : null}
+        </EvalsHeader>
+      }
+    >
+      <>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <ResizablePanelGroup
             direction="horizontal"
             className="flex-1 overflow-hidden"

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -40,6 +40,7 @@ import {
   getEffectiveSuiteServers,
 } from "./evals/helpers";
 import { EvalTabGate } from "./evals/EvalTabGate";
+import { EvalsHeader } from "./evals/evals-header";
 import {
   createPlaygroundSuiteNavigation,
   navigatePlaygroundEvalsRoute,
@@ -578,7 +579,7 @@ function EvalsTabContent({
   // The evals tool group + this screen's command handlers and snapshot.
   // Lives HERE, in the surface component, and NEVER in use-eval-handlers or
   // any hook CiEvalsTab also mounts — a shared-hook bridge would register
-  // the evals group under the wrong surface on /ci-evals (see
+  // the evals group under the wrong surface on Runs mode (see
   // use-surface-agent-bridge's contract). Handlers reuse the EXACT callbacks
   // the buttons use: the quota-gated run wrapper, handleCancelRun,
   // setSuiteToDelete → confirmDelete, and generateTestsForSuite.
@@ -844,8 +845,7 @@ function EvalsTabContent({
       }
       const currentRun =
         route.type === "run-detail"
-          ? (runsForSelectedSuite.find((run) => run._id === route.runId) ??
-            null)
+          ? runsForSelectedSuite.find((run) => run._id === route.runId) ?? null
           : null;
       return {
         view: route.type,
@@ -1060,16 +1060,8 @@ function EvalsTabContent({
     }
 
     if (hasDetailRoute) {
-      const breadcrumb = renderPlaygroundBreadcrumb();
       return (
         <div className="flex h-full min-h-0 flex-col">
-          {breadcrumb ? (
-            <div className="shrink-0 border-b border-border/60 bg-muted/15 px-4 py-2.5 sm:px-6">
-              <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-                {breadcrumb}
-              </div>
-            </div>
-          ) : null}
           {queries.isSuiteDetailsLoading ? (
             <div className="flex min-h-0 flex-1 items-center justify-center">
               <div className="text-center">
@@ -1191,6 +1183,9 @@ function EvalsTabContent({
       user={user}
       projectId={projectId}
       isDirectGuest={isDirectGuest}
+      header={
+        <EvalsHeader mode="suites">{renderPlaygroundBreadcrumb()}</EvalsHeader>
+      }
     >
       <>
         <CreateSuiteDialog

--- a/mcpjam-inspector/client/src/components/__tests__/CiEvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/CiEvalsTab.test.tsx
@@ -50,7 +50,7 @@ vi.mock("@/lib/config", () => ({
 }));
 
 vi.mock("@/lib/eval-route-url", () => ({
-  useCiEvalsRouteFromUrl: () => mocks.route.current,
+  useEvalsRunsRouteFromUrl: () => mocks.route.current,
 }));
 
 vi.mock("@/components/ui/resizable", () => ({
@@ -123,7 +123,20 @@ vi.mock("../evals/create-suite-navigation", () => ({
 }));
 
 vi.mock("../evals/EvalTabGate", () => ({
-  EvalTabGate: ({ children }: { children: ReactNode }) => <>{children}</>,
+  // Mirror the real gate's `header` slot: the Suites | Runs switcher and the
+  // breadcrumb render there, above whichever gate state is active.
+  EvalTabGate: ({
+    header,
+    children,
+  }: {
+    header?: ReactNode;
+    children: ReactNode;
+  }) => (
+    <>
+      {header}
+      {children}
+    </>
+  ),
 }));
 
 vi.mock("../evals/ci-suite-list-sidebar", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -128,7 +128,20 @@ vi.mock("../evals/create-suite-navigation", () => ({
 }));
 
 vi.mock("../evals/EvalTabGate", () => ({
-  EvalTabGate: ({ children }: { children: ReactNode }) => <>{children}</>,
+  // Mirror the real gate's `header` slot: the Suites | Runs switcher and the
+  // breadcrumb render there, above whichever gate state is active.
+  EvalTabGate: ({
+    header,
+    children,
+  }: {
+    header?: ReactNode;
+    children: ReactNode;
+  }) => (
+    <>
+      {header}
+      {children}
+    </>
+  ),
 }));
 
 vi.mock("../evals/ConfirmationDialogs", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import {
   applyBillingGateNavState,
   filterByFeatureFlags,
-  getEvalsSubnavItems,
   getHostedNavigationSections,
   navigationSections,
 } from "../mcp-sidebar";
@@ -16,7 +15,7 @@ const makeSections = () => [
       { title: "Always Visible", url: "#always", icon: FakeIcon },
       {
         title: "Testing",
-        url: "#ci-evals",
+        url: "/evals",
         icon: FakeIcon,
       },
     ],
@@ -114,43 +113,20 @@ describe("filterByFeatureFlags", () => {
     expect(result[0].items[0].title).toBe("Plain");
   });
 
-  it("keeps Evaluate item visible when evaluate-ci is off", () => {
-    const result = filterByFeatureFlags(
-      [
-        {
-          id: "mcp-apps",
-          items: [
-            { title: "Views", url: "#views", icon: FakeIcon },
-            {
-              title: "Evaluate",
-              url: "#evals",
-              icon: FakeIcon,
-              billingFeature: "evals" as const,
-              evalsSubnav: true,
-            },
-          ],
-        },
-      ],
-      { "evaluate-ci": false },
-    );
-    const titles = result[0].items.map((i) => i.title);
-    expect(titles).toEqual(["Views", "Evaluate"]);
-  });
-
-  it("renders no subnav when evaluate-ci is off (Evaluate is a flat link)", () => {
-    expect(
-      getEvalsSubnavItems({ evaluateRunsEnabled: false }).map(
-        (item) => item.title,
-      ),
-    ).toEqual([]);
-  });
-
-  it("shows Runs as the only subnav item when evaluate-ci is on", () => {
-    expect(
-      getEvalsSubnavItems({ evaluateRunsEnabled: true }).map(
-        (item) => item.title,
-      ),
-    ).toEqual(["Runs"]);
+  it("ships Evaluate as one flat, unflagged item (Runs is an in-page mode)", () => {
+    // Runs used to be a nested subnav item gated by `evaluate-ci`. Both lenses
+    // now live under one Evaluate entry and switch in the page header, so the
+    // sidebar carries no eval sub-items and no eval flag.
+    const evalsItems = navigationSections
+      .flatMap((section) => section.items)
+      .filter((item) => item.url.startsWith("/evals"));
+    expect(evalsItems).toHaveLength(1);
+    expect(evalsItems[0]).toMatchObject({
+      title: "Evaluate",
+      url: "/evals",
+      billingFeature: "evals",
+    });
+    expect(evalsItems[0].featureFlag).toBeUndefined();
   });
 
   it("hides Conformance when the feature flag is off", () => {
@@ -248,7 +224,7 @@ describe("applyBillingGateNavState", () => {
           items: [
             {
               title: "Testing",
-              url: "#ci-evals",
+              url: "/evals",
               icon: FakeIcon,
               billingFeature: "evals",
             },
@@ -273,7 +249,7 @@ describe("applyBillingGateNavState", () => {
           items: [
             {
               title: "Testing",
-              url: "#ci-evals",
+              url: "/evals",
               icon: FakeIcon,
               billingFeature: "evals",
             },
@@ -311,7 +287,7 @@ describe("getHostedNavigationSections", () => {
           { title: "Tasks", url: "#tasks", icon: FakeIcon },
           {
             title: "Testing",
-            url: "#ci-evals",
+            url: "/evals",
             icon: FakeIcon,
             billingFeature: "evals",
           },
@@ -333,7 +309,7 @@ describe("getHostedNavigationSections", () => {
       { title: "Tasks", url: "#tasks", icon: FakeIcon },
       {
         title: "Testing",
-        url: "#ci-evals",
+        url: "/evals",
         icon: FakeIcon,
         billingFeature: "evals",
       },
@@ -363,7 +339,7 @@ describe("getHostedNavigationSections", () => {
         items: [
           {
             title: "Testing",
-            url: "#ci-evals",
+            url: "/evals",
             icon: FakeIcon,
           },
         ],
@@ -377,7 +353,7 @@ describe("getHostedNavigationSections", () => {
     ]);
   });
 
-  it("keeps Evaluate subnav entry with #evals in hosted mode", () => {
+  it("keeps the Evaluate entry in hosted mode", () => {
     const hostedSections = getHostedNavigationSections([
       {
         id: "mcp-apps",
@@ -387,7 +363,6 @@ describe("getHostedNavigationSections", () => {
             url: "#evals",
             icon: FakeIcon,
             billingFeature: "evals",
-            evalsSubnav: true,
           },
         ],
       },
@@ -399,7 +374,6 @@ describe("getHostedNavigationSections", () => {
         url: "#evals",
         icon: FakeIcon,
         billingFeature: "evals",
-        evalsSubnav: true,
       },
     ]);
   });

--- a/mcpjam-inspector/client/src/components/evals/EvalTabGate.tsx
+++ b/mcpjam-inspector/client/src/components/evals/EvalTabGate.tsx
@@ -11,6 +11,7 @@ export function EvalTabGate({
   user,
   projectId,
   isDirectGuest = false,
+  header,
   children,
 }: {
   variant: EvalTabGateVariant;
@@ -24,12 +25,31 @@ export function EvalTabGate({
    * wall for the Playground variant only.
    */
   isDirectGuest?: boolean;
+  /**
+   * Chrome rendered ABOVE every gate state, including the sign-in wall and the
+   * loading spinner. The Suites | Runs switcher lives here: Runs mode is
+   * guest-reachable (it hosts the SDK quickstart), so a signed-out user stuck
+   * on the Suites wall must still be able to get there.
+   */
+  header?: ReactNode;
   children: ReactNode;
 }) {
   const Icon = variant === "playground" ? FlaskConical : GitBranch;
 
+  const withHeader = (body: ReactNode) =>
+    header ? (
+      <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+        {header}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          {body}
+        </div>
+      </div>
+    ) : (
+      <>{body}</>
+    );
+
   if (isLoading) {
-    return (
+    return withHeader(
       <div className="p-6">
         <div className="flex min-h-[calc(100vh-200px)] items-center justify-center">
           <div className="text-center">
@@ -45,11 +65,11 @@ export function EvalTabGate({
 
   if (variant === "playground") {
     if (isDirectGuest) {
-      return <>{children}</>;
+      return withHeader(children);
     }
 
     if (!isAuthenticated || (!user && !projectId)) {
-      return (
+      return withHeader(
         <div className="p-6">
           <EmptyState
             icon={Icon}
@@ -62,7 +82,7 @@ export function EvalTabGate({
     }
 
     if (!projectId) {
-      return (
+      return withHeader(
         <div className="p-6">
           <EmptyState
             icon={Icon}
@@ -75,5 +95,5 @@ export function EvalTabGate({
     }
   }
 
-  return <>{children}</>;
+  return withHeader(children);
 }

--- a/mcpjam-inspector/client/src/components/evals/__tests__/create-suite-navigation.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/create-suite-navigation.test.ts
@@ -23,7 +23,7 @@ describe("createCiSuiteNavigation", () => {
     });
     nav.toSuiteOverview("s2", "runs");
     expect(navigateSpy).toHaveBeenCalledWith(
-      "/ci-evals/suite/s2?fromCommit=abc123",
+      "/evals/runs/suite/s2?fromCommit=abc123",
       { replace: undefined },
     );
   });
@@ -35,7 +35,7 @@ describe("createCiSuiteNavigation", () => {
     });
     nav.toSuiteOverview("s2", "test-cases");
     expect(navigateSpy).toHaveBeenCalledWith(
-      "/ci-evals/suite/s2?view=test-cases",
+      "/evals/runs/suite/s2?view=test-cases",
       { replace: undefined },
     );
   });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/sdk-eval-quickstart.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/sdk-eval-quickstart.test.tsx
@@ -216,7 +216,7 @@ describe("SdkEvalQuickstart", () => {
     renderWithProviders(<SdkEvalQuickstart projectId="ws-1" />);
 
     expect(screen.queryByRole("button", { name: "Create API key" })).toBeNull();
-    // /ci-evals is guest-reachable (EvalTabGate only gates the playground
+    // /evals/runs is guest-reachable (EvalTabGate only gates the playground
     // variant) and /api/web/api-keys requires a session bearer — firing the
     // list here would be a guaranteed 401 with an error to show for it.
     expect(mocks.listApiKeys).not.toHaveBeenCalled();
@@ -225,7 +225,7 @@ describe("SdkEvalQuickstart", () => {
       screen.getByRole("button", { name: "Sign in to create an API key" }),
     );
     expect(mocks.writeApiKeysSignInReturnPath).toHaveBeenCalledWith(
-      "/ci-evals",
+      "/evals/runs",
     );
     expect(mocks.signIn).toHaveBeenCalled();
   });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -544,7 +544,7 @@ describe("useEvalHandlers", () => {
       expect(requestBody.convexAuthToken).toBeUndefined();
 
       expect(mockNavigateApp).toHaveBeenCalledWith(
-        "/ci-evals/suite/suite-123/runs/run-replay?insights=1",
+        "/evals/runs/suite/suite-123/runs/run-replay?insights=1",
       );
     });
 
@@ -604,7 +604,7 @@ describe("useEvalHandlers", () => {
       });
 
       expect(mockNavigateApp).toHaveBeenCalledWith(
-        "/ci-evals/suite/suite-123/runs/run-replay?insights=1",
+        "/evals/runs/suite/suite-123/runs/run-replay?insights=1",
       );
     });
 
@@ -1443,7 +1443,7 @@ describe("useEvalHandlers", () => {
       expect(requestBody.convexAuthToken).toBeUndefined();
 
       expect(mockNavigateApp).toHaveBeenCalledWith(
-        "/ci-evals/suite/suite-456/runs/run-new?insights=1",
+        "/evals/runs/suite/suite-456/runs/run-new?insights=1",
       );
     });
   });

--- a/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
@@ -15,7 +15,7 @@ import {
 } from "./helpers";
 import { PassCriteriaBadge } from "./pass-criteria-badge";
 import { RunHeaderCompactStats } from "./run-header-compact-stats";
-import { buildCiEvalsPath, navigateApp } from "@/lib/app-navigation";
+import { buildEvalsRunsPath, navigateApp } from "@/lib/app-navigation";
 import type { EvalRoute } from "@/lib/eval-route-types";
 import { useRunDetailData } from "./use-suite-data";
 import { RunDetailView } from "./run-detail-view";
@@ -80,7 +80,7 @@ export function CommitDetailView({
   const handleSelectIteration = (iterationId: string) => {
     if (selectedSuiteId) {
       navigateApp(
-        buildCiEvalsPath({
+        buildEvalsRunsPath({
           type: "commit-detail",
           commitSha: commitGroup.commitSha,
           suite: selectedSuiteId,
@@ -281,7 +281,7 @@ function CommitSuiteRunDetail({
         onSelectIteration={onSelectIteration}
         onSelectRun={(runId) =>
           navigateApp(
-            buildCiEvalsPath({
+            buildEvalsRunsPath({
               type: "run-detail",
               suiteId: run.suiteId,
               runId,

--- a/mcpjam-inspector/client/src/components/evals/create-suite-navigation.ts
+++ b/mcpjam-inspector/client/src/components/evals/create-suite-navigation.ts
@@ -1,6 +1,6 @@
 import type { EvalRoute } from "@/lib/eval-route-types";
 import {
-  buildCiEvalsPath,
+  buildEvalsRunsPath,
   buildEvalsPath,
   navigateApp,
 } from "@/lib/app-navigation";
@@ -14,7 +14,7 @@ function applyPlaygroundEvalsPath(
 }
 
 function applyCiEvalsPath(route: EvalRoute, options?: { replace?: boolean }) {
-  navigateApp(buildCiEvalsPath(route), { replace: options?.replace });
+  navigateApp(buildEvalsRunsPath(route), { replace: options?.replace });
 }
 
 /** Playground Explore: same path shape as `buildEvalsPath`. */

--- a/mcpjam-inspector/client/src/components/evals/evals-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/evals-header.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import { EvalsModeNav } from "./evals-mode-nav";
+import type { EvalsMode } from "@/lib/eval-route-url";
+
+/**
+ * The Evaluate header strip, shared by both modes.
+ *
+ * It renders unconditionally — including on the list routes — because it now
+ * carries the Suites | Runs switcher, which is how a user moves between the
+ * two lenses. `children` is each mode's own breadcrumb trail on detail routes.
+ */
+export function EvalsHeader({
+  mode,
+  children,
+}: {
+  mode: EvalsMode;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="shrink-0 border-b border-border/60 bg-muted/15 px-4 py-2.5 sm:px-6">
+      <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <EvalsModeNav mode={mode} />
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/evals-mode-nav.tsx
+++ b/mcpjam-inspector/client/src/components/evals/evals-mode-nav.tsx
@@ -1,0 +1,49 @@
+import { FlaskConical, GitBranch } from "lucide-react";
+import { SegmentedControl } from "@/components/ui/json-editor/segmented-control";
+import {
+  buildEvalsPath,
+  buildEvalsRunsPath,
+  navigateApp,
+} from "@/lib/app-navigation";
+import type { EvalsMode } from "@/lib/eval-route-url";
+
+/**
+ * Suites | Runs — the two lenses over the same eval suites, switched in the
+ * Evaluate header rather than in the sidebar.
+ *
+ * Switching always lands on the target mode's list. The modes address suites
+ * under different prefixes, so carrying the current route across would deep
+ * link into a suite through the other lens, which is a different question than
+ * the one the user asked by clicking the other tab.
+ */
+export function EvalsModeNav({ mode }: { mode: EvalsMode }) {
+  return (
+    <SegmentedControl
+      value={mode}
+      onChange={(next) => {
+        if (next === mode) return;
+        navigateApp(
+          next === "runs"
+            ? buildEvalsRunsPath({ type: "list" })
+            : buildEvalsPath({ type: "list" }),
+        );
+      }}
+      size="default"
+      className="shrink-0"
+      options={[
+        {
+          value: "suites",
+          label: "Suites",
+          icon: <FlaskConical className="h-4 w-4" />,
+          title: "Author and run eval suites",
+        },
+        {
+          value: "runs",
+          label: "Runs",
+          icon: <GitBranch className="h-4 w-4" />,
+          title: "Review eval results from CI, grouped by commit",
+        },
+      ]}
+    />
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -165,7 +165,7 @@ interface RunDetailViewProps {
   onExportTraces?: () => void;
   /**
    * Navigate to another run on the accuracy hero's recent-run dot. Required for
-   * CI/commit-detail callers so the jump stays on `/ci-evals/...` instead of
+   * CI/commit-detail callers so the jump stays on `/evals/runs/...` instead of
    * the default `buildEvalsPath` (`/evals/...`).
    */
   onSelectRun?: (runId: string) => void;

--- a/mcpjam-inspector/client/src/components/evals/sdk-eval-quickstart.tsx
+++ b/mcpjam-inspector/client/src/components/evals/sdk-eval-quickstart.tsx
@@ -219,7 +219,7 @@ function CreateApiKeyStep({
   const keyReady = hasKey || keys.length > 0;
 
   const handleSignIn = useCallback(() => {
-    writeApiKeysSignInReturnPath(routePaths.ciEvals);
+    writeApiKeysSignInReturnPath(routePaths.evalsRuns);
     signIn();
   }, [signIn]);
 

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -678,7 +678,6 @@ export function SuiteIterationsView({
     navigation.toSuiteOverview(suite._id);
   };
 
-  const ciEnabled = useFeatureFlagEnabled("evaluate-ci") === true;
   const syntheticMonitorsEnabled =
     useFeatureFlagEnabled("synthetic-monitors") === true;
   // Not a PostHog flag like its neighbours: GitHub Checks availability is
@@ -948,7 +947,7 @@ export function SuiteIterationsView({
             aggregate={aggregate}
             testCases={cases}
             onSetupCi={onSetupCi}
-            onOpenExportSuite={ciEnabled ? handleOpenSuiteExport : undefined}
+            onOpenExportSuite={handleOpenSuiteExport}
             readOnlyConfig={readOnlyConfig}
             hideRunActions={hideRunActions}
             unifiedSuiteDashboard={hideRunActions && !caseListInSidebar}
@@ -998,7 +997,7 @@ export function SuiteIterationsView({
                   isDirectGuest={isDirectGuest}
                   ensureServersReady={ensureServersReady}
                   projectServers={projectServers}
-                  onExportDraft={ciEnabled ? handleOpenDraftExport : undefined}
+                  onExportDraft={handleOpenDraftExport}
                   openCompareFromRoute={
                     route.type === "test-edit" && Boolean(route.openCompare)
                   }

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { track } from "@/lib/analytics";
 import { isMCPJamProvidedModel } from "@/shared/types";
 import {
-  buildCiEvalsPath,
+  buildEvalsRunsPath,
   buildEvalsPath,
   navigateApp,
 } from "@/lib/app-navigation";
@@ -50,7 +50,7 @@ import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
 
 function navigateEvalRoute(route: EvalRoute, context: "evals" | "ci-evals") {
   navigateApp(
-    context === "ci-evals" ? buildCiEvalsPath(route) : buildEvalsPath(route)
+    context === "ci-evals" ? buildEvalsRunsPath(route) : buildEvalsPath(route)
   );
 }
 import type { RemoteServer } from "@/hooks/useProjects";
@@ -195,8 +195,8 @@ interface UseEvalHandlersProps {
   ) => Promise<EnsureServersReadyResult>;
   latestRunBySuiteId?: Map<string, EvalSuiteRun | null>;
   /**
-   * When `ci-evals`, navigation after test-case mutations stays on CI evals
-   * routes (`#/ci-evals/...`). Defaults to main evals (`#/evals/...`).
+   * When `ci-evals`, navigation after test-case mutations stays on Runs
+   * mode (`/evals/runs/...`). Defaults to Suites mode (`/evals/...`).
    */
   evalsNavigationContext?: "evals" | "ci-evals";
   /** For user-facing server labels (names instead of raw Convex ids). */

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -15,7 +15,6 @@ import {
   GraduationCap,
   Network,
   LayoutGrid,
-  GitBranch,
   UserPlus,
   Users,
   ShieldCheck,
@@ -37,9 +36,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
@@ -65,12 +61,7 @@ import {
   isHostedSidebarTabAllowed,
   normalizeHostedHashTab,
 } from "@/lib/hosted-tab-policy";
-import {
-  buildCiEvalsPath,
-  buildEvalsPath,
-  navigateApp,
-  useAppNavigate,
-} from "@/lib/app-navigation";
+import { useAppNavigate } from "@/lib/app-navigation";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
 import {
@@ -96,8 +87,6 @@ interface NavItem {
   matchTabs?: string[];
   /** Hide this item when billing enforcement is active and the org lacks this feature */
   billingFeature?: BillingFeatureName;
-  /** Nested Playground / Runs entries; omit from the flat main menu */
-  evalsSubnav?: boolean;
 }
 
 interface NavSection {
@@ -240,7 +229,6 @@ export const navigationSections: NavSection[] = [
         url: "/evals",
         icon: FlaskConical,
         billingFeature: "evals",
-        evalsSubnav: true,
       },
     ],
   },
@@ -412,141 +400,6 @@ interface MCPSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onBeforeSignOut?: () => void | Promise<void>;
 }
 
-function navigateToEvalsExploreList() {
-  navigateApp(buildEvalsPath({ type: "list" }));
-}
-
-function navigateToEvalsRunsList() {
-  navigateApp(buildCiEvalsPath({ type: "list" }));
-}
-
-type EvalsSubnavItem = {
-  title: "Runs";
-  href: string;
-  icon: typeof GitBranch;
-  isActive: (activeTab?: string) => boolean;
-  onClick: () => void;
-};
-
-export function getEvalsSubnavItems(options: {
-  evaluateRunsEnabled: boolean;
-}): EvalsSubnavItem[] {
-  if (!options.evaluateRunsEnabled) return [];
-  return [
-    {
-      title: "Runs",
-      href: "/ci-evals",
-      icon: GitBranch,
-      isActive: (activeTab) => activeTab === "ci-evals",
-      onClick: navigateToEvalsRunsList,
-    },
-  ];
-}
-
-export function SidebarEvalsNavGroup({
-  title,
-  Icon,
-  disabled,
-  disabledTooltip,
-  activeTab,
-  showRuns = true,
-}: {
-  title: string;
-  Icon: React.ComponentType<{ className?: string }>;
-  disabled?: boolean;
-  disabledTooltip?: string;
-  activeTab?: string;
-  showRuns?: boolean;
-}) {
-  const isEvalsFamily = activeTab === "evals" || activeTab === "ci-evals";
-  const subnavItems = getEvalsSubnavItems({
-    evaluateRunsEnabled: showRuns,
-  });
-  const hasSubnav = subnavItems.length > 0;
-
-  const parentButton = (
-    <SidebarMenuButton
-      tooltip={title}
-      isActive={!disabled && isEvalsFamily}
-      onClick={() => {
-        if (disabled) return;
-        navigateToEvalsExploreList();
-      }}
-      aria-disabled={disabled || undefined}
-      tabIndex={disabled ? -1 : undefined}
-      className={
-        disabled
-          ? "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground"
-          : isEvalsFamily
-          ? "[&[data-active=true]]:bg-accent cursor-pointer"
-          : "cursor-pointer"
-      }
-    >
-      <Icon className="h-4 w-4" />
-      <span>{title}</span>
-    </SidebarMenuButton>
-  );
-
-  return (
-    <SidebarGroup>
-      <SidebarGroupContent>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            {disabled ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
-                    className="w-full cursor-not-allowed"
-                    title={disabledTooltip}
-                  >
-                    {parentButton}
-                  </div>
-                </TooltipTrigger>
-                {disabledTooltip ? (
-                  <TooltipContent side="right" align="center">
-                    {disabledTooltip}
-                  </TooltipContent>
-                ) : null}
-              </Tooltip>
-            ) : (
-              parentButton
-            )}
-            {hasSubnav ? (
-              <SidebarMenuSub>
-                {subnavItems.map((item) => {
-                  const ItemIcon = item.icon;
-
-                  return (
-                    <SidebarMenuSubItem key={item.title}>
-                      <SidebarMenuSubButton
-                        isActive={!disabled && item.isActive(activeTab)}
-                        href={item.href}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          if (disabled) return;
-                          item.onClick();
-                        }}
-                        aria-disabled={disabled || undefined}
-                        className={cn(
-                          disabled &&
-                            "pointer-events-none cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground"
-                        )}
-                      >
-                        <ItemIcon className="h-4 w-4" />
-                        <span className="min-w-0 truncate">{item.title}</span>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                  );
-                })}
-              </SidebarMenuSub>
-            ) : null}
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarGroupContent>
-    </SidebarGroup>
-  );
-}
-
 export function MCPSidebar({
   onNavigate,
   activeTab,
@@ -572,7 +425,6 @@ export function MCPSidebar({
   const learningFlagEnabled = useFeatureFlagEnabled("mcpjam-learning");
   const sandboxesEnabled = useFeatureFlagEnabled("sandboxes-enabled");
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
-  const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-ci");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
@@ -795,26 +647,10 @@ export function MCPSidebar({
             <SidebarNavSkeleton />
           ) : (
             visibleNavigationSections.map((section, sectionIndex) => {
-              const rawEvalsEntry = section.items.find(
-                (item) => item.evalsSubnav
-              );
-              // Only render Evaluate through the SidebarEvalsNavGroup wrapper
-              // (which adds its own SidebarGroup padding) when there's actually
-              // a Runs sub-item to nest. Otherwise, fold Evaluate into flatItems
-              // so it sits flush with Views and matches sibling spacing.
-              const useEvalsSubnavWrapper =
-                !!rawEvalsEntry && evaluateRunsEnabled === true;
-              const evalsEntry = useEvalsSubnavWrapper
-                ? rawEvalsEntry
-                : undefined;
-              const flatItems = section.items.filter(
-                (item) => !item.evalsSubnav || !useEvalsSubnavWrapper
-              );
-
               return (
                 <React.Fragment key={section.id}>
                   <NavMain
-                    items={flatItems.map((item) => ({
+                    items={section.items.map((item) => ({
                       ...item,
                       isActive: isNavItemActive(item),
                     }))}
@@ -827,16 +663,6 @@ export function MCPSidebar({
                         : null
                     }
                   />
-                  {evalsEntry ? (
-                    <SidebarEvalsNavGroup
-                      title={evalsEntry.title}
-                      Icon={evalsEntry.icon}
-                      disabled={evalsEntry.disabled}
-                      disabledTooltip={evalsEntry.disabledTooltip}
-                      activeTab={activeTab}
-                      showRuns={evaluateRunsEnabled === true}
-                    />
-                  ) : null}
                   {/* Add subtle divider between sections (except after the last section) */}
                   {sectionIndex < visibleNavigationSections.length - 1 && (
                     <div className="mx-4 my-1 border-t border-border/50" />

--- a/mcpjam-inspector/client/src/hooks/useApiKeys.ts
+++ b/mcpjam-inspector/client/src/hooks/useApiKeys.ts
@@ -15,7 +15,7 @@ import {
  *
  *  - `enabled`. The list call requires a session bearer
  *    (`server/routes/web/api-keys.ts` mounts `bearerAuthMiddleware` on the
- *    whole sub-router), and `/ci-evals` is reachable by guests — `EvalTabGate`
+ *    whole sub-router), and `/evals/runs` is reachable by guests — `EvalTabGate`
  *    only gates the playground variant. Firing the list for a signed-out
  *    visitor produces a guaranteed 401 and, on the settings page's behavior,
  *    an error toast on a page they never asked to manage keys from.

--- a/mcpjam-inspector/client/src/lib/__tests__/agent-bridge-modules.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/agent-bridge-modules.ts
@@ -12,8 +12,12 @@
  */
 export const BRIDGE_MODULES: Record<string, string> = {
   registry: "client/src/components/RegistryTab.tsx",
-  // EvalsTab only — NEVER use-eval-handlers or anything CiEvalsTab mounts:
-  // ci-evals stays agentTools kind "none".
+  // Evaluate has two lenses and both register the "evals" surface, but only
+  // ONE of them carries the tool group: EvalsTab (Suites). CiEvalsTab (Runs)
+  // registers a snapshot only — it is read-only review of results CI already
+  // produced. The bridge call must stay in each tab's OWN component, NEVER in
+  // the eval state hooks both mount, which would register the authoring tools
+  // on the Runs lens too.
   evals: "client/src/components/EvalsTab.tsx",
   // SwarmsTab owns its personas/journeys and the launch path; it does not
   // share state hooks with another surface, so the bridge lives here.
@@ -61,10 +65,6 @@ export const BRIDGE_MODULES: Record<string, string> = {
   // which registers the same "host-compare" provider so the claim stays honest
   // there too; this row points at the canonical destination component.
   "host-compare": "client/src/components/hosts/comparison/HostConfigCompareView.tsx",
-  // CiEvalsTab owns the CI lens over suites/commits. The bridge lives in its
-  // OWN component with the literal "ci-evals" id — NEVER in the eval state
-  // hooks EvalsTab also mounts, which would mis-scope the provider on /evals.
-  "ci-evals": "client/src/components/CiEvalsTab.tsx",
   // TasksTab owns the selected server's long-running MCP task list.
   tasks: "client/src/components/TasksTab.tsx",
   // OAuthFlowTab owns the debugger's flow state, the state machine, and the

--- a/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
@@ -5,6 +5,7 @@ import {
   buildSwarmPath,
   captureCurrentReturnPath,
   isDebugOAuthCallbackPath,
+  legacyCiEvalsPathToRunsPath,
   legacyHashBookmarkToPath,
   navigationTargetToPath,
   normalizeInitialLegacyHashBookmark,
@@ -278,5 +279,64 @@ describe("organization route sections", () => {
     window.history.replaceState({}, "", "/organizations/org_1/nope");
     const { result } = renderHook(() => useCurrentOrgRoute());
     expect(result.current?.orgSection).toBe("overview");
+  });
+});
+
+describe("legacy /ci-evals redirects", () => {
+  // These URLs shipped in CI logs, bookmarks, and the SDK quickstart's
+  // post-sign-in return path. Without an explicit redirect they fall through
+  // to the router's catch-all, which renders Servers — silently wrong, not a
+  // 404 the user can recognize.
+  it("rewrites every legacy shape onto /evals/runs", () => {
+    const cases: Array<[string, string]> = [
+      ["/ci-evals", "/evals/runs"],
+      ["/ci-evals/create", "/evals/runs/create"],
+      ["/ci-evals/commit/abc1234567890", "/evals/runs/commit/abc1234567890"],
+      ["/ci-evals/suite/s_123", "/evals/runs/suite/s_123"],
+      ["/ci-evals/suite/s_123/edit", "/evals/runs/suite/s_123/edit"],
+      ["/ci-evals/suite/s_123/runs/r_9", "/evals/runs/suite/s_123/runs/r_9"],
+      ["/ci-evals/suite/s_123/test/t_7", "/evals/runs/suite/s_123/test/t_7"],
+      [
+        "/ci-evals/suite/s_123/test/t_7/edit",
+        "/evals/runs/suite/s_123/test/t_7/edit",
+      ],
+    ];
+    for (const [from, to] of cases) {
+      expect(legacyCiEvalsPathToRunsPath(from), from).toBe(to);
+    }
+  });
+
+  it("carries query and hash through", () => {
+    expect(
+      legacyCiEvalsPathToRunsPath(
+        "/ci-evals/commit/abc123",
+        "?suite=s_1&iteration=i_4",
+      ),
+    ).toBe("/evals/runs/commit/abc123?suite=s_1&iteration=i_4");
+    expect(
+      legacyCiEvalsPathToRunsPath(
+        "/ci-evals/suite/s_1/runs/r_2",
+        "?iteration=i_4&case=c_1&compareTo=r_1&project=p_9",
+      ),
+    ).toBe(
+      "/evals/runs/suite/s_1/runs/r_2?iteration=i_4&case=c_1&compareTo=r_1&project=p_9",
+    );
+    expect(
+      legacyCiEvalsPathToRunsPath("/ci-evals", "?project=p_9", "#frag"),
+    ).toBe("/evals/runs?project=p_9#frag");
+  });
+
+  it("preserves encoded path segments verbatim", () => {
+    // Rebuilding from decoded router params would split an id containing a
+    // reserved character into extra segments and fail to match.
+    expect(
+      legacyCiEvalsPathToRunsPath("/ci-evals/suite/suite%20one"),
+    ).toBe("/evals/runs/suite/suite%20one");
+  });
+
+  it("only rewrites the leading segment", () => {
+    expect(
+      legacyCiEvalsPathToRunsPath("/ci-evals/suite/ci-evals"),
+    ).toBe("/evals/runs/suite/ci-evals");
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/eval-route-url.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/eval-route-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCiEvalsPath, buildEvalsPath } from "../app-navigation";
+import { buildEvalsRunsPath, buildEvalsPath } from "../app-navigation";
 import { parseEvalRouteFromUrl } from "../eval-route-url";
 
 describe("eval-route-url", () => {
@@ -7,7 +7,7 @@ describe("eval-route-url", () => {
     expect(parseEvalRouteFromUrl("/evals", "/evals")).toEqual({
       type: "list",
     });
-    expect(parseEvalRouteFromUrl("/ci-evals", "ci-evals")).toEqual({
+    expect(parseEvalRouteFromUrl("/evals/runs", "evals/runs")).toEqual({
       type: "list",
     });
     expect(parseEvalRouteFromUrl("/evals", "/evals/create")).toEqual({
@@ -188,11 +188,11 @@ describe("eval-route-url", () => {
     ).toBe("/evals/suite/s_abc/test/t_def/edit?compare=1&iteration=i_42");
   });
 
-  it("parses ci eval commit detail query state", () => {
+  it("parses runs-mode commit detail query state", () => {
     expect(
       parseEvalRouteFromUrl(
-        "/ci-evals",
-        "/ci-evals/commit/abc1234567890",
+        "/evals/runs",
+        "/evals/runs/commit/abc1234567890",
         "?suite=s_abc&iteration=i_4"
       )
     ).toEqual({
@@ -203,30 +203,30 @@ describe("eval-route-url", () => {
     });
   });
 
-  it("builds ci eval commit detail and suite routes", () => {
+  it("builds runs-mode commit detail and suite routes", () => {
     expect(
-      buildCiEvalsPath({
+      buildEvalsRunsPath({
         type: "commit-detail",
         commitSha: "abc1234567890",
         suite: "s_abc",
         iteration: "i_4",
       })
-    ).toBe("/ci-evals/commit/abc1234567890?suite=s_abc&iteration=i_4");
+    ).toBe("/evals/runs/commit/abc1234567890?suite=s_abc&iteration=i_4");
     expect(
-      buildCiEvalsPath({
+      buildEvalsRunsPath({
         type: "suite-overview",
         suiteId: "s_abc",
         view: "test-cases",
         fromCommit: "sha9abcdef",
       })
-    ).toBe("/ci-evals/suite/s_abc?view=test-cases&fromCommit=sha9abcdef");
+    ).toBe("/evals/runs/suite/s_abc?view=test-cases&fromCommit=sha9abcdef");
   });
 
-  it("parses ci eval suite drill-down paths", () => {
+  it("parses runs-mode suite drill-down paths", () => {
     expect(
       parseEvalRouteFromUrl(
-        "/ci-evals",
-        "/ci-evals/suite/s_123/test/t_789/edit",
+        "/evals/runs",
+        "/evals/runs/suite/s_123/test/t_789/edit",
         "?compare=1"
       )
     ).toEqual({
@@ -238,7 +238,29 @@ describe("eval-route-url", () => {
   });
 
   it("returns null outside the requested prefix", () => {
-    expect(parseEvalRouteFromUrl("/ci-evals", "/evals/suite/s_123")).toBeNull();
+    expect(
+      parseEvalRouteFromUrl("/evals/runs", "/evals/suite/s_123")
+    ).toBeNull();
+  });
+
+  it("keeps the two modes mutually exclusive under the shared /evals root", () => {
+    // Runs lives inside Suites' path space, so Suites must NOT swallow a Runs
+    // URL as a bare list route — that would render the wrong lens instead of
+    // letting the Runs route match.
+    expect(parseEvalRouteFromUrl("/evals", "/evals/runs")).toBeNull();
+    expect(
+      parseEvalRouteFromUrl("/evals", "/evals/runs/suite/s_123")
+    ).toBeNull();
+    expect(
+      parseEvalRouteFromUrl("/evals", "/evals/runs/commit/abc123")
+    ).toBeNull();
+  });
+
+  it("degrades a commit route built in Suites mode to that mode's list", () => {
+    // Commits are a Runs-only lens; Suites has no cross-suite SHA view.
+    expect(
+      buildEvalsPath({ type: "commit-detail", commitSha: "abc1234567890" })
+    ).toBe("/evals");
   });
 
   it("decodes path params", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
@@ -21,8 +21,14 @@ describe("hosted-tab-policy", () => {
     expect(isHostedSidebarTabAllowed("prompts")).toBe(true);
   });
 
-  it("keeps ci-evals visible in hosted sidebar allow-list", () => {
-    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("ci-evals");
+  it("keeps evals visible in hosted sidebar allow-list, including Runs", () => {
+    // Runs is a mode under `/evals` now, not its own tab. The legacy
+    // `ci-evals` id stays an alias so old hash bookmarks resolve rather than
+    // falling through to Servers.
+    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("evals");
+    expect(isHostedSidebarTabAllowed("evals")).toBe(true);
+    expect(HOSTED_SIDEBAR_ALLOWED_TABS).not.toContain("ci-evals");
+    expect(normalizeHostedHashTab("ci-evals")).toBe("evals");
     expect(isHostedSidebarTabAllowed("ci-evals")).toBe(true);
   });
 

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -11,6 +11,7 @@ import { useCallback, useContext, useLayoutEffect, useState } from "react";
 import { UNSAFE_LocationContext, UNSAFE_NavigationContext } from "react-router";
 import { getAppRouter } from "../router-ref";
 import type { EvalRoute } from "./eval-route-types";
+import type { EvalRoutePrefix } from "./eval-route-url";
 import { normalizeHostedHashTab } from "./hosted-tab-policy";
 import { listAppSurfaceNavSegments } from "@/shared/app-surfaces";
 
@@ -61,7 +62,8 @@ export const routePaths = {
   callback: "/callback",
   billing: "/billing",
   evals: "/evals",
-  ciEvals: "/ci-evals",
+  /** Runs mode of Evaluate. Legacy `/ci-evals` URLs redirect here. */
+  evalsRuns: "/evals/runs",
   organizations: "/organizations",
 } as const;
 
@@ -209,20 +211,42 @@ export function buildOrganizationPath(
 }
 
 /**
- * Build an eval (Playground) route path from a typed EvalRoute.
+ * Build an eval route path in Suites mode from a typed EvalRoute.
  */
 export function buildEvalsPath(route: EvalRoute): string {
-  return buildEvalRoutePath("/evals", route);
+  return buildEvalRoutePath(routePaths.evals, route);
 }
 
-export function buildCiEvalsPath(route: EvalRoute): string {
-  return buildEvalRoutePath("/ci-evals", route);
+/** Build the same typed EvalRoute in Runs mode (`/evals/runs/...`). */
+export function buildEvalsRunsPath(route: EvalRoute): string {
+  return buildEvalRoutePath(routePaths.evalsRuns, route);
 }
 
-function buildEvalRoutePath(
-  prefix: "/evals" | "/ci-evals",
-  route: EvalRoute
+/**
+ * Legacy `/ci-evals/*` → `/evals/runs/*`, for the router's redirect loader.
+ *
+ * A raw-string prefix rewrite rather than a rebuild from route params: the
+ * sub-tree is matched with a splat, and the string form preserves commit SHAs
+ * and suite ids exactly as they were encoded. Query and hash come along —
+ * commit links carry `?suite=&iteration=`, run links carry
+ * `?iteration=&case=&compareTo=`, and anything can carry `?project=`.
+ *
+ * These URLs shipped in CI logs, bookmarks, and the SDK quickstart's
+ * post-sign-in return path, so they redirect rather than 404 into the
+ * catch-all (which renders Servers — a silently wrong landing page).
+ */
+export function legacyCiEvalsPathToRunsPath(
+  pathname: string,
+  search = "",
+  hash = ""
 ): string {
+  return `${pathname.replace(
+    /^\/ci-evals/,
+    routePaths.evalsRuns
+  )}${search}${hash}`;
+}
+
+function buildEvalRoutePath(prefix: EvalRoutePrefix, route: EvalRoute): string {
   switch (route.type) {
     case "list":
       return prefix;
@@ -270,12 +294,14 @@ function buildEvalRoutePath(
     case "suite-edit":
       return `${prefix}/suite/${encodeURIComponent(route.suiteId)}/edit`;
     case "commit-detail": {
-      if (prefix !== "/ci-evals") return prefix;
+      // Commits are a Runs-mode lens: Suites mode has no cross-suite SHA view,
+      // so a commit route built there degrades to that mode's list.
+      if (prefix !== routePaths.evalsRuns) return prefix;
       const params = new URLSearchParams();
       if (route.suite) params.set("suite", route.suite);
       if (route.iteration) params.set("iteration", route.iteration);
       const query = params.toString();
-      return `/ci-evals/commit/${encodeURIComponent(route.commitSha)}${
+      return `${prefix}/commit/${encodeURIComponent(route.commitSha)}${
         query ? `?${query}` : ""
       }`;
     }

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -171,33 +171,45 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
     surfaceId: "evals",
   },
   { path: "evals/suite/:suiteId/edit", kind: "screen", surfaceId: "evals" },
-  { path: "ci-evals", kind: "screen", surfaceId: "ci-evals" },
-  { path: "ci-evals/create", kind: "screen", surfaceId: "ci-evals" },
+  // Runs mode. Same suite screens as Suites mode above, plus the cross-suite
+  // commit lens; one surface, two lenses over the same eval suites.
+  { path: "evals/runs", kind: "screen", surfaceId: "evals" },
+  { path: "evals/runs/create", kind: "screen", surfaceId: "evals" },
   {
-    path: "ci-evals/commit/:commitSha",
+    path: "evals/runs/commit/:commitSha",
     kind: "screen",
-    surfaceId: "ci-evals",
+    surfaceId: "evals",
   },
-  { path: "ci-evals/suite/:suiteId", kind: "screen", surfaceId: "ci-evals" },
+  { path: "evals/runs/suite/:suiteId", kind: "screen", surfaceId: "evals" },
   {
-    path: "ci-evals/suite/:suiteId/runs/:runId",
+    path: "evals/runs/suite/:suiteId/runs/:runId",
     kind: "screen",
-    surfaceId: "ci-evals",
-  },
-  {
-    path: "ci-evals/suite/:suiteId/test/:testId",
-    kind: "screen",
-    surfaceId: "ci-evals",
+    surfaceId: "evals",
   },
   {
-    path: "ci-evals/suite/:suiteId/test/:testId/edit",
+    path: "evals/runs/suite/:suiteId/test/:testId",
     kind: "screen",
-    surfaceId: "ci-evals",
+    surfaceId: "evals",
   },
   {
-    path: "ci-evals/suite/:suiteId/edit",
+    path: "evals/runs/suite/:suiteId/test/:testId/edit",
     kind: "screen",
-    surfaceId: "ci-evals",
+    surfaceId: "evals",
+  },
+  {
+    path: "evals/runs/suite/:suiteId/edit",
+    kind: "screen",
+    surfaceId: "evals",
+  },
+  {
+    path: "ci-evals",
+    kind: "redirect",
+    note: "Legacy: Runs moved under Evaluate; redirects to /evals/runs.",
+  },
+  {
+    path: "ci-evals/*",
+    kind: "redirect",
+    note: "Legacy Runs deep links (commit SHAs, suites, runs). These shipped in CI logs, bookmarks, and the SDK quickstart's post-sign-in return path, so the whole sub-tree is rewritten onto /evals/runs with query and hash intact.",
   },
   {
     path: "billing",

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -33,8 +33,11 @@ export function getAnnualDiscountPercent(
 }
 
 export const BILLING_FEATURE_BY_TAB = {
+  // Both Evaluate lenses (Suites and Runs) gate on `evals`: they are one tab
+  // now, and this map is keyed by tab id. `cicd` still exists as a backend
+  // feature — server-side ingest enforces it — it just no longer gates a
+  // client route.
   evals: "evals",
-  "ci-evals": "cicd",
   chatboxes: "chatboxes",
   // The agent Swarm surface shares the human Chatbox's billing feature.
   swarms: "chatboxes",

--- a/mcpjam-inspector/client/src/lib/eval-route-types.ts
+++ b/mcpjam-inspector/client/src/lib/eval-route-types.ts
@@ -5,8 +5,9 @@ export type SuiteOverviewView =
   | "cross-host";
 
 /**
- * Unified eval hash routes for Playground (`#/evals`) and CI/CD (`#/ci-evals`).
- * CI-only shapes (`commit-detail`, `fromCommit`) are omitted from Playground URLs at runtime.
+ * Unified eval routes for both Evaluate modes: Suites (`/evals`) and Runs
+ * (`/evals/runs`). Runs-only shapes (`commit-detail`, `fromCommit`) are
+ * omitted from Suites URLs at runtime.
  */
 
 export type EvalRoute =

--- a/mcpjam-inspector/client/src/lib/eval-route-url.ts
+++ b/mcpjam-inspector/client/src/lib/eval-route-url.ts
@@ -2,7 +2,13 @@ import { useContext, useMemo } from "react";
 import { UNSAFE_LocationContext } from "react-router";
 import type { EvalRoute, SuiteOverviewView } from "./eval-route-types";
 
-export type EvalRoutePrefix = "/evals" | "/ci-evals";
+/**
+ * Both eval modes live under `/evals`; Runs is the `/evals/runs` sub-tree.
+ * The two prefixes stay mutually exclusive — parsing a Runs URL against the
+ * Suites prefix returns null rather than a bare list route, so a mode never
+ * silently renders the other mode's URL.
+ */
+export type EvalRoutePrefix = "/evals" | "/evals/runs";
 
 export function parseEvalRouteFromUrl(
   prefix: EvalRoutePrefix,
@@ -23,32 +29,38 @@ export function parseEvalRouteFromUrl(
     search.startsWith("?") ? search : search ? `?${search}` : ""
   );
   const segments = normalizedPathname.replace(/^\/+/, "").split("/");
-  const routeRoot = prefix.replace(/^\/+/, "");
-  if (segments[0] !== routeRoot) return null;
+  const prefixSegments = prefix.replace(/^\/+/, "").split("/");
+  if (prefixSegments.some((segment, index) => segments[index] !== segment)) {
+    return null;
+  }
+  // `/evals/runs` is Runs mode's own root, not a Suites route.
+  if (prefix === "/evals" && segments[1] === "runs") return null;
 
-  if (segments.length === 1 || !segments[1]) {
+  const tail = segments.slice(prefixSegments.length);
+
+  if (tail.length === 0 || !tail[0]) {
     return { type: "list" };
   }
 
-  if (segments[1] === "create") {
+  if (tail[0] === "create") {
     return { type: "create" };
   }
 
-  if (prefix === "/ci-evals" && segments[1] === "commit" && segments[2]) {
+  if (prefix === "/evals/runs" && tail[0] === "commit" && tail[1]) {
     return {
       type: "commit-detail",
-      commitSha: decodePathSegment(segments[2]),
+      commitSha: decodePathSegment(tail[1]),
       suite: params.get("suite") || undefined,
       iteration: params.get("iteration") || undefined,
     };
   }
 
-  if (segments[1] !== "suite" || !segments[2]) {
+  if (tail[0] !== "suite" || !tail[1]) {
     return { type: "list" };
   }
 
-  const suiteId = decodePathSegment(segments[2]);
-  const rest = segments.slice(3);
+  const suiteId = decodePathSegment(tail[1]);
+  const rest = tail.slice(2);
 
   if (rest.length === 0) {
     return {
@@ -124,12 +136,30 @@ export function useEvalRouteFromUrl(prefix: EvalRoutePrefix): EvalRoute {
   );
 }
 
+/** The two lenses over the same eval suites, switched in the Evaluate header. */
+export type EvalsMode = "suites" | "runs";
+
+export function evalsModeForPathname(pathname: string): EvalsMode {
+  const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  return normalized === "/evals/runs" || normalized.startsWith("/evals/runs/")
+    ? "runs"
+    : "suites";
+}
+
+export function useEvalsMode(): EvalsMode {
+  const locationContext = useContext(UNSAFE_LocationContext);
+  const pathname =
+    locationContext?.location.pathname ??
+    (typeof window === "undefined" ? "/evals" : window.location.pathname);
+  return evalsModeForPathname(pathname);
+}
+
 export function useEvalsRouteFromUrl(): EvalRoute {
   return useEvalRouteFromUrl("/evals");
 }
 
-export function useCiEvalsRouteFromUrl(): EvalRoute {
-  return useEvalRouteFromUrl("/ci-evals");
+export function useEvalsRunsRouteFromUrl(): EvalRoute {
+  return useEvalRouteFromUrl("/evals/runs");
 }
 
 function parseSuiteOverviewView(value: string | null): SuiteOverviewView {

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -6,6 +6,12 @@ const HASH_TAB_ALIASES = {
   hosts: "clients",
   /** Public path is `/user-testing`; the in-app tab id stays `chatboxes`. */
   "user-testing": "chatboxes",
+  /**
+   * Legacy: Runs was its own tab at `/ci-evals` before both eval lenses
+   * merged under `/evals`. Kept so an old `#ci-evals` hash bookmark resolves
+   * to Evaluate instead of falling through to Servers.
+   */
+  "ci-evals": "evals",
 } as const;
 
 export const HOSTED_SIDEBAR_ALLOWED_TABS = [
@@ -19,7 +25,6 @@ export const HOSTED_SIDEBAR_ALLOWED_TABS = [
   "playground",
   "client-config",
   "evals",
-  "ci-evals",
   // Project Environments are Convex-backed and hosted-first; the sidebar item
   // and route are additionally gated behind `project-environments-enabled`
   // (PostHog), so this entry only makes the tab REACHABLE — visibility still

--- a/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
+++ b/mcpjam-inspector/client/src/lib/webmcp/ADDING_SURFACE_TOOLS.md
@@ -29,7 +29,7 @@ call in the surface component.
 
    The shared-hook hazard is real: EvalsTab and CiEvalsTab share their state
    hooks, so a bridge call inside one of those would register the evals
-   group under the wrong surface on /ci-evals. The coverage test enforces a
+   group under the wrong surface on Runs mode. The coverage test enforces a
    literal `surfaceId: "<id>"` in the module you list.
 4. **Manifest.** Flip the surface's `agentTools` from `{ kind: "none", … }`
    to `{ kind: "group" }` and set `hasSnapshotProvider: true` (a group ships

--- a/mcpjam-inspector/client/src/lib/webmcp/use-surface-agent-bridge.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/use-surface-agent-bridge.ts
@@ -34,7 +34,7 @@
  *   component, exactly once per surface. The hazard is real: EvalsTab and
  *   CiEvalsTab share their state hooks (`use-eval-handlers` and friends), so
  *   a bridge call inside a shared hook would register the evals group and
- *   handlers under the WRONG surface id on /ci-evals — or twice at once when
+ *   handlers under the WRONG lens on /evals/runs — or twice at once when
  *   both screens' machinery is alive. Same reason `use-playground-state`
  *   takes an explicit opt-in `snapshotSurfaceId` instead of hardcoding one.
  */

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -6,7 +6,6 @@ import App, {
   AuthRoute,
   ChatAliasRoute,
   ChatboxesRoute,
-  CiEvalsRoute,
   ConformanceRoute,
   CaniuseCapabilityRoute,
   EnvironmentsRoute,
@@ -39,12 +38,23 @@ import App, {
   XAAFlowRoute,
 } from "./App";
 import { getAppRouter, setAppRouter } from "./router-ref";
-import { buildHostsPath, routePaths } from "./lib/app-navigation";
+import {
+  buildHostsPath,
+  legacyCiEvalsPathToRunsPath,
+  routePaths,
+} from "./lib/app-navigation";
 import { APP_ROUTES } from "./lib/app-routes";
 
 export { getAppRouter };
 
 type AppRouter = ReturnType<typeof createBrowserRouter>;
+
+function ciEvalsRedirect({ request }: { request: Request }) {
+  const url = new URL(request.url);
+  return redirect(
+    legacyCiEvalsPathToRunsPath(url.pathname, url.search, url.hash)
+  );
+}
 
 /**
  * The element each route renders, keyed by the path declared in
@@ -162,14 +172,31 @@ const ROUTE_ELEMENTS: Record<
   "evals/suite/:suiteId/test/:testId": { element: <EvalsRoute /> },
   "evals/suite/:suiteId/test/:testId/edit": { element: <EvalsRoute /> },
   "evals/suite/:suiteId/edit": { element: <EvalsRoute /> },
-  "ci-evals": { element: <CiEvalsRoute /> },
-  "ci-evals/create": { element: <CiEvalsRoute /> },
-  "ci-evals/commit/:commitSha": { element: <CiEvalsRoute /> },
-  "ci-evals/suite/:suiteId": { element: <CiEvalsRoute /> },
-  "ci-evals/suite/:suiteId/runs/:runId": { element: <CiEvalsRoute /> },
-  "ci-evals/suite/:suiteId/test/:testId": { element: <CiEvalsRoute /> },
-  "ci-evals/suite/:suiteId/test/:testId/edit": { element: <CiEvalsRoute /> },
-  "ci-evals/suite/:suiteId/edit": { element: <CiEvalsRoute /> },
+  // Runs mode. `mode` comes from the route table rather than sniffing the URL
+  // inside the component, so the two lenses stay one route element with one
+  // billing gate.
+  "evals/runs": { element: <EvalsRoute mode="runs" /> },
+  "evals/runs/create": { element: <EvalsRoute mode="runs" /> },
+  "evals/runs/commit/:commitSha": { element: <EvalsRoute mode="runs" /> },
+  "evals/runs/suite/:suiteId": { element: <EvalsRoute mode="runs" /> },
+  "evals/runs/suite/:suiteId/runs/:runId": {
+    element: <EvalsRoute mode="runs" />,
+  },
+  "evals/runs/suite/:suiteId/test/:testId": {
+    element: <EvalsRoute mode="runs" />,
+  },
+  "evals/runs/suite/:suiteId/test/:testId/edit": {
+    element: <EvalsRoute mode="runs" />,
+  },
+  "evals/runs/suite/:suiteId/edit": { element: <EvalsRoute mode="runs" /> },
+  // Legacy `/ci-evals/*` → `/evals/runs/*`. Rewrite the raw pathname rather
+  // than rebuilding from params: the sub-tree is matched with a splat, and the
+  // string form preserves commit SHAs and suite ids exactly as encoded.
+  // Search and hash come along — commit links carry `?suite=&iteration=`, run
+  // links carry `?iteration=&case=&compareTo=`, and anything can carry
+  // `?project=`.
+  "ci-evals": { loader: ciEvalsRedirect },
+  "ci-evals/*": { loader: ciEvalsRedirect },
   billing: { element: <ServersRoute /> },
   callback: { element: <ServersRoute /> },
   "oauth/callback/*": { element: <ServersRoute /> },

--- a/mcpjam-inspector/docs/analytics-flag-defaults.md
+++ b/mcpjam-inspector/docs/analytics-flag-defaults.md
@@ -31,7 +31,6 @@ Every gate resolves `undefined` → **hidden/off**. Two shapes:
 | Flag | Gates (representative) | Blocked-state default | Safe? |
 |------|------------------------|-----------------------|-------|
 | `billing-entitlements-ui` | `App.tsx:1321`, `OrganizationsTab.tsx:561`, `ShareProjectDialog.tsx:235` | Billing/entitlements UI hidden | ⚠️ see below |
-| `evaluate-ci` | `App.tsx`, `mcp-sidebar.tsx` | Evals-CI nav hidden | ✅ |
 | `mcpjam-learning` | `mcp-sidebar.tsx` | Learning nav hidden | ✅ |
 | `registry-enabled` | `mcp-sidebar.tsx` | Registry nav hidden | ✅ |
 | `mcpjam-conformance` / `mcpjam-compatibility` | `mcp-sidebar.tsx` | Nav hidden | ✅ |

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -310,49 +310,33 @@ export const APP_SURFACES = [
       "evals/suite/:suiteId/runs/:runId",
       "evals/suite/:suiteId/test/:testId",
       "evals/suite/:suiteId/test/:testId/edit",
+      "evals/runs",
+      "evals/runs/create",
+      "evals/runs/commit/:commitSha",
+      "evals/runs/suite/:suiteId",
+      "evals/runs/suite/:suiteId/edit",
+      "evals/runs/suite/:suiteId/runs/:runId",
+      "evals/runs/suite/:suiteId/test/:testId",
+      "evals/runs/suite/:suiteId/test/:testId/edit",
     ],
     navSegments: ["evals"],
     title: "Evaluate",
     purpose:
-      "Build and run eval suites against a host: test cases with expected tool calls, scored over repeated runs.",
+      "Build and run eval suites against a host: test cases with expected tool calls, scored over repeated runs. Two lenses over the same suites — Suites (`/evals`) authors and runs them; Runs (`/evals/runs`) reviews the results CI already produced, keyed by commit.",
     userActivities: [
       "Create or edit an eval suite and its test cases",
       "Run a suite and watch its runs",
       "Generate suggested test cases for a suite",
       "Open a run to inspect each step, tool call, and score",
       "Compare runs",
+      "Review eval results for a commit under Runs",
+      "Open a CI run's details under Runs",
     ],
     hasSnapshotProvider: true,
+    // Authoring tools register from Suites mode only. Runs mode is read-only
+    // review of results CI already produced (runs start from CI, not this
+    // screen), so it contributes its snapshot but no tools.
     agentTools: { kind: "group" },
-    showInAtlas: true,
-  },
-  {
-    id: "ci-evals",
-    canonicalPath: "/ci-evals",
-    routePatterns: [
-      "ci-evals",
-      "ci-evals/create",
-      "ci-evals/commit/:commitSha",
-      "ci-evals/suite/:suiteId",
-      "ci-evals/suite/:suiteId/edit",
-      "ci-evals/suite/:suiteId/runs/:runId",
-      "ci-evals/suite/:suiteId/test/:testId",
-      "ci-evals/suite/:suiteId/test/:testId/edit",
-    ],
-    navSegments: ["ci-evals"],
-    title: "CI Evals",
-    purpose:
-      "The same eval suites as Evaluate, but as they ran in CI — results keyed by commit.",
-    userActivities: [
-      "Review eval results for a commit",
-      "Open a CI run's details",
-    ],
-    hasSnapshotProvider: true,
-    agentTools: {
-      kind: "none",
-      reason:
-        "Read-only review of results CI already produced (runs start from CI, not this screen); snapshot-only for observability so the agent can see the suites, commits, and pass rates.",
-    },
     showInAtlas: true,
   },
   {


### PR DESCRIPTION
## What

Evaluate ships as two sibling surfaces today: the playground at `/evals` and the CI runs lens at `/ci-evals`, the latter behind the `evaluate-ci` flag with a nested **Runs** item in the sidebar. They're one product with two lenses over the same suites — origin (`ui`/`sdk`) is metadata, not a second product. This is also how the CI-gate category structures it (SonarQube, Codecov, Chromatic): one surface, a commit-centric runs view, origin as a badge.

After this PR there is one sidebar item, **Evaluate**, with two modes switched in the page header:

| Mode | URL | What it is |
|---|---|---|
| **Suites** | `/evals` | Author and run eval suites |
| **Runs** | `/evals/runs` | Review the results CI already produced, keyed by commit |


## URL scheme

The Runs sub-tree mirrors the old `/ci-evals/*` shapes one-to-one, so the redirect is a pure prefix rewrite:

| Old | New |
|---|---|
| `/ci-evals` | `/evals/runs` |
| `/ci-evals/commit/:sha` | `/evals/runs/commit/:sha` |
| `/ci-evals/suite/:id` (+ `/edit`, `/runs/:runId`, `/test/:testId`, `/test/:testId/edit`) | `/evals/runs/suite/:id` (+ same) |

**Mode is a path segment, not `?view=`.** Two reasons: `?view=` is already a suite-level param (`/evals/suite/:id?view=runs` is its stripped default), and billing, `ui_navigate`, and the agent's per-turn orientation snapshot all resolve from the pathname and never read the query string — a query-param mode would be invisible to all three.

Redirects rewrite the raw pathname rather than rebuilding from router params, so commit SHAs and suite ids survive exactly as encoded, with query and hash carried through (`?suite=`, `?iteration=`, `?case=`, `?compareTo=`, `?project=`). These URLs shipped in CI logs, bookmarks, and the SDK quickstart's post-sign-in return path; without an explicit redirect they'd fall through to the router's catch-all, which renders **Servers** — silently wrong rather than a recognizable 404.

## Consequences, taken knowingly

- **The `ci-evals` surface and tab id are deleted.** Runs now gates on the `evals` billing feature rather than `cicd` (`BILLING_FEATURE_BY_TAB` is keyed by tab id, and there's one tab now). `cicd` is untouched as a backend feature — server-side ingest still enforces it — it just no longer gates a client route.
- **Agents lose `ui_navigate("ci-evals")`** and the separate "CI Evals" atlas entry. Both tabs register the `evals` surface; only `EvalsTab` carries the tool group, so Runs stays snapshot-only exactly as before. The `evals` manifest's `purpose`/`userActivities` now describe both lenses so the concept isn't lost to the agent.
- **`evaluate-ci` is GA'd.** No flag read, no "Loading Runs..." spinner, no redirect effect. The row is removed from `docs/analytics-flag-defaults.md`; the PostHog flag can be archived after this ships.

## One thing worth reviewing closely

The mode switcher renders **above** `EvalTabGate`, not inside it (new `header` prop on the gate). Runs is guest-reachable — it hosts the SDK quickstart NUX — so a signed-out user sitting on the Suites sign-in wall must still be able to get there. That path used to be served by the sidebar's Runs item; putting the switcher inside the gate would have silently removed it. Caught by running the app, not by a test.

## Deliberately unchanged

- `readOnlyConfig` stays a Runs-lens property — SDK run records remain immutable evidence.
- `EvalTabGate` variants stay per-mode (`playground` vs `ci`), including the guest-reachability split.
- `SdkEvalQuickstart`, `ProjectRunsTable`, the commit timeline and CI suite sidebar remain distinct views inside Runs, not filters.
- Analytics keep their `location: "ci_evals_tab"` vs `"evals_tab"` split (keyed off `evalsNavigationContext`, not URLs), so existing dashboards don't break.
- Backend ingest (`convex/sdkEvals.ts`, `/v1/evals/ingest`) and the Stripe entitlement definitions.

## Verification

- `typecheck:client` clean; `build:inspector` passes.
- Full suite: **13025 passed, 1 failed** — the one failure is `host-config-comparison-matrix.test.tsx > shows per-host verified dates only in public caniuse mode`, which is **pre-existing and unrelated** (a hardcoded `2026-07-08` verified date that has aged past its 30-day threshold; fails identically on a clean `main`).
- New coverage: the full `/ci-evals/*` → `/evals/runs/*` redirect matrix incl. query/hash/encoded segments; mutual exclusivity of the two prefixes under the shared `/evals` root; commit routes degrading to the list in Suites mode; Runs rendering with no flag gate; the `evals` billing gate applying to Runs.
- Drove the running app: sidebar is flat, the switcher navigates both directions, all three legacy URL shapes redirect, and Runs renders the SDK quickstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad routing, billing, and navigation changes affect bookmarks and entitlements; legacy redirects and new prefix parsing reduce breakage, but wrong deep links or billing mapping would be user-visible.
> 
> **Overview**
> **Evaluate** is now a single sidebar entry with two in-page modes (**Suites** at `/evals`, **Runs** at `/evals/runs`) switched via a shared header (`EvalsHeader` / `EvalsModeNav`), replacing the separate `/ci-evals` tab and nested sidebar subnav.
> 
> `EvalsRoute` picks `EvalsTab` vs `CiEvalsTab` from URL mode (or an explicit `mode` prop on router children). **`evaluate-ci` is removed**—no loading spinner or redirect when opening Runs. **`/ci-evals/*` redirects** to `/evals/runs/*` via `legacyCiEvalsPathToRunsPath`, preserving path encoding, query, and hash.
> 
> **Billing** for Runs now uses the **`evals`** gate (not `cicd`). The **`ci-evals` app surface** is folded into **`evals`**; Runs stays snapshot-only on the agent bridge. **`EvalTabGate`** accepts an optional **`header`** rendered above sign-in/loading so guests can still reach Runs (SDK quickstart). Navigation helpers rename to `buildEvalsRunsPath` / `useEvalsRunsRouteFromUrl`; suite export in Runs no longer depends on the CI flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fffff60d5e2201aa1384dff0b443a777358873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Merged Evaluate and CI Runs into one Evaluate surface with two modes: Suites at /evals and Runs at /evals/runs. This flattens the sidebar, removes the `evaluate-ci` flag, unifies billing under the `evals` feature, and adds safe redirects from all legacy /ci-evals URLs.

- **New Features**
  - One sidebar item: Evaluate, with a Suites | Runs switcher in the page header.
  - Runs lives at /evals/runs; Suites stays at /evals. Mode is a path segment, not a query param.
  - Legacy /ci-evals/* routes redirect to /evals/runs/*, preserving IDs, query, and hash.
  - Runs is guest-reachable and hosts the SDK quickstart.
  - Agents: only Suites registers the eval tool group; Runs provides snapshots only. Analytics continue via navigation context.

- **Migration**
  - Update any references or bookmarks from /ci-evals to /evals/runs (redirects in place).
  - Replace `ui_navigate("ci-evals")` with `ui_navigate("evals")`; use the in-page mode switcher to reach Runs.
  - Billing: Runs now gates on `evals` (not `cicd`). Backend `cicd` enforcement for ingest remains.
  - Remove the `evaluate-ci` PostHog flag; the docs row was deleted.

<sup>Written for commit 72fffff60d5e2201aa1384dff0b443a777358873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

