### PR TITLE
fix(discord): stable thread identity + write the binding on first turn (A2)

### DIFF
--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -18,6 +18,7 @@ import {
 	Routes,
 	SlashCommandBuilder,
 } from "discord.js";
+import { deriveConversation, ensureThreadBinding } from "./conversation.js";
 import { createDiscordDelivery } from "./delivery.js";
 import { fetchHistory } from "./history.js";
 import { recordPresence } from "./presence.js";
@@ -143,19 +144,23 @@ client.on(Events.MessageCreate, async (message) => {
 		const claim = await claims.claimEvent(dedupeKey);
 		if (claim.outcome !== "claimed") return;
 	}
+	// The stable pair, NOT `message.id` for both: the binding key must be
+	// identical for every message in the conversation or a written binding can
+	// never be found again.
+	const { conversationId, threadId } = deriveConversation(message);
 	const ref = {
 		surfaceKind: "discord",
 		tenantId: message.guildId,
 		actorId: message.author.id,
 		projectId: process.env.MCPJAM_PROJECT_ID,
-		conversationId: message.channelId,
-		threadId: message.id,
+		conversationId,
+		threadId,
 	};
 	const delivery = createDiscordDelivery(message.channel);
 	try {
 		const target = await resolveTurnTarget(ref, {
-			conversationId: message.channelId,
-			threadId: message.id,
+			conversationId,
+			threadId,
 		});
 		if (target.mode === "unlinked") {
 			const url = await mintConnectUrl({
@@ -193,6 +198,29 @@ client.on(Events.MessageCreate, async (message) => {
 			return;
 		}
 		ref.projectId = target.projectId;
+		// A new conversation binds to the initiator's org/project so later
+		// speakers stay in it. Fail the turn rather than running unbound — an
+		// unbound conversation re-resolves per speaker and drifts between
+		// projects (see conversation.js).
+		const bound = await ensureThreadBinding({
+			backend: claimBackend,
+			target,
+			tenantId: message.guildId,
+			actorId: message.author.id,
+			conversationId,
+			threadId,
+		});
+		if (!bound.ok) {
+			const content = textContent(
+				"I could not pin this conversation to a project. Try again in a moment.",
+				"warning",
+			);
+			await delivery.deliver(ref, content);
+			if (claims.hasClaimBackend())
+				await claims.completeEvent(dedupeKey, content);
+			return;
+		}
+		if (bound.projectId) ref.projectId = bound.projectId;
 		const result = await runTurn({
 			ref,
 			fetchHistory: (args) =>
@@ -209,7 +237,7 @@ client.on(Events.MessageCreate, async (message) => {
 			turn: (history) =>
 				api
 					.runAgentTurn(history, ref, {
-						conversationId: message.channelId,
+						conversationId,
 						idempotencyKey: dedupeKey,
 					})
 					.then((result) => ({

--- a/discord-app/conversation.js
+++ b/discord-app/conversation.js
@@ -1,0 +1,82 @@
+// @ts-nocheck
+
+/**
+ * Derive the stable (conversationId, threadId) pair for a Discord message.
+ *
+ * The pair is the thread-binding KEY, so it must be identical for every
+ * message in the same conversation. Discord threads are channels of their
+ * own: for a message inside one, the thread channel id is the stable thread
+ * identity and its parent is the conversation. For a top-level channel
+ * message there is no thread yet — the message's own id becomes the root,
+ * exactly like Slack keying a new thread on the root message's ts.
+ *
+ * Passing `message.id` unconditionally (the previous shape) keyed every
+ * lookup on a fresh id, so a binding written for a thread could never be
+ * found again.
+ */
+export function deriveConversation(message) {
+	const channel = message.channel;
+	const inThread =
+		typeof channel?.isThread === "function" && channel.isThread();
+	if (inThread)
+		return {
+			conversationId: channel.parentId ?? message.channelId,
+			threadId: message.channelId,
+			inThread: true,
+		};
+	return {
+		conversationId: message.channelId,
+		threadId: message.id,
+		inThread: false,
+	};
+}
+
+/**
+ * Pin an unbound conversation to the initiator's org/project — or say why not.
+ *
+ * Mirrors slack-app/listeners/events/run-and-reply.js: a new conversation
+ * binds to the initiator's project, and everything said in it afterwards
+ * belongs to that project WHOEVER says it. The alternative is a thread that
+ * re-resolves per speaker and drifts between projects — a silent
+ * cross-project write, which is worse than a visible "try again".
+ *
+ * First writer wins server-side: a lost race returns the existing binding,
+ * and the caller must adopt ITS projectId rather than the target's.
+ *
+ * Wire contract (backend surfaceRoutes.ts /agent/thread-bindings/create):
+ * body needs `threadTs` and `initiatorSurfaceUserId` (those exact names);
+ * the route 401s when the initiator is not linked to the claimed org, and
+ * the mutation answers `{created:false, reason}` when the project is not in
+ * the org — both are failures here, never a downgrade to unbound.
+ *
+ * @returns {Promise<{ok: true, projectId?: string} | {ok: false}>}
+ */
+export async function ensureThreadBinding({
+	backend,
+	target,
+	tenantId,
+	actorId,
+	conversationId,
+	threadId,
+}) {
+	const needsBinding =
+		!target.boundThread &&
+		target.mode === "user" &&
+		Boolean(target.organizationId) &&
+		Boolean(target.projectId);
+	if (!needsBinding) return { ok: true, projectId: target.projectId };
+	const result = await backend
+		.createThreadBinding({
+			surfaceKind: "discord",
+			surfaceTenantId: tenantId,
+			channelId: conversationId,
+			threadTs: threadId,
+			projectId: target.projectId,
+			organizationId: target.organizationId,
+			initiatorSurfaceUserId: actorId,
+		})
+		.catch(() => null);
+	if (!result || (result.created === false && result.reason))
+		return { ok: false };
+	return { ok: true, projectId: result.projectId || target.projectId };
+}

--- a/discord-app/tests/conversation.test.js
+++ b/discord-app/tests/conversation.test.js
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { deriveConversation, ensureThreadBinding } from "../conversation.js";
+
+const channelMessage = {
+	id: "msg-100",
+	channelId: "chan-1",
+	channel: { isThread: () => false },
+};
+
+const threadMessage = {
+	id: "msg-200",
+	channelId: "thread-9",
+	channel: { isThread: () => true, parentId: "chan-1" },
+};
+
+test("a top-level message roots its own conversation, like Slack keying on the root ts", () => {
+	assert.deepEqual(deriveConversation(channelMessage), {
+		conversationId: "chan-1",
+		threadId: "msg-100",
+		inThread: false,
+	});
+});
+
+test("a thread message keys on the thread channel, not its own id — the binding must be findable next turn", () => {
+	const first = deriveConversation(threadMessage);
+	const second = deriveConversation({ ...threadMessage, id: "msg-201" });
+	assert.deepEqual(first, {
+		conversationId: "chan-1",
+		threadId: "thread-9",
+		inThread: true,
+	});
+	// The old shape (threadId = message.id) made this differ per message.
+	assert.deepEqual(second, first);
+});
+
+test("a channel object without isThread is treated as a plain channel", () => {
+	assert.equal(
+		deriveConversation({ id: "m", channelId: "c", channel: {} }).threadId,
+		"m",
+	);
+});
+
+function backendRecording(result) {
+	const calls = [];
+	return {
+		calls,
+		createThreadBinding: async (args) => {
+			calls.push(args);
+			if (result instanceof Error) throw result;
+			return result;
+		},
+	};
+}
+
+const userTarget = {
+	mode: "user",
+	projectId: "proj-1",
+	organizationId: "org-1",
+};
+
+const bindingArgs = (backend) => ({
+	backend,
+	target: userTarget,
+	tenantId: "guild-1",
+	actorId: "user-1",
+	conversationId: "chan-1",
+	threadId: "thread-9",
+});
+
+test("an already-bound thread writes nothing", async () => {
+	const backend = backendRecording({ created: true });
+	const out = await ensureThreadBinding({
+		...bindingArgs(backend),
+		target: { ...userTarget, boundThread: true },
+	});
+	assert.deepEqual(out, { ok: true, projectId: "proj-1" });
+	assert.equal(backend.calls.length, 0);
+});
+
+test("legacy mode writes nothing", async () => {
+	const backend = backendRecording({ created: true });
+	const out = await ensureThreadBinding({
+		...bindingArgs(backend),
+		target: { mode: "legacy", projectId: "proj-legacy" },
+	});
+	assert.deepEqual(out, { ok: true, projectId: "proj-legacy" });
+	assert.equal(backend.calls.length, 0);
+});
+
+test("a fresh user turn writes the binding with the exact wire field names", async () => {
+	const backend = backendRecording({
+		created: true,
+		organizationId: "org-1",
+		projectId: "proj-1",
+	});
+	const out = await ensureThreadBinding(bindingArgs(backend));
+	assert.deepEqual(out, { ok: true, projectId: "proj-1" });
+	// Pin the deployed contract (backend surfaceRoutes.ts): `threadTs` and
+	// `initiatorSurfaceUserId`, not the resolver's local vocabulary.
+	assert.deepEqual(backend.calls, [
+		{
+			surfaceKind: "discord",
+			surfaceTenantId: "guild-1",
+			channelId: "chan-1",
+			threadTs: "thread-9",
+			projectId: "proj-1",
+			organizationId: "org-1",
+			initiatorSurfaceUserId: "user-1",
+		},
+	]);
+});
+
+test("a lost first-writer race adopts the EXISTING binding's project", async () => {
+	const backend = backendRecording({
+		created: false,
+		organizationId: "org-2",
+		projectId: "proj-existing",
+		initiatorSurfaceUserId: "someone-else",
+	});
+	const out = await ensureThreadBinding(bindingArgs(backend));
+	assert.deepEqual(out, { ok: true, projectId: "proj-existing" });
+});
+
+test("a rejected write fails the turn — never a silent downgrade to unbound", async () => {
+	const rejected = backendRecording({
+		created: false,
+		reason: "project_not_in_org",
+	});
+	assert.deepEqual(await ensureThreadBinding(bindingArgs(rejected)), {
+		ok: false,
+	});
+
+	const unreachable = backendRecording(new Error("backend down"));
+	assert.deepEqual(await ensureThreadBinding(bindingArgs(unreachable)), {
+		ok: false,
+	});
+});


### PR DESCRIPTION
## The bugs (A2 of the agent-surfaces plan, after #3785)

**Thread bindings could never match.** The lookup key was `threadId: message.id` — the message's *own* id, fresh on every mention — so a binding written for a conversation was unfindable one message later.

**And no binding was ever written anyway.** `createThreadBinding` existed only as a definition; zero call sites in `discord-app/`. Every turn fell through the resolver ladder to *whoever-spoke-last*'s default project — two people in one conversation writing into two different projects, exactly the drift the binding exists to prevent (per the Slack comment in `run-and-reply.js`).

## The fix

**`deriveConversation(message)`** — the stable pair. Discord threads are channels of their own: inside one, the thread channel id is the thread identity and its parent is the conversation; at top level the message's own id becomes the root (same model as Slack keying a new thread on the root `ts`).

**`ensureThreadBinding(...)`** — mirrors `slack-app/listeners/events/run-and-reply.js:74-105`:
- first unbound `user`-mode turn binds the initiator's org/project
- a lost first-writer race adopts the **existing** binding's project
- a rejected write or unreachable backend **fails the turn** with a visible "try again" — never a silent downgrade to unbound

Both live in a new `discord-app/conversation.js` so they're unit-testable; `app.js` stays wiring.

## Wire contract

Body pinned by test against the deployed backend (`surfaceRoutes.ts` `/agent/thread-bindings/create`): `threadTs` + `initiatorSurfaceUserId`, exact names. The route 401s an initiator not linked to the claimed org, and the mutation answers `{created:false, reason}` for a project outside the org — both are turn-failures here.

## Tests

- stable derivation: two messages in the same thread produce the identical pair (the old shape differed per message)
- binding write body pinned field-for-field
- race-lost adoption, `boundThread`/`legacy` no-ops, rejected/unreachable → `{ok:false}`

`npm run verify -w @mcpjam/discord-app` exit 0. `slack-app`/`surface-core` untouched — no live deploy fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which MCPJam project Discord conversations attach to and when turns abort; incorrect keys or binding logic could misroute multi-user threads or block legitimate mentions.
> 
> **Overview**
> Fixes Discord agent **thread binding** so lookups can match across turns and new conversations are pinned to the initiator’s project instead of drifting per speaker.
> 
> **Stable identity:** New `deriveConversation` replaces using `channelId` + each message’s id as the thread key. In threads, `conversationId` is the parent channel and `threadId` is the thread channel id; for a root mention, `threadId` is that message’s id (Slack-style). `app.js` uses this pair everywhere it resolves targets, binds, and runs turns.
> 
> **First-turn bind:** New `ensureThreadBinding` calls `createThreadBinding` on the first unbound `user` turn (mirroring Slack), adopts the winner’s `projectId` on a race, and **fails the turn** with a user-visible warning if the backend rejects or is unreachable—no silent unbound fallback. Unit tests cover derivation stability and the wire payload (`threadTs`, `initiatorSurfaceUserId`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4142037f3dcea1ca5117646fd9fd587cc4149846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Discord thread binding by deriving a stable conversation/thread key and writing a binding on the first user turn. Prevents cross-project drift and keeps a conversation in one project.

- **Bug Fixes**
  - Stable key via `deriveConversation(message)`:
    - Threads: `conversationId = parentId`, `threadId = thread channel id`.
    - Top-level: `conversationId = channelId`, `threadId = message.id`.
  - First unbound `user` turn calls `ensureThreadBinding(...)`:
    - Writes with `threadTs` and `initiatorSurfaceUserId`.
    - If race is lost, adopt the existing binding’s project.
    - On rejection or backend error, fail the turn with a visible “try again”; never run unbound.
  - New logic lives in `discord-app/conversation.js`; `discord-app/app.js` only wires it in. Tests cover derivation, wire contract, race, and failure paths.

<sup>Written for commit 4142037f3dcea1ca5117646fd9fd587cc4149846. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

