### PR TITLE
fix(discord): preserve replies across redelivery, dedupe unlinked prompts

### DIFF
--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -5,6 +5,7 @@ import {
 	createChannelBindingCache,
 	createEventClaims,
 	createTurnTargetResolver,
+	EventDedupe,
 	mintConnectUrl,
 	runTurnForEvent,
 	textContent,
@@ -23,6 +24,7 @@ import { buildInteractionRef, buildMessageRef } from "./context.js";
 import { createDiscordDelivery } from "./delivery.js";
 import { fetchHistory } from "./history.js";
 import { recordPresence } from "./presence.js";
+import { toDeliverableResult, toReplayContent } from "./turn-result.js";
 import { watchDiscordRun } from "./watcher.js";
 
 if (!config.botToken) throw new Error("DISCORD_BOT_TOKEN is required");
@@ -74,6 +76,17 @@ const claims = createEventClaims({
 	backend: claimBackend,
 	surfaceKind: "discord",
 });
+// The "connect your account" / "pick a project" prompts happen BEFORE
+// runTurnForEvent's own durable claim (they return before a target is ever
+// resolved into a turn), so a Gateway redelivery of the same mention while
+// the user is still unlinked would otherwise re-post the prompt. In-memory
+// only, and deliberately NOT the durable claim backend: taking that here
+// too would collide with runTurnForEvent's own claim on the same
+// `guildId:messageId` key once the user IS linked, silently dropping the
+// turn (the inner claim would see "inflight" against a claim this code
+// already opened and never completed). A prompt is cheap to resend and
+// short-TTL in-memory suppression is all the redelivery case needs.
+const promptDedupe = new EventDedupe();
 // Every mention asks whether its channel is bound, which put a Convex round
 // trip on the hot path of every single message with no caching at all.
 // Channel bindings are written by an admin through a separate settings flow,
@@ -214,28 +227,33 @@ client.on(Events.MessageCreate, async (message) => {
 			threadId: context.threadId,
 		});
 
-		if (target.mode === "unlinked") {
-			const url = await connectUrlFor({
-				tenantId: message.guildId,
-				actorId: message.author.id,
-			});
-			await delivery.deliver(ref, {
-				severity: "info",
-				parts: [
-					"Connect MCPJam before asking me to act: ",
-					{ link: { url, label: "open the connect link" } },
-				],
-			});
-			return;
-		}
-		if (target.mode === "needs_project") {
-			await delivery.deliver(
-				ref,
-				textContent(
-					"Your account is connected, but no default MCPJam project is configured for this organization. Set one in MCPJam settings and mention me again.",
-					"warning",
-				),
-			);
+		if (target.mode === "unlinked" || target.mode === "needs_project") {
+			// One message may redeliver on a Gateway resume; without this a
+			// redelivery while still unlinked/unconfigured re-posts the same
+			// prompt. See promptDedupe's own comment for why this is NOT the
+			// durable claim.
+			if (!promptDedupe.claim(message.id)) return;
+			if (target.mode === "unlinked") {
+				const url = await connectUrlFor({
+					tenantId: message.guildId,
+					actorId: message.author.id,
+				});
+				await delivery.deliver(ref, {
+					severity: "info",
+					parts: [
+						"Connect MCPJam before asking me to act: ",
+						{ link: { url, label: "open the connect link" } },
+					],
+				});
+			} else {
+				await delivery.deliver(
+					ref,
+					textContent(
+						"Your account is connected, but no default MCPJam project is configured for this organization. Set one in MCPJam settings and mention me again.",
+						"warning",
+					),
+				);
+			}
 			return;
 		}
 
@@ -279,10 +297,7 @@ client.on(Events.MessageCreate, async (message) => {
 							conversationId: context.conversationId,
 							idempotencyKey: opts.idempotencyKey,
 						})
-						.then((turnResult) => ({
-							...textContent(turnResult.reply || "", "info"),
-							proposedActions: turnResult.proposedActions || [],
-						})),
+						.then(toDeliverableResult),
 			},
 			onResult: async (result) => {
 				await delivery.deliver(ref, result);
@@ -349,9 +364,10 @@ client.on(Events.MessageCreate, async (message) => {
 					});
 			},
 			// A redelivery of an event already answered: re-post the stored
-			// reply rather than re-running the turn.
+			// reply rather than re-running the turn. See turn-result.js for why
+			// this needs its own rebuild rather than delivering the envelope raw.
 			onReplay: async (envelope) => {
-				await delivery.deliver(ref, envelope);
+				await delivery.deliver(ref, toReplayContent(envelope));
 			},
 		});
 	} catch (error) {

--- a/discord-app/tests/turn-result.test.js
+++ b/discord-app/tests/turn-result.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { toDeliverableResult, toReplayContent } from "../turn-result.js";
+
+/**
+ * Pins the exact bug two independent reviewers caught on PR #3817: the
+ * turn's reply text must survive the round trip through the core's
+ * persisted-claim contract (`normalizeResult` in
+ * surface-core/src/turn-runner.js, which reads ONLY `.reply`, a plain
+ * string) as well as live delivery (which reads `.parts`,
+ * StructuredContent). Losing either meant a redelivered event replayed
+ * blank text — or, if there were no proposed-action buttons either, threw
+ * trying to send an empty Discord message.
+ */
+
+test("toDeliverableResult carries BOTH .reply (for persistence) and .parts (for live delivery)", () => {
+	const result = toDeliverableResult({
+		reply: "the answer",
+		proposedActions: [{ actionId: "a1" }],
+	});
+	assert.equal(result.reply, "the answer");
+	assert.ok(Array.isArray(result.parts));
+	assert.ok(result.parts.some((part) => part === "the answer"));
+	assert.deepEqual(result.proposedActions, [{ actionId: "a1" }]);
+});
+
+test("toDeliverableResult defaults a missing reply to an empty string, not undefined", () => {
+	const result = toDeliverableResult({});
+	assert.equal(result.reply, "");
+	assert.deepEqual(result.proposedActions, []);
+});
+
+test("toReplayContent rebuilds .parts from a persisted envelope's .reply — .parts never survived storage", () => {
+	const content = toReplayContent({
+		reply: "the stored answer",
+		proposedActions: [{ actionId: "a1" }],
+	});
+	assert.ok(Array.isArray(content.parts));
+	assert.ok(content.parts.some((part) => part === "the stored answer"));
+	assert.deepEqual(content.proposedActions, [{ actionId: "a1" }]);
+});
+
+test("toReplayContent falls back to a visible placeholder rather than an empty message", () => {
+	// An empty Discord message send can throw — a blank-but-successful reply
+	// is bad; a thrown error replacing it with a scary failure is worse.
+	const content = toReplayContent({});
+	assert.ok(
+		content.parts.some((part) => typeof part === "string" && part.length > 0),
+	);
+});

--- a/discord-app/turn-result.js
+++ b/discord-app/turn-result.js
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import { textContent } from "@mcpjam/surface-core";
+
+/**
+ * Shape a live turn result so both delivery paths work from ONE object:
+ *
+ *   - live delivery (`delivery.deliver`) reads `.parts` (StructuredContent).
+ *   - the core's persisted-claim contract (`normalizeResult`, in
+ *     surface-core/src/turn-runner.js) reads ONLY `.reply` — a plain string
+ *     — when storing this for replay. `.parts` never survives that trip.
+ *
+ * Omitting `.reply` here (returning StructuredContent alone) meant every
+ * durable claim stored an EMPTY reply, so a redelivered event replayed
+ * blank text — the exact bug this function exists to prevent.
+ *
+ * @param {{reply?: string, proposedActions?: any[]}} turnResult
+ */
+export function toDeliverableResult(turnResult) {
+	return {
+		reply: turnResult.reply || "",
+		...textContent(turnResult.reply || "", "info"),
+		proposedActions: turnResult.proposedActions || [],
+	};
+}
+
+/**
+ * Rebuild deliverable content from a PERSISTED envelope on replay.
+ *
+ * The stored envelope only ever carries `.reply` and `.proposedActions` —
+ * see `toDeliverableResult` above for why `.parts` is never among them — so
+ * this reconstructs the same shape a live turn produces, from what
+ * actually survived storage.
+ *
+ * @param {{reply?: string, proposedActions?: any[]}} envelope
+ */
+export function toReplayContent(envelope) {
+	return {
+		...textContent(
+			envelope.reply || "Done — though I have nothing to add.",
+			"info",
+		),
+		proposedActions: envelope.proposedActions || [],
+	};
+}


### PR DESCRIPTION
## Context

Two automated reviewers (Codex and CodeRabbit) independently flagged real
regressions in #3817's move of Discord's message handler onto the core's
`runTurnForEvent`. I verified both against the actual code before fixing —
this PR addresses the two real ones. A third finding (Slack's
`conversations.replies` has no pagination for threads over 200 messages)
turned out to be **pre-existing**, byte-for-byte identical to what the
original fork already did — not a regression, so left out of this PR.

## Fix 1 — a redelivered turn replayed with an empty reply

The `apiClient.runAgentTurn` closure converted the turn result to
StructuredContent (`.parts`) before handing it to `runTurnForEvent`. Live
delivery reads `.parts`, so that path looked fine in testing — but the
core's persisted-claim contract (`normalizeResult` in
`surface-core/src/turn-runner.js`) reads **only** `.reply` (a plain string)
when storing the envelope for replay. `.parts` never survives that trip, so
every completed claim was stored with an empty reply. On redelivery,
`onReplay` rendered that blank envelope — and with no proposed-action
buttons to render either, the resulting empty Discord message send likely
throws, turning "lost the original answer" into a scary generic error on
top of it.

