### PR TITLE
feat(plugins): open the plugin surface to guests; tracked uploads

### DIFF
--- a/mcpjam-inspector/client/src/components/plugins/__tests__/AddPluginModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/plugins/__tests__/AddPluginModal.test.tsx
@@ -33,7 +33,6 @@ vi.mock("@/hooks/usePluginImportApi", () => ({
     startImport: h.startImport,
     inspectImport: h.inspectImport,
     commitImport: h.commitImport,
-    generateBundleUploadUrl: vi.fn(),
     createImport: vi.fn(),
   }),
 }));

--- a/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
@@ -28,8 +28,10 @@ import { useAuth } from "@workos-inc/authkit-react";
 import {
   assertPluginBundleWithinCap,
   toPluginApiError,
-  uploadPluginBundleToUrl,
+  uploadPluginBundleTracked,
 } from "@/lib/plugins/plugin-api";
+import { getConvexSiteUrl } from "@/lib/convex-site-url";
+import { getGuestBearerToken } from "@/lib/guest-session";
 import { shouldQueryProjectId } from "./useProjects";
 import {
   PluginApiError,
@@ -55,25 +57,19 @@ import { usePluginsEnabled } from "./usePluginsEnabled";
 // ---------------------------------------------------------------------------
 
 /**
- * Shared gate: `plugins-enabled` (fail-closed) AND a *signed-in* actor.
+ * Shared gate: `plugins-enabled` (fail-closed) AND a resolved Convex actor.
  *
- * `isAuthenticated` alone is not enough: guests authenticate to Convex through
- * the same provider chain (see `useUnifiedConvexAuth`), so it is true for them
- * too. Every plugin function is a `signedInQuery`, which rejects guests with
- * "Authenticated user required" — a render-time throw that takes down the whole
- * route, since Connect mounts `PluginsSection` inline. The WorkOS user is the
- * signed-in/guest discriminator (same predicate as `use-project-state`'s
- * `isAuthenticated && !hasSignedInUser`).
- *
- * TEMPORARY: remove the `Boolean(user)` term once the backend serves guests —
- * this gate exists only because the frontend is ready for guest plugins and the
- * backend is not.
+ * Guests count: the backend serves them across the whole plugin surface
+ * (mcpjam-backend#913 — `user*` wrappers, guest-tier rate ceilings, tracked
+ * uploads), and `isAuthenticated` is true for a guest session through the
+ * same provider chain (see `useUnifiedConvexAuth`). The historical
+ * `Boolean(user)` term existed only because the backend was `signedIn*`
+ * while the frontend was already guest-ready.
  */
 function usePluginQueriesReady(): boolean {
   const enabled = usePluginsEnabled();
   const { isAuthenticated } = useConvexAuth();
-  const { user } = useAuth();
-  return enabled && isAuthenticated && Boolean(user);
+  return enabled && isAuthenticated;
 }
 
 /**
@@ -224,6 +220,7 @@ export interface PluginImportActions {
  */
 export function usePluginImportActions(): PluginImportActions {
   const enabled = usePluginsEnabled();
+  const { getAccessToken } = useAuth();
   const generateUploadUrlMutation = useMutation(
     "plugins:generateBundleUploadUrl" as any,
   );
@@ -239,6 +236,24 @@ export function usePluginImportActions(): PluginImportActions {
       );
     }
   }, [enabled]);
