### PR TITLE
fix(analytics): route /array remote config to the ingest host; bundle web-vitals

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/posthog-bundled-extensions.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/posthog-bundled-extensions.test.ts
@@ -50,6 +50,7 @@ describe("preloadPosthogBundledExtensions", () => {
       generateSurveys: expect.anything(), // surveys popover
       errorWrappingFunctions: expect.anything(), // $exception capture
       initDeadClicksAutocapture: expect.anything(),
+      postHogWebVitalsCallbacks: expect.anything(), // $web_vitals
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/posthog-bundled-extensions.ts
+++ b/mcpjam-inspector/client/src/lib/posthog-bundled-extensions.ts
@@ -16,7 +16,8 @@ import { isErrorCaptureSurface, isPostHogDisabled } from "./PosthogUtils";
  * Importing the `posthog-js/dist/*` bundles registers each feature on
  * `window.__PosthogExtensions__` (`rrweb`/`initSessionRecording`,
  * `generateSurveys`, `errorWrappingFunctions`,
- * `initDeadClicksAutocapture`), and the SDK uses a registered extension
+ * `initDeadClicksAutocapture`, `postHogWebVitalsCallbacks`), and the SDK
+ * uses a registered extension
  * instead of calling `loadExternalDependency` — verified against the
  * installed posthog-js build. Because the bundles ship in the SAME package
  * version as the SDK consuming them, the registration keys cannot drift.
@@ -41,6 +42,7 @@ export async function preloadPosthogBundledExtensions(): Promise<void> {
       import("posthog-js/dist/surveys"),
       import("posthog-js/dist/exception-autocapture"),
       import("posthog-js/dist/dead-clicks-autocapture"),
+      import("posthog-js/dist/web-vitals"),
     ]);
   } catch {
     // Analytics must never block boot. On a failed chunk load posthog-js

--- a/mcpjam-inspector/client/src/types/posthog-dist-modules.d.ts
+++ b/mcpjam-inspector/client/src/types/posthog-dist-modules.d.ts
@@ -7,3 +7,4 @@ declare module "posthog-js/dist/posthog-recorder";
 declare module "posthog-js/dist/surveys";
 declare module "posthog-js/dist/exception-autocapture";
 declare module "posthog-js/dist/dead-clicks-autocapture";
+declare module "posthog-js/dist/web-vitals";

--- a/mcpjam-inspector/server/routes/__tests__/relay.test.ts
+++ b/mcpjam-inspector/server/routes/__tests__/relay.test.ts
@@ -83,21 +83,21 @@ describe("posthog relay proxy", () => {
       body: "batch",
     });
 
-    // The alias exists because Railway's edge 403s GETs under /relay/static
-    // and /relay/array on hosted; PostHog must still receive the bare
-    // subpaths — never /tlm/....
+    // PostHog must receive the bare subpaths — never /tlm/... — and the
+    // remote-config path must hit the INGEST host (the assets host 403s our
+    // production egress; see the routing comment in relay.ts).
     expect(mockedFetchUrl(0)).toBe(
       "https://us-assets.i.posthog.com/static/recorder.js",
     );
     expect(mockedFetchUrl(1)).toBe(
-      "https://us-assets.i.posthog.com/array/phc_x/config",
+      "https://us.i.posthog.com/array/phc_x/config",
     );
     expect(mockedFetchUrl(2)).toBe(
       "https://us.i.posthog.com/i/v0/e/?compression=gzip-js",
     );
   });
 
