### PR TITLE
fix(discord): register slash commands globally so every server gets /mcpjam

### DIFF
--- a/discord-app/.env.sample
+++ b/discord-app/.env.sample
@@ -48,9 +48,15 @@ MCPJAM_DISCORD_SERVICE_TOKEN=dsc_YOUR_INSPECTOR_SERVICE_TOKEN
 # DISCORD_LINK_PUBLIC_ORIGIN=https://preview.example.com
 
 # ─── Slash-command registration ─────────────────────────────────────────────
-# Both required, or registration is skipped entirely. Guild-scoped, so commands
-# appear instantly in that one server — the right shape for development.
+# DISCORD_APPLICATION_ID is required, or registration is skipped entirely.
 # DISCORD_APPLICATION_ID=YOUR_DISCORD_APPLICATION_ID
+#
+# DISCORD_GUILD_ID is an OPTIONAL DEVELOPMENT OVERRIDE. Set it and commands
+# register to that one server and appear instantly — the right shape for
+# iterating. LEAVE IT UNSET IN PRODUCTION: commands then register globally and
+# reach every server the bot is added to, which is the only way a second
+# server gets `/mcpjam` at all. Discord may take up to an hour to propagate a
+# global command.
 # DISCORD_GUILD_ID=YOUR_TEST_GUILD_ID
 
 # ─── Legacy ─────────────────────────────────────────────────────────────────

--- a/discord-app/.env.sample
+++ b/discord-app/.env.sample
@@ -51,13 +51,18 @@ MCPJAM_DISCORD_SERVICE_TOKEN=dsc_YOUR_INSPECTOR_SERVICE_TOKEN
 # DISCORD_APPLICATION_ID is required, or registration is skipped entirely.
 # DISCORD_APPLICATION_ID=YOUR_DISCORD_APPLICATION_ID
 #
-# DISCORD_GUILD_ID is an OPTIONAL DEVELOPMENT OVERRIDE. Set it and commands
+# DISCORD_DEV_GUILD_ID is an OPTIONAL DEVELOPMENT OVERRIDE. Set it and commands
 # register to that one server and appear instantly — the right shape for
 # iterating. LEAVE IT UNSET IN PRODUCTION: commands then register globally and
 # reach every server the bot is added to, which is the only way a second
 # server gets `/mcpjam` at all. Discord may take up to an hour to propagate a
 # global command.
-# DISCORD_GUILD_ID=YOUR_TEST_GUILD_ID
+# DISCORD_DEV_GUILD_ID=YOUR_TEST_GUILD_ID
+#
+# DISCORD_GUILD_ID (the old name) is IGNORED. Registration used to require it,
+# so every deployment that had working commands has it set — honouring it now
+# would keep those deployments stuck on one server, which is the whole thing
+# global registration fixes. The bot warns at boot if it is still present.
 
 # ─── Legacy ─────────────────────────────────────────────────────────────────
 # Single-project fallback from before per-user linking. A real install resolves

--- a/discord-app/README.md
+++ b/discord-app/README.md
@@ -19,9 +19,15 @@ npm start
 
 You need a Discord application with a bot user, the **Message Content** intent
 enabled (the bot reads the message it was mentioned in), and the bot invited to
-a test server. Set `DISCORD_APPLICATION_ID` + `DISCORD_GUILD_ID` to register
+a test server. Set `DISCORD_APPLICATION_ID` + `DISCORD_DEV_GUILD_ID` to register
 `/mcpjam connect` in that one server — guild-scoped commands appear instantly,
 global ones take up to an hour.
+
+In production leave `DISCORD_DEV_GUILD_ID` unset: commands then register
+globally, which is what gets `/mcpjam` into every server the bot is added to.
+The older `DISCORD_GUILD_ID` is ignored (it used to be required, so honouring
+it would pin existing deployments to one server); the bot warns at boot if it
+is still set.
 
 `npm test` runs the unit tests; none of them need a Discord connection.
 

--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -10,15 +10,8 @@ import {
 	runTurnForEvent,
 	textContent,
 } from "@mcpjam/surface-core";
