### PR TITLE
fix(sidebar): drop the guest sign-in button from the footer

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -34,9 +34,9 @@ vi.mock("@/components/notifications/NotificationsPanel", () => ({
   NotificationsPanelContent: () => <div data-testid="notifications-panel" />,
 }));
 
-// Represent local/npx mode (VITE_MCPJAM_HOSTED_MODE unset). The sidebar
-// sign-in affordance is intentionally mode-agnostic — a guest must see it in
-// both hosted and local, since the header sign-in is hidden on the Home route.
+// Represent local/npx mode (VITE_MCPJAM_HOSTED_MODE unset). Guests get no
+// sidebar footer at all in either mode — they sign in from the header button or
+// the org switcher's sign-in chip.
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: false,
 }));
@@ -114,20 +114,10 @@ describe("SidebarUser", () => {
     window.isElectron = false;
   });
 
-  it("renders sign-in button when unauthenticated", () => {
-    render(<SidebarUser />);
-    expect(screen.getByText("Sign in")).toBeDefined();
-    const signInButton = screen.getByRole("button", { name: "Sign in" });
-    expect(signInButton).toHaveAttribute("aria-label", "Sign in");
-    expect(signInButton.className).toContain(
-      "data-[state=open]:bg-sidebar-accent"
-    );
-  });
-
-  it("calls signIn when button is clicked", () => {
-    render(<SidebarUser />);
-    fireEvent.click(screen.getByText("Sign in"));
-    expect(authState.signInMock).toHaveBeenCalled();
+  it("renders nothing when unauthenticated", () => {
+    const { container } = render(<SidebarUser />);
+    expect(screen.queryByText("Sign in")).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("no longer renders credit usage in the account dropdown (moved to the org switcher)", () => {

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -23,7 +23,6 @@ import {
 import { getInitials } from "@/lib/utils";
 import {
   Bell,
-  LogIn,
   ChevronsUpDown,
   CircleUser,
   LogOut,
@@ -44,7 +43,7 @@ interface SidebarUserProps {
 
 export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
   const { isLoading, isAuthenticated } = useConvexAuth();
-  const { user, signIn, signOut, isLoading: isWorkOsAuthLoading } = useAuth();
+  const { user, signOut, isLoading: isWorkOsAuthLoading } = useAuth();
   const { profilePictureUrl } = useProfilePicture();
   const convexUser = useQuery("users:getCurrentUser" as any);
   const { isMobile } = useSidebar();
@@ -135,28 +134,11 @@ export function SidebarUser({ onBeforeSignOut }: SidebarUserProps = {}) {
     return loadingState;
   }
 
-  // No WorkOS user → offer sign-in. In local/npx mode the actor is an anonymous
-  // guest (the raw WorkOS `user` stays null), and the header's sign-in button is
-  // hidden on the Home route, so the sidebar footer is the only sign-in
-  // affordance there. Surface it in both modes for parity with hosted.
+  // No WorkOS user → render nothing. Guests sign in from the header button and
+  // the org switcher's sign-in chip; a third affordance in the sidebar footer is
+  // redundant.
   if (!user) {
-    return (
-      <SidebarMenu>
-        <SidebarMenuItem>
-          <SidebarMenuButton
-            size="lg"
-            onClick={() => signIn()}
-            aria-label="Sign in"
-            className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:justify-center"
-          >
-            <LogIn className="size-4" />
-            <span className="truncate group-data-[collapsible=icon]:hidden">
-              Sign in
-            </span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      </SidebarMenu>
-    );
+    return null;
   }
 
   if (isLoading) {

--- a/mcpjam-inspector/e2e/sidebar-rail-alignment.spec.ts
+++ b/mcpjam-inspector/e2e/sidebar-rail-alignment.spec.ts
@@ -2,18 +2,16 @@ import { expect, test } from "@playwright/test";
 
 // Guards the collapsed (icon-mode) sidebar rail: every icon-only control in
 // the footer must sit on the rail's horizontal centerline. This is geometry
-// the vitest suite can't see (jsdom has no layout engine). Regression context:
-// the signed-out "Sign in" footer button uses a `size="lg"` menu button, which
-// drops its padding in icon mode so a 32px avatar can fill it — with a 16px
-// icon instead, the icon parked 8px left of the centerline.
+// the vitest suite can't see (jsdom has no layout engine).
 test("collapsed sidebar rail centers the footer icons", async ({ page }) => {
   await page.goto("/");
   await expect(page.getByTestId("app-shell")).toBeVisible({ timeout: 30_000 });
 
-  // Guest footer (local mode and hosted signed-out): Sign in + Support and
-  // Settings utility buttons. Waiting for Sign in also waits out authResolving.
-  const signInButton = page.locator('button[aria-label="Sign in"]');
-  await expect(signInButton).toBeVisible({ timeout: 30_000 });
+  // Guest footer (local mode and hosted signed-out): the Support and Settings
+  // utility buttons. They're suppressed while auth resolves, so waiting for
+  // Support also waits out authResolving.
+  const supportButton = page.locator('button[aria-label="Support"]');
+  await expect(supportButton).toBeVisible({ timeout: 30_000 });
 
   const sidebar = page.locator('[data-slot="sidebar"][data-state]');
   if ((await sidebar.getAttribute("data-state")) !== "collapsed") {
@@ -31,7 +29,7 @@ test("collapsed sidebar rail centers the footer icons", async ({ page }) => {
   expect(railBox).not.toBeNull();
   const railCenter = railBox!.x + railBox!.width / 2;
 
-  for (const label of ["Sign in", "Support", "Settings"]) {
+  for (const label of ["Support", "Settings"]) {
     const icon = page.locator(`button[aria-label="${label}"] svg`).first();
     await expect(
       icon,

--- a/mcpjam-inspector/e2e/sidebar-rail-alignment.spec.ts
+++ b/mcpjam-inspector/e2e/sidebar-rail-alignment.spec.ts
@@ -4,6 +4,17 @@ import { expect, test } from "@playwright/test";
 // the footer must sit on the rail's horizontal centerline. This is geometry
 // the vitest suite can't see (jsdom has no layout engine).
 test("collapsed sidebar rail centers the footer icons", async ({ page }) => {
+  // Seed completed onboarding so the NUX first-run redirect doesn't fire. It
+  // navigates "/" → /playground asynchronously, which remounts the sidebar at
+  // its default expanded width — after the collapse poll below has passed, so
+  // the geometry loop would measure an expanded rail. See nux.spec.ts.
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "mcp-onboarding-state",
+      JSON.stringify({ status: "completed", completedAt: 1 })
+    );
+  });
+
   await page.goto("/");
   await expect(page.getByTestId("app-shell")).toBeVisible({ timeout: 30_000 });
 


### PR DESCRIPTION
The footer sign-in was a third sign-in affordance for guests, alongside the header button and the org switcher's sign-in chip. Render nothing for guests instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the guest sign-in button from the sidebar footer. Guests now sign in from the header or the org switcher; the footer keeps only Support and Settings.

- **Refactors**
  - Render null in `SidebarUser` when `user` is absent; remove `signIn` usage and `LogIn` icon.
  - Update tests: unit test asserts `SidebarUser` renders nothing for guests; E2E rail alignment anchors on "Support" and checks centering for "Support" and "Settings" only.
  - E2E: seed completed onboarding in localStorage to prevent the first-run redirect from racing the rail alignment check.

<sup>Written for commit 1683209b70eeefd69026213a36c72ab95281a873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

