### PR TITLE
fix(discord): derive a stable thread key and pin the binding (A2)

### DIFF
--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -213,6 +213,19 @@ client.on(Events.MessageCreate, async (message) => {
 			// THEIR default project and create resources somewhere the initiator
 			// never chose — a silent cross-project write, which is worse than a
 			// visible "try again".
+			// Released, not completed: the bind failure is transient, so a
+			// redelivery of this same message should be allowed to run.
+			//
+			// Release BEFORE delivering. `channel.send` can reject on a rate limit,
+			// a missing permission or a deleted channel, and that throw would escape
+			// to the outer catch — which COMPLETES the claim. The turn would then be
+			// permanently marked done and could never be redelivered, which is the
+			// exact opposite of what this branch is for.
+			if (claims.hasClaimBackend())
+				await claims.releaseEvent(dedupeKey).catch((error) => {
+					// Swallowing this hides the one failure that strands the message.
+					console.error(`Could not release claim ${dedupeKey}: ${error}`);
+				});
 			await delivery.deliver(
 				ref,
 				textContent(
@@ -220,10 +233,6 @@ client.on(Events.MessageCreate, async (message) => {
 					"warning",
 				),
 			);
-			// Released, not completed: the bind failure is transient, so a
-			// redelivery of this same message should be allowed to run.
-			if (claims.hasClaimBackend())
-				await claims.releaseEvent(dedupeKey).catch(() => {});
 			return;
 		}
 		if (bound.projectId) ref.projectId = bound.projectId;

--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -18,6 +18,10 @@ import {
 	Routes,
 	SlashCommandBuilder,
 } from "discord.js";
+import {
+	deriveConversationIdentity,
+	ensureThreadBinding,
+} from "./conversation.js";
 import { createDiscordDelivery } from "./delivery.js";
 import { fetchHistory } from "./history.js";
 import { recordPresence } from "./presence.js";
@@ -143,19 +147,22 @@ client.on(Events.MessageCreate, async (message) => {
 		const claim = await claims.claimEvent(dedupeKey);
 		if (claim.outcome !== "claimed") return;
 	}
+	const identity = deriveConversationIdentity(message);
+	// No `projectId` before the target resolves. Seeding it from the environment
+	// makes every unresolved path act in whatever project the operator happened
+	// to set, which is a cross-project write dressed up as a default.
 	const ref = {
 		surfaceKind: "discord",
 		tenantId: message.guildId,
 		actorId: message.author.id,
-		projectId: process.env.MCPJAM_PROJECT_ID,
-		conversationId: message.channelId,
-		threadId: message.id,
+		conversationId: identity.conversationId,
+		threadId: identity.threadId,
 	};
 	const delivery = createDiscordDelivery(message.channel);
 	try {
 		const target = await resolveTurnTarget(ref, {
-			conversationId: message.channelId,
-			threadId: message.id,
+			conversationId: identity.conversationId,
+			threadId: identity.threadId,
 		});
 		if (target.mode === "unlinked") {
 			const url = await mintConnectUrl({
@@ -193,6 +200,33 @@ client.on(Events.MessageCreate, async (message) => {
 			return;
 		}
 		ref.projectId = target.projectId;
+		const bound = await ensureThreadBinding({
+			backend: claimBackend,
+			ctx: ref,
+			conversationId: identity.conversationId,
+			threadId: identity.threadId,
+			target,
+		});
+		if (!bound.ok) {
+			// FAIL the turn rather than running unbound. An unbound thread
+			// re-resolves on every reply, so the next person to speak would get
+			// THEIR default project and create resources somewhere the initiator
+			// never chose — a silent cross-project write, which is worse than a
+			// visible "try again".
+			await delivery.deliver(
+				ref,
+				textContent(
+					"I could not pin this thread to a project. Try again in a moment.",
+					"warning",
+				),
+			);
+			// Released, not completed: the bind failure is transient, so a
+			// redelivery of this same message should be allowed to run.
+			if (claims.hasClaimBackend())
+				await claims.releaseEvent(dedupeKey).catch(() => {});
+			return;
+		}
+		if (bound.projectId) ref.projectId = bound.projectId;
 		const result = await runTurn({
 			ref,
 			fetchHistory: (args) =>

--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -235,7 +235,12 @@ client.on(Events.MessageCreate, async (message) => {
 					),
 				)
 				.catch((error) => {
-					console.error(`Could not report the bind failure: ${error}`);
+					// Nothing more can be said to the user: the only channel we have is
+					// the one that just refused a message. Carry the ids so the dropped
+					// turn is at least traceable from the logs.
+					console.error(
+						`Could not report the bind failure for ${dedupeKey} in ${identity.conversationId}: ${error}`,
+					);
 				});
 			return;
 		}

--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -213,26 +213,30 @@ client.on(Events.MessageCreate, async (message) => {
 			// THEIR default project and create resources somewhere the initiator
 			// never chose — a silent cross-project write, which is worse than a
 			// visible "try again".
-			// Released, not completed: the bind failure is transient, so a
-			// redelivery of this same message should be allowed to run.
 			//
-			// Release BEFORE delivering. `channel.send` can reject on a rate limit,
-			// a missing permission or a deleted channel, and that throw would escape
-			// to the outer catch — which COMPLETES the claim. The turn would then be
-			// permanently marked done and could never be redelivered, which is the
-			// exact opposite of what this branch is for.
+			// Released, not completed: the bind failure is transient, so a
+			// redelivery of this same message should be allowed to run. Two things
+			// protect that, and BOTH are needed. `channel.send` can reject on a rate
+			// limit, a missing permission or a deleted channel, and this handler's
+			// outer catch ends in `completeEvent` — so a propagating send failure
+			// would mark the turn permanently done. Hence: release first, and
+			// contain the send's throw rather than letting it reach that catch.
 			if (claims.hasClaimBackend())
 				await claims.releaseEvent(dedupeKey).catch((error) => {
 					// Swallowing this hides the one failure that strands the message.
 					console.error(`Could not release claim ${dedupeKey}: ${error}`);
 				});
-			await delivery.deliver(
-				ref,
-				textContent(
-					"I could not pin this thread to a project. Try again in a moment.",
-					"warning",
-				),
-			);
+			await delivery
+				.deliver(
+					ref,
+					textContent(
+						"I could not pin this thread to a project. Try again in a moment.",
+						"warning",
+					),
+				)
+				.catch((error) => {
+					console.error(`Could not report the bind failure: ${error}`);
+				});
 			return;
 		}
 		if (bound.projectId) ref.projectId = bound.projectId;

--- a/discord-app/conversation.js
+++ b/discord-app/conversation.js
@@ -1,0 +1,96 @@
+// @ts-nocheck
+
+/**
+ * Derive the `(conversationId, threadId)` pair a turn resolves and binds against.
+ *
+ * Discord has no single "thread key", so the pair has to be built. It must
+ * satisfy one property to be worth anything: a mention posted in a channel and
+ * every later message in the thread started from that mention MUST derive the
+ * SAME pair. Otherwise the binding written by the first turn is invisible to the
+ * second, the thread re-resolves on every reply, and each turn silently runs in
+ * the default project of whoever happened to speak last.
+ *
+ * It does hold, because a Discord thread started from a message takes that
+ * message's id as its own channel id:
+ *
+ *   channel mention   → conversationId = channelId          threadId = message.id
+ *   inside the thread → conversationId = channel.parentId   threadId = channelId
+ *
+ * `channel.parentId` in the second row is the channel from the first, and the
+ * thread's `channelId` is the first row's `message.id` — so both rows produce
+ * one key and the binding carries across the boundary. This also mirrors Slack,
+ * where a top-level message's `threadTs` is its own `ts`: the id of the thread
+ * that would be created if someone replied.
+ *
+ * The previous derivation used `message.id` for the threadId in BOTH cases, so
+ * every single message minted a fresh thread key and no binding ever matched.
+ */
+export function deriveConversationIdentity(message) {
+	const inThread = Boolean(message.channel?.isThread?.());
+	// `parentId` is null when a thread's parent is gone. Falling back to the
+	// thread's own id keeps the pair well-formed instead of sending `null`
+	// through to the backend as a channel id.
+	const conversationId = inThread
+		? message.channel.parentId || message.channelId
+		: message.channelId;
+	const threadId = inThread ? message.channelId : message.id;
+	return { inThread, conversationId, threadId };
+}
+
+/**
+ * Pin a thread to the project its first turn resolved to.
+ *
+ * A new conversation binds to the initiator's org/project. Everything said in
+ * this thread afterwards belongs to that project, whoever says it — the
+ * alternative is a thread that drifts between projects and lands a suite
+ * somewhere nobody expected. First writer wins server-side, so a race here
+ * resolves to one binding rather than to the last writer's.
+ *
+ * Only `user`-mode turns bind: `legacy` runs on a shared key with no org to
+ * attribute the thread to, and the other modes never reach a run.
+ *
+ * @returns {Promise<{ok: true, projectId?: string} | {ok: false}>}
+ */
+export async function ensureThreadBinding({
+	backend,
+	ctx,
+	conversationId,
+	threadId,
+	target,
+	logger = console,
+}) {
+	if (
+		target.boundThread ||
+		target.mode !== "user" ||
+		!target.organizationId ||
+		!target.projectId
+	)
+		return { ok: true, projectId: target.projectId };
+
+	const binding = await backend
+		.createThreadBinding({
+			surfaceKind: "discord",
+			surfaceTenantId: ctx.tenantId,
+			channelId: conversationId,
+			// `threadTs` is the wire name the backend reads for every surface — a
+			// Slack-shaped field name carried into a shared route, not a timestamp.
+			threadTs: threadId,
+			organizationId: target.organizationId,
+			projectId: target.projectId,
+			initiatorSurfaceUserId: ctx.actorId,
+		})
+		.catch((error) => {
+			logger.error(`Could not bind thread to a project: ${error}`);
+			return null;
+		});
+
+	// A 200 carrying no projectId still means nothing was pinned — the backend
+	// answers `{created: false, reason: 'project_not_in_org'}` in that shape — so
+	// treat it exactly like a thrown error rather than like a successful bind.
+	if (!binding?.projectId) return { ok: false };
+
+	// First writer wins server-side, and the loser of a race is handed the
+	// WINNER's project here. Using it is what keeps two racing turns acting in
+	// the same place instead of one of them running against its own resolution.
+	return { ok: true, projectId: binding.projectId };
+}

--- a/discord-app/tests/conversation.test.js
+++ b/discord-app/tests/conversation.test.js
@@ -170,6 +170,32 @@ test("legacy-mode turns do not bind", async () => {
 	assert.deepEqual(result, { ok: true, projectId: "PLEGACY" });
 });
 
+test("a user-mode turn with no resolved project does not bind", async () => {
+	// `resolveTurnTarget` has no branch that returns `user` without a projectId
+	// (that case is `needs_project`), so this pins the guard rather than a live
+	// path. Nothing is written, and the turn proceeds with no project — A3's
+	// restored NO_PROJECT guard in the credential seam is what stops it there.
+	let called = false;
+	const backend = {
+		createThreadBinding: async () => {
+			called = true;
+			return { created: true, projectId: "P1" };
+		},
+	};
+
+	const result = await ensureThreadBinding({
+		backend,
+		ctx: { tenantId: "G1", actorId: "U1" },
+		conversationId: "CHAN1",
+		threadId: "MSG1",
+		target: { mode: "user", organizationId: "O1" },
+		logger: silentLogger,
+	});
+
+	assert.equal(called, false);
+	assert.deepEqual(result, { ok: true, projectId: undefined });
+});
+
 test("the loser of a race adopts the winning binding's project", async () => {
 	const backend = {
 		// First writer wins server-side, so the losing turn is handed the

--- a/discord-app/tests/conversation.test.js
+++ b/discord-app/tests/conversation.test.js
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	deriveConversationIdentity,
+	ensureThreadBinding,
+} from "../conversation.js";
+
+const channelMessage = (id, channelId) => ({
+	id,
+	channelId,
+	channel: { isThread: () => false },
+});
+
+const threadMessage = (id, threadChannelId, parentId) => ({
+	id,
+	channelId: threadChannelId,
+	channel: { isThread: () => true, parentId },
+});
+
+const silentLogger = { error() {} };
+
+test("a channel mention keys on the channel and the message", () => {
+	const identity = deriveConversationIdentity(channelMessage("MSG1", "CHAN1"));
+
+	assert.deepEqual(identity, {
+		inThread: false,
+		conversationId: "CHAN1",
+		threadId: "MSG1",
+	});
+});
+
+test("a message in a thread keys on the parent channel and the thread", () => {
+	const identity = deriveConversationIdentity(
+		threadMessage("MSG2", "THREAD1", "CHAN1"),
+	);
+
+	assert.deepEqual(identity, {
+		inThread: true,
+		conversationId: "CHAN1",
+		threadId: "THREAD1",
+	});
+});
+
+test("a thread started from a mention derives the same key as the mention", () => {
+	// This is the whole point of the derivation. A Discord thread started from a
+	// message takes that message's id as its own channel id, so the binding the
+	// first turn writes is the one later in-thread turns find.
+	const mention = deriveConversationIdentity(channelMessage("MSG1", "CHAN1"));
+	// ...someone starts a thread on MSG1, so the thread's channel id IS "MSG1".
+	const reply = deriveConversationIdentity(
+		threadMessage("MSG9", "MSG1", "CHAN1"),
+	);
+
+	assert.equal(reply.conversationId, mention.conversationId);
+	assert.equal(reply.threadId, mention.threadId);
+});
+
+test("two messages in one thread derive one key, unlike the per-message id", () => {
+	const first = deriveConversationIdentity(
+		threadMessage("MSG2", "THREAD1", "CHAN1"),
+	);
+	const second = deriveConversationIdentity(
+		threadMessage("MSG3", "THREAD1", "CHAN1"),
+	);
+
+	assert.deepEqual(first, second);
+	// The old derivation used message.id as the threadId, which differed here
+	// and is why no binding ever matched.
+	assert.notEqual("MSG2", "MSG3");
+});
+
+test("an orphaned thread falls back to its own id rather than a null channel", () => {
+	const identity = deriveConversationIdentity(
+		threadMessage("MSG2", "THREAD1", null),
+	);
+
+	assert.deepEqual(identity, {
+		inThread: true,
+		conversationId: "THREAD1",
+		threadId: "THREAD1",
+	});
+});
+
+test("a message from a client without isThread is treated as a channel message", () => {
+	const identity = deriveConversationIdentity({
+		id: "MSG1",
+		channelId: "CHAN1",
+		channel: {},
+	});
+
+	assert.equal(identity.inThread, false);
+	assert.equal(identity.conversationId, "CHAN1");
+});
+
+test("the first user-mode turn writes the thread binding", async () => {
+	const calls = [];
+	const backend = {
+		createThreadBinding: async (body) => {
+			calls.push(body);
+			return { created: true, projectId: "P1", organizationId: "O1" };
+		},
+	};
+
+	const result = await ensureThreadBinding({
+		backend,
+		ctx: { tenantId: "G1", actorId: "U1" },
+		conversationId: "CHAN1",
+		threadId: "MSG1",
+		target: { mode: "user", projectId: "P1", organizationId: "O1" },
+	});
+
+	assert.deepEqual(result, { ok: true, projectId: "P1" });
+	assert.deepEqual(calls, [
+		{
+			surfaceKind: "discord",
+			surfaceTenantId: "G1",
+			channelId: "CHAN1",
+			threadTs: "MSG1",
+			organizationId: "O1",
+			projectId: "P1",
+			initiatorSurfaceUserId: "U1",
+		},
+	]);
+});
+
+test("an already-bound thread is not rewritten", async () => {
+	let called = false;
+	const backend = {
+		createThreadBinding: async () => {
+			called = true;
+			return { created: true, projectId: "P1" };
+		},
+	};
+
+	const result = await ensureThreadBinding({
+		backend,
+		ctx: { tenantId: "G1", actorId: "U1" },
+		conversationId: "CHAN1",
+		threadId: "MSG1",
+		target: {
+			mode: "user",
+			projectId: "P1",
+			organizationId: "O1",
+			boundThread: true,
+		},
+	});
+
+	assert.equal(called, false);
+	assert.deepEqual(result, { ok: true, projectId: "P1" });
+});
+
+test("legacy-mode turns do not bind", async () => {
+	let called = false;
+	const backend = {
+		createThreadBinding: async () => {
+			called = true;
+			return { created: true, projectId: "P1" };
+		},
+	};
+
+	const result = await ensureThreadBinding({
+		backend,
+		ctx: { tenantId: "G1", actorId: "U1" },
+		conversationId: "CHAN1",
+		threadId: "MSG1",
+		target: { mode: "legacy", projectId: "PLEGACY" },
+	});
+
+	assert.equal(called, false);
+	assert.deepEqual(result, { ok: true, projectId: "PLEGACY" });
+});
+
+test("the loser of a race adopts the winning binding's project", async () => {
+	const backend = {
+		// First writer wins server-side, so the losing turn is handed the
+		// winner's project rather than its own resolution.
+		createThreadBinding: async () => ({
+			created: false,
+			projectId: "P-WINNER",
+			organizationId: "O1",
+		}),
+	};
+
+	const result = await ensureThreadBinding({
+		backend,
+		ctx: { tenantId: "G1", actorId: "U1" },
+		conversationId: "CHAN1",
+		threadId: "MSG1",
+		target: { mode: "user", projectId: "P-LOSER", organizationId: "O1" },
+	});
+
+	assert.deepEqual(result, { ok: true, projectId: "P-WINNER" });
+});
+
+test("a thrown binding write fails the turn", async () => {
+	const backend = {
+		createThreadBinding: async () => {
+			throw new Error("backend down");
+		},
+	};
+
+	const result = await ensureThreadBinding({
+		backend,
+		ctx: { tenantId: "G1", actorId: "U1" },
+		conversationId: "CHAN1",
+		threadId: "MSG1",
+		target: { mode: "user", projectId: "P1", organizationId: "O1" },
+		logger: silentLogger,
+	});
+
+	assert.deepEqual(result, { ok: false });
+});
+
+test("a 200 that pinned nothing fails the turn too", async () => {
+	const backend = {
+		// The backend answers this shape when the project is not in the org, and
+		// nothing was written — a success status but not a successful bind.
+		createThreadBinding: async () => ({
+			created: false,
+			reason: "project_not_in_org",
+		}),
+	};
+
+	const result = await ensureThreadBinding({
+		backend,
+		ctx: { tenantId: "G1", actorId: "U1" },
+		conversationId: "CHAN1",
+		threadId: "MSG1",
+		target: { mode: "user", projectId: "P1", organizationId: "O1" },
+		logger: silentLogger,
+	});
+
+	assert.deepEqual(result, { ok: false });
+});


### PR DESCRIPTION
Second step of the agent-surfaces plan, following #3785 (A1). Discord-only again — `slack-app` and `surface-core` are untouched, so the `deploy-slack-app.yml` trigger on `surface-core/**` stays cold.

## The bug

Thread bindings never matched anything, for two independent reasons:

- `threadId` was `message.id`, so **every message minted a fresh thread key**. A binding keyed on one message could never be found by the next.
- `createThreadBinding` was **never called at all** — nothing was ever written to match.

Net effect: every turn fell through to whoever-spoke-last's default project. Two people in one conversation would silently run against two different projects.

## The derivation

Discord has no single "thread key", so the pair has to be built:

| trigger | `conversationId` | `threadId` |
| --- | --- | --- |
| channel mention | `channelId` | `message.id` |
| inside a thread | `channel.parentId` | `channelId` |

These two rows produce **one key**, which is the whole point. A Discord thread started from a message takes that message's id as its own channel id, and its `parentId` is the channel the mention was posted in — so the binding written by the first turn is exactly the one later in-thread turns look up. This also mirrors Slack, where a top-level message's `threadTs` is its own `ts`: the id of the thread that *would* be created if someone replied.

An orphaned thread (`parentId === null`) falls back to its own id rather than sending `null` through as a channel id.

This lives in a new `discord-app/conversation.js` rather than inline in `app.js`, because `app.js` calls `client.login()` at module scope and can't be imported by a test.

## The binding write

The first user-mode turn now writes the binding and **fails the turn if the write fails**, mirroring `slack-app/listeners/events/run-and-reply.js` and carrying its reasoning across: an unbound thread re-resolves on every reply, so the next person to speak gets *their* default project and creates resources somewhere the initiator never chose. A silent cross-project write is worse than a visible "try again".

Three details worth calling out:

- **A 200 can still be a failed bind.** The backend answers `{created: false, reason: 'project_not_in_org'}` with no `projectId` — nothing was pinned, so it's treated exactly like a thrown error. (This is slightly stricter than Slack's fork, which only fails on a throw. The stricter branch is what the invariant actually calls for.)
- **The loser of a race adopts the winner's project.** Binding creation is first-writer-wins server-side and hands the loser the winning `projectId`, so both racing turns act in the same place instead of one running against its own resolution.
- **The claim is released, not completed.** A bind failure is transient, so a redelivery of the same message should be allowed to run rather than being permanently marked done.

Only `user`-mode turns bind — `legacy` runs on a shared key with no org to attribute the thread to, and the other modes never reach a run.

## Also in this diff

`projectId: process.env.MCPJAM_PROJECT_ID` is gone from the pre-resolution `ref`. Seeding it meant every path that returned before resolution acted in whatever project the operator happened to set — a cross-project write dressed up as a default. The resolved target is now the only source. (The same class of bug in the *approval* handler is bug 4, which A4 fixes; this is just the message path.)

This PR depends on A1 having removed history's `conversationId` filter. `conversationId` is now the parent channel for in-thread turns, and that filter would have matched it against nothing — leaving every threaded turn with an empty history.

## Tests

13 new cases in `discord-app/tests/conversation.test.js` (25 total in the workspace, up from 13).

Identity: channel mention, in-thread message, the **carryover case** (a thread started from a mention derives the mention's key), two messages in one thread collapsing to one key, orphaned-thread fallback, and a client without `isThread`.

Binding: the exact wire body, already-bound threads not rewritten, legacy mode not binding, race-loser adopting the winner's project, a thrown write failing the turn, and a 200-that-pinned-nothing failing the turn.

## Verification

| workspace | result |
| --- | --- |
| `@mcpjam/discord-app` | 25 pass, 0 fail — `tsc --checkJs` and biome clean |
| `@mcpjam/surface-core` | 20 pass, 0 fail (untouched) |
| `@mcpjam/slack-app` | 242 pass, 0 fail (untouched) |

## Not in this PR

A3 (credential split), A4 (approval handler target resolution), A5 (connect-link origin normalization), A6 (hardening), then Phase B. Each lands separately.

One thing I deliberately left alone: the `conversationId` passed to `api.runAgentTurn` is still `message.channelId`, not the derived pair. Changing it would alter server-side conversation grouping — in-thread turns would merge under the parent channel — which is a product decision outside this diff's scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6uPdzFLQtSMBHr4rnEiqd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which MCPJam project Discord threads run against and when turns are allowed to proceed; mistakes could still cause wrong-project writes, but failures are surfaced rather than silent drift.
> 
> **Overview**
> Fixes Discord agent turns that **never matched thread bindings** because every message used `message.id` as `threadId`, and **nothing called** `createThreadBinding`. Turns kept re-resolving to each speaker’s default project.
> 
> Adds **`discord-app/conversation.js`**: channel mentions use `(channelId, message.id)`; in-thread messages use `(parentId, threadId)` so replies share the same key as the mention that started the thread (aligned with Slack’s `threadTs` model). After target resolution, the **first user-mode turn** pins the thread via `ensureThreadBinding`; bind failures **abort the turn**, **release** the dedupe claim (not complete), and warn the user instead of running unbound. Race losers adopt the winner’s `projectId`; empty-success bind responses are treated as failure.
> 
> The mention handler **stops seeding** `ref.projectId` from `MCPJAM_PROJECT_ID` before resolution and uses the derived identity for `resolveTurnTarget`. **13 unit tests** cover identity carryover and binding edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 590b106a109005965c2d6bd9082030b5d119ee66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Discord thread routing by deriving a stable `(conversationId, threadId)` and pinning the thread to the resolved project on the first user turn. Adds safer claim handling to avoid stranded messages, prevents cross‑project writes, and makes bind‑failure logs traceable.

- **Bug Fixes**
  - Stable identity: channel mention → `(conversationId=channelId, threadId=message.id)`; in-thread → `(conversationId=parentId || channelId, threadId=channelId)`. Implemented in `discord-app/conversation.js` with tests.
  - Bind on the first user-mode turn; first-writer-wins, and a race loser adopts the winner’s `projectId`. Skip if already bound, mode ≠ user, or the target lacks `organizationId`/`projectId`.
  - On bind failure (throw or no `projectId`): abort the turn, release the claim before warning, and contain the warning send’s throw to avoid re‑completing the claim. Log the dedupe key and conversation id if the warning cannot be delivered. Do not run unbound.
  - Remove pre-resolution `projectId` seeding from the `ref` to prevent cross‑project actions.

<sup>Written for commit 590b106a109005965c2d6bd9082030b5d119ee66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

