### PR TITLE
feat(settings): a Discord card on the Integrations page

### DIFF
--- a/mcpjam-inspector/client/src/components/settings/IntegrationsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/IntegrationsRoute.tsx
@@ -1,11 +1,13 @@
 import { Navigate } from "react-router";
 import { useConvexAuth } from "convex/react";
-import { ChevronRight, Github, Slack } from "lucide-react";
+import { ChevronRight, Github, MessageSquare, Slack } from "lucide-react";
 import { useAppNavigate } from "@/lib/app-navigation";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useOrganizationQueries } from "@/hooks/useOrganizations";
 import { SettingsNav } from "./SettingsNav";
 import { useGithubChecksSettings } from "@/hooks/useGithubChecksSettings";
+import { useDiscordAgentEnabled } from "@/hooks/useDiscordAgentEnabled";
+import { discordInstallUrl } from "@/lib/config";
 
 /**
  * `/settings/integrations` — the one place a connectable outside service is
@@ -28,28 +30,33 @@ interface IntegrationsRouteProps {
   activeOrganizationId?: string | null;
 }
 
+/**
+ * `onSelect` navigates in-app; `href` leaves for the service's own site. A
+ * card has exactly one of the two — an anchor rather than a button-that-calls-
+ * `window.open`, so the destination shows in the status bar, middle-click and
+ * "open in new tab" work, and screen readers announce it as a link.
+ */
 function IntegrationCard({
   icon,
   title,
   description,
   status,
   onSelect,
+  href,
   testId,
 }: {
   icon: React.ReactNode;
   title: string;
   description: string;
   status: string;
-  onSelect: () => void;
+  onSelect?: () => void;
+  href?: string;
   testId: string;
 }) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      data-testid={testId}
