### PR TITLE
fix(e2e): stabilize sidebar-rail-alignment against async remount races

### DIFF
--- a/mcpjam-inspector/e2e/sidebar-rail-alignment.spec.ts
+++ b/mcpjam-inspector/e2e/sidebar-rail-alignment.spec.ts
@@ -19,38 +19,57 @@ test("collapsed sidebar rail centers the footer icons", async ({ page }) => {
   await expect(page.getByTestId("app-shell")).toBeVisible({ timeout: 30_000 });
 
   // Guest footer (local mode and hosted signed-out): the Support and Settings
-  // utility buttons. They're suppressed while auth resolves, so waiting for
-  // Support also waits out authResolving.
+  // utility buttons. NOTE: in local mode `authResolving` is hosted-only
+  // (mcp-sidebar.tsx), so Support renders on first paint — its visibility
+  // does NOT mean the guest session has settled. Async auth/session
+  // resolution can still remount the sidebar at its default expanded width
+  // after this point, which is why the collapse below must be re-asserted
+  // until stable rather than performed once.
   const supportButton = page.locator('button[aria-label="Support"]');
   await expect(supportButton).toBeVisible({ timeout: 30_000 });
 
   const sidebar = page.locator('[data-slot="sidebar"][data-state]');
-  if ((await sidebar.getAttribute("data-state")) !== "collapsed") {
-    await page.keyboard.press("Control+b");
-  }
-  await expect(sidebar).toHaveAttribute("data-state", "collapsed");
-
-  // Let the 200ms width transition settle before measuring geometry.
   const rail = page.locator('[data-slot="sidebar-container"]');
-  await expect
-    .poll(async () => (await rail.boundingBox())?.width ?? 0)
-    .toBeLessThan(60);
 
-  const railBox = await rail.boundingBox();
-  expect(railBox).not.toBeNull();
-  const railCenter = railBox!.x + railBox!.width / 2;
+  // Collapse until it STICKS: a late remount (guest session resolving, data
+  // loading) re-expands a just-collapsed sidebar, so one Ctrl+B plus a single
+  // width poll races it. The whole block retries — re-collapsing if needed —
+  // and only passes once the rail has stayed collapsed across a settle
+  // window. All geometry is measured inside the same stable window so the
+  // rail cannot flip between the rail and icon measurements.
+  await expect(async () => {
+    if ((await sidebar.getAttribute("data-state")) !== "collapsed") {
+      await page.keyboard.press("Control+b");
+    }
+    await expect(sidebar).toHaveAttribute("data-state", "collapsed");
 
-  for (const label of ["Support", "Settings"]) {
-    const icon = page.locator(`button[aria-label="${label}"] svg`).first();
-    await expect(
-      icon,
-      `${label} icon should be visible in the collapsed rail`
-    ).toBeVisible();
-    const box = (await icon.boundingBox())!;
-    const iconCenter = box.x + box.width / 2;
-    expect(
-      Math.abs(iconCenter - railCenter),
-      `${label} icon center (${iconCenter}px) should sit on the rail centerline (${railCenter}px)`
-    ).toBeLessThanOrEqual(1.5);
-  }
+    // Let the 200ms width transition settle before measuring geometry.
+    await expect
+      .poll(async () => (await rail.boundingBox())?.width ?? 0, {
+        timeout: 3_000,
+      })
+      .toBeLessThan(60);
+
+    // Still collapsed after a settle window → no pending remount raced us.
+    await page.waitForTimeout(400);
+    expect(await sidebar.getAttribute("data-state")).toBe("collapsed");
+    const railBox = await rail.boundingBox();
+    expect(railBox).not.toBeNull();
+    expect(railBox!.width).toBeLessThan(60);
+    const railCenter = railBox!.x + railBox!.width / 2;
+
+    for (const label of ["Support", "Settings"]) {
+      const icon = page.locator(`button[aria-label="${label}"] svg`).first();
+      await expect(
+        icon,
+        `${label} icon should be visible in the collapsed rail`
+      ).toBeVisible();
+      const box = (await icon.boundingBox())!;
+      const iconCenter = box.x + box.width / 2;
+      expect(
+        Math.abs(iconCenter - railCenter),
+        `${label} icon center (${iconCenter}px) should sit on the rail centerline (${railCenter}px)`
+      ).toBeLessThanOrEqual(1.5);
+    }
+  }).toPass({ timeout: 30_000 });
 });


### PR DESCRIPTION
## Summary

`e2e/sidebar-rail-alignment.spec.ts` has failed on **every `main` run since #3794** — last green was `0394fe2902` (#3793); #3794's own CI run was cancelled, so the breakage merged unvalidated. It is also failing on unrelated PRs that rebased onto current main (e.g. #3797).

## Root cause

#3794 removed the signed-out "Sign in" footer button and switched the spec's wait anchor to the Support button, with the comment "They're suppressed while auth resolves, so waiting for Support also waits out authResolving." That premise is false in the local binary CI runs: `authResolving` is hosted-only (`mcp-sidebar.tsx`: `HOSTED_MODE && !user && …`), so **Support renders on first paint** and its visibility guarantees nothing about session settlement.

The old "Sign in" anchor incidentally synchronized with WorkOS auth loading (`SidebarUser` returns a loading state before the signed-out branch). Without that accidental barrier, the async guest-session resolution can remount the sidebar at its default expanded width *after* the test collapses it. The CI failures show exactly this race, in both shapes:

- attempt 1: width poll passes, then the rail measures 192px (center 96) while the icon still measures at its collapsed position (center 26) — sampled on opposite sides of a flip;
- retries: the width poll never sees a collapsed rail at all (192px for the full 5s).

## Fix

Cause-agnostic stabilization: the whole collapse+measure block runs under `expect().toPass()` —

- re-collapses (`Ctrl+B`) whenever a remount re-expanded the rail,
- requires the collapsed state to survive a 400ms settle window,
- measures rail and icon geometry **inside that same stable window**, so the two samples can never straddle a flip.

The centering assertion itself — the actual regression guard from #3793 (icon center within 1.5px of the rail centerline) — is unchanged, so the test still fails loudly on a real mis-centering.

## Validation

Local `npm run start` cannot serve the app from a fresh worktree (gitignored codegen artifacts), so CI on this PR is the validation run; the NUX and smoke specs prove the shell mounts fine on this infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 55a73a0e6372279b722192a8ba17481aa6049977. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the sidebar rail alignment e2e by making the collapse-and-measure step resilient to async sidebar remounts during session/auth settling. The centering assertion remains the same; only timing and retries changed to remove CI flakiness.

- **Bug Fixes**
  - Wrap collapse+measure in `expect().toPass()` with retries.
  - Re-collapse via Ctrl+B when a remount re-expands the rail.
  - Require the collapsed state to persist for a 400ms settle window.
  - Measure rail and icon geometry within the same stable window.

<sup>Written for commit 55a73a0e6372279b722192a8ba17481aa6049977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

