### PR TITLE
feat(user-testing): bring back the live Preview of a scenario

### DIFF
--- a/mcpjam-inspector/client/src/components/UserTestingTab.tsx
+++ b/mcpjam-inspector/client/src/components/UserTestingTab.tsx
@@ -586,6 +586,7 @@ export function UserTestingTab({
     return (
       <UserTestingScenarioDetail
         chatbox={chatbox}
+        isAuthenticated={effectiveAuth}
         onBack={goOverview}
         onDeleted={goOverview}
       />

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxPreviewPane.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxPreviewPane.tsx
@@ -1,0 +1,121 @@
+import { ExternalLink, Inbox } from "lucide-react";
+import type { HostConfigMcpProfileV1 } from "@/lib/client-config-v2";
+import { previewIframeAllow } from "@/lib/client-preview-iframe-allow";
+
+/**
+ * The live published chatbox, embedded, so a scenario can be spot-checked
+ * (chrome, welcome copy, tool flow) without leaving the page. Points at the
+ * real share URL — the same one "Open" launches.
+ *
+ * Two things make the embed work at all, and both are easy to break:
+ *
+ *  - The self-embed is a deliberate exception to the misrouted-pushState
+ *    guard in `main.tsx`, which matches on the `/chatbox/<slug>/<token>`
+ *    PATHNAME. Query params are fine; a shape change is not.
+ *  - `isEmbeddedPreview()` (`lib/embedded-preview.ts`) makes the embedded
+ *    runtime skip its sessionStorage writes. Without it the guest session
+ *    leaks into the dashboard's own storage and the next reload boots the
+ *    inspector into the tester's chatbox.
+ *
+ * Both guards key off same-origin, which is also the only way an embed can
+ * render — a cross-origin share link (desktop builds, where the app isn't
+ * served over http(s)) loads the remote app, which then renders its OWN
+ * iframe guard. We check the origin here and offer the link instead, rather
+ * than framing an error page.
+ */
+export function ChatboxPreviewPane({
+  publishLink,
+  mcpProfile,
+  emptyTitle = "No share link yet",
+  emptyBody = "Publish this scenario to get a share link, then come back here to preview it.",
+}: {
+  publishLink: string | null;
+  mcpProfile: HostConfigMcpProfileV1 | undefined;
+  emptyTitle?: string;
+  emptyBody?: string;
+}) {
+  const src = publishLink ? buildPreviewSrc(publishLink) : null;
+
+  if (!publishLink) {
+    return (
+      <PreviewEmptyState title={emptyTitle} body={emptyBody} link={null} />
+    );
+  }
+
+  if (!src) {
+    return (
+      <PreviewEmptyState
+        title="Preview isn't available here"
+        body="This build serves share links from another origin, so the chatbox can't be embedded. Open it in a new tab instead."
+        link={publishLink}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-muted/10">
+      <iframe
+        // Keyed on the src so a rotated link remounts the runtime rather than
+        // leaving the previous token's session on screen.
+        key={src}
+        src={src}
+        title="Scenario preview"
+        data-testid="user-testing-preview-frame"
+        className="size-full flex-1 border-0 bg-background"
+        allow={previewIframeAllow(mcpProfile)}
+      />
+    </div>
+  );
+}
+
+/**
+ * Tag the embedded run as `preview` traffic. The chatbox runtime reads
+ * `?surface=` on bootstrap (`readChatboxSurfaceFromUrl`) and carries it onto
+ * the session, so sessions started from this pane are distinguishable from a
+ * real tester's in Sessions and in analytics. Returns null when the link
+ * can't be embedded — unparseable, or a different origin than the app.
+ */
+function buildPreviewSrc(publishLink: string): string | null {
+  try {
+    const url = new URL(publishLink, window.location.href);
+    if (url.origin !== window.location.origin) return null;
+    url.searchParams.set("surface", "preview");
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function PreviewEmptyState({
+  title,
+  body,
+  link,
+}: {
+  title: string;
+  body: string;
+  link: string | null;
+}) {
+  return (
+    <div
+      className="flex h-full items-center justify-center px-6 text-center"
+      data-testid="user-testing-preview-empty"
+    >
+      <div className="max-w-sm">
+        <Inbox className="mx-auto size-8 text-muted-foreground/70" />
+        <p className="mt-3 text-sm font-medium">{title}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{body}</p>
+        {link ? (
+          <a
+            href={link}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+          >
+            <ExternalLink className="size-3.5" />
+            Open in a new tab
+          </a>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxPreviewPane.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxPreviewPane.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from "react";
 import { ExternalLink, Inbox } from "lucide-react";
 import type { HostConfigMcpProfileV1 } from "@/lib/client-config-v2";
 import { previewIframeAllow } from "@/lib/client-preview-iframe-allow";
@@ -22,6 +23,22 @@ import { previewIframeAllow } from "@/lib/client-preview-iframe-allow";
  * served over http(s)) loads the remote app, which then renders its OWN
  * iframe guard. We check the origin here and offer the link instead, rather
  * than framing an error page.
+ *
+ * KNOWN LIMITATION — the embed is not a faithful guest simulation, in two
+ * ways this pane surfaces rather than hides:
+ *
+ *  - Same-origin means the frame shares the dashboard's WorkOS/Convex auth,
+ *    so the runtime redeems the link as the signed-in member, not as an
+ *    anonymous tester. Access-mode and sign-in behaviour a real guest hits
+ *    are therefore NOT reproduced here. Hence the footnote.
+ *  - Authorizing an OAuth-backed MCP server calls `window.location.assign`
+ *    (`lib/oauth/mcp-oauth.ts`), which navigates THIS frame to the provider
+ *    and returns to `/oauth/callback` — a path the `main.tsx` exemption
+ *    deliberately does not cover, so the frame would land on
+ *    `IframeRouterError`. We detect the frame leaving the chatbox path and
+ *    hand the user back to a real browser tab, where the flow completes.
+ *    Making OAuth work in-frame means changing where that redirect goes;
+ *    that belongs in its own change, not silently in this one.
  */
 export function ChatboxPreviewPane({
   publishLink,
@@ -52,21 +69,69 @@ export function ChatboxPreviewPane({
     );
   }
 
+  return <PreviewFrame src={src} link={publishLink} mcpProfile={mcpProfile} />;
+}
+
+function PreviewFrame({
+  src,
+  link,
+  mcpProfile,
+}: {
+  src: string;
+  link: string;
+  mcpProfile: HostConfigMcpProfileV1 | undefined;
+}) {
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const [navigatedAway, setNavigatedAway] = useState(false);
+
+  // A document navigation inside the frame (OAuth is the one that happens in
+  // practice) fires `load` on a path the runtime never serves. Same-origin, so
+  // reading it is allowed; a throw means it went cross-origin, which is just
+  // as much "no longer the chatbox".
+  const handleLoad = () => {
+    try {
+      const path = frameRef.current?.contentWindow?.location.pathname;
+      setNavigatedAway(!path || !PUBLIC_CHATBOX_RUNTIME_PATH.test(path));
+    } catch {
+      setNavigatedAway(true);
+    }
+  };
+
+  if (navigatedAway) {
+    return (
+      <PreviewEmptyState
+        title="This flow can't finish inside the preview"
+        body="The scenario navigated away from the chatbox — an OAuth sign-in does this. Open it in a real browser tab to complete the flow."
+        link={link}
+        onRetry={() => setNavigatedAway(false)}
+      />
+    );
+  }
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-muted/10">
       <iframe
         // Keyed on the src so a rotated link remounts the runtime rather than
         // leaving the previous token's session on screen.
         key={src}
+        ref={frameRef}
         src={src}
+        onLoad={handleLoad}
         title="Scenario preview"
         data-testid="user-testing-preview-frame"
         className="size-full flex-1 border-0 bg-background"
         allow={previewIframeAllow(mcpProfile)}
       />
+      {/* Not a faithful guest run: the frame shares the dashboard's login. */}
+      <p className="shrink-0 border-t border-border/40 px-3 py-1.5 text-[10px] text-muted-foreground">
+        Previewing as you, signed in — a tester opening this link gets the
+        guest experience, which can differ.
+      </p>
     </div>
   );
 }
+
+const PUBLIC_CHATBOX_RUNTIME_PATH = /^\/chatbox\/[^/]+\/[^/]+\/?$/;
 
 /**
  * Tag the embedded run as `preview` traffic. The chatbox runtime reads
@@ -90,10 +155,12 @@ function PreviewEmptyState({
   title,
   body,
   link,
+  onRetry,
 }: {
   title: string;
   body: string;
   link: string | null;
+  onRetry?: () => void;
 }) {
   return (
     <div
@@ -104,17 +171,28 @@ function PreviewEmptyState({
         <Inbox className="mx-auto size-8 text-muted-foreground/70" />
         <p className="mt-3 text-sm font-medium">{title}</p>
         <p className="mt-1 text-xs text-muted-foreground">{body}</p>
-        {link ? (
-          <a
-            href={link}
-            target="_blank"
-            rel="noreferrer noopener"
-            className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
-          >
-            <ExternalLink className="size-3.5" />
-            Open in a new tab
-          </a>
-        ) : null}
+        <div className="mt-3 flex items-center justify-center gap-4">
+          {link ? (
+            <a
+              href={link}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+            >
+              <ExternalLink className="size-3.5" />
+              Open in a new tab
+            </a>
+          ) : null}
+          {onRetry ? (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="text-xs font-medium text-muted-foreground hover:text-foreground hover:underline"
+            >
+              Reload preview
+            </button>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -187,12 +187,16 @@ export function UserTestingScenarioDetail({
     if (tab === "preview") setHasOpenedPreview(true);
   }, [tab]);
 
-  // The host config decides which browser features the preview iframe may
-  // pass through to the mcp-apps renderer inside it. The `allow` attribute
-  // only takes effect at mount, and its no-config default is permissive, so
-  // a deny-all host would get the wrong frame if we mounted before this
-  // resolved. `useHost` reports a SKIPPED query as loading forever — treat it
-  // as pending only when it can actually resolve.
+  // The host config sets the preview iframe's `allow` ceiling. Waiting for it
+  // is about FIDELITY, not enforcement: the attribute only takes effect at
+  // mount and its no-config default is permissive, so mounting early would
+  // give a deny-all host a wider wrapper than it asked for. It is not a
+  // security hole when the host doesn't resolve — the wrapper is a ceiling,
+  // and the mcp-apps renderer INSIDE the frame re-reads the real host policy
+  // and enforces it per resource (see `previewIframeAllow`). So a null host
+  // still previews; only a genuinely pending one waits.
+  // `useHost` reports a SKIPPED query as loading forever — treat it as
+  // pending only when it can actually resolve.
   const previewHostId = chatbox.namedHostId ?? null;
   const { host: previewHost, isLoading: previewHostLoading } = useHost({
     isAuthenticated,

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import {
   AlertTriangle,
@@ -14,11 +14,13 @@ import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection";
 import { ChatboxUsagePanel } from "@/components/chatboxes/ChatboxUsagePanel";
+import { ChatboxPreviewPane } from "@/components/chatboxes/ChatboxPreviewPane";
 import { ChatboxDeleteConfirmDialog } from "@/components/chatboxes/ChatboxDeleteConfirmDialog";
 import {
   useChatboxMutations,
   type ChatboxSettings,
 } from "@/hooks/useChatboxes";
+import { useHost } from "@/hooks/useClients";
 import {
   getChatboxHostLabel,
   getChatboxHostLogo,
@@ -41,9 +43,17 @@ import { cn } from "@/lib/utils";
  * so the topic map here only ever covers this scenario's own sessions. There is
  * deliberately no project-wide clusters view: aggregating across scenarios that
  * point at different servers would produce themes nobody can act on.
+ *
+ * Preview embeds the live share link, which means opening that tab starts a
+ * REAL guest session against this scenario — it shows up in Sessions and in
+ * guest analytics like any tester's. That's why it mounts lazily (opening a
+ * scenario costs nothing) and why the embed tags itself `?surface=preview`
+ * (so the session it starts is labelled rather than passing for a tester's).
  */
 interface UserTestingScenarioDetailProps {
   chatbox: ChatboxSettings;
+  /** Gates the host query behind Preview's iframe permissions. */
+  isAuthenticated: boolean;
   onBack: () => void;
   /** Parent returns to the list. */
   onDeleted: () => void;
@@ -55,10 +65,12 @@ const TAB_OPTIONS: ReadonlyArray<{
 }> = [
   { value: "sessions", label: "Sessions" },
   { value: "clusters", label: "Clusters" },
+  { value: "preview", label: "Preview" },
 ];
 
 export function UserTestingScenarioDetail({
   chatbox,
+  isAuthenticated,
   onBack,
   onDeleted,
 }: UserTestingScenarioDetailProps) {
@@ -89,6 +101,29 @@ export function UserTestingScenarioDetail({
     ? buildChatboxLink(chatbox.link.token, chatbox.name)
     : null;
   const displayLink = publishLink?.replace(/^https?:\/\//, "") ?? null;
+
+  // Preview embeds the live share link, so it starts a real guest session.
+  // Mount it only once the tab has been opened — and then keep it mounted
+  // (hidden) so flipping back to Sessions and returning doesn't start a
+  // second one. A deep link straight to `?tab=preview` opens it immediately.
+  const [hasOpenedPreview, setHasOpenedPreview] = useState(tab === "preview");
+  useEffect(() => {
+    if (tab === "preview") setHasOpenedPreview(true);
+  }, [tab]);
+
+  // The host config decides which browser features the preview iframe may
+  // pass through to the mcp-apps renderer inside it. The `allow` attribute
+  // only takes effect at mount, and its no-config default is permissive, so
+  // a deny-all host would get the wrong frame if we mounted before this
+  // resolved. `useHost` reports a SKIPPED query as loading forever — treat it
+  // as pending only when it can actually resolve.
+  const previewHostId = chatbox.namedHostId ?? null;
+  const { host: previewHost, isLoading: previewHostLoading } = useHost({
+    isAuthenticated,
+    hostId: previewHostId,
+  });
+  const isPreviewProfilePending =
+    isAuthenticated && Boolean(previewHostId) && previewHostLoading;
 
   const goToTab = (next: UserTestingDetailTab) => {
     // Replace, not push: flipping a sub-tab shouldn't put a stop on the back
@@ -268,29 +303,62 @@ export function UserTestingScenarioDetail({
         </nav>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
         {tab === "sessions" ? (
-          <ChatboxUsagePanel
-            chatbox={chatbox}
-            section="sessions"
-            initialThreadId={sessionDeepLinkThreadId}
-          />
-        ) : (
-          <ChatboxUsagePanel
-            chatbox={chatbox}
-            section="insights"
-            onOpenSession={(threadId) => {
-              // Stash the target in the URL, then flip the tab — the same
-              // reason the tab itself lives there.
-              navigate(
-                buildUserTestingScenarioPath(chatbox.chatboxId, {
-                  session: threadId,
-                }),
-                { replace: true },
-              );
-            }}
-          />
-        )}
+          <div className="absolute inset-0">
+            <ChatboxUsagePanel
+              chatbox={chatbox}
+              section="sessions"
+              initialThreadId={sessionDeepLinkThreadId}
+            />
+          </div>
+        ) : null}
+        {tab === "clusters" ? (
+          <div className="absolute inset-0">
+            <ChatboxUsagePanel
+              chatbox={chatbox}
+              section="insights"
+              onOpenSession={(threadId) => {
+                // Stash the target in the URL, then flip the tab — the same
+                // reason the tab itself lives there.
+                navigate(
+                  buildUserTestingScenarioPath(chatbox.chatboxId, {
+                    session: threadId,
+                  }),
+                  { replace: true },
+                );
+              }}
+            />
+          </div>
+        ) : null}
+        {hasOpenedPreview ? (
+          // Hidden rather than unmounted: re-mounting would abandon the
+          // tester session already running in the frame and start another.
+          <div
+            className={cn("absolute inset-0", tab === "preview" ? "" : "hidden")}
+          >
+            {isPreviewProfilePending ? (
+              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                Loading preview…
+              </div>
+            ) : (
+              <ChatboxPreviewPane
+                publishLink={environmentError ? null : publishLink}
+                mcpProfile={previewHost?.config.mcpProfile}
+                emptyTitle={
+                  environmentError
+                    ? "This scenario can't be previewed"
+                    : undefined
+                }
+                emptyBody={
+                  environmentError
+                    ? `${environmentError.message} Its sessions are unaffected.`
+                    : undefined
+                }
+              />
+            )}
+          </div>
+        ) : null}
       </div>
 
       <ChatboxDeleteConfirmDialog

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPreviewPane.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPreviewPane.test.tsx
@@ -10,7 +10,7 @@
  *    render an error page inside the pane; offering the link is the honest
  *    answer.
  */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { HostConfigMcpProfileV1 } from "@/lib/client-config-v2";
 import { ChatboxPreviewPane } from "../ChatboxPreviewPane";
@@ -81,5 +81,80 @@ describe("ChatboxPreviewPane", () => {
       screen.queryByTestId("user-testing-preview-frame"),
     ).not.toBeInTheDocument();
     expect(screen.getByText("No share link yet")).toBeInTheDocument();
+  });
+
+  it("says the preview runs as the signed-in member, not as a guest", () => {
+    render(
+      <ChatboxPreviewPane publishLink={sameOriginLink} mcpProfile={undefined} />,
+    );
+
+    // Same-origin means the frame shares the dashboard's login, so this is a
+    // fidelity caveat the user needs stated, not a detail to bury.
+    expect(screen.getByText(/Previewing as you, signed in/i)).toBeInTheDocument();
+  });
+
+  /**
+   * Authorizing an OAuth-backed MCP server navigates THIS frame (via
+   * window.location.assign) and returns to /oauth/callback, which the
+   * main.tsx self-embed exemption deliberately doesn't cover — the frame
+   * would land on IframeRouterError. Hand the flow back to a real tab.
+   */
+  it("hands off to a browser tab when the frame navigates off the chatbox", () => {
+    render(
+      <ChatboxPreviewPane publishLink={sameOriginLink} mcpProfile={undefined} />,
+    );
+
+    const frame = screen.getByTestId("user-testing-preview-frame");
+    // jsdom won't navigate for us; drive the load event with the frame
+    // parked somewhere that isn't the chatbox runtime path.
+    Object.defineProperty(frame, "contentWindow", {
+      configurable: true,
+      value: { location: { pathname: "/oauth/callback" } },
+    });
+    fireEvent.load(frame);
+
+    expect(
+      screen.queryByTestId("user-testing-preview-frame"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/can't finish inside the preview/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /open in a new tab/i }),
+    ).toHaveAttribute("href", sameOriginLink);
+  });
+
+  it("keeps the frame when a load lands back on the chatbox path", () => {
+    render(
+      <ChatboxPreviewPane publishLink={sameOriginLink} mcpProfile={undefined} />,
+    );
+
+    const frame = screen.getByTestId("user-testing-preview-frame");
+    Object.defineProperty(frame, "contentWindow", {
+      configurable: true,
+      value: { location: { pathname: "/chatbox/payments-beta/tok-1" } },
+    });
+    fireEvent.load(frame);
+
+    expect(
+      screen.getByTestId("user-testing-preview-frame"),
+    ).toBeInTheDocument();
+  });
+
+  it("can reload back into the preview after a hand-off", () => {
+    render(
+      <ChatboxPreviewPane publishLink={sameOriginLink} mcpProfile={undefined} />,
+    );
+
+    const frame = screen.getByTestId("user-testing-preview-frame");
+    Object.defineProperty(frame, "contentWindow", {
+      configurable: true,
+      value: { location: { pathname: "/oauth/callback" } },
+    });
+    fireEvent.load(frame);
+
+    fireEvent.click(screen.getByRole("button", { name: /reload preview/i }));
+
+    expect(screen.getByTestId("user-testing-preview-frame")).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPreviewPane.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxPreviewPane.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * The preview embed. Three things are load-bearing:
+ *
+ *  - `?surface=preview` on the src. Without it the guest session the embed
+ *    starts is indistinguishable from a real tester's in Sessions.
+ *  - The `allow` attribute comes from the host's mcpProfile. Permissions-Policy
+ *    ratchets at every iframe boundary, so an attribute that's too narrow
+ *    silently blanks UI resources the inner renderer would otherwise allow.
+ *  - Cross-origin links are NOT framed. The app's own iframe guard would
+ *    render an error page inside the pane; offering the link is the honest
+ *    answer.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { HostConfigMcpProfileV1 } from "@/lib/client-config-v2";
+import { ChatboxPreviewPane } from "../ChatboxPreviewPane";
+
+// jsdom serves the app from localhost — same-origin links must match it.
+const sameOriginLink = `${window.location.origin}/chatbox/payments-beta/tok-1`;
+
+describe("ChatboxPreviewPane", () => {
+  it("tags the embedded run as preview traffic", () => {
+    render(
+      <ChatboxPreviewPane publishLink={sameOriginLink} mcpProfile={undefined} />,
+    );
+
+    const src = screen
+      .getByTestId("user-testing-preview-frame")
+      .getAttribute("src");
+    expect(new URL(src!).searchParams.get("surface")).toBe("preview");
+    // The path shape is what main.tsx's self-embed exception matches on.
+    expect(new URL(src!).pathname).toBe("/chatbox/payments-beta/tok-1");
+  });
+
+  it("passes the full spec feature set through when the host has no policy", () => {
+    render(
+      <ChatboxPreviewPane publishLink={sameOriginLink} mcpProfile={undefined} />,
+    );
+
+    expect(screen.getByTestId("user-testing-preview-frame")).toHaveAttribute(
+      "allow",
+      "camera; microphone; geolocation; clipboard-write",
+    );
+  });
+
+  it("emits an empty allow for a deny-all host", () => {
+    const profile = {
+      apps: { sandbox: { permissions: { mode: "deny-all" } } },
+    } as unknown as HostConfigMcpProfileV1;
+
+    render(
+      <ChatboxPreviewPane publishLink={sameOriginLink} mcpProfile={profile} />,
+    );
+
+    expect(screen.getByTestId("user-testing-preview-frame")).toHaveAttribute(
+      "allow",
+      "",
+    );
+  });
+
+  it("offers the link instead of framing a cross-origin share URL", () => {
+    render(
+      <ChatboxPreviewPane
+        publishLink="https://elsewhere.example/chatbox/x/tok"
+        mcpProfile={undefined}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("user-testing-preview-frame"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /open in a new tab/i }),
+    ).toHaveAttribute("href", "https://elsewhere.example/chatbox/x/tok");
+  });
+
+  it("shows the empty state, and no frame, without a share link", () => {
+    render(<ChatboxPreviewPane publishLink={null} mcpProfile={undefined} />);
+
+    expect(
+      screen.queryByTestId("user-testing-preview-frame"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("No share link yet")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -13,13 +13,21 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 
-const { navigateMock, locationState, usagePanelMock, deleteChatboxMock } =
-  vi.hoisted(() => ({
-    navigateMock: vi.fn(),
-    locationState: { search: "" },
-    usagePanelMock: vi.fn(),
-    deleteChatboxMock: vi.fn().mockResolvedValue(undefined),
-  }));
+const {
+  navigateMock,
+  locationState,
+  usagePanelMock,
+  deleteChatboxMock,
+  previewPaneMock,
+  hostState,
+} = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  locationState: { search: "" },
+  usagePanelMock: vi.fn(),
+  deleteChatboxMock: vi.fn().mockResolvedValue(undefined),
+  previewPaneMock: vi.fn(),
+  hostState: { host: null as unknown, isLoading: false },
+}));
 
 vi.mock("react-router", () => ({
   useNavigate: () => navigateMock,
@@ -66,6 +74,20 @@ vi.mock("@/components/chatboxes/ChatboxUsagePanel", () => ({
   },
 }));
 
+// Stubbed so jsdom never mounts the real iframe — it would try to fetch the
+// share URL, and the point of these specs is WHEN the pane exists, not what
+// it renders (see ChatboxPreviewPane.test.tsx for that).
+vi.mock("@/components/chatboxes/ChatboxPreviewPane", () => ({
+  ChatboxPreviewPane: (props: Record<string, unknown>) => {
+    previewPaneMock(props);
+    return <div data-testid="stub-preview" />;
+  },
+}));
+
+vi.mock("@/hooks/useClients", () => ({
+  useHost: () => hostState,
+}));
+
 import { UserTestingScenarioDetail } from "../UserTestingScenarioDetail";
 
 const chatbox = {
@@ -86,18 +108,23 @@ const chatbox = {
   link: { token: "tok", path: "/t/tok", url: "u", rotatedAt: 0, updatedAt: 0 },
 } as unknown as ChatboxSettings;
 
+const detail = (over: Partial<ChatboxSettings> = {}) => (
+  <UserTestingScenarioDetail
+    chatbox={{ ...chatbox, ...over } as ChatboxSettings}
+    isAuthenticated
+    onBack={vi.fn()}
+    onDeleted={vi.fn()}
+  />
+);
+
 const renderDetail = (over: Partial<ChatboxSettings> = {}) =>
-  render(
-    <UserTestingScenarioDetail
-      chatbox={{ ...chatbox, ...over } as ChatboxSettings}
-      onBack={vi.fn()}
-      onDeleted={vi.fn()}
-    />,
-  );
+  render(detail(over));
 
 beforeEach(() => {
   vi.clearAllMocks();
   locationState.search = "";
+  hostState.host = { config: { mcpProfile: undefined } };
+  hostState.isLoading = false;
 });
 
 describe("UserTestingScenarioDetail", () => {
@@ -185,5 +212,93 @@ describe("UserTestingScenarioDetail", () => {
 
     expect(screen.getByTestId("stub-delete-dialog")).toBeInTheDocument();
     expect(deleteChatboxMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Preview embeds the live share link, which bootstraps a real guest session.
+ * When it mounts is therefore a behaviour, not an implementation detail: too
+ * eager and every visit to a scenario pollutes its own Sessions list.
+ */
+describe("UserTestingScenarioDetail — preview", () => {
+  it("does not embed anything until the Preview tab is opened", () => {
+    renderDetail();
+
+    expect(screen.queryByTestId("stub-preview")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+
+    expect(navigateMock).toHaveBeenCalledWith("/user-testing/cb-1?tab=preview", {
+      replace: true,
+    });
+  });
+
+  it("embeds this scenario's share link when opened", () => {
+    locationState.search = "?tab=preview";
+    renderDetail();
+
+    expect(screen.getByTestId("stub-preview")).toBeInTheDocument();
+    expect(previewPaneMock).toHaveBeenCalledWith(
+      expect.objectContaining({ publishLink: "https://mcpjam.link/t/tok" }),
+    );
+  });
+
+  it("hides the preview instead of unmounting it when you switch away", () => {
+    locationState.search = "?tab=preview";
+    const { rerender } = renderDetail();
+
+    locationState.search = "";
+    rerender(detail());
+
+    // Still mounted — remounting would abandon the running tester session and
+    // start a second one on the way back.
+    expect(screen.getByTestId("stub-usage-sessions")).toBeInTheDocument();
+    expect(screen.getByTestId("stub-preview").parentElement).toHaveClass(
+      "hidden",
+    );
+    expect(previewPaneMock.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it("passes the host's mcp profile through for the iframe permissions", () => {
+    const mcpProfile = { apps: { sandbox: { permissions: { mode: "deny-all" } } } };
+    hostState.host = { config: { mcpProfile } };
+    locationState.search = "?tab=preview";
+    renderDetail();
+
+    expect(previewPaneMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mcpProfile }),
+    );
+  });
+
+  it("waits for the host config rather than embedding with default permissions", () => {
+    hostState.isLoading = true;
+    hostState.host = null;
+    locationState.search = "?tab=preview";
+    renderDetail();
+
+    // `allow` only applies at mount, and its no-config default is permissive.
+    expect(screen.queryByTestId("stub-preview")).not.toBeInTheDocument();
+    expect(screen.getByText(/Loading preview/i)).toBeInTheDocument();
+  });
+
+  it("refuses to embed a scenario whose environment can't resolve", () => {
+    locationState.search = "?tab=preview";
+    renderDetail({
+      environmentId: "env-1",
+      environmentName: "Checkout flow",
+      environmentError: {
+        code: "ENV_ARCHIVED",
+        message: "Environment “Checkout flow” is archived.",
+      },
+    });
+
+    // The link doesn't open for testers either — framing it would show them
+    // the same failure with less explanation.
+    expect(previewPaneMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publishLink: null,
+        emptyTitle: "This scenario can't be previewed",
+      }),
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
@@ -188,6 +188,14 @@ export function ThreadCard({
             Needs review
           </span>
         ) : null}
+        {/* Sessions started from the in-app Preview pane, not by a tester.
+            Only rendered when the session actually carries the tag — older
+            sessions predate it and shouldn't be labelled either way. */}
+        {thread.surface === "preview" ? (
+          <span className="rounded-sm bg-muted px-1 py-0.5 text-[10px] font-medium text-muted-foreground">
+            Preview
+          </span>
+        ) : null}
         {thread.themeClusterLabel ? (
           <span className="max-w-[120px] truncate text-[10px] text-muted-foreground">
             {thread.themeClusterLabel}

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -91,7 +91,13 @@ export function buildHostComparePath(
 export const userTestingCreatePath = `${routePaths.userTesting}/new`;
 
 /** Sub-tabs on `/user-testing/:scenarioId`. Sessions is the landing tab. */
-export type UserTestingDetailTab = "sessions" | "clusters";
+export type UserTestingDetailTab = "sessions" | "clusters" | "preview";
+
+const USER_TESTING_DETAIL_TABS: ReadonlySet<string> = new Set([
+  "sessions",
+  "clusters",
+  "preview",
+]);
 
 /**
  * Build a path to one User Testing scenario. `scenarioId` is the scenario's
@@ -117,8 +123,9 @@ export function buildUserTestingScenarioPath(
 export function parseUserTestingDetailTab(
   search: string
 ): UserTestingDetailTab {
-  return new URLSearchParams(search).get("tab") === "clusters"
-    ? "clusters"
+  const tab = new URLSearchParams(search).get("tab");
+  return tab && USER_TESTING_DETAIL_TABS.has(tab)
+    ? (tab as UserTestingDetailTab)
     : "sessions";
 }
 


### PR DESCRIPTION
## What

Restores the embedded live preview of a published chatbox on the User Testing scenario detail page, as a third sub-tab: **Sessions / Clusters / Preview**.

The old Chatbox surface docked a preview next to the share form (added in #2130). The scenario list → detail rebuild (#3748) dropped it, leaving only the **Open** button, which sends you to a separate browser tab just to check whether the welcome copy and tool flow look right.

## Why a tab, not the old split-pane

The detail header now owns the share band, access settings and members, so a side-by-side pane would crowd it. A tab also gives us lazy mounting for free — which matters more than it sounds, see below.

## The guest-session problem, fixed this time

Embedding the share link bootstraps a **real guest session**. The old pane mounted eagerly, so every visit to the Publish tab started one and preview traffic landed in the scenario's own Sessions list, indistinguishable from a tester's. The original code even carried a comment admitting this.

Two changes make it honest:

- **Lazy mount, then keep mounted.** Nothing is embedded until you open Preview. Once opened it stays mounted (hidden) when you switch tabs, so returning doesn't abandon the running session and start a second one.
- **Tagged traffic.** The iframe src carries `?surface=preview`. The chatbox runtime already reads this on bootstrap (`readChatboxSurfaceFromUrl`) and records it on the session, and it already flows through to ingestion — nothing was setting it for embeds. Session rows carrying the tag now show a muted **Preview** chip in the list.

## Permissions and origin correctness

- `allow` is built by the existing `previewIframeAllow()` from the host's `mcpProfile`. That helper survived the removal with **zero production callers**; this restores its only one.
- Because `allow` only applies at mount and its no-config default is permissive, the pane **waits for the host query to resolve** rather than framing a `deny-all` host with the wrong permissions. `useHost` reports a skipped query as loading forever, so that case is distinguished explicitly.
- **Cross-origin share links are not framed at all.** They'd load the remote app, which would render its own iframe guard inside our pane; the user gets the link instead.
- A scenario whose environment can't resolve isn't framed either — that link doesn't open for testers, so framing it would just show the same failure with less explanation.

The two load-bearing prerequisites both survived #3748 and are unchanged here: the same-origin self-embed exception in `main.tsx`, and the `isEmbeddedPreview()` sessionStorage guards that stop the embed from hijacking the dashboard on the next reload. Both match on **pathname**, so the added query string is safe.

## Files

| File | Change |
|---|---|
| `chatboxes/ChatboxPreviewPane.tsx` | New. The iframe, the `surface=preview` src, empty/cross-origin states. |
| `chatboxes/UserTestingScenarioDetail.tsx` | Preview tab, mount latch, host-profile gate. |
| `lib/app-navigation.ts` | `preview` joins the tab union; parser now validates against a closed set instead of a `=== "clusters"` ternary. |
| `share-usage/ShareUsageThreadList.tsx` | Preview chip, rendered only when the session actually carries the tag. |

## Verification

- `npm run typecheck` (root) — pass
- `npm run typecheck:client -w @mcpjam/inspector` — pass
- `npm run build:inspector` — pass
- Full client suite: **8097 passed**, 0 failures
- 19 new/updated specs covering the `surface=preview` src, `allow` derivation (default + `deny-all`), cross-origin refusal, lazy mount, hide-don't-unmount, and the environment-error path

### Worth checking by hand

Open a scenario and confirm no chatbox bootstrap fires until you click Preview; send a message and confirm the session shows the Preview chip; flip Preview → Sessions → Preview and confirm the conversation survives; then reload the dashboard and confirm it does not boot into the guest chatbox.

## Note on overlap

Independent of #3829 (inline rename / description / name-environment), which touches the header of the same file. Different regions; expect at most a trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and navigation changes; preview creates real sessions but they are explicitly tagged and mount behavior is tested.
> 
> **Overview**
> Adds a **Preview** sub-tab on User Testing scenario detail so authors can spot-check the published chatbox inline via the real share URL.
> 
> **`ChatboxPreviewPane`** embeds same-origin links with `?surface=preview`, sets iframe `allow` from the host `mcpProfile`, refuses cross-origin or missing links, and hands off to a new tab when OAuth navigates the frame off `/chatbox/...`. A footnote states preview runs as the signed-in member, not a guest.
> 
> **`UserTestingScenarioDetail`** mounts preview only after the tab is opened (then keeps it hidden, not unmounted), waits on `useHost` before framing so `deny-all` hosts don’t get permissive defaults, and skips embed when the environment can’t resolve. **`UserTestingTab`** passes `isAuthenticated` for that host query.
> 
> Session list rows show a **Preview** chip when `thread.surface === "preview"`. **`app-navigation`** adds `preview` to the detail tab union and validates `?tab=` against a closed set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa64df5b06352e5a50b4bac38040550e9c71b7b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the live Preview as a third tab on scenario detail (Sessions / Clusters / Preview) so you can check the chatbox inline without leaving the page. Now handles OAuth sign-ins by handing off to a new tab, and clearly notes that preview runs as your signed-in session.

- **New Features**
  - Added Preview tab that embeds the same-origin share link; mounts only when opened and stays mounted (hidden) when switching tabs.
  - Tagged preview runs via `?surface=preview`; session rows now show a muted “Preview” chip when tagged.
  - Preview iframe `allow` comes from `previewIframeAllow(mcpProfile)`; waits for host config via `useHost` (gated by `isAuthenticated`) before mounting to avoid permissive defaults.
  - Detects in-frame navigation off the chatbox path (e.g. OAuth) and shows a hand-off with “Open in a new tab” plus a reload option; adds a footer note: “Previewing as you, signed in”.
  - Cross‑origin share links and unresolved environments are not embedded; show an explain-and-link empty state instead.
  - Navigation updates: `preview` added to the tab union and parser now validates against a closed set.
  - Tests cover OAuth hand‑off, src tagging, iframe permissions and host-loading gate, cross‑origin refusal, lazy mount/keep‑mounted behavior, and environment error handling.

<sup>Written for commit aa64df5b06352e5a50b4bac38040550e9c71b7b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