+
+  // The bearer the tracked upload route authorizes with: the WorkOS access
+  // token when signed in, else the guest bearer — the same fallback order the
+  // chat session uses to hit Convex HTTP routes.
+  const acquireBearerToken = useCallback(async (): Promise<string> => {
+    try {
+      const token = await getAccessToken?.();
+      if (token) return token;
+    } catch {
+      // Not signed in (LoginRequiredError) — fall through to the guest bearer.
+    }
+    const guestToken = await getGuestBearerToken();
+    if (guestToken) return guestToken;
+    throw new PluginApiError(
+      "UPLOAD_FAILED",
+      "No Convex session available to upload the bundle.",
+    );
+  }, [getAccessToken]);
 
   const generateBundleUploadUrl = useCallback(
     async (projectId: string): Promise<string> => {
@@ -307,15 +322,27 @@ export function usePluginImportActions(): PluginImportActions {
   const startImport = useCallback(
     async (args: StartPluginImportArgs): Promise<StartPluginImportResult> => {
       requireEnabled();
-      // Size-check BEFORE minting: generateBundleUploadUrl is rate-limited,
-      // and an oversized bundle must not burn a token on a doomed upload.
-      // uploadPluginBundleToUrl re-checks as defense in depth.
+      // Size-check BEFORE uploading: the tracked route is rate-limited, and
+      // an oversized bundle must not burn a token on a doomed upload.
+      // uploadPluginBundleTracked re-checks as defense in depth.
       assertPluginBundleWithinCap(args.bundle);
-      const uploadUrl = await generateBundleUploadUrl(args.projectId);
-      const bundleStorageId = await uploadPluginBundleToUrl(
-        uploadUrl,
-        args.bundle,
-      );
+      // ONE upload path for every actor: the tracked route stores AND
+      // records the blob server-side so an abandoned upload is sweepable —
+      // required for guests (minted URLs refuse them), harmless for members.
+      const siteUrl = getConvexSiteUrl();
+      if (!siteUrl) {
+        throw new PluginApiError(
+          "UPLOAD_FAILED",
+          "Convex site URL is not configured; cannot upload the bundle.",
+        );
+      }
+      const bearerToken = await acquireBearerToken();
+      const bundleStorageId = await uploadPluginBundleTracked({
+        siteUrl,
+        projectId: args.projectId,
+        bundle: args.bundle,
+        bearerToken,
+      });
       const { importId } = await createImport({
         projectId: args.projectId,
         bundleStorageId,
@@ -332,7 +359,7 @@ export function usePluginImportActions(): PluginImportActions {
       const inspect = await inspectImport(importId);
       return { importId, inspect };
     },
-    [requireEnabled, generateBundleUploadUrl, createImport, inspectImport],
+    [requireEnabled, acquireBearerToken, createImport, inspectImport],
   );
 
   return useMemo(

--- a/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
+++ b/mcpjam-inspector/client/src/hooks/usePluginImportApi.ts
@@ -24,14 +24,13 @@
 
 import { useCallback, useMemo } from "react";
 import { useAction, useConvexAuth, useMutation, useQuery } from "convex/react";
-import { useAuth } from "@workos-inc/authkit-react";
 import {
   assertPluginBundleWithinCap,
   toPluginApiError,
   uploadPluginBundleTracked,
 } from "@/lib/plugins/plugin-api";
 import { getConvexSiteUrl } from "@/lib/convex-site-url";
-import { getGuestBearerToken } from "@/lib/guest-session";
+import { useConvexAccessToken } from "./use-convex-access-token";
 import { shouldQueryProjectId } from "./useProjects";
 import {
   PluginApiError,
@@ -185,8 +184,6 @@ export interface StartPluginImportResult {
 }
 
 export interface PluginImportActions {
-  /** Mint a storage upload URL (`plugins.generateBundleUploadUrl`). */
-  generateBundleUploadUrl: (projectId: string) => Promise<string>;
   /** Stage an uploaded bundle blob as an import (`plugins.createImport`). */
   createImport: (args: {
     projectId: string;
@@ -201,10 +198,11 @@ export interface PluginImportActions {
     options?: { setActive?: boolean },
   ) => Promise<PluginCommitResult>;
   /**
-   * Full upload path: mint URL → POST the ZIP to storage → `createImport` →
-   * `inspectImport`. Resolves once inspection lands `preview_ready` (or
-   * `failed` — inspect failures are recorded on the row, not thrown).
-   * Subscribe with `usePluginImport(importId)` for live progress.
+   * Full upload path: POST the ZIP to the tracked upload route →
+   * `createImport` → `inspectImport`. Resolves once inspection lands
+   * `preview_ready` (or `failed` — inspect failures are recorded on the
+   * row, not thrown). Subscribe with `usePluginImport(importId)` for live
+   * progress.
    */
   startImport: (
     args: StartPluginImportArgs,
@@ -220,10 +218,7 @@ export interface PluginImportActions {
  */
 export function usePluginImportActions(): PluginImportActions {
   const enabled = usePluginsEnabled();
-  const { getAccessToken } = useAuth();
-  const generateUploadUrlMutation = useMutation(
-    "plugins:generateBundleUploadUrl" as any,
-  );
+  const getConvexAccessToken = useConvexAccessToken();
   const createImportMutation = useMutation("plugins:createImport" as any);
   const inspectImportAction = useAction("pluginsNode:inspectImport" as any);
   const commitImportAction = useAction("pluginsNode:commitImport" as any);
@@ -237,37 +232,20 @@ export function usePluginImportActions(): PluginImportActions {
     }
   }, [enabled]);
 
-  // The bearer the tracked upload route authorizes with: the WorkOS access
-  // token when signed in, else the guest bearer — the same fallback order the
-  // chat session uses to hit Convex HTTP routes.
+  // The bearer the tracked upload route authorizes with, resolved through
+  // the shared `resolveConvexAccessToken` order: WorkOS token when signed
+  // in, guest bearer only when there is NO WorkOS user. A signed-in user
+  // whose token transiently fails to refresh must get an error here — never
+  // a silent guest fallback, or the staged upload would belong to a
+  // different actor than the `createImport` that adopts it.
   const acquireBearerToken = useCallback(async (): Promise<string> => {
-    try {
-      const token = await getAccessToken?.();
-      if (token) return token;
-    } catch {
-      // Not signed in (LoginRequiredError) — fall through to the guest bearer.
-    }
-    const guestToken = await getGuestBearerToken();
-    if (guestToken) return guestToken;
+    const token = await getConvexAccessToken();
+    if (token) return token;
     throw new PluginApiError(
       "UPLOAD_FAILED",
-      "No Convex session available to upload the bundle.",
+      "Your session could not be refreshed for the upload. Please retry, or sign in again.",
     );
-  }, [getAccessToken]);
-
-  const generateBundleUploadUrl = useCallback(
-    async (projectId: string): Promise<string> => {
-      requireEnabled();
-      try {
-        return (await generateUploadUrlMutation({
-          projectId,
-        } as any)) as string;
-      } catch (err) {
-        throw toPluginApiError(err, "Could not create an upload URL");
-      }
-    },
-    [requireEnabled, generateUploadUrlMutation],
-  );
+  }, [getConvexAccessToken]);
 
   const createImport = useCallback(
     async (args: {
@@ -364,19 +342,12 @@ export function usePluginImportActions(): PluginImportActions {
 
   return useMemo(
     () => ({
-      generateBundleUploadUrl,
       createImport,
       inspectImport,
       commitImport,
       startImport,
     }),
-    [
-      generateBundleUploadUrl,
-      createImport,
-      inspectImport,
-      commitImport,
-      startImport,
-    ],
+    [createImport, inspectImport, commitImport, startImport],
   );
 }
 

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-api.test.ts
@@ -4,8 +4,73 @@ import {
   MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES,
   toPluginApiError,
   uploadPluginBundleToUrl,
+  uploadPluginBundleTracked,
 } from "../plugin-api";
 import { PluginApiError } from "../plugin-api-types";
+
+describe("uploadPluginBundleTracked", () => {
+  const baseArgs = {
+    siteUrl: "https://demo.convex.site",
+    projectId: "prj_123",
+    bearerToken: "bearer-abc",
+  };
+
+  it("POSTs to the tracked route with the bearer and returns the storage id", async () => {
+    const fetchImpl = vi.fn(async () =>
+      okJson({ ok: true, storageId: "st_tracked" }),
+    );
+    const storageId = await uploadPluginBundleTracked({
+      ...baseArgs,
+      bundle: new Blob(["zip-bytes"]),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(storageId).toBe("st_tracked");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://demo.convex.site/plugin-bundle-upload?projectId=prj_123",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer bearer-abc",
+        }),
+      }),
+    );
+  });
+
+  it("surfaces the route's stable error codes structurally", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 429,
+          json: async () => ({
+            ok: false,
+            code: "RATE_LIMITED",
+            error: "Guest plugin uploads are busy right now. Try again later.",
+          }),
+        }) as unknown as Response,
+    );
+    await expect(
+      uploadPluginBundleTracked({
+        ...baseArgs,
+        bundle: new Blob(["zip-bytes"]),
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "RATE_LIMITED" });
+  });
+
+  it("rejects an oversized bundle before any network call", async () => {
+    const fetchImpl = vi.fn();
+    const oversized = new Uint8Array(MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES + 1);
+    await expect(
+      uploadPluginBundleTracked({
+        ...baseArgs,
+        bundle: oversized,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "ARCHIVE_TOO_LARGE_COMPRESSED" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
 
 function okJson(payload: unknown): Response {
   return {

--- a/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-api.test.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/__tests__/plugin-api.test.ts
@@ -3,7 +3,6 @@ import {
   assertPluginBundleWithinCap,
   MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES,
   toPluginApiError,
-  uploadPluginBundleToUrl,
   uploadPluginBundleTracked,
 } from "../plugin-api";
 import { PluginApiError } from "../plugin-api-types";
@@ -70,78 +69,82 @@ describe("uploadPluginBundleTracked", () => {
     ).rejects.toMatchObject({ code: "ARCHIVE_TOO_LARGE_COMPRESSED" });
     expect(fetchImpl).not.toHaveBeenCalled();
   });
-});
 
-function okJson(payload: unknown): Response {
-  return {
-    ok: true,
-    status: 200,
-    json: async () => payload,
-  } as unknown as Response;
-}
-
-describe("uploadPluginBundleToUrl", () => {
-  it("POSTs the bundle and returns the storage id", async () => {
-    const fetchImpl = vi.fn(async () => okJson({ storageId: "st_123" }));
-    const storageId = await uploadPluginBundleToUrl(
-      "https://upload.example/x",
-      new Uint8Array([1, 2, 3]),
-      { fetchImpl: fetchImpl as unknown as typeof fetch },
+  it("still uploads a zero-length bundle (the backend rejects it as a malformed archive)", async () => {
+    const fetchImpl = vi.fn(async () =>
+      okJson({ ok: true, storageId: "st_empty" }),
     );
-    expect(storageId).toBe("st_123");
-    expect(fetchImpl).toHaveBeenCalledWith(
-      "https://upload.example/x",
-      expect.objectContaining({
-        method: "POST",
-        signal: expect.any(AbortSignal),
-      }),
-    );
+    const storageId = await uploadPluginBundleTracked({
+      ...baseArgs,
+      bundle: new Uint8Array(0),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(storageId).toBe("st_empty");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects an oversized bundle before uploading (backend cap mirror)", async () => {
-    const fetchImpl = vi.fn();
-    const oversized = {
-      size: MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES + 1,
-    } as unknown as Blob;
-    Object.setPrototypeOf(oversized, Blob.prototype);
+  it("maps a network failure to UPLOAD_FAILED with the cause", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
     await expect(
-      uploadPluginBundleToUrl("https://upload.example/x", oversized, {
+      uploadPluginBundleTracked({
+        ...baseArgs,
+        bundle: new Blob(["zip-bytes"]),
         fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
-    ).rejects.toMatchObject({ code: "ARCHIVE_TOO_LARGE_COMPRESSED" });
-    expect(fetchImpl).not.toHaveBeenCalled();
+    ).rejects.toMatchObject({
+      code: "UPLOAD_FAILED",
+      message: expect.stringContaining("Failed to fetch"),
+    });
   });
 
-  it("maps a non-2xx response to UPLOAD_FAILED", async () => {
+  it("maps a 2xx response without a storage id to UPLOAD_FAILED", async () => {
+    const fetchImpl = vi.fn(async () => okJson({ ok: true }));
+    await expect(
+      uploadPluginBundleTracked({
+        ...baseArgs,
+        bundle: new Blob(["zip-bytes"]),
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toMatchObject({
+      code: "UPLOAD_FAILED",
+      message: expect.stringContaining("storage id"),
+    });
+  });
+
+  it("aborts when the response body stalls past timeoutMs", async () => {
+    // fetch resolves on HEADERS; the abort timer must survive into the body
+    // read, so a response whose json() never settles still times out.
     const fetchImpl = vi.fn(
-      async () => ({ ok: false, status: 500 }) as unknown as Response,
+      async (_url: string, init: RequestInit) =>
+        ({
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              init.signal?.addEventListener("abort", () =>
+                reject(
+                  new DOMException("The operation was aborted.", "AbortError"),
+                ),
+              );
+            }),
+        }) as unknown as Response,
     );
     await expect(
-      uploadPluginBundleToUrl("https://upload.example/x", new Uint8Array([1]), {
+      uploadPluginBundleTracked({
+        ...baseArgs,
+        bundle: new Blob(["zip-bytes"]),
         fetchImpl: fetchImpl as unknown as typeof fetch,
+        timeoutMs: 20,
       }),
-    ).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
+    ).rejects.toMatchObject({
+      code: "UPLOAD_FAILED",
+      message: expect.stringContaining("timed out"),
+    });
   });
 
-  it("maps a missing storageId to UPLOAD_FAILED", async () => {
-    const fetchImpl = vi.fn(async () => okJson({}));
-    await expect(
-      uploadPluginBundleToUrl("https://upload.example/x", new Uint8Array([1]), {
-        fetchImpl: fetchImpl as unknown as typeof fetch,
-      }),
-    ).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
-  });
-
-  it("rejects an empty-string storageId as UPLOAD_FAILED", async () => {
-    const fetchImpl = vi.fn(async () => okJson({ storageId: "" }));
-    await expect(
-      uploadPluginBundleToUrl("https://upload.example/x", new Uint8Array([1]), {
-        fetchImpl: fetchImpl as unknown as typeof fetch,
-      }),
-    ).rejects.toMatchObject({ code: "UPLOAD_FAILED" });
-  });
-
-  it("aborts a stalled upload after timeoutMs", async () => {
+  it("aborts a stalled request after timeoutMs", async () => {
     const fetchImpl = vi.fn(
       (_url: string, init: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
@@ -153,7 +156,9 @@ describe("uploadPluginBundleToUrl", () => {
         }),
     );
     await expect(
-      uploadPluginBundleToUrl("https://upload.example/x", new Uint8Array([1]), {
+      uploadPluginBundleTracked({
+        ...baseArgs,
+        bundle: new Blob(["zip-bytes"]),
         fetchImpl: fetchImpl as unknown as typeof fetch,
         timeoutMs: 20,
       }),
@@ -163,6 +168,14 @@ describe("uploadPluginBundleToUrl", () => {
     });
   });
 });
+
+function okJson(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  } as unknown as Response;
+}
 
 describe("assertPluginBundleWithinCap", () => {
   it("accepts a bundle at the cap and rejects one byte over", () => {

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-api.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-api.ts
@@ -1,6 +1,6 @@
 /**
- * Pure (non-hook) helpers for the plugin import API: the direct-to-storage
- * bundle upload and structured error mapping. Hook wrappers live in
+ * Pure (non-hook) helpers for the plugin import API: the tracked bundle
+ * upload and structured error mapping. Hook wrappers live in
  * `client/src/hooks/usePluginImportApi.ts`.
  */
 
@@ -10,9 +10,9 @@ import { MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES } from "@/shared/plugin-bundle-limit
 /**
  * Re-exported so existing import sites keep working; the value now lives in
  * `shared/` because the local materializer route enforces the same cap.
- * Used here to reject an oversized ZIP before burning an upload-URL
- * rate-limit token; the backend re-enforces it at `createImport` and inspect
- * time.
+ * Used here to reject an oversized ZIP before burning a tracked-upload
+ * rate-limit token; the backend re-enforces it at the upload route,
+ * `createImport`, and inspect time.
  */
 export { MAX_PLUGIN_BUNDLE_COMPRESSED_BYTES };
 
@@ -29,7 +29,7 @@ export function pluginBundleByteSize(bundle: Blob | Uint8Array): number {
 
 /**
  * Throw `ARCHIVE_TOO_LARGE_COMPRESSED` when a bundle exceeds the backend's
- * compressed cap. Call this BEFORE minting an upload URL — the mint is
+ * compressed cap. Call this BEFORE hitting the tracked upload route — it is
  * rate-limited, so an oversized bundle must not burn a token on an upload
  * that can never be imported.
  */
@@ -40,78 +40,6 @@ export function assertPluginBundleWithinCap(bundle: Blob | Uint8Array): void {
       "The plugin bundle exceeds the maximum compressed size (25 MB).",
     );
   }
-}
-
-export interface UploadPluginBundleOptions {
-  fetchImpl?: typeof fetch;
-  /** Abort the upload after this many ms (default 5 minutes). */
-  timeoutMs?: number;
-}
-
-/**
- * Upload a plugin bundle ZIP to a Convex storage upload URL (minted by
- * `plugins.generateBundleUploadUrl`) and return the storage id to pass to
- * `plugins.createImport`.
- */
-export async function uploadPluginBundleToUrl(
-  uploadUrl: string,
-  bundle: Blob | Uint8Array,
-  options?: UploadPluginBundleOptions,
-): Promise<string> {
-  const fetchImpl = options?.fetchImpl ?? fetch;
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_PLUGIN_UPLOAD_TIMEOUT_MS;
-  const body =
-    bundle instanceof Blob
-      ? bundle
-      : new Blob([bundle as unknown as BlobPart], {
-          type: "application/zip",
-        });
-  assertPluginBundleWithinCap(body);
-
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  let response: Response;
-  try {
-    response = await fetchImpl(uploadUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/zip" },
-      body,
-      signal: controller.signal,
-    });
-  } catch (error) {
-    if (controller.signal.aborted) {
-      throw new PluginApiError(
-        "UPLOAD_FAILED",
-        `Bundle upload timed out after ${timeoutMs}ms`,
-      );
-    }
-    throw new PluginApiError(
-      "UPLOAD_FAILED",
-      `Bundle upload failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  } finally {
-    clearTimeout(timeout);
-  }
-  if (!response.ok) {
-    throw new PluginApiError(
-      "UPLOAD_FAILED",
-      `Bundle upload failed with status ${response.status}`,
-    );
-  }
-
-  const payload = (await response.json().catch(() => null)) as {
-    storageId?: unknown;
-  } | null;
-  const storageId = payload?.storageId;
-  if (typeof storageId !== "string" || storageId.length === 0) {
-    throw new PluginApiError(
-      "UPLOAD_FAILED",
-      "Bundle upload did not return a storage id",
-    );
-  }
-  return storageId;
 }
 
 /**
@@ -153,39 +81,54 @@ export async function uploadPluginBundleTracked(args: {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   let response: Response;
-  try {
-    response = await fetchImpl(url.toString(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/zip",
-        Authorization: `Bearer ${args.bearerToken}`,
-      },
-      body,
-      signal: controller.signal,
-    });
-  } catch (error) {
-    if (controller.signal.aborted) {
-      throw new PluginApiError(
-        "UPLOAD_FAILED",
-        `Bundle upload timed out after ${timeoutMs}ms`,
-      );
-    }
-    throw new PluginApiError(
-      "UPLOAD_FAILED",
-      `Bundle upload failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  } finally {
-    clearTimeout(timeout);
-  }
-
-  const payload = (await response.json().catch(() => null)) as {
+  let payload: {
     ok?: unknown;
     storageId?: unknown;
     code?: unknown;
     error?: unknown;
   } | null;
+  try {
+    try {
+      response = await fetchImpl(url.toString(), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/zip",
+          Authorization: `Bearer ${args.bearerToken}`,
+        },
+        body,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new PluginApiError(
+          "UPLOAD_FAILED",
+          `Bundle upload timed out after ${timeoutMs}ms`,
+        );
+      }
+      throw new PluginApiError(
+        "UPLOAD_FAILED",
+        `Bundle upload failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    // `fetch` resolves on response HEADERS; the body read below rides the
+    // same abort signal, so the timer must stay armed until the JSON lands
+    // or a stalled body would hang the import modal forever.
+    try {
+      payload = (await response.json()) as typeof payload;
+    } catch {
+      if (controller.signal.aborted) {
+        throw new PluginApiError(
+          "UPLOAD_FAILED",
+          `Bundle upload timed out after ${timeoutMs}ms`,
+        );
+      }
+      payload = null;
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
   if (!response.ok) {
     // The route returns the backend's stable codes (RATE_LIMITED, FORBIDDEN,
     // ARCHIVE_TOO_LARGE_COMPRESSED, ...) — surface them structurally so the

--- a/mcpjam-inspector/client/src/lib/plugins/plugin-api.ts
+++ b/mcpjam-inspector/client/src/lib/plugins/plugin-api.ts
@@ -115,6 +115,102 @@ export async function uploadPluginBundleToUrl(
 }
 
 /**
+ * Upload a plugin bundle through the TRACKED route (`POST
+ * /plugin-bundle-upload` on the Convex site URL) and return the storage id
+ * to pass to `plugins.createImport`.
+ *
+ * Unlike a minted upload URL — whose resulting storageId only the client
+ * ever learns, so an abandoned blob is unreclaimable storage — the tracked
+ * route stores the blob server-side, records it with a TTL, and the backend
+ * sweeps whatever `createImport` never adopts. REQUIRED for guests (minted
+ * URLs refuse them); used for every actor so there is exactly one upload
+ * path.
+ */
+export async function uploadPluginBundleTracked(args: {
+  /** Convex HTTP actions base URL (`getConvexSiteUrl()`). */
+  siteUrl: string;
+  projectId: string;
+  bundle: Blob | Uint8Array;
+  /** Convex bearer (WorkOS or guest) — the route authorizes with it. */
+  bearerToken: string;
+  fetchImpl?: typeof fetch;
+  /** Abort the upload after this many ms (default 5 minutes). */
+  timeoutMs?: number;
+}): Promise<string> {
+  const fetchImpl = args.fetchImpl ?? fetch;
+  const timeoutMs = args.timeoutMs ?? DEFAULT_PLUGIN_UPLOAD_TIMEOUT_MS;
+  const body =
+    args.bundle instanceof Blob
+      ? args.bundle
+      : new Blob([args.bundle as unknown as BlobPart], {
+          type: "application/zip",
+        });
+  assertPluginBundleWithinCap(body);
+
+  const url = new URL("/plugin-bundle-upload", args.siteUrl);
+  url.searchParams.set("projectId", args.projectId);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  let response: Response;
+  try {
+    response = await fetchImpl(url.toString(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/zip",
+        Authorization: `Bearer ${args.bearerToken}`,
+      },
+      body,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new PluginApiError(
+        "UPLOAD_FAILED",
+        `Bundle upload timed out after ${timeoutMs}ms`,
+      );
+    }
+    throw new PluginApiError(
+      "UPLOAD_FAILED",
+      `Bundle upload failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    ok?: unknown;
+    storageId?: unknown;
+    code?: unknown;
+    error?: unknown;
+  } | null;
+  if (!response.ok) {
+    // The route returns the backend's stable codes (RATE_LIMITED, FORBIDDEN,
+    // ARCHIVE_TOO_LARGE_COMPRESSED, ...) — surface them structurally so the
+    // modal renders the matching remedy instead of a generic failure.
+    const code =
+      typeof payload?.code === "string"
+        ? (payload.code as PluginApiErrorCode)
+        : "UPLOAD_FAILED";
+    const message =
+      typeof payload?.error === "string"
+        ? payload.error
+        : `Bundle upload failed with status ${response.status}`;
+    throw new PluginApiError(code, message);
+  }
+  const storageId = payload?.storageId;
+  if (typeof storageId !== "string" || storageId.length === 0) {
+    throw new PluginApiError(
+      "UPLOAD_FAILED",
+      "Bundle upload did not return a storage id",
+    );
+  }
+  return storageId;
+}
+
+/**
  * Map an unknown rejection from a plugin Convex call to a structured
  * `PluginApiError`. Convex `ConvexError` payloads land on `err.data` — the
  * backend throws `{code, message}` records with stable codes (`FORBIDDEN`,


### PR DESCRIPTION
## Summary

Agent Plugins program, **Phase 4.2** — the client half of [mcpjam-backend#913](https://github.com/MCPJam/mcpjam-backend/pull/913), deleting the gate that PR existed to make removable. Guests now see and use the full plugin surface.

## What changes

- **The gate**: `usePluginQueriesReady` drops its self-documented `// TEMPORARY: remove the Boolean(user) term once the backend serves guests`. The backend does (user* wrappers, guest-tier + rotation-proof global rate ceilings, tracked uploads), so the gate is `plugins-enabled` AND a resolved Convex actor — guests included. `PluginsSection` / `AddPluginModal` render for guests with no further changes; everything downstream (environments, runtime resolution, chat) already served them.
- **One upload path**: `startImport` uploads through the tracked route (`POST /plugin-bundle-upload` on the Convex site URL) for **every** actor — required for guests (minted URLs refuse them, since their storageId is unreclaimable), harmless for members, and it means abandoned uploads are sweepable stock server-side. Bearer acquisition mirrors the chat session's order: WorkOS access token, else the guest bearer. The route's stable error codes (`RATE_LIMITED`, `FORBIDDEN`, `ARCHIVE_TOO_LARGE_COMPRESSED`) surface structurally so the modal shows the matching remedy.
- `generateBundleUploadUrl` stays exported for compatibility; the import flow no longer uses it.

## Deploy order

Backend #913 merged first (its deploy carries the tracked route and guest wrappers); this PR is the switch-flip. If it ever ran against an older backend, guests would see clean FORBIDDEN errors rather than broken UI — the same failure shape as today.

## Tests

New `uploadPluginBundleTracked` cases: POSTs with the bearer and returns the storage id; stable route codes surface structurally; oversized bundles rejected before any network call. Full client plugin + hooks suites green (854 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guest access to plugin data and replaces the upload/auth path; misconfigured site URL or token resolution could block imports or mis-attribute uploads, but scope is client-side with explicit errors.
> 
> **Overview**
> **Guests** can use the plugin import UI and subscriptions: `usePluginQueriesReady` no longer requires a WorkOS user—only `plugins-enabled` and a resolved Convex session (`isAuthenticated`), which includes guests.
> 
> **Bundle upload** is unified on the **tracked** Convex site route instead of minting a storage URL. `startImport` resolves a bearer via `useConvexAccessToken` (WorkOS when signed in, no silent guest fallback for signed-in users), POSTs the ZIP to `/plugin-bundle-upload?projectId=…`, then continues with `createImport` and `inspectImport`. `generateBundleUploadUrl` is removed from the import actions API; tests and `AddPluginModal` mocks drop it.
> 
> **`uploadPluginBundleTracked`** replaces `uploadPluginBundleToUrl`: Authorization header, maps route JSON error `code`/`error` into `PluginApiError` (e.g. `RATE_LIMITED`), keeps size checks and abort timeout through response body read. Test suite expanded for route behavior, network failures, and timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36304c08ea2aa3c84e08678dc4090fce50d1f7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the full plugin UI to guests and moves all plugin bundle uploads to a single tracked Convex route for better reliability and cleanup. Also hardens auth and timeouts to avoid silent guest downgrades and stalled uploads.

- **New Features**
  - Plugins render for guests when plugins are enabled and a Convex session is resolved.
  - All imports upload via the tracked route (POST /plugin-bundle-upload); server records uploads and sweeps abandoned blobs.
  - Auth bearer comes from `useConvexAccessToken`; if a signed-in token can’t refresh, the upload fails instead of falling back to a guest.
  - Upload timeout now covers the response body read; stalled requests fail with a clear `UPLOAD_FAILED` error.
  - Stable route error codes (`RATE_LIMITED`, `FORBIDDEN`, `ARCHIVE_TOO_LARGE_COMPRESSED`) surface structurally; pre-upload size checks remain.
  - Removed the client minted-URL path; the backend mutation remains for non-browser consumers.

- **Migration**
  - Deploy the backend with guest support and tracked uploads first; on older backends, guests will see clean FORBIDDEN errors.

<sup>Written for commit c36304c08ea2aa3c84e08678dc4090fce50d1f7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

