### PR TITLE
fix(discord): split the two service credentials (A3)

### DIFF
--- a/discord-app/.env.sample
+++ b/discord-app/.env.sample
@@ -8,30 +8,43 @@ DISCORD_BOT_TOKEN=YOUR_DISCORD_BOT_TOKEN
 # DISCORD_GUILD_ID=YOUR_DEV_GUILD_ID
 
 # ─── The two service credentials ────────────────────────────────────────────
-# THESE ARE TWO DIFFERENT SECRETS AND MUST NOT BE SET TO THE SAME VALUE.
-# They authenticate to two different servers, over two different mechanisms,
-# and neither falls back to the other. One value doing both jobs means either
-# secret leaking compromises both halves of the system at once.
+# TWO NAMES, TWO JOBS — but TODAY THEY MUST HOLD THE SAME `dsc_` VALUE.
+#
+# The two variables name the two jobs the bot's credential does, and every call
+# site asks for the token by job. They cannot yet hold different values, and
+# that is forced by the server rather than being a matter of taste:
+#
+#   The inspector does not terminate the bot's bearer token. On both
+#   /api/v1/* and /api/surface-link/session it FORWARDS that token to Convex
+#   verbatim as `x-discord-service-token`, where Convex checks it against its
+#   own DISCORD_SERVICE_TOKEN. So the app API token has to satisfy the Convex
+#   check too — one value, seeded in three places, carrying the `dsc_` prefix
+#   (the /api/v1 hash check runs first and rejects anything else).
+#
+# Splitting them for real needs a server change: the inspector→Convex hop must
+# present its OWN Convex credential instead of relaying the caller's. Until
+# then, generate ONE token and set it in all three places:
+#
+#   TOKEN="dsc_$(openssl rand -hex 32)"
+#     → DISCORD_SERVICE_TOKEN        here (below)
+#     → MCPJAM_DISCORD_SERVICE_TOKEN here (below)
+#     → DISCORD_SERVICE_TOKEN        on the Convex deployment
+#   and seed its SHA-256 hash on the inspector as
+#     MCPJAM_DISCORD_SERVICE_TOKEN_HASH
 
 # 1. The CONVEX service credential. Sent as the `x-discord-service-token`
 #    header to the backend's /agent/* routes — thread bindings, account links,
-#    durable event claims, presence. Set the SAME value as DISCORD_SERVICE_TOKEN
-#    on the Convex deployment.
+#    durable event claims, presence.
 #    Deliberately NOT the inspector's INSPECTOR_SERVICE_TOKEN: that token also
 #    opens user delegation and delegated-JWT minting, and must never exist in
 #    this app's environment.
 MCPJAM_CONVEX_HTTP_URL=https://YOUR-DEPLOYMENT.convex.site
-DISCORD_SERVICE_TOKEN=YOUR_DISCORD_SERVICE_TOKEN
+DISCORD_SERVICE_TOKEN=dsc_YOUR_TOKEN
 
 # 2. The APP API credential. Sent as `Authorization: Bearer` to /api/v1/* and
 #    /api/surface-link/session. It names the BOT and grants nothing on its own:
 #    every request also carries the Discord guild/user headers, and the server
 #    resolves the LINKED user's identity from those.
-#    The server requires the `dsc_` prefix and hash-matches the token, so the
-#    Convex credential above cannot stand in for it — it fails the prefix check
-#    before anything else. Seed the SHA-256 hash on the inspector as
-#    MCPJAM_DISCORD_SERVICE_TOKEN_HASH.
-#      TOKEN="dsc_$(openssl rand -hex 32)"
 MCPJAM_DISCORD_SERVICE_TOKEN=dsc_YOUR_TOKEN
 
 # ─── Endpoints ──────────────────────────────────────────────────────────────

