### PR TITLE
feat(plugins): implement the ${PLUGIN_DATA} writable data directory

### DIFF
--- a/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
@@ -288,6 +288,40 @@ describe("plugin stdio origin resolution", () => {
     expect(cache.activeEntries()).toEqual([]);
   });
 
+  it("tolerates placeholder-shaped text in the machine's own paths", async () => {
+    await cache.materialize(
+      { projectId: PROJECT_ID, pluginVersionId: VERSION_ID, bundleHash },
+      { source: await fixtureBundleSource() }
+    );
+    // The guard scans the SPEC, never the resolved launch: a data root that
+    // happens to contain a placeholder-shaped segment is the machine's own
+    // path, not an unresolved bundle input, and must not refuse the spawn.
+    const weirdDataRoot = join(cacheRoot, "${PLUGIN_DATA}-lookalike");
+
+    const prepared = await preparePluginStdioLaunch({
+      client: stubClient({ bundleHash }),
+      cache,
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      spec: {
+        ...PLACEHOLDER_SPEC,
+        args: [
+          "${PLUGIN_ROOT}/server/index.js",
+          "--cache=${PLUGIN_DATA}/cache.db",
+        ],
+      },
+      leaseId: SERVER_ID,
+      dataRoot: weirdDataRoot,
+    });
+
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    expect(prepared.launch.args[1]).toBe(
+      `--cache=${join(weirdDataRoot, PROJECT_ID, PLUGIN_ID)}/cache.db`
+    );
+    prepared.release();
+  });
+
   it.each([
     [
       "a plugin that no longer resolves",

--- a/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConvexHttpClient } from "convex/browser";
-import { appendFile } from "node:fs/promises";
+import { appendFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { PluginBundleCache } from "../bundle-cache.js";
 import {
@@ -194,11 +194,12 @@ describe("plugin stdio origin resolution", () => {
     prepared.release();
   });
 
-  it("fails closed on a ${PLUGIN_DATA} placeholder, reporting only the token", async () => {
+  it("substitutes ${PLUGIN_DATA} against a created per-plugin data directory", async () => {
     await cache.materialize(
       { projectId: PROJECT_ID, pluginVersionId: VERSION_ID, bundleHash },
       { source: await fixtureBundleSource() }
     );
+    const dataRoot = join(cacheRoot, "plugin-data");
 
     const prepared = await preparePluginStdioLaunch({
       client: stubClient({ bundleHash }),
@@ -213,17 +214,18 @@ describe("plugin stdio origin resolution", () => {
         ],
       },
       leaseId: SERVER_ID,
+      dataRoot,
     });
 
-    expect(prepared).toMatchObject({
-      ok: false,
-      reason: "unsupported_placeholder",
-      // The bare token only — never the containing argv value, which can
-      // embed expanded paths or adjacent secrets.
-      placeholder: "${PLUGIN_DATA}",
-    });
-    // Nothing spawned, nothing leased.
-    expect(cache.activeEntries()).toEqual([]);
+    expect(prepared.ok).toBe(true);
+    if (!prepared.ok) return;
+    // Keyed by pluginId, NOT bundleHash: the directory survives version
+    // activations, which is the spec's whole point for PLUGIN_DATA.
+    const expectedDataDir = join(dataRoot, PROJECT_ID, PLUGIN_ID);
+    expect(prepared.launch.args[1]).toBe(`--cache=${expectedDataDir}/cache.db`);
+    expect(prepared.launch.env.PLUGIN_DATA).toBe(expectedDataDir);
+    await expect(stat(expectedDataDir)).resolves.toMatchObject({});
+    prepared.release();
   });
 
   it.each([
@@ -373,6 +375,7 @@ describe("materializePluginStdioForConnect", () => {
       serverName: SERVER_ID,
       spec: PLACEHOLDER_SPEC,
       cache,
+      dataRoot: join(cacheRoot, "plugin-data"),
     });
 
     expect(result?.args[0]).toBe(`${result?.pluginRoot}/server/index.js`);
@@ -387,6 +390,7 @@ describe("materializePluginStdioForConnect", () => {
       serverName: SERVER_ID,
       spec: PLACEHOLDER_SPEC,
       cache,
+      dataRoot: join(cacheRoot, "plugin-data"),
     });
     expect(cache.activeEntries()).toEqual([result?.pluginRoot]);
     releasePluginLease(SERVER_ID);
@@ -407,6 +411,7 @@ describe("materializePluginStdioForConnect", () => {
       serverName: SERVER_ID,
       spec: PLACEHOLDER_SPEC,
       cache,
+      dataRoot: join(cacheRoot, "plugin-data"),
     }).catch((err) => err);
 
     expect(error).toBeInstanceOf(WebRouteError);

--- a/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
@@ -224,8 +224,68 @@ describe("plugin stdio origin resolution", () => {
     const expectedDataDir = join(dataRoot, PROJECT_ID, PLUGIN_ID);
     expect(prepared.launch.args[1]).toBe(`--cache=${expectedDataDir}/cache.db`);
     expect(prepared.launch.env.PLUGIN_DATA).toBe(expectedDataDir);
-    await expect(stat(expectedDataDir)).resolves.toMatchObject({});
+    const dirStat = await stat(expectedDataDir);
+    if (process.platform !== "win32") {
+      // Owner-only regardless of umask: persisted plugin state must not be
+      // readable by other local users.
+      expect(dirStat.mode & 0o777).toBe(0o700);
+    }
     prepared.release();
+  });
+
+  it("reports a filesystem problem as plugin_data_unavailable, never a bundle problem", async () => {
+    await cache.materialize(
+      { projectId: PROJECT_ID, pluginVersionId: VERSION_ID, bundleHash },
+      { source: await fixtureBundleSource() }
+    );
+    // A FILE where the data root must be a directory: mkdir fails.
+    const blockedRoot = join(cacheRoot, "blocked-data-root");
+    await appendFile(blockedRoot, "not a directory");
+
+    const prepared = await preparePluginStdioLaunch({
+      client: stubClient({ bundleHash }),
+      cache,
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      spec: PLACEHOLDER_SPEC,
+      leaseId: SERVER_ID,
+      dataRoot: blockedRoot,
+    });
+
+    expect(prepared).toMatchObject({
+      ok: false,
+      reason: "plugin_data_unavailable",
+    });
+    expect(cache.activeEntries()).toEqual([]);
+  });
+
+  it("fails closed on a placeholder this build does not implement", async () => {
+    await cache.materialize(
+      { projectId: PROJECT_ID, pluginVersionId: VERSION_ID, bundleHash },
+      { source: await fixtureBundleSource() }
+    );
+
+    const prepared = await preparePluginStdioLaunch({
+      client: stubClient({ bundleHash }),
+      cache,
+      projectId: PROJECT_ID,
+      serverId: SERVER_ID,
+      spec: {
+        ...PLACEHOLDER_SPEC,
+        // A future spec placeholder: the generic guard must refuse the
+        // spawn and report only the bare token.
+        args: ["${PLUGIN_ROOT}/server/index.js", "--x=${PLUGIN_CACHE}/db"],
+      },
+      leaseId: SERVER_ID,
+      dataRoot: join(cacheRoot, "plugin-data"),
+    });
+
+    expect(prepared).toMatchObject({
+      ok: false,
+      reason: "unsupported_placeholder",
+      placeholder: "${PLUGIN_CACHE}",
+    });
+    expect(cache.activeEntries()).toEqual([]);
   });
 
   it.each([

--- a/mcpjam-inspector/server/services/plugins/__tests__/plugin-root.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/plugin-root.test.ts
@@ -3,19 +3,37 @@ import {
   needsPluginRoot,
   pluginRootEnv,
   resolvePluginStdioLaunch,
+  substitutePluginPlaceholders,
   substitutePluginRoot,
 } from "../plugin-root.js";
 
 const ROOT = "/home/tester/.mcpjam/plugins/p1/pl1/abc123";
+const DATA = "/home/tester/.mcpjam/plugin-data/p1/pl1";
 
 describe("plugin root substitution", () => {
-  it("substitutes ${PLUGIN_ROOT} but never ${PLUGIN_DATA}", () => {
+  it("substitutes ${PLUGIN_ROOT} and ${PLUGIN_DATA} against their own roots", () => {
     expect(substitutePluginRoot("${PLUGIN_ROOT}/a", ROOT)).toBe(`${ROOT}/a`);
-    // PLUGIN_DATA resolves to the writable data directory, not the bundle
-    // root — until the data-directory runtime lands it stays verbatim.
-    expect(substitutePluginRoot("${PLUGIN_DATA}/a", ROOT)).toBe(
-      "${PLUGIN_DATA}/a"
-    );
+    expect(
+      substitutePluginPlaceholders("${PLUGIN_DATA}/a", {
+        root: ROOT,
+        dataDir: DATA,
+      })
+    ).toBe(`${DATA}/a`);
+    // Distinct roots: the data dir is writable per-plugin state, never the
+    // immutable bundle.
+    expect(
+      substitutePluginPlaceholders("${PLUGIN_ROOT}/x:${PLUGIN_DATA}/y", {
+        root: ROOT,
+        dataDir: DATA,
+      })
+    ).toBe(`${ROOT}/x:${DATA}/y`);
+  });
+
+  it("leaves ${PLUGIN_DATA} verbatim when no data dir is supplied", () => {
+    // The caller's leftover-placeholder guard then refuses the spawn.
+    expect(
+      substitutePluginPlaceholders("${PLUGIN_DATA}/a", { root: ROOT })
+    ).toBe("${PLUGIN_DATA}/a");
   });
 
   it("substitutes every occurrence, not just the first", () => {
@@ -82,5 +100,23 @@ describe("plugin root substitution", () => {
       ROOT
     );
     expect(resolved.env).toEqual({ PLUGIN_ROOT: ROOT });
+  });
+
+  it("injects and substitutes PLUGIN_DATA when a data dir is supplied", () => {
+    const resolved = resolvePluginStdioLaunch(
+      {
+        command: "node",
+        args: ["--cache=${PLUGIN_DATA}/cache.db"],
+        env: { STATE_DIR: "${PLUGIN_DATA}/state" },
+      },
+      ROOT,
+      { dataDir: DATA }
+    );
+    expect(resolved.env).toEqual({
+      PLUGIN_ROOT: ROOT,
+      PLUGIN_DATA: DATA,
+      STATE_DIR: `${DATA}/state`,
+    });
+    expect(resolved.args).toEqual([`--cache=${DATA}/cache.db`]);
   });
 });

--- a/mcpjam-inspector/server/services/plugins/__tests__/plugin-root.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/plugin-root.test.ts
@@ -36,6 +36,18 @@ describe("plugin root substitution", () => {
     ).toBe("${PLUGIN_DATA}/a");
   });
 
+  it("substitutes in a single pass — inserted values are never re-scanned", () => {
+    // A root that happens to CONTAIN a literal placeholder token must land
+    // verbatim; sequential per-token replacement would substitute it again.
+    const weirdRoot = "/tmp/${PLUGIN_DATA}/cache";
+    expect(
+      substitutePluginPlaceholders("${PLUGIN_ROOT}/a", {
+        root: weirdRoot,
+        dataDir: DATA,
+      })
+    ).toBe(`${weirdRoot}/a`);
+  });
+
   it("substitutes every occurrence, not just the first", () => {
     expect(
       substitutePluginRoot("${PLUGIN_ROOT}:${PLUGIN_ROOT}", ROOT)

--- a/mcpjam-inspector/server/services/plugins/local-stdio.ts
+++ b/mcpjam-inspector/server/services/plugins/local-stdio.ts
@@ -30,6 +30,7 @@ import {
   resolvePluginStdioLaunch,
   type PluginStdioLaunchSpec,
 } from "./plugin-root.js";
+import { ensurePluginDataDir } from "./plugin-data.js";
 import {
   containsPluginPlaceholder,
   PLUGIN_PLACEHOLDERS,
@@ -197,6 +198,8 @@ export async function preparePluginStdioLaunch(args: {
   leaseId: string;
   /** Just-imported bundle content, when the caller has it (desktop import). */
   source?: PluginFileSource;
+  /** Test seam for the `${PLUGIN_DATA}` root; defaults to `~/.mcpjam/plugin-data`. */
+  dataRoot?: string;
 }): Promise<PluginStdioPreparation> {
   const origin = await resolvePluginOriginForServer(args.client, {
     projectId: args.projectId,
@@ -266,14 +269,37 @@ export async function preparePluginStdioLaunch(args: {
     }
   }
 
-  const launch = resolvePluginStdioLaunch(args.spec, root);
+  // The writable per-plugin data directory (spec: created before launch,
+  // preserved across updates — keyed by pluginId, NOT bundleHash, so a
+  // version activation keeps the component's state). Creation failure is a
+  // launch failure, not a silent downgrade: a component that referenced
+  // ${PLUGIN_DATA} would otherwise spawn against a missing directory.
+  let dataDir: string;
+  try {
+    dataDir = await ensurePluginDataDir({
+      projectId: args.projectId,
+      pluginId: origin.pluginId,
+      ...(args.dataRoot !== undefined ? { rootDir: args.dataRoot } : {}),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "bundle_verification_failed",
+      origin,
+      message: `plugin data directory could not be created: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
 
-  // Substitution expands only ${PLUGIN_ROOT}; anything still carrying a
-  // placeholder (today: ${PLUGIN_DATA}, pending its runtime) must not spawn —
-  // the literal string would reach the child as an argv/env/cwd value. Only
-  // the placeholder TOKEN is reported: the containing string may embed an
-  // expanded cache path or an adjacent secret, and this reason surfaces in
-  // an error response.
+  const launch = resolvePluginStdioLaunch(args.spec, root, { dataDir });
+
+  // Defense in depth: anything STILL carrying a placeholder after both
+  // substitutions (a future placeholder this build doesn't implement) must
+  // not spawn — the literal string would reach the child as an argv/env/cwd
+  // value. Only the placeholder TOKEN is reported: the containing string may
+  // embed an expanded cache path or an adjacent secret, and this reason
+  // surfaces in an error response.
   const launchValues = [
     launch.command,
     ...launch.args,
@@ -348,6 +374,8 @@ export async function materializePluginStdioForConnect(args: {
   serverName: string;
   spec: PluginStdioLaunchSpec;
   cache?: PluginBundleCache;
+  /** Test seam for the `${PLUGIN_DATA}` root. */
+  dataRoot?: string;
 }): Promise<{
   command: string;
   args: string[];
@@ -366,6 +394,7 @@ export async function materializePluginStdioForConnect(args: {
     serverId: args.serverId,
     spec: args.spec,
     leaseId: args.serverName,
+    ...(args.dataRoot !== undefined ? { dataRoot: args.dataRoot } : {}),
   });
 
   if (!prepared.ok) {

--- a/mcpjam-inspector/server/services/plugins/local-stdio.ts
+++ b/mcpjam-inspector/server/services/plugins/local-stdio.ts
@@ -219,6 +219,39 @@ export async function preparePluginStdioLaunch(args: {
     return { ok: false, reason: "missing_bundle_hash", origin };
   }
 
+  // A placeholder the bundle declared that this build does not implement
+  // must not spawn — the literal would reach the child as an argv/env/cwd
+  // value. The scan runs on the ORIGINAL spec, never the resolved launch:
+  // the machine's own root/data paths may legitimately contain
+  // placeholder-shaped text, and substitution deliberately never re-scans
+  // inserted values — re-checking resolved output would refuse exactly the
+  // paths the single-pass substitution promises to preserve. The GENERIC
+  // token shape (minus the implemented set) is what makes this
+  // future-proof: `${PLUGIN_CACHE}` from a spec revision we haven't
+  // shipped trips it today. Only the bare token is reported — the
+  // containing value may embed an adjacent secret.
+  const implementedTokens = new Set(["${PLUGIN_ROOT}", "${PLUGIN_DATA}"]);
+  const specValues = [
+    args.spec.command,
+    ...args.spec.args,
+    ...Object.values(args.spec.env),
+    ...(args.spec.workingDirectory !== undefined
+      ? [args.spec.workingDirectory]
+      : []),
+  ];
+  for (const value of specValues) {
+    for (const match of value.matchAll(/\$\{PLUGIN_[A-Z0-9_]+\}/g)) {
+      if (!implementedTokens.has(match[0])) {
+        return {
+          ok: false,
+          reason: "unsupported_placeholder",
+          origin,
+          placeholder: match[0],
+        };
+      }
+    }
+  }
+
   // The writable per-plugin data directory (spec: created before launch,
   // preserved across updates — keyed by pluginId, NOT bundleHash, so a
   // version activation keeps the component's state). Created BEFORE the
@@ -302,37 +335,6 @@ export async function preparePluginStdioLaunch(args: {
   }
 
   const launch = resolvePluginStdioLaunch(args.spec, root, { dataDir });
-
-  // Defense in depth: anything STILL carrying a placeholder-shaped token
-  // after substitution (a future spec placeholder this build doesn't
-  // implement) must not spawn — the literal string would reach the child as
-  // an argv/env/cwd value. The GENERIC pattern (not the known-token list)
-  // is what makes this future-proof: `${PLUGIN_CACHE}` from a spec revision
-  // we haven't shipped trips it today. Only the placeholder TOKEN is
-  // reported: the containing string may embed an expanded cache path or an
-  // adjacent secret, and this reason surfaces in an error response.
-  const launchValues = [
-    launch.command,
-    ...launch.args,
-    ...Object.values(launch.env),
-    ...(launch.workingDirectory !== undefined ? [launch.workingDirectory] : []),
-  ];
-  let leftoverToken: string | undefined;
-  for (const value of launchValues) {
-    const match = value.match(/\$\{PLUGIN_[A-Z0-9_]+\}/);
-    if (match) {
-      leftoverToken = match[0];
-      break;
-    }
-  }
-  if (leftoverToken !== undefined) {
-    return {
-      ok: false,
-      reason: "unsupported_placeholder",
-      origin,
-      placeholder: leftoverToken,
-    };
-  }
 
   // Unique per call, not just per server: a reconnect acquires the new lease
   // BEFORE releasing the old one, and two holders sharing an id would make

--- a/mcpjam-inspector/server/services/plugins/local-stdio.ts
+++ b/mcpjam-inspector/server/services/plugins/local-stdio.ts
@@ -33,7 +33,6 @@ import {
 import { ensurePluginDataDir } from "./plugin-data.js";
 import {
   containsPluginPlaceholder,
-  PLUGIN_PLACEHOLDERS,
   type PluginFileSource,
 } from "@mcpjam/sdk/plugin-bundle";
 import { createZipPluginFileSource } from "./bundle-file-sources.js";
@@ -156,15 +155,25 @@ export type PluginStdioPreparationFailure =
     }
   | {
       /**
-       * A placeholder survived substitution — today that means
-       * `${PLUGIN_DATA}`, whose writable-directory runtime is not built yet.
-       * Fail closed: a child process must never see a placeholder verbatim.
-       * `placeholder` is the bare token only — never the containing value,
-       * which may embed expanded paths or adjacent secrets.
+       * A placeholder-shaped token survived substitution — a future spec
+       * placeholder this build does not implement. Fail closed: a child
+       * process must never see a placeholder verbatim. `placeholder` is the
+       * bare token only — never the containing value, which may embed
+       * expanded paths or adjacent secrets.
        */
       reason: "unsupported_placeholder";
       origin: PluginServerOrigin;
       placeholder: string;
+    }
+  | {
+      /**
+       * The writable `${PLUGIN_DATA}` directory could not be created — a
+       * LOCAL filesystem problem (unwritable `~/.mcpjam`, full disk,
+       * permissions), never a bundle problem: re-importing cannot fix it.
+       */
+      reason: "plugin_data_unavailable";
+      origin: PluginServerOrigin;
+      message: string;
     };
 
 export type PluginStdioPreparation =
@@ -208,6 +217,29 @@ export async function preparePluginStdioLaunch(args: {
   if (!origin) return { ok: false, reason: "no_plugin_origin" };
   if (!origin.bundleHash) {
     return { ok: false, reason: "missing_bundle_hash", origin };
+  }
+
+  // The writable per-plugin data directory (spec: created before launch,
+  // preserved across updates — keyed by pluginId, NOT bundleHash, so a
+  // version activation keeps the component's state). Created BEFORE the
+  // bundle materializes: this await must not sit between materialization
+  // and the lease acquisition below, where a concurrent GC sweep could
+  // reclaim the just-verified entry. Creation failure is a launch failure
+  // with its own reason — a filesystem problem, not a bundle problem.
+  let dataDir: string;
+  try {
+    dataDir = await ensurePluginDataDir({
+      projectId: args.projectId,
+      pluginId: origin.pluginId,
+      ...(args.dataRoot !== undefined ? { rootDir: args.dataRoot } : {}),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "plugin_data_unavailable",
+      origin,
+      message: error instanceof Error ? error.message : String(error),
+    };
   }
 
   const identity: PluginBundleIdentity = {
@@ -269,46 +301,30 @@ export async function preparePluginStdioLaunch(args: {
     }
   }
 
-  // The writable per-plugin data directory (spec: created before launch,
-  // preserved across updates — keyed by pluginId, NOT bundleHash, so a
-  // version activation keeps the component's state). Creation failure is a
-  // launch failure, not a silent downgrade: a component that referenced
-  // ${PLUGIN_DATA} would otherwise spawn against a missing directory.
-  let dataDir: string;
-  try {
-    dataDir = await ensurePluginDataDir({
-      projectId: args.projectId,
-      pluginId: origin.pluginId,
-      ...(args.dataRoot !== undefined ? { rootDir: args.dataRoot } : {}),
-    });
-  } catch (error) {
-    return {
-      ok: false,
-      reason: "bundle_verification_failed",
-      origin,
-      message: `plugin data directory could not be created: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    };
-  }
-
   const launch = resolvePluginStdioLaunch(args.spec, root, { dataDir });
 
-  // Defense in depth: anything STILL carrying a placeholder after both
-  // substitutions (a future placeholder this build doesn't implement) must
-  // not spawn — the literal string would reach the child as an argv/env/cwd
-  // value. Only the placeholder TOKEN is reported: the containing string may
-  // embed an expanded cache path or an adjacent secret, and this reason
-  // surfaces in an error response.
+  // Defense in depth: anything STILL carrying a placeholder-shaped token
+  // after substitution (a future spec placeholder this build doesn't
+  // implement) must not spawn — the literal string would reach the child as
+  // an argv/env/cwd value. The GENERIC pattern (not the known-token list)
+  // is what makes this future-proof: `${PLUGIN_CACHE}` from a spec revision
+  // we haven't shipped trips it today. Only the placeholder TOKEN is
+  // reported: the containing string may embed an expanded cache path or an
+  // adjacent secret, and this reason surfaces in an error response.
   const launchValues = [
     launch.command,
     ...launch.args,
     ...Object.values(launch.env),
     ...(launch.workingDirectory !== undefined ? [launch.workingDirectory] : []),
   ];
-  const leftoverToken = PLUGIN_PLACEHOLDERS.find((placeholder) =>
-    launchValues.some((value) => value.includes(placeholder))
-  );
+  let leftoverToken: string | undefined;
+  for (const value of launchValues) {
+    const match = value.match(/\$\{PLUGIN_[A-Z0-9_]+\}/);
+    if (match) {
+      leftoverToken = match[0];
+      break;
+    }
+  }
   if (leftoverToken !== undefined) {
     return {
       ok: false,
@@ -468,12 +484,24 @@ function pluginStdioFailureToRouteError(
       return new WebRouteError(
         409,
         ErrorCode.CONFLICT,
-        `Plugin "${failure.origin.name}" uses \${PLUGIN_DATA}, which this MCPJam version cannot provide yet, so the component will not be launched.`,
+        `Plugin "${failure.origin.name}" uses ${failure.placeholder}, which this MCPJam version does not provide, so the component will not be launched. Update MCPJam to run it.`,
         {
           reason: failure.reason,
           serverName,
           pluginId: failure.origin.pluginId,
           placeholder: failure.placeholder,
+        }
+      );
+    case "plugin_data_unavailable":
+      return new WebRouteError(
+        409,
+        ErrorCode.CONFLICT,
+        `Plugin "${failure.origin.name}" needs its data directory, but it could not be created on this machine. Check that ~/.mcpjam is writable and has free space.`,
+        {
+          reason: failure.reason,
+          serverName,
+          pluginId: failure.origin.pluginId,
+          details: failure.message,
         }
       );
   }

--- a/mcpjam-inspector/server/services/plugins/plugin-data.ts
+++ b/mcpjam-inspector/server/services/plugins/plugin-data.ts
@@ -1,0 +1,48 @@
+/**
+ * The writable per-plugin data directory behind `${PLUGIN_DATA}` (Agent
+ * Plugins spec: "Create a dedicated writable PLUGIN_DATA directory before
+ * launch and preserve it across plugin updates").
+ *
+ * Keyed by LOGICAL plugin identity — `<root>/<projectId>/<pluginId>` — never
+ * by version or bundle hash: the whole point of the directory is surviving a
+ * version activation, so a component's cache/state carries across updates.
+ * Contrast with the bundle cache (`bundle-cache.ts`), which is content-
+ * addressed, immutable, verified on every hit, and garbage-collected; the
+ * data directory is none of those things — it is the component's own mutable
+ * scratch space and its contents are never trusted, verified, or executed by
+ * MCPJam.
+ */
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const SAFE_SEGMENT = /^[A-Za-z0-9_-]+$/;
+
+export function defaultPluginDataRoot(): string {
+  return join(homedir(), ".mcpjam", "plugin-data");
+}
+
+/**
+ * Resolve and create the data directory for one plugin. Throws on malformed
+ * ids rather than joining them into a path: both segments are Convex ids and
+ * must never carry separators.
+ */
+export async function ensurePluginDataDir(args: {
+  projectId: string;
+  pluginId: string;
+  /** Test seam; defaults to `~/.mcpjam/plugin-data`. */
+  rootDir?: string;
+}): Promise<string> {
+  if (!SAFE_SEGMENT.test(args.projectId) || !SAFE_SEGMENT.test(args.pluginId)) {
+    throw new Error(
+      `plugin data dir refuses unsafe id segments: ${args.projectId}/${args.pluginId}`
+    );
+  }
+  const dir = join(
+    args.rootDir ?? defaultPluginDataRoot(),
+    args.projectId,
+    args.pluginId
+  );
+  await mkdir(dir, { recursive: true });
+  return dir;
+}

--- a/mcpjam-inspector/server/services/plugins/plugin-data.ts
+++ b/mcpjam-inspector/server/services/plugins/plugin-data.ts
@@ -43,6 +43,9 @@ export async function ensurePluginDataDir(args: {
     args.projectId,
     args.pluginId
   );
-  await mkdir(dir, { recursive: true });
+  // Owner-only regardless of umask: persisted plugin state (caches, auth
+  // artifacts a component chooses to write) must not be readable by other
+  // local users. Applies on creation; an existing directory keeps its mode.
+  await mkdir(dir, { recursive: true, mode: 0o700 });
   return dir;
 }

--- a/mcpjam-inspector/server/services/plugins/plugin-root.ts
+++ b/mcpjam-inspector/server/services/plugins/plugin-root.ts
@@ -75,11 +75,12 @@ export function substitutePluginPlaceholders(
   value: string,
   roots: { root: string; dataDir?: string }
 ): string {
-  let out = substitutePluginRoot(value, roots.root);
-  if (roots.dataDir !== undefined) {
-    out = out.split("${PLUGIN_DATA}").join(roots.dataDir);
-  }
-  return out;
+  // Single pass over the ORIGINAL value: sequential per-token replacement
+  // would re-scan earlier substitutions, so a substituted path that happened
+  // to contain a literal placeholder token would be substituted again.
+  return value.replace(/\$\{PLUGIN_ROOT\}|\$\{PLUGIN_DATA\}/g, (token) =>
+    token === "${PLUGIN_ROOT}" ? roots.root : (roots.dataDir ?? token)
+  );
 }
 
 /**

--- a/mcpjam-inspector/server/services/plugins/plugin-root.ts
+++ b/mcpjam-inspector/server/services/plugins/plugin-root.ts
@@ -8,12 +8,11 @@
  * directory into everyone's pin). Substitution belongs here, at the last
  * possible moment, against a cache directory derived from the bundle hash.
  *
- * `${PLUGIN_DATA}` (the writable per-plugin data directory the Agent Plugins
- * spec requires) is detected but NOT yet substituted — the data-directory
- * runtime lands in the runtime-fidelity phase. Until then a component whose
- * spec references it is still recognized as a plugin component, so it can
- * never spawn through the ordinary non-plugin path with the placeholder
- * intact.
+ * `${PLUGIN_DATA}` substitutes to the writable per-plugin data directory
+ * (`plugin-data.ts`) when the caller supplies one; without it the
+ * placeholder stays verbatim and the leftover guard in
+ * `preparePluginStdioLaunch` refuses the spawn — a child process never sees
+ * a placeholder either way.
  *
  * The placeholder list itself is imported from the SDK rather than restated —
  * one list, one rule, no drift when the spec evolves.
@@ -65,29 +64,59 @@ export function needsPluginRoot(spec: PluginStdioLaunchSpec): boolean {
 }
 
 /**
- * Resolve a plugin stdio component against its materialized bundle.
+ * Substitute both runtime placeholders in one value. `${PLUGIN_ROOT}` maps to
+ * the immutable materialized bundle; `${PLUGIN_DATA}` maps to the writable
+ * per-plugin data directory (spec: created before launch, preserved across
+ * updates). When no data directory is supplied, `${PLUGIN_DATA}` is left
+ * verbatim — the caller's leftover-placeholder guard then refuses the spawn,
+ * so the literal can never reach a child process.
+ */
+export function substitutePluginPlaceholders(
+  value: string,
+  roots: { root: string; dataDir?: string }
+): string {
+  let out = substitutePluginRoot(value, roots.root);
+  if (roots.dataDir !== undefined) {
+    out = out.split("${PLUGIN_DATA}").join(roots.dataDir);
+  }
+  return out;
+}
+
+/**
+ * Resolve a plugin stdio component against its materialized bundle and its
+ * writable data directory.
  *
- * The injected `PLUGIN_ROOT` alias is applied FIRST; the component's own env
- * entries are substituted over it. (The SDK parser rejects bundles whose env
- * declares the reserved `PLUGIN_ROOT`/`PLUGIN_DATA` keys, so the spec's env
- * can never shadow the injected alias.)
+ * The injected `PLUGIN_ROOT`/`PLUGIN_DATA` aliases are applied FIRST; the
+ * component's own env entries are substituted over them. (The SDK parser
+ * rejects bundles whose env declares the reserved `PLUGIN_ROOT`/`PLUGIN_DATA`
+ * keys, so the spec's env can never shadow the injected aliases.)
  */
 export function resolvePluginStdioLaunch(
   spec: PluginStdioLaunchSpec,
-  root: string
+  root: string,
+  options?: { dataDir?: string }
 ): Required<Pick<PluginStdioLaunchSpec, "command" | "args" | "env">> & {
   workingDirectory?: string;
 } {
-  const env: Record<string, string> = { ...pluginRootEnv(root) };
+  const roots = { root, dataDir: options?.dataDir };
+  const env: Record<string, string> = {
+    ...pluginRootEnv(root),
+    ...(roots.dataDir !== undefined ? { PLUGIN_DATA: roots.dataDir } : {}),
+  };
   for (const [key, value] of Object.entries(spec.env)) {
-    env[key] = substitutePluginRoot(value, root);
+    env[key] = substitutePluginPlaceholders(value, roots);
   }
   return {
-    command: substitutePluginRoot(spec.command, root),
-    args: spec.args.map((arg) => substitutePluginRoot(arg, root)),
+    command: substitutePluginPlaceholders(spec.command, roots),
+    args: spec.args.map((arg) => substitutePluginPlaceholders(arg, roots)),
     env,
     ...(spec.workingDirectory !== undefined
-      ? { workingDirectory: substitutePluginRoot(spec.workingDirectory, root) }
+      ? {
+          workingDirectory: substitutePluginPlaceholders(
+            spec.workingDirectory,
+            roots
+          ),
+        }
       : {}),
   };
 }


### PR DESCRIPTION
## Summary

Agent Plugins program, **Phase 3 (runtime fidelity)**. The parser has accepted `${PLUGIN_DATA}` since the retarget (#3797), but the local runtime substituted only `${PLUGIN_ROOT}` and failed closed (`unsupported_placeholder` 409) on any component referencing the data directory. This implements the spec behavior: *"Create a dedicated writable PLUGIN_DATA directory before launch and preserve it across plugin updates."*

## Design

- **`plugin-data.ts`**: `~/.mcpjam/plugin-data/<projectId>/<pluginId>`, created before launch. Keyed by **logical plugin identity, never version or bundleHash** — a version activation preserves the component's state, which is the spec's whole point. Deliberate contrast with the bundle cache: the data dir is mutable scratch space — never verified, never trusted, never executed by MCPJam. Id segments are validated before path-joining.
- `resolvePluginStdioLaunch` substitutes both placeholders (args/env values/cwd, per spec scope) and injects `PLUGIN_ROOT` + `PLUGIN_DATA` env; `substitutePluginPlaceholders` is the shared primitive the Phase-8 VM materializer will reuse.
- `preparePluginStdioLaunch` creates the directory — creation failure is a launch failure, never a silent downgrade — and the leftover-placeholder guard stays as defense in depth for placeholders a future spec version adds that this build doesn't implement.

## Tests

Distinct-root substitution (`${PLUGIN_ROOT}` vs `${PLUGIN_DATA}` in one value), env injection, directory created and keyed by pluginId, verbatim passthrough + fail-closed when no data dir is supplied. Connect-path tests pass a temp data root so suites never write to the real `~/.mcpjam`. `services/plugins` + `services/environments` green (118 tests).

Remaining Phase-3 item (deliberately excluded): `preferSSE` wiring for declared-`sse` components — it needs `httpVariant` in the runtime payload, which lands with the Phase 2 backend bump after the SDK publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the local plugin spawn path (filesystem layout, env injection, and launch ordering); failures are fail-closed with new error reasons, but incorrect path or permission handling could block launches or affect persisted plugin state on disk.
> 
> **Overview**
> Implements **Agent Plugins** runtime support for **`${PLUGIN_DATA}`**: before a local stdio plugin spawns, MCPJam creates a **per-plugin writable directory** under `~/.mcpjam/plugin-data/<projectId>/<pluginId>` (stable across version/bundle changes), substitutes the placeholder in command/args/env/cwd, and injects **`PLUGIN_DATA`** into the child environment alongside **`PLUGIN_ROOT`**.
> 
> Launch prep now **creates the data dir before bundle materialization** (avoids a GC/lease race), returns **`plugin_data_unavailable`** when mkdir fails (distinct from bundle errors), and **scans the original spec** for unknown **`${PLUGIN_*}`** tokens so future placeholders fail closed without false positives from machine paths. Substitution uses a **single-pass** helper so expanded paths are never re-scanned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87060aab99d94781e484689e2bf40a66736b1aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime support for the `${PLUGIN_DATA}` writable data directory so plugin components can persist state across updates. Substitutes placeholders in command/args/env/cwd and injects `PLUGIN_DATA`/`PLUGIN_ROOT` into the env. The unsupported-placeholder guard now scans the original spec before any side effects.

- **Bug Fixes**
  - Data directories are created with 0o700 permissions regardless of umask; asserted in tests on POSIX.
  - Failed data-dir creation now returns `plugin_data_unavailable` with a helpful message, not a bundle error.
  - Closed a GC race by creating the data dir before bundle materialization/lease.
  - Placeholder handling is single-pass; inserted values are never re-scanned.
  - The guard scans the spec for generic `${PLUGIN_[A-Z0-9_]+}` tokens minus the implemented set, failing unknown placeholders fast with only the bare token reported, and without creating a data dir. Placeholder-shaped text in local machine paths no longer triggers false positives.

<sup>Written for commit 87060aab99d94781e484689e2bf40a66736b1aaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

