### PR TITLE
feat(swarms): statline + Sankey-hero insights layout with drill-through panel

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxGoalOutcomeDrilldown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { AlertTriangle, ChevronRight, X } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import {
@@ -43,6 +43,10 @@ interface ChatboxGoalOutcomeDrilldownProps {
   filter: UsageFilterState;
   onClose: () => void;
   onOpenSession: (sessionId: string) => void;
+  /** Panel keeps the list itself scrollable when it is a flex sibling. */
+  variant?: "inline" | "panel";
+  /** Optional action/content rendered below the paged session list. */
+  footer?: ReactNode;
 }
 
 /**
@@ -133,6 +137,8 @@ export function ChatboxGoalOutcomeDrilldown({
   filter,
   onClose,
   onOpenSession,
+  variant = "inline",
+  footer,
 }: ChatboxGoalOutcomeDrilldownProps) {
   const open = selection !== null && !isEmptySelection(selection);
   const requestKey = requestKeyOf(scope, open ? selection : null, filter);
@@ -203,7 +209,13 @@ export function ChatboxGoalOutcomeDrilldown({
   const showEmpty = !isLoading && drilldown !== undefined && rows.length === 0;
 
   return (
-    <div className="flex flex-col gap-2 border-b bg-muted/20 px-5 py-4">
+    <div
+      className={
+        variant === "panel"
+          ? "flex h-full min-h-0 flex-col gap-2 px-4 py-3"
+          : "flex flex-col gap-2 border-b bg-muted/20 px-5 py-4"
+      }
+    >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="min-w-0">
           <h3 className="truncate text-sm font-medium">
@@ -241,7 +253,13 @@ export function ChatboxGoalOutcomeDrilldown({
         </div>
       ) : null}
 
-      <ul className="divide-y divide-border/60">
+      <ul
+        className={
+          variant === "panel"
+            ? "min-h-0 flex-1 overflow-y-auto divide-y divide-border/60"
+            : "divide-y divide-border/60"
+        }
+      >
         {rows.map((session) => (
           <li key={session._id}>
             <button
@@ -278,6 +296,8 @@ export function ChatboxGoalOutcomeDrilldown({
           Load {PAGE_SIZE} more
         </Button>
       ) : null}
+
+      {footer}
 
       {showEmpty ? (
         <p className="text-[11px] text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxInsightsSankey.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxInsightsSankey.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { AlertTriangle, Info, RefreshCw, Target } from "lucide-react";
 import {
   Tooltip,
@@ -24,6 +30,7 @@ import {
   type SankeyLayoutLink,
   type SankeyLayoutNode,
 } from "@/components/chatboxes/insights-sankey";
+import { cn } from "@/lib/utils";
 
 interface ChatboxInsightsSankeyProps {
   breakdown: UsageBreakdown | null | undefined;
@@ -54,6 +61,12 @@ interface ChatboxInsightsSankeyProps {
    * in the header row — e.g. a Session flow / Clusters toggle on swarms.
    */
   headerActions?: ReactNode;
+  /**
+   * Stretch into the parent height and re-lay the diagram to match the
+   * available pane (run-detail Insights). Default keeps content-sized height
+   * for scrollable surfaces like the chatbox usage panel.
+   */
+  fillHeight?: boolean;
 }
 
 /**
@@ -73,6 +86,56 @@ const VIEW_WIDTH = 1160;
 const LABEL_GUTTER = 260;
 /** Band at the top of the SVG holding the column headers. */
 const HEADER_HEIGHT = 26;
