### PR TITLE
fix(model-picker): stop weak fuzzy matches from surviving row-level search

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-selector.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-selector.test.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ModelSelector } from "../chat-input/model-selector";
+import { defaultFilter } from "cmdk";
+import { ModelSelector, modelFilter } from "../chat-input/model-selector";
 import type { ModelDefinition } from "@/shared/types";
 import { useModelPickerIntentStore } from "@/stores/model-picker-intent-store";
 
@@ -81,6 +82,27 @@ const searchModels: ModelDefinition[] = [
     id: "gpt-4.1",
     name: "GPT-4.1",
     provider: "openai",
+  },
+];
+
+// Every row here matches "opus" under cmdk's raw subsequence scoring — the
+// Sonnet and Qwen ids both carry o-p-u-s in order — but only the Opus row is
+// something a user searching "opus" asked for.
+const weakMatchModels: ModelDefinition[] = [
+  {
+    id: "anthropic/claude-opus-4.5",
+    name: "Claude Opus 4.5",
+    provider: "anthropic",
+  },
+  {
+    id: "anthropic/claude-sonnet-4.5",
+    name: "Claude Sonnet 4.5",
+    provider: "anthropic",
+  },
+  {
+    id: "qwen/qwen3-coder-plus",
+    name: "Qwen3 Coder Plus",
+    provider: "qwen",
   },
 ];
 
@@ -368,6 +390,82 @@ describe("ModelSelector", () => {
     expect(screen.getByText("Anthropic")).toBeInTheDocument();
   });
 
