### PR TITLE
feat(user-testing): agent tools address environments and scenarios

### DIFF
--- a/mcpjam-inspector/client/src/components/UserTestingTab.tsx
+++ b/mcpjam-inspector/client/src/components/UserTestingTab.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { AlertTriangle, Boxes, Inbox, Loader2, Plus } from "lucide-react";
-import { useConvexAuth, useMutation } from "convex/react";
+import { useConvexAuth } from "convex/react";
 import { toast } from "@/lib/toast";
 import { Button } from "@mcpjam/design-system/button";
 import { UserTestingOverviewPanel } from "@/components/chatboxes/UserTestingOverviewPanel";
@@ -14,7 +14,10 @@ import {
   useChatboxMutations,
   useEnvironmentChatboxMutations,
 } from "@/hooks/useChatboxes";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
+import { environmentLabel } from "@/lib/environment-label";
+import { settingsFromChatboxAccessPreset } from "@/lib/chatbox-access-presets";
 import { isDeliberateScenario } from "@/lib/user-testing-scenarios";
 import { useHostList, useHostMutations } from "@/hooks/useClients";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
@@ -97,13 +100,20 @@ export function UserTestingTab({
     projectId,
   });
   const listLoading = queryable && listQueryLoading;
-  // Still needed for the agent's host-addressed publish tool (re-pointed at
-  // scenario identity in a follow-up) and for the Swarms dead-end below.
+  // Only for the Swarms dead-end below: a standalone Journeys host has no
+  // chatbox, so an old link to one resolves to nothing and deserves a better
+  // answer than "not found".
   const { hosts, isLoading: hostsQueryLoading } = useHostList({
     isAuthenticated: effectiveAuth,
     projectId,
   });
   const hostsLoading = queryable && hostsQueryLoading;
+  // What the agent's publish tool addresses, and what the snapshot advertises.
+  const environments = useProjectEnvironments(queryable ? projectId : null);
+  const liveEnvironments = useMemo(
+    () => (environments ?? []).filter((env) => !env.archivedAt),
+    [environments],
+  );
 
   // Which rows are SCENARIOS. Every client mints a chatbox row whether or not
   // anyone meant to test with it (three of them are seeded into an empty
