### PR TITLE
feat(surface-core): channel-binding cache, wired into Discord's resolver (B2)

### DIFF
--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -2,6 +2,7 @@
 import {
 	createApiClient,
 	createBackendClient,
+	createChannelBindingCache,
 	createEventClaims,
 	createTurnTargetResolver,
 	mintConnectUrl,
@@ -73,10 +74,18 @@ const claims = createEventClaims({
 	backend: claimBackend,
 	surfaceKind: "discord",
 });
+// Every mention asks whether its channel is bound, which put a Convex round
+// trip on the hot path of every single message with no caching at all.
+// Channel bindings are written by an admin through a separate settings flow,
+// not by the turn reading one, so caching (including a "no binding" answer —
+// the common case) is safe. See channel-binding-cache.js for why this does
+// not also cover thread bindings.
+const channelBindingCache = createChannelBindingCache();
 const resolveTurnTarget = createTurnTargetResolver({
 	backend: claimBackend,
 	hasPerUserAuth: () => Boolean(config.convexServiceToken),
 	legacyProjectId: () => config.legacyProjectId,
+	channelBindingCache,
 });
 
 const api = createApiClient({
@@ -134,12 +143,16 @@ client.on(Events.GuildCreate, (guild) =>
 		`presence installed (${guild.id})`,
 	),
 );
-client.on(Events.GuildDelete, (guild) =>
+client.on(Events.GuildDelete, (guild) => {
+	// A removed-then-reinstalled guild may come back under a DIFFERENT org.
+	// Without this, the first minute of turns after reinstall could still be
+	// routed by channel bindings written for the org that just left.
+	channelBindingCache.clearTenant(`discord:${guild.id}:`);
 	detach(
 		recordPresence({ tenantId: guild.id, status: "removed" }),
 		`presence removed (${guild.id})`,
-	),
-);
+	);
+});
 
 // ── /mcpjam connect ─────────────────────────────────────────────────────────
 

--- a/surface-core/src/channel-binding-cache.js
+++ b/surface-core/src/channel-binding-cache.js
@@ -1,0 +1,135 @@
+// @ts-nocheck — not yet adopted by slack-app. Typed as each module is
+// migrated off its slack-app twin; the marker tracks that remaining work.
+
+/**
+ * TTL cache for channel→project bindings, extracted from the correctness
+ * properties slack-app/agent/binding-cache.js has carried in production.
+ *
+ * Every turn in a channel asks whether that channel is bound, which puts a
+ * backend round trip on the hot path of every single message. A short TTL
+ * takes it off that path without making a stale binding interesting: the
+ * org-settings UI that writes these already promises changes take effect
+ * within a minute, so caching for that same window costs nothing new.
+ *
+ * NEGATIVES ARE CACHED, deliberately. Most channels have no binding, so a
+ * cache that refused to remember "no binding here" would do nothing for the
+ * traffic that needs it most — the common case, not the rare one. This is
+ * safe specifically BECAUSE a channel binding is written by an admin through
+ * a separate settings flow, never by the turn that is reading it: there is
+ * no same-request write-then-stale-read race to worry about the way there
+ * would be for a THREAD binding, which the reading turn may itself go on to
+ * create a moment later. (That coupling is why this module does not also
+ * cover thread bindings — see the note on `resolveTurnTarget` in
+ * `turn-target.js`.)
+ *
+ * Process-local. A surface that runs more than one replica of the same
+ * process needs a shared cache or none at all; nothing here coordinates
+ * across processes.
+ */
+
+const DEFAULT_TTL_MS = 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 5000;
+
+/**
+ * @typedef {Object} ChannelBindingCache
+ * @property {(key: string) => any} get Cached value, or `undefined` for a
+ *   miss. `null` is a real cached answer ("no binding") — callers must
+ *   distinguish it from `undefined` ("never asked, or expired").
+ * @property {(key: string, value: any) => void} set
+ * @property {(key: string, read: () => Promise<any>) => Promise<any>} coalesce
+ *   Share one in-flight read per key, then cache its result — unless a
+ *   `clearTenant` invalidated that exact read while it was in flight.
+ * @property {(prefix: string) => void} clearTenant Drop every cached AND
+ *   in-flight entry whose key starts with `prefix`.
+ * @property {() => number} size
+ */
+
+/**
+ * @param {{ttlMs?: number, maxEntries?: number}} [options]
+ * @returns {ChannelBindingCache}
+ */
+export function createChannelBindingCache(options = {}) {
+	const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+	const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+
+	/** @type {Map<string, {value: any, expiresAt: number}>} */
+	const cache = new Map();
+	/**
+	 * Reads currently in flight, keyed the same way as the cache. Two turns
+	 * racing in the same channel — the common cold-start burst — would
+	 * otherwise each make a round trip, and the SLOWER answer could land last
+	 * and overwrite a value that was already correct. Sharing one promise
+	 * removes both the duplicate call and the race.
+	 * @type {Map<string, Promise<any>>}
+	 */
+	const inflight = new Map();
+
+	/**
+	 * Drop expired entries, then oldest-first down to the bound. Only runs
+	 * when the map is actually near its bound: this executes on every write,
+	 * and the whole point of this cache is to stay off the turn's hot path,
+	 * so an unconditional full-map walk on every insert would defeat it.
+	 */
+	function evictIfNeeded() {
+		if (cache.size <= maxEntries) return;
+		const now = Date.now();
+		for (const [key, entry] of cache) {
+			if (entry.expiresAt <= now) cache.delete(key);
+		}
+		if (cache.size <= maxEntries) return;
+		const byExpiry = [...cache.entries()].sort(
+			(a, b) => a[1].expiresAt - b[1].expiresAt,
+		);
+		for (const [key] of byExpiry.slice(0, cache.size - maxEntries))
+			cache.delete(key);
+	}
+
+	function get(key) {
+		const hit = cache.get(key);
+		if (!hit) return undefined;
+		if (hit.expiresAt <= Date.now()) {
+			cache.delete(key);
+			return undefined;
+		}
+		return hit.value;
+	}
+
+	function set(key, value) {
+		cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+		evictIfNeeded();
+	}
+
+	function coalesce(key, read) {
+		const existing = inflight.get(key);
+		if (existing) return existing;
+		const pending = read()
+			.then((value) => {
+				// Only cache if this exact read was not invalidated by a
+				// clearTenant while it was running — otherwise a purge could be
+				// raced by an in-flight read for the workspace that just left,
+				// repopulating the cache with the departing tenant's answer.
+				if (inflight.get(key) === pending) set(key, value);
+				return value;
+			})
+			.finally(() => {
+				if (inflight.get(key) === pending) inflight.delete(key);
+			});
+		inflight.set(key, pending);
+		return pending;
+	}
+
+	function clearTenant(prefix) {
+		for (const key of cache.keys())
+			if (key.startsWith(prefix)) cache.delete(key);
+		for (const key of inflight.keys())
+			if (key.startsWith(prefix)) inflight.delete(key);
+	}
+
+	return {
+		get,
+		set,
+		coalesce,
+		clearTenant,
+		size: () => cache.size,
+	};
+}

--- a/surface-core/src/index.js
+++ b/surface-core/src/index.js
@@ -1,5 +1,6 @@
 export * from "./api-client.js";
 export * from "./backend-client.js";
+export * from "./channel-binding-cache.js";
 export * from "./connect-link.js";
 export * from "./copy.js";
 export * from "./event-claims.js";

--- a/surface-core/src/turn-target.js
+++ b/surface-core/src/turn-target.js
@@ -22,12 +22,30 @@
  *   surfaceKind: string,
  *   hasPerUserAuth?: () => boolean,
  *   legacyProjectId?: () => string | undefined,
+ *   channelBindingCache?: import('./channel-binding-cache.js').ChannelBindingCache,
  * }} options
  */
 export function createTurnTargetResolver(options) {
 	const hasAuth = options.hasPerUserAuth || (() => true);
 	const legacyProjectId =
 		options.legacyProjectId || (() => process.env.MCPJAM_PROJECT_ID);
+	// Channel bindings are written by an admin through a separate settings
+	// flow, never by the turn that reads one — so unlike a thread binding,
+	// there is no same-request write-then-stale-read race, and caching (INCLUDING
+	// negatives, the common case: most channels have none) is safe. Optional:
+	// a caller that supplies no cache gets the prior uncached behavior exactly.
+	const channelBindingCache = options.channelBindingCache;
+	/** @param {any} ctx @param {string} conversationId @param {{fetchImpl?: typeof fetch}} opts */
+	const fetchChannelBinding = (ctx, conversationId, opts) => {
+		const read = () =>
+			options.backend.fetchChannelBinding(ctx, conversationId, opts);
+		if (!channelBindingCache) return read();
+		const key = `${options.surfaceKind}:${ctx.tenantId}:${conversationId}`;
+		const cached = channelBindingCache.get(key);
+		return cached !== undefined
+			? Promise.resolve(cached)
+			: channelBindingCache.coalesce(key, read);
+	};
 
 	/**
 	 * @param {any} ctx
@@ -80,7 +98,7 @@ export function createTurnTargetResolver(options) {
 		// exactly the channels an org configured to be frictionless.
 		const [channelBinding, link] = await Promise.all([
 			conversationId && options.backend.fetchChannelBinding
-				? options.backend.fetchChannelBinding(ctx, conversationId, opts)
+				? fetchChannelBinding(ctx, conversationId, opts)
 				: Promise.resolve(null),
 			options.backend.fetchAccountLink(ctx, opts),
 		]);

--- a/surface-core/tests/channel-binding-cache.test.js
+++ b/surface-core/tests/channel-binding-cache.test.js
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createChannelBindingCache } from "../src/channel-binding-cache.js";
+import { createTurnTargetResolver } from "../src/turn-target.js";
+
+describe("channel binding cache", () => {
+	it('distinguishes a cached "no binding" (null) from a miss (undefined)', () => {
+		const cache = createChannelBindingCache();
+		assert.equal(cache.get("k1"), undefined);
+		cache.set("k1", null);
+		assert.equal(cache.get("k1"), null);
+	});
+
+	it("keys are independent", () => {
+		const cache = createChannelBindingCache();
+		cache.set("discord:g1:c1", { projectId: "p1" });
+		assert.equal(cache.get("discord:g1:c2"), undefined);
+	});
+
+	it("expires an entry at its TTL", (t) => {
+		t.mock.timers.enable({ apis: ["Date"] });
+		try {
+			const cache = createChannelBindingCache({ ttlMs: 60_000 });
+			cache.set("k1", { projectId: "p1" });
+			t.mock.timers.tick(61_000);
+			assert.equal(cache.get("k1"), undefined);
+		} finally {
+			t.mock.timers.reset();
+		}
+	});
+
+	it("stays bounded under unboundedly many keys", () => {
+		const cache = createChannelBindingCache({ maxEntries: 100 });
+		for (let i = 0; i < 150; i += 1) cache.set(`k${i}`, null);
+		assert.ok(cache.size() <= 100);
+	});
+
+	it("coalesces concurrent reads into one call", async () => {
+		const cache = createChannelBindingCache();
+		let calls = 0;
+		const read = async () => {
+			calls += 1;
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			return { projectId: "p1" };
+		};
+		const [a, b] = await Promise.all([
+			cache.coalesce("k1", read),
+			cache.coalesce("k1", read),
+		]);
+		assert.equal(calls, 1);
+		assert.deepEqual(a, b);
+		assert.deepEqual(cache.get("k1"), { projectId: "p1" });
+	});
+
+	it("does NOT cache a read that rejects — an outage is not an answer", async () => {
+		const cache = createChannelBindingCache();
+		await assert.rejects(
+			() => cache.coalesce("k1", async () => Promise.reject(new Error("down"))),
+			/down/,
+		);
+		assert.equal(cache.get("k1"), undefined);
+		// A retry after the outage must not be suppressed by a bad cached value.
+		let calls = 0;
+		await cache.coalesce("k1", async () => {
+			calls += 1;
+			return null;
+		});
+		assert.equal(calls, 1);
+	});
+
+	it("clearTenant drops cached entries by prefix, leaving other tenants alone", () => {
+		const cache = createChannelBindingCache();
+		cache.set("discord:g1:c1", { projectId: "p1" });
+		cache.set("discord:g2:c1", { projectId: "p2" });
+		cache.clearTenant("discord:g1:");
+		assert.equal(cache.get("discord:g1:c1"), undefined);
+		assert.deepEqual(cache.get("discord:g2:c1"), { projectId: "p2" });
+	});
+
+	it("clearTenant also drops an in-flight read, so it cannot repopulate the cache for a tenant that just left", async () => {
+		const cache = createChannelBindingCache();
+		let resolveRead;
+		const pending = cache.coalesce(
+			"discord:g1:c1",
+			() => new Promise((resolve) => (resolveRead = resolve)),
+		);
+		cache.clearTenant("discord:g1:");
+		resolveRead({ projectId: "stale-org's-project" });
+		await pending;
+		// The read that was in flight during the purge must not have cached its
+		// answer — that answer belongs to the org that just disconnected.
+		assert.equal(cache.get("discord:g1:c1"), undefined);
+	});
+});
+
+describe("createTurnTargetResolver wired to a channel binding cache", () => {
+	function backendReturning(channelBinding, link) {
+		let channelBindingCalls = 0;
+		return {
+			calls: () => channelBindingCalls,
+			backend: {
+				fetchThreadBinding: async () => null,
+				fetchChannelBinding: async () => {
+					channelBindingCalls += 1;
+					return channelBinding;
+				},
+				fetchAccountLink: async () => link,
+			},
+		};
+	}
+
+	it("asks the backend once for two rapid resolves in the same channel, uncached by default otherwise", async () => {
+		const { backend, calls } = backendReturning(
+			{ organizationId: "org1", projectId: "proj1" },
+			{ organizationId: "org1" },
+		);
+		const cache = createChannelBindingCache();
+		const resolve = createTurnTargetResolver({
+			backend,
+			surfaceKind: "discord",
+			channelBindingCache: cache,
+		});
+		const ctx = { tenantId: "g1" };
+		const [a, b] = await Promise.all([
+			resolve(ctx, { conversationId: "c1" }),
+			resolve(ctx, { conversationId: "c1" }),
+		]);
+		assert.equal(calls(), 1);
+		assert.equal(a.boundChannel, true);
+		assert.equal(b.boundChannel, true);
+	});
+
+	it("without a cache, each resolve asks the backend again (unchanged prior behavior)", async () => {
+		const { backend, calls } = backendReturning(null, {
+			organizationId: "org1",
+		});
+		const resolve = createTurnTargetResolver({
+			backend,
+			surfaceKind: "discord",
+		});
+		const ctx = { tenantId: "g1" };
+		await resolve(ctx, { conversationId: "c1" });
+		await resolve(ctx, { conversationId: "c1" });
+		assert.equal(calls(), 2);
+	});
+});


### PR DESCRIPTION
## Context

Every turn asks "is this channel bound to a project", which puts a Convex
round trip on the hot path of every single message. Slack's fork
(`slack-app/agent/binding-cache.js`) has cached this for a while; the twin
`surface-core` used to have was deleted outright by #3791 (along with the
thread-binding twin), and `discord-app` has never had caching here at all.

This is a **fresh build**, not an upstream — the deleted twin no longer
exists to upstream into.

## What's in `createChannelBindingCache()`

Carries the fork's correctness properties, not just its shape:

- **miss (`undefined`) vs cached-negative (`null`)** are distinguishable.
  Most channels have no binding, so caching that negative answer is what
  makes the cache useful for the traffic that actually needs it — an edge
  case would be caching only positives.
- **Concurrent reads for the same key coalesce** into one backend call, so
  a cold-start burst of two turns in the same channel doesn't double-fetch
  (and the slower answer can't land last and stomp a fresher one).
- **A rejected read is never cached** — an outage is not an answer.
- **A purge landing mid-read is respected**: that read's result, even if it
  resolves after the purge, does not repopulate the cache for a tenant that
  just disconnected.
- **Bounded with a cheap eviction path** — only sweeps when actually near
  the bound, so inserts stay off the O(cache size) path this cache exists
  to avoid in the first place.

## Deliberately scoped to channel bindings, not thread bindings

A channel binding is written by an admin through a separate settings flow
— there's no same-request write-then-stale-read race. A **thread** binding
is written by the *same turn* that may have just read it as unbound (see
`discord-app/conversation.js`'s `ensureThreadBinding`, and Slack's
`run-and-reply.js`). Caching that safely needs write-path invalidation
coupled to each surface's own binding-write call site — which belongs with
whichever piece of surface work touches that path next, not bundled into a
general-purpose cache module. Calling this out explicitly so it doesn't
read as an oversight.

## Wiring

`createTurnTargetResolver` takes an optional `channelBindingCache`;
omitting it preserves the exact prior uncached behavior (pinned by test —
"without a cache, each resolve asks the backend again"). `discord-app` now
constructs one and passes it, and clears it by tenant prefix on
`GuildDelete` — mirroring Slack's purge-on-uninstall: a guild that leaves
and later reinstalls may return under a different org, and a stale cached
binding must not route its first minute of turns using the org that just
left.

`slack-app` is untouched.

## Tests

10 new tests: 8 on the cache module in isolation (miss/negative, TTL,
bounded eviction, coalescing, outage-not-cached, purge-drops-cache,
purge-drops-in-flight), 2 integration tests proving the resolver wiring
(cached → one backend call for two rapid resolves; uncached → unchanged
prior behavior). `npm run verify` green for `surface-core`, `discord-app`,
and `slack-app` (48/48, then 58 total across the suite; typecheck; lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Caching changes turn routing for up to ~60s and is process-local; incorrect invalidation or stale positives could mis-route projects, though admin-only writes and GuildDelete purge limit exposure.
> 
> **Overview**
> Adds **`createChannelBindingCache`** in `surface-core`: a 60s TTL, process-local cache for channel→project bindings with negative caching, in-flight read coalescing, bounded eviction, no caching on failed reads, and **`clearTenant`** so purges cannot be repopulated by stale in-flight fetches.
> 
> **`createTurnTargetResolver`** accepts an optional cache and routes **`fetchChannelBinding`** through it (keys like `discord:{tenantId}:{conversationId}`); omitting the cache keeps the old per-resolve backend behavior.
> 
> **`discord-app`** constructs the cache, passes it into the resolver, and on **`GuildDelete`** clears entries for `discord:{guild.id}:` so a reinstalled guild is not routed with the previous org’s bindings for up to a minute.
> 
> Thread bindings are intentionally **not** cached. Tests cover the cache module and resolver wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7bc2efd21571c0c00e6134a5c27104cf4d0fd36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TTL cache for channel→project bindings in `surface-core` and wires it into `discord-app`’s resolver to remove a backend round trip from every message. Behavior is unchanged if no cache is provided; `slack-app` is untouched.

- **New Features**
  - Added `createChannelBindingCache` (60s TTL, bounded with eviction). Caches positives and negatives (`null`), coalesces concurrent reads, never caches rejects, and supports tenant-scoped purges.
  - `createTurnTargetResolver` accepts an optional `channelBindingCache`; falls back to previous uncached behavior when omitted.
  - `discord-app` now builds the cache, passes it to the resolver, and clears it by tenant on `GuildDelete` to prevent stale routing after re-install.
  - Exported from `surface-core/index.js`; tests cover cache behavior and resolver wiring.

<sup>Written for commit d7bc2efd21571c0c00e6134a5c27104cf4d0fd36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