Fixed by shaping the live result to carry **both** `.reply` (for
persistence) and `.parts` (for live delivery) from one place, and
rebuilding deliverable content from the persisted `.reply`/`.proposedActions`
on replay. Extracted into `discord-app/turn-result.js` so the shape is
independently testable rather than living as an inline closure.

## Fix 2 — redelivering a mention from a still-unlinked user re-posted the connect prompt

Before #3817, Discord claimed every mentioned message **before** resolving
the turn target, so the unlinked/needs_project branches were covered by
the same durable claim as everything else. The migration moved claiming
inside `runTurnForEvent`, which only the "user" branch reaches —
unlinked/needs_project return before ever getting there.

Fixed with a dedicated **in-memory** `EventDedupe` scoped to just those two
branches — deliberately *not* the durable claim backend: taking that here
too would collide with `runTurnForEvent`'s own claim on the same
`guildId:messageId` key once a user links, since the outer claim would
never complete and the inner one would see "inflight" and silently drop
the turn. A repeated prompt is cheap; short-TTL in-memory suppression is
what the redelivery case actually needs.

## Scope

Neither fix touches `surface-core` or `slack-app` — no live-bot deploy
risk beyond Discord's own (already-gated, unprovisioned) service.

## Tests

37 tests pass in `discord-app` (33 existing + 4 new, pinning the reply-shape
contract in `turn-result.test.js`). Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Discord-only changes with no surface-core or Slack impact; behavior is narrowly scoped to turn result shaping and pre-turn prompt deduplication.
> 
> **Overview**
> Fixes two regressions from moving Discord mentions onto core `runTurnForEvent`.
> 
> **Redelivery replay** now keeps reply text: live turn results are shaped with both `.reply` (what `normalizeResult` persists) and `.parts` (what Discord delivery uses), via `toDeliverableResult`; `onReplay` rebuilds deliverable content from the stored envelope with `toReplayContent` instead of posting a blank or empty message.
> 
> **Unlinked / needs-project prompts** use an in-memory `EventDedupe` on `message.id` so Gateway redeliveries do not spam the same connect or project warning; this deliberately avoids the durable claim backend so it does not collide with `runTurnForEvent` once the user is linked.
> 
> Adds `discord-app/turn-result.js` and unit tests for the reply-shape contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a5a717332992e5eaf0b748203dd63d5c82147a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Discord redelivery so replies are preserved and replays render correctly, and de-duplicates connect/project prompts for unlinked users. Prevents empty messages on replay and avoids duplicate prompts after Gateway resumes.

- Bug Fixes
  - Preserve reply on replay: unify turn results with `toDeliverableResult` to include `.reply` (for persistence) and `.parts` (for live delivery), and rebuild replay content with `toReplayContent`. Adds tests to pin this shape and avoid empty sends.
  - De-dupe unlinked prompts: add in-memory `EventDedupe` for the "connect your account" and "pick a project" branches before runTurnForEvent, so redelivered mentions don't repost the prompt; avoids durable-claim collisions after linking.

<sup>Written for commit 9a5a717332992e5eaf0b748203dd63d5c82147a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