+  it("drops rows that only match the search as a scattered subsequence", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelSelector
+        currentModel={weakMatchModels[0]}
+        availableModels={weakMatchModels}
+        onModelChange={() => {}}
+      />
+    );
+
+    await user.click(screen.getByTestId("model-selector-trigger"));
+    await user.type(screen.getByPlaceholderText("Search models"), "opus");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("option", { name: /claude sonnet 4\.5/i })
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("option", { name: /qwen3 coder plus/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: /claude opus 4\.5/i })
+    ).toBeInTheDocument();
+  });
+
+  it("hides a provider heading whose only match is a weak one", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelSelector
+        currentModel={weakMatchModels[0]}
+        availableModels={weakMatchModels}
+        onModelChange={() => {}}
+      />
+    );
+
+    await user.click(screen.getByTestId("model-selector-trigger"));
+    expect(screen.getByText("Qwen")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Search models"), "opus");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Qwen")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Anthropic")).toBeInTheDocument();
+  });
+
+  it("keeps every row of a multi-word search that names one model", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelSelector
+        currentModel={weakMatchModels[0]}
+        availableModels={weakMatchModels}
+        onModelChange={() => {}}
+      />
+    );
+
+    await user.click(screen.getByTestId("model-selector-trigger"));
+    await user.type(
+      screen.getByPlaceholderText("Search models"),
+      "claude opus 4.5"
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("option", { name: /claude sonnet 4\.5/i })
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("option", { name: /claude opus 4\.5/i })
+    ).toBeInTheDocument();
+  });
+
   it("selects an enabled provider model when the BYOK intent opens providers", async () => {
     render(<ProviderIntentControlledModelSelector />);
 
@@ -499,5 +597,39 @@ describe("ModelSelector", () => {
       expect(screen.getByPlaceholderText("Search models")).toBeInTheDocument();
     });
     expect(onModelChange).not.toHaveBeenCalled();
+  });
+});
+
+// The threshold in `modelFilter` is calibrated against cmdk's scoring, so a
+// cmdk bump that reshapes `defaultFilter` can silently loosen or break search.
+// These pin the band it was measured on: across the 173-model hosted catalog,
+// real matches scored 0.891 or better and incidental subsequence hits topped
+// out at 0.166, with the tightest junk being "gpt" against Glm 5 Turbo.
+describe("modelFilter", () => {
+  const opus = "Claude Opus 4.5 Anthropic anthropic/claude-opus-4.5";
+  const sonnet = "Claude Sonnet 4.5 Anthropic anthropic/claude-sonnet-4.5";
+  const glm = "Glm 5 Turbo Zhipu AI z-ai/glm-5-turbo";
+  const geminiPro =
+    "Gemini 3.1 Pro Preview Google google/gemini-3.1-pro-preview";
+
+  it("scores real matches far above the incidental ones", () => {
+    expect(defaultFilter(opus, "opus")).toBeGreaterThanOrEqual(0.89);
+    expect(defaultFilter(sonnet, "opus")).toBeLessThan(0.17);
+    expect(defaultFilter(glm, "gpt")).toBeLessThan(0.17);
+  });
+
+  it("keeps real matches and zeroes the incidental ones", () => {
+    expect(modelFilter(opus, "opus")).toBeGreaterThan(0);
+    expect(modelFilter(sonnet, "opus")).toBe(0);
+    expect(modelFilter(glm, "gpt")).toBe(0);
+  });
+
+  it("keeps a multi-word query that cmdk scores below the threshold", () => {
+    expect(defaultFilter(geminiPro, "gemini 3 pro")).toBeLessThan(0.3);
+    expect(modelFilter(geminiPro, "gemini 3 pro")).toBeGreaterThan(0);
+  });
+
+  it("preserves cmdk's ranking for the matches it keeps", () => {
+    expect(modelFilter(opus, "opus")).toBe(defaultFilter(opus, "opus"));
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
@@ -127,15 +127,51 @@ const modelSearchValue = (model: ModelDefinition, groupTitle: string): string =>
   `${model.name} ${groupTitle} ${String(model.id)}`.trim();
 
 /**
+ * cmdk's `defaultFilter` accepts any subsequence, so o-p-u-s scattered across
+ * "Claude Sonnet 4.5 Anthropic anthropic/claude-sonnet-4.5" scores above zero
+ * and renders under a search for "opus". Real matches score ~0.89+ against the
+ * hosted catalog while that incidental noise tops out near 0.17, so anything
+ * below this is treated as no match.
+ */
+const MIN_MODEL_SEARCH_SCORE = 0.3;
+
+/**
+ * The threshold is applied per word rather than to the whole query, because
+ * cmdk scores a multi-word search as one gapped subsequence and the gaps drag
+ * even an exact hit under it — "gemini 3 pro" scores 0.168 against Gemini 3.1
+ * Pro Preview, while its words score 0.99 each. Single-character words are
+ * exempt: they only clear the threshold when they start a word, so gating on
+ * them would drop every Qwen3 Coder row from a search for "qwen 3 coder".
+ * cmdk's own score is returned untouched so ranking is unchanged.
+ */
+export const modelFilter = (
+  value: string,
+  search: string,
+  keywords?: string[]
+): number => {
+  const score = defaultFilter(value, search, keywords);
+  if (score <= 0) {
+    return 0;
+  }
+
+  const words = search.split(/\s+/).filter((word) => word.length > 1);
+  const everyWordMatches = words.every(
+    (word) => defaultFilter(value, word, keywords) >= MIN_MODEL_SEARCH_SCORE
+  );
+
+  return everyWordMatches ? score : 0;
+};
+
+/**
  * Provider headings are plain rows, not `CommandGroup`s, so cmdk's own
  * empty-group hiding never applies to them: without this, a search shows a
- * heading for every provider even when it has no matching model. Scoring with
- * cmdk's `defaultFilter` keeps the heading's visibility in lockstep with the
- * rows cmdk itself keeps.
+ * heading for every provider even when it has no matching model. This must
+ * score with the same `modelFilter` the `Command` below is given — the two
+ * drifting apart is what left headings stranded over no rows once already.
  */
 const groupHasMatch = (group: ModelGroup, search: string): boolean =>
   group.models.some(
-    (model) => defaultFilter(modelSearchValue(model, group.title), search) > 0
+    (model) => modelFilter(modelSearchValue(model, group.title), search) > 0
   );
 
 function sameModelOrder(
@@ -677,7 +713,7 @@ export function ModelSelector({
           sideOffset={8}
           collisionPadding={8}
         >
-          <Command shouldFilter={true}>
+          <Command shouldFilter={true} filter={modelFilter}>
             <CommandInput
               placeholder="Search models"
               value={search}


### PR DESCRIPTION
Follow-up to #3712.

#3712 hid provider headings with no matching rows. It didn't touch row scoring, so a heading with one junk row still rendered and real searches carried noise.

cmdk's `defaultFilter` accepts any subsequence. "Claude Sonnet 4.5 Anthropic anthropic/claude-sonnet-4.5" contains o-p-u-s in order, so it scores above zero under a search for "opus" and renders. Measured against the 173-model hosted catalog (`hostedModelDefinitionsFromSnapshot()`):

| query | kept | real | junk |
| --- | --- | --- | --- |
| `opus` | 14/173 | 7 Opus rows @ 0.891 | 4 Claude Sonnet @ 0.026, Mercury Coder Small, Nemotron 3 Super, Qwen3 Coder Plus |
| `sonnet` | 14/173 | 4 Sonnet rows @ 0.891 | 3 Gemini Flash Lite @ 0.0003, 5 GPT rows, Claude Opus 4.6 Fast @ 0.0001 |
| `gpt` | 40/173 | 34 GPT rows @ 0.990 | Glm 5 Turbo @ 0.149, Gemini 3.1 Flash Lite Preview @ 0.145, Kimi K2.7 @ 0.005 |

## The fix

`Command` gets a custom `filter` that zeroes anything cmdk scores below `MIN_MODEL_SEARCH_SCORE` (0.3). Real matches score 0.89+ and incidental hits top out at 0.166, so the band is wide. The design-system `Command` spreads its props into `CommandPrimitive`, so `filter` passes through with no wrapper change.

`groupHasMatch` scores through the same `modelFilter`. If the rows get a stricter filter and the headings don't, they drift apart again — the exact bug #3712 closed. There's a comment on it, since that coupling has now bitten twice.

## Per-word, not per-query

The planned shape — threshold the whole query's score — breaks multi-word search. cmdk scores a multi-word query as one gapped subsequence, and the gaps sink even an exact hit well under any useful threshold:

```
"gemini 3 pro" vs "Gemini 3.1 Pro Preview Google google/gemini-3.1-pro-preview"  ->  0.168
```

A 0.3 cutoff would delete the exact row you're typing toward. So the threshold applies to each whitespace-separated word instead, and cmdk's own score is returned untouched so ranking is unchanged.

Single-character words are exempt. A bare `3` only clears the threshold when it starts a word, so gating on it dropped Qwen3 Coder, Qwen3 Coder Next and Qwen3 Coder Plus from `qwen 3 coder` while keeping only Qwen3 Coder 30b A3b.

## Validation

Scored the full hosted catalog through the candidate filter. Whole-word, mid-word and multi-word queries all resolve to the rows you'd expect:

```
"opus":         14 -> 7    dropped: 4 Claude Sonnet, Mercury Coder Small, Nemotron 3 Super, Qwen3 Coder Plus
"son":          33 -> 4    kept: the 4 Claude Sonnet rows
"gpt":          40 -> 34   dropped: Glm 5 Turbo, Glm 5v Turbo, Glm 5.2 Fast, Gemini 3.1 Flash Lite Preview, ...
"hai":          53 -> 2
"nano":         70 -> 10   kept: 3 Nemotron Nano, 3 GPT Nano, 4 Nova
"llama":        36 -> 3
"4.5":          11 -> 7    dropped: the Gpt 5.4 rows
"gemini 3 pro":  3 -> 1    kept: Gemini 3.1 Pro Preview
"qwen 3 coder":  4 -> 4
"grok 4 fast":   2 -> 2
```

Also walked every prefix of 25 whole queries against the row each one aims at, to confirm no target ever dips below the threshold mid-typing.

## Tests

Extends `chat-v2/__tests__/model-selector.test.tsx`:

- searching `opus` shows the Opus row but not Claude Sonnet 4.5 or Qwen3 Coder Plus
- the Qwen heading disappears when its only match is a weak one
- `claude opus 4.5` keeps the Opus row

Plus a `modelFilter` unit block pinning the score band, so a cmdk bump that reshapes `defaultFilter` fails loudly instead of silently loosening search. One case asserts `defaultFilter("gemini 3 pro") < 0.3` while `modelFilter` keeps it — that's the guard against someone re-applying the threshold to the whole query.

All four behavior tests were confirmed red against the pre-fix filter.

`npm run typecheck` exits 0. `npx vitest run client/src/components/chat-v2` — 54 files, 757 tests, all passing.

Not narrowing the scored string to `model.name`: searching by provider name ("anthropic", "openai") is intentional and would regress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops weak fuzzy matches from showing in the Model Picker and hides provider headings that only had junk results. Adds a per-word threshold to `cmdk` scoring so search results match user intent while keeping ranking.

- **Bug Fixes**
  - Implemented a per‑word `modelFilter` over `cmdk` that zeroes matches below 0.3; single‑character words are exempt; kept results preserve `cmdk`’s ranking.
  - Applied the same filter to both the `Command` list (via `filter` prop) and the heading visibility check to keep them in sync.
  - Searchable text still includes model name, provider, and id to preserve provider‑name searches.

- **Tests**
  - Behavior tests for dropping weak matches (e.g., “opus”), hiding headings with only weak hits, and keeping exact multi‑word targets (e.g., “claude opus 4.5”).
  - Unit tests for `modelFilter` pin the score band against `defaultFilter`, verify multi‑word queries that `cmdk` scores low are kept, and confirm ranking is unchanged for kept matches.

<sup>Written for commit 46ffc8d551baf69b553b22da45748a2041201bcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