+
+function contentSankeyHeight(nodeCountWidestColumn: number): number {
+  return Math.max(320, nodeCountWidestColumn * 42 + 40);
+}
+
+/**
+ * Measure a flex child that should absorb leftover viewport height. Returns
+ * zero until the first layout so callers can fall back to content height.
+ *
+ * A callback ref, not useRef + effect: the pane div only mounts once the
+ * breakdown arrives (the loading/empty branches skip it), which is after a
+ * mount effect keyed on `enabled` has already run against a null ref — it
+ * would observe nothing and never re-attach, leaving the diagram at its
+ * content floor inside a full-height pane.
+ */
+function usePaneSize(enabled: boolean) {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const detachRef = useRef<(() => void) | null>(null);
+
+  const ref = useCallback(
+    (element: HTMLDivElement | null) => {
+      detachRef.current?.();
+      detachRef.current = null;
+      if (!enabled || !element) return;
+
+      const update = () => {
+        const width = Math.round(element.clientWidth);
+        const height = Math.round(element.clientHeight);
+        setSize((current) =>
+          current.width === width && current.height === height
+            ? current
+            : { width, height },
+        );
+      };
+
+      update();
+      if (typeof ResizeObserver === "undefined") {
+        window.addEventListener("resize", update);
+        detachRef.current = () => window.removeEventListener("resize", update);
+        return;
+      }
+      const observer = new ResizeObserver(update);
+      observer.observe(element);
+      detachRef.current = () => observer.disconnect();
+    },
+    [enabled],
+  );
+
+  return { ref, size };
+}
 
 function RebuildButton({
   onRebuild,
@@ -115,23 +178,43 @@ export function ChatboxInsightsSankey({
   showLinkThreshold,
   stageTitles,
   headerActions,
+  fillHeight = false,
 }: ChatboxInsightsSankeyProps) {
   const [hovered, setHovered] = useState<string | null>(null);
   const [readout, setReadout] = useState<string | null>(null);
+  const { ref: chartPaneRef, size: chartPaneSize } = usePaneSize(fillHeight);
 
   const sankey = breakdown?.sankey;
   const scan = breakdown?.scan;
   const signalsVersion = breakdown?.latestRun?.signalsVersion ?? null;
 
-  const height = useMemo(() => {
+  const contentHeight = useMemo(() => {
     const widest = Math.max(
       1,
       ...STAGE_ORDER.map(
         (stage) => sankey?.nodes.filter((n) => n.stage === stage).length ?? 0,
       ),
     );
-    return Math.max(320, widest * 42 + 40);
+    return contentSankeyHeight(widest);
   }, [sankey]);
+
+  // When filling the viewport, map the chart pane's CSS box into viewBox
+  // units at VIEW_WIDTH so `meet` can occupy the full pane without
+  // letterboxing. Never shrink below the content floor — overflow instead.
+  const height = useMemo(() => {
+    if (
+      !fillHeight ||
+      chartPaneSize.width <= 0 ||
+      chartPaneSize.height <= 0
+    ) {
+      return contentHeight;
+    }
+    const available = Math.round(
+      (chartPaneSize.height / chartPaneSize.width) * VIEW_WIDTH -
+        HEADER_HEIGHT,
+    );
+    return Math.max(contentHeight, available);
+  }, [fillHeight, chartPaneSize.height, chartPaneSize.width, contentHeight]);
 
   const layout = useMemo(() => {
     if (!sankey || sankey.nodes.length === 0) return null;
@@ -143,6 +226,14 @@ export function ChatboxInsightsSankey({
   }, [sankey, height]);
 
   const latestRun = breakdown?.latestRun ?? null;
+  const chartNeedsScroll =
+    fillHeight &&
+    chartPaneSize.height > 0 &&
+    height + HEADER_HEIGHT >
+      (chartPaneSize.width > 0
+        ? (chartPaneSize.height / chartPaneSize.width) * VIEW_WIDTH
+        : 0) +
+        1;
 
   /**
    * The tuning control, rendered in EVERY state including the two that return
@@ -165,7 +256,12 @@ export function ChatboxInsightsSankey({
 
   if (!breakdown) {
     return (
-      <div className="flex items-center justify-between gap-3 px-5 py-10 text-xs text-muted-foreground">
+      <div
+        className={cn(
+          "flex items-center justify-between gap-3 text-xs text-muted-foreground",
+          fillHeight ? "h-full px-0 py-6" : "px-5 py-10",
+        )}
+      >
         <span className="flex-1 text-center">Loading session flow…</span>
         <div className="flex items-center gap-2">
           {headerActions}
@@ -177,7 +273,12 @@ export function ChatboxInsightsSankey({
 
   if (!sankey || sankey.nodes.length === 0 || !layout) {
     return (
-      <div className="flex flex-col items-center gap-2 px-5 py-10 text-center">
+      <div
+        className={cn(
+          "flex flex-col items-center gap-2 text-center",
+          fillHeight ? "h-full justify-center px-0 py-6" : "px-5 py-10",
+        )}
+      >
         <Target className="h-6 w-6 text-muted-foreground/60" />
         <p className="text-sm font-medium">No session flow yet</p>
         <p className="max-w-md text-xs text-muted-foreground">
@@ -216,8 +317,17 @@ export function ChatboxInsightsSankey({
   );
 
   return (
-    <div className="flex flex-col gap-2 border-b px-5 py-4">
-      <div className="flex flex-wrap items-center justify-between gap-2">
+    <div
+      className={cn(
+        "flex flex-col gap-2",
+        fillHeight
+          ? "h-full min-h-0 overflow-hidden px-0 py-1"
+          : "border-b px-5 py-4",
+      )}
+      data-testid="chatbox-insights-sankey"
+      data-fill-height={fillHeight ? "true" : undefined}
+    >
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-medium">Session flow</h3>
           <Tooltip delayDuration={200}>
@@ -258,7 +368,7 @@ export function ChatboxInsightsSankey({
       {scan?.truncated ? (
         <div
           role="status"
-          className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning-foreground"
+          className="flex shrink-0 items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning-foreground"
         >
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
           <span>
@@ -277,7 +387,7 @@ export function ChatboxInsightsSankey({
       {analysisInFlight ? (
         <div
           role="status"
-          className="flex items-start gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground"
+          className="flex shrink-0 items-start gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground"
         >
           <RefreshCw className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin" />
           <span>
@@ -288,7 +398,7 @@ export function ChatboxInsightsSankey({
       ) : latestRun === null ? (
         <div
           role="status"
-          className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground"
+          className="flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground"
         >
           <span>
             These sessions haven&rsquo;t been analyzed yet &mdash; the flow
@@ -304,7 +414,7 @@ export function ChatboxInsightsSankey({
       ) : needsThemeRebuild ? (
         <div
           role="status"
-          className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground"
+          className="flex shrink-0 flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-2 text-[11px] text-muted-foreground"
         >
           <span>
             These sessions were analyzed before every column was clustered, so
@@ -318,7 +428,14 @@ export function ChatboxInsightsSankey({
         </div>
       ) : null}
 
-      <div className="w-full min-w-0">
+      <div
+        ref={chartPaneRef}
+        className={cn(
+          "w-full min-w-0",
+          fillHeight && "min-h-0 flex-1",
+          chartNeedsScroll ? "overflow-auto" : "overflow-hidden",
+        )}
+      >
         <svg
           viewBox={`0 0 ${VIEW_WIDTH} ${height + HEADER_HEIGHT}`}
           // Scale to the panel width; viewBox keeps column/header coordinates
@@ -329,8 +446,13 @@ export function ChatboxInsightsSankey({
           // point of making them focusable in the first place.
           role="group"
           aria-label="Session flow from goal through behavior and outcome to sentiment"
-          preserveAspectRatio="xMidYMid meet"
-          className="mt-1 block h-auto w-full"
+          preserveAspectRatio="xMidYMin meet"
+          className={cn(
+            "block w-full",
+            fillHeight && !chartNeedsScroll
+              ? "h-full"
+              : "mt-1 h-auto",
+          )}
         >
           {/*
             Headers live INSIDE the diagram, at the same x as the columns they
@@ -367,7 +489,7 @@ export function ChatboxInsightsSankey({
                   offset="0%"
                   stopColor={
                     link.discordant
-                      ? "hsl(var(--warning))"
+                      ? "var(--warning)"
                       : STAGE_COLOR[link.source.stage].node
                   }
                 />
@@ -375,7 +497,7 @@ export function ChatboxInsightsSankey({
                   offset="100%"
                   stopColor={
                     link.discordant
-                      ? "hsl(var(--warning))"
+                      ? "var(--warning)"
                       : STAGE_COLOR[link.target.stage].node
                   }
                 />
@@ -465,11 +587,8 @@ export function ChatboxInsightsSankey({
         </svg>
       </div>
 
-      <div
-        aria-live="polite"
-        className="min-h-[20px] border-t pt-2 text-[11px] text-muted-foreground"
-      >
-        {readout ?? "Hover or tab through a theme or ribbon to inspect it."}
+      <div aria-live="polite" className="sr-only">
+        {readout}
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxInsightsSankey.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxInsightsSankey.test.tsx
@@ -372,4 +372,62 @@ describe("ChatboxInsightsSankey", () => {
       /not the full history/,
     );
   });
+
+  it("fills the parent pane when fillHeight is set", () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class ResizeObserverMock {
+      constructor(private cb: ResizeObserverCallback) {}
+      observe(target: Element) {
+        Object.defineProperty(target, "clientWidth", {
+          configurable: true,
+          get: () => 800,
+        });
+        Object.defineProperty(target, "clientHeight", {
+          configurable: true,
+          get: () => 640,
+        });
+        this.cb(
+          [
+            {
+              target,
+              contentRect: {
+                width: 800,
+                height: 640,
+                top: 0,
+                left: 0,
+                bottom: 640,
+                right: 800,
+                x: 0,
+                y: 0,
+                toJSON: () => ({}),
+              },
+              borderBoxSize: [],
+              contentBoxSize: [],
+              devicePixelContentBoxSize: [],
+            } as ResizeObserverEntry,
+          ],
+          this as unknown as ResizeObserver,
+        );
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      renderSankey({ fillHeight: true });
+      const root = screen.getByTestId("chatbox-insights-sankey");
+      expect(root).toHaveAttribute("data-fill-height", "true");
+      expect(root.className).toMatch(/h-full/);
+      const svg = screen.getByRole("group", {
+        name: /Session flow from goal/,
+      });
+      // Tall pane → taller viewBox than the content floor (320 for one node
+      // per column), so ribbons and bars actually use the leftover space.
+      const viewBox = svg.getAttribute("viewBox") ?? "";
+      const viewHeight = Number(viewBox.split(/\s+/)[3]);
+      expect(viewHeight).toBeGreaterThan(320);
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
 });

--- a/mcpjam-inspector/client/src/components/swarms/CriterionScorecard.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/CriterionScorecard.tsx
@@ -12,6 +12,25 @@ import {
   type PredicateKind,
 } from "@/shared/predicate-kinds";
 
+/** Keep the scorecard headline and compact statline on one calculation. */
+export function summarizeCriterionFacets(facets: readonly CriterionFacet[]) {
+  const totalPass = facets.reduce((sum, facet) => sum + facet.passCount, 0);
+  const totalFail = facets.reduce((sum, facet) => sum + facet.failCount, 0);
+  const totalGraded = totalPass + totalFail;
+  const cleanCount = facets.filter(
+    (facet) =>
+      facet.passCount + facet.failCount > 0 && facet.failCount === 0,
+  ).length;
+  return {
+    totalPass,
+    totalFail,
+    totalGraded,
+    cleanCount,
+    scorePct:
+      totalGraded === 0 ? null : Math.round((totalPass / totalGraded) * 100),
+  };
+}
+
 /**
  * Aggregate rubric scorecard for the swarm Insights view — the same table
  * shape as the per-run scorecard, but tallied across every graded session in
@@ -55,14 +74,8 @@ export function CriterionScorecard({
 
   // The headline is verdict-weighted, not criterion-weighted: 100 sessions
   // failing one check should read worse than 2 sessions failing another.
-  const totalPass = facets.reduce((sum, f) => sum + f.passCount, 0);
-  const totalFail = facets.reduce((sum, f) => sum + f.failCount, 0);
-  const totalGraded = totalPass + totalFail;
-  const scorePct =
-    totalGraded === 0 ? null : Math.round((totalPass / totalGraded) * 100);
-  const cleanCount = facets.filter(
-    (f) => f.passCount + f.failCount > 0 && f.failCount === 0,
-  ).length;
+  const { totalFail, totalGraded, cleanCount, scorePct } =
+    summarizeCriterionFacets(facets);
 
   return (
     <div className="px-5 pb-4 pt-4">

--- a/mcpjam-inspector/client/src/components/swarms/SwarmInsightsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmInsightsPanel.tsx
@@ -16,6 +16,7 @@ import {
   selectionChipsToAdd,
   toggleChip,
   type InsightsSelection,
+  type ThemeRef,
   type UsageFilterChip,
   type UsageFilterState,
 } from "@/hooks/chatbox-usage-filters";
@@ -24,6 +25,7 @@ import { ChatboxInsightsSankey } from "@/components/chatboxes/ChatboxInsightsSan
 import { ChatboxGoalOutcomeDrilldown } from "@/components/chatboxes/ChatboxGoalOutcomeDrilldown";
 import { ChatboxTopicMapPanel } from "@/components/chatboxes/ChatboxTopicMapPanel";
 import { CriterionScorecard } from "@/components/swarms/CriterionScorecard";
+import { SwarmInsightsStatline } from "@/components/swarms/SwarmInsightsStatline";
 import { rebuildFeedback } from "@/components/shared/usage-insights/rebuild-feedback";
 import type { ClusterTuning } from "@/lib/cluster-tuning";
 import { cn } from "@/lib/utils";
@@ -41,23 +43,31 @@ interface SwarmInsightsPanelProps {
   journeyRunIds?: readonly string[];
   /** Open a session in the Sessions browser (the parent owns the tab flip). */
   onOpenSession?: (sessionId: string) => void;
+  /** Open the Sessions tab without selecting a particular session. */
+  onOpenSessionsTab?: () => void;
+  /** Selection restored from the `sel` URL parameter. */
+  urlSelection?: ReadonlyArray<Pick<ThemeRef, "dimension" | "clusterId">> | null;
+  /** Persist flow selection changes in the owning route. */
+  onSelectionChange?: (
+    themes: ReadonlyArray<Pick<ThemeRef, "dimension" | "clusterId">> | null,
+  ) => void;
+  /** Leading statline content supplied by the run detail page. */
+  personasSlot?: ReactNode;
+  /** Pattern summary chip supplied by the run detail page. */
+  strugglesSlot?: ReactNode;
+  /** Extra content shown below the rubric scorecard in its popover. */
+  checksExtras?: ReactNode;
   /**
    * When false, render body content without an inner ScrollArea so a parent
    * can own scrolling. Ignored when `fillViewport` is true.
    */
   withScrollArea?: boolean;
   /**
-   * Fill the parent height with a vertical stack: insights + scorecard
-   * side-by-side in a capped top rail, diagram/map below (≥ half height).
-   * A flow selection swaps the top rail to the session drill-down. Use this
-   * on run-detail Insights.
+   * Fill the parent height: compact statline on top, diagram/map absorbing the
+   * rest (Session flow re-lays to the pane height). A flow selection opens the
+   * session drill-down beside the chart. Use this on run-detail Insights.
    */
   fillViewport?: boolean;
-  /**
-   * Extra content for the idle top rail (e.g. findings). Hidden while a
-   * flow selection's drill-down is open so the viewport stays stable.
-   */
-  children?: ReactNode;
 }
 
 /**
@@ -73,9 +83,14 @@ export function SwarmInsightsPanel({
   projectId,
   journeyRunIds,
   onOpenSession,
+  onOpenSessionsTab,
+  urlSelection,
+  onSelectionChange,
+  personasSlot,
+  strugglesSlot,
+  checksExtras,
   withScrollArea = true,
   fillViewport = false,
-  children,
 }: SwarmInsightsPanelProps) {
   const journeyRunIdsKey = journeyRunIds?.join("\0") ?? "";
   const stableJourneyRunIds = useMemo(
@@ -105,6 +120,12 @@ export function SwarmInsightsPanel({
   // the chatbox panel's contract so teardown never deletes a chip another
   // writer put there.
   const [flowOwnedKeys, setFlowOwnedKeys] = useState<string[]>([]);
+  const flowSelectionRef = useRef<InsightsSelection | null>(null);
+  const filterRef = useRef<UsageFilterState>(EMPTY_USAGE_FILTER);
+  const flowOwnedKeysRef = useRef<string[]>([]);
+  flowSelectionRef.current = flowSelection;
+  filterRef.current = filter;
+  flowOwnedKeysRef.current = flowOwnedKeys;
   const [rebuildBusy, setRebuildBusy] = useState(false);
   const rebuildInFlightRef = useRef(false);
   // One-shot topic-map backfill per project. Server queueSwarmClusterRebuild
@@ -125,7 +146,8 @@ export function SwarmInsightsPanel({
     setView("flow");
     rebuildInFlightRef.current = false;
     setRebuildBusy(false);
-  }, [projectId, journeyRunIdsKey]);
+    onSelectionChange?.(null);
+  }, [projectId, journeyRunIdsKey, onSelectionChange]);
 
   // The selection's own chips must not reach the breakdown query — they are
   // the diagram's own output, and feeding them back collapses the diagram to
@@ -142,22 +164,42 @@ export function SwarmInsightsPanel({
     breakdownEnabled: scope !== null,
   });
 
-  const handleSelectFlow = useCallback(
-    (next: InsightsSelection) => {
-      const isAlreadyOpen = isSameSelection(flowSelection, next);
-      const cleared = removeChipsByKeys(filter, flowOwnedKeys);
+  const commitSelection = useCallback(
+    (
+      next: InsightsSelection | null,
+      opts?: { silent?: boolean },
+    ) => {
+      const currentFlowSelection = flowSelectionRef.current;
+      const currentFilter = filterRef.current;
+      const currentOwnedKeys = flowOwnedKeysRef.current;
+      if (next === null) {
+        setFilter((prev) => removeChipsByKeys(prev, currentOwnedKeys));
+        setFlowSelection(null);
+        setFlowOwnedKeys([]);
+        if (!opts?.silent) onSelectionChange?.(null);
+        return;
+      }
+      const isAlreadyOpen = isSameSelection(currentFlowSelection, next);
+      const cleared = removeChipsByKeys(currentFilter, currentOwnedKeys);
       if (isAlreadyOpen) {
         setFilter(cleared);
         setFlowSelection(null);
         setFlowOwnedKeys([]);
+        if (!opts?.silent) onSelectionChange?.(null);
         return;
       }
       const added = selectionChipsToAdd(cleared, next);
       setFilter({ ...cleared, chips: [...cleared.chips, ...added] });
       setFlowSelection(next);
       setFlowOwnedKeys(added.map(chipKey));
+      if (!opts?.silent) onSelectionChange?.(next.themes);
     },
-    [filter, flowSelection, flowOwnedKeys],
+    [onSelectionChange],
+  );
+
+  const handleSelectFlow = useCallback(
+    (next: InsightsSelection) => commitSelection(next),
+    [commitSelection],
   );
 
   // Criterion chips are ORDINARY filter chips, not flow-owned: they are the
@@ -181,11 +223,63 @@ export function SwarmInsightsPanel({
     return filter.chips.filter((chip) => !owned.has(chipKey(chip)));
   }, [filter.chips, flowOwnedKeys]);
 
-  const handleCloseFlow = useCallback(() => {
-    setFilter((prev) => removeChipsByKeys(prev, flowOwnedKeys));
-    setFlowSelection(null);
-    setFlowOwnedKeys([]);
-  }, [flowOwnedKeys]);
+  const handleCloseFlow = useCallback(
+    () => commitSelection(null),
+    [commitSelection],
+  );
+
+  const urlSelectionKey = urlSelection
+    ?.map((theme) => `${theme.dimension}:${theme.clusterId}`)
+    .join("\0");
+  const resolvedUrlSelection = useMemo<InsightsSelection | null>(() => {
+    if (!urlSelection || urlSelection.length === 0) return null;
+    const nodes = breakdown?.sankey?.nodes ?? [];
+    return {
+      themes: urlSelection.map((theme) => {
+        const node = nodes.find(
+          (candidate) =>
+            candidate.stage === theme.dimension &&
+            candidate.key === theme.clusterId,
+        );
+        return { ...theme, ...(node ? { label: node.label } : {}) };
+      }),
+    };
+  }, [urlSelectionKey, breakdown?.sankey]);
+
+  // URL state is an external owner. Reconcile only when that external value
+  // changes, so a local click is not cleared before navigate updates it.
+  useEffect(() => {
+    if (urlSelection === undefined) return;
+    if (resolvedUrlSelection === null) {
+      if (flowSelectionRef.current !== null) {
+        commitSelection(null, { silent: true });
+      }
+      return;
+    }
+    if (isSameSelection(flowSelectionRef.current, resolvedUrlSelection)) {
+      // The URL identity is unchanged, but the Sankey may just have supplied
+      // labels for a selection restored before the breakdown loaded.
+      setFlowSelection(resolvedUrlSelection);
+      return;
+    }
+    commitSelection(resolvedUrlSelection, { silent: true });
+  }, [
+    urlSelectionKey,
+    resolvedUrlSelection,
+    commitSelection,
+  ]);
+
+  useEffect(() => {
+    if (!flowSelection) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        commitSelection(null);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [flowSelection, commitSelection]);
 
   const handleRebuild = useCallback(
     async (args?: { tuning?: ClusterTuning; force?: boolean }) => {
@@ -309,20 +403,27 @@ export function SwarmInsightsPanel({
     ) : null;
 
   const sankeyBlock = (
-    <>
-      <ChatboxInsightsSankey
-        breakdown={breakdown}
-        selection={flowSelection}
-        onSelectNode={handleSelectFlow}
-        onSelectLink={handleSelectFlow}
-        onRebuild={handleRebuild}
-        rebuildBusy={rebuildBusy}
-        onApplyTuning={handleApplyTuning}
-        showLinkThreshold
-        headerActions={viewToggle}
-      />
+    <div
+      className={cn(
+        fillViewport && "flex h-full min-h-0 flex-col overflow-hidden",
+      )}
+    >
+      <div className={cn(fillViewport && "min-h-0 flex-1 overflow-hidden")}>
+        <ChatboxInsightsSankey
+          breakdown={breakdown}
+          selection={flowSelection}
+          onSelectNode={handleSelectFlow}
+          onSelectLink={handleSelectFlow}
+          onRebuild={handleRebuild}
+          rebuildBusy={rebuildBusy}
+          onApplyTuning={handleApplyTuning}
+          showLinkThreshold
+          headerActions={fillViewport ? undefined : viewToggle}
+          fillHeight={fillViewport}
+        />
+      </div>
       {chipRow}
-    </>
+    </div>
   );
 
   const clustersBlock = (
@@ -338,7 +439,7 @@ export function SwarmInsightsPanel({
           onRebuild={() => void handleRebuild()}
           rebuildBusy={rebuildBusy}
           onOpenSession={onOpenSession}
-          headerActions={viewToggle}
+          headerActions={fillViewport ? undefined : viewToggle}
         />
       </div>
     </div>
@@ -364,36 +465,53 @@ export function SwarmInsightsPanel({
 
   if (fillViewport) {
     const selectionOpen = flowSelection !== null;
-    // Vertical stack: answer (insights ∥ scorecard) on top in a capped rail,
-    // diagram below with ≥ half the height so the flow keeps presence.
     return (
       <div
-        className="flex h-full min-h-0 flex-col gap-3 overflow-hidden"
+        className="flex h-full min-h-0 flex-col gap-2 overflow-hidden"
         data-testid="swarm-insights-panel"
       >
-        <div
-          className="flex max-h-[40%] min-h-0 shrink-0 flex-col gap-3 overflow-y-auto sm:flex-row sm:items-stretch"
-          data-testid="swarm-insights-rail"
-        >
-          {selectionOpen ? (
-            <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
-              {drilldownBlock}
+        <SwarmInsightsStatline
+          breakdown={breakdown}
+          filter={filter}
+          flowSelection={flowSelection}
+          onSelectFlow={handleSelectFlow}
+          onToggleChip={handleToggleChip}
+          onOpenSessionsTab={onOpenSessionsTab}
+          personasSlot={personasSlot}
+          strugglesSlot={strugglesSlot}
+          checksExtras={checksExtras}
+          trailing={viewToggle}
+        />
+        <div className="relative flex min-h-0 flex-1 overflow-hidden">
+          <div className="min-w-0 flex-1 overflow-hidden">
+            {view === "clusters" ? clustersBlock : sankeyBlock}
+          </div>
+          {view === "flow" && selectionOpen ? (
+            <div
+              className="absolute inset-0 z-10 bg-background sm:static sm:w-[22rem] lg:w-[24rem] sm:shrink-0 sm:border-l sm:border-border/40"
+              data-testid="swarm-insights-drill-panel"
+            >
+              <ChatboxGoalOutcomeDrilldown
+                scope={scope}
+                selection={flowSelection}
+                filter={filter}
+                variant="panel"
+                onClose={handleCloseFlow}
+                onOpenSession={(sessionId) => onOpenSession?.(sessionId)}
+                footer={
+                  onOpenSessionsTab ? (
+                    <button
+                      type="button"
+                      className="self-start text-xs font-medium text-primary hover:underline"
+                      onClick={onOpenSessionsTab}
+                    >
+                      Open in Sessions tab →
+                    </button>
+                  ) : null
+                }
+              />
             </div>
-          ) : (
-            <>
-              {children ? (
-                <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
-                  {children}
-                </div>
-              ) : null}
-              <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
-                {scorecardBlock}
-              </div>
-            </>
-          )}
-        </div>
-        <div className="min-h-[50%] min-w-0 flex-1 overflow-hidden border-t border-border/40 pt-3">
-          {view === "clusters" ? clustersBlock : sankeyBlock}
+          ) : null}
         </div>
       </div>
     );
@@ -407,7 +525,6 @@ export function SwarmInsightsPanel({
         {sankeyBlock}
         {scorecardBlock}
         {drilldownBlock}
-        {children}
       </>
     );
 

--- a/mcpjam-inspector/client/src/components/swarms/SwarmInsightsStatline.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/SwarmInsightsStatline.tsx
@@ -1,0 +1,180 @@
+import type { ReactNode } from "react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import {
+  isSameSelection,
+  type InsightsSelection,
+  type UsageFilterChip,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+import type { UsageBreakdown } from "@/hooks/useUsageInsights";
+import {
+  selectionForNode,
+  stageValueLabel,
+} from "@/components/chatboxes/insights-sankey";
+import {
+  CriterionScorecard,
+  summarizeCriterionFacets,
+} from "@/components/swarms/CriterionScorecard";
+import { cn } from "@/lib/utils";
+
+const CHIP_CLASS =
+  "inline-flex min-w-0 items-center gap-1 rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs font-medium tabular-nums transition-colors hover:bg-muted/50";
+
+const STAGE_LABELS: Record<"outcome" | "sentiment", string> = {
+  outcome: "Outcome",
+  sentiment: "Sentiment",
+};
+
+interface SwarmInsightsStatlineProps {
+  breakdown: UsageBreakdown | null | undefined;
+  filter: UsageFilterState;
+  flowSelection: InsightsSelection | null;
+  onSelectFlow: (selection: InsightsSelection) => void;
+  onToggleChip: (chip: UsageFilterChip) => void;
+  onOpenSessionsTab?: () => void;
+  personasSlot?: ReactNode;
+  strugglesSlot?: ReactNode;
+  checksExtras?: ReactNode;
+  trailing?: ReactNode;
+}
+
+function topClickableNode(
+  breakdown: UsageBreakdown | null | undefined,
+  stage: "outcome" | "sentiment"
+) {
+  const sankey = breakdown?.sankey;
+  if (!sankey || (breakdown.totalSessions ?? 0) <= 0) return null;
+  const nodes = sankey.nodes
+    .filter((node) => node.stage === stage && node.clickable)
+    .sort((a, b) => b.count - a.count);
+  const node = nodes[0];
+  if (!node) return null;
+  const stageTotal = sankey.nodes
+    .filter((candidate) => candidate.stage === stage)
+    .reduce((sum, candidate) => sum + candidate.count, 0);
+  if (stageTotal <= 0) return null;
+  const selection = selectionForNode(node);
+  if (!selection) return null;
+  return {
+    node,
+    selection,
+    share: Math.round((node.count / stageTotal) * 100),
+  };
+}
+
+function FlowFacetChip({
+  stage,
+  value,
+  flowSelection,
+  onSelectFlow,
+}: {
+  stage: "outcome" | "sentiment";
+  value: NonNullable<ReturnType<typeof topClickableNode>>;
+  flowSelection: InsightsSelection | null;
+  onSelectFlow: (selection: InsightsSelection) => void;
+}) {
+  const label = `${stageValueLabel(value.node)} ${value.share}%`;
+  return (
+    <button
+      type="button"
+      className={cn(CHIP_CLASS, "max-w-[16rem]")}
+      title={`${STAGE_LABELS[stage]}: ${label}`}
+      aria-label={`${STAGE_LABELS[stage]}: ${label}`}
+      aria-pressed={isSameSelection(flowSelection, value.selection)}
+      onClick={() => onSelectFlow(value.selection)}
+    >
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}
+
+export function SwarmInsightsStatline({
+  breakdown,
+  filter,
+  flowSelection,
+  onSelectFlow,
+  onToggleChip,
+  onOpenSessionsTab,
+  personasSlot,
+  strugglesSlot,
+  checksExtras,
+  trailing,
+}: SwarmInsightsStatlineProps) {
+  const outcome = topClickableNode(breakdown, "outcome");
+  const sentiment = topClickableNode(breakdown, "sentiment");
+  const facets = breakdown?.criterionBreakdown ?? [];
+  const summary = facets.length ? summarizeCriterionFacets(facets) : null;
+  const checksLabel = summary
+    ? summary.totalFail > 0
+      ? `✕ Checks ${summary.cleanCount}/${facets.length} · ${summary.totalFail} failing`
+      : `✓ Checks ${summary.cleanCount}/${facets.length}`
+    : checksExtras
+    ? "Checks"
+    : null;
+
+  return (
+    <div
+      className="flex shrink-0 flex-wrap items-center gap-1.5"
+      data-testid="swarm-insights-statline"
+    >
+      {personasSlot}
+      <button
+        type="button"
+        className={CHIP_CLASS}
+        onClick={onOpenSessionsTab}
+        disabled={!onOpenSessionsTab}
+      >
+        {breakdown?.totalSessions ?? 0} sessions
+      </button>
+      {outcome ? (
+        <FlowFacetChip
+          stage="outcome"
+          value={outcome}
+          flowSelection={flowSelection}
+          onSelectFlow={onSelectFlow}
+        />
+      ) : null}
+      {sentiment ? (
+        <FlowFacetChip
+          stage="sentiment"
+          value={sentiment}
+          flowSelection={flowSelection}
+          onSelectFlow={onSelectFlow}
+        />
+      ) : null}
+      {checksLabel ? (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                CHIP_CLASS,
+                Boolean(summary && summary.totalFail > 0) &&
+                  "border-destructive/50 bg-destructive/10 text-destructive hover:bg-destructive/20"
+              )}
+              aria-label={checksLabel}
+            >
+              {checksLabel}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-[26rem] max-w-[90vw] p-0">
+            <div className="flex max-h-[60vh] min-h-0 flex-col overflow-y-auto">
+              <CriterionScorecard
+                facets={facets}
+                filter={filter}
+                onToggleChip={onToggleChip}
+              />
+              {checksExtras}
+            </div>
+          </PopoverContent>
+        </Popover>
+      ) : null}
+      {strugglesSlot}
+      {trailing ? <div className="ml-auto">{trailing}</div> : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmInsightsPanel.test.tsx
@@ -51,15 +51,20 @@ const JOURNEY_NODE: InsightsSelection = {
 vi.mock("@/components/chatboxes/ChatboxInsightsSankey", () => ({
   ChatboxInsightsSankey: ({
     onSelectNode,
+    selection,
     stageTitles,
     headerActions,
   }: {
     onSelectNode: (selection: InsightsSelection) => void;
+    selection?: InsightsSelection | null;
     stageTitles?: Partial<Record<string, string>>;
     headerActions?: React.ReactNode;
   }) => (
     <>
       <span data-testid="goal-header">{stageTitles?.goal ?? "Goal"}</span>
+      <span data-testid="selected-themes">
+        {(selection?.themes ?? []).map((theme) => theme.clusterId).join(",")}
+      </span>
       {headerActions}
       <button type="button" onClick={() => onSelectNode(JOURNEY_NODE)}>
         pick journey theme
@@ -157,21 +162,61 @@ describe("SwarmInsightsPanel", () => {
     expect(breakdownChips).toEqual([]);
   });
 
-  it("fillViewport puts a capped top rail above the diagram and swaps it to the drill-down", async () => {
+  it("restores a URL selection and keeps it beside the Sankey", async () => {
+    render(
+      <SwarmInsightsPanel
+        projectId="proj-1"
+        fillViewport
+        urlSelection={[{ dimension: "goal", clusterId: "journey-1" }]}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("selected-themes")).toHaveTextContent(
+        "journey-1",
+      ),
+    );
+    expect(screen.getByTestId("swarm-insights-drill-panel")).toBeInTheDocument();
+    expect(lastDrilldownCall().enabled !== false).toBe(true);
+  });
+
+  it("persists click and close changes, including Escape", async () => {
+    const user = userEvent.setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <SwarmInsightsPanel
+        projectId="proj-1"
+        fillViewport
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "pick journey theme" }));
+    expect(onSelectionChange).toHaveBeenLastCalledWith([
+      { dimension: "goal", clusterId: "journey-1", label: "Draw a diagram" },
+    ]);
+    await user.keyboard("{Escape}");
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null);
+    expect(screen.queryByTestId("swarm-insights-drill-panel")).toBeNull();
+  });
+
+  it("fillViewport keeps the statline and diagram visible beside the drill-down", async () => {
     const user = userEvent.setup();
     render(
-      <SwarmInsightsPanel projectId="proj-1" journeyRunIds={["run-a"]} fillViewport>
-        <div data-testid="idle-footer">findings</div>
-      </SwarmInsightsPanel>,
+      <SwarmInsightsPanel
+        projectId="proj-1"
+        journeyRunIds={["run-a"]}
+        fillViewport
+      />,
     );
     const panel = screen.getByTestId("swarm-insights-panel");
     expect(panel.className).toContain("flex-col");
-    const rail = screen.getByTestId("swarm-insights-rail");
-    expect(rail.className).toContain("max-h-[40%]");
-    expect(rail.className).toContain("sm:flex-row");
-    expect(screen.getByTestId("idle-footer")).toBeInTheDocument();
+    expect(screen.getByTestId("swarm-insights-statline")).toBeInTheDocument();
+    expect(screen.queryByTestId("swarm-insights-rail")).toBeNull();
+    expect(screen.getByTestId("goal-header")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "pick journey theme" }));
-    expect(screen.queryByTestId("idle-footer")).toBeNull();
+    expect(screen.getByTestId("swarm-insights-drill-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("goal-header")).toBeInTheDocument();
     expect(lastDrilldownCall().enabled !== false).toBe(true);
   });
 

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/SwarmsTab.overview.test.tsx
@@ -607,9 +607,7 @@ describe("Swarm Run detail — /swarms/:swarmId", () => {
       "Swarm run-2b"
     );
     expect(await screen.findByTestId("swarm-insights-panel")).toBeTruthy();
-    expect(
-      await screen.findByTestId("swarm-overview-wave-findings")
-    ).toBeTruthy();
+    expect(await screen.findByTestId("swarm-insights-statline")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Overview" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Personas" })).toBeNull();
     expect(screen.getByRole("button", { name: "Insights" })).toBeTruthy();
@@ -622,6 +620,7 @@ describe("Swarm Run detail — /swarms/:swarmId", () => {
     renderTab("run-2b");
     await screen.findByTestId("swarm-run-detail");
 
+    fireEvent.click(screen.getByRole("button", { name: "2 personas" }));
     expect(await screen.findByTestId("swarm-run-detail-personas")).toBeTruthy();
     expect(screen.getAllByTestId("swarm-run-detail-persona").length).toBeGreaterThan(
       0
@@ -635,6 +634,7 @@ describe("Swarm Run detail — /swarms/:swarmId", () => {
       projectId: "proj-1",
       journeyRunIds: expect.arrayContaining(["run-2b", "run-2"]),
     });
+    fireEvent.click(screen.getByRole("button", { name: "Checks" }));
     expect(await screen.findByTestId("swarm-overview-wave-findings")).toBeTruthy();
 
     const findings = screen.getAllByTestId("swarm-overview-finding");
@@ -664,6 +664,7 @@ describe("Swarm Run detail — /swarms/:swarmId", () => {
     renderTab("run-2b");
     await screen.findByTestId("swarm-run-detail");
     fireEvent.click(screen.getByRole("button", { name: "Insights" }));
+    fireEvent.click(screen.getByRole("button", { name: "Checks" }));
 
     const finding = (
       await screen.findAllByTestId("swarm-overview-finding")

--- a/mcpjam-inspector/client/src/components/swarms/swarm-run-detail.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-run-detail.tsx
@@ -9,22 +9,35 @@ import { useCallback, useMemo, useState } from "react";
 import { useQuery } from "convex/react";
 import { Loader2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { toast } from "@/lib/toast";
 import {
   buildSwarmPath,
   parseSwarmDetailTab,
   routePaths,
+  useCurrentSearchParam,
   useAppNavigate,
   type SwarmDetailTab,
 } from "@/lib/app-navigation";
+import {
+  parseSelectionParam,
+  serializeSelectionParam,
+  type ThemeRef,
+} from "@/hooks/chatbox-usage-filters";
 import { getShareableAppOrigin } from "@/lib/chatbox-session";
 import { SWARM_QUERIES, type SwarmOverview } from "@/lib/swarm-api";
 import { shouldQueryProjectId } from "@/hooks/useProjects";
 import { formatSwarmAbsoluteTime } from "@/components/swarms/journey-run-format";
 import { SwarmsSessionsPanel } from "@/components/swarms/SwarmsSessionsPanel";
 import { SwarmInsightsPanel } from "@/components/swarms/SwarmInsightsPanel";
-import { SwarmRunInsights } from "@/components/swarms/swarm-run-insights";
+import {
+  SwarmRunInsightsChip,
+} from "@/components/swarms/swarm-run-insights";
 import {
   groupRunsIntoSwarmWaves,
   resolveSwarmWave,
@@ -62,17 +75,16 @@ export function SwarmRunDetail({
   onOpenPersona,
 }: SwarmRunDetailProps) {
   const navigate = useAppNavigate();
-  const [tab, setTab] = useState<SwarmDetailTab>(() =>
-    parseSwarmDetailTab(
-      typeof window !== "undefined" ? window.location.search : ""
-    )
+  const tabParam = useCurrentSearchParam("tab");
+  const tab: SwarmDetailTab = parseSwarmDetailTab(
+    tabParam ? `?tab=${encodeURIComponent(tabParam)}` : "",
   );
+  const sessionParam = useCurrentSearchParam("session");
+  const selParam = useCurrentSearchParam("sel");
+  const urlSelection = useMemo(() => parseSelectionParam(selParam), [selParam]);
   const [sessionsPersonaFilter, setSessionsPersonaFilter] = useState<
     string | null
   >(null);
-  const [drilldownThreadId, setDrilldownThreadId] = useState<string | null>(
-    null
-  );
   const [runAgainBusy, setRunAgainBusy] = useState(false);
 
   const queryable = shouldQueryProjectId(projectId);
@@ -92,27 +104,57 @@ export function SwarmRunDetail({
 
   const handleTabChange = useCallback(
     (next: SwarmDetailTab) => {
-      setTab(next);
-      navigate(buildSwarmPath(swarmId, next), { replace: true });
+      navigate(
+        buildSwarmPath(swarmId, {
+          tab: next,
+          sel: selParam ?? undefined,
+        }),
+        { replace: true },
+      );
     },
-    [navigate, swarmId]
+    [navigate, selParam, swarmId],
   );
 
   const handleShare = useCallback(async () => {
-    const url = `${getShareableAppOrigin()}${buildSwarmPath(swarmId, tab)}`;
+    const url = `${getShareableAppOrigin()}${buildSwarmPath(swarmId, {
+      tab,
+      session: sessionParam ?? undefined,
+      sel: selParam ?? undefined,
+    })}`;
     try {
       await navigator.clipboard.writeText(url);
       toast.success("Link copied");
     } catch {
       toast.error("Could not copy link");
     }
-  }, [swarmId, tab]);
+  }, [selParam, sessionParam, swarmId, tab]);
 
-  const handleOpenSession = useCallback((sessionId: string) => {
-    setDrilldownThreadId(sessionId);
-    setTab("sessions");
-    navigate(buildSwarmPath(swarmId, "sessions"), { replace: true });
-  }, [navigate, swarmId]);
+  const handleOpenSession = useCallback(
+    (sessionId: string) => {
+      navigate(
+        buildSwarmPath(swarmId, {
+          tab: "sessions",
+          session: sessionId,
+          sel: selParam ?? undefined,
+        }),
+      );
+    },
+    [navigate, selParam, swarmId],
+  );
+
+  const handleSelectionChange = useCallback(
+    (themes: ReadonlyArray<Pick<ThemeRef, "dimension" | "clusterId">> | null) => {
+      navigate(
+        buildSwarmPath(swarmId, {
+          tab,
+          session: sessionParam ?? undefined,
+          sel: themes ? serializeSelectionParam(themes) : undefined,
+        }),
+        { replace: true },
+      );
+    },
+    [navigate, sessionParam, swarmId, tab],
+  );
 
   const launchableJourneyIds = useMemo(() => {
     if (!wave) return [];
@@ -251,40 +293,40 @@ export function SwarmRunDetail({
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {tab === "insights" ? (
-          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden px-8 py-5">
-            <DetailPersonasStrip
-              wave={wave}
-              onOpenPersona={onOpenPersona}
-            />
-            <div className="min-h-0 flex-1">
-              {/* The panel stacks: insights ∥ scorecard on top, diagram below
-                  (≥ half height). */}
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-8 py-4">
+            <div className="min-h-0 flex-1 overflow-hidden">
               <SwarmInsightsPanel
                 projectId={projectId}
                 journeyRunIds={runIds}
                 onOpenSession={handleOpenSession}
+                onOpenSessionsTab={() => handleTabChange("sessions")}
+                urlSelection={urlSelection}
+                onSelectionChange={handleSelectionChange}
+                personasSlot={
+                  <DetailPersonasChip
+                    wave={wave}
+                    onOpenPersona={onOpenPersona}
+                  />
+                }
+                strugglesSlot={
+                  projectId && wave.runs[0]?.swarmRunGroupId ? (
+                    <SwarmRunInsightsChip
+                      projectId={projectId}
+                      swarmRunGroupId={wave.runs[0].swarmRunGroupId}
+                      onOpenSession={handleOpenSession}
+                    />
+                  ) : null
+                }
+                checksExtras={
+                  wave.runs.some((run) => run.findings.length > 0) ? (
+                    <SwarmWaveFindingsList
+                      runs={wave.runs}
+                      onOpenSession={handleOpenSession}
+                    />
+                  ) : null
+                }
                 fillViewport
-              >
-                {/* Keyed on the durable run id — legacy time-clustered runs
-                    have none and simply get no insights. */}
-                {projectId && wave.runs[0]?.swarmRunGroupId ? (
-                  <SwarmRunInsights
-                    projectId={projectId}
-                    swarmRunGroupId={wave.runs[0].swarmRunGroupId}
-                    onOpenSession={handleOpenSession}
-                  />
-                ) : null}
-                {/* Only when it has something to say. Its empty state ("No
-                    findings for this run.") is noise under a scorecard that
-                    already reports every criterion, and failing criteria
-                    surface as insight rows anyway. */}
-                {wave.runs.some((run) => run.findings.length > 0) ? (
-                  <SwarmWaveFindingsList
-                    runs={wave.runs}
-                    onOpenSession={handleOpenSession}
-                  />
-                ) : null}
-              </SwarmInsightsPanel>
+              />
             </div>
           </div>
         ) : null}
@@ -295,7 +337,7 @@ export function SwarmRunDetail({
             hosts={hosts}
             personaRefId={sessionsPersonaFilter}
             onPersonaRefIdChange={setSessionsPersonaFilter}
-            initialThreadId={drilldownThreadId}
+            initialThreadId={sessionParam}
             runLabels={runLabels}
             goalLabels={goalLabels}
             journeyRunIds={runIds}
@@ -324,8 +366,8 @@ function DetailBackLink({ onBack }: { onBack: () => void }) {
   );
 }
 
-/** Compact persona chips for Insights — jump to list Personas on click. */
-function DetailPersonasStrip({
+/** Compact persona chip for Insights — details remain available in a popover. */
+function DetailPersonasChip({
   wave,
   onOpenPersona,
 }: {
@@ -345,34 +387,47 @@ function DetailPersonasStrip({
   if (rows.length === 0) return null;
 
   return (
-    <div
-      className="flex flex-wrap items-center gap-1.5"
-      data-testid="swarm-run-detail-personas"
-    >
-      <span className="mr-0.5 text-[11px] font-medium text-muted-foreground">
-        Personas
-      </span>
-      {rows.map((row) => (
+    <Popover>
+      <PopoverTrigger asChild>
         <button
-          key={row.name}
           type="button"
-          title={
-            row.journeyCount === 1
-              ? row.name
-              : `${row.name} · ${row.journeyCount} goals`
-          }
-          className="inline-flex max-w-[14rem] items-center gap-1 rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs font-medium text-foreground/90 transition-colors hover:bg-muted/50 hover:text-foreground"
-          onClick={() => onOpenPersona(row.name)}
-          data-testid="swarm-run-detail-persona"
+          className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs font-medium text-foreground/90 transition-colors hover:bg-muted/50 hover:text-foreground"
+          aria-label={`${rows.length} ${rows.length === 1 ? "persona" : "personas"}`}
         >
-          <span className="truncate">{row.name}</span>
-          {row.journeyCount > 1 ? (
-            <span className="shrink-0 tabular-nums text-muted-foreground">
-              {row.journeyCount}
-            </span>
-          ) : null}
+          {rows.length} {rows.length === 1 ? "persona" : "personas"}
         </button>
-      ))}
-    </div>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-72 max-w-[90vw] p-3"
+      >
+        <div
+          className="flex flex-wrap items-center gap-1.5"
+          data-testid="swarm-run-detail-personas"
+        >
+          {rows.map((row) => (
+            <button
+              key={row.name}
+              type="button"
+              title={
+                row.journeyCount === 1
+                  ? row.name
+                  : `${row.name} · ${row.journeyCount} goals`
+              }
+              className="inline-flex max-w-[14rem] items-center gap-1 rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs font-medium text-foreground/90 transition-colors hover:bg-muted/50 hover:text-foreground"
+              onClick={() => onOpenPersona(row.name)}
+              data-testid="swarm-run-detail-persona"
+            >
+              <span className="truncate">{row.name}</span>
+              {row.journeyCount > 1 ? (
+                <span className="shrink-0 tabular-nums text-muted-foreground">
+                  {row.journeyCount}
+                </span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/mcpjam-inspector/client/src/components/swarms/swarm-run-insights.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-run-insights.tsx
@@ -17,6 +17,11 @@
 import { useMemo, useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { ChevronRight, Loader2 } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
 
 import { cn } from "@/lib/utils";
 import {
@@ -230,7 +235,7 @@ export function SwarmRunInsights({
       className="rounded-lg border border-border/60 bg-muted/20"
       data-testid="swarm-run-insights"
     >
-      {(insights?.summary || busy || error) && (
+      {(insights?.summary || busy) && (
         <div className="flex items-start gap-2 border-b border-border/40 px-3 py-2">
           {busy ? (
             <p
@@ -239,21 +244,6 @@ export function SwarmRunInsights({
             >
               <Loader2 className="size-3.5 animate-spin" />
               Working out what went wrong…
-            </p>
-          ) : error ? (
-            <p
-              className="flex items-center gap-2 text-sm text-muted-foreground"
-              data-testid="swarm-run-insights-error"
-            >
-              {error}
-              <button
-                type="button"
-                className="font-medium text-primary hover:underline"
-                onClick={() => request(true)}
-                data-testid="swarm-run-insights-retry"
-              >
-                Try again
-              </button>
             </p>
           ) : (
             <RunSummary summary={insights!.summary} />
@@ -281,20 +271,38 @@ export function SwarmRunInsights({
         ))}
       </div>
 
-      <div className="flex items-center justify-between gap-3 px-3 py-1.5">
-        <p className="truncate text-[11px] text-muted-foreground">
-          {signals.sessionCount} sessions
-          {caveats.length > 0 ? ` · ${caveats.join(" · ")}` : ""}
-        </p>
-        {rows.length > VISIBLE_ROWS ? (
-          <button
-            type="button"
-            className="shrink-0 text-[11px] font-medium text-primary hover:underline"
-            onClick={() => setShowAll((prev) => !prev)}
-            data-testid="swarm-run-insights-toggle"
+      <div className="flex flex-col gap-1 px-3 py-1.5">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="text-[11px] text-muted-foreground">
+            {signals.sessionCount} sessions
+            {caveats.length > 0 ? ` · ${caveats.join(" · ")}` : ""}
+          </p>
+          {rows.length > VISIBLE_ROWS ? (
+            <button
+              type="button"
+              className="shrink-0 text-[11px] font-medium text-primary hover:underline"
+              onClick={() => setShowAll((prev) => !prev)}
+              data-testid="swarm-run-insights-toggle"
+            >
+              {showAll ? "Show fewer" : `Show all ${rows.length}`}
+            </button>
+          ) : null}
+        </div>
+        {error ? (
+          <p
+            className="text-[11px] text-muted-foreground"
+            data-testid="swarm-run-insights-error"
           >
-            {showAll ? "Show fewer" : `Show all ${rows.length}`}
-          </button>
+            {error}{" "}
+            <button
+              type="button"
+              className="font-medium text-primary hover:underline"
+              onClick={() => request(true)}
+              data-testid="swarm-run-insights-retry"
+            >
+              Try again
+            </button>
+          </p>
         ) : null}
       </div>
 
@@ -303,6 +311,82 @@ export function SwarmRunInsights({
         onOpenSession={onOpenSession}
       />
     </section>
+  );
+}
+
+/** Compact statline chip for the signal/finding detail popover. */
+export function SwarmRunInsightsChip({
+  projectId,
+  swarmRunGroupId,
+  onOpenSession,
+}: {
+  projectId: string;
+  swarmRunGroupId: string;
+  onOpenSession: (sessionId: string) => void;
+}) {
+  const signals = useQuery(
+    SWARM_QUERIES.getWaveSignals as any,
+    { projectId, swarmRunGroupId } as any,
+  ) as SwarmWaveSignals | null | undefined;
+  const findings = useQuery(
+    SWARM_QUERIES.listSwarmFindings as any,
+    { projectId } as any,
+  ) as SwarmFinding[] | undefined;
+
+  const activeCount = useMemo(() => {
+    if (!signals || !findings) return 0;
+    const findingByFingerprint = new Map(
+      findings.map((finding) => [finding.fingerprint, finding]),
+    );
+    return signals.candidates.reduce((count, candidate) => {
+      const finding = findingByFingerprint.get(signalFingerprint(candidate));
+      return count + (finding && finding.status !== "resolved" ? 1 : 0);
+    }, 0);
+  }, [signals, findings]);
+
+  if (!signals) return null;
+  if (!signals.terminal) {
+    return (
+      <span
+        className="inline-flex items-center rounded-md border border-border/50 bg-muted/25 px-2 py-0.5 text-xs text-muted-foreground"
+        data-testid="swarm-run-insights-chip"
+      >
+        Analyzing…
+      </span>
+    );
+  }
+
+  const label =
+    activeCount > 0
+      ? `⚠ ${activeCount} pattern${activeCount === 1 ? "" : "s"}`
+      : "No patterns";
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
+            activeCount > 0
+              ? STATUS_CHIP.new.className
+              : "border-border/50 bg-muted/25 text-muted-foreground hover:bg-muted/50",
+          )}
+          data-testid="swarm-run-insights-chip"
+        >
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="max-h-[65vh] w-[34rem] max-w-[90vw] overflow-y-auto p-0"
+      >
+        <SwarmRunInsights
+          projectId={projectId}
+          swarmRunGroupId={swarmRunGroupId}
+          onOpenSession={onOpenSession}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -373,29 +457,29 @@ function InsightRow({
       data-detector={signal.detector}
       data-dismissed={dismissed ? "true" : "false"}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         <button
           type="button"
-          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+          className="flex min-w-0 flex-1 items-start gap-1.5 text-left"
           onClick={() => hasDetail && setExpanded((prev) => !prev)}
           data-testid="swarm-run-insight-headline"
         >
           <span
             className={cn(
-              "size-1.5 shrink-0 rounded-full",
+              "mt-[7px] size-1.5 shrink-0 rounded-full",
               isBlockingShaped(signal.detector)
                 ? "bg-red-500/70"
                 : "bg-amber-500/60",
             )}
             aria-hidden="true"
           />
-          <span className="truncate text-sm text-foreground">
+          <span className="min-w-0 text-sm text-foreground">
             {signalSentence(signal)}
           </span>
           {hasDetail ? (
             <ChevronRight
               className={cn(
-                "size-3 shrink-0 text-muted-foreground transition-transform",
+                "mt-1 size-3 shrink-0 text-muted-foreground transition-transform",
                 expanded && "rotate-90",
               )}
               aria-hidden="true"
@@ -405,7 +489,7 @@ function InsightRow({
         {chip ? (
           <span
             className={cn(
-              "shrink-0 rounded border px-1 py-0 text-[10px] font-medium",
+              "mt-0.5 shrink-0 rounded border px-1 py-0 text-[10px] font-medium",
               chip.className,
             )}
             data-testid="swarm-run-insight-status"
@@ -419,7 +503,7 @@ function InsightRow({
         {finding ? (
           <button
             type="button"
-            className="shrink-0 text-[11px] text-muted-foreground hover:text-foreground"
+            className="mt-0.5 shrink-0 text-[11px] text-muted-foreground hover:text-foreground"
             onClick={toggleDismiss}
             data-testid="swarm-run-insight-dismiss"
           >

--- a/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-selection.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/chatbox-usage-filters-selection.test.ts
@@ -10,6 +10,8 @@ import {
   threadThemeId,
   toggleChip,
   removeChipsByKeys,
+  parseSelectionParam,
+  serializeSelectionParam,
   selectionChipsToAdd,
   type InsightsSelection,
   type UsageFilterState,
@@ -214,6 +216,24 @@ describe("isSameSelection", () => {
   it("handles null on either side", () => {
     expect(isSameSelection(null, null)).toBe(true);
     expect(isSameSelection(null, GOAL_A)).toBe(false);
+  });
+});
+
+describe("selection URL serialization", () => {
+  it("round-trips opaque cluster ids", () => {
+    const themes = [
+      { dimension: "goal" as const, clusterId: "a:b,c% d/雪" },
+      { dimension: "sentiment" as const, clusterId: "calm, mostly" },
+    ];
+    const encoded = serializeSelectionParam(themes);
+    const throughUrl = new URLSearchParams({ sel: encoded }).get("sel");
+    expect(parseSelectionParam(throughUrl)).toEqual(themes);
+  });
+
+  it("rejects unknown axes and malformed encodings", () => {
+    expect(parseSelectionParam("mood:calm")).toBeNull();
+    expect(parseSelectionParam("goal:%E0%A4%A")).toBeNull();
+    expect(parseSelectionParam("goal:")).toBeNull();
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
+++ b/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
@@ -404,6 +404,41 @@ export type ThemeRef = {
 };
 
 /**
+ * Encode a flow selection for a shareable URL. Cluster ids are opaque values,
+ * so only the dimension and separators are kept readable; ids are encoded
+ * independently before the whole value is handed to URLSearchParams.
+ */
+export function serializeSelectionParam(
+  themes: readonly Pick<ThemeRef, "dimension" | "clusterId">[],
+): string {
+  return themes
+    .map(({ dimension, clusterId }) => `${dimension}:${encodeURIComponent(clusterId)}`)
+    .join(",");
+}
+
+/** Parse a serialized flow selection, rejecting malformed or unknown axes. */
+export function parseSelectionParam(value: string | null): ThemeRef[] | null {
+  if (!value) return null;
+  const themes: ThemeRef[] = [];
+  for (const part of value.split(",")) {
+    const separator = part.indexOf(":");
+    if (separator <= 0 || separator === part.length - 1) return null;
+    const dimension = part.slice(0, separator);
+    if (!(SIGNAL_DIMENSIONS as readonly string[]).includes(dimension)) {
+      return null;
+    }
+    try {
+      const clusterId = decodeURIComponent(part.slice(separator + 1));
+      if (!clusterId) return null;
+      themes.push({ dimension: dimension as SignalDimension, clusterId });
+    } catch {
+      return null;
+    }
+  }
+  return themes.length > 0 ? themes : null;
+}
+
+/**
  * A selection in the insights flow: one theme per axis, for any subset of axes.
  *
  * A node click selects one theme; a link click selects the two it joins, which

--- a/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
@@ -43,9 +43,18 @@ describe("buildSwarmPath / parseSwarmDetailTab", () => {
   });
 
   it("omits insights (default) from the query and includes sessions", () => {
-    expect(buildSwarmPath("wave-1", "insights")).toBe("/swarms/wave-1");
-    expect(buildSwarmPath("wave-1", "sessions")).toBe(
+    expect(buildSwarmPath("wave-1", { tab: "insights" })).toBe("/swarms/wave-1");
+    expect(buildSwarmPath("wave-1", { tab: "sessions" })).toBe(
       "/swarms/wave-1?tab=sessions",
+    );
+    expect(
+      buildSwarmPath("wave-1", {
+        tab: "sessions",
+        session: "thread/1",
+        sel: "outcome:goal%3Areached,sentiment:calm",
+      }),
+    ).toBe(
+      "/swarms/wave-1?tab=sessions&session=thread%2F1&sel=outcome%3Agoal%253Areached%2Csentiment%3Acalm",
     );
   });
 

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -129,11 +129,19 @@ export type SwarmDetailTab = "insights" | "sessions";
  */
 export function buildSwarmPath(
   swarmId: string,
-  tab?: SwarmDetailTab
+  opts: {
+    tab?: SwarmDetailTab;
+    session?: string;
+    sel?: string;
+  } = {},
 ): string {
   const base = `${routePaths.swarms}/${encodeURIComponent(swarmId)}`;
-  if (!tab || tab === "insights") return base;
-  return `${base}?tab=${tab}`;
+  const search = new URLSearchParams();
+  if (opts.tab && opts.tab !== "insights") search.set("tab", opts.tab);
+  if (opts.session) search.set("session", opts.session);
+  if (opts.sel) search.set("sel", opts.sel);
+  const query = search.toString();
+  return query ? `${base}?${query}` : base;
 }
 
 /**


### PR DESCRIPTION
## What

Redesigns the Swarm run **Insights** tab so the Sankey is the hero and everything above it earns its space.

**Before:** the top ~45% of the tab was two side-by-side cards — "Where sessions struggled" and "Rubric checks" — with no scannable numbers (the real scores lived only inside Sankey node labels), an all-green checks card stretching one line of information across half the width, and error copy/resolved items in prime real estate. Clicking a Sankey node swapped the drilldown *into* that rail.

**After:**

- **Statline** — one slim row of clickable chips: `N personas · N sessions · <top outcome> % · <top sentiment> % · ✓ Checks n/n · ⚠ N patterns`, sharing the row with the Session flow/Clusters toggle. A failing check turns its chip destructive-red with the failing count but never reclaims vertical space.
- **Popover detail** — the personas, rubric-checks, and struggle-patterns chips open popovers reusing the existing components (`CriterionScorecard`, `SwarmRunInsights`); the spend-cap error demotes to the popover footer. The insights view stays fixed-viewport with no page scroll.
- **Drill-through side panel** — Sankey node/ribbon clicks (and outcome/sentiment chip clicks) open a session list *beside* the diagram (`ChatboxGoalOutcomeDrilldown variant="panel"`); the SVG rescales via viewBox. Esc/✕ restores full width. Session rows open the Sessions tab.
- **URL state** — `?sel=` carries the flow selection, `?session=` (pushed, not replaced) carries the opened transcript, and `tab`/`session`/`sel` are derived from the URL each render instead of seeded once. Browser-back from a transcript returns to Insights with the selection intact, and **Share now copies the live URL** instead of a reconstructed bare one — a shared link reproduces the exact slice.

## Fixes along the way

- `usePaneSize` in `ChatboxInsightsSankey` is now a callback ref. The old mount effect ran before the breakdown arrived, observed a null ref, and never re-attached — so the fill-height Sankey stayed at its content floor, letterboxed at the top of a full-height pane with a large void below. (Visible fingerprint: the diagram only filled after toggling Clusters and back.)
- Struggles popover readability: pattern headlines wrap instead of truncating, the footer stacks session-count/caveats and the spend-cap error onto separate wrapping lines, and the popover widens to 34rem.
- Discordant-ribbon tint: `hsl(var(--warning))` over an oklch token is invalid CSS; now `var(--warning)`, so "outcome and sentiment disagree" ribbons actually render their warning color.

## Notes for review

- The flow-ownership chip contract (selection chips subtracted from the breakdown query) is preserved; all selection mutations funnel through one `commitSelection` path, and the existing test pinning the contract is kept.
- `ChatboxGoalOutcomeDrilldown` changes are optional-prop additions; the chatbox surface renders unchanged by default.
- Known nicety deliberately deferred: a `?sel=` pointing at clusters from before a rebuild shows an honest empty panel (✕ clears it) rather than auto-pruning.

## Testing

- 386 tests across 37 files pass: all `client/src/components/swarms/__tests__` suites, `ChatboxInsightsSankey` (+ tuning states), `ChatboxUsagePanel.flow-selection`, `insights-sankey`, `app-navigation`, `chatbox-usage-filters-selection`.
- Manually verified on a live run: statline + popovers, side-panel drill-through, URL round-trips (reload restore, browser-back from transcript), Share with live params, Sankey filling the viewport on first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches navigation, filter/selection ownership, and viewport layout for a primary Insights surface; behavior is well covered by tests but URL sync and resize logic add integration surface area.
> 
> **Overview**
> Redesigns **Swarm run Insights** so a compact **statline** sits above a full-height **Session flow** Sankey, with detail moved into popovers and a side drill panel instead of a capped top rail.
> 
> **Layout & UX:** `SwarmInsightsStatline` adds chips for sessions, top outcome/sentiment shares, rubric checks, and slots for personas/patterns; checks and wave findings open in popovers. Flow selection opens `ChatboxGoalOutcomeDrilldown` as a **panel** beside the chart (Esc/close clears it); the Sankey gains **`fillHeight`** and a **callback-ref `ResizeObserver`** so the diagram scales to the pane on first paint. Personas collapse to a popover chip; struggle patterns use **`SwarmRunInsightsChip`**.
> 
> **State & sharing:** Flow selection serializes to **`?sel=`** via `serializeSelectionParam` / `parseSelectionParam`; run detail reads **`tab`**, **`session`**, and **`sel`** from the URL each render and **`buildSwarmPath`** carries them so Share and deep links preserve tab, transcript, and flow slice. Selection updates funnel through **`commitSelection`** with URL reconcile and silent restore.
> 
> **Small fixes:** Discordant ribbon gradients use **`var(--warning)`** instead of invalid `hsl(var(--warning))`; rubric headline math is shared via **`summarizeCriterionFacets`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f4b0ce7325f47460ef87e52c9ec4259e83eeb6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Swarm run Insights tab so the Sankey is the hero and the top rail becomes a compact, clickable statline; selections now drill into a side panel and the exact view is shareable via URL.

- New Features
  - Added `SwarmInsightsStatline`: one-line chips for personas, session count, top outcome/sentiment shares (clickable), rubric checks, and struggle patterns (popover).
  - Drill-through side panel: `ChatboxGoalOutcomeDrilldown` supports `variant="panel"`; opens from Sankey nodes/ribbons and outcome/sentiment chips; Esc/✕ closes; rows open Sessions.
  - URL state: persist flow selection with `?sel=` and open session with `?session=`; added `parseSelectionParam`/`serializeSelectionParam`; `buildSwarmPath` now accepts `{ tab, session, sel }`. Share copies the live URL.
  - `ChatboxInsightsSankey` can `fillHeight` to occupy the pane and re-lay via viewBox; header actions move to the statline when filling.
  - Run detail integration: personas chip popover, `SwarmRunInsightsChip` for pattern count with a detail popover, and `SwarmInsightsPanel` props for `urlSelection`, `onSelectionChange`, `onOpenSessionsTab`, and slots for personas/struggles/checks.

- Bug Fixes
  - Fixed Sankey letterboxing by converting `usePaneSize` to a callback ref so it measures after mount.
  - Corrected discordant-ribbon tint to `var(--warning)`.
  - Improved struggles popover readability (wrapped headlines, stacked footer) and widened to 34rem.

<sup>Written for commit 1f4b0ce7325f47460ef87e52c9ec4259e83eeb6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