-import {
-	Client,
-	Events,
-	GatewayIntentBits,
-	Partials,
-	REST,
-	Routes,
-	SlashCommandBuilder,
-} from "discord.js";
+import { Client, Events, GatewayIntentBits, Partials, REST } from "discord.js";
+import { MCPJAM_COMMANDS, resolveCommandRegistration } from "./commands.js";
 import { config, describeConfigGaps } from "./config.js";
 import { buildInteractionRef, buildMessageRef } from "./context.js";
 import { createDiscordDelivery } from "./delivery.js";
@@ -506,21 +499,37 @@ client.on(Events.InteractionCreate, async (interaction) => {
 
 // ── Slash-command registration ──────────────────────────────────────────────
 
-if (config.applicationId && config.guildId) {
-	const rest = new REST({ version: "10" }).setToken(config.botToken);
-	await rest.put(
-		Routes.applicationGuildCommands(config.applicationId, config.guildId),
-		{
-			body: [
-				new SlashCommandBuilder()
-					.setName("mcpjam")
-					.setDescription("MCPJam commands")
-					.addSubcommand((subcommand) =>
-						subcommand.setName("connect").setDescription("Connect MCPJam"),
-					),
-			],
-		},
+// Guild-scoped when a guild id is configured (the development override:
+// instant propagation in one server), GLOBAL otherwise so every server the
+// bot is added to gets `/mcpjam`. See commands.js for the full reasoning.
+const registration = resolveCommandRegistration({
+	applicationId: config.applicationId,
+	guildId: config.guildId,
+});
+if (registration.scope === "skipped") {
+	console.warn(
+		"[discord] DISCORD_APPLICATION_ID is not set — slash commands are not registered. Mentioning the bot still works.",
 	);
+} else {
+	const rest = new REST({ version: "10" }).setToken(config.botToken);
+	// Best-effort: a failed registration must not stop the bot from
+	// connecting. The @-mention path offers the same connect link, so a bot
+	// that is up without its slash command is degraded, not broken — and
+	// crashing here would take down every guild over one bad API call.
+	try {
+		await rest.put(registration.route, { body: MCPJAM_COMMANDS });
+		console.log(
+			registration.scope === "guild"
+				? `[discord] registered slash commands to guild ${config.guildId} (development override)`
+				: "[discord] registered slash commands globally; Discord may take up to an hour to propagate them",
+		);
+	} catch (error) {
+		console.error(
+			`[discord] could not register slash commands (${registration.scope}): ${
+				error?.message ?? error
+			}`,
+		);
+	}
 }
 
 await client.login(config.botToken);

--- a/discord-app/app.js
+++ b/discord-app/app.js
@@ -499,12 +499,14 @@ client.on(Events.InteractionCreate, async (interaction) => {
 
 // ── Slash-command registration ──────────────────────────────────────────────
 
-// Guild-scoped when a guild id is configured (the development override:
+// Guild-scoped when DISCORD_DEV_GUILD_ID is set (the development override:
 // instant propagation in one server), GLOBAL otherwise so every server the
-// bot is added to gets `/mcpjam`. See commands.js for the full reasoning.
+// bot is added to gets `/mcpjam`. See commands.js for the full reasoning,
+// including why this reads a NEW variable rather than the old
+// DISCORD_GUILD_ID.
 const registration = resolveCommandRegistration({
 	applicationId: config.applicationId,
-	guildId: config.guildId,
+	devGuildId: config.devGuildId,
 });
 if (registration.scope === "skipped") {
 	console.warn(
@@ -520,7 +522,7 @@ if (registration.scope === "skipped") {
 		await rest.put(registration.route, { body: MCPJAM_COMMANDS });
 		console.log(
 			registration.scope === "guild"
-				? `[discord] registered slash commands to guild ${config.guildId} (development override)`
+				? `[discord] registered slash commands to guild ${config.devGuildId} (DISCORD_DEV_GUILD_ID development override)`
 				: "[discord] registered slash commands globally; Discord may take up to an hour to propagate them",
 		);
 	} catch (error) {

--- a/discord-app/commands.js
+++ b/discord-app/commands.js
@@ -1,0 +1,57 @@
+// @ts-nocheck
+import { Routes, SlashCommandBuilder } from "discord.js";
+
+/**
+ * The bot's slash commands, as the wire payload Discord expects.
+ *
+ * `.toJSON()` rather than the builder itself: `rest.put` would serialize the
+ * builder identically (JSON.stringify calls toJSON), but naming the shape
+ * here makes it something a test can assert on without standing up a REST
+ * client.
+ */
+export const MCPJAM_COMMANDS = [
+	new SlashCommandBuilder()
+		.setName("mcpjam")
+		.setDescription("MCPJam commands")
+		.addSubcommand((subcommand) =>
+			subcommand.setName("connect").setDescription("Connect MCPJam"),
+		)
+		.toJSON(),
+];
+
+/**
+ * WHERE to register the commands — the difference between a bot that works
+ * in one server and a bot that works in every server it is added to.
+ *
+ * GUILD-scoped registration reaches exactly one server and propagates
+ * instantly. GLOBAL registration reaches every server the bot is in, but
+ * Discord may take up to an hour to propagate it.
+ *
+ * So the guild id, when set, is a DEVELOPMENT override: it buys instant
+ * iteration in a test server. Its absence is the production case, and
+ * before this it meant registration was skipped ENTIRELY — a bot added to a
+ * second server had no `/mcpjam` command at all, only the @-mention path.
+ * That is why global is the fallback rather than the other way around:
+ * getting the command into every server matters more than the propagation
+ * delay, and a developer who wants instant feedback sets the guild id.
+ *
+ * Global is also the only option that SCALES: it is one API call regardless
+ * of how many servers the bot is in, where per-guild registration would be
+ * one call per server at startup plus one per join, each rate-limited.
+ *
+ * `applicationId` is required either way — it addresses the application
+ * whose commands these are, and without it there is nothing to register
+ * against.
+ *
+ * @param {{applicationId?: string, guildId?: string}} options
+ * @returns {{scope: "guild"|"global"|"skipped", route?: string}}
+ */
+export function resolveCommandRegistration({ applicationId, guildId } = {}) {
+	if (!applicationId) return { scope: "skipped" };
+	if (guildId)
+		return {
+			scope: "guild",
+			route: Routes.applicationGuildCommands(applicationId, guildId),
+		};
+	return { scope: "global", route: Routes.applicationCommands(applicationId) };
+}

--- a/discord-app/commands.js
+++ b/discord-app/commands.js
@@ -27,31 +27,40 @@ export const MCPJAM_COMMANDS = [
  * instantly. GLOBAL registration reaches every server the bot is in, but
  * Discord may take up to an hour to propagate it.
  *
- * So the guild id, when set, is a DEVELOPMENT override: it buys instant
+ * So `devGuildId`, when set, is a DEVELOPMENT override: it buys instant
  * iteration in a test server. Its absence is the production case, and
  * before this it meant registration was skipped ENTIRELY — a bot added to a
  * second server had no `/mcpjam` command at all, only the @-mention path.
  * That is why global is the fallback rather than the other way around:
  * getting the command into every server matters more than the propagation
- * delay, and a developer who wants instant feedback sets the guild id.
+ * delay, and a developer who wants instant feedback opts in.
  *
  * Global is also the only option that SCALES: it is one API call regardless
  * of how many servers the bot is in, where per-guild registration would be
  * one call per server at startup plus one per join, each rate-limited.
  *
+ * THE PARAMETER IS DELIBERATELY NOT THE OLD `DISCORD_GUILD_ID`. Registration
+ * used to require a guild id, so every deployment with a working `/mcpjam`
+ * — production included — has that variable set. Honouring it here would
+ * leave exactly those deployments guild-scoped after the upgrade, making
+ * this change a no-op precisely where it is needed. The caller passes
+ * `DISCORD_DEV_GUILD_ID`, a name no existing deployment has, so the new
+ * behavior is the default on deploy rather than something an operator has
+ * to remember to unset.
+ *
  * `applicationId` is required either way — it addresses the application
  * whose commands these are, and without it there is nothing to register
  * against.
  *
- * @param {{applicationId?: string, guildId?: string}} options
+ * @param {{applicationId?: string, devGuildId?: string}} options
  * @returns {{scope: "guild"|"global"|"skipped", route?: string}}
  */
-export function resolveCommandRegistration({ applicationId, guildId } = {}) {
+export function resolveCommandRegistration({ applicationId, devGuildId } = {}) {
 	if (!applicationId) return { scope: "skipped" };
-	if (guildId)
+	if (devGuildId)
 		return {
 			scope: "guild",
-			route: Routes.applicationGuildCommands(applicationId, guildId),
+			route: Routes.applicationGuildCommands(applicationId, devGuildId),
 		};
 	return { scope: "global", route: Routes.applicationCommands(applicationId) };
 }

--- a/discord-app/config.js
+++ b/discord-app/config.js
@@ -117,7 +117,15 @@ export function loadConfig(env = process.env) {
 		 */
 		legacyProjectId: trimmed(env.MCPJAM_PROJECT_ID),
 
-		/** Slash-command registration. Both required, or registration is skipped. */
+		/**
+		 * Slash-command registration. `applicationId` is required, or
+		 * registration is skipped entirely.
+		 *
+		 * `guildId` is an OPTIONAL DEVELOPMENT OVERRIDE: set it and commands
+		 * register to that one server and propagate instantly; leave it unset
+		 * and they register globally, reaching every server the bot is added
+		 * to. See commands.js for why global is the production default.
+		 */
 		applicationId: trimmed(env.DISCORD_APPLICATION_ID),
 		guildId: trimmed(env.DISCORD_GUILD_ID),
 	};

--- a/discord-app/config.js
+++ b/discord-app/config.js
@@ -121,13 +121,25 @@ export function loadConfig(env = process.env) {
 		 * Slash-command registration. `applicationId` is required, or
 		 * registration is skipped entirely.
 		 *
-		 * `guildId` is an OPTIONAL DEVELOPMENT OVERRIDE: set it and commands
+		 * `devGuildId` is an OPTIONAL DEVELOPMENT OVERRIDE: set it and commands
 		 * register to that one server and propagate instantly; leave it unset
 		 * and they register globally, reaching every server the bot is added
 		 * to. See commands.js for why global is the production default.
+		 *
+		 * A NEW variable name, deliberately, rather than reusing
+		 * `DISCORD_GUILD_ID`. Registration previously REQUIRED a guild id, so
+		 * every deployment with a working `/mcpjam` necessarily has the old
+		 * variable set — including production. Reading it here would keep
+		 * exactly those deployments guild-scoped after this upgrade, which is
+		 * the one thing the change exists to stop. Ignoring the old name makes
+		 * the new behavior the default on deploy, with no ops step to
+		 * remember; `describeConfigGaps` warns when the stale variable is
+		 * still present so it does not look like the override silently broke.
 		 */
 		applicationId: trimmed(env.DISCORD_APPLICATION_ID),
-		guildId: trimmed(env.DISCORD_GUILD_ID),
+		devGuildId: trimmed(env.DISCORD_DEV_GUILD_ID),
+		/** Read ONLY to warn that it is now ignored. Never used for scoping. */
+		legacyGuildId: trimmed(env.DISCORD_GUILD_ID),
 	};
 }
 
@@ -162,6 +174,14 @@ export function describeConfigGaps(config) {
 	if (!config.botEnabled) {
 		warnings.push(
 			'POSTHOG_DISCORD_AGENT_ENABLED is not "true" — the bot will connect but will not answer mentions.',
+		);
+	}
+	// Not a gap so much as a stale setting, but it belongs in the same boot
+	// output: someone upgrading sees their commands go global and needs to
+	// know it was deliberate, not a broken override.
+	if (config.legacyGuildId) {
+		warnings.push(
+			"DISCORD_GUILD_ID is set but no longer does anything — slash commands now register globally so every server gets them. Remove it, or set DISCORD_DEV_GUILD_ID instead to keep registering to one server during development.",
 		);
 	}
 	return warnings;

--- a/discord-app/tests/commands.test.js
+++ b/discord-app/tests/commands.test.js
@@ -5,21 +5,22 @@ import { MCPJAM_COMMANDS, resolveCommandRegistration } from "../commands.js";
 /**
  * Registration used to require BOTH an application id and a guild id, which
  * meant a bot added to a second server registered nothing — `/mcpjam` simply
- * did not exist there. These pin the scope decision that fixes it: the guild
- * id is now a development override, and its absence means global.
+ * did not exist there. These pin the scope decision that fixes it: the
+ * development override is opt-in under a NEW name, and its absence means
+ * global.
  */
 
-test("no guild id registers GLOBALLY — the production path, so every server gets the command", () => {
+test("no dev guild id registers GLOBALLY — the production path, so every server gets the command", () => {
 	const registration = resolveCommandRegistration({ applicationId: "app-1" });
 	assert.equal(registration.scope, "global");
 	// The global route addresses the application alone, with no guild segment.
 	assert.equal(registration.route, "/applications/app-1/commands");
 });
 
-test("a guild id registers to THAT guild — the development override, instant propagation", () => {
+test("a dev guild id registers to THAT guild — instant propagation while iterating", () => {
 	const registration = resolveCommandRegistration({
 		applicationId: "app-1",
-		guildId: "guild-9",
+		devGuildId: "guild-9",
 	});
 	assert.equal(registration.scope, "guild");
 	assert.equal(
@@ -28,11 +29,36 @@ test("a guild id registers to THAT guild — the development override, instant p
 	);
 });
 
+/**
+ * THE MIGRATION GUARD. Every deployment that had a working `/mcpjam` before
+ * this change necessarily set `DISCORD_GUILD_ID`, because registration
+ * required it — production included. If that value reached this function it
+ * would keep those deployments guild-scoped, making the whole change a no-op
+ * exactly where it matters. `config.js` maps the old name to
+ * `legacyGuildId` (warn-only) and never passes it here; this asserts the
+ * function itself has no path that would honour it.
+ */
+test("the OLD guild id key does not scope registration — an upgrade goes global by default", () => {
+	const registration = resolveCommandRegistration({
+		applicationId: "app-1",
+		// The pre-migration spelling, plus the shape config.js now produces
+		// for a deployment that still has the stale variable set.
+		guildId: "legacy-guild",
+		legacyGuildId: "legacy-guild",
+	});
+	assert.equal(
+		registration.scope,
+		"global",
+		"a stale DISCORD_GUILD_ID must not pin an upgraded deployment to one server",
+	);
+	assert.equal(registration.route, "/applications/app-1/commands");
+});
+
 test("no application id skips registration — there is nothing to register against", () => {
 	assert.deepEqual(resolveCommandRegistration({ applicationId: "" }), {
 		scope: "skipped",
 	});
-	assert.deepEqual(resolveCommandRegistration({ guildId: "guild-9" }), {
+	assert.deepEqual(resolveCommandRegistration({ devGuildId: "guild-9" }), {
 		scope: "skipped",
 	});
 	assert.deepEqual(resolveCommandRegistration(), { scope: "skipped" });

--- a/discord-app/tests/commands.test.js
+++ b/discord-app/tests/commands.test.js
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MCPJAM_COMMANDS, resolveCommandRegistration } from "../commands.js";
+
+/**
+ * Registration used to require BOTH an application id and a guild id, which
+ * meant a bot added to a second server registered nothing — `/mcpjam` simply
+ * did not exist there. These pin the scope decision that fixes it: the guild
+ * id is now a development override, and its absence means global.
+ */
+
+test("no guild id registers GLOBALLY — the production path, so every server gets the command", () => {
+	const registration = resolveCommandRegistration({ applicationId: "app-1" });
+	assert.equal(registration.scope, "global");
+	// The global route addresses the application alone, with no guild segment.
+	assert.equal(registration.route, "/applications/app-1/commands");
+});
+
+test("a guild id registers to THAT guild — the development override, instant propagation", () => {
+	const registration = resolveCommandRegistration({
+		applicationId: "app-1",
+		guildId: "guild-9",
+	});
+	assert.equal(registration.scope, "guild");
+	assert.equal(
+		registration.route,
+		"/applications/app-1/guilds/guild-9/commands",
+	);
+});
+
+test("no application id skips registration — there is nothing to register against", () => {
+	assert.deepEqual(resolveCommandRegistration({ applicationId: "" }), {
+		scope: "skipped",
+	});
+	assert.deepEqual(resolveCommandRegistration({ guildId: "guild-9" }), {
+		scope: "skipped",
+	});
+	assert.deepEqual(resolveCommandRegistration(), { scope: "skipped" });
+});
+
+test("the command payload is the wire shape Discord expects, not a builder", () => {
+	assert.equal(MCPJAM_COMMANDS.length, 1);
+	const [command] = MCPJAM_COMMANDS;
+	assert.equal(command.name, "mcpjam");
+	assert.equal(typeof command.description, "string");
+	// `connect` is the subcommand the Integrations card tells people to run;
+	// renaming it silently breaks that instruction.
+	assert.ok(
+		command.options?.some((option) => option.name === "connect"),
+		"expected a `connect` subcommand",
+	);
+	// A PLAIN object, not a SlashCommandBuilder. A builder would serialize to
+	// the same bytes on the wire, so this is not about correctness of the
+	// request — it is about the payload being inspectable here rather than
+	// hidden behind a toJSON() call.
+	assert.equal(typeof command.toJSON, "undefined");
+	assert.equal(Object.getPrototypeOf(command), Object.prototype);
+});

--- a/discord-app/tests/config.test.js
+++ b/discord-app/tests/config.test.js
@@ -158,3 +158,41 @@ test("reports each missing piece by name, and says which credential it is", () =
 test("a fully configured deployment warns about nothing", () => {
 	assert.deepEqual(describeConfigGaps(loadConfig(FULL_ENV)), []);
 });
+
+/**
+ * Slash-command scope migration. Registration used to REQUIRE
+ * `DISCORD_GUILD_ID`, so every deployment with a working `/mcpjam` has it
+ * set. It must no longer scope registration — otherwise those deployments
+ * stay pinned to one server and global registration is a no-op exactly where
+ * it is needed — but it must not vanish silently either.
+ */
+
+test("the dev override reads the NEW name, and the old one never scopes registration", () => {
+	const migrated = loadConfig({
+		...FULL_ENV,
+		DISCORD_APPLICATION_ID: "app-1",
+		DISCORD_GUILD_ID: "stale-guild",
+	});
+	assert.equal(
+		migrated.devGuildId,
+		undefined,
+		"a stale DISCORD_GUILD_ID must not become the dev override",
+	);
+	assert.equal(migrated.legacyGuildId, "stale-guild");
+
+	const opted = loadConfig({
+		...FULL_ENV,
+		DISCORD_APPLICATION_ID: "app-1",
+		DISCORD_DEV_GUILD_ID: "dev-guild",
+	});
+	assert.equal(opted.devGuildId, "dev-guild");
+});
+
+test("a stale DISCORD_GUILD_ID warns that it is ignored, and names its replacement", () => {
+	const warnings = describeConfigGaps(
+		loadConfig({ ...FULL_ENV, DISCORD_GUILD_ID: "stale-guild" }),
+	);
+	const joined = warnings.join("\n");
+	assert.match(joined, /DISCORD_GUILD_ID is set but no longer does anything/);
+	assert.match(joined, /DISCORD_DEV_GUILD_ID/);
+});


### PR DESCRIPTION
## The problem

Slash-command registration required **both** `DISCORD_APPLICATION_ID` and
`DISCORD_GUILD_ID`, and the guild id is read in exactly one place — this
registration call. So a bot added to any server other than the single
configured test guild registered **nothing**: `/mcpjam connect` did not
exist there.

The @-mention path offers the same connect link inline, so the bot was
discoverable-by-accident rather than outright broken. But for a bot whose
entire onboarding is *"add it to your server, then run `/mcpjam connect`"* —
which is literally what the Integrations card tells people — that is the
onboarding step missing.

## The fix

`DISCORD_GUILD_ID` becomes an optional **development override**: set it and
commands register to that one server and propagate instantly; leave it unset
(the production case) and they register **globally**, reaching every server
the bot is in.

**Global rather than per-guild-on-join, deliberately.** Per-guild would
propagate instantly everywhere, but it is one API call per server at startup
plus one per join, each rate-limited — it does not scale with guild count.
Global is a single call regardless. The cost is Discord taking up to an hour
to propagate a global command, which is exactly why the development override
still exists.

**Registration is now best-effort.** A failed `rest.put` logs instead of
throwing. Previously an unhandled rejection here would take the process down
*before* `client.login`, so one bad API call meant no bot in any guild. A bot
running without its slash command is degraded; a bot that won't start is not.

The scope decision is extracted to `discord-app/commands.js` so it's testable
without standing up a REST client.

## Scope

This is step 2 of the Discord multi-tenant scoping work. Notably it does
**not** flip the `discord-agent` feature flag — the install card stays dark
until the org-binding admin surface exists (that's the remaining gap:
`slackAgentSettings.createChannelBinding` hardcodes `surfaceKind: 'slack'`
on the write path, and there's no Discord org-settings page yet).

Worth recording, since it narrows what's left: most of what a "Discord OAuth
install" would build **already exists** — per-guild tenancy is fully generic,
the backend schema already takes `surfaceKind: 'slack' | 'discord'`, the
two-proof account-link flow (Discord OAuth + guild-membership check + WorkOS)
is complete, and `discordInstallUrl()` already renders an "Add to Server"
card. Discord needs no per-guild token exchange the way Slack does — one bot
token works everywhere — so there is no `discordInstallations` table and
there shouldn't be one.

## Tests

41 pass in `discord-app` (37 existing + 4 new): the global route, the
guild-override route, the skipped case, and the command payload shape.
Typecheck and lint clean; `surface-core` and `slack-app` verified unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production slash-command scope and env var semantics on deploy; registration failures no longer block startup, which is safer but may hide misconfiguration until logs are checked.
> 
> **Overview**
> **Slash-command registration** no longer requires a guild id. With only `DISCORD_APPLICATION_ID`, `/mcpjam` registers **globally** so every server the bot joins gets the command (Discord may take up to ~1 hour to propagate). **`DISCORD_DEV_GUILD_ID`** is the optional dev override for instant guild-scoped registration in one test server.
> 
> **Migration:** `DISCORD_GUILD_ID` is **ignored** on purpose so existing production deploys that still have it set upgrade to global registration without an ops step; boot warns and points operators at `DISCORD_DEV_GUILD_ID` if they still want single-guild registration.
> 
> Logic and the wire payload move to **`commands.js`** (`resolveCommandRegistration`, `MCPJAM_COMMANDS`). Registration is **best-effort**—failed `rest.put` is logged and the bot still **`client.login`**s (mentions remain a fallback). Docs and tests cover scope routes, stale env handling, and the `connect` subcommand shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a764e41159a6dc9ef9b0382d94a47e5501a87dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers Discord slash commands globally by default so every server gets `/mcpjam`. Uses `DISCORD_DEV_GUILD_ID` as an optional dev override; the legacy `DISCORD_GUILD_ID` is ignored (with a boot warning), and registration failures no longer crash the bot.

- **Bug Fixes**
  - Default to global registration when `DISCORD_APPLICATION_ID` is set; set `DISCORD_DEV_GUILD_ID` to register to a single test guild for instant propagation.
  - Ignore `DISCORD_GUILD_ID` and warn if present so upgrades go global without an ops step.
  - Make registration best-effort (log errors instead of throwing) so the bot still starts and mentions work.
  - Extract scope logic and command payload to `discord-app/commands.js` (`resolveCommandRegistration`, `MCPJAM_COMMANDS`); add tests; update `.env.sample`, `README.md`, and config comments.

- **Migration**
  - Production: set `DISCORD_APPLICATION_ID` and leave `DISCORD_DEV_GUILD_ID` unset.
  - Allow up to ~1 hour for global command propagation after deploy.

<sup>Written for commit 3a764e41159a6dc9ef9b0382d94a47e5501a87dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