-      className="w-full flex items-center justify-between gap-4 px-4 py-3 rounded-md border border-border/40 bg-muted/20 text-left transition-colors hover:bg-muted/40"
-    >
+  const className =
+    "w-full flex items-center justify-between gap-4 px-4 py-3 rounded-md border border-border/40 bg-muted/20 text-left transition-colors hover:bg-muted/40";
+  const Inner = (
+    <>
       <div className="flex items-center gap-3 min-w-0">
         <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
           {icon}
@@ -63,6 +70,30 @@ function IntegrationCard({
         <span className="text-xs text-muted-foreground">{status}</span>
         <ChevronRight className="size-4 text-muted-foreground" aria-hidden />
       </div>
+    </>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        data-testid={testId}
+        className={className}
+      >
+        {Inner}
+      </a>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      data-testid={testId}
+      className={className}
+    >
+      {Inner}
     </button>
   );
 }
@@ -104,6 +135,40 @@ function GithubChecksCard({
       description="Run an eval suite on every pull request."
       status={status}
       onSelect={() => appNavigate("/settings/integrations/github")}
+    />
+  );
+}
+
+/**
+ * The Discord agent.
+ *
+ * Unlike the other two, this card LEAVES the app. Discord's setup does not
+ * happen here and cannot: an admin adds the bot to a server, and then each
+ * member links their own account from inside Discord with `/mcpjam connect`.
+ * There is no org-scoped Discord settings page yet — when there is, this
+ * becomes an in-app `onSelect` like the others, and the copy changes with it.
+ *
+ * Two gates, both fail-closed. The FLAG, because the agent is dark; and the
+ * CLIENT ID, because an install URL built without one lands on a Discord
+ * error page that reads as our bug rather than as missing configuration.
+ * Saying nothing is better than offering an install that cannot work.
+ */
+function DiscordCard() {
+  const enabled = useDiscordAgentEnabled();
+  const installUrl = discordInstallUrl();
+  if (!enabled || !installUrl) return null;
+
+  return (
+    <IntegrationCard
+      testId="integration-card-discord"
+      icon={<MessageSquare className="size-4 text-primary" aria-hidden />}
+      title="Discord"
+      description="Mention the agent in a channel to run and approve evals."
+      // Not "Not connected": this page is org-scoped and a Discord link is
+      // per-member, so it cannot honestly report a connection state. It
+      // reports the ACTION instead.
+      status="Add to a server"
+      href={installUrl}
     />
   );
 }
@@ -159,6 +224,8 @@ export function IntegrationsRoute({
             status="Configured per project"
             onSelect={() => appNavigate("/project-settings")}
           />
+
+          <DiscordCard />
         </div>
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/settings/__tests__/integrations-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/settings/__tests__/integrations-route.test.tsx
@@ -2,17 +2,29 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
-const { mockAvailability, mockRepos, mockNavigate, mockOrgsLoading } =
-  vi.hoisted(() => ({
-    mockAvailability: {
-      value: undefined as { state: "enabled" | "disabled" } | undefined,
-      /** When set, the hook throws — what `useQuery` does on a query error. */
-      error: null as Error | null,
-    },
-    mockRepos: { value: undefined as unknown[] | undefined },
-    mockNavigate: vi.fn(),
-    mockOrgsLoading: { value: false },
-  }));
+const {
+  mockAvailability,
+  mockRepos,
+  mockNavigate,
+  mockOrgsLoading,
+  mockDiscord,
+} = vi.hoisted(() => ({
+  mockDiscord: {
+    enabled: false,
+    /** null models VITE_MCPJAM_DISCORD_CLIENT_ID being unset. */
+    installUrl: "https://discord.com/oauth2/authorize?client_id=1" as
+      | string
+      | null,
+  },
+  mockAvailability: {
+    value: undefined as { state: "enabled" | "disabled" } | undefined,
+    /** When set, the hook throws — what `useQuery` does on a query error. */
+    error: null as Error | null,
+  },
+  mockRepos: { value: undefined as unknown[] | undefined },
+  mockNavigate: vi.fn(),
+  mockOrgsLoading: { value: false },
+}));
 
 vi.mock("@/hooks/useGithubChecksSettings", () => ({
   useGithubChecksSettings: () => {
@@ -41,6 +53,14 @@ vi.mock("../SettingsNav", () => ({
   SettingsNav: () => <nav data-testid="settings-nav" />,
 }));
 
+vi.mock("@/hooks/useDiscordAgentEnabled", () => ({
+  useDiscordAgentEnabled: () => mockDiscord.enabled,
+}));
+
+vi.mock("@/lib/config", () => ({
+  discordInstallUrl: () => mockDiscord.installUrl,
+}));
+
 import { IntegrationsRoute } from "../IntegrationsRoute";
 
 function renderRoute({
@@ -53,6 +73,8 @@ function renderRoute({
   repos?: unknown[];
   error?: Error | null;
   activeOrganizationId?: string | null;
+  discordEnabled?: boolean;
+  discordInstallUrl?: string | null;
 }) {
   mockAvailability.value = availability;
   mockAvailability.error = error;
@@ -69,7 +91,7 @@ function renderRoute({
         />
         <Route path="/settings" element={<div>Settings Screen</div>} />
       </Routes>
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 }
 
@@ -141,6 +163,58 @@ describe("IntegrationsRoute", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  describe("the Discord card", () => {
+    it("is hidden while the agent flag is off", () => {
+      // The agent is dark: the bot lives in one test guild and cannot answer
+      // anyone else. Offering an install would invite a dead bot into a server.
+      renderRoute({ availability: { state: "enabled" }, repos: [] });
+      expect(screen.queryByText("Discord")).not.toBeInTheDocument();
+    });
+
+    it("is hidden when no client id is configured, even with the flag on", () => {
+      mockDiscord.enabled = true;
+      mockDiscord.installUrl = null;
+      try {
+        renderRoute({ availability: { state: "enabled" }, repos: [] });
+        expect(screen.queryByText("Discord")).not.toBeInTheDocument();
+      } finally {
+        mockDiscord.enabled = false;
+        mockDiscord.installUrl =
+          "https://discord.com/oauth2/authorize?client_id=1";
+      }
+    });
+
+    it("renders as a real link out to Discord, not an in-app navigation", () => {
+      mockDiscord.enabled = true;
+      try {
+        renderRoute({ availability: { state: "enabled" }, repos: [] });
+        const card = screen.getByTestId("integration-card-discord");
+        expect(card.tagName).toBe("A");
+        expect(card).toHaveAttribute(
+          "href",
+          "https://discord.com/oauth2/authorize?client_id=1",
+        );
+        expect(card).toHaveAttribute("target", "_blank");
+        expect(card).toHaveAttribute("rel", "noreferrer");
+        expect(mockNavigate).not.toHaveBeenCalled();
+      } finally {
+        mockDiscord.enabled = false;
+      }
+    });
+
+    it("reports an action rather than a connection state", () => {
+      // This page is org-scoped and a Discord link is per-member, so it cannot
+      // honestly say "Not connected" the way the GitHub card can.
+      mockDiscord.enabled = true;
+      try {
+        renderRoute({ availability: { state: "enabled" }, repos: [] });
+        expect(screen.getByText("Add to a server")).toBeInTheDocument();
+      } finally {
+        mockDiscord.enabled = false;
+      }
+    });
   });
 
   it("redirects to Settings when there is no active organization", () => {

--- a/mcpjam-inspector/client/src/hooks/useDiscordAgentEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useDiscordAgentEnabled.ts
@@ -1,0 +1,18 @@
+import { useFeatureFlagEnabled } from "posthog-js/react";
+
+export const DISCORD_AGENT_FEATURE_FLAG = "discord-agent";
+
+/**
+ * The Discord agent is dark while it rolls out — the bot is installed in a
+ * single test guild and its org-level settings do not exist yet. This gates
+ * the only client exposure it has: the Integrations card.
+ *
+ * `useFeatureFlagEnabled` returns `undefined` while flags load, and that is
+ * treated as OFF, same as the Slack agent flag. Fail-closed matters more than
+ * usual here because the card's action is an INSTALL link: showing it early
+ * would invite someone to add a bot to their server that cannot yet answer
+ * them.
+ */
+export function useDiscordAgentEnabled(): boolean {
+  return useFeatureFlagEnabled(DISCORD_AGENT_FEATURE_FLAG) === true;
+}

--- a/mcpjam-inspector/client/src/lib/config.ts
+++ b/mcpjam-inspector/client/src/lib/config.ts
@@ -76,3 +76,46 @@ export function isAllowedEmployeeEmail(
 
   return EMPLOYEE_EMAIL_DOMAINS.includes(normalizedEmail.slice(atIndex + 1));
 }
+
+/**
+ * The Discord application the agent bot runs as, used to build the "add to
+ * server" URL on the Integrations page.
+ *
+ * A Discord client id is a public identifier — it travels in every install
+ * URL — but it is deployment-specific, so it is configured rather than
+ * hardcoded. When unset the Discord card does not render: an install link
+ * built from a missing id sends people to a Discord error page, which reads
+ * as our bug rather than as missing configuration.
+ *
+ * Set via `VITE_MCPJAM_DISCORD_CLIENT_ID` at build time.
+ */
+export const DISCORD_CLIENT_ID: string | null = (() => {
+  const raw = import.meta.env.VITE_MCPJAM_DISCORD_CLIENT_ID;
+  return typeof raw === "string" && /^\d+$/.test(raw.trim())
+    ? raw.trim()
+    : null;
+})();
+
+/**
+ * Permissions the bot actually uses, and nothing else: View Channels (without
+ * it a mention never arrives), Send Messages, Attach Files (run evidence), and
+ * Read Message History (thread context).
+ */
+const DISCORD_BOT_PERMISSIONS = String(
+  (1 << 10) | (1 << 11) | (1 << 15) | (1 << 16),
+);
+
+/**
+ * Where "Add to Discord" goes. `bot` puts the bot user in the server;
+ * `applications.commands` is what lets `/mcpjam connect` register — without
+ * it the app installs but the command never appears.
+ */
+export function discordInstallUrl(): string | null {
+  if (!DISCORD_CLIENT_ID) return null;
+  const params = new URLSearchParams({
+    client_id: DISCORD_CLIENT_ID,
+    scope: "bot applications.commands",
+    permissions: DISCORD_BOT_PERMISSIONS,
+  });
+  return `https://discord.com/oauth2/authorize?${params.toString()}`;
+}


### PR DESCRIPTION
## What

A **Discord** card on Settings → Integrations. The page was built as a card list specifically so "a card list absorbs the next service for free" — this is the first service to take it up on that, and two things make it unlike its neighbours.

## It leaves the app

Discord's setup doesn't happen in MCPJam and can't: an admin adds the bot to a server, then each member links their own account from inside Discord with `/mcpjam connect`.

So `IntegrationCard` gained an optional `href` and renders an `<a>` for it — deliberately not a button that calls `window.open`, so the destination shows in the status bar, middle-click and "open in new tab" work, and it's announced as a link. Every other card still passes `onSelect` and renders a `<button>`; a card has exactly one of the two.

When an org-scoped Discord settings page exists, this becomes an in-app `onSelect` like the others and the copy changes with it.

## It reports an action, not a connection state

"Not connected" would be a guess. This page is org-scoped and a Discord link is **per-member**, so it has nothing it could honestly read — the same reasoning that made the Slack card say "Configured per project" rather than invent a status. It says **"Add to a server"**.

## Two fail-closed gates

- **The flag** (`discord-agent`, `undefined` → off, mirroring `useSlackAgentSettingsEnabled`). The agent is dark: the bot is installed in a single test guild and cannot answer anyone else. Showing an install link would invite a dead bot into someone's server — a worse failure than the card being absent.
- **The client id.** An install URL built without one lands on a Discord error page, which reads as our bug rather than as missing configuration. `VITE_MCPJAM_DISCORD_CLIENT_ID` is deployment config, not a constant to hardcode in an OSS client.

The permissions integer is built from named bits rather than a magic number: View Channels (**without it a mention never arrives at all**), Send Messages, Attach Files for run evidence, Read Message History for thread context. Nothing else — `101376`.

## Testing

`34 tests pass` across the settings suite (10 → 14 in this file). The four new ones cover both gates, that the card is an anchor with `target`/`rel` and does **not** call the in-app navigate, and the action-not-status copy. Verified they fail without the card — two of the four go red when `<DiscordCard />` is removed (the two "hidden" cases correctly pass either way, since absence is absence).

`typecheck:client` clean. Prettier checked with `--trailing-comma all`: this repo's prettier is v2 with no config, so a bare run rewrites **pre-existing** lines — `config.ts` is untouched by my change under the correct flag.

## Not in this PR

The naming split I'd still recommend before this page grows further: the Slack card says "eval results **and agent activity**" but navigates to the per-project webhook page, while the Slack **agent** (org-scoped, `organizations/:orgId/slack`) has no card at all. Discord will reproduce that same pair. Worth settling with a small registry (`{surfaceKind, label, icon, flag, route}`) so the next surface is a line rather than a component — but that's a refactor of existing behaviour, not this addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only settings surface behind feature flag and env config; no auth or data-path changes.
> 
> **Overview**
> Adds a **Discord** integration card on Settings → Integrations that sends users to Discord’s OAuth “add bot” flow instead of an in-app settings page.
> 
> **IntegrationCard** now accepts optional **`href`** (renders a real `<a>` with `target="_blank"`) or **`onSelect`** (existing button navigation)—each card uses one or the other. **DiscordCard** only appears when the PostHog **`discord-agent`** flag is on and **`VITE_MCPJAM_DISCORD_CLIENT_ID`** is set; otherwise it stays hidden. Status copy is **“Add to a server”** rather than a connection state.
> 
> New **`useDiscordAgentEnabled`** (fail-closed while flags load) and **`discordInstallUrl()`** in config build the authorize URL with scoped bot permissions and `applications.commands`. Tests cover both gates, link semantics, and the action-oriented status text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e7369f741f043985ad0bbcf6cb16c66231f837e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Discord integration card to Settings → Integrations. It opens the Discord install flow in a new tab and shows “Add to a server” instead of a connection state.

- New Features
  - `IntegrationCard` now supports external `href`; renders an `<a>` with `target="_blank"` and `rel="noreferrer"`.
  - Discord card renders only when the `discord-agent` flag is enabled and `VITE_MCPJAM_DISCORD_CLIENT_ID` is set via `discordInstallUrl()`.
  - Install URL requests only needed permissions: View Channels, Send Messages, Attach Files, Read Message History.
  - Added `useDiscordAgentEnabled` (fail-closed) and tests for flag/config gates, link behavior, and copy.

- Migration
  - Set `VITE_MCPJAM_DISCORD_CLIENT_ID` in each environment.
  - Enable the `discord-agent` feature flag to reveal the card.

<sup>Written for commit 8e7369f741f043985ad0bbcf6cb16c66231f837e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

