### PR TITLE
fix(settings): stop the Organization tab from rebuilding the page

### DIFF
--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -349,25 +349,29 @@ function OrganizationAccessRestricted({
   const { leaveConfirmOpen, setLeaveConfirmOpen, isLeaving, handleLeave } =
     useLeaveOrganization(organization);
 
+  // A member without admin rights is still ON the Organization section, so the
+  // tab stays and stays current — they just cannot manage what is behind it.
+  // Losing the shell here left them with no route to the other Settings
+  // sections at all.
   return (
-    <div className="flex flex-col items-center justify-center h-full p-8">
-      <div className="text-center space-y-4 max-w-md">
-        <Building2 className="size-12 text-muted-foreground/50 mx-auto" />
-        <h2 className="text-2xl font-bold">Access restricted</h2>
-        <p className="text-muted-foreground">
-          You don't have permission to view organization settings. Contact an
-          admin or owner for access.
-        </p>
-        <div className="flex flex-col items-center gap-3">
-          <Button onClick={() => appNavigate("/servers")}>Go to Servers</Button>
-          <button
-            type="button"
-            onClick={() => setLeaveConfirmOpen(true)}
-            className="text-sm text-muted-foreground transition-colors hover:text-destructive"
-          >
-            Leave organization
-          </button>
-        </div>
+    <OrganizationStateShell organizationId={organization._id}>
+      <Building2 className="size-8 text-muted-foreground/50" aria-hidden />
+      <h2 className="text-lg font-semibold">Access restricted</h2>
+      <p className="max-w-prose text-sm text-muted-foreground">
+        You don't have permission to view organization settings. Contact an
+        admin or owner for access.
+      </p>
+      <div className="flex flex-col items-center gap-3">
+        <Button variant="outline" onClick={() => appNavigate("/servers")}>
+          Go to Servers
+        </Button>
+        <button
+          type="button"
+          onClick={() => setLeaveConfirmOpen(true)}
+          className="rounded-sm text-sm text-muted-foreground outline-none transition-colors hover:text-destructive focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          Leave organization
+        </button>
       </div>
 
       <LeaveOrganizationDialog
@@ -377,7 +381,7 @@ function OrganizationAccessRestricted({
         isLeaving={isLeaving}
         onConfirm={handleLeave}
       />
-    </div>
+    </OrganizationStateShell>
   );
 }
 
@@ -1235,19 +1239,23 @@ function OrganizationPage({
             </div>
           </div>
         </CardContent>
-        <nav
-          className="flex items-end gap-1 border-t border-border/60 bg-muted/20 px-3 pt-1 sm:px-4"
-          aria-label="Organization settings sections"
-        >
-          {organizationSections.map((tab) => (
-            <SectionTab
-              key={tab.id}
-              label={tab.label}
-              isActive={activeSection === tab.id}
-              onSelect={() => navigateToSection(tab.id)}
-            />
-          ))}
-        </nav>
+        {/* Scrolls for the same reason the top-level strip does: the tabs do
+            not shrink, and Slack makes four of them on a phone. */}
+        <div className="overflow-x-auto scrollbar-hidden border-t border-border/60 bg-muted/20">
+          <nav
+            className="flex w-max min-w-full items-end gap-1 px-3 pt-1 sm:px-4"
+            aria-label="Organization settings sections"
+          >
+            {organizationSections.map((tab) => (
+              <SectionTab
+                key={tab.id}
+                label={tab.label}
+                isActive={activeSection === tab.id}
+                onSelect={() => navigateToSection(tab.id)}
+              />
+            ))}
+          </nav>
+        </div>
       </Card>
 
       {activeSection === "models" ? (

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -1239,12 +1239,12 @@ function OrganizationPage({
           className="flex items-end gap-1 border-t border-border/60 bg-muted/20 px-3 pt-1 sm:px-4"
           aria-label="Organization settings sections"
         >
-          {organizationSections.map((section) => (
+          {organizationSections.map((tab) => (
             <SectionTab
-              key={section.id}
-              label={section.label}
-              isActive={activeSection === section.id}
-              onSelect={() => navigateToSection(section.id)}
+              key={tab.id}
+              label={tab.label}
+              isActive={activeSection === tab.id}
+              onSelect={() => navigateToSection(tab.id)}
             />
           ))}
         </nav>

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, type ReactNode } from "react";
 import { useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useFeatureFlagEnabled } from "posthog-js/react";
@@ -67,13 +67,14 @@ import {
 } from "@/lib/billing-entitlements";
 import type { CheckoutIntentWithOrganization } from "@/lib/billing-deep-link";
 import type { OrganizationRouteSection } from "@/lib/app-navigation";
-import { SettingsNav } from "@/components/settings/SettingsNav";
+import { SectionTab } from "@/components/settings/SectionTab";
+import { SettingsPageShell } from "@/components/settings/SettingsPageShell";
+import { SettingsStatePanel } from "@/components/settings/SettingsStatePanel";
 import { BILLING_GATES, resolveBillingGateState } from "@/lib/billing-gates";
 import {
   getBillingUpsellCtaLabel,
   getBillingUpsellTeaser,
 } from "@/lib/billing-upsell";
-import { cn } from "@/lib/utils";
 import { OrganizationAuditLog } from "./organization/OrganizationAuditLog";
 import { OrganizationBillingSection } from "./organization/OrganizationBillingSection";
 import { OrganizationCurrentPlanPanel } from "./organization/OrganizationCurrentPlanPanel";
@@ -380,6 +381,32 @@ function OrganizationAccessRestricted({
   );
 }
 
+/**
+ * The org page's pre-content states — still a Settings section, so they keep
+ * the shell. Rendering them bare used to strand the user: signing out and
+ * clicking Organization replaced the whole page, tab strip included, with a
+ * lone sign-in button and no way back to the other sections.
+ *
+ * `organizationId` is what the Organization tab would point at, so it is passed
+ * only when this org is real and reachable — not for a deleted or bogus id.
+ */
+function OrganizationStateShell({
+  organizationId,
+  children,
+}: {
+  organizationId?: string | null;
+  children: ReactNode;
+}) {
+  return (
+    <SettingsPageShell
+      active="organization"
+      activeOrganizationId={organizationId}
+    >
+      <SettingsStatePanel>{children}</SettingsStatePanel>
+    </SettingsPageShell>
+  );
+}
+
 export function OrganizationsTab({
   organizationId,
   section = "overview",
@@ -404,54 +431,54 @@ export function OrganizationsTab({
 
   if (isAuthLoading) {
     return (
-      <div className="flex flex-col items-center justify-center h-full p-8">
-        <div className="flex items-center gap-2 text-muted-foreground">
+      <OrganizationStateShell organizationId={organizationId}>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <RefreshCw className="size-4 animate-spin" />
           Completing sign-in...
         </div>
-      </div>
+      </OrganizationStateShell>
     );
   }
 
   if (!user || !isAuthenticated) {
     return (
-      <div className="flex flex-col items-center justify-center h-full p-8">
-        <div className="text-center space-y-4 max-w-md">
-          <h2 className="text-2xl font-bold">
-            Sign in to manage organizations
-          </h2>
-          <Button onClick={() => signIn()} size="lg">
-            Sign In
-          </Button>
-        </div>
-      </div>
+      <OrganizationStateShell organizationId={organizationId}>
+        <h2 className="text-lg font-semibold">
+          Sign in to manage organizations
+        </h2>
+        <p className="max-w-prose text-sm text-muted-foreground">
+          Members, models, and billing live on your organization. Sign in to
+          manage them.
+        </p>
+        <Button onClick={() => signIn()}>Sign in</Button>
+      </OrganizationStateShell>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="flex flex-col items-center justify-center h-full p-8">
-        <div className="flex items-center gap-2 text-muted-foreground">
+      <OrganizationStateShell organizationId={organizationId}>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <RefreshCw className="size-4 animate-spin" />
           Loading organization...
         </div>
-      </div>
+      </OrganizationStateShell>
     );
   }
 
   if (!organization) {
     return (
-      <div className="flex flex-col items-center justify-center h-full p-8">
-        <div className="text-center space-y-4 max-w-md">
-          <Building2 className="size-12 text-muted-foreground/50 mx-auto" />
-          <h2 className="text-2xl font-bold">Organization not found</h2>
-          <p className="text-muted-foreground">
-            This organization may have been deleted or you don't have access to
-            it.
-          </p>
-          <Button onClick={() => appNavigate("/servers")}>Go to Servers</Button>
-        </div>
-      </div>
+      <OrganizationStateShell>
+        <Building2 className="size-8 text-muted-foreground/50" aria-hidden />
+        <h2 className="text-lg font-semibold">Organization not found</h2>
+        <p className="max-w-prose text-sm text-muted-foreground">
+          This organization may have been deleted or you don't have access to
+          it.
+        </p>
+        <Button variant="outline" onClick={() => appNavigate("/servers")}>
+          Go to Servers
+        </Button>
+      </OrganizationStateShell>
     );
   }
 
@@ -579,9 +606,9 @@ function OrganizationPage({
       : section === "billing"
       ? "billing"
       : // Flag OFF collapses the Slack section back to the overview rather
-        // than rendering an empty page: a user who kept the URL from a
-        // flagged-in session should land somewhere real.
-        section === "slack" && slackAgentSettingsEnabled
+      // than rendering an empty page: a user who kept the URL from a
+      // flagged-in session should land somewhere real.
+      section === "slack" && slackAgentSettingsEnabled
       ? "slack"
       : "overview";
   // The sub-tab lives in `?tab=` — three views of one settings section, not
@@ -781,7 +808,9 @@ function OrganizationPage({
       const result = await finishSeatPayment(seatPaymentIntentId);
       if (result.status === "paid") {
         toast.success(
-          `${email ?? activeSeatPaymentIntent?.email ?? "Member"} added to the organization.`
+          `${
+            email ?? activeSeatPaymentIntent?.email ?? "Member"
+          } added to the organization.`
         );
       }
     } catch (error) {
@@ -899,6 +928,17 @@ function OrganizationPage({
   const navigateToSection = (nextSection: OrganizationRouteSection) => {
     appNavigate(buildOrganizationPath(organization._id, nextSection));
   };
+  const organizationSections: {
+    id: OrganizationRouteSection;
+    label: string;
+  }[] = [
+    { id: "overview", label: "General" },
+    { id: "models", label: "Models" },
+    ...(slackAgentSettingsEnabled
+      ? ([{ id: "slack", label: "Slack" }] as const)
+      : []),
+    { id: "billing", label: "Billing" },
+  ];
   const navigateToSlackTab = (tab: SlackSettingsTabId) => {
     appNavigate(
       `${buildOrganizationPath(organization._id, "slack")}?tab=${tab}`
@@ -1138,464 +1178,404 @@ function OrganizationPage({
     ) : null;
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-5">
-        <SettingsNav
-          active="organization"
-          activeOrganizationId={organization._id}
-        />
-        <Card className="overflow-hidden border-border/60">
-          <CardContent className="space-y-5 p-5">
-            <div className="flex flex-col gap-4 md:flex-row md:items-center">
-              <div className="relative shrink-0">
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={handleLogoFileChange}
-                />
-                <Avatar
-                  className={`h-24 w-24 ${canEdit ? "cursor-pointer" : ""}`}
-                  onClick={handleLogoClick}
-                >
-                  <AvatarImage
-                    src={organization.logoUrl}
-                    alt={organization.name}
-                  />
-                  <AvatarFallback className="bg-muted text-3xl">
-                    {initial}
-                  </AvatarFallback>
-                </Avatar>
-                {canEdit ? (
-                  <button
-                    onClick={handleLogoClick}
-                    disabled={isUploadingLogo}
-                    className="absolute -bottom-1 -right-1 rounded-full border bg-background p-2"
-                    aria-label="Upload organization logo"
-                  >
-                    {isUploadingLogo ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-                    ) : (
-                      <Camera className="h-3.5 w-3.5 text-muted-foreground" />
-                    )}
-                  </button>
-                ) : null}
-              </div>
-
-              <div className="flex-1 space-y-1">
-                {canEdit ? (
-                  <EditableText
-                    value={organization.name}
-                    onSave={handleSaveName}
-                    className="text-3xl font-semibold -ml-2"
-                    placeholder="Organization name"
-                  />
-                ) : (
-                  <h1 className="text-3xl font-semibold">
-                    {organization.name}
-                  </h1>
-                )}
-                {billingUiEnabled ? (
-                  <p className="text-sm text-muted-foreground">
-                    Organization settings
-                  </p>
-                ) : null}
-              </div>
-            </div>
-          </CardContent>
-          <nav
-            className="flex items-end gap-1 border-t border-border/60 bg-muted/20 px-2 sm:px-5"
-            aria-label="Organization settings sections"
-          >
-            <button
-              type="button"
-              onClick={() => navigateToSection("overview")}
-              aria-current={activeSection === "overview" ? "page" : undefined}
-              className={cn(
-                "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
-                activeSection === "overview"
-                  ? "border-primary text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground"
-              )}
-            >
-              General
-            </button>
-            <button
-              type="button"
-              onClick={() => navigateToSection("models")}
-              aria-current={activeSection === "models" ? "page" : undefined}
-              className={cn(
-                "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
-                activeSection === "models"
-                  ? "border-primary text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground"
-              )}
-            >
-              Models
-            </button>
-            {slackAgentSettingsEnabled ? (
-              <button
-                type="button"
-                onClick={() => navigateToSection("slack")}
-                aria-current={activeSection === "slack" ? "page" : undefined}
-                className={cn(
-                  "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
-                  activeSection === "slack"
-                    ? "border-primary text-foreground"
-                    : "border-transparent text-muted-foreground hover:text-foreground"
-                )}
+    <SettingsPageShell
+      active="organization"
+      activeOrganizationId={organization._id}
+    >
+      <Card className="overflow-hidden border-border/60">
+        <CardContent className="p-5">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center">
+            <div className="relative shrink-0">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleLogoFileChange}
+              />
+              <Avatar
+                className={`h-16 w-16 ${canEdit ? "cursor-pointer" : ""}`}
+                onClick={handleLogoClick}
               >
-                Slack
-              </button>
-            ) : null}
-            <button
-              type="button"
-              onClick={() => navigateToSection("billing")}
-              aria-current={activeSection === "billing" ? "page" : undefined}
-              className={cn(
-                "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
-                activeSection === "billing"
-                  ? "border-primary text-foreground"
-                  : "border-transparent text-muted-foreground hover:text-foreground"
+                <AvatarImage
+                  src={organization.logoUrl}
+                  alt={organization.name}
+                />
+                <AvatarFallback className="bg-muted text-xl">
+                  {initial}
+                </AvatarFallback>
+              </Avatar>
+              {canEdit ? (
+                <button
+                  onClick={handleLogoClick}
+                  disabled={isUploadingLogo}
+                  className="absolute -bottom-1 -right-1 rounded-full border bg-background p-1.5 outline-none transition-colors hover:bg-muted focus-visible:ring-1 focus-visible:ring-ring"
+                  aria-label="Upload organization logo"
+                >
+                  {isUploadingLogo ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                  ) : (
+                    <Camera className="h-3.5 w-3.5 text-muted-foreground" />
+                  )}
+                </button>
+              ) : null}
+            </div>
+
+            <div className="min-w-0 flex-1">
+              {canEdit ? (
+                <EditableText
+                  value={organization.name}
+                  onSave={handleSaveName}
+                  className="-ml-2 text-xl font-semibold"
+                  placeholder="Organization name"
+                />
+              ) : (
+                <h2 className="text-xl font-semibold">{organization.name}</h2>
               )}
-            >
-              Billing
-            </button>
-          </nav>
-        </Card>
-
-        {activeSection === "models" ? (
-          <OrganizationModelsSection
-            organizationId={organization._id}
-            isAdmin={canEdit}
-          />
-        ) : activeSection === "slack" ? (
-          <SlackAgentSettingsSection
-            organizationId={organization._id}
-            isAdmin={canEdit}
-            tab={slackTab}
-            onTabChange={navigateToSlackTab}
-          />
-        ) : activeSection === "billing" ? (
-          <>
-            {pendingSeatPaymentNotice}
-            <OrganizationBillingSection
-              organizationId={organization._id}
-              showPlanBilling={billingUiEnabled}
-              showCredits
-              billingStatus={billingStatus}
-              organizationName={organization.name}
-              canManageCredits={canEdit || organization.isCreator === true}
-              planCatalog={planCatalog}
-              isLoadingBilling={isLoadingBilling}
-              isLoadingPlanCatalog={isLoadingPlanCatalog}
-              isStartingPlanChange={isStartingPlanChange}
-              pendingPlanChangeTarget={pendingPlanChangeTarget}
-              isOpeningPortal={isOpeningPortal}
-              onDowngradePlan={handleDowngradePlan}
-              onStartPlanChange={handlePlanChange}
-              onStartAutoPlanChange={handleAutoPlanChange}
-              checkoutIntent={checkoutIntent}
-              onCheckoutIntentConsumed={onCheckoutIntentConsumed}
-              currentPlanPanel={
-                billingUiEnabled ? (
-                  <Card className="border-border/60">
-                    <CardHeader className="pb-2">
-                      <CardTitle className="flex items-center gap-2 text-xl">
-                        <CreditCard className="size-4 text-muted-foreground" />
-                        Billing
-                      </CardTitle>
-                      <p className="text-sm text-muted-foreground">
-                        Review your current plan and subscription.
-                      </p>
-                    </CardHeader>
-                    <CardContent className="space-y-3 pt-0">
-                      {isLoadingBilling ? (
-                        <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
-                          Loading billing details...
-                        </div>
-                      ) : billingStatus && !billingStatus.billingConfigured ? (
-                        <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
-                          Billing is not configured in this environment.
-                        </div>
-                      ) : billingStatus ? (
-                        <>
-                          <OrganizationCurrentPlanPanel
-                            billingStatus={billingStatus}
-                            planCatalog={planCatalog}
-                            isLoadingPlanCatalog={isLoadingPlanCatalog}
-                            onChangeBillingInterval={
-                              handleChangeBillingInterval
-                            }
-                            onCancelScheduledBillingChange={
-                              scheduledBillingChangeCancellation
-                                ? handleOpenScheduledBillingChangeCancelDialog
-                                : undefined
-                            }
-                            cancelScheduledBillingChangeLabel={
-                              scheduledBillingChangeCancellation?.ctaLabel ??
-                              null
-                            }
-                            onManageBilling={handleManageBilling}
-                            isOpeningPortal={isOpeningPortal}
-                          />
-                          {!billingStatus.canManageBilling ? (
-                            <p className="min-w-0 text-sm font-medium text-primary">
-                              Only organization owners can manage billing.
-                            </p>
-                          ) : null}
-                        </>
-                      ) : null}
-                    </CardContent>
-                  </Card>
-                ) : null
-              }
+            </div>
+          </div>
+        </CardContent>
+        <nav
+          className="flex items-end gap-1 border-t border-border/60 bg-muted/20 px-3 pt-1 sm:px-4"
+          aria-label="Organization settings sections"
+        >
+          {organizationSections.map((section) => (
+            <SectionTab
+              key={section.id}
+              label={section.label}
+              isActive={activeSection === section.id}
+              onSelect={() => navigateToSection(section.id)}
             />
-            {billingError ? (
-              <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
-                {billingError}
-              </div>
-            ) : null}
-          </>
-        ) : (
-          <>
-            <Card className="border-border/60">
-              <CardHeader className="pb-2">
-                <CardTitle className="flex items-center gap-2 text-xl">
-                  <Users className="size-4 text-muted-foreground" />
-                  Members
-                </CardTitle>
-                <p className="text-sm text-muted-foreground">
-                  Active members ({activeMembers.length})
-                  {pendingMembers.length > 0
-                    ? ` • Pending invites (${pendingMembers.length})`
-                    : ""}
-                </p>
-              </CardHeader>
-              <CardContent className="space-y-4 pt-0">
-                {canInvite ? (
-                  <div className="space-y-3">
-                    {pendingSeatPaymentNotice}
-                    <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
-                      <Input
-                        placeholder="Email address"
-                        value={inviteEmail}
-                        onChange={(e) => setInviteEmail(e.target.value)}
-                        onKeyDown={(e) =>
-                          e.key === "Enter" && void handleInvite()
-                        }
-                        className="h-9 w-full sm:w-80"
-                      />
-                      <Button
-                        size="sm"
-                        className="h-9"
-                        onClick={handleInvite}
-                        disabled={
-                          !inviteEmail.trim() ||
-                          isInviting ||
-                          isHandlingSeatPayment ||
-                          memberInviteGate.isLoading ||
-                          memberInviteGate.isDenied
-                        }
-                      >
-                        <UserPlus className="mr-2 size-4" />
-                        {isInviting || isHandlingSeatPayment
-                          ? "Working..."
-                          : "Add member"}
-                      </Button>
-                    </div>
+          ))}
+        </nav>
+      </Card>
 
-                    {billingStatus?.plan &&
-                    planCatalog?.plans[billingStatus.plan]?.billingModel ===
-                      "per_seat" ? (
-                      <p className="text-xs text-muted-foreground">
-                        Pending invites are free. You'll be billed for this seat
-                        once the invite is accepted.
-                      </p>
-                    ) : null}
-
-                    {memberInviteGate.isDenied ? (
-                      <Alert
-                        className="border-primary/20 bg-primary/[0.04]"
-                        data-testid="member-limit-upsell"
-                      >
-                        <CreditCard className="size-4 text-primary" />
-                        <AlertTitle>Need more members?</AlertTitle>
-                        <AlertDescription className="gap-2">
-                          {memberInviteGate.denialMessage ? (
-                            <p>{memberInviteGate.denialMessage}</p>
-                          ) : null}
-                          {memberUpsellTeaser ? (
-                            <p className="text-foreground/80">
-                              {memberUpsellTeaser}
-                            </p>
-                          ) : null}
-                          {billingStatus?.canManageBilling ? (
-                            <Button
-                              type="button"
-                              size="sm"
-                              className="mt-1"
-                              onClick={handleViewBilling}
-                            >
-                              {memberUpsellCtaLabel}
-                            </Button>
-                          ) : (
-                            <p className="font-medium text-foreground/80">
-                              Ask an organization owner to review billing
-                              options.
-                            </p>
-                          )}
-                        </AlertDescription>
-                      </Alert>
-                    ) : null}
-                  </div>
-                ) : null}
-
-                {membersLoading ? (
-                  <div className="flex items-center gap-2 py-3 text-muted-foreground">
-                    <RefreshCw className="size-4 animate-spin" />
-                    Loading members...
-                  </div>
-                ) : (
-                  <div className="space-y-1">
-                    {activeMembers.map((member) => {
-                      const memberRole = resolveOrganizationRole(member);
-                      return (
-                        <OrganizationMemberRow
-                          key={member._id}
-                          member={member}
-                          role={memberRole}
-                          currentUserEmail={currentUserEmail}
-                          canEditRole={isOwner && memberRole !== "owner"}
-                          isRoleUpdating={roleUpdatingEmail === member.email}
-                          onRoleChange={
-                            isOwner && memberRole !== "owner"
-                              ? (role) =>
-                                  void handleChangeMemberRole(member, role)
+      {activeSection === "models" ? (
+        <OrganizationModelsSection
+          organizationId={organization._id}
+          isAdmin={canEdit}
+        />
+      ) : activeSection === "slack" ? (
+        <SlackAgentSettingsSection
+          organizationId={organization._id}
+          isAdmin={canEdit}
+          tab={slackTab}
+          onTabChange={navigateToSlackTab}
+        />
+      ) : activeSection === "billing" ? (
+        <>
+          {pendingSeatPaymentNotice}
+          <OrganizationBillingSection
+            organizationId={organization._id}
+            showPlanBilling={billingUiEnabled}
+            showCredits
+            billingStatus={billingStatus}
+            organizationName={organization.name}
+            canManageCredits={canEdit || organization.isCreator === true}
+            planCatalog={planCatalog}
+            isLoadingBilling={isLoadingBilling}
+            isLoadingPlanCatalog={isLoadingPlanCatalog}
+            isStartingPlanChange={isStartingPlanChange}
+            pendingPlanChangeTarget={pendingPlanChangeTarget}
+            isOpeningPortal={isOpeningPortal}
+            onDowngradePlan={handleDowngradePlan}
+            onStartPlanChange={handlePlanChange}
+            onStartAutoPlanChange={handleAutoPlanChange}
+            checkoutIntent={checkoutIntent}
+            onCheckoutIntentConsumed={onCheckoutIntentConsumed}
+            currentPlanPanel={
+              billingUiEnabled ? (
+                <Card className="border-border/60">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="flex items-center gap-2 text-xl">
+                      <CreditCard className="size-4 text-muted-foreground" />
+                      Billing
+                    </CardTitle>
+                    <p className="text-sm text-muted-foreground">
+                      Review your current plan and subscription.
+                    </p>
+                  </CardHeader>
+                  <CardContent className="space-y-3 pt-0">
+                    {isLoadingBilling ? (
+                      <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
+                        Loading billing details...
+                      </div>
+                    ) : billingStatus && !billingStatus.billingConfigured ? (
+                      <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
+                        Billing is not configured in this environment.
+                      </div>
+                    ) : billingStatus ? (
+                      <>
+                        <OrganizationCurrentPlanPanel
+                          billingStatus={billingStatus}
+                          planCatalog={planCatalog}
+                          isLoadingPlanCatalog={isLoadingPlanCatalog}
+                          onChangeBillingInterval={handleChangeBillingInterval}
+                          onCancelScheduledBillingChange={
+                            scheduledBillingChangeCancellation
+                              ? handleOpenScheduledBillingChangeCancelDialog
                               : undefined
                           }
-                          onTransferOwnership={
-                            isOwner && memberRole !== "owner"
-                              ? () => setTransferTargetMember(member)
-                              : undefined
+                          cancelScheduledBillingChangeLabel={
+                            scheduledBillingChangeCancellation?.ctaLabel ?? null
                           }
-                          isTransferringOwnership={
-                            isTransferringOwnership &&
-                            transferTargetMember?.email === member.email
-                          }
-                          onRemove={
-                            canRemoveMember(member)
-                              ? () => handleRemoveMember(member.email)
-                              : undefined
-                          }
+                          onManageBilling={handleManageBilling}
+                          isOpeningPortal={isOpeningPortal}
                         />
-                      );
-                    })}
+                        {!billingStatus.canManageBilling ? (
+                          <p className="min-w-0 text-sm font-medium text-primary">
+                            Only organization owners can manage billing.
+                          </p>
+                        ) : null}
+                      </>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              ) : null
+            }
+          />
+          {billingError ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+              {billingError}
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <>
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <Users className="size-4 text-muted-foreground" />
+                Members
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Active members ({activeMembers.length})
+                {pendingMembers.length > 0
+                  ? ` • Pending invites (${pendingMembers.length})`
+                  : ""}
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-4 pt-0">
+              {canInvite ? (
+                <div className="space-y-3">
+                  {pendingSeatPaymentNotice}
+                  <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+                    <Input
+                      placeholder="Email address"
+                      value={inviteEmail}
+                      onChange={(e) => setInviteEmail(e.target.value)}
+                      onKeyDown={(e) =>
+                        e.key === "Enter" && void handleInvite()
+                      }
+                      className="h-9 w-full sm:w-80"
+                    />
+                    <Button
+                      size="sm"
+                      className="h-9"
+                      onClick={handleInvite}
+                      disabled={
+                        !inviteEmail.trim() ||
+                        isInviting ||
+                        isHandlingSeatPayment ||
+                        memberInviteGate.isLoading ||
+                        memberInviteGate.isDenied
+                      }
+                    >
+                      <UserPlus className="mr-2 size-4" />
+                      {isInviting || isHandlingSeatPayment
+                        ? "Working..."
+                        : "Add member"}
+                    </Button>
                   </div>
-                )}
 
-                {pendingMembers.length > 0 ? (
-                  <div className="space-y-1 pt-2">
-                    {pendingMembers.map((member) => (
+                  {billingStatus?.plan &&
+                  planCatalog?.plans[billingStatus.plan]?.billingModel ===
+                    "per_seat" ? (
+                    <p className="text-xs text-muted-foreground">
+                      Pending invites are free. You'll be billed for this seat
+                      once the invite is accepted.
+                    </p>
+                  ) : null}
+
+                  {memberInviteGate.isDenied ? (
+                    <Alert
+                      className="border-primary/20 bg-primary/[0.04]"
+                      data-testid="member-limit-upsell"
+                    >
+                      <CreditCard className="size-4 text-primary" />
+                      <AlertTitle>Need more members?</AlertTitle>
+                      <AlertDescription className="gap-2">
+                        {memberInviteGate.denialMessage ? (
+                          <p>{memberInviteGate.denialMessage}</p>
+                        ) : null}
+                        {memberUpsellTeaser ? (
+                          <p className="text-foreground/80">
+                            {memberUpsellTeaser}
+                          </p>
+                        ) : null}
+                        {billingStatus?.canManageBilling ? (
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="mt-1"
+                            onClick={handleViewBilling}
+                          >
+                            {memberUpsellCtaLabel}
+                          </Button>
+                        ) : (
+                          <p className="font-medium text-foreground/80">
+                            Ask an organization owner to review billing options.
+                          </p>
+                        )}
+                      </AlertDescription>
+                    </Alert>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {membersLoading ? (
+                <div className="flex items-center gap-2 py-3 text-muted-foreground">
+                  <RefreshCw className="size-4 animate-spin" />
+                  Loading members...
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  {activeMembers.map((member) => {
+                    const memberRole = resolveOrganizationRole(member);
+                    return (
                       <OrganizationMemberRow
                         key={member._id}
                         member={member}
+                        role={memberRole}
                         currentUserEmail={currentUserEmail}
-                        isPending
+                        canEditRole={isOwner && memberRole !== "owner"}
+                        isRoleUpdating={roleUpdatingEmail === member.email}
+                        onRoleChange={
+                          isOwner && memberRole !== "owner"
+                            ? (role) =>
+                                void handleChangeMemberRole(member, role)
+                            : undefined
+                        }
+                        onTransferOwnership={
+                          isOwner && memberRole !== "owner"
+                            ? () => setTransferTargetMember(member)
+                            : undefined
+                        }
+                        isTransferringOwnership={
+                          isTransferringOwnership &&
+                          transferTargetMember?.email === member.email
+                        }
                         onRemove={
-                          canRemovePendingMember()
+                          canRemoveMember(member)
                             ? () => handleRemoveMember(member.email)
                             : undefined
                         }
                       />
-                    ))}
-                  </div>
-                ) : null}
-              </CardContent>
-            </Card>
+                    );
+                  })}
+                </div>
+              )}
 
-            <Card className="border-border/60">
-              <CardHeader className="pb-2">
-                <CardTitle className="flex items-center gap-2 text-xl">
-                  <Building2 className="size-4 text-muted-foreground" />
-                  Audit Log
-                </CardTitle>
-                <p className="text-sm text-muted-foreground">
-                  Review organization activity and export it as CSV.
-                </p>
-              </CardHeader>
-              <CardContent className="space-y-3 pt-0">
-                {billingUiEnabled &&
-                (isLoadingEntitlements || isLoadingOrganizationPremiumness) ? (
-                  <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
-                    Loading audit log access...
-                  </div>
-                ) : auditLogLocked ? (
-                  <div className="rounded-md border border-border/70 p-4">
-                    <div className="space-y-1.5">
-                      <h3 className="text-sm font-medium">
-                        Audit Log requires Enterprise
-                      </h3>
-                      <p className="text-sm text-muted-foreground">
-                        Audit Log is not included on your current plan.
-                        {billingStatus?.canManageBilling
-                          ? " Upgrade this organization to Enterprise to restore access."
-                          : " Ask an organization owner to upgrade to Enterprise."}
-                      </p>
-                    </div>
-                    {billingUiEnabled ? (
-                      <Button className="mt-3" onClick={handleViewBilling}>
-                        View billing options
-                      </Button>
-                    ) : null}
-                  </div>
-                ) : (
-                  <OrganizationAuditLog
-                    organizationId={organization._id}
-                    organizationName={organization.name}
-                    isAuthenticated={isAuthenticated}
-                  />
-                )}
-              </CardContent>
-            </Card>
+              {pendingMembers.length > 0 ? (
+                <div className="space-y-1 pt-2">
+                  {pendingMembers.map((member) => (
+                    <OrganizationMemberRow
+                      key={member._id}
+                      member={member}
+                      currentUserEmail={currentUserEmail}
+                      isPending
+                      onRemove={
+                        canRemovePendingMember()
+                          ? () => handleRemoveMember(member.email)
+                          : undefined
+                      }
+                    />
+                  ))}
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
 
-            <Card className="border-destructive/40">
-              <CardHeader className="pb-2">
-                <CardTitle className="flex items-center gap-2 text-xl text-destructive">
-                  <AlertTriangle className="size-4" />
-                  Danger Zone
-                </CardTitle>
-                <p className="text-sm text-muted-foreground">
-                  These actions are permanent and may remove access for members.
-                </p>
-              </CardHeader>
-              <CardContent className="space-y-2.5 pt-0">
-                {!membersLoading && !isOwner ? (
-                  <Button
-                    variant="outline"
-                    className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                    onClick={() => setLeaveConfirmOpen(true)}
-                  >
-                    <LogOut className="mr-2 size-4" />
-                    Leave Organization
-                  </Button>
-                ) : null}
-                {!membersLoading && isOwner ? (
-                  <Button
-                    variant="outline"
-                    className="text-destructive hover:bg-destructive/10 hover:text-destructive"
-                    onClick={() => setDeleteConfirmOpen(true)}
-                  >
-                    <Trash2 className="mr-2 size-4" />
-                    Delete Organization
-                  </Button>
-                ) : null}
-              </CardContent>
-            </Card>
-          </>
-        )}
-      </div>
+          <Card className="border-border/60">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-xl">
+                <Building2 className="size-4 text-muted-foreground" />
+                Audit Log
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Review organization activity and export it as CSV.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-3 pt-0">
+              {billingUiEnabled &&
+              (isLoadingEntitlements || isLoadingOrganizationPremiumness) ? (
+                <div className="rounded-md border border-dashed border-border/70 p-3 text-sm text-muted-foreground">
+                  Loading audit log access...
+                </div>
+              ) : auditLogLocked ? (
+                <div className="rounded-md border border-border/70 p-4">
+                  <div className="space-y-1.5">
+                    <h3 className="text-sm font-medium">
+                      Audit Log requires Enterprise
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Audit Log is not included on your current plan.
+                      {billingStatus?.canManageBilling
+                        ? " Upgrade this organization to Enterprise to restore access."
+                        : " Ask an organization owner to upgrade to Enterprise."}
+                    </p>
+                  </div>
+                  {billingUiEnabled ? (
+                    <Button className="mt-3" onClick={handleViewBilling}>
+                      View billing options
+                    </Button>
+                  ) : null}
+                </div>
+              ) : (
+                <OrganizationAuditLog
+                  organizationId={organization._id}
+                  organizationName={organization.name}
+                  isAuthenticated={isAuthenticated}
+                />
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="border-destructive/40">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-xl text-destructive">
+                <AlertTriangle className="size-4" />
+                Danger Zone
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                These actions are permanent and may remove access for members.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-2.5 pt-0">
+              {!membersLoading && !isOwner ? (
+                <Button
+                  variant="outline"
+                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  onClick={() => setLeaveConfirmOpen(true)}
+                >
+                  <LogOut className="mr-2 size-4" />
+                  Leave Organization
+                </Button>
+              ) : null}
+              {!membersLoading && isOwner ? (
+                <Button
+                  variant="outline"
+                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  onClick={() => setDeleteConfirmOpen(true)}
+                >
+                  <Trash2 className="mr-2 size-4" />
+                  Delete Organization
+                </Button>
+              ) : null}
+            </CardContent>
+          </Card>
+        </>
+      )}
 
       {/* Ownership Transfer Confirmation */}
       <AlertDialog
@@ -1772,7 +1752,7 @@ function OrganizationPage({
         isLeaving={isLeaving}
         onConfirm={handleLeave}
       />
-    </div>
+    </SettingsPageShell>
   );
 }
 const PAID_PLAN_CHANGE_CONFIRMATION_REQUIRED_MESSAGE =

--- a/mcpjam-inspector/client/src/components/SettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SettingsTab.tsx
@@ -10,7 +10,7 @@ import { updateThemeMode } from "@/lib/theme-utils";
 import { track } from "@/lib/analytics";
 import { Info, KeyRound } from "lucide-react";
 import { HOSTED_MODE } from "@/lib/config";
-import { SettingsNav } from "./settings/SettingsNav";
+import { SettingsPageShell } from "./settings/SettingsPageShell";
 
 interface SettingsTabProps {
   activeOrganizationId?: string;
@@ -40,113 +40,106 @@ export function SettingsTab({
   };
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="p-10 space-y-8 max-w-3xl">
-        <div className="space-y-4">
-          <h1 className="text-2xl font-semibold">Settings</h1>
-          <SettingsNav
-            active="general"
-            activeOrganizationId={activeOrganizationId}
-          />
-        </div>
+    <SettingsPageShell
+      active="general"
+      activeOrganizationId={activeOrganizationId}
+    >
+      {/* About */}
+      <SettingsSection title="About">
+        <SettingsRow label="Version" value={`v${__APP_VERSION__}`} />
+      </SettingsSection>
 
-        {/* About */}
-        <SettingsSection title="About">
-          <SettingsRow label="Version" value={`v${__APP_VERSION__}`} />
-        </SettingsSection>
+      {/* Appearance */}
+      <SettingsSection title="Appearance">
+        <SettingsRow
+          label="Theme"
+          value={
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground">
+                {themeMode === "dark" ? "Dark" : "Light"}
+              </span>
+              <Switch
+                checked={themeMode === "dark"}
+                onCheckedChange={handleThemeToggle}
+                aria-label="Toggle dark mode"
+              />
+            </div>
+          }
+        />
+      </SettingsSection>
 
-        {/* Appearance */}
-        <SettingsSection title="Appearance">
-          <SettingsRow
-            label="Theme"
-            value={
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">
-                  {themeMode === "dark" ? "Dark" : "Light"}
-                </span>
-                <Switch
-                  checked={themeMode === "dark"}
-                  onCheckedChange={handleThemeToggle}
-                  aria-label="Toggle dark mode"
-                />
-              </div>
-            }
-          />
-        </SettingsSection>
-
-        {!HOSTED_MODE && !byokAllowed && (
-          <SettingsSection title="LLM Providers">
-            <EmptyState
-              icon={KeyRound}
-              title="Sign in to configure model providers"
-              description="Provider keys are managed at the organization level. Sign in to set up your organization's models and use them in chat, evals, and the playground."
-              className="py-10"
+      {!HOSTED_MODE && !byokAllowed && (
+        <SettingsSection title="LLM Providers">
+          <EmptyState
+            icon={KeyRound}
+            title="Sign in to configure model providers"
+            description="Provider keys are managed at the organization level. Sign in to set up your organization's models and use them in chat, evals, and the playground."
+            className="py-10"
+          >
+            <Button
+              type="button"
+              onClick={() => {
+                track("login_button_clicked", {
+                  location: "byok_signin_gate",
+                });
+                signIn();
+              }}
+              size="sm"
             >
+              Sign in
+            </Button>
+          </EmptyState>
+        </SettingsSection>
+      )}
+
+      {!HOSTED_MODE && byokAllowed && isOrgBacked && (
+        <SettingsSection title="LLM Providers">
+          <div className="flex items-start gap-3 px-4 py-3 rounded-md border border-border/40 bg-muted/30">
+            <Info className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">
+                Model providers are managed in your organization settings.
+              </span>
               <Button
-                type="button"
-                onClick={() => {
-                  track("login_button_clicked", {
-                    location: "byok_signin_gate",
-                  });
-                  signIn();
-                }}
-                size="sm"
+                variant="link"
+                className="h-auto p-0 text-sm justify-start"
+                onClick={() =>
+                  onNavigate?.(`organizations/${activeOrganizationId}/models`)
+                }
               >
-                Sign in
+                Go to Organization Models
               </Button>
-            </EmptyState>
-          </SettingsSection>
-        )}
-
-        {!HOSTED_MODE && byokAllowed && isOrgBacked && (
-          <SettingsSection title="LLM Providers">
-            <div className="flex items-start gap-3 px-4 py-3 rounded-md border border-border/40 bg-muted/30">
-              <Info className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
-              <div className="flex flex-col gap-1">
-                <span className="text-sm text-muted-foreground">
-                  Model providers are managed in your organization settings.
-                </span>
-                <Button
-                  variant="link"
-                  className="h-auto p-0 text-sm justify-start"
-                  onClick={() =>
-                    onNavigate?.(`organizations/${activeOrganizationId}/models`)
-                  }
-                >
-                  Go to Organization Models
-                </Button>
-              </div>
             </div>
-          </SettingsSection>
-        )}
+          </div>
+        </SettingsSection>
+      )}
 
-        {!HOSTED_MODE && byokAllowed && !isOrgBacked && (
-          <SettingsSection title="LLM Providers">
-            <div className="flex items-start gap-3 px-4 py-3 rounded-md border border-border/40 bg-muted/30">
-              <Info className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
-              <div className="flex flex-col gap-1">
-                <span className="text-sm text-muted-foreground">
-                  Model providers are configured at the organization level.
-                  Create or join an organization on mcpjam.com to set them up.
-                </span>
-                <Button
-                  variant="link"
-                  className="h-auto p-0 text-sm justify-start"
-                  onClick={() =>
-                    window.open(
-                      "https://app.mcpjam.com/organizations",
-                      "_blank",
-                      "noopener,noreferrer"
-                    )
-                  }
-                >
-                  Open mcpjam.com
-                </Button>
-              </div>
+      {!HOSTED_MODE && byokAllowed && !isOrgBacked && (
+        <SettingsSection title="LLM Providers">
+          <div className="flex items-start gap-3 px-4 py-3 rounded-md border border-border/40 bg-muted/30">
+            <Info className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">
+                Model providers are configured at the organization level. Create
+                or join an organization on mcpjam.com to set them up.
+              </span>
+              <Button
+                variant="link"
+                className="h-auto p-0 text-sm justify-start"
+                onClick={() =>
+                  window.open(
+                    "https://app.mcpjam.com/organizations",
+                    "_blank",
+                    "noopener,noreferrer"
+                  )
+                }
+              >
+                Open mcpjam.com
+              </Button>
             </div>
-          </SettingsSection>
-        )}
-      </div>
-    </div>
+          </div>
+        </SettingsSection>
+      )}
+    </SettingsPageShell>
   );
 }

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
@@ -398,6 +398,17 @@ describe("OrganizationsTab member management", () => {
     expect(
       screen.getByRole("button", { name: "Go to Servers" })
     ).toBeInTheDocument();
+    // Without the shell this state is a dead end — no way to any other
+    // Settings section.
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Settings" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Settings sections" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Organization" })
+    ).toHaveAttribute("aria-current", "page");
   });
 
   it("lets a non-admin member leave from the access restricted screen", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.admin.test.tsx
@@ -263,6 +263,24 @@ describe("OrganizationsTab member management", () => {
     mockUpdateOrganizationLogo.mockResolvedValue({ success: true });
   });
 
+  // The org page is one of four Settings sections and has to render inside the
+  // same shell as the rest. It used to own its container and skip the page
+  // heading, so selecting Organization moved the tab strip out from under the
+  // pointer and dropped "Settings" off the page.
+  it("renders inside the shared settings shell", () => {
+    render(<OrganizationsTab organizationId="org-1" />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Settings" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Settings sections" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Organization settings sections" })
+    ).toBeInTheDocument();
+  });
+
   it("shows members section for owners and allows role changes", async () => {
     render(<OrganizationsTab organizationId="org-1" />);
 
@@ -428,7 +446,7 @@ describe("OrganizationsTab member management", () => {
     ).toBeInTheDocument();
     expect(mockUseOrganizationBilling).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
     expect(signIn).toHaveBeenCalledTimes(1);
   });
 

--- a/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/ApiKeysRoute.tsx
@@ -12,7 +12,8 @@ import { useOrganizationQueries } from "@/hooks/useOrganizations";
 import { useApiKeys } from "@/hooks/useApiKeys";
 import { type ApiKey } from "@/lib/apis/web/api-keys";
 import { writeApiKeysSignInReturnPath } from "@/lib/api-keys-signin-return-path";
-import { SettingsNav } from "./SettingsNav";
+import { SettingsPageShell } from "./SettingsPageShell";
+import { SettingsStatePanel } from "./SettingsStatePanel";
 
 /**
  * `/settings/api-keys` — manage WorkOS-issued `sk_…` API keys for the
@@ -96,125 +97,126 @@ export function ApiKeysRoute({ activeOrganizationId }: ApiKeysRouteProps = {}) {
     }
   };
 
+  // Both gates keep the shell so the other Settings sections stay one click
+  // away — replacing the page with a bare sign-in button strands the user.
   if (isAuthLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-        Loading…
-      </div>
+      <SettingsPageShell
+        active="api-keys"
+        activeOrganizationId={activeOrganizationId}
+      >
+        <SettingsStatePanel>
+          <span className="text-sm text-muted-foreground">Loading…</span>
+        </SettingsStatePanel>
+      </SettingsPageShell>
     );
   }
 
   if (!isSignedIn) {
     return (
-      <div className="flex flex-col items-center justify-center h-full p-8">
-        <div className="text-center space-y-4 max-w-md">
-          <h2 className="text-2xl font-bold">Sign in to manage API keys</h2>
-          <p className="text-sm text-muted-foreground">
+      <SettingsPageShell
+        active="api-keys"
+        activeOrganizationId={activeOrganizationId}
+      >
+        <SettingsStatePanel>
+          <h2 className="text-lg font-semibold">Sign in to manage API keys</h2>
+          <p className="max-w-prose text-sm text-muted-foreground">
             API keys for the MCPJam API are tied to your account. Sign in (or
             create a free account) and you'll come right back here to create
             one.
           </p>
-          <Button onClick={handleSignIn} size="lg">
-            Sign In
-          </Button>
-        </div>
-      </div>
+          <Button onClick={handleSignIn}>Sign in</Button>
+        </SettingsStatePanel>
+      </SettingsPageShell>
     );
   }
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="p-10 space-y-8 max-w-3xl">
-        <div className="space-y-4">
-          <h1 className="text-2xl font-semibold">Settings</h1>
-          <SettingsNav
-            active="api-keys"
-            activeOrganizationId={activeOrganizationId}
-          />
-        </div>
+    <SettingsPageShell
+      active="api-keys"
+      activeOrganizationId={activeOrganizationId}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <p className="max-w-prose text-sm text-muted-foreground">
+          Use these keys to call the MCPJam v1 public API from CI, scripts, or
+          other non-browser contexts. Keys carry your account's permissions and
+          can be revoked any time.
+        </p>
+        <Button onClick={() => setCreateOpen(true)} className="shrink-0">
+          <Plus className="mr-2 size-4" aria-hidden /> Create API key
+        </Button>
+      </div>
 
-        <div className="flex items-start justify-between gap-4">
-          <p className="text-sm text-muted-foreground">
-            Use these keys to call the MCPJam v1 public API from CI, scripts, or
-            other non-browser contexts. Keys carry your account's permissions
-            and can be revoked any time.
-          </p>
-          <Button onClick={() => setCreateOpen(true)} className="shrink-0">
-            <Plus className="mr-2 size-4" aria-hidden /> Create API key
-          </Button>
-        </div>
-
-        <SettingsSection title="Your keys">
-          {loading ? (
-            <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
-              Loading…
-            </div>
-          ) : keys.length === 0 ? (
-            <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
-              No API keys yet. Create one to start using the v1 API.
-            </div>
-          ) : (
-            keys.map((key) => (
-              <div
-                key={key.id}
-                className="flex items-center justify-between px-4 py-3 rounded-md border border-border/40 bg-muted/20 transition-colors"
-              >
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
-                    <Key className="size-4 text-primary" aria-hidden />
-                  </div>
-                  <div className="flex flex-col min-w-0">
-                    <span className="text-sm font-medium truncate">
-                      {key.name}
-                    </span>
-                    <span className="text-xs text-muted-foreground font-mono truncate">
-                      {key.obfuscated_value}
-                    </span>
-                  </div>
+      <SettingsSection title="Your keys">
+        {loading ? (
+          <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+            Loading…
+          </div>
+        ) : keys.length === 0 ? (
+          <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+            No API keys yet. Create one to start using the v1 API.
+          </div>
+        ) : (
+          keys.map((key) => (
+            <div
+              key={key.id}
+              className="flex items-center justify-between px-4 py-3 rounded-md border border-border/40 bg-muted/20 transition-colors"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
+                  <Key className="size-4 text-primary" aria-hidden />
                 </div>
-                <div className="flex items-center gap-1">
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="size-8 text-destructive hover:text-destructive hover:bg-destructive/10"
-                    onClick={() => setRevokeTarget(key)}
-                    aria-label={`Revoke ${key.name}`}
-                  >
-                    <Trash2 className="size-3.5" />
-                  </Button>
+                <div className="flex flex-col min-w-0">
+                  <span className="text-sm font-medium truncate">
+                    {key.name}
+                  </span>
+                  <span className="text-xs text-muted-foreground font-mono truncate">
+                    {key.obfuscated_value}
+                  </span>
                 </div>
               </div>
-            ))
-          )}
-        </SettingsSection>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+                  onClick={() => setRevokeTarget(key)}
+                  aria-label={`Revoke ${key.name}`}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </SettingsSection>
 
-        <CreateApiKeyDialog
-          open={createOpen}
-          onOpenChange={setCreateOpen}
-          isCreating={isCreating}
-          organizations={sortedOrganizations}
-          orgsLoading={orgsLoading}
-          onCreate={handleCreate}
-        />
+      <CreateApiKeyDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        isCreating={isCreating}
+        organizations={sortedOrganizations}
+        orgsLoading={orgsLoading}
+        onCreate={handleCreate}
+      />
 
-        <RevealOnceDialog
-          open={revealValue !== null}
-          onOpenChange={(next) => {
-            if (!next) setRevealValue(null);
-          }}
-          value={revealValue}
-        />
+      <RevealOnceDialog
+        open={revealValue !== null}
+        onOpenChange={(next) => {
+          if (!next) setRevealValue(null);
+        }}
+        value={revealValue}
+      />
 
-        <RevokeApiKeyDialog
-          open={revokeTarget !== null}
-          onOpenChange={(next) => {
-            if (!next) setRevokeTarget(null);
-          }}
-          keyName={revokeTarget?.name ?? ""}
-          isRevoking={isRevoking}
-          onConfirm={handleRevoke}
-        />
-      </div>
-    </div>
+      <RevokeApiKeyDialog
+        open={revokeTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) setRevokeTarget(null);
+        }}
+        keyName={revokeTarget?.name ?? ""}
+        isRevoking={isRevoking}
+        onConfirm={handleRevoke}
+      />
+    </SettingsPageShell>
   );
 }

--- a/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/GithubChecksRoute.tsx
@@ -15,7 +15,7 @@ import {
 } from "@mcpjam/design-system/select";
 import { useOrganizationQueries } from "@/hooks/useOrganizations";
 import { SettingsSection } from "../setting/SettingsSection";
-import { SettingsNav } from "./SettingsNav";
+import { SettingsPageShell } from "./SettingsPageShell";
 import {
   GITHUB_CHECKS_UNAVAILABLE_MESSAGE,
   useGithubChecksSettings,
@@ -267,178 +267,169 @@ export function GithubChecksRoute({
         );
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="p-10 space-y-8 max-w-3xl">
-        <div className="space-y-4">
-          <h1 className="text-2xl font-semibold">Settings</h1>
-          <SettingsNav
-            active="integrations"
-            activeOrganizationId={activeOrganizationId}
-          />
-        </div>
-
-        {/* This page sits one level below the Integrations directory, and the
+    <SettingsPageShell
+      active="integrations"
+      activeOrganizationId={activeOrganizationId}
+    >
+      {/* This page sits one level below the Integrations directory, and the
             nav's Integrations tab reads as active while you are on it — so
             without this there is no visible way back up. */}
-        <div className="space-y-2">
-          <button
-            type="button"
-            onClick={() => appNavigate("/settings/integrations")}
-            className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ChevronLeft className="size-3" aria-hidden />
-            Integrations
-          </button>
-          <h2 className="text-lg font-medium">GitHub Checks</h2>
-        </div>
+      <div className="space-y-2">
+        <button
+          type="button"
+          onClick={() => appNavigate("/settings/integrations")}
+          className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="size-3" aria-hidden />
+          Integrations
+        </button>
+        <h2 className="text-lg font-medium">GitHub Checks</h2>
+      </div>
 
-        <p className="text-sm text-muted-foreground">
-          Connect a repository to run an eval suite as a GitHub check on every
-          pull request. The check runs the suite you pick here against the PR's
-          head commit and reports back as a status check.
-        </p>
+      <p className="text-sm text-muted-foreground">
+        Connect a repository to run an eval suite as a GitHub check on every
+        pull request. The check runs the suite you pick here against the PR's
+        head commit and reports back as a status check.
+      </p>
 
-        <SettingsSection title="Connected repositories">
-          {repos === undefined ? (
-            <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
-              Loading…
-            </div>
-          ) : rows.length === 0 ? (
-            <div className="space-y-3 px-4 py-8 text-sm text-muted-foreground">
-              <p>
-                No repositories connected yet. Install the MCPJam GitHub App on
-                a repository, then connect it below to start running checks on
-                its pull requests.
-              </p>
-              <p>
-                A repository can declare its check recipe in a{" "}
-                <code className="rounded bg-muted px-1 py-0.5 text-xs">
-                  mcpjam.yaml
-                </code>{" "}
-                at the repo root. Without one, MCPJam detects a recipe
-                automatically.{" "}
-                <a
-                  className="underline underline-offset-2 hover:text-foreground"
-                  href="https://docs.mcpjam.com/github-checks"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Read the docs
-                </a>
-                .
-              </p>
-            </div>
-          ) : (
-            rows.map((row) => (
-              <div
-                key={row._id}
-                className="flex items-center justify-between gap-4 px-4 py-3 rounded-md border border-border/40 bg-muted/20 transition-colors"
-                data-testid={`repo-row-${row.repoFullName}`}
+      <SettingsSection title="Connected repositories">
+        {repos === undefined ? (
+          <div className="flex items-center justify-center px-4 py-8 text-sm text-muted-foreground">
+            Loading…
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="space-y-3 px-4 py-8 text-sm text-muted-foreground">
+            <p>
+              No repositories connected yet. Install the MCPJam GitHub App on a
+              repository, then connect it below to start running checks on its
+              pull requests.
+            </p>
+            <p>
+              A repository can declare its check recipe in a{" "}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                mcpjam.yaml
+              </code>{" "}
+              at the repo root. Without one, MCPJam detects a recipe
+              automatically.{" "}
+              <a
+                className="underline underline-offset-2 hover:text-foreground"
+                href="https://docs.mcpjam.com/github-checks"
+                target="_blank"
+                rel="noreferrer"
               >
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
-                    <Github className="size-4 text-primary" aria-hidden />
-                  </div>
-                  <div className="flex flex-col min-w-0">
-                    <span className="text-sm font-medium truncate">
-                      {row.repoFullName}
-                    </span>
-                    <RepoCheckState enabled={row.enabled} />
-                  </div>
+                Read the docs
+              </a>
+              .
+            </p>
+          </div>
+        ) : (
+          rows.map((row) => (
+            <div
+              key={row._id}
+              className="flex items-center justify-between gap-4 px-4 py-3 rounded-md border border-border/40 bg-muted/20 transition-colors"
+              data-testid={`repo-row-${row.repoFullName}`}
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="size-8 rounded-md bg-primary/10 flex items-center justify-center shrink-0">
+                  <Github className="size-4 text-primary" aria-hidden />
                 </div>
-
-                <div className="flex items-center gap-3 shrink-0">
-                  <Select
-                    value={row.suiteId}
-                    onValueChange={(value) =>
-                      void handleSuiteChange(row, value)
-                    }
-                  >
-                    <SelectTrigger
-                      className="w-48"
-                      aria-label={`Suite for ${row.repoFullName}`}
-                    >
-                      <SelectValue placeholder="Select a suite" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {suiteOptions.map((suite) => (
-                        <SelectItem key={suite._id} value={suite._id}>
-                          {suite.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-
-                  <Switch
-                    checked={row.enabled}
-                    disabled={pendingToggles.has(row._id)}
-                    onCheckedChange={() => void handleToggle(row)}
-                    aria-label={`Enable checks for ${row.repoFullName}`}
-                  />
-
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    aria-label={`Disconnect ${row.repoFullName}`}
-                    onClick={() => void handleDisconnect(row)}
-                  >
-                    <Trash2 className="size-4" aria-hidden />
-                  </Button>
+                <div className="flex flex-col min-w-0">
+                  <span className="text-sm font-medium truncate">
+                    {row.repoFullName}
+                  </span>
+                  <RepoCheckState enabled={row.enabled} />
                 </div>
               </div>
-            ))
-          )}
-        </SettingsSection>
 
-        <SettingsSection title="Connect a repository">
-          <div className="flex flex-wrap items-center gap-3 px-4 py-3">
-            <Select value={pickerRepo} onValueChange={setPickerRepo}>
-              <SelectTrigger className="w-64" aria-label="Repository">
-                <SelectValue placeholder="Select a repository" />
-              </SelectTrigger>
-              <SelectContent>
-                {connectableRepos.map((repo) => (
-                  <SelectItem key={repo.fullName} value={repo.fullName}>
-                    {repo.fullName}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              <div className="flex items-center gap-3 shrink-0">
+                <Select
+                  value={row.suiteId}
+                  onValueChange={(value) => void handleSuiteChange(row, value)}
+                >
+                  <SelectTrigger
+                    className="w-48"
+                    aria-label={`Suite for ${row.repoFullName}`}
+                  >
+                    <SelectValue placeholder="Select a suite" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {suiteOptions.map((suite) => (
+                      <SelectItem key={suite._id} value={suite._id}>
+                        {suite.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
 
-            <Select value={pickerSuite} onValueChange={setPickerSuite}>
-              <SelectTrigger className="w-56" aria-label="Suite">
-                <SelectValue placeholder="Select a suite" />
-              </SelectTrigger>
-              <SelectContent>
-                {suiteOptions.map((suite) => (
-                  <SelectItem key={suite._id} value={suite._id}>
-                    {suite.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                <Switch
+                  checked={row.enabled}
+                  disabled={pendingToggles.has(row._id)}
+                  onCheckedChange={() => void handleToggle(row)}
+                  aria-label={`Enable checks for ${row.repoFullName}`}
+                />
 
-            <Button
-              onClick={() => void handleConnect()}
-              disabled={connecting || !pickerRepo || !pickerSuite}
-            >
-              <Plus className="mr-2 size-4" aria-hidden /> Connect
-            </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Disconnect ${row.repoFullName}`}
+                  onClick={() => void handleDisconnect(row)}
+                >
+                  <Trash2 className="size-4" aria-hidden />
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </SettingsSection>
+
+      <SettingsSection title="Connect a repository">
+        <div className="flex flex-wrap items-center gap-3 px-4 py-3">
+          <Select value={pickerRepo} onValueChange={setPickerRepo}>
+            <SelectTrigger className="w-64" aria-label="Repository">
+              <SelectValue placeholder="Select a repository" />
+            </SelectTrigger>
+            <SelectContent>
+              {connectableRepos.map((repo) => (
+                <SelectItem key={repo.fullName} value={repo.fullName}>
+                  {repo.fullName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select value={pickerSuite} onValueChange={setPickerSuite}>
+            <SelectTrigger className="w-56" aria-label="Suite">
+              <SelectValue placeholder="Select a suite" />
+            </SelectTrigger>
+            <SelectContent>
+              {suiteOptions.map((suite) => (
+                <SelectItem key={suite._id} value={suite._id}>
+                  {suite.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Button
+            onClick={() => void handleConnect()}
+            disabled={connecting || !pickerRepo || !pickerSuite}
+          >
+            <Plus className="mr-2 size-4" aria-hidden /> Connect
+          </Button>
+        </div>
+
+        {installationReposFailed ? (
+          <div className="px-4 pb-4 text-sm text-muted-foreground">
+            Could not load repositories from GitHub. This is usually temporary —
+            reload the page to try again.
           </div>
-
-          {installationReposFailed ? (
-            <div className="px-4 pb-4 text-sm text-muted-foreground">
-              Could not load repositories from GitHub. This is usually temporary
-              — reload the page to try again.
-            </div>
-          ) : installationRepos !== null && installationRepos.length === 0 ? (
-            <div className="px-4 pb-4 text-sm text-muted-foreground">
-              No repositories available. Install the MCPJam GitHub App on the
-              repositories you want checked, then reload this page.
-            </div>
-          ) : null}
-        </SettingsSection>
-      </div>
-    </div>
+        ) : installationRepos !== null && installationRepos.length === 0 ? (
+          <div className="px-4 pb-4 text-sm text-muted-foreground">
+            No repositories available. Install the MCPJam GitHub App on the
+            repositories you want checked, then reload this page.
+          </div>
+        ) : null}
+      </SettingsSection>
+    </SettingsPageShell>
   );
 }

--- a/mcpjam-inspector/client/src/components/settings/IntegrationsRoute.tsx
+++ b/mcpjam-inspector/client/src/components/settings/IntegrationsRoute.tsx
@@ -5,7 +5,7 @@ import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useOrganizationQueries } from "@/hooks/useOrganizations";
 import { useOrgSlackSettings } from "@/hooks/useOrgSlackSettings";
-import { SettingsNav } from "./SettingsNav";
+import { SettingsPageShell } from "./SettingsPageShell";
 import { useGithubChecksSettings } from "@/hooks/useGithubChecksSettings";
 import { useDiscordAgentEnabled } from "@/hooks/useDiscordAgentEnabled";
 import { discordInstallUrl } from "@/lib/config";
@@ -170,10 +170,10 @@ function SlackIntegrationCard({
     connections === undefined
       ? ""
       : !installedCount
-        ? "Not connected"
-        : `${installedCount} ${
-            installedCount === 1 ? "workspace" : "workspaces"
-          } connected`;
+      ? "Not connected"
+      : `${installedCount} ${
+          installedCount === 1 ? "workspace" : "workspaces"
+        } connected`;
 
   return (
     <IntegrationCard
@@ -240,34 +240,25 @@ export function IntegrationsRoute({
   }
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="p-10 space-y-8 max-w-3xl">
-        <div className="space-y-4">
-          <h1 className="text-2xl font-semibold">Settings</h1>
-          <SettingsNav
-            active="integrations"
-            activeOrganizationId={activeOrganizationId}
-          />
-        </div>
+    <SettingsPageShell
+      active="integrations"
+      activeOrganizationId={activeOrganizationId}
+    >
+      <p className="max-w-prose text-sm text-muted-foreground">
+        Connect MCPJam to the services your team already uses.
+      </p>
 
-        <p className="text-sm text-muted-foreground">
-          Connect MCPJam to the services your team already uses.
-        </p>
+      <div className="space-y-2">
+        <ErrorBoundary fallback={null}>
+          <GithubChecksCard activeOrganizationId={activeOrganizationId} />
+        </ErrorBoundary>
 
-        <div className="space-y-2">
-          <ErrorBoundary fallback={null}>
-            <GithubChecksCard activeOrganizationId={activeOrganizationId} />
-          </ErrorBoundary>
+        <ErrorBoundary fallback={null}>
+          <SlackIntegrationCard activeOrganizationId={activeOrganizationId} />
+        </ErrorBoundary>
 
-          <ErrorBoundary fallback={null}>
-            <SlackIntegrationCard
-              activeOrganizationId={activeOrganizationId}
-            />
-          </ErrorBoundary>
-
-          <DiscordCard />
-        </div>
+        <DiscordCard />
       </div>
-    </div>
+    </SettingsPageShell>
   );
 }

--- a/mcpjam-inspector/client/src/components/settings/SectionTab.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SectionTab.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+interface SectionTabProps {
+  label: string;
+  isActive: boolean;
+  onSelect: () => void;
+}
+
+/**
+ * One tab in a Settings tab strip. Shared by the top-level section nav and the
+ * organization's sub-sections so both strips keep the same height and rhythm —
+ * two nav rows stacked at different metrics read as two unrelated widgets.
+ */
+export function SectionTab({ label, isActive, onSelect }: SectionTabProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (!isActive) onSelect();
+      }}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "-mb-px shrink-0 rounded-t-sm border-b-2 px-3 py-2 text-sm font-medium outline-none transition-colors focus-visible:ring-1 focus-visible:ring-ring",
+        isActive
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground"
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/lib/utils";
 import { buildOrganizationPath, useAppNavigate } from "@/lib/app-navigation";
+import { SectionTab } from "./SectionTab";
 
 export type SettingsNavSection =
   | "general"
@@ -22,39 +22,11 @@ interface TabDescriptor {
   path: string;
 }
 
-function SettingsNavTab({
-  tab,
-  active,
-  onSelect,
-}: {
-  tab: TabDescriptor;
-  active: SettingsNavSection;
-  onSelect: (path: string) => void;
-}) {
-  const isActive = active === tab.id;
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        if (!isActive) onSelect(tab.path);
-      }}
-      aria-current={isActive ? "page" : undefined}
-      className={cn(
-        "-mb-px shrink-0 border-b-2 px-3 py-2 text-sm font-medium transition-colors",
-        isActive
-          ? "border-primary text-foreground"
-          : "border-transparent text-muted-foreground hover:text-foreground"
-      )}
-    >
-      {tab.label}
-    </button>
-  );
-}
-
 /**
  * Top-level Settings sections, shared across `/settings`,
  * `/settings/api-keys`, and the organization page so they read as one
- * Settings surface. Styling mirrors the org page's section tabs.
+ * Settings surface. Render it through `SettingsPageShell` rather than
+ * directly, so the strip lands in the same place on every section.
  */
 export function SettingsNav({
   active,
@@ -94,22 +66,14 @@ export function SettingsNav({
       aria-label="Settings sections"
       className="flex items-end gap-1 border-b border-border/60"
     >
-      {tabs.map((tab) => (
-        <SettingsNavTab
+      {(organizationTab ? [...tabs, organizationTab] : tabs).map((tab) => (
+        <SectionTab
           key={tab.id}
-          tab={tab}
-          active={active}
-          onSelect={appNavigate}
+          label={tab.label}
+          isActive={active === tab.id}
+          onSelect={() => appNavigate(tab.path)}
         />
       ))}
-
-      {organizationTab ? (
-        <SettingsNavTab
-          tab={organizationTab}
-          active={active}
-          onSelect={appNavigate}
-        />
-      ) : null}
     </nav>
   );
 }

--- a/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsNav.tsx
@@ -61,19 +61,26 @@ export function SettingsNav({
       }
     : null;
 
+  // The tabs never shrink, so on a phone they overflow the column rather than
+  // wrapping — four of them need ~380px against the ~343px a 375px viewport
+  // leaves. Scrolling the strip keeps every section reachable. The border stays
+  // on the nav so it scrolls with the tabs, and `w-max min-w-full` lets the nav
+  // grow past the scroller while still spanning it when the tabs fit.
   return (
-    <nav
-      aria-label="Settings sections"
-      className="flex items-end gap-1 border-b border-border/60"
-    >
-      {(organizationTab ? [...tabs, organizationTab] : tabs).map((tab) => (
-        <SectionTab
-          key={tab.id}
-          label={tab.label}
-          isActive={active === tab.id}
-          onSelect={() => appNavigate(tab.path)}
-        />
-      ))}
-    </nav>
+    <div className="overflow-x-auto scrollbar-hidden">
+      <nav
+        aria-label="Settings sections"
+        className="flex w-max min-w-full items-end gap-1 border-b border-border/60"
+      >
+        {(organizationTab ? [...tabs, organizationTab] : tabs).map((tab) => (
+          <SectionTab
+            key={tab.id}
+            label={tab.label}
+            isActive={active === tab.id}
+            onSelect={() => appNavigate(tab.path)}
+          />
+        ))}
+      </nav>
+    </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/settings/SettingsPageShell.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsPageShell.tsx
@@ -11,10 +11,10 @@ interface SettingsPageShellProps {
  * Frame shared by every Settings section, including the organization page.
  *
  * The section nav is persistent navigation, so it has to land on the same
- * pixels on all four routes. Each page used to own its container: `/settings/*`
- * rendered a left-aligned `max-w-3xl` column with `p-10`, while the org page
- * rendered a centered `max-w-5xl` column with `p-4`, so clicking Organization
- * moved the strip you had just clicked and dropped the page heading with it.
+ * pixels on every route. Each page used to own its container — `/settings/*`
+ * a left-aligned `max-w-3xl` column, the org page a centered `max-w-5xl` one
+ * with different padding and no heading — so clicking Organization moved the
+ * strip you had just clicked and dropped the page heading with it.
  */
 export function SettingsPageShell({
   active,
@@ -23,7 +23,7 @@ export function SettingsPageShell({
 }: SettingsPageShellProps) {
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto w-full max-w-5xl space-y-8 p-10">
+      <div className="mx-auto w-full max-w-5xl space-y-8 p-4 md:p-10">
         <div className="space-y-4">
           <h1 className="text-2xl font-semibold">Settings</h1>
           <SettingsNav

--- a/mcpjam-inspector/client/src/components/settings/SettingsPageShell.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsPageShell.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { SettingsNav, type SettingsNavSection } from "./SettingsNav";
+
+interface SettingsPageShellProps {
+  active: SettingsNavSection;
+  activeOrganizationId?: string | null;
+  children: ReactNode;
+}
+
+/**
+ * Frame shared by every Settings section, including the organization page.
+ *
+ * The section nav is persistent navigation, so it has to land on the same
+ * pixels on all four routes. Each page used to own its container: `/settings/*`
+ * rendered a left-aligned `max-w-3xl` column with `p-10`, while the org page
+ * rendered a centered `max-w-5xl` column with `p-4`, so clicking Organization
+ * moved the strip you had just clicked and dropped the page heading with it.
+ */
+export function SettingsPageShell({
+  active,
+  activeOrganizationId,
+  children,
+}: SettingsPageShellProps) {
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto w-full max-w-5xl space-y-8 p-10">
+        <div className="space-y-4">
+          <h1 className="text-2xl font-semibold">Settings</h1>
+          <SettingsNav
+            active={active}
+            activeOrganizationId={activeOrganizationId}
+          />
+        </div>
+
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/settings/SettingsStatePanel.tsx
+++ b/mcpjam-inspector/client/src/components/settings/SettingsStatePanel.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+/**
+ * Panel for a Settings section that has no content to show yet — loading, a
+ * sign-in gate, or a missing record. It sits inside `SettingsPageShell` rather
+ * than replacing the page, so the tab strip survives: a section that swaps the
+ * whole surface for a lone button leaves nowhere to go but the back button.
+ */
+export function SettingsStatePanel({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-md border border-dashed border-border/60 px-6 py-16 text-center">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Selecting **Organization** in Settings moved the tab strip you had just clicked, and took the page heading with it.

The four Settings sections each owned their own container. `/settings`, `/settings/api-keys`, `/settings/integrations`, and `/settings/integrations/github` rendered a left-aligned `max-w-3xl` column with `p-10` under an `<h1>Settings</h1>`. The org page rendered a centered `max-w-5xl` column with `p-4 md:p-5` and no heading at all, then a card whose 96px avatar and `text-3xl` title read as a second page header. Only `SettingsNav` was shared; every page positioned it differently.

This adds `SettingsPageShell` — one scroll container, one width, one heading, one nav — and renders every section through it, org page included.

## Changes

- **`SettingsPageShell`** wraps all five Settings routes. The strip now lands on identical pixels (`x=344, y=137, w=944` at 1440px) on every one; verified in the browser across routes.
- **`SectionTab`** replaces the top-level nav's tab component and the org sub-nav's four hand-copied buttons (~50 lines). Both strips get the same height and rhythm, plus a `focus-visible` ring neither had.
- **Org profile card is content, not chrome.** The avatar goes 96px → 64px, the title `text-3xl` → `text-xl`, and it becomes an `h2` now that `Settings` is the page's `h1` — the page had two competing top-level headings. The `Organization settings` subtitle is dropped; the active tab already says it.
- **Pre-content states keep the shell.** Sign-in gates, loading, and "organization not found" render in a `SettingsStatePanel` inside the shell instead of replacing the page. Signed out, clicking Organization used to leave a lone button and no way back to the other sections.
- Sign-in button copy is sentence case (`Sign in`), matching the header and sidebar buttons.

## Screenshots

Organization, signed out — before and after:

| Before | After |
| --- | --- |
| <img width="720" src="https://raw.githubusercontent.com/olartgabo/inspector/27e24caf6f17621147f6fbd25bc287a6689cf5bd/docs/media/settings-shell/org-signedout-before.png" /> | <img width="720" src="https://raw.githubusercontent.com/olartgabo/inspector/27e24caf6f17621147f6fbd25bc287a6689cf5bd/docs/media/settings-shell/org-signedout-after.png" /> |

The other sections, for the shared geometry:

| General | API Keys | Integrations |
| --- | --- | --- |
| <img width="480" src="https://raw.githubusercontent.com/olartgabo/inspector/27e24caf6f17621147f6fbd25bc287a6689cf5bd/docs/media/settings-shell/settings-general.png" /> | <img width="480" src="https://raw.githubusercontent.com/olartgabo/inspector/27e24caf6f17621147f6fbd25bc287a6689cf5bd/docs/media/settings-shell/settings-api-keys.png" /> | <img width="480" src="https://raw.githubusercontent.com/olartgabo/inspector/27e24caf6f17621147f6fbd25bc287a6689cf5bd/docs/media/settings-shell/settings-integrations.png" /> |

The signed-in organization body (members, models, billing) is not captured here — the local dev instance has no account. Its container is the same `SettingsPageShell` as the sections above; the new unit test covers that it renders inside the shell.

## Reviewing

Most of the line count is re-indentation from removing a wrapper `<div>` level. `?w=1` cuts it from 931/906 to 164/225.

## Testing

- `npm run typecheck:client` — clean
- `npx vitest run --project client` — 756 files, 7846 tests, all passing
- New test: the org page renders inside the settings shell (page `h1`, section nav, org sub-nav)
- Browser: measured the nav's bounding box on `/settings`, `/settings/integrations`, and `/organizations/:id` — identical on all three; checked light and dark

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies all Settings routes under a shared `SettingsPageShell` so the Organization tab no longer rebuilds the page or moves the nav. Tabs now work on mobile via horizontal scroll, and the shell persists in gated states to keep navigation reachable.

- **Bug Fixes**
  - Organization tab no longer shifts the tab strip or page heading; nav geometry is identical across `/settings`, `/settings/integrations`, `/settings/api-keys`, and `/organizations/:id`.
  - Signed-out, loading, not-found, and access-restricted states render inside the shell, so the Settings nav stays accessible.
  - Tabs fit on phones: top-level and org sub-tabs scroll horizontally; active underline stays aligned; consistent `focus-visible` ring across both strips.

- **Refactors**
  - Added `SettingsPageShell`, `SettingsStatePanel`, and shared `SectionTab`; applied to General, Integrations (and GitHub Checks), API Keys, and Organization views.
  - Organization profile card is content, not page chrome (avatar 96→64, title is `h2` at `text-xl`); removed redundant subtitle and standardized button copy to “Sign in”.
  - Renamed org tab mapping param to avoid shadowing the `section` prop, and updated tests to assert the org page and access-restricted state render inside the shared shell.

<sup>Written for commit 1a9ef3c446d6afe3a9e18e185d01559219d85ccd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