-  it("routes /static and /array to the assets host and /flags to the ingest host", async () => {
+  it("routes /static to the assets host and /array + /flags to the ingest host", async () => {
     const app = createTestApp();
     vi.mocked(fetch).mockResolvedValue(upstreamResponse());
 
@@ -111,8 +111,11 @@ describe("posthog relay proxy", () => {
     expect(mockedFetchUrl(0)).toBe(
       "https://us-assets.i.posthog.com/static/recorder.js",
     );
+    // Remote config deliberately targets the ingest host, matching what
+    // posthog-js does unproxied — the assets host rejects our production
+    // egress (relay.ts routing comment).
     expect(mockedFetchUrl(1)).toBe(
-      "https://us-assets.i.posthog.com/array/phc_x/config.js",
+      "https://us.i.posthog.com/array/phc_x/config.js",
     );
     expect(mockedFetchUrl(2)).toBe("https://us.i.posthog.com/flags/?v=2");
   });

--- a/mcpjam-inspector/server/routes/relay.ts
+++ b/mcpjam-inspector/server/routes/relay.ts
@@ -266,14 +266,21 @@ relayRoutes.all("*", async (c) => {
 
   const url = new URL(c.req.url);
   const subpath = stripRelayPrefix(url.pathname);
-  // Static assets (recorder.js, array config) live on the assets host; all
-  // other endpoints (/i/v0/e/, /flags/, /decide/, /s/) on the ingest host.
+  // Only /static/* goes to the assets host. Everything else — including
+  // /array/<token>/config(.js), the SDK's remote-config fetch — goes to the
+  // ingest host, which serves it too and is what posthog-js itself targets
+  // when unproxied (it derives the config URL from api_host). This matters
+  // in production: the assets host 403s our server's egress (Cloudflare in
+  // front of us-assets challenging datacenter IPs — the block page our relay
+  // then piped through verbatim), while the ingest host demonstrably accepts
+  // it (events and flags have always flowed). /static is unaffected in
+  // practice: every runtime script is compiled into the client bundle
+  // (client/src/lib/posthog-bundled-extensions.ts).
   // Unknown subpaths forward to ingest rather than 404ing here: the
   // posthog-js endpoint set changes across SDK versions.
-  const upstreamBase =
-    subpath.startsWith("/static/") || subpath.startsWith("/array/")
-      ? ASSET_HOST
-      : INGEST_HOST;
+  const upstreamBase = subpath.startsWith("/static/")
+    ? ASSET_HOST
+    : INGEST_HOST;
   // Preserve the subpath verbatim (trailing slashes matter to PostHog) and
   // the full query string (compression=gzip-js, ver, ip flags).
   const target = `${upstreamBase}${subpath}${url.search}`;


### PR DESCRIPTION
## Why

#3810's `/tlm` alias didn't clear the 403 on `/array/<token>/config` — because the block was never an inbound edge rule at all. Post-deploy probes told the real story:

- `/tlm/array/...` and `/tlm/static/...` → 403 (same Cloudflare block page), while `POST /tlm/e/` and `/tlm/flags` reach PostHog fine
- decoy paths (`/zzz/static/recorder.js`) that never proxy anywhere → 200
- i.e. **every prefix fails identically the moment it actually proxies to the assets host** — the 403 is generated upstream: Cloudflare in front of `us-assets.i.posthog.com` rejects our production egress (datacenter IP), and the relay pipes the block page back verbatim. The `/relay` vs `/tlm` distinction never mattered; the earlier "edge blocks /relay" read was wrong.

## What

- **Route `/array/*` to the ingest host** (`us.i.posthog.com`), which serves the remote config too (probed: 200 JSON + 200 config.js), matches what posthog-js targets unproxied (it derives the config URL from `api_host` = ingest), and demonstrably accepts our egress — events and flags have always flowed through it. This is the piece that lets the SDK finally receive `sessionRecording: enabled` and start recording.
- `/static/*` stays pointed at the assets host, which no longer matters at runtime: every script is compiled into the client bundle (#3804).
- **Bundle `web-vitals` too** — the one remaining assets-host lazy load; without it, `$web_vitals` silently never activates on hosted (project has web-vitals autocapture on; the 16k weekly events all come from self-hosted installs whose residential egress the assets host accepts).
- `/tlm` (from #3810) stays: harmless, and mounting both prefixes remains right.

## Verification

- Relay tests updated: `/array` → ingest host on both `/relay` and `/tlm` mounts, `/static` → assets host, ingest POSTs unchanged (8/8).
- Bundled-extensions test now asserts `postHogWebVitalsCallbacks` registers alongside the other five keys, executing the real dist bundle (3/3). `typecheck:client` green.
- Post-deploy (staging): `curl https://staging.mcpjam.com/tlm/array/<token>/config` → **200 JSON** (was 403); fresh browser session → `$recording_status: active/buffering` and the project's first hosted recording; `$web_vitals` events with `$host = staging.mcpjam.com` appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production analytics relay routing for remote config paths; impact is bounded to PostHog proxy behavior and client-side extension preloading, with tests updated for the new upstream targets.
> 
> **Overview**
> Fixes hosted PostHog features that were failing because **remote config** (`/array/<token>/config`) was proxied to the assets host, which returns 403 for production server egress. The relay now sends **only** `/static/*` to the assets host and forwards **`/array/*` (and everything else)** to the **ingest** host, matching unproxied `posthog-js` behavior so session recording config can load.
> 
> On the client, **`posthog-js/dist/web-vitals`** is preloaded with the other bundled extensions so **`$web_vitals`** does not depend on a blocked assets-host lazy load. Tests and module typings assert **`postHogWebVitalsCallbacks`** registration and updated relay upstream URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b286c6ad614ee1a7837a9293c95964a0dfc00772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PostHog remote config 403s by routing `/array/*` to the ingest host. Also bundles web-vitals so `$web_vitals` events fire on hosted.

- **Bug Fixes**
  - Route `/array/*` to `https://us.i.posthog.com` (ingest) instead of the assets host; keeps `/static/*` on assets. Enables remote config and session recording.
  - Bundle `posthog-js` web vitals by importing `posthog-js/dist/web-vitals`, registering `postHogWebVitalsCallbacks` so `$web_vitals` works on hosted.
  - Update tests to assert new routing and the web-vitals extension; add the `posthog-js/dist/web-vitals` type declaration.

<sup>Written for commit b286c6ad614ee1a7837a9293c95964a0dfc00772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

