### PR TITLE
fix(analytics): tag deployment/source, fix environment clobber, forward anon PostHog id on signup

### DIFF
--- a/mcpjam-inspector/.env.production
+++ b/mcpjam-inspector/.env.production
@@ -4,4 +4,5 @@ VITE_WORKOS_CLIENT_ID=client_01K4C1TVPBE7JTBFQJF9SDW9P9
 VITE_WORKOS_REDIRECT_URI=mcpjam://oauth/callback
 CONVEX_HTTP_URL=https://outstanding-fennec-304.convex.site
 ENVIRONMENT=production
+VITE_ENVIRONMENT=production
 VITE_DISABLE_POSTHOG_LOCAL=false

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
@@ -390,6 +390,25 @@ describe("useEnsureDbUser", () => {
     });
   });
 
+  it("still falls back to get_distinct_id() when get_property throws (not just returns undefined)", async () => {
+    mockState.auth.user = { id: "workos-user-1" };
+    mockState.actorKey = "workos-user-1";
+    mockState.posthog = {
+      get_property: vi.fn(() => {
+        throw new Error("boom");
+      }),
+      get_distinct_id: vi.fn(() => "distinct-abc"),
+    };
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledWith({
+        posthogAnonDistinctId: "distinct-abc",
+      });
+    });
+  });
+
   it("does not retry unrelated ensureUser errors", async () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEnsureDbUser.test.tsx
@@ -17,11 +17,19 @@ const mockState = vi.hoisted(() => ({
   getExistingGuestId: vi.fn().mockResolvedValue(null as string | null),
   isGuestActivated: vi.fn().mockReturnValue(false),
   sentrySetUser: vi.fn(),
+  posthog: null as {
+    get_property?: (key: string) => unknown;
+    get_distinct_id?: () => string;
+  } | null,
 }));
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => mockState.convexAuth,
   useMutation: () => mockState.ensureUser,
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => mockState.posthog,
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -55,6 +63,7 @@ describe("useEnsureDbUser", () => {
     mockState.auth.user = null;
     mockState.convexAuth.isAuthenticated = true;
     mockState.convexAuth.isLoading = false;
+    mockState.posthog = null;
   });
 
   afterEach(() => {
@@ -296,6 +305,89 @@ describe("useEnsureDbUser", () => {
     expect(mockState.getGuestPromotionProof).not.toHaveBeenCalled();
     expect(mockState.revokeGuestSessionAndCookie).not.toHaveBeenCalled();
     expect(mockState.ensureUser).toHaveBeenCalledWith({});
+  });
+
+  it("sends posthogAnonDistinctId ($device_id) for WorkOS auth", async () => {
+    mockState.auth.user = { id: "workos-user-1" };
+    mockState.actorKey = "workos-user-1";
+    mockState.posthog = {
+      get_property: vi.fn((key: string) =>
+        key === "$device_id" ? "device-abc" : undefined
+      ),
+      get_distinct_id: vi.fn(() => "distinct-abc"),
+    };
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledWith({
+        posthogAnonDistinctId: "device-abc",
+      });
+    });
+  });
+
+  it("falls back to get_distinct_id() when $device_id is unavailable", async () => {
+    mockState.auth.user = { id: "workos-user-1" };
+    mockState.actorKey = "workos-user-1";
+    mockState.posthog = {
+      get_property: vi.fn(() => undefined),
+      get_distinct_id: vi.fn(() => "distinct-abc"),
+    };
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledWith({
+        posthogAnonDistinctId: "distinct-abc",
+      });
+    });
+  });
+
+  it("never sends posthogAnonDistinctId for guest identities", async () => {
+    mockState.auth.user = null;
+    mockState.actorKey = "guest-1";
+    mockState.posthog = {
+      get_property: vi.fn(() => "device-abc"),
+      get_distinct_id: vi.fn(() => "distinct-abc"),
+    };
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledTimes(1);
+    });
+    expect(mockState.ensureUser).toHaveBeenCalledWith({});
+  });
+
+  it("still calls ensureUser when posthog is absent", async () => {
+    mockState.auth.user = { id: "workos-user-1" };
+    mockState.actorKey = "workos-user-1";
+    mockState.posthog = null;
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledWith({});
+    });
+  });
+
+  it("still calls ensureUser when posthog getters throw", async () => {
+    mockState.auth.user = { id: "workos-user-1" };
+    mockState.actorKey = "workos-user-1";
+    mockState.posthog = {
+      get_property: vi.fn(() => {
+        throw new Error("boom");
+      }),
+      get_distinct_id: vi.fn(() => {
+        throw new Error("boom");
+      }),
+    };
+
+    renderHook(() => useEnsureDbUser());
+
+    await waitFor(() => {
+      expect(mockState.ensureUser).toHaveBeenCalledWith({});
+    });
   });
 
   it("does not retry unrelated ensureUser errors", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePostHogIdentify.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePostHogIdentify.test.ts
@@ -41,6 +41,10 @@ vi.mock("@/lib/PosthogUtils", () => ({
   detectPlatform: mockState.detectPlatform,
 }));
 
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: false,
+}));
+
 vi.mock("@/hooks/use-actor-key", () => ({
   useActorKey: () => mockState.actorKey,
 }));
