### PR TITLE
feat(computers): config endpoint reports per-engine availability and the personal/ephemeral capability split (PR 4)

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../../config.js", async () => {
 });
 
 import { createComputersRoutes } from "../computers";
+import { isLocalComputerEngineAvailable } from "../../../utils/computers/local-machine";
 import type { BashRunner } from "../../../utils/computers/run-command";
 
 // Route-level tests: GET /config (data-plane discovery) and POST /exec (the
@@ -120,27 +121,44 @@ afterEach(() => {
 });
 
 describe("GET /api/web/computers/config", () => {
+  // The local-engine block depends on the host running the tests (bash on
+  // PATH); compose the expectation from the same probe the route consults so
+  // the suite is honest on a bash-less machine instead of failing on it.
+  function expectedLocalEngineBlock() {
+    const availability = isLocalComputerEngineAvailable();
+    return availability.available
+      ? {
+          available: true,
+          terminalAvailable: false,
+          workspaceDisplayRoot: "~/.mcpjam/computer",
+        }
+      : {
+          available: false,
+          terminalAvailable: false,
+          workspaceDisplayRoot: null,
+          reason: availability.reason,
+        };
+  }
+
   it("reports an unconfigured server — legacy fields intact, engines added", async () => {
+    const localBlock = expectedLocalEngineBlock();
     const response = await createApp().request("/api/web/computers/config");
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       localConfigured: false,
       remoteDataPlaneUrl: null,
       engines: {
-        // Non-hosted test env with bash on PATH ⇒ the local engine exists;
-        // the terminal stays off until the node-pty PR wires its probe.
-        local: {
-          available: true,
-          terminalAvailable: false,
-          workspaceDisplayRoot: "~/.mcpjam/computer",
-        },
+        // Terminal stays off until the node-pty PR wires its probe.
+        local: localBlock,
         cloud: { available: false },
       },
       capabilities: {
         personalCloudAvailable: false,
         ephemeralCloudAvailable: false,
       },
-      defaultEngine: "local",
+      // No cloud anywhere ⇒ local when the machine can serve it, else the
+      // honest "no engine exists" null.
+      defaultEngine: localBlock.available ? "local" : null,
     });
   });
 
@@ -185,12 +203,23 @@ describe("GET /api/web/computers/config", () => {
     expect(body.defaultEngine).toBe("cloud");
   });
 
-  it("kill switch off: local engine unavailable with a reason", async () => {
+  it("kill switch off + no cloud: NO contradictory default — defaultEngine is null", async () => {
+    // Telling the client "the default engine is cloud" while every
+    // availability flag says cloud doesn't exist would send the engine UI
+    // chasing a phantom; null lets it fall through to its empty state.
     configState.localEnabled = false;
     const response = await createApp().request("/api/web/computers/config");
     const body = (await response.json()) as Record<string, any>;
     expect(body.engines.local.available).toBe(false);
     expect(body.engines.local.reason).toMatch(/disabled/);
+    expect(body.defaultEngine).toBeNull();
+  });
+
+  it("kill switch off with a cloud data plane: default falls back to cloud", async () => {
+    configState.localEnabled = false;
+    stubLocalDataPlaneEnv();
+    const response = await createApp().request("/api/web/computers/config");
+    const body = (await response.json()) as Record<string, any>;
     expect(body.defaultEngine).toBe("cloud");
   });
 
@@ -198,7 +227,9 @@ describe("GET /api/web/computers/config", () => {
     const response = await createApp().request("/api/web/computers/config");
     const raw = JSON.stringify(await response.json());
     expect(raw).not.toContain(process.env.HOME ?? "::never::");
-    expect(raw).toContain("~/.mcpjam/computer");
+    if (isLocalComputerEngineAvailable().available) {
+      expect(raw).toContain("~/.mcpjam/computer");
+    }
   });
 });
 

--- a/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
+
+// Controllable HOSTED_MODE / kill switch: both are import-time consts in the
+// real config module, so env stubs can't reach them.
+const configState = vi.hoisted(() => ({ hosted: false, localEnabled: true }));
+vi.mock("../../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../config.js")>(
+    "../../../config.js"
+  );
+  return {
+    ...actual,
+    get HOSTED_MODE() {
+      return configState.hosted;
+    },
+    get LOCAL_COMPUTER_ENABLED() {
+      return configState.localEnabled;
+    },
+  };
+});
+
 import { createComputersRoutes } from "../computers";
 import type { BashRunner } from "../../../utils/computers/run-command";
 
