### PR TITLE
fix(playground): say "no server connected" in the Tools panel

### DIFF
--- a/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
@@ -201,6 +201,7 @@ function ToolsBody({
       onDeleteRequest={state.savedRequestsHook.handleDeleteRequest}
       showLogger={false}
       builtinTools={harnessBuiltinTools}
+      hasConnectedServer={false}
     />
   );
 }

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
@@ -66,6 +66,8 @@ interface PlaygroundLeftProps {
   showLogger?: boolean;
   /** Harness native built-in tools (display-only). Present for harness hosts. */
   builtinTools?: HarnessBuiltinToolInfo[];
+  /** Whether any MCP server is connected — drives the tool list's empty state. */
+  hasConnectedServer?: boolean;
 }
 
 export function PlaygroundLeft({
@@ -89,6 +91,7 @@ export function PlaygroundLeft({
   onClose,
   showLogger = true,
   builtinTools = [],
+  hasConnectedServer = true,
 }: PlaygroundLeftProps) {
   const [isListExpanded, setIsListExpanded] = useState(!selectedToolName);
   const [activeTab, setActiveTab] = useState<"tools" | "saved">("tools");
@@ -208,6 +211,7 @@ export function PlaygroundLeft({
           builtinTools={builtinTools}
           selectedBuiltinKey={isListExpanded ? null : builtin.selectedKey}
           onSelectBuiltin={handleSelectBuiltin}
+          hasConnectedServer={hasConnectedServer}
         />
       ) : builtin.selected ? (
         <BuiltinToolDetailView

--- a/mcpjam-inspector/client/src/components/ui-playground/ToolList.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/ToolList.tsx
@@ -129,7 +129,15 @@ export function ToolList({
 
   const totalShown =
     filteredToolNames.length + filteredAppEntries.length + filteredBuiltinCount;
-  const hasNoTools = toolNames.length === 0 && appEntries.length === 0;
+  // Mirrors every source `totalShown` counts, unfiltered — built-ins included.
+  // Omitting them let a search that hides a harness's built-ins fall through to
+  // the no-server copy, which would be reporting the wrong reason for an empty
+  // list (the rail's zero-server fallback passes built-ins and
+  // `hasConnectedServer={false}` together, so that pairing is reachable).
+  const hasNoTools =
+    toolNames.length === 0 &&
+    appEntries.length === 0 &&
+    builtinTools.length === 0;
 
   return (
     <div className="h-full flex flex-col">

--- a/mcpjam-inspector/client/src/components/ui-playground/ToolList.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/ToolList.tsx
@@ -7,8 +7,10 @@
 
 import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { RefreshCw } from "lucide-react";
+import { Plug, RefreshCw } from "lucide-react";
 import type { Tool } from "@modelcontextprotocol/client";
+import { Button } from "@mcpjam/design-system/button";
+import { useAppNavigate, routePaths } from "@/lib/app-navigation";
 import { SearchInput } from "../ui/search-input";
 import {
   detectUIType,
@@ -44,6 +46,12 @@ interface ToolListProps {
   selectedBuiltinKey?: string | null;
   /** Select a built-in tool (drives the same detail+Run flow as server tools). */
   onSelectBuiltin?: (key: string) => void;
+  /**
+   * Whether at least one MCP server is connected. When false, the empty state
+   * says so and offers a way out instead of blaming a server that isn't there.
+   * Defaults to true so callers that don't track connections keep the old copy.
+   */
+  hasConnectedServer?: boolean;
 }
 
 export function ToolList({
@@ -59,7 +67,9 @@ export function ToolList({
   builtinTools = [],
   selectedBuiltinKey = null,
   onSelectBuiltin,
+  hasConnectedServer = true,
 }: ToolListProps) {
+  const navigate = useAppNavigate();
   // App-provided tools are widget-lifecycle. Pull them out of the registry
   // as a flat list of `AppEntry`. `useShallow` keeps the selector stable
   // across renders that didn't actually change the array.
@@ -119,6 +129,7 @@ export function ToolList({
 
   const totalShown =
     filteredToolNames.length + filteredAppEntries.length + filteredBuiltinCount;
+  const hasNoTools = toolNames.length === 0 && appEntries.length === 0;
 
   return (
     <div className="h-full flex flex-col">
@@ -139,12 +150,24 @@ export function ToolList({
             <p className="text-xs text-muted-foreground">Loading tools...</p>
           </div>
         ) : totalShown === 0 ? (
-          <div className="text-center py-8 space-y-4">
+          <div className="text-center py-8 px-2 space-y-3">
             <p className="text-xs text-muted-foreground">
-              {toolNames.length === 0 && appEntries.length === 0
+              {!hasNoTools
+                ? "No tools match your search"
+                : hasConnectedServer
                 ? "No tools found. Try refreshing and make sure the server is running."
-                : "No tools match your search"}
+                : "No server connected yet. Connect one to load its tools and use them in chat."}
             </p>
+            {hasNoTools && !hasConnectedServer && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate(routePaths.servers)}
+              >
+                <Plug className="h-3.5 w-3.5" />
+                Connect a server
+              </Button>
+            )}
           </div>
         ) : (
           <div className="space-y-0.5">

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/ToolList.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/ToolList.test.tsx
@@ -369,6 +369,26 @@ describe("ToolList", () => {
     expect(navigate).toHaveBeenCalledWith("/servers");
   });
 
+  it("prefers the search-miss message when a search hides a harness's built-ins", () => {
+    render(
+      <ToolList
+        {...defaultProps}
+        hasConnectedServer={false}
+        builtinTools={[
+          { key: "read", name: "Read", description: "Read a file" },
+          { key: "bash", name: "Bash", description: "Run a command" },
+        ]}
+        onSelectBuiltin={vi.fn()}
+        searchQuery="zzz"
+      />,
+    );
+
+    expect(screen.getByText("No tools match your search")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /connect a server/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("prefers the search-miss message over the no-server copy", () => {
     render(
       <ToolList

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/ToolList.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/ToolList.test.tsx
@@ -22,6 +22,13 @@ vi.mock("../../ui/search-input", () => ({
   ),
 }));
 
+const { navigate } = vi.hoisted(() => ({ navigate: vi.fn() }));
+
+vi.mock("@/lib/app-navigation", () => ({
+  useAppNavigate: () => navigate,
+  routePaths: { servers: "/servers" },
+}));
+
 vi.mock("@mcpjam/design-system/tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
@@ -337,6 +344,47 @@ describe("ToolList", () => {
         "No tools found. Try refreshing and make sure the server is running.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("names the missing connection when no server is connected", () => {
+    render(<ToolList {...defaultProps} hasConnectedServer={false} />);
+
+    expect(
+      screen.getByText(
+        "No server connected yet. Connect one to load its tools and use them in chat.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "No tools found. Try refreshing and make sure the server is running.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("routes to Servers from the no-server empty state", () => {
+    render(<ToolList {...defaultProps} hasConnectedServer={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /connect a server/i }));
+
+    expect(navigate).toHaveBeenCalledWith("/servers");
+  });
+
+  it("prefers the search-miss message over the no-server copy", () => {
+    render(
+      <ToolList
+        {...defaultProps}
+        hasConnectedServer={false}
+        tools={{ read_me: makeTool("read_me") }}
+        toolNames={["read_me"]}
+        filteredToolNames={[]}
+        searchQuery="xyz"
+      />,
+    );
+
+    expect(screen.getByText("No tools match your search")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /connect a server/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows search-miss message when filter yields no results", () => {


### PR DESCRIPTION
Closes PUR-10.

## The dead end

A user with no server connected opens the Playground and clicks a starter prompt — "What tools can I use?", "What can this server do?". The model answers that it cannot check what is available because no server is connected. That is the first time anything tells them what is wrong.

Meanwhile the Tools rail, sitting right next to those starter prompts, said:

> No tools found. Try refreshing and make sure the server is running.

That blames a server the user never added, and it sends them to a Refresh button that cannot help. The zero-server case is the only path that renders this copy — `PlaygroundLeftRail`'s `ToolsBody` falls back to `PlaygroundLeft` exclusively when `activeServerNames` is empty, so the message was misleading every time it appeared.

## Change

The empty state now names the missing connection and offers the fix.

| Before | After |
| --- | --- |
| <img width="300" src="https://raw.githubusercontent.com/olartgabo/inspector/d454d9e7c5907c6c82ed1d20222f5db525aca07c/pur-10-no-server-connected/before.png" /> | <img width="300" src="https://raw.githubusercontent.com/olartgabo/inspector/d454d9e7c5907c6c82ed1d20222f5db525aca07c/pur-10-no-server-connected/after.png" /> |

"Connect a server" routes to `/servers` via `useAppNavigate`, the same navigation the sidebar's own Servers entry uses.

## Scope

`ToolList` takes a `hasConnectedServer` prop that defaults to `true`, threaded through `PlaygroundLeft` from the rail's zero-server branch. Two states are deliberately unchanged:

- **Search miss** — still "No tools match your search", and no CTA, so a search never looks like a connection problem.
- **Connected server exposing no tools** — still the original refresh copy, which is accurate there.

Only the Tools panel changed. The task asks to check the copy with Vignesh; the wording here drops the "Looks like…" hedge from the ticket but says the same thing. Whether the chat surface should also warn before a starter prompt is sent is a separate call — happy to follow up if that is wanted.

## Verification

- `npx vitest run client/src/components/ui-playground/__tests__/` — 219 passed (12 files), including three new `ToolList` cases: the no-server copy, the CTA's route, and search-miss precedence.
- `npm run typecheck` — clean.
- Screenshots above are from `npm run dev:app` on this branch, Playground with zero servers connected. Clicking the CTA sets `location.pathname` to `/servers`.

Prettier reports pre-existing formatting drift in all four touched files at `main`, so I left the formatting alone rather than bury the diff in a reformat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Playground Tools panel to say “No server connected” and add a “Connect a server” button that routes to /servers. Also fix the empty-state logic to consider built-in tools so searches don’t show the wrong message (PUR-10).

- **Bug Fixes**
  - Show a no-server empty state with a CTA that navigates to /servers via useAppNavigate.
  - Add `hasConnectedServer` prop to `ToolList` (default `true`) and thread it from `PlaygroundLeftRail` → `PlaygroundLeft` → `ToolList`.
  - Preserve existing messages for search misses and for connected servers with no tools.
  - Count built-in tools in the empty-state check to avoid false “no server” messages when a search hides them; covered by a regression test.

<sup>Written for commit 1b85177cdce119cd2b45ee3b19ac3f900b7f7599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

