### PR TITLE
feat(user-testing): make scenarios editable — name the ad-hoc environment, rename inline

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import {
   AlertTriangle,
@@ -24,6 +24,7 @@ import {
   type ChatboxSettings,
 } from "@/hooks/useChatboxes";
 import { useProjectEnvironment } from "@/hooks/useProjectEnvironments";
+import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { isAdhocEnvironment } from "@/lib/environment-label";
 import { convexErrMessage } from "@/lib/convex-error";
 import {
@@ -80,12 +81,16 @@ export function UserTestingScenarioDetail({
 
   // The environment row itself — for `origin` and `revision`, which the
   // chatbox settings envelope deliberately doesn't carry. Host-backed
-  // scenarios (no environmentId) skip the query entirely. NOTE:
+  // scenarios (no environmentId) skip the query entirely, and so does a
+  // project without `project-environments-enabled`: promotion's whole payoff
+  // is "now manage it from Environments", a surface that flag gates — offering
+  // it flag-off would mutate a row the user then has no page to see. NOTE:
   // `chatbox.environmentName` is non-null even for an ad-hoc row (the backend
   // synthesizes a label from the client name), so ad-hoc-ness must come from
   // this row, never from name presence on the envelope.
+  const environmentsEnabled = useProjectEnvironmentsEnabled();
   const environment = useProjectEnvironment(
-    chatbox.environmentId ? chatbox.projectId : null,
+    environmentsEnabled && chatbox.environmentId ? chatbox.projectId : null,
     chatbox.environmentId ?? null,
   );
   // Fail closed: `undefined` (loading) and `null` (not visible) both hide the
@@ -96,11 +101,18 @@ export function UserTestingScenarioDetail({
 
   // Draft state for the description, persisted on blur. Reseeded whenever the
   // reactive envelope changes so another member's edit doesn't get silently
-  // overwritten by a stale draft on the next blur.
+  // overwritten by a stale draft on the next blur — but NOT while the field
+  // holds focus. Two races live in that exception: our own save echoing back
+  // after the user has already refocused and started the next edit, and a
+  // collaborator's edit landing mid-sentence; both would otherwise replace
+  // in-progress typing without a trace. The remote value skipped during focus
+  // is picked up on blur instead (see `persistDescription`).
   const [descriptionDraft, setDescriptionDraft] = useState(
     chatbox.description ?? "",
   );
+  const descriptionFocusedRef = useRef(false);
   useEffect(() => {
+    if (descriptionFocusedRef.current) return;
     setDescriptionDraft(chatbox.description ?? "");
   }, [chatbox.description]);
 
@@ -115,8 +127,14 @@ export function UserTestingScenarioDetail({
   };
 
   const persistDescription = async () => {
+    descriptionFocusedRef.current = false;
     const next = descriptionDraft.trim();
-    if (next === (chatbox.description ?? "").trim()) return;
+    if (next === (chatbox.description ?? "").trim()) {
+      // No-op blur: resync the draft with the envelope, which also adopts any
+      // remote value the focused-guard above deliberately skipped.
+      setDescriptionDraft(chatbox.description ?? "");
+      return;
+    }
     try {
       await updateChatbox({
         chatboxId: chatbox.chatboxId,
@@ -271,6 +289,9 @@ export function UserTestingScenarioDetail({
               data-testid="user-testing-description"
               value={descriptionDraft}
               onChange={(e) => setDescriptionDraft(e.target.value)}
+              onFocus={() => {
+                descriptionFocusedRef.current = true;
+              }}
               onBlur={() => void persistDescription()}
               minRows={1}
               maxRows={4}

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import {
   AlertTriangle,
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   Layers,
   Link2,
+  PenLine,
   Trash2,
 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
@@ -15,10 +16,16 @@ import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection";
 import { ChatboxUsagePanel } from "@/components/chatboxes/ChatboxUsagePanel";
 import { ChatboxDeleteConfirmDialog } from "@/components/chatboxes/ChatboxDeleteConfirmDialog";
+import { EditableTitle } from "@/components/evals/EditableTitle";
+import { NameEnvironmentDialog } from "@/components/project-environments/NameEnvironmentDialog";
+import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import {
   useChatboxMutations,
   type ChatboxSettings,
 } from "@/hooks/useChatboxes";
+import { useProjectEnvironment } from "@/hooks/useProjectEnvironments";
+import { isAdhocEnvironment } from "@/lib/environment-label";
+import { convexErrMessage } from "@/lib/convex-error";
 import {
   getChatboxHostLabel,
   getChatboxHostLogo,
@@ -66,9 +73,60 @@ export function UserTestingScenarioDetail({
   const location = useLocation();
   const computersEnabled = useComputersEnabled();
   const themeMode = usePreferencesStore((s) => s.themeMode);
-  const { deleteChatbox } = useChatboxMutations();
+  const { deleteChatbox, updateChatbox } = useChatboxMutations();
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [nameEnvironmentOpen, setNameEnvironmentOpen] = useState(false);
+
+  // The environment row itself — for `origin` and `revision`, which the
+  // chatbox settings envelope deliberately doesn't carry. Host-backed
+  // scenarios (no environmentId) skip the query entirely. NOTE:
+  // `chatbox.environmentName` is non-null even for an ad-hoc row (the backend
+  // synthesizes a label from the client name), so ad-hoc-ness must come from
+  // this row, never from name presence on the envelope.
+  const environment = useProjectEnvironment(
+    chatbox.environmentId ? chatbox.projectId : null,
+    chatbox.environmentId ?? null,
+  );
+  // Fail closed: `undefined` (loading) and `null` (not visible) both hide the
+  // promote affordance rather than guessing.
+  const environmentIsAdhoc = Boolean(
+    environment && isAdhocEnvironment(environment),
+  );
+
+  // Draft state for the description, persisted on blur. Reseeded whenever the
+  // reactive envelope changes so another member's edit doesn't get silently
+  // overwritten by a stale draft on the next blur.
+  const [descriptionDraft, setDescriptionDraft] = useState(
+    chatbox.description ?? "",
+  );
+  useEffect(() => {
+    setDescriptionDraft(chatbox.description ?? "");
+  }, [chatbox.description]);
+
+  const handleRename = async (name: string) => {
+    try {
+      await updateChatbox({ chatboxId: chatbox.chatboxId, name } as any);
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Failed to rename the scenario"));
+      // Rethrow so EditableTitle reverts to the persisted name.
+      throw err;
+    }
+  };
+
+  const persistDescription = async () => {
+    const next = descriptionDraft.trim();
+    if (next === (chatbox.description ?? "").trim()) return;
+    try {
+      await updateChatbox({
+        chatboxId: chatbox.chatboxId,
+        description: next,
+      } as any);
+    } catch (err) {
+      toast.error(convexErrMessage(err, "Failed to save the description"));
+      setDescriptionDraft(chatbox.description ?? "");
+    }
+  };
 
   // The URL is the stash for both the tab and the opened session: the gates
   // above remount this route during a cold boot, so state captured on first
@@ -142,10 +200,16 @@ export function UserTestingScenarioDetail({
           User Testing
         </button>
         <div className="mt-2 flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
-            <h1 className="truncate text-xl font-semibold tracking-tight">
-              {chatbox.name}
-            </h1>
+          <div className="min-w-0 flex-1">
+            <EditableTitle
+              value={chatbox.name}
+              onSave={handleRename}
+              variant="h1"
+              fullWidth
+              placeholder="Scenario name"
+              className="-ml-2 px-2 text-xl font-semibold tracking-tight"
+              inputClassName="text-xl font-semibold tracking-tight"
+            />
             <div className="mt-1.5 flex items-center gap-2 text-sm text-muted-foreground">
               {environmentName ? (
                 // Environment-backed: the environment IS the scenario's
@@ -156,6 +220,22 @@ export function UserTestingScenarioDetail({
                   <span className="truncate font-medium text-foreground">
                     {environmentName}
                   </span>
+                  {environmentIsAdhoc ? (
+                    // The row behind this label is ad-hoc: content-addressed,
+                    // immutable, and labeled by its client rather than a name.
+                    // Naming it (in place, same id) is what makes it — and
+                    // therefore this scenario's execution config — editable.
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 shrink-0 px-2 text-xs text-muted-foreground"
+                      onClick={() => setNameEnvironmentOpen(true)}
+                      data-testid="user-testing-name-environment"
+                    >
+                      <PenLine className="mr-1 size-3" />
+                      Name environment
+                    </Button>
+                  ) : null}
                 </>
               ) : (
                 <>
@@ -186,6 +266,22 @@ export function UserTestingScenarioDetail({
                 />
               ) : null}
             </div>
+            <TextareaAutosize
+              aria-label="Scenario description"
+              data-testid="user-testing-description"
+              value={descriptionDraft}
+              onChange={(e) => setDescriptionDraft(e.target.value)}
+              onBlur={() => void persistDescription()}
+              minRows={1}
+              maxRows={4}
+              maxLength={2000}
+              placeholder="Add a description…"
+              className={cn(
+                "mt-1 min-h-0 resize-none border-0 bg-transparent px-0 py-0 text-sm",
+                "text-muted-foreground shadow-none placeholder:text-muted-foreground/60",
+                "focus-visible:border-0 focus-visible:ring-0",
+              )}
+            />
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {publishLink ? (
@@ -301,6 +397,15 @@ export function UserTestingScenarioDetail({
         isDeleting={isDeleting}
         onConfirm={handleDelete}
       />
+
+      {environment ? (
+        <NameEnvironmentDialog
+          open={nameEnvironmentOpen}
+          onOpenChange={setNameEnvironmentOpen}
+          projectId={chatbox.projectId}
+          environment={environment}
+        />
+      ) : null}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -13,13 +13,23 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 
-const { navigateMock, locationState, usagePanelMock, deleteChatboxMock } =
-  vi.hoisted(() => ({
-    navigateMock: vi.fn(),
-    locationState: { search: "" },
-    usagePanelMock: vi.fn(),
-    deleteChatboxMock: vi.fn().mockResolvedValue(undefined),
-  }));
+const {
+  navigateMock,
+  locationState,
+  usagePanelMock,
+  deleteChatboxMock,
+  updateChatboxMock,
+  environmentState,
+} = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  locationState: { search: "" },
+  usagePanelMock: vi.fn(),
+  deleteChatboxMock: vi.fn().mockResolvedValue(undefined),
+  updateChatboxMock: vi.fn().mockResolvedValue(undefined),
+  // What `useProjectEnvironment` answers with: `undefined` = loading,
+  // `null` = not visible, a row = loaded. Mutable per test.
+  environmentState: { row: undefined as unknown },
+}));
 
 vi.mock("react-router", () => ({
   useNavigate: () => navigateMock,
@@ -47,7 +57,21 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 vi.mock("@/hooks/useChatboxes", () => ({
-  useChatboxMutations: () => ({ deleteChatbox: deleteChatboxMock }),
+  useChatboxMutations: () => ({
+    deleteChatbox: deleteChatboxMock,
+    updateChatbox: updateChatboxMock,
+  }),
+}));
+
+// Mandatory: the real hook calls `useConvexAuth`, which has no provider here.
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  useProjectEnvironment: (projectId: string | null, envId: string | null) =>
+    projectId && envId ? environmentState.row : null,
+}));
+
+vi.mock("@/components/project-environments/NameEnvironmentDialog", () => ({
+  NameEnvironmentDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="stub-name-environment-dialog" /> : null,
 }));
 
 vi.mock("@/components/chatboxes/ChatboxShareSection", () => ({
@@ -97,7 +121,12 @@ const renderDetail = (over: Partial<ChatboxSettings> = {}) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `clearAllMocks` clears calls but NOT implementations — reinstate the
+  // resolved defaults so a per-test rejection can't leak into later cases.
+  deleteChatboxMock.mockResolvedValue(undefined);
+  updateChatboxMock.mockResolvedValue(undefined);
   locationState.search = "";
+  environmentState.row = undefined;
 });
 
 describe("UserTestingScenarioDetail", () => {
@@ -185,5 +214,96 @@ describe("UserTestingScenarioDetail", () => {
 
     expect(screen.getByTestId("stub-delete-dialog")).toBeInTheDocument();
     expect(deleteChatboxMock).not.toHaveBeenCalled();
+  });
+
+  describe("naming the backing ad-hoc environment", () => {
+    const adhocRow = {
+      environmentId: "env-1",
+      projectId: "p1",
+      origin: "adhoc",
+      hostId: "host-1",
+      revision: 1,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    it("offers it for an ad-hoc row, and opens the dialog", () => {
+      environmentState.row = adhocRow;
+      // The label is synthesized from the client for ad-hoc rows — its
+      // presence must NOT read as "named".
+      renderDetail({ environmentId: "env-1", environmentName: "ChatGPT" });
+
+      const button = screen.getByTestId("user-testing-name-environment");
+      fireEvent.click(button);
+
+      expect(
+        screen.getByTestId("stub-name-environment-dialog"),
+      ).toBeInTheDocument();
+    });
+
+    it("hides it while the environment row is still loading (fail closed)", () => {
+      environmentState.row = undefined;
+      renderDetail({ environmentId: "env-1", environmentName: "ChatGPT" });
+
+      expect(
+        screen.queryByTestId("user-testing-name-environment"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides it for a named environment", () => {
+      environmentState.row = {
+        ...adhocRow,
+        origin: "named",
+        name: "Checkout flow",
+      };
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      expect(
+        screen.queryByTestId("user-testing-name-environment"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides it for a host-backed scenario (no environment at all)", () => {
+      renderDetail();
+
+      expect(
+        screen.queryByTestId("user-testing-name-environment"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("editing the scenario itself", () => {
+    it("renames via updateChatbox from the header title", async () => {
+      renderDetail();
+
+      fireEvent.click(screen.getByText("Payments beta"));
+      const input = screen.getByDisplayValue("Payments beta");
+      fireEvent.change(input, { target: { value: "Payments GA" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(updateChatboxMock).toHaveBeenCalledWith({
+        chatboxId: "cb-1",
+        name: "Payments GA",
+      });
+    });
+
+    it("persists the description on blur, only when it changed", () => {
+      renderDetail({ description: "Old copy" });
+
+      const textarea = screen.getByTestId("user-testing-description");
+      // Blur with no edit: no write.
+      fireEvent.blur(textarea);
+      expect(updateChatboxMock).not.toHaveBeenCalled();
+
+      fireEvent.change(textarea, { target: { value: "New copy" } });
+      fireEvent.blur(textarea);
+      expect(updateChatboxMock).toHaveBeenCalledWith({
+        chatboxId: "cb-1",
+        description: "New copy",
+      });
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -9,7 +9,7 @@
  *    back button goes from a scenario to the list rather than walking back
  *    through every tab the user tried.
  */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 
@@ -20,6 +20,7 @@ const {
   deleteChatboxMock,
   updateChatboxMock,
   environmentState,
+  flagState,
 } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
   locationState: { search: "" },
@@ -29,6 +30,7 @@ const {
   // What `useProjectEnvironment` answers with: `undefined` = loading,
   // `null` = not visible, a row = loaded. Mutable per test.
   environmentState: { row: undefined as unknown },
+  flagState: { environmentsEnabled: true },
 }));
 
 vi.mock("react-router", () => ({
@@ -67,6 +69,10 @@ vi.mock("@/hooks/useChatboxes", () => ({
 vi.mock("@/hooks/useProjectEnvironments", () => ({
   useProjectEnvironment: (projectId: string | null, envId: string | null) =>
     projectId && envId ? environmentState.row : null,
+}));
+
+vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
+  useProjectEnvironmentsEnabled: () => flagState.environmentsEnabled,
 }));
 
 vi.mock("@/components/project-environments/NameEnvironmentDialog", () => ({
@@ -127,6 +133,7 @@ beforeEach(() => {
   updateChatboxMock.mockResolvedValue(undefined);
   locationState.search = "";
   environmentState.row = undefined;
+  flagState.environmentsEnabled = true;
 });
 
 describe("UserTestingScenarioDetail", () => {
@@ -250,6 +257,29 @@ describe("UserTestingScenarioDetail", () => {
       ).not.toBeInTheDocument();
     });
 
+    it("hides it for a row this member cannot see (null, fail closed)", () => {
+      // Distinct from loading: the backend answered, and the answer was no.
+      environmentState.row = null;
+      renderDetail({ environmentId: "env-1", environmentName: "ChatGPT" });
+
+      expect(
+        screen.queryByTestId("user-testing-name-environment"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides it when project-environments is flag-off", () => {
+      // Promotion's payoff is "manage it from Environments" — a surface the
+      // flag gates. Offering it flag-off would mutate a row the user then
+      // has no page to see.
+      flagState.environmentsEnabled = false;
+      environmentState.row = adhocRow;
+      renderDetail({ environmentId: "env-1", environmentName: "ChatGPT" });
+
+      expect(
+        screen.queryByTestId("user-testing-name-environment"),
+      ).not.toBeInTheDocument();
+    });
+
     it("hides it for a named environment", () => {
       environmentState.row = {
         ...adhocRow,
@@ -284,10 +314,18 @@ describe("UserTestingScenarioDetail", () => {
       fireEvent.change(input, { target: { value: "Payments GA" } });
       fireEvent.keyDown(input, { key: "Enter" });
 
-      expect(updateChatboxMock).toHaveBeenCalledWith({
-        chatboxId: "cb-1",
-        name: "Payments GA",
-      });
+      // Settle the save inside act: EditableTitle's setState after the await
+      // would otherwise land after the test body returns.
+      await waitFor(() =>
+        expect(updateChatboxMock).toHaveBeenCalledWith({
+          chatboxId: "cb-1",
+          name: "Payments GA",
+        }),
+      );
+      // Edit mode exits and the CONTROLLED value re-renders — still the old
+      // name here, because the mocked chatbox never updates. The new name
+      // arriving is the reactive envelope's job, not EditableTitle's.
+      await screen.findByText("Payments beta");
     });
 
     it("persists the description on blur, only when it changed", () => {

--- a/mcpjam-inspector/client/src/components/project-environments/NameEnvironmentDialog.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/NameEnvironmentDialog.tsx
@@ -138,6 +138,8 @@ export function NameEnvironmentDialog({
               placeholder="e.g. ChatGPT · staging servers"
               value={name}
               disabled={isSaving}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? "name-environment-error" : undefined}
               onChange={(e) => setName(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" && canSubmit) {
@@ -168,7 +170,11 @@ export function NameEnvironmentDialog({
             />
           </div>
           {error ? (
+            // The rejection is the dialog's principal feedback channel —
+            // `role="alert"` so assistive tech announces it on arrival.
             <p
+              id="name-environment-error"
+              role="alert"
               className="text-sm text-destructive"
               data-testid="name-environment-error"
             >

--- a/mcpjam-inspector/client/src/components/project-environments/NameEnvironmentDialog.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/NameEnvironmentDialog.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import { TextareaAutosize } from "@/components/ui/textarea-autosize";
+import {
+  usePromoteProjectEnvironment,
+  type ProjectEnvironmentView,
+} from "@/hooks/useProjectEnvironments";
+import { convexErrMessage } from "@/lib/convex-error";
+import { toast } from "@/lib/toast";
+
+/**
+ * Name an ad-hoc environment, promoting it IN PLACE to an ordinary named row.
+ *
+ * This is the ad-hoc program's escape hatch made visible: ad-hoc rows are
+ * content-addressed and therefore immutable, so every surface that shows one —
+ * a User Testing scenario, a swarm's "From runs" row — is frozen until the row
+ * is named. Promotion keeps the SAME environmentId, so everything pointing at
+ * the row (scenarios, suites, historical run session ids) follows it into its
+ * named life untouched.
+ *
+ * `expectedRevision` is captured when the dialog OPENS, per the repo's
+ * expectedRevision convention (see `useUpdateProjectEnvironment`): sending the
+ * newest reactive revision at submit time would let a stale dialog silently
+ * clobber a concurrent promotion. On a rejection the backend's own sentence is
+ * shown verbatim — the three CONFLICT causes (already named / row changed /
+ * name taken) are distinct instructions to the user, and paraphrasing them
+ * into one generic error would erase exactly that.
+ */
+export interface NameEnvironmentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  environment: ProjectEnvironmentView;
+  /** After a successful promotion, in addition to the toast + close. */
+  onNamed?: (named: ProjectEnvironmentView) => void;
+}
+
+export function NameEnvironmentDialog({
+  open,
+  onOpenChange,
+  projectId,
+  environment,
+  onNamed,
+}: NameEnvironmentDialogProps) {
+  const promoteEnvironment = usePromoteProjectEnvironment();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  // The revision this dialog is editing against. A ref, not derived state:
+  // the reactive `environment` prop keeps updating underneath an open dialog,
+  // and substituting its fresh revision would defeat the handshake.
+  const expectedRevisionRef = useRef(environment.revision);
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setDescription("");
+      setError(null);
+      expectedRevisionRef.current = environment.revision;
+    }
+    // Capture on OPEN only — `environment.revision` is deliberately not a
+    // trigger, so a background change surfaces as the backend's CONFLICT
+    // instead of being silently absorbed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const trimmedName = name.trim();
+  const canSubmit = trimmedName.length > 0 && !isSaving;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      const named = await promoteEnvironment({
+        projectId,
+        environmentId: environment.environmentId,
+        expectedRevision: expectedRevisionRef.current,
+        name: trimmedName,
+        ...(description.trim() ? { description: description.trim() } : {}),
+      });
+      toast.success(
+        `Environment named "${trimmedName}" — it is now editable from Environments.`,
+      );
+      onOpenChange(false);
+      onNamed?.(named);
+    } catch (err) {
+      setError(convexErrMessage(err, "Failed to name the environment."));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && isSaving) return;
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        showCloseButton={!isSaving}
+        className="gap-4 sm:max-w-md"
+        data-testid="name-environment-dialog"
+      >
+        <DialogHeader className="gap-2 text-left">
+          <DialogTitle className="text-foreground">
+            Name this environment
+          </DialogTitle>
+          <DialogDescription>
+            This environment was created automatically from a setup, so it
+            can&apos;t be edited. Naming it turns it into an ordinary
+            environment you can manage from the Environments page — everything
+            already running on it follows along.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-2">
+            <Label htmlFor="name-environment-name">Name</Label>
+            <Input
+              id="name-environment-name"
+              autoComplete="off"
+              maxLength={100}
+              placeholder="e.g. ChatGPT · staging servers"
+              value={name}
+              disabled={isSaving}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canSubmit) {
+                  e.preventDefault();
+                  void handleSubmit();
+                }
+              }}
+              data-testid="name-environment-name-input"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="name-environment-description">
+              Description{" "}
+              <span className="font-normal text-muted-foreground">
+                (optional)
+              </span>
+            </Label>
+            <TextareaAutosize
+              id="name-environment-description"
+              minRows={2}
+              maxRows={5}
+              maxLength={2000}
+              placeholder="What this setup is for…"
+              value={description}
+              disabled={isSaving}
+              onChange={(e) => setDescription(e.target.value)}
+              data-testid="name-environment-description-input"
+            />
+          </div>
+          {error ? (
+            <p
+              className="text-sm text-destructive"
+              data-testid="name-environment-error"
+            >
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isSaving}
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!canSubmit}
+            onClick={() => void handleSubmit()}
+            data-testid="name-environment-submit"
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+                Naming…
+              </>
+            ) : (
+              "Name environment"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/name-environment-dialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/name-environment-dialog.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * NameEnvironmentDialog — promotion of an ad-hoc row, in place.
+ *
+ * The load-bearing behaviours:
+ *  - `expectedRevision` is captured when the dialog OPENS and survives the
+ *    reactive prop updating underneath it — substituting the fresh revision at
+ *    submit would defeat the double-promote handshake.
+ *  - Backend rejections render VERBATIM: the three CONFLICT causes (already
+ *    named / row changed / name taken) are distinct instructions, and the
+ *    dialog stays open so the user can act on them.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectEnvironmentView } from "@/hooks/useProjectEnvironments";
+
+const { promoteMock, toastMock } = vi.hoisted(() => ({
+  promoteMock: vi.fn(),
+  toastMock: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/hooks/useProjectEnvironments", () => ({
+  usePromoteProjectEnvironment: () => promoteMock,
+}));
+vi.mock("@/lib/toast", () => ({ toast: toastMock }));
+
+import { NameEnvironmentDialog } from "../NameEnvironmentDialog";
+
+const adhocEnvironment = {
+  environmentId: "env-1",
+  projectId: "p1",
+  origin: "adhoc",
+  hostId: "host-1",
+  revision: 1,
+  createdAt: 0,
+  updatedAt: 0,
+} as unknown as ProjectEnvironmentView;
+
+const renderDialog = (props: {
+  open?: boolean;
+  environment?: ProjectEnvironmentView;
+  onOpenChange?: (open: boolean) => void;
+}) =>
+  render(
+    <NameEnvironmentDialog
+      open={props.open ?? true}
+      onOpenChange={props.onOpenChange ?? vi.fn()}
+      projectId="p1"
+      environment={props.environment ?? adhocEnvironment}
+    />,
+  );
+
+const typeName = (value: string) =>
+  fireEvent.change(screen.getByTestId("name-environment-name-input"), {
+    target: { value },
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  promoteMock.mockResolvedValue(adhocEnvironment);
+});
+
+describe("NameEnvironmentDialog", () => {
+  it("submits the revision captured at open, blank description omitted", async () => {
+    renderDialog({});
+
+    typeName("  Checkout flow  ");
+    fireEvent.click(screen.getByTestId("name-environment-submit"));
+
+    await waitFor(() => expect(promoteMock).toHaveBeenCalledTimes(1));
+    expect(promoteMock).toHaveBeenCalledWith({
+      projectId: "p1",
+      environmentId: "env-1",
+      expectedRevision: 1,
+      name: "Checkout flow",
+    });
+  });
+
+  it("keeps the captured revision when the reactive row changes under an open dialog", async () => {
+    const { rerender } = renderDialog({});
+
+    // The row updates underneath (another member touched it) — the open
+    // dialog must still send what it was editing against, so the backend's
+    // CONFLICT fires instead of a silent clobber.
+    rerender(
+      <NameEnvironmentDialog
+        open
+        onOpenChange={vi.fn()}
+        projectId="p1"
+        environment={
+          { ...(adhocEnvironment as object), revision: 7 } as never
+        }
+      />,
+    );
+
+    typeName("Checkout flow");
+    fireEvent.click(screen.getByTestId("name-environment-submit"));
+
+    await waitFor(() => expect(promoteMock).toHaveBeenCalledTimes(1));
+    expect(promoteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedRevision: 1 }),
+    );
+  });
+
+  it("sends the description when one is provided", async () => {
+    renderDialog({});
+
+    typeName("Checkout flow");
+    fireEvent.change(
+      screen.getByTestId("name-environment-description-input"),
+      { target: { value: "Staging servers for the checkout revamp" } },
+    );
+    fireEvent.click(screen.getByTestId("name-environment-submit"));
+
+    await waitFor(() =>
+      expect(promoteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: "Staging servers for the checkout revamp",
+        }),
+      ),
+    );
+  });
+
+  it("renders the backend's rejection verbatim and stays open", async () => {
+    promoteMock.mockRejectedValue({
+      data: {
+        code: "CONFLICT",
+        message: 'An environment named "Checkout flow" already exists.',
+      },
+    });
+    const onOpenChange = vi.fn();
+    renderDialog({ onOpenChange });
+
+    typeName("Checkout flow");
+    fireEvent.click(screen.getByTestId("name-environment-submit"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("name-environment-error")).toHaveTextContent(
+        'An environment named "Checkout flow" already exists.',
+      ),
+    );
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
+  it("disables submit while the name is empty", () => {
+    renderDialog({});
+
+    expect(screen.getByTestId("name-environment-submit")).toBeDisabled();
+    typeName("   ");
+    expect(screen.getByTestId("name-environment-submit")).toBeDisabled();
+  });
+
+  it("closes and toasts on success", async () => {
+    const onOpenChange = vi.fn();
+    renderDialog({ onOpenChange });
+
+    typeName("Checkout flow");
+    fireEvent.click(screen.getByTestId("name-environment-submit"));
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(toastMock.success).toHaveBeenCalledWith(
+      expect.stringContaining('named "Checkout flow"'),
+    );
+  });
+});


### PR DESCRIPTION
The scenario detail page had no edit affordance at all (Open/Delete only), and for composer-created scenarios the execution config was doubly frozen: it lives on the backing project environment, which is **ad-hoc** — content-addressed and immutable by design (`updateEnvironment` refuses with "Name it first to make it editable"). The escape hatch shipped in backend #912 — `nameEnvironment` promotes a row **in place**, same id — but its client hook had zero callers. Same for `updateChatbox`. This PR is the wiring; **zero backend changes**.

## What's new

**"Name environment"** — a ghost button beside the environment label in the scenario header, shown only when the backing row is ad-hoc. Opens a small dialog (name + optional description). On success the row keeps its id, so the scenario and its session history follow it into its named life; it then appears in the Environments list, where editing its servers/skills/image edits the live scenario (env-backed chatboxes re-resolve per request).

**Inline rename + description** on the scenario itself — `EditableTitle` on the header (the SwarmsTab persona pattern) and a borderless description textarea persisted on blur, both through the previously dead `updateChatbox`.

## Correctness notes

- **Ad-hoc detection never uses `environmentName`.** The settings envelope synthesizes a non-null label from the client name even for unnamed rows, so name-presence proves nothing. The button gates on a separate `useProjectEnvironment` read + `isAdhocEnvironment`, and **fails closed** while the row loads (`undefined`) or isn't visible (`null`). It stays visible for archived ad-hoc rows — promotion is the fix path there (the backend allows it deliberately).
- **`expectedRevision` is captured when the dialog opens**, held in a ref, and never replaced by the fresh reactive revision at submit — per the repo's expectedRevision convention. Two people promoting the same row from the same screen produce the backend's CONFLICT instead of a silent clobber; there is a test that churns the prop's revision under an open dialog and asserts the captured value is sent.
- **Backend rejections render verbatim** (`convexErrMessage`), because the three CONFLICT causes — already named, row changed, name taken — are distinct instructions to the user. The dialog stays open on error.
- The description draft **reseeds from the reactive envelope**, so a stale draft can't clobber another member's edit on the next blur. Rename failures toast and rethrow so `EditableTitle` reverts.
- No cache work anywhere: `getChatbox` reads the environment row, so the header label, list row, and the named-only environment pickers all self-heal reactively after promote/rename.

`NameEnvironmentDialog` lives in `project-environments/`, not `chatboxes/` — it's the ad-hoc program's missing last mile, and other surfaces that show ad-hoc rows (swarm "From runs", eval bars) will want the same affordance.

## Tests

- 7 new detail cases: fail-closed gating (loading / named / host-backed), dialog opening for ad-hoc, rename payload, description blur-only-when-changed.
- 6 dialog cases: captured-revision threading (incl. prop churn under an open dialog), verbatim CONFLICT stays open, blank description omitted from args, empty-name disabled, success close + toast.
- Full client project: **8,059 passed**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only client changes using existing mutations and promotion APIs; concurrency is handled via expectedRevision and conservative gating, with broad test coverage.
> 
> **Overview**
> **User Testing scenario detail** is no longer read-only for metadata: the header uses **`EditableTitle`** and **`updateChatbox`** for renames (errors toast and revert the title), and a borderless description field saves on blur only when the text changed, with draft sync that respects focus so remote edits are not clobbered mid-typing.
> 
> For **environment-backed** scenarios whose execution config is frozen on an **ad-hoc** project environment, a **“Name environment”** control appears only after a separate **`useProjectEnvironment`** read confirms ad-hoc origin (not from synthesized `environmentName`), with **fail-closed** hiding while loading, invisible, named, host-backed, or when project-environments is flag-off. It opens new **`NameEnvironmentDialog`**, which calls **`usePromoteProjectEnvironment`** with **`expectedRevision` captured at open** (ref, not live revision), shows backend **CONFLICT** messages verbatim, and closes on success.
> 
> **Tests** cover ad-hoc gating, rename/description persistence, revision threading under prop churn, and dialog submit/error paths. **No backend changes** — client wiring only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274dbf7ab76b92a12cef9b7772ff186294ca7ecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables editing for User Testing scenarios. You can name the ad‑hoc environment in place and edit the scenario title and description inline.

- **New Features**
  - Added `NameEnvironmentDialog` to promote ad‑hoc environments to named ones in place (same id). Captures `expectedRevision` at open; shows backend errors verbatim with `role="alert"`; optional description supported.
  - Scenario header shows a “Name environment” ghost button next to the environment label only when the backing row is ad‑hoc (via `useProjectEnvironment` + `isAdhocEnvironment`); hidden while loading/`null`, for named rows, for host‑backed scenarios, and when `project-environments-enabled` is off (via `useProjectEnvironmentsEnabled`).
  - Inline edits: scenario title via `EditableTitle` and description via a borderless textarea saved on blur, both through `updateChatbox`. Description draft reseeds from reactive data except while focused; a no‑op blur resyncs to avoid overwriting concurrent edits.
  - No backend changes. Reactive reads (`getChatbox`) ensure labels and pickers update automatically after promotion or rename.

<sup>Written for commit 274dbf7ab76b92a12cef9b7772ff186294ca7ecd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