@@ -154,6 +158,8 @@ describe("usePostHogIdentify", () => {
       environment: import.meta.env.MODE,
       platform: "mac",
       version: "2.0.13-test",
+      deployment: "self_hosted",
+      source: "client",
     });
     expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {});
     expect(mockState.posthog.register).toHaveBeenCalledWith({

--- a/mcpjam-inspector/client/src/hooks/use-onboarding.ts
+++ b/mcpjam-inspector/client/src/hooks/use-onboarding.ts
@@ -13,7 +13,6 @@ import {
   EXCALIDRAW_SERVER_CONFIG,
   EXCALIDRAW_SERVER_NAME,
 } from "@/lib/excalidraw-quick-connect";
-import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { HOSTED_MODE } from "@/lib/config";
 import type { ServerFormData } from "@/shared/types.js";
 import type { ServerWithName } from "@/hooks/use-app-state";
@@ -107,13 +106,10 @@ export function useOnboarding({
   const markOnboardingAsShownMutation = useMutation(
     "users:markOnboardingShown" as any,
   );
-  const trackingProps = useMemo(
-    () => ({
-      platform: detectPlatform(),
-      environment: detectEnvironment(),
-    }),
-    [],
-  );
+  // `environment`/`platform` are omitted here — track() treats both as
+  // authoritative and strips any caller-supplied value before merging in
+  // the real ones from standardEventProps(), so passing them here was inert.
+  const trackingProps = useMemo(() => ({}), []);
 
   const [phase, setPhase] = useState<OnboardingPhase>(() =>
     getInitialLocalPhase(servers, {

--- a/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
+++ b/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useMutation, useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
+import { usePostHog } from "posthog-js/react";
 import * as Sentry from "@sentry/react";
 import {
   getExistingGuestId,
@@ -19,6 +20,16 @@ const ENSURE_USER_RETRY_DELAYS_MS = [50, 150];
 
 type EnsureUserArgs = {
   guestProofJwt?: string;
+  /**
+   * The browser's pre-signup anonymous PostHog id ($device_id — stable even
+   * if usePostHogIdentify already identified the browser as a guest,
+   * unlike get_distinct_id() which changes on identify). Lets the backend
+   * merge the anonymous click funnel into the signed-in actor via
+   * identifyProductActor server-side, independent of whether the client's
+   * own posthog.identify() call ever fires (it doesn't on every path —
+   * Electron system-browser OAuth, closed tabs, old builds).
+   */
+  posthogAnonDistinctId?: string;
 };
 
 type EnsureUserMutation = (args: EnsureUserArgs) => Promise<unknown>;
@@ -100,6 +111,7 @@ async function ensureUserWithRetry(
 export function useEnsureDbUser() {
   const { user } = useAuth();
   const workosUserId = user?.id ?? null;
+  const posthog = usePostHog();
   const { isAuthenticated, isLoading } = useConvexAuth();
   const actorKey = useActorKey();
   const ensureUser = useMutation(
@@ -199,7 +211,20 @@ export function useEnsureDbUser() {
       // stolen bearer cannot be used to absorb a victim's projects.
       const isWorkOsAuth = !!workosUserId;
       let guestProofJwt: string | null = null;
+      // Device id survives even when usePostHogIdentify already identified
+      // this browser (e.g. as a guest) — get_distinct_id() would return the
+      // post-identify id instead of the original anonymous one. Best-effort:
+      // an absent/throwing posthog instance must never block ensureUser.
+      let posthogAnonDistinctId: string | undefined;
       if (isWorkOsAuth) {
+        try {
+          posthogAnonDistinctId =
+            posthog?.get_property?.("$device_id") ??
+            posthog?.get_distinct_id?.();
+        } catch {
+          posthogAnonDistinctId = undefined;
+        }
+
         // Gate promotion on *activation*, not mere cookie presence. The
         // server-rendered guest bootstrap (Pillar 1) can leave an incidental
         // guest cookie on a browser whose user then signs in; that guest was
@@ -241,7 +266,10 @@ export function useEnsureDbUser() {
         return;
       }
 
-      const ensureArgs = guestProofJwt ? { guestProofJwt } : {};
+      const ensureArgs: EnsureUserArgs = {
+        ...(guestProofJwt ? { guestProofJwt } : {}),
+        ...(posthogAnonDistinctId ? { posthogAnonDistinctId } : {}),
+      };
       let ensurePromise = inFlightEnsureRef.current?.promise;
       if (inFlightEnsureRef.current?.identityKey !== identityKey) {
         ensurePromise = ensureUserWithRetry(ensureUser, ensureArgs, () => {
@@ -303,7 +331,14 @@ export function useEnsureDbUser() {
         activeEnsureIdentityRef.current = null;
       }
     };
-  }, [identityKey, isAuthenticated, isLoading, workosUserId, ensureUser]);
+  }, [
+    identityKey,
+    isAuthenticated,
+    isLoading,
+    workosUserId,
+    ensureUser,
+    posthog,
+  ]);
 
   return { isEnsuringUser, isUserReady };
 }

--- a/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
+++ b/mcpjam-inspector/client/src/hooks/useEnsureDbUser.ts
@@ -217,12 +217,20 @@ export function useEnsureDbUser() {
       // an absent/throwing posthog instance must never block ensureUser.
       let posthogAnonDistinctId: string | undefined;
       if (isWorkOsAuth) {
+        // Each getter is tried independently — a throw from $device_id
+        // (e.g. an unusual posthog-js build) must not skip the
+        // get_distinct_id() fallback, only the getter that actually failed.
         try {
-          posthogAnonDistinctId =
-            posthog?.get_property?.("$device_id") ??
-            posthog?.get_distinct_id?.();
+          posthogAnonDistinctId = posthog?.get_property?.("$device_id");
         } catch {
           posthogAnonDistinctId = undefined;
+        }
+        if (!posthogAnonDistinctId) {
+          try {
+            posthogAnonDistinctId = posthog?.get_distinct_id?.();
+          } catch {
+            posthogAnonDistinctId = undefined;
+          }
         }
 
         // Gate promotion on *activation*, not mere cookie presence. The

--- a/mcpjam-inspector/client/src/hooks/usePostHogIdentify.ts
+++ b/mcpjam-inspector/client/src/hooks/usePostHogIdentify.ts
@@ -3,6 +3,7 @@ import { usePostHog } from "posthog-js/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useQuery } from "convex/react";
 import { detectPlatform } from "@/lib/PosthogUtils";
+import { HOSTED_MODE } from "@/lib/config";
 import { useActorKey } from "@/hooks/use-actor-key";
 
 /**
@@ -38,6 +39,8 @@ export function usePostHogIdentify() {
         environment: import.meta.env.MODE,
         platform: detectPlatform(),
         version: __APP_VERSION__,
+        deployment: HOSTED_MODE ? "hosted" : "self_hosted",
+        source: "client",
       });
     }
 

--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -1,4 +1,5 @@
 import { getCachedGuestSession } from "./guest-session";
+import { HOSTED_MODE } from "./config";
 
 export const VITE_PUBLIC_POSTHOG_KEY =
   "phc_dTOPniyUNU2kD8Jx8yHMXSqiZHM8I91uWopTMX6EBE9";
@@ -118,6 +119,16 @@ export const options = {
       environment: import.meta.env.MODE, // "development" or "production"
       platform: detectPlatform(),
       version: __APP_VERSION__,
+      // OSS self-hosted installs (including ones that never touch
+      // app.mcpjam.com, e.g. airgapped lab VMs) share this project's key
+      // with the hosted app. `deployment` is the clean discriminator between
+      // the two going forward — see PosthogUtils.ts module docs for the
+      // relay rationale that put every install in the same project.
+      deployment: HOSTED_MODE ? "hosted" : "self_hosted",
+      // Symmetric with the server-side `source: "server"` stamp
+      // (convex/posthog.ts, server/utils/analytics.ts) — client events
+      // previously carried no `source` at all.
+      source: "client",
     });
   },
 };
@@ -193,13 +204,30 @@ export function detectPlatform() {
 }
 
 export function detectEnvironment() {
-  return import.meta.env.ENVIRONMENT;
+  // Vite's envPrefix is "VITE_" (vite.renderer.config.mts), so the
+  // unprefixed `ENVIRONMENT` from .env.production is never replaced into
+  // the client bundle and this always read as undefined — silently
+  // clobbering the registered `environment` super-property on every
+  // track() call (see standardEventProps below). `VITE_ENVIRONMENT` is the
+  // client-visible counterpart; it stays unset for ordinary dev/prod builds
+  // (MODE already covers that split) and is set explicitly for builds that
+  // need a finer-grained label (e.g. staging).
+  return import.meta.env.VITE_ENVIRONMENT;
 }
 
-export function standardEventProps(location: string) {
+export function standardEventProps(location: string): {
+  location: string;
+  platform: string;
+  environment?: string;
+} {
+  const environment = detectEnvironment();
   return {
     location,
     platform: detectPlatform(),
-    environment: detectEnvironment(),
+    // Omit rather than send `environment: undefined` — an explicit
+    // undefined key still overrides the registered super-property when
+    // merged into the captured event, which is exactly the bug this
+    // guards against.
+    ...(environment !== undefined ? { environment } : {}),
   };
 }

--- a/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/analytics.test.ts
@@ -36,4 +36,30 @@ describe("track()", () => {
     expect(props.environment).toBe("test");
     expect(props.location).toBe("skills_tab");
   });
+
+  it("strips a caller-supplied environment so it can't survive when standardEventProps omits it", async () => {
+    // Regression for the self-hosted/dev case: standardEventProps() omits
+    // `environment` when VITE_ENVIRONMENT is unset, so a caller-supplied
+    // value must be dropped explicitly — an omitted key on the later spread
+    // can't override anything already present from the caller's props.
+    vi.resetModules();
+    vi.doMock("../PosthogUtils", () => ({
+      standardEventProps: (location: string) => ({
+        location,
+        platform: "web",
+      }),
+    }));
+    const { track: trackWithOmittedEnv } = await import("../analytics");
+
+    trackWithOmittedEnv("skill_viewed", {
+      location: "skills_tab",
+      environment: "should-not-survive",
+    } as Record<string, unknown> & { location: string });
+
+    const props = captureMock.mock.calls[0][1];
+    expect(props).not.toHaveProperty("environment");
+
+    vi.doUnmock("../PosthogUtils");
+    vi.resetModules();
+  });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/posthog-utils.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/posthog-utils.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  detectEnvironment,
   getPageviewCaptureOptions,
   isPostHogBooleanFlagOn,
   options,
+  standardEventProps,
 } from "../PosthogUtils";
 
 describe("PosthogUtils", () => {
@@ -37,6 +39,46 @@ describe("PosthogUtils", () => {
       environment: import.meta.env.MODE,
       platform: expect.any(String),
       version: "2.0.13-test",
+      // Test build has VITE_MCPJAM_HOSTED_MODE unset -> self_hosted.
+      deployment: "self_hosted",
+      source: "client",
+    });
+  });
+
+  it("registers deployment: hosted when built for hosted mode", async () => {
+    vi.stubEnv("VITE_MCPJAM_HOSTED_MODE", "true");
+    vi.resetModules();
+    const { options: hostedOptions } = await import("../PosthogUtils");
+
+    const posthog = { register: vi.fn() };
+    hostedOptions.loaded(posthog);
+
+    expect(posthog.register).toHaveBeenCalledWith(
+      expect.objectContaining({ deployment: "hosted", source: "client" }),
+    );
+  });
+
+  describe("standardEventProps / detectEnvironment", () => {
+    it("omits environment when VITE_ENVIRONMENT is unset, so the registered super-property wins", () => {
+      // Neither Vite's envPrefix ("VITE_") nor .env.production expose an
+      // unprefixed ENVIRONMENT to the client bundle — this must resolve to
+      // undefined, not silently pick up a same-named var from elsewhere.
+      expect(detectEnvironment()).toBeUndefined();
+
+      const props = standardEventProps("skills_tab");
+      expect(props).not.toHaveProperty("environment");
+      expect(props.location).toBe("skills_tab");
+    });
+
+    it("includes environment when VITE_ENVIRONMENT is set", async () => {
+      vi.stubEnv("VITE_ENVIRONMENT", "staging");
+      vi.resetModules();
+      const mod = await import("../PosthogUtils");
+
+      expect(mod.detectEnvironment()).toBe("staging");
+      expect(mod.standardEventProps("skills_tab")).toMatchObject({
+        environment: "staging",
+      });
     });
   });
 

--- a/mcpjam-inspector/client/src/lib/analytics.ts
+++ b/mcpjam-inspector/client/src/lib/analytics.ts
@@ -24,8 +24,18 @@ export function track(
   event: ClientAnalyticsEventName,
   props: Record<string, unknown> & { location?: string } = {},
 ): void {
-  const { location = "unknown", ...rest } = props;
-  // Standard props spread LAST so location/platform/environment stay
-  // authoritative even if a caller passes them in `rest`.
+  // Drop platform/environment from the caller's props rather than relying
+  // on spread order alone: standardEventProps() OMITS `environment` when
+  // VITE_ENVIRONMENT is unset (so the registered super-property can win),
+  // and an omitted key can't override anything on the spread below — a
+  // caller-supplied `environment: undefined` would otherwise survive into
+  // the captured event and reintroduce the exact clobber bug this guards
+  // against.
+  const {
+    location = "unknown",
+    platform: _platform,
+    environment: _environment,
+    ...rest
+  } = props;
   posthog.capture(event, { ...rest, ...standardEventProps(location) });
 }

--- a/mcpjam-inspector/client/src/vite-env.d.ts
+++ b/mcpjam-inspector/client/src/vite-env.d.ts
@@ -9,6 +9,7 @@ interface ImportMetaEnv {
   readonly VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS?: string;
   readonly VITE_MCPJAM_SANDBOX_ORIGIN?: string;
   readonly VITE_WORKOS_DEV_MODE?: string;
+  readonly VITE_ENVIRONMENT?: string;
   // more env variables...
 }
 

--- a/mcpjam-inspector/server/utils/__tests__/analytics.hosted.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/analytics.hosted.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "hono";
+
+// HOSTED_MODE is a module-load-time const, so it has to be mocked before
+// importing analytics.ts. Kept in its own file so the main analytics tests
+// (analytics.test.ts) run with the real (local, self-hosted) config.
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return { ...actual, HOSTED_MODE: true };
+});
+
+const captureMock = vi.fn();
+const shutdownMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("posthog-node", () => ({
+  PostHog: vi.fn(() => ({ capture: captureMock, shutdown: shutdownMock })),
+}));
+
+import { captureServerEvent, shutdownAnalytics } from "../analytics.js";
+
+function fakeContext(overrides: {
+  requestLogContext?: Record<string, unknown>;
+}): Context {
+  return {
+    var: { requestLogContext: overrides.requestLogContext },
+    get: () => undefined,
+  } as unknown as Context;
+}
+
+describe("captureServerEvent (hosted mode)", () => {
+  beforeEach(() => {
+    captureMock.mockClear();
+    delete process.env.VITE_DISABLE_POSTHOG_LOCAL;
+    delete process.env.DO_NOT_TRACK;
+  });
+
+  afterEach(async () => {
+    await shutdownAnalytics();
+  });
+
+  it("stamps deployment: hosted", () => {
+    captureServerEvent(
+      fakeContext({ requestLogContext: { userExternalId: "u1" } }),
+      "send_message_server",
+    );
+    expect(captureMock.mock.calls[0][0].properties.deployment).toBe(
+      "hosted",
+    );
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
@@ -51,6 +51,10 @@ describe("captureServerEvent", () => {
     expect(call.properties.origin).toBe("playground");
     expect(call.properties.$insert_id).toEqual(expect.any(String));
     expect(call.properties.source).toBe("server");
+    // Real (non-hosted) config in this test file — the hosted case is
+    // covered by analytics.hosted.test.ts, which mocks HOSTED_MODE at
+    // module-load time.
+    expect(call.properties.deployment).toBe("self_hosted");
   });
 
   it("falls back to guestExternalId then the guestId context var", () => {

--- a/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/analytics.test.ts
@@ -8,6 +8,16 @@ vi.mock("posthog-node", () => ({
   PostHog: vi.fn(() => ({ capture: captureMock, shutdown: shutdownMock })),
 }));
 
+// HOSTED_MODE is a module-load-time const computed from the ambient
+// process.env — pinning it here (rather than relying on the CI shell
+// happening not to have VITE_MCPJAM_HOSTED_MODE set) is what makes the
+// "self_hosted" deployment assertion below deterministic. The hosted case
+// is covered by analytics.hosted.test.ts, which pins the opposite value.
+vi.mock("../../config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config.js")>();
+  return { ...actual, HOSTED_MODE: false };
+});
+
 import { captureServerEvent, shutdownAnalytics } from "../analytics.js";
 
 function fakeContext(overrides: {

--- a/mcpjam-inspector/server/utils/analytics.ts
+++ b/mcpjam-inspector/server/utils/analytics.ts
@@ -101,6 +101,11 @@ export function captureServerEvent(
         platform: serverPlatform(),
         environment: resolveEnvironment(),
         source: "server",
+        // Same discriminator the client registers (client/src/lib/
+        // PosthogUtils.ts) — this server runs on self-hosted machines too
+        // (npm installs, the Electron-embedded local server, Docker), not
+        // just the hosted Railway deployment.
+        deployment: HOSTED_MODE ? "hosted" : "self_hosted",
         ...(ctx?.orgId ? { organization_id: ctx.orgId } : {}),
         ...(ctx?.projectId ? { project_id: ctx.projectId } : {}),
       },


### PR DESCRIPTION
## Summary

Part of the fix for the false "98% signup drop-off" reported from PostHog notebook Fg0Q. Two of the three root causes live in this repo:

1. **Self-hosted OSS telemetry pollutes the hosted-app project.** The client PostHog key is shared by every install — including Hack The Box lab machines running pinned old builds on airgapped VMs where OAuth can never complete. There was no way to tell hosted traffic from self-hosted traffic in PostHog.
2. **`environment` was silently clobbered on every client event.** `detectEnvironment()` read `import.meta.env.ENVIRONMENT`, but Vite's `envPrefix` is `"VITE_"` — that var is never replaced into the client bundle, so it was always `undefined`. Since `standardEventProps()` spread it last, every `track()` call shipped `environment: undefined`, permanently overwriting the registered `environment` super-property.

It also includes the inspector-side half of the identity-stitching fix (paired backend PR: `mcpjam/mcpjam-backend#<TBD>`).

### Changes

- **`client/src/lib/PosthogUtils.ts`**
  - `loaded` hook now registers `deployment: HOSTED_MODE ? "hosted" : "self_hosted"` and `source: "client"` alongside the existing `environment`/`platform`/`version` super-properties — `deployment` is the clean discriminator between hosted and self-hosted traffic going forward.
  - `detectEnvironment()` now reads `VITE_ENVIRONMENT` (added to `client/src/vite-env.d.ts` and `.env.production`) instead of the never-set `ENVIRONMENT`.
  - `standardEventProps()` omits the `environment` key entirely when unset, instead of sending an explicit `environment: undefined` — so the registered super-property survives when no fine-grained value is configured.
- **`client/src/hooks/usePostHogIdentify.ts`** — mirrors the same `deployment`/`source` registration when super-properties are re-registered on a reset (authed → guest actor switch).
- **`server/utils/analytics.ts`** — stamps the same `deployment` property on server-side events (this Hono server runs on self-hosted machines too — npm installs, the Electron-embedded local server, Docker — not just the hosted Railway deployment).
- **`client/src/hooks/useEnsureDbUser.ts`** — in the WorkOS sign-in branch, reads `posthog.get_property('$device_id')` (falling back to `get_distinct_id()`), defensively wrapped so an absent/throwing PostHog instance never blocks `ensureUser`, and forwards it as `posthogAnonDistinctId`. Never sent for guest identities. This lets the backend merge the anonymous pre-signup click funnel into the signed-in person server-side, independent of whether the client's own `posthog.identify()` call fires (it doesn't on every path — Electron system-browser OAuth, closed tabs, old builds).
- `.env.production` gains `VITE_ENVIRONMENT=production` alongside the existing unprefixed `ENVIRONMENT=production` (kept as-is — it's still read server-side by `server/config.ts` / `resolveEnvironment()`). `.env.development` is gitignored in this repo (opt-in only), so it isn't touched — local dev without `VITE_ENVIRONMENT` set just keeps falling back to the `MODE`-based super-property, which is strictly no worse than before.

### Not in this PR (already applied directly)

- PostHog: new "Hosted signup funnel (corrected)" insight, filtered to `$host = app.mcpjam.com` at the step-1 level with `date_from` pinned to `signup_completed`'s instrumentation date (2026-07-10). Shows 135 clickers → 74 completions (~55%), not 4,081 → 74 (98% drop).
- PostHog project settings: added `$host` regex exclusions for `\.htb(:|$)` and `^10\.129\.` (HTB lab traffic) to "Filter out internal and test users". Verified negative `$host` filters don't drop host-less server-side events.

## Test plan

- [x] `npm run build -w @mcpjam/sdk && npm run test -w @mcpjam/inspector` — full suite green (13089 passed, 0 failed).
- [x] Extended `client/src/lib/__tests__/posthog-utils.test.ts`, `client/src/hooks/__tests__/usePostHogIdentify.test.ts`, `client/src/hooks/__tests__/useEnsureDbUser.test.tsx`, `server/utils/__tests__/analytics.test.ts`; added `server/utils/__tests__/analytics.hosted.test.ts`.
- [x] `npx tsc --noEmit` diff-clean (same pre-existing error count with and without this change).
- [ ] Manual: run locally (`HOSTED_MODE` false) and a hosted-mode build; confirm new PostHog events carry `deployment`, `source: "client"`, and a defined `environment` in Activity.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mv8MuBmti3m4Zn96vhipUP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics and optional signup metadata only; PostHog failures are guarded so `ensureUser` still runs, with broad test coverage and no auth or payment path changes.
> 
> **Overview**
> Fixes PostHog funnel noise and identity stitching by changing how client and server events are tagged and how signup links anonymous activity to users.
> 
> **Telemetry tagging:** Client init (`PosthogUtils`), identity reset (`usePostHogIdentify`), and server capture (`analytics.ts`) now stamp **`deployment`** (`hosted` vs `self_hosted`) and **`source: "client"`** on events so hosted traffic can be separated from OSS/self-hosted installs sharing the same project key.
> 
> **Environment super-property:** `detectEnvironment()` reads **`VITE_ENVIRONMENT`** (added to `.env.production` and `vite-env.d.ts`) instead of the non-Vite `ENVIRONMENT` that never reached the bundle. **`standardEventProps()`** omits `environment` when unset, and **`track()`** explicitly strips caller `platform`/`environment` so `undefined` cannot overwrite registered super-properties again.
> 
> **Signup identity:** On WorkOS sign-in, **`useEnsureDbUser`** best-effort forwards **`posthogAnonDistinctId`** from `$device_id` (fallback `get_distinct_id()`) to `users:ensureUser` for server-side funnel merge; never sent for guests and never blocks user creation if PostHog fails.
> 
> **Cleanup:** Onboarding stops passing redundant platform/environment into `track()`; tests cover hosted/self-hosted deployment stamps and the new ensureUser/PostHog paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41a02da143874ccdbcb98b6571caa7f6f1a23009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tags analytics with `deployment` and `source`, fixes the client `environment` overwrite, and forwards the anonymous PostHog id on signup. Also hardens event prop handling to prevent caller-supplied env/platform from leaking into events.

- **Bug Fixes**
  - Client and server tag events with `deployment` (`hosted`/`self_hosted`); client also registers `source: "client"` (server sends `source: "server"`). Tests pin `HOSTED_MODE` at module-load time for deterministic deployment assertions.
  - `detectEnvironment()` reads `VITE_ENVIRONMENT`; `standardEventProps()` omits `environment` when unset to avoid clobbering super-properties. Added `VITE_ENVIRONMENT` to `.env.production` and `vite-env.d.ts`.
  - `track()` now strips caller-supplied `environment`/`platform` so omitted env cannot survive the merge; removed inert env/platform props from onboarding tracking.
  - On WorkOS sign-in, send `posthogAnonDistinctId` from `$device_id` (fallback to `get_distinct_id()`), now with independent try/catch so fallback works even if `$device_id` throws; never sent for guests and analytics errors never block user creation.

<sup>Written for commit 41a02da143874ccdbcb98b6571caa7f6f1a23009. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

