### PR TITLE
feat(computers): label swarm/eval/user-testing computer execution as cloud-only (PR 2)

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioCreateFlow.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioCreateFlow.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@mcpjam/design-system/dropdown-menu";
 import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
 import { saveEnvironmentDraftSeed } from "@/lib/environment-draft-seed";
 import { environmentLabel } from "@/lib/environment-label";
@@ -67,6 +68,7 @@ export function UserTestingScenarioCreateFlow({
   onCreateEnvironment,
   onCreateScenario,
 }: UserTestingScenarioCreateFlowProps) {
+  const computersEnabled = useComputersEnabled();
   const environments = useProjectEnvironments(projectId);
   const [environmentId, setEnvironmentId] = useState<string | null>(null);
   const [name, setName] = useState("");
@@ -210,6 +212,15 @@ export function UserTestingScenarioCreateFlow({
                 </button>
               </>
             )}
+            {computersEnabled ? (
+              <p
+                className="text-xs text-muted-foreground"
+                data-testid="user-testing-create-cloud-note"
+              >
+                Tester-session computer commands run in MCPJam cloud sandboxes —
+                never on the machine serving this inspector.
+              </p>
+            ) : null}
           </div>
 
           <div className="space-y-2">

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -9,7 +9,9 @@ import {
   Trash2,
 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
+import { CloudRunBadge } from "@/components/computer/CloudRunBadge";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
+import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection";
 import { ChatboxUsagePanel } from "@/components/chatboxes/ChatboxUsagePanel";
 import { ChatboxDeleteConfirmDialog } from "@/components/chatboxes/ChatboxDeleteConfirmDialog";
@@ -62,6 +64,7 @@ export function UserTestingScenarioDetail({
 }: UserTestingScenarioDetailProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const computersEnabled = useComputersEnabled();
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const { deleteChatbox } = useChatboxMutations();
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -176,6 +179,12 @@ export function UserTestingScenarioDetail({
                   <span className="truncate">{chatbox.namedHostName}</span>
                 </>
               )}
+              {computersEnabled ? (
+                <CloudRunBadge
+                  tooltip="Tester computer commands run in per-conversation MCPJam cloud sandboxes — never on the machine serving this inspector."
+                  data-testid="user-testing-cloud-run-badge"
+                />
+              ) : null}
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">

--- a/mcpjam-inspector/client/src/components/computer/CloudRunBadge.tsx
+++ b/mcpjam-inspector/client/src/components/computer/CloudRunBadge.tsx
@@ -1,0 +1,38 @@
+import { Cloud } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Small provenance chip for surfaces whose COMPUTER EXECUTION is cloud-only:
+ * swarms, evals, and user-testing sessions run their bash/sandbox commands in
+ * MCPJam cloud sandboxes regardless of where the inspector itself runs.
+ *
+ * Deliberately scoped to computer execution — it must not read as "this whole
+ * run happens remotely" (a locally-launched swarm still orchestrates and calls
+ * models from this process). The tooltip carries the per-surface nuance.
+ *
+ * Styled after the composer's "Custom" badge so provenance chips read as one
+ * family.
+ */
+export function CloudRunBadge({
+  tooltip,
+  className,
+  "data-testid": testId,
+}: {
+  tooltip?: string;
+  className?: string;
+  "data-testid"?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground",
+        className,
+      )}
+      title={tooltip}
+      data-testid={testId ?? "cloud-run-badge"}
+    >
+      <Cloud className="size-3" aria-hidden />
+      Computer: MCPJam cloud
+    </span>
+  );
+}

