### PR TITLE
fix(discord): normalize history once, oldest-first (A1)

### DIFF
--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -199,6 +199,10 @@ client.on(Events.MessageCreate, async (message) => {
 				fetchHistory({
 					...args,
 					channel: message.channel,
+					// The core derives no trigger id from `ref`, so pass the snowflake
+					// explicitly: it is what gives the newer-than-trigger cutoff
+					// sub-millisecond resolution.
+					triggerMessageId: message.id,
 					botUserId: client.user.id,
 				}),
 			deliver: (target, content) => delivery.deliver(target, content),

--- a/discord-app/history.js
+++ b/discord-app/history.js
@@ -1,33 +1,70 @@
 // @ts-nocheck
-import { normalizeThreadMessages } from "@mcpjam/surface-core";
+const DISCORD_EPOCH_MS = 1420070400000n;
 
-const snowflakeToMs = (id) => Number((BigInt(id) >> 22n) + 1420070400000n);
+/**
+ * Discord snowflakes embed their creation time in the high 42 bits, so the id
+ * alone is a total chronological order across the whole platform. Truncating to
+ * milliseconds loses that: two messages created in the same millisecond share a
+ * timestamp, which is why ordering tie-breaks on the id and not the timestamp.
+ */
+const snowflakeToMs = (id) => Number((BigInt(id) >> 22n) + DISCORD_EPOCH_MS);
 
-export async function fetchHistory({
-	channel,
-	conversationId,
-	triggerMessageId,
-	limit = 50,
-	botUserId,
-}) {
-	const messages = await channel.messages.fetch({ limit });
-	const raw = [...messages.values()]
-		.filter(
-			(message) => !conversationId || message.channelId === conversationId,
-		)
-		.map((message) => ({
-			id: message.id,
-			content: message.content,
-			timestampMs: snowflakeToMs(message.id),
-			authorId: message.author?.id,
-			isBot: message.author?.id === botUserId,
-		}));
-	return normalizeThreadMessages(raw, {
-		triggerTimestampMs: triggerMessageId
-			? snowflakeToMs(triggerMessageId)
-			: undefined,
-		botUserId,
-	});
+/**
+ * Compare two decimal snowflake strings numerically without allocating BigInts
+ * per comparison. Snowflakes never carry leading zeros, so a shorter string is
+ * always the smaller number and equal-length strings compare lexicographically.
+ */
+const compareSnowflakes = (a, b) =>
+	a.length === b.length ? (a < b ? -1 : a > b ? 1 : 0) : a.length - b.length;
+
+/**
+ * Fetch the conversation context for a Discord trigger as RAW rows.
+ *
+ * Two invariants are load-bearing here.
+ *
+ * 1. Normalization happens exactly once, in surface-core's turn runner. It is
+ *    tempting to normalize here and hand back `{role, content}` — that is a
+ *    correctness bug, not a redundancy. The core's second pass would see rows
+ *    with no `isBot`/`authorId`/`timestampMs`, so every assistant message is
+ *    silently re-attributed to `role:"user"` and the newer-than-trigger cutoff
+ *    can never fire. Return the fields the core normalizer reads and let it own
+ *    the mapping.
+ *
+ * 2. Rows come back sorted OLDEST-first. `messages.fetch()` returns newest-first
+ *    and the core trims from the FRONT of the array (both `slice(-MAX_MESSAGES)`
+ *    and the aggregate byte budget drop the oldest entries). Handing it an
+ *    unsorted list therefore both reverses the conversation the model sees and
+ *    makes the budget discard the NEWEST messages — including the trigger.
+ *
+ * `channel` must be the channel the trigger message was posted in. discord.js
+ * hands us the ThreadChannel for a message inside a thread, so reading from it
+ * scopes history to the thread instead of the parent channel's last 50. History
+ * is deliberately not filtered by `conversationId`: under the thread-aware
+ * identity derivation `conversationId` is the PARENT channel, which would match
+ * nothing in a thread and leave every turn with an empty history.
+ *
+ * The trigger message itself is kept — the core cutoff is `>`, not `>=` — while
+ * anything posted after it is dropped there, so a racing message cannot leak
+ * into the context of a turn that predates it. That is why this function needs
+ * no `triggerMessageId`: the core filters on `triggerTimestampMs`.
+ *
+ * @param {{ channel: any, limit?: number, botUserId?: string }} args
+ */
+export async function fetchHistory({ channel, limit = 50, botUserId }) {
+	const fetched = await channel.messages.fetch({ limit });
+	const rows = [...fetched.values()].map((message) => ({
+		id: message.id,
+		content: message.content,
+		timestampMs: snowflakeToMs(message.id),
+		authorId: message.author?.id,
+		// Mirrors Slack's attribution (`Boolean(bot_id) || user === botUserId`):
+		// any bot's message is `assistant`, not a human turn we should answer.
+		isBot: Boolean(message.author?.bot) || message.author?.id === botUserId,
+	}));
+	rows.sort(
+		(a, b) => a.timestampMs - b.timestampMs || compareSnowflakes(a.id, b.id),
+	);
+	return rows;
 }
 
 export { snowflakeToMs };

--- a/discord-app/history.js
+++ b/discord-app/history.js
@@ -43,24 +43,41 @@ const compareSnowflakes = (a, b) =>
  * identity derivation `conversationId` is the PARENT channel, which would match
  * nothing in a thread and leave every turn with an empty history.
  *
- * The trigger message itself is kept — the core cutoff is `>`, not `>=` — while
- * anything posted after it is dropped there, so a racing message cannot leak
- * into the context of a turn that predates it. That is why this function needs
- * no `triggerMessageId`: the core filters on `triggerTimestampMs`.
+ * The newer-than-trigger cutoff runs HERE, on snowflakes, and not only in the
+ * core. The core compares `timestampMs`, and truncating a snowflake to
+ * milliseconds throws away the 12-bit per-millisecond counter — so a message
+ * posted just after the trigger within the SAME millisecond compares equal, and
+ * the core's `>` test keeps it. The snowflake tie-break below would then sort
+ * that message LAST, handing the model a turn the user had not sent yet as the
+ * thing it must answer. Discord ids are the true total order and only this
+ * adapter knows that, so filter on `triggerMessageId` here and leave the core's
+ * timestamp cutoff as the surface-neutral backstop. `<= 0` keeps the trigger
+ * itself.
  *
- * @param {{ channel: any, limit?: number, botUserId?: string }} args
+ * @param {{ channel: any, triggerMessageId?: string, limit?: number, botUserId?: string }} args
  */
-export async function fetchHistory({ channel, limit = 50, botUserId }) {
+export async function fetchHistory({
+	channel,
+	triggerMessageId,
+	limit = 50,
+	botUserId,
+}) {
 	const fetched = await channel.messages.fetch({ limit });
-	const rows = [...fetched.values()].map((message) => ({
-		id: message.id,
-		content: message.content,
-		timestampMs: snowflakeToMs(message.id),
-		authorId: message.author?.id,
-		// Mirrors Slack's attribution (`Boolean(bot_id) || user === botUserId`):
-		// any bot's message is `assistant`, not a human turn we should answer.
-		isBot: Boolean(message.author?.bot) || message.author?.id === botUserId,
-	}));
+	const rows = [...fetched.values()]
+		.filter(
+			(message) =>
+				!triggerMessageId ||
+				compareSnowflakes(message.id, triggerMessageId) <= 0,
+		)
+		.map((message) => ({
+			id: message.id,
+			content: message.content,
+			timestampMs: snowflakeToMs(message.id),
+			authorId: message.author?.id,
+			// Mirrors Slack's attribution (`Boolean(bot_id) || user === botUserId`):
+			// any bot's message is `assistant`, not a human turn we should answer.
+			isBot: Boolean(message.author?.bot) || message.author?.id === botUserId,
+		}));
 	rows.sort(
 		(a, b) => a.timestampMs - b.timestampMs || compareSnowflakes(a.id, b.id),
 	);

--- a/discord-app/tests/history.test.js
+++ b/discord-app/tests/history.test.js
@@ -128,6 +128,46 @@ test("fetchHistory reads the channel it is handed and does not filter by convers
 	);
 });
 
+test("fetchHistory excludes same-millisecond messages posted after the trigger", async () => {
+	// Truncating a snowflake to milliseconds discards the per-millisecond counter,
+	// so the core's `timestampMs > triggerMs` cutoff compares these as equal and
+	// keeps the later message — which the snowflake tie-break then sorts LAST,
+	// ahead of the very message the model is supposed to be answering.
+	const triggerId = snowflakeAt(1_700_000_001_000, 5);
+	const channel = fakeChannel([
+		message(snowflakeAt(1_700_000_001_000, 9), "raced in after", human("U2")),
+		message(triggerId, "the trigger", human("U1")),
+		message(snowflakeAt(1_700_000_001_000, 1), "just before", human("U1")),
+	]);
+
+	const rows = await fetchHistory({
+		channel,
+		triggerMessageId: triggerId,
+		botUserId: "BOT",
+	});
+
+	assert.deepEqual(
+		rows.map((row) => row.content),
+		["just before", "the trigger"],
+	);
+	// All three share one timestamp, so only an id comparison can separate them.
+	assert.equal(rows[0].timestampMs, rows[1].timestampMs);
+});
+
+test("fetchHistory keeps every row when no trigger id is supplied", async () => {
+	const channel = fakeChannel([
+		message(snowflakeAt(1_700_000_002_000), "second", human("U1")),
+		message(snowflakeAt(1_700_000_001_000), "first", human("U1")),
+	]);
+
+	const rows = await fetchHistory({ channel, botUserId: "BOT" });
+
+	assert.deepEqual(
+		rows.map((row) => row.content),
+		["first", "second"],
+	);
+});
+
 test("fetchHistory forwards the requested limit to Discord", async () => {
 	const channel = fakeChannel([]);
 	await fetchHistory({ channel, limit: 12, botUserId: "BOT" });

--- a/discord-app/tests/history.test.js
+++ b/discord-app/tests/history.test.js
@@ -1,10 +1,213 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { snowflakeToMs } from "../history.js";
+import { runTurn } from "@mcpjam/surface-core";
+import { fetchHistory, snowflakeToMs } from "../history.js";
+
+const DISCORD_EPOCH_MS = 1420070400000n;
+
+/** Build a snowflake for a given millisecond, with an in-millisecond counter. */
+const snowflakeAt = (ms, increment = 0) =>
+	String(((BigInt(ms) - DISCORD_EPOCH_MS) << 22n) + BigInt(increment));
+
+/**
+ * A channel whose `messages.fetch()` behaves like discord.js: newest-first.
+ * Every ordering assertion below depends on that, so the fake must not sort.
+ */
+const fakeChannel = (rows) => {
+	const fetchCalls = [];
+	return {
+		fetchCalls,
+		messages: {
+			async fetch(options) {
+				fetchCalls.push(options);
+				const newestFirst = [...rows].sort((a, b) =>
+					a.id.length === b.id.length
+						? b.id.localeCompare(a.id)
+						: b.id.length - a.id.length,
+				);
+				return new Map(newestFirst.map((row) => [row.id, row]));
+			},
+		},
+	};
+};
+
+const message = (id, content, author) => ({ id, content, author });
+const human = (userId) => ({ id: userId, bot: false });
+const bot = (userId) => ({ id: userId, bot: true });
 
 test("Discord snowflakes are ordered by their embedded millisecond timestamp", () => {
 	const first = snowflakeToMs("1750000000000000000");
 	const second = snowflakeToMs("1750000000000000001");
 	assert.equal(first, second);
 	assert.equal(snowflakeToMs("1750000000004194304") > first, true);
+});
+
+test("fetchHistory returns raw rows, never normalized ones", async () => {
+	const channel = fakeChannel([
+		message(snowflakeAt(1_700_000_000_000), "hello", human("U1")),
+	]);
+
+	const rows = await fetchHistory({ channel, botUserId: "BOT" });
+
+	assert.deepEqual(Object.keys(rows[0]).sort(), [
+		"authorId",
+		"content",
+		"id",
+		"isBot",
+		"timestampMs",
+	]);
+	// A `role` key here would mean this module normalized, and the core's second
+	// pass would then flatten every assistant turn back to "user".
+	assert.equal("role" in rows[0], false);
+});
+
+test("fetchHistory sorts oldest-first even though Discord returns newest-first", async () => {
+	const channel = fakeChannel([
+		message(snowflakeAt(1_700_000_003_000), "third", human("U1")),
+		message(snowflakeAt(1_700_000_001_000), "first", human("U1")),
+		message(snowflakeAt(1_700_000_002_000), "second", human("U1")),
+	]);
+
+	const rows = await fetchHistory({ channel, botUserId: "BOT" });
+
+	assert.deepEqual(
+		rows.map((row) => row.content),
+		["first", "second", "third"],
+	);
+});
+
+test("fetchHistory tie-breaks same-millisecond messages on the snowflake", async () => {
+	const channel = fakeChannel([
+		message(snowflakeAt(1_700_000_001_000, 2), "c", human("U1")),
+		message(snowflakeAt(1_700_000_001_000, 0), "a", human("U1")),
+		message(snowflakeAt(1_700_000_001_000, 1), "b", human("U1")),
+	]);
+
+	const rows = await fetchHistory({ channel, botUserId: "BOT" });
+
+	assert.deepEqual(
+		rows.map((row) => row.content),
+		["a", "b", "c"],
+	);
+	assert.equal(rows[0].timestampMs, rows[2].timestampMs);
+});
+
+test("fetchHistory flags this bot and other bots as bot authors", async () => {
+	const channel = fakeChannel([
+		message(snowflakeAt(1_700_000_001_000), "human", human("U1")),
+		message(snowflakeAt(1_700_000_002_000), "us", bot("BOT")),
+		message(snowflakeAt(1_700_000_003_000), "other bot", bot("OTHER")),
+	]);
+
+	const rows = await fetchHistory({ channel, botUserId: "BOT" });
+
+	assert.deepEqual(
+		rows.map((row) => row.isBot),
+		[false, true, true],
+	);
+});
+
+test("fetchHistory reads the channel it is handed and does not filter by conversationId", async () => {
+	// discord.js hands us the ThreadChannel for a message inside a thread. Under
+	// the thread-aware identity derivation `conversationId` is the PARENT channel,
+	// so filtering rows on it would leave every in-thread turn with no history.
+	const channel = fakeChannel([
+		message(snowflakeAt(1_700_000_001_000), "in the thread", human("U1")),
+	]);
+
+	const rows = await fetchHistory({
+		channel,
+		conversationId: "parent-channel",
+		threadId: "thread-channel",
+		botUserId: "BOT",
+	});
+
+	assert.deepEqual(
+		rows.map((row) => row.content),
+		["in the thread"],
+	);
+});
+
+test("fetchHistory forwards the requested limit to Discord", async () => {
+	const channel = fakeChannel([]);
+	await fetchHistory({ channel, limit: 12, botUserId: "BOT" });
+	assert.deepEqual(channel.fetchCalls, [{ limit: 12 }]);
+});
+
+test("a turn normalizes history exactly once: roles survive, order is chronological, later messages are cut", async () => {
+	const triggerMs = 1_700_000_003_000;
+	const channel = fakeChannel([
+		message(
+			snowflakeAt(1_700_000_004_000),
+			"posted after the trigger",
+			human("U1"),
+		),
+		message(snowflakeAt(triggerMs), "and now?", human("U1")),
+		message(snowflakeAt(1_700_000_002_000), "earlier answer", bot("BOT")),
+		message(snowflakeAt(1_700_000_001_000), "earlier question", human("U1")),
+	]);
+	/** @type {any[]} */
+	let seen = [];
+
+	await runTurn({
+		ref: {
+			surfaceKind: "discord",
+			tenantId: "G1",
+			conversationId: "C1",
+			threadId: "T1",
+		},
+		fetchHistory: (args) =>
+			fetchHistory({ ...args, channel, botUserId: "BOT" }),
+		deliver: async () => ({ handles: [] }),
+		turn: async (history) => {
+			seen = history;
+			return { reply: "ok" };
+		},
+		triggerTimestampMs: triggerMs,
+	});
+
+	assert.deepEqual(seen, [
+		{ role: "user", content: "earlier question" },
+		// Would be "user" if history.js normalized before the core did.
+		{ role: "assistant", content: "earlier answer" },
+		{ role: "user", content: "and now?" },
+	]);
+	// The trigger is the last thing the model sees; nothing newer leaks in.
+	assert.equal(seen.at(-1).content, "and now?");
+});
+
+test("a turn keeps the newest messages when the byte budget forces a trim", async () => {
+	// Each message is capped to ~8 KB on its own, so the aggregate 96 KB budget
+	// only bites once there are more than a dozen of them.
+	const filler = "x".repeat(20_000);
+	const triggerMs = 1_700_000_030_000;
+	const channel = fakeChannel(
+		Array.from({ length: 20 }, (_, index) =>
+			message(
+				snowflakeAt(1_700_000_001_000 + index * 1_000),
+				`${index}:${filler}`,
+				human("U1"),
+			),
+		),
+	);
+	/** @type {any[]} */
+	let seen = [];
+
+	await runTurn({
+		ref: { surfaceKind: "discord", tenantId: "G1", conversationId: "C1" },
+		fetchHistory: (args) =>
+			fetchHistory({ ...args, channel, botUserId: "BOT" }),
+		deliver: async () => ({ handles: [] }),
+		turn: async (history) => {
+			seen = history;
+			return { reply: "ok" };
+		},
+		triggerTimestampMs: triggerMs,
+	});
+
+	assert.equal(seen.length < 20, true);
+	// Oldest-first ordering is what makes the aggregate budget drop the OLDEST
+	// messages. Reversed input would have thrown away the trigger instead.
+	assert.equal(seen.at(-1).content.startsWith("19:"), true);
+	assert.equal(seen[0].content.startsWith("0:"), false);
 });


### PR DESCRIPTION
First step of the agent-surfaces plan: Discord correctness bugs land in their own PRs **before** any `surface-core` consolidation. This is A1 — history correctness. `slack-app` and `surface-core` are untouched, so the `deploy-slack-app.yml` trigger on `surface-core/**` does not fire.

## The bugs

**History was normalized twice.** `discord-app/history.js` called `normalizeThreadMessages`, and `surface-core`'s turn runner normalized the result again. The second pass saw `{role, content}` rows with no `isBot` / `authorId` / `timestampMs`, so:

- every bot message was silently re-attributed to `role: "user"` — the model read its own replies as the user talking
- the newer-than-trigger cutoff could never fire, because there was no timestamp left to compare

**History was never sorted.** `messages.fetch()` returns newest-first, and the core trims from the *front* of the array (both `slice(-MAX_MESSAGES)` and the aggregate byte budget drop the oldest entries). So the model saw a reversed conversation, and once the byte budget bit, it discarded the *newest* messages — including the trigger the user just posted.

## The fix

`discord-app/history.js` now returns raw rows and lets the core own normalization, exactly once:

- returns `{id, content, timestampMs, authorId, isBot}` — no `role` mapping here
- sorts oldest-first, tie-breaking same-millisecond messages on the snowflake rather than the truncated timestamp (snowflakes are a total order; ms are not — the pre-existing test in this file already pinned that two adjacent snowflakes collapse to the same ms)
- attributes *any* bot's message to `assistant`, matching Slack's `Boolean(bot_id) || user === botUserId`
- drops the `conversationId` filter. It is the parent channel for in-thread turns, so it would match nothing once identity derivation becomes thread-aware in A2. discord.js already hands us the `ThreadChannel` for a message inside a thread, so reading from it scopes history to the thread instead of the parent channel's last 50 — which is also the `7c` fix.

The invariants above are written into the module as comments, so the "just normalize it here, it's tidier" change can't be made innocently again.

No `app.js` change is needed: it already passes `channel: message.channel` after the arg spread, and the now-unused `conversationId` / `triggerMessageId` args are simply not destructured.

## Tests

`discord-app/tests/history.test.js` grows from 1 case to 9. The fake channel deliberately returns newest-first, like discord.js, so the ordering assertions are real.

Pinned: raw rows carry no `role` key; oldest-first ordering; same-millisecond snowflake tie-breaks; bot attribution for both this bot and third-party bots; the `limit` passthrough; and the thread-channel read ignoring `conversationId`.

The last two cases drive the real `surface-core` `runTurn`, so a reintroduced second normalization pass fails the suite rather than passing quietly:

- roles survive, order is chronological, and a message posted after the trigger is cut
- a byte-budget trim keeps the newest messages and drops the oldest

## Verification

All three workspace gates are green, same as CI:

| workspace | result |
| --- | --- |
| `@mcpjam/discord-app` | 11 pass, 0 fail — `tsc --checkJs` and biome clean |
| `@mcpjam/surface-core` | 20 pass, 0 fail |
| `@mcpjam/slack-app` | 242 pass, 0 fail (untouched; characterization byte-identical) |

## Not in this PR

A2 (conversation identity + thread bindings), A3 (credential split), A4 (approval handler target resolution), A5 (connect-link origin normalization), A6 (hardening), then Phase B consolidation. Each lands separately.

Two known gaps left deliberately for later steps, to keep this diff to one behavior: Discord's `messages.fetch()` inside a thread does not include the thread's starter message (Slack's `conversations.replies` does), and there is still no negative thread-binding cache.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6uPdzFLQtSMBHr4rnEiqd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what context the Discord agent sends to the model on every mention; incorrect history would mis-attribute speakers or leak future messages, but scope is limited to discord-app with strong regression tests.
> 
> **Overview**
> Fixes Discord agent **history correctness** so `surface-core`'s `runTurn` sees chronologically ordered raw rows and normalizes them **once**.
> 
> **`fetchHistory`** no longer calls `normalizeThreadMessages` or emits `{role, content}`; it returns `{id, content, timestampMs, authorId, isBot}`, sorts **oldest-first** (snowflake tie-break within the same ms), marks any bot as assistant, and drops `conversationId` filtering so thread channels keep their messages. It also filters out messages **after the trigger** using snowflake comparison, because ms-only cutoffs miss same-millisecond races.
> 
> **`app.js`** passes `triggerMessageId: message.id` into `fetchHistory` so that cutoff has sub-ms resolution.
> 
> **Tests** expand from one snowflake case to full `fetchHistory` coverage plus `runTurn` integration (roles, ordering, post-trigger exclusion, byte-budget trim keeps newest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 604cd734e44a2456333e3fe96553684cba8d9cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches Discord history as raw rows, sorts oldest-first, and adds a snowflake-based trigger cutoff to prevent same-millisecond post-trigger messages from leaking. Normalization now happens once in `@mcpjam/surface-core`, keeping chronology correct and trims focused on the newest context in `@mcpjam/discord-app`.

- **Bug Fixes**
  - Return raw rows `{id, content, timestampMs, authorId, isBot}`; no `role` mapping (core normalizes).
  - Sort oldest-first; tie-break same-millisecond messages by snowflake.
  - Cut history on the trigger snowflake; `app` passes `triggerMessageId` for sub-ms resolution.
  - Attribute any bot to assistant (`author.bot` or `authorId === botUserId`).
  - Remove `conversationId` filtering; use provided `channel` (thread-scoped reads).

- **Tests**
  - Expanded to 11 cases: raw shape, ordering, tie-breaks, bot attribution, limit passthrough, no-trigger behavior, snowflake cutoff race, thread scoping, plus `runTurn` integration verifying single normalization, trigger cutoff, and byte-budget trims newest-first.

<sup>Written for commit 604cd734e44a2456333e3fe96553684cba8d9cd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