--- a/discord-app/.env.sample
+++ b/discord-app/.env.sample
@@ -1,0 +1,56 @@
+# ─── Discord app ────────────────────────────────────────────────────────────
+# From the Discord developer portal. DISCORD_BOT_TOKEN is required to boot.
+DISCORD_BOT_TOKEN=YOUR_DISCORD_BOT_TOKEN
+
+# Optional — when BOTH are set the bot registers its `/mcpjam` guild command on
+# boot. Leave unset to register commands out of band.
+# DISCORD_APPLICATION_ID=YOUR_DISCORD_APPLICATION_ID
+# DISCORD_GUILD_ID=YOUR_DEV_GUILD_ID
+
+# ─── The two service credentials ────────────────────────────────────────────
+# THESE ARE TWO DIFFERENT SECRETS AND MUST NOT BE SET TO THE SAME VALUE.
+# They authenticate to two different servers, over two different mechanisms,
+# and neither falls back to the other. One value doing both jobs means either
+# secret leaking compromises both halves of the system at once.
+
+# 1. The CONVEX service credential. Sent as the `x-discord-service-token`
+#    header to the backend's /agent/* routes — thread bindings, account links,
+#    durable event claims, presence. Set the SAME value as DISCORD_SERVICE_TOKEN
+#    on the Convex deployment.
+#    Deliberately NOT the inspector's INSPECTOR_SERVICE_TOKEN: that token also
+#    opens user delegation and delegated-JWT minting, and must never exist in
+#    this app's environment.
+MCPJAM_CONVEX_HTTP_URL=https://YOUR-DEPLOYMENT.convex.site
+DISCORD_SERVICE_TOKEN=YOUR_DISCORD_SERVICE_TOKEN
+
+# 2. The APP API credential. Sent as `Authorization: Bearer` to /api/v1/* and
+#    /api/surface-link/session. It names the BOT and grants nothing on its own:
+#    every request also carries the Discord guild/user headers, and the server
+#    resolves the LINKED user's identity from those.
+#    The server requires the `dsc_` prefix and hash-matches the token, so the
+#    Convex credential above cannot stand in for it — it fails the prefix check
+#    before anything else. Seed the SHA-256 hash on the inspector as
+#    MCPJAM_DISCORD_SERVICE_TOKEN_HASH.
+#      TOKEN="dsc_$(openssl rand -hex 32)"
+MCPJAM_DISCORD_SERVICE_TOKEN=dsc_YOUR_TOKEN
+
+# ─── Endpoints ──────────────────────────────────────────────────────────────
+# Optional, defaults to https://app.mcpjam.com. Point at a local inspector
+# (e.g. http://localhost:6274) during development. A trailing slash is fine —
+# it is normalized before use.
+# MCPJAM_BASE_URL=https://app.mcpjam.com
+
+# Optional — where deep links in Discord messages point. Defaults to
+# MCPJAM_BASE_URL. In local dev the app UI (5173) differs from the API (6274).
+# MCPJAM_APP_URL=http://localhost:5173
+
+# Optional — the public origin the Discord account-link flow is served from,
+# when it differs from the two above. Added to the allowlist a minted connect
+# link is checked against.
+# DISCORD_LINK_PUBLIC_ORIGIN=https://YOUR-PUBLIC-ORIGIN
+
+# ─── Legacy single-tenant fallback ──────────────────────────────────────────
+# The project a legacy tenant acts in before per-user account linking. Consulted
+# ONLY for tenants flagged legacy; everyone else resolves through their own
+# account link. Unset it once every tenant has linked.
+# MCPJAM_PROJECT_ID=YOUR_MCPJAM_PROJECT_ID

--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -22,6 +22,13 @@ import {
 	deriveConversationIdentity,
 	ensureThreadBinding,
 } from "./conversation.js";
+import {
+	baseUrl,
+	connectLinkOrigins,
+	convexServiceToken,
+	getConfig,
+	requireApiServiceToken,
+} from "./credentials.js";
 import { createDiscordDelivery } from "./delivery.js";
 import { fetchHistory } from "./history.js";
 import { recordPresence } from "./presence.js";
