### PR TITLE
fix(sentry): tag packaged Electron builds as prod, not dev

### DIFF
--- a/mcpjam-inspector/shared/__tests__/sentry-config.test.ts
+++ b/mcpjam-inspector/shared/__tests__/sentry-config.test.ts
@@ -1,0 +1,51 @@
+/**
+ * electronMainSentryConfig — the environment tag on desktop crash reports.
+ *
+ * The main process is the one Sentry caller that can't learn its environment
+ * from NODE_ENV: the renderer gets it inlined by Vite at build time and the
+ * npm flavors get it exported by the `start` script, but a packaged desktop
+ * app sets it nowhere. That gap silently tagged every shipped release as
+ * "dev", so ~97% of real desktop errors never appeared in a production-scoped
+ * view. Pin the mapping so a future refactor can't quietly reintroduce it.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  electronMainSentryConfig,
+  electronSentryConfig,
+} from "../sentry-config";
+
+describe("electronMainSentryConfig", () => {
+  it("tags a packaged build as prod regardless of NODE_ENV", () => {
+    expect(electronMainSentryConfig(true).environment).toBe("prod");
+  });
+
+  it("tags an unpackaged build as dev regardless of NODE_ENV", () => {
+    expect(electronMainSentryConfig(false).environment).toBe("dev");
+  });
+
+  it("does not depend on NODE_ENV in either direction", () => {
+    const original = process.env.NODE_ENV;
+    try {
+      // The bug was that a packaged app fell through to "dev" because
+      // NODE_ENV was unset. Absent NODE_ENV must no longer change the answer.
+      delete process.env.NODE_ENV;
+      expect(electronMainSentryConfig(true).environment).toBe("prod");
+
+      process.env.NODE_ENV = "development";
+      expect(electronMainSentryConfig(true).environment).toBe("prod");
+
+      process.env.NODE_ENV = "production";
+      expect(electronMainSentryConfig(false).environment).toBe("dev");
+    } finally {
+      if (original === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = original;
+    }
+  });
+
+  it("preserves the electron DSN and the shared base config", () => {
+    const config = electronMainSentryConfig(true);
+    expect(config.dsn).toBe(electronSentryConfig.dsn);
+    expect(config.sendDefaultPii).toBe(false);
+    expect(config.tracesSampleRate).toBe(electronSentryConfig.tracesSampleRate);
+  });
+});

--- a/mcpjam-inspector/shared/sentry-config.ts
+++ b/mcpjam-inspector/shared/sentry-config.ts
@@ -13,6 +13,27 @@ export const electronSentryConfig = {
   ...baseSentryConfig,
   dsn: "https://6a41a208e72267f181f66c47138f2b9d@o4510109778378752.ingest.us.sentry.io/4510112190431232",
 };
+
+/**
+ * Sentry config for the Electron main process.
+ *
+ * `baseSentryConfig` resolves `environment` from NODE_ENV, which the renderer
+ * and the npm-served flavors get right (Vite inlines it at build time; the
+ * `start` script exports it). The packaged desktop app sets neither, so the
+ * main process read NODE_ENV as undefined at runtime and tagged every shipped
+ * release as "dev" — hiding real user errors from production-scoped views.
+ *
+ * `app.isPackaged` is the authoritative signal there, but this module is also
+ * imported by the browser bundle and so cannot import "electron" itself.
+ * The caller passes it in.
+ */
+export function electronMainSentryConfig(isPackaged: boolean) {
+  return {
+    ...electronSentryConfig,
+    environment: isPackaged ? "prod" : "dev",
+  };
+}
+
 export const serverSentryConfig = {
   ...baseSentryConfig,
   dsn: "https://ec309069e18ebe1d0be9088fa7bf56d9@o4510109778378752.ingest.us.sentry.io/4510112186433536",

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -1,13 +1,16 @@
 /// <reference types="@electron-forge/plugin-vite/forge-vite-env" />
 import * as Sentry from "@sentry/electron/main";
-import { electronSentryConfig } from "../shared/sentry-config.js";
+import { app } from "electron";
+import { electronMainSentryConfig } from "../shared/sentry-config.js";
 
 Sentry.init({
-  ...electronSentryConfig,
+  // `app.isPackaged`, not NODE_ENV: the packaged app never sets NODE_ENV, so
+  // the shared default would tag every shipped release as "dev".
+  ...electronMainSentryConfig(app.isPackaged),
   ipcMode: Sentry.IPCMode.Both, // Enables communication with renderer process
 });
 
-import { app, BrowserWindow, shell, Menu, dialog } from "electron";
+import { BrowserWindow, shell, Menu, dialog } from "electron";
 import type { BrowserWindowConstructorOptions } from "electron";
 import { serve } from "@hono/node-server";
 import path from "path";


### PR DESCRIPTION
- Crashes from the shipped desktop app were being labelled `dev` instead of production, so they were invisible in any Sentry view filtered to prod. Over the last 90 days that hid 24,085 of 24,789 desktop errors (97%) — you'd look at ~700 and think the desktop app was healthy.
- Cause: the code asks `NODE_ENV` what environment it's in, but a packaged Electron app never sets that variable, so it always fell through to "dev". Confirmed on real user events (e.g. release 2.0.9 on macOS, stack frames inside the packaged bundle, tagged `dev`).
- Fix: the desktop app now asks Electron directly via `app.isPackaged`, which is always correct and can't be forgotten by a build script.
- Nothing else changes — the web client and the npx/Docker flavors already got this right by different routes, so they're untouched.
- Heads up: once this ships, desktop error volume in prod views jumps from ~700 to ~25k. That's not a regression, it's the errors that were always there. Worth clearing the known noise (the tokenizer warnings, the HackTheBox crypto issues) first so the prod feed starts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Sentry environment tagging for the desktop app. Packaged Electron builds now report as `prod` instead of `dev`, so real user crashes show up in production views.

- **Bug Fixes**
  - Cause: the Electron main process read `NODE_ENV`, which is unset in packaged apps, so events were tagged `dev` (~24,085/24,789 last 90 days).
  - Change: added `electronMainSentryConfig(isPackaged)` and now use `app.isPackaged` in `src/main.ts` to set `environment` (`prod` when packaged, `dev` otherwise).
  - Tests: added unit tests to lock the mapping and keep parity with `electronSentryConfig`.
  - Scope: web renderer and npm/Docker flavors unchanged; they already tag correctly.
  - Impact: production error volume will rise to include previously hidden desktop errors.

<sup>Written for commit d076054e59016bc7418776c8832e0ea4a865736e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

