### PR TITLE
fix(tests): freeze clock in host-comparison verified-date test

### DIFF
--- a/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/comparison/__tests__/host-config-comparison-matrix.test.tsx
@@ -113,6 +113,14 @@ describe("HostConfigComparisonMatrix", () => {
       Date.UTC(2026, 6, 8)
     );
 
+    // Freeze the clock 2 days after the verified date so it stays inside the
+    // 30-day "recent" window. Without this the test is a time bomb: it passed
+    // when written in mid-July 2026, then broke once real time crossed 30 days
+    // past the hardcoded date and the row flipped to "Last checked over 30 days
+    // ago". Mirrors the frozen-clock setup in the sibling test below.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T00:00:00.000Z"));
+
     const { rerender } = render(
       <HostConfigComparisonMatrix subjects={[subject]} />
     );


### PR DESCRIPTION
## What

Fixes a time-dependent unit test that started failing on **every** PR without any code change.

`host-config-comparison-matrix.test.tsx` → *"shows per-host verified dates only in public caniuse mode"* hardcodes a verified date of `2026-07-08` and asserts that date renders in the matrix — but it never froze the clock, so it depended on the real system time.

## Root cause

`HostConfigComparisonMatrix` only renders the literal date when the check is within the last 30 days; otherwise it renders **"Last checked over 30 days ago"**. Once real time passed 30 days after the hardcoded `2026-07-08`, the row flipped to the stale message and `getByText("2026-07-08")` could no longer find it:

```
TestingLibraryElementError: Unable to find an element with the text: 2026-07-08
  128|  expect(screen.getByText("Verified at")).toBeInTheDocument();
  129|  expect(screen.getByText("2026-07-08")).toBeInTheDocument();
```

The test was effectively a time bomb — green when written in mid-July 2026, self-breaking once the calendar crossed the 30-day line. It is currently red on `main`, blocking CI for all open PRs.

## Fix

Freeze the clock to `2026-07-10` (2 days after the verified date, inside the 30-day window) with `vi.useFakeTimers()` / `vi.setSystemTime(...)` — exactly mirroring the frozen-clock setup already used by the sibling *"flags caniuse hosts checked over 30 days ago"* test right below it. The existing `afterEach(() => vi.useRealTimers())` restores real timers.

**Test-only change — no product code touched.**

## Verification

```
npm run test -w @mcpjam/inspector -- host-config-comparison-matrix
→ Test Files 1 passed (1)
→ Tests 21 passed (21)
```

Includes the previously-failing test and the sibling stale-date test.

## Note / possible follow-up

This was the one test currently detonating. A broader sweep for other hardcoded-recent-date fixtures that lean on the real clock could be worth a follow-up, but is intentionally out of scope here to keep this a focused CI unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze the clock in the `HostConfigComparisonMatrix` test to stabilize a time-dependent assertion and unblock CI. The test now stays within the 30‑day “recent” window instead of flipping to “over 30 days ago” based on real time.

- **Bug Fixes**
  - Use `vi.useFakeTimers()` and `vi.setSystemTime('2026-07-10T00:00:00Z')` to keep the hardcoded `2026-07-08` verified date within 30 days.
  - Mirrors the sibling stale-date test’s setup; test-only change, no product code.

<sup>Written for commit f79c9c0994c298e0dc21298f8b5abb08935c6062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