--- a/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
+++ b/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
@@ -9,6 +9,13 @@ export const EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE =
   "This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes.";
 
 /**
+ * Replay-specific variant: a replay provisions from the RUN's frozen snapshot
+ * pin, which outlives clearing the live suite pin.
+ */
+export const EVAL_REPLAY_SNAPSHOT_CLOUD_UNREACHABLE_MESSAGE =
+  "This run replays from its pinned sandbox image, but this inspector can't run MCPJam cloud sandboxes.";
+
+/**
  * Amber preflight band for a cloud-only surface whose sandbox execution this
  * inspector cannot provide (`ephemeralCloudAvailable === false`) — shown
  * BEFORE a run is started, so the user isn't invited into a known failure.

--- a/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
+++ b/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
@@ -1,6 +1,14 @@
 import { AlertTriangle } from "lucide-react";
 
 /**
+ * One sentence, two surfaces: the suite header's disabled-run tooltip and the
+ * Computer-environment section's notice band. Shared so a copy edit can't
+ * leave one of them stale.
+ */
+export const EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE =
+  "This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes.";
+
+/**
  * Amber preflight band for a cloud-only surface whose sandbox execution this
  * inspector cannot provide (`ephemeralCloudAvailable === false`) — shown
  * BEFORE a run is started, so the user isn't invited into a known failure.

--- a/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
+++ b/mcpjam-inspector/client/src/components/computer/CloudUnreachableNotice.tsx
@@ -1,0 +1,35 @@
+import { AlertTriangle } from "lucide-react";
+
+/**
+ * Amber preflight band for a cloud-only surface whose sandbox execution this
+ * inspector cannot provide (`ephemeralCloudAvailable === false`) — shown
+ * BEFORE a run is started, so the user isn't invited into a known failure.
+ *
+ * Tone contract mirrors `ComputersUnavailableMessage`: name the situation in
+ * product terms; never instruct the user to set server environment variables.
+ * Visual pattern mirrors the User Testing environment-error band.
+ */
+export function CloudUnreachableNotice({
+  message,
+  detail,
+  "data-testid": testId,
+}: {
+  message: string;
+  detail?: string;
+  "data-testid"?: string;
+}) {
+  return (
+    <div
+      className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+      data-testid={testId ?? "cloud-unreachable-notice"}
+    >
+      <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+      <div className="min-w-0 text-sm">
+        <p className="font-medium text-foreground">{message}</p>
+        {detail ? (
+          <p className="mt-0.5 text-xs text-muted-foreground">{detail}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/__tests__/helpers-sandbox-pin.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/helpers-sandbox-pin.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { evalSuitePinsSandboxImage } from "../helpers";
+
+/**
+ * The pin can come from TWO places — the suite's own field (migration-era
+ * override) or an ATTACHED project environment. Missing the second source is
+ * exactly how env-backed suites would slip past the cloud preflight.
+ */
+describe("evalSuitePinsSandboxImage", () => {
+  const env = { environmentId: "env-1", computerEnvironmentId: "img-1" };
+  const bareEnv = { environmentId: "env-2" };
+
+  it("detects the suite-level pin", () => {
+    expect(
+      evalSuitePinsSandboxImage(
+        { environment: { servers: [], computerEnvironmentId: "img-9" } },
+        undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a pin on an attached environment", () => {
+    expect(
+      evalSuitePinsSandboxImage(
+        { environment: { servers: [] }, environmentIds: ["env-1"] },
+        [env],
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores attached environments without a pin", () => {
+    expect(
+      evalSuitePinsSandboxImage(
+        { environment: { servers: [] }, environmentIds: ["env-2"] },
+        [bareEnv],
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores pinned environments that are NOT attached to this suite", () => {
+    expect(
+      evalSuitePinsSandboxImage(
+        { environment: { servers: [] }, environmentIds: ["env-2"] },
+        [env, bareEnv],
+      ),
+    ).toBe(false);
+  });
+
+  it("is false with no pins anywhere — including undefined env rows", () => {
+    expect(
+      evalSuitePinsSandboxImage(
+        { environment: { servers: [] }, environmentIds: ["env-1"] },
+        undefined,
+      ),
+    ).toBe(false);
+    expect(evalSuitePinsSandboxImage({ environment: { servers: [] } }, [])).toBe(
+      false,
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-playground-actions.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-playground-actions.test.tsx
@@ -56,4 +56,28 @@ describe("RunDetailPlaygroundActions", () => {
     await user.click(screen.getByRole("button", { name: /replay this run/i }));
     expect(onReplayRun).toHaveBeenCalledWith(suite, baseRun);
   });
+
+  it("blocks replay AND rerun when a runsDisabledReason is supplied", () => {
+    // A replay provisions from the run's frozen image pin just like a rerun —
+    // an external block (billing, unreachable cloud sandboxes) covers both.
+    render(
+      <RunDetailPlaygroundActions
+        suite={suite}
+        selectedRun={baseRun}
+        readOnlyConfig
+        onReplayRun={vi.fn()}
+        onRerun={vi.fn()}
+        onCancelRun={vi.fn()}
+        rerunningSuiteId={null}
+        replayingRunId={null}
+        cancellingRunId={null}
+        hasServersConfigured
+        missingServers={[]}
+        runsDisabledReason="This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes."
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /replay this run/i }),
+    ).toBeDisabled();
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-playground-actions.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/run-detail-playground-actions.test.tsx
@@ -1,6 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+const cloudState = vi.hoisted(() => ({
+  ephemeralAvailable: true as boolean | undefined,
+}));
+vi.mock("@/hooks/useProjectComputer", () => ({
+  useEphemeralCloudAvailable: () => cloudState.ephemeralAvailable,
+}));
+
 import { RunDetailPlaygroundActions } from "../run-detail-playground-actions";
 import type { EvalSuite, EvalSuiteRun } from "../types";
 
@@ -35,6 +43,10 @@ const baseRun = {
 } satisfies EvalSuiteRun;
 
 describe("RunDetailPlaygroundActions", () => {
+  beforeEach(() => {
+    cloudState.ephemeralAvailable = true;
+  });
+
   it("calls onReplayRun when replay is available", async () => {
     const user = userEvent.setup();
     const onReplayRun = vi.fn();
@@ -74,6 +86,40 @@ describe("RunDetailPlaygroundActions", () => {
         hasServersConfigured
         missingServers={[]}
         runsDisabledReason="This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes."
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /replay this run/i }),
+    ).toBeDisabled();
+  });
+
+  it("blocks replay from the RUN's frozen snapshot pin, even when the live suite no longer pins", () => {
+    // The externally-derived reason reflects live suite/environment state; a
+    // historical run's snapshot pin outlives clearing the live pin, and its
+    // replay still provisions from that frozen image.
+    cloudState.ephemeralAvailable = false;
+    render(
+      <RunDetailPlaygroundActions
+        suite={suite}
+        selectedRun={{
+          ...baseRun,
+          configSnapshot: {
+            tests: [],
+            environment: {
+              servers: ["srv"],
+              computerEnvironmentId: "img-frozen",
+            },
+          },
+        }}
+        readOnlyConfig
+        onReplayRun={vi.fn()}
+        onRerun={vi.fn()}
+        onCancelRun={vi.fn()}
+        rerunningSuiteId={null}
+        replayingRunId={null}
+        cancellingRunId={null}
+        hasServersConfigured
+        missingServers={[]}
       />,
     );
     expect(

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -20,18 +20,14 @@ vi.mock("posthog-js", () => ({
   default: { capture: vi.fn() },
 }));
 
+// Consumed by the RunDetailPlaygroundActions child (replay snapshot gate);
+// pinned `true` so header tests never see a cloud-gated state they didn't ask
+// for. The derivation itself lives in suite-iterations-view, not here.
 const cloudState = vi.hoisted(() => ({
   ephemeralAvailable: true as boolean | undefined,
 }));
 vi.mock("@/hooks/useProjectComputer", () => ({
   useEphemeralCloudAvailable: () => cloudState.ephemeralAvailable,
-}));
-
-const envState = vi.hoisted(() => ({
-  rows: [] as Array<{ environmentId: string; computerEnvironmentId?: string }>,
-}));
-vi.mock("@/hooks/useProjectEnvironments", () => ({
-  useProjectEnvironments: () => envState.rows,
 }));
 
 vi.mock("@/components/chat-v2/chat-input/model/provider-logo", () => ({
@@ -92,7 +88,6 @@ describe("SuiteHeader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cloudState.ephemeralAvailable = true;
-    envState.rows = [];
     mockIsHostedMode.mockReturnValue(false);
   });
 
@@ -365,18 +360,14 @@ describe("SuiteHeader", () => {
     expect(onRerun).toHaveBeenCalledWith(baseSuite, {});
   });
 
-  it("blocks every run action when the suite pins a sandbox image this inspector can't run", () => {
-    // A pinned image provisions a disposable MCPJam cloud box per iteration;
-    // from a non-data-plane inspector every run would fail its computer
-    // setup, so launch is disabled up front instead of inviting the failure.
-    cloudState.ephemeralAvailable = false;
+  it("blocks Run all when the parent-derived evalRunsDisabledReason is set", () => {
+    // The cloud-sandbox preflight is derived in suite-iterations-view (the
+    // owner of every run control) and arrives here as a plain prop — this
+    // pins that the header honors it.
     renderWithProviders(
       <SuiteHeader
         {...baseProps}
-        suite={{
-          ...baseSuite,
-          environment: { servers: ["asana"], computerEnvironmentId: "img-1" },
-        }}
+        evalRunsDisabledReason="This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes."
         viewMode="overview"
         selectedRunDetails={null}
         runsViewMode="runs"
@@ -398,76 +389,6 @@ describe("SuiteHeader", () => {
     expect(
       screen.getByRole("button", { name: /Run all cases in this suite/i })
     ).toBeDisabled();
-  });
-
-  it("catches a pin carried by an ATTACHED environment, not just the suite field", () => {
-    // Env-backed suites resolve their image server-side at launch — checking
-    // only `suite.environment.computerEnvironmentId` would let exactly those
-    // suites launch into the failure the preflight exists to prevent.
-    cloudState.ephemeralAvailable = false;
-    envState.rows = [
-      { environmentId: "env-9", computerEnvironmentId: "img-9" },
-    ];
-    renderWithProviders(
-      <SuiteHeader
-        {...baseProps}
-        suite={{
-          ...baseSuite,
-          environmentIds: ["env-9"],
-        }}
-        projectId="proj-1"
-        viewMode="overview"
-        selectedRunDetails={null}
-        runsViewMode="runs"
-        hideRunActions
-        unifiedSuiteDashboard
-        onCreateTestCase={vi.fn()}
-        onGenerateTestCases={vi.fn()}
-        canGenerateTestCases
-        testCases={[
-          {
-            _id: "c1",
-            models: [{ provider: "openai", model: "gpt-4" }],
-          } as any,
-        ]}
-        connectedServerNames={new Set(["asana"])}
-      />
-    );
-
-    expect(
-      screen.getByRole("button", { name: /Run all cases in this suite/i })
-    ).toBeDisabled();
-  });
-
-  it("leaves runs alone when the pinned-image suite CAN reach cloud sandboxes", () => {
-    renderWithProviders(
-      <SuiteHeader
-        {...baseProps}
-        suite={{
-          ...baseSuite,
-          environment: { servers: ["asana"], computerEnvironmentId: "img-1" },
-        }}
-        viewMode="overview"
-        selectedRunDetails={null}
-        runsViewMode="runs"
-        hideRunActions
-        unifiedSuiteDashboard
-        onCreateTestCase={vi.fn()}
-        onGenerateTestCases={vi.fn()}
-        canGenerateTestCases
-        testCases={[
-          {
-            _id: "c1",
-            models: [{ provider: "openai", model: "gpt-4" }],
-          } as any,
-        ]}
-        connectedServerNames={new Set(["asana"])}
-      />
-    );
-
-    expect(
-      screen.getByRole("button", { name: /Run all cases in this suite/i })
-    ).toBeEnabled();
   });
 
   it("keeps Run all disabled while the latest suite run is still running", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -27,6 +27,13 @@ vi.mock("@/hooks/useProjectComputer", () => ({
   useEphemeralCloudAvailable: () => cloudState.ephemeralAvailable,
 }));
 
+const envState = vi.hoisted(() => ({
+  rows: [] as Array<{ environmentId: string; computerEnvironmentId?: string }>,
+}));
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => envState.rows,
+}));
+
 vi.mock("@/components/chat-v2/chat-input/model/provider-logo", () => ({
   ProviderLogo: () => null,
 }));
@@ -85,6 +92,7 @@ describe("SuiteHeader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cloudState.ephemeralAvailable = true;
+    envState.rows = [];
     mockIsHostedMode.mockReturnValue(false);
   });
 
@@ -369,6 +377,45 @@ describe("SuiteHeader", () => {
           ...baseSuite,
           environment: { servers: ["asana"], computerEnvironmentId: "img-1" },
         }}
+        viewMode="overview"
+        selectedRunDetails={null}
+        runsViewMode="runs"
+        hideRunActions
+        unifiedSuiteDashboard
+        onCreateTestCase={vi.fn()}
+        onGenerateTestCases={vi.fn()}
+        canGenerateTestCases
+        testCases={[
+          {
+            _id: "c1",
+            models: [{ provider: "openai", model: "gpt-4" }],
+          } as any,
+        ]}
+        connectedServerNames={new Set(["asana"])}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Run all cases in this suite/i })
+    ).toBeDisabled();
+  });
+
+  it("catches a pin carried by an ATTACHED environment, not just the suite field", () => {
+    // Env-backed suites resolve their image server-side at launch — checking
+    // only `suite.environment.computerEnvironmentId` would let exactly those
+    // suites launch into the failure the preflight exists to prevent.
+    cloudState.ephemeralAvailable = false;
+    envState.rows = [
+      { environmentId: "env-9", computerEnvironmentId: "img-9" },
+    ];
+    renderWithProviders(
+      <SuiteHeader
+        {...baseProps}
+        suite={{
+          ...baseSuite,
+          environmentIds: ["env-9"],
+        }}
+        projectId="proj-1"
         viewMode="overview"
         selectedRunDetails={null}
         runsViewMode="runs"

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -20,6 +20,13 @@ vi.mock("posthog-js", () => ({
   default: { capture: vi.fn() },
 }));
 
+const cloudState = vi.hoisted(() => ({
+  ephemeralAvailable: true as boolean | undefined,
+}));
+vi.mock("@/hooks/useProjectComputer", () => ({
+  useEphemeralCloudAvailable: () => cloudState.ephemeralAvailable,
+}));
+
 vi.mock("@/components/chat-v2/chat-input/model/provider-logo", () => ({
   ProviderLogo: () => null,
 }));
@@ -77,6 +84,7 @@ describe("SuiteHeader", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    cloudState.ephemeralAvailable = true;
     mockIsHostedMode.mockReturnValue(false);
   });
 
@@ -347,6 +355,72 @@ describe("SuiteHeader", () => {
     expect(runAll).toBeEnabled();
     await user.click(runAll);
     expect(onRerun).toHaveBeenCalledWith(baseSuite, {});
+  });
+
+  it("blocks every run action when the suite pins a sandbox image this inspector can't run", () => {
+    // A pinned image provisions a disposable MCPJam cloud box per iteration;
+    // from a non-data-plane inspector every run would fail its computer
+    // setup, so launch is disabled up front instead of inviting the failure.
+    cloudState.ephemeralAvailable = false;
+    renderWithProviders(
+      <SuiteHeader
+        {...baseProps}
+        suite={{
+          ...baseSuite,
+          environment: { servers: ["asana"], computerEnvironmentId: "img-1" },
+        }}
+        viewMode="overview"
+        selectedRunDetails={null}
+        runsViewMode="runs"
+        hideRunActions
+        unifiedSuiteDashboard
+        onCreateTestCase={vi.fn()}
+        onGenerateTestCases={vi.fn()}
+        canGenerateTestCases
+        testCases={[
+          {
+            _id: "c1",
+            models: [{ provider: "openai", model: "gpt-4" }],
+          } as any,
+        ]}
+        connectedServerNames={new Set(["asana"])}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Run all cases in this suite/i })
+    ).toBeDisabled();
+  });
+
+  it("leaves runs alone when the pinned-image suite CAN reach cloud sandboxes", () => {
+    renderWithProviders(
+      <SuiteHeader
+        {...baseProps}
+        suite={{
+          ...baseSuite,
+          environment: { servers: ["asana"], computerEnvironmentId: "img-1" },
+        }}
+        viewMode="overview"
+        selectedRunDetails={null}
+        runsViewMode="runs"
+        hideRunActions
+        unifiedSuiteDashboard
+        onCreateTestCase={vi.fn()}
+        onGenerateTestCases={vi.fn()}
+        canGenerateTestCases
+        testCases={[
+          {
+            _id: "c1",
+            models: [{ provider: "openai", model: "gpt-4" }],
+          } as any,
+        ]}
+        connectedServerNames={new Set(["asana"])}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Run all cases in this suite/i })
+    ).toBeEnabled();
   });
 
   it("keeps Run all disabled while the latest suite run is still running", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-master-detail.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-master-detail.test.tsx
@@ -11,6 +11,20 @@ const mocks = vi.hoisted(() => ({
   runOverview: vi.fn(),
 }));
 
+const cloudState = vi.hoisted(() => ({
+  ephemeralAvailable: true as boolean | undefined,
+  environments: [] as Array<{
+    environmentId: string;
+    computerEnvironmentId?: string;
+  }>,
+}));
+vi.mock("@/hooks/useProjectComputer", () => ({
+  useEphemeralCloudAvailable: () => cloudState.ephemeralAvailable,
+}));
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironments: () => cloudState.environments,
+}));
+
 vi.mock("convex/react", () => ({
   useMutation: (name: any) => (mocks.useMutation as any)(name),
   useQuery: (name: any, args: any) => (mocks.useQuery as any)(name, args),
@@ -375,6 +389,92 @@ describe("SuiteIterationsView caseListInSidebar", () => {
       expect.objectContaining({
         canDeleteSuite: true,
       }),
+    );
+  });
+});
+
+describe("SuiteIterationsView cloud-sandbox gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cloudState.ephemeralAvailable = true;
+    cloudState.environments = [];
+    mocks.useMutation.mockReturnValue(vi.fn());
+    mocks.useQuery.mockReturnValue(undefined);
+  });
+
+  function renderView(suite: EvalSuite, projectId?: string) {
+    render(
+      <SuiteIterationsView
+        suite={suite}
+        {...(projectId ? { projectId } : {})}
+        cases={[]}
+        iterations={[]}
+        allIterations={[]}
+        runs={[]}
+        runsLoading={false}
+        aggregate={null}
+        onRerun={vi.fn()}
+        onCancelRun={vi.fn()}
+        onDelete={vi.fn()}
+        onDeleteRun={vi.fn()}
+        onDirectDeleteRun={vi.fn().mockResolvedValue(undefined)}
+        connectedServerNames={new Set()}
+        canDeleteSuite={false}
+        rerunningSuiteId={null}
+        cancellingRunId={null}
+        deletingSuiteId={null}
+        deletingRunId={null}
+        availableModels={[]}
+        route={{
+          type: "suite-overview",
+          suiteId: "suite-1",
+          view: "test-cases",
+        }}
+        navigation={noopNav}
+      />,
+    );
+  }
+
+  it("folds the preflight into the reason handed to EVERY run control", () => {
+    // The parent derives the gate exactly once; the header (and the per-case
+    // dashboards, which read the same shadowed variable) receive it as the
+    // ordinary disabled-reason prop.
+    cloudState.ephemeralAvailable = false;
+    renderView({
+      ...baseSuite,
+      environment: { servers: [], computerEnvironmentId: "img-1" },
+    });
+    expect(mocks.suiteHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        evalRunsDisabledReason: expect.stringMatching(
+          /can't run MCPJam cloud sandboxes/,
+        ),
+      }),
+    );
+  });
+
+  it("catches a pin carried by an ATTACHED environment", () => {
+    cloudState.ephemeralAvailable = false;
+    cloudState.environments = [
+      { environmentId: "env-9", computerEnvironmentId: "img-9" },
+    ];
+    renderView({ ...baseSuite, environmentIds: ["env-9"] }, "proj-1");
+    expect(mocks.suiteHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        evalRunsDisabledReason: expect.stringMatching(
+          /can't run MCPJam cloud sandboxes/,
+        ),
+      }),
+    );
+  });
+
+  it("passes no reason when the pinned suite CAN reach cloud sandboxes", () => {
+    renderView({
+      ...baseSuite,
+      environment: { servers: [], computerEnvironmentId: "img-1" },
+    });
+    expect(mocks.suiteHeader).toHaveBeenCalledWith(
+      expect.objectContaining({ evalRunsDisabledReason: null }),
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -1148,3 +1148,30 @@ export function pickLatestCompletedRun(
     r.runNumber > best.runNumber ? r : best,
   );
 }
+
+/**
+ * Does anything about this suite pin a sandbox image for its NEXT run?
+ *
+ * Two sources, both checked: the suite's own
+ * `environment.computerEnvironmentId` (the migration-era override) and any
+ * ATTACHED project environment's pin — env-backed suites resolve their image
+ * server-side at launch, so checking only the suite field would miss exactly
+ * the suites that increasingly carry the pin. Historical runs' frozen
+ * snapshot pins are deliberately NOT consulted here: they gate REPLAY of that
+ * run, not fresh runs (see `RunDetailPlaygroundActions`).
+ */
+export function evalSuitePinsSandboxImage(
+  suite: Pick<EvalSuite, "environment" | "environmentIds">,
+  attachedEnvironments:
+    | Array<{ environmentId: string; computerEnvironmentId?: string | null }>
+    | undefined,
+): boolean {
+  if (suite.environment?.computerEnvironmentId) return true;
+  return (suite.environmentIds ?? []).some((environmentId) =>
+    Boolean(
+      (attachedEnvironments ?? []).find(
+        (environment) => environment.environmentId === environmentId,
+      )?.computerEnvironmentId,
+    ),
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/run-detail-playground-actions.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-playground-actions.tsx
@@ -23,6 +23,7 @@ export function RunDetailPlaygroundActions({
   missingServers,
   showCloseButton = false,
   onBackToOverview,
+  runsDisabledReason = null,
   className,
 }: {
   suite: EvalSuite;
@@ -38,6 +39,12 @@ export function RunDetailPlaygroundActions({
   missingServers: string[];
   showCloseButton?: boolean;
   onBackToOverview?: () => void;
+  /**
+   * Externally-derived reason no run may start (billing gate, unreachable
+   * cloud sandboxes for a pinned-image suite). Blocks BOTH rerun and replay —
+   * a replay provisions from the run's frozen image pin just like a rerun.
+   */
+  runsDisabledReason?: string | null;
   className?: string;
 }) {
   const isCancelling = cancellingRunId === selectedRun._id;
@@ -53,9 +60,12 @@ export function RunDetailPlaygroundActions({
   const showRunAction = Boolean(replayableSelectedRun) || !readOnlyConfig;
   const isReplayAction = Boolean(replayableSelectedRun);
   const canUseLiveRun = hasServersConfigured;
-  const runActionDisabled = isReplayAction
-    ? showAsRunning || !onReplayRun
-    : !canUseLiveRun || showAsRunning;
+  const runActionDisabled = Boolean(
+    runsDisabledReason ||
+      (isReplayAction
+        ? showAsRunning || !onReplayRun
+        : !canUseLiveRun || showAsRunning)
+  );
   const runActionLabel = showAsRunning
     ? isReplayAction
       ? "Replaying..."
@@ -63,13 +73,15 @@ export function RunDetailPlaygroundActions({
     : isReplayAction
       ? "Replay this run"
       : "Rerun";
-  const runActionTooltip = isReplayAction
-    ? "Replay this CI run in the playground"
-    : !hasServersConfigured
-      ? "No MCP servers are configured for this suite"
-      : missingServers.length > 0
-        ? "Connect and run."
-        : "Run all cases";
+  const runActionTooltip = runsDisabledReason
+    ? runsDisabledReason
+    : isReplayAction
+      ? "Replay this CI run in the playground"
+      : !hasServersConfigured
+        ? "No MCP servers are configured for this suite"
+        : missingServers.length > 0
+          ? "Connect and run."
+          : "Run all cases";
 
   return (
     <div

--- a/mcpjam-inspector/client/src/components/evals/run-detail-playground-actions.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-playground-actions.tsx
@@ -6,6 +6,8 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import { cn } from "@/lib/utils";
 import { Loader2, RotateCw, X } from "lucide-react";
+import { EVAL_REPLAY_SNAPSHOT_CLOUD_UNREACHABLE_MESSAGE } from "@/components/computer/CloudUnreachableNotice";
+import { useEphemeralCloudAvailable } from "@/hooks/useProjectComputer";
 import type { EvalSuite, EvalSuiteRun } from "./types";
 
 /** Replay / rerun / cancel controls for a run detail view (SuiteHeader row or CI sidebar). */
@@ -60,8 +62,20 @@ export function RunDetailPlaygroundActions({
   const showRunAction = Boolean(replayableSelectedRun) || !readOnlyConfig;
   const isReplayAction = Boolean(replayableSelectedRun);
   const canUseLiveRun = hasServersConfigured;
+  // A replay provisions from the RUN's frozen snapshot pin — the live suite
+  // pin may have been cleared or changed since, so the externally-derived
+  // reason (live suite/environment state) can't cover this case.
+  const ephemeralCloudAvailable = useEphemeralCloudAvailable();
+  const replaySnapshotBlockedReason =
+    isReplayAction &&
+    ephemeralCloudAvailable === false &&
+    Boolean(selectedRun.configSnapshot?.environment?.computerEnvironmentId)
+      ? EVAL_REPLAY_SNAPSHOT_CLOUD_UNREACHABLE_MESSAGE
+      : null;
+  const effectiveDisabledReason =
+    runsDisabledReason ?? replaySnapshotBlockedReason;
   const runActionDisabled = Boolean(
-    runsDisabledReason ||
+    effectiveDisabledReason ||
       (isReplayAction
         ? showAsRunning || !onReplayRun
         : !canUseLiveRun || showAsRunning)
@@ -73,8 +87,8 @@ export function RunDetailPlaygroundActions({
     : isReplayAction
       ? "Replay this run"
       : "Rerun";
-  const runActionTooltip = runsDisabledReason
-    ? runsDisabledReason
+  const runActionTooltip = effectiveDisabledReason
+    ? effectiveDisabledReason
     : isReplayAction
       ? "Replay this CI run in the playground"
       : !hasServersConfigured

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -44,6 +44,7 @@ import {
   SuiteAggregate,
 } from "./types";
 import { useMutation } from "convex/react";
+import { useEphemeralCloudAvailable } from "@/hooks/useProjectComputer";
 import { toast } from "sonner";
 
 import { CiMetadataDisplay } from "./ci-metadata-display";
@@ -168,7 +169,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     onGenerateTestCases,
     canGenerateTestCases = false,
     generateTestCasesDisabledReason,
-    evalRunsDisabledReason = null,
+    evalRunsDisabledReason: evalRunsDisabledReasonProp = null,
     isGeneratingTestCases = false,
     onCreateTestCase,
     blockTestCaseRuns: _blockTestCaseRuns = false,
@@ -179,6 +180,19 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     runDetailKpiStrip,
     omitRunDetailIdentity = false,
   } = props;
+
+  // A suite that pins a sandbox image provisions a disposable MCPJam cloud
+  // box per iteration — from an inspector that can't execute in those boxes,
+  // every run would fail its computer setup. Fold that preflight into the
+  // same disabled-reason channel billing uses, so every run control (Run all,
+  // per-case, rerun) blocks with one consistent tooltip.
+  const ephemeralCloudAvailable = useEphemeralCloudAvailable();
+  const evalRunsDisabledReason =
+    evalRunsDisabledReasonProp ??
+    (suite.environment?.computerEnvironmentId &&
+    ephemeralCloudAvailable === false
+      ? "This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes."
+      : null);
 
   const showTestCaseCtas =
     runsViewMode === "test-cases" ||

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -45,6 +45,8 @@ import {
 } from "./types";
 import { useMutation } from "convex/react";
 import { useEphemeralCloudAvailable } from "@/hooks/useProjectComputer";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
+import { EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE } from "@/components/computer/CloudUnreachableNotice";
 import { toast } from "sonner";
 
 import { CiMetadataDisplay } from "./ci-metadata-display";
@@ -69,6 +71,11 @@ import type { SuiteOverviewView } from "@/lib/eval-route-types";
 
 interface SuiteHeaderProps {
   suite: EvalSuite;
+  /**
+   * Needed only to resolve ATTACHED project environments' sandbox-image pins
+   * for the cloud preflight; absent ⇒ only the suite's own pin is checked.
+   */
+  projectId?: string | null;
   viewMode: "overview" | "run-detail" | "test-detail" | "test-edit";
   selectedRunDetails: EvalSuiteRun | null;
   isEditMode: boolean;
@@ -154,6 +161,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     iterationOverride,
     onIterationOverrideChange,
     connectedServerNames,
+    projectId,
     rerunningSuiteId,
     replayingRunId = null,
     cancellingRunId,
@@ -185,13 +193,29 @@ export function SuiteHeader(props: SuiteHeaderProps) {
   // box per iteration — from an inspector that can't execute in those boxes,
   // every run would fail its computer setup. Fold that preflight into the
   // same disabled-reason channel billing uses, so every run control (Run all,
-  // per-case, rerun) blocks with one consistent tooltip.
+  // per-case, rerun, run-detail rerun/replay) blocks with one consistent
+  // tooltip. The pin can come from TWO places: the suite's own
+  // `environment.computerEnvironmentId` (migration-era override) or any
+  // ATTACHED project environment's pin, which the backend resolves fresh at
+  // launch — checking only the suite field would let env-backed suites launch
+  // into the exact failure this preflight exists to prevent.
   const ephemeralCloudAvailable = useEphemeralCloudAvailable();
+  const attachedEnvironments = useProjectEnvironments(
+    (suite.environmentIds?.length ?? 0) > 0 ? (projectId ?? null) : null
+  );
+  const suitePinsSandboxImage =
+    Boolean(suite.environment?.computerEnvironmentId) ||
+    (suite.environmentIds ?? []).some((environmentId) =>
+      Boolean(
+        (attachedEnvironments ?? []).find(
+          (environment) => environment.environmentId === environmentId
+        )?.computerEnvironmentId
+      )
+    );
   const evalRunsDisabledReason =
     evalRunsDisabledReasonProp ??
-    (suite.environment?.computerEnvironmentId &&
-    ephemeralCloudAvailable === false
-      ? "This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes."
+    (suitePinsSandboxImage && ephemeralCloudAvailable === false
+      ? EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE
       : null);
 
   const showTestCaseCtas =
@@ -377,6 +401,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
               cancellingRunId={cancellingRunId}
               hasServersConfigured={hasServersConfigured}
               missingServers={missingServers}
+              runsDisabledReason={evalRunsDisabledReason}
               showCloseButton
               onBackToOverview={() => onViewModeChange("overview")}
             />
@@ -441,6 +466,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                 cancellingRunId={cancellingRunId}
                 hasServersConfigured={hasServersConfigured}
                 missingServers={missingServers}
+                runsDisabledReason={evalRunsDisabledReason}
                 showCloseButton
                 onBackToOverview={() => onViewModeChange("overview")}
               />

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -44,9 +44,6 @@ import {
   SuiteAggregate,
 } from "./types";
 import { useMutation } from "convex/react";
-import { useEphemeralCloudAvailable } from "@/hooks/useProjectComputer";
-import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
-import { EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE } from "@/components/computer/CloudUnreachableNotice";
 import { toast } from "sonner";
 
 import { CiMetadataDisplay } from "./ci-metadata-display";
@@ -71,11 +68,6 @@ import type { SuiteOverviewView } from "@/lib/eval-route-types";
 
 interface SuiteHeaderProps {
   suite: EvalSuite;
-  /**
-   * Needed only to resolve ATTACHED project environments' sandbox-image pins
-   * for the cloud preflight; absent ⇒ only the suite's own pin is checked.
-   */
-  projectId?: string | null;
   viewMode: "overview" | "run-detail" | "test-detail" | "test-edit";
   selectedRunDetails: EvalSuiteRun | null;
   isEditMode: boolean;
@@ -161,7 +153,6 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     iterationOverride,
     onIterationOverrideChange,
     connectedServerNames,
-    projectId,
     rerunningSuiteId,
     replayingRunId = null,
     cancellingRunId,
@@ -177,7 +168,10 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     onGenerateTestCases,
     canGenerateTestCases = false,
     generateTestCasesDisabledReason,
-    evalRunsDisabledReason: evalRunsDisabledReasonProp = null,
+    // Effective reason, derived by the PARENT (suite-iterations-view) — it
+    // owns every run control, so the cloud-sandbox preflight is folded in
+    // there, not here (deriving here left the per-case buttons ungated).
+    evalRunsDisabledReason = null,
     isGeneratingTestCases = false,
     onCreateTestCase,
     blockTestCaseRuns: _blockTestCaseRuns = false,
@@ -188,35 +182,6 @@ export function SuiteHeader(props: SuiteHeaderProps) {
     runDetailKpiStrip,
     omitRunDetailIdentity = false,
   } = props;
-
-  // A suite that pins a sandbox image provisions a disposable MCPJam cloud
-  // box per iteration — from an inspector that can't execute in those boxes,
-  // every run would fail its computer setup. Fold that preflight into the
-  // same disabled-reason channel billing uses, so every run control (Run all,
-  // per-case, rerun, run-detail rerun/replay) blocks with one consistent
-  // tooltip. The pin can come from TWO places: the suite's own
-  // `environment.computerEnvironmentId` (migration-era override) or any
-  // ATTACHED project environment's pin, which the backend resolves fresh at
-  // launch — checking only the suite field would let env-backed suites launch
-  // into the exact failure this preflight exists to prevent.
-  const ephemeralCloudAvailable = useEphemeralCloudAvailable();
-  const attachedEnvironments = useProjectEnvironments(
-    (suite.environmentIds?.length ?? 0) > 0 ? (projectId ?? null) : null
-  );
-  const suitePinsSandboxImage =
-    Boolean(suite.environment?.computerEnvironmentId) ||
-    (suite.environmentIds ?? []).some((environmentId) =>
-      Boolean(
-        (attachedEnvironments ?? []).find(
-          (environment) => environment.environmentId === environmentId
-        )?.computerEnvironmentId
-      )
-    );
-  const evalRunsDisabledReason =
-    evalRunsDisabledReasonProp ??
-    (suitePinsSandboxImage && ephemeralCloudAvailable === false
-      ? EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE
-      : null);
 
   const showTestCaseCtas =
     runsViewMode === "test-cases" ||

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -6,7 +6,10 @@ import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useSandboxImages } from "@/hooks/useSandboxImages";
 import { useEphemeralCloudAvailable } from "@/hooks/useProjectComputer";
 import { CloudRunBadge } from "@/components/computer/CloudRunBadge";
-import { CloudUnreachableNotice } from "@/components/computer/CloudUnreachableNotice";
+import {
+  CloudUnreachableNotice,
+  EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE,
+} from "@/components/computer/CloudUnreachableNotice";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { SuiteProjectEnvironmentsPicker } from "./suite-project-environments-picker";
 import { toast } from "sonner";
@@ -932,6 +935,7 @@ export function SuiteIterationsView({
         <div className="shrink-0">
           <SuiteHeader
             suite={suite}
+            projectId={projectId}
             viewMode={headerViewMode}
             selectedRunDetails={selectedRunDetails}
             isEditMode={isEditMode}
@@ -1472,7 +1476,7 @@ export function SuiteIterationsView({
                     <div className="mt-2">
                       <CloudUnreachableNotice
                         data-testid="suite-eval-cloud-unreachable"
-                        message="This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes."
+                        message={EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE}
                         detail="Runs started here would fail their computer setup — Run all is disabled until cloud sandboxes are reachable."
                       />
                     </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -5,6 +5,7 @@ import { useHostList } from "@/hooks/useClients";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useSandboxImages } from "@/hooks/useSandboxImages";
 import { useEphemeralCloudAvailable } from "@/hooks/useProjectComputer";
+import { useProjectEnvironments } from "@/hooks/useProjectEnvironments";
 import { CloudRunBadge } from "@/components/computer/CloudRunBadge";
 import {
   CloudUnreachableNotice,
@@ -17,6 +18,7 @@ import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import {
   buildHostNamesById,
   compareRunsBySequence,
+  evalSuitePinsSandboxImage,
   getLatestRunMetricSource,
   getRunMetricSource,
   runEnvironmentRef,
@@ -216,7 +218,7 @@ export function SuiteIterationsView({
   onContinueInChat,
   projectServers,
   generateTestCasesDisabledReason,
-  evalRunsDisabledReason,
+  evalRunsDisabledReason: evalRunsDisabledReasonProp,
   isDirectGuest = false,
   ensureServersReady,
 }: {
@@ -409,6 +411,22 @@ export function SuiteIterationsView({
     computersEnabled && projectId ? projectId : null
   );
   const ephemeralCloudAvailable = useEphemeralCloudAvailable();
+  // Cloud-sandbox preflight, derived ONCE here — the parent owns every run
+  // control (header Run all, run-detail rerun/replay, per-case play buttons
+  // in both dashboards), so deriving any lower down leaves some of them
+  // ungated. Folded into the same disabled-reason channel billing uses.
+  const attachedEnvironments = useProjectEnvironments(
+    (suite.environmentIds?.length ?? 0) > 0 ? (projectId ?? null) : null
+  );
+  const suitePinsSandboxImage = evalSuitePinsSandboxImage(
+    suite,
+    attachedEnvironments ?? undefined
+  );
+  const evalRunsDisabledReason =
+    evalRunsDisabledReasonProp ??
+    (suitePinsSandboxImage && ephemeralCloudAvailable === false
+      ? EVAL_SANDBOX_CLOUD_UNREACHABLE_MESSAGE
+      : null);
   // Hosts available to attach in the header's "+ Attach host" picker. The
   // query is owned here (not inside SuiteOverviewClientBar) so the bar stays
   // pure-props and renderable in test environments without a Convex provider.
@@ -935,7 +953,6 @@ export function SuiteIterationsView({
         <div className="shrink-0">
           <SuiteHeader
             suite={suite}
-            projectId={projectId}
             viewMode={headerViewMode}
             selectedRunDetails={selectedRunDetails}
             isEditMode={isEditMode}
@@ -1471,8 +1488,7 @@ export function SuiteIterationsView({
                     cloud sandboxes — never on the machine running this
                     inspector.
                   </p>
-                  {suite.environment?.computerEnvironmentId &&
-                  ephemeralCloudAvailable === false ? (
+                  {suitePinsSandboxImage && ephemeralCloudAvailable === false ? (
                     <div className="mt-2">
                       <CloudUnreachableNotice
                         data-testid="suite-eval-cloud-unreachable"

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -4,6 +4,9 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useHostList } from "@/hooks/useClients";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useSandboxImages } from "@/hooks/useSandboxImages";
+import { useEphemeralCloudAvailable } from "@/hooks/useProjectComputer";
+import { CloudRunBadge } from "@/components/computer/CloudRunBadge";
+import { CloudUnreachableNotice } from "@/components/computer/CloudUnreachableNotice";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { SuiteProjectEnvironmentsPicker } from "./suite-project-environments-picker";
 import { toast } from "sonner";
@@ -402,6 +405,7 @@ export function SuiteIterationsView({
   const computerEnvironments = useSandboxImages(
     computersEnabled && projectId ? projectId : null
   );
+  const ephemeralCloudAvailable = useEphemeralCloudAvailable();
   // Hosts available to attach in the header's "+ Attach host" picker. The
   // query is owned here (not inside SuiteOverviewClientBar) so the bar stays
   // pure-props and renderable in test environments without a Convex provider.
@@ -1397,6 +1401,12 @@ export function SuiteIterationsView({
               {computersEnabled && projectId ? (
                 <SettingsSection
                   label="Computer environment"
+                  labelAccessory={
+                    <CloudRunBadge
+                      tooltip="Eval iterations run their computer commands in disposable MCPJam cloud sandboxes — never on the machine running this inspector."
+                      data-testid="suite-eval-cloud-run-badge"
+                    />
+                  }
                   layout="inline"
                   inlineSlot={
                     <select
@@ -1453,8 +1463,20 @@ export function SuiteIterationsView({
                     Each eval iteration boots a fresh sandbox from this image
                     and the agent gets a <span className="font-mono">bash</span>{" "}
                     tool in it. Build the environment before running, or the run
-                    fails fast.
+                    fails fast. Eval computer commands always run in MCPJam
+                    cloud sandboxes — never on the machine running this
+                    inspector.
                   </p>
+                  {suite.environment?.computerEnvironmentId &&
+                  ephemeralCloudAvailable === false ? (
+                    <div className="mt-2">
+                      <CloudUnreachableNotice
+                        data-testid="suite-eval-cloud-unreachable"
+                        message="This suite pins a sandbox image, but this inspector can't run MCPJam cloud sandboxes."
+                        detail="Runs started here would fail their computer setup — Run all is disabled until cloud sandboxes are reachable."
+                      />
+                    </div>
+                  ) : null}
                 </SettingsSection>
               ) : null}
 

--- a/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/ProjectEnvironmentEditor.tsx
@@ -482,10 +482,11 @@ export function ProjectEnvironmentEditor({
             ) : null}
           </div>
           <p className="text-[11px] text-muted-foreground">
-            Applies to eval runs in this environment: each run boots a fresh,
-            isolated sandbox from this image. Playground, chatboxes, and swarms
-            don&apos;t use the sandbox image yet. A not-built image fails at
-            launch — build it first under Computer → Images.
+            Applies to cloud runs in this environment: evals, swarms, and
+            user-testing sessions each boot a fresh, isolated sandbox from this
+            image. Cloud runs only — sandbox images never apply to the machine
+            running this inspector. A not-built image fails at launch — build
+            it first under Computer → Images.
           </p>
         </div>
       ) : null}

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-composer.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-composer.test.tsx
@@ -231,14 +231,20 @@ describe("SwarmTargetComposer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("blocks the sandbox-image opt-in when cloud sandboxes are unreachable", () => {
+  it("blocks NEW sandbox-image pins but keeps the clear path when cloud is unreachable", () => {
     // `false` means a sandbox-backed session WOULD fail per-attempt — the
-    // composer must warn and disable the opt-in instead of inviting it.
+    // composer must warn and disable the opt-in. But the SELECT stays live:
+    // a pin seeded from a saved environment/draft must remain clearable back
+    // to "Computer · default" (the opt-out the notice promises).
     flagState.computers = true;
     cloudState.ephemeralAvailable = false;
     render(<Harness />);
     expect(screen.getByTestId("new-swarm-cloud-unreachable")).toBeVisible();
-    expect(screen.getByTestId("new-swarm-sandbox-image")).toBeDisabled();
+    expect(screen.getByTestId("new-swarm-sandbox-image")).not.toBeDisabled();
+    expect(screen.getByRole("option", { name: /Base box/i })).toBeDisabled();
+    expect(
+      screen.getByRole("option", { name: /Computer · default/i })
+    ).not.toBeDisabled();
   });
 
   it("stays quiet while cloud availability is still loading", () => {

--- a/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-composer.test.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/__tests__/swarm-target-composer.test.tsx
@@ -31,6 +31,12 @@ vi.mock("@/hooks/useSandboxImages", () => ({
     },
   ],
 }));
+const cloudState = vi.hoisted(() => ({
+  ephemeralAvailable: true as boolean | undefined,
+}));
+vi.mock("@/hooks/useProjectComputer", () => ({
+  useEphemeralCloudAvailable: () => cloudState.ephemeralAvailable,
+}));
 vi.mock("@/hooks/useClients", () => ({
   useHostList: () => ({
     hosts: [{ hostId: "host-1", name: "Claude" }],
@@ -126,6 +132,7 @@ beforeEach(() => {
   flagState.skills = false;
   flagState.computers = false;
   flagState.environments = true;
+  cloudState.ephemeralAvailable = true;
 });
 
 describe("SwarmTargetComposer", () => {
@@ -209,5 +216,40 @@ describe("SwarmTargetComposer", () => {
     expect(screen.getByTestId("new-swarm-sandbox-image")).toHaveTextContent(
       /Computer · default/i
     );
+  });
+
+  it("labels computer execution as MCPJam cloud when computers are on", () => {
+    flagState.computers = true;
+    render(<Harness />);
+    expect(screen.getByTestId("new-swarm-cloud-run-badge")).toBeVisible();
+  });
+
+  it("shows no cloud badge when computers are off", () => {
+    render(<Harness />);
+    expect(
+      screen.queryByTestId("new-swarm-cloud-run-badge")
+    ).not.toBeInTheDocument();
+  });
+
+  it("blocks the sandbox-image opt-in when cloud sandboxes are unreachable", () => {
+    // `false` means a sandbox-backed session WOULD fail per-attempt — the
+    // composer must warn and disable the opt-in instead of inviting it.
+    flagState.computers = true;
+    cloudState.ephemeralAvailable = false;
+    render(<Harness />);
+    expect(screen.getByTestId("new-swarm-cloud-unreachable")).toBeVisible();
+    expect(screen.getByTestId("new-swarm-sandbox-image")).toBeDisabled();
+  });
+
+  it("stays quiet while cloud availability is still loading", () => {
+    // Loading/fetch-failure must never paint the warning — only a real
+    // server `false` may.
+    flagState.computers = true;
+    cloudState.ephemeralAvailable = undefined;
+    render(<Harness />);
+    expect(
+      screen.queryByTestId("new-swarm-cloud-unreachable")
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("new-swarm-sandbox-image")).not.toBeDisabled();
   });
 });

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-running-step.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-running-step.tsx
@@ -713,7 +713,9 @@ export function NewSwarmRunningStep({
         if (attempt.status !== "rate_limited" && attempt.status !== "failed") {
           continue;
         }
-        if (!attempt.errorMessage) continue;
+        // A structured code alone is enough — the humanizer maps recognized
+        // sandbox codes without any stored message.
+        if (!attempt.errorMessage && !attempt.errorCode) continue;
         return {
           kind: attempt.status,
           info: humanizeSwarmAttemptError(

--- a/mcpjam-inspector/client/src/components/swarms/new-swarm-running-step.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/new-swarm-running-step.tsx
@@ -716,7 +716,10 @@ export function NewSwarmRunningStep({
         if (!attempt.errorMessage) continue;
         return {
           kind: attempt.status,
-          info: humanizeSwarmAttemptError(attempt.errorMessage),
+          info: humanizeSwarmAttemptError(
+            attempt.errorMessage,
+            attempt.errorCode,
+          ),
         };
       }
     }

--- a/mcpjam-inspector/client/src/components/swarms/swarm-target-composer.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-target-composer.tsx
@@ -20,6 +20,8 @@ import {
 import { EnvironmentPicker } from "@/components/project-environments/environment-picker";
 import { ProjectEnvironmentSkillsPicker } from "@/components/project-environments/ProjectEnvironmentSkillsPicker";
 import { ServerGroupPicker } from "@/components/hosts/ServerGroupPicker";
+import { CloudRunBadge } from "@/components/computer/CloudRunBadge";
+import { CloudUnreachableNotice } from "@/components/computer/CloudUnreachableNotice";
 import { EnvironmentBuildBadge } from "@/components/computer/EnvironmentBuildBadge";
 import { MAX_ENVIRONMENTS_PER_JOURNEY } from "@/components/swarms/journey-environments";
 import {
@@ -33,6 +35,7 @@ import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { useSkillsEnabled } from "@/hooks/useSkillsEnabled";
 import { useSandboxImages } from "@/hooks/useSandboxImages";
+import { useEphemeralCloudAvailable } from "@/hooks/useProjectComputer";
 import type {
   ProjectEnvironmentSkillSelection,
   ProjectEnvironmentView,
@@ -275,6 +278,12 @@ export function SwarmTargetComposer({
   const computersEnabled = useComputersEnabled();
   const environmentsEnabled = useProjectEnvironmentsEnabled();
   const sandboxImages = useSandboxImages(computersEnabled ? projectId : null);
+  const ephemeralCloudAvailable = useEphemeralCloudAvailable();
+  // `false` only from a real server answer — loading/fetch-failure never
+  // paints the warning. Gates the sandbox-image opt-in AND shows the
+  // preflight band, so a user isn't invited into a known per-attempt failure.
+  const sandboxCloudUnreachable =
+    computersEnabled && ephemeralCloudAvailable === false;
   const liveEnvironments = useMemo(
     () => environments.filter((e) => !e.archivedAt),
     [environments]
@@ -348,13 +357,29 @@ export function SwarmTargetComposer({
   return (
     <div className="space-y-3" data-testid="new-swarm-target-composer">
       <div className="space-y-1">
-        <Label>Where it runs</Label>
+        <div className="flex flex-wrap items-center gap-2">
+          <Label>Where it runs</Label>
+          {computersEnabled ? (
+            <CloudRunBadge
+              tooltip="Swarm sessions run their computer commands in disposable MCPJam cloud sandboxes — never on the machine running this inspector."
+              data-testid="new-swarm-cloud-run-badge"
+            />
+          ) : null}
+        </div>
         <p className="text-sm leading-relaxed text-muted-foreground">
           {environmentsEnabled
             ? "Start from an environment or build from clients and the shared stack below. Clients are the usual fan-out."
             : "Build from clients and the shared stack below. Clients are the usual fan-out."}
         </p>
       </div>
+
+      {sandboxCloudUnreachable ? (
+        <CloudUnreachableNotice
+          data-testid="new-swarm-cloud-unreachable"
+          message="Swarm computer commands need an MCPJam cloud sandbox, which this inspector can't run."
+          detail="Runs without a computer can continue; sandbox-backed sessions would fail, so picking a sandbox image is disabled here."
+        />
+      ) : null}
 
       {environmentsEnabled ? (
         <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -415,7 +440,7 @@ export function SwarmTargetComposer({
             data-testid="new-swarm-sandbox-image"
             aria-label="Sandbox image"
             value={value.legos.computerEnvironmentId ?? ""}
-            disabled={disabled}
+            disabled={disabled || sandboxCloudUnreachable}
             onChange={(e) =>
               patchLegos({
                 computerEnvironmentId: e.target.value || null,

--- a/mcpjam-inspector/client/src/components/swarms/swarm-target-composer.tsx
+++ b/mcpjam-inspector/client/src/components/swarms/swarm-target-composer.tsx
@@ -377,7 +377,7 @@ export function SwarmTargetComposer({
         <CloudUnreachableNotice
           data-testid="new-swarm-cloud-unreachable"
           message="Swarm computer commands need an MCPJam cloud sandbox, which this inspector can't run."
-          detail="Runs without a computer can continue; sandbox-backed sessions would fail, so picking a sandbox image is disabled here."
+          detail="Runs without a computer can continue; sandbox-backed sessions would fail. Picking a new sandbox image is disabled — clear an existing one with Computer · default."
         />
       ) : null}
 
@@ -440,7 +440,7 @@ export function SwarmTargetComposer({
             data-testid="new-swarm-sandbox-image"
             aria-label="Sandbox image"
             value={value.legos.computerEnvironmentId ?? ""}
-            disabled={disabled || sandboxCloudUnreachable}
+            disabled={disabled}
             onChange={(e) =>
               patchLegos({
                 computerEnvironmentId: e.target.value || null,
@@ -456,7 +456,11 @@ export function SwarmTargetComposer({
                 <option
                   key={img.environmentId}
                   value={img.environmentId}
-                  disabled={isDraft}
+                  // When cloud sandboxes are unreachable, IMAGE options are
+                  // disabled but the select itself stays live — a pin seeded
+                  // from a saved environment/draft must remain clearable back
+                  // to "Computer · default" (the opt-out the notice promises).
+                  disabled={isDraft || sandboxCloudUnreachable}
                 >
                   {img.name}
                   {isDraft

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEphemeralCloudAvailable.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEphemeralCloudAvailable.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+/**
+ * The preflight bit the cloud-only surfaces (swarms / evals / user testing)
+ * read before launch. The subtle rows are the derivations: a server that
+ * predates `capabilities` falls back to `localConfigured` — NOT to
+ * `remoteDataPlaneUrl`, because remote delegation covers only the personal
+ * computer and says nothing about executing in disposable sandboxes.
+ *
+ * `vi.resetModules()` per test because the module caches its first parsed
+ * /config answer for the whole SPA session.
+ */
+describe("useEphemeralCloudAvailable", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  async function loadWithConfig(response: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => response })),
+    );
+    return await import("../useProjectComputer");
+  }
+
+  it("reads capabilities.ephemeralCloudAvailable when the server sends it", async () => {
+    const mod = await loadWithConfig({
+      localConfigured: true,
+      remoteDataPlaneUrl: null,
+      capabilities: { ephemeralCloudAvailable: false },
+    });
+    const { result } = renderHook(() => mod.useEphemeralCloudAvailable());
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it("derives from localConfigured on an older server — a remote data plane does NOT count", async () => {
+    // Remote-only inspector: personal bash/terminal delegate fine, but not a
+    // single disposable-sandbox command can run here.
+    const mod = await loadWithConfig({
+      localConfigured: false,
+      remoteDataPlaneUrl: "https://dp.example.com",
+    });
+    const { result } = renderHook(() => mod.useEphemeralCloudAvailable());
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it("is true on an older server that holds the credentials itself", async () => {
+    const mod = await loadWithConfig({
+      localConfigured: true,
+      remoteDataPlaneUrl: null,
+    });
+    const { result } = renderHook(() => mod.useEphemeralCloudAvailable());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("fails open on a fetch failure — no scary banners from a flaky request", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    const mod = await import("../useProjectComputer");
+    const { result } = renderHook(() => mod.useEphemeralCloudAvailable());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useEphemeralCloudAvailable.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useEphemeralCloudAvailable.test.ts
@@ -55,6 +55,22 @@ describe("useEphemeralCloudAvailable", () => {
     await waitFor(() => expect(result.current).toBe(true));
   });
 
+  it("ignores a non-boolean capabilities value and derives from localConfigured", async () => {
+    const mod = await loadWithConfig({
+      localConfigured: false,
+      remoteDataPlaneUrl: null,
+      capabilities: { ephemeralCloudAvailable: "yes" },
+    });
+    const { result } = renderHook(() => mod.useEphemeralCloudAvailable());
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it("treats an unparseable body like a fetch failure — per-mount fail-open", async () => {
+    const mod = await loadWithConfig(null);
+    const { result } = renderHook(() => mod.useEphemeralCloudAvailable());
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
   it("fails open on a fetch failure — no scary banners from a flaky request", async () => {
     vi.stubGlobal(
       "fetch",

--- a/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
@@ -148,6 +148,16 @@ export function useMintTerminalToken(): (args: {
 export interface ComputersDataPlaneConfig {
   localConfigured: boolean;
   remoteDataPlaneUrl: string | null;
+  /**
+   * Can this inspector EXECUTE in ephemeral (eval/swarm/chatbox) sandboxes?
+   * Distinct from personal-computer availability: `remoteDataPlaneUrl`
+   * delegates only personal bash/terminal, so a remote-only inspector can
+   * drive a personal Computer yet cannot run a single disposable-sandbox
+   * command. Read from the server's `capabilities.ephemeralCloudAvailable`
+   * when present; older servers omit it and the derivation falls back to
+   * `localConfigured` (creds present ⇔ ephemeral exec works).
+   */
+  ephemeralCloudAvailable?: boolean;
 }
 
 // One fetch per page load — the answer is env-derived and can't change
@@ -158,13 +168,37 @@ function parseDataPlaneConfig(value: unknown): ComputersDataPlaneConfig | null {
   if (!value || typeof value !== "object") return null;
   const record = value as Record<string, unknown>;
   if (typeof record.localConfigured !== "boolean") return null;
+  const capabilities =
+    record.capabilities && typeof record.capabilities === "object"
+      ? (record.capabilities as Record<string, unknown>)
+      : undefined;
   return {
     localConfigured: record.localConfigured,
     remoteDataPlaneUrl:
       typeof record.remoteDataPlaneUrl === "string"
         ? record.remoteDataPlaneUrl
         : null,
+    ...(typeof capabilities?.ephemeralCloudAvailable === "boolean"
+      ? { ephemeralCloudAvailable: capabilities.ephemeralCloudAvailable }
+      : {}),
   };
+}
+
+/**
+ * Preflight bit for the cloud-only surfaces (swarms / evals / user testing):
+ * `false` means a run that needs a disposable sandbox WILL fail to execute
+ * commands on this inspector, and the UI should say so before launch instead
+ * of after. `undefined` while the config is loading.
+ *
+ * Fail-open on transient /config failures (the per-mount fallback assumes a
+ * local data plane) — a flaky fetch must not paint scary banners on a
+ * perfectly configured deployment; a genuine `false` only comes from a real
+ * server answer.
+ */
+export function useEphemeralCloudAvailable(): boolean | undefined {
+  const config = useComputersDataPlaneConfig();
+  if (config === undefined) return undefined;
+  return config.ephemeralCloudAvailable ?? config.localConfigured;
 }
 
 /** `undefined` while loading. On fetch failure assumes a local data plane —

--- a/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
@@ -163,6 +163,10 @@ export interface ComputersDataPlaneConfig {
 // One fetch per page load — the answer is env-derived and can't change
 // without a server restart.
 let cachedDataPlaneConfig: ComputersDataPlaneConfig | null = null;
+// Concurrent first mounts (e.g. suite view + suite header) share one request
+// instead of racing duplicate fetches to the same env-derived answer.
+let inFlightDataPlaneConfigFetch: Promise<ComputersDataPlaneConfig | null> | null =
+  null;
 
 function parseDataPlaneConfig(value: unknown): ComputersDataPlaneConfig | null {
   if (!value || typeof value !== "object") return null;
@@ -213,25 +217,28 @@ export function useComputersDataPlaneConfig():
   useEffect(() => {
     if (cachedDataPlaneConfig) return;
     let cancelled = false;
-    void fetch("/api/web/computers/config")
+    // Only cache real answers. The assume-local fallback below is per-mount,
+    // so a transient /config failure can't pin the wrong data plane for the
+    // rest of the SPA session. The in-flight promise IS shared (deduped), but
+    // it resolves `null` on failure so each mount applies its own fallback.
+    inFlightDataPlaneConfigFetch ??= fetch("/api/web/computers/config")
       .then((response) => (response.ok ? response.json() : null))
       .then((json: unknown) => {
-        // Only cache real answers. The assume-local fallback below is
-        // per-mount, so a transient /config failure can't pin the wrong
-        // data plane for the rest of the SPA session.
         const parsed = parseDataPlaneConfig(json);
         if (parsed) cachedDataPlaneConfig = parsed;
-        if (!cancelled) {
-          setConfig(
-            parsed ?? { localConfigured: true, remoteDataPlaneUrl: null }
-          );
-        }
+        return parsed;
       })
-      .catch(() => {
-        if (!cancelled) {
-          setConfig({ localConfigured: true, remoteDataPlaneUrl: null });
-        }
+      .catch(() => null)
+      .finally(() => {
+        inFlightDataPlaneConfigFetch = null;
       });
+    void inFlightDataPlaneConfigFetch.then((parsed) => {
+      if (!cancelled) {
+        setConfig(
+          parsed ?? { localConfigured: true, remoteDataPlaneUrl: null }
+        );
+      }
+    });
     return () => {
       cancelled = true;
     };

--- a/mcpjam-inspector/shared/__tests__/swarm-attempt-error.test.ts
+++ b/mcpjam-inspector/shared/__tests__/swarm-attempt-error.test.ts
@@ -138,6 +138,12 @@ describe("humanizeSwarmAttemptError — sandbox error codes", () => {
     expect(info.message).toBe("Daily limit reached");
   });
 
+  it("maps a recognized code even with no stored message at all", () => {
+    const info = humanizeSwarmAttemptError(undefined, "sandbox_at_capacity");
+    expect(info.message).toMatch(/at capacity/i);
+    expect(info.code).toBe("sandbox_at_capacity");
+  });
+
   it("stays idempotent-compatible when no code is passed", () => {
     const info = humanizeSwarmAttemptError("Could not provision a sandbox.");
     expect(info.message).toBe("Could not provision a sandbox.");

--- a/mcpjam-inspector/shared/__tests__/swarm-attempt-error.test.ts
+++ b/mcpjam-inspector/shared/__tests__/swarm-attempt-error.test.ts
@@ -104,3 +104,43 @@ describe("humanizeSwarmAttemptError", () => {
     expect(info.canTopUp).toBeUndefined();
   });
 });
+
+describe("humanizeSwarmAttemptError — sandbox error codes", () => {
+  it("maps each sandbox code to a cloud-framed sentence", () => {
+    for (const code of [
+      "sandbox_unavailable",
+      "sandbox_at_capacity",
+      "sandbox_error",
+    ]) {
+      const info = humanizeSwarmAttemptError("whatever was stored", code);
+      expect(info.code).toBe(code);
+      expect(info.message).toMatch(/MCPJam cloud|cloud sandbox/i);
+      expect(info.message.length).toBeLessThanOrEqual(MAX_ATTEMPT_ERROR_CHARS);
+    }
+  });
+
+  it("prefers the code over the stored operator-framed message", () => {
+    // The stored sentence talks about data planes — accurate for operators,
+    // opaque for the user whose swarm didn't run.
+    const info = humanizeSwarmAttemptError(
+      "This server is not configured to provision disposable sandboxes (the computers data plane is unavailable), so this session cannot run the shell its target requires.",
+      "sandbox_unavailable"
+    );
+    expect(info.message).not.toMatch(/data plane/i);
+    expect(info.message).toMatch(/MCPJam cloud/i);
+  });
+
+  it("ignores unknown codes and falls back to message parsing", () => {
+    const info = humanizeSwarmAttemptError(
+      '{"error":"Daily limit reached"}',
+      "spend_cap_exceeded"
+    );
+    expect(info.message).toBe("Daily limit reached");
+  });
+
+  it("stays idempotent-compatible when no code is passed", () => {
+    const info = humanizeSwarmAttemptError("Could not provision a sandbox.");
+    expect(info.message).toBe("Could not provision a sandbox.");
+    expect(info.code).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/shared/swarm-attempt-error.ts
+++ b/mcpjam-inspector/shared/swarm-attempt-error.ts
@@ -87,15 +87,44 @@ function compose(headline: string, details?: string): string {
 }
 
 /**
+ * Cloud-sandbox failure codes (`journeyRunAttempts.errorCode`, written by the
+ * runner's sandbox path) → user-facing sentences. Framed around "MCPJam
+ * cloud" because the stored messages talk about data planes and control
+ * planes — accurate for operators, opaque for the person whose swarm just
+ * didn't run. Keyed by the exact literals the runner reports
+ * (`swarm-runner.ts` / `swarm-sandbox.ts`).
+ */
+const SANDBOX_ERROR_CODE_MESSAGES: Record<string, string> = {
+  sandbox_unavailable:
+    "This session needed an MCPJam cloud sandbox for its computer commands, but this inspector can't run cloud sandboxes — the session could not execute commands.",
+  sandbox_at_capacity:
+    "MCPJam cloud is at capacity right now — try the run again in a few minutes.",
+  sandbox_error:
+    "The cloud sandbox for this session hit an error while starting — try the run again.",
+};
+
+/**
  * Extract a clean message + structured hints from whatever the runner caught.
  *
  * Never throws and never returns an empty message — an unparseable input is
  * scrubbed and passed through, because a slightly ugly real error beats a
  * confident "Unknown error".
+ *
+ * `errorCode` is the attempt row's structured code, when the caller has one.
+ * A recognized sandbox code wins over the stored message: those messages are
+ * operator-framed ("not configured to provision disposable sandboxes"), and
+ * the code says precisely what a user can act on.
  */
 export function humanizeSwarmAttemptError(
-  raw: string | undefined | null
+  raw: string | undefined | null,
+  errorCode?: string | null
 ): SwarmAttemptErrorInfo {
+  const sandboxMessage = errorCode
+    ? SANDBOX_ERROR_CODE_MESSAGES[errorCode]
+    : undefined;
+  if (sandboxMessage && errorCode) {
+    return { message: sandboxMessage, code: errorCode };
+  }
   const input = (raw ?? "").trim();
   if (!input) return { message: "The session failed for an unknown reason." };
 


### PR DESCRIPTION
PR 2 of the local-computer-engine program (PR 1: #3799, merged). Client-only, independent of the server-side engine PRs — ships against today's config endpoint and forward-reads the `capabilities` shape PR 4 will add.

## What this does

Swarms, evals, and User Testing run their computer commands in disposable **MCPJam cloud** sandboxes regardless of where the inspector runs. Nothing in the UI said so, and an inspector that can't execute in those sandboxes (e.g. a local `npx` install) let users launch runs that then failed opaquely per-attempt.

**Badges** — new shared `CloudRunBadge` ("Computer: MCPJam cloud", tooltip carries the per-surface nuance) on:
- the swarm composer's "Where it runs" section,
- the eval suite's "Computer environment" section (via `SettingsSection.labelAccessory`) + a sentence in its helper copy,
- the User Testing scenario identity band + a note under the create-flow environment picker.

The badge deliberately describes **computer execution only** — not "this whole run happens remotely" (a locally-launched swarm still orchestrates and calls models from this process).

**Preflights** — new `useEphemeralCloudAvailable()`: reads the server's `capabilities.ephemeralCloudAvailable` when present (PR 4's shape), else derives from `localConfigured`. **Never** from `remoteDataPlaneUrl` — remote delegation covers only personal-computer exec, so a remote-only inspector can drive a personal Computer yet can't run one disposable-sandbox command (the per-plan capability split). When `false`:
- swarm composer shows an amber `CloudUnreachableNotice` and disables the sandbox-image opt-in,
- every eval run control (Run all / per-case / rerun) blocks through the existing `evalRunsDisabledReason` channel with one consistent reason, plus a notice next to the pin when the suite pins an image.

Loading and fetch failures stay quiet — only a real server `false` warns (module-cached config, per-mount fail-open fallback preserved).

**Swarm error mapping** — attempt `errorCode`s `sandbox_unavailable` / `sandbox_at_capacity` / `sandbox_error` now map to user-framed cloud-sandbox sentences in `shared/swarm-attempt-error.ts` (the code wins over the stored operator-framed "computers data plane" message); the run-failure banner passes `attempt.errorCode` through.

**Copy fix** — the environments editor claimed "Playground, chatboxes, and swarms don't use the sandbox image yet", which is false since swarms provision per-attempt and User Testing per-conversation from the pin. Now: cloud runs (evals, swarms, user-testing) boot from the image; sandbox images never apply to the machine running the inspector.

Note: the plan's copy referenced "the local machine engine" — that engine ships in PR 3+, so this PR's copy says "the machine running this inspector" instead; happy to switch once the engine exists.

## Tests

- Composer: badge on/off with the flag, notice + disabled opt-in when unreachable, quiet while loading (4 new).
- Suite header: pinned-image + unreachable blocks Run all; reachable stays enabled (2 new).
- Humanizer: 3 codes mapped, code-over-message precedence, unknown code falls through, no-code idempotent (4 new).
- Hook: capabilities read, localConfigured derivation (remote data plane does NOT count), fail-open on fetch error (4 new).
- Collateral: all 29 chatboxes/project-environments/evals-tab suites green (273 tests); client typecheck exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UX, gating, and copy; preflight fails open on config fetch errors so it should not block healthy deployments.
> 
> **Overview**
> Makes it explicit that **swarm, eval, and User Testing computer commands** run in MCPJam cloud sandboxes (not on the inspector host), and **blocks or warns** before launches that would fail when this inspector cannot run those sandboxes.
> 
> Adds shared **`CloudRunBadge`** and **`CloudUnreachableNotice`** on swarms, eval suite settings, and User Testing (create + detail). Introduces **`useEphemeralCloudAvailable()`** from `/api/web/computers/config` (`capabilities.ephemeralCloudAvailable`, else `localConfigured` — not `remoteDataPlaneUrl`). When cloud is unavailable: swarm composer shows a notice and disables new sandbox-image options while still allowing clear to “Computer · default”; **`suite-iterations-view`** derives **`evalRunsDisabledReason`** once via **`evalSuitePinsSandboxImage`** (suite pin or attached environment) and gates all run controls; run detail adds a separate replay gate when the **frozen snapshot** still pins an image.
> 
> **`humanizeSwarmAttemptError`** now accepts **`errorCode`** and maps sandbox failure codes to user-facing cloud messages; the running-step failure banner passes **`attempt.errorCode`**. Environment editor copy is corrected for cloud-only sandbox use. Config fetch is deduped; fetch/parse failures fail open so warnings only appear on a real server **`false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe67a750948cfca01e680e48da99f0369b9d211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks and enforces that computer commands for swarms, evals, and User Testing run in MCPJam cloud sandboxes. Adds clear badges and preflight checks, and blocks launches that would fail; eval gating now consistently covers all controls and replay-from-snapshot.

- New Features
  - Added `CloudRunBadge` on swarm “Where it runs,” evals “Computer environment,” and User Testing scenario header; added a note in the User Testing create flow.
  - Added `useEphemeralCloudAvailable()` preflight: reads `capabilities.ephemeralCloudAvailable` (fallback to `localConfigured`; never `remoteDataPlaneUrl`). When false:
    - Swarm composer shows `CloudUnreachableNotice`; disables new sandbox-image options but keeps the select enabled so an existing pin can be cleared to “Computer · default.”
    - Evals disable all run controls for suites that pin a sandbox image, including pins from ATTACHED project environments; the gate is derived once in `SuiteIterationsView` so header, per-case, and run-detail actions share one disabled reason.
  - Loading/fetch failures stay quiet; the `/api/web/computers/config` fetch is deduped across first mounts and still fails open per mount.

- Bug Fixes
  - Run-detail replay also blocks when the selected run’s snapshot pins a sandbox image and cloud sandboxes are unavailable, even if the live suite no longer pins.
  - Map attempt `errorCode`s `sandbox_unavailable`, `sandbox_at_capacity`, `sandbox_error` to clear, user-focused messages; mapping now works even when there’s no stored message. The run banner passes `attempt.errorCode`.
  - Updated environment editor copy: swarms, evals, and user-testing boot from the pinned image; images apply only to cloud runs, not the machine running the inspector.

<sup>Written for commit 9fe67a750948cfca01e680e48da99f0369b9d211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

