### PR TITLE
feat(user-testing): create a scenario by publishing an environment

### DIFF
--- a/mcpjam-inspector/client/src/components/UserTestingTab.tsx
+++ b/mcpjam-inspector/client/src/components/UserTestingTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { AlertTriangle, Boxes, Inbox, Loader2, Plus } from "lucide-react";
 import { useConvexAuth, useMutation } from "convex/react";
@@ -7,11 +7,15 @@ import { Button } from "@mcpjam/design-system/button";
 import { UserTestingOverviewPanel } from "@/components/chatboxes/UserTestingOverviewPanel";
 import { UserTestingScenarioDetail } from "@/components/chatboxes/UserTestingScenarioDetail";
 import { UserTestingCreateFlow } from "@/components/chatboxes/UserTestingCreateFlow";
+import { UserTestingScenarioCreateFlow } from "@/components/chatboxes/UserTestingScenarioCreateFlow";
 import {
   useChatbox,
   useChatboxList,
   useChatboxMutations,
+  useEnvironmentChatboxMutations,
 } from "@/hooks/useChatboxes";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { isDeliberateScenario } from "@/lib/user-testing-scenarios";
 import { useHostList, useHostMutations } from "@/hooks/useClients";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { useUsageInsights } from "@/hooks/useUsageInsights";
@@ -101,19 +105,38 @@ export function UserTestingTab({
   });
   const hostsLoading = queryable && hostsQueryLoading;
 
+  // Which rows are SCENARIOS. Every client mints a chatbox row whether or not
+  // anyone meant to test with it (three of them are seeded into an empty
+  // project before it is ever opened), so the list filters to rows that show
+  // deliberate intent — see `isDeliberateScenario`.
+  //
+  // Filtered CLIENT-side on purpose: the same query feeds the public API v1
+  // list and the Environments page's consumer counts, and neither should
+  // inherit this surface's editorial rule.
+  //
+  // The filter is scoped to the environments flag. A project without
+  // environments has no other kind of scenario, so hiding its client rows
+  // would leave it with a surface it cannot use.
+  const environmentsEnabled = useProjectEnvironmentsEnabled();
+  const rows = useMemo(() => {
+    const all = chatboxes ?? [];
+    return environmentsEnabled ? all.filter(isDeliberateScenario) : all;
+  }, [chatboxes, environmentsEnabled]);
+
   // Resolution ladder. The param is a chatbox id; a param that matches a HOST
   // is a link minted under the old scheme and gets redirected rather than
-  // 404'd.
-  const rows = chatboxes ?? [];
+  // 404'd. Deliberately searches the UNFILTERED rows: a direct link to a
+  // scenario the list chooses not to advertise must still open.
+  const allRows = chatboxes ?? [];
   const scenarioRow = scenarioId
-    ? rows.find((c) => c.chatboxId === scenarioId) ?? null
+    ? allRows.find((c) => c.chatboxId === scenarioId) ?? null
     : null;
   // `!environmentId` mirrors the backend's `getHostPublishChatbox`: an
   // environment-backed row displays a host it does not belong to, and must
   // never absorb that host's legacy links.
   const legacyHostRow =
     scenarioId && !scenarioRow
-      ? rows.find((c) => c.namedHostId === scenarioId && !c.environmentId) ??
+      ? allRows.find((c) => c.namedHostId === scenarioId && !c.environmentId) ??
         null
       : null;
   // A Journeys-owned host is standalone — it has no chatbox at all, so an old
