### PR TITLE
fix(analytics): serve the PostHog relay on an edge-safe /tlm alias

### DIFF
--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -16,7 +16,13 @@ export function getPostHogApiHost(): string {
     typeof window !== "undefined" &&
     window.location?.origin?.startsWith("http")
   ) {
-    return `${window.location.origin}/relay`;
+    // `/tlm`, not `/relay`: Railway's edge in front of the hosted app 403s
+    // GETs under `/relay/static/*` and `/relay/array/*` (block is scoped to
+    // the /relay prefix — verified with decoy-prefix probes), which starved
+    // posthog-js of its remote config and kept session recording `disabled`.
+    // The server mounts the same proxy on both prefixes; see
+    // RELAY_MOUNT_PREFIXES in server/routes/relay.ts.
+    return `${window.location.origin}/tlm`;
   }
   // Non-browser context (tests) — no relay origin to derive.
   return VITE_PUBLIC_POSTHOG_HOST;

--- a/mcpjam-inspector/client/vite.config.ts
+++ b/mcpjam-inspector/client/vite.config.ts
@@ -191,6 +191,13 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           secure: false,
         },
+        // /tlm is the same relay on its edge-safe alias prefix (see
+        // RELAY_MOUNT_PREFIXES in server/routes/relay.ts).
+        "/tlm": {
+          target: env.VITE_API_BASE_URL || "http://localhost:6274",
+          changeOrigin: true,
+          secure: false,
+        },
         ...(() => {
           const siteUrlFromEnv = env.VITE_CONVEX_SITE_URL;
           const cloudUrl = env.VITE_CONVEX_URL || "";

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -338,8 +338,13 @@ export async function createHonoApp() {
   // catch-all only skips /api/* and would otherwise swallow /relay GETs
   // with index.html. Mirror of the mount in server/index.ts — both
   // production entries must wire this up.
+  // Mounted on BOTH prefixes — see RELAY_MOUNT_PREFIXES in routes/relay.ts:
+  // /tlm is the alias new clients use because Railway's edge 403s GETs under
+  // /relay/static and /relay/array on hosted; /relay stays for old builds.
   app.use("/relay/*", relayBodyLimit());
   app.route("/relay", relayRoutes);
+  app.use("/tlm/*", relayBodyLimit());
+  app.route("/tlm", relayRoutes);
 
   // XAA Client ID Metadata Document. Also deliberately OUTSIDE /api (the
   // target authorization server fetches it anonymously) and mounted before

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -508,8 +508,13 @@ app.route("/api/cli/auth", cliAuthRoutes);
 // whose catch-all only skips /api/* and would otherwise swallow /relay GETs
 // with index.html. Mirror of the mount in server/app.ts::createHonoApp —
 // both production entries must wire this up.
+// Mounted on BOTH prefixes — see RELAY_MOUNT_PREFIXES in routes/relay.ts:
+// /tlm is the alias new clients use because Railway's edge 403s GETs under
+// /relay/static and /relay/array on hosted; /relay stays for old builds.
 app.use("/relay/*", relayBodyLimit());
 app.route("/relay", relayRoutes);
+app.use("/tlm/*", relayBodyLimit());
+app.route("/tlm", relayRoutes);
 
 // XAA Client ID Metadata Document. Also deliberately OUTSIDE /api (the
 // target authorization server fetches it anonymously) and mounted before

--- a/mcpjam-inspector/server/routes/__tests__/relay.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/relay.test.ts
@@ -7,14 +7,16 @@ import { sessionAuthMiddleware } from "../../middleware/session-auth.js";
 
 const ORIGINAL_FETCH = global.fetch;
 
-// Mount via app.route("/relay", ...) exactly like both production entries so
-// the tests exercise the mounted-path behavior: inside the sub-app
-// c.req.path still includes the /relay prefix, and the route must strip it
-// before forwarding.
+// Mount on BOTH prefixes exactly like both production entries so the tests
+// exercise the mounted-path behavior: inside the sub-app c.req.path still
+// includes the mount prefix (/relay or its edge-safe alias /tlm), and the
+// route must strip whichever one it was reached through before forwarding.
 function createTestApp() {
   const app = new Hono();
   app.use("/relay/*", relayBodyLimit());
   app.route("/relay", relayRoutes);
+  app.use("/tlm/*", relayBodyLimit());
+  app.route("/tlm", relayRoutes);
   return app;
 }
 
@@ -67,6 +69,32 @@ describe("posthog relay proxy", () => {
     expect(init.method).toBe("POST");
     expect(new TextDecoder().decode(init.body as ArrayBuffer)).toBe(payload);
     expect(new Headers(init.headers).get("content-type")).toBe("text/plain");
+  });
+
+  it("serves the /tlm alias identically: prefix stripped, static/array/ingest routing intact", async () => {
+    const app = createTestApp();
+    vi.mocked(fetch).mockResolvedValue(upstreamResponse());
+
+    await app.request("http://localhost:6274/tlm/static/recorder.js");
+    await app.request("http://localhost:6274/tlm/array/phc_x/config");
+    await app.request("http://localhost:6274/tlm/i/v0/e/?compression=gzip-js", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "batch",
+    });
+
+    // The alias exists because Railway's edge 403s GETs under /relay/static
+    // and /relay/array on hosted; PostHog must still receive the bare
+    // subpaths — never /tlm/....
+    expect(mockedFetchUrl(0)).toBe(
+      "https://us-assets.i.posthog.com/static/recorder.js",
+    );
+    expect(mockedFetchUrl(1)).toBe(
+      "https://us-assets.i.posthog.com/array/phc_x/config",
+    );
+    expect(mockedFetchUrl(2)).toBe(
+      "https://us.i.posthog.com/i/v0/e/?compression=gzip-js",
+    );
   });
 
   it("routes /static and /array to the assets host and /flags to the ingest host", async () => {

--- a/mcpjam-inspector/server/routes/relay.ts
+++ b/mcpjam-inspector/server/routes/relay.ts
@@ -212,14 +212,36 @@ export function relayBodyLimit() {
 // The proxy itself.
 // ---------------------------------------------------------------------------
 
-// Inside a sub-app mounted via app.route("/relay", ...), c.req.path is still
+// The relay answers on TWO mount prefixes:
+//
+// - `/relay` — the original mount. Railway's edge (in front of the hosted
+//   app; Cloudflare-branded, `x-hikari-trace` on responses) 403s GETs under
+//   `/relay/static/*` and `/relay/array/*` while letting the event/flags
+//   POSTs through. That silently broke session replay and posthog-js remote
+//   config on hosted — the SDK's server-side-enabled flag never arrived, so
+//   recording stayed `disabled` even with the recorder code bundled
+//   (client/src/lib/posthog-bundled-extensions.ts).
+// - `/tlm` — the alias new clients point `api_host` at. Verified against the
+//   deployed edge: the block is scoped to the `/relay` prefix (identical
+//   subpaths under a decoy prefix pass), and `tlm` is deliberately short and
+//   meaningless so it matches no analytics-proxy WAF signature.
+//
+// `/relay` stays mounted for already-shipped clients (Electron builds pin
+// old bundles), whose events and flags still flow through it.
+export const RELAY_MOUNT_PREFIXES = ["/relay", "/tlm"] as const;
+
+// Inside a sub-app mounted via app.route(prefix, ...), c.req.path is still
 // the full request path including the mount prefix. PostHog must receive
-// /i/v0/e/, /static/array.js, etc. — never /relay/... — so strip explicitly.
+// /i/v0/e/, /static/array.js, etc. — never /relay/... or /tlm/... — so strip
+// explicitly.
 function stripRelayPrefix(path: string): string {
-  const stripped = path.startsWith("/relay")
-    ? path.slice("/relay".length)
-    : path;
-  return stripped === "" ? "/" : stripped;
+  for (const prefix of RELAY_MOUNT_PREFIXES) {
+    if (path === prefix || path.startsWith(`${prefix}/`)) {
+      const stripped = path.slice(prefix.length);
+      return stripped === "" ? "/" : stripped;
+    }
+  }
+  return path;
 }
 
 function isTimeoutError(error: unknown): boolean {

--- a/mcpjam-inspector/vite.renderer.config.mts
+++ b/mcpjam-inspector/vite.renderer.config.mts
@@ -70,6 +70,12 @@ export default defineConfig(({ mode }) => {
           target: "http://localhost:6274",
           changeOrigin: true,
         },
+        // /tlm is the same relay on its edge-safe alias prefix (see
+        // RELAY_MOUNT_PREFIXES in server/routes/relay.ts).
+        "/tlm": {
+          target: "http://localhost:6274",
+          changeOrigin: true,
+        },
       },
     },
     define: {


### PR DESCRIPTION
## Why

#3804 fixed **code** delivery by bundling PostHog's feature scripts — but live verification on staging showed session recording still `disabled` while exception capture worked. Console + persistence forensics found the last gap: posthog-js also fetches its **remote config** at runtime (`GET /relay/array/<token>/config`, `.js` fallback), Railway's edge 403s both variants, and without that response the SDK's persisted server-side-enabled flag never arrives — recording stays `disabled` no matter that the recorder code is bundled. (Staging console confirmed all 8 `__PosthogExtensions__` registered and no recording key in persistence; there is no `disable_remote_config` escape hatch in posthog-js.)

Decoy-prefix probes settle the rule's shape: `/zzz/array/<token>/config.js` and `/zzz/static/recorder.js` reach the origin (200 SPA fallback), while the same subpaths under `/relay/` 403 — **the block is scoped to the `/relay` prefix**, not a path signature.

## What

- Mount the same relay routes at **`/tlm`** in both production entries (`server/index.ts`, `server/app.ts`); `stripRelayPrefix` now strips whichever prefix the request came through (`RELAY_MOUNT_PREFIXES`).
- Client `api_host` → `${origin}/tlm` (`PosthogUtils.getPostHogApiHost`). Every SDK URL derives from it, so events, flags, remote config, and any residual script fetches all move to the alias.
- Vite dev proxies mirror the alias in both the web and Electron renderer configs.
- **`/relay` stays mounted** for already-shipped clients (pinned Electron builds, old tabs) — their events/flags continue to flow.
- `tlm` is deliberately short and meaningless so it matches no analytics-proxy WAF signature; if an edge ever learns it, it is a two-line re-alias.

## Verification

- Relay suite covers the alias end-to-end: `/tlm` prefix stripped, `/static`→assets host, `/array`→assets host, ingest POSTs→ingest host (8/8 green).
- `typecheck:client` green; built server bundle contains both mounts.
- Post-deploy (staging): `curl -sI https://staging.mcpjam.com/tlm/array/<token>/config` → 200 JSON through the edge; a fresh browser session should show `$recording_status: active/buffering` and the project's **first hosted recording**. Exception capture + the Slack error alert were already confirmed live on staging today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics routing change only: same proxy logic on a second path with backward-compatible `/relay`; no auth or data-handling changes.
> 
> **Overview**
> Hosted PostHog traffic was still broken for **session replay and remote config** because Railway’s edge returns **403** on `GET /relay/static/*` and `GET /relay/array/*`, while event POSTs kept working—so posthog-js never got its server-side recording config.
> 
> This PR adds a second mount of the **same** reverse proxy at **`/tlm`**, documents it via `RELAY_MOUNT_PREFIXES`, and updates **`stripRelayPrefix`** so either prefix is stripped before forwarding to PostHog. **`/relay` stays** for older clients.
> 
> New builds point **`getPostHogApiHost()`** at **`${origin}/tlm`** instead of `/relay`, and Vite dev proxies for web and Electron mirror **`/tlm`**. Relay tests cover the alias end-to-end (static, array, ingest routing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569a7973b05846fc33818934131ea716b6c18063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the PostHog relay on an edge-safe /tlm alias to bypass Railway edge 403s under /relay, restoring remote config and session recording on hosted. Keep /relay for existing clients; new clients point to /tlm.

- **Bug Fixes**
  - Mounted the relay on both `/relay` and `/tlm`; `/relay` kept for backwards compatibility.
  - Client `api_host` now `${origin}/tlm` so all `posthog-js` requests use the alias.
  - Added `RELAY_MOUNT_PREFIXES` and updated `stripRelayPrefix` to handle both prefixes.
  - Mirrored Vite dev proxies (web and Electron) for `/tlm`.
  - Tests cover the alias end-to-end; staging confirms `/tlm/array/<token>/config` returns 200 and recording activates.

<sup>Written for commit 569a7973b05846fc33818934131ea716b6c18063. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