@@ -50,31 +57,14 @@ const claims = createEventClaims({
 });
 const resolveTurnTarget = createTurnTargetResolver({
 	backend: claimBackend,
-	hasPerUserAuth: () => Boolean(process.env.DISCORD_SERVICE_TOKEN),
+	hasPerUserAuth: () => Boolean(convexServiceToken()),
 	legacyProjectId: () => process.env.MCPJAM_PROJECT_ID,
 });
 const api = createApiClient({
 	routePrefix: "/agent",
 	conversationField: "conversationId",
 	baseUrl: process.env.MCPJAM_BASE_URL,
-	getConfig: (ctx, overrides = {}) => ({
-		apiKey:
-			overrides.apiKey ||
-			process.env.MCPJAM_DISCORD_SERVICE_TOKEN ||
-			process.env.DISCORD_SERVICE_TOKEN ||
-			process.env.DISCORD_API_TOKEN,
-		projectId: overrides.projectId || ctx.projectId,
-		baseUrl:
-			overrides.baseUrl ||
-			process.env.MCPJAM_BASE_URL ||
-			"https://app.mcpjam.com",
-		appUrl: process.env.MCPJAM_APP_URL || "https://app.mcpjam.com",
-		headers: {
-			"x-mcpjam-surface-tenant-id": ctx.tenantId,
-			"x-mcpjam-surface-actor-id": ctx.actorId,
-		},
-		routePrefix: "/agent",
-	}),
+	getConfig,
 });
 
 client.once(Events.ClientReady, async (ready) => {
@@ -105,22 +95,13 @@ client.on(Events.InteractionCreate, async (interaction) => {
 		allowedMentions: { parse: [] },
 	});
 	try {
-		const baseUrl = process.env.MCPJAM_BASE_URL || "https://app.mcpjam.com";
-		const origins = [
-			process.env.MCPJAM_APP_URL,
-			process.env.DISCORD_LINK_PUBLIC_ORIGIN,
-			baseUrl,
-		].filter(Boolean);
 		const url = await mintConnectUrl({
 			surfaceKind: "discord",
 			tenantId: interaction.guildId,
 			actorId: interaction.user.id,
-			token:
-				process.env.DISCORD_SERVICE_TOKEN ||
-				process.env.MCPJAM_DISCORD_SERVICE_TOKEN ||
-				process.env.DISCORD_API_TOKEN,
-			baseUrl,
-			origins,
+			token: requireApiServiceToken(),
+			baseUrl: baseUrl(),
+			origins: connectLinkOrigins(),
 		});
 		await interaction.editReply({
 			content: `Connect MCPJam: ${url}`,
@@ -169,13 +150,9 @@ client.on(Events.MessageCreate, async (message) => {
 				surfaceKind: "discord",
 				tenantId: message.guildId,
 				actorId: message.author.id,
-				token: process.env.DISCORD_SERVICE_TOKEN,
-				baseUrl: process.env.MCPJAM_BASE_URL || "https://app.mcpjam.com",
-				origins: [
-					process.env.MCPJAM_APP_URL,
-					process.env.DISCORD_LINK_PUBLIC_ORIGIN,
-					process.env.MCPJAM_BASE_URL || "https://app.mcpjam.com",
-				].filter(Boolean),
+				token: requireApiServiceToken(),
+				baseUrl: baseUrl(),
+				origins: connectLinkOrigins(),
 			});
 			const content = {
 				severity: "info",

--- a/discord-app/credentials.js
+++ b/discord-app/credentials.js
@@ -7,10 +7,7 @@ const DEFAULT_BASE_URL = "https://app.mcpjam.com";
 const trimOrigin = (value) => String(value || "").replace(/\/+$/, "");
 
 /**
- * TWO SECRETS, TWO JOBS. They are not interchangeable and must never fall back
- * to one another — a single value doing both jobs is exactly the coupling
- * slack-app's .env.sample forbids, because it widens the blast radius of either
- * secret leaking to both surfaces of the system.
+ * TWO NAMES, TWO JOBS — but, for now, ONE VALUE.
  *
  *   DISCORD_SERVICE_TOKEN        the CONVEX service credential. Presented as
  *                                the `x-discord-service-token` header to the
@@ -22,13 +19,34 @@ const trimOrigin = (value) => String(value || "").replace(/\/+$/, "");
  *                                `Authorization: Bearer` to `/api/v1/*` and
  *                                `/api/surface-link/session`. The server
  *                                requires a `dsc_` prefix and hash-matches it
- *                                against MCPJAM_DISCORD_SERVICE_TOKEN_HASH, so
- *                                handing it the Convex token cannot work — it
- *                                fails the prefix check before anything else.
+ *                                against MCPJAM_DISCORD_SERVICE_TOKEN_HASH.
  *
- * The old code had three different precedence orders for "the token" across one
- * file, and the only configuration that worked was one secret doing both jobs.
- * These accessors exist so there is exactly one answer per job, named.
+ * THEY MUST CURRENTLY HOLD THE SAME `dsc_` VALUE, and that is not a nicety of
+ * configuration — it is forced by the server. The inspector does not terminate
+ * the bot's bearer token: it FORWARDS it to Convex verbatim as
+ * `x-discord-service-token`, on both legs.
+ *
+ *   /api/v1/*                    surface-service-auth.ts hands the bearer to
+ *                                `resolveSurfaceActingUser(..., {surfaceServiceToken})`
+ *   /api/surface-link/session    surface-link/index.ts hands it to
+ *                                `createSurfaceLinkSession(args, token)`
+ *
+ * Both land in `slack-backend.ts`'s `post()`, which sets
+ * `x-discord-service-token: <that same bearer>`. Convex then checks it against
+ * ITS `DISCORD_SERVICE_TOKEN`. So the app API token has to satisfy the Convex
+ * check too, which means one value seeded in three places — and it must carry
+ * the `dsc_` prefix, because the /api/v1 hash check runs first.
+ *
+ * Splitting them for real needs a server change: the inspector→Convex hop has
+ * to present its OWN Convex credential instead of relaying the caller's. These
+ * accessors are the seam that makes that a configuration change rather than a
+ * code change — every call site already asks for the token by JOB, so the day
+ * the hop is fixed the two variables can diverge and nothing here moves.
+ *
+ * What this module does fix today is the mess it replaces: three different
+ * precedence orders for "the token" across one file, one of which preferred the
+ * Convex-shaped token for the connect-link mint — a route that rejects anything
+ * without a `dsc_` prefix, so it could never have worked.
  */
 
 /** The Convex service credential, or undefined when unset. */
@@ -41,18 +59,30 @@ export function apiServiceToken() {
 	return process.env.MCPJAM_DISCORD_SERVICE_TOKEN || undefined;
 }
 
+const API_TOKEN_PREFIX = "dsc_";
+
 /**
  * The app API credential, or a NAMED config error.
  *
  * Callers that mint a connect link need the failure to say which variable is
- * missing: the message is shown to an operator, and "Unable to create a connect
+ * wrong: the message is shown to an operator, and "Unable to create a connect
  * link: undefined" tells them nothing.
+ *
+ * The prefix is checked HERE as well as on the server. The server's check is
+ * the one that matters for security, but it answers a bare "Invalid API key" —
+ * so a token pasted from the wrong variable looks identical to a revoked one.
+ * Failing locally names the variable and the expected shape instead.
  */
 export function requireApiServiceToken() {
 	const token = apiServiceToken();
 	if (!token)
 		throw new McpjamApiError(
 			"MCPJAM_DISCORD_SERVICE_TOKEN must be set to reach the MCPJam API (see .env.sample).",
+			{ code: "CONFIG" },
+		);
+	if (!token.startsWith(API_TOKEN_PREFIX))
+		throw new McpjamApiError(
+			`MCPJAM_DISCORD_SERVICE_TOKEN must start with "${API_TOKEN_PREFIX}" — the server rejects anything else before it checks the value (see .env.sample).`,
 			{ code: "CONFIG" },
 		);
 	return token;
@@ -71,14 +101,22 @@ export function appUrl() {
 }
 
 /**
- * Origins a minted connect link is allowed to point at. Empty entries are
- * dropped rather than defaulted, so an unset variable narrows the allowlist
- * instead of silently widening it.
+ * Origins a minted connect link is allowed to point at.
+ *
+ * Every entry is normalized, because the allowlist is compared against a
+ * canonical `new URL(...).origin`, which never carries a trailing slash. An
+ * unnormalized `MCPJAM_APP_URL=https://app.example.com/` therefore matches
+ * nothing and makes the bot unlinkable — the variable looks right, the link
+ * mints, and the check rejects it.
+ *
+ * Empty entries are dropped rather than defaulted, so an unset variable narrows
+ * the allowlist instead of silently widening it. `trimOrigin(undefined)` is the
+ * empty string, which is exactly what the filter removes.
  */
 export function connectLinkOrigins() {
 	return [
-		process.env.MCPJAM_APP_URL,
-		process.env.DISCORD_LINK_PUBLIC_ORIGIN,
+		trimOrigin(process.env.MCPJAM_APP_URL),
+		trimOrigin(process.env.DISCORD_LINK_PUBLIC_ORIGIN),
 		baseUrl(),
 	].filter(Boolean);
 }

--- a/discord-app/credentials.js
+++ b/discord-app/credentials.js
@@ -1,0 +1,129 @@
+// @ts-nocheck
+import { McpjamApiError } from "@mcpjam/surface-core";
+
+const DEFAULT_BASE_URL = "https://app.mcpjam.com";
+
+/** @param {string} value */
+const trimOrigin = (value) => String(value || "").replace(/\/+$/, "");
+
+/**
+ * TWO SECRETS, TWO JOBS. They are not interchangeable and must never fall back
+ * to one another — a single value doing both jobs is exactly the coupling
+ * slack-app's .env.sample forbids, because it widens the blast radius of either
+ * secret leaking to both surfaces of the system.
+ *
+ *   DISCORD_SERVICE_TOKEN        the CONVEX service credential. Presented as
+ *                                the `x-discord-service-token` header to the
+ *                                `/agent/*` routes (bindings, links, claims,
+ *                                presence). Verified against the Convex
+ *                                deployment's own configured token.
+ *
+ *   MCPJAM_DISCORD_SERVICE_TOKEN the APP API credential. Presented as
+ *                                `Authorization: Bearer` to `/api/v1/*` and
+ *                                `/api/surface-link/session`. The server
+ *                                requires a `dsc_` prefix and hash-matches it
+ *                                against MCPJAM_DISCORD_SERVICE_TOKEN_HASH, so
+ *                                handing it the Convex token cannot work — it
+ *                                fails the prefix check before anything else.
+ *
+ * The old code had three different precedence orders for "the token" across one
+ * file, and the only configuration that worked was one secret doing both jobs.
+ * These accessors exist so there is exactly one answer per job, named.
+ */
+
+/** The Convex service credential, or undefined when unset. */
+export function convexServiceToken() {
+	return process.env.DISCORD_SERVICE_TOKEN || undefined;
+}
+
+/** The app API credential, or undefined when unset. */
+export function apiServiceToken() {
+	return process.env.MCPJAM_DISCORD_SERVICE_TOKEN || undefined;
+}
+
+/**
+ * The app API credential, or a NAMED config error.
+ *
+ * Callers that mint a connect link need the failure to say which variable is
+ * missing: the message is shown to an operator, and "Unable to create a connect
+ * link: undefined" tells them nothing.
+ */
+export function requireApiServiceToken() {
+	const token = apiServiceToken();
+	if (!token)
+		throw new McpjamApiError(
+			"MCPJAM_DISCORD_SERVICE_TOKEN must be set to reach the MCPJam API (see .env.sample).",
+			{ code: "CONFIG" },
+		);
+	return token;
+}
+
+export function baseUrl() {
+	return trimOrigin(process.env.MCPJAM_BASE_URL || DEFAULT_BASE_URL);
+}
+
+/**
+ * Deep links can point somewhere other than the API host — in local dev the API
+ * is on one port while the app UI is served on another.
+ */
+export function appUrl() {
+	return trimOrigin(process.env.MCPJAM_APP_URL || baseUrl());
+}
+
+/**
+ * Origins a minted connect link is allowed to point at. Empty entries are
+ * dropped rather than defaulted, so an unset variable narrows the allowlist
+ * instead of silently widening it.
+ */
+export function connectLinkOrigins() {
+	return [
+		process.env.MCPJAM_APP_URL,
+		process.env.DISCORD_LINK_PUBLIC_ORIGIN,
+		baseUrl(),
+	].filter(Boolean);
+}
+
+/**
+ * The credential seam for the API client: the last point before a secret is
+ * handed out, so every guard is re-asserted HERE rather than trusted from the
+ * call path.
+ *
+ * The guards are the point. Without them a turn with no resolved project builds
+ * `/projects/undefined/...` and a turn with no token sends `Bearer undefined`,
+ * and both fail as an opaque 401 from the server instead of a named config
+ * error naming the variable an operator has to set.
+ *
+ * @param {any} ctx
+ * @param {{apiKey?:string, projectId?:string, baseUrl?:string, appUrl?:string}} [overrides]
+ */
+export function getConfig(ctx, overrides = {}) {
+	if (!ctx?.tenantId || !ctx?.actorId)
+		throw new McpjamApiError(
+			"MCPJam credentials were requested without a Discord tenant context.",
+			{ code: "CONFIG" },
+		);
+	const apiKey = overrides.apiKey || apiServiceToken();
+	const projectId = overrides.projectId || ctx.projectId;
+	if (!apiKey)
+		throw new McpjamApiError(
+			"MCPJAM_DISCORD_SERVICE_TOKEN must be set to reach the MCPJam API (see .env.sample).",
+			{ code: "CONFIG" },
+		);
+	if (!projectId)
+		throw new McpjamApiError("No project resolved for this turn.", {
+			code: "NO_PROJECT",
+		});
+	return {
+		apiKey,
+		projectId,
+		baseUrl: trimOrigin(overrides.baseUrl || baseUrl()),
+		appUrl: trimOrigin(overrides.appUrl || appUrl()),
+		// The identity. Without both, the server has no user to act as and
+		// answers 401 — which is the correct outcome, not a fallback.
+		headers: {
+			"x-mcpjam-surface-tenant-id": String(ctx.tenantId),
+			"x-mcpjam-surface-actor-id": String(ctx.actorId),
+		},
+		routePrefix: "/agent",
+	};
+}

--- a/discord-app/tests/credentials.test.js
+++ b/discord-app/tests/credentials.test.js
@@ -78,6 +78,25 @@ test("a missing API token throws a CONFIG error naming the variable", () => {
 	});
 });
 
+test("an API token without the dsc_ prefix fails locally, not as a bare 401", () => {
+	// The server rejects a non-`dsc_` token with "Invalid API key", which reads
+	// identically to a revoked one. Failing here names the variable instead.
+	withEnv({ MCPJAM_DISCORD_SERVICE_TOKEN: "sk_wrong_variable" }, () => {
+		assert.throws(
+			() => requireApiServiceToken(),
+			(error) => {
+				assert.equal(error.code, "CONFIG");
+				assert.match(error.message, /dsc_/);
+				return true;
+			},
+		);
+	});
+
+	withEnv({ MCPJAM_DISCORD_SERVICE_TOKEN: "dsc_ok" }, () => {
+		assert.equal(requireApiServiceToken(), "dsc_ok");
+	});
+});
+
 test("getConfig resolves the API token, not the Convex one", () => {
 	withEnv(
 		{
@@ -192,4 +211,26 @@ test("connect-link origins drop unset entries instead of widening", () => {
 	withEnv({ MCPJAM_BASE_URL: "https://api.example.com" }, () => {
 		assert.deepEqual(connectLinkOrigins(), ["https://api.example.com"]);
 	});
+});
+
+test("connect-link origins are normalized, or the bot becomes unlinkable", () => {
+	// The allowlist is compared against a canonical `new URL(...).origin`, which
+	// never carries a trailing slash. An unnormalized entry matches nothing: the
+	// variable looks right, the link mints, and the check rejects it.
+	withEnv(
+		{
+			MCPJAM_BASE_URL: "https://api.example.com/",
+			MCPJAM_APP_URL: "https://app.example.com/",
+			DISCORD_LINK_PUBLIC_ORIGIN: "https://link.example.com//",
+		},
+		() => {
+			assert.deepEqual(connectLinkOrigins(), [
+				"https://app.example.com",
+				"https://link.example.com",
+				"https://api.example.com",
+			]);
+			for (const origin of connectLinkOrigins())
+				assert.equal(origin, new URL(origin).origin);
+		},
+	);
 });

--- a/discord-app/tests/credentials.test.js
+++ b/discord-app/tests/credentials.test.js
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	apiServiceToken,
+	appUrl,
+	baseUrl,
+	connectLinkOrigins,
+	convexServiceToken,
+	getConfig,
+	requireApiServiceToken,
+} from "../credentials.js";
+
+const CREDENTIAL_VARS = [
+	"DISCORD_SERVICE_TOKEN",
+	"MCPJAM_DISCORD_SERVICE_TOKEN",
+	"DISCORD_API_TOKEN",
+	"MCPJAM_BASE_URL",
+	"MCPJAM_APP_URL",
+	"DISCORD_LINK_PUBLIC_ORIGIN",
+];
+
+/** Run `body` with exactly the given credential env, restoring afterwards. */
+function withEnv(env, body) {
+	const saved = new Map(CREDENTIAL_VARS.map((key) => [key, process.env[key]]));
+	for (const key of CREDENTIAL_VARS) delete process.env[key];
+	Object.assign(process.env, env);
+	try {
+		return body();
+	} finally {
+		for (const key of CREDENTIAL_VARS) delete process.env[key];
+		for (const [key, value] of saved)
+			if (value !== undefined) process.env[key] = value;
+	}
+}
+
+const ctx = { tenantId: "G1", actorId: "U1", projectId: "P1" };
+
+test("the two tokens read their own variables and never each other's", () => {
+	withEnv(
+		{
+			DISCORD_SERVICE_TOKEN: "convex-token",
+			MCPJAM_DISCORD_SERVICE_TOKEN: "dsc_api-token",
+		},
+		() => {
+			assert.equal(convexServiceToken(), "convex-token");
+			assert.equal(apiServiceToken(), "dsc_api-token");
+		},
+	);
+
+	// The whole point of the split: neither falls back to the other, so a
+	// deployment that sets only one gets a named error rather than a token
+	// silently doing a job it cannot do.
+	withEnv({ DISCORD_SERVICE_TOKEN: "convex-token" }, () => {
+		assert.equal(apiServiceToken(), undefined);
+	});
+	withEnv({ MCPJAM_DISCORD_SERVICE_TOKEN: "dsc_api-token" }, () => {
+		assert.equal(convexServiceToken(), undefined);
+	});
+});
+
+test("the phantom DISCORD_API_TOKEN is not consulted", () => {
+	withEnv({ DISCORD_API_TOKEN: "phantom" }, () => {
+		assert.equal(convexServiceToken(), undefined);
+		assert.equal(apiServiceToken(), undefined);
+	});
+});
+
+test("a missing API token throws a CONFIG error naming the variable", () => {
+	withEnv({ DISCORD_SERVICE_TOKEN: "convex-token" }, () => {
+		assert.throws(
+			() => requireApiServiceToken(),
+			(error) => {
+				assert.equal(error.code, "CONFIG");
+				assert.match(error.message, /MCPJAM_DISCORD_SERVICE_TOKEN/);
+				return true;
+			},
+		);
+	});
+});
+
+test("getConfig resolves the API token, not the Convex one", () => {
+	withEnv(
+		{
+			DISCORD_SERVICE_TOKEN: "convex-token",
+			MCPJAM_DISCORD_SERVICE_TOKEN: "dsc_api-token",
+		},
+		() => {
+			const config = getConfig(ctx);
+			assert.equal(config.apiKey, "dsc_api-token");
+			assert.equal(config.projectId, "P1");
+			assert.deepEqual(config.headers, {
+				"x-mcpjam-surface-tenant-id": "G1",
+				"x-mcpjam-surface-actor-id": "U1",
+			});
+		},
+	);
+});
+
+test("getConfig throws CONFIG rather than sending `Bearer undefined`", () => {
+	withEnv({ DISCORD_SERVICE_TOKEN: "convex-token" }, () => {
+		assert.throws(
+			() => getConfig(ctx),
+			(error) => {
+				assert.equal(error.code, "CONFIG");
+				assert.match(error.message, /MCPJAM_DISCORD_SERVICE_TOKEN/);
+				return true;
+			},
+		);
+	});
+});
+
+test("getConfig throws NO_PROJECT rather than building /projects/undefined/", () => {
+	withEnv({ MCPJAM_DISCORD_SERVICE_TOKEN: "dsc_api-token" }, () => {
+		assert.throws(
+			() => getConfig({ tenantId: "G1", actorId: "U1" }),
+			(error) => {
+				assert.equal(error.code, "NO_PROJECT");
+				return true;
+			},
+		);
+	});
+});
+
+test("getConfig requires a tenant and an actor", () => {
+	withEnv({ MCPJAM_DISCORD_SERVICE_TOKEN: "dsc_api-token" }, () => {
+		for (const partial of [
+			{ actorId: "U1", projectId: "P1" },
+			{ tenantId: "G1", projectId: "P1" },
+		])
+			assert.throws(
+				() => getConfig(partial),
+				(error) => {
+					assert.equal(error.code, "CONFIG");
+					return true;
+				},
+			);
+	});
+});
+
+test("overrides win over the environment", () => {
+	withEnv({ MCPJAM_DISCORD_SERVICE_TOKEN: "dsc_api-token" }, () => {
+		const config = getConfig(ctx, {
+			apiKey: "dsc_override",
+			projectId: "P2",
+			baseUrl: "https://override.example.com/",
+		});
+		assert.equal(config.apiKey, "dsc_override");
+		assert.equal(config.projectId, "P2");
+		assert.equal(config.baseUrl, "https://override.example.com");
+	});
+});
+
+test("trailing slashes are trimmed from both origins", () => {
+	withEnv(
+		{
+			MCPJAM_DISCORD_SERVICE_TOKEN: "dsc_api-token",
+			MCPJAM_BASE_URL: "https://api.example.com/",
+			MCPJAM_APP_URL: "https://app.example.com///",
+		},
+		() => {
+			assert.equal(baseUrl(), "https://api.example.com");
+			assert.equal(appUrl(), "https://app.example.com");
+			const config = getConfig(ctx);
+			assert.equal(config.baseUrl, "https://api.example.com");
+			assert.equal(config.appUrl, "https://app.example.com");
+		},
+	);
+});
+
+test("appUrl falls back to baseUrl", () => {
+	withEnv({ MCPJAM_BASE_URL: "https://api.example.com" }, () => {
+		assert.equal(appUrl(), "https://api.example.com");
+	});
+});
+
+test("connect-link origins drop unset entries instead of widening", () => {
+	withEnv(
+		{
+			MCPJAM_BASE_URL: "https://api.example.com",
+			MCPJAM_APP_URL: "https://app.example.com",
+			DISCORD_LINK_PUBLIC_ORIGIN: "https://link.example.com",
+		},
+		() => {
+			assert.deepEqual(connectLinkOrigins(), [
+				"https://app.example.com",
+				"https://link.example.com",
+				"https://api.example.com",
+			]);
+		},
+	);
+
+	withEnv({ MCPJAM_BASE_URL: "https://api.example.com" }, () => {
+		assert.deepEqual(connectLinkOrigins(), ["https://api.example.com"]);
+	});
+});


### PR DESCRIPTION
Third step of the agent-surfaces plan, following #3785 (A1) and #3788 (A2). Discord-only — `slack-app` and `surface-core` are untouched, so the `deploy-slack-app.yml` trigger on `surface-core/**` stays cold.

## The bug

One file carried **three different precedence orders** for "the token", and the only configuration that actually worked was a single secret doing both jobs — precisely the coupling `slack-app/.env.sample` warns against.

They are two different secrets, authenticating to two different servers over two different mechanisms. I verified both ends against the backend:

| variable | sent as | reaches | verified by |
| --- | --- | --- | --- |
| `DISCORD_SERVICE_TOKEN` | `x-discord-service-token` header | Convex `/agent/*` — bindings, links, claims, presence | `requireDiscord` in `convex/surfaceRoutes.ts` |
| `MCPJAM_DISCORD_SERVICE_TOKEN` | `Authorization: Bearer` | `/api/v1/*` and `/api/surface-link/session` | `handleSurfaceServiceAuth` in `middleware/surface-service-auth.ts` |

The second requires a `dsc_` prefix and hash-matches `MCPJAM_DISCORD_SERVICE_TOKEN_HASH`, so the Convex token **cannot** stand in for it — it fails the prefix check before anything else is considered. The old precedence at the connect-link mint preferred exactly that token, for a route it can never satisfy.

Also deletes the phantom `DISCORD_API_TOKEN`. It appears nowhere else in this repo or the backend; it was a third fallback to a variable nothing ever sets.

## The dropped guards

Discord's custom `getConfig` also skipped the core's guards, so:

- no token → `Authorization: Bearer undefined`
- no project → `/api/v1/projects/undefined/agent`

Both surfaced as an opaque 401 from the server rather than a config error naming the variable an operator needs to set. The seam now throws named `CONFIG` / `NO_PROJECT` errors, and applies `trimOrigin` to both origins so a trailing slash in `MCPJAM_BASE_URL` stops changing behavior.

## One deviation from the plan

The plan said to *delete* the custom `getConfig` and use the core's. I kept it as an injected seam, because the core's default resolves `MCPJAM_SURFACE_API_KEY` / `MCPJAM_API_KEY` and has no way to learn Discord's variable name — deleting it would have meant either widening `surface-core` (which trips the live Slack deploy) or reading the wrong variable.

`slack-app/agent/mcpjam-client.js` injects its own `getConfig` for exactly this reason, with the same named-throw shape. So this matches the established per-surface credential seam rather than inventing a third pattern. The plan's actual intent — restore `trimOrigin` and the `CONFIG`/`NO_PROJECT` guards — is delivered in full.

## Also in this diff

`discord-app/.env.sample`, mirroring slack-app's separation warning: which token reaches which server, why neither falls back to the other, and that setting them to the same value means either secret leaking compromises both halves at once.

## Tests

12 new cases in `discord-app/tests/credentials.test.js` (37 total in the workspace, up from 26). Each runs against a scrubbed credential environment and restores it afterwards, so they can't leak into one another.

Pinned: each token reads only its own variable and neither falls back to the other; the phantom `DISCORD_API_TOKEN` is not consulted; the named `CONFIG` error mentions `MCPJAM_DISCORD_SERVICE_TOKEN`; `getConfig` resolves the API token rather than the Convex one; `CONFIG` instead of `Bearer undefined`; `NO_PROJECT` instead of `/projects/undefined/`; tenant and actor both required; overrides beat the environment; trailing slashes trimmed from both origins; `appUrl` falls back to `baseUrl`; and connect-link origins drop unset entries instead of widening the allowlist.

## Verification

| workspace | result |
| --- | --- |
| `@mcpjam/discord-app` | 37 pass, 0 fail — `tsc --checkJs` and biome clean |
| `@mcpjam/surface-core` | 20 pass, 0 fail (untouched) |
| `@mcpjam/slack-app` | 242 pass, 0 fail (untouched) |

## Deployment note

This changes which variable the bot reads. Discord's Railway service isn't provisioned yet (Phase C), so nothing is live to break — but whenever it is provisioned, **both** variables must be set, with `MCPJAM_DISCORD_SERVICE_TOKEN` being the `dsc_`-prefixed one whose hash is seeded on the inspector.

## Not in this PR

A4 (approval handler target resolution), A5 (connect-link origin normalization — the one Phase A change inside `surface-core`), A6 (hardening), then Phase B.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6uPdzFLQtSMBHr4rnEiqd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which env vars the bot reads for API and connect-link auth; misconfiguration breaks linking and turns until both `dsc_` tokens are set correctly.
> 
> **Overview**
> **Discord-only** refactor that stops mixing two service secrets behind ad-hoc env fallbacks and routes each job through a dedicated `credentials.js` seam.
> 
> `DISCORD_SERVICE_TOKEN` is used only for Convex `/agent/*` (`x-discord-service-token`); `MCPJAM_DISCORD_SERVICE_TOKEN` is used only for `/api/v1/*` and connect-link minting (`Authorization: Bearer`, must be `dsc_`). Cross-fallbacks and the unused `DISCORD_API_TOKEN` are removed. Connect-link flows now always call `requireApiServiceToken()` with a normalized origin allowlist from `connectLinkOrigins()`.
> 
> `getConfig` is centralized in that module with **`CONFIG` / `NO_PROJECT`** errors instead of `Bearer undefined` or `/projects/undefined/...`, plus trailing-slash normalization on base/app URLs. **`discord-app/.env.sample`** documents the split (and that both vars must still share one `dsc_` value until the inspector stops forwarding the bearer to Convex). **`credentials.test.js`** adds coverage for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97d819cab129c975d46901803d1a470a987fce56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split Discord service credentials by job and fixed auth precedence so Convex and the app API use the right header. Also corrected docs: for now both env vars must hold the same `dsc_` token due to inspector forwarding, and hardened accessors with clear errors and normalized origins.

- **Bug Fixes**
  - Use `DISCORD_SERVICE_TOKEN` for Convex `/agent/*` (`x-discord-service-token`) and `MCPJAM_DISCORD_SERVICE_TOKEN` for `/api/v1/*` and `/api/surface-link/session` (`Authorization: Bearer`). No cross-fallback.
  - Add local checks: require `dsc_` prefix for the API token; throw named `CONFIG` / `NO_PROJECT` errors; always send tenant/actor headers.
  - Normalize and trim origins for connect-link allowlist; drop blank entries. Connect-link mint now requires the API token.
  - Remove unused `DISCORD_API_TOKEN`. Add `discord-app/.env.sample` and targeted tests. Injected `getConfig` seam centralizes guards.

- **Migration**
  - Set both `DISCORD_SERVICE_TOKEN` and `MCPJAM_DISCORD_SERVICE_TOKEN` to the same `dsc_...` value. Seed its SHA-256 as `MCPJAM_DISCORD_SERVICE_TOKEN_HASH` on the inspector and set Convex `DISCORD_SERVICE_TOKEN` to that value.

<sup>Written for commit 97d819cab129c975d46901803d1a470a987fce56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

