### PR TITLE
feat(plugins): fetch the backend bundle on a local cache miss

### DIFF
--- a/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConvexHttpClient } from "convex/browser";
 import { appendFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -10,8 +10,10 @@ import {
   resolvePluginOriginForServer,
 } from "../local-stdio.js";
 import {
+  fixtureBundleFiles,
   fixtureBundleHash,
   fixtureBundleSource,
+  fixtureBundleZip,
   makeCacheRoot,
 } from "./fixture-bundle.js";
 import { WebRouteError } from "../../../routes/web/errors.js";
@@ -30,6 +32,8 @@ function stubClient(options?: {
   enabled?: boolean;
   available?: boolean;
   bundleHash?: string | null;
+  /** When set, `plugins:getBundleDownloadUrl` answers with this URL. */
+  downloadUrl?: string;
 }): ConvexHttpClient {
   const enabled = options?.enabled ?? true;
   const available = options?.available ?? true;
@@ -37,6 +41,12 @@ function stubClient(options?: {
     options?.bundleHash === undefined ? "hash-pending" : options.bundleHash;
   return {
     async query(name: string) {
+      if (name === "plugins:getBundleDownloadUrl") {
+        if (options?.downloadUrl === undefined) {
+          throw new Error("no downloadable bundle");
+        }
+        return { url: options.downloadUrl, bundleHash };
+      }
       if (name === "plugins:listProjectPlugins") {
         return [
           {
@@ -87,6 +97,7 @@ describe("plugin stdio origin resolution", () => {
 
   afterEach(async () => {
     releasePluginLease(SERVER_ID);
+    vi.unstubAllGlobals();
     await cleanup();
   });
 
@@ -235,6 +246,68 @@ describe("plugin stdio origin resolution", () => {
       ok: false,
       reason: "bundle_not_materialized",
     });
+  });
+
+  it("downloads the backend bundle on a cache miss and materializes it", async () => {
+    // Nothing pre-seeded in the cache — the historical dead end. The
+    // download endpoint serves the fixture bytes; the verified cache
+    // re-hashes them against the pinned bundleHash before anything spawns.
+    const zipBytes = await fixtureBundleZip();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(zipBytes as unknown as BodyInit))
+    );
+
+    const prepared = await preparePluginStdioLaunch({
+      client: stubClient({
+        bundleHash,
+        downloadUrl: "https://convex.example/storage/fixture-bundle",
+      }),
+      cache,
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      spec: PLACEHOLDER_SPEC,
+      leaseId: SERVER_ID,
+    });
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.launch.args[0]).toBe(
+      `${prepared.pluginRoot}/server/index.js`
+    );
+    expect(cache.activeEntries()).toEqual([prepared.pluginRoot]);
+    prepared.release();
+  });
+
+  it("fails closed when the downloaded content does not hash to the pinned bundle", async () => {
+    // A valid archive with the WRONG content: the cache's re-parse computes
+    // a different bundleHash than the pin, so nothing materializes.
+    const tamperedZip = await fixtureBundleZip({
+      ...fixtureBundleFiles(),
+      "data.txt": "tampered payload\n",
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(tamperedZip as unknown as BodyInit))
+    );
+
+    const prepared = await preparePluginStdioLaunch({
+      client: stubClient({
+        bundleHash,
+        downloadUrl: "https://convex.example/storage/tampered-bundle",
+      }),
+      cache,
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      spec: PLACEHOLDER_SPEC,
+      leaseId: SERVER_ID,
+    });
+
+    expect(prepared).toMatchObject({
+      ok: false,
+      reason: "bundle_verification_failed",
+    });
+    expect(cache.activeEntries()).toEqual([]);
   });
 });
 

--- a/mcpjam-inspector/server/services/plugins/local-stdio.ts
+++ b/mcpjam-inspector/server/services/plugins/local-stdio.ts
@@ -35,10 +35,13 @@ import {
   PLUGIN_PLACEHOLDERS,
   type PluginFileSource,
 } from "@mcpjam/sdk/plugin-bundle";
+import { createZipPluginFileSource } from "./bundle-file-sources.js";
+import { MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES } from "../../../shared/plugin-bundle-limits.js";
 
 export { PluginBundleCache, PluginBundleCacheError };
 
 const LIST_PLUGINS_FUNCTION_REF = "plugins:listProjectPlugins" as const;
+const BUNDLE_DOWNLOAD_FUNCTION_REF = "plugins:getBundleDownloadUrl" as const;
 
 let leaseSequence = 0;
 
@@ -102,6 +105,44 @@ export async function resolvePluginOriginForServer(
   // without an attested origin there is no bundle hash to materialize against.
   const origin = attribution?.serverOrigins.get(args.serverId);
   return origin ? { ...origin } : null;
+}
+
+/**
+ * Fetch a version's bundle bytes from the backend's authorized read
+ * (`plugins:getBundleDownloadUrl`, Phase 0.4) as a parseable source.
+ *
+ * Every failure returns `null` rather than throwing: a backend without the
+ * endpoint yet, revoked access, a network error, an over-cap body, or a
+ * non-archive response all fall back to the historical "re-import on this
+ * device" remedy. Integrity is NOT judged here — the verified cache
+ * re-hashes whatever this returns against the pinned bundleHash.
+ */
+async function downloadBundleSource(
+  client: ConvexHttpClient,
+  pluginVersionId: string
+): Promise<PluginFileSource | null> {
+  let url: string;
+  try {
+    const raw: unknown = await client.query(
+      BUNDLE_DOWNLOAD_FUNCTION_REF as any,
+      { pluginVersionId } as any
+    );
+    if (!isRecord(raw) || typeof raw.url !== "string" || raw.url.length === 0) {
+      return null;
+    }
+    url = raw.url;
+  } catch {
+    return null;
+  }
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES) return null;
+    return await createZipPluginFileSource(new Uint8Array(buffer));
+  } catch {
+    return null;
+  }
 }
 
 export type PluginStdioPreparationFailure =
@@ -180,15 +221,49 @@ export async function preparePluginStdioLaunch(args: {
   } catch (error) {
     const code =
       error instanceof PluginBundleCacheError ? error.code : "invalid_bundle";
-    return {
-      ok: false,
-      reason:
-        code === "not_cached"
-          ? "bundle_not_materialized"
-          : "bundle_verification_failed",
-      origin,
-      message: error instanceof Error ? error.message : String(error),
-    };
+    if (code !== "not_cached" || args.source !== undefined) {
+      return {
+        ok: false,
+        reason:
+          code === "not_cached"
+            ? "bundle_not_materialized"
+            : "bundle_verification_failed",
+        origin,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+    // Cache miss with no caller-supplied content: fetch the backend's stored
+    // bundle (the version's own bytes, re-stored at commit). The cache
+    // re-parses the download through the SDK parser and compares the
+    // computed hash against the pinned `bundleHash`, so the URL grants
+    // CONTENT, never trust — wrong bytes surface as verification failures
+    // below and never materialize.
+    const downloaded = await downloadBundleSource(
+      args.client,
+      origin.pluginVersionId
+    );
+    if (downloaded === null) {
+      return {
+        ok: false,
+        reason: "bundle_not_materialized",
+        origin,
+        message: error instanceof Error ? error.message : String(error),
+      };
+    }
+    try {
+      const materialized = await args.cache.materialize(identity, {
+        source: downloaded,
+      });
+      root = materialized.root;
+    } catch (retryError) {
+      return {
+        ok: false,
+        reason: "bundle_verification_failed",
+        origin,
+        message:
+          retryError instanceof Error ? retryError.message : String(retryError),
+      };
+    }
   }
 
   const launch = resolvePluginStdioLaunch(args.spec, root);
@@ -339,7 +414,7 @@ function pluginStdioFailureToRouteError(
       return new WebRouteError(
         409,
         ErrorCode.CONFLICT,
-        `Plugin "${failure.origin.name}" is not materialized on this machine. Re-import the plugin from its folder on this device to run its local component.`,
+        `Plugin "${failure.origin.name}" is not materialized on this machine and its bundle could not be downloaded from MCPJam. Re-import the plugin from its folder on this device to run its local component.`,
         {
           reason: failure.reason,
           serverName,


### PR DESCRIPTION
## Summary

Agent Plugins program, **Phase 0.5** — the inspector half of [mcpjam-backend#908](https://github.com/MCPJam/mcpjam-backend/pull/908). Cross-machine local stdio no longer dead-ends: on a cache miss, `preparePluginStdioLaunch` fetches the version's stored bundle bytes through the backend's new authorized read (`plugins:getBundleDownloadUrl`) and materializes from the download.

## Trust model (unchanged)

The verified cache re-parses the download through the SDK parser and compares the computed hash against the backend-pinned `bundleHash` — the URL grants **content, never trust**. Tampered or stale bytes surface as `bundle_verification_failed` and nothing spawns.

## Deploy-order safety

Every download failure — endpoint missing on an older backend, revoked access, network error, body over the 25 MB compressed cap, non-archive response — returns `null` and falls back to the historical "re-import from this device" 409 (message updated to mention the failed download). So this merges safely regardless of when #908's deploy lands.

## Tests

`local-stdio.test.ts`: fetch-on-miss materializes, substitutes, and leases; a valid archive with the wrong content fails closed with nothing cached; the no-download path still reports `bundle_not_materialized`. Full `services/plugins` suite green (50 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plugin spawn preparation and remote bundle fetch, but integrity still depends on pinned bundle hashes and failures remain fail-closed without spawning children.
> 
> **Overview**
> **Cross-machine local stdio** no longer stops at an empty bundle cache: when `preparePluginStdioLaunch` hits a cache miss without caller-supplied bytes, it resolves a download URL via `plugins:getBundleDownloadUrl`, fetches the zip (with a compressed size cap), and materializes through the existing verified cache.
> 
> The **trust model is unchanged** — downloaded bytes are re-parsed and hashed against the pinned `bundleHash`; mismatches return `bundle_verification_failed` and nothing is cached or spawned. Any download failure (missing endpoint, bad response, oversize body, invalid archive) still fails closed as `bundle_not_materialized`, with the 409 message now noting that MCPJam could not download the bundle.
> 
> Tests cover fetch-on-miss success, tampered archive rejection, and stubbed Convex/fetch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d8cff9f5b2b3e7e92dfe73beb3db30acaef46b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch the plugin bundle from the backend on a local cache miss and materialize it to unblock cross‑machine local stdio. Verification stays strict: downloads are re‑hashed against the pinned `bundleHash`, and we fall back to re‑import if anything fails.

- New Features
  - Fetch-on-miss in `preparePluginStdioLaunch` via `plugins:getBundleDownloadUrl`; materializes from the downloaded ZIP.
  - Download guardrails: 25 MB compressed cap (`MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES`), non-OK/non-archive responses return null.
  - Safe fallback: missing endpoint, revoked access, or network errors return `bundle_not_materialized` and keep the 409 path; 409 message now mentions a failed download.
  - Tests: success path, tampered ZIP → `bundle_verification_failed`, and no-download path → `bundle_not_materialized`.

<sup>Written for commit 1d8cff9f5b2b3e7e92dfe73beb3db30acaef46b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

