### PR TITLE
refactor(plugins): attribute a turn's plugins in one probe call

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -427,6 +427,15 @@ describe("web chat-v2 — environment execution target", () => {
         ? {
             pluginVersions: [ENV_SPEC.pluginVersions[0]],
             effectiveServerIds: ["env-server-2"],
+            serverComponents: [
+              {
+                pluginVersionId: ENV_SPEC.pluginVersions[0].pluginVersionId,
+                componentKey: "server:asana",
+                placement: "remote",
+                authenticationPolicy: "on_use",
+                materializedServerId: "env-server-2",
+              },
+            ],
             pluginSkills: [],
             unavailableComponents: [],
           }
@@ -486,6 +495,7 @@ describe("web chat-v2 — environment execution target", () => {
         ? {
             pluginVersions: [],
             effectiveServerIds: [],
+            serverComponents: [],
             pluginSkills: [],
             unavailableComponents: [
               { pluginVersionId: "pv_1", reason: "disabled" },
@@ -509,6 +519,28 @@ describe("web chat-v2 — environment execution target", () => {
   });
 
   it("delivers ONLY the resolved skills to the emulated engine (no cloudSkills)", async () => {
+    // The attribution probe answers the single-call shape: pv_1 contributed
+    // env-server-2 and no skills, so the capability set carries no plugin
+    // skills and no problems.
+    convexQueryMock.mockImplementation(async (ref: string) =>
+      ref === "plugins:resolvePluginRuntimePreview"
+        ? {
+            pluginVersions: [ENV_SPEC.pluginVersions[0]],
+            effectiveServerIds: ["env-server-2"],
+            serverComponents: [
+              {
+                pluginVersionId: ENV_SPEC.pluginVersions[0].pluginVersionId,
+                componentKey: "server:asana",
+                placement: "remote",
+                authenticationPolicy: "on_use",
+                materializedServerId: "env-server-2",
+              },
+            ],
+            pluginSkills: [],
+            unavailableComponents: [],
+          }
+        : ENV_SPEC
+    );
     const { app, token } = createWebTestApp();
     await postJson(
       app,
@@ -639,8 +671,21 @@ describe("web chat-v2 — plugin capability attribution", () => {
       },
     ],
     effectiveServerIds: ["env-server-2"],
+    serverComponents: [
+      {
+        pluginVersionId: "pv_1",
+        componentKey: "server:asana",
+        placement: "remote",
+        authenticationPolicy: "on_use",
+        materializedServerId: "env-server-2",
+      },
+    ],
     pluginSkills: [
-      { modelRef: "linear/summarize", materializedSkillId: "sk_plugin" },
+      {
+        pluginVersionId: "pv_1",
+        modelRef: "linear/summarize",
+        materializedSkillId: "sk_plugin",
+      },
     ],
     unavailableComponents: [],
   };

--- a/mcpjam-inspector/server/services/environments/__tests__/plugin-attribution.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/plugin-attribution.test.ts
@@ -10,6 +10,51 @@ function clientWith(
 
 const PREVIEW = "plugins:resolvePluginRuntimePreview";
 
+/** A well-formed probe response for two pinned versions. */
+function twoVersionResponse() {
+  return {
+    pluginVersions: [
+      {
+        pluginId: "p_a",
+        pluginVersionId: "pv_a",
+        name: "alpha",
+        bundleHash: "hash_a",
+      },
+      {
+        pluginId: "p_b",
+        pluginVersionId: "pv_b",
+        name: "beta",
+        bundleHash: "hash_b",
+      },
+    ],
+    effectiveServerIds: ["srv_a", "srv_b"],
+    serverComponents: [
+      {
+        pluginVersionId: "pv_a",
+        componentKey: "server:api",
+        placement: "remote",
+        authenticationPolicy: "on_use",
+        materializedServerId: "srv_a",
+      },
+      {
+        pluginVersionId: "pv_b",
+        componentKey: "server:tools",
+        placement: "remote",
+        authenticationPolicy: "on_use",
+        materializedServerId: "srv_b",
+      },
+    ],
+    pluginSkills: [
+      {
+        pluginVersionId: "pv_b",
+        modelRef: "beta/summarize",
+        materializedSkillId: "sk_b",
+      },
+    ],
+    unavailableComponents: [],
+  };
+}
+
 describe("fetchPluginRuntimeAttribution", () => {
   it("costs zero reads when the environment pins no plugins", async () => {
     const query = vi.fn();
@@ -25,75 +70,43 @@ describe("fetchPluginRuntimeAttribution", () => {
     });
   });
 
-  it("probes ONE version per call so components are attributable to a version", async () => {
-    const client = clientWith((_ref, args) => {
-      const id = args.pluginVersionIds[0];
-      return {
-        pluginVersions: [
-          {
-            pluginId: `p_${id}`,
-            pluginVersionId: id,
-            name: id === "pv_a" ? "alpha" : "beta",
-            bundleHash: `hash_${id}`,
-          },
-        ],
-        effectiveServerIds: [`srv_${id}`],
-        pluginSkills: [
-          {
-            modelRef: `${id === "pv_a" ? "alpha" : "beta"}/summarize`,
-            materializedSkillId: `sk_${id}`,
-          },
-        ],
-        unavailableComponents: [],
-      };
-    });
+  it("attributes every component from ONE call covering the whole pin set", async () => {
+    const client = clientWith(() => twoVersionResponse());
 
     const result = await fetchPluginRuntimeAttribution(client, {
       projectId: "prj",
       pluginVersionIds: ["pv_a", "pv_b"],
     });
 
-    expect(client.query).toHaveBeenCalledTimes(2);
+    // The historical per-version fan-out is gone: one probe, all edges.
+    expect(client.query).toHaveBeenCalledTimes(1);
     expect(client.query).toHaveBeenCalledWith(PREVIEW, {
       projectId: "prj",
-      pluginVersionIds: ["pv_a"],
+      pluginVersionIds: ["pv_a", "pv_b"],
     });
-    expect(result?.serverOrigins.get("srv_pv_a")).toEqual({
-      pluginId: "p_pv_a",
+    expect(result?.serverOrigins.get("srv_a")).toEqual({
+      pluginId: "p_a",
       pluginVersionId: "pv_a",
       name: "alpha",
-      bundleHash: "hash_pv_a",
+      bundleHash: "hash_a",
     });
-    expect(result?.skillOrigins.get("sk_pv_b")).toEqual({
+    expect(result?.serverOrigins.get("srv_b")?.name).toBe("beta");
+    expect(result?.skillOrigins.get("sk_b")).toEqual({
       modelRef: "beta/summarize",
       plugin: {
-        pluginId: "p_pv_b",
+        pluginId: "p_b",
         pluginVersionId: "pv_b",
         name: "beta",
-        bundleHash: "hash_pv_b",
+        bundleHash: "hash_b",
       },
     });
+    expect(result?.unattributedVersionIds).toEqual([]);
   });
 
-  it("returns null — never a partial map — when a probe fails", async () => {
-    let calls = 0;
+  it("returns null — never a partial map — when the probe fails", async () => {
     const client = clientWith(() => {
-      calls += 1;
-      if (calls === 2) throw new Error("Could not find public function");
-      return {
-        pluginVersions: [
-          {
-            pluginId: "p",
-            pluginVersionId: "pv_a",
-            name: "alpha",
-            bundleHash: "h",
-          },
-        ],
-        effectiveServerIds: ["srv_a"],
-        pluginSkills: [],
-      };
+      throw new Error("Could not find public function");
     });
-
     const result = await fetchPluginRuntimeAttribution(client, {
       projectId: "prj",
       pluginVersionIds: ["pv_a", "pv_b"],
@@ -101,30 +114,34 @@ describe("fetchPluginRuntimeAttribution", () => {
     expect(result).toBeNull();
   });
 
-  it("skips a version the probe reports as unavailable rather than inventing an origin", async () => {
-    const client = clientWith((_ref, args) =>
-      args.pluginVersionIds[0] === "pv_a"
-        ? {
-            pluginVersions: [],
-            effectiveServerIds: [],
-            pluginSkills: [],
-            unavailableComponents: [
-              { pluginVersionId: "pv_a", reason: "disabled" },
-            ],
-          }
-        : {
-            pluginVersions: [
-              {
-                pluginId: "p_b",
-                pluginVersionId: "pv_b",
-                name: "beta",
-                bundleHash: "h_b",
-              },
-            ],
-            effectiveServerIds: ["srv_b"],
-            pluginSkills: [],
-          }
+  it("returns null when the deployed backend omits serverComponents (deploy skew)", async () => {
+    // An older probe without component rows cannot supply the version edge —
+    // guessing from the flat effectiveServerIds list would misattribute.
+    const client = clientWith(() => ({
+      pluginVersions: twoVersionResponse().pluginVersions,
+      effectiveServerIds: ["srv_a", "srv_b"],
+      pluginSkills: [],
+    }));
+    const result = await fetchPluginRuntimeAttribution(client, {
+      projectId: "prj",
+      pluginVersionIds: ["pv_a", "pv_b"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("reports a version the probe drops as unattributed rather than inventing an origin", async () => {
+    const response = twoVersionResponse();
+    // pv_a became unavailable between the environment read and this probe.
+    response.pluginVersions = response.pluginVersions.filter(
+      (version) => version.pluginVersionId !== "pv_a"
     );
+    response.serverComponents = response.serverComponents.filter(
+      (component) => component.pluginVersionId !== "pv_a"
+    );
+    response.unavailableComponents = [
+      { pluginVersionId: "pv_a", reason: "disabled" },
+    ] as never[];
+    const client = clientWith(() => response);
 
     const result = await fetchPluginRuntimeAttribution(client, {
       projectId: "prj",
@@ -161,6 +178,9 @@ describe("fetchPluginRuntimeAttribution", () => {
         { pluginId: "p", pluginVersionId: "pv_a", name: "alpha" },
       ],
       effectiveServerIds: ["srv_a"],
+      serverComponents: [
+        { pluginVersionId: "pv_a", materializedServerId: "srv_a" },
+      ],
       pluginSkills: [],
     }));
     const result = await fetchPluginRuntimeAttribution(client, {

--- a/mcpjam-inspector/server/services/environments/plugin-attribution.ts
+++ b/mcpjam-inspector/server/services/environments/plugin-attribution.ts
@@ -8,31 +8,25 @@
  * materialized name. Two pinned plugins therefore look identical at the point
  * where a tool call or a skill load has to say where it came from.
  *
- * The edge exists backend-side (`pluginServerComponents` /
- * `pluginSkillComponents` both key on `pluginVersionId`), and
- * `lib/pluginRuntimeResolution.resolvePluginVersionsRuntime` returns it — but
- * the INS-facing probe `plugins.resolvePluginRuntimePreview` FLATTENS it into
- * `effectiveServerIds` / `pluginSkills` across every version it was asked
- * about. So we recover the edge the only way the deployed API allows: ask the
- * probe about ONE version at a time. Each response is then unambiguously that
- * version's components.
+ * The edge lives backend-side (`pluginServerComponents` /
+ * `pluginSkillComponents` both key on `pluginVersionId`), and the probe
+ * `plugins.resolvePluginRuntimePreview` now returns it directly: full
+ * `serverComponents` rows and per-skill `pluginVersionId`. So attribution is
+ * ONE call for the whole pin set — the historical per-version fan-out (which
+ * recovered the edge by asking about one version at a time) is gone.
  *
- * That is deliberately a consumption trick, not a reimplementation: every
- * lifecycle rule (ready + installed + enabled + same-project, never a fallback
- * to `activeVersionId`) still runs backend-side inside the probe, and the
- * `modelRef` we read is the one `pluginSkillComponents` stored at
- * materialization — never a `<name>/<name>` string we assembled here.
- *
- * FOLLOW-UP: a probe that returned component rows (pluginVersionId +
- * componentKey per server) would collapse this to one call. Worth doing when
- * pin counts grow; today a pinned set is a handful of versions read in
- * parallel.
+ * This is consumption, not reimplementation: every lifecycle rule (ready +
+ * installed + enabled + same-project, never a fallback to `activeVersionId`)
+ * still runs backend-side inside the probe, and the `modelRef` we read is the
+ * one `pluginSkillComponents` stored at materialization — never a
+ * `<name>/<name>` string we assembled here.
  *
  * ATTRIBUTION IS PROVENANCE, NEVER A GATE. Every failure mode returns `null`
  * (tri-state — never a half-filled map, which would label some plugin servers
  * as ordinary ones), and every caller must degrade to "origin unknown" rather
  * than dropping a capability. The environment resolution already decided what
- * runs; this only decides what we can honestly say about it.
+ * runs; this only decides what we can honestly say about it. A deployed
+ * backend old enough to omit `serverComponents` lands in the same `null`.
  */
 import type { ConvexHttpClient } from "convex/browser";
 import { logger } from "../../utils/logger.js";
@@ -43,7 +37,7 @@ const PREVIEW_FUNCTION_REF = "plugins:resolvePluginRuntimePreview" as const;
 export interface AttributedPluginVersion {
   pluginId: string;
   pluginVersionId: string;
-  /** Normalized kebab-case plugin name — the `modelRef` namespace. */
+  /** Normalized plugin name — the `modelRef` namespace. */
   name: string;
   /** Absent only under deploy skew; never synthesized. */
   bundleHash: string | null;
@@ -74,7 +68,7 @@ export interface PluginRuntimeAttribution {
 }
 
 /**
- * How long the whole attribution fan-out may take before we give up.
+ * How long the attribution read may take before we give up.
  *
  * `ConvexHttpClient.query` has no per-call deadline, so without this a Convex
  * read that never settles blocks the chat route BEFORE the turn starts — the
@@ -83,11 +77,11 @@ export interface PluginRuntimeAttribution {
  * through; on expiry we return `null` and the turn runs with origin unreported,
  * the same as every other failure here.
  *
- * The timed-out queries are left to settle on their own rather than aborted via
+ * The timed-out query is left to settle on its own rather than aborted via
  * `setFetchOptions`: that setter mutates the SHARED client the route also uses
  * for the environment resolution, so an attribution deadline would silently
- * become that read's deadline too. Dangling reads are harmless — they are pure
- * queries whose results we drop.
+ * become that read's deadline too. A dangling read is harmless — it is a pure
+ * query whose result we drop.
  */
 const ATTRIBUTION_TIMEOUT_MS = 5_000;
 
@@ -100,66 +94,8 @@ function readString(value: unknown): string | null {
 }
 
 /**
- * One probe call, scoped to a single pinned version.
- *
- * Returns `null` when the probe reports the version as unavailable or answers
- * in a shape we cannot read. That is NOT an error: the environment resolution
- * and this probe are separate reads, so a plugin disabled between them is a
- * torn view, and the environment's answer is the one the turn already
- * committed to. Reporting no origin is honest; inventing one is not.
- */
-async function probeOneVersion(
-  client: ConvexHttpClient,
-  projectId: string,
-  pluginVersionId: string
-): Promise<{
-  plugin: AttributedPluginVersion;
-  serverIds: string[];
-  skills: Array<{ skillId: string; modelRef: string }>;
-} | null> {
-  const raw: unknown = await client.query(PREVIEW_FUNCTION_REF as any, {
-    projectId,
-    pluginVersionIds: [pluginVersionId],
-  } as any);
-  if (!isRecord(raw)) return null;
-
-  const versions = Array.isArray(raw.pluginVersions) ? raw.pluginVersions : [];
-  const version = versions.find(
-    (entry) =>
-      isRecord(entry) && readString(entry.pluginVersionId) === pluginVersionId
-  );
-  // Absent ⇒ the probe put it in `unavailableComponents`. Nothing to attribute.
-  if (!isRecord(version)) return null;
-  const pluginId = readString(version.pluginId);
-  const name = readString(version.name);
-  if (!pluginId || !name) return null;
-
-  const plugin: AttributedPluginVersion = {
-    pluginId,
-    pluginVersionId,
-    name,
-    bundleHash: readString(version.bundleHash),
-  };
-
-  const serverIds = (
-    Array.isArray(raw.effectiveServerIds) ? raw.effectiveServerIds : []
-  )
-    .map(readString)
-    .filter((id): id is string => id !== null);
-
-  const skills: Array<{ skillId: string; modelRef: string }> = [];
-  for (const entry of Array.isArray(raw.pluginSkills) ? raw.pluginSkills : []) {
-    if (!isRecord(entry)) continue;
-    const skillId = readString(entry.materializedSkillId);
-    const modelRef = readString(entry.modelRef);
-    if (skillId && modelRef) skills.push({ skillId, modelRef });
-  }
-
-  return { plugin, serverIds, skills };
-}
-
-/**
- * Build the server/skill → pinned-version edges for a turn.
+ * Build the server/skill → pinned-version edges for a turn, from ONE probe
+ * call covering the whole pin set.
  *
  * `null` means "no attribution available" and MUST be treated as such by
  * callers — see the module note. An empty pin list short-circuits to empty maps
@@ -178,14 +114,13 @@ export async function fetchPluginRuntimeAttribution(
       unattributedVersionIds: [],
     };
   }
-  let probed: Array<Awaited<ReturnType<typeof probeOneVersion>>>;
+  let raw: unknown;
   try {
-    probed = await Promise.race([
-      Promise.all(
-        args.pluginVersionIds.map((id) =>
-          probeOneVersion(client, args.projectId, id)
-        )
-      ),
+    raw = await Promise.race([
+      client.query(PREVIEW_FUNCTION_REF as any, {
+        projectId: args.projectId,
+        pluginVersionIds: args.pluginVersionIds,
+      } as any),
       // Rejects on expiry, landing in the same catch as any other failure.
       new Promise<never>((_resolve, reject) => {
         const timer = setTimeout(
@@ -197,8 +132,7 @@ export async function fetchPluginRuntimeAttribution(
     ]);
   } catch (error) {
     // Includes the deploy-skew case (`Could not find public function`) and the
-    // deadline above. One failed probe poisons the whole map: a partial map
-    // would silently present an unattributed plugin server as an ordinary one.
+    // deadline above.
     logger.warn(
       "[plugin-attribution] probe failed; running without plugin origin",
       { error: error instanceof Error ? error.message : String(error) }
@@ -206,33 +140,71 @@ export async function fetchPluginRuntimeAttribution(
     return null;
   }
 
+  if (!isRecord(raw) || !Array.isArray(raw.serverComponents)) {
+    // A backend old enough to omit the component rows cannot supply the
+    // version edge. Reporting no origin is honest; guessing from the flat
+    // `effectiveServerIds` list is not.
+    logger.warn(
+      "[plugin-attribution] probe response has no serverComponents; running without plugin origin"
+    );
+    return null;
+  }
+
+  const versionsById = new Map<string, AttributedPluginVersion>();
+  for (const entry of Array.isArray(raw.pluginVersions)
+    ? raw.pluginVersions
+    : []) {
+    if (!isRecord(entry)) continue;
+    const pluginVersionId = readString(entry.pluginVersionId);
+    const pluginId = readString(entry.pluginId);
+    const name = readString(entry.name);
+    if (!pluginVersionId || !pluginId || !name) continue;
+    versionsById.set(pluginVersionId, {
+      pluginId,
+      pluginVersionId,
+      name,
+      bundleHash: readString(entry.bundleHash),
+    });
+  }
+
   const serverOrigins = new Map<string, AttributedPluginVersion>();
-  const skillOrigins = new Map<string, AttributedPluginSkill>();
-  const unattributedVersionIds: string[] = [];
-  for (const [index, result] of probed.entries()) {
-    if (!result) {
-      // The version resolved for the environment but not for this probe — a
-      // torn read. Its components still run; we just cannot name their origin.
-      unattributedVersionIds.push(args.pluginVersionIds[index]);
-      continue;
-    }
-    for (const serverId of result.serverIds) {
-      // First pin wins, matching the backend's dedupe of `effectiveServerIds`
-      // in pin order. Two versions of the same plugin can materialize the same
-      // component only across a re-import, which the environment's own dedupe
-      // already collapsed.
-      if (!serverOrigins.has(serverId)) {
-        serverOrigins.set(serverId, result.plugin);
-      }
-    }
-    for (const skill of result.skills) {
-      if (!skillOrigins.has(skill.skillId)) {
-        skillOrigins.set(skill.skillId, {
-          modelRef: skill.modelRef,
-          plugin: result.plugin,
-        });
-      }
+  for (const component of raw.serverComponents) {
+    if (!isRecord(component)) continue;
+    const serverId = readString(component.materializedServerId);
+    const pluginVersionId = readString(component.pluginVersionId);
+    if (!serverId || !pluginVersionId) continue;
+    const plugin = versionsById.get(pluginVersionId);
+    if (!plugin) continue;
+    // First pin wins, matching the backend's dedupe of `effectiveServerIds`
+    // in pin order. Two versions of the same plugin can materialize the same
+    // component only across a re-import, which the environment's own dedupe
+    // already collapsed.
+    if (!serverOrigins.has(serverId)) {
+      serverOrigins.set(serverId, plugin);
     }
   }
+
+  const skillOrigins = new Map<string, AttributedPluginSkill>();
+  for (const entry of Array.isArray(raw.pluginSkills) ? raw.pluginSkills : []) {
+    if (!isRecord(entry)) continue;
+    const skillId = readString(entry.materializedSkillId);
+    const modelRef = readString(entry.modelRef);
+    const pluginVersionId = readString(entry.pluginVersionId);
+    if (!skillId || !modelRef || !pluginVersionId) continue;
+    const plugin = versionsById.get(pluginVersionId);
+    if (!plugin) continue;
+    if (!skillOrigins.has(skillId)) {
+      skillOrigins.set(skillId, { modelRef, plugin });
+    }
+  }
+
+  // A pinned version absent from the resolved list is a torn read: it
+  // resolved for the environment but not for this probe (disabled or
+  // uninstalled in between). Its components still run; we just cannot name
+  // their origin — and the short map must announce itself.
+  const unattributedVersionIds = args.pluginVersionIds.filter(
+    (id) => !versionsById.has(id)
+  );
+
   return { serverOrigins, skillOrigins, unattributedVersionIds };
 }

--- a/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
@@ -58,7 +58,14 @@ function stubClient(options?: {
         ];
       }
       if (name === "plugins:resolvePluginRuntimePreview") {
-        if (!available) return { pluginVersions: [], effectiveServerIds: [] };
+        if (!available) {
+          return {
+            pluginVersions: [],
+            effectiveServerIds: [],
+            serverComponents: [],
+            pluginSkills: [],
+          };
+        }
         return {
           pluginVersions: [
             {
@@ -69,6 +76,15 @@ function stubClient(options?: {
             },
           ],
           effectiveServerIds: [SERVER_ID],
+          serverComponents: [
+            {
+              pluginVersionId: VERSION_ID,
+              componentKey: "server:fixture-local",
+              placement: "local",
+              authenticationPolicy: "on_use",
+              materializedServerId: SERVER_ID,
+            },
+          ],
           pluginSkills: [],
         };
       }


### PR DESCRIPTION
## Summary

Agent Plugins program, **Phase 0.6**. Plugin attribution for a turn was N parallel Convex calls — one `plugins:resolvePluginRuntimePreview` probe **per pinned version** — because the probe used to flatten components across versions, and asking about one version at a time was the only way to recover the version → component edge (the module documented this as a "consumption trick" with a FOLLOW-UP note). The probe has since grown full `serverComponents` rows and per-skill `pluginVersionId`, so attribution is now **one call covering the whole pin set**; the fan-out machinery is deleted.

## Semantics preserved

- **Provenance, never a gate**: every failure returns `null` and callers degrade to origin-unknown; the 5s deadline still bounds the read; the shared-client no-abort rationale is unchanged.
- **First-pin-wins** dedupe matches the backend's `effectiveServerIds` ordering.
- A version the probe drops (torn read between environment resolution and attribution) is still announced via `unattributedVersionIds` — a short map always says it is short.
- **Deploy skew**: a backend old enough to omit `serverComponents` lands in the same `null` (with a warn log) rather than a mapping guessed from the flat id list.

## Tests

`plugin-attribution.test.ts` rewritten for the single-call contract (one call asserted, edges from `serverComponents`, dropped-version announcement, deploy-skew null, deadline, missing bundleHash). Stubs in `local-stdio.test.ts` and `chat-v2.environment.test.ts` updated to answer the new shape. All affected suites green: `services/environments`, `services/plugins`, `chat-v2.environment`, `chat-v2.chatbox-environment` — 136 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches environment-turn plugin provenance and plugin narrowing logic; behavior is heavily tested but mis-parsing the new probe shape could misattribute servers/skills or affect fail-closed narrowing.
> 
> **Overview**
> **Plugin runtime attribution** no longer fans out one `plugins:resolvePluginRuntimePreview` query per pinned version. It issues **one probe** for the full pin set and builds server/skill → version edges from **`serverComponents`** and per-skill **`pluginVersionId`**, removing the old per-version probe helper.
> 
> **Failure handling** is unchanged in spirit: probe errors, timeouts, or responses **without `serverComponents`** (older backend) still return **`null`** so turns run with origin unknown; versions missing from the probe answer are still listed in **`unattributedVersionIds`**. First-pin-wins server dedupe is preserved.
> 
> **Tests** now assert the single-call contract and stub the richer preview shape in **`chat-v2.environment`**, **`plugin-attribution`**, and **`local-stdio`** suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c59a98aeb5c8e158108358e95a9b9a8bea85bdfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attribute plugin servers and skills for a turn using one `plugins:resolvePluginRuntimePreview` call instead of N per pinned version. This removes probe fan-out while keeping provenance behavior the same.

- **Refactors**
  - Use the probe’s `serverComponents` and per-skill `pluginVersionId` to build all version→component edges in one call; delete per-version fan-out.
  - Preserve semantics: failures return null, 5s timeout stays, and first-pin-wins dedupe matches backend ordering.
  - Report torn reads via `unattributedVersionIds`; if the backend omits `serverComponents` (deploy skew), return null rather than guessing.
  - Update tests and stubs to the single-call shape; all affected suites pass.

<sup>Written for commit c59a98aeb5c8e158108358e95a9b9a8bea85bdfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

