### PR TITLE
feat(byok): link to org models from the model picker

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -13,8 +13,10 @@ import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useQuery } from "convex/react";
 import {
   canManageOrgCredits,
+  canManageOrgModels,
   useOrganizationQueries,
 } from "@/hooks/useOrganizations";
+import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
 import type { ContentBlock } from "@modelcontextprotocol/client";
 import { toast } from "@/lib/toast";
 import { ModelDefinition } from "@/shared/types";
@@ -328,6 +330,18 @@ export function ChatTabV2({
   const modelConfigOrganizationId = hostedContext?.projectId
     ? null
     : organizationId;
+  // The model picker's "Your providers" footer points at the org whose keys back
+  // this chat, so hosted surfaces (no org page to reach) get no footer.
+  const appNavigate = useAppNavigate();
+  const canManageOrgModelsForActiveOrg = canManageOrgModels(
+    modelConfigOrganizationId
+      ? sortedOrganizations.find((org) => org._id === modelConfigOrganizationId)
+      : null
+  );
+  const handleManageOrgProviders = useCallback(() => {
+    if (!modelConfigOrganizationId) return;
+    appNavigate(buildOrganizationPath(modelConfigOrganizationId, "models"));
+  }, [appNavigate, modelConfigOrganizationId]);
   const hostedOrgModelConfig = useHostedOrgModelConfig({
     projectId: effectiveHostedProjectId,
     organizationId: modelConfigOrganizationId,
@@ -2141,6 +2155,9 @@ export function ChatTabV2({
         ? chatboxOptionalInventory
         : undefined,
     onAttachChatboxServer: onEnableChatboxOptionalServer,
+    onManageOrgProviders: canManageOrgModelsForActiveOrg
+      ? handleManageOrgProviders
+      : undefined,
   };
 
   const showStarterPrompts =

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -13,10 +13,9 @@ import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useQuery } from "convex/react";
 import {
   canManageOrgCredits,
-  canManageOrgModels,
   useOrganizationQueries,
 } from "@/hooks/useOrganizations";
-import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
+import { useOrgModelsHandoff } from "@/hooks/use-org-models-handoff";
 import type { ContentBlock } from "@modelcontextprotocol/client";
 import { toast } from "@/lib/toast";
 import { ModelDefinition } from "@/shared/types";
@@ -332,16 +331,7 @@ export function ChatTabV2({
     : organizationId;
   // The model picker's "Your providers" footer points at the org whose keys back
   // this chat, so hosted surfaces (no org page to reach) get no footer.
-  const appNavigate = useAppNavigate();
-  const canManageOrgModelsForActiveOrg = canManageOrgModels(
-    modelConfigOrganizationId
-      ? sortedOrganizations.find((org) => org._id === modelConfigOrganizationId)
-      : null
-  );
-  const handleManageOrgProviders = useCallback(() => {
-    if (!modelConfigOrganizationId) return;
-    appNavigate(buildOrganizationPath(modelConfigOrganizationId, "models"));
-  }, [appNavigate, modelConfigOrganizationId]);
+  const manageOrgProviders = useOrgModelsHandoff(modelConfigOrganizationId);
   const hostedOrgModelConfig = useHostedOrgModelConfig({
     projectId: effectiveHostedProjectId,
     organizationId: modelConfigOrganizationId,
@@ -2155,9 +2145,7 @@ export function ChatTabV2({
         ? chatboxOptionalInventory
         : undefined,
     onAttachChatboxServer: onEnableChatboxOptionalServer,
-    onManageOrgProviders: canManageOrgModelsForActiveOrg
-      ? handleManageOrgProviders
-      : undefined,
+    onManageOrgProviders: manageOrgProviders,
   };
 
   const showStarterPrompts =

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-selector.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-selector.test.tsx
@@ -650,6 +650,55 @@ describe("ModelSelector", () => {
     ).not.toBeInTheDocument();
   });
 
+  // The people who need the hand-off most have no keys at all, and the tab
+  // used to be hidden entirely until the configured list was non-empty.
+  it("keeps the providers tab reachable with no keys configured", async () => {
+    const user = userEvent.setup();
+    const onManageOrgProviders = vi.fn();
+    const freeOnly = byokIntentModels.filter((model) => model.hosted);
+
+    render(
+      <ModelSelector
+        currentModel={freeOnly[0]!}
+        availableModels={freeOnly}
+        onModelChange={() => {}}
+        onManageOrgProviders={onManageOrgProviders}
+      />
+    );
+
+    await user.click(screen.getByTestId("model-selector-trigger"));
+    await user.click(await screen.findByText("Your providers"));
+
+    expect(await screen.findByText("No provider keys yet.")).toBeVisible();
+    // cmdk's Empty would otherwise claim the search found nothing.
+    expect(screen.queryByText("No matching models.")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /manage organization models/i })
+    );
+    expect(onManageOrgProviders).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the providers tab hidden with no keys and no hand-off", async () => {
+    const user = userEvent.setup();
+    const freeOnly = byokIntentModels.filter((model) => model.hosted);
+
+    render(
+      <ModelSelector
+        currentModel={freeOnly[0]!}
+        availableModels={freeOnly}
+        onModelChange={() => {}}
+      />
+    );
+
+    await user.click(screen.getByTestId("model-selector-trigger"));
+
+    expect(
+      await screen.findByRole("option", { name: /claude haiku/i })
+    ).toBeVisible();
+    expect(screen.queryByText("Your providers")).not.toBeInTheDocument();
+  });
+
   it("keeps the footer out of the free models tab", async () => {
     const user = userEvent.setup();
 

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-selector.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-selector.test.tsx
@@ -598,6 +598,77 @@ describe("ModelSelector", () => {
     });
     expect(onModelChange).not.toHaveBeenCalled();
   });
+
+  it("hands off to org models from the Your providers footer", async () => {
+    const user = userEvent.setup();
+    const onManageOrgProviders = vi.fn();
+
+    render(
+      <ModelSelector
+        currentModel={byokIntentModels[1]!}
+        availableModels={byokIntentModels}
+        onModelChange={() => {}}
+        onManageOrgProviders={onManageOrgProviders}
+      />
+    );
+
+    await user.click(screen.getByTestId("model-selector-trigger"));
+
+    const footer = await screen.findByRole("button", {
+      name: /manage organization models/i,
+    });
+    await user.click(footer);
+
+    expect(onManageOrgProviders).toHaveBeenCalledTimes(1);
+    // Left mounted, the popover would float over whatever the handler navigates
+    // to.
+    await waitFor(() => {
+      expect(
+        screen.queryByPlaceholderText("Search models")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // Members who can't open org settings would only reach the access-restricted
+  // screen, so the caller omits the handler and the footer goes with it.
+  it("omits the footer when the viewer can't manage org models", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelSelector
+        currentModel={byokIntentModels[1]!}
+        availableModels={byokIntentModels}
+        onModelChange={() => {}}
+      />
+    );
+
+    await user.click(screen.getByTestId("model-selector-trigger"));
+
+    expect(await screen.findByText("Your providers")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /manage organization models/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the footer out of the free models tab", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelSelector
+        currentModel={byokIntentModels[0]!}
+        availableModels={byokIntentModels}
+        onModelChange={() => {}}
+        onManageOrgProviders={() => {}}
+      />
+    );
+
+    await user.click(screen.getByTestId("model-selector-trigger"));
+
+    expect(await screen.findByText("Free models")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /manage organization models/i })
+    ).not.toBeInTheDocument();
+  });
 });
 
 // The threshold in `modelFilter` is calibrated against cmdk's scoring, so a

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -356,6 +356,11 @@ interface ChatInputProps {
   }>;
   onAttachChatboxServer?: (serverId: string) => void;
   /**
+   * Opens the org's model providers page from the model picker's "Your
+   * providers" footer. Passed only when the viewer may open org settings.
+   */
+  onManageOrgProviders?: () => void;
+  /**
    * Environment mode (Project Environments): the environment's resolved
    * servers, id-first from the preview. When present (even empty) this
    * REPLACES the ad-hoc rows above in the "+" menu — environment servers are
@@ -437,6 +442,7 @@ export function ChatInput({
   voiceInputAuthHeaders,
   chatboxAttachableServers,
   onAttachChatboxServer,
+  onManageOrgProviders,
   environmentServers,
   onEnvironmentServerToggle,
   environmentServersOverridden = false,
@@ -1854,6 +1860,7 @@ export function ChatInput({
                   onSelectedModelsChange={onSelectedModelsChange}
                   onMultiModelEnabledChange={onMultiModelEnabledChange}
                   respondToProviderTabIntent
+                  onManageOrgProviders={onManageOrgProviders}
                 />
               )}
             </div>

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { defaultFilter } from "cmdk";
-import { Check, X } from "lucide-react";
+import { ArrowUpRight, Check, X } from "lucide-react";
 import { track } from "@/lib/analytics";
 import { Button } from "@mcpjam/design-system/button";
 import {
@@ -76,6 +76,13 @@ interface ModelSelectorProps {
    * on the configured tab. Only the chat-input instance opts in.
    */
   respondToProviderTabIntent?: boolean;
+  /**
+   * Navigates to the org's model providers page. Rendered as a footer under the
+   * "Your providers" list so adding another BYOK key doesn't mean hunting
+   * through Settings. Callers pass it only when the viewer may actually open
+   * org settings; omitted, the footer is absent rather than disabled.
+   */
+  onManageOrgProviders?: () => void;
 }
 
 type GroupKey = string;
@@ -205,6 +212,7 @@ export function ModelSelector({
   align = "start",
   analyticsLocation = "chat_input",
   respondToProviderTabIntent = false,
+  onManageOrgProviders,
 }: ModelSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [providerTab, setProviderTab] = useState<"provided" | "configured">(
@@ -301,6 +309,16 @@ export function ModelSelector({
     if (!nextOpen) {
       setHoveredLockedModelId(null);
     }
+  };
+
+  const handleManageOrgProviders = () => {
+    track("chat_model_selector_manage_org_models_clicked", {
+      location: analyticsLocation,
+    });
+    // Navigating away from a chat while the popover is mounted leaves it
+    // orphaned over the next screen, so close it before handing off.
+    setIsOpen(false);
+    onManageOrgProviders?.();
   };
 
   const selectedModelsData =
@@ -863,6 +881,22 @@ export function ModelSelector({
                       </CommandGroup>
                     ) : null}
                   </CommandList>
+
+                  {/* Only under the user's own providers, and only when there
+                      is a list to append to — while searching the rows are a
+                      transient mix of both sections. */}
+                  {onManageOrgProviders && showConfigured && !isSearching ? (
+                    <div className="border-t px-2 py-1.5">
+                      <button
+                        type="button"
+                        onClick={handleManageOrgProviders}
+                        className="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                      >
+                        Manage organization models
+                        <ArrowUpRight className="size-3 shrink-0" />
+                      </button>
+                    </div>
+                  ) : null}
                 </>
               );
             })()}

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
@@ -394,10 +394,9 @@ export function ModelSelector({
     availableModels.length > 1;
   const leadModel = selectedModelsData[0] ?? currentModel;
   const isComparingModels = multiModelEnabled && selectedModelsData.length > 1;
-  const triggerLabel =
-    isComparingModels
-      ? `${compactModelLabel(leadModel.name)} +${selectedModelsData.length - 1}`
-      : compactModelLabel(leadModel.name);
+  const triggerLabel = isComparingModels
+    ? `${compactModelLabel(leadModel.name)} +${selectedModelsData.length - 1}`
+    : compactModelLabel(leadModel.name);
   const modelSections = useMemo(() => {
     const provided = modelGroups.filter((g) => g.providerType === "provided");
     const configured = modelGroups.filter(
@@ -670,7 +669,7 @@ export function ModelSelector({
                 disabled={disabled || isLoading}
                 className={cn(
                   "h-8 rounded-full px-2 text-xs transition-colors hover:bg-muted/80 @max-2xl/toolbar:max-w-none @max-2xl/toolbar:w-8 @max-2xl/toolbar:px-0",
-                  isComparingModels ? "max-w-[280px] gap-1" : "max-w-[180px]",
+                  isComparingModels ? "max-w-[280px] gap-1" : "max-w-[180px]"
                 )}
                 data-testid="model-selector-trigger"
               >
@@ -683,7 +682,7 @@ export function ModelSelector({
                           "inline-flex h-5 w-[82px] min-w-0 shrink-0 items-center gap-1 rounded-full border px-1.5 text-[10px] font-medium",
                           index === 0
                             ? "border-primary/25 text-foreground"
-                            : "border-border/50 text-muted-foreground",
+                            : "border-border/50 text-muted-foreground"
                         )}
                       >
                         <ProviderLogo
@@ -806,19 +805,27 @@ export function ModelSelector({
             ) : null}
 
             {(() => {
-              const hasBothSections =
-                modelSections.provided.length > 0 &&
-                modelSections.configured.length > 0;
               const isSearching = search.trim().length > 0;
-              const showTabs = hasBothSections && !isSearching;
+              // An org admin with no keys yet is exactly who the footer below is
+              // for, so the tab stays reachable while their list is empty —
+              // gating it on a non-empty list hid the offer to add a key from
+              // everyone who had none.
+              const offerEmptyConfigured =
+                !!onManageOrgProviders && modelSections.configured.length === 0;
+              const showTabs =
+                !isSearching &&
+                modelSections.provided.length > 0 &&
+                (modelSections.configured.length > 0 || offerEmptyConfigured);
               const showProvided =
                 visibleSections.provided.length > 0 &&
-                (isSearching || !hasBothSections || providerTab === "provided");
+                (isSearching || !showTabs || providerTab === "provided");
               const showConfigured =
                 visibleSections.configured.length > 0 &&
-                (isSearching ||
-                  !hasBothSections ||
-                  providerTab === "configured");
+                (isSearching || !showTabs || providerTab === "configured");
+              const showConfiguredEmpty =
+                showTabs &&
+                providerTab === "configured" &&
+                visibleSections.configured.length === 0;
 
               return (
                 <>
@@ -845,7 +852,18 @@ export function ModelSelector({
                   ) : null}
 
                   <CommandList className="max-h-[min(320px,45vh)]">
-                    <CommandEmpty>No matching models.</CommandEmpty>
+                    {/* cmdk renders Empty whenever no rows are mounted, which
+                        the empty providers tab below would otherwise inherit —
+                        and "No matching models" reads as a failed search. */}
+                    {showConfiguredEmpty ? null : (
+                      <CommandEmpty>No matching models.</CommandEmpty>
+                    )}
+
+                    {showConfiguredEmpty ? (
+                      <p className="px-2.5 py-3 text-[11px] text-muted-foreground">
+                        No provider keys yet.
+                      </p>
+                    ) : null}
 
                     {showProvided ? (
                       <CommandGroup
@@ -882,10 +900,11 @@ export function ModelSelector({
                     ) : null}
                   </CommandList>
 
-                  {/* Only under the user's own providers, and only when there
-                      is a list to append to — while searching the rows are a
-                      transient mix of both sections. */}
-                  {onManageOrgProviders && showConfigured && !isSearching ? (
+                  {/* Only under the user's own providers — while searching the
+                      rows are a transient mix of both sections. */}
+                  {onManageOrgProviders &&
+                  !isSearching &&
+                  (showConfigured || showConfiguredEmpty) ? (
                     <div className="border-t px-2 py-1.5">
                       <button
                         type="button"

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/model-selector.tsx
@@ -394,9 +394,10 @@ export function ModelSelector({
     availableModels.length > 1;
   const leadModel = selectedModelsData[0] ?? currentModel;
   const isComparingModels = multiModelEnabled && selectedModelsData.length > 1;
-  const triggerLabel = isComparingModels
-    ? `${compactModelLabel(leadModel.name)} +${selectedModelsData.length - 1}`
-    : compactModelLabel(leadModel.name);
+  const triggerLabel =
+    isComparingModels
+      ? `${compactModelLabel(leadModel.name)} +${selectedModelsData.length - 1}`
+      : compactModelLabel(leadModel.name);
   const modelSections = useMemo(() => {
     const provided = modelGroups.filter((g) => g.providerType === "provided");
     const configured = modelGroups.filter(
@@ -669,7 +670,7 @@ export function ModelSelector({
                 disabled={disabled || isLoading}
                 className={cn(
                   "h-8 rounded-full px-2 text-xs transition-colors hover:bg-muted/80 @max-2xl/toolbar:max-w-none @max-2xl/toolbar:w-8 @max-2xl/toolbar:px-0",
-                  isComparingModels ? "max-w-[280px] gap-1" : "max-w-[180px]"
+                  isComparingModels ? "max-w-[280px] gap-1" : "max-w-[180px]",
                 )}
                 data-testid="model-selector-trigger"
               >
@@ -682,7 +683,7 @@ export function ModelSelector({
                           "inline-flex h-5 w-[82px] min-w-0 shrink-0 items-center gap-1 rounded-full border px-1.5 text-[10px] font-medium",
                           index === 0
                             ? "border-primary/25 text-foreground"
-                            : "border-border/50 text-muted-foreground"
+                            : "border-border/50 text-muted-foreground",
                         )}
                       >
                         <ProviderLogo

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -107,6 +107,11 @@ import { Settings2 } from "lucide-react";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
 import { useConvexAuth, useQuery } from "convex/react";
 import {
+  canManageOrgModels,
+  useOrganizationQueries,
+} from "@/hooks/useOrganizations";
+import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
+import {
   useHost,
   useHostList,
   useHostMutations,
@@ -746,10 +751,27 @@ export function PlaygroundMain({
     isAuthenticated: isConvexAuthenticated,
   });
   const attachmentUploadInFlightRef = useRef(false);
+  const projectOrganizationId = activeProject?.organizationId ?? null;
   const hostedOrgModelConfig = useHostedOrgModelConfig({
     projectId: convexProjectId,
-    organizationId: activeProject?.organizationId ?? null,
+    organizationId: projectOrganizationId,
   });
+  // Hand-off from the model picker's "Your providers" footer to where the org's
+  // keys live. Only owners/admins, who are the only roles the org settings
+  // screens let in.
+  const { sortedOrganizations } = useOrganizationQueries({
+    isAuthenticated: isConvexAuthenticated,
+  });
+  const canManageOrgModelsForActiveOrg = canManageOrgModels(
+    projectOrganizationId
+      ? sortedOrganizations.find((org) => org._id === projectOrganizationId)
+      : null
+  );
+  const appNavigate = useAppNavigate();
+  const handleManageOrgProviders = useCallback(() => {
+    if (!projectOrganizationId) return;
+    appNavigate(buildOrganizationPath(projectOrganizationId, "models"));
+  }, [appNavigate, projectOrganizationId]);
   const { serversById, serversByName } = useProjectServers({
     isAuthenticated: isConvexAuthenticated,
     projectId: convexProjectId,
@@ -4062,6 +4084,9 @@ export function PlaygroundMain({
         }
       : undefined,
     voiceInputAuthHeaders: authHeaders,
+    onManageOrgProviders: canManageOrgModelsForActiveOrg
+      ? handleManageOrgProviders
+      : undefined,
   };
 
   // Check if widget should take over the full container

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -106,11 +106,7 @@ import { useSharedAppState } from "@/state/app-state-context";
 import { Settings2 } from "lucide-react";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
 import { useConvexAuth, useQuery } from "convex/react";
-import {
-  canManageOrgModels,
-  useOrganizationQueries,
-} from "@/hooks/useOrganizations";
-import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
+import { useOrgModelsHandoff } from "@/hooks/use-org-models-handoff";
 import {
   useHost,
   useHostList,
@@ -756,22 +752,7 @@ export function PlaygroundMain({
     projectId: convexProjectId,
     organizationId: projectOrganizationId,
   });
-  // Hand-off from the model picker's "Your providers" footer to where the org's
-  // keys live. Only owners/admins, who are the only roles the org settings
-  // screens let in.
-  const { sortedOrganizations } = useOrganizationQueries({
-    isAuthenticated: isConvexAuthenticated,
-  });
-  const canManageOrgModelsForActiveOrg = canManageOrgModels(
-    projectOrganizationId
-      ? sortedOrganizations.find((org) => org._id === projectOrganizationId)
-      : null
-  );
-  const appNavigate = useAppNavigate();
-  const handleManageOrgProviders = useCallback(() => {
-    if (!projectOrganizationId) return;
-    appNavigate(buildOrganizationPath(projectOrganizationId, "models"));
-  }, [appNavigate, projectOrganizationId]);
+  const manageOrgProviders = useOrgModelsHandoff(projectOrganizationId);
   const { serversById, serversByName } = useProjectServers({
     isAuthenticated: isConvexAuthenticated,
     projectId: convexProjectId,
@@ -4084,9 +4065,7 @@ export function PlaygroundMain({
         }
       : undefined,
     voiceInputAuthHeaders: authHeaders,
-    onManageOrgProviders: canManageOrgModelsForActiveOrg
-      ? handleManageOrgProviders
-      : undefined,
+    onManageOrgProviders: manageOrgProviders,
   };
 
   // Check if widget should take over the full container

--- a/mcpjam-inspector/client/src/hooks/__tests__/useOrganizations.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useOrganizations.test.tsx
@@ -2,7 +2,10 @@ import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DbUserReadyProvider } from "@/contexts/db-user-ready-context";
-import { useOrganizationQueries } from "../useOrganizations";
+import {
+  canManageOrgModels,
+  useOrganizationQueries,
+} from "../useOrganizations";
 
 const mockUseQuery = vi.hoisted(() => vi.fn());
 
@@ -77,5 +80,20 @@ describe("useOrganizationQueries", () => {
       "skip"
     );
     expect(result.current.isLoading).toBe(false);
+  });
+});
+
+describe("canManageOrgModels", () => {
+  it("allows owners and admins", () => {
+    expect(canManageOrgModels({ myRole: "owner" })).toBe(true);
+    expect(canManageOrgModels({ myRole: "admin" })).toBe(true);
+  });
+
+  it("fails closed for everyone else", () => {
+    expect(canManageOrgModels({ myRole: "member" })).toBe(false);
+    expect(canManageOrgModels({ myRole: "guest" })).toBe(false);
+    expect(canManageOrgModels({ myRole: undefined })).toBe(false);
+    expect(canManageOrgModels(null)).toBe(false);
+    expect(canManageOrgModels(undefined)).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/use-org-models-handoff.ts
+++ b/mcpjam-inspector/client/src/hooks/use-org-models-handoff.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+import { useConvexAuth } from "convex/react";
+import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
+import {
+  canManageOrgModels,
+  useOrganizationQueries,
+} from "@/hooks/useOrganizations";
+
+/**
+ * Navigates to where an organization's provider keys live, for the model
+ * picker's "Your providers" footer.
+ *
+ * Returns `undefined` when there is no org (personal or hosted surfaces) or the
+ * viewer may not open its settings screens, so callers pass nothing and the
+ * footer stays absent rather than rendering a control that lands on
+ * `OrganizationAccessRestricted`. Fails closed while the org list loads.
+ */
+export function useOrgModelsHandoff(
+  organizationId: string | null,
+): (() => void) | undefined {
+  const { isAuthenticated } = useConvexAuth();
+  const { sortedOrganizations } = useOrganizationQueries({ isAuthenticated });
+  const canManage = canManageOrgModels(
+    organizationId
+      ? sortedOrganizations.find((org) => org._id === organizationId)
+      : null,
+  );
+  const appNavigate = useAppNavigate();
+  const navigateToOrgModels = useCallback(() => {
+    if (!organizationId) return;
+    appNavigate(buildOrganizationPath(organizationId, "models"));
+  }, [appNavigate, organizationId]);
+
+  return canManage ? navigateToOrgModels : undefined;
+}

--- a/mcpjam-inspector/client/src/hooks/useOrganizations.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizations.ts
@@ -61,6 +61,20 @@ export function canManageOrgCredits(
   );
 }
 
+/**
+ * Whether the current user may reach the organization settings screens, where
+ * provider keys are configured. `OrganizationsTab` route-gates on this same
+ * owner/admin pair, so offering the link to anyone else would only land them on
+ * the access-restricted screen. Deliberately narrower than
+ * `canManageOrgCredits`: `isCreator` alone does not open those screens.
+ */
+export function canManageOrgModels(
+  org: Pick<Organization, "myRole"> | null | undefined,
+): boolean {
+  if (!org) return false;
+  return org.myRole === "owner" || org.myRole === "admin";
+}
+
 export function useOrganizationQueries({
   isAuthenticated,
 }: {

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -70,6 +70,7 @@ export const ANALYTICS_EVENTS = {
   chat_attachment_button_clicked: { source: "client" },
   chat_cleared: { source: "client" },
   chat_model_selector_clicked: { source: "client" },
+  chat_model_selector_manage_org_models_clicked: { source: "client" },
   chat_options_plus_clicked: { source: "client" },
   // Every starter-chip surface fires this one event; props: prompt (chip
   // text), location: chat_tab | playground_single | playground_compare.


### PR DESCRIPTION
Closes BACK2-695.

Adding another BYOK provider key meant leaving chat, opening Settings, and finding the organization page by hand. The model picker's **Your providers** list now ends in a footer that navigates straight to `/organizations/:orgId/models`.

<img src="https://raw.githubusercontent.com/olartgabo/inspector/0cf8c421b7a856c562aea08a1c4a4e043ad16aa8/providers-footer.png" width="320" alt="Your providers tab with a Manage organization models footer" />

<img src="https://raw.githubusercontent.com/olartgabo/inspector/0cf8c421b7a856c562aea08a1c4a4e043ad16aa8/playground-picker.jpg" width="900" alt="The same picker open in the playground composer" />

## Permission gating

`useOrgModelsHandoff` returns the navigation handler only for org owners and admins, and the picker renders no footer when the handler is absent — a disabled control would be worse, since there is nothing the viewer could do to enable it. `OrganizationsTab` route-gates on that same owner/admin pair, so offering the link to a member would only land them on the access-restricted screen.

The new `canManageOrgModels` is deliberately narrower than the neighbouring `canManageOrgCredits`: `isCreator` alone does not open the org settings screens. It fails closed while the org list loads, and hosted/chatbox surfaces get no footer because they have no org page to reach.

This is a render gate, not an enforcement boundary. The org models route keeps its own gate and the `organizationModelProviders` mutations keep their server-side checks.

## Empty state

The footer alone would have missed the people who need it most. The **Your providers** tab only rendered once a key existed, so an admin with no keys never saw an offer to add one. For admins the tab now stays reachable while the list is empty, showing a short empty line above the footer. Everyone else sees exactly what they see today — with no handler passed, the tab stays hidden.

cmdk renders `Command.Empty` whenever no rows are mounted, so the empty tab would otherwise have claimed "No matching models", which reads as a failed search. That copy is suppressed for this one state only.

## Both composer surfaces

`/playground` renders `ChatInput` through `PlaygroundMain`, not `ChatTabV2`, so wiring only the latter left the footer missing on the surface the task screenshot came from. Both are wired now through the one hook.

## Testing

- `npm run typecheck:client` — clean.
- `npx vitest run client/src/components/ui-playground client/src/components/chat-v2 client/src/components/__tests__/ChatTabV2 client/src/hooks/__tests__` — 139 files, 1794 tests passed.
- Five new picker tests: the hand-off fires and closes the popover, no footer without a handler, no footer on the Free models tab, the tab stays reachable with zero keys, and it stays hidden with zero keys and no handler. Plus role coverage for `canManageOrgModels`.
- Verified in the running app against a real org: the tab appeared with zero providers configured, the footer appeared once an OpenRouter key was added, and clicking it closed the popover and landed on the org models page.

## Unrelated bug found while verifying

Signing in and opening `/playground` crashes the route against a Convex deployment that predates the environment-origin split:

```
[CONVEX Q(projectEnvironments:listEnvironments)] ArgumentValidationError:
Object contains extra field `origin` that is not in the validator.
```

`useProjectEnvironments` (`client/src/hooks/useProjectEnvironments.ts:140`) sends `origin: "all"` whenever `includeAdhoc` is set, and the playground opts in. The hook's own comment anticipates this skew — "a backend that predates the split rejects unknown args, so passing the default explicitly would turn a harmless skew into a hard failure" — but that reasoning only covers the default; the opt-in path sends the arg unconditionally and takes the whole route down with an unhandled query error. Not touched here; worth its own ticket.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Manage organization models” footer to the model picker so admins can jump straight to `/organizations/:orgId/models` and add BYOK keys without leaving the composer. Applies to Chat and Playground; addresses BACK2-695.

- New Features
  - Footer button under “Your providers” opens org models; popover closes before navigating.
  - Visible only to org owners/admins; hidden on hosted/personal surfaces with no org.
  - Keeps “Your providers” tab reachable with zero keys and shows “No provider keys yet.”; suppresses “No matching models.” in this state.
  - Tracks clicks via `chat_model_selector_manage_org_models_clicked`.

- Refactors
  - Introduced `useOrgModelsHandoff` to centralize permission + navigation; used in `ChatTabV2` and `PlaygroundMain`.
  - Added `canManageOrgModels` (owner/admin only). This is a render gate; routes and `organizationModelProviders` still enforce access.

<sup>Written for commit 4702a5dd6fd7ce7e8a9639d20b1df90dc5759963. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

