### PR TITLE
feat(computers): Computer tab "This machine" face + engine toggle + WebMCP refusal (PR 6)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -63,7 +63,7 @@ import { HostConfigCompareView } from "./components/hosts/comparison/HostConfigC
 import { CaniuseCapabilityPage } from "./components/hosts/comparison/CaniuseCapabilityPage";
 import { HostSectionTabs } from "./components/hosts/HostSectionTabs";
 import { ConnectViewHeader } from "./components/hosts/ConnectViewHeader";
-import { ComputerView } from "./components/computer/ComputerView";
+import { ComputerTabView } from "./components/computer/ComputerTabView";
 import { useComputersEnabledState } from "./hooks/useComputersEnabled";
 import { useSkillsEnabledState } from "./hooks/useSkillsEnabled";
 import { motion } from "framer-motion";
@@ -1108,7 +1108,7 @@ export function ComputerRoute() {
   }
 
   const computerView = (
-    <ComputerView
+    <ComputerTabView
       projectId={convexProjectId}
       isSignedInMember={isSignedInMember}
     />

--- a/mcpjam-inspector/client/src/components/computer/ComputerTabView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTabView.tsx
@@ -1,0 +1,67 @@
+import { HOSTED_MODE } from "@/lib/config";
+import { ViewModeSelector } from "@/components/shared/view-mode-selector";
+import { useComputerEngine } from "@/hooks/useComputerEngine";
+import { ComputerView } from "./ComputerView";
+import { LocalComputerView } from "./LocalComputerView";
+
+/**
+ * The Computer tab's outer shell. Chooses the FACE:
+ *
+ *  - Hosted, a guest/non-member, or no synced project ⇒ the existing cloud
+ *    `ComputerView`, byte-identical to before (it also owns the sign-in /
+ *    no-project empty states).
+ *  - A signed-in member on a non-hosted inspector ⇒ a Local⇄Cloud face chosen
+ *    by the user's SELECTED engine, with a toggle when both engines exist.
+ *
+ * The face follows `selectedEngine` (consent-blind) rather than the resolved
+ * `engine`, so picking "This machine" before consenting shows the local
+ * face's consent gate instead of bouncing back to cloud.
+ */
+export function ComputerTabView({
+  projectId,
+  isSignedInMember,
+}: {
+  projectId: string | null;
+  isSignedInMember: boolean;
+}) {
+  // Called unconditionally (hooks rule); returns cloud defaults when there's
+  // no project or in hosted mode.
+  const engine = useComputerEngine(projectId);
+
+  if (HOSTED_MODE || !isSignedInMember || !projectId) {
+    return (
+      <ComputerView projectId={projectId} isSignedInMember={isSignedInMember} />
+    );
+  }
+
+  const showLocalFace = engine.selectedEngine === "local";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {engine.toggleVisible ? (
+        <div className="flex justify-end px-6 pt-4">
+          <ViewModeSelector
+            value={engine.selectedEngine}
+            ariaLabel="Computer engine"
+            indicatorId="computer-engine"
+            options={[
+              { value: "local", label: "This machine" },
+              { value: "cloud", label: "Cloud" },
+            ]}
+            onChange={(next) => engine.setEngine(next)}
+          />
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1">
+        {showLocalFace ? (
+          <LocalComputerView projectId={projectId} engine={engine} />
+        ) : (
+          <ComputerView
+            projectId={projectId}
+            isSignedInMember={isSignedInMember}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerConsentGate.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerConsentGate.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { ShieldQuestion } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+
+/**
+ * First-run consent for the local computer engine. Allowing it grants the
+ * device capability (see `useLocalComputerConsent`) that lets agents run bash
+ * — and, once the terminal ships, a shell — on THIS machine as the user's own
+ * account. Deliberately blunt about that: it is not a sandbox.
+ *
+ * `onUseCloud` is shown only when a cloud computer is also available, so a
+ * pure-local inspector doesn't offer a fallback that doesn't exist.
+ */
+export function LocalComputerConsentGate({
+  onAllow,
+  onUseCloud,
+}: {
+  onAllow: () => Promise<boolean> | boolean;
+  onUseCloud?: () => void;
+}) {
+  const [granting, setGranting] = useState(false);
+  const [error, setError] = useState(false);
+
+  const handleAllow = async () => {
+    setGranting(true);
+    setError(false);
+    try {
+      const ok = await onAllow();
+      if (!ok) setError(true);
+    } catch {
+      setError(true);
+    } finally {
+      setGranting(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid="local-computer-consent-gate"
+      className="mx-auto flex max-w-md flex-col items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-6 py-8 text-center"
+    >
+      <ShieldQuestion className="size-6 text-muted-foreground" aria-hidden />
+      <h2 className="text-base font-semibold text-foreground">
+        Allow agents to run commands on this machine?
+      </h2>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        The bash tool runs real commands on this computer, as your user
+        account. The project folder is only a starting directory, not a
+        sandbox — commands can read or change any files and credentials your
+        user can access. Each agent command still asks for approval in chat
+        before it runs.
+      </p>
+      <div className="mt-1 flex items-center gap-2">
+        <Button size="sm" onClick={() => void handleAllow()} disabled={granting}>
+          {granting ? "Allowing…" : "Allow"}
+        </Button>
+        {onUseCloud ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onUseCloud}
+            disabled={granting}
+          >
+            Use cloud instead
+          </Button>
+        ) : null}
+      </div>
+      {error ? (
+        <p className="text-xs text-destructive" data-testid="consent-error">
+          Couldn't enable the local computer. Check that you're signed in and
+          try again.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
@@ -1,0 +1,114 @@
+import { Laptop, FolderTree } from "lucide-react";
+import { createInspectorCommandClientError } from "@/lib/inspector-command-handlers";
+import { useSurfaceAgentBridge } from "@/lib/webmcp/use-surface-agent-bridge";
+import type { ComputerEngineState } from "@/hooks/useComputerEngine";
+import { LocalComputerConsentGate } from "./LocalComputerConsentGate";
+import { PaneMessage } from "./PaneMessage";
+
+/**
+ * The "This machine" face of the Computer tab: agents run bash on the computer
+ * the inspector is running on, in a per-project workspace directory. Always
+ * ready — no sleep/wake/image/billing. Shown only for a signed-in member on a
+ * non-hosted inspector when the local engine is SELECTED (see `ComputerTabView`).
+ *
+ * The interactive terminal lands in a later PR (node-pty); until
+ * `engine.localTerminalAvailable` flips true this shows a terminal-unavailable
+ * note — bash from chat already works.
+ */
+export function LocalComputerView({
+  projectId,
+  engine,
+}: {
+  projectId: string;
+  engine: ComputerEngineState;
+}) {
+  const { consent, setEngine, cloudAvailable, localTerminalAvailable } = engine;
+  const workspaceDir = engine.workspaceDisplayRoot
+    ? `${engine.workspaceDisplayRoot}/${projectId}`
+    : null;
+
+  // Registered while THIS face is mounted (ComputerView's real bridge is
+  // unmounted meanwhile). The cloud-lifecycle verbs don't apply to the local
+  // machine, so they refuse rather than vanish from the catalog mid-session.
+  useSurfaceAgentBridge({
+    surfaceId: "computer",
+    handlers: {
+      startComputer: refuseLocal,
+      hibernateComputer: refuseLocal,
+      resetComputer: refuseLocal,
+      deleteComputer: refuseLocal,
+    },
+    snapshot: () => ({
+      engine: "local" as const,
+      consentGranted: consent.granted,
+      terminalAvailable: localTerminalAvailable,
+      workspaceDir,
+    }),
+  });
+
+  const onAllow = async (): Promise<boolean> => {
+    const ok = await consent.grant();
+    // Persist the preference too, so the resolved engine sticks at local for
+    // chat/rail even after a reload — grant alone flips `granted`, this pins it.
+    if (ok) setEngine("local");
+    return ok;
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-4 p-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-lg font-semibold text-foreground">Computer</h1>
+        <span
+          className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground"
+          data-testid="this-machine-chip"
+        >
+          <Laptop className="size-3.5" aria-hidden />
+          This machine
+        </span>
+      </div>
+
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        Agents run commands directly on this machine — the same computer the
+        inspector is running on. Commands run as your user, in the working
+        directory below. Nothing to start or wake; it&apos;s always ready.
+      </p>
+
+      {workspaceDir ? (
+        <div className="flex items-center gap-2 rounded-md border border-border/50 bg-muted/20 px-3 py-2 text-sm">
+          <FolderTree className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+          <span className="text-muted-foreground">Working directory:</span>
+          <span className="truncate font-mono text-foreground">
+            {workspaceDir}
+          </span>
+        </div>
+      ) : null}
+
+      <div className="min-h-0 flex-1">
+        {!consent.granted ? (
+          <LocalComputerConsentGate
+            onAllow={onAllow}
+            {...(cloudAvailable
+              ? { onUseCloud: () => setEngine("cloud") }
+              : {})}
+          />
+        ) : localTerminalAvailable ? (
+          // The node-pty terminal PR wires the real pane here; until then this
+          // branch is unreachable (terminalAvailable is false).
+          <PaneMessage>Terminal ready.</PaneMessage>
+        ) : (
+          <PaneMessage dashed>
+            The terminal for this machine isn&apos;t available yet. Agents can
+            already run bash commands here from chat.
+          </PaneMessage>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function refuseLocal(): never {
+  throw createInspectorCommandClientError(
+    "unsupported_in_mode",
+    "The computer engine is set to 'This machine' — start/hibernate/reset/delete only apply to the cloud computer. Switch the toggle to Cloud to manage it.",
+  );
+}

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
@@ -102,6 +102,25 @@ export function LocalComputerView({
           </PaneMessage>
         )}
       </div>
+
+      {consent.granted ? (
+        // Recovery path: the stored capability can go stale (another browser
+        // profile re-granted, or the server-side consent file was removed) —
+        // `granted` only reflects a stored token, so without this the gate
+        // would never return. Forgetting clears it (and best-effort revokes on
+        // the server), which re-shows the consent gate to re-authorize.
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>Agent commands are allowed on this machine.</span>
+          <button
+            type="button"
+            data-testid="local-computer-reauthorize"
+            className="font-medium text-primary hover:underline"
+            onClick={() => void consent.revoke()}
+          >
+            Forget &amp; re-authorize
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTabView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTabView.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hosted = vi.hoisted(() => ({ value: false }));
+vi.mock("@/lib/config", () => ({
+  get HOSTED_MODE() {
+    return hosted.value;
+  },
+}));
+
+// The two faces are stubbed — this suite is about which one the wrapper picks
+// and whether the toggle shows, not their internals.
+vi.mock("../ComputerView", () => ({
+  ComputerView: (props: { projectId: string | null; isSignedInMember: boolean }) => (
+    <div
+      data-testid="cloud-face"
+      data-project={String(props.projectId)}
+      data-member={String(props.isSignedInMember)}
+    />
+  ),
+}));
+vi.mock("../LocalComputerView", () => ({
+  LocalComputerView: (props: { projectId: string }) => (
+    <div data-testid="local-face" data-project={props.projectId} />
+  ),
+}));
+
+const engineState = vi.hoisted(() => ({
+  value: {
+    engine: "cloud" as "local" | "cloud",
+    selectedEngine: "cloud" as "local" | "cloud",
+    setEngine: vi.fn(),
+    resolved: true,
+    localAvailable: true,
+    localTerminalAvailable: false,
+    workspaceDisplayRoot: "~/.mcpjam/computer",
+    cloudAvailable: true,
+    toggleVisible: true,
+    consent: { status: "absent", granted: false, token: null, grant: vi.fn(), revoke: vi.fn() },
+  },
+}));
+vi.mock("@/hooks/useComputerEngine", () => ({
+  useComputerEngine: () => engineState.value,
+}));
+
+import { ComputerTabView } from "../ComputerTabView";
+
+describe("ComputerTabView", () => {
+  beforeEach(() => {
+    hosted.value = false;
+    engineState.value.selectedEngine = "cloud";
+    engineState.value.toggleVisible = true;
+    engineState.value.setEngine = vi.fn();
+  });
+
+  it("hosted: always the cloud face, no toggle", () => {
+    hosted.value = true;
+    engineState.value.selectedEngine = "local"; // ignored hosted
+    render(<ComputerTabView projectId="p1" isSignedInMember />);
+    expect(screen.getByTestId("cloud-face")).toBeInTheDocument();
+    expect(screen.queryByTestId("local-face")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("navigation", { name: /Computer engine/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("non-member: cloud face (it owns the sign-in state), no toggle", () => {
+    engineState.value.selectedEngine = "local";
+    render(<ComputerTabView projectId="p1" isSignedInMember={false} />);
+    const cloud = screen.getByTestId("cloud-face");
+    expect(cloud.dataset.member).toBe("false");
+    expect(screen.queryByTestId("local-face")).not.toBeInTheDocument();
+  });
+
+  it("no synced project: cloud face (owns the no-project empty state)", () => {
+    engineState.value.selectedEngine = "local";
+    render(<ComputerTabView projectId={null} isSignedInMember />);
+    expect(screen.getByTestId("cloud-face")).toBeInTheDocument();
+  });
+
+  it("signed-in member, selectedEngine local → local face", () => {
+    engineState.value.selectedEngine = "local";
+    render(<ComputerTabView projectId="p1" isSignedInMember />);
+    expect(screen.getByTestId("local-face")).toBeInTheDocument();
+    expect(screen.queryByTestId("cloud-face")).not.toBeInTheDocument();
+  });
+
+  it("signed-in member, selectedEngine cloud → cloud face", () => {
+    render(<ComputerTabView projectId="p1" isSignedInMember />);
+    expect(screen.getByTestId("cloud-face")).toBeInTheDocument();
+  });
+
+  it("shows the Local⇄Cloud toggle only when both engines exist", () => {
+    render(<ComputerTabView projectId="p1" isSignedInMember />);
+    expect(
+      screen.getByRole("button", { name: /This machine/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Cloud/i })).toBeInTheDocument();
+  });
+
+  it("hides the toggle when only one engine is available", () => {
+    engineState.value.toggleVisible = false;
+    render(<ComputerTabView projectId="p1" isSignedInMember />);
+    expect(
+      screen.queryByRole("button", { name: /This machine/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("the toggle persists the picked engine", () => {
+    render(<ComputerTabView projectId="p1" isSignedInMember />);
+    fireEvent.click(screen.getByRole("button", { name: /This machine/i }));
+    expect(engineState.value.setEngine).toHaveBeenCalledWith("local");
+  });
+});

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.agent.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * The local face registers the SAME `surfaceId: "computer"` agent bridge as the
+ * cloud ComputerView (only one is mounted at a time), but the cloud-lifecycle
+ * verbs don't apply to the user's own machine — so they refuse with
+ * `unsupported_in_mode` rather than vanishing from the catalog, and the
+ * snapshot reports the local engine.
+ */
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeInspectorCommand } from "@/lib/inspector-command-handlers";
+import { readSurfaceSnapshot } from "@/lib/webmcp/surface-snapshot-registry";
+import type {
+  InspectorCommand,
+  InspectorCommandResponse,
+} from "@/shared/inspector-command.js";
+import { LocalComputerView } from "../LocalComputerView";
+import type { ComputerEngineState } from "@/hooks/useComputerEngine";
+
+function engineState(): ComputerEngineState {
+  return {
+    engine: "local",
+    selectedEngine: "local",
+    setEngine: vi.fn(),
+    resolved: true,
+    localAvailable: true,
+    localTerminalAvailable: false,
+    workspaceDisplayRoot: "~/.mcpjam/computer",
+    cloudAvailable: true,
+    consent: {
+      status: "granted",
+      granted: true,
+      token: "tok",
+      grant: vi.fn(),
+      revoke: vi.fn(),
+    },
+    toggleVisible: true,
+  };
+}
+
+let seq = 0;
+async function dispatch(command: Omit<InspectorCommand, "id">) {
+  seq += 1;
+  let response!: InspectorCommandResponse;
+  await act(async () => {
+    response = await executeInspectorCommand({
+      ...command,
+      id: `local-bridge-${seq}`,
+    } as InspectorCommand);
+  });
+  return response;
+}
+
+describe("LocalComputerView — agent bridge", () => {
+  beforeEach(() => {
+    render(<LocalComputerView projectId="proj_1" engine={engineState()} />);
+  });
+
+  it.each([
+    "startComputer",
+    "hibernateComputer",
+    "resetComputer",
+    "deleteComputer",
+  ] as const)("%s refuses with unsupported_in_mode on the local engine", async (type) => {
+    const response = await dispatch({ type });
+    expect(response).toMatchObject({
+      status: "error",
+      error: { code: "unsupported_in_mode" },
+    });
+    expect(JSON.stringify(response)).toMatch(/This machine/);
+  });
+
+  it("the snapshot reports the local engine and never a token", async () => {
+    const snapshot = await readSurfaceSnapshot("computer");
+    expect(snapshot).toMatchObject({
+      ok: true,
+      data: {
+        engine: "local",
+        consentGranted: true,
+        terminalAvailable: false,
+        workspaceDir: "~/.mcpjam/computer/proj_1",
+      },
+    });
+    // The capability token must never appear in the snapshot.
+    expect(JSON.stringify(snapshot).toLowerCase()).not.toContain("token");
+  });
+});

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
@@ -68,7 +68,7 @@ describe("LocalComputerView", () => {
     expect(setEngine).toHaveBeenCalledWith("local");
   });
 
-  it("does not pin the engine if the grant fails", async () => {
+  it("does not pin the engine if the grant resolves false", async () => {
     const grant = vi.fn().mockResolvedValue(false);
     const setEngine = vi.fn();
     render(
@@ -80,6 +80,25 @@ describe("LocalComputerView", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Allow$/ }));
     await waitFor(() =>
       expect(screen.getByTestId("consent-error")).toBeInTheDocument(),
+    );
+    expect(setEngine).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the error and does not pin the engine if the grant REJECTS", async () => {
+    const grant = vi.fn().mockRejectedValue(new Error("network down"));
+    const setEngine = vi.fn();
+    render(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({ setEngine, consent: { grant } })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Allow$/ }));
+    await waitFor(() =>
+      expect(screen.getByTestId("consent-error")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("consent-error").textContent).toMatch(
+      /Couldn't enable the local computer/i,
     );
     expect(setEngine).not.toHaveBeenCalled();
   });

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// The agent bridge is exercised in LocalComputerView.agent.test — here it's a
+// no-op so these render tests don't touch the global command registry.
+vi.mock("@/lib/webmcp/use-surface-agent-bridge", () => ({
+  useSurfaceAgentBridge: () => {},
+}));
+
+import { LocalComputerView } from "../LocalComputerView";
+import type { ComputerEngineState } from "@/hooks/useComputerEngine";
+
+function engineState(
+  overrides: Partial<ComputerEngineState> & {
+    consent?: Partial<ComputerEngineState["consent"]>;
+  } = {},
+): ComputerEngineState {
+  const { consent: consentOverrides, ...rest } = overrides;
+  return {
+    engine: "local",
+    selectedEngine: "local",
+    setEngine: vi.fn(),
+    resolved: true,
+    localAvailable: true,
+    localTerminalAvailable: false,
+    workspaceDisplayRoot: "~/.mcpjam/computer",
+    cloudAvailable: true,
+    toggleVisible: true,
+    consent: {
+      status: "absent",
+      granted: false,
+      token: null,
+      grant: vi.fn().mockResolvedValue(true),
+      revoke: vi.fn(),
+      ...consentOverrides,
+    },
+    ...rest,
+  };
+}
+
+describe("LocalComputerView", () => {
+  it("renders the 'This machine' identity and the per-project workdir", () => {
+    render(<LocalComputerView projectId="proj_1" engine={engineState()} />);
+    expect(screen.getByTestId("this-machine-chip")).toBeInTheDocument();
+    expect(
+      screen.getByText("~/.mcpjam/computer/proj_1"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the consent gate until consent is granted", () => {
+    render(<LocalComputerView projectId="proj_1" engine={engineState()} />);
+    expect(
+      screen.getByTestId("local-computer-consent-gate"),
+    ).toBeInTheDocument();
+  });
+
+  it("Allow grants consent then pins the engine preference to local", async () => {
+    const grant = vi.fn().mockResolvedValue(true);
+    const setEngine = vi.fn();
+    render(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({ setEngine, consent: { grant } })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Allow$/ }));
+    await waitFor(() => expect(grant).toHaveBeenCalledTimes(1));
+    expect(setEngine).toHaveBeenCalledWith("local");
+  });
+
+  it("does not pin the engine if the grant fails", async () => {
+    const grant = vi.fn().mockResolvedValue(false);
+    const setEngine = vi.fn();
+    render(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({ setEngine, consent: { grant } })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Allow$/ }));
+    await waitFor(() =>
+      expect(screen.getByTestId("consent-error")).toBeInTheDocument(),
+    );
+    expect(setEngine).not.toHaveBeenCalled();
+  });
+
+  it("offers 'Use cloud instead' only when a cloud computer exists", () => {
+    const setEngine = vi.fn();
+    const { rerender } = render(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({ cloudAvailable: true, setEngine })}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Use cloud instead/i }));
+    expect(setEngine).toHaveBeenCalledWith("cloud");
+
+    rerender(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({ cloudAvailable: false })}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Use cloud instead/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("once granted, shows the terminal-not-available-yet note (terminal ships later)", () => {
+    render(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({
+          localTerminalAvailable: false,
+          consent: { granted: true, token: "tok", status: "granted" },
+        })}
+      />,
+    );
+    expect(
+      screen.queryByTestId("local-computer-consent-gate"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/terminal for this machine isn't available yet/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
@@ -142,4 +142,28 @@ describe("LocalComputerView", () => {
       screen.getByText(/terminal for this machine isn't available yet/i),
     ).toBeInTheDocument();
   });
+
+  it("granted: offers a re-authorize action that revokes a stale capability", async () => {
+    // A stale token (another profile re-granted / server file removed) would
+    // otherwise hide the gate forever; forgetting clears it so the user can
+    // re-grant.
+    const revoke = vi.fn().mockResolvedValue(undefined);
+    render(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({
+          consent: { granted: true, token: "tok", status: "granted", revoke },
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("local-computer-reauthorize"));
+    await waitFor(() => expect(revoke).toHaveBeenCalledTimes(1));
+  });
+
+  it("ungranted: no re-authorize action (the consent gate is the entry point)", () => {
+    render(<LocalComputerView projectId="proj_1" engine={engineState()} />);
+    expect(
+      screen.queryByTestId("local-computer-reauthorize"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -745,6 +745,16 @@ export function PlaygroundMain({
   // chat hook. Hosted mode / no local engine ⇒ cloud, and the turn sends
   // nothing extra.
   const playgroundComputerEngine = useComputerEngine(convexProjectId);
+  // The resolved engine passed to every chat session on this tab — the root
+  // and each comparison column — so "This machine" runs bash consistently
+  // across model/host comparison, not just the primary session.
+  const personalComputerEngineOption = useMemo(
+    () => ({
+      engine: playgroundComputerEngine.engine,
+      consentToken: playgroundComputerEngine.consent.token,
+    }),
+    [playgroundComputerEngine.engine, playgroundComputerEngine.consent.token],
+  );
 
   // COMP-14: when the previewed host attaches a personal computer, composer
   // attachments are ALSO uploaded into the sandbox (reserve → mint → upload,
@@ -978,10 +988,7 @@ export function PlaygroundMain({
     // execution-context helper, so this also flows through chatbox sessions
     // (where the persisted host config wins via the runtime-config fetch).
     builtInToolIds: previewedHost?.config?.builtInToolIds,
-    personalComputerEngine: {
-      engine: playgroundComputerEngine.engine,
-      consentToken: playgroundComputerEngine.consent.token,
-    },
+    personalComputerEngine: personalComputerEngineOption,
     onReset: (reason?: ChatSessionResetReason) => {
       setModelContextQueue([]);
       setPreludeTraceExecutions([]);
@@ -4786,6 +4793,7 @@ export function PlaygroundMain({
                             hostId: column.compareId,
                           }}
                           hostedOrgModelConfig={hostedOrgModelConfig}
+                          personalComputerEngine={personalComputerEngineOption}
                           displayMode={displayMode}
                           onDisplayModeChange={handleDisplayModeChange}
                           hostStyle={column.hostSnapshot.hostStyle}
@@ -4886,6 +4894,7 @@ export function PlaygroundMain({
                                 ? { hostId: previewedHostId }
                                 : {}),
                             }}
+                            personalComputerEngine={personalComputerEngineOption}
                             displayMode={displayMode}
                             onDisplayModeChange={handleDisplayModeChange}
                             hostStyle={hostStyle}

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -123,6 +123,7 @@ import {
 import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
 import { getCatalogHost, getCatalogTemplate } from "@mcpjam/sdk/host-compat";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
+import { useComputerEngine } from "@/hooks/useComputerEngine";
 import { usePlaygroundEnvironment } from "@/hooks/use-playground-environment";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { PlaygroundEnvironmentSection } from "@/components/playground/PlaygroundEnvironmentSection";
@@ -737,6 +738,14 @@ export function PlaygroundMain({
   const activeProject = appState.projects[appState.activeProjectId];
   const convexProjectId = activeProject?.sharedProjectId ?? null;
 
+  // Resolved Local⇄Cloud engine for this project's personal computer. Passed
+  // into useChatSession so a direct turn runs this host's bash on the local
+  // machine when the user has selected + consented to "This machine". The
+  // config fetch lives here (the surface that uses it), not in the central
+  // chat hook. Hosted mode / no local engine ⇒ cloud, and the turn sends
+  // nothing extra.
+  const playgroundComputerEngine = useComputerEngine(convexProjectId);
+
   // COMP-14: when the previewed host attaches a personal computer, composer
   // attachments are ALSO uploaded into the sandbox (reserve → mint → upload,
   // the same primitives the Shell uses) and the outgoing message carries a
@@ -969,6 +978,10 @@ export function PlaygroundMain({
     // execution-context helper, so this also flows through chatbox sessions
     // (where the persisted host config wins via the runtime-config fetch).
     builtInToolIds: previewedHost?.config?.builtInToolIds,
+    personalComputerEngine: {
+      engine: playgroundComputerEngine.engine,
+      consentToken: playgroundComputerEngine.consent.token,
+    },
     onReset: (reason?: ChatSessionResetReason) => {
       setModelContextQueue([]);
       setPreludeTraceExecutions([]);

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -138,6 +138,15 @@ interface MultiModelPlaygroundCardProps {
   executionConfig: ExecutionConfig;
   hostedContext?: HostedRuntimeContext;
   hostedOrgModelConfig?: OrgVisibleConfig;
+  /**
+   * Resolved Local⇄Cloud engine for the project's personal computer, so a
+   * comparison column runs bash on the same engine ("This machine") the tab
+   * root does — omitted ⇒ cloud, like every other surface.
+   */
+  personalComputerEngine?: {
+    engine: "local" | "cloud";
+    consentToken: string | null;
+  };
   displayMode: DisplayMode;
   onDisplayModeChange: (mode: DisplayMode) => void;
   hostStyle: ChatboxHostStyle;
@@ -217,6 +226,7 @@ export function MultiModelPlaygroundCard({
   executionConfig,
   hostedContext,
   hostedOrgModelConfig,
+  personalComputerEngine,
   displayMode,
   onDisplayModeChange,
   hostStyle,
@@ -332,6 +342,7 @@ export function MultiModelPlaygroundCard({
     selectedServers,
     hostedContext,
     hostedOrgModelConfig,
+    ...(personalComputerEngine ? { personalComputerEngine } : {}),
     executionConfig: {
       ...executionConfig,
       modelId: String(model.id),

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
@@ -26,7 +26,9 @@ const mockState = vi.hoisted(() => ({
   sendMessage: vi.fn(async () => {}),
   stop: vi.fn(),
   addToolApprovalResponse: vi.fn(),
-  getAccessToken: vi.fn(async () => null),
+  // A member (WorkOS) bearer by default → authIsMemberRef true. Individual
+  // tests flip it to null to model a signed-out guest.
+  getAccessToken: vi.fn(async () => "workos-jwt"),
   hasToken: vi.fn(() => false),
   getToken: vi.fn(() => ""),
   getOpenRouterSelectedModels: vi.fn(() => []),
@@ -160,6 +162,12 @@ async function renderWithEngine(
     } as never),
   );
   await waitFor(() => expect(mockState.chatOnData).not.toBeNull());
+  // Wait for the async auth effect to settle (it re-renders → rebuilds the
+  // transport) so the member-gated header/body reflect the resolved auth,
+  // not the pre-effect default.
+  await waitFor(() =>
+    expect(mockState.transportOptions.length).toBeGreaterThan(1),
+  );
   return rendered;
 }
 
@@ -227,6 +235,17 @@ describe("useChatSession — local computer engine transmission", () => {
       { engine: "local", consentToken: "cap-token-123" },
       { projectId: "proj-1", chatboxId: "cbx-1", accessVersion: 1 },
     );
+    const { body, headers } = lastTransport();
+    expect(body.computerEngine).toBeUndefined();
+    expect(headers[LOCAL_CONSENT_HEADER]).toBeUndefined();
+  });
+
+  it("never sends the local engine on a GUEST turn (signed out, stale token)", async () => {
+    // A previously-signed-in user's consent token can outlive sign-out. The
+    // guest turn attaches a guest bearer, not a member one — the local engine
+    // must not be forwarded even though a token is present.
+    mockState.getAccessToken.mockResolvedValue(null);
+    await renderWithEngine({ engine: "local", consentToken: "cap-token-123" });
     const { body, headers } = lastTransport();
     expect(body.computerEngine).toBeUndefined();
     expect(headers[LOCAL_CONSENT_HEADER]).toBeUndefined();

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
@@ -209,6 +209,19 @@ describe("useChatSession — local computer engine transmission", () => {
     expect(headers[LOCAL_CONSENT_HEADER]).toBeUndefined();
   });
 
+  it("never sends the local engine when the turn routes to the org-aware web API", async () => {
+    // The local engine only exists on the local /api/mcp path. A turn forced
+    // to /api/web/chat-v2 (org-runtime model, environment mode, etc.) must NOT
+    // carry the field or leak the consent header onto the web route.
+    await renderWithEngine(
+      { engine: "local", consentToken: "cap-token-123" },
+      { projectId: "proj-1", requiresWebChatApi: true },
+    );
+    const { body, headers } = lastTransport();
+    expect(body.computerEngine).toBeUndefined();
+    expect(headers[LOCAL_CONSENT_HEADER]).toBeUndefined();
+  });
+
   it("never sends the local engine on a chatbox (share-link) session", async () => {
     await renderWithEngine(
       { engine: "local", consentToken: "cap-token-123" },

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.local-engine.test.tsx
@@ -1,0 +1,228 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatSession } from "../use-chat-session";
+import { LOCAL_CONSENT_HEADER } from "@/lib/local-computer-consent";
+
+/**
+ * Local computer engine transmission: when the CALLER (Playground) passes a
+ * resolved `personalComputerEngine` of `local` + a consent token, a direct
+ * /api/mcp/chat-v2 turn forwards `computerEngine:"local"` in the body and the
+ * consent capability in the `X-MCPJam-Local-Consent` HEADER (never the body).
+ * Absent / cloud ⇒ the turn is byte-identical to before.
+ *
+ * The engine is caller-provided on purpose: the central chat hook must not run
+ * the `useComputerEngine` config fetch (it would perturb every chat surface).
+ */
+const mockState = vi.hoisted(() => ({
+  chatOnData: null as ((part: unknown) => void) | null,
+  transportOptions: [] as Array<{
+    body?: () => Record<string, unknown>;
+    headers?: Record<string, string>;
+  }>,
+  chatStatus: "ready" as string,
+  messages: [] as unknown[],
+  convexMutation: vi.fn(async () => ({ ok: true })),
+  setMessages: vi.fn(),
+  sendMessage: vi.fn(async () => {}),
+  stop: vi.fn(),
+  addToolApprovalResponse: vi.fn(),
+  getAccessToken: vi.fn(async () => null),
+  hasToken: vi.fn(() => false),
+  getToken: vi.fn(() => ""),
+  getOpenRouterSelectedModels: vi.fn(() => []),
+  getOllamaBaseUrl: vi.fn(() => "http://127.0.0.1:11434"),
+  getAzureBaseUrl: vi.fn(() => ""),
+  getCustomProviderByName: vi.fn(),
+  setSelectedModelId: vi.fn(),
+  getToolsMetadata: vi.fn(async () => ({
+    metadata: {},
+    toolServerMap: {},
+    tokenCounts: null,
+  })),
+  countTextTokens: vi.fn(async () => null),
+  convexAuth: { isAuthenticated: true, isLoading: false },
+  detectOllamaModels: vi.fn(async () => ({
+    isRunning: false,
+    availableModels: [],
+  })),
+  detectOllamaToolCapableModels: vi.fn(async () => []),
+  idCounter: 0,
+}));
+
+const byokModel = { id: "gpt-4", name: "GPT-4", provider: "openai" as const };
+
+function nextSessionId() {
+  mockState.idCounter += 1;
+  return `chat-session-${mockState.idCounter}`;
+}
+
+vi.mock("@/state/oauth-orchestrator", () => ({
+  applyToolCallStepUp: vi.fn(),
+}));
+vi.mock("@/lib/config", () => ({ HOSTED_MODE: false }));
+vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
+  buildAvailableModels: vi.fn(() => [byokModel]),
+  getDefaultModel: vi.fn(() => byokModel),
+  isMCPJamProvidedModelMenuItem: vi.fn(() => false),
+}));
+vi.mock("@/hooks/use-hosted-model-catalog", () => ({
+  useHostedModelCatalog: () => ({ hostedCatalog: [], status: "fallback" }),
+}));
+vi.mock("@/hooks/use-ai-provider-keys", () => ({
+  useAiProviderKeys: () => ({
+    hasToken: mockState.hasToken,
+    getToken: mockState.getToken,
+    getOpenRouterSelectedModels: mockState.getOpenRouterSelectedModels,
+    getOllamaBaseUrl: mockState.getOllamaBaseUrl,
+    getAzureBaseUrl: mockState.getAzureBaseUrl,
+  }),
+}));
+vi.mock("@/hooks/use-custom-providers", () => ({
+  useCustomProviders: () => ({
+    customProviders: [],
+    getCustomProviderByName: mockState.getCustomProviderByName,
+  }),
+}));
+vi.mock("@/hooks/use-persisted-model", () => ({
+  usePersistedModel: () => ({
+    selectedModelId: "gpt-4",
+    setSelectedModelId: mockState.setSelectedModelId,
+    selectedModelIds: ["gpt-4"],
+    setSelectedModelIds: vi.fn(),
+    multiModelEnabled: false,
+    setMultiModelEnabled: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useSharedChatWidgetCapture", () => ({
+  useSharedChatWidgetCapture: vi.fn(),
+}));
+vi.mock("@/lib/ollama-utils", () => ({
+  detectOllamaModels: mockState.detectOllamaModels,
+  detectOllamaToolCapableModels: mockState.detectOllamaToolCapableModels,
+}));
+vi.mock("@/lib/apis/mcp-tools-api", () => ({
+  getToolsMetadata: mockState.getToolsMetadata,
+}));
+vi.mock("@/lib/apis/mcp-tokenizer-api", () => ({
+  countTextTokens: mockState.countTextTokens,
+}));
+vi.mock("@/lib/session-token", () => ({
+  authFetch: vi.fn(),
+  getAuthHeaders: vi.fn(() => ({})),
+}));
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({ getAccessToken: mockState.getAccessToken }),
+}));
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => mockState.convexAuth,
+  useQuery: () => undefined,
+  useConvex: () => ({ mutation: mockState.convexMutation }),
+}));
+vi.mock("@ai-sdk/react", () => ({
+  useChat: vi.fn((options: { onData?: (part: unknown) => void }) => {
+    mockState.chatOnData = options.onData ?? null;
+    return {
+      messages: mockState.messages,
+      sendMessage: mockState.sendMessage,
+      stop: mockState.stop,
+      status: mockState.chatStatus,
+      error: undefined,
+      setMessages: mockState.setMessages,
+      addToolApprovalResponse: mockState.addToolApprovalResponse,
+    };
+  }),
+}));
+vi.mock("ai", () => ({
+  DefaultChatTransport: class MockTransport {
+    constructor(options: {
+      body?: () => Record<string, unknown>;
+      headers?: Record<string, string>;
+    }) {
+      mockState.transportOptions.push(options);
+    }
+  },
+  generateId: vi.fn(() => nextSessionId()),
+  lastAssistantMessageIsCompleteWithApprovalResponses: vi.fn(),
+  convertToModelMessages: vi.fn(async () => []),
+}));
+
+type EnginePref = { engine: "local" | "cloud"; consentToken: string | null };
+
+async function renderWithEngine(
+  personalComputerEngine?: EnginePref,
+  hostedContext?: Record<string, unknown>,
+) {
+  const rendered = renderHook(() =>
+    useChatSession({
+      selectedServers: ["server-1"],
+      ...(personalComputerEngine ? { personalComputerEngine } : {}),
+      ...(hostedContext ? { hostedContext } : {}),
+    } as never),
+  );
+  await waitFor(() => expect(mockState.chatOnData).not.toBeNull());
+  return rendered;
+}
+
+function lastTransport() {
+  const t = mockState.transportOptions.at(-1);
+  return {
+    body: t?.body?.() ?? {},
+    headers: (t?.headers ?? {}) as Record<string, string>,
+  };
+}
+
+describe("useChatSession — local computer engine transmission", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockState.chatOnData = null;
+    mockState.transportOptions = [];
+    mockState.chatStatus = "ready";
+    mockState.idCounter = 0;
+    mockState.messages = [];
+  });
+
+  it("forwards computerEngine:local in the body and the consent header when local + consented", async () => {
+    await renderWithEngine({ engine: "local", consentToken: "cap-token-123" });
+    const { body, headers } = lastTransport();
+    expect(body.computerEngine).toBe("local");
+    expect(headers[LOCAL_CONSENT_HEADER]).toBe("cap-token-123");
+  });
+
+  it("the token rides the HEADER, never the body (kept out of transcripts)", async () => {
+    await renderWithEngine({ engine: "local", consentToken: "cap-token-123" });
+    const { body } = lastTransport();
+    expect(JSON.stringify(body)).not.toContain("cap-token-123");
+  });
+
+  it("sends nothing extra when the engine resolves cloud", async () => {
+    await renderWithEngine({ engine: "cloud", consentToken: "cap-token-123" });
+    const { body, headers } = lastTransport();
+    expect(body.computerEngine).toBeUndefined();
+    expect(headers[LOCAL_CONSENT_HEADER]).toBeUndefined();
+  });
+
+  it("sends nothing when local is selected but there is no consent token", async () => {
+    await renderWithEngine({ engine: "local", consentToken: null });
+    const { body, headers } = lastTransport();
+    expect(body.computerEngine).toBeUndefined();
+    expect(headers[LOCAL_CONSENT_HEADER]).toBeUndefined();
+  });
+
+  it("never sends the local engine on a chatbox (share-link) session", async () => {
+    await renderWithEngine(
+      { engine: "local", consentToken: "cap-token-123" },
+      { projectId: "proj-1", chatboxId: "cbx-1", accessVersion: 1 },
+    );
+    const { body, headers } = lastTransport();
+    expect(body.computerEngine).toBeUndefined();
+    expect(headers[LOCAL_CONSENT_HEADER]).toBeUndefined();
+  });
+
+  it("omits the field entirely when no engine is provided (byte-identical legacy)", async () => {
+    await renderWithEngine();
+    const { body, headers } = lastTransport();
+    expect("computerEngine" in body).toBe(false);
+    expect(headers[LOCAL_CONSENT_HEADER]).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useComputerEngine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useComputerEngine.test.tsx
@@ -90,6 +90,25 @@ describe("useComputerEngine", () => {
     expect(result.current.engine).toBe("cloud");
   });
 
+  it("selectedEngine is consent-BLIND: local default selects local without consent", () => {
+    // The toggle/face follow the user's pick; execution still waits on consent.
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.selectedEngine).toBe("local");
+    expect(result.current.engine).toBe("cloud"); // no consent yet
+  });
+
+  it("selectedEngine follows a stored 'local' pref even without consent", () => {
+    saveComputerEngine("p1", "local");
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.selectedEngine).toBe("local");
+  });
+
+  it("selectedEngine falls to cloud when local is unavailable", () => {
+    state.config = config({ localAvailable: false });
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.selectedEngine).toBe("cloud");
+  });
+
   it("a stored 'cloud' pref beats the server's local default even with consent", () => {
     state.consentGranted = true;
     saveComputerEngine("p1", "cloud");

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -2387,8 +2387,16 @@ export function useChatSession(
     // body, so it can't land in a persisted transcript. Only on a direct
     // (non-chatbox) turn whose resolved engine is local; the server re-checks
     // !HOSTED_MODE + non-guest + non-chatbox + verifies the token.
+    //
+    // Scoped to the /api/mcp/chat-v2 path (`!shouldUseOrgAwareChatApi`): the
+    // local engine only exists on the local server's mcp route (both this
+    // transmission AND the server-side resolver live there). An org-runtime
+    // model routes to /api/web/chat-v2, which has no local engine — so we send
+    // nothing local there (no stray consent header on the web route) and that
+    // turn's bash resolves cloud, as it must. Local engine + org model is a
+    // deliberate non-combo in v1.
     const sendLocalEngine =
-      !HOSTED_MODE &&
+      !shouldUseOrgAwareChatApi &&
       resolvedLocalEngine &&
       !hostedChatboxId &&
       Boolean(localConsentToken);

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -86,6 +86,7 @@ import {
 } from "@/lib/mcpjam-limit";
 import { getGuestBearerToken } from "@/lib/guest-session";
 import { HOSTED_MODE } from "@/lib/config";
+import { LOCAL_CONSENT_HEADER } from "@/lib/local-computer-consent";
 import {
   preserveHydratedMessageIds,
   transcriptToUIMessages,
@@ -306,6 +307,18 @@ export interface UseChatSessionOptions {
   hostedContext?: HostedRuntimeContext;
   /** Minimal UI mode for shared chat (hides diagnostics surfaces only) */
   minimalMode?: boolean;
+  /**
+   * Resolved Local⇄Cloud engine for this project's personal computer, provided
+   * by the caller (Playground) so the CENTRAL hook stays free of the config
+   * fetch `useComputerEngine` runs. When `engine === "local"` a direct
+   * /api/mcp/chat-v2 turn forwards `computerEngine:"local"` plus the consent
+   * capability header, so the server runs this host's bash on the local
+   * machine. Absent ⇒ legacy cloud-family resolution (every other surface).
+   */
+  personalComputerEngine?: {
+    engine: "local" | "cloud";
+    consentToken: string | null;
+  };
   /** Execution configuration (model, system prompt, temperature, tool approval) */
   executionConfig?: ExecutionConfig;
   /**
@@ -1460,8 +1473,13 @@ export function useChatSession(
     minimalMode: _minimalMode = false,
     executionConfig,
     hostStyle,
+    personalComputerEngine,
     onReset,
   } = options;
+  // Caller-provided (Playground): send local only when it will actually run
+  // there. Consent-gated `engine`, device-scoped token — both from the caller.
+  const resolvedLocalEngine = personalComputerEngine?.engine === "local";
+  const localConsentToken = personalComputerEngine?.consentToken ?? null;
   // Surfaces that omit `executionConfig` entirely (e.g. Playground) own their
   // chat-execution state imperatively and must not be re-synced from prop
   // defaults. Surfaces that pass `executionConfig` are in controlled mode and
@@ -2365,6 +2383,18 @@ export function useChatSession(
       string,
       string
     >;
+    // Consent capability for the local computer engine — a header, never the
+    // body, so it can't land in a persisted transcript. Only on a direct
+    // (non-chatbox) turn whose resolved engine is local; the server re-checks
+    // !HOSTED_MODE + non-guest + non-chatbox + verifies the token.
+    const sendLocalEngine =
+      !HOSTED_MODE &&
+      resolvedLocalEngine &&
+      !hostedChatboxId &&
+      Boolean(localConsentToken);
+    if (sendLocalEngine && localConsentToken) {
+      mergedHeaders[LOCAL_CONSENT_HEADER] = localConsentToken;
+    }
     // When authFetch carries the request (hosted builds, chatbox runtime
     // sessions), it owns the Authorization header — don't double-attach.
     const transportHeaders =
@@ -2521,6 +2551,13 @@ export function useChatSession(
                 ...(!hostedChatboxId && !hostedExecutionTarget && hostedHostId
                   ? { hostId: hostedHostId }
                   : {}),
+                // "This machine": run this host's bash on the local computer
+                // engine. The consent capability rides the header above; the
+                // server ignores this without it (and off the /mcp direct
+                // path). Absent ⇒ the legacy cloud-family resolution.
+                ...(sendLocalEngine
+                  ? { computerEngine: "local" as const }
+                  : {}),
                 // Pass projectId for BYOK direct-chat history persistence
                 ...(hostedProjectId ? { projectId: hostedProjectId } : {}),
                 // Convex server Ids parallel to `selectedServers`. Only sent
@@ -2639,6 +2676,11 @@ export function useChatSession(
     getAzureBaseUrl,
     hostStyle,
     chatFetch,
+    // Local computer engine: rebuild the transport when the resolved engine or
+    // consent token changes, so the header/body reflect a grant or toggle on
+    // the very next turn.
+    resolvedLocalEngine,
+    localConsentToken,
     // requireToolApproval read from ref at request time
   ]);
   // `@ai-sdk/react` only recreates its internal Chat when the chat id changes.

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1583,6 +1583,13 @@ export function useChatSession(
   const [authHeaders, setAuthHeaders] = useState<
     Record<string, string> | undefined
   >(undefined);
+  // Whether the turn's Authorization is a real member (WorkOS) bearer vs a
+  // guest bearer (which the auth effect attaches when signed out). Defense in
+  // depth for the local engine: a stale consent token can outlive sign-out, so
+  // never forward the local engine on a guest turn even if the token verifies.
+  // The server independently rejects guest local turns — this just avoids
+  // sending a header a guest can't use.
+  const authIsMemberRef = useRef(false);
   const [isSessionBootstrapComplete, setIsSessionBootstrapComplete] =
     useState(false);
   const [systemPrompt, setSystemPromptState] = useState(initialSystemPrompt);
@@ -2399,7 +2406,8 @@ export function useChatSession(
       !shouldUseOrgAwareChatApi &&
       resolvedLocalEngine &&
       !hostedChatboxId &&
-      Boolean(localConsentToken);
+      Boolean(localConsentToken) &&
+      authIsMemberRef.current;
     if (sendLocalEngine && localConsentToken) {
       mergedHeaders[LOCAL_CONSENT_HEADER] = localConsentToken;
     }
@@ -3900,12 +3908,15 @@ export function useChatSession(
         if (!active) return;
         if (token) {
           resolvedAuthHeaders = { Authorization: `Bearer ${token}` };
+          authIsMemberRef.current = true;
           setAuthHeaders(resolvedAuthHeaders);
           resolved = true;
         }
       } catch {
         // getAccessToken threw (e.g. LoginRequiredError) — not authenticated
       }
+      // Anything past the WorkOS-token path is a guest (or unauthenticated).
+      if (!resolved) authIsMemberRef.current = false;
 
       // In non-hosted mode, attach a guest bearer so local chat persistence and
       // history lookups use the same Convex identity as the active thread.

--- a/mcpjam-inspector/client/src/hooks/useComputerEngine.ts
+++ b/mcpjam-inspector/client/src/hooks/useComputerEngine.ts
@@ -33,8 +33,20 @@ import {
 import { useComputersDataPlaneConfig } from "@/hooks/useProjectComputer";
 
 export interface ComputerEngineState {
-  /** Resolved engine — honest under the one rule above, never aspirational. */
+  /**
+   * Resolved engine for EXECUTION — consent-gated: `local` only when consent
+   * is granted. Chat/rail/terminal run against this; the badge follows it, so
+   * it never says "This machine" while commands go to the cloud.
+   */
   engine: ComputerEngineChoice;
+  /**
+   * The user's SELECTED engine — the same candidate order as `engine` but
+   * consent-BLIND (`local` qualifies on availability alone). This is what the
+   * Local⇄Cloud toggle shows and which FACE the Computer tab renders: picking
+   * "This machine" before consenting must show the local face's consent gate,
+   * not bounce to cloud. Execution still waits on `engine`/consent.
+   */
+  selectedEngine: ComputerEngineChoice;
   /** Persist a preference for this project (and notify every consumer). */
   setEngine: (engine: ComputerEngineChoice) => void;
   /** Config fetch settled (the answer below is real, not loading defaults). */
@@ -83,23 +95,36 @@ export function useComputerEngine(
   const cloudAvailable = config?.engines.cloud.available ?? false;
 
   let engine: ComputerEngineChoice = "cloud";
+  let selectedEngine: ComputerEngineChoice = "cloud";
   if (!HOSTED_MODE && config) {
-    const qualifies = (candidate: ComputerEngineChoice | null): boolean => {
-      if (candidate === "local") return localAvailable && consent.granted;
-      if (candidate === "cloud") return cloudAvailable;
-      return false;
-    };
     const candidates: Array<ComputerEngineChoice | null> = [
       storedPref,
       config.defaultEngine,
       "local",
       "cloud",
     ];
+    // Consent-blind: which engine the user has SELECTED / would default to.
+    const selectable = (candidate: ComputerEngineChoice | null): boolean =>
+      candidate === "local"
+        ? localAvailable
+        : candidate === "cloud"
+          ? cloudAvailable
+          : false;
+    selectedEngine =
+      (candidates.find(selectable) as ComputerEngineChoice) ?? "cloud";
+    // Execution-resolved: `local` additionally requires granted consent.
+    const qualifies = (candidate: ComputerEngineChoice | null): boolean =>
+      candidate === "local"
+        ? localAvailable && consent.granted
+        : candidate === "cloud"
+          ? cloudAvailable
+          : false;
     engine = (candidates.find(qualifies) as ComputerEngineChoice) ?? "cloud";
   }
 
   return {
     engine,
+    selectedEngine,
     setEngine,
     resolved: config !== undefined,
     localAvailable,

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -30,6 +30,14 @@ import { authFetch } from "@/lib/session-token";
 const STORAGE_KEY = "mcp-local-computer-consent-v1";
 const EVENT_NAME = "local-computer-consent-changed";
 
+/**
+ * Header that carries the consent capability on a local-engine chat turn. The
+ * server reads it case-insensitively (`x-mcpjam-local-consent`); this is the
+ * canonical casing. Kept out of the request BODY so it can't enter persisted
+ * transcripts.
+ */
+export const LOCAL_CONSENT_HEADER = "X-MCPJam-Local-Consent";
+
 export interface StoredLocalComputerConsent {
   token: string;
   grantedAt: string;

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -80,6 +80,7 @@ import {
   LOCAL_CONSENT_HEADER,
   verifyLocalComputerConsent,
 } from "../../utils/computers/local-consent.js";
+import { isGuestChatRequest } from "../../utils/computers/local-engine-request.js";
 import { convertToMcpjamModelMessages } from "../../utils/mcp-tool-result-model-output.js";
 import { type ExecutionScope } from "../../utils/execution-scope.js";
 import {
@@ -1041,12 +1042,16 @@ chatV2.post("/", async (c) => {
       rawEnginePref === "local" || rawEnginePref === "cloud"
         ? rawEnginePref
         : undefined;
+    // A GUEST must never resolve the local engine — bash on the local machine
+    // has no backend reserve gate (unlike the cloud path), so the request-level
+    // guest check IS the boundary (see isGuestChatRequest).
+    const requestIsGuest = isGuestChatRequest(requestAuthHeader);
     const localPrefEligible =
-      enginePref === "local" && Boolean(requestAuthHeader) && !isChatboxSession;
+      enginePref === "local" && !requestIsGuest && !isChatboxSession;
     if (enginePref === "local" && !localPrefEligible) {
       logger.debug(
         "[mcp/chat-v2] computerEngine=local ignored for an ineligible request",
-        { isChatboxSession, hasAuth: Boolean(requestAuthHeader) }
+        { isChatboxSession, isGuest: requestIsGuest }
       );
     }
     const localConsentValid = localPrefEligible

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-engine-request.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-engine-request.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const guest = vi.hoisted(() => ({
+  result: { valid: false } as { valid: boolean; guestId?: string },
+  throws: false,
+}));
+vi.mock("../../../services/guest-token-verifier.js", () => ({
+  validateGuestToken: (_token: string) => {
+    if (guest.throws) throw new Error("guest keys not initialized");
+    return guest.result;
+  },
+}));
+
+import { isGuestChatRequest } from "../local-engine-request.js";
+
+describe("isGuestChatRequest — local-engine boundary", () => {
+  beforeEach(() => {
+    guest.result = { valid: false };
+    guest.throws = false;
+  });
+
+  it("no Authorization ⇒ guest (anonymous; the route mints a bearer later)", () => {
+    expect(isGuestChatRequest(undefined)).toBe(true);
+    expect(isGuestChatRequest("")).toBe(true);
+    expect(isGuestChatRequest("Bearer ")).toBe(true);
+  });
+
+  it("a member bearer (not a valid guest token) ⇒ NOT guest", () => {
+    guest.result = { valid: false };
+    expect(isGuestChatRequest("Bearer member-workos-jwt")).toBe(false);
+  });
+
+  it("a valid GUEST bearer ⇒ guest (the signed-out-with-stale-token case)", () => {
+    guest.result = { valid: true, guestId: "g-1" };
+    expect(isGuestChatRequest("Bearer guest-jwt")).toBe(true);
+  });
+
+  it("keys uninitialized (throws) ⇒ a present bearer is treated as a member", () => {
+    // Guest tokens can't have been minted, so a present bearer is a member.
+    guest.throws = true;
+    expect(isGuestChatRequest("Bearer some-token")).toBe(false);
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/local-engine-request.ts
+++ b/mcpjam-inspector/server/utils/computers/local-engine-request.ts
@@ -1,0 +1,25 @@
+import { validateGuestToken } from "../../services/guest-token-verifier.js";
+
+/**
+ * Is this chat request a GUEST (for local-engine eligibility)?
+ *
+ * The local computer engine runs bash on the machine as the user, with NO
+ * backend reserve gate (unlike the cloud path, which the backend rejects for
+ * guests) — so this request-level guest check IS the security boundary.
+ *
+ *  - No Authorization ⇒ anonymous guest (the route mints a guest bearer later).
+ *  - A PRESENT bearer can still be a guest bearer: a signed-out user's turn
+ *    attaches one, and a consent token can outlive sign-out — so validate it.
+ *  - Guest keys uninitialized ⇒ guest tokens can't exist ⇒ a present bearer is
+ *    a member bearer.
+ */
+export function isGuestChatRequest(authHeader: string | undefined): boolean {
+  if (!authHeader) return true;
+  const bearer = authHeader.replace(/^Bearer\s+/i, "");
+  if (!bearer) return true;
+  try {
+    return validateGuestToken(bearer).valid;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
PR 6 of the local-computer-engine program (PRs 1–5: #3799, #3805, #3812, #3815, #3818, all merged). The **first user-visible slice** — the Computer tab's "This machine" face and the Local⇄Cloud toggle, consuming the PR-5 hooks.

## What this adds

`ComputerRoute` now renders a thin **`ComputerTabView`** wrapper instead of `ComputerView`:

- **Hosted, a guest/non-member, or no synced project ⇒ the existing cloud `ComputerView`, unchanged.** It still owns the sign-in and no-project empty states. `ComputerView` itself is not touched — the wrapper picks the face; each face keeps its own "Computer" header.
- **A signed-in member on a non-hosted inspector ⇒ a Local⇄Cloud face**, with a `ViewModeSelector` (Skills-toggle style) shown only when both engines exist.

**Face follows a consent-blind `selectedEngine`.** New field on `useComputerEngine`: same candidate order as the execution-resolved `engine`, but `local` qualifies on availability alone. So picking "This machine" *before* consenting shows the local face's consent gate rather than bouncing to cloud — while execution still resolves through the consent-gated `engine`, so the badge never says "This machine" while commands go to the cloud.

**`LocalComputerView`** (the local face): the "This machine" identity chip, the per-project workspace dir (`${workspaceDisplayRoot}/<projectId>`, rendered from the tilde root the open config endpoint returns — no absolute path), the first-run **consent gate** (`LocalComputerConsentGate` — "Allow agents to run commands on this machine?"; Allow grants the device capability then pins the engine preference to local; "Use cloud instead" appears only when a cloud computer exists), and a **terminal-not-available-yet note** — the interactive terminal is the node-pty PR (8); bash from chat already works once PR 7 wires transmission.

**WebMCP.** `LocalComputerView` registers the *same* `surfaceId:"computer"` agent bridge as `ComputerView` (only one face is mounted at a time). The cloud-lifecycle verbs — `start/hibernate/reset/delete` — **refuse with `unsupported_in_mode`** ("switch to Cloud to manage it") rather than vanishing from the catalog mid-session, and the snapshot reports `{engine:"local", consentGranted, terminalAvailable, workspaceDir}` — never a token. The existing `ComputerView.agent.test` is unaffected (it renders `ComputerView` directly).

## Scope notes

- **Inert until PR 7.** Granting consent + toggling local sets the preference, but chat doesn't send `computerEngine`/the consent header until PR 7, and the terminal is PR 8. This PR is the tab UI + consent entry point; it's independently reviewable.
- **Consent hook unchanged.** Built strictly on the merged pure-storage projection — no new client-side consent logic (Allow just calls `consent.grant()`), per the lesson from that hook's six review rounds.

## Tests

`selectedEngine` matrix on the hook; `ComputerTabView` face/toggle selection incl. hosted / non-member / no-project passthrough and toggle-persists; `LocalComputerView` consent-gate → grant → pin, grant-failure (no pin, error shown), cloud-fallback visibility, granted degrade, workdir render; the refusing agent bridge (4 verbs) + redacted local snapshot. Client typecheck exit 0; all 9 computer component suites (85 tests) + the `ComputerRoute` flag-hydration test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Enables local bash execution with consent headers and tightens guest vs member boundaries on chat; mistakes could run commands on the user's machine or leak capability tokens into the wrong routes.
> 
> **Overview**
> Introduces **`ComputerTabView`** as the Computer route shell: hosted, guests, or missing projects still get cloud **`ComputerView`**; signed-in members on a local inspector get a **Local ⇄ Cloud** toggle and either **`LocalComputerView`** or cloud. **`useComputerEngine`** gains consent-blind **`selectedEngine`** so choosing “This machine” before consent shows the local consent gate instead of snapping back to cloud, while execution still uses consent-gated **`engine`**.
> 
> **`LocalComputerView`** adds the “This machine” UI (workspace path, **`LocalComputerConsentGate`**, terminal placeholder), WebMCP lifecycle commands that refuse with **`unsupported_in_mode`**, and a redacted local snapshot. **Playground** resolves the engine via **`useComputerEngine`** and passes **`personalComputerEngine`** into **`useChatSession`** (root + comparison columns); eligible direct **`/api/mcp/chat-v2`** turns send **`computerEngine: "local"`** and **`X-MCPJam-Local-Consent`** (header only, member-only, not on web/chatbox/guest paths). **`chat-v2`** uses **`isGuestChatRequest`** so guest bearers cannot enable the local engine even with a stale consent token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 924517bcbb9cc04570af1bda95532fb67029ef60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the “This machine” face to the Computer tab with a Local⇄Cloud toggle, and runs Playground chat on the local machine when selected and consented. Tightens safety so only signed-in members on direct `/api/mcp/chat-v2` turns can use the local engine; guests, org-web, and chatbox turns ignore it.

- New Features
  - `ComputerRoute` renders `ComputerTabView`, which picks the face:
    - Hosted, guest/non-member, or no project → cloud `ComputerView`.
    - Signed-in member on non-hosted → Local⇄Cloud face with a toggle when both engines exist.
  - `useComputerEngine` adds `selectedEngine` (consent-blind). The face/toggle follow `selectedEngine`; execution uses consent-gated `engine`.
  - `LocalComputerView`: “This machine” chip, per-project workspace dir (`${workspaceDisplayRoot}/<projectId>`), consent gate (`LocalComputerConsentGate`) with “Use cloud instead” only when cloud exists, terminal-not-available note, and a “Forget & re-authorize” action to clear stale consent.
  - WebMCP: same `surfaceId: "computer"` bridge; `start/hibernate/reset/delete` refuse with `unsupported_in_mode`; snapshot reports `{engine: "local", consentGranted, terminalAvailable, workspaceDir}` with no token.
  - Playground: `useChatSession` accepts `personalComputerEngine` ({engine, consentToken}). `PlaygroundMain` resolves via `useComputerEngine` and passes it to the root session and comparison columns. Eligible `/api/mcp/chat-v2` turns send `computerEngine: "local"` and `X-MCPJam-Local-Consent` (header-only; never in the body).

- Bug Fixes
  - Scoped the local-engine field and consent header to direct `/api/mcp/chat-v2` only; suppressed on `/api/web/chat-v2`, chatbox sessions, and guest turns.
  - Server blocks guest local-engine requests via `isGuestChatRequest`; client also forwards local only when a member bearer is present.

<sup>Written for commit 924517bcbb9cc04570af1bda95532fb67029ef60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

