### PR TITLE
fix(user-testing): tell a visitor a scenario was archived, not that we broke

### DIFF
--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -70,6 +70,7 @@ type ChatboxErrorKind =
   | "guest_blocked"
   | "invalid_link"
   | "playground_expired"
+  | "scenario_unavailable"
   | "unexpected";
 
 interface ChatboxDisplayError {
@@ -130,9 +131,20 @@ async function readRouteError(response: Response): Promise<ChatboxRouteError> {
       code?: string;
       message?: string;
       error?: string;
+      details?: { code?: string } | null;
     } | null;
 
-    code = typeof body?.code === "string" ? body.code : undefined;
+    // The DOMAIN code wins when the route forwarded one. Top-level `code` is
+    // the transport classification (CONFLICT, NOT_FOUND…); `details.code`
+    // says WHY — e.g. ENV_ARCHIVED, which is the difference between "this
+    // link is broken" and "its owner retired it".
+    const domainCode = body?.details?.code;
+    code =
+      typeof domainCode === "string" && domainCode
+        ? domainCode
+        : typeof body?.code === "string"
+          ? body.code
+          : undefined;
     message =
       body?.message ||
       body?.error ||
@@ -185,6 +197,22 @@ function getChatboxDisplayError(
   const isPlaygroundExpired = normalizedMessage.includes(
     "playground session expired"
   );
+  // The scenario exists and the link is valid — its environment just isn't
+  // openable (archived by its owner, a disabled plugin, a deleted host). The
+  // backend already authored visitor-facing copy for each case, so it is shown
+  // verbatim rather than re-derived from a status code.
+  const isScenarioUnavailable = Boolean(error.code?.startsWith("ENV_"));
+
+  if (isScenarioUnavailable) {
+    return {
+      kind: "scenario_unavailable",
+      title:
+        error.code === "ENV_ARCHIVED"
+          ? "This link has been archived"
+          : "This link isn't available right now",
+      message: error.message,
+    };
+  }
 
   if (isPlaygroundExpired) {
     return {

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -365,6 +365,61 @@ describe("ChatboxChatPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("says a scenario was archived, rather than showing the generic failure", async () => {
+    // The link redeemed fine and the access check passed — its environment was
+    // archived on purpose. The backend authored the visitor-facing copy and
+    // sends the reason in `details.code`; showing "we couldn't open this"
+    // instead makes a deliberate retirement look like an outage.
+    mockAuthFetch.mockResolvedValueOnce(
+      createFetchResponse(
+        {
+          code: "CONFLICT",
+          message:
+            "This link has been archived by its owner and can no longer be opened.",
+          details: { code: "ENV_ARCHIVED" },
+        },
+        { ok: false, status: 410, statusText: "Gone" }
+      )
+    );
+
+    render(<ChatboxChatPage pathToken="archived-token" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "This link has been archived" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This link has been archived by its owner and can no longer be opened."
+      )
+    ).toBeInTheDocument();
+    // Signing in cannot un-archive an environment, so no sign-in CTA.
+    expect(
+      screen.queryByRole("button", { name: "Sign in" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the not-archived copy for other environment failures", async () => {
+    mockAuthFetch.mockResolvedValueOnce(
+      createFetchResponse(
+        {
+          code: "CONFLICT",
+          message:
+            "This link isn't available right now — the setup behind it can't be loaded.",
+          details: { code: "ENV_PLUGIN_UNAVAILABLE" },
+        },
+        { ok: false, status: 409, statusText: "Conflict" }
+      )
+    );
+
+    render(<ChatboxChatPage pathToken="unresolvable-token" />);
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "This link isn't available right now",
+      })
+    ).toBeInTheDocument();
+  });
+
   it("persists the redeemed session to sessionStorage when standalone", async () => {
     window.history.replaceState({}, "", "/chatbox/demo/chatbox-token");
 

--- a/mcpjam-inspector/server/routes/web/__tests__/chatboxes.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatboxes.test.ts
@@ -72,6 +72,105 @@ describe("web routes — chatboxes redeem", () => {
     expect(data.code).toBe("RATE_LIMITED");
   });
 
+  it("keeps an archived scenario's 410 and forwards ENV_ARCHIVED in details", async () => {
+    // The link redeemed fine; its environment was archived on purpose. This
+    // used to reach the visitor as a generic failure, which reads as "MCPJam
+    // is broken" rather than "the owner retired this".
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error:
+              "This link has been archived by its owner and can no longer be opened.",
+            code: "ENV_ARCHIVED",
+          }),
+          { status: 410, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/redeem",
+      { chatboxToken: "chatbox-link-token" },
+      token,
+    );
+    const { status, data } = await expectJson<{
+      code: string;
+      message: string;
+      details?: { code?: string };
+    }>(response);
+
+    expect(status).toBe(410);
+    // Top-level code is this route's TRANSPORT classification…
+    expect(data.code).toBe("CONFLICT");
+    // …the domain reason rides in details, so the client can pick its copy.
+    expect(data.details?.code).toBe("ENV_ARCHIVED");
+    expect(data.message).toContain("archived by its owner");
+  });
+
+  it("maps a 409 (environment unresolvable) to CONFLICT too", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: false,
+            error: "This link isn't available right now.",
+            code: "ENV_PLUGIN_UNAVAILABLE",
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/redeem",
+      { chatboxToken: "chatbox-link-token" },
+      token,
+    );
+    const { status, data } = await expectJson<{
+      code: string;
+      details?: { code?: string };
+    }>(response);
+
+    expect(status).toBe(409);
+    expect(data.code).toBe("CONFLICT");
+    expect(data.details?.code).toBe("ENV_PLUGIN_UNAVAILABLE");
+  });
+
+  it("omits details when the upstream sent no domain code", async () => {
+    // Absence stays absence: a bare 403 must not grow an empty details block
+    // the client would then branch on.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: false, error: "nope" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/redeem",
+      { chatboxToken: "chatbox-link-token" },
+      token,
+    );
+    const { status, data } = await expectJson<{
+      code: string;
+      details?: unknown;
+    }>(response);
+
+    expect(status).toBe(403);
+    expect(data.code).toBe("FORBIDDEN");
+    expect(data.details).toBeUndefined();
+  });
+
   it("coerces 2xx with ok:false to a 502 instead of leaking a misleading 200", async () => {
     vi.stubGlobal(
       "fetch",

--- a/mcpjam-inspector/server/routes/web/chatboxes.ts
+++ b/mcpjam-inspector/server/routes/web/chatboxes.ts
@@ -36,6 +36,11 @@ function mapRedeemStatusToErrorCode(status: number): ErrorCode {
   if (status === 403) return ErrorCode.FORBIDDEN;
   if (status === 404) return ErrorCode.NOT_FOUND;
   if (status === 429) return ErrorCode.RATE_LIMITED;
+  // 410 Gone (the scenario's environment was archived) and 409 (it can't be
+  // resolved right now) are both "the link is fine, the thing behind it is
+  // not" — a state conflict, not a bad request and not our fault. See the
+  // CONFLICT doc in ./errors.ts.
+  if (status === 409 || status === 410) return ErrorCode.CONFLICT;
   if (status === 502 || status === 503 || status === 504) {
     return ErrorCode.SERVER_UNREACHABLE;
   }
@@ -76,6 +81,12 @@ chatboxes.post("/redeem", async (c) =>
         result.status || 500,
         mapRedeemStatusToErrorCode(result.status),
         result.error,
+        // The backend's domain code rides in `details`, not the top level:
+        // the top-level `code` is this route's TRANSPORT classification, and
+        // collapsing the two would make `ENV_ARCHIVED` look like an
+        // inspector-side error code. Same split `readEnvironmentErrorPayload`
+        // documents on the client.
+        result.code ? { code: result.code } : undefined,
       );
     }
 

--- a/mcpjam-inspector/server/utils/chatbox-redeem.ts
+++ b/mcpjam-inspector/server/utils/chatbox-redeem.ts
@@ -68,6 +68,15 @@ export type ChatboxRedeemFailure = {
   ok: false;
   status: number;
   error: string;
+  /**
+   * The backend's DOMAIN code, when it sent one — today that means an `ENV_*`
+   * environment-resolution failure (mcpjam-backend #890): the link and the
+   * access check both passed, and only the environment behind the scenario is
+   * unavailable. Carried separately from the HTTP status because "archived on
+   * purpose" and "temporarily unresolvable" share a 4xx but read very
+   * differently to the visitor.
+   */
+  code?: string;
 };
 
 export type ChatboxRedeemResult = ChatboxRedeemSuccess | ChatboxRedeemFailure;
@@ -139,6 +148,7 @@ export async function redeemChatboxToken(args: {
         typeof payload?.error === "string"
           ? payload.error
           : `Chatbox redeem failed (${response.status})`,
+      ...(typeof payload?.code === "string" ? { code: payload.code } : {}),
     };
   }
 


### PR DESCRIPTION
## Why

mcpjam-backend #890 made an unresolvable environment a **4xx with its reason attached** — 410 + `ENV_ARCHIVED` when the owner archived it, 409 + the specific `ENV_*` code otherwise.

Nothing on this side read any of it. The redeem proxy dropped the code, the route mapped both statuses to `INTERNAL_ERROR`, and `getChatboxDisplayError` had no branch for them. So a scenario retired on purpose still told its testers:

> We couldn't open this swarm right now. Please try again or open MCPJam.

An outage message for a deliberate act.

## What

Three small links in that chain:

1. **`redeemChatboxToken`** keeps the upstream `code` on its failure result.
2. **The redeem route** maps 409/410 → `CONFLICT` (whose own doc in `errors.ts` already covers archive-state rejections) and forwards the domain code in **`details`, not top-level**. Top-level `code` is this route's *transport* classification; collapsing the two would make `ENV_ARCHIVED` look like an inspector-side error code. Same split `readEnvironmentErrorPayload` documents.
3. **`readRouteError`** prefers `details.code` over the transport code, and a new `scenario_unavailable` display kind renders the backend's authored copy verbatim — titled "This link has been archived" for `ENV_ARCHIVED`, "This link isn't available right now" for the rest.

**No sign-in CTA** on that state. It already renders through the non-access-denied arm, which is correct: signing in cannot un-archive an environment.

## Deliberately unchanged

- Every existing status mapping (401/403/404/429/5xx) is untouched.
- A failure with **no** domain code carries no `details` at all, rather than an empty block the client would then branch on. There's a test for that.

## Tests

`server/routes/web/__tests__/chatboxes.test.ts` +3: the 410 keeps its status with `CONFLICT` top-level and `ENV_ARCHIVED` in details; a 409 maps the same way; a bare 403 grows no `details`.

`client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx` +2: the archived link renders the archived heading, the backend's message verbatim, and **no** sign-in button; a non-archived `ENV_*` gets the other heading.

```
npx vitest run server/routes/web client/src/components/hosted client/src/lib/__tests__
# 140 files, 1612 tests passed

vite build --config client/vite.config.ts    # ✓ built
```

Formatting note: `ChatboxChatPage.tsx` and its test don't satisfy `prettier --trailing-comma all` — they already didn't on main, so I left their pre-existing lines alone. The three files that were conformant stayed conformant.

Closes the User Testing environment-first program (#3761, #3765, #3768, backend #887/#889/#890/#891).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted error-mapping and visitor-facing copy on chatbox redeem; existing auth/not-found/rate-limit paths are unchanged and covered by new tests.
> 
> **Overview**
> **Visitors opening a valid swarm link whose scenario environment is gone** no longer see a generic “we couldn’t open this swarm” outage message.
> 
> The redeem proxy now **preserves upstream `ENV_*` domain codes**, maps **409/410** to transport **`CONFLICT`** (instead of treating them as internal errors), and puts the domain reason in **`details.code`** so it stays separate from the route’s top-level error code. **`readRouteError`** prefers `details.code`, and **`scenario_unavailable`** UI shows backend-authored copy — **“This link has been archived”** for `ENV_ARCHIVED`, otherwise **“This link isn’t available right now”** — without a sign-in CTA.
> 
> Server and client tests cover 410/409 forwarding, missing `details`, and the archived vs other `ENV_*` headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6babefa1326d866b797c3566548b396e97660370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show accurate messaging when a user opens an archived or otherwise unavailable scenario link, instead of a generic outage error. This maps backend `ENV_*` errors to clear UI and removes the sign-in CTA for these cases.

- **Bug Fixes**
  - `redeemChatboxToken` preserves upstream domain `code` on failures.
  - Redeem route maps 409/410 to `CONFLICT` and forwards domain reason in `details.code`; top-level `code` remains the transport classification.
  - Client prefers `details.code` and adds a `scenario_unavailable` state:
    - `ENV_ARCHIVED`: "This link has been archived".
    - Other `ENV_*`: "This link isn't available right now".
    - Renders backend message verbatim; no sign-in button.
  - Existing status mappings unchanged; omit `details` when no domain code.
  - Added tests for 409/410 mapping, `details.code` propagation, and UI rendering.

<sup>Written for commit 6babefa1326d866b797c3566548b396e97660370. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