@@ -90,6 +109,8 @@ function stubLocalDataPlaneEnv() {
 
 beforeEach(() => {
   installFetchStub();
+  configState.hosted = false;
+  configState.localEnabled = true;
 });
 
 afterEach(() => {
@@ -99,34 +120,85 @@ afterEach(() => {
 });
 
 describe("GET /api/web/computers/config", () => {
-  it("reports an unconfigured server", async () => {
+  it("reports an unconfigured server — legacy fields intact, engines added", async () => {
     const response = await createApp().request("/api/web/computers/config");
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
       localConfigured: false,
       remoteDataPlaneUrl: null,
+      engines: {
+        // Non-hosted test env with bash on PATH ⇒ the local engine exists;
+        // the terminal stays off until the node-pty PR wires its probe.
+        local: {
+          available: true,
+          terminalAvailable: false,
+          workspaceDisplayRoot: "~/.mcpjam/computer",
+        },
+        cloud: { available: false },
+      },
+      capabilities: {
+        personalCloudAvailable: false,
+        ephemeralCloudAvailable: false,
+      },
+      defaultEngine: "local",
     });
   });
 
-  it("reports a locally configured data plane", async () => {
+  it("reports a locally configured data plane — BOTH cloud capabilities", async () => {
     stubLocalDataPlaneEnv();
     const response = await createApp().request("/api/web/computers/config");
-    expect(await response.json()).toEqual({
-      localConfigured: true,
-      remoteDataPlaneUrl: null,
+    const body = (await response.json()) as Record<string, any>;
+    expect(body.localConfigured).toBe(true);
+    expect(body.remoteDataPlaneUrl).toBeNull();
+    expect(body.engines.cloud).toEqual({ available: true });
+    expect(body.capabilities).toEqual({
+      personalCloudAvailable: true,
+      ephemeralCloudAvailable: true,
     });
   });
 
-  it("advertises the remote data plane origin", async () => {
+  it("remote-only: personal cloud works, ephemeral does NOT — the capability split", async () => {
+    // `remoteDataPlaneUrl` delegates only personal-computer exec/terminal;
+    // eval/swarm/chatbox sandboxes need THIS process to hold the creds. A
+    // single "cloud available" bit would lie to exactly those surfaces.
     vi.stubEnv(
       "COMPUTERS_REMOTE_DATA_PLANE_URL",
       "https://dp.example.test/ignored-path"
     );
     const response = await createApp().request("/api/web/computers/config");
-    expect(await response.json()).toEqual({
-      localConfigured: false,
-      remoteDataPlaneUrl: "https://dp.example.test",
+    const body = (await response.json()) as Record<string, any>;
+    expect(body.localConfigured).toBe(false);
+    expect(body.remoteDataPlaneUrl).toBe("https://dp.example.test");
+    expect(body.capabilities).toEqual({
+      personalCloudAvailable: true,
+      ephemeralCloudAvailable: false,
     });
+  });
+
+  it("hosted: no local engine, cloud default — and no reason leaks paths", async () => {
+    configState.hosted = true;
+    stubLocalDataPlaneEnv();
+    const response = await createApp().request("/api/web/computers/config");
+    const body = (await response.json()) as Record<string, any>;
+    expect(body.engines.local.available).toBe(false);
+    expect(body.engines.local.workspaceDisplayRoot).toBeNull();
+    expect(body.defaultEngine).toBe("cloud");
+  });
+
+  it("kill switch off: local engine unavailable with a reason", async () => {
+    configState.localEnabled = false;
+    const response = await createApp().request("/api/web/computers/config");
+    const body = (await response.json()) as Record<string, any>;
+    expect(body.engines.local.available).toBe(false);
+    expect(body.engines.local.reason).toMatch(/disabled/);
+    expect(body.defaultEngine).toBe("cloud");
+  });
+
+  it("never leaks an absolute home path — the display root is a tilde literal", async () => {
+    const response = await createApp().request("/api/web/computers/config");
+    const raw = JSON.stringify(await response.json());
+    expect(raw).not.toContain(process.env.HOME ?? "::never::");
+    expect(raw).toContain("~/.mcpjam/computer");
   });
 });
 

--- a/mcpjam-inspector/server/routes/web/computers.ts
+++ b/mcpjam-inspector/server/routes/web/computers.ts
@@ -33,6 +33,7 @@ import { z } from "zod";
 import { executionScopeSchema } from "../../utils/execution-scope.js";
 import { resolveComputersLocalConfigured } from "../../utils/computers/runtime-config.js";
 import { resolveComputersRemoteDataPlaneUrl } from "../../utils/computers/remote-data-plane.js";
+import { isLocalComputerEngineAvailable } from "../../utils/computers/local-machine.js";
 import {
   MAX_COMMAND_TIMEOUT_S,
   e2bRunner,
@@ -66,7 +67,42 @@ export function createComputersRoutes(runner: BashRunner = e2bRunner): Hono {
       resolveComputersLocalConfigured(),
       resolveComputersRemoteDataPlaneUrl(),
     ]);
-    return c.json({ localConfigured, remoteDataPlaneUrl });
+    const localEngine = isLocalComputerEngineAvailable();
+    // The capability SPLIT is the point of this shape: `remoteDataPlaneUrl`
+    // delegates only PERSONAL-computer exec/terminal, so a remote-only
+    // inspector can drive a personal Computer yet cannot execute one
+    // disposable-sandbox command. Cloud-only surfaces (swarms/evals/user
+    // testing) preflight on `ephemeralCloudAvailable`; a single "cloud
+    // available" bit would lie to exactly those surfaces.
+    const personalCloudAvailable = localConfigured || remoteDataPlaneUrl !== null;
+    return c.json({
+      // Legacy pair, verbatim — older clients read only these.
+      localConfigured,
+      remoteDataPlaneUrl,
+      engines: {
+        local: {
+          available: localEngine.available,
+          // PR 8 (node-pty) wires the real probe; until then the local
+          // engine is bash-only and the client shows the terminal-off state.
+          terminalAvailable: false,
+          // This endpoint is OPEN (no bearer), so only the tilde display
+          // root ever leaves the server — never an absolute home path or OS
+          // username. The client renders `${workspaceDisplayRoot}/<projectId>`;
+          // the server independently validates and resolves the real path at
+          // exec time.
+          workspaceDisplayRoot: localEngine.available
+            ? "~/.mcpjam/computer"
+            : null,
+          ...(localEngine.available ? {} : { reason: localEngine.reason }),
+        },
+        cloud: { available: personalCloudAvailable },
+      },
+      capabilities: {
+        personalCloudAvailable,
+        ephemeralCloudAvailable: localConfigured,
+      },
+      defaultEngine: localEngine.available ? "local" : "cloud",
+    });
   });
 
   computers.post("/exec", async (c) =>

--- a/mcpjam-inspector/server/routes/web/computers.ts
+++ b/mcpjam-inspector/server/routes/web/computers.ts
@@ -101,7 +101,14 @@ export function createComputersRoutes(runner: BashRunner = e2bRunner): Hono {
         personalCloudAvailable,
         ephemeralCloudAvailable: localConfigured,
       },
-      defaultEngine: localEngine.available ? "local" : "cloud",
+      // Honest tri-state: `null` when NO engine can serve this inspector —
+      // a "cloud" default with every availability flag false would tell the
+      // client to prefer an engine that does not exist.
+      defaultEngine: localEngine.available
+        ? "local"
+        : personalCloudAvailable
+          ? "cloud"
+          : null,
     });
   });
 


### PR DESCRIPTION
PR 4 of the local-computer-engine program (PRs 1–3: #3799, #3805, #3812, all merged). Small, server-only: the config endpoint now reports per-engine availability. Unblocks the client engine UI (PRs 5–7).

## Shape

`GET /api/web/computers/config` keeps the legacy pair (`localConfigured`, `remoteDataPlaneUrl`) **verbatim** and adds:

```jsonc
{
  "engines": {
    "local": {
      "available": true,
      "terminalAvailable": false,      // stays false until PR 8 (node-pty) wires its probe
      "workspaceDisplayRoot": "~/.mcpjam/computer",  // tilde literal or null
      "reason": "…"                     // only when unavailable
    },
    "cloud": { "available": true }      // = personalCloudAvailable
  },
  "capabilities": {
    "personalCloudAvailable": true,     // localConfigured || remoteDataPlaneUrl
    "ephemeralCloudAvailable": false    // localConfigured only — no remote delegation for sandboxes
  },
  "defaultEngine": "local"
}
```

- **The capability split is the point**: `remoteDataPlaneUrl` delegates only personal-computer exec/terminal, so a remote-only inspector can drive a personal Computer yet can't execute one disposable-sandbox command. Cloud-only surfaces preflight on `ephemeralCloudAvailable` — PR 2's client hook already reads exactly this field, falling back to `localConfigured` on servers that predate it.
- **The endpoint is open (no bearer)**, so only the tilde display root leaves the server — never an absolute home path or OS username; pinned by test. The client renders `${workspaceDisplayRoot}/<projectId>`; the server independently validates and resolves the real path at exec time (PR 3).
- `engines.local.available` comes straight from `isLocalComputerEngineAvailable()` — hosted and the `MCPJAM_LOCAL_COMPUTER_ENABLED` kill switch both force it false server-side.

## Tests

Six new rows in `computers.test.ts` (10 total in the suite): legacy-fields-intact exact shape, both-capabilities row, the remote-only split row, hosted (no local engine, cloud default, null display root), kill-switch-off with reason, and the no-absolute-path guarantee. `HOSTED_MODE`/`LOCAL_COMPUTER_ENABLED` are import-time consts, so the suite mocks the config module with live getters.

Server tsc error count unchanged (108, all pre-existing); adjacent terminal/upload suites and the client hook suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Server-only discovery response extension with backward-compatible legacy fields; no auth or exec behavior changes.
> 
> **Overview**
> **`GET /api/web/computers/config`** still returns `localConfigured` and `remoteDataPlaneUrl` unchanged, and now adds **`engines`**, **`capabilities`**, and **`defaultEngine`** for the client engine UI.
> 
> **`engines.local`** reflects `isLocalComputerEngineAvailable()` (availability, optional `reason`, `terminalAvailable: false` until node-pty), and exposes only the tilde **`workspaceDisplayRoot`** when local is available. **`engines.cloud.available`** tracks personal cloud delegation (`localConfigured` or a remote data plane URL).
> 
> **`capabilities`** splits **personal** vs **ephemeral** cloud: remote-only inspectors can advertise personal cloud without claiming ephemeral sandboxes (`ephemeralCloudAvailable` stays tied to `localConfigured`). **`defaultEngine`** is `"local"` when local works, else `"cloud"` when personal cloud exists, else **`null`** so the UI does not default to a missing engine.
> 
> Route tests mock import-time **`HOSTED_MODE`** / **`LOCAL_COMPUTER_ENABLED`**, assert hosted and kill-switch behavior, the remote-only capability split, and that responses never leak an absolute home path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d46ee0f7f29359288726d1226fbdb8624ce3be65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose per-engine availability and the personal vs ephemeral capability split in `GET /api/web/computers/config`. This powers the client engine UI and avoids advertising ephemeral sandboxes on remote-only setups.

- New Features
  - Keeps `localConfigured` and `remoteDataPlaneUrl` as-is.
  - Adds `engines`: `local { available, terminalAvailable:false, workspaceDisplayRoot:"~/.mcpjam/computer"|null, reason? }`, `cloud { available }` (personal delegation counts).
  - Adds `capabilities`: `personalCloudAvailable = localConfigured || remoteDataPlaneUrl`, `ephemeralCloudAvailable = localConfigured` (no remote delegation).
  - Sets `defaultEngine` to `"local"` when local is available, else `"cloud"` if personal cloud is available, else `null`.
  - Local availability comes from `isLocalComputerEngineAvailable()`; hosted mode or the kill switch disables it. Endpoint is open; only a tilde path is exposed (no absolute home/username).

- Bug Fixes
  - Return `defaultEngine: null` when no engine exists; config tests now use the same availability probe and don’t depend on bash being on PATH.

<sup>Written for commit d46ee0f7f29359288726d1226fbdb8624ce3be65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

