### PR TITLE
fix(chatbox): preflight the ephemeral sandbox before provisioning (billable-orphan fix)

### DIFF
--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -208,7 +208,7 @@ const HARNESS_RESET_MESSAGES: Record<HarnessResetReason, string | null> = {
 
 // User-facing copy for a chatbox ephemeral-sandbox notice, keyed by reason.
 //
-// Both are shown. A reset is the sharper one: the model may have written files
+// All are shown. A reset is the sharper one: the model may have written files
 // in an earlier turn and will otherwise reason confidently about a filesystem
 // that no longer exists, so silence is worse than an interruption.
 const SANDBOX_NOTICE_MESSAGES: Record<SandboxNoticeReason, string> = {
@@ -216,6 +216,8 @@ const SANDBOX_NOTICE_MESSAGES: Record<SandboxNoticeReason, string> = {
     "This conversation's sandbox was reset after being idle — files and shell state from earlier turns are gone.",
   stale_image:
     "This conversation is still running on the computer image it started with; a newer build is available and will be used by your next conversation.",
+  sandbox_unavailable:
+    "This conversation's bash runs in a disposable cloud sandbox, but this inspector can't execute disposable sandboxes. The conversation continues without bash.",
 };
 
 // SEP-1865 App-Provided Tools: opaque alias shape minted by

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.chatbox-sandbox.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.chatbox-sandbox.test.ts
@@ -18,6 +18,7 @@ const {
   disconnectAllServersMock,
   provisionChatboxSandboxMock,
   ackChatboxSandboxNoticesMock,
+  isComputersDataPlaneConfiguredMock,
   maybeAppendEnvironmentContextMock,
   buildSandboxBashToolMock,
   buildBashToolMock,
@@ -29,6 +30,7 @@ const {
   disconnectAllServersMock: vi.fn(),
   provisionChatboxSandboxMock: vi.fn(),
   ackChatboxSandboxNoticesMock: vi.fn(),
+  isComputersDataPlaneConfiguredMock: vi.fn(),
   maybeAppendEnvironmentContextMock: vi.fn(),
   buildSandboxBashToolMock: vi.fn(),
   buildBashToolMock: vi.fn(),
@@ -104,6 +106,10 @@ vi.mock("../../../utils/computers/control-plane-client.js", async () => {
     ...actual,
     provisionChatboxSandbox: provisionChatboxSandboxMock,
     ackChatboxSandboxNotices: ackChatboxSandboxNoticesMock,
+    // Env-derived in the real module (false in a bare test process). The
+    // preflight consults it BEFORE provisioning, so the suite pins it `true`
+    // by default and individual tests flip it to model a local inspector.
+    isComputersDataPlaneConfigured: isComputersDataPlaneConfiguredMock,
   };
 });
 
@@ -209,6 +215,7 @@ describe("web chat-v2 — chatbox ephemeral sandbox", () => {
       async (args: { systemPrompt?: string }) => args.systemPrompt
     );
     ackChatboxSandboxNoticesMock.mockResolvedValue(undefined);
+    isComputersDataPlaneConfiguredMock.mockReturnValue(true);
     provisionChatboxSandboxMock.mockResolvedValue({
       ok: true,
       value: {
@@ -695,6 +702,68 @@ describe("web chat-v2 — chatbox ephemeral sandbox", () => {
     expect(provisionChatboxSandboxMock).not.toHaveBeenCalled();
     expect(buildBashToolMock).not.toHaveBeenCalled();
     expect(buildSandboxBashToolMock).not.toHaveBeenCalled();
+  });
+
+  it("never provisions from a server that is not a computers data plane", async () => {
+    // `provisionChatboxSandbox` is bearer-authed and would SUCCEED from a
+    // credential-less local inspector — stranding a BILLABLE box that
+    // `sandbox-bash` (which has no remote delegation) could never exec in.
+    // The capability check must therefore come before the reserve.
+    isComputersDataPlaneConfiguredMock.mockReturnValue(false);
+    const writes: unknown[] = [];
+    handleMCPJamFreeChatModelMock.mockImplementation(async (options: any) => {
+      options.onStreamWriterReady?.({ write: (c: unknown) => writes.push(c) });
+      options.onStreamComplete?.();
+      return new Response("ok", { status: 200 });
+    });
+
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    expect(provisionChatboxSandboxMock).not.toHaveBeenCalled();
+    expect(buildSandboxBashToolMock).not.toHaveBeenCalled();
+    expect(buildBashToolMock).not.toHaveBeenCalled();
+    expect(builtInToolsFromLastTurn()?.bash).toBeUndefined();
+
+    // The tester is told, instead of watching every command fail opaquely.
+    expect(
+      writes.filter((chunk: any) => chunk?.type === "data-sandbox-notice")
+    ).toEqual([
+      {
+        type: "data-sandbox-notice",
+        data: { reason: "sandbox_unavailable" },
+        transient: true,
+      },
+    ]);
+    // Inspector-minted notice: there is no backend notice row, nothing to ack.
+    expect(ackChatboxSandboxNoticesMock).not.toHaveBeenCalled();
+  });
+
+  it("tells the MODEL bash is unavailable, not only the tester's toast", async () => {
+    isComputersDataPlaneConfiguredMock.mockReturnValue(false);
+    const { app, token } = createWebTestApp();
+    await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+
+    const prompt = prepareChatV2Mock.mock.calls.at(-1)![0].systemPrompt;
+    expect(prompt).toMatch(/NO bash tool this conversation/);
+  });
+
+  it("leaves a legacy marker-absent config untouched by the data-plane preflight", async () => {
+    // Absent marker = personal-computer behavior. The preflight governs only
+    // the ephemeral path; the personal path's own cloud-family resolution is a
+    // different seam and must not start suppressing here.
+    isComputersDataPlaneConfiguredMock.mockReturnValue(false);
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: chatboxConfig(),
+    });
+
+    const { app, token } = createWebTestApp();
+    await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+
+    expect(provisionChatboxSandboxMock).not.toHaveBeenCalled();
+    expect((builtInToolsFromLastTurn()?.bash as any)?.__path).toBe("personal");
   });
 
   it("tells the model the box survives between turns", async () => {

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -61,6 +61,7 @@ import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
 import {
   fetchChatboxRuntimeConfig,
+  planChatboxSandbox,
   readChatboxEnvironment,
   readComputerSandboxMode,
   type ChatboxEnvironmentRuntime,
@@ -102,6 +103,7 @@ import {
 } from "../../utils/built-in-tools/registry.js";
 import {
   ackChatboxSandboxNotices,
+  isComputersDataPlaneConfigured,
   provisionChatboxSandbox,
 } from "../../utils/computers/control-plane-client.js";
 import {
@@ -1102,96 +1104,107 @@ chatV2.post("/", async (c) => {
     let ackSandboxNotices:
       | ((delivered: SandboxNoticeReason[]) => void)
       | undefined;
-    // Drop the personal-computer resource for this turn, so `bash` is not
-    // advertised at all rather than falling back to the member's own box —
-    // which is precisely the behaviour this feature replaces.
-    //
-    // Set for BOTH marker states, not just the one that provisions:
-    //   - `ephemeral` + no box  → we asked and failed; no fallback.
-    //   - `unavailable`         → the backend has already dropped `computer`,
+    // Drop the personal-computer resource for every suppressing plan, so
+    // `bash` is not advertised at all rather than falling back to the member's
+    // own box — which is precisely the behaviour this feature replaces:
+    //   - `ephemeral` + no box   → we asked and failed; no fallback.
+    //   - `not_a_data_plane`     → we never ask: `provisionChatboxSandbox` is
+    //     bearer-authed and would SUCCEED from a server that cannot exec in
+    //     the box (`sandbox-bash` has no remote delegation), stranding a
+    //     billable sandbox whose every command fails. The tester gets a
+    //     notice instead of an opaque broken shell.
+    //   - `unavailable`          → the backend has already dropped `computer`,
     //     but that is its promise, not ours to depend on. Enforcing the marker
     //     locally means a payload that ever carried both (a backend regression,
     //     a proxy that merges configs) still cannot expose the member's
     //     personal shell to a share-link-reachable chatbox turn.
-    let suppressComputerResource = computerSandboxMode === "unavailable";
-    if (
-      computerSandboxMode === "ephemeral" &&
-      chatboxId &&
-      (resolvedExecution.builtInToolIds ?? []).includes(BASH_TOOL_NAME)
-    ) {
-      if (!body.chatSessionId) {
-        // The conversation id IS the isolation boundary (`scopeKey =
-        // chatbox:<chatSessionId>`). Without one there is nothing to key a box
-        // to, and binding anyway would put every session that omits it on one
-        // shared box. No shell beats the wrong shell.
+    const sandboxPlan = planChatboxSandbox({
+      mode: computerSandboxMode,
+      bashRequested: (resolvedExecution.builtInToolIds ?? []).includes(
+        BASH_TOOL_NAME
+      ),
+      ephemeralCloudAvailable: isComputersDataPlaneConfigured(),
+      hasChatSessionId: Boolean(body.chatSessionId),
+    });
+    let suppressComputerResource = sandboxPlan.action === "suppress";
+    if (sandboxPlan.suppressReason === "no_chat_session_id") {
+      // The conversation id IS the isolation boundary (`scopeKey =
+      // chatbox:<chatSessionId>`). Without one there is nothing to key a box
+      // to, and binding anyway would put every session that omits it on one
+      // shared box. No shell beats the wrong shell.
+      logger.warn(
+        "[chat-v2] ephemeral chatbox sandbox requested without a chatSessionId; bash suppressed",
+        { chatboxId }
+      );
+    } else if (sandboxPlan.suppressReason === "not_a_data_plane") {
+      logger.warn(
+        "[chat-v2] ephemeral chatbox sandbox requested but this server is not a computers data plane; bash suppressed without provisioning",
+        { chatboxId }
+      );
+      if (sandboxPlan.notice) sandboxNotices = [sandboxPlan.notice];
+    }
+    if (sandboxPlan.action === "provision" && chatboxId && body.chatSessionId) {
+      const provisioned = await provisionChatboxSandbox({
+        bearer: bearerToken,
+        chatboxId,
+        chatSessionId: body.chatSessionId,
+        signal: c.req.raw.signal as AbortSignal | undefined,
+      });
+      if (provisioned.ok) {
+        sandboxBinding = {
+          sandboxId: provisioned.value.sandboxId,
+          ...(provisioned.value.workdir
+            ? { workdir: provisioned.value.workdir }
+            : {}),
+          // Tell the model the truth about the box's lifetime. The default
+          // (`run`) copy says it is destroyed after this session — a chatbox
+          // box is not, and a model that believes otherwise won't build work
+          // up across turns, which is the whole point of a persistent shell.
+          lifetime: "conversation",
+        };
+        const notices = (provisioned.value.notices ?? []).filter(
+          isSandboxNoticeReason
+        );
+        if (notices.length > 0) sandboxNotices = notices;
+        // PEEK/ACK (mcpjam-backend #829). The control plane hands the notice
+        // over WITHOUT consuming it and waits for us to confirm it reached
+        // the wire, because the SSE writer does not exist yet — provisioning
+        // happens here, streaming starts several steps later. Anything that
+        // throws in between used to destroy the notice, and did so exactly
+        // when a reset was most likely to have happened (flaky setup and "the
+        // box was idle long enough to be reaped" share a cause).
+        //
+        // Unacked ⇒ re-delivered next turn. That makes duplicate display the
+        // worst case instead of silent loss, which is the right way round for
+        // "earlier files are gone": a repeated toast is noise, a missing one
+        // makes the model confabulate about a filesystem it can't see.
+        //
+        // `noticeAckPending: false` means the backend already consumed them
+        // (a deploy that predates #829) — leave `ackSandboxNotices` unset and
+        // behave exactly as before.
+        const sandboxRowId = provisioned.value.sandboxRowId;
+        if (provisioned.value.noticeAckPending && notices.length > 0) {
+          ackSandboxNotices = (delivered) => {
+            void ackChatboxSandboxNotices({
+              bearer: bearerToken,
+              sandboxRowId,
+              notices: delivered,
+            });
+          };
+        }
+      } else {
+        // Degrade to a turn with no shell rather than failing the turn: the
+        // conversation is still useful, and 503 (at capacity / a sibling call
+        // still booting) resolves on its own by the next turn.
         logger.warn(
-          "[chat-v2] ephemeral chatbox sandbox requested without a chatSessionId; bash suppressed",
-          { chatboxId }
+          "[chat-v2] chatbox sandbox provision failed; running without bash",
+          {
+            chatboxId,
+            status: provisioned.status,
+            error: provisioned.error,
+          }
         );
         suppressComputerResource = true;
-      } else {
-        const provisioned = await provisionChatboxSandbox({
-          bearer: bearerToken,
-          chatboxId,
-          chatSessionId: body.chatSessionId,
-          signal: c.req.raw.signal as AbortSignal | undefined,
-        });
-        if (provisioned.ok) {
-          sandboxBinding = {
-            sandboxId: provisioned.value.sandboxId,
-            ...(provisioned.value.workdir
-              ? { workdir: provisioned.value.workdir }
-              : {}),
-            // Tell the model the truth about the box's lifetime. The default
-            // (`run`) copy says it is destroyed after this session — a chatbox
-            // box is not, and a model that believes otherwise won't build work
-            // up across turns, which is the whole point of a persistent shell.
-            lifetime: "conversation",
-          };
-          const notices = (provisioned.value.notices ?? []).filter(
-            isSandboxNoticeReason
-          );
-          if (notices.length > 0) sandboxNotices = notices;
-          // PEEK/ACK (mcpjam-backend #829). The control plane hands the notice
-          // over WITHOUT consuming it and waits for us to confirm it reached
-          // the wire, because the SSE writer does not exist yet — provisioning
-          // happens here, streaming starts several steps later. Anything that
-          // throws in between used to destroy the notice, and did so exactly
-          // when a reset was most likely to have happened (flaky setup and "the
-          // box was idle long enough to be reaped" share a cause).
-          //
-          // Unacked ⇒ re-delivered next turn. That makes duplicate display the
-          // worst case instead of silent loss, which is the right way round for
-          // "earlier files are gone": a repeated toast is noise, a missing one
-          // makes the model confabulate about a filesystem it can't see.
-          //
-          // `noticeAckPending: false` means the backend already consumed them
-          // (a deploy that predates #829) — leave `ackSandboxNotices` unset and
-          // behave exactly as before.
-          const sandboxRowId = provisioned.value.sandboxRowId;
-          if (provisioned.value.noticeAckPending && notices.length > 0) {
-            ackSandboxNotices = (delivered) => {
-              void ackChatboxSandboxNotices({
-                bearer: bearerToken,
-                sandboxRowId,
-                notices: delivered,
-              });
-            };
-          }
-        } else {
-          // Degrade to a turn with no shell rather than failing the turn: the
-          // conversation is still useful, and 503 (at capacity / a sibling call
-          // still booting) resolves on its own by the next turn.
-          logger.warn(
-            "[chat-v2] chatbox sandbox provision failed; running without bash",
-            {
-              chatboxId,
-              status: provisioned.status,
-              error: provisioned.error,
-            }
-          );
-          suppressComputerResource = true;
-        }
       }
     }
 
@@ -1253,9 +1266,13 @@ chatV2.post("/", async (c) => {
     // TURN-INJECTED, never persisted: `persist.systemPrompt` keeps the raw host
     // prompt, so a resumed turn does not replay a stale "your sandbox was
     // reset" long after the fact. Same rule as the blueprint image block above.
+    // Notices exist in exactly two states: derived from a provisioned box
+    // (binding present) or minted by the preflight that refused to provision
+    // (binding absent, `sandbox_unavailable`). Both carry model-facing copy in
+    // the exhaustive SANDBOX_NOTICE_MODEL_CONTEXT record, so no binding gate.
     const effectiveSystemPrompt = appendSandboxNoticeContext(
       withEnvironmentContext,
-      sandboxBinding ? sandboxNotices : undefined
+      sandboxNotices
     );
 
     try {

--- a/mcpjam-inspector/server/utils/__tests__/computer-sandbox-marker.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/computer-sandbox-marker.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { readComputerSandboxMode } from "../chatbox-runtime-config.js";
+import {
+  planChatboxSandbox,
+  readComputerSandboxMode,
+} from "../chatbox-runtime-config.js";
 
 /**
  * The `computerSandbox` marker has THREE states, and the third one — absence —
@@ -39,5 +42,87 @@ describe("readComputerSandboxMode", () => {
       null
     );
     expect(readComputerSandboxMode({ computerSandbox: {} })).toBe(null);
+  });
+});
+
+/**
+ * The plan is the ONLY thing standing between a chatbox turn and a call that
+ * spends money, so the matrix is pinned exhaustively. The load-bearing row is
+ * `not_a_data_plane`: provisioning is bearer-authed and succeeds from any
+ * inspector, but a server without the E2B credentials can never exec in the
+ * box — the old code stranded a billable sandbox whose every command failed.
+ */
+describe("planChatboxSandbox", () => {
+  const ephemeral = {
+    mode: "ephemeral" as const,
+    bashRequested: true,
+    ephemeralCloudAvailable: true,
+    hasChatSessionId: true,
+  };
+
+  it("provisions only when every requirement holds", () => {
+    expect(planChatboxSandbox(ephemeral)).toEqual({ action: "provision" });
+  });
+
+  it("suppresses WITH a tester notice when this server is not a data plane", () => {
+    expect(
+      planChatboxSandbox({ ...ephemeral, ephemeralCloudAvailable: false })
+    ).toEqual({
+      action: "suppress",
+      suppressReason: "not_a_data_plane",
+      notice: "sandbox_unavailable",
+    });
+  });
+
+  it("checks the data plane before the session id — the tester deserves the explanation either way", () => {
+    expect(
+      planChatboxSandbox({
+        ...ephemeral,
+        ephemeralCloudAvailable: false,
+        hasChatSessionId: false,
+      })
+    ).toMatchObject({ suppressReason: "not_a_data_plane" });
+  });
+
+  it("suppresses silently (log-only) without a chatSessionId", () => {
+    expect(
+      planChatboxSandbox({ ...ephemeral, hasChatSessionId: false })
+    ).toEqual({ action: "suppress", suppressReason: "no_chat_session_id" });
+  });
+
+  it("suppresses on an `unavailable` marker regardless of anything else", () => {
+    expect(
+      planChatboxSandbox({
+        ...ephemeral,
+        mode: "unavailable",
+        ephemeralCloudAvailable: false,
+        bashRequested: false,
+      })
+    ).toEqual({
+      action: "suppress",
+      suppressReason: "sandbox_mode_unavailable",
+    });
+  });
+
+  it("does nothing for a legacy (marker-absent) config — even on a non-data-plane server", () => {
+    // Absent marker = personal-computer behavior; the preflight must not
+    // start stripping bash from legacy chatboxes on deploy skew.
+    expect(
+      planChatboxSandbox({
+        ...ephemeral,
+        mode: null,
+        ephemeralCloudAvailable: false,
+      })
+    ).toEqual({ action: "none" });
+  });
+
+  it("does nothing when the turn never asked for bash — no notice noise", () => {
+    expect(
+      planChatboxSandbox({
+        ...ephemeral,
+        bashRequested: false,
+        ephemeralCloudAvailable: false,
+      })
+    ).toEqual({ action: "none" });
   });
 });

--- a/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
@@ -14,6 +14,7 @@
  */
 
 import { type Harness } from "@mcpjam/sdk/host-config/internal";
+import type { SandboxNoticeReason } from "@/shared/sandbox-notice";
 import { logger } from "./logger.js";
 import type {
   McpToolResultImageRenderingPolicy,
@@ -168,6 +169,64 @@ export function readComputerSandboxMode(
   if (!raw || typeof raw !== "object") return null;
   const mode = (raw as { mode?: unknown }).mode;
   return mode === "ephemeral" || mode === "unavailable" ? mode : null;
+}
+
+export interface ChatboxSandboxPlan {
+  /**
+   * `provision` — reserve the per-conversation box, then bind bash to it.
+   * `suppress`  — drop the computer resource for this turn; bash is not
+   *               advertised. `suppressReason` says why (the caller picks the
+   *               matching log line).
+   * `none`      — nothing to do: legacy marker-absent config, or a turn that
+   *               never asked for bash.
+   */
+  action: "provision" | "suppress" | "none";
+  suppressReason?:
+    | "sandbox_mode_unavailable"
+    | "not_a_data_plane"
+    | "no_chat_session_id";
+  /** Set when the suppression should be narrated to the tester (SSE notice). */
+  notice?: SandboxNoticeReason;
+}
+
+/**
+ * Decide what the chatbox turn does about its ephemeral sandbox BEFORE any
+ * call that spends money.
+ *
+ * The load-bearing branch is `not_a_data_plane`: `provisionChatboxSandbox` is
+ * bearer-authed and succeeds from ANY inspector, but executing in the box
+ * requires this process to hold the E2B credentials (`sandbox-bash` has no
+ * remote delegation). Provisioning without them used to strand a BILLABLE box
+ * whose every command failed opaquely — so the capability check must come
+ * before the reserve, not after.
+ *
+ * Checked before `no_chat_session_id` on purpose: on a non-data-plane server
+ * the missing-session case would otherwise suppress silently, and the tester
+ * deserves the explanation either way.
+ */
+export function planChatboxSandbox(args: {
+  mode: "ephemeral" | "unavailable" | null;
+  bashRequested: boolean;
+  ephemeralCloudAvailable: boolean;
+  hasChatSessionId: boolean;
+}): ChatboxSandboxPlan {
+  if (args.mode === "unavailable") {
+    return { action: "suppress", suppressReason: "sandbox_mode_unavailable" };
+  }
+  if (args.mode !== "ephemeral" || !args.bashRequested) {
+    return { action: "none" };
+  }
+  if (!args.ephemeralCloudAvailable) {
+    return {
+      action: "suppress",
+      suppressReason: "not_a_data_plane",
+      notice: "sandbox_unavailable",
+    };
+  }
+  if (!args.hasChatSessionId) {
+    return { action: "suppress", suppressReason: "no_chat_session_id" };
+  }
+  return { action: "provision" };
 }
 
 export type ChatboxRuntimeConfigResult =

--- a/mcpjam-inspector/server/utils/computers/environment-context.ts
+++ b/mcpjam-inspector/server/utils/computers/environment-context.ts
@@ -126,6 +126,12 @@ const SANDBOX_NOTICE_MODEL_CONTEXT: Record<SandboxNoticeReason, string> = {
     "environment image; a newer build exists but was deliberately not " +
     "swapped in, to preserve your shell state. If a tool or package seems " +
     "to be missing or out of date, that is why.",
+  sandbox_unavailable:
+    "This conversation normally runs bash in a disposable cloud sandbox, " +
+    "but the server handling this turn cannot execute one, so you have NO " +
+    "bash tool this conversation. Do not claim to have run commands or " +
+    "inspected files; if a step needs a shell, say plainly that it can't be " +
+    "done here.",
 };
 
 /**

--- a/mcpjam-inspector/shared/__tests__/sandbox-notice.test.ts
+++ b/mcpjam-inspector/shared/__tests__/sandbox-notice.test.ts
@@ -7,7 +7,11 @@ import {
 
 describe("sandbox notice data part", () => {
   it("accepts each known reason", () => {
-    for (const reason of ["sandbox_reset", "stale_image"]) {
+    for (const reason of [
+      "sandbox_reset",
+      "stale_image",
+      "sandbox_unavailable",
+    ]) {
       expect(
         isSandboxNoticeDataPart({
           type: SANDBOX_NOTICE_DATA_PART_TYPE,

--- a/mcpjam-inspector/shared/sandbox-notice.ts
+++ b/mcpjam-inspector/shared/sandbox-notice.ts
@@ -24,7 +24,16 @@ export type SandboxNoticeReason =
    * deliberately KEPT (swapping mid-conversation would destroy the user's shell
    * state), so this conversation is one revision behind.
    */
-  | "stale_image";
+  | "stale_image"
+  /**
+   * The conversation's bash needs a disposable cloud sandbox, but the server
+   * handling this turn cannot execute one (it is not a computers data plane),
+   * so no box was provisioned and bash is not advertised this turn.
+   *
+   * Unlike the two reasons above, this one is minted by the INSPECTOR, not the
+   * control plane — there is no backing Convex notice row and nothing to ack.
+   */
+  | "sandbox_unavailable";
 
 export interface SandboxNoticeInfo {
   reason: SandboxNoticeReason;
@@ -40,6 +49,7 @@ export const SANDBOX_NOTICE_DATA_PART_TYPE = "data-sandbox-notice" as const;
 const SANDBOX_NOTICE_REASONS: ReadonlySet<SandboxNoticeReason> = new Set([
   "sandbox_reset",
   "stale_image",
+  "sandbox_unavailable",
 ]);
 
 export function isSandboxNoticeReason(


### PR DESCRIPTION
PR 1 of the local-computer-engine program (plan: local computers in Playground, cloud-only everywhere else). Independent hazard fix — no dependency on the rest of the program.

## The hazard

A User Testing / chatbox turn in ephemeral-sandbox mode, served by an inspector that is **not** a computers data plane (e.g. a local `npx` inspector serving a share link):

1. `provisionChatboxSandbox` is bearer-authed and succeeds from **any** server → a **billable E2B box is reserved**.
2. Every `bash` call then fails opaquely ("Command failed to run in the sandbox.") because `sandbox-bash` execs via `e2bRunner` directly with the process's own E2B credentials — the ephemeral path has **no remote delegation**, unlike personal-computer bash.
3. Provision failures separately degraded to a shell-less turn with no user-visible explanation.

## The fix

- New pure helper `planChatboxSandbox({mode, bashRequested, ephemeralCloudAvailable, hasChatSessionId})` in `chatbox-runtime-config.ts` decides provision / suppress / none **before any call that spends money**. The capability check (`isComputersDataPlaneConfigured()`) comes before the reserve.
- On a non-data-plane server: no provision, computer resource dropped, and the situation is narrated both ways via a new categorical notice reason `sandbox_unavailable`:
  - tester toast (SSE `data-sandbox-notice`): "This conversation's bash runs in a disposable cloud sandbox, but this inspector can't execute disposable sandboxes. The conversation continues without bash."
  - model-facing system-prompt context so the model doesn't confabulate command runs.
- The notice is inspector-minted — there is no backend notice row and nothing to ack. The `appendSandboxNoticeContext` call no longer gates on a sandbox binding (both Records over `SandboxNoticeReason` are exhaustive, so every reason carries copy).
- Legacy marker-absent configs (old backend / no pinned image) are untouched — pinned by test.

## Tests

- `planChatboxSandbox` matrix (7 cases) in `computer-sandbox-marker.test.ts`, including check-order (data plane before session id) and legacy/no-bash no-op rows.
- Route-level: never provisions from a non-data-plane server (+ notice on the wire, nothing acked), model context present, legacy path untouched — `chat-v2.chatbox-sandbox.test.ts` now mocks `isComputersDataPlaneConfigured` (default `true`; env-derived and false in a bare test process).
- `sandbox_unavailable` accepted by the shared type guard.
- Full web-route suite green: 54 files / 565 tests. Client typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chat-v2 provisioning and bash advertisement for ephemeral chatboxes; mistakes could block bash on data planes or still provision on locals, but behavior is heavily tested and legacy marker-absent paths are preserved.
> 
> **Overview**
> **Ephemeral chatbox bash** no longer calls `provisionChatboxSandbox` until `planChatboxSandbox` (using `isComputersDataPlaneConfigured()`) says the inspector can actually exec in the box. On a local/non–data-plane server this **suppresses bash**, avoids reserving a billable E2B sandbox that every command would fail on, and emits a new **`sandbox_unavailable`** notice.
> 
> Testers see that reason in the chatbox toast (`SANDBOX_NOTICE_MESSAGES`); the model gets matching turn-injected system prompt copy via `appendSandboxNoticeContext`, which now runs for notices **without** requiring a sandbox binding. Legacy configs with no `computerSandbox` marker still use personal-computer bash unchanged.
> 
> Tests cover the plan matrix, route behavior (no provision, SSE notice, no ack), and the shared notice type guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3008c29c58dd445cce1b0db3e9e79bc67e84bf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preflighted ephemeral chatbox sandboxes to avoid billable orphan boxes and made bash unavailability explicit to both testers and the model.

- **Bug Fixes**
  - Added `planChatboxSandbox({ mode, bashRequested, ephemeralCloudAvailable, hasChatSessionId })` to decide provision/suppress/none before any billable call.
  - Check `isComputersDataPlaneConfigured()` first; on non–data-plane servers we never provision, drop the computer resource, and suppress bash instead of failing opaquely.
  - When provision fails, degrade to a turn without bash (no fallback to a personal box); ensure lifetime is set to “conversation” on success.

- **New Features**
  - Introduced `sandbox_unavailable` notice (SSE `data-sandbox-notice`); inspector-minted with no backend ack.
  - Added model-facing prompt context when bash is unavailable to prevent claims of command execution.
  - Tests cover the planning matrix, route behavior, and legacy marker-absent configs (unchanged).

<sup>Written for commit c3008c29c58dd445cce1b0db3e9e79bc67e84bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

