### PR TITLE
fix(sidebar): stop the project switcher flickering and bouncing off settings

### DIFF
--- a/.changeset/sidebar-switcher-flicker.md
+++ b/.changeset/sidebar-switcher-flicker.md
@@ -1,0 +1,8 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Fix flicker in the sidebar project/org switcher. Hovering a project row no
+longer shifts the member avatars sideways, the learn-more preview card no
+longer animates over the open menu, and the per-row settings gear now lands on
+project settings instead of flashing it and bouncing to Servers.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3563,7 +3563,6 @@ export default function App() {
     }
   }, [
     activeProjectId,
-    activeTab,
     isAuthLoading,
     isLoadingRemoteProjects,
     isWorkOsLoading,
@@ -3910,7 +3909,11 @@ export default function App() {
       await handleSwitchProject(projectId);
 
       const navigationTarget = getProjectSwitchNavigationTarget({
-        activeTab,
+        // Read the tab from the live pathname, not the `activeTab` hook value:
+        // the switcher's per-row gear navigates while this switch is still in
+        // flight, and a closure-captured tab would send the user back to
+        // Servers on top of the settings page they just opened.
+        activeTab: pathnameToActiveTab(window.location.pathname),
         activeOrganizationId,
         nextProjectOrganizationId: nextProject?.organizationId,
       });
@@ -3918,13 +3921,7 @@ export default function App() {
         navigateToTarget(navigationTarget);
       }
     },
-    [
-      activeOrganizationId,
-      activeTab,
-      handleSwitchProject,
-      navigateToTarget,
-      projects,
-    ]
+    [activeOrganizationId, handleSwitchProject, navigateToTarget, projects]
   );
 
   const isBillingEntryHandoff =

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -3553,7 +3553,10 @@ export default function App() {
       shouldSnapToServersOnActiveProjectChange({
         previousActiveProjectId,
         nextActiveProjectId: activeProjectId,
-        activeTab,
+        // Deliberately not the `activeTab` hook value: the router commits in a
+        // transition, so that still names the page being left while the project
+        // change is already live. `navigateToServers` reads the same source.
+        activeTab: pathnameToActiveTab(window.location.pathname),
       })
     ) {
       navigateToServers();

--- a/mcpjam-inspector/client/src/components/learn-more/LearnMoreHoverCard.tsx
+++ b/mcpjam-inspector/client/src/components/learn-more/LearnMoreHoverCard.tsx
@@ -49,6 +49,11 @@ interface LearnMoreHoverCardProps {
   triggerTooltipDelayMs?: number;
   /** Message shown inside the hover card for disabled items (e.g. "Available locally") */
   disabledMessage?: string;
+  /**
+   * Holds the hover card shut. Set it while the trigger owns another popover
+   * (a menu, a dialog) so the two don't animate over the same rectangle.
+   */
+  suppressed?: boolean;
 }
 
 export function LearnMoreHoverCard({
@@ -58,6 +63,7 @@ export function LearnMoreHoverCard({
   triggerTooltip,
   triggerTooltipDelayMs,
   disabledMessage,
+  suppressed = false,
 }: LearnMoreHoverCardProps) {
   const entry = learnMoreContent[tabId];
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -65,6 +71,7 @@ export function LearnMoreHoverCard({
   const [open, setOpen] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const handoffTimerRef = useRef<number | null>(null);
+  const isOpen = open && !suppressed;
 
   const clearHandoffTimer = () => {
     if (handoffTimerRef.current !== null) {
@@ -78,11 +85,20 @@ export function LearnMoreHoverCard({
   }, []);
 
   useEffect(() => {
-    if (open && videoRef.current) {
+    if (isOpen && videoRef.current) {
       videoRef.current.currentTime = 0;
       videoRef.current.play().catch(() => {});
     }
-  }, [open]);
+  }, [isOpen]);
+
+  // Drop any pending open the moment the trigger hands off to another popover,
+  // so lifting suppression later doesn't replay a stale hover intent.
+  useEffect(() => {
+    if (!suppressed) return;
+    clearHandoffTimer();
+    setOpen(false);
+    setTooltipOpen(false);
+  }, [suppressed]);
 
   useEffect(() => {
     return () => {
@@ -97,6 +113,12 @@ export function LearnMoreHoverCard({
 
   const handleOpenChange = (nextOpen: boolean) => {
     clearHandoffTimer();
+
+    if (suppressed) {
+      setTooltipOpen(false);
+      setOpen(false);
+      return;
+    }
 
     if (!shouldShowTooltipFirst) {
       setOpen(nextOpen);
@@ -140,7 +162,7 @@ export function LearnMoreHoverCard({
     <HoverCard
       openDelay={shouldShowTooltipFirst ? 0 : 400}
       closeDelay={200}
-      open={open}
+      open={isOpen}
       onOpenChange={handleOpenChange}
     >
       {shouldShowTooltipFirst ? (

--- a/mcpjam-inspector/client/src/components/learn-more/__tests__/LearnMoreHoverCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/learn-more/__tests__/LearnMoreHoverCard.test.tsx
@@ -1,0 +1,77 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LearnMoreHoverCard } from "../LearnMoreHoverCard";
+
+// From learnMoreContent["projects"] — the card body, so its presence proves the
+// hover card actually opened rather than just the tooltip.
+const CARD_BODY = "Organize your MCP servers into projects.";
+const HANDOFF_MS = 1000;
+
+function card(suppressed: boolean) {
+  return (
+    <LearnMoreHoverCard
+      tabId="projects"
+      onExpand={vi.fn()}
+      // Both required for the tooltip-then-card handoff, which is the path
+      // that arms the timer. nav-main uses it for the collapsed sidebar.
+      triggerTooltip="Projects"
+      triggerTooltipDelayMs={HANDOFF_MS}
+      suppressed={suppressed}
+    >
+      <button type="button">Projects</button>
+    </LearnMoreHoverCard>
+  );
+}
+
+function hoverTrigger() {
+  fireEvent.pointerEnter(screen.getByRole("button", { name: "Projects" }), {
+    pointerType: "mouse",
+  });
+  // Radix's own openDelay is 0 on this path; let it fire so onOpenChange runs.
+  act(() => {
+    vi.advanceTimersByTime(0);
+  });
+}
+
+describe("LearnMoreHoverCard handoff timer", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens the card once the handoff delay elapses", () => {
+    // Control for the suppression test below: without it, a card that never
+    // opens in jsdom would make that assertion vacuously true.
+    vi.useFakeTimers();
+    render(card(false));
+    hoverTrigger();
+    expect(screen.queryByText(CARD_BODY)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(HANDOFF_MS);
+    });
+
+    expect(screen.getByText(CARD_BODY)).toBeInTheDocument();
+  });
+
+  it("cancels a pending handoff when suppression lands before it fires", () => {
+    vi.useFakeTimers();
+    const { rerender } = render(card(false));
+    hoverTrigger();
+
+    // The trigger hands off to another popover mid-delay.
+    rerender(card(true));
+    act(() => {
+      vi.advanceTimersByTime(HANDOFF_MS * 2);
+    });
+    expect(screen.queryByText(CARD_BODY)).not.toBeInTheDocument();
+
+    // The `open && !suppressed` gate alone would satisfy the assertion above,
+    // so release suppression: only a genuinely cancelled timer leaves the card
+    // shut here. A surviving one banked `open` and pops it without a hover.
+    rerender(card(false));
+    act(() => {
+      vi.advanceTimersByTime(HANDOFF_MS * 2);
+    });
+    expect(screen.queryByText(CARD_BODY)).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
@@ -133,10 +133,19 @@ vi.mock("@/components/learn-more/LearnMoreHoverCard", () => ({
   LearnMoreHoverCard: ({
     tabId,
     children,
+    suppressed,
   }: {
     tabId: string;
     children: ReactNode;
-  }) => <div data-testid={`learn-more-${tabId}`}>{children}</div>,
+    suppressed?: boolean;
+  }) => (
+    <div
+      data-testid={`learn-more-${tabId}`}
+      data-suppressed={String(!!suppressed)}
+    >
+      {children}
+    </div>
+  ),
 }));
 
 const mockCreateOrgDialog = vi.fn();
@@ -506,14 +515,11 @@ describe("SidebarContextSwitcher", () => {
     });
   });
 
-  it("waits for another project to become active before opening its settings", async () => {
-    let resolveSwitch: () => void = () => {};
-    const onSwitchProject = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveSwitch = resolve;
-        })
-    );
+  it("navigates to settings in the same gesture as the switch, without waiting for it", () => {
+    // Regression: awaiting the switch let the project change land while the
+    // URL was still the page being left, where App's snap-to-Servers effect
+    // read it as a bare project switch and bounced off the settings page.
+    const onSwitchProject = vi.fn(() => new Promise<void>(() => {}));
     const onNavigateToSettings = vi.fn();
     render(
       <SidebarContextSwitcher
@@ -531,12 +537,8 @@ describe("SidebarContextSwitcher", () => {
       screen.getByRole("button", { name: "Open Sandbox settings" })
     );
     expect(onSwitchProject).toHaveBeenCalledWith("p2");
-    expect(onNavigateToSettings).not.toHaveBeenCalled();
-
-    resolveSwitch();
-    await waitFor(() => {
-      expect(onNavigateToSettings).toHaveBeenCalled();
-    });
+    // Never resolves, yet navigation already happened.
+    expect(onNavigateToSettings).toHaveBeenCalled();
   });
 
   it("clicking the per-row gear on the active project navigates without re-switching", () => {
@@ -822,6 +824,30 @@ describe("SidebarContextSwitcher", () => {
     expect(screen.getByTestId("learn-more-projects")).toBeInTheDocument();
     expect(screen.getByTestId("learn-more-projects")).toHaveTextContent(
       "Inspector"
+    );
+  });
+
+  it("suppresses the learn more hover card while the menu is open", () => {
+    render(
+      <SidebarContextSwitcher
+        activeProjectId="p1"
+        activeOrganizationId="org_a"
+        projects={projects}
+        onSwitchProject={vi.fn()}
+        onCreateProject={vi.fn(async () => "")}
+        onDeleteProject={vi.fn()}
+        onLearnMoreExpand={vi.fn()}
+      />
+    );
+    // Both open to the right of the same trigger, so they'd otherwise overlap.
+    expect(screen.getByTestId("learn-more-projects")).toHaveAttribute(
+      "data-suppressed",
+      "false"
+    );
+    openMainDropdown();
+    expect(screen.getByTestId("learn-more-projects")).toHaveAttribute(
+      "data-suppressed",
+      "true"
     );
   });
 

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
@@ -254,7 +254,13 @@ export function SidebarContextSwitcher({
         <SidebarMenuItem>
           <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
             {onLearnMoreExpand ? (
-              <LearnMoreHoverCard tabId="projects" onExpand={onLearnMoreExpand}>
+              <LearnMoreHoverCard
+                tabId="projects"
+                onExpand={onLearnMoreExpand}
+                // Both open to the right of this same trigger, so the preview
+                // card would otherwise animate over the open menu.
+                suppressed={menuOpen}
+              >
                 <DropdownMenuTrigger asChild>
                   {triggerButton}
                 </DropdownMenuTrigger>
@@ -325,10 +331,15 @@ export function SidebarContextSwitcher({
                         }}
                         onOpenSettings={
                           onNavigateToSettings
-                            ? async () => {
+                            ? () => {
                                 setMenuOpen(false);
+                                // Switch and navigate in one gesture. Awaiting
+                                // the switch first let the project change land
+                                // on the old route, where the snap-to-Servers
+                                // effect read it as a bare project switch and
+                                // bounced off the settings page.
                                 if (project.id !== activeProjectId) {
-                                  await onSwitchProject(project.id);
+                                  onSwitchProject(project.id);
                                 }
                                 onNavigateToSettings();
                               }
@@ -573,7 +584,9 @@ function ProjectRow({
         projectId={project.sharedProjectId ?? null}
         isAuthenticated={isAuthenticated}
       />
-      <div className="hidden group-hover/proj:flex group-focus-within/proj:flex items-center gap-0.5 shrink-0">
+      {/* Keep the cluster in flow (invisible, not display:none) so revealing it
+          on hover doesn't shove the member avatars sideways. */}
+      <div className="invisible group-hover/proj:visible group-focus-within/proj:visible flex items-center gap-0.5 shrink-0">
         {onOpenSettings ? (
           <button
             type="button"

--- a/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-navigation.test.ts
@@ -153,6 +153,20 @@ describe("shouldSnapToServersOnActiveProjectChange", () => {
     ).toBe(false);
   });
 
+  it("does NOT snap while on project settings", () => {
+    // Regression: the switcher's per-row gear switches project and opens that
+    // project's settings as one gesture. Snapping here flashed the settings
+    // page and bounced the user to Servers. Project settings renders whichever
+    // project is active, so it is still correct after the switch.
+    expect(
+      shouldSnapToServersOnActiveProjectChange({
+        previousActiveProjectId: "p1",
+        nextActiveProjectId: "p2",
+        activeTab: "project-settings",
+      }),
+    ).toBe(false);
+  });
+
   it("does not snap on initial hydration (no previous project id)", () => {
     expect(
       shouldSnapToServersOnActiveProjectChange({

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -593,6 +593,14 @@ export function captureCurrentReturnPath(): string | null {
   return `${pathname}${search}`;
 }
 
+/**
+ * Where a manual project switch should land, if anywhere.
+ *
+ * As with `shouldSnapToServersOnActiveProjectChange`, callers must resolve
+ * `activeTab` from the live pathname rather than a routing hook: a switch that
+ * resolves after the caller has already navigated would otherwise be judged
+ * against the page the user left.
+ */
 export function getProjectSwitchNavigationTarget({
   activeTab,
   activeOrganizationId,

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -651,6 +651,14 @@ export function getInvalidOrganizationRouteNavigationTarget({
  * org-scoped, not project-scoped, so snapping there would bounce the user right
  * back off the settings they just opened.
  *
+ * Project settings is exempt for the same reason: it renders whichever project
+ * is active, so it is still correct after the switch, and the switcher's
+ * per-row gear reaches it by switching project and navigating as one gesture.
+ *
+ * Callers must resolve `activeTab` from the live pathname, not from a routing
+ * hook — the router commits navigations in a transition, so a hook-derived tab
+ * can still name the page the user is leaving when this runs.
+ *
  * The initial hydration (no previous id) and the local-default `"none"`
  * placeholder are never treated as real switches.
  */
@@ -672,7 +680,7 @@ export function shouldSnapToServersOnActiveProjectChange({
     return false;
   }
 
-  if (activeTab === "organizations") {
+  if (activeTab === "organizations" || activeTab === "project-settings") {
     return false;
   }
 


### PR DESCRIPTION
Three defects in the sidebar project/org switcher. Each was reproduced in the running app before the fix and re-verified after.

## 1. Hover icons shifted the row

The per-row action cluster used `hidden` / `group-hover/proj:flex`, so revealing it added 38px of content to the row and pushed the member avatars sideways. Measured on the same row:

| | avatar strip x | actions |
|---|---|---|
| not hovered | **456** | 0px |
| hovered | **410** | 38px @ 434 |

A 46px jump every time the pointer crossed a row. The org rows a few functions down in the same file already use opacity for exactly this reason.

**Fix:** `invisible` / `group-hover/proj:visible` with `flex` always applied, so the cluster keeps its box. `group-focus-within` still works — the row itself carries `tabIndex={0}`. After the fix, hovered and unhovered geometry are identical (avatars `x=410`, actions reserved at `434` w=`38`), and the icons still reveal (`visibility: visible`, both buttons present).

## 2. The learn-more card opened on top of the menu

`LearnMoreHoverCard` and the context `DropdownMenu` both open `side="right"` off the same trigger, and nothing closed the card when the menu opened. Both mounted, overlapping:

```
hover-card-content     x=191 y=0  288x236
dropdown-menu-content  x=187 y=42 300x185
```

Hovering the switcher and then clicking it could leave the preview card showing *instead of* the menu.

**Fix:** a `suppressed` prop on `LearnMoreHoverCard` that holds the card shut, drops any pending open timer, and gates the video autoplay. The switcher passes `suppressed={menuOpen}`. Verified: the card stays `closed` for 2s with the cursor parked on the trigger while the menu is open, and still opens normally when the menu is closed.

## 3. The per-row gear flashed project settings, then bounced to Servers

Reproduced from `/tools`, clicking the gear on a non-active project:

```
/tools  ->  pushState /project-settings  ->  pushState /servers
```

The handler did `await onSwitchProject(...)` before navigating, so the project change landed a microtask *before* any navigation. Instrumented log at the moment `App`'s snap-to-Servers effect ran:

```
activeTab: "tools", path: "/tools"
```

The destination did not exist yet, so the effect correctly read "bare project switch on a project-scoped tab" and queued `/servers`, which committed after the settings navigation.

**Fix**, three coordinated parts:

- `sidebar-context-switcher.tsx` — drop the `await`, so switch and navigate are one gesture and the URL is committed before the project change is evaluated.
- `app-navigation.ts` — exempt `project-settings` alongside `organizations`. By the effect's own rationale it should never have snapped: project settings renders whichever project is active, so it stays correct after the switch.
- `App.tsx` — resolve the tab from `pathnameToActiveTab(window.location.pathname)` instead of the `activeTab` hook. The router commits navigations in a transition, so the hook value can still name the page being left. This is the existing idiom — `navigateToServers` reads the same source, and two nearby call sites already do this with a local named `committedTab`.

Verified after the fix: single navigation, lands on `/project-settings`, still there after 4s, correct project shown. **A plain row click still snaps to Servers** — the intended behavior is intact.

## Testing

`npm run test -w @mcpjam/inspector` — 13080 passed. (2 failures are `EPERM: operation not permitted, symlink` in `server/services/github-checks/__tests__/repoFiles.test.ts`, a Windows-only limitation on the dev machine; untouched by this branch.)

`npm run typecheck`, `npm run typecheck:client -w @mcpjam/inspector`, `npm run build:inspector` — all pass.

One existing test was replaced deliberately: `"waits for another project to become active before opening its settings"` pinned the `await` that caused defect 3. It is now `"navigates to settings in the same gesture as the switch, without waiting for it"`, using a promise that never resolves to prove navigation no longer depends on it. Two new tests cover the hover-card suppression and the `project-settings` snap exemption.

## Noted, not fixed here

`/playground` crashes on an unrelated Convex validator mismatch — `projectEnvironments:listEnvironments` rejects an `origin: "all"` field the client sends. Out of scope for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flicker and “bounce to Servers” in the sidebar project/org switcher. Rows no longer shift on hover, the preview card no longer overlays the menu, and the gear opens project settings reliably.

- **Bug Fixes**
  - Prevent row layout shift: keep action icons in flow using invisible/visible so avatar strips don’t move; focus styles still work.
  - Suppress `LearnMoreHoverCard` while the menu is open to avoid overlapping popovers; drops pending opens and pauses autoplay. Tests cover the handoff-timer cancellation.
  - Open project settings in the same gesture: don’t await the project switch; resolve the active tab from the live pathname in both the snap effect and switch-target logic to avoid post-navigation bounce; exempt `project-settings` from snap-to-Servers. Tests cover the snap exemption and same-gesture navigation.

<sup>Written for commit 91fc44ac08a19c68fa25e534a4fd3f42c0088e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

