### PR TITLE
feat(computers): client engine foundation — parser, engine storage, useComputerEngine, server-backed consent (PR 5)

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/useComputerEngine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useComputerEngine.test.tsx
@@ -107,6 +107,22 @@ describe("useComputerEngine", () => {
     expect(result.current.engine).toBe("cloud");
   });
 
+  it("a project switch reads the NEW project's preference immediately (no stale render)", () => {
+    state.consentGranted = true;
+    // p1 pinned to cloud; p2 has no stored pref → the server 'local' default.
+    saveComputerEngine("p1", "cloud");
+    const { result, rerender } = renderHook(
+      ({ pid }: { pid: string | null }) => useComputerEngine(pid),
+      { initialProps: { pid: "p1" as string | null } },
+    );
+    expect(result.current.engine).toBe("cloud");
+    rerender({ pid: "p2" });
+    // Must NOT briefly report p1's "cloud" for p2 — synchronous re-key.
+    expect(result.current.engine).toBe("local");
+    rerender({ pid: null });
+    expect(result.current.engine).toBe("local"); // no project pref → default
+  });
+
   it("local-only machine with consent: local wins even with defaultEngine null", () => {
     state.consentGranted = true;
     state.config = config({

--- a/mcpjam-inspector/client/src/hooks/__tests__/useComputerEngine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useComputerEngine.test.tsx
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+/**
+ * The one resolution rule, pinned as a matrix. The load-bearing rows: consent
+ * GATES local at every step (a stored "local" pref without a verified
+ * capability falls through to cloud — the badge can never say "This machine"
+ * while commands go elsewhere), and hosted never reads storage at all.
+ */
+const state = vi.hoisted(() => ({
+  hosted: false,
+  config: undefined as unknown,
+  consentGranted: false,
+}));
+
+vi.mock("@/lib/config", () => ({
+  get HOSTED_MODE() {
+    return state.hosted;
+  },
+}));
+vi.mock("@/hooks/useProjectComputer", () => ({
+  useComputersDataPlaneConfig: () => state.config,
+}));
+vi.mock("@/hooks/useLocalComputerConsent", () => ({
+  useLocalComputerConsent: () => ({
+    status: state.consentGranted ? "granted" : "absent",
+    granted: state.consentGranted,
+    token: state.consentGranted ? "tok" : null,
+    grant: vi.fn(),
+    revoke: vi.fn(),
+  }),
+}));
+
+import { useComputerEngine } from "../useComputerEngine";
+import { saveComputerEngine } from "@/lib/computer-engine-storage";
+
+function config(overrides: {
+  localAvailable?: boolean;
+  cloudAvailable?: boolean;
+  defaultEngine?: "local" | "cloud" | null;
+  terminalAvailable?: boolean;
+}) {
+  return {
+    localConfigured: false,
+    remoteDataPlaneUrl: null,
+    engines: {
+      local: {
+        available: overrides.localAvailable ?? true,
+        terminalAvailable: overrides.terminalAvailable ?? false,
+        workspaceDisplayRoot:
+          (overrides.localAvailable ?? true) ? "~/.mcpjam/computer" : null,
+      },
+      cloud: { available: overrides.cloudAvailable ?? true },
+    },
+    defaultEngine: overrides.defaultEngine ?? "local",
+  };
+}
+
+describe("useComputerEngine", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    state.hosted = false;
+    state.config = config({});
+    state.consentGranted = false;
+  });
+
+  it("hosted: always cloud, toggle hidden, storage untouched", () => {
+    state.hosted = true;
+    saveComputerEngine("p1", "local");
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("cloud");
+    expect(result.current.toggleVisible).toBe(false);
+    expect(result.current.localAvailable).toBe(false);
+  });
+
+  it("consent gates local: server default 'local' without consent resolves cloud", () => {
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("cloud");
+  });
+
+  it("consent granted: server default 'local' resolves local — no stored pref needed", () => {
+    state.consentGranted = true;
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("local");
+  });
+
+  it("a stored 'local' pref without consent falls through to cloud", () => {
+    saveComputerEngine("p1", "local");
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("cloud");
+  });
+
+  it("a stored 'cloud' pref beats the server's local default even with consent", () => {
+    state.consentGranted = true;
+    saveComputerEngine("p1", "cloud");
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("cloud");
+  });
+
+  it("setEngine persists and re-resolves live", () => {
+    state.consentGranted = true;
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("local");
+    act(() => {
+      result.current.setEngine("cloud");
+    });
+    expect(result.current.engine).toBe("cloud");
+  });
+
+  it("local-only machine with consent: local wins even with defaultEngine null", () => {
+    state.consentGranted = true;
+    state.config = config({
+      cloudAvailable: false,
+      defaultEngine: null,
+    });
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("local");
+    expect(result.current.toggleVisible).toBe(false);
+  });
+
+  it("nothing available: cloud with cloudAvailable=false (the honest empty state)", () => {
+    state.config = config({
+      localAvailable: false,
+      cloudAvailable: false,
+      defaultEngine: null,
+    });
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("cloud");
+    expect(result.current.cloudAvailable).toBe(false);
+    expect(result.current.toggleVisible).toBe(false);
+  });
+
+  it("loading config: resolved=false and the safe cloud default", () => {
+    state.config = undefined;
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.resolved).toBe(false);
+    expect(result.current.engine).toBe("cloud");
+  });
+
+  it("toggle shows only when BOTH engines exist (consent not required to see it)", () => {
+    state.config = config({});
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.toggleVisible).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useComputersDataPlaneConfig.parse.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useComputersDataPlaneConfig.parse.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+/**
+ * Parser back-compat matrix for the /config shape. The rule under test: the
+ * `engines` block is always present POST-PARSE — a server that predates it
+ * (or sends a malformed block) gets the legacy-pair derivation, in which the
+ * local engine NEVER exists (an old server has no local engine to offer).
+ *
+ * `vi.resetModules()` per test: the module caches its first parsed answer.
+ */
+describe("useComputersDataPlaneConfig — engines parse", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  async function loadWithConfig(response: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => response })),
+    );
+    return await import("../useProjectComputer");
+  }
+
+  it("parses the full new shape", async () => {
+    const mod = await loadWithConfig({
+      localConfigured: false,
+      remoteDataPlaneUrl: null,
+      engines: {
+        local: {
+          available: true,
+          terminalAvailable: true,
+          workspaceDisplayRoot: "~/.mcpjam/computer",
+        },
+        cloud: { available: true },
+      },
+      capabilities: {
+        personalCloudAvailable: true,
+        ephemeralCloudAvailable: false,
+      },
+      defaultEngine: "local",
+    });
+    const { result } = renderHook(() => mod.useComputersDataPlaneConfig());
+    await waitFor(() => expect(result.current).toBeDefined());
+    expect(result.current!.engines.local).toEqual({
+      available: true,
+      terminalAvailable: true,
+      workspaceDisplayRoot: "~/.mcpjam/computer",
+    });
+    expect(result.current!.defaultEngine).toBe("local");
+  });
+
+  it("derives for an OLD server: local never exists, cloud from the legacy pair", async () => {
+    const mod = await loadWithConfig({
+      localConfigured: false,
+      remoteDataPlaneUrl: "https://dp.example.com",
+    });
+    const { result } = renderHook(() => mod.useComputersDataPlaneConfig());
+    await waitFor(() => expect(result.current).toBeDefined());
+    expect(result.current!.engines.local.available).toBe(false);
+    expect(result.current!.engines.cloud.available).toBe(true);
+    expect(result.current!.defaultEngine).toBe("cloud");
+  });
+
+  it("reads a MALFORMED engines block like an old server — never half-trusted", async () => {
+    const mod = await loadWithConfig({
+      localConfigured: false,
+      remoteDataPlaneUrl: null,
+      engines: { local: { available: "yes" }, cloud: {} },
+      defaultEngine: "local",
+    });
+    const { result } = renderHook(() => mod.useComputersDataPlaneConfig());
+    await waitFor(() => expect(result.current).toBeDefined());
+    // A partial parse could invent a local engine; derivation cannot.
+    expect(result.current!.engines.local.available).toBe(false);
+    expect(result.current!.defaultEngine).toBeNull();
+  });
+
+  it("tolerates defaultEngine null (no engine exists on that server)", async () => {
+    const mod = await loadWithConfig({
+      localConfigured: false,
+      remoteDataPlaneUrl: null,
+      engines: {
+        local: {
+          available: false,
+          terminalAvailable: false,
+          workspaceDisplayRoot: null,
+          reason: "disabled",
+        },
+        cloud: { available: false },
+      },
+      defaultEngine: null,
+    });
+    const { result } = renderHook(() => mod.useComputersDataPlaneConfig());
+    await waitFor(() => expect(result.current).toBeDefined());
+    expect(result.current!.defaultEngine).toBeNull();
+    expect(result.current!.engines.local.reason).toBe("disabled");
+  });
+
+  it("fetch-failure fallback keeps legacy semantics — no phantom local engine", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    const mod = await import("../useProjectComputer");
+    const { result } = renderHook(() => mod.useComputersDataPlaneConfig());
+    await waitFor(() => expect(result.current).toBeDefined());
+    expect(result.current!.localConfigured).toBe(true);
+    expect(result.current!.engines.local.available).toBe(false);
+    expect(result.current!.engines.cloud.available).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
@@ -15,21 +15,24 @@ vi.mock("@/lib/config", () => ({
 }));
 
 const lib = vi.hoisted(() => ({
-  hasStored: true,
+  storedToken: "tok" as string | null,
   verify: vi.fn(),
   grant: vi.fn(),
   revoke: vi.fn(),
   clear: vi.fn(),
   subscribers: new Set<() => void>(),
+  fireSubscribers() {
+    for (const cb of this.subscribers) cb();
+  },
 }));
 vi.mock("@/lib/local-computer-consent", () => ({
   loadStoredLocalComputerConsent: () =>
-    lib.hasStored ? { token: "tok", grantedAt: "now" } : null,
+    lib.storedToken ? { token: lib.storedToken, grantedAt: "now" } : null,
   verifyStoredLocalComputerConsent: () => lib.verify(),
   grantLocalComputerConsent: () => lib.grant(),
   revokeLocalComputerConsent: () => lib.revoke(),
   clearStoredLocalComputerConsent: () => {
-    lib.hasStored = false;
+    lib.storedToken = null;
     lib.clear();
   },
   subscribeLocalComputerConsent: (cb: () => void) => {
@@ -43,7 +46,7 @@ import { useLocalComputerConsent } from "../useLocalComputerConsent";
 describe("useLocalComputerConsent", () => {
   beforeEach(() => {
     hosted.value = false;
-    lib.hasStored = true;
+    lib.storedToken = "tok";
     lib.verify.mockReset();
     lib.grant.mockReset();
     lib.revoke.mockReset();
@@ -99,5 +102,74 @@ describe("useLocalComputerConsent", () => {
       expect(ok).toBe(true);
     });
     expect(result.current.status).toBe("granted");
+    expect(result.current.token).toBe("tok");
+  });
+
+  it("a token rotation that keeps status 'granted' updates the returned token", async () => {
+    // Tab B rotates the capability while this hook is already granted. Status
+    // stays "granted" but the returned token MUST follow — reading it from
+    // storage at render time would go stale when React bails on same-value
+    // status.
+    lib.verify.mockResolvedValue(true);
+    const { result } = renderHook(() => useLocalComputerConsent());
+    await waitFor(() => expect(result.current.token).toBe("tok"));
+
+    lib.storedToken = "tok-B";
+    await act(async () => {
+      lib.fireSubscribers();
+    });
+    await waitFor(() => expect(result.current.token).toBe("tok-B"));
+    expect(result.current.status).toBe("granted");
+  });
+
+  it("a storage event carrying an invalidated token drops status to absent", async () => {
+    // The docstring'd re-verify path: a subscriber fires, verify now says no.
+    lib.verify.mockResolvedValueOnce(true).mockResolvedValue(false);
+    const { result } = renderHook(() => useLocalComputerConsent());
+    await waitFor(() => expect(result.current.status).toBe("granted"));
+
+    await act(async () => {
+      lib.fireSubscribers();
+    });
+    await waitFor(() => expect(result.current.status).toBe("absent"));
+    expect(result.current.token).toBeNull();
+  });
+
+  it("a later revoke beats an EARLIER in-flight grant (claim-before-await)", async () => {
+    // grant claims its sequence before awaiting; a revoke that starts after
+    // gets a higher sequence and wins even though the grant resolves later.
+    // The stale grant must also undo its persisted token (clear + server
+    // revoke) so the revoke stays final.
+    lib.verify.mockResolvedValue(false);
+    let resolveGrant: (ok: boolean) => void = () => {};
+    lib.grant.mockReturnValue(
+      new Promise<boolean>((r) => {
+        resolveGrant = r;
+      }),
+    );
+    lib.revoke.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useLocalComputerConsent());
+    await waitFor(() => expect(result.current.status).toBe("absent"));
+
+    let grantResult: Promise<boolean> = Promise.resolve(false);
+    act(() => {
+      grantResult = result.current.grant();
+    });
+    // Revoke starts AFTER grant claimed its slot but BEFORE grant resolves.
+    await act(async () => {
+      await result.current.revoke();
+    });
+    expect(result.current.status).toBe("absent");
+
+    // The grant server call finally succeeds — but it's stale.
+    await act(async () => {
+      resolveGrant(true);
+      await grantResult;
+    });
+    expect(await grantResult).toBe(false);
+    expect(result.current.status).toBe("absent");
+    // The stale grant undid its own persistence via the server revoke.
+    expect(lib.revoke).toHaveBeenCalledTimes(2); // explicit revoke + stale undo
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
@@ -44,7 +44,8 @@ vi.mock("@/lib/local-computer-consent", () => ({
     lib.storedToken = null;
     lib.fire();
   },
-  revokeLocalComputerConsentOnServer: () => lib.revokeServer(),
+  revokeLocalComputerConsentOnServer: (token: string | null = null) =>
+    lib.revokeServer(token),
   subscribeLocalComputerConsent: (cb: () => void) => {
     lib.subscribers.add(cb);
     return () => lib.subscribers.delete(cb);
@@ -137,7 +138,10 @@ describe("useLocalComputerConsent", () => {
     });
     expect(result.current.status).toBe("absent");
     expect(lib.storedToken).toBeNull();
+    // The server revoke is scoped to the token that was just forgotten, so a
+    // delayed request can't sever a capability a newer grant rotates in.
     expect(lib.revokeServer).toHaveBeenCalledTimes(1);
+    expect(lib.revokeServer).toHaveBeenCalledWith("tok");
   });
 
   it("reflects a cross-tab revoke: an external clear event drops to absent", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
@@ -116,6 +116,9 @@ describe("useLocalComputerConsent", () => {
     expect(ok).toBe(false);
     expect(result.current.status).toBe("absent");
     expect(result.current.token).toBeNull();
+    // The mint rotated the server capability to a token nothing can present —
+    // grant must release it (scoped) instead of leaving it orphaned.
+    expect(lib.revokeServer).toHaveBeenCalledWith("granted-tok");
   });
 
   it("grant returns FALSE when the mint fails", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+/**
+ * The out-of-order guard: verify/grant/revoke resolve asynchronously and can
+ * complete in any order, but only the LATEST-initiated op may write status.
+ * The load-bearing case is a slow stale verify landing after a revoke — it
+ * must NOT restore `granted`.
+ */
+const hosted = vi.hoisted(() => ({ value: false }));
+vi.mock("@/lib/config", () => ({
+  get HOSTED_MODE() {
+    return hosted.value;
+  },
+}));
+
+const lib = vi.hoisted(() => ({
+  hasStored: true,
+  verify: vi.fn(),
+  grant: vi.fn(),
+  revoke: vi.fn(),
+  clear: vi.fn(),
+  subscribers: new Set<() => void>(),
+}));
+vi.mock("@/lib/local-computer-consent", () => ({
+  loadStoredLocalComputerConsent: () =>
+    lib.hasStored ? { token: "tok", grantedAt: "now" } : null,
+  verifyStoredLocalComputerConsent: () => lib.verify(),
+  grantLocalComputerConsent: () => lib.grant(),
+  revokeLocalComputerConsent: () => lib.revoke(),
+  clearStoredLocalComputerConsent: () => {
+    lib.hasStored = false;
+    lib.clear();
+  },
+  subscribeLocalComputerConsent: (cb: () => void) => {
+    lib.subscribers.add(cb);
+    return () => lib.subscribers.delete(cb);
+  },
+}));
+
+import { useLocalComputerConsent } from "../useLocalComputerConsent";
+
+describe("useLocalComputerConsent", () => {
+  beforeEach(() => {
+    hosted.value = false;
+    lib.hasStored = true;
+    lib.verify.mockReset();
+    lib.grant.mockReset();
+    lib.revoke.mockReset();
+    lib.clear.mockReset();
+    lib.subscribers.clear();
+  });
+
+  it("hosted: absent forever, never calls the server", () => {
+    hosted.value = true;
+    const { result } = renderHook(() => useLocalComputerConsent());
+    expect(result.current.status).toBe("absent");
+    expect(lib.verify).not.toHaveBeenCalled();
+  });
+
+  it("verifies a stored token on mount → granted", async () => {
+    lib.verify.mockResolvedValue(true);
+    const { result } = renderHook(() => useLocalComputerConsent());
+    await waitFor(() => expect(result.current.status).toBe("granted"));
+    expect(result.current.token).toBe("tok");
+  });
+
+  it("a stale verify resolving AFTER revoke does NOT restore granted", async () => {
+    // Mount verify hangs; we revoke while it's in flight, then it resolves
+    // true. The op-sequence guard must drop that stale result.
+    let resolveVerify: (v: boolean) => void = () => {};
+    lib.verify.mockReturnValue(
+      new Promise<boolean>((r) => {
+        resolveVerify = r;
+      }),
+    );
+    lib.revoke.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useLocalComputerConsent());
+    await act(async () => {
+      await result.current.revoke();
+    });
+    expect(result.current.status).toBe("absent");
+
+    // The mount's verify finally answers "valid" — must be ignored.
+    await act(async () => {
+      resolveVerify(true);
+    });
+    expect(result.current.status).toBe("absent");
+  });
+
+  it("grant success sets granted immediately", async () => {
+    lib.verify.mockResolvedValue(false);
+    lib.grant.mockResolvedValue(true);
+    const { result } = renderHook(() => useLocalComputerConsent());
+    await waitFor(() => expect(result.current.status).toBe("absent"));
+    await act(async () => {
+      const ok = await result.current.grant();
+      expect(ok).toBe(true);
+    });
+    expect(result.current.status).toBe("granted");
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
@@ -34,13 +34,16 @@ vi.mock("@/lib/local-computer-consent", () => ({
   loadStoredLocalComputerConsent: () =>
     lib.storedToken ? { token: lib.storedToken, grantedAt: "now" } : null,
   verifyStoredLocalComputerConsent: () => lib.verify(),
-  grantLocalComputerConsent: async () => {
+  // mint = network only, NO persist, NO event (matches the real split).
+  mintLocalComputerConsent: async () => {
     const ok = await lib.grant();
-    if (ok) {
-      lib.storedToken = lib.grantToken; // persist
-      lib.fireSubscribers(); // persist()'s synchronous same-tab event
-    }
-    return ok;
+    return ok ? { token: lib.grantToken, grantedAt: "now" } : null;
+  },
+  // persist = synchronous storage write + same-tab event.
+  persistLocalComputerConsent: (c: { token: string }) => {
+    lib.storedToken = c.token;
+    lib.fireSubscribers();
+    return true;
   },
   revokeLocalComputerConsent: () => lib.revoke(),
   clearStoredLocalComputerConsent: () => {
@@ -157,10 +160,10 @@ describe("useLocalComputerConsent", () => {
   });
 
   it("a later revoke beats an EARLIER in-flight grant (claim-before-await)", async () => {
-    // grant claims its sequence before awaiting; a revoke that starts after
-    // gets a higher sequence and wins even though the grant resolves later.
-    // The stale grant must also undo its persisted token (clear + server
-    // revoke) so the revoke stays final.
+    // grant claims its sequence before minting; a revoke that starts after
+    // gets a higher sequence and wins even though the mint resolves later.
+    // The stale grant never persists, and drops the just-minted server
+    // capability so the revoke stays final.
     lib.verify.mockResolvedValue(false);
     let resolveGrant: (ok: boolean) => void = () => {};
     lib.grant.mockReturnValue(
@@ -177,20 +180,60 @@ describe("useLocalComputerConsent", () => {
     act(() => {
       grantResult = result.current.grant();
     });
-    // Revoke starts AFTER grant claimed its slot but BEFORE grant resolves.
+    // Revoke starts AFTER grant claimed its slot but BEFORE the mint resolves.
     await act(async () => {
       await result.current.revoke();
     });
     expect(result.current.status).toBe("absent");
 
-    // The grant server call finally succeeds — but it's stale.
+    // The mint finally succeeds — but it's stale.
     await act(async () => {
       resolveGrant(true);
       await grantResult;
     });
     expect(await grantResult).toBe(false);
     expect(result.current.status).toBe("absent");
-    // The stale grant undid its own persistence via the server revoke.
-    expect(lib.revoke).toHaveBeenCalledTimes(2); // explicit revoke + stale undo
+    expect(lib.storedToken).toBeNull(); // never persisted
+    // explicit revoke + the stale grant dropping its minted capability.
+    expect(lib.revoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("an EXTERNAL revoke during a pending grant is not overwritten (mint wait is unguarded)", async () => {
+    // The round-4 regression: guarding the whole grant network wait also hid
+    // genuine cross-tab events. Now only the synchronous persist is guarded, so
+    // an external revoke arriving mid-mint advances the sequence and the
+    // completing grant discards itself.
+    lib.storedToken = null;
+    lib.verify.mockResolvedValue(false);
+    let resolveMint: (ok: boolean) => void = () => {};
+    lib.grant.mockReturnValue(
+      new Promise<boolean>((r) => {
+        resolveMint = r;
+      }),
+    );
+    lib.revoke.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useLocalComputerConsent());
+    await waitFor(() => expect(result.current.status).toBe("absent"));
+
+    let grantResult: Promise<boolean> = Promise.resolve(false);
+    act(() => {
+      grantResult = result.current.grant();
+    });
+    // Another tab revokes while the mint is in flight — its storage clear fires
+    // the same-tab subscribers here. The unguarded mint await lets it through.
+    await act(async () => {
+      lib.storedToken = null;
+      lib.fireSubscribers();
+    });
+
+    await act(async () => {
+      resolveMint(true);
+      await grantResult;
+    });
+    expect(await grantResult).toBe(false);
+    expect(result.current.status).toBe("absent");
+    expect(lib.storedToken).toBeNull();
+    expect(lib.revoke).toHaveBeenCalled(); // dropped the minted capability
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
@@ -14,12 +14,17 @@ vi.mock("@/lib/config", () => ({
   },
 }));
 
+// FAITHFUL mock: the real module's grant persists a token AND
+// `clearStoredLocalComputerConsent` both reach `persist()`, which dispatches
+// the same-tab consent event SYNCHRONOUSLY. Reproducing that side effect is
+// what exercises the hook's re-entrant refresh — without it, a whole class of
+// self-supersede bugs passes silently.
 const lib = vi.hoisted(() => ({
   storedToken: "tok" as string | null,
+  grantToken: "granted-tok",
   verify: vi.fn(),
   grant: vi.fn(),
   revoke: vi.fn(),
-  clear: vi.fn(),
   subscribers: new Set<() => void>(),
   fireSubscribers() {
     for (const cb of this.subscribers) cb();
@@ -29,11 +34,18 @@ vi.mock("@/lib/local-computer-consent", () => ({
   loadStoredLocalComputerConsent: () =>
     lib.storedToken ? { token: lib.storedToken, grantedAt: "now" } : null,
   verifyStoredLocalComputerConsent: () => lib.verify(),
-  grantLocalComputerConsent: () => lib.grant(),
+  grantLocalComputerConsent: async () => {
+    const ok = await lib.grant();
+    if (ok) {
+      lib.storedToken = lib.grantToken; // persist
+      lib.fireSubscribers(); // persist()'s synchronous same-tab event
+    }
+    return ok;
+  },
   revokeLocalComputerConsent: () => lib.revoke(),
   clearStoredLocalComputerConsent: () => {
-    lib.storedToken = null;
-    lib.clear();
+    lib.storedToken = null; // persist(null)
+    lib.fireSubscribers(); // persist(null)'s synchronous same-tab event
   },
   subscribeLocalComputerConsent: (cb: () => void) => {
     lib.subscribers.add(cb);
@@ -47,10 +59,10 @@ describe("useLocalComputerConsent", () => {
   beforeEach(() => {
     hosted.value = false;
     lib.storedToken = "tok";
+    lib.grantToken = "granted-tok";
     lib.verify.mockReset();
     lib.grant.mockReset();
     lib.revoke.mockReset();
-    lib.clear.mockReset();
     lib.subscribers.clear();
   });
 
@@ -92,17 +104,26 @@ describe("useLocalComputerConsent", () => {
     expect(result.current.status).toBe("absent");
   });
 
-  it("grant success sets granted immediately", async () => {
+  it("grant succeeds despite its OWN persistence event (self-write guard)", async () => {
+    // The regression this pins: the real grant dispatches a same-tab event
+    // that re-enters refresh() and bumps the sequence. Without the self-write
+    // guard, grant classifies itself as superseded, clears its own token, and
+    // returns false — making consent impossible to grant.
+    lib.storedToken = null; // start ungranted
     lib.verify.mockResolvedValue(false);
     lib.grant.mockResolvedValue(true);
     const { result } = renderHook(() => useLocalComputerConsent());
     await waitFor(() => expect(result.current.status).toBe("absent"));
+    let ok = false;
     await act(async () => {
-      const ok = await result.current.grant();
-      expect(ok).toBe(true);
+      ok = await result.current.grant();
     });
+    expect(ok).toBe(true);
     expect(result.current.status).toBe("granted");
-    expect(result.current.token).toBe("tok");
+    expect(result.current.token).toBe("granted-tok");
+    // Its own persistence event must NOT have triggered a self-revoke.
+    expect(lib.revoke).not.toHaveBeenCalled();
+    expect(lib.storedToken).toBe("granted-tok");
   });
 
   it("a token rotation that keeps status 'granted' updates the returned token", async () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useLocalComputerConsent.test.tsx
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 /**
- * The out-of-order guard: verify/grant/revoke resolve asynchronously and can
- * complete in any order, but only the LATEST-initiated op may write status.
- * The load-bearing case is a slow stale verify landing after a revoke — it
- * must NOT restore `granted`.
+ * The hook is now a pure projection of localStorage — no client-side verify,
+ * no sequence/self-write guards. These tests pin that projection: reads follow
+ * writes from any tab, grant reports storage-failure honestly, and revoke uses
+ * a storage-free server primitive so it can't clobber a concurrent grant.
  */
 const hosted = vi.hoisted(() => ({ value: false }));
 vi.mock("@/lib/config", () => ({
@@ -14,42 +14,37 @@ vi.mock("@/lib/config", () => ({
   },
 }));
 
-// FAITHFUL mock: the real module's grant persists a token AND
-// `clearStoredLocalComputerConsent` both reach `persist()`, which dispatches
-// the same-tab consent event SYNCHRONOUSLY. Reproducing that side effect is
-// what exercises the hook's re-entrant refresh — without it, a whole class of
-// self-supersede bugs passes silently.
+// Faithful mock: persist/clear mutate the in-memory token AND fire the
+// same-tab subscribers, exactly as the real module's `persist()` does.
 const lib = vi.hoisted(() => ({
-  storedToken: "tok" as string | null,
+  storedToken: null as string | null,
   grantToken: "granted-tok",
-  verify: vi.fn(),
-  grant: vi.fn(),
-  revoke: vi.fn(),
+  persistOk: true,
+  mint: vi.fn(),
+  revokeServer: vi.fn(),
   subscribers: new Set<() => void>(),
-  fireSubscribers() {
+  fire() {
     for (const cb of this.subscribers) cb();
   },
 }));
 vi.mock("@/lib/local-computer-consent", () => ({
   loadStoredLocalComputerConsent: () =>
     lib.storedToken ? { token: lib.storedToken, grantedAt: "now" } : null,
-  verifyStoredLocalComputerConsent: () => lib.verify(),
-  // mint = network only, NO persist, NO event (matches the real split).
   mintLocalComputerConsent: async () => {
-    const ok = await lib.grant();
+    const ok = await lib.mint();
     return ok ? { token: lib.grantToken, grantedAt: "now" } : null;
   },
-  // persist = synchronous storage write + same-tab event.
   persistLocalComputerConsent: (c: { token: string }) => {
+    if (!lib.persistOk) return false;
     lib.storedToken = c.token;
-    lib.fireSubscribers();
+    lib.fire();
     return true;
   },
-  revokeLocalComputerConsent: () => lib.revoke(),
   clearStoredLocalComputerConsent: () => {
-    lib.storedToken = null; // persist(null)
-    lib.fireSubscribers(); // persist(null)'s synchronous same-tab event
+    lib.storedToken = null;
+    lib.fire();
   },
+  revokeLocalComputerConsentOnServer: () => lib.revokeServer(),
   subscribeLocalComputerConsent: (cb: () => void) => {
     lib.subscribers.add(cb);
     return () => lib.subscribers.delete(cb);
@@ -61,179 +56,109 @@ import { useLocalComputerConsent } from "../useLocalComputerConsent";
 describe("useLocalComputerConsent", () => {
   beforeEach(() => {
     hosted.value = false;
-    lib.storedToken = "tok";
+    lib.storedToken = null;
     lib.grantToken = "granted-tok";
-    lib.verify.mockReset();
-    lib.grant.mockReset();
-    lib.revoke.mockReset();
+    lib.persistOk = true;
+    lib.mint.mockReset();
+    lib.revokeServer.mockReset().mockResolvedValue(undefined);
     lib.subscribers.clear();
   });
 
-  it("hosted: absent forever, never calls the server", () => {
+  it("hosted: absent, and grant/revoke never touch the server", async () => {
     hosted.value = true;
+    lib.storedToken = "leftover"; // even a stray token is ignored hosted
     const { result } = renderHook(() => useLocalComputerConsent());
     expect(result.current.status).toBe("absent");
-    expect(lib.verify).not.toHaveBeenCalled();
+    expect(result.current.token).toBeNull();
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.grant();
+    });
+    expect(ok).toBe(false);
+    expect(lib.mint).not.toHaveBeenCalled();
   });
 
-  it("verifies a stored token on mount → granted", async () => {
-    lib.verify.mockResolvedValue(true);
+  it("projects a stored token as granted on mount", () => {
+    lib.storedToken = "tok";
     const { result } = renderHook(() => useLocalComputerConsent());
-    await waitFor(() => expect(result.current.status).toBe("granted"));
+    expect(result.current.status).toBe("granted");
     expect(result.current.token).toBe("tok");
   });
 
-  it("a stale verify resolving AFTER revoke does NOT restore granted", async () => {
-    // Mount verify hangs; we revoke while it's in flight, then it resolves
-    // true. The op-sequence guard must drop that stale result.
-    let resolveVerify: (v: boolean) => void = () => {};
-    lib.verify.mockReturnValue(
-      new Promise<boolean>((r) => {
-        resolveVerify = r;
-      }),
-    );
-    lib.revoke.mockResolvedValue(undefined);
-
+  it("no stored token → absent", () => {
     const { result } = renderHook(() => useLocalComputerConsent());
-    await act(async () => {
-      await result.current.revoke();
-    });
-    expect(result.current.status).toBe("absent");
-
-    // The mount's verify finally answers "valid" — must be ignored.
-    await act(async () => {
-      resolveVerify(true);
-    });
-    expect(result.current.status).toBe("absent");
+    expect(result.current.granted).toBe(false);
+    expect(result.current.token).toBeNull();
   });
 
-  it("grant succeeds despite its OWN persistence event (self-write guard)", async () => {
-    // The regression this pins: the real grant dispatches a same-tab event
-    // that re-enters refresh() and bumps the sequence. Without the self-write
-    // guard, grant classifies itself as superseded, clears its own token, and
-    // returns false — making consent impossible to grant.
-    lib.storedToken = null; // start ungranted
-    lib.verify.mockResolvedValue(false);
-    lib.grant.mockResolvedValue(true);
+  it("grant mints, persists, and flips to granted via the storage event", async () => {
+    lib.mint.mockResolvedValue(true);
     const { result } = renderHook(() => useLocalComputerConsent());
-    await waitFor(() => expect(result.current.status).toBe("absent"));
     let ok = false;
     await act(async () => {
       ok = await result.current.grant();
     });
     expect(ok).toBe(true);
-    expect(result.current.status).toBe("granted");
-    expect(result.current.token).toBe("granted-tok");
-    // Its own persistence event must NOT have triggered a self-revoke.
-    expect(lib.revoke).not.toHaveBeenCalled();
-    expect(lib.storedToken).toBe("granted-tok");
-  });
-
-  it("a token rotation that keeps status 'granted' updates the returned token", async () => {
-    // Tab B rotates the capability while this hook is already granted. Status
-    // stays "granted" but the returned token MUST follow — reading it from
-    // storage at render time would go stale when React bails on same-value
-    // status.
-    lib.verify.mockResolvedValue(true);
-    const { result } = renderHook(() => useLocalComputerConsent());
-    await waitFor(() => expect(result.current.token).toBe("tok"));
-
-    lib.storedToken = "tok-B";
-    await act(async () => {
-      lib.fireSubscribers();
-    });
-    await waitFor(() => expect(result.current.token).toBe("tok-B"));
-    expect(result.current.status).toBe("granted");
-  });
-
-  it("a storage event carrying an invalidated token drops status to absent", async () => {
-    // The docstring'd re-verify path: a subscriber fires, verify now says no.
-    lib.verify.mockResolvedValueOnce(true).mockResolvedValue(false);
-    const { result } = renderHook(() => useLocalComputerConsent());
     await waitFor(() => expect(result.current.status).toBe("granted"));
+    expect(result.current.token).toBe("granted-tok");
+  });
 
+  it("grant returns FALSE and stays absent when persistence fails", async () => {
+    // Storage blocked/full: a token nothing can read must never read as granted.
+    lib.mint.mockResolvedValue(true);
+    lib.persistOk = false;
+    const { result } = renderHook(() => useLocalComputerConsent());
+    let ok = true;
     await act(async () => {
-      lib.fireSubscribers();
+      ok = await result.current.grant();
     });
-    await waitFor(() => expect(result.current.status).toBe("absent"));
+    expect(ok).toBe(false);
+    expect(result.current.status).toBe("absent");
     expect(result.current.token).toBeNull();
   });
 
-  it("a later revoke beats an EARLIER in-flight grant (claim-before-await)", async () => {
-    // grant claims its sequence before minting; a revoke that starts after
-    // gets a higher sequence and wins even though the mint resolves later.
-    // The stale grant never persists, and drops the just-minted server
-    // capability so the revoke stays final.
-    lib.verify.mockResolvedValue(false);
-    let resolveGrant: (ok: boolean) => void = () => {};
-    lib.grant.mockReturnValue(
-      new Promise<boolean>((r) => {
-        resolveGrant = r;
-      }),
-    );
-    lib.revoke.mockResolvedValue(undefined);
-
+  it("grant returns FALSE when the mint fails", async () => {
+    lib.mint.mockResolvedValue(false);
     const { result } = renderHook(() => useLocalComputerConsent());
-    await waitFor(() => expect(result.current.status).toBe("absent"));
-
-    let grantResult: Promise<boolean> = Promise.resolve(false);
-    act(() => {
-      grantResult = result.current.grant();
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.grant();
     });
-    // Revoke starts AFTER grant claimed its slot but BEFORE the mint resolves.
+    expect(ok).toBe(false);
+    expect(result.current.status).toBe("absent");
+  });
+
+  it("revoke clears storage synchronously and calls the server-only primitive", async () => {
+    lib.storedToken = "tok";
+    const { result } = renderHook(() => useLocalComputerConsent());
+    expect(result.current.status).toBe("granted");
     await act(async () => {
       await result.current.revoke();
     });
     expect(result.current.status).toBe("absent");
-
-    // The mint finally succeeds — but it's stale.
-    await act(async () => {
-      resolveGrant(true);
-      await grantResult;
-    });
-    expect(await grantResult).toBe(false);
-    expect(result.current.status).toBe("absent");
-    expect(lib.storedToken).toBeNull(); // never persisted
-    // explicit revoke + the stale grant dropping its minted capability.
-    expect(lib.revoke).toHaveBeenCalledTimes(2);
+    expect(lib.storedToken).toBeNull();
+    expect(lib.revokeServer).toHaveBeenCalledTimes(1);
   });
 
-  it("an EXTERNAL revoke during a pending grant is not overwritten (mint wait is unguarded)", async () => {
-    // The round-4 regression: guarding the whole grant network wait also hid
-    // genuine cross-tab events. Now only the synchronous persist is guarded, so
-    // an external revoke arriving mid-mint advances the sequence and the
-    // completing grant discards itself.
-    lib.storedToken = null;
-    lib.verify.mockResolvedValue(false);
-    let resolveMint: (ok: boolean) => void = () => {};
-    lib.grant.mockReturnValue(
-      new Promise<boolean>((r) => {
-        resolveMint = r;
-      }),
-    );
-    lib.revoke.mockResolvedValue(undefined);
-
+  it("reflects a cross-tab revoke: an external clear event drops to absent", async () => {
+    lib.storedToken = "tok";
     const { result } = renderHook(() => useLocalComputerConsent());
-    await waitFor(() => expect(result.current.status).toBe("absent"));
-
-    let grantResult: Promise<boolean> = Promise.resolve(false);
-    act(() => {
-      grantResult = result.current.grant();
-    });
-    // Another tab revokes while the mint is in flight — its storage clear fires
-    // the same-tab subscribers here. The unguarded mint await lets it through.
+    expect(result.current.status).toBe("granted");
     await act(async () => {
       lib.storedToken = null;
-      lib.fireSubscribers();
+      lib.fire(); // another tab cleared consent
     });
+    await waitFor(() => expect(result.current.status).toBe("absent"));
+  });
 
-    await act(async () => {
-      resolveMint(true);
-      await grantResult;
-    });
-    expect(await grantResult).toBe(false);
+  it("reflects a cross-tab grant: an external token event flips to granted", async () => {
+    const { result } = renderHook(() => useLocalComputerConsent());
     expect(result.current.status).toBe("absent");
-    expect(lib.storedToken).toBeNull();
-    expect(lib.revoke).toHaveBeenCalled(); // dropped the minted capability
+    await act(async () => {
+      lib.storedToken = "tok-from-other-tab";
+      lib.fire();
+    });
+    await waitFor(() => expect(result.current.token).toBe("tok-from-other-tab"));
+    expect(result.current.status).toBe("granted");
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useComputerEngine.ts
+++ b/mcpjam-inspector/client/src/hooks/useComputerEngine.ts
@@ -1,0 +1,111 @@
+/**
+ * The Local⇄Cloud computer-engine choice, resolved for a project.
+ *
+ * ONE rule, applied everywhere (Computer tab, Playground rail, chat body
+ * builder), so the badge can never say "This machine" while commands go
+ * elsewhere:
+ *
+ *   1. HOSTED_MODE ⇒ cloud. Toggle hidden, storage never read.
+ *   2. Candidates in order: stored preference → server defaultEngine →
+ *      local → cloud. The first candidate that is AVAILABLE — and, for
+ *      `local`, whose consent capability is SERVER-VERIFIED — wins.
+ *   3. Nothing qualifies ⇒ `cloud` with `cloudAvailable:false`; consumers
+ *      render the existing unavailable state.
+ *
+ * Consent GATES the engine: an unconsented machine never resolves local —
+ * selecting Local is what opens the consent dialog (PR 6/7 UI), and a grant
+ * flips the resolution over. "Default = Local in local mode" means the
+ * server's `defaultEngine:"local"` wins the candidate race as soon as
+ * consent exists — no stored preference required.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { HOSTED_MODE } from "@/lib/config";
+import {
+  loadComputerEngine,
+  saveComputerEngine,
+  subscribeComputerEngine,
+  type ComputerEngineChoice,
+} from "@/lib/computer-engine-storage";
+import {
+  useLocalComputerConsent,
+  type LocalComputerConsent,
+} from "@/hooks/useLocalComputerConsent";
+import { useComputersDataPlaneConfig } from "@/hooks/useProjectComputer";
+
+export interface ComputerEngineState {
+  /** Resolved engine — honest under the one rule above, never aspirational. */
+  engine: ComputerEngineChoice;
+  /** Persist a preference for this project (and notify every consumer). */
+  setEngine: (engine: ComputerEngineChoice) => void;
+  /** Config fetch settled (the answer below is real, not loading defaults). */
+  resolved: boolean;
+  localAvailable: boolean;
+  localTerminalAvailable: boolean;
+  /** Tilde display root; render `${workspaceDisplayRoot}/<projectId>`. */
+  workspaceDisplayRoot: string | null;
+  cloudAvailable: boolean;
+  /** Show the Local⇄Cloud switcher — both engines exist and we're not hosted. */
+  toggleVisible: boolean;
+  /** The consent capability backing the local engine (grant/revoke/status). */
+  consent: LocalComputerConsent;
+}
+
+export function useComputerEngine(
+  projectId: string | null,
+): ComputerEngineState {
+  const config = useComputersDataPlaneConfig();
+  const consent = useLocalComputerConsent();
+  const [storedPref, setStoredPref] = useState<ComputerEngineChoice | null>(
+    () => (HOSTED_MODE || !projectId ? null : loadComputerEngine(projectId)),
+  );
+
+  useEffect(() => {
+    if (HOSTED_MODE || !projectId) return;
+    setStoredPref(loadComputerEngine(projectId));
+    return subscribeComputerEngine(projectId, () => {
+      setStoredPref(loadComputerEngine(projectId));
+    });
+  }, [projectId]);
+
+  const setEngine = useCallback(
+    (engine: ComputerEngineChoice) => {
+      if (HOSTED_MODE || !projectId) return;
+      saveComputerEngine(projectId, engine);
+    },
+    [projectId],
+  );
+
+  const localAvailable = !HOSTED_MODE && (config?.engines.local.available ?? false);
+  const cloudAvailable = config?.engines.cloud.available ?? false;
+
+  let engine: ComputerEngineChoice = "cloud";
+  if (!HOSTED_MODE && config) {
+    const qualifies = (candidate: ComputerEngineChoice | null): boolean => {
+      if (candidate === "local") return localAvailable && consent.granted;
+      if (candidate === "cloud") return cloudAvailable;
+      return false;
+    };
+    const candidates: Array<ComputerEngineChoice | null> = [
+      storedPref,
+      config.defaultEngine,
+      "local",
+      "cloud",
+    ];
+    engine = (candidates.find(qualifies) as ComputerEngineChoice) ?? "cloud";
+  }
+
+  return {
+    engine,
+    setEngine,
+    resolved: config !== undefined,
+    localAvailable,
+    localTerminalAvailable:
+      !HOSTED_MODE && (config?.engines.local.terminalAvailable ?? false),
+    workspaceDisplayRoot: HOSTED_MODE
+      ? null
+      : (config?.engines.local.workspaceDisplayRoot ?? null),
+    cloudAvailable,
+    toggleVisible: !HOSTED_MODE && localAvailable && cloudAvailable,
+    consent,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/useComputerEngine.ts
+++ b/mcpjam-inspector/client/src/hooks/useComputerEngine.ts
@@ -18,7 +18,7 @@
  * server's `defaultEngine:"local"` wins the candidate race as soon as
  * consent exists — no stored preference required.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { HOSTED_MODE } from "@/lib/config";
 import {
   loadComputerEngine,
@@ -55,17 +55,21 @@ export function useComputerEngine(
 ): ComputerEngineState {
   const config = useComputersDataPlaneConfig();
   const consent = useLocalComputerConsent();
-  const [storedPref, setStoredPref] = useState<ComputerEngineChoice | null>(
-    () => (HOSTED_MODE || !projectId ? null : loadComputerEngine(projectId)),
-  );
-
-  useEffect(() => {
-    if (HOSTED_MODE || !projectId) return;
-    setStoredPref(loadComputerEngine(projectId));
-    return subscribeComputerEngine(projectId, () => {
-      setStoredPref(loadComputerEngine(projectId));
-    });
+  // Read the stored preference SYNCHRONOUSLY, keyed to the CURRENT projectId —
+  // via useSyncExternalStore rather than a passive effect, so a project switch
+  // never renders once with the previous project's preference (and switching
+  // to null yields null immediately instead of stranding a stale value). The
+  // snapshot is a primitive, so React's value-compare handles re-render.
+  const { subscribe, getSnapshot } = useMemo(() => {
+    if (HOSTED_MODE || !projectId) {
+      return { subscribe: () => () => {}, getSnapshot: () => null };
+    }
+    return {
+      subscribe: (cb: () => void) => subscribeComputerEngine(projectId, cb),
+      getSnapshot: () => loadComputerEngine(projectId),
+    };
   }, [projectId]);
+  const storedPref = useSyncExternalStore(subscribe, getSnapshot, () => null);
 
   const setEngine = useCallback(
     (engine: ComputerEngineChoice) => {

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -1,154 +1,89 @@
 /**
  * React face of the local-computer consent capability (`lib/local-computer-consent.ts`).
  *
- * `granted` is SERVER-verified truth, not a localStorage bit: on mount (and
- * whenever the stored token changes) the hook re-verifies against
- * `/api/mcp/computers/local-consent/verify`. Until that answer lands the
- * status is `"unknown"`, which consumers must treat as not-granted — the
- * engine resolution in `useComputerEngine` only honors `"granted"`.
+ * `granted` is a SYNCHRONOUS projection of localStorage: consent exists iff a
+ * capability token is stored on this device. There is deliberately no
+ * client-side verification loop — the server re-verifies the token on every
+ * actual bash/terminal use (the engine resolver, PR #3812), so a stale or
+ * tampered token just fails the next turn's server check and falls back. That
+ * makes this hook a pure store projection (via `useSyncExternalStore`), which
+ * has no async status to race: earlier versions that verified on mount grew
+ * five rounds of out-of-order/self-supersede/cross-tab-clobber guards for no
+ * safety the server wasn't already providing.
  *
- * Hosted mode short-circuits to `"absent"` forever: there is no local
- * machine to consent to, and the server routes don't exist there anyway.
+ * Reads reflect writes from any tab/hook immediately (same-tab custom event +
+ * cross-tab storage event); concurrent grant/revoke are plain last-write-wins
+ * on localStorage, which is the honest semantics for "did the user allow this
+ * on this device".
+ *
+ * Hosted mode short-circuits to `"absent"`: there is no local machine to
+ * consent to, and the server routes don't exist there.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { HOSTED_MODE } from "@/lib/config";
 import {
   clearStoredLocalComputerConsent,
   loadStoredLocalComputerConsent,
   mintLocalComputerConsent,
   persistLocalComputerConsent,
-  revokeLocalComputerConsent,
+  revokeLocalComputerConsentOnServer,
   subscribeLocalComputerConsent,
-  verifyStoredLocalComputerConsent,
 } from "@/lib/local-computer-consent";
 
-export type LocalComputerConsentStatus = "unknown" | "granted" | "absent";
+export type LocalComputerConsentStatus = "granted" | "absent";
 
 export interface LocalComputerConsent {
   status: LocalComputerConsentStatus;
-  /** `status === "granted"` — server-verified, safe to gate the engine on. */
+  /** `true` — a capability token is stored; safe to gate the engine on. */
   granted: boolean;
-  /** The verified capability token to send as `X-MCPJam-Local-Consent`. */
+  /** The capability token to send as `X-MCPJam-Local-Consent`. */
   token: string | null;
+  /** Mint + persist; resolves to whether consent ended up stored. */
   grant: () => Promise<boolean>;
+  /** Forget locally (synchronously) + best-effort server unlink. */
   revoke: () => Promise<void>;
 }
 
-interface ConsentSnapshot {
-  status: LocalComputerConsentStatus;
-  token: string | null;
+function getStoredToken(): string | null {
+  if (HOSTED_MODE) return null;
+  return loadStoredLocalComputerConsent()?.token ?? null;
+}
+
+function subscribe(callback: () => void): () => void {
+  if (HOSTED_MODE) return () => {};
+  return subscribeLocalComputerConsent(callback);
 }
 
 export function useLocalComputerConsent(): LocalComputerConsent {
-  // status AND token live together in state, so a token rotation that keeps
-  // status "granted" (tab B rotated A→B) still forces a re-render and the
-  // returned `token` follows — reading it from storage at render time would
-  // go stale whenever React bailed on the same-value status update.
-  const [snapshot, setSnapshot] = useState<ConsentSnapshot>(
-    HOSTED_MODE
-      ? { status: "absent", token: null }
-      : { status: "unknown", token: null },
-  );
-  // Monotonic sequence guarding every write. Verify, grant, and revoke all
-  // resolve asynchronously and can complete out of order (mount + storage
-  // event + an explicit grant race routinely); each op CLAIMS its slot
-  // synchronously and only the latest-claimed op may write. That ordering —
-  // claim-before-await — is what makes a later revoke beat an earlier in-flight
-  // grant, not merely a faster one.
-  const opSeqRef = useRef(0);
-  // Local storage writes dispatch the same-tab consent event SYNCHRONOUSLY, so
-  // the subscription below would re-enter refresh() and bump the sequence for
-  // OUR OWN write, making an op supersede itself. This depth counter marks the
-  // SYNCHRONOUS write region we cause; while it's non-zero the subscription
-  // ignores the notification (we set the resulting state directly).
-  //
-  // Critically, it wraps only the synchronous persist/clear — NEVER a network
-  // await. An external revoke (another tab/hook) arriving while a grant's
-  // request is still in flight must stay visible, so it can advance the
-  // sequence and make the completing grant discard itself.
-  const selfWriteDepthRef = useRef(0);
-  const selfWrite = useCallback(<T>(write: () => T): T => {
-    selfWriteDepthRef.current += 1;
-    try {
-      return write();
-    } finally {
-      selfWriteDepthRef.current -= 1;
-    }
-  }, []);
-  const apply = useCallback((seq: number, next: ConsentSnapshot) => {
-    if (seq !== opSeqRef.current) return;
-    setSnapshot((prev) =>
-      prev.status === next.status && prev.token === next.token ? prev : next,
-    );
-  }, []);
-
-  const refresh = useCallback(async (): Promise<void> => {
-    if (HOSTED_MODE) return;
-    const seq = ++opSeqRef.current;
-    if (!loadStoredLocalComputerConsent()) {
-      apply(seq, { status: "absent", token: null });
-      return;
-    }
-    const valid = await verifyStoredLocalComputerConsent();
-    // Re-read after verify — a concurrent grant may have rotated the token;
-    // whatever is stored now is the capability this "granted" refers to.
-    const token = loadStoredLocalComputerConsent()?.token ?? null;
-    apply(
-      seq,
-      valid && token
-        ? { status: "granted", token }
-        : { status: "absent", token: null },
-    );
-  }, [apply]);
-
-  useEffect(() => {
-    if (HOSTED_MODE) return;
-    void refresh();
-    return subscribeLocalComputerConsent(() => {
-      // Ignore the storage notification our own grant/revoke just caused.
-      if (selfWriteDepthRef.current > 0) return;
-      void refresh();
-    });
-  }, [refresh]);
+  // A primitive string snapshot — value-compared by React, so writes from any
+  // tab re-render and stale reads are impossible.
+  const token = useSyncExternalStore(subscribe, getStoredToken, () => null);
 
   const grant = useCallback(async (): Promise<boolean> => {
     if (HOSTED_MODE) return false;
-    // CLAIM before awaiting: a revoke that starts after this line gets a higher
-    // sequence and wins, even if the grant request resolves later.
-    const seq = ++opSeqRef.current;
-    // Mint on the server WITHOUT persisting — the network wait is UNGUARDED so
-    // an external revoke during it stays visible and advances the sequence.
     const minted = await mintLocalComputerConsent();
     if (!minted) return false;
-    if (seq !== opSeqRef.current) {
-      // A genuinely later op (a revoke, possibly cross-tab) landed while the
-      // mint was in flight. Do NOT persist; drop the just-minted server
-      // capability so the later revoke stays final.
-      void revokeLocalComputerConsent();
-      return false;
-    }
-    // Persist is synchronous and fires the same-tab event — guard only THIS.
-    selfWrite(() => persistLocalComputerConsent(minted));
-    apply(seq, { status: "granted", token: minted.token });
-    return true;
-  }, [apply, selfWrite]);
+    // persist returns false when storage is blocked/full — then consent is NOT
+    // stored, so we must report failure rather than a token nothing can read.
+    // The successful persist fires a storage event → useSyncExternalStore
+    // re-reads → status flips to granted; no optimistic write needed.
+    return persistLocalComputerConsent(minted);
+  }, []);
 
   const revoke = useCallback(async (): Promise<void> => {
     if (HOSTED_MODE) return;
-    // Claim the latest slot, then forget the capability locally FIRST and
-    // unconditionally — this is the user's explicit revoke. The higher
-    // sequence makes any in-flight grant/verify discard itself on resolve; the
-    // server call is best-effort on top of the guaranteed local forget.
-    const seq = ++opSeqRef.current;
-    selfWrite(() => clearStoredLocalComputerConsent());
-    apply(seq, { status: "absent", token: null });
-    await revokeLocalComputerConsent();
-  }, [apply, selfWrite]);
+    // Forget locally FIRST and synchronously — the user's explicit revoke,
+    // and the only write that touches storage (fires the event → re-read →
+    // absent). The server call is storage-free and best-effort, so a slow
+    // revoke resuming later can't clobber a token a newer grant just stored.
+    clearStoredLocalComputerConsent();
+    await revokeLocalComputerConsentOnServer();
+  }, []);
 
   return {
-    status: snapshot.status,
-    granted: snapshot.status === "granted",
-    token: snapshot.status === "granted" ? snapshot.token : null,
+    status: token ? "granted" : "absent",
+    granted: token != null,
+    token,
     grant,
     revoke,
   };

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { HOSTED_MODE } from "@/lib/config";
 import {
+  clearStoredLocalComputerConsent,
   grantLocalComputerConsent,
   loadStoredLocalComputerConsent,
   revokeLocalComputerConsent,
@@ -85,6 +86,13 @@ export function useLocalComputerConsent(): LocalComputerConsent {
 
   const revoke = useCallback(async (): Promise<void> => {
     if (HOSTED_MODE) return;
+    // Forget the capability locally FIRST and unconditionally — this is the
+    // user's explicit revoke. If we skipped it when getAccessToken threw (a
+    // transient auth refresh), the still-valid stored token would survive and
+    // a later remount could re-verify it and silently restore consent. The
+    // server call is best-effort on top of the guaranteed local forget.
+    clearStoredLocalComputerConsent();
+    setStatus("absent");
     let accessToken: string | undefined;
     try {
       accessToken = await getAccessToken?.();
@@ -94,7 +102,6 @@ export function useLocalComputerConsent(): LocalComputerConsent {
     if (accessToken) {
       await revokeLocalComputerConsent(accessToken);
     }
-    setStatus("absent");
   }, [getAccessToken]);
 
   return {

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -33,33 +33,53 @@ export interface LocalComputerConsent {
   revoke: () => Promise<void>;
 }
 
+interface ConsentSnapshot {
+  status: LocalComputerConsentStatus;
+  token: string | null;
+}
+
 export function useLocalComputerConsent(): LocalComputerConsent {
-  const [status, setStatus] = useState<LocalComputerConsentStatus>(
-    HOSTED_MODE ? "absent" : "unknown",
+  // status AND token live together in state, so a token rotation that keeps
+  // status "granted" (tab B rotated A→B) still forces a re-render and the
+  // returned `token` follows — reading it from storage at render time would
+  // go stale whenever React bailed on the same-value status update.
+  const [snapshot, setSnapshot] = useState<ConsentSnapshot>(
+    HOSTED_MODE
+      ? { status: "absent", token: null }
+      : { status: "unknown", token: null },
   );
-  // Monotonic sequence guarding every status write. Verify, grant, and revoke
-  // all resolve asynchronously and can complete out of order (mount + storage
-  // event + an explicit grant race routinely); only the LATEST-initiated
-  // operation may write status, so a slow stale verify can never restore
-  // `granted` after a revoke, nor "absent" after a fresh grant.
+  // Monotonic sequence guarding every write. Verify, grant, and revoke all
+  // resolve asynchronously and can complete out of order (mount + storage
+  // event + an explicit grant race routinely); each op CLAIMS its slot
+  // synchronously and only the latest-claimed op may write. That ordering —
+  // claim-before-await — is what makes a later revoke beat an earlier in-flight
+  // grant, not merely a faster one.
   const opSeqRef = useRef(0);
-  const commit = useCallback(
-    (seq: number, next: LocalComputerConsentStatus) => {
-      if (seq === opSeqRef.current) setStatus(next);
-    },
-    [],
-  );
+  const apply = useCallback((seq: number, next: ConsentSnapshot) => {
+    if (seq !== opSeqRef.current) return;
+    setSnapshot((prev) =>
+      prev.status === next.status && prev.token === next.token ? prev : next,
+    );
+  }, []);
 
   const refresh = useCallback(async (): Promise<void> => {
     if (HOSTED_MODE) return;
     const seq = ++opSeqRef.current;
     if (!loadStoredLocalComputerConsent()) {
-      commit(seq, "absent");
+      apply(seq, { status: "absent", token: null });
       return;
     }
     const valid = await verifyStoredLocalComputerConsent();
-    commit(seq, valid ? "granted" : "absent");
-  }, [commit]);
+    // Re-read after verify — a concurrent grant may have rotated the token;
+    // whatever is stored now is the capability this "granted" refers to.
+    const token = loadStoredLocalComputerConsent()?.token ?? null;
+    apply(
+      seq,
+      valid && token
+        ? { status: "granted", token }
+        : { status: "absent", token: null },
+    );
+  }, [apply]);
 
   useEffect(() => {
     if (HOSTED_MODE) return;
@@ -71,31 +91,41 @@ export function useLocalComputerConsent(): LocalComputerConsent {
 
   const grant = useCallback(async (): Promise<boolean> => {
     if (HOSTED_MODE) return false;
+    // CLAIM before awaiting: a revoke that starts after this line gets a higher
+    // sequence and wins, even if the grant request resolves later.
+    const seq = ++opSeqRef.current;
     const ok = await grantLocalComputerConsent();
-    // Claim the latest slot so an in-flight refresh can't overwrite this.
-    // grant's persist fired the subscription → a refresh will re-confirm
-    // "granted"; this just makes the Allow click feel immediate.
-    if (ok) commit(++opSeqRef.current, "granted");
-    return ok;
-  }, [commit]);
+    if (!ok) return false;
+    if (seq === opSeqRef.current) {
+      apply(seq, {
+        status: "granted",
+        token: loadStoredLocalComputerConsent()?.token ?? null,
+      });
+      return true;
+    }
+    // Superseded by a later op (a revoke). The grant already persisted a token;
+    // undo it so the later revoke stays final — including cross-tab.
+    clearStoredLocalComputerConsent();
+    void revokeLocalComputerConsent();
+    return false;
+  }, [apply]);
 
   const revoke = useCallback(async (): Promise<void> => {
     if (HOSTED_MODE) return;
-    // Forget the capability locally FIRST and unconditionally — this is the
-    // user's explicit revoke — and claim the latest op slot so any in-flight
-    // verify (older seq) can't restore consent. The server call is best-effort
-    // on top of the guaranteed local forget.
+    // Claim the latest slot, then forget the capability locally FIRST and
+    // unconditionally — this is the user's explicit revoke. The higher
+    // sequence makes any in-flight grant/verify discard itself on resolve; the
+    // server call is best-effort on top of the guaranteed local forget.
+    const seq = ++opSeqRef.current;
     clearStoredLocalComputerConsent();
-    commit(++opSeqRef.current, "absent");
+    apply(seq, { status: "absent", token: null });
     await revokeLocalComputerConsent();
-  }, [commit]);
+  }, [apply]);
 
   return {
-    status,
-    granted: status === "granted",
-    token: status === "granted"
-      ? (loadStoredLocalComputerConsent()?.token ?? null)
-      : null,
+    status: snapshot.status,
+    granted: snapshot.status === "granted",
+    token: snapshot.status === "granted" ? snapshot.token : null,
     grant,
     revoke,
   };

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -75,9 +75,12 @@ export function useLocalComputerConsent(): LocalComputerConsent {
     // Forget locally FIRST and synchronously — the user's explicit revoke,
     // and the only write that touches storage (fires the event → re-read →
     // absent). The server call is storage-free and best-effort, so a slow
-    // revoke resuming later can't clobber a token a newer grant just stored.
+    // revoke resuming later can't clobber a token a newer grant just stored;
+    // it is also SCOPED to the token being forgotten, so on the server side a
+    // delayed revoke can't sever a capability a newer grant rotated in.
+    const stored = loadStoredLocalComputerConsent()?.token ?? null;
     clearStoredLocalComputerConsent();
-    await revokeLocalComputerConsentOnServer();
+    await revokeLocalComputerConsentOnServer(stored);
   }, []);
 
   return {

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -10,8 +10,7 @@
  * Hosted mode short-circuits to `"absent"` forever: there is no local
  * machine to consent to, and the server routes don't exist there anyway.
  */
-import { useCallback, useEffect, useState } from "react";
-import { useAuth } from "@workos-inc/authkit-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { HOSTED_MODE } from "@/lib/config";
 import {
   clearStoredLocalComputerConsent,
@@ -35,30 +34,32 @@ export interface LocalComputerConsent {
 }
 
 export function useLocalComputerConsent(): LocalComputerConsent {
-  const { getAccessToken } = useAuth();
   const [status, setStatus] = useState<LocalComputerConsentStatus>(
     HOSTED_MODE ? "absent" : "unknown",
+  );
+  // Monotonic sequence guarding every status write. Verify, grant, and revoke
+  // all resolve asynchronously and can complete out of order (mount + storage
+  // event + an explicit grant race routinely); only the LATEST-initiated
+  // operation may write status, so a slow stale verify can never restore
+  // `granted` after a revoke, nor "absent" after a fresh grant.
+  const opSeqRef = useRef(0);
+  const commit = useCallback(
+    (seq: number, next: LocalComputerConsentStatus) => {
+      if (seq === opSeqRef.current) setStatus(next);
+    },
+    [],
   );
 
   const refresh = useCallback(async (): Promise<void> => {
     if (HOSTED_MODE) return;
+    const seq = ++opSeqRef.current;
     if (!loadStoredLocalComputerConsent()) {
-      setStatus("absent");
+      commit(seq, "absent");
       return;
     }
-    let accessToken: string | undefined;
-    try {
-      accessToken = await getAccessToken?.();
-    } catch {
-      // Not signed in — the consent routes require a verified bearer.
-    }
-    if (!accessToken) {
-      setStatus("absent");
-      return;
-    }
-    const valid = await verifyStoredLocalComputerConsent(accessToken);
-    setStatus(valid ? "granted" : "absent");
-  }, [getAccessToken]);
+    const valid = await verifyStoredLocalComputerConsent();
+    commit(seq, valid ? "granted" : "absent");
+  }, [commit]);
 
   useEffect(() => {
     if (HOSTED_MODE) return;
@@ -70,39 +71,24 @@ export function useLocalComputerConsent(): LocalComputerConsent {
 
   const grant = useCallback(async (): Promise<boolean> => {
     if (HOSTED_MODE) return false;
-    let accessToken: string | undefined;
-    try {
-      accessToken = await getAccessToken?.();
-    } catch {
-      return false;
-    }
-    if (!accessToken) return false;
-    const ok = await grantLocalComputerConsent(accessToken);
-    // The persist inside grant fires the subscription → refresh → verified
-    // "granted"; set optimistically so the Allow click feels immediate.
-    if (ok) setStatus("granted");
+    const ok = await grantLocalComputerConsent();
+    // Claim the latest slot so an in-flight refresh can't overwrite this.
+    // grant's persist fired the subscription → a refresh will re-confirm
+    // "granted"; this just makes the Allow click feel immediate.
+    if (ok) commit(++opSeqRef.current, "granted");
     return ok;
-  }, [getAccessToken]);
+  }, [commit]);
 
   const revoke = useCallback(async (): Promise<void> => {
     if (HOSTED_MODE) return;
     // Forget the capability locally FIRST and unconditionally — this is the
-    // user's explicit revoke. If we skipped it when getAccessToken threw (a
-    // transient auth refresh), the still-valid stored token would survive and
-    // a later remount could re-verify it and silently restore consent. The
-    // server call is best-effort on top of the guaranteed local forget.
+    // user's explicit revoke — and claim the latest op slot so any in-flight
+    // verify (older seq) can't restore consent. The server call is best-effort
+    // on top of the guaranteed local forget.
     clearStoredLocalComputerConsent();
-    setStatus("absent");
-    let accessToken: string | undefined;
-    try {
-      accessToken = await getAccessToken?.();
-    } catch {
-      accessToken = undefined;
-    }
-    if (accessToken) {
-      await revokeLocalComputerConsent(accessToken);
-    }
-  }, [getAccessToken]);
+    commit(++opSeqRef.current, "absent");
+    await revokeLocalComputerConsent();
+  }, [commit]);
 
   return {
     status,

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -1,0 +1,109 @@
+/**
+ * React face of the local-computer consent capability (`lib/local-computer-consent.ts`).
+ *
+ * `granted` is SERVER-verified truth, not a localStorage bit: on mount (and
+ * whenever the stored token changes) the hook re-verifies against
+ * `/api/mcp/computers/local-consent/verify`. Until that answer lands the
+ * status is `"unknown"`, which consumers must treat as not-granted — the
+ * engine resolution in `useComputerEngine` only honors `"granted"`.
+ *
+ * Hosted mode short-circuits to `"absent"` forever: there is no local
+ * machine to consent to, and the server routes don't exist there anyway.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
+import { HOSTED_MODE } from "@/lib/config";
+import {
+  grantLocalComputerConsent,
+  loadStoredLocalComputerConsent,
+  revokeLocalComputerConsent,
+  subscribeLocalComputerConsent,
+  verifyStoredLocalComputerConsent,
+} from "@/lib/local-computer-consent";
+
+export type LocalComputerConsentStatus = "unknown" | "granted" | "absent";
+
+export interface LocalComputerConsent {
+  status: LocalComputerConsentStatus;
+  /** `status === "granted"` — server-verified, safe to gate the engine on. */
+  granted: boolean;
+  /** The verified capability token to send as `X-MCPJam-Local-Consent`. */
+  token: string | null;
+  grant: () => Promise<boolean>;
+  revoke: () => Promise<void>;
+}
+
+export function useLocalComputerConsent(): LocalComputerConsent {
+  const { getAccessToken } = useAuth();
+  const [status, setStatus] = useState<LocalComputerConsentStatus>(
+    HOSTED_MODE ? "absent" : "unknown",
+  );
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (HOSTED_MODE) return;
+    if (!loadStoredLocalComputerConsent()) {
+      setStatus("absent");
+      return;
+    }
+    let accessToken: string | undefined;
+    try {
+      accessToken = await getAccessToken?.();
+    } catch {
+      // Not signed in — the consent routes require a verified bearer.
+    }
+    if (!accessToken) {
+      setStatus("absent");
+      return;
+    }
+    const valid = await verifyStoredLocalComputerConsent(accessToken);
+    setStatus(valid ? "granted" : "absent");
+  }, [getAccessToken]);
+
+  useEffect(() => {
+    if (HOSTED_MODE) return;
+    void refresh();
+    return subscribeLocalComputerConsent(() => {
+      void refresh();
+    });
+  }, [refresh]);
+
+  const grant = useCallback(async (): Promise<boolean> => {
+    if (HOSTED_MODE) return false;
+    let accessToken: string | undefined;
+    try {
+      accessToken = await getAccessToken?.();
+    } catch {
+      return false;
+    }
+    if (!accessToken) return false;
+    const ok = await grantLocalComputerConsent(accessToken);
+    // The persist inside grant fires the subscription → refresh → verified
+    // "granted"; set optimistically so the Allow click feels immediate.
+    if (ok) setStatus("granted");
+    return ok;
+  }, [getAccessToken]);
+
+  const revoke = useCallback(async (): Promise<void> => {
+    if (HOSTED_MODE) return;
+    let accessToken: string | undefined;
+    try {
+      accessToken = await getAccessToken?.();
+    } catch {
+      accessToken = undefined;
+    }
+    if (accessToken) {
+      await revokeLocalComputerConsent(accessToken);
+    }
+    setStatus("absent");
+  }, [getAccessToken]);
+
+  return {
+    status,
+    granted: status === "granted",
+    token: status === "granted"
+      ? (loadStoredLocalComputerConsent()?.token ?? null)
+      : null,
+    grant,
+    revoke,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -55,6 +55,14 @@ export function useLocalComputerConsent(): LocalComputerConsent {
   // claim-before-await — is what makes a later revoke beat an earlier in-flight
   // grant, not merely a faster one.
   const opSeqRef = useRef(0);
+  // grant/revoke write storage, and `persist()` dispatches the same-tab
+  // consent event SYNCHRONOUSLY — so the subscription below would re-enter
+  // refresh() and bump the sequence mid-operation, making an op supersede
+  // itself. This depth counter marks writes WE cause: while it's non-zero the
+  // subscription ignores the notification (we set the resulting state
+  // directly). Genuinely external changes (cross-tab, or a sibling hook)
+  // still refresh.
+  const selfWriteDepthRef = useRef(0);
   const apply = useCallback((seq: number, next: ConsentSnapshot) => {
     if (seq !== opSeqRef.current) return;
     setSnapshot((prev) =>
@@ -85,6 +93,8 @@ export function useLocalComputerConsent(): LocalComputerConsent {
     if (HOSTED_MODE) return;
     void refresh();
     return subscribeLocalComputerConsent(() => {
+      // Ignore the storage notification our own grant/revoke just caused.
+      if (selfWriteDepthRef.current > 0) return;
       void refresh();
     });
   }, [refresh]);
@@ -94,7 +104,13 @@ export function useLocalComputerConsent(): LocalComputerConsent {
     // CLAIM before awaiting: a revoke that starts after this line gets a higher
     // sequence and wins, even if the grant request resolves later.
     const seq = ++opSeqRef.current;
-    const ok = await grantLocalComputerConsent();
+    selfWriteDepthRef.current += 1;
+    let ok = false;
+    try {
+      ok = await grantLocalComputerConsent();
+    } finally {
+      selfWriteDepthRef.current -= 1;
+    }
     if (!ok) return false;
     if (seq === opSeqRef.current) {
       apply(seq, {
@@ -103,9 +119,15 @@ export function useLocalComputerConsent(): LocalComputerConsent {
       });
       return true;
     }
-    // Superseded by a later op (a revoke). The grant already persisted a token;
-    // undo it so the later revoke stays final — including cross-tab.
-    clearStoredLocalComputerConsent();
+    // Superseded by a genuinely later op (a revoke). The grant already
+    // persisted a token; undo it so the later revoke stays final — cross-tab
+    // included. This undo is itself a self-write.
+    selfWriteDepthRef.current += 1;
+    try {
+      clearStoredLocalComputerConsent();
+    } finally {
+      selfWriteDepthRef.current -= 1;
+    }
     void revokeLocalComputerConsent();
     return false;
   }, [apply]);
@@ -117,7 +139,12 @@ export function useLocalComputerConsent(): LocalComputerConsent {
     // sequence makes any in-flight grant/verify discard itself on resolve; the
     // server call is best-effort on top of the guaranteed local forget.
     const seq = ++opSeqRef.current;
-    clearStoredLocalComputerConsent();
+    selfWriteDepthRef.current += 1;
+    try {
+      clearStoredLocalComputerConsent();
+    } finally {
+      selfWriteDepthRef.current -= 1;
+    }
     apply(seq, { status: "absent", token: null });
     await revokeLocalComputerConsent();
   }, [apply]);

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -67,7 +67,15 @@ export function useLocalComputerConsent(): LocalComputerConsent {
     // stored, so we must report failure rather than a token nothing can read.
     // The successful persist fires a storage event → useSyncExternalStore
     // re-reads → status flips to granted; no optimistic write needed.
-    return persistLocalComputerConsent(minted);
+    const stored = persistLocalComputerConsent(minted);
+    if (!stored) {
+      // The mint already rotated the server capability to this token, and
+      // nothing can ever present it now — release it (best-effort) rather
+      // than leave an orphaned capability. Scoped to the minted token, so if
+      // an even newer grant rotated again this is a no-op.
+      void revokeLocalComputerConsentOnServer(minted.token);
+    }
+    return stored;
   }, []);
 
   const revoke = useCallback(async (): Promise<void> => {

--- a/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
+++ b/mcpjam-inspector/client/src/hooks/useLocalComputerConsent.ts
@@ -14,8 +14,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { HOSTED_MODE } from "@/lib/config";
 import {
   clearStoredLocalComputerConsent,
-  grantLocalComputerConsent,
   loadStoredLocalComputerConsent,
+  mintLocalComputerConsent,
+  persistLocalComputerConsent,
   revokeLocalComputerConsent,
   subscribeLocalComputerConsent,
   verifyStoredLocalComputerConsent,
@@ -55,14 +56,25 @@ export function useLocalComputerConsent(): LocalComputerConsent {
   // claim-before-await — is what makes a later revoke beat an earlier in-flight
   // grant, not merely a faster one.
   const opSeqRef = useRef(0);
-  // grant/revoke write storage, and `persist()` dispatches the same-tab
-  // consent event SYNCHRONOUSLY — so the subscription below would re-enter
-  // refresh() and bump the sequence mid-operation, making an op supersede
-  // itself. This depth counter marks writes WE cause: while it's non-zero the
-  // subscription ignores the notification (we set the resulting state
-  // directly). Genuinely external changes (cross-tab, or a sibling hook)
-  // still refresh.
+  // Local storage writes dispatch the same-tab consent event SYNCHRONOUSLY, so
+  // the subscription below would re-enter refresh() and bump the sequence for
+  // OUR OWN write, making an op supersede itself. This depth counter marks the
+  // SYNCHRONOUS write region we cause; while it's non-zero the subscription
+  // ignores the notification (we set the resulting state directly).
+  //
+  // Critically, it wraps only the synchronous persist/clear — NEVER a network
+  // await. An external revoke (another tab/hook) arriving while a grant's
+  // request is still in flight must stay visible, so it can advance the
+  // sequence and make the completing grant discard itself.
   const selfWriteDepthRef = useRef(0);
+  const selfWrite = useCallback(<T>(write: () => T): T => {
+    selfWriteDepthRef.current += 1;
+    try {
+      return write();
+    } finally {
+      selfWriteDepthRef.current -= 1;
+    }
+  }, []);
   const apply = useCallback((seq: number, next: ConsentSnapshot) => {
     if (seq !== opSeqRef.current) return;
     setSnapshot((prev) =>
@@ -104,33 +116,22 @@ export function useLocalComputerConsent(): LocalComputerConsent {
     // CLAIM before awaiting: a revoke that starts after this line gets a higher
     // sequence and wins, even if the grant request resolves later.
     const seq = ++opSeqRef.current;
-    selfWriteDepthRef.current += 1;
-    let ok = false;
-    try {
-      ok = await grantLocalComputerConsent();
-    } finally {
-      selfWriteDepthRef.current -= 1;
+    // Mint on the server WITHOUT persisting — the network wait is UNGUARDED so
+    // an external revoke during it stays visible and advances the sequence.
+    const minted = await mintLocalComputerConsent();
+    if (!minted) return false;
+    if (seq !== opSeqRef.current) {
+      // A genuinely later op (a revoke, possibly cross-tab) landed while the
+      // mint was in flight. Do NOT persist; drop the just-minted server
+      // capability so the later revoke stays final.
+      void revokeLocalComputerConsent();
+      return false;
     }
-    if (!ok) return false;
-    if (seq === opSeqRef.current) {
-      apply(seq, {
-        status: "granted",
-        token: loadStoredLocalComputerConsent()?.token ?? null,
-      });
-      return true;
-    }
-    // Superseded by a genuinely later op (a revoke). The grant already
-    // persisted a token; undo it so the later revoke stays final — cross-tab
-    // included. This undo is itself a self-write.
-    selfWriteDepthRef.current += 1;
-    try {
-      clearStoredLocalComputerConsent();
-    } finally {
-      selfWriteDepthRef.current -= 1;
-    }
-    void revokeLocalComputerConsent();
-    return false;
-  }, [apply]);
+    // Persist is synchronous and fires the same-tab event — guard only THIS.
+    selfWrite(() => persistLocalComputerConsent(minted));
+    apply(seq, { status: "granted", token: minted.token });
+    return true;
+  }, [apply, selfWrite]);
 
   const revoke = useCallback(async (): Promise<void> => {
     if (HOSTED_MODE) return;
@@ -139,15 +140,10 @@ export function useLocalComputerConsent(): LocalComputerConsent {
     // sequence makes any in-flight grant/verify discard itself on resolve; the
     // server call is best-effort on top of the guaranteed local forget.
     const seq = ++opSeqRef.current;
-    selfWriteDepthRef.current += 1;
-    try {
-      clearStoredLocalComputerConsent();
-    } finally {
-      selfWriteDepthRef.current -= 1;
-    }
+    selfWrite(() => clearStoredLocalComputerConsent());
     apply(seq, { status: "absent", token: null });
     await revokeLocalComputerConsent();
-  }, [apply]);
+  }, [apply, selfWrite]);
 
   return {
     status: snapshot.status,

--- a/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjectComputer.ts
@@ -145,6 +145,18 @@ export function useMintTerminalToken(): (args: {
  * here and the UI should say so instead of offering a terminal that can't
  * connect.
  */
+export interface ComputerEnginesConfig {
+  local: {
+    available: boolean;
+    /** Bash may work while the terminal doesn't (node-pty failed to load). */
+    terminalAvailable: boolean;
+    /** Tilde display root ("~/.mcpjam/computer") — render `${root}/<projectId>`. */
+    workspaceDisplayRoot: string | null;
+    reason?: string;
+  };
+  cloud: { available: boolean };
+}
+
 export interface ComputersDataPlaneConfig {
   localConfigured: boolean;
   remoteDataPlaneUrl: string | null;
@@ -158,6 +170,35 @@ export interface ComputersDataPlaneConfig {
    * `localConfigured` (creds present ⇔ ephemeral exec works).
    */
   ephemeralCloudAvailable?: boolean;
+  /**
+   * Per-engine availability. Always present POST-PARSE: servers that predate
+   * the field get a derived block — local unavailable (an old server has no
+   * local engine to offer), cloud from the legacy pair — so consumers never
+   * branch on absence.
+   */
+  engines: ComputerEnginesConfig;
+  /** Server's suggested engine; `null` when NO engine can serve here. */
+  defaultEngine: "local" | "cloud" | null;
+}
+
+/** The legacy-pair derivation, shared by old-server parse and fallbacks. */
+function deriveEnginesFromLegacyPair(args: {
+  localConfigured: boolean;
+  remoteDataPlaneUrl: string | null;
+}): Pick<ComputersDataPlaneConfig, "engines" | "defaultEngine"> {
+  const cloudAvailable =
+    args.localConfigured || args.remoteDataPlaneUrl !== null;
+  return {
+    engines: {
+      local: {
+        available: false,
+        terminalAvailable: false,
+        workspaceDisplayRoot: null,
+      },
+      cloud: { available: cloudAvailable },
+    },
+    defaultEngine: cloudAvailable ? "cloud" : null,
+  };
 }
 
 // One fetch per page load — the answer is env-derived and can't change
@@ -168,23 +209,71 @@ let cachedDataPlaneConfig: ComputersDataPlaneConfig | null = null;
 let inFlightDataPlaneConfigFetch: Promise<ComputersDataPlaneConfig | null> | null =
   null;
 
+function parseEngines(value: unknown): ComputerEnginesConfig | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const local =
+    record.local && typeof record.local === "object"
+      ? (record.local as Record<string, unknown>)
+      : null;
+  const cloud =
+    record.cloud && typeof record.cloud === "object"
+      ? (record.cloud as Record<string, unknown>)
+      : null;
+  if (
+    !local ||
+    !cloud ||
+    typeof local.available !== "boolean" ||
+    typeof cloud.available !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    local: {
+      available: local.available,
+      terminalAvailable: local.terminalAvailable === true,
+      workspaceDisplayRoot:
+        typeof local.workspaceDisplayRoot === "string"
+          ? local.workspaceDisplayRoot
+          : null,
+      ...(typeof local.reason === "string" ? { reason: local.reason } : {}),
+    },
+    cloud: { available: cloud.available },
+  };
+}
+
 function parseDataPlaneConfig(value: unknown): ComputersDataPlaneConfig | null {
   if (!value || typeof value !== "object") return null;
   const record = value as Record<string, unknown>;
   if (typeof record.localConfigured !== "boolean") return null;
+  const localConfigured = record.localConfigured;
+  const remoteDataPlaneUrl =
+    typeof record.remoteDataPlaneUrl === "string"
+      ? record.remoteDataPlaneUrl
+      : null;
   const capabilities =
     record.capabilities && typeof record.capabilities === "object"
       ? (record.capabilities as Record<string, unknown>)
       : undefined;
+  // A malformed `engines` block is read like an OLD server (derive), never
+  // half-trusted — a partial parse could invent a local engine.
+  const engines = parseEngines(record.engines);
+  const derived = deriveEnginesFromLegacyPair({
+    localConfigured,
+    remoteDataPlaneUrl,
+  });
   return {
-    localConfigured: record.localConfigured,
-    remoteDataPlaneUrl:
-      typeof record.remoteDataPlaneUrl === "string"
-        ? record.remoteDataPlaneUrl
-        : null,
+    localConfigured,
+    remoteDataPlaneUrl,
     ...(typeof capabilities?.ephemeralCloudAvailable === "boolean"
       ? { ephemeralCloudAvailable: capabilities.ephemeralCloudAvailable }
       : {}),
+    engines: engines ?? derived.engines,
+    defaultEngine: engines
+      ? record.defaultEngine === "local" || record.defaultEngine === "cloud"
+        ? record.defaultEngine
+        : null
+      : derived.defaultEngine,
   };
 }
 
@@ -234,8 +323,17 @@ export function useComputersDataPlaneConfig():
       });
     void inFlightDataPlaneConfigFetch.then((parsed) => {
       if (!cancelled) {
+        // Legacy fail-open fallback: assume a local data plane (cloud engine
+        // served by this server), NEVER a phantom local machine engine.
         setConfig(
-          parsed ?? { localConfigured: true, remoteDataPlaneUrl: null }
+          parsed ?? {
+            localConfigured: true,
+            remoteDataPlaneUrl: null,
+            ...deriveEnginesFromLegacyPair({
+              localConfigured: true,
+              remoteDataPlaneUrl: null,
+            }),
+          }
         );
       }
     });

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-engine-storage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-engine-storage.test.ts
@@ -25,13 +25,18 @@ describe("computer-engine-storage", () => {
   });
 
   it("reads garbage as no-preference, never a guess", () => {
-    localStorage.setItem("mcp-computer-engine", '"local"');
+    localStorage.setItem("mcp-computer-engine:p1", "warp-drive");
     expect(loadComputerEngine("p1")).toBeNull();
-    localStorage.setItem(
-      "mcp-computer-engine",
-      JSON.stringify({ p1: "warp-drive" }),
-    );
-    expect(loadComputerEngine("p1")).toBeNull();
+  });
+
+  it("per-key: a concurrent write to another project cannot clobber this one", () => {
+    // Simulate the shared-map race: two "tabs" read, then both write. With
+    // per-key storage each write touches only its own key, so nothing is lost.
+    saveComputerEngine("p1", "local");
+    // Another tab sets p2 without ever having seen p1.
+    saveComputerEngine("p2", "cloud");
+    expect(loadComputerEngine("p1")).toBe("local");
+    expect(loadComputerEngine("p2")).toBe("cloud");
   });
 
   it("notifies same-tab subscribers for the matching project only", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-engine-storage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-engine-storage.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadComputerEngine,
+  saveComputerEngine,
+  subscribeComputerEngine,
+} from "../computer-engine-storage";
+
+describe("computer-engine-storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips a per-project choice; projects are independent", () => {
+    saveComputerEngine("p1", "local");
+    saveComputerEngine("p2", "cloud");
+    expect(loadComputerEngine("p1")).toBe("local");
+    expect(loadComputerEngine("p2")).toBe("cloud");
+    expect(loadComputerEngine("p3")).toBeNull();
+  });
+
+  it("clearing with null removes the entry", () => {
+    saveComputerEngine("p1", "local");
+    saveComputerEngine("p1", null);
+    expect(loadComputerEngine("p1")).toBeNull();
+  });
+
+  it("reads garbage as no-preference, never a guess", () => {
+    localStorage.setItem("mcp-computer-engine", '"local"');
+    expect(loadComputerEngine("p1")).toBeNull();
+    localStorage.setItem(
+      "mcp-computer-engine",
+      JSON.stringify({ p1: "warp-drive" }),
+    );
+    expect(loadComputerEngine("p1")).toBeNull();
+  });
+
+  it("notifies same-tab subscribers for the matching project only", () => {
+    const p1 = vi.fn();
+    const p2 = vi.fn();
+    const unsub1 = subscribeComputerEngine("p1", p1);
+    const unsub2 = subscribeComputerEngine("p2", p2);
+    saveComputerEngine("p1", "local");
+    expect(p1).toHaveBeenCalledTimes(1);
+    expect(p2).not.toHaveBeenCalled();
+    unsub1();
+    saveComputerEngine("p1", "cloud");
+    expect(p1).toHaveBeenCalledTimes(1);
+    unsub2();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
@@ -81,6 +81,14 @@ describe("local-computer-consent client", () => {
     try {
       expect(await grantLocalComputerConsent()).toBe(false);
       expect(loadStoredLocalComputerConsent()).toBeNull();
+      // The unpresentable just-minted capability gets released, token-scoped.
+      const revokeCall = fetchMock.mock.calls.find(([url]) =>
+        String(url).endsWith("/local-consent/revoke"),
+      );
+      expect(revokeCall).toBeDefined();
+      expect(JSON.parse(String(revokeCall![1]?.body))).toEqual({
+        token: "tok_".padEnd(40, "x"),
+      });
     } finally {
       setItem.mockRestore();
     }

--- a/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// authFetch adds session plumbing irrelevant here; a plain passthrough keeps
+// the tests about THIS module's contract (headers, storage effects).
+const fetchMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/session-token", () => ({
+  authFetch: (input: RequestInfo | URL, init?: RequestInit) =>
+    fetchMock(input, init),
+}));
+
+import {
+  clearStoredLocalComputerConsent,
+  grantLocalComputerConsent,
+  loadStoredLocalComputerConsent,
+  revokeLocalComputerConsent,
+  verifyStoredLocalComputerConsent,
+} from "../local-computer-consent";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("local-computer-consent client", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    fetchMock.mockReset();
+  });
+
+  it("grant stores the minted token and sends the verified bearer", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "2026-08-09" }),
+    );
+    expect(await grantLocalComputerConsent("workos-jwt")).toBe(true);
+    expect(loadStoredLocalComputerConsent()?.token).toMatch(/^tok_/);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("/api/mcp/computers/local-consent/grant");
+    expect((init?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer workos-jwt",
+    );
+  });
+
+  it("a failed grant stores nothing", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(401, { error: "unauthorized" }));
+    expect(await grantLocalComputerConsent("workos-jwt")).toBe(false);
+    expect(loadStoredLocalComputerConsent()).toBeNull();
+  });
+
+  it("verify: a definitive server NO clears the stale token (re-prompt path)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
+    );
+    await grantLocalComputerConsent("workos-jwt");
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { valid: false }));
+    expect(await verifyStoredLocalComputerConsent("workos-jwt")).toBe(false);
+    expect(loadStoredLocalComputerConsent()).toBeNull();
+  });
+
+  it("verify: a network failure does NOT clear (capability may still be good)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
+    );
+    await grantLocalComputerConsent("workos-jwt");
+
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    expect(await verifyStoredLocalComputerConsent("workos-jwt")).toBe(false);
+    expect(loadStoredLocalComputerConsent()).not.toBeNull();
+  });
+
+  it("verify without a stored token never calls the server", async () => {
+    expect(await verifyStoredLocalComputerConsent("workos-jwt")).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("revoke forgets locally even when the server call fails", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
+    );
+    await grantLocalComputerConsent("workos-jwt");
+
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    await revokeLocalComputerConsent("workos-jwt");
+    expect(loadStoredLocalComputerConsent()).toBeNull();
+  });
+
+  it("reads garbage storage as absent", () => {
+    localStorage.setItem("mcp-local-computer-consent-v1", '{"token":123}');
+    expect(loadStoredLocalComputerConsent()).toBeNull();
+    clearStoredLocalComputerConsent();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
@@ -104,6 +104,23 @@ describe("local-computer-consent client", () => {
     );
   });
 
+  it("server revoke is token-scoped when given a token, bodiless otherwise", async () => {
+    // Scoped: the server must receive the token being revoked so a delayed
+    // revoke can't sever a capability a newer grant rotated in.
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    await revokeLocalComputerConsentOnServer("tok_scoped".padEnd(40, "x"));
+    const [, scopedInit] = fetchMock.mock.calls.at(-1)!;
+    expect(JSON.parse(String(scopedInit?.body))).toEqual({
+      token: "tok_scoped".padEnd(40, "x"),
+    });
+
+    // No stored token → no body → the server unlinks unconditionally.
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    await revokeLocalComputerConsentOnServer();
+    const [, bareInit] = fetchMock.mock.calls.at(-1)!;
+    expect(bareInit?.body).toBeUndefined();
+  });
+
   it("server revoke swallows a network failure", async () => {
     fetchMock.mockRejectedValueOnce(new Error("offline"));
     await expect(revokeLocalComputerConsentOnServer()).resolves.toBeUndefined();

--- a/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
@@ -12,8 +12,9 @@ import {
   clearStoredLocalComputerConsent,
   grantLocalComputerConsent,
   loadStoredLocalComputerConsent,
-  revokeLocalComputerConsent,
-  verifyStoredLocalComputerConsent,
+  mintLocalComputerConsent,
+  persistLocalComputerConsent,
+  revokeLocalComputerConsentOnServer,
 } from "../local-computer-consent";
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -51,71 +52,21 @@ describe("local-computer-consent client", () => {
     expect(loadStoredLocalComputerConsent()).toBeNull();
   });
 
-  it("verify: a definitive server NO clears the stale token (re-prompt path)", async () => {
-    fetchMock.mockResolvedValueOnce(
+  it("mint returns the token WITHOUT persisting (the hook persists separately)", async () => {
+    fetchMock.mockResolvedValue(
       jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
     );
-    await grantLocalComputerConsent();
-
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, { valid: false }));
-    expect(await verifyStoredLocalComputerConsent()).toBe(false);
+    const minted = await mintLocalComputerConsent();
+    expect(minted?.token).toMatch(/^tok_/);
+    // Mint is network-only — nothing is written to storage yet.
     expect(loadStoredLocalComputerConsent()).toBeNull();
   });
 
-  it("verify: a network failure does NOT clear (capability may still be good)", async () => {
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
-    );
-    await grantLocalComputerConsent();
-
-    fetchMock.mockRejectedValueOnce(new Error("offline"));
-    expect(await verifyStoredLocalComputerConsent()).toBe(false);
-    expect(loadStoredLocalComputerConsent()).not.toBeNull();
-  });
-
-  it("verify: a non-ok HTTP response (401/500) returns false WITHOUT clearing", async () => {
-    // A transient server/auth failure must not force a re-prompt by deleting a
-    // capability that may still be valid — only a definitive valid:false does.
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
-    );
-    await grantLocalComputerConsent();
-
-    fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: "boom" }));
-    expect(await verifyStoredLocalComputerConsent()).toBe(false);
-    expect(loadStoredLocalComputerConsent()).not.toBeNull();
-  });
-
-  it("verify: a stale 'no' for token A does NOT delete a replacement token B", async () => {
-    // Grant A, then a concurrent grant rotates to B while A's verify is in
-    // flight; A's late valid:false must not clobber B.
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { token: "tokA".padEnd(40, "a"), grantedAt: "now" }),
-    );
-    await grantLocalComputerConsent();
-
-    let resolveVerify: (r: Response) => void = () => {};
-    fetchMock.mockReturnValueOnce(
-      new Promise<Response>((r) => {
-        resolveVerify = r;
-      }),
-    );
-    const verifyPromise = verifyStoredLocalComputerConsent();
-
-    // Token B lands mid-flight.
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse(200, { token: "tokB".padEnd(40, "b"), grantedAt: "now" }),
-    );
-    await grantLocalComputerConsent();
-
-    resolveVerify(jsonResponse(200, { valid: false }));
-    expect(await verifyPromise).toBe(false);
-    expect(loadStoredLocalComputerConsent()?.token).toMatch(/^tokB/);
-  });
-
-  it("verify without a stored token never calls the server", async () => {
-    expect(await verifyStoredLocalComputerConsent()).toBe(false);
-    expect(fetchMock).not.toHaveBeenCalled();
+  it("persist stores a minted token and returns true", () => {
+    expect(
+      persistLocalComputerConsent({ token: "tok_abc".padEnd(40, "x"), grantedAt: "now" }),
+    ).toBe(true);
+    expect(loadStoredLocalComputerConsent()?.token).toMatch(/^tok_abc/);
   });
 
   it("grant reports FALSE when persistence fails — no phantom granted state", async () => {
@@ -135,15 +86,27 @@ describe("local-computer-consent client", () => {
     }
   });
 
-  it("revoke forgets locally even when the server call fails", async () => {
+  it("server revoke is storage-free (the hook clears storage separately)", async () => {
+    // The revoke primitive must NOT touch localStorage — that separation is
+    // what stops a slow revoke from deleting a token a newer grant just stored.
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
     );
     await grantLocalComputerConsent();
+    expect(loadStoredLocalComputerConsent()).not.toBeNull();
 
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    await revokeLocalComputerConsentOnServer();
+    // Storage is untouched by the server primitive.
+    expect(loadStoredLocalComputerConsent()).not.toBeNull();
+    expect(String(fetchMock.mock.calls.at(-1)?.[0])).toBe(
+      "/api/mcp/computers/local-consent/revoke",
+    );
+  });
+
+  it("server revoke swallows a network failure", async () => {
     fetchMock.mockRejectedValueOnce(new Error("offline"));
-    await revokeLocalComputerConsent();
-    expect(loadStoredLocalComputerConsent()).toBeNull();
+    await expect(revokeLocalComputerConsentOnServer()).resolves.toBeUndefined();
   });
 
   it("reads garbage storage as absent", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
@@ -71,9 +71,53 @@ describe("local-computer-consent client", () => {
     expect(loadStoredLocalComputerConsent()).not.toBeNull();
   });
 
+  it("verify: a stale 'no' for token A does NOT delete a replacement token B", async () => {
+    // Grant A, then a concurrent grant rotates to B while A's verify is in
+    // flight; A's late valid:false must not clobber B.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { token: "tokA".padEnd(40, "a"), grantedAt: "now" }),
+    );
+    await grantLocalComputerConsent("workos-jwt");
+
+    let resolveVerify: (r: Response) => void = () => {};
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((r) => {
+        resolveVerify = r;
+      }),
+    );
+    const verifyPromise = verifyStoredLocalComputerConsent("workos-jwt");
+
+    // Token B lands mid-flight.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { token: "tokB".padEnd(40, "b"), grantedAt: "now" }),
+    );
+    await grantLocalComputerConsent("workos-jwt");
+
+    resolveVerify(jsonResponse(200, { valid: false }));
+    expect(await verifyPromise).toBe(false);
+    expect(loadStoredLocalComputerConsent()?.token).toMatch(/^tokB/);
+  });
+
   it("verify without a stored token never calls the server", async () => {
     expect(await verifyStoredLocalComputerConsent("workos-jwt")).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("grant reports FALSE when persistence fails — no phantom granted state", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
+    );
+    const setItem = vi
+      .spyOn(localStorage, "setItem")
+      .mockImplementation(() => {
+        throw new Error("quota exceeded");
+      });
+    try {
+      expect(await grantLocalComputerConsent("workos-jwt")).toBe(false);
+      expect(loadStoredLocalComputerConsent()).toBeNull();
+    } finally {
+      setItem.mockRestore();
+    }
   });
 
   it("revoke forgets locally even when the server call fails", async () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/local-computer-consent.test.ts
@@ -29,23 +29,25 @@ describe("local-computer-consent client", () => {
     fetchMock.mockReset();
   });
 
-  it("grant stores the minted token and sends the verified bearer", async () => {
+  it("grant stores the token; does NOT set Authorization (authFetch owns it)", async () => {
     fetchMock.mockResolvedValue(
       jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "2026-08-09" }),
     );
-    expect(await grantLocalComputerConsent("workos-jwt")).toBe(true);
+    expect(await grantLocalComputerConsent()).toBe(true);
     expect(loadStoredLocalComputerConsent()?.token).toMatch(/^tok_/);
 
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(String(url)).toBe("/api/mcp/computers/local-consent/grant");
-    expect((init?.headers as Record<string, string>).Authorization).toBe(
-      "Bearer workos-jwt",
-    );
+    // A manual Authorization would trip authFetch's callerProvidedAuthorization
+    // guard and disable the on-401 session-token refresh.
+    expect(
+      (init?.headers as Record<string, string>).Authorization,
+    ).toBeUndefined();
   });
 
   it("a failed grant stores nothing", async () => {
     fetchMock.mockResolvedValue(jsonResponse(401, { error: "unauthorized" }));
-    expect(await grantLocalComputerConsent("workos-jwt")).toBe(false);
+    expect(await grantLocalComputerConsent()).toBe(false);
     expect(loadStoredLocalComputerConsent()).toBeNull();
   });
 
@@ -53,10 +55,10 @@ describe("local-computer-consent client", () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
     );
-    await grantLocalComputerConsent("workos-jwt");
+    await grantLocalComputerConsent();
 
     fetchMock.mockResolvedValueOnce(jsonResponse(200, { valid: false }));
-    expect(await verifyStoredLocalComputerConsent("workos-jwt")).toBe(false);
+    expect(await verifyStoredLocalComputerConsent()).toBe(false);
     expect(loadStoredLocalComputerConsent()).toBeNull();
   });
 
@@ -64,10 +66,23 @@ describe("local-computer-consent client", () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
     );
-    await grantLocalComputerConsent("workos-jwt");
+    await grantLocalComputerConsent();
 
     fetchMock.mockRejectedValueOnce(new Error("offline"));
-    expect(await verifyStoredLocalComputerConsent("workos-jwt")).toBe(false);
+    expect(await verifyStoredLocalComputerConsent()).toBe(false);
+    expect(loadStoredLocalComputerConsent()).not.toBeNull();
+  });
+
+  it("verify: a non-ok HTTP response (401/500) returns false WITHOUT clearing", async () => {
+    // A transient server/auth failure must not force a re-prompt by deleting a
+    // capability that may still be valid — only a definitive valid:false does.
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
+    );
+    await grantLocalComputerConsent();
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(500, { error: "boom" }));
+    expect(await verifyStoredLocalComputerConsent()).toBe(false);
     expect(loadStoredLocalComputerConsent()).not.toBeNull();
   });
 
@@ -77,7 +92,7 @@ describe("local-computer-consent client", () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { token: "tokA".padEnd(40, "a"), grantedAt: "now" }),
     );
-    await grantLocalComputerConsent("workos-jwt");
+    await grantLocalComputerConsent();
 
     let resolveVerify: (r: Response) => void = () => {};
     fetchMock.mockReturnValueOnce(
@@ -85,13 +100,13 @@ describe("local-computer-consent client", () => {
         resolveVerify = r;
       }),
     );
-    const verifyPromise = verifyStoredLocalComputerConsent("workos-jwt");
+    const verifyPromise = verifyStoredLocalComputerConsent();
 
     // Token B lands mid-flight.
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { token: "tokB".padEnd(40, "b"), grantedAt: "now" }),
     );
-    await grantLocalComputerConsent("workos-jwt");
+    await grantLocalComputerConsent();
 
     resolveVerify(jsonResponse(200, { valid: false }));
     expect(await verifyPromise).toBe(false);
@@ -99,7 +114,7 @@ describe("local-computer-consent client", () => {
   });
 
   it("verify without a stored token never calls the server", async () => {
-    expect(await verifyStoredLocalComputerConsent("workos-jwt")).toBe(false);
+    expect(await verifyStoredLocalComputerConsent()).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -113,7 +128,7 @@ describe("local-computer-consent client", () => {
         throw new Error("quota exceeded");
       });
     try {
-      expect(await grantLocalComputerConsent("workos-jwt")).toBe(false);
+      expect(await grantLocalComputerConsent()).toBe(false);
       expect(loadStoredLocalComputerConsent()).toBeNull();
     } finally {
       setItem.mockRestore();
@@ -124,10 +139,10 @@ describe("local-computer-consent client", () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse(200, { token: "tok_".padEnd(40, "x"), grantedAt: "now" }),
     );
-    await grantLocalComputerConsent("workos-jwt");
+    await grantLocalComputerConsent();
 
     fetchMock.mockRejectedValueOnce(new Error("offline"));
-    await revokeLocalComputerConsent("workos-jwt");
+    await revokeLocalComputerConsent();
     expect(loadStoredLocalComputerConsent()).toBeNull();
   });
 

--- a/mcpjam-inspector/client/src/lib/computer-engine-storage.ts
+++ b/mcpjam-inspector/client/src/lib/computer-engine-storage.ts
@@ -1,0 +1,83 @@
+/**
+ * The user's Local⇄Cloud computer-engine choice, per project. Source of truth
+ * lives in `localStorage` under `mcp-computer-engine` (an object keyed by
+ * `projectId` → `"local" | "cloud"`).
+ *
+ * A DEVICE-scoped preference, deliberately not a project document: the choice
+ * is about THIS machine ("run agent commands here or on my cloud box"), and a
+ * teammate opening the same project must never inherit it.
+ *
+ * Same-tab updates propagate via a custom `computer-engine-changed` window
+ * event (the Computer tab and the Playground rail must move together);
+ * cross-tab updates come free through the browser `storage` event. Pattern
+ * mirrors `previewed-client-storage.ts`.
+ */
+
+export type ComputerEngineChoice = "local" | "cloud";
+
+const STORAGE_KEY = "mcp-computer-engine";
+const EVENT_NAME = "computer-engine-changed";
+
+interface ComputerEngineChangedDetail {
+  projectId: string;
+  engine: ComputerEngineChoice | null;
+}
+
+function readAll(): Record<string, unknown> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function loadComputerEngine(
+  projectId: string,
+): ComputerEngineChoice | null {
+  const value = readAll()[projectId];
+  return value === "local" || value === "cloud" ? value : null;
+}
+
+export function saveComputerEngine(
+  projectId: string,
+  engine: ComputerEngineChoice | null,
+): void {
+  try {
+    const all = readAll();
+    if (engine) {
+      all[projectId] = engine;
+    } else {
+      delete all[projectId];
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+    const detail: ComputerEngineChangedDetail = { projectId, engine };
+    window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail }));
+  } catch {
+    // ignore
+  }
+}
+
+export function subscribeComputerEngine(
+  projectId: string,
+  callback: () => void,
+): () => void {
+  const onCustom = (event: Event) => {
+    const detail = (event as CustomEvent<ComputerEngineChangedDetail>).detail;
+    if (!detail || detail.projectId === projectId) callback();
+  };
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY) callback();
+  };
+  window.addEventListener(EVENT_NAME, onCustom as EventListener);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(EVENT_NAME, onCustom as EventListener);
+    window.removeEventListener("storage", onStorage);
+  };
+}

--- a/mcpjam-inspector/client/src/lib/computer-engine-storage.ts
+++ b/mcpjam-inspector/client/src/lib/computer-engine-storage.ts
@@ -1,7 +1,11 @@
 /**
- * The user's Local⇄Cloud computer-engine choice, per project. Source of truth
- * lives in `localStorage` under `mcp-computer-engine` (an object keyed by
- * `projectId` → `"local" | "cloud"`).
+ * The user's Local⇄Cloud computer-engine choice, per project. Each project's
+ * choice lives under its OWN localStorage key (`mcp-computer-engine:<projectId>`).
+ *
+ * Per-key, NOT a shared `{projectId → engine}` map, on purpose: a shared map
+ * is read-modify-write, so two tabs setting DIFFERENT projects' engines in the
+ * same tick each write back a stale copy and one project's choice is lost.
+ * Independent keys can't clobber each other.
  *
  * A DEVICE-scoped preference, deliberately not a project document: the choice
  * is about THIS machine ("run agent commands here or on my cloud box"), and a
@@ -9,39 +13,32 @@
  *
  * Same-tab updates propagate via a custom `computer-engine-changed` window
  * event (the Computer tab and the Playground rail must move together);
- * cross-tab updates come free through the browser `storage` event. Pattern
- * mirrors `previewed-client-storage.ts`.
+ * cross-tab updates come free through the browser `storage` event, now
+ * project-precise (a p1 change no longer wakes p2 subscribers).
  */
 
 export type ComputerEngineChoice = "local" | "cloud";
 
-const STORAGE_KEY = "mcp-computer-engine";
+const STORAGE_PREFIX = "mcp-computer-engine:";
 const EVENT_NAME = "computer-engine-changed";
 
 interface ComputerEngineChangedDetail {
   projectId: string;
-  engine: ComputerEngineChoice | null;
 }
 
-function readAll(): Record<string, unknown> {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return {};
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
-    return {};
-  }
+function storageKey(projectId: string): string {
+  return `${STORAGE_PREFIX}${projectId}`;
 }
 
 export function loadComputerEngine(
   projectId: string,
 ): ComputerEngineChoice | null {
-  const value = readAll()[projectId];
-  return value === "local" || value === "cloud" ? value : null;
+  try {
+    const value = localStorage.getItem(storageKey(projectId));
+    return value === "local" || value === "cloud" ? value : null;
+  } catch {
+    return null;
+  }
 }
 
 export function saveComputerEngine(
@@ -49,14 +46,12 @@ export function saveComputerEngine(
   engine: ComputerEngineChoice | null,
 ): void {
   try {
-    const all = readAll();
     if (engine) {
-      all[projectId] = engine;
+      localStorage.setItem(storageKey(projectId), engine);
     } else {
-      delete all[projectId];
+      localStorage.removeItem(storageKey(projectId));
     }
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
-    const detail: ComputerEngineChangedDetail = { projectId, engine };
+    const detail: ComputerEngineChangedDetail = { projectId };
     window.dispatchEvent(new CustomEvent(EVENT_NAME, { detail }));
   } catch {
     // ignore
@@ -67,12 +62,13 @@ export function subscribeComputerEngine(
   projectId: string,
   callback: () => void,
 ): () => void {
+  const key = storageKey(projectId);
   const onCustom = (event: Event) => {
     const detail = (event as CustomEvent<ComputerEngineChangedDetail>).detail;
     if (!detail || detail.projectId === projectId) callback();
   };
   const onStorage = (event: StorageEvent) => {
-    if (event.key === STORAGE_KEY) callback();
+    if (event.key === key) callback();
   };
   window.addEventListener(EVENT_NAME, onCustom as EventListener);
   window.addEventListener("storage", onStorage);

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -139,11 +139,16 @@ export function persistLocalComputerConsent(
 /**
  * Convenience: mint + persist in one call. Returns whether consent ended up
  * stored — false on either a mint failure or a persist failure, so a caller
- * never treats a token it can't read back as granted.
+ * never treats a token it can't read back as granted. A persist failure
+ * releases the just-minted (now unpresentable) server capability,
+ * best-effort and token-scoped.
  */
 export async function grantLocalComputerConsent(): Promise<boolean> {
   const minted = await mintLocalComputerConsent();
-  return minted ? persistLocalComputerConsent(minted) : false;
+  if (!minted) return false;
+  const stored = persistLocalComputerConsent(minted);
+  if (!stored) void revokeLocalComputerConsentOnServer(minted.token);
+  return stored;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -1,0 +1,150 @@
+/**
+ * Client side of the local-computer consent CAPABILITY.
+ *
+ * The server (`/api/mcp/computers/local-consent/*`, PR #3812) is the
+ * authority: grant mints a token whose hash it persists; this module stores
+ * the plaintext in `localStorage` and the UI treats consent as granted ONLY
+ * after a server `verify` succeeds — a localStorage value alone proves
+ * nothing (any script can write one; only the server knows the hash).
+ *
+ * DEVICE-scoped (not per-project): the thing consented to is this machine
+ * executing commands. The stored token is what later rides the
+ * `X-MCPJam-Local-Consent` header on chat turns.
+ *
+ * Every server call goes through `authFetch` (inspector session header) with
+ * an explicit WorkOS bearer — the routes mount `requireVerifiedAuth`, so a
+ * guest or an unverified bearer can never mint or verify.
+ */
+import { authFetch } from "@/lib/session-token";
+
+const STORAGE_KEY = "mcp-local-computer-consent-v1";
+const EVENT_NAME = "local-computer-consent-changed";
+
+export interface StoredLocalComputerConsent {
+  token: string;
+  grantedAt: string;
+}
+
+export function loadStoredLocalComputerConsent(): StoredLocalComputerConsent | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const record = parsed as Record<string, unknown>;
+    if (typeof record.token !== "string" || record.token.length < 16) {
+      return null;
+    }
+    return {
+      token: record.token,
+      grantedAt:
+        typeof record.grantedAt === "string" ? record.grantedAt : "unknown",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function persist(consent: StoredLocalComputerConsent | null): void {
+  try {
+    if (consent) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(consent));
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+    window.dispatchEvent(new CustomEvent(EVENT_NAME));
+  } catch {
+    // ignore
+  }
+}
+
+export function clearStoredLocalComputerConsent(): void {
+  persist(null);
+}
+
+export function subscribeLocalComputerConsent(callback: () => void): () => void {
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY) callback();
+  };
+  window.addEventListener(EVENT_NAME, callback);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(EVENT_NAME, callback);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function consentRequest(
+  path: "grant" | "verify" | "revoke",
+  accessToken: string,
+  body?: unknown,
+): Promise<Response> {
+  return authFetch(`/api/mcp/computers/local-consent/${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+/** Mint + store a fresh capability. Returns whether the grant succeeded. */
+export async function grantLocalComputerConsent(
+  accessToken: string,
+): Promise<boolean> {
+  try {
+    const response = await consentRequest("grant", accessToken);
+    if (!response.ok) return false;
+    const json = (await response.json()) as {
+      token?: unknown;
+      grantedAt?: unknown;
+    };
+    if (typeof json.token !== "string" || json.token.length < 16) return false;
+    persist({
+      token: json.token,
+      grantedAt:
+        typeof json.grantedAt === "string" ? json.grantedAt : "unknown",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify the stored capability against the server. A definitive "no" (the
+ * server answered `valid:false` — revoked elsewhere, or rotated by another
+ * browser profile) CLEARS the stale token so the UI re-prompts; a network
+ * failure returns false WITHOUT clearing (the capability may still be good).
+ */
+export async function verifyStoredLocalComputerConsent(
+  accessToken: string,
+): Promise<boolean> {
+  const stored = loadStoredLocalComputerConsent();
+  if (!stored) return false;
+  try {
+    const response = await consentRequest("verify", accessToken, {
+      token: stored.token,
+    });
+    if (!response.ok) return false;
+    const json = (await response.json()) as { valid?: unknown };
+    if (json.valid === true) return true;
+    clearStoredLocalComputerConsent();
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Revoke on the server AND forget locally (best-effort on the server side). */
+export async function revokeLocalComputerConsent(
+  accessToken: string,
+): Promise<void> {
+  try {
+    await consentRequest("revoke", accessToken);
+  } catch {
+    // The local forget below still applies — a later verify fails closed.
+  }
+  clearStoredLocalComputerConsent();
+}

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -92,27 +92,53 @@ function consentRequest(
   });
 }
 
-/** Mint + store a fresh capability. Returns whether the grant succeeded. */
-export async function grantLocalComputerConsent(): Promise<boolean> {
+/**
+ * Mint a fresh capability on the SERVER, without persisting it locally.
+ *
+ * Split from the persist step so a caller can keep the network wait
+ * OUT of any "my own write" guard — an external revoke arriving mid-mint must
+ * stay visible — and then persist (which dispatches the synchronous same-tab
+ * event) in a tightly-scoped, guarded region. Returns null on any failure.
+ */
+export async function mintLocalComputerConsent(): Promise<StoredLocalComputerConsent | null> {
   try {
     const response = await consentRequest("grant");
-    if (!response.ok) return false;
+    if (!response.ok) return null;
     const json = (await response.json()) as {
       token?: unknown;
       grantedAt?: unknown;
     };
-    if (typeof json.token !== "string" || json.token.length < 16) return false;
-    // Persistence is the whole point — a granted capability the UI can't read
-    // back (storage disabled/full) would let the engine resolve local while
-    // no `X-MCPJam-Local-Consent` header exists to send. Report the failure.
-    return persist({
+    if (typeof json.token !== "string" || json.token.length < 16) return null;
+    return {
       token: json.token,
       grantedAt:
         typeof json.grantedAt === "string" ? json.grantedAt : "unknown",
-    });
+    };
   } catch {
-    return false;
+    return null;
   }
+}
+
+/**
+ * Persist a minted capability locally (storage + same-tab event). Returns
+ * whether the write landed — a granted capability the UI can't read back
+ * (storage disabled/full) would let the engine resolve local while no
+ * `X-MCPJam-Local-Consent` header exists to send.
+ */
+export function persistLocalComputerConsent(
+  consent: StoredLocalComputerConsent,
+): boolean {
+  return persist(consent);
+}
+
+/**
+ * Convenience: mint + persist in one call. The React hook uses the split
+ * primitives above so it can guard only the persist; this stays for
+ * standalone/non-hook use and lib-level tests.
+ */
+export async function grantLocalComputerConsent(): Promise<boolean> {
+  const minted = await mintLocalComputerConsent();
+  return minted ? persistLocalComputerConsent(minted) : false;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -45,7 +45,8 @@ export function loadStoredLocalComputerConsent(): StoredLocalComputerConsent | n
   }
 }
 
-function persist(consent: StoredLocalComputerConsent | null): void {
+/** Returns whether the write actually landed (storage can be disabled/full). */
+function persist(consent: StoredLocalComputerConsent | null): boolean {
   try {
     if (consent) {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(consent));
@@ -53,8 +54,9 @@ function persist(consent: StoredLocalComputerConsent | null): void {
       localStorage.removeItem(STORAGE_KEY);
     }
     window.dispatchEvent(new CustomEvent(EVENT_NAME));
+    return true;
   } catch {
-    // ignore
+    return false;
   }
 }
 
@@ -101,12 +103,14 @@ export async function grantLocalComputerConsent(
       grantedAt?: unknown;
     };
     if (typeof json.token !== "string" || json.token.length < 16) return false;
-    persist({
+    // Persistence is the whole point — a granted capability the UI can't read
+    // back (storage disabled/full) would let the engine resolve local while
+    // no `X-MCPJam-Local-Consent` header exists to send. Report the failure.
+    return persist({
       token: json.token,
       grantedAt:
         typeof json.grantedAt === "string" ? json.grantedAt : "unknown",
     });
-    return true;
   } catch {
     return false;
   }
@@ -130,7 +134,15 @@ export async function verifyStoredLocalComputerConsent(
     if (!response.ok) return false;
     const json = (await response.json()) as { valid?: unknown };
     if (json.valid === true) return true;
-    clearStoredLocalComputerConsent();
+    // Clear ONLY if the stored token is still the one we verified. Granting
+    // rotates the server capability and storage events trigger concurrent
+    // refreshes, so an in-flight verify of token A can land after a new tab
+    // (or a fresh grant) stored token B — clearing then would delete a
+    // perfectly good B on A's stale "no".
+    const current = loadStoredLocalComputerConsent();
+    if (current?.token === stored.token) {
+      clearStoredLocalComputerConsent();
+    }
     return false;
   } catch {
     return false;

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -147,15 +147,22 @@ export async function grantLocalComputerConsent(): Promise<boolean> {
 }
 
 /**
- * SERVER-ONLY revoke: unlink the device's singleton capability. Deliberately
- * does NOT touch local storage — the caller clears storage synchronously up
- * front (the user's explicit forget) and this best-effort network call runs
- * after. Keeping it storage-free means a slow revoke can never, on resume,
- * delete a token a newer grant persisted while it was in flight.
+ * SERVER-ONLY revoke: unlink the device's capability. Deliberately does NOT
+ * touch local storage — the caller clears storage synchronously up front (the
+ * user's explicit forget) and this best-effort network call runs after.
+ * Keeping it storage-free means a slow revoke can never, on resume, delete a
+ * token a newer grant persisted while it was in flight — and passing the
+ * token being revoked makes the SERVER side equally race-safe: the server
+ * unlinks only if that token still matches, so a delayed revoke can't sever
+ * a capability a newer grant rotated in while this request was in flight.
+ * With no token (nothing was stored locally) the server unlinks
+ * unconditionally — the user's intent is to sever this device.
  */
-export async function revokeLocalComputerConsentOnServer(): Promise<void> {
+export async function revokeLocalComputerConsentOnServer(
+  token: string | null = null,
+): Promise<void> {
   try {
-    await consentRequest("revoke");
+    await consentRequest("revoke", token != null ? { token } : undefined);
   } catch {
     // Local forget already happened; the server capability is best-effort.
   }

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -11,9 +11,14 @@
  * executing commands. The stored token is what later rides the
  * `X-MCPJam-Local-Consent` header on chat turns.
  *
- * Every server call goes through `authFetch` (inspector session header) with
- * an explicit WorkOS bearer — the routes mount `requireVerifiedAuth`, so a
- * guest or an unverified bearer can never mint or verify.
+ * Every server call goes through `authFetch`, which attaches BOTH the
+ * inspector session header AND the verified WorkOS bearer (the consent path
+ * is in `HOSTED_AUTH_PATH_PREFIXES`). We deliberately do NOT set the
+ * `Authorization` header ourselves: doing so trips authFetch's
+ * `callerProvidedAuthorization` guard and disables the on-401 session-token
+ * refresh, which would leave grant/verify/revoke stuck at 401 after a
+ * dev-server restart. The routes mount `requireVerifiedAuth`, so a guest or
+ * unverified bearer still can't mint or verify.
  */
 import { authFetch } from "@/lib/session-token";
 
@@ -78,25 +83,19 @@ export function subscribeLocalComputerConsent(callback: () => void): () => void 
 
 function consentRequest(
   path: "grant" | "verify" | "revoke",
-  accessToken: string,
   body?: unknown,
 ): Promise<Response> {
   return authFetch(`/api/mcp/computers/local-consent/${path}`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
-    },
+    headers: { "Content-Type": "application/json" },
     ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
   });
 }
 
 /** Mint + store a fresh capability. Returns whether the grant succeeded. */
-export async function grantLocalComputerConsent(
-  accessToken: string,
-): Promise<boolean> {
+export async function grantLocalComputerConsent(): Promise<boolean> {
   try {
-    const response = await consentRequest("grant", accessToken);
+    const response = await consentRequest("grant");
     if (!response.ok) return false;
     const json = (await response.json()) as {
       token?: unknown;
@@ -122,13 +121,11 @@ export async function grantLocalComputerConsent(
  * browser profile) CLEARS the stale token so the UI re-prompts; a network
  * failure returns false WITHOUT clearing (the capability may still be good).
  */
-export async function verifyStoredLocalComputerConsent(
-  accessToken: string,
-): Promise<boolean> {
+export async function verifyStoredLocalComputerConsent(): Promise<boolean> {
   const stored = loadStoredLocalComputerConsent();
   if (!stored) return false;
   try {
-    const response = await consentRequest("verify", accessToken, {
+    const response = await consentRequest("verify", {
       token: stored.token,
     });
     if (!response.ok) return false;
@@ -150,11 +147,9 @@ export async function verifyStoredLocalComputerConsent(
 }
 
 /** Revoke on the server AND forget locally (best-effort on the server side). */
-export async function revokeLocalComputerConsent(
-  accessToken: string,
-): Promise<void> {
+export async function revokeLocalComputerConsent(): Promise<void> {
   try {
-    await consentRequest("revoke", accessToken);
+    await consentRequest("revoke");
   } catch {
     // The local forget below still applies — a later verify fails closed.
   }

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -2,23 +2,28 @@
  * Client side of the local-computer consent CAPABILITY.
  *
  * The server (`/api/mcp/computers/local-consent/*`, PR #3812) is the
- * authority: grant mints a token whose hash it persists; this module stores
- * the plaintext in `localStorage` and the UI treats consent as granted ONLY
- * after a server `verify` succeeds — a localStorage value alone proves
- * nothing (any script can write one; only the server knows the hash).
+ * authority: grant mints a token whose HASH it persists server-side; this
+ * module stores the plaintext in `localStorage`, and it rides the
+ * `X-MCPJam-Local-Consent` header on chat turns where the engine resolver
+ * re-verifies it on every use. That server-side re-verification is the real
+ * enforcement point — so the CLIENT treats a stored token as consent and does
+ * NOT pre-verify. Pre-verifying (an async status racing grant/revoke and the
+ * same-tab storage event) was a large, bug-prone race surface for zero real
+ * safety: a stale/tampered token simply fails the next turn's server check.
+ * localStorage is therefore the single source of truth here, read
+ * synchronously.
  *
  * DEVICE-scoped (not per-project): the thing consented to is this machine
- * executing commands. The stored token is what later rides the
- * `X-MCPJam-Local-Consent` header on chat turns.
+ * executing commands.
  *
  * Every server call goes through `authFetch`, which attaches BOTH the
  * inspector session header AND the verified WorkOS bearer (the consent path
  * is in `HOSTED_AUTH_PATH_PREFIXES`). We deliberately do NOT set the
  * `Authorization` header ourselves: doing so trips authFetch's
  * `callerProvidedAuthorization` guard and disables the on-401 session-token
- * refresh, which would leave grant/verify/revoke stuck at 401 after a
- * dev-server restart. The routes mount `requireVerifiedAuth`, so a guest or
- * unverified bearer still can't mint or verify.
+ * refresh, which would leave grant/revoke stuck at 401 after a dev-server
+ * restart. The routes mount `requireVerifiedAuth`, so a guest or unverified
+ * bearer still can't mint.
  */
 import { authFetch } from "@/lib/session-token";
 
@@ -132,9 +137,9 @@ export function persistLocalComputerConsent(
 }
 
 /**
- * Convenience: mint + persist in one call. The React hook uses the split
- * primitives above so it can guard only the persist; this stays for
- * standalone/non-hook use and lib-level tests.
+ * Convenience: mint + persist in one call. Returns whether consent ended up
+ * stored — false on either a mint failure or a persist failure, so a caller
+ * never treats a token it can't read back as granted.
  */
 export async function grantLocalComputerConsent(): Promise<boolean> {
   const minted = await mintLocalComputerConsent();
@@ -142,42 +147,16 @@ export async function grantLocalComputerConsent(): Promise<boolean> {
 }
 
 /**
- * Verify the stored capability against the server. A definitive "no" (the
- * server answered `valid:false` — revoked elsewhere, or rotated by another
- * browser profile) CLEARS the stale token so the UI re-prompts; a network
- * failure returns false WITHOUT clearing (the capability may still be good).
+ * SERVER-ONLY revoke: unlink the device's singleton capability. Deliberately
+ * does NOT touch local storage — the caller clears storage synchronously up
+ * front (the user's explicit forget) and this best-effort network call runs
+ * after. Keeping it storage-free means a slow revoke can never, on resume,
+ * delete a token a newer grant persisted while it was in flight.
  */
-export async function verifyStoredLocalComputerConsent(): Promise<boolean> {
-  const stored = loadStoredLocalComputerConsent();
-  if (!stored) return false;
-  try {
-    const response = await consentRequest("verify", {
-      token: stored.token,
-    });
-    if (!response.ok) return false;
-    const json = (await response.json()) as { valid?: unknown };
-    if (json.valid === true) return true;
-    // Clear ONLY if the stored token is still the one we verified. Granting
-    // rotates the server capability and storage events trigger concurrent
-    // refreshes, so an in-flight verify of token A can land after a new tab
-    // (or a fresh grant) stored token B — clearing then would delete a
-    // perfectly good B on A's stale "no".
-    const current = loadStoredLocalComputerConsent();
-    if (current?.token === stored.token) {
-      clearStoredLocalComputerConsent();
-    }
-    return false;
-  } catch {
-    return false;
-  }
-}
-
-/** Revoke on the server AND forget locally (best-effort on the server side). */
-export async function revokeLocalComputerConsent(): Promise<void> {
+export async function revokeLocalComputerConsentOnServer(): Promise<void> {
   try {
     await consentRequest("revoke");
   } catch {
-    // The local forget below still applies — a later verify fails closed.
+    // Local forget already happened; the server capability is best-effort.
   }
-  clearStoredLocalComputerConsent();
 }

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -325,6 +325,11 @@ const HOSTED_AUTH_PATH_PREFIXES = [
   // needs the bearer for the hosted-issuer forward (harmless locally).
   // Boundary matching keeps this from also matching /token-exchange.
   "/api/mcp/xaa/token",
+  // Local-computer consent capability (grant/verify/revoke): the routes mount
+  // `requireVerifiedAuth`, so they need the user's WorkOS bearer. Attaching
+  // via authFetch (not a manual header) keeps the on-401 session-token refresh
+  // so a dev-server restart doesn't strand consent at 401 until a page reload.
+  "/api/mcp/computers/local-consent",
   // Convex HTTP actions called via absolute URL (OAuth completion, etc.).
   "/web/oauth/",
 ];

--- a/mcpjam-inspector/server/routes/mcp/__tests__/computers-consent.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/computers-consent.test.ts
@@ -136,6 +136,31 @@ describe("local-consent routes", () => {
     expect(await after.json()).toEqual({ valid: false });
   });
 
+  it("a revoke scoped to a superseded token leaves the newer capability alive", async () => {
+    const app = makeApp();
+    const first = (await (await post(app, "/local-consent/grant")).json()) as {
+      token: string;
+    };
+    const second = (await (await post(app, "/local-consent/grant")).json()) as {
+      token: string;
+    };
+
+    // Delayed revoke carrying the rotated-out token: must be a no-op.
+    await post(app, "/local-consent/revoke", { token: first.token });
+    const alive = await post(app, "/local-consent/verify", {
+      token: second.token,
+    });
+    expect(await alive.json()).toEqual({ valid: true });
+
+    // Bodiless revoke stays unconditional (nothing stored client-side, but
+    // the user still asked to sever this device).
+    await post(app, "/local-consent/revoke");
+    const dead = await post(app, "/local-consent/verify", {
+      token: second.token,
+    });
+    expect(await dead.json()).toEqual({ valid: false });
+  });
+
   it("verify tolerates a malformed body", async () => {
     const response = await post(makeApp(), "/local-consent/verify");
     expect(await response.json()).toEqual({ valid: false });

--- a/mcpjam-inspector/server/routes/mcp/computers.ts
+++ b/mcpjam-inspector/server/routes/mcp/computers.ts
@@ -15,7 +15,9 @@
  * grant  → mints + persists (hash-only) a device capability, returns the
  *          plaintext ONCE. Called only from the explicit Allow action.
  * verify → lets a returning client validate its stored capability.
- * revoke → clears the persisted capability.
+ * revoke → clears the persisted capability; scoped to the presented token
+ *          when one is supplied (a delayed revoke must not sever a newer
+ *          grant's rotated capability), unconditional otherwise.
  */
 import { Hono } from "hono";
 import { LOCAL_COMPUTER_ENABLED } from "../../config.js";
@@ -54,7 +56,11 @@ computers.post("/local-consent/verify", async (c) => {
 });
 
 computers.post("/local-consent/revoke", async (c) => {
-  await revokeLocalComputerConsent();
+  const body = (await c.req.json().catch(() => null)) as {
+    token?: unknown;
+  } | null;
+  const token = typeof body?.token === "string" ? body.token : null;
+  await revokeLocalComputerConsent(token);
   return c.json({ ok: true });
 });
 

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-consent.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-consent.test.ts
@@ -46,6 +46,23 @@ describe("local computer consent capability", () => {
     await revokeLocalComputerConsent();
   });
 
+  it("a token-scoped revoke no-ops when a newer grant rotated the capability", async () => {
+    const stale = await grantLocalComputerConsent();
+    const current = await grantLocalComputerConsent(); // rotates; `stale` is dead
+    // The delayed revoke, scoped to the stale token, must NOT sever `current`.
+    await revokeLocalComputerConsent(stale.token);
+    expect(await verifyLocalComputerConsent(current.token)).toBe(true);
+    // Scoped to the live token it does revoke.
+    await revokeLocalComputerConsent(current.token);
+    expect(await verifyLocalComputerConsent(current.token)).toBe(false);
+  });
+
+  it("an unscoped revoke (no token) unlinks unconditionally", async () => {
+    const { token } = await grantLocalComputerConsent();
+    await revokeLocalComputerConsent();
+    expect(await verifyLocalComputerConsent(token)).toBe(false);
+  });
+
   it("rejects garbage without a persisted capability", async () => {
     expect(await verifyLocalComputerConsent(undefined)).toBe(false);
     expect(await verifyLocalComputerConsent("")).toBe(false);

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-consent.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-consent.test.ts
@@ -9,6 +9,31 @@ vi.mock("node:os", async () => {
   return { ...actual, homedir: () => scratch };
 });
 
+// Passthrough fs with a one-shot gate on unlink, so a test can hold a revoke
+// open exactly inside its verify→unlink window and prove a concurrent grant
+// cannot interleave there (the module's mutation lock).
+const unlinkGate = vi.hoisted(() => ({
+  armed: false,
+  release: null as (() => void) | null,
+}));
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>(
+    "node:fs/promises"
+  );
+  return {
+    ...actual,
+    unlink: async (path: Parameters<typeof actual.unlink>[0]) => {
+      if (unlinkGate.armed) {
+        unlinkGate.armed = false;
+        await new Promise<void>((resolve) => {
+          unlinkGate.release = resolve;
+        });
+      }
+      return actual.unlink(path);
+    },
+  };
+});
+
 import {
   grantLocalComputerConsent,
   revokeLocalComputerConsent,
@@ -55,6 +80,26 @@ describe("local computer consent capability", () => {
     // Scoped to the live token it does revoke.
     await revokeLocalComputerConsent(current.token);
     expect(await verifyLocalComputerConsent(current.token)).toBe(false);
+  });
+
+  it("a grant overlapping a scoped revoke's verify→unlink window survives it", async () => {
+    // Deterministic interleave: the revoke verifies its (still-current) token,
+    // then parks INSIDE the window before its unlink. Without the mutation
+    // lock, the concurrent grant would write the new capability during that
+    // window and the resumed unlink would delete it. With the lock, the grant
+    // queues until the revoke finishes, so the fresh capability survives.
+    const stale = await grantLocalComputerConsent();
+    unlinkGate.armed = true;
+    const revoking = revokeLocalComputerConsent(stale.token);
+    const granting = grantLocalComputerConsent();
+    await vi.waitFor(() => {
+      if (!unlinkGate.release) throw new Error("revoke not at unlink yet");
+    });
+    unlinkGate.release!();
+    unlinkGate.release = null;
+    await revoking;
+    const fresh = await granting;
+    expect(await verifyLocalComputerConsent(fresh.token)).toBe(true);
   });
 
   it("an unscoped revoke (no token) unlinks unconditionally", async () => {

--- a/mcpjam-inspector/server/utils/computers/local-consent.ts
+++ b/mcpjam-inspector/server/utils/computers/local-consent.ts
@@ -37,6 +37,25 @@ function consentFilePath(): string {
   return join(getLocalComputerWorkspaceRoot(), "consent.json");
 }
 
+/**
+ * Grant and revoke are read-modify-write on the consent file, and a scoped
+ * revoke's verify-then-unlink spans multiple awaits — without exclusion, a
+ * concurrent grant can rotate the capability between the verify and the
+ * unlink and the stale revoke would delete the NEW capability. The file is
+ * only ever mutated through this module in the single server process, so an
+ * in-process chain is sufficient exclusion. `verify` stays lock-free: it is
+ * a pure read, and the enforcement path must never queue behind mutations.
+ */
+let mutationChain: Promise<unknown> = Promise.resolve();
+function withConsentMutationLock<T>(op: () => Promise<T>): Promise<T> {
+  const run = mutationChain.then(op, op);
+  mutationChain = run.then(
+    () => undefined,
+    () => undefined
+  );
+  return run;
+}
+
 function hashToken(token: string): string {
   return createHash("sha256").update(token, "utf8").digest("hex");
 }
@@ -68,21 +87,23 @@ async function readPersistedConsent(): Promise<PersistedConsent | null> {
  * machine — re-granting from a second browser profile rotates it, and the
  * old profile re-prompts, which is the honest behavior).
  */
-export async function grantLocalComputerConsent(): Promise<{
+export function grantLocalComputerConsent(): Promise<{
   token: string;
   grantedAt: string;
 }> {
-  const token = randomBytes(32).toString("base64url");
-  const grantedAt = new Date().toISOString();
-  const dir = getLocalComputerWorkspaceRoot();
-  await mkdir(dir, { recursive: true, mode: 0o700 });
-  const file = consentFilePath();
-  const tmp = `${file}.tmp`;
-  const body: PersistedConsent = { tokenHash: hashToken(token), grantedAt };
-  await writeFile(tmp, JSON.stringify(body), { mode: 0o600 });
-  await rename(tmp, file);
-  logger.info("[local-consent] capability granted");
-  return { token, grantedAt };
+  return withConsentMutationLock(async () => {
+    const token = randomBytes(32).toString("base64url");
+    const grantedAt = new Date().toISOString();
+    const dir = getLocalComputerWorkspaceRoot();
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+    const file = consentFilePath();
+    const tmp = `${file}.tmp`;
+    const body: PersistedConsent = { tokenHash: hashToken(token), grantedAt };
+    await writeFile(tmp, JSON.stringify(body), { mode: 0o600 });
+    await rename(tmp, file);
+    logger.info("[local-consent] capability granted");
+    return { token, grantedAt };
+  });
 }
 
 /** Constant-time verify of a presented capability against the stored hash. */
@@ -107,12 +128,17 @@ export async function verifyLocalComputerConsent(
  * nothing stored but the user still asked to sever this device) it unlinks
  * unconditionally.
  */
-export async function revokeLocalComputerConsent(
+export function revokeLocalComputerConsent(
   token?: string | null
 ): Promise<void> {
-  if (token != null && !(await verifyLocalComputerConsent(token))) {
-    return;
-  }
-  await unlink(consentFilePath()).catch(() => {});
-  logger.info("[local-consent] capability revoked");
+  // The verify and the unlink must be one atomic step (the mutation lock):
+  // otherwise a grant landing between them rotates the capability and this
+  // stale revoke would delete the newly granted one.
+  return withConsentMutationLock(async () => {
+    if (token != null && !(await verifyLocalComputerConsent(token))) {
+      return;
+    }
+    await unlink(consentFilePath()).catch(() => {});
+    logger.info("[local-consent] capability revoked");
+  });
 }

--- a/mcpjam-inspector/server/utils/computers/local-consent.ts
+++ b/mcpjam-inspector/server/utils/computers/local-consent.ts
@@ -99,7 +99,20 @@ export async function verifyLocalComputerConsent(
   );
 }
 
-export async function revokeLocalComputerConsent(): Promise<void> {
+/**
+ * Revoke the persisted capability. When `token` is supplied the revoke is
+ * SCOPED: it unlinks only if that token still matches the stored hash, so a
+ * slow revoke request that lost a race to a newer grant cannot sever the
+ * rotated capability that grant just minted. Without a token (the client had
+ * nothing stored but the user still asked to sever this device) it unlinks
+ * unconditionally.
+ */
+export async function revokeLocalComputerConsent(
+  token?: string | null
+): Promise<void> {
+  if (token != null && !(await verifyLocalComputerConsent(token))) {
+    return;
+  }
   await unlink(consentFilePath()).catch(() => {});
   logger.info("[local-consent] capability revoked");
 }


### PR DESCRIPTION
PR 5 of the local-computer-engine program (PRs 1–4: #3799, #3805, #3812, #3815, all merged). Foundation only — **no visible UI change yet**; the tab/rail faces (PRs 6–7) build on these hooks. Almost entirely client-side, plus one small server touch (token-scoped revoke, below).

## What this adds

**Parser** (`useProjectComputer.ts`) — `engines` + `defaultEngine` are always present *post-parse*: servers that predate PR 4's shape (and malformed `engines` blocks — read like an old server, never half-trusted, since a partial parse could invent a local engine) get the legacy-pair derivation, in which the local engine never exists. The fetch-failure fallback keeps its assume-local-data-plane semantics with no phantom local engine. The module cache + in-flight dedupe from PR 2 are unchanged.

**Engine storage** (`lib/computer-engine-storage.ts`) — per-project Local⇄Cloud choice in localStorage, deliberately **device-scoped** (the choice is about *this machine*; a teammate opening the same project must never inherit it). Per-project keys (no shared map to clobber across tabs); custom event for same-tab sync (tab + rail move together), `storage` event for cross-tab.

**Consent client** (`lib/local-computer-consent.ts` + `useLocalComputerConsent()`) — client of PR 3's capability. `granted` is a **synchronous projection of localStorage** (via `useSyncExternalStore`): consent exists iff a capability token is stored on this device. There is deliberately no client-side verify loop — the server re-verifies the token on **every actual use** (the engine resolver, PR #3812), so a stale or tampered token just fails the next turn's server check; earlier revisions that pre-verified on mount grew five review rounds of out-of-order/self-supersede/cross-tab guards for no safety the server wasn't already providing. Grant = mint on server, then persist; a persist failure (storage blocked/full) reports `false` rather than a granted state nothing can read back. Revoke forgets locally first (synchronously), then issues a best-effort, **token-scoped** server revoke: the server unlinks only if the presented token still matches its stored hash, so a delayed revoke resuming after a newer grant can't sever the capability that grant just rotated in. That scoping is this PR's one server change (`/local-consent/revoke` accepts an optional token; bodiless stays unconditional for the storage-was-empty "sever this device" case). Calls ride `authFetch` (inspector session + verified WorkOS bearer), matching the routes' `requireVerifiedAuth`.

**Resolution** (`hooks/useComputerEngine.ts`) — one rule for every consumer:
1. Hosted ⇒ cloud; toggle hidden; storage never read.
2. Else the first qualifying candidate of `[stored pref, server defaultEngine, local, cloud]` — where `local` qualifies only when available **and consent is stored on this device** (the server re-verifies on every use). A stored "local" pref without consent falls through to cloud: the badge can never say "This machine" while commands go elsewhere.
3. Nothing qualifies ⇒ `cloud` with `cloudAvailable:false` (the existing unavailable state). PR 4's `defaultEngine: null` slots in as a non-qualifying candidate.

"Default = Local in local mode" lands as: the server's `defaultEngine:"local"` wins the candidate race as soon as consent exists — no stored preference required; granting consent is what flips a fresh install over.

## Tests

Suites cover the resolution matrix (hosted × availability × stored pref × consent, incl. consent-gates-local rows and the honest empty state), parser back-compat (full shape, old server, malformed block, `defaultEngine: null`, failure fallback), the consent projection (grant/persist-failure honesty, cross-tab grant/revoke events, hosted short-circuit, token-scoped storage-free server revoke), storage event scoping, and — server-side — the scoped revoke (stale-token revoke no-ops, bodiless revoke unlinks). Client typecheck exit 0.

## Next
PR 6 (Computer tab "This machine" face + WebMCP hoist) and PR 7 (Playground rail + chat `computerEngine`/consent-header transmission — including clearing the stored token when the server definitively rejects it, so the UI re-prompts) consume these hooks; PR 8 (node-pty terminal) flips `terminalAvailable`; PR 9 renders the transcript badge off the PR-3 `engine` stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local-computer consent capabilities, engine resolution, and verified-auth API paths; server-side verification on actual use limits client-only mistakes, but grant/revoke race handling is security-relevant.
> 
> **Overview**
> Adds **foundation-only** client plumbing for per-project Local⇄Cloud computer engine choice (no UI in this PR). Future tab/rail surfaces will consume these hooks.
> 
> **Config parsing** extends `/api/web/computers/config` handling so `engines` and `defaultEngine` are always present after parse: legacy servers and malformed `engines` blocks fall back to derivation where **local is never offered**; fetch-failure fallback stays “assume local data plane” without inventing a local machine engine.
> 
> **Device-scoped storage** (`computer-engine-storage`) persists each project’s engine under its own `localStorage` key with same-tab/cross-tab sync.
> 
> **Consent** (`local-computer-consent` + `useLocalComputerConsent`) treats a stored capability token as granted via synchronous `useSyncExternalStore` (no client verify loop); grant mints then persists, revoke clears storage first then token-scoped server unlink. **`authFetch`** now attaches hosted auth for `/api/mcp/computers/local-consent`.
> 
> **`useComputerEngine`** applies one resolution rule everywhere: hosted ⇒ cloud; else first qualifying candidate among stored pref → server `defaultEngine` → local → cloud, with **local gated on stored consent** so UI cannot show “this machine” while routing elsewhere.
> 
> **Server**: `/local-consent/revoke` accepts optional token (scoped no-op if superseded); grant/revoke run under an in-process mutation lock to prevent races with concurrent grant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f1e7a8da343a7b2093faa7d7228aeccfe8fe92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->