@@ -171,13 +181,8 @@ export function UserTestingTab({
   // intentional deletes, and a stuck-timer). All of it is gone: a scenario is
   // now addressed by the chatbox that already exists, so there is nothing to
   // back-mint on the way in. A host without a chatbox simply has no scenario.
-  //
-  // The mutation itself survives for ONE caller — the agent's host-addressed
-  // publish tool below, where provisioning is the explicit request rather than
-  // a side effect of looking at a URL.
-  const ensureChatboxForHost = useMutation(
-    "chatboxes:ensureChatboxForHost" as any,
-  );
+  // `chatboxes:ensureChatboxForHost` has no caller on this surface any more —
+  // the agent's publish tool publishes an environment, like the create flow.
 
   // Legacy deep links: `/chatboxes?host=X&session=Y` redirects here with its
   // query intact, so translate it into the scenario path. Every session link
@@ -230,30 +235,45 @@ export function UserTestingTab({
     }
   };
 
-  // Exact resolution against the loaded host list — unknown or ambiguous →
-  // invalid_request, never a fuzzy guess.
-  const resolveAgentHost = (raw: unknown) => {
+  /**
+   * Exact resolution by id or by the name shown on screen — unknown or
+   * ambiguous is `invalid_request`, never a fuzzy guess. Both commands act on
+   * the wrong thing silently if resolution guesses, so it refuses instead and
+   * says how to disambiguate.
+   */
+  const resolveAgentTarget = <T,>(
+    raw: unknown,
+    args: {
+      field: string;
+      noun: string;
+      rows: T[];
+      idOf: (row: T) => string;
+      nameOf: (row: T) => string;
+    },
+  ): T => {
     if (typeof raw !== "string" || raw.trim().length === 0) {
       throw createInspectorCommandClientError(
         "invalid_request",
-        "Missing required 'host' string (a client name or id).",
+        `Missing required '${args.field}' string (a ${args.noun} name or id).`,
       );
     }
     const wanted = raw.trim();
     const wantedLower = wanted.toLowerCase();
-    const matches = hosts.filter(
-      (h) => h.hostId === wanted || h.name.toLowerCase() === wantedLower,
+    const matches = args.rows.filter(
+      (row) =>
+        args.idOf(row) === wanted ||
+        args.nameOf(row).toLowerCase() === wantedLower,
     );
     if (matches.length === 1) return matches[0];
     if (matches.length === 0) {
       throw createInspectorCommandClientError(
         "invalid_request",
-        `No client matches "${wanted}". Use a client name or id from this screen (list them with ui_snapshot_app).`,
+        `No ${args.noun} matches "${wanted}". Use a ${args.noun} name or id from this screen (list them with ui_snapshot_app).`,
       );
     }
     throw createInspectorCommandClientError(
       "invalid_request",
-      `${matches.length} clients match "${wanted}" — pass the client id instead (ids are in ui_snapshot_app).`,
+      `${matches.length} ${args.noun}s match "${wanted}" — pass the ${args.noun} id instead (ids are in ui_snapshot_app).`,
     );
   };
 
@@ -265,33 +285,47 @@ export function UserTestingTab({
       publishChatbox: async (command) => {
         requireAgentOperable();
         const { payload } = command as PublishChatboxInspectorCommand;
-        const target = resolveAgentHost(payload?.host);
-        // Swarms-owned dead-end: a standalone Journeys host has NO share
-        // surface and must never be back-minted one — the same reason the
-        // "Managed by Swarms" notice shows.
-        if (target.ownerScope?.type === "journeys") {
+        // The tool publishes an environment, so a project without the
+        // environments surface has nothing it can act on. Refusing beats
+        // falling back to minting a client, which is the thing the scenario
+        // list stopped showing.
+        if (!environmentsEnabled) {
           throw createInspectorCommandClientError(
             "unsupported_in_mode",
-            `"${target.name}" belongs to the Swarms surface and has no share surface. Manage its journeys and runs on the Swarms screen, or publish a different client.`,
+            "Publishing a scenario needs Environments, which isn't enabled for this project. Create the scenario from the New scenario screen instead.",
           );
         }
+        const target = resolveAgentTarget(payload?.environment, {
+          field: "environment",
+          noun: "environment",
+          rows: liveEnvironments,
+          idOf: (env) => env.environmentId,
+          nameOf: (env) => environmentLabel(env),
+        });
         try {
-          // The mutation is idempotent and returns the chatbox either way, so
-          // its id is what we navigate with — no round trip through the
-          // legacy host-id redirect.
-          const settings = (await ensureChatboxForHost({
-            hostId: target.hostId,
-          } as any)) as { chatboxId: string } | null;
-          if (!settings?.chatboxId) {
-            throw new Error("Publishing returned no scenario.");
-          }
-          navigate(buildUserTestingScenarioPath(settings.chatboxId));
+          const result = await publishEnvironmentChatbox({
+            environmentId: target.environmentId,
+            ...(payload?.name ? { name: payload.name } : {}),
+            ...(payload?.access
+              ? {
+                  mode: settingsFromChatboxAccessPreset(payload.access).mode,
+                }
+              : {}),
+          });
+          navigate(buildUserTestingScenarioPath(result.chatboxId));
           return {
             status: "chatbox_published",
-            scenarioId: settings.chatboxId,
-            hostId: target.hostId,
-            name: target.name,
-            note: "The client's scenario is provisioned and open. Copying its share link is a human action — check ui_snapshot_app for whether a link exists.",
+            scenarioId: result.chatboxId,
+            environmentId: target.environmentId,
+            name: result.name,
+            mode: result.mode,
+            // Says which happened: re-publishing keeps the existing scenario's
+            // name and access, so reporting "created" either way would be a
+            // lie the model then repeats to the user.
+            created: result.created,
+            note: result.created
+              ? "The scenario is published and open. Copying its share link is a human action — check ui_snapshot_app for whether a link exists."
+              : "That environment was already published; its existing scenario is open, with the name and access it already had.",
           };
         } catch (e) {
           throw createInspectorCommandClientError(
@@ -303,27 +337,30 @@ export function UserTestingTab({
       deleteChatbox: async (command) => {
         requireAgentOperable();
         const { payload } = command as DeleteChatboxInspectorCommand;
-        const target = resolveAgentHost(payload?.host);
-        // Host-addressed, so it deletes the host's OWN publish surface — never
-        // an environment-backed row that merely displays this host (same rule
-        // as the backend's `getHostPublishChatbox`).
-        const match = rows.find(
-          (c) => c.namedHostId === target.hostId && !c.environmentId,
-        );
-        if (!match) {
-          throw createInspectorCommandClientError(
-            "invalid_request",
-            `"${target.name}" has no scenario to delete.`,
-          );
-        }
+        // Resolved against the SAME rows the snapshot advertises, so the agent
+        // can only delete something it (and the user) can see. A row the list
+        // filters out is not addressable here.
+        const target = resolveAgentTarget(payload?.scenario, {
+          field: "scenario",
+          noun: "scenario",
+          rows,
+          idOf: (row) => row.chatboxId,
+          nameOf: (row) => row.name,
+        });
         try {
-          await deleteChatbox({ chatboxId: match.chatboxId } as any);
+          await deleteChatbox({ chatboxId: target.chatboxId } as any);
           return {
             status: "chatbox_deleted",
-            scenarioId: match.chatboxId,
-            hostId: target.hostId,
-            chatboxId: match.chatboxId,
+            scenarioId: target.chatboxId,
+            chatboxId: target.chatboxId,
             name: target.name,
+            // Deleting a published scenario never touches the environment it
+            // was published from; saying so keeps the model from reporting
+            // more damage than was done.
+            environmentId: target.environmentId ?? null,
+            note: target.environmentId
+              ? "The scenario and its history are gone. The environment it was published from is unchanged."
+              : "The scenario and its history are gone.",
           };
         } catch (e) {
           throw createInspectorCommandClientError(
@@ -365,6 +402,14 @@ export function UserTestingTab({
         activeView,
         scenarioCount: scenarios.length,
         scenarios,
+        // What `ui_publish_chatbox` addresses. Without this the agent would
+        // have to guess an environment name, and exact resolution would refuse
+        // it — the tool's own input is only discoverable here.
+        environments: liveEnvironments.map((env) => ({
+          environmentId: env.environmentId,
+          name: environmentLabel(env),
+          published: rows.some((r) => r.environmentId === env.environmentId),
+        })),
       };
       if (activeView !== "detail") return base;
       const sessions = (agentSessionThreads ?? [])

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.agent.test.tsx
@@ -1,20 +1,25 @@
 /**
  * UserTestingTab agent bridge handlers. Commands are dispatched through the
- * real command bus against a mounted UserTestingTab; the ensure/delete
- * mutations, the host list and the chatbox list are mocked so the handlers act
- * through the SAME callbacks the buttons/dialogs use.
+ * real command bus against a mounted UserTestingTab; the publish/delete
+ * mutations, the environment list and the chatbox list are mocked so the
+ * handlers act through the SAME callbacks the buttons and dialogs use.
  *
  * Findings this pins:
- * - publish resolves a host, provisions its scenario, and OPENS the scenario
- *   route (the surface has no in-page selection any more — the URL is the
- *   view state, so "select it" means navigate);
- * - publish HONORS the Swarms-owned dead-end (unsupported_in_mode, no ensure);
- * - host resolution is EXACT: unknown and ambiguous both fail invalid_request
+ * - publish targets an ENVIRONMENT, carries name/access in the SAME mutation,
+ *   and OPENS the scenario route (the surface has no in-page selection any
+ *   more — the URL is the view state, so "select it" means navigate);
+ * - re-publishing reports `created: false` and the EXISTING name/access rather
+ *   than claiming it made something;
+ * - publish refuses when Environments is off, instead of falling back to
+ *   minting a client — the thing the scenario list stopped showing;
+ * - resolution is EXACT: unknown and ambiguous both fail invalid_request
  *   without touching a mutation;
- * - delete maps to deleteChatbox, and a deleted scenario STAYS deleted;
+ * - delete addresses a SCENARIO, can only reach rows the list advertises, and
+ *   leaves the environment behind it alone;
+ * - a deleted scenario STAYS deleted (nothing re-provisions it);
  * - every command is refused when signed out;
  * - the snapshot reports redacted state and NEVER the share token / transcript
- *   text / visitor PII.
+ *   text / visitor PII, and advertises the environments publish addresses.
  */
 import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -185,14 +190,16 @@ const sessionThreads: SharedChatThread[] = [
 ];
 
 const {
-  ensureChatboxForHostMock,
+  publishEnvironmentChatboxMock,
   deleteChatboxMock,
   navigateMock,
   hostListState,
   chatboxState,
   usageState,
+  environmentsState,
+  flagState,
 } = vi.hoisted(() => ({
-  ensureChatboxForHostMock: vi.fn(),
+  publishEnvironmentChatboxMock: vi.fn(),
   deleteChatboxMock: vi.fn(),
   navigateMock: vi.fn(),
   // Mutable so a case can vary the host list (ambiguity) or drop the scenario's
@@ -204,6 +211,8 @@ const {
     breakdown: undefined,
     rebuild: vi.fn(),
   },
+  environmentsState: { value: [] as any[] },
+  flagState: { enabled: true },
 }));
 
 vi.mock("react-router", () => ({
@@ -213,10 +222,7 @@ vi.mock("react-router", () => ({
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true }),
-  useMutation: (name: string) =>
-    name === "chatboxes:ensureChatboxForHost"
-      ? ensureChatboxForHostMock
-      : vi.fn(),
+  useMutation: () => vi.fn(),
 }));
 
 // The surface resolves `:scenarioId` out of the host LIST — there is no
@@ -233,15 +239,19 @@ vi.mock("@/hooks/useChatboxes", () => ({
   useChatboxList: () => ({ chatboxes: listRows, isLoading: false }),
   useChatboxMutations: () => ({ deleteChatbox: deleteChatboxMock }),
   useEnvironmentChatboxMutations: () => ({
-    publishEnvironmentChatbox: vi.fn(),
+    publishEnvironmentChatbox: publishEnvironmentChatboxMock,
   }),
 }));
 
-// The agent suite drives host-addressed commands; the list filter is exercised
-// in UserTestingTab.scenario-list.test.tsx. Off here so its host-backed
-// fixtures stay visible to the snapshot.
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => environmentsState.value,
+}));
+
+// The list filter itself is exercised in UserTestingTab.scenario-list.test.tsx;
+// here it is ON so the fixtures the snapshot and the delete tool see are the
+// SAME rows a user sees.
 vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
-  useProjectEnvironmentsEnabled: () => false,
+  useProjectEnvironmentsEnabled: () => flagState.enabled,
 }));
 
 vi.mock("@/hooks/useUsageInsights", () => ({
@@ -305,111 +315,189 @@ beforeEach(() => {
   chatboxState.chatbox = { ...scenarioChatbox };
   chatboxState.isLoading = false;
   usageState.threads = sessionThreads;
-  // The publish handler navigates with the id the mutation returns, so the
-  // mock has to behave like the real (idempotent) mutation and return a row.
-  ensureChatboxForHostMock.mockResolvedValue({ chatboxId: "cb-2" });
+  flagState.enabled = true;
+  environmentsState.value = [
+    { environmentId: "env-1", name: "Checkout flow", revision: 1 },
+    { environmentId: "env-2", name: "Onboarding", revision: 1 },
+    // Two environments legitimately share a name; only the ambiguity case
+    // depends on it.
+    { environmentId: "env-3", name: "Onboarding", revision: 1 },
+  ];
+  // Behaves like the real (idempotent) mutation: returns the row either way.
+  publishEnvironmentChatboxMock.mockResolvedValue({
+    chatboxId: "cb-env",
+    environmentId: "env-1",
+    name: "Checkout flow",
+    mode: "invited_only",
+    created: true,
+    link: null,
+    accessVersion: 1,
+  });
   deleteChatboxMock.mockResolvedValue(undefined);
 });
 
 describe("UserTestingTab — agent bridge handlers", () => {
-  it("publishChatbox resolves the host, ensures its scenario, and opens it", async () => {
+  it("publishChatbox publishes an ENVIRONMENT and opens the scenario", async () => {
     renderUserTesting();
     const response = await dispatch({
       type: "publishChatbox",
-      payload: { host: "Cursor" },
+      payload: { environment: "Checkout flow", access: "link_guests" },
     });
+
     expect(response).toMatchObject({
       status: "success",
       result: {
         status: "chatbox_published",
-        scenarioId: "cb-2",
-        hostId: "host-2",
-        name: "Cursor",
+        scenarioId: "cb-env",
+        environmentId: "env-1",
+        created: true,
       },
     });
-    expect(ensureChatboxForHostMock).toHaveBeenCalledWith({ hostId: "host-2" });
-    // Selection is the ROUTE now (buildUserTestingScenarioPath), not in-page
-    // state — a publish that ensured but never navigated leaves the agent
-    // reporting a scenario the user cannot see. It navigates with the id the
-    // mutation returned rather than the host id, so there is no redirect hop.
-    expect(navigateMock).toHaveBeenCalledWith("/user-testing/cb-2");
+    // Access rides in the SAME mutation as the publish — never a follow-up
+    // setChatboxMode, which would leave a window in the wrong mode.
+    expect(publishEnvironmentChatboxMock).toHaveBeenCalledWith({
+      environmentId: "env-1",
+      mode: "anyone_with_link",
+    });
+    // Selection is the ROUTE, not in-page state: a publish that never
+    // navigated leaves the agent reporting a scenario the user cannot see.
+    expect(navigateMock).toHaveBeenCalledWith("/user-testing/cb-env");
   });
 
-  it("publishChatbox HONORS the Swarms-owned dead-end without ensuring", async () => {
+  it("publishChatbox passes a name through, and reports an already-published environment honestly", async () => {
+    publishEnvironmentChatboxMock.mockResolvedValue({
+      chatboxId: "cb-env",
+      environmentId: "env-1",
+      name: "Round 1",
+      mode: "invited_only",
+      created: false,
+      link: null,
+      accessVersion: 1,
+    });
     renderUserTesting();
+
     const response = await dispatch({
       type: "publishChatbox",
-      payload: { host: "Journey bot" },
+      payload: { environment: "env-1", name: "Round 2" },
     });
-    const error = expectCommandError(response);
-    expect(error.code).toBe("unsupported_in_mode");
-    expect(error.message).toContain("Swarms");
-    expect(ensureChatboxForHostMock).not.toHaveBeenCalled();
-    expect(navigateMock).not.toHaveBeenCalled();
+
+    expect(publishEnvironmentChatboxMock).toHaveBeenCalledWith({
+      environmentId: "env-1",
+      name: "Round 2",
+    });
+    // Re-publishing keeps the EXISTING name and access (backend #887), so
+    // claiming it was created — or renamed — would be a lie the model repeats.
+    expect(response).toMatchObject({
+      status: "success",
+      result: { created: false, name: "Round 1", mode: "invited_only" },
+    });
+    expect((response as any).result.note).toMatch(/already published/i);
   });
 
-  it("rejects an unknown host as invalid_request on both commands", async () => {
+  it("publishChatbox refuses when Environments is off, rather than minting a client", async () => {
+    flagState.enabled = false;
+    renderUserTesting();
+
+    const error = expectCommandError(
+      await dispatch({
+        type: "publishChatbox",
+        payload: { environment: "Checkout flow" },
+      })
+    );
+    expect(error.code).toBe("unsupported_in_mode");
+    expect(publishEnvironmentChatboxMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown target as invalid_request on both commands", async () => {
     renderUserTesting();
     const publishError = expectCommandError(
-      await dispatch({ type: "publishChatbox", payload: { host: "Nope" } })
+      await dispatch({ type: "publishChatbox", payload: { environment: "Nope" } })
     );
     expect(publishError.code).toBe("invalid_request");
     const deleteError = expectCommandError(
-      await dispatch({ type: "deleteChatbox", payload: { host: "Nope" } })
+      await dispatch({ type: "deleteChatbox", payload: { scenario: "Nope" } })
     );
     expect(deleteError.code).toBe("invalid_request");
-    expect(ensureChatboxForHostMock).not.toHaveBeenCalled();
+    expect(publishEnvironmentChatboxMock).not.toHaveBeenCalled();
     expect(deleteChatboxMock).not.toHaveBeenCalled();
   });
 
-  it("rejects an AMBIGUOUS host name and asks for the id instead of guessing", async () => {
-    // Two clients legitimately share a name; picking either one would publish
-    // or delete the wrong scenario, so resolution refuses rather than guesses.
-    hostListState.hosts = [hostClaude, hostCursor, hostCursorTwin];
+  it("rejects an AMBIGUOUS environment name and asks for the id instead of guessing", async () => {
+    // Publishing the wrong environment hands testers the wrong setup, so
+    // resolution refuses rather than picking one.
     renderUserTesting();
     const error = expectCommandError(
-      await dispatch({ type: "publishChatbox", payload: { host: "Cursor" } })
+      await dispatch({ type: "publishChatbox", payload: { environment: "Onboarding" } })
     );
     expect(error.code).toBe("invalid_request");
     expect(error.message).toContain("id");
-    expect(ensureChatboxForHostMock).not.toHaveBeenCalled();
+    expect(publishEnvironmentChatboxMock).not.toHaveBeenCalled();
   });
 
-  it("deleteChatbox maps to the deleteChatbox mutation on the host's chatbox", async () => {
+  it("deleteChatbox addresses a SCENARIO by name and leaves its environment alone", async () => {
+    listRows = [
+      ...listRows,
+      {
+        ...chatboxList[0],
+        chatboxId: "cb-env",
+        name: "Checkout flow",
+        namedHostId: "host-1",
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      },
+    ];
     renderUserTesting();
+
     const response = await dispatch({
       type: "deleteChatbox",
-      payload: { host: "Cursor" },
+      payload: { scenario: "Checkout flow" },
     });
+
+    expect(deleteChatboxMock).toHaveBeenCalledWith({ chatboxId: "cb-env" });
     expect(response).toMatchObject({
       status: "success",
-      result: {
-        status: "chatbox_deleted",
-        scenarioId: "cb-2",
-        chatboxId: "cb-2",
-        name: "Cursor",
-      },
+      result: { status: "chatbox_deleted", scenarioId: "cb-env", environmentId: "env-1" },
     });
-    expect(deleteChatboxMock).toHaveBeenCalledWith({ chatboxId: "cb-2" });
+    expect((response as any).result.note).toMatch(/environment.*unchanged/i);
+  });
+
+  it("deleteChatbox can only reach rows the list actually advertises", async () => {
+    // An auto-minted client row is filtered out of the list; addressing it by
+    // name must not delete it behind the user's back.
+    listRows = [
+      {
+        ...chatboxList[0],
+        chatboxId: "cb-hidden",
+        name: "Copilot",
+        mode: "project_members",
+        link: null,
+        uniqueTesterCount: undefined,
+        lastSessionAt: undefined,
+      },
+    ];
+    renderUserTesting();
+
+    const error = expectCommandError(
+      await dispatch({ type: "deleteChatbox", payload: { scenario: "Copilot" } })
+    );
+    expect(error.code).toBe("invalid_request");
+    expect(deleteChatboxMock).not.toHaveBeenCalled();
   });
 
   it("keeps the OPEN scenario deleted — nothing re-provisions it", async () => {
-    // cb-1 (Claude) is the scenario on screen and is currently published.
     const { rerender } = renderUserTesting({ scenarioId: "cb-1" });
     const response = await dispatch({
       type: "deleteChatbox",
-      payload: { host: "Claude" },
+      payload: { scenario: "Claude" },
     });
     expect(response).toMatchObject({
       status: "success",
       result: { status: "chatbox_deleted", scenarioId: "cb-1" },
     });
-    expect(deleteChatboxMock).toHaveBeenCalledWith({ chatboxId: "cb-1" });
 
     // The reactive queries now report the row gone. This used to need a
     // suppression latch, because a back-mint effect read `chatbox === null` as
-    // drift and re-provisioned — contradicting chatbox_deleted. The surface no
-    // longer provisions anything, so the delete simply stands.
+    // drift and re-provisioned — contradicting chatbox_deleted.
     listRows = listRows.filter((row) => row.chatboxId !== "cb-1");
     chatboxState.chatbox = null;
     await act(async () => {
@@ -417,22 +505,24 @@ describe("UserTestingTab — agent bridge handlers", () => {
         <UserTestingTab projectId="proj-1" isAuthenticated scenarioId="cb-1" />
       );
     });
-    expect(ensureChatboxForHostMock).not.toHaveBeenCalled();
     expect(await screen.findByText(/Scenario not found/i)).toBeInTheDocument();
   });
 
   it("refuses every command as unsupported_in_mode when signed out", async () => {
     renderUserTesting({ isAuthenticated: false });
     const deleteError = expectCommandError(
-      await dispatch({ type: "deleteChatbox", payload: { host: "Cursor" } })
+      await dispatch({ type: "deleteChatbox", payload: { scenario: "Claude" } })
     );
     expect(deleteError.code).toBe("unsupported_in_mode");
     const publishError = expectCommandError(
-      await dispatch({ type: "publishChatbox", payload: { host: "Cursor" } })
+      await dispatch({
+        type: "publishChatbox",
+        payload: { environment: "Checkout flow" },
+      })
     );
     expect(publishError.code).toBe("unsupported_in_mode");
     expect(deleteChatboxMock).not.toHaveBeenCalled();
-    expect(ensureChatboxForHostMock).not.toHaveBeenCalled();
+    expect(publishEnvironmentChatboxMock).not.toHaveBeenCalled();
   });
 
   it("snapshot reports redacted state and NEVER the token / transcript / PII", async () => {
@@ -470,5 +560,23 @@ describe("UserTestingTab — agent bridge handlers", () => {
     expect(serialized).not.toContain(TRANSCRIPT);
     expect(serialized).not.toContain("jane@example.com");
     expect(serialized).not.toContain("Jane Visitor");
+  });
+
+  it("snapshot advertises the environments ui_publish_chatbox addresses", async () => {
+    // Exact resolution refuses a name it can't match, so the tool's own input
+    // has to be discoverable somewhere — this is that somewhere.
+    listRows = [
+      ...listRows,
+      { ...chatboxList[0], chatboxId: "cb-env", environmentId: "env-1" },
+    ];
+    renderUserTesting();
+
+    const snapshot = (await readSurfaceSnapshot("chatboxes")) as any;
+    expect(snapshot.data.environments).toEqual(
+      expect.arrayContaining([
+        { environmentId: "env-1", name: "Checkout flow", published: true },
+        { environmentId: "env-2", name: "Onboarding", published: false },
+      ])
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.journeys.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.journeys.test.tsx
@@ -61,7 +61,10 @@ vi.mock("@/hooks/useClients", () => ({
 }));
 
 vi.mock("@/hooks/useChatboxes", () => ({
-  useChatbox: (args: { isAuthenticated: boolean; chatboxId: string | null }) => {
+  useChatbox: (args: {
+    isAuthenticated: boolean;
+    chatboxId: string | null;
+  }) => {
     chatboxQuerySpy(args);
     return chatboxState;
   },
@@ -70,6 +73,12 @@ vi.mock("@/hooks/useChatboxes", () => ({
   useEnvironmentChatboxMutations: () => ({
     publishEnvironmentChatbox: vi.fn(),
   }),
+}));
+
+// The surface reads environments for the agent's publish tool and its
+// snapshot; these suites don't exercise either.
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => [],
 }));
 
 vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
@@ -133,7 +142,11 @@ function rowFixture(overrides: Partial<ChatboxListItem>): ChatboxListItem {
 
 function renderScenario(scenarioId: string = SCENARIO_HOST_ID) {
   return render(
-    <UserTestingTab projectId="proj-1" isAuthenticated scenarioId={scenarioId} />
+    <UserTestingTab
+      projectId="proj-1"
+      isAuthenticated
+      scenarioId={scenarioId}
+    />,
   );
 }
 
@@ -161,7 +174,7 @@ describe("UserTestingTab — scenario resolution", () => {
 
     expect(await screen.findByText(/Managed by Swarms/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Go to Swarms/i })
+      screen.getByRole("button", { name: /Go to Swarms/i }),
     ).toBeInTheDocument();
     await waitFor(() => {
       expect(ensureMock).not.toHaveBeenCalled();
@@ -226,7 +239,7 @@ describe("UserTestingTab — scenario resolution", () => {
 
     expect(await screen.findByText(/Scenario not found/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Back to User Testing/i })
+      screen.getByRole("button", { name: /Back to User Testing/i }),
     ).toBeInTheDocument();
     await waitFor(() => {
       expect(ensureMock).not.toHaveBeenCalled();

--- a/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.scenario-list.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/UserTestingTab.scenario-list.test.tsx
@@ -50,6 +50,12 @@ vi.mock("@/hooks/useChatboxes", () => ({
   }),
 }));
 
+// The surface reads environments for the agent's publish tool and its
+// snapshot; these suites don't exercise either.
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => [],
+}));
+
 vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
   useProjectEnvironmentsEnabled: () => flagState.enabled,
 }));

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/chatboxes.test.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/__tests__/chatboxes.test.ts
@@ -1,11 +1,10 @@
 /**
  * The chatboxes group's own contract: exact tool set, honest annotations (the
- * destructive set is exactly delete — irreversible
- * is irreversible; publish only provisions and is idempotent), dispatch shapes,
- * and command errors (the Swarms-owned dead-end + the generate model gate)
- * passing through as tool errors. The host/chatbox resolution and the
- * money-spending endpoints live in UserTestingTab's handlers (see
- * UserTestingTab.agent.test.tsx).
+ * destructive set is exactly delete — irreversible is irreversible; publish
+ * creates a share surface and converges, so it is idempotent), dispatch
+ * shapes, in-execute validation, and command errors passing through as tool
+ * errors. Resolving an environment/scenario to a row lives in UserTestingTab's
+ * handlers (see UserTestingTab.agent.test.tsx).
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { InspectorCommandResponse } from "@/shared/inspector-command.js";
@@ -82,24 +81,56 @@ describe("buildChatboxesUiTools", () => {
     }
   });
 
-  it("ui_publish_chatbox dispatches publishChatbox and requires a host", async () => {
-    await getTool("ui_publish_chatbox").execute({ host: "Claude" });
+  it("ui_publish_chatbox dispatches publishChatbox for an ENVIRONMENT", async () => {
+    await getTool("ui_publish_chatbox").execute({
+      environment: "Checkout flow",
+      access: "link_guests",
+      name: "Round 1",
+    });
     expect(dispatchInspectorCommandMock).toHaveBeenCalledWith({
       type: "publishChatbox",
-      payload: { host: "Claude" },
+      payload: {
+        environment: "Checkout flow",
+        access: "link_guests",
+        name: "Round 1",
+      },
     });
+  });
 
-    dispatchInspectorCommandMock.mockClear();
-    const missing = await getTool("ui_publish_chatbox").execute({ host: "  " });
+  it("ui_publish_chatbox omits absent optionals rather than sending empties", async () => {
+    // An empty string would be applied as the scenario's NAME.
+    await getTool("ui_publish_chatbox").execute({
+      environment: "Checkout flow",
+      name: "   ",
+    });
+    expect(dispatchInspectorCommandMock).toHaveBeenCalledWith({
+      type: "publishChatbox",
+      payload: { environment: "Checkout flow" },
+    });
+  });
+
+  it("ui_publish_chatbox validates in code, so the model can self-correct", async () => {
+    const missing = await getTool("ui_publish_chatbox").execute({
+      environment: "  ",
+    });
     expect(missing.isError).toBe(true);
+    expect(missing.content[0].text).toContain("environment");
+
+    const badAccess = await getTool("ui_publish_chatbox").execute({
+      environment: "Checkout flow",
+      access: "public",
+    });
+    expect(badAccess.isError).toBe(true);
+    // Names the accepted values rather than just refusing.
+    expect(badAccess.content[0].text).toContain("invited_only");
     expect(dispatchInspectorCommandMock).not.toHaveBeenCalled();
   });
 
-  it("ui_delete_chatbox dispatches deleteChatbox and requires a host", async () => {
-    await getTool("ui_delete_chatbox").execute({ host: "host-123" });
+  it("ui_delete_chatbox dispatches deleteChatbox for a SCENARIO", async () => {
+    await getTool("ui_delete_chatbox").execute({ scenario: "Checkout flow" });
     expect(dispatchInspectorCommandMock).toHaveBeenCalledWith({
       type: "deleteChatbox",
-      payload: { host: "host-123" },
+      payload: { scenario: "Checkout flow" },
     });
 
     dispatchInspectorCommandMock.mockClear();
@@ -108,31 +139,36 @@ describe("buildChatboxesUiTools", () => {
     expect(dispatchInspectorCommandMock).not.toHaveBeenCalled();
   });
 
-  it("surfaces the Swarms-owned dead-end (unsupported_in_mode) as a tool error", async () => {
+  it("surfaces the environments-off refusal (unsupported_in_mode) as a tool error", async () => {
     dispatchInspectorCommandMock.mockResolvedValue({
       id: "cmd-1",
       status: "error",
       error: {
         code: "unsupported_in_mode",
         message:
-          '"Journey bot" belongs to the Swarms surface and has no publish surface.',
+          "Publishing a scenario needs Environments, which isn't enabled for this project.",
       },
     } satisfies InspectorCommandResponse);
     const result = await getTool("ui_publish_chatbox").execute({
-      host: "Journey bot",
+      environment: "Checkout flow",
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("unsupported_in_mode");
-    expect(result.content[0].text).toContain("no publish surface");
+    expect(result.content[0].text).toContain("Environments");
   });
 
-  it("surfaces an unknown-host command error (invalid_request) as a tool error", async () => {
+  it("surfaces an unknown-target command error (invalid_request) as a tool error", async () => {
     dispatchInspectorCommandMock.mockResolvedValue({
       id: "cmd-1",
       status: "error",
-      error: { code: "invalid_request", message: 'No client matches "Nope".' },
+      error: {
+        code: "invalid_request",
+        message: 'No scenario matches "Nope".',
+      },
     } satisfies InspectorCommandResponse);
-    const result = await getTool("ui_delete_chatbox").execute({ host: "Nope" });
+    const result = await getTool("ui_delete_chatbox").execute({
+      scenario: "Nope",
+    });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("invalid_request");
   });

--- a/mcpjam-inspector/client/src/lib/webmcp/groups/chatboxes.ts
+++ b/mcpjam-inspector/client/src/lib/webmcp/groups/chatboxes.ts
@@ -1,19 +1,24 @@
 /**
- * Chatboxes-screen tools: publish a host's chatbox and delete it.
+ * User Testing tools: publish an environment as a scenario, and delete one.
  *
  * Mount-scoped like the evals/registry/hosts groups: `UserTestingTab` owns the
- * command handlers and the hosts/chatboxes they resolve against, so the tools
- * exist exactly while `/user-testing` is mounted. Deliberate postures:
+ * command handlers and the environments/scenarios they resolve against, so the
+ * tools exist exactly while `/user-testing` is mounted. Deliberate postures:
  *
- * - **Publish is host-anchored + respects the Swarms-owned dead-end.** A
- *   chatbox is the publish surface bound 1:1 to a host, so `ui_publish_chatbox`
- *   targets a host by name/id and provisions its chatbox the way the publish
- *   flow does (`ensureChatboxForHost`). It is idempotent (a host that already
- *   has a chatbox converges) and stays inside MCPJam. A standalone
- *   Journeys-owned host has NO publish surface — the handler refuses it as
- *   `unsupported_in_mode`, never back-minting one.
- * - **Delete is destructive.** `ui_delete_chatbox` removes a host's chatbox,
- *   its hosted link, and usage history.
+ * - **Publish is ENVIRONMENT-anchored.** A scenario is a published environment
+ *   — its client, servers and skills — behind a share link, so
+ *   `ui_publish_chatbox` targets an environment by name/id. It is idempotent:
+ *   an environment that is already published is opened rather than re-published,
+ *   and its access mode is left alone. Both `access` and `name` apply at
+ *   creation only, in the same mutation as the publish.
+ * - **Delete is destructive and SCENARIO-anchored.** `ui_delete_chatbox`
+ *   removes a scenario, its share link and its tester-session history — never
+ *   the environment behind it.
+ *
+ * Both address things by the name the human sees on screen (Chrome's "semantic
+ * values, not internal identifiers"), with ids accepted for disambiguation.
+ * Resolution is EXACT and refuses ambiguity rather than guessing, because both
+ * commands act on the wrong thing silently if they guess wrong.
  *
  * Read-only by design: reviewing sessions and copying the share link are human
  * actions surfaced in the snapshot, not tools. The share TOKEN never crosses
@@ -27,28 +32,42 @@ import {
 } from "../ui-actions";
 import { asOptionalString, errorResult, fromActionResult } from "./shared";
 
-const HOST_PROPERTY = {
-  type: "string",
-  description:
-    "Client (host) as the scenario list shows it: its name (e.g. 'Claude') or its host id. Scenarios are 1:1 with clients.",
-} as const;
+const ACCESS_VALUES = ["invited_only", "link_guests", "project"] as const;
+type AccessValue = (typeof ACCESS_VALUES)[number];
 
 export function buildChatboxesUiTools(): UiToolDefinition[] {
   return [
     {
       name: "ui_publish_chatbox",
       description:
-        "Publish a client's scenario on the User Testing screen — provision its shareable chat surface if it doesn't have one yet, and open that scenario. Idempotent: a client that already has a scenario just gets opened. A client that belongs to the Swarms surface has NO share surface and is refused (use Swarms for it instead). Copying the resulting share link is a human action — check ui_snapshot_app for whether a link exists.",
+        "Publish one of this project's environments as a User Testing scenario — a share link real testers can open, whose sessions come back as insights — and open that scenario. Use it when someone wants to hand their setup to real people and read what happened. Idempotent: an environment that is already published is opened as-is, keeping the access it already has. Copying the share link is a human action — check ui_snapshot_app for whether a link exists.",
       inputSchema: {
         type: "object",
-        properties: { host: HOST_PROPERTY },
-        required: ["host"],
+        properties: {
+          environment: {
+            type: "string",
+            description:
+              "Environment to publish, as the Environments screen names it (e.g. 'Checkout flow'), or its environment id.",
+          },
+          access: {
+            type: "string",
+            enum: [...ACCESS_VALUES],
+            description:
+              "Who may open the link: 'invited_only' (people invited by email), 'link_guests' (anyone with the link, including signed-out visitors, funded by this organization), or 'project' (signed-in project members). Applied when the scenario is created; defaults to 'invited_only'.",
+          },
+          name: {
+            type: "string",
+            description:
+              "What to call the scenario. Defaults to the environment's own name. Applied when the scenario is created.",
+          },
+        },
+        required: ["environment"],
         additionalProperties: false,
       },
       readOnly: false,
-      // Provisions (creates) rather than wipes, and re-publishing a client that
-      // already has a chatbox converges → idempotent, not destructive. Stays
-      // inside MCPJam.
+      // Creates a share surface rather than wiping one, and re-publishing an
+      // already-published environment converges on the same scenario →
+      // idempotent, not destructive. Stays inside MCPJam.
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -56,13 +75,30 @@ export function buildChatboxesUiTools(): UiToolDefinition[] {
         openWorldHint: false,
       },
       execute: async (args) => {
-        const host = asOptionalString(args.host);
-        if (!host) {
-          return errorResult("Missing required 'host' string (a client name or id).");
+        // Validate strictly here, loosely in the schema (Chrome): the errors
+        // are what let the model correct itself on the next turn.
+        const environment = asOptionalString(args.environment);
+        if (!environment) {
+          return errorResult(
+            "Missing required 'environment' string (an environment name or id — list them with ui_snapshot_app).",
+          );
         }
+        const access = asOptionalString(args.access);
+        if (access && !ACCESS_VALUES.includes(access as AccessValue)) {
+          return errorResult(
+            `Unknown access "${access}". Use one of: ${ACCESS_VALUES.join(
+              ", ",
+            )}.`,
+          );
+        }
+        const name = asOptionalString(args.name);
         const response = await dispatchInspectorCommand({
           type: "publishChatbox",
-          payload: { host },
+          payload: {
+            environment,
+            ...(access ? { access: access as AccessValue } : {}),
+            ...(name ? { name } : {}),
+          },
         });
         return fromActionResult(commandResponseToActionResult(response));
       },
@@ -70,16 +106,22 @@ export function buildChatboxesUiTools(): UiToolDefinition[] {
     {
       name: "ui_delete_chatbox",
       description:
-        "Permanently delete a client's scenario on the User Testing screen — its share link stops working and its saved tester-session history is cleared. Irreversible; be sure the user wants this exact client's scenario gone. Addressed by client name or id, exactly as the scenario list shows it.",
+        "Permanently delete a User Testing scenario — its share link stops working and its saved tester-session history is cleared. Irreversible; be sure the user wants this exact scenario gone. Addressed by scenario name or id, exactly as the scenario list shows it. The environment behind the scenario is left untouched.",
       inputSchema: {
         type: "object",
-        properties: { host: HOST_PROPERTY },
-        required: ["host"],
+        properties: {
+          scenario: {
+            type: "string",
+            description:
+              "Scenario to delete, as the User Testing list names it, or its scenario id.",
+          },
+        },
+        required: ["scenario"],
         additionalProperties: false,
       },
       readOnly: false,
-      // Irreversible delete → approval pill. Deleting an already-deleted chatbox
-      // fails cleanly rather than deleting something else.
+      // Irreversible delete → approval pill. Deleting an already-deleted
+      // scenario fails cleanly rather than deleting something else.
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
@@ -87,13 +129,15 @@ export function buildChatboxesUiTools(): UiToolDefinition[] {
         openWorldHint: false,
       },
       execute: async (args) => {
-        const host = asOptionalString(args.host);
-        if (!host) {
-          return errorResult("Missing required 'host' string (a client name or id).");
+        const scenario = asOptionalString(args.scenario);
+        if (!scenario) {
+          return errorResult(
+            "Missing required 'scenario' string (a scenario name or id — list them with ui_snapshot_app).",
+          );
         }
         const response = await dispatchInspectorCommand({
           type: "deleteChatbox",
-          payload: { host },
+          payload: { scenario },
         });
         return fromActionResult(commandResponseToActionResult(response));
       },

--- a/mcpjam-inspector/shared/inspector-command.ts
+++ b/mcpjam-inspector/shared/inspector-command.ts
@@ -576,15 +576,23 @@ export interface DeleteComputerInspectorCommand {
  */
 
 /**
- * Publish (provision-on-first-use) the chatbox for a host, then select that
- * host so the publish surface follows. Idempotent — calling `ensureChatboxForHost`
- * the way the publish flow does, so a host that already has a chatbox converges.
- * Refuses a Swarms-owned host (no publish surface).
+ * Publish an ENVIRONMENT as a User Testing scenario, then open it.
+ *
+ * The environment carries the client, servers and skills a tester will meet, so
+ * this addresses one by name or id. `access` and `name` are applied in the same
+ * mutation as the publish, so the scenario is never briefly live in a mode
+ * nobody asked for. Idempotent — an environment that is already published is
+ * returned and opened UNCHANGED, so a second call can never re-mode or rename
+ * a live scenario.
  */
 export interface PublishChatboxInspectorCommand {
   id: string;
   type: "publishChatbox";
-  payload: { host: string };
+  payload: {
+    environment: string;
+    access?: "invited_only" | "link_guests" | "project";
+    name?: string;
+  };
   timeoutMs?: number;
 }
 
@@ -597,11 +605,16 @@ export interface PublishChatboxInspectorCommand {
  * computer.
  */
 
-/** Permanently delete a host's chatbox — its hosted link and usage history. */
+/**
+ * Permanently delete a User Testing scenario — its share link and its saved
+ * tester-session history. Addressed by scenario name or id, exactly as the
+ * scenario list shows it; deleting an environment-backed scenario leaves the
+ * environment itself untouched.
+ */
 export interface DeleteChatboxInspectorCommand {
   id: string;
   type: "deleteChatbox";
-  payload: { host: string };
+  payload: { scenario: string };
   timeoutMs?: number;
 }
 


### PR DESCRIPTION
## Why

`ui_publish_chatbox` still took a **client** and provisioned its host chatbox — the exact kind of row #3765 stopped showing. An agent asked to "create a scenario" would mint one, and it wouldn't appear in the list. The tools were the last place the pre-environments model survived.

## Re-pointed, not duplicated

Chrome's WebMCP guidance is explicit that overlapping tools confuse the agent, and the catalog re-advertises on every chat POST — so the new semantics are picked up next turn without a host-addressed twin lingering beside them.

### `ui_publish_chatbox` → publishes an environment

`{ environment, access?, name? }`, resolved by the name the Environments screen shows or by id.

- `access` and `name` ride in the **same mutation** as the publish (#887), so a scenario is never briefly live in a mode nobody asked for.
- Re-publishing reports `created: false` with the **existing** name and access, rather than claiming it made something. The model repeats whatever we tell it.
- With Environments off it refuses as `unsupported_in_mode` instead of falling back to minting a client.

### `ui_delete_chatbox` → deletes a scenario

`{ scenario }`, resolved against the **same filtered rows the snapshot advertises** — an agent can only delete something the user can also see. A row the list filters out is not addressable.

Its result states that the environment behind the scenario is untouched, so the model doesn't report more damage than was done.

## Following the WebMCP guidance

- **Semantic values, not internal identifiers** — both tools take the name a human reads on screen; ids are accepted for disambiguation.
- **Validate strictly in code, loosely in schema** — validation lives in `execute` with descriptive errors, so an unknown `access` names the accepted values rather than just failing, and the model can self-correct.
- **Refuse rather than guess** — resolution is exact; unknown *and* ambiguous both refuse and say how to disambiguate, because publishing or deleting the wrong thing is silent when resolution guesses.
- Annotations unchanged and still honest: publish is idempotent/non-destructive, delete is destructive (approval pill).

## Snapshot

Now advertises the project's environments with a `published` flag. Exact resolution refuses a name it can't match, so without this the publish tool's own input would be discoverable nowhere. Still redacted: no share token, no transcript text, no visitor PII — asserted.

## Also

`chatboxes:ensureChatboxForHost` now has no caller on this surface.

## Tests

`UserTestingTab.agent.test.tsx` rewritten around the new addressing (11 cases): environment publish with access in one call; the `created: false` honesty case; the Environments-off refusal; exact + ambiguous resolution; scenario-addressed delete that leaves the environment alone; the "can only reach rows the list advertises" case; and the new snapshot assertion.

`groups/__tests__/chatboxes.test.ts` covers the tool contract itself, including that absent optionals are omitted rather than sent as empty strings (an empty `name` would become the scenario's name).

```
npx vitest run client/src/components/__tests__ client/src/lib/webmcp client/src/components/chatboxes
# 94 files, 1046 tests passed

npx vitest run client/src/components/chatboxes client/src/components/__tests__ client/src/lib \
  client/src/__tests__/ChatboxesRoute.billing.test.tsx client/src/components/project-environments/__tests__ client/src/hooks
# 332 files, 3617 tests passed

vite build --config client/vite.config.ts    # ✓ built
```

Note on formatting: `UserTestingTab.agent.test.tsx` doesn't satisfy `prettier --trailing-comma all` — it already didn't on main, so I left its pre-existing lines alone rather than reformatting a file this PR only partly touches. Every other file here was conformant and stayed conformant.

Last of the User Testing environment-first program (#3761 identity, #3765 create + list, this one the agent surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 070b29510474a3126176bad548ba981765bea04c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repointed User Testing agent tools to environments and scenarios. Publish now targets an environment and delete targets a scenario, fixing invisible rows and aligning with the environment-first model.

- **New Features**
  - `ui_publish_chatbox` publishes an environment: `{ environment, access?, name? }`. Resolves by on-screen name or id, applies `access`/`name` in the same mutation, returns `created`, and opens the scenario. Refuses with `unsupported_in_mode` when Environments is off.
  - `ui_delete_chatbox` deletes a scenario: `{ scenario }`. Resolves against the same filtered list the snapshot shows, deletes only the scenario, and leaves its environment untouched.
  - Snapshot now lists environments with `published` to make publish inputs discoverable. Redactions unchanged (no share token, transcript text, or visitor PII).
  - Exact resolution with descriptive errors; no fuzzy guesses. Removed host back-minting; no callers of `chatboxes:ensureChatboxForHost`. Tests updated.

- **Migration**
  - Update tool payloads: publish uses `environment` (plus optional `access`, `name`); delete uses `scenario`. Replace any host-based calls.
  - Publishing via tool needs Environments enabled; otherwise, create scenarios from the New scenario screen.

<sup>Written for commit 070b29510474a3126176bad548ba981765bea04c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

