### PR TITLE
feat(environments): declare the local runtime venue on environment resolution

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.environment.test.ts
@@ -414,6 +414,8 @@ describe("web chat-v2 — environment execution target", () => {
         projectId: "project-1",
         environmentId: "env_1",
         serverOverrideIds: [],
+        // This suite runs un-hosted; the service declares the local venue.
+        runtimeVenue: "local",
       }
     );
   });
@@ -459,7 +461,7 @@ describe("web chat-v2 — environment execution target", () => {
     // no plugin argument, and sending one would fail its validator.
     expect(convexQueryMock).toHaveBeenCalledWith(
       "projectEnvironments:resolveEnvironmentForRuntime",
-      { projectId: "project-1", environmentId: "env_1" }
+      { projectId: "project-1", environmentId: "env_1", runtimeVenue: "local" }
     );
 
     // The plugin's server is gone from the turn; the host's own remains.

--- a/mcpjam-inspector/server/routes/web/__tests__/environments-preview.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/environments-preview.test.ts
@@ -107,7 +107,7 @@ describe("GET /api/web/environments/:id/preview", () => {
     expect(response.status).toBe(200);
     expect(convexQueryMock).toHaveBeenCalledWith(
       "projectEnvironments:resolveEnvironmentForRuntime",
-      { projectId: "p_1", environmentId: "env_1" }
+      { projectId: "p_1", environmentId: "env_1", runtimeVenue: "local" }
     );
     // A preview describes the SAVED environment; a caller must not be able to
     // reshape it into a configuration nobody stored.

--- a/mcpjam-inspector/server/routes/web/__tests__/environments-tools.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/environments-tools.test.ts
@@ -110,7 +110,7 @@ describe("GET /api/web/environments/:id/tools", () => {
     expect(response.status).toBe(200);
     expect(convexQueryMock).toHaveBeenCalledWith(
       "projectEnvironments:resolveEnvironmentForRuntime",
-      { projectId: "p_1", environmentId: "env_1" }
+      { projectId: "p_1", environmentId: "env_1", runtimeVenue: "local" }
     );
     // ONE manager per resolved server id — the only path that reaches
     // plugin-contributed servers, isolated so one server's authorization

--- a/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
+++ b/mcpjam-inspector/server/services/environments/__tests__/runtime.test.ts
@@ -112,6 +112,21 @@ describe("resolveEnvironmentForRuntime", () => {
     expect(calls[1]).toMatchObject({ serverOverrideIds: [] });
   });
 
+  it("declares the LOCAL venue on the wire (this suite runs un-hosted)", async () => {
+    // The venue is decided HERE, once, for every caller of this service.
+    // Local binaries declare "local" so the backend admits local-placement
+    // plugin components (which this process spawns via the stdio divert);
+    // hosted deployments send NOTHING — absent already means hosted
+    // fail-closed, and omitting keeps hosted requests byte-identical.
+    const calls: unknown[] = [];
+    const client = fakeConvexClient(SPEC, (args) => calls.push(args));
+    await resolveEnvironmentForRuntime(client, {
+      projectId: "p_1",
+      environmentId: "env_1",
+    });
+    expect(calls[0]).toMatchObject({ runtimeVenue: "local" });
+  });
+
   it("TOLERATES a backend that omits additive fields", async () => {
     // Older/newer deploy: no skills, no plugin versions, no connectable
     // projection, no specVersion. None of those is an invariant.

--- a/mcpjam-inspector/server/services/environments/runtime.ts
+++ b/mcpjam-inspector/server/services/environments/runtime.ts
@@ -25,6 +25,7 @@
  *     configuration the user launched. Those raise, never default.
  */
 import type { ConvexHttpClient } from "convex/browser";
+import { HOSTED_MODE } from "../../config.js";
 import { ErrorCode, WebRouteError } from "../../routes/web/errors.js";
 import type { EnvironmentOverrides } from "../../../shared/execution-target.js";
 import type { RuntimeSkill } from "../../utils/harness/runtime-skills.js";
@@ -259,6 +260,14 @@ function assertRuntimeInvariants(raw: unknown): ResolvedEnvironmentRuntime {
  * unknown args. That narrowing is applied to the RESOLVED spec by
  * `./plugin-override`, which can only remove versions this environment already
  * resolved for this caller.
+ *
+ * `runtimeVenue: "local"` is declared — HERE, once, for every caller of this
+ * service (chat-v2, the preview route, the connect check) — when this
+ * deployment IS the local binary. The backend then admits `local`-placement
+ * plugin components, which this process spawns itself through the
+ * `createAuthorizedManager` stdio divert. Hosted deployments send NOTHING
+ * (not an explicit "hosted"): absent already means hosted fail-closed on the
+ * backend, and omitting the field keeps hosted requests byte-identical.
  */
 export async function resolveEnvironmentForRuntime(
   convexClient: ConvexHttpClient,
@@ -277,6 +286,7 @@ export async function resolveEnvironmentForRuntime(
         projectId: args.projectId,
         environmentId: args.environmentId,
         ...(serverOverrideIds !== undefined ? { serverOverrideIds } : {}),
+        ...(HOSTED_MODE ? {} : { runtimeVenue: "local" }),
       } as any
     );
   } catch (error) {


### PR DESCRIPTION
## What

The local binary's web routes now send `runtimeVenue: "local"` on `projectEnvironments:resolveEnvironmentForRuntime` (shipped backend-side in mcpjam-backend#917, deployed), so the backend admits `local`-placement plugin components — which this process spawns itself through the `createAuthorizedManager` stdio divert (#3826).

The venue is declared in **one place** — the runtime service wrapper (`services/environments/runtime.ts`) — so every caller inherits it: the chat-v2 environment target, the environment preview, and the tools listing.

**Hosted deployments send nothing** (not an explicit `"hosted"`): absent already means hosted fail-closed on the backend, and omitting the field keeps hosted requests byte-identical — also robust against a backend rollback.

## Why

This is the last piece of Phase 5 of the Agent Plugins program. With #3826 (spawn side) + backend #917 (resolution side) + this (declaration side), a local Playground environment turn now resolves an environment pinning an Agent Plugin with a stdio server, materializes the verified bundle (fetch-on-miss), substitutes `${PLUGIN_ROOT}`/`${PLUGIN_DATA}`, and spawns the component end-to-end.

## Testing

- New service test pinning `runtimeVenue: "local"` on the wire in un-hosted runs, alongside the existing absent-vs-empty override discipline.
- Updated the four strict wire assertions (chat-v2 environment, preview, tools) to include the new field.
- Full server project: 350 files / 4,977 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive query argument gated on deployment mode; hosted traffic is unchanged and behavior is covered by updated wire assertions.
> 
> **Overview**
> **Local Playground** now tells Convex `runtimeVenue: "local"` when resolving an environment for a live turn, so the backend can include **local-placement** agent plugin components that this process spawns via stdio.
> 
> The flag is added in **one place** — `resolveEnvironmentForRuntime` in `runtime.ts` — using `HOSTED_MODE`: local binaries send `"local"`; hosted deployments **omit** the field so requests stay unchanged and absent still means hosted fail-closed on the backend.
> 
> Chat-v2 environment turns, environment preview, and tools listing all pick this up through the shared service. Tests assert the new wire shape for those paths plus a dedicated runtime service test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2921a58a1ef44523e4bd4196ecbf959b6dac9601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare the local runtime venue on environment resolution so the backend admits local-placement plugins and the local binary can spawn their stdio servers. Centralized in the runtime service; hosted behavior and wire format remain unchanged.

- **New Features**
  - Send `runtimeVenue: "local"` from the local binary when resolving environments.
  - Implemented once in `server/services/environments/runtime.ts`, inherited by chat-v2, preview, and tools routes.
  - Hosted deployments omit the field to keep requests byte-identical and fail-closed by default.
  - Updated route and service tests to assert the new field in un-hosted runs.

<sup>Written for commit 2921a58a1ef44523e4bd4196ecbf959b6dac9601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

