### PR TITLE
fix(surface-core): give runTurnForEvent the durable-claim correctness the Slack fork has always had (B1)

### DIFF
--- a/surface-core/src/turn-runner.js
+++ b/surface-core/src/turn-runner.js
@@ -1,5 +1,7 @@
 // @ts-nocheck — not yet adopted by slack-app. Typed as each module is
 // migrated off its slack-app twin; the marker tracks that remaining work.
+import { McpjamApiError } from "./api-client.js";
+
 const MAX_MESSAGES = 50;
 const MAX_MESSAGE_CHARS = 8_000;
 const MAX_MESSAGE_BYTES = 8_192;
@@ -75,6 +77,22 @@ export class KeyedQueue {
 	}
 }
 
+/**
+ * Module-level shared instances, mirroring the Slack fork this module is
+ * meant to replace.
+ *
+ * `runTurnForEvent`'s `dedupe`/`queue` params default to a FRESH instance per
+ * call unless a caller injects one — which means dedupe and per-conversation
+ * serialization silently do nothing for any caller that does not know to
+ * share an instance across its own calls. That is not a safe default for a
+ * module whose whole job is dedupe and serialization. Exporting one shared
+ * pair and defaulting to THEM restores "just works" for a single-process
+ * surface, while a caller that genuinely wants isolation (tests, multiple
+ * independent bots in one process) can still pass its own.
+ */
+export const dedupe = new EventDedupe();
+export const queue = new KeyedQueue();
+
 /** @param {Array<Record<string,any>>} raw @param {{triggerMessageId?:string,triggerTimestampMs?:number,botUserId?:string}} opts */
 export function normalizeEnvelope(raw, opts) {
 	const triggerMs = opts.triggerTimestampMs;
@@ -119,7 +137,16 @@ export function normalizeEnvelope(raw, opts) {
 	return recent;
 }
 
-/** Compatibility name used by the Slack adapter and characterization tests. */
+/**
+ * Compatibility name — the Slack adapter's entry point once it migrates onto
+ * this core (see slack-app/agent/turn-runner.js, which currently has its own
+ * copy). Slack's ts values are its own unit: a decimal-seconds string, not
+ * milliseconds. `opts.triggerTs` is translated here for the same reason each
+ * row's own `ts` is translated below — a caller that passes `triggerTs`
+ * without this translation would have the newer-than-trigger cutoff in
+ * `normalizeEnvelope` silently never fire, because `triggerTimestampMs` would
+ * stay undefined.
+ */
 export function normalizeThreadMessages(raw, opts = {}) {
 	return normalizeEnvelope(
 		raw.map((message) => ({
@@ -143,82 +170,135 @@ export function normalizeThreadMessages(raw, opts = {}) {
 						? Boolean(message.bot_id)
 						: undefined,
 		})),
-		opts,
+		{
+			...opts,
+			triggerTimestampMs:
+				opts.triggerTimestampMs ??
+				(opts.triggerTs ? Number.parseFloat(opts.triggerTs) * 1000 : undefined),
+		},
 	);
 }
 
-/** @param {{fetchHistory:(args:any)=>Promise<any[]>,delivery:any,apiClient:any,eventClaims?:any,ctx:any,conversationId:string,threadId?:string,triggerMessageId:string,triggerTimestampMs?:number,fallbackText:string,eventId?:string,botUserId?:string,onStart?:()=>Promise<void>,onResult:(result:any)=>Promise<void>,onReplay?:(result:any)=>Promise<void>,dedupe?:EventDedupe,queue?:KeyedQueue}} args */
+/**
+ * Claim an event, run its turn inside a per-conversation queue, and finish
+ * the durable claim according to what provably happened.
+ *
+ * `dedupe`/`queue` default to the module-level shared instances above, NOT a
+ * fresh instance per call — see the comment on those exports.
+ *
+ * `queueKey`, if given, overrides the default
+ * `${tenantId}:${conversationId}:${threadId || "root"}` serialization key.
+ * Slack needs this: its `threadTs` is populated even for a top-level DM
+ * message (it is set to that message's own ts by convention), so `threadId ||
+ * "root"` cannot tell "a real thread" from "no thread" the way Discord's
+ * `undefined` can — an adapter that always has SOME truthy threadId needs to
+ * say so itself.
+ *
+ * @param {{fetchHistory:(args:any)=>Promise<any[]>,delivery:any,apiClient:any,eventClaims?:any,ctx:any,conversationId:string,threadId?:string,triggerMessageId:string,triggerTimestampMs?:number,fallbackText:string,eventId?:string,botUserId?:string,queueKey?:string,onStart?:()=>Promise<void>,onResult:(result:any)=>Promise<void>,onReplay?:(result:any)=>Promise<void>,dedupe?:EventDedupe,queue?:KeyedQueue}} args
+ */
 export async function runTurnForEvent(args) {
-	const dedupe = args.dedupe || new EventDedupe();
-	const queue = args.queue || new KeyedQueue();
+	const claimDedupe = args.dedupe || dedupe;
+	const claimQueue = args.queue || queue;
 	const eventKey = `${args.ctx.tenantId}:${args.conversationId}:${args.triggerMessageId}`;
-	if (!dedupe.claim(eventKey)) return false;
+	if (!claimDedupe.claim(eventKey)) return false;
 	const dedupeKey = args.eventId
 		? `${args.ctx.tenantId}:${args.eventId}`
 		: eventKey;
+	const conversationKey =
+		args.queueKey ??
+		`${args.ctx.tenantId}:${args.conversationId}:${args.threadId || "root"}`;
 	let durable = null;
 	if (args.eventClaims?.hasClaimBackend?.()) {
-		durable = await args.eventClaims.claimEvent(dedupeKey);
+		try {
+			durable = await args.eventClaims.claimEvent(dedupeKey);
+		} catch (error) {
+			// FAIL CLOSED. Treating an unreachable claim backend as "you own it"
+			// turns one delivery into two billed turns — the exact failure the
+			// claim exists to prevent. Release the in-memory claim so a retry
+			// against a healthy backend can still run, and drop this delivery.
+			claimDedupe.release(eventKey);
+			throw error;
+		}
 		if (durable.outcome === "inflight") {
-			dedupe.complete(eventKey);
+			claimDedupe.complete(eventKey);
 			return false;
 		}
 		if (durable.outcome === "completed") {
-			if (durable.resultEnvelope && args.onReplay)
-				await queue.enqueue(
-					`${args.ctx.tenantId}:${args.conversationId}:${args.threadId || "root"}`,
-					() => args.onReplay(normalizeResult(durable.resultEnvelope)),
-				);
-			dedupe.complete(eventKey);
+			if (durable.resultEnvelope && args.onReplay) {
+				try {
+					await claimQueue.enqueue(conversationKey, () =>
+						args.onReplay(normalizeResult(durable.resultEnvelope)),
+					);
+				} catch (error) {
+					// The stored answer never reached the surface. RELEASE the
+					// in-memory claim so the next redelivery can try again, rather
+					// than being suppressed for the whole TTL with nothing posted.
+					claimDedupe.release(eventKey);
+					throw error;
+				}
+			}
+			claimDedupe.complete(eventKey);
 			return false;
 		}
 	}
 	try {
 		await args.onStart?.();
 	} catch (error) {
-		dedupe.release(eventKey);
+		claimDedupe.release(eventKey);
 		if (durable) await args.eventClaims.releaseEvent(dedupeKey).catch(() => {});
 		throw error;
 	}
 	const state = { dispatched: false, started: false, result: null };
 	try {
-		await queue.enqueue(
-			`${args.ctx.tenantId}:${args.conversationId}:${args.threadId || "root"}`,
-			async () => {
-				let history = normalizeEnvelope(
-					await args.fetchHistory({
-						conversationId: args.conversationId,
-						threadId: args.threadId,
-						triggerMessageId: args.triggerMessageId,
-						limit: MAX_MESSAGES,
-					}),
-					{
-						triggerMessageId: args.triggerMessageId,
-						triggerTimestampMs: args.triggerTimestampMs,
-						botUserId: args.botUserId,
-					},
-				);
-				if (!history.length)
-					history = [{ role: "user", content: args.fallbackText }];
-				state.dispatched = true;
-				const result = await args.apiClient.runAgentTurn(history, args.ctx, {
-					idempotencyKey: dedupeKey,
+		await claimQueue.enqueue(conversationKey, async () => {
+			let history = normalizeEnvelope(
+				await args.fetchHistory({
 					conversationId: args.conversationId,
-				});
-				state.result = result;
-				state.started = true;
-				await args.onResult(result);
-				if (durable)
-					await args.eventClaims
-						.completeEvent(dedupeKey, result)
-						.catch(() => {});
-			},
-		);
-		dedupe.complete(eventKey);
+					threadId: args.threadId,
+					triggerMessageId: args.triggerMessageId,
+					limit: MAX_MESSAGES,
+				}),
+				{
+					triggerMessageId: args.triggerMessageId,
+					triggerTimestampMs: args.triggerTimestampMs,
+					botUserId: args.botUserId,
+				},
+			);
+			if (!history.length)
+				history = [{ role: "user", content: args.fallbackText }];
+			state.dispatched = true;
+			const result = await args.apiClient.runAgentTurn(history, args.ctx, {
+				idempotencyKey: dedupeKey,
+				conversationId: args.conversationId,
+			});
+			state.result = result;
+			state.started = true;
+			await args.onResult(result);
+			// Store only the shape the replay path reads, not `result` verbatim:
+			// the stored envelope is a persisted contract, and it must not silently
+			// change every time the API client's return type gains or drops a
+			// field.
+			if (durable)
+				await args.eventClaims
+					.completeEvent(dedupeKey, normalizeResult(result))
+					.catch(() => {});
+		});
+		claimDedupe.complete(eventKey);
 		return true;
 	} catch (error) {
-		if (!state.dispatched) {
-			dedupe.release(eventKey);
+		// Pre-network failures — credential/config resolution inside the API
+		// client, before any request left the process — are provably NOT server
+		// work. Identified by a client-thrown code with NO http status (a real
+		// 401 carries one); finalizing them would replay "it failed" for the
+		// claim's full TTL after an operator fixes the config that caused it.
+		const preflightFailure =
+			error instanceof McpjamApiError &&
+			error.status === undefined &&
+			(error.code === "CONFIG" ||
+				error.code === "NO_PROJECT" ||
+				error.code === "UNAUTHORIZED");
+		if (!state.dispatched || preflightFailure) {
+			claimDedupe.release(eventKey);
 			if (durable)
 				await args.eventClaims.releaseEvent(dedupeKey).catch(() => {});
 			throw error;
@@ -227,13 +307,14 @@ export async function runTurnForEvent(args) {
 			const details = error?.details || {};
 			const envelope = {
 				reply:
-					error?.structuredContent?.parts?.[0] ||
-					"Something went wrong running that turn. Ask again to retry.",
+					error instanceof McpjamApiError
+						? error.friendlyMessage
+						: "Something went wrong running that turn. Ask again to retry.",
 				toolCalls: [],
 				createdResources: details.createdResources || [],
 				proposedActions: details.proposedActions || [],
 			};
-			dedupe.complete(eventKey);
+			claimDedupe.complete(eventKey);
 			if (durable)
 				await args.eventClaims
 					.completeEvent(dedupeKey, envelope)
@@ -241,10 +322,10 @@ export async function runTurnForEvent(args) {
 			error.failureEnvelope = envelope;
 			throw error;
 		}
-		dedupe.complete(eventKey);
+		claimDedupe.complete(eventKey);
 		if (durable && state.result)
 			await args.eventClaims
-				.completeEvent(dedupeKey, state.result)
+				.completeEvent(dedupeKey, normalizeResult(state.result))
 				.catch(() => {});
 		throw error;
 	}

--- a/surface-core/tests/turn-runner-correctness.test.js
+++ b/surface-core/tests/turn-runner-correctness.test.js
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	dedupe,
+	EventDedupe,
+	KeyedQueue,
+	McpjamApiError,
+	normalizeThreadMessages,
+	runTurnForEvent,
+} from "../src/index.js";
+
+/**
+ * These pin correctness properties the Slack fork (slack-app/agent/turn-runner.js)
+ * has always had and this core's `runTurnForEvent` did not: what happens when
+ * the durable-claim backend is unreachable, when a replay fails to post, and
+ * which failures release a claim versus finalize it. All three matter because
+ * this function is a durable claim state machine — getting the wrong exit
+ * either double-bills a turn or silences an event forever.
+ */
+
+const CTX = { tenantId: "guild-1" };
+
+function baseArgs(overrides = {}) {
+	return {
+		ctx: CTX,
+		conversationId: "conv-1",
+		triggerMessageId: "trigger-1",
+		fallbackText: "hi",
+		fetchHistory: async () => [],
+		apiClient: {
+			runAgentTurn: async () => ({
+				reply: "done",
+				toolCalls: [],
+				createdResources: [],
+				proposedActions: [],
+			}),
+		},
+		onResult: async () => {},
+		dedupe: new EventDedupe(),
+		queue: new KeyedQueue(),
+		...overrides,
+	};
+}
+
+test("an unreachable claim backend releases the in-memory claim and rethrows (fail closed)", async () => {
+	const localDedupe = new EventDedupe();
+	const args = baseArgs({
+		dedupe: localDedupe,
+		eventClaims: {
+			hasClaimBackend: () => true,
+			claimEvent: async () => {
+				throw new Error("backend down");
+			},
+		},
+	});
+	await assert.rejects(() => runTurnForEvent(args), /backend down/);
+	// Released, not left in-flight: a retry against a healthy backend must be
+	// able to claim this same event again, or the outage silences it forever.
+	assert.equal(localDedupe.claim("guild-1:conv-1:trigger-1"), true);
+});
+
+test("a replay that fails to post releases the claim instead of burning the redelivery", async () => {
+	const localDedupe = new EventDedupe();
+	const args = baseArgs({
+		dedupe: localDedupe,
+		onReplay: async () => {
+			throw new Error("post failed");
+		},
+		eventClaims: {
+			hasClaimBackend: () => true,
+			claimEvent: async () => ({
+				outcome: "completed",
+				resultEnvelope: { reply: "stored answer" },
+			}),
+		},
+	});
+	await assert.rejects(() => runTurnForEvent(args), /post failed/);
+	assert.equal(localDedupe.claim("guild-1:conv-1:trigger-1"), true);
+});
+
+test("a pre-network CONFIG error releases the claim rather than finalizing a stale failure", async () => {
+	const localDedupe = new EventDedupe();
+	const completed = [];
+	const args = baseArgs({
+		dedupe: localDedupe,
+		apiClient: {
+			runAgentTurn: async () => {
+				throw new McpjamApiError("missing credentials", { code: "CONFIG" });
+			},
+		},
+		eventClaims: {
+			hasClaimBackend: () => true,
+			claimEvent: async () => ({ outcome: "claimed" }),
+			completeEvent: async (key, envelope) => completed.push({ key, envelope }),
+			releaseEvent: async () => {},
+		},
+	});
+	await assert.rejects(() => runTurnForEvent(args), /missing credentials/);
+	// Not finalized: an operator fixing the env var must not find the claim
+	// still answering every redelivery with a stored failure for the next 72h.
+	assert.equal(completed.length, 0);
+	assert.equal(localDedupe.claim("guild-1:conv-1:trigger-1"), true);
+});
+
+test("a genuine post-dispatch failure (an HTTP status) is finalized, not released", async () => {
+	// Contrast case for the one above: this error carries a status, so it is
+	// proof a request reached the server — releasing here would let a
+	// redelivery re-run a turn that may have already been billed.
+	const localDedupe = new EventDedupe();
+	const completed = [];
+	const args = baseArgs({
+		dedupe: localDedupe,
+		apiClient: {
+			runAgentTurn: async () => {
+				throw new McpjamApiError("server exploded", {
+					code: "SERVER_UNREACHABLE",
+					status: 500,
+				});
+			},
+		},
+		eventClaims: {
+			hasClaimBackend: () => true,
+			claimEvent: async () => ({ outcome: "claimed" }),
+			completeEvent: async (key, envelope) => completed.push({ key, envelope }),
+			releaseEvent: async () => {
+				throw new Error("must not be called on this path");
+			},
+		},
+	});
+	await assert.rejects(() => runTurnForEvent(args), /server exploded/);
+	assert.equal(completed.length, 1);
+	assert.equal(
+		completed[0].envelope.reply,
+		"I can't reach MCPJam right now. Try again in a moment.",
+	);
+});
+
+test("the stored envelope on success is exactly the four fields, not the raw API result", async () => {
+	const completed = [];
+	const args = baseArgs({
+		apiClient: {
+			runAgentTurn: async () => ({
+				reply: "done",
+				toolCalls: [{ name: "x" }],
+				createdResources: [],
+				proposedActions: [],
+				// Fields a future API response might add — must not leak into the
+				// persisted contract.
+				usage: { tokens: 500 },
+				requestId: "req_123",
+			}),
+		},
+		eventClaims: {
+			hasClaimBackend: () => true,
+			claimEvent: async () => ({ outcome: "claimed" }),
+			completeEvent: async (_key, envelope) => completed.push(envelope),
+		},
+	});
+	await runTurnForEvent(args);
+	assert.deepEqual(completed[0], {
+		reply: "done",
+		toolCalls: [{ name: "x" }],
+		createdResources: [],
+		proposedActions: [],
+	});
+});
+
+test("queueKey lets a caller override the default thread-vs-DM key", async () => {
+	// Slack's threadTs is populated even for a top-level DM (it is the message's
+	// own ts), so `threadId || 'root'` alone cannot tell a real thread from a DM
+	// the way Discord's `undefined` can. A caller in that position must be able
+	// to say so itself.
+	const order = [];
+	const sharedQueue = new KeyedQueue();
+	const make = (id, queueKey) =>
+		baseArgs({
+			ctx: CTX,
+			triggerMessageId: id,
+			queue: sharedQueue,
+			dedupe: new EventDedupe(),
+			queueKey,
+			fetchHistory: async () => {
+				order.push(`start:${id}`);
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return [];
+			},
+			onResult: async () => order.push(`done:${id}`),
+		});
+	await Promise.all([
+		runTurnForEvent(make("a", "same-key")),
+		runTurnForEvent(make("b", "same-key")),
+	]);
+	// Same explicit queueKey: strictly serialized, so "a" finishes before "b"
+	// starts.
+	assert.deepEqual(order, ["start:a", "done:a", "start:b", "done:b"]);
+});
+
+test("the module-level dedupe/queue are the default — a caller that injects neither still dedupes", async () => {
+	dedupe.clear();
+	let calls = 0;
+	const args = {
+		ctx: { tenantId: "shared-test-tenant" },
+		conversationId: "conv-shared",
+		triggerMessageId: "trigger-shared",
+		fallbackText: "hi",
+		fetchHistory: async () => [],
+		apiClient: {
+			runAgentTurn: async () => {
+				calls += 1;
+				return {
+					reply: "ok",
+					toolCalls: [],
+					createdResources: [],
+					proposedActions: [],
+				};
+			},
+		},
+		onResult: async () => {},
+		// Deliberately NOT passing dedupe/queue — this must still work.
+	};
+	const [first, second] = await Promise.all([
+		runTurnForEvent(args),
+		runTurnForEvent({ ...args }),
+	]);
+	assert.equal(first, true);
+	assert.equal(second, false);
+	assert.equal(calls, 1);
+	dedupe.clear();
+});
+
+test("normalizeThreadMessages translates Slack's triggerTs so the newer-than-trigger cutoff actually fires", () => {
+	const messages = normalizeThreadMessages(
+		[
+			{ user: "U1", ts: "1700000000.000000", text: "before the trigger" },
+			{ user: "U1", ts: "1700000002.000000", text: "after the trigger" },
+		],
+		{ triggerTs: "1700000001.000000" },
+	);
+	assert.deepEqual(messages, [{ role: "user", content: "before the trigger" }]);
+});


### PR DESCRIPTION
## Context

`surface-core/src/turn-runner.js` is meant to eventually replace
`slack-app/agent/turn-runner.js` (532 lines), the fork Slack has run in
production since before this package existed. Nothing calls the core's
`runTurnForEvent` in production today — `discord-app` uses the thin
`runTurn` adapter — so this catches the core up on correctness **before**
anything depends on it, rather than transplanting these fixes under time
pressure during the eventual Slack swap.

Comparing the two side by side, the core wasn't a reduction of the fork —
it was an independent reimplementation that quietly dropped every hard-won
correctness property.

## What changed, and why each one is load-bearing

**Fail-closed on an unreachable claim backend.** `claimEvent` was called
bare; a network error would leave the in-memory dedupe claim held with no
durable claim ever recorded, silencing every redelivery of that event for
the dedupe TTL. Now: release + rethrow, so a retry against a healthy backend
can still run.

**A failed replay now releases too.** If the stored answer for a completed
turn fails to post, the in-memory claim is released so the next redelivery
tries again — instead of burning the delivery with nothing ever reaching
the user.

**Pre-network failures take the release path.** `CONFIG`/`NO_PROJECT`/
`UNAUTHORIZED` errors with no HTTP status are provably credential/config
resolution failures that happened before any request left the process. The
core used to finalize these as a stored failure — which meant fixing a
missing env var still replayed "it failed" to every redelivery for the
claim's full TTL. Contrast case pinned by test: an error that *does* carry
a status (proof a request reached the server) still finalizes, since
releasing there could double-run an already-billed turn.

**`dedupe`/`queue` default to shared instances, not one-per-call.** The old
default (`args.dedupe || new EventDedupe()`) meant dedupe silently did
nothing for any caller that didn't know to inject a shared instance across
its own calls — a landmine for whoever adopts this next. Now the module
exports one shared `dedupe`/`queue` pair, mirroring the fork.

**The stored envelope is an explicit 4-field pick**, not the raw API client
result — so the persisted contract doesn't silently reshape itself whenever
the API response gains a field.

**A new `queueKey` override.** Discord's `threadId` is `undefined` outside
a real thread; Slack's `threadTs` is always populated (it's the message's
own ts for a top-level DM). The default `threadId || "root"` key can't
express that distinction for an adapter like Slack's — `queueKey` lets one
say so explicitly, without the core needing to know about either surface.

**`normalizeThreadMessages` (the documented Slack entry point) now
translates `triggerTs`.** It previously accepted the option but never used
it, so a caller passing Slack-shaped `{triggerTs}` got no
`triggerTimestampMs` and the newer-than-trigger cutoff silently never
fired.

## Scope

`slack-app` and `discord-app` are untouched. This only prepares the core;
neither surface's behavior changes.

## Tests

8 new tests in `surface-core/tests/turn-runner-correctness.test.js`, each
pinning one property above (including the release-vs-finalize contrast
pair, the `queueKey` serialization order, and the triggerTs translation).
`npm run verify -w @mcpjam/surface-core` — 38/38 tests, typecheck, lint,
all green. `verify` also re-confirmed green for `slack-app` and
`discord-app` (unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core turn orchestration and durable-claim state machine logic that will gate billing and redelivery once surfaces adopt it; mitigated by new tests and no production callers yet.
> 
> **Overview**
> Brings **`runTurnForEvent`** in `surface-core` up to the durable-claim behavior the Slack fork already had, ahead of any production cutover.
> 
> **Claim and dedupe defaults:** Exports shared module-level **`dedupe`** / **`queue`** and uses them by default instead of a new instance per call, so in-process dedupe and per-conversation serialization work without injection. Adds optional **`queueKey`** for surfaces (e.g. Slack) where `threadId || "root"` is not enough.
> 
> **Fail-closed paths:** **`claimEvent`** errors release the in-memory claim and rethrow. Failed **`onReplay`** posts also release so redelivery can retry. Pre-network **`McpjamApiError`** codes (`CONFIG`, `NO_PROJECT`, `UNAUTHORIZED` with no HTTP status) release instead of persisting a failure; errors with a status still finalize to avoid double-billing.
> 
> **Persistence contract:** Durable **`completeEvent`** stores **`normalizeResult`** (four fields only), passes **`conversationId`** into **`runAgentTurn`**, and uses **`McpjamApiError.friendlyMessage`** for failure envelopes. **`normalizeThreadMessages`** now maps Slack **`triggerTs`** to **`triggerTimestampMs`** so the newer-than-trigger filter works.
> 
> Eight new tests in **`turn-runner-correctness.test.js`** lock these behaviors. Slack and Discord apps are unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89718ba1706953270964e8dd2136ebdd2ba42c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings `runTurnForEvent` up to the Slack fork’s correctness so durable claims are safe and redeliveries behave correctly. Core-only change with new tests; `slack-app` and `discord-app` are unchanged.

- **Bug Fixes**
  - Durable-claim safety: fail-closed on unreachable claim backend; release the in-memory claim when a replay post fails.
  - Correct release vs finalize: release on pre-network `CONFIG`/`NO_PROJECT`/`UNAUTHORIZED` errors; finalize only when an HTTP status proves server work.
  - Stable behavior and replay: default to shared `dedupe`/`queue`; persist only the 4-field result envelope; `normalizeThreadMessages` now translates `triggerTs` to `triggerTimestampMs`.

- **New Features**
  - `queueKey` option to override the per-conversation serialization key (needed for Slack’s always-populated thread id).

<sup>Written for commit 89718ba1706953270964e8dd2136ebdd2ba42c03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

