### PR TITLE
fix(analytics): bundle PostHog replay/surveys/exception extensions instead of lazy-loading

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/posthog-bundled-extensions.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/posthog-bundled-extensions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { preloadPosthogBundledExtensions } from "../posthog-bundled-extensions";
+
+// Mutable gates so one module instance can be driven through both branches.
+// Order matters below: the skip case must run BEFORE the register case,
+// because once the dist bundles execute they stay in the ESM cache and
+// `__PosthogExtensions__` can never be un-registered.
+const gates = vi.hoisted(() => ({ disabled: false, surface: false }));
+
+vi.mock("../PosthogUtils", () => ({
+  get isPostHogDisabled() {
+    return gates.disabled;
+  },
+  isErrorCaptureSurface: () => gates.surface,
+}));
+
+function registeredExtensions(): Record<string, unknown> | undefined {
+  return (window as unknown as Record<string, unknown>)
+    .__PosthogExtensions__ as Record<string, unknown> | undefined;
+}
+
+describe("preloadPosthogBundledExtensions", () => {
+  it("loads nothing off the error-capture surfaces", async () => {
+    gates.surface = false;
+    gates.disabled = false;
+    await preloadPosthogBundledExtensions();
+    expect(registeredExtensions()).toBeUndefined();
+  });
+
+  it("loads nothing in the dev opt-out branch even on a capture surface", async () => {
+    gates.surface = true;
+    gates.disabled = true;
+    await preloadPosthogBundledExtensions();
+    expect(registeredExtensions()).toBeUndefined();
+  });
+
+  it("registers every extension posthog-js would otherwise fetch from /relay/static", async () => {
+    gates.surface = true;
+    gates.disabled = false;
+    await preloadPosthogBundledExtensions();
+
+    const extensions = registeredExtensions();
+    expect(extensions).toBeDefined();
+    // These keys are exactly what the SDK checks before calling
+    // loadExternalDependency (the remote fetch Railway's edge blocks on
+    // hosted). Same-package bundles mean the keys cannot drift from the SDK.
+    expect(extensions).toMatchObject({
+      rrweb: expect.anything(), // posthog-recorder (session replay)
+      initSessionRecording: expect.anything(),
+      generateSurveys: expect.anything(), // surveys popover
+      errorWrappingFunctions: expect.anything(), // $exception capture
+      initDeadClicksAutocapture: expect.anything(),
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/posthog-bundled-extensions.ts
+++ b/mcpjam-inspector/client/src/lib/posthog-bundled-extensions.ts
@@ -1,0 +1,49 @@
+import { isErrorCaptureSurface, isPostHogDisabled } from "./PosthogUtils";
+
+/**
+ * Compile PostHog's lazy-loaded feature code into our own build instead of
+ * letting posthog-js fetch it at runtime.
+ *
+ * By default the SDK downloads replay (`posthog-recorder.js`), surveys,
+ * exception autocapture, and dead-clicks autocapture from its `api_host` —
+ * which we point at the same-origin `/relay` proxy. On app.mcpjam.com those
+ * `GET /relay/static/*.js` fetches are 403'd by Railway's edge (NOT our
+ * Cloudflare zone — its WAF skip rule is in place and logs Skip events), so
+ * replay, surveys, and exception capture silently never activated on the one
+ * surface they matter most. Events were unaffected: small POSTs to
+ * `/relay/e/` pass the same edge.
+ *
+ * Importing the `posthog-js/dist/*` bundles registers each feature on
+ * `window.__PosthogExtensions__` (`rrweb`/`initSessionRecording`,
+ * `generateSurveys`, `errorWrappingFunctions`,
+ * `initDeadClicksAutocapture`), and the SDK uses a registered extension
+ * instead of calling `loadExternalDependency` — verified against the
+ * installed posthog-js build. Because the bundles ship in the SAME package
+ * version as the SDK consuming them, the registration keys cannot drift.
+ *
+ * Dynamic imports, not static: Vite splits them into chunks served from our
+ * `/assets/` path (which every edge already lets through, or the app itself
+ * wouldn't load), and only the error-capture surfaces pay the download —
+ * npx/Docker installs keep today's lazy loading, which works on their own
+ * origins.
+ *
+ * Must complete BEFORE `PostHogProvider` initializes the SDK: registration is
+ * checked at feature start, and losing the race would fall back to the
+ * blocked remote fetch.
+ */
+export async function preloadPosthogBundledExtensions(): Promise<void> {
+  // The dev opt-out branch runs with replay/exceptions off; fetching four
+  // chunks there would be pure waste.
+  if (isPostHogDisabled || !isErrorCaptureSurface()) return;
+  try {
+    await Promise.all([
+      import("posthog-js/dist/posthog-recorder"),
+      import("posthog-js/dist/surveys"),
+      import("posthog-js/dist/exception-autocapture"),
+      import("posthog-js/dist/dead-clicks-autocapture"),
+    ]);
+  } catch {
+    // Analytics must never block boot. On a failed chunk load posthog-js
+    // falls back to its normal remote lazy loading — no worse than today.
+  }
+}

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { AppRouterProvider } from "./router";
 import "./index.css";
 import { getPostHogKey, getPostHogOptions } from "./lib/PosthogUtils.js";
+import { preloadPosthogBundledExtensions } from "./lib/posthog-bundled-extensions";
 import { PostHogProvider } from "posthog-js/react";
 import { AuthKitProvider } from "@workos-inc/authkit-react";
 import { ConvexReactClient } from "convex/react";
@@ -346,6 +347,12 @@ if (isInIframe) {
       );
       return;
     }
+
+    // Replay/surveys/exception bundles must be REGISTERED before the provider
+    // initializes the SDK, or feature start falls back to the remote fetch
+    // that Railway's edge blocks on hosted — see lib/posthog-bundled-extensions.ts.
+    // No-op (and no chunk download) off the error-capture surfaces.
+    await preloadPosthogBundledExtensions();
 
     root.render(
       <StrictMode>

--- a/mcpjam-inspector/client/src/types/posthog-dist-modules.d.ts
+++ b/mcpjam-inspector/client/src/types/posthog-dist-modules.d.ts
@@ -1,0 +1,9 @@
+// posthog-js ships its lazy-loadable feature bundles as plain dist files with
+// no `exports` map and no type declarations. These side-effect imports only
+// register onto `window.__PosthogExtensions__` (see
+// lib/posthog-bundled-extensions.ts), so an untyped module declaration is the
+// whole contract.
+declare module "posthog-js/dist/posthog-recorder";
+declare module "posthog-js/dist/surveys";
+declare module "posthog-js/dist/exception-autocapture";
+declare module "posthog-js/dist/dead-clicks-autocapture";


### PR DESCRIPTION
## Why

Session replay has never recorded a hosted session. Root cause (established in the Aug 7 quality audit + live probes): posthog-js lazy-loads its feature code from `api_host` at runtime — `GET https://app.mcpjam.com/relay/static/*.js` — and **Railway's edge 403s exactly those requests**. It is not our Cloudflare zone: our WAF skip rule for `/relay/*` is deployed and logs Skip events while the 403 persists, and the block response carries Railway's `x-hikari-trace` header, placing it behind our zone. Event POSTs to `/relay/e/` pass the same edge (thousands/day) — only script downloads are blocked, which is why we had events but zero recordings, with `$recording_status` stuck at `disabled`/`lazy_loading` on 75k hosted events/week.

This also means #3789's `capture_exceptions` / `capture_dead_clicks`, and the PMF survey popover, would **silently never activate on hosted** — they lazy-load through the same blocked path.

## What

Compile the features into our own build so there is no runtime script fetch left to block:

- `client/src/lib/posthog-bundled-extensions.ts` — dynamic-imports `posthog-js/dist/{posthog-recorder,surveys,exception-autocapture,dead-clicks-autocapture}`, gated on the existing `isErrorCaptureSurface()` (hosted + packaged desktop) and skipped in the dev opt-out branch. Never throws; a failed chunk load degrades to today's lazy loading.
- Awaited in `bootstrap()` **before** `PostHogProvider` initializes — registration is checked at feature start, and losing that race would fall back to the blocked remote fetch.
- The bundles register `window.__PosthogExtensions__.{rrweb,initSessionRecording,generateSurveys,errorWrappingFunctions,initDeadClicksAutocapture}`; the SDK short-circuits `loadExternalDependency` when these are present (verified against the installed build). Same-package versioning means the keys cannot drift.
- Vite emits them as code-split `/assets/` chunks (~88KB gzip total) that only the gated surfaces download — npx/Docker bundles are unchanged.

## Verification

- New test: gate off → nothing registered; dev opt-out → nothing; gate on → all five extension keys present after executing the **real** dist bundles in jsdom.
- `typecheck:client` green; `build:client` emits the four chunks (`posthog-recorder` 47KB gzip, `surveys` 31KB, `exception-autocapture` 4.3KB, `dead-clicks` 5.5KB).
- Post-deploy check: hosted events should show `$recording_status: active/buffering` within a day, recordings for `$host = app.mcpjam.com` appear, and a thrown test error produces an `$exception` → the armed error-tracking Slack alert fires. **The PMF survey launch is sequenced after this deploys.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only boot ordering change with existing surface gates and a non-throwing fallback; no auth or data-path changes.
> 
> **Overview**
> **Fixes hosted PostHog features that never activated** because `posthog-js` lazy-loads replay, surveys, exception, and dead-clicks code from `/relay/static/*.js`, which Railway’s edge blocks while event POSTs still work.
> 
> Adds **`preloadPosthogBundledExtensions`**, which dynamically imports the same `posthog-js/dist/*` bundles so they register on `window.__PosthogExtensions__` and the SDK skips remote `loadExternalDependency`. Downloads are limited to **error-capture surfaces** (hosted + packaged desktop) and skipped when PostHog is dev-disabled; failed chunk loads are swallowed so boot is unchanged.
> 
> **`bootstrap()` now awaits this preload before `PostHogProvider` mounts** so registration wins the init race. Vitest covers skip vs register paths, plus ambient module declarations for the untyped dist imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3a03044ba3507ad12a6ddbba642d6ef3ad17a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundles `posthog-js` replay, surveys, exception, and dead-clicks extensions into our client build to bypass Railway’s 403 on lazy-loaded scripts. This enables session replay and error/survey features on hosted and packaged desktop by preloading extensions before `PostHogProvider`.

- **Bug Fixes**
  - Preloads `posthog-js/dist/{posthog-recorder,surveys,exception-autocapture,dead-clicks-autocapture}` behind `isErrorCaptureSurface()` and the dev opt-out.
  - Registers onto `window.__PosthogExtensions__` to short-circuit `loadExternalDependency`, avoiding `GET /relay/static/*.js` at runtime.
  - Awaits preload before initializing `PostHogProvider`; failures degrade to current lazy-loading behavior and never block boot.
  - Vite code-splits these into `/assets/` chunks downloaded only on gated surfaces; other installs remain unchanged.
  - Adds tests to verify gating and extension registration.

<sup>Written for commit 6b3a03044ba3507ad12a6ddbba642d6ef3ad17a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

