### PR TITLE
fix(surface-core): timeout, error-code mapping and a real JSON-parse guard for the direct connect-link mint (B3)

### DIFF
--- a/surface-core/src/connect-link.js
+++ b/surface-core/src/connect-link.js
@@ -54,28 +54,29 @@ export function assertConnectUrl(candidate, origins) {
 	return candidate;
 }
 
-/** @param {{backend:any, ctx:any, origins?:string[], opts?:any}} args */
-export async function mintConnectUrl({
-	backend,
-	ctx,
-	origins = [],
-	opts = {},
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+/**
+ * The direct-fetch mint, used by a caller with no `backend` client of its
+ * own (today: discord-app). `backend.mintLink` goes through
+ * `createBackendClient`'s `post()` instead, which already carries its own
+ * timeout and error-code mapping — this one needed its own copy.
+ *
+ * @param {{baseUrl:string, token:string, path:string, surfaceKind?:string, tenantId?:string, actorId?:string, fetchImpl:typeof fetch, timeoutMs:number}} args
+ */
+async function mintConnectUrlDirect({
 	baseUrl,
 	token,
-	path = "/api/surface-link/session",
+	path,
 	surfaceKind,
 	tenantId,
 	actorId,
-	fetchImpl = fetch,
+	fetchImpl,
+	timeoutMs,
 }) {
-	let url;
-	if (backend) {
-		url = await backend.mintLink(ctx, opts);
-	} else {
-		if (!baseUrl || !token)
-			throw new InstallationBackendError("Connect link config is required.", {
-				code: "CONFIG",
-			});
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
 		const response = await fetchImpl(
 			`${String(baseUrl).replace(/\/+$/, "")}${path}`,
 			{
@@ -89,15 +90,71 @@ export async function mintConnectUrl({
 					surfaceTenantId: tenantId,
 					surfaceUserId: actorId,
 				}),
+				signal: controller.signal,
 			},
 		);
-		const payload = await response.json().catch(() => null);
+		let payload = null;
+		try {
+			payload = await response.json();
+		} catch (error) {
+			// Only an empty/malformed body reads as "no body". Anything else — a
+			// stream failure mid-read — is a real failure and must propagate, not
+			// be laundered into a response that merely lacks a url.
+			if (!(error instanceof SyntaxError)) throw error;
+		}
 		if (!response.ok)
 			throw new InstallationBackendError(
 				payload?.error || "Unable to create a connect link.",
 				{ status: response.status },
 			);
-		url = payload?.url;
+		return payload?.url;
+	} catch (error) {
+		if (error instanceof InstallationBackendError) throw error;
+		const aborted = error instanceof Error && error.name === "AbortError";
+		throw new InstallationBackendError(
+			aborted
+				? "Connect-link request timed out"
+				: `Connect-link request failed: ${error}`,
+			{ code: aborted ? "TIMEOUT" : "NETWORK" },
+		);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** @param {{backend:any, ctx:any, origins?:string[], opts?:any}} args */
+export async function mintConnectUrl({
+	backend,
+	ctx,
+	origins = [],
+	opts = {},
+	baseUrl,
+	token,
+	path = "/api/surface-link/session",
+	surfaceKind,
+	tenantId,
+	actorId,
+	fetchImpl = fetch,
+	timeoutMs = DEFAULT_TIMEOUT_MS,
+}) {
+	let url;
+	if (backend) {
+		url = await backend.mintLink(ctx, opts);
+	} else {
+		if (!baseUrl || !token)
+			throw new InstallationBackendError("Connect link config is required.", {
+				code: "CONFIG",
+			});
+		url = await mintConnectUrlDirect({
+			baseUrl,
+			token,
+			path,
+			surfaceKind,
+			tenantId,
+			actorId,
+			fetchImpl,
+			timeoutMs,
+		});
 	}
 	if (typeof url !== "string")
 		throw new InstallationBackendError(

--- a/surface-core/tests/connect-link-mint.test.js
+++ b/surface-core/tests/connect-link-mint.test.js
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mock, test } from "node:test";
+import { InstallationBackendError, mintConnectUrl } from "../src/index.js";
+
+/**
+ * `mintConnectUrl`'s direct-fetch branch (no `backend` — today: discord-app)
+ * used to have none of the robustness slack-app/agent/connect-link.js has
+ * always had: no timeout, no TIMEOUT/NETWORK error-code mapping, and a
+ * `.catch(() => null)` on the body parse that swallowed a mid-stream read
+ * failure the same way it swallows an empty body. These pin the fix.
+ */
+
+const BASE = { baseUrl: "https://app.mcpjam.com", token: "tok" };
+
+function jsonResponse(body, status = 200) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+test("the happy path is unaffected: mints, validates the origin, returns the url", async () => {
+	const fetchImpl = async () =>
+		jsonResponse({ url: "https://app.mcpjam.com/connect?t=x" });
+	const url = await mintConnectUrl({ ...BASE, fetchImpl });
+	assert.equal(url, "https://app.mcpjam.com/connect?t=x");
+});
+
+test("a network failure maps to a NETWORK-coded InstallationBackendError", async () => {
+	const fetchImpl = async () => {
+		throw new TypeError("fetch failed");
+	};
+	await assert.rejects(mintConnectUrl({ ...BASE, fetchImpl }), (error) => {
+		assert.ok(error instanceof InstallationBackendError);
+		assert.equal(error.code, "NETWORK");
+		return true;
+	});
+});
+
+test("a timeout maps to a TIMEOUT-coded error, driven in milliseconds via timeoutMs", async () => {
+	const fetchImpl = mock.fn(async (_url, init) => {
+		await new Promise((resolve, reject) => {
+			init.signal.addEventListener("abort", () => {
+				const error = new Error("aborted");
+				error.name = "AbortError";
+				reject(error);
+			});
+			// Never resolves on its own — the abort is the only exit, exactly like
+			// the real request the abort is standing in for.
+			setTimeout(resolve, 60_000).unref?.();
+		});
+		return jsonResponse({ url: "x" });
+	});
+	await assert.rejects(
+		mintConnectUrl({ ...BASE, fetchImpl, timeoutMs: 1 }),
+		(error) => {
+			assert.ok(error instanceof InstallationBackendError);
+			assert.equal(error.code, "TIMEOUT");
+			return true;
+		},
+	);
+});
+
+test("an empty/malformed body on a non-ok response still surfaces the HTTP status", async () => {
+	const fetchImpl = async () => new Response("not json", { status: 503 });
+	await assert.rejects(mintConnectUrl({ ...BASE, fetchImpl }), (error) => {
+		assert.ok(error instanceof InstallationBackendError);
+		assert.equal(error.status, 503);
+		return true;
+	});
+});
+
+test("a body read failure that is NOT a parse error propagates, instead of reading as 'no url'", async () => {
+	// Simulates a stream error mid-read: response.json() rejects with something
+	// other than SyntaxError. `.catch(() => null)` used to launder this into a
+	// silent 'no url', which then reported as the generic 'did not return a
+	// connect link' — hiding that the request itself actually failed.
+	const fetchImpl = async () => ({
+		ok: true,
+		status: 200,
+		json: async () => {
+			throw new Error("stream reset");
+		},
+	});
+	await assert.rejects(mintConnectUrl({ ...BASE, fetchImpl }), /stream reset/);
+});
+
+test("missing config still throws CONFIG before any fetch happens", async () => {
+	const fetchImpl = mock.fn(async () => jsonResponse({ url: "x" }));
+	await assert.rejects(
+		mintConnectUrl({ baseUrl: undefined, token: undefined, fetchImpl }),
+		(error) => {
+			assert.ok(error instanceof InstallationBackendError);
+			assert.equal(error.code, "CONFIG");
+			return true;
+		},
+	);
+	assert.equal(fetchImpl.mock.callCount(), 0);
+});


### PR DESCRIPTION
## Context

`mintConnectUrl`'s direct-fetch branch — no `backend` client, today used
only by `discord-app` — had none of the robustness
`slack-app/agent/connect-link.js` has always had for the identical request.
Origin normalization (the other gap this branch had) was already fixed in
#3791; this closes what was left.

## What changed

- **No timeout.** A hung `/api/surface-link/session` call would hang the
  caller indefinitely. Now bounded by an `AbortController`, defaulting to
  the fork's 10s, overridable via `timeoutMs` for tests.
- **No TIMEOUT/NETWORK error-code mapping.** A network failure surfaced as
  whatever raw error `fetch` threw — uncoded, un-wrapped in
  `InstallationBackendError`. Now classified the same way the fork does:
  `AbortError` → `TIMEOUT`, anything else → `NETWORK`.
- **`response.json().catch(() => null)` swallowed every parse failure**,
  including a body-stream error mid-read, the same way it swallowed a
  genuinely empty body. Only a `SyntaxError` (malformed/empty JSON) should
  read as "no body" — anything else is a real failure and must propagate.
  Before this, a stream error surfaced as "the backend did not return a
  connect link", hiding that the request itself actually failed.

## Scope

Narrow on purpose: only the direct-fetch path. `backend.mintLink()` already
goes through `createBackendClient`'s `post()`, which has its own timeout
and error mapping — wrapping it again would be redundant. No call-site
changes needed anywhere (`discord-app/app.js` is the only production caller
of the direct-fetch branch); `timeoutMs` is a new optional param with the
fork's own default, so nothing changes for a caller that doesn't pass one.

## Tests

6 new tests in `surface-core/tests/connect-link-mint.test.js`: happy path
unaffected, a network failure maps to `NETWORK`, a timeout (driven in
milliseconds via `timeoutMs`, matching the fork's own test technique) maps
to `TIMEOUT`, a malformed body on a non-ok response still surfaces the HTTP
status, a non-parse body-read failure propagates instead of reading as "no
url", and missing config still throws `CONFIG` before any fetch happens.

`npm run verify` green for `surface-core`, `discord-app`, and `slack-app`
(unaffected — the fork itself is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the direct-fetch branch in surface-core; backend mint path and call sites are unchanged aside from safer failure behavior on hung or failed HTTP.
> 
> **Overview**
> **Hardens the direct-fetch path in `mintConnectUrl`** (no `backend` client — e.g. discord-app) so it matches the robustness already used elsewhere for the same kind of request.
> 
> The inline POST is moved into **`mintConnectUrlDirect`**, which bounds the call with **`AbortController`** (default **10s**, overridable via **`timeoutMs`**). Failures are wrapped in **`InstallationBackendError`** with **`TIMEOUT`** or **`NETWORK`** instead of raw fetch errors. **JSON body handling** no longer swallows every parse failure: only **`SyntaxError`** is treated as an empty/malformed body; mid-stream read errors propagate instead of turning into “did not return a connect link.” The **`backend.mintLink`** branch is unchanged.
> 
> Adds **`surface-core/tests/connect-link-mint.test.js`** with six tests covering happy path, network/timeout codes, non-OK malformed body, stream errors, and CONFIG-before-fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eb5d1b4951081b00173060b83b4729521f9d7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 10s timeout, clear error-code mapping, and safer JSON parsing to the direct connect-link mint in `surface-core`. Prevents hangs and surfaces accurate failures for `discord-app`.

- **Bug Fixes**
  - Added `AbortController` timeout for `/api/surface-link/session`; configurable via `timeoutMs` (default 10s).
  - Mapped fetch errors to `InstallationBackendError`: `AbortError` → `TIMEOUT`, others → `NETWORK`.
  - Only treat `SyntaxError` as empty/malformed JSON; propagate other body-read failures and preserve non-OK HTTP status.
  - Scope: only the direct-fetch path; `backend.mintLink` via `createBackendClient` is unchanged; no call-site changes.

<sup>Written for commit 1eb5d1b4951081b00173060b83b4729521f9d7b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