@@ -187,6 +210,7 @@ export function UserTestingTab({
   // agent would get an empty snapshot and failing commands.
   const agentOperable = effectiveAuth && shouldQueryProjectId(projectId);
   const { deleteChatbox } = useChatboxMutations();
+  const { publishEnvironmentChatbox } = useEnvironmentChatboxMutations();
   const { createHost } = useHostMutations();
   // Session rows for the snapshot only — the same list query the Sessions view
   // reads, unfiltered, redacted at read time.
@@ -395,6 +419,30 @@ export function UserTestingTab({
         />
       );
     }
+    if (environmentsEnabled) {
+      return (
+        <UserTestingScenarioCreateFlow
+          projectId={projectId}
+          onCancel={goOverview}
+          onCreateEnvironment={() => navigate(routePaths.environments)}
+          onCreateScenario={async ({ environmentId, name, mode }) => {
+            // The one write. Publishing applies the name and the access mode
+            // in the same mutation, so the scenario is never briefly live in a
+            // mode nobody asked for. Idempotent: re-publishing an environment
+            // returns its existing scenario UNCHANGED rather than re-moding it.
+            const result = await publishEnvironmentChatbox({
+              environmentId,
+              name,
+              mode,
+            });
+            navigate(buildUserTestingScenarioPath(result.chatboxId), {
+              replace: true,
+            });
+            return { scenarioId: result.chatboxId, created: result.created };
+          }}
+        />
+      );
+    }
     return (
       <UserTestingCreateFlow
         projectId={projectId}
@@ -522,7 +570,9 @@ export function UserTestingTab({
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5 sm:px-8">
         <UserTestingOverviewPanel
-          chatboxes={chatboxes}
+          // The filtered rows — `undefined` while the query is still loading,
+          // so the panel can tell "nothing yet" from "nothing to show".
+          chatboxes={chatboxes === undefined ? undefined : rows}
           isLoading={listLoading}
           onOpenScenario={(id) => navigate(buildUserTestingScenarioPath(id))}
           onCreateScenario={goCreate}

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.agent.test.tsx
@@ -232,6 +232,16 @@ vi.mock("@/hooks/useChatboxes", () => ({
   useChatbox: () => chatboxState,
   useChatboxList: () => ({ chatboxes: listRows, isLoading: false }),
   useChatboxMutations: () => ({ deleteChatbox: deleteChatboxMock }),
+  useEnvironmentChatboxMutations: () => ({
+    publishEnvironmentChatbox: vi.fn(),
+  }),
+}));
+
+// The agent suite drives host-addressed commands; the list filter is exercised
+// in UserTestingTab.scenario-list.test.tsx. Off here so its host-backed
+// fixtures stay visible to the snapshot.
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => false,
 }));
 
 vi.mock("@/hooks/useUsageInsights", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.journeys.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.journeys.test.tsx
@@ -67,6 +67,13 @@ vi.mock("@/hooks/useChatboxes", () => ({
   },
   useChatboxList: () => listState,
   useChatboxMutations: () => ({ deleteChatbox: vi.fn() }),
+  useEnvironmentChatboxMutations: () => ({
+    publishEnvironmentChatbox: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => true,
 }));
 
 vi.mock("@/hooks/useUsageInsights", () => ({

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.scenario-list.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.scenario-list.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * What the scenario list is allowed to show.
+ *
+ * The reported bug: a brand-new project showed four or five "scenarios" nobody
+ * created — the three clients the Playground seeds into an empty project, the
+ * "MCPJam" one the host bar seeds, and one per client set up in Servers. They
+ * were there because a chatbox row is minted 1:1 with every host, and the list
+ * rendered every row.
+ *
+ * The filter runs only where environments exist (the flag), because a project
+ * without them has no other kind of scenario to show. Direct links keep
+ * working either way — that is asserted here too, since filtering the list is
+ * an editorial choice about what to advertise, not about what exists.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatboxListItem } from "@/hooks/useChatboxes";
+
+const { navigateMock, listState, chatboxState, flagState } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  listState: {
+    chatboxes: [] as ChatboxListItem[] | undefined,
+    isLoading: false,
+  },
+  chatboxState: { chatbox: null as unknown, isLoading: false },
+  flagState: { enabled: true },
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+  useMutation: () => vi.fn(),
+}));
+
+vi.mock("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock("@/hooks/useClients", () => ({
+  useHostList: () => ({ hosts: [], isLoading: false }),
+  useHostMutations: () => ({ createHost: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useChatboxes", () => ({
+  useChatbox: () => chatboxState,
+  useChatboxList: () => listState,
+  useChatboxMutations: () => ({ deleteChatbox: vi.fn() }),
+  useEnvironmentChatboxMutations: () => ({
+    publishEnvironmentChatbox: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => flagState.enabled,
+}));
+
+vi.mock("@/hooks/useUsageInsights", () => ({
+  useUsageInsights: () => ({
+    threads: undefined,
+    breakdown: undefined,
+    rebuild: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/toast", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// The overview panel reads the theme to pick client logos; the store has no
+// provider in a bare render.
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: () => "light",
+}));
+
+vi.mock("@/components/chatboxes/UserTestingScenarioDetail", () => ({
+  UserTestingScenarioDetail: () => <div data-testid="scenario-detail" />,
+}));
+
+import { UserTestingTab } from "../UserTestingTab";
+
+const row = (over: Partial<ChatboxListItem>): ChatboxListItem => ({
+  chatboxId: "cb-seed",
+  projectId: "proj-1",
+  name: "Claude Code",
+  hostStyle: "claude",
+  // The backend default every auto-mint path uses.
+  mode: "project_members",
+  allowGuestAccess: false,
+  serverCount: 0,
+  serverNames: [],
+  namedHostId: "host-seed",
+  namedHostName: "Claude Code",
+  createdAt: 0,
+  updatedAt: 0,
+  ...over,
+});
+
+/** The exact lineup a fresh project reported: seeds + one real scenario. */
+const SEEDED_PROJECT: ChatboxListItem[] = [
+  row({ chatboxId: "cb-seed-1", name: "Claude Code", namedHostId: "h1" }),
+  row({ chatboxId: "cb-seed-2", name: "ChatGPT", namedHostId: "h2" }),
+  row({ chatboxId: "cb-seed-3", name: "MCPJam", namedHostId: "h3" }),
+  row({
+    chatboxId: "cb-real",
+    name: "Checkout flow",
+    namedHostId: "h4",
+    environmentId: "env-1",
+    environmentName: "Checkout flow",
+  }),
+];
+
+afterEach(() => {
+  navigateMock.mockClear();
+  listState.chatboxes = [];
+  listState.isLoading = false;
+  chatboxState.chatbox = null;
+  flagState.enabled = true;
+});
+
+describe("UserTestingTab — which scenarios the list advertises", () => {
+  it("hides auto-minted client rows and keeps the published environment", async () => {
+    listState.chatboxes = SEEDED_PROJECT;
+
+    render(<UserTestingTab projectId="proj-1" isAuthenticated />);
+
+    const rows = await screen.findAllByTestId("user-testing-overview-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute("data-scenario-id", "cb-real");
+    expect(screen.queryByText("ChatGPT")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state for a project that only has seeded clients", async () => {
+    listState.chatboxes = SEEDED_PROJECT.filter((r) => !r.environmentId);
+
+    render(<UserTestingTab projectId="proj-1" isAuthenticated />);
+
+    // "You haven't made one yet" is the truth here; four phantom rows were not.
+    expect(
+      await screen.findByTestId("user-testing-overview-empty"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a legacy client row that real testers actually used", async () => {
+    listState.chatboxes = [
+      row({ chatboxId: "cb-used", name: "Cursor", uniqueTesterCount: 3 }),
+      row({ chatboxId: "cb-idle", name: "Copilot" }),
+    ];
+
+    render(<UserTestingTab projectId="proj-1" isAuthenticated />);
+
+    const rows = await screen.findAllByTestId("user-testing-overview-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute("data-scenario-id", "cb-used");
+  });
+
+  it("still opens a filtered-out row by direct link", async () => {
+    // Hiding a row from the list says "not worth advertising", never "gone".
+    listState.chatboxes = SEEDED_PROJECT;
+    chatboxState.chatbox = { chatboxId: "cb-seed-1", name: "Claude Code" };
+
+    render(
+      <UserTestingTab
+        projectId="proj-1"
+        isAuthenticated
+        scenarioId="cb-seed-1"
+      />,
+    );
+
+    expect(await screen.findByTestId("scenario-detail")).toBeInTheDocument();
+    expect(screen.queryByText(/Scenario not found/i)).not.toBeInTheDocument();
+  });
+
+  it("does not filter when environments are off", async () => {
+    // Such a project has no environment-backed scenarios, so filtering would
+    // leave it with a surface it cannot use.
+    flagState.enabled = false;
+    listState.chatboxes = SEEDED_PROJECT;
+
+    render(<UserTestingTab projectId="proj-1" isAuthenticated />);
+
+    await waitFor(async () => {
+      expect(
+        await screen.findAllByTestId("user-testing-overview-row"),
+      ).toHaveLength(4);
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingCreateFlow.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingCreateFlow.tsx
@@ -29,6 +29,7 @@ import {
   type HostConfigInputV2,
 } from "@/lib/client-config-v2";
 import {
+  CHATBOX_ACCESS_OPTIONS as ACCESS_OPTIONS,
   settingsFromChatboxAccessPreset,
   type ChatboxAccessPreset,
 } from "@/lib/chatbox-access-presets";
@@ -66,29 +67,6 @@ interface UserTestingCreateFlowProps {
   }) => Promise<{ hostId: string }>;
 }
 
-const ACCESS_OPTIONS: ReadonlyArray<{
-  value: ChatboxAccessPreset;
-  label: string;
-  description: string;
-}> = [
-  {
-    value: "invited_only",
-    label: "Invited users only",
-    description: "Only people you invite by email can open this scenario.",
-  },
-  {
-    value: "link_guests",
-    label: "Anyone with the link",
-    description:
-      "Anyone with the link can open it, including guests without an account. Guest usage runs on your organization's credits.",
-  },
-  {
-    value: "project",
-    label: "Project members",
-    description:
-      "Signed-in members of this project can open it with the link. Guests cannot.",
-  },
-];
 
 export function UserTestingCreateFlow({
   projectId,

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingOverviewPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingOverviewPanel.tsx
@@ -227,9 +227,9 @@ function EmptyState({
       <Inbox className="size-8 text-muted-foreground/70" />
       <h2 className="mt-4 text-base font-semibold">No scenarios yet</h2>
       <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-        A scenario is one client pointed at one of your servers, behind a link
-        you can hand to a real person. Every client you set up in Connect is
-        published as one.
+        A scenario is one of your environments — its client, servers and skills
+        — behind a link you can hand to a real person, so you can read what
+        happened in their sessions.
       </p>
       <Button className="mt-5" onClick={onCreateScenario}>
         <Plus className="mr-1.5 size-4" />

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioCreateFlow.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioCreateFlow.tsx
@@ -1,0 +1,303 @@
+import { useRef, useState } from "react";
+import { ArrowLeft, ChevronDown, Layers, Loader2, Plus } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
+import { saveEnvironmentDraftSeed } from "@/lib/environment-draft-seed";
+import { environmentLabel } from "@/lib/environment-label";
+import {
+  CHATBOX_ACCESS_OPTIONS as ACCESS_OPTIONS,
+  settingsFromChatboxAccessPreset,
+  type ChatboxAccessPreset,
+} from "@/lib/chatbox-access-presets";
+import type { ChatboxMode } from "@/hooks/useChatboxes";
+import { toast } from "@/lib/toast";
+import { cn } from "@/lib/utils";
+
+/**
+ * `/user-testing/new` — create a scenario by publishing an ENVIRONMENT behind
+ * a share link.
+ *
+ * An environment already names the whole execution context a tester will meet:
+ * the client, its servers, its skills, its sandbox image. So this screen asks
+ * for the two things the environment does NOT carry — what to call the
+ * scenario, and who may open it — and nothing else. The version this replaces
+ * asked for a server and a client template and quietly minted a host, which is
+ * why every project accumulated "scenarios" nobody made.
+ *
+ * **It never CREATES an environment.** Scenario surfaces select one; Swarms is
+ * the only surface that materializes them. "New environment" hands off to the
+ * Environments editor with the typed name seeded, and the user comes back.
+ *
+ * **Nothing is written until Save.** Every choice is local state; the single
+ * write is `onCreateScenario`, injected by the parent — the same inversion
+ * `new-swarm-create-flow` and the legacy flow both use.
+ */
+interface UserTestingScenarioCreateFlowProps {
+  projectId: string;
+  onCancel: () => void;
+  /** Navigates to the Environments editor with `name` pre-seeded. */
+  onCreateEnvironment: () => void;
+  /**
+   * The ONLY write path: publishes the environment, applying the name and
+   * access mode in the same mutation so the scenario is never briefly live in
+   * a mode nobody asked for. Resolves to the new scenario's id, plus whether
+   * this call actually created it (`false` ⇒ the environment was already
+   * published and the existing scenario is what opens).
+   */
+  onCreateScenario: (draft: {
+    environmentId: string;
+    name: string;
+    mode: ChatboxMode;
+  }) => Promise<{ scenarioId: string; created: boolean }>;
+}
+
+export function UserTestingScenarioCreateFlow({
+  projectId,
+  onCancel,
+  onCreateEnvironment,
+  onCreateScenario,
+}: UserTestingScenarioCreateFlowProps) {
+  const environments = useProjectEnvironments(projectId);
+  const [environmentId, setEnvironmentId] = useState<string | null>(null);
+  const [name, setName] = useState("");
+  // Default to the least-exposed option: a scenario that reaches further than
+  // its author expected is the failure that costs something.
+  const [accessPreset, setAccessPreset] =
+    useState<ChatboxAccessPreset>("invited_only");
+  const [isSaving, setIsSaving] = useState(false);
+  // Synchronous guard: a double-click must not publish twice before React
+  // commits `isSaving`.
+  const savingRef = useRef(false);
+  // Once the user types a name, stop tracking the environment — but a name
+  // they never touched should keep following their pick.
+  const userEditedNameRef = useRef(false);
+
+  const liveEnvironments = (environments ?? []).filter(
+    (env) => !env.archivedAt,
+  );
+  const selected = liveEnvironments.find(
+    (env) => env.environmentId === environmentId,
+  );
+  const effectiveName = name.trim();
+  const canSave =
+    Boolean(environmentId) && effectiveName.length > 0 && !isSaving;
+
+  const handlePickEnvironment = (next: string | null) => {
+    setEnvironmentId(next);
+    if (userEditedNameRef.current) return;
+    const picked = liveEnvironments.find((env) => env.environmentId === next);
+    setName(picked ? environmentLabel(picked) : "");
+  };
+
+  const handleCreateEnvironment = () => {
+    // Carry the typed name across so the round trip doesn't cost it. The
+    // Environments route consumes this seed into its create form.
+    saveEnvironmentDraftSeed(projectId, {
+      ...(effectiveName ? { name: effectiveName } : {}),
+      hostId: null,
+      serverAttachmentId: null,
+      skillSelection: null,
+    });
+    onCreateEnvironment();
+  };
+
+  const handleSave = async () => {
+    if (!environmentId || !effectiveName || savingRef.current) return;
+    savingRef.current = true;
+    setIsSaving(true);
+    try {
+      const { created } = await onCreateScenario({
+        environmentId,
+        name: effectiveName,
+        mode: settingsFromChatboxAccessPreset(accessPreset).mode,
+      });
+      toast.success(
+        created
+          ? "Scenario created"
+          : "That environment is already published — opening its scenario",
+      );
+    } catch (err) {
+      // Surface the backend's copy verbatim: publishing is project-admin
+      // gated, and "you need admin" is a different problem than "it failed".
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create the scenario",
+      );
+      savingRef.current = false;
+      setIsSaving(false);
+    }
+  };
+
+  const accessLabel = ACCESS_OPTIONS.find((o) => o.value === accessPreset);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto">
+      <div className="mx-auto w-full max-w-2xl px-6 py-6 sm:px-8">
+        <button
+          type="button"
+          onClick={onCancel}
+          data-testid="user-testing-create-back"
+          className={cn(
+            "inline-flex items-center gap-1 rounded-sm text-sm font-medium text-primary",
+            "hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          <ArrowLeft className="size-3.5" />
+          User Testing
+        </button>
+
+        <h1 className="mt-3 text-xl font-bold tracking-tight text-foreground">
+          New scenario
+        </h1>
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          Publish one of your environments behind a link you can hand to a real
+          person, then read what happened in their sessions.
+        </p>
+
+        <div className="mt-6 space-y-5">
+          <div className="space-y-2">
+            <Label>Environment</Label>
+            {environments !== undefined && liveEnvironments.length === 0 ? (
+              <div
+                data-testid="user-testing-create-no-environments"
+                className="rounded-md border border-dashed border-border/70 px-4 py-5 text-center"
+              >
+                <Layers className="mx-auto size-6 text-muted-foreground/70" />
+                <p className="mt-2 text-sm font-medium">No environments yet</p>
+                <p className="mx-auto mt-1 max-w-sm text-xs text-muted-foreground">
+                  An environment is the client, servers and skills a tester will
+                  meet. Build one, then come back and publish it.
+                </p>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="mt-3"
+                  onClick={handleCreateEnvironment}
+                  data-testid="user-testing-create-new-environment"
+                >
+                  <Plus className="mr-1.5 size-4" />
+                  New environment
+                </Button>
+              </div>
+            ) : (
+              <>
+                <EnvironmentPicker
+                  projectId={projectId}
+                  value={environmentId}
+                  onChange={handlePickEnvironment}
+                  multi={false}
+                  disabled={isSaving}
+                  emptyLabel="Select an environment"
+                  triggerTestId="user-testing-create-environment"
+                  triggerAriaLabel="Environment to publish"
+                />
+                <button
+                  type="button"
+                  onClick={handleCreateEnvironment}
+                  data-testid="user-testing-create-new-environment"
+                  className="text-xs text-primary hover:underline"
+                >
+                  None of these fit — build a new environment
+                </button>
+              </>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="user-testing-create-name">Scenario name</Label>
+            <Input
+              id="user-testing-create-name"
+              data-testid="user-testing-create-name"
+              value={name}
+              disabled={isSaving}
+              placeholder={
+                selected ? environmentLabel(selected) : "Checkout flow"
+              }
+              onChange={(e) => {
+                userEditedNameRef.current = true;
+                setName(e.target.value);
+              }}
+            />
+            <p className="text-xs text-muted-foreground">
+              What you&apos;ll recognize this run of testing by. Renaming the
+              environment later won&apos;t rename it.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Who can open it</Label>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  data-testid="user-testing-create-access"
+                  disabled={isSaving}
+                  className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-60"
+                >
+                  <span className="flex-1 truncate text-left">
+                    {accessLabel?.label}
+                  </span>
+                  <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                className="w-[--radix-dropdown-menu-trigger-width]"
+              >
+                <DropdownMenuRadioGroup
+                  value={accessPreset}
+                  onValueChange={(v) =>
+                    setAccessPreset(v as ChatboxAccessPreset)
+                  }
+                >
+                  {ACCESS_OPTIONS.map((option) => (
+                    <DropdownMenuRadioItem
+                      key={option.value}
+                      value={option.value}
+                    >
+                      {option.label}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            {accessLabel ? (
+              <p className="text-xs text-muted-foreground">
+                {accessLabel.description}
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-7 flex items-center justify-end gap-2">
+          <Button variant="ghost" onClick={onCancel} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void handleSave()}
+            disabled={!canSave}
+            data-testid="user-testing-create-save"
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="mr-1.5 size-4 animate-spin" />
+                Creating…
+              </>
+            ) : (
+              "Create scenario"
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioCreateFlow.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioCreateFlow.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * `/user-testing/new`, environment-first.
+ *
+ * What this pins:
+ *  - nothing is written until Save, and Save is ONE call carrying the name and
+ *    the access mode (so a scenario is never briefly live in a mode nobody
+ *    asked for);
+ *  - the access default is the least-exposed option;
+ *  - the name follows the picked environment until the user types, then stops;
+ *  - an already-published environment is reported as such rather than as a
+ *    failure;
+ *  - the flow never CREATES an environment — it hands off to the Environments
+ *    editor with the typed name seeded.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+
+const { environmentsState, saveSeedMock, toastSuccess, toastError } =
+  vi.hoisted(() => ({
+    environmentsState: {
+      value: undefined as ProjectEnvironmentView[] | undefined,
+    },
+    saveSeedMock: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+  }));
+
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => environmentsState.value,
+}));
+
+vi.mock("@/lib/environment-draft-seed", () => ({
+  saveEnvironmentDraftSeed: saveSeedMock,
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
+// Pure presentation in the real thing; stubbed to a plain select so the test
+// drives selection without Radix portals.
+vi.mock("@/components/project-environments/environment-picker", () => ({
+  EnvironmentPicker: ({
+    value,
+    onChange,
+  }: {
+    value: string | null;
+    onChange: (next: string | null) => void;
+  }) => (
+    <select
+      data-testid="user-testing-create-environment"
+      value={value ?? ""}
+      onChange={(e) => onChange(e.target.value || null)}
+    >
+      <option value="">none</option>
+      <option value="env-1">Checkout flow</option>
+      <option value="env-2">Onboarding</option>
+    </select>
+  ),
+}));
+
+import { UserTestingScenarioCreateFlow } from "@/components/chatboxes/UserTestingScenarioCreateFlow";
+
+const env = (over: Partial<ProjectEnvironmentView>): ProjectEnvironmentView =>
+  ({
+    environmentId: "env-1",
+    projectId: "p1",
+    name: "Checkout flow",
+    hostId: "host-1",
+    revision: 1,
+    createdAt: 0,
+    updatedAt: 0,
+    ...over,
+  } as ProjectEnvironmentView);
+
+function renderFlow(
+  onCreateScenario = vi.fn().mockResolvedValue({
+    scenarioId: "cb-1",
+    created: true,
+  }),
+  onCreateEnvironment = vi.fn(),
+) {
+  render(
+    <UserTestingScenarioCreateFlow
+      projectId="p1"
+      onCancel={vi.fn()}
+      onCreateEnvironment={onCreateEnvironment}
+      onCreateScenario={onCreateScenario}
+    />,
+  );
+  return { onCreateScenario, onCreateEnvironment };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  environmentsState.value = [
+    env({}),
+    env({ environmentId: "env-2", name: "Onboarding" }),
+  ];
+});
+
+describe("UserTestingScenarioCreateFlow", () => {
+  it("writes nothing until Save, then publishes in ONE call", async () => {
+    const { onCreateScenario } = renderFlow();
+
+    fireEvent.change(screen.getByTestId("user-testing-create-environment"), {
+      target: { value: "env-1" },
+    });
+    expect(onCreateScenario).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("user-testing-create-save"));
+
+    await waitFor(() => {
+      expect(onCreateScenario).toHaveBeenCalledTimes(1);
+    });
+    expect(onCreateScenario).toHaveBeenCalledWith({
+      environmentId: "env-1",
+      name: "Checkout flow",
+      // Least-exposed default, carried in the same call as the publish.
+      mode: "invited_only",
+    });
+  });
+
+  it("cannot be saved without an environment", () => {
+    renderFlow();
+    expect(screen.getByTestId("user-testing-create-save")).toBeDisabled();
+  });
+
+  it("names the scenario after the environment until the user types", () => {
+    renderFlow();
+    const picker = screen.getByTestId("user-testing-create-environment");
+
+    fireEvent.change(picker, { target: { value: "env-1" } });
+    expect(screen.getByTestId("user-testing-create-name")).toHaveValue(
+      "Checkout flow",
+    );
+
+    // Switching before typing keeps tracking...
+    fireEvent.change(picker, { target: { value: "env-2" } });
+    expect(screen.getByTestId("user-testing-create-name")).toHaveValue(
+      "Onboarding",
+    );
+
+    // ...and a typed name is never overwritten.
+    fireEvent.change(screen.getByTestId("user-testing-create-name"), {
+      target: { value: "Round 2 with real users" },
+    });
+    fireEvent.change(picker, { target: { value: "env-1" } });
+    expect(screen.getByTestId("user-testing-create-name")).toHaveValue(
+      "Round 2 with real users",
+    );
+  });
+
+  it("reports an already-published environment as such, not as a failure", async () => {
+    const onCreateScenario = vi
+      .fn()
+      .mockResolvedValue({ scenarioId: "cb-9", created: false });
+    renderFlow(onCreateScenario);
+
+    fireEvent.change(screen.getByTestId("user-testing-create-environment"), {
+      target: { value: "env-1" },
+    });
+    fireEvent.click(screen.getByTestId("user-testing-create-save"));
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith(
+        expect.stringMatching(/already published/i),
+      );
+    });
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the backend's message verbatim when publishing is refused", async () => {
+    // Publishing is project-admin gated: "you need admin" and "it broke" send
+    // the user to different places.
+    const onCreateScenario = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("Publishing an environment chatbox requires project admin."),
+      );
+    renderFlow(onCreateScenario);
+
+    fireEvent.change(screen.getByTestId("user-testing-create-environment"), {
+      target: { value: "env-1" },
+    });
+    fireEvent.click(screen.getByTestId("user-testing-create-save"));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        "Publishing an environment chatbox requires project admin.",
+      );
+    });
+    // Recoverable — the form is usable again rather than stuck mid-save.
+    expect(screen.getByTestId("user-testing-create-save")).not.toBeDisabled();
+  });
+
+  it("hands off to the Environments editor instead of creating one here", () => {
+    const { onCreateEnvironment } = renderFlow();
+
+    fireEvent.change(screen.getByTestId("user-testing-create-name"), {
+      target: { value: "Checkout, take three" },
+    });
+    fireEvent.click(screen.getByTestId("user-testing-create-new-environment"));
+
+    // Scenario surfaces select environments; only Swarms materializes them.
+    // The typed name rides along so the round trip doesn't cost it.
+    expect(saveSeedMock).toHaveBeenCalledWith("p1", {
+      name: "Checkout, take three",
+      hostId: null,
+      serverAttachmentId: null,
+      skillSelection: null,
+    });
+    expect(onCreateEnvironment).toHaveBeenCalled();
+  });
+
+  it("offers the handoff, not a dead end, when the project has no environments", () => {
+    environmentsState.value = [];
+    renderFlow();
+
+    expect(
+      screen.getByTestId("user-testing-create-no-environments"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("user-testing-create-new-environment"),
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentsRoute.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Navigate } from "react-router";
+import { Link, Navigate } from "react-router";
 import {
   Archive,
   ArchiveRestore,
@@ -7,11 +7,15 @@ import {
   Layers,
   Loader2,
   Plus,
+  Users,
 } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { Badge } from "@mcpjam/design-system/badge";
-import { routePaths } from "@/lib/app-navigation";
+import {
+  buildUserTestingScenarioPath,
+  routePaths,
+} from "@/lib/app-navigation";
 import { isNamedEnvironment } from "@/lib/environment-label";
 import { convexErrMessage } from "@/lib/convex-error";
 import { useProjectEnvironmentsEnabledState } from "@/hooks/useProjectEnvironmentsEnabled";
@@ -29,6 +33,7 @@ import {
 import { ProjectEnvironmentEditor } from "./ProjectEnvironmentEditor";
 import { EnvironmentCanvasPanel } from "./EnvironmentCanvasPanel";
 import { useProjectEnvironmentConsumers } from "./use-project-environment-consumers";
+import { useEnvironmentChatbox } from "@/hooks/useChatboxes";
 import {
   takeEnvironmentDraftSeed,
   type EnvironmentDraftSeed,
@@ -496,6 +501,12 @@ function EnvironmentDetail({
       projectId,
       confirmingArchive ? environment.environmentId : null
     );
+  // Reads the shared chatbox-list subscription, so this costs no extra query.
+  const { chatbox: publishedScenario } = useEnvironmentChatbox({
+    isAuthenticated,
+    projectId,
+    environmentId: environment.environmentId,
+  });
 
   const isArchived = !!environment.archivedAt;
 
@@ -575,6 +586,22 @@ function EnvironmentDetail({
                   </span>
                 </span>
               </div>
+
+              {publishedScenario ? (
+                // Absence renders nothing: an unpublished environment isn't in
+                // a state worth naming. Publishing happens in User Testing —
+                // this is only the pointer back to it, so someone editing an
+                // environment can see it has real testers behind a live link.
+                <Link
+                  to={buildUserTestingScenarioPath(publishedScenario.chatboxId)}
+                  data-testid="environment-published-scenario"
+                  className="flex items-center gap-1.5 text-xs text-primary hover:underline"
+                >
+                  <Users className="size-3.5" />
+                  Published as the User Testing scenario “
+                  {publishedScenario.name}”
+                </Link>
+              ) : null}
 
               {isArchived ? (
                 <div className="flex items-center justify-between gap-3 rounded-md border bg-muted/30 p-3">

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/archive-consumer-counts.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/archive-consumer-counts.test.tsx
@@ -43,6 +43,13 @@ vi.mock("../EnvironmentCanvasPanel", () => ({
   EnvironmentCanvasPanel: () => <div data-testid="stub-env-canvas" />,
 }));
 
+// The detail pane links back to a published scenario, reading the shared
+// chatbox list. Unpublished here — the link's own behavior is covered in the
+// User Testing suites.
+vi.mock("@/hooks/useChatboxes", () => ({
+  useEnvironmentChatbox: () => ({ chatbox: null, isLoading: false }),
+}));
+
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";
 
 const environment = {

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.flag-gate.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.flag-gate.test.tsx
@@ -32,6 +32,13 @@ vi.mock("../EnvironmentCanvasPanel", () => ({
   EnvironmentCanvasPanel: () => <div data-testid="stub-env-canvas" />,
 }));
 
+// The detail pane links back to a published scenario, reading the shared
+// chatbox list. Unpublished here — the link's own behavior is covered in the
+// User Testing suites.
+vi.mock("@/hooks/useChatboxes", () => ({
+  useEnvironmentChatbox: () => ({ chatbox: null, isLoading: false }),
+}));
+
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";
 
 function renderAtEnvironments(projectId = "proj-1") {

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.seed.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.seed.test.tsx
@@ -48,6 +48,14 @@ vi.mock("../EnvironmentCanvasPanel", () => ({
 vi.mock("@/lib/toast", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock("react-router", () => ({
   Navigate: () => <div data-testid="redirect" />,
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+// The detail pane links back to a published scenario, reading the shared
+// chatbox list. Unpublished here — the link's own behavior is covered in the
+// User Testing suites.
+vi.mock("@/hooks/useChatboxes", () => ({
+  useEnvironmentChatbox: () => ({ chatbox: null, isLoading: false }),
 }));
 
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.tentative-drafts.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/project-environments-route.tentative-drafts.test.tsx
@@ -51,6 +51,14 @@ vi.mock("../EnvironmentCanvasPanel", () => ({
 vi.mock("@/lib/toast", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock("react-router", () => ({
   Navigate: () => <div data-testid="redirect" />,
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}));
+
+// The detail pane links back to a published scenario, reading the shared
+// chatbox list. Unpublished here — the link's own behavior is covered in the
+// User Testing suites.
+vi.mock("@/hooks/useChatboxes", () => ({
+  useEnvironmentChatbox: () => ({ chatbox: null, isLoading: false }),
 }));
 
 import { ProjectEnvironmentsRoute } from "../ProjectEnvironmentsRoute";

--- a/mcpjam-inspector/client/src/hooks/useChatboxes.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxes.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { shouldQueryProjectId } from "./useProjects";
 import type { ChatboxHostStyle } from "@/lib/chatbox-client-style";
@@ -149,11 +150,15 @@ export interface ChatboxListItem {
    * chatbox row (mcpjam-backend). Optional so a deployment predating them
    * renders "—" rather than a confident zero — the two are different claims.
    * Excludes preview and synthetic sessions: a tester is someone who opened
-   * the share link. (The backend also returns `sessionCount`; it is left out
-   * here until a column reads it, so the type can't advertise a value the UI
-   * ignores.)
+   * the share link.
+   *
+   * `sessionCount` has no column of its own — it is read by
+   * `isDeliberateScenario`, which uses any real tester history as evidence
+   * that a row is a scenario someone made rather than a client's auto-minted
+   * publish surface.
    */
   uniqueTesterCount?: number;
+  sessionCount?: number;
   lastSessionAt?: number | null;
   createdAt: number;
   updatedAt: number;
@@ -180,6 +185,71 @@ export function useChatboxList({
     chatboxes,
     isLoading: enabled && chatboxes === undefined,
   };
+}
+
+/**
+ * The scenario published from one environment, or null when it isn't
+ * published. Derived from the shared list subscription rather than its own
+ * query — two subscriptions to the same rows is two chances to disagree.
+ *
+ * `undefined` while the list is still loading: "not published" and "we don't
+ * know yet" send a viewer to different places.
+ */
+export function useEnvironmentChatbox({
+  isAuthenticated,
+  projectId,
+  environmentId,
+}: {
+  isAuthenticated: boolean;
+  projectId: string | null;
+  environmentId: string | null;
+}): { chatbox: ChatboxListItem | null | undefined; isLoading: boolean } {
+  const { chatboxes, isLoading } = useChatboxList({
+    isAuthenticated,
+    projectId,
+  });
+  const chatbox = useMemo(() => {
+    if (!environmentId || chatboxes === undefined) return undefined;
+    return chatboxes.find((row) => row.environmentId === environmentId) ?? null;
+  }, [chatboxes, environmentId]);
+  return { chatbox, isLoading };
+}
+
+/**
+ * Publishing an environment as a User Testing scenario, and retiring it.
+ *
+ * Both are PROJECT-ADMIN gated backend-side (a scenario is shared mutable
+ * execution config, and a spend surface) — surface the `FORBIDDEN` copy
+ * verbatim rather than paraphrasing it.
+ *
+ * Publish is idempotent: one scenario per environment, and a second call
+ * returns the existing row with `created: false` and IGNORES the overrides,
+ * so re-publishing can never silently rename or re-mode a live scenario
+ * (mcpjam-backend #887).
+ */
+export function useEnvironmentChatboxMutations() {
+  const publishEnvironmentChatbox = useMutation(
+    "chatboxes:publishEnvironmentChatbox" as any,
+  ) as (args: {
+    environmentId: string;
+    name?: string;
+    description?: string;
+    mode?: ChatboxMode;
+  }) => Promise<{
+    chatboxId: string;
+    environmentId: string;
+    name: string;
+    mode: ChatboxMode;
+    accessVersion: number;
+    link: { token: string; path: string; url: string } | null;
+    created: boolean;
+  }>;
+  const unpublishEnvironmentChatbox = useMutation(
+    "chatboxes:unpublishEnvironmentChatbox" as any,
+  ) as (args: {
+    environmentId: string;
+  }) => Promise<{ deleted: boolean; chatboxId?: string }>;
+  return { publishEnvironmentChatbox, unpublishEnvironmentChatbox };
 }
 
 export function useChatbox({

--- a/mcpjam-inspector/client/src/lib/__tests__/user-testing-scenarios.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/user-testing-scenarios.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The rule that decides which chatbox rows are SCENARIOS.
+ *
+ * The bug it exists for: `hosts.createHost` mints a chatbox per client, and an
+ * empty project gets four of them before anyone opens User Testing (three
+ * seeded by the Playground, one by the host bar). The surface listed all of
+ * them, so a brand-new project showed scenarios nobody made.
+ */
+import { describe, expect, it } from "vitest";
+import type { ChatboxListItem } from "@/hooks/useChatboxes";
+import { isDeliberateScenario } from "@/lib/user-testing-scenarios";
+
+const row = (over: Partial<ChatboxListItem> = {}): ChatboxListItem => ({
+  chatboxId: "cb-1",
+  projectId: "p1",
+  name: "Claude Code",
+  hostStyle: "claude",
+  // What every auto-mint path produces: the backend default.
+  mode: "project_members",
+  allowGuestAccess: false,
+  serverCount: 0,
+  serverNames: [],
+  namedHostId: "host-1",
+  namedHostName: "Claude Code",
+  createdAt: 1,
+  updatedAt: 2,
+  ...over,
+});
+
+describe("isDeliberateScenario", () => {
+  it("hides an untouched auto-minted client row", () => {
+    // The exact shape of a Playground- or host-bar-seeded client.
+    expect(isDeliberateScenario(row())).toBe(false);
+  });
+
+  it("keeps every environment-backed row", () => {
+    // These exist ONLY because someone published an environment.
+    expect(isDeliberateScenario(row({ environmentId: "env-1" }))).toBe(true);
+  });
+
+  it("keeps a row whose access was deliberately changed", () => {
+    expect(isDeliberateScenario(row({ mode: "invited_only" }))).toBe(true);
+    expect(isDeliberateScenario(row({ mode: "anyone_with_link" }))).toBe(true);
+  });
+
+  it("keeps a legacy row that real testers actually used", () => {
+    expect(isDeliberateScenario(row({ uniqueTesterCount: 2 }))).toBe(true);
+    expect(isDeliberateScenario(row({ sessionCount: 1 }))).toBe(true);
+    expect(isDeliberateScenario(row({ lastSessionAt: 1700000000000 }))).toBe(
+      true,
+    );
+  });
+
+  it("treats absent counters as no evidence, not as zero evidence", () => {
+    // A deployment predating the counters omits them. Absence must not be read
+    // as "used" — that would put every seeded client back in the list.
+    expect(
+      isDeliberateScenario(
+        row({
+          uniqueTesterCount: undefined,
+          sessionCount: undefined,
+          lastSessionAt: undefined,
+        }),
+      ),
+    ).toBe(false);
+    // ...and an explicit zero is not evidence either.
+    expect(
+      isDeliberateScenario(
+        row({ uniqueTesterCount: 0, sessionCount: 0, lastSessionAt: null }),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps an environment-backed row even when it is unresolvable", () => {
+    // Its share link is minted; the owner has to see it to retire it.
+    expect(
+      isDeliberateScenario(
+        row({
+          environmentId: "env-1",
+          environmentError: { code: "ENV_ARCHIVED", message: "archived" },
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/chatbox-access-presets.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-access-presets.ts
@@ -19,6 +19,35 @@ export function chatboxAccessPresetFromSettings(
   return allowGuestAccess ? "link_guests" : "project";
 }
 
+/**
+ * The access choice as a create flow offers it, ordered least- to
+ * most-exposed. Shared by both scenario create flows so the wording a user
+ * reads doesn't depend on which one they happened to open.
+ */
+export const CHATBOX_ACCESS_OPTIONS: ReadonlyArray<{
+  value: ChatboxAccessPreset;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "invited_only",
+    label: "Invited users only",
+    description: "Only people you invite by email can open this scenario.",
+  },
+  {
+    value: "link_guests",
+    label: "Anyone with the link",
+    description:
+      "Anyone with the link can open it, including guests without an account. Guest usage runs on your organization's credits.",
+  },
+  {
+    value: "project",
+    label: "Project members",
+    description:
+      "Signed-in members of this project can open it with the link. Guests cannot.",
+  },
+];
+
 export function settingsFromChatboxAccessPreset(
   preset: ChatboxAccessPreset,
 ): { mode: ChatboxMode; allowGuestAccess: boolean } {

--- a/mcpjam-inspector/client/src/lib/user-testing-scenarios.ts
+++ b/mcpjam-inspector/client/src/lib/user-testing-scenarios.ts
@@ -1,0 +1,38 @@
+import type { ChatboxListItem } from "@/hooks/useChatboxes";
+
+/**
+ * Is this chatbox row a SCENARIO someone deliberately made, rather than the
+ * publish surface every client is born with?
+ *
+ * `chatboxes` rows are minted 1:1 with hosts by `hosts.createHost`, so a
+ * project accumulates one per client whether or not anyone intended to test
+ * with it — including the three the Playground seeds into an empty project and
+ * the "MCPJam" one the host bar seeds. Listing them all made a brand-new
+ * project show four or five "scenarios" nobody created.
+ *
+ * There is no `publishedAt` bit on the row to read, so intent is inferred from
+ * signals that only a deliberate act produces:
+ *
+ *  - `environmentId` — the row exists ONLY because someone published an
+ *    environment. This is the canonical scenario going forward;
+ *  - a non-default access mode — every auto-mint path uses the backend default
+ *    (`project_members`), so `invited_only` / `anyone_with_link` means a human
+ *    chose who could open it;
+ *  - real tester history — someone opened the share link, whatever the row's
+ *    origin. Positive counters are reliable (they are written at session
+ *    insert); zero is ambiguous for rows that predate them, which is why zero
+ *    is not treated as evidence of anything.
+ *
+ * The known miss: a legacy host-backed scenario left at the default mode whose
+ * sessions all predate the counters. It stays reachable by its link and by the
+ * public API — the alternative is showing every client forever.
+ */
+export function isDeliberateScenario(row: ChatboxListItem): boolean {
+  if (row.environmentId) return true;
+  if (row.mode !== "project_members") return true;
+  return (
+    (row.sessionCount ?? 0) > 0 ||
+    (row.uniqueTesterCount ?? 0) > 0 ||
+    row.lastSessionAt != null
+  );
+}


### PR DESCRIPTION
## Why

**This is the PR that fixes the reported bug.** A fresh project listed four or five "scenarios" nobody created — `Claude Code`, `MCPJam`, `ChatGPT`, `Cursor (CLI)`, `Copilot`, all with 0 testers.

They were there because a chatbox row is minted 1:1 with every host, two seeds run before anyone opens the tab (the Playground seeds three clients into an empty project; the host bar seeds "MCPJam"), and the list rendered every row. The empty-state copy even advertised it: *"Every client you set up in Connect is published as one."*

The deeper cause: the create flow asked for a **server and a client template** and called `hosts.createHost`. But a scenario is an **environment** shared with real people.

## What changed

Both changes are gated on `project-environments-enabled`.

### Create publishes an environment

Pick an environment, name it, choose who can open it. The environment already carries the client, servers, skills and sandbox image a tester meets, so the flow asks only for what it does *not* carry.

**One write.** `publishEnvironmentChatbox` applies the name and access mode in the same mutation (mcpjam-backend #887), so a scenario is never briefly live in a mode nobody asked for. Re-publishing an already-published environment reports that and opens the existing scenario rather than erroring — and, per #887, cannot silently re-mode it.

**It never creates an environment.** Scenario surfaces select; only Swarms materializes (the ad-hoc environments rule). "New environment" hands off to the Environments editor with the typed name seeded, through the same sessionStorage handoff Connect already uses.

### The list shows scenarios, not clients

`isDeliberateScenario` (`client/src/lib/user-testing-scenarios.ts`) keeps rows that could only exist on purpose:
- environment-backed rows — they exist *only* because someone published;
- rows whose access mode was moved off the auto-mint default (`project_members`);
- rows with real tester history.

Absent counters are read as **no evidence**, not as zero — otherwise a deployment predating them resurrects every seeded client.

Two deliberate scoping calls:
- **Client-side.** The same query feeds public API v1 (`GET /v1/chatboxes`) and the Environments page's consumer counts; neither should inherit this surface's editorial rule.
- **The resolution ladder still searches unfiltered rows.** Hiding a row says "not worth advertising", never "gone" — a direct link to a filtered-out scenario still opens. There's a test for it.

**Flag-off projects are untouched** — legacy create flow, unfiltered list. Without environments there is no other kind of scenario, so filtering would leave them a surface they can't use. Both legacy branches get deleted when the flag retires.

### Also

- Restores `useEnvironmentChatbox` / `useEnvironmentChatboxMutations`, removed in #3658 along with the old Environments publish panel.
- One line on an environment's detail: "Published as the User Testing scenario …", rendered only when it is. No publish controls there — creation lives in User Testing.
- `ACCESS_OPTIONS` moved to `lib/chatbox-access-presets.ts` so both flows read the same wording.

## Known limit

A legacy host-backed scenario left at the default access mode whose sessions all predate the counters won't be listed. It stays reachable by its link and through v1 — the alternative is showing every client forever. Stated rather than hidden.

## Tests

New: `user-testing-scenarios.test.ts` (the filter matrix, including the absent-vs-zero distinction) and `UserTestingScenarioCreateFlow.test.tsx` (nothing written until Save; one call carrying name + mode; least-exposed default; name tracks the environment until you type; already-published reported as such; admin refusal surfaced verbatim; the handoff seeds the name).

`UserTestingTab.scenario-list.test.tsx` reproduces the exact reported lineup and asserts the phantom rows are gone, the empty state appears instead, a used legacy row survives, a filtered-out row still opens by link, and flag-off doesn't filter.

```
npx vitest run client/src/components/chatboxes client/src/components/__tests__ \
  client/src/lib/__tests__ client/src/components/project-environments/__tests__
# 150 files, 1807 tests passed

vite build --config client/vite.config.ts    # ✓ built
```

Two bugs in my own work were caught by these tests while writing them: the list rendered the unfiltered query, and (in #3761) a deleted mutation binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scenario discovery and creation behind a feature flag, including access-mode defaults and admin-gated publish mutations; list filtering could hide edge-case legacy scenarios still reachable by link/API.
> 
> **Overview**
> Fixes fresh projects showing phantom “scenarios” from every auto-minted client chatbox by **client-side filtering** with `isDeliberateScenario` when `project-environments-enabled` is on—environment publishes, non-default access, or real tester history stay visible; resolution by URL still searches the **unfiltered** list. Flag-off projects keep the legacy create flow and unfiltered list.
> 
> **Create path (flag on):** `/user-testing/new` uses `UserTestingScenarioCreateFlow`—pick an environment, name, and access—then a single **`publishEnvironmentChatbox`** call (name + mode together; idempotent re-publish opens the existing scenario). “New environment” seeds the Environments editor via sessionStorage; scenarios never create environments here.
> 
> Also restores **`useEnvironmentChatbox`** / **`useEnvironmentChatboxMutations`**, centralizes **`CHATBOX_ACCESS_OPTIONS`**, updates empty-state copy, and adds an environment detail link to the published User Testing scenario when one exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eb10e36fbd04229f07f7e3149168ad16b062223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create User Testing scenarios by publishing an environment, and hide auto-minted client rows so new projects no longer show phantom scenarios.

- **New Features**
  - New environment-first create flow: pick an environment, name it, and choose access; one mutation applies name and access together; re-publishing opens the existing scenario.
  - Restored `useEnvironmentChatbox` and `useEnvironmentChatboxMutations`; environment detail now links to its published scenario.
  - Shared access presets moved to `lib/chatbox-access-presets.ts`.
  - All changes gated behind `project-environments-enabled`.

- **Bug Fixes**
  - Scenario list now shows only deliberate scenarios via `isDeliberateScenario`: environment-backed, non-default access, or real tester activity. Direct links still work, and projects without environments keep the legacy, unfiltered list.

<sup>Written for commit 2eb10e36fbd04229f07f7e3149168ad16b062223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

