### PR TITLE
feat(environments): connect stdio servers on local web-route turns

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -163,6 +163,11 @@ describe("web auth manager batching", () => {
     // through /web/authorize-batch-local with the same bearer and builds a
     // spawnable stdio config, while the http sibling stays on the hosted
     // mint path untouched.
+    //
+    // Captured, not asserted inside the mock: `authorizeBatchLocal` wraps any
+    // throw from fetch (including a failed expect) into a 502 WebRouteError,
+    // which would surface as a misleading transport error.
+    let localInit: RequestInit | undefined;
     global.fetch = vi.fn(async (input, init) => {
       const url = fetchUrl(input);
       if (url.endsWith("/web/authorize-batch")) {
@@ -195,13 +200,7 @@ describe("web auth manager batching", () => {
         );
       }
       if (url.endsWith("/web/authorize-batch-local")) {
-        expect(
-          (init?.headers as Record<string, string>).Authorization
-        ).toBe("Bearer bearer-token");
-        expect(JSON.parse(init?.body as string)).toEqual({
-          projectId: "project-1",
-          serverIds: ["srv-stdio"],
-        });
+        localInit = init;
         return new Response(
           JSON.stringify({
             results: {
@@ -234,6 +233,13 @@ describe("web auth manager batching", () => {
       10_000
     );
 
+    expect((localInit?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer bearer-token"
+    );
+    expect(JSON.parse(localInit?.body as string)).toEqual({
+      projectId: "project-1",
+      serverIds: ["srv-stdio"],
+    });
     expect(mcpClientManagerMock).toHaveBeenCalledWith(
       {
         "srv-http": expect.objectContaining({
@@ -249,6 +255,91 @@ describe("web auth manager batching", () => {
       },
       expect.any(Object)
     );
+  });
+
+  // Codex P2 regression: the harness proxy authenticates via WorkOS API key
+  // and deliberately passes an EMPTY bearer — the caller context carries the
+  // service-token + acting-as exchange instead. The stdio divert's local
+  // reread must forward that delegated identity, not send `Bearer ` verbatim
+  // (which failed every local harness turn against a stdio server).
+  it("diverts stdio with the delegated exchange when the caller used a WorkOS API key", async () => {
+    const originalServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    mockVars.authMethod = "workos_api_key";
+    mockVars.workosUserId = "user_workos_1";
+    mockVars.mcpjamOrganizationId = "org_1";
+
+    let hostedInit: RequestInit | undefined;
+    let localInit: RequestInit | undefined;
+    global.fetch = vi.fn(async (input, init) => {
+      const url = fetchUrl(input);
+      if (url.endsWith("/web/authorize-batch")) {
+        hostedInit = init;
+        return new Response(
+          JSON.stringify({
+            results: {
+              "srv-stdio": {
+                ok: true,
+                role: "member",
+                accessLevel: "project_member",
+                permissions: { chatOnly: false },
+                serverConfig: { transportType: "stdio" },
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      if (url.endsWith("/web/authorize-batch-local")) {
+        localInit = init;
+        return new Response(
+          JSON.stringify({
+            results: {
+              "srv-stdio": {
+                ok: true,
+                role: "member",
+                accessLevel: "project_member",
+                permissions: { chatOnly: false },
+                serverConfig: {
+                  transportType: "stdio",
+                  command: "node",
+                  args: ["server.js"],
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    try {
+      await createAuthorizedManager(
+        callerContextFromHono(mockContext),
+        "", // bearer ignored on the workos_api_key path (harness proxy)
+        "project-1",
+        ["srv-stdio"],
+        10_000
+      );
+
+      // Both the hosted batch and the local reread ride the same exchange.
+      for (const init of [hostedInit, localInit]) {
+        const headers = init?.headers as Record<string, string>;
+        expect(headers.Authorization).toBe("Bearer service-token");
+        expect(headers["x-mcpjam-acting-as"]).toBe("user_workos_1");
+        expect(headers["x-mcpjam-acting-in-org"]).toBe("org_1");
+      }
+    } finally {
+      delete mockVars.authMethod;
+      delete mockVars.workosUserId;
+      delete mockVars.mcpjamOrganizationId;
+      if (originalServiceToken === undefined) {
+        delete process.env.INSPECTOR_SERVICE_TOKEN;
+      } else {
+        process.env.INSPECTOR_SERVICE_TOKEN = originalServiceToken;
+      }
+    }
   });
 
   it("attaches hosted OAuth onUnauthorized and force-refreshes through Convex", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -156,6 +156,101 @@ describe("web auth manager batching", () => {
     );
   });
 
+  it("diverts stdio servers to the local resolver in local mode (mixed batch)", async () => {
+    // This suite runs with HOSTED_MODE unset (local). The hosted authorize
+    // batch answers for BOTH servers but strips the stdio row's
+    // command/args/env by contract; the divert re-reads that one server
+    // through /web/authorize-batch-local with the same bearer and builds a
+    // spawnable stdio config, while the http sibling stays on the hosted
+    // mint path untouched.
+    global.fetch = vi.fn(async (input, init) => {
+      const url = fetchUrl(input);
+      if (url.endsWith("/web/authorize-batch")) {
+        return new Response(
+          JSON.stringify({
+            results: {
+              "srv-http": {
+                ok: true,
+                role: "member",
+                accessLevel: "project_member",
+                permissions: { chatOnly: false },
+                serverConfig: {
+                  transportType: "http",
+                  url: "https://srv-http.example.com/mcp",
+                  headers: { "X-Test": "yes" },
+                },
+              },
+              "srv-stdio": {
+                ok: true,
+                role: "member",
+                accessLevel: "project_member",
+                permissions: { chatOnly: false },
+                serverConfig: {
+                  transportType: "stdio",
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      if (url.endsWith("/web/authorize-batch-local")) {
+        expect(
+          (init?.headers as Record<string, string>).Authorization
+        ).toBe("Bearer bearer-token");
+        expect(JSON.parse(init?.body as string)).toEqual({
+          projectId: "project-1",
+          serverIds: ["srv-stdio"],
+        });
+        return new Response(
+          JSON.stringify({
+            results: {
+              "srv-stdio": {
+                ok: true,
+                role: "member",
+                accessLevel: "project_member",
+                permissions: { chatOnly: false },
+                serverConfig: {
+                  transportType: "stdio",
+                  command: "node",
+                  args: ["plugin-server.js"],
+                  env: { FOO: "bar" },
+                  cwd: "/srv/plugin-root",
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    await createAuthorizedManager(
+      callerContextFromHono(mockContext),
+      "bearer-token",
+      "project-1",
+      ["srv-http", "srv-stdio"],
+      10_000
+    );
+
+    expect(mcpClientManagerMock).toHaveBeenCalledWith(
+      {
+        "srv-http": expect.objectContaining({
+          url: "https://srv-http.example.com/mcp",
+        }),
+        "srv-stdio": expect.objectContaining({
+          command: "node",
+          args: ["plugin-server.js"],
+          env: { FOO: "bar" },
+          cwd: "/srv/plugin-root",
+          timeout: 10_000,
+        }),
+      },
+      expect.any(Object)
+    );
+  });
+
   it("attaches hosted OAuth onUnauthorized and force-refreshes through Convex", async () => {
     global.fetch = vi.fn(async (input, init) => {
       const url = fetchUrl(input);

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -35,6 +35,7 @@ import {
 } from "../../utils/effective-auth.js";
 import type { EffectiveAuthMethod } from "../../utils/effective-auth.js";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config.js";
+import { resolveLocalStdioServerConfig } from "../../utils/local-server-resolver.js";
 import type { RequestLogContext } from "../../utils/log-events.js";
 import {
   type InternalLogContext,
@@ -893,6 +894,8 @@ function resolveEffectiveInitializePinsForServer(
       supportedProtocolVersions?: string[];
       mcpProtocolVersion?: McpProtocolVersion;
       mirrorToolParamHeaders?: boolean;
+      firstPageOnly?: boolean;
+      supportsMrtr?: boolean;
     }
   | undefined {
   const perServerPin = mcpProtocolVersionsByServerId?.[serverId];
@@ -1251,6 +1254,54 @@ export async function createAuthorizedManager(
       const effectiveAuth = effectiveAuthByServerId.get(
         serverId
       ) as EffectiveAuthMethod;
+
+      const effectiveInitializePins = resolveEffectiveInitializePinsForServer(
+        serverId,
+        options?.initializePins,
+        options?.mcpProtocolVersionsByServerId
+      );
+      // Per-server timeout: a pinned `requestTimeoutOverride` (threaded by the
+      // swarm runner) wins over the batch-uniform host default. Guard against a
+      // malformed snapshot value falling through to a non-positive timeout.
+      const perServerTimeout = options?.requestTimeoutByServerId?.[serverId];
+      const effectiveTimeoutMs =
+        typeof perServerTimeout === "number" &&
+        Number.isFinite(perServerTimeout) &&
+        perServerTimeout > 0
+          ? perServerTimeout
+          : timeoutMs;
+
+      // LOCAL RUNTIME stdio divert. When this /api/web deployment IS the
+      // local binary (npx/desktop), a stdio server — an ordinary one or a
+      // plugin's local component — CAN spawn here: this is the same process
+      // the /api/mcp engine spawns stdio children from. The hosted authorize
+      // batch strips command/args/env by contract, so the local resolver
+      // re-reads the full config through /web/authorize-batch-local (same
+      // bearer — authorization is re-checked, not assumed), applies runtime
+      // secrets, and materializes plugin bundles before building the SDK
+      // config. HOSTED deployments keep the `toHttpConfig` 400 below: there
+      // is genuinely no local process to spawn into (until stdio-in-computer
+      // execution lands).
+      if (auth.serverConfig.transportType !== "http" && !HOSTED_MODE) {
+        const config = await resolveLocalStdioServerConfig(
+          bearerToken,
+          projectId,
+          serverId,
+          {
+            timeoutMs: effectiveTimeoutMs,
+            clientCapabilities,
+            serverDisplayName: displayServerName,
+            clientInfo: effectiveInitializePins?.clientInfo,
+            supportedProtocolVersions:
+              effectiveInitializePins?.supportedProtocolVersions,
+            firstPageOnly: effectiveInitializePins?.firstPageOnly,
+            supportsMrtr: effectiveInitializePins?.supportsMrtr,
+            xaaPolicy: options?.xaaPolicy,
+          }
+        );
+        return [serverId, config] as const;
+      }
+
       const usesOAuthFlow = effectiveAuth === "oauth";
       // "discover" (non-XAA auto) rides the OAuth rails only when a stored
       // token exists; tokenless discover connects unauthenticated instead of
@@ -1401,21 +1452,6 @@ export async function createAuthorizedManager(
         };
       }
 
-      const effectiveInitializePins = resolveEffectiveInitializePinsForServer(
-        serverId,
-        options?.initializePins,
-        options?.mcpProtocolVersionsByServerId
-      );
-      // Per-server timeout: a pinned `requestTimeoutOverride` (threaded by the
-      // swarm runner) wins over the batch-uniform host default. Guard against a
-      // malformed snapshot value falling through to a non-positive timeout.
-      const perServerTimeout = options?.requestTimeoutByServerId?.[serverId];
-      const effectiveTimeoutMs =
-        typeof perServerTimeout === "number" &&
-        Number.isFinite(perServerTimeout) &&
-        perServerTimeout > 0
-          ? perServerTimeout
-          : timeoutMs;
       const authForConfig =
         auth.serverConfig.hasHeaders === true &&
         !hasNonEmptyStringRecord(auth.serverConfig.headers)

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -1237,6 +1237,20 @@ export async function createAuthorizedManager(
     }
   }
 
+  // Plugin bundle leases acquired by the stdio divert below. Held per
+  // MANAGER, not in the process-wide registry: two concurrent turns on the
+  // same plugin server must each pin the bundle independently (the
+  // registry's replace-on-retain would let the second turn unpin the
+  // first's still-running child), and this batch releases its own leases at
+  // teardown. Drained (not just iterated) so a double disconnect can't
+  // double-release.
+  const pluginLeaseReleases: Array<() => void> = [];
+  const releasePluginLeases = () => {
+    while (pluginLeaseReleases.length > 0) {
+      pluginLeaseReleases.pop()!();
+    }
+  };
+
   // PASS 2 — connect/mint concurrently. Every server reaching this point has
   // already cleared the batch-wide validation above.
   const configEntries = await Promise.all(
@@ -1317,6 +1331,7 @@ export async function createAuthorizedManager(
                     mcpjamOrganizationId: caller.mcpjamOrganizationId,
                   }
                 : undefined,
+            onPluginLease: (release) => pluginLeaseReleases.push(release),
           }
         );
         return [serverId, config] as const;
@@ -1533,7 +1548,13 @@ export async function createAuthorizedManager(
         ),
       ] as const;
     })
-  );
+  ).catch((error) => {
+    // A sibling server's throw (OAuth-required, XAA mint failure, …) aborts
+    // the whole batch — leases already acquired by other servers' diverts
+    // must not outlive the manager that will now never exist.
+    releasePluginLeases();
+    throw error;
+  });
 
   const manager = new MCPClientManager(Object.fromEntries(configEntries), {
     defaultTimeout: timeoutMs,
@@ -1546,6 +1567,21 @@ export async function createAuthorizedManager(
       ? { elicitationTimeoutExtensionMs: options.elicitationTimeoutExtensionMs }
       : {}),
   });
+  if (pluginLeaseReleases.length > 0) {
+    // Every ephemeral-manager teardown path (withManager, web-chat-turn
+    // cleanup, manual-connection callers) funnels through
+    // `disconnectAllServers`, so decorating the instance releases this
+    // batch's plugin bundle leases on ALL of them without threading a new
+    // return value to every caller. The drain makes a second call a no-op.
+    const disconnect = manager.disconnectAllServers.bind(manager);
+    manager.disconnectAllServers = async () => {
+      try {
+        await disconnect();
+      } finally {
+        releasePluginLeases();
+      }
+    };
+  }
   // SYNCHRONOUS, before any `await` — the constructor above queued its connects
   // as microtasks, and `buildCapabilities` (which decides whether `elicitation`
   // survives onto the initialize wire) runs inside them. Registering here always

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -975,6 +975,9 @@ export async function createAuthorizedManager(
       mcpProtocolVersion?: McpProtocolVersion;
       /** SEP-2243 `Mcp-Param-*` mirroring; host-level, so batch-uniform. */
       mirrorToolParamHeaders?: boolean;
+      /** Client-conformance knobs; host-level, so batch-uniform. */
+      firstPageOnly?: boolean;
+      supportsMrtr?: boolean;
     };
     /**
      * Per-server `mcpProtocolVersion` overrides keyed by serverId.
@@ -1297,6 +1300,23 @@ export async function createAuthorizedManager(
             firstPageOnly: effectiveInitializePins?.firstPageOnly,
             supportsMrtr: effectiveInitializePins?.supportsMrtr,
             xaaPolicy: options?.xaaPolicy,
+            // The local reread + secret reveal must carry the same scope and
+            // delegated identity as the hosted mint path below — a harness
+            // caller's bearer is deliberately empty (workos_api_key supplies
+            // the service-token exchange), and a chatbox-scoped caller's
+            // reveal is gated on chatboxId/accessVersion.
+            accessScope: options?.accessScope,
+            chatboxId: options?.chatboxId,
+            accessVersion: options?.accessVersion,
+            workosApiKeyActingAs:
+              caller.authMethod === "workos_api_key" &&
+              caller.workosUserId &&
+              caller.mcpjamOrganizationId
+                ? {
+                    workosUserId: caller.workosUserId,
+                    mcpjamOrganizationId: caller.mcpjamOrganizationId,
+                  }
+                : undefined,
           }
         );
         return [serverId, config] as const;

--- a/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
+++ b/mcpjam-inspector/server/services/plugins/__tests__/local-stdio.test.ts
@@ -491,6 +491,42 @@ describe("materializePluginStdioForConnect", () => {
     expect(cache.activeEntries()).toEqual([]);
   });
 
+  // Ephemeral web-route managers: each concurrent turn holds its OWN lease
+  // via onLease — the registry's replace-on-retain must not apply, or turn B
+  // would unpin turn A's still-running child.
+  it("hands the lease to the caller via onLease, bypassing the registry", async () => {
+    await cache.materialize(
+      { projectId: PROJECT_ID, pluginVersionId: VERSION_ID, bundleHash },
+      { source: await fixtureBundleSource() }
+    );
+
+    const held: Array<() => void> = [];
+    const materializeHeld = () =>
+      materializePluginStdioForConnect({
+        createClient: () => stubClient({ bundleHash }),
+        projectId: PROJECT_ID,
+        serverId: SERVER_ID,
+        serverName: SERVER_ID,
+        onLease: (release) => held.push(release),
+        spec: PLACEHOLDER_SPEC,
+        cache,
+        dataRoot: join(cacheRoot, "plugin-data"),
+      });
+
+    const first = await materializeHeld();
+    const second = await materializeHeld();
+    expect(held).toHaveLength(2);
+    expect(cache.activeEntries()).toEqual([first?.pluginRoot]);
+
+    // The registry never saw these leases: releasing by serverName is a
+    // no-op, and dropping one held lease keeps the other's pin alive.
+    releasePluginLease(SERVER_ID);
+    held.pop()!();
+    expect(cache.activeEntries()).toEqual([second?.pluginRoot]);
+    held.pop()!();
+    expect(cache.activeEntries()).toEqual([]);
+  });
+
   it("throws an actionable 409 when the cached bundle was tampered with", async () => {
     const { root } = await cache.materialize(
       { projectId: PROJECT_ID, pluginVersionId: VERSION_ID, bundleHash },

--- a/mcpjam-inspector/server/services/plugins/local-stdio.ts
+++ b/mcpjam-inspector/server/services/plugins/local-stdio.ts
@@ -395,6 +395,15 @@ export async function materializePluginStdioForConnect(args: {
    * managers key by serverId). Defaults to `serverName`.
    */
   displayName?: string;
+  /**
+   * Caller-held lease: when provided, the bundle's release closure is handed
+   * here INSTEAD of the process-wide per-serverName registry. Ephemeral
+   * web-route managers need this — two concurrent turns on the same server
+   * must each pin the bundle independently (the registry's replace-on-retain
+   * semantics would let the second turn unpin the first's running child),
+   * and the caller releases at its own teardown.
+   */
+  onLease?: (release: () => void) => void;
   spec: PluginStdioLaunchSpec;
   cache?: PluginBundleCache;
   /** Test seam for the `${PLUGIN_DATA}` root. */
@@ -427,7 +436,11 @@ export async function materializePluginStdioForConnect(args: {
     );
   }
 
-  retainPluginLease(args.serverName, prepared.release);
+  if (args.onLease) {
+    args.onLease(prepared.release);
+  } else {
+    retainPluginLease(args.serverName, prepared.release);
+  }
   return {
     command: prepared.launch.command,
     args: prepared.launch.args,

--- a/mcpjam-inspector/server/services/plugins/local-stdio.ts
+++ b/mcpjam-inspector/server/services/plugins/local-stdio.ts
@@ -390,6 +390,11 @@ export async function materializePluginStdioForConnect(args: {
   serverId: string;
   /** Manager key the lease is bound to. */
   serverName: string;
+  /**
+   * Human label for error messages when the manager key isn't one (web-route
+   * managers key by serverId). Defaults to `serverName`.
+   */
+  displayName?: string;
   spec: PluginStdioLaunchSpec;
   cache?: PluginBundleCache;
   /** Test seam for the `${PLUGIN_DATA}` root. */
@@ -416,7 +421,10 @@ export async function materializePluginStdioForConnect(args: {
   });
 
   if (!prepared.ok) {
-    throw pluginStdioFailureToRouteError(args.serverName, prepared);
+    throw pluginStdioFailureToRouteError(
+      args.displayName ?? args.serverName,
+      prepared
+    );
   }
 
   retainPluginLease(args.serverName, prepared.release);

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
@@ -1316,4 +1316,57 @@ describe("resolveLocalStdioServerConfig — web-route stdio divert", () => {
       resolveLocalStdioServerConfig("bearer-xyz", "proj-1", "srv-stdio")
     ).rejects.toMatchObject({ status: 409, code: "CONFLICT" });
   });
+
+  // The stated invariant of the shared runtime resolution: a row with
+  // `hasEnv: true` and an empty env means the values live in the vault —
+  // the reveal must run and its env must land on the SDK config, carrying
+  // the same scope fields the hosted mint path would send.
+  it("reveals deferred secrets (hasEnv with empty env) with the caller's scope", async () => {
+    let revealInit: RequestInit | undefined;
+    const fetchMock = vi.fn(async (input: any, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/web/authorize-batch-local")) {
+        return localBatchResponse({
+          transportType: "stdio",
+          command: "node",
+          args: ["server.js"],
+          hasEnv: true,
+          env: {},
+        });
+      }
+      if (url.endsWith("/web/server/reveal-secrets")) {
+        revealInit = init;
+        return new Response(
+          JSON.stringify({ success: true, env: { API_KEY: "vault-value" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const config: any = await resolveLocalStdioServerConfig(
+      "bearer-xyz",
+      "proj-1",
+      "srv-stdio",
+      {
+        accessScope: "chat_v2",
+        chatboxId: "chatbox-1",
+        accessVersion: 7,
+      }
+    );
+
+    expect(config.env).toEqual({ API_KEY: "vault-value" });
+    expect((revealInit?.headers as Record<string, string>).Authorization).toBe(
+      "Bearer bearer-xyz"
+    );
+    expect(JSON.parse(revealInit?.body as string)).toMatchObject({
+      purpose: "runtime",
+      projectId: "proj-1",
+      serverId: "srv-stdio",
+      accessScope: "chat_v2",
+      chatboxId: "chatbox-1",
+      accessVersion: 7,
+    });
+  });
 });

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
@@ -4,6 +4,7 @@ import {
   executeLocalServerConnect,
   parseConnectionDefaults,
   resolveLocalServerForConnect,
+  resolveLocalStdioServerConfig,
   toMCPServerConfig,
 } from "../local-server-resolver.js";
 
@@ -1218,5 +1219,101 @@ describe("toMCPServerConfig — malformed protocol versions fail closed", () => 
       mcpProtocolVersion: "2025-11-52" as any,
     });
     expect(config.clientCapabilities.elicitation).toEqual({ form: {} });
+  });
+});
+
+describe("resolveLocalStdioServerConfig — web-route stdio divert", () => {
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_CONVEX_HTTP_URL === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = ORIGINAL_CONVEX_HTTP_URL;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  function localBatchResponse(serverConfig: Record<string, unknown>) {
+    return new Response(
+      JSON.stringify({
+        results: {
+          "srv-stdio": {
+            ok: true,
+            role: "owner",
+            accessLevel: "project_member",
+            permissions: { chatOnly: false },
+            serverConfig,
+          },
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  it("builds a stdio SDK config from authorize-batch-local, threading cwd/timeout/capabilities", async () => {
+    const fetchMock = vi.fn(async (input: any) => {
+      const url = String(input);
+      if (url.endsWith("/web/authorize-batch-local")) {
+        return localBatchResponse({
+          transportType: "stdio",
+          command: "node",
+          args: ["server.js"],
+          env: { FOO: "bar" },
+          cwd: "/srv/plugin-root",
+        });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const config: any = await resolveLocalStdioServerConfig(
+      "bearer-xyz",
+      "proj-1",
+      "srv-stdio",
+      {
+        timeoutMs: 12_345,
+        clientCapabilities: { sampling: {} },
+        serverDisplayName: "Stdio Server",
+      }
+    );
+
+    expect(config).toMatchObject({
+      command: "node",
+      args: ["server.js"],
+      env: { FOO: "bar" },
+      cwd: "/srv/plugin-root",
+      timeout: 12_345,
+    });
+    expect(config.url).toBeUndefined();
+    expect(config.capabilities).toMatchObject({ sampling: {} });
+    // The bearer is re-checked against the LOCAL endpoint — one call, no
+    // secret/plugin reads for a plain stdio server.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchMock.mock.calls[0] as [
+      string,
+      RequestInit,
+    ];
+    expect(String(calledUrl)).toContain("/web/authorize-batch-local");
+    expect((calledInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer bearer-xyz"
+    );
+  });
+
+  it("refuses an http row instead of silently building one", async () => {
+    const fetchMock = vi.fn(async () =>
+      localBatchResponse({
+        transportType: "http",
+        url: "https://hosted.example.com/mcp",
+        headers: {},
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      resolveLocalStdioServerConfig("bearer-xyz", "proj-1", "srv-stdio")
+    ).rejects.toMatchObject({ status: 409, code: "CONFLICT" });
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
@@ -1369,4 +1369,46 @@ describe("resolveLocalStdioServerConfig — web-route stdio divert", () => {
       accessVersion: 7,
     });
   });
+
+  // Plugin runtime reads ride the Convex QUERY protocol (user JWT), which
+  // cannot carry the service-token acting-as exchange. A delegated caller
+  // hitting a plugin component must get the real reason, not an
+  // unauthenticated-query failure.
+  it("fails closed when a delegated caller resolves a plugin component", async () => {
+    const originalServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
+    const fetchMock = vi.fn(async (input: any) => {
+      const url = String(input);
+      if (url.endsWith("/web/authorize-batch-local")) {
+        return localBatchResponse({
+          transportType: "stdio",
+          command: "node",
+          args: ["${PLUGIN_ROOT}/server/index.js"],
+          env: {},
+        });
+      }
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      await expect(
+        resolveLocalStdioServerConfig("", "proj-1", "srv-stdio", {
+          workosApiKeyActingAs: {
+            workosUserId: "user_workos_1",
+            mcpjamOrganizationId: "org_1",
+          },
+        })
+      ).rejects.toMatchObject({
+        status: 501,
+        code: "FEATURE_NOT_SUPPORTED",
+      });
+    } finally {
+      if (originalServiceToken === undefined) {
+        delete process.env.INSPECTOR_SERVICE_TOKEN;
+      } else {
+        process.env.INSPECTOR_SERVICE_TOKEN = originalServiceToken;
+      }
+    }
+  });
 });

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -829,6 +829,12 @@ async function applyLocalRuntimeResolution<
     chatboxId?: string;
     accessVersion?: number;
     workosApiKeyActingAs?: WorkosApiKeyActingAs;
+    /**
+     * Caller-held plugin bundle lease (see `materializePluginStdioForConnect`).
+     * Absent ⇒ the process-wide registry, which is what the /api/mcp
+     * long-lived manager wants.
+     */
+    onPluginLease?: (release: () => void) => void;
   }
 ): Promise<T> {
   const { bearerToken, projectId, serverId } = args;
@@ -872,11 +878,30 @@ async function applyLocalRuntimeResolution<
     const materialized = await materializePluginStdioForConnect({
       // Lazy: an ordinary stdio server must not pay a Convex read — or
       // require Convex configuration at all — to connect.
-      createClient: () => createPluginRuntimeConvexClient(bearerToken),
+      createClient: () => {
+        // The plugin runtime reads ride the Convex QUERY protocol (a user
+        // JWT via setAuth) — the service-token acting-as exchange is an
+        // HTTP-route header mechanism and cannot authenticate
+        // `client.query()`. A delegated (WorkOS API key) caller's bearer is
+        // deliberately empty, so fail closed with the real reason instead of
+        // letting the reads run unauthenticated into a confusing 401.
+        if (args.workosApiKeyActingAs) {
+          throw new WebRouteError(
+            501,
+            ErrorCode.FEATURE_NOT_SUPPORTED,
+            `Server "${
+              args.serverDisplayName ?? args.managerKey
+            }" is a plugin component; plugin materialization is not yet supported for API-key (delegated) callers.`,
+            { serverId }
+          );
+        }
+        return createPluginRuntimeConvexClient(bearerToken);
+      },
       projectId,
       serverId,
       serverName: args.managerKey,
       displayName: args.serverDisplayName ?? args.managerKey,
+      onLease: args.onPluginLease,
       spec: {
         command: stdioConfig.command,
         args: stdioConfig.args ?? [],
@@ -952,6 +977,13 @@ export async function resolveLocalStdioServerConfig(
     chatboxId?: string;
     accessVersion?: number;
     workosApiKeyActingAs?: WorkosApiKeyActingAs;
+    /**
+     * Receives the plugin bundle release closure when this server is a
+     * plugin component. Ephemeral web-route managers MUST pass this and
+     * release at teardown — the process-wide registry's replace-on-retain
+     * semantics assume one long-lived manager per key.
+     */
+    onPluginLease?: (release: () => void) => void;
   }
 ): Promise<MCPServerConfig> {
   let result = await authorizeServerLocal(
@@ -983,6 +1015,7 @@ export async function resolveLocalStdioServerConfig(
     chatboxId: options?.chatboxId,
     accessVersion: options?.accessVersion,
     workosApiKeyActingAs: options?.workosApiKeyActingAs,
+    onPluginLease: options?.onPluginLease,
   });
   return toMCPServerConfig(result, {
     timeoutMs: options?.timeoutMs,

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -163,6 +163,20 @@ function hasNonEmptyStringRecord(value: unknown): boolean {
 }
 
 /**
+ * Delegated-identity exchange for callers authenticated via a WorkOS API key
+ * (the harness proxy passes an EMPTY bearer on that path): Inspector swaps
+ * the bearer for `INSPECTOR_SERVICE_TOKEN` + acting-as headers, exactly as
+ * `fetchRuntimeServerSecrets` and the hosted `authorizeBatch` exchange do.
+ * The backend resolves delegation before JWT verification, so the local
+ * authorize endpoint honors the same trust model.
+ */
+export interface WorkosApiKeyActingAs {
+  /** WorkOS user id (Convex `externalId`), NOT the Convex user `_id`. */
+  workosUserId: string;
+  mcpjamOrganizationId: string;
+}
+
+/**
  * Call Convex `/web/authorize-batch-local` with the user's bearer.
  * Returns the full server config for each requested serverId, including
  * STDIO command/args/env. Hosted-only fields (share/chatbox tokens) are not
@@ -176,7 +190,8 @@ export async function authorizeBatchLocal(
   c: Context | null,
   bearerToken: string,
   projectId: string,
-  serverIds: string[]
+  serverIds: string[],
+  workosApiKeyActingAs?: WorkosApiKeyActingAs
 ): Promise<LocalAuthorizeBatchResponse> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   if (!convexUrl) {
@@ -198,14 +213,31 @@ export async function authorizeBatchLocal(
     AUTHORIZE_BATCH_LOCAL_TIMEOUT_MS
   );
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (workosApiKeyActingAs) {
+    const serviceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+    if (!serviceToken) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Server missing INSPECTOR_SERVICE_TOKEN for WorkOS API key auth"
+      );
+    }
+    headers["Authorization"] = `Bearer ${serviceToken}`;
+    headers["x-mcpjam-acting-as"] = workosApiKeyActingAs.workosUserId;
+    headers["x-mcpjam-acting-in-org"] =
+      workosApiKeyActingAs.mcpjamOrganizationId;
+  } else {
+    headers["Authorization"] = `Bearer ${bearerToken}`;
+  }
+
   let response: Response;
   try {
     response = await fetch(`${convexUrl}/web/authorize-batch-local`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${bearerToken}`,
-      },
+      headers,
       body: JSON.stringify({ projectId, serverIds }),
       signal: controller.signal,
     });
@@ -296,16 +328,21 @@ export async function authorizeServerLocal(
   c: Context | null,
   bearerToken: string,
   projectId: string,
-  serverId: string
+  serverId: string,
+  workosApiKeyActingAs?: WorkosApiKeyActingAs
 ): Promise<
   LocalAuthorizeBatchSuccess & {
     organizationId?: string | null;
     isAnonymous?: boolean;
   }
 > {
-  const batch = await authorizeBatchLocal(c, bearerToken, projectId, [
-    serverId,
-  ]);
+  const batch = await authorizeBatchLocal(
+    c,
+    bearerToken,
+    projectId,
+    [serverId],
+    workosApiKeyActingAs
+  );
   const result = batch.results[serverId];
   if (!result) {
     throw new WebRouteError(
@@ -778,7 +815,20 @@ async function applyLocalRuntimeResolution<
     bearerToken: string;
     projectId: string;
     serverId: string;
+    /**
+     * The key THIS surface's manager registers the server under — the plugin
+     * bundle lease is bound to it, so acquire and any later release always
+     * agree. /api/mcp managers key by display name; web-route managers key
+     * by serverId (display names are user-entered and can collide across
+     * servers, which would let one server's reconnect drop another's lease).
+     */
+    managerKey: string;
     serverDisplayName?: string;
+    /** Secret-reveal scope; must match what the hosted mint path would send. */
+    accessScope?: "project_member" | "chat_v2";
+    chatboxId?: string;
+    accessVersion?: number;
+    workosApiKeyActingAs?: WorkosApiKeyActingAs;
   }
 ): Promise<T> {
   const { bearerToken, projectId, serverId } = args;
@@ -794,6 +844,10 @@ async function applyLocalRuntimeResolution<
       bearerToken,
       projectId,
       serverId,
+      accessScope: args.accessScope,
+      chatboxId: args.chatboxId,
+      accessVersion: args.accessVersion,
+      workosApiKeyActingAs: args.workosApiKeyActingAs,
     });
     result = {
       ...result,
@@ -821,7 +875,8 @@ async function applyLocalRuntimeResolution<
       createClient: () => createPluginRuntimeConvexClient(bearerToken),
       projectId,
       serverId,
-      serverName: args.serverDisplayName ?? serverId,
+      serverName: args.managerKey,
+      displayName: args.serverDisplayName ?? args.managerKey,
       spec: {
         command: stdioConfig.command,
         args: stdioConfig.args ?? [],
@@ -886,13 +941,25 @@ export async function resolveLocalStdioServerConfig(
     firstPageOnly?: boolean;
     supportsMrtr?: boolean;
     xaaPolicy?: XaaEnterprisePolicy;
+    /**
+     * Secret-reveal scope + delegated identity, threaded from
+     * `createAuthorizedManager`'s options and caller context so the local
+     * reread and reveal follow the same trust model as the hosted batch —
+     * a chatbox-scoped or WorkOS-API-key caller must not get a lesser (or
+     * failing) resolution just because the deployment is local.
+     */
+    accessScope?: "project_member" | "chat_v2";
+    chatboxId?: string;
+    accessVersion?: number;
+    workosApiKeyActingAs?: WorkosApiKeyActingAs;
   }
 ): Promise<MCPServerConfig> {
   let result = await authorizeServerLocal(
     null,
     bearerToken,
     projectId,
-    serverId
+    serverId,
+    options?.workosApiKeyActingAs
   );
   if (result.serverConfig.transportType !== "stdio") {
     throw new WebRouteError(
@@ -908,7 +975,14 @@ export async function resolveLocalStdioServerConfig(
     bearerToken,
     projectId,
     serverId,
+    // Web-route managers register servers under their serverId, so the
+    // plugin bundle lease is keyed by it here (see managerKey docs).
+    managerKey: serverId,
     serverDisplayName: options?.serverDisplayName,
+    accessScope: options?.accessScope,
+    chatboxId: options?.chatboxId,
+    accessVersion: options?.accessVersion,
+    workosApiKeyActingAs: options?.workosApiKeyActingAs,
   });
   return toMCPServerConfig(result, {
     timeoutMs: options?.timeoutMs,
@@ -1160,6 +1234,10 @@ export async function resolveLocalServerForConnect(
     bearerToken,
     projectId,
     serverId,
+    // /api/mcp managers register servers under their display name — the same
+    // key `releasePluginLease` gets on the disconnect route and on connect
+    // failure — so the lease binds to it here.
+    managerKey: options?.serverDisplayName ?? serverId,
     serverDisplayName: options?.serverDisplayName,
   });
 

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -167,9 +167,13 @@ function hasNonEmptyStringRecord(value: unknown): boolean {
  * Returns the full server config for each requested serverId, including
  * STDIO command/args/env. Hosted-only fields (share/chatbox tokens) are not
  * accepted by this endpoint by design.
+ *
+ * `c` is only a request-log sink; callers without a live Hono context (the
+ * web-route stdio divert inside `createAuthorizedManager`, whose caller
+ * already logged attribution from the hosted batch) pass `null` and skip it.
  */
 export async function authorizeBatchLocal(
-  c: Context,
+  c: Context | null,
   bearerToken: string,
   projectId: string,
   serverIds: string[]
@@ -252,7 +256,7 @@ export async function authorizeBatchLocal(
   );
   const sourceCtx = successful.find(([, r]) => r.internalLogContext)?.[1]
     .internalLogContext;
-  if (sourceCtx) {
+  if (sourceCtx && c) {
     const partial = mapInternalToRequestContext(sourceCtx);
     if (successful.length > 1) {
       // Multi-server batch: a single per-server identifier on the request log
@@ -289,7 +293,7 @@ export async function authorizeBatchLocal(
  * payload directly. Throws WebRouteError for any non-ok result.
  */
 export async function authorizeServerLocal(
-  c: Context,
+  c: Context | null,
   bearerToken: string,
   projectId: string,
   serverId: string
@@ -750,6 +754,177 @@ export function toMCPServerConfig(
 }
 
 /**
+ * Runtime resolution shared by every local connect surface, applied AFTER
+ * authorization and BEFORE the SDK config is built:
+ *
+ *   1. Vault-backed runtime secrets — fill in env (stdio) / headers (http)
+ *      the authorize batch deliberately omitted (`hasEnv` / `hasHeaders`
+ *      with no values).
+ *   2. Plugin bundle materialization — stdio components whose config still
+ *      carries the SDK's `${PLUGIN_ROOT}` placeholders (the parser preserves
+ *      them verbatim; substitution belongs at spawn) resolve against the
+ *      verified local bundle cache, so a launch can never inherit a stale
+ *      root and a component whose plugin was just disabled fails closed
+ *      instead of running from cached files.
+ *
+ * Order matters: materialization substitutes over the COMPLETE env, so
+ * secrets must land first.
+ */
+async function applyLocalRuntimeResolution<
+  T extends LocalAuthorizeBatchSuccess
+>(
+  result: T,
+  args: {
+    bearerToken: string;
+    projectId: string;
+    serverId: string;
+    serverDisplayName?: string;
+  }
+): Promise<T> {
+  const { bearerToken, projectId, serverId } = args;
+  const needsRuntimeSecrets =
+    (result.serverConfig.transportType === "stdio" &&
+      result.serverConfig.hasEnv === true &&
+      !hasNonEmptyStringRecord(result.serverConfig.env)) ||
+    (result.serverConfig.transportType === "http" &&
+      result.serverConfig.hasHeaders === true &&
+      !hasNonEmptyStringRecord(result.serverConfig.headers));
+  if (needsRuntimeSecrets) {
+    const secrets = await fetchRuntimeServerSecrets({
+      bearerToken,
+      projectId,
+      serverId,
+    });
+    result = {
+      ...result,
+      serverConfig:
+        result.serverConfig.transportType === "stdio"
+          ? {
+              ...result.serverConfig,
+              env: secrets.env ?? result.serverConfig.env ?? {},
+            }
+          : {
+              ...result.serverConfig,
+              headers: {
+                ...(result.serverConfig.headers ?? {}),
+                ...(secrets.headers ?? {}),
+              },
+            },
+    };
+  }
+
+  if (result.serverConfig.transportType === "stdio") {
+    const stdioConfig = result.serverConfig;
+    const materialized = await materializePluginStdioForConnect({
+      // Lazy: an ordinary stdio server must not pay a Convex read — or
+      // require Convex configuration at all — to connect.
+      createClient: () => createPluginRuntimeConvexClient(bearerToken),
+      projectId,
+      serverId,
+      serverName: args.serverDisplayName ?? serverId,
+      spec: {
+        command: stdioConfig.command,
+        args: stdioConfig.args ?? [],
+        env: stdioConfig.env ?? {},
+        // A plugin component's declared cwd rides the config as a
+        // `${PLUGIN_ROOT}`-rooted template; substitution happens with the
+        // rest of the launch spec.
+        ...(stdioConfig.cwd !== undefined
+          ? { workingDirectory: stdioConfig.cwd }
+          : {}),
+      },
+    });
+    if (materialized) {
+      logger.debug("[plugin-stdio] materialized bundle for launch", {
+        serverId,
+        pluginId: materialized.origin.pluginId,
+        bundleHash: materialized.origin.bundleHash,
+      });
+      result = {
+        ...result,
+        serverConfig: {
+          ...stdioConfig,
+          command: materialized.command,
+          args: materialized.args,
+          env: materialized.env,
+          ...(materialized.workingDirectory !== undefined
+            ? { cwd: materialized.workingDirectory }
+            : {}),
+        },
+      };
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Resolve ONE stdio server to a connectable SDK config for a web-route
+ * surface running as the LOCAL binary (`createAuthorizedManager`'s stdio
+ * divert). The hosted authorize batch strips `command`/`args`/`env` by
+ * contract, so this re-reads the full config through
+ * `/web/authorize-batch-local` — with the same bearer, so authorization is
+ * re-checked, not assumed — then applies runtime secrets, materializes
+ * plugin bundles, and builds the stdio `MCPServerConfig` exactly as the
+ * /api/mcp connect path would.
+ *
+ * Refuses an http row rather than silently building one: the caller routes
+ * http servers through the hosted mint path (OAuth/XAA), so a transport
+ * mismatch between the two authorize reads means the row changed
+ * mid-request — connecting either way would race the edit.
+ */
+export async function resolveLocalStdioServerConfig(
+  bearerToken: string,
+  projectId: string,
+  serverId: string,
+  options?: {
+    timeoutMs?: number;
+    clientCapabilities?: Record<string, unknown>;
+    serverDisplayName?: string;
+    clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+    supportedProtocolVersions?: string[];
+    firstPageOnly?: boolean;
+    supportsMrtr?: boolean;
+    xaaPolicy?: XaaEnterprisePolicy;
+  }
+): Promise<MCPServerConfig> {
+  let result = await authorizeServerLocal(
+    null,
+    bearerToken,
+    projectId,
+    serverId
+  );
+  if (result.serverConfig.transportType !== "stdio") {
+    throw new WebRouteError(
+      409,
+      ErrorCode.CONFLICT,
+      `Server "${
+        options?.serverDisplayName ?? serverId
+      }" changed transport while the request was in flight. Retry the request.`,
+      { serverId }
+    );
+  }
+  result = await applyLocalRuntimeResolution(result, {
+    bearerToken,
+    projectId,
+    serverId,
+    serverDisplayName: options?.serverDisplayName,
+  });
+  return toMCPServerConfig(result, {
+    timeoutMs: options?.timeoutMs,
+    clientCapabilities: options?.clientCapabilities,
+    clientInfo: options?.clientInfo,
+    supportedProtocolVersions: options?.supportedProtocolVersions,
+    firstPageOnly: options?.firstPageOnly,
+    supportsMrtr: options?.supportsMrtr,
+    // Advertises the EMA extension host-wide on stdio too, matching the
+    // /api/mcp path; stdio never gets OAuth/XAA hooks, so no
+    // refreshContext / xaaUnauthorizedHandler here.
+    xaaPolicy: options?.xaaPolicy,
+  });
+}
+
+/**
  * Single-call convenience: authorize a serverId and return both the raw
  * response (for OAuth token plumbing) and a ready-to-pass MCPServerConfig.
  * Throws WebRouteError for unauthorized / not found / OAuth-required cases.
@@ -981,85 +1156,12 @@ export async function resolveLocalServerForConnect(
     };
   }
 
-  const needsRuntimeSecrets =
-    (result.serverConfig.transportType === "stdio" &&
-      result.serverConfig.hasEnv === true &&
-      !hasNonEmptyStringRecord(result.serverConfig.env)) ||
-    (result.serverConfig.transportType === "http" &&
-      result.serverConfig.hasHeaders === true &&
-      !hasNonEmptyStringRecord(result.serverConfig.headers));
-  if (needsRuntimeSecrets) {
-    const secrets = await fetchRuntimeServerSecrets({
-      bearerToken,
-      projectId,
-      serverId,
-    });
-    result = {
-      ...result,
-      serverConfig:
-        result.serverConfig.transportType === "stdio"
-          ? {
-              ...result.serverConfig,
-              env: secrets.env ?? result.serverConfig.env ?? {},
-            }
-          : {
-              ...result.serverConfig,
-              headers: {
-                ...(result.serverConfig.headers ?? {}),
-                ...(secrets.headers ?? {}),
-              },
-            },
-    };
-  }
-
-  // Plugin components reach this path as ordinary stdio servers whose
-  // command/args/env still carry the SDK's `${PLUGIN_ROOT}` placeholders (the
-  // parser preserves them verbatim; substitution belongs at spawn). Resolve
-  // them against the verified local bundle cache HERE — after authorization,
-  // after secrets, immediately before the SDK config is built — so a launch
-  // can never inherit a stale root and a component whose plugin was just
-  // disabled fails closed instead of running from cached files.
-  if (result.serverConfig.transportType === "stdio") {
-    const stdioConfig = result.serverConfig;
-    const materialized = await materializePluginStdioForConnect({
-      // Lazy: an ordinary stdio server must not pay a Convex read — or
-      // require Convex configuration at all — to connect.
-      createClient: () => createPluginRuntimeConvexClient(bearerToken),
-      projectId,
-      serverId,
-      serverName: options?.serverDisplayName ?? serverId,
-      spec: {
-        command: stdioConfig.command,
-        args: stdioConfig.args ?? [],
-        env: stdioConfig.env ?? {},
-        // A plugin component's declared cwd rides the config as a
-        // `${PLUGIN_ROOT}`-rooted template; substitution happens with the
-        // rest of the launch spec.
-        ...(stdioConfig.cwd !== undefined
-          ? { workingDirectory: stdioConfig.cwd }
-          : {}),
-      },
-    });
-    if (materialized) {
-      logger.debug("[plugin-stdio] materialized bundle for launch", {
-        serverId,
-        pluginId: materialized.origin.pluginId,
-        bundleHash: materialized.origin.bundleHash,
-      });
-      result = {
-        ...result,
-        serverConfig: {
-          ...stdioConfig,
-          command: materialized.command,
-          args: materialized.args,
-          env: materialized.env,
-          ...(materialized.workingDirectory !== undefined
-            ? { cwd: materialized.workingDirectory }
-            : {}),
-        },
-      };
-    }
-  }
+  result = await applyLocalRuntimeResolution(result, {
+    bearerToken,
+    projectId,
+    serverId,
+    serverDisplayName: options?.serverDisplayName,
+  });
 
   const config = toMCPServerConfig(result, {
     timeoutMs: options?.timeoutMs ?? options?.defaults?.timeoutMs,


### PR DESCRIPTION
## What

`/api/web` routed every authorized server through `toHttpConfig`, which throws for stdio. The Playground's environment mode always uses the web route (the local `/api/mcp` engine can't resolve an environment), so an environment turn in the **local binary** failed any stdio server with *"requires the local runtime (desktop app)"* — an impossible instruction coming **from** the local runtime.

`createAuthorizedManager` now diverts stdio batch entries to the local resolver when the deployment is not hosted (`!HOSTED_MODE`):

- The hosted authorize batch strips `command`/`args`/`env` by contract, so the new `resolveLocalStdioServerConfig` re-reads that one server through `/web/authorize-batch-local` — **with the same bearer, so authorization is re-checked, not assumed**.
- It then applies vault-backed runtime secrets, materializes plugin bundles for `${PLUGIN_ROOT}` components via the verified local cache (fetch-on-miss included), and builds the stdio SDK config exactly as the `/api/mcp` connect path would.
- The shared secrets + plugin-materialization middle is extracted into `applyLocalRuntimeResolution`, used by both `resolveLocalServerForConnect` and the new entry, so the two paths cannot drift.
- A transport mismatch between the two authorize reads (row edited mid-request) is refused with 409 rather than silently connecting either way.

**Hosted deployments are unchanged**: the `toHttpConfig` 400 (`local_runtime_required`) still applies — there is genuinely no local process to spawn into until stdio-in-computer execution lands (Phase 8), and that behavior stays locked by `local-stdio.desktop.test.ts`.

## Why now

Part of the Agent Plugins program (Phase 5 — local Playground environments). This PR is independently valuable today: environments pinning ordinary user-created stdio servers now work in the local binary. Plugin stdio components additionally need the backend env resolution to admit `placement: 'local'` for a local venue — that `runtimeVenue` arg is the next (backend) PR, after which local environment turns run plugin stdio end-to-end.

## Testing

- New: mixed hosted batch (http + stdio) → stdio entry built from the local resolver with cwd/timeout/capabilities threaded, http sibling untouched; bearer + body asserted on the local call.
- New: `resolveLocalStdioServerConfig` unit tests (stdio built, http row refused 409).
- Full server project: 350 files / 4,972 tests green. Client untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization, secret reveal, and plugin spawn paths for web-route MCP connects; mistakes could affect identity scoping or bundle lifecycle, but behavior is gated to local runtime with new regression tests.
> 
> **Overview**
> **Local `/api/web` can spawn stdio MCP servers** instead of always failing with “requires the local runtime.” When `!HOSTED_MODE`, `createAuthorizedManager` diverts non-HTTP batch entries to `resolveLocalStdioServerConfig`, which re-authorizes via `/web/authorize-batch-local`, reveals vault secrets, materializes plugin bundles, and builds the same stdio SDK config as `/api/mcp`. HTTP servers in the same batch still use the hosted mint path. Hosted deployments are unchanged.
> 
> Shared runtime steps are consolidated in **`applyLocalRuntimeResolution`** (used by both the new web divert and `resolveLocalServerForConnect`). **`authorizeBatchLocal`** now supports optional WorkOS API-key acting-as headers (matching hosted batch/secret reveal) and an optional Hono context. Transport mismatch between hosted and local authorize reads returns **409**.
> 
> **Plugin leases** for ephemeral web managers use caller-held `onLease` instead of the process-wide registry; `disconnectAllServers` releases leases on batch failure or teardown. Delegated API-key callers get **501** for plugin components (Convex query path cannot use the exchange).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee39d012e2afa62c49fc985799d87f0bb8af0da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables connecting stdio MCP servers during local Playground environment turns routed via `/api/web`. In local mode, stdio servers are resolved and spawned locally; fixes add delegated identity handling, scoped secret reveal, per‑manager plugin leases with safe teardown, and a clear 501 for delegated plugin reads; hosted behavior is unchanged.

- **New Features**
  - Diverts stdio servers to `resolveLocalStdioServerConfig` in `!HOSTED_MODE`: re-authorizes via `/web/authorize-batch-local`, reveals vault secrets, materializes plugin bundles, and builds the stdio SDK config (matching `/api/mcp`), with per-server timeouts and `firstPageOnly`/`supportsMrtr`.
  - Extracts `applyLocalRuntimeResolution` and reuses it across connect paths.
  - Returns 409 when transport changes mid-request to avoid unsafe connects.

- **Bug Fixes**
  - Holds plugin bundle leases per manager via `onLease`, releases on batch failure and on `disconnectAllServers` teardown; avoids process-wide replace-on-retain collisions.
  - Forwards WorkOS API-key delegated identity through the local re-read; secret reveal uses the same `accessScope`/`chatboxId`/`accessVersion` as the hosted path.
  - Fails closed with 501 FEATURE_NOT_SUPPORTED when a delegated (API key) caller tries to materialize a plugin component.

<sup>Written for commit ee39d012e2afa62c49fc985799d87f0bb8af0da6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

