### PR TITLE
feat(user-testing): edit a scenario's setup from the header — composer + rebind

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
 import {
   AlertTriangle,
@@ -17,13 +17,25 @@ import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection"
 import { ChatboxUsagePanel } from "@/components/chatboxes/ChatboxUsagePanel";
 import { ChatboxDeleteConfirmDialog } from "@/components/chatboxes/ChatboxDeleteConfirmDialog";
 import { EditableTitle } from "@/components/evals/EditableTitle";
+import { EnvironmentComposer } from "@/components/environment-composer/environment-composer";
+import {
+  composerStateFromEnvironments,
+  composerHasTarget,
+  emptyComposerState,
+  type EnvironmentComposerState,
+} from "@/components/environment-composer/environment-stack";
+import { isAdhocUnavailable } from "@/components/environment-composer/resolve-stacks";
+import { useComposerResolver } from "@/components/environment-composer/use-composer-resolver";
 import { NameEnvironmentDialog } from "@/components/project-environments/NameEnvironmentDialog";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import {
   useChatboxMutations,
   type ChatboxSettings,
 } from "@/hooks/useChatboxes";
-import { useProjectEnvironment } from "@/hooks/useProjectEnvironments";
+import {
+  useProjectEnvironment,
+  useProjectEnvironments,
+} from "@/hooks/useProjectEnvironments";
 import { useProjectEnvironmentsEnabled } from "@/hooks/useProjectEnvironmentsEnabled";
 import { isAdhocEnvironment } from "@/lib/environment-label";
 import { convexErrMessage } from "@/lib/convex-error";
@@ -74,7 +86,8 @@ export function UserTestingScenarioDetail({
   const location = useLocation();
   const computersEnabled = useComputersEnabled();
   const themeMode = usePreferencesStore((s) => s.themeMode);
-  const { deleteChatbox, updateChatbox } = useChatboxMutations();
+  const { deleteChatbox, updateChatbox, rebindEnvironmentChatbox } =
+    useChatboxMutations();
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [nameEnvironmentOpen, setNameEnvironmentOpen] = useState(false);
@@ -98,6 +111,79 @@ export function UserTestingScenarioDetail({
   const environmentIsAdhoc = Boolean(
     environment && isAdhocEnvironment(environment),
   );
+
+  // ── Setup editor: the shared composer, committing through REBIND ────────
+  //
+  // The strip edits the scenario's execution context in place: each change
+  // resolves the composition to a real environment row (ad-hoc get-or-create,
+  // or a matching NAMED row) and re-points the chatbox at it. The environment
+  // itself is never mutated — a named row may back suites and other runs, and
+  // an ad-hoc row is immutable by construction. Session history stays with the
+  // chatbox either way.
+  const namedEnvironments = useProjectEnvironments(
+    environmentsEnabled && chatbox.environmentId ? chatbox.projectId : null,
+  );
+  const liveNamedEnvironments = useMemo(
+    () => (namedEnvironments ?? []).filter((env) => !env.archivedAt),
+    [namedEnvironments],
+  );
+  const resolveComposerTargets = useComposerResolver(chatbox.projectId);
+  const [composer, setComposer] = useState<EnvironmentComposerState>(
+    emptyComposerState,
+  );
+  const [isRebinding, setIsRebinding] = useState(false);
+  // Blocks the reseed below while a commit is in flight, so the rebind's own
+  // reactive echo doesn't clobber the state the user is mid-editing against.
+  const committingRef = useRef(false);
+  useEffect(() => {
+    if (!environment || committingRef.current) return;
+    setComposer(composerStateFromEnvironments([environment]));
+    // Keyed on identity + revision, not the (always-fresh) row object.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [environment?.environmentId, environment?.revision]);
+
+  const composerActive = Boolean(
+    environmentsEnabled && chatbox.environmentId && environment,
+  );
+
+  const handleComposerChange = (next: EnvironmentComposerState) => {
+    const previous = composer;
+    setComposer(next);
+    // No target (cleared clients / detached selection) commits nothing — the
+    // scenario keeps its current environment until the state resolves again.
+    if (!composerHasTarget(next)) return;
+    void (async () => {
+      committingRef.current = true;
+      setIsRebinding(true);
+      try {
+        const resolved = await resolveComposerTargets({
+          state: next,
+          liveEnvironments: liveNamedEnvironments,
+          max: 1,
+        });
+        const nextEnvironmentId = resolved.environmentIds[0];
+        if (nextEnvironmentId && nextEnvironmentId !== chatbox.environmentId) {
+          await rebindEnvironmentChatbox({
+            chatboxId: chatbox.chatboxId,
+            environmentId: nextEnvironmentId,
+          } as any);
+        }
+      } catch (err) {
+        // Roll back to what the scenario actually runs, then say why —
+        // verbatim, because the refusals are instructions ("that setup
+        // already has a scenario — …", "requires project admin").
+        setComposer(previous);
+        toast.error(
+          isAdhocUnavailable(err)
+            ? "This workspace's backend doesn't support editing a scenario's setup yet."
+            : convexErrMessage(err, "Could not update this scenario's setup"),
+        );
+      } finally {
+        committingRef.current = false;
+        setIsRebinding(false);
+      }
+    })();
+  };
 
   // Draft state for the description, persisted on blur. Reseeded whenever the
   // reactive envelope changes so another member's edit doesn't get silently
@@ -228,21 +314,27 @@ export function UserTestingScenarioDetail({
               className="-ml-2 px-2 text-xl font-semibold tracking-tight"
               inputClassName="text-xl font-semibold tracking-tight"
             />
-            <div className="mt-1.5 flex items-center gap-2 text-sm text-muted-foreground">
-              {environmentName ? (
-                // Environment-backed: the environment IS the scenario's
-                // identity. Its client is a detail of the environment, not a
-                // second name for the thing.
-                <>
-                  <Layers className="size-4 shrink-0" />
-                  <span className="truncate font-medium text-foreground">
-                    {environmentName}
-                  </span>
+            {composerActive ? (
+              // The scenario's setup, editable in place. Each pill edit
+              // resolves to a real environment row and REBINDS the scenario —
+              // "same setup, different server group" is one pill change on a
+              // live share link, not a trip to /environments.
+              <div className="mt-2 min-w-0">
+                <EnvironmentComposer
+                  projectId={chatbox.projectId}
+                  environments={liveNamedEnvironments}
+                  value={composer}
+                  onChange={handleComposerChange}
+                  maxTargets={1}
+                  disabled={isRebinding}
+                  testIdPrefix="user-testing-detail"
+                />
+                <div className="mt-1.5 flex items-center gap-2 text-sm text-muted-foreground">
                   {environmentIsAdhoc ? (
-                    // The row behind this label is ad-hoc: content-addressed,
-                    // immutable, and labeled by its client rather than a name.
-                    // Naming it (in place, same id) is what makes it — and
-                    // therefore this scenario's execution config — editable.
+                    // The row behind this setup is ad-hoc: content-addressed,
+                    // immutable, labeled by its client rather than a name.
+                    // Naming it (in place, same id) turns it into a curated
+                    // environment other surfaces can pick.
                     <Button
                       variant="ghost"
                       size="sm"
@@ -254,6 +346,25 @@ export function UserTestingScenarioDetail({
                       Name environment
                     </Button>
                   ) : null}
+                  {computersEnabled ? (
+                    <CloudRunBadge
+                      tooltip="Tester computer commands run in per-conversation MCPJam cloud sandboxes — never on the machine serving this inspector."
+                      data-testid="user-testing-cloud-run-badge"
+                    />
+                  ) : null}
+                </div>
+              </div>
+            ) : (
+            <div className="mt-1.5 flex items-center gap-2 text-sm text-muted-foreground">
+              {environmentName ? (
+                // Environment-backed but the composer can't run here (flag
+                // off, or the row hasn't loaded / isn't visible): the static
+                // identity row.
+                <>
+                  <Layers className="size-4 shrink-0" />
+                  <span className="truncate font-medium text-foreground">
+                    {environmentName}
+                  </span>
                 </>
               ) : (
                 <>
@@ -284,6 +395,7 @@ export function UserTestingScenarioDetail({
                 />
               ) : null}
             </div>
+            )}
             <TextareaAutosize
               aria-label="Scenario description"
               data-testid="user-testing-description"

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -135,6 +135,21 @@ export function UserTestingScenarioDetail({
   // Blocks the reseed below while a commit is in flight, so the rebind's own
   // reactive echo doesn't clobber the state the user is mid-editing against.
   const committingRef = useRef(false);
+  // The environment the backend ACTUALLY points at, as far as this client
+  // knows — advanced synchronously when a rebind succeeds, because the
+  // reactive `chatbox.environmentId` echo lags the mutation. Comparing
+  // against the prop instead let an immediate "change it back" edit read as
+  // a no-op and get silently swallowed while the backend stayed on the FIRST
+  // target.
+  const committedEnvironmentIdRef = useRef<string | null>(
+    chatbox.environmentId ?? null,
+  );
+  useEffect(() => {
+    // Adopt remote rebinds (another member, or our own echo) — but never
+    // mid-commit, when the ref is ahead of the subscription on purpose.
+    if (committingRef.current) return;
+    committedEnvironmentIdRef.current = chatbox.environmentId ?? null;
+  }, [chatbox.environmentId]);
   useEffect(() => {
     if (!environment || committingRef.current) return;
     setComposer(composerStateFromEnvironments([environment]));
@@ -145,8 +160,16 @@ export function UserTestingScenarioDetail({
   const composerActive = Boolean(
     environmentsEnabled && chatbox.environmentId && environment,
   );
+  // Held closed until the NAMED list settles, like the create flow: the
+  // resolver reuses a matching named environment, and resolving against an
+  // empty not-yet-loaded list would mint an unnamed twin of one that exists.
+  const composerReady = namedEnvironments !== undefined;
 
   const handleComposerChange = (next: EnvironmentComposerState) => {
+    // One commit at a time: a second edit mid-flight would clear
+    // `committingRef` out from under the first one's rollback. The strip is
+    // disabled while committing, so this guard only closes the setState gap.
+    if (committingRef.current) return;
     const previous = composer;
     setComposer(next);
     // No target (cleared clients / detached selection) commits nothing — the
@@ -162,11 +185,20 @@ export function UserTestingScenarioDetail({
           max: 1,
         });
         const nextEnvironmentId = resolved.environmentIds[0];
-        if (nextEnvironmentId && nextEnvironmentId !== chatbox.environmentId) {
+        if (!nextEnvironmentId) {
+          // Should be unreachable (a target implies one resolved id), but a
+          // silent skip here would leave the strip showing a setup the
+          // scenario does not run.
+          setComposer(previous);
+          toast.error("Could not resolve this setup to an environment.");
+          return;
+        }
+        if (nextEnvironmentId !== committedEnvironmentIdRef.current) {
           await rebindEnvironmentChatbox({
             chatboxId: chatbox.chatboxId,
             environmentId: nextEnvironmentId,
           } as any);
+          committedEnvironmentIdRef.current = nextEnvironmentId;
         }
       } catch (err) {
         // Roll back to what the scenario actually runs, then say why —
@@ -326,7 +358,7 @@ export function UserTestingScenarioDetail({
                   value={composer}
                   onChange={handleComposerChange}
                   maxTargets={1}
-                  disabled={isRebinding}
+                  disabled={isRebinding || !composerReady}
                   testIdPrefix="user-testing-detail"
                 />
                 <div className="mt-1.5 flex items-center gap-2 text-sm text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/UserTestingScenarioDetail.tsx
@@ -156,6 +156,17 @@ export function UserTestingScenarioDetail({
   const committedEnvironmentIdRef = useRef<string | null>(
     chatbox.environmentId ?? null,
   );
+  // Always the CURRENT reactive values, for the post-commit reconciliation
+  // below: a subscription update that lands mid-commit is deliberately
+  // skipped by both sync effects, and their deps have already settled by the
+  // time the commit ends — clearing the guard alone never replays it. The
+  // closure's own props are frozen at edit time, so it reads these instead.
+  const latestEnvironmentIdRef = useRef<string | null>(
+    chatbox.environmentId ?? null,
+  );
+  latestEnvironmentIdRef.current = chatbox.environmentId ?? null;
+  const latestEnvironmentRowRef = useRef(environment);
+  latestEnvironmentRowRef.current = environment;
   useEffect(() => {
     // Adopt remote rebinds (another member, or our own echo) — but never
     // mid-commit, when the ref is ahead of the subscription on purpose.
@@ -190,6 +201,9 @@ export function UserTestingScenarioDetail({
     void (async () => {
       committingRef.current = true;
       setIsRebinding(true);
+      // What this commit is moving AWAY from — needed to tell a collaborator's
+      // mid-flight rebind (a third id) apart from our own not-yet-echoed one.
+      const startedFromId = committedEnvironmentIdRef.current;
       try {
         const resolved = await resolveComposerTargets({
           state: next,
@@ -225,6 +239,25 @@ export function UserTestingScenarioDetail({
       } finally {
         committingRef.current = false;
         setIsRebinding(false);
+        // Replay what the guard skipped. A subscription value that is neither
+        // what this commit started from (our own echo still pending) nor what
+        // it committed is a collaborator's rebind that landed mid-flight —
+        // without this, a FAILED commit rolls back to a setup the backend no
+        // longer points at, and the stale ref then swallows follow-up edits
+        // as no-ops.
+        const latest = latestEnvironmentIdRef.current;
+        if (
+          latest !== committedEnvironmentIdRef.current &&
+          latest !== startedFromId
+        ) {
+          committedEnvironmentIdRef.current = latest;
+          const row = latestEnvironmentRowRef.current;
+          if (row && row.environmentId === latest) {
+            setComposer(composerStateFromEnvironments([row]));
+          }
+          // If the row for `latest` hasn't loaded yet, the reseed effect
+          // fires when it does — `committingRef` is already false.
+        }
       }
     })();
   };

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -612,6 +612,40 @@ describe("UserTestingScenarioDetail", () => {
       expect(rebindChatboxMock).toHaveBeenCalledTimes(2);
     });
 
+    it("adopts a collaborator's rebind that landed mid-commit", async () => {
+      environmentState.row = namedRow;
+      let rejectResolve!: (err: unknown) => void;
+      resolveTargetsMock.mockImplementation(
+        () => new Promise((_res, rej) => (rejectResolve = rej)),
+      );
+      const { rerender } = renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      act(() => lastComposerProps().onChange(composeState));
+
+      // A collaborator rebinds the scenario to env-9 while our resolve is in
+      // flight — both sync effects deliberately skip the update.
+      environmentState.row = {
+        ...namedRow,
+        environmentId: "env-9",
+        name: "Remote setup",
+      };
+      rerender(detail({ environmentId: "env-9", environmentName: "Remote" }));
+
+      // Our commit then FAILS. Without reconciliation the rollback restores
+      // the pre-commit setup (env-1) and the stale committed ref swallows
+      // follow-up edits — while the backend points at env-9.
+      await act(async () => {
+        rejectResolve(new Error("boom"));
+      });
+
+      await waitFor(() =>
+        expect(lastComposerProps().value.environmentIds).toEqual(["env-9"]),
+      );
+    });
+
     it("a refused rebind rolls the strip back and shows the backend's sentence", async () => {
       environmentState.row = namedRow;
       resolveTargetsMock.mockResolvedValue({

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -9,7 +9,7 @@
  *    back button goes from a scenario to the list rather than walking back
  *    through every tab the user tried.
  */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 
@@ -19,6 +19,9 @@ const {
   usagePanelMock,
   deleteChatboxMock,
   updateChatboxMock,
+  rebindChatboxMock,
+  resolveTargetsMock,
+  composerMock,
   environmentState,
   flagState,
 } = vi.hoisted(() => ({
@@ -27,6 +30,11 @@ const {
   usagePanelMock: vi.fn(),
   deleteChatboxMock: vi.fn().mockResolvedValue(undefined),
   updateChatboxMock: vi.fn().mockResolvedValue(undefined),
+  rebindChatboxMock: vi.fn().mockResolvedValue({}),
+  resolveTargetsMock: vi.fn(),
+  // Captures the props of every EnvironmentComposer render, so tests can
+  // assert the seeded value and drive onChange without the real pills.
+  composerMock: vi.fn(),
   // What `useProjectEnvironment` answers with: `undefined` = loading,
   // `null` = not visible, a row = loaded. Mutable per test.
   environmentState: { row: undefined as unknown },
@@ -62,6 +70,7 @@ vi.mock("@/hooks/useChatboxes", () => ({
   useChatboxMutations: () => ({
     deleteChatbox: deleteChatboxMock,
     updateChatbox: updateChatboxMock,
+    rebindEnvironmentChatbox: rebindChatboxMock,
   }),
 }));
 
@@ -69,6 +78,19 @@ vi.mock("@/hooks/useChatboxes", () => ({
 vi.mock("@/hooks/useProjectEnvironments", () => ({
   useProjectEnvironment: (projectId: string | null, envId: string | null) =>
     projectId && envId ? environmentState.row : null,
+  useProjectEnvironments: () => [],
+}));
+
+// Same reason: the real resolver hook binds a Convex mutation.
+vi.mock("@/components/environment-composer/use-composer-resolver", () => ({
+  useComposerResolver: () => resolveTargetsMock,
+}));
+
+vi.mock("@/components/environment-composer/environment-composer", () => ({
+  EnvironmentComposer: (props: Record<string, unknown>) => {
+    composerMock(props);
+    return <div data-testid="stub-environment-composer" />;
+  },
 }));
 
 vi.mock("@/hooks/useProjectEnvironmentsEnabled", () => ({
@@ -97,6 +119,7 @@ vi.mock("@/components/chatboxes/ChatboxUsagePanel", () => ({
 }));
 
 import { UserTestingScenarioDetail } from "../UserTestingScenarioDetail";
+import { toast } from "@/lib/toast";
 
 const chatbox = {
   chatboxId: "cb-1",
@@ -131,6 +154,13 @@ beforeEach(() => {
   // resolved defaults so a per-test rejection can't leak into later cases.
   deleteChatboxMock.mockResolvedValue(undefined);
   updateChatboxMock.mockResolvedValue(undefined);
+  rebindChatboxMock.mockResolvedValue({});
+  resolveTargetsMock.mockResolvedValue({
+    environmentIds: ["env-1"],
+    environments: [],
+    createdIds: [],
+    reusedIds: ["env-1"],
+  });
   locationState.search = "";
   environmentState.row = undefined;
   flagState.environmentsEnabled = true;
@@ -342,6 +372,163 @@ describe("UserTestingScenarioDetail", () => {
         chatboxId: "cb-1",
         description: "New copy",
       });
+    });
+  });
+
+  describe("editing the setup (composer → rebind)", () => {
+    const namedRow = {
+      environmentId: "env-1",
+      projectId: "p1",
+      origin: "named",
+      name: "Checkout flow",
+      hostId: "host-1",
+      revision: 3,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const composeState = {
+      environmentIds: [],
+      stack: {
+        hostIds: ["host-2"],
+        serverAttachmentId: null,
+        skillSelection: null,
+        computerEnvironmentId: null,
+      },
+      customized: true,
+    };
+    const lastComposerProps = () =>
+      composerMock.mock.calls.at(-1)?.[0] as {
+        value: { environmentIds: string[] };
+        onChange: (next: unknown) => void;
+      };
+
+    it("renders the composer seeded from the backing environment", () => {
+      environmentState.row = namedRow;
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      expect(
+        screen.getByTestId("stub-environment-composer"),
+      ).toBeInTheDocument();
+      expect(lastComposerProps().value.environmentIds).toEqual(["env-1"]);
+    });
+
+    it("does not render the composer while the row is loading, or flag-off", () => {
+      environmentState.row = undefined;
+      const { unmount } = renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+      expect(
+        screen.queryByTestId("stub-environment-composer"),
+      ).not.toBeInTheDocument();
+      unmount();
+
+      flagState.environmentsEnabled = false;
+      environmentState.row = namedRow;
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+      expect(
+        screen.queryByTestId("stub-environment-composer"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("a composer edit resolves the stack and rebinds the scenario", async () => {
+      environmentState.row = namedRow;
+      resolveTargetsMock.mockResolvedValue({
+        environmentIds: ["env-2"],
+        environments: [],
+        createdIds: ["env-2"],
+        reusedIds: [],
+      });
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      act(() => lastComposerProps().onChange(composeState));
+
+      await waitFor(() =>
+        expect(rebindChatboxMock).toHaveBeenCalledWith({
+          chatboxId: "cb-1",
+          environmentId: "env-2",
+        }),
+      );
+      expect(resolveTargetsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ state: composeState, max: 1 }),
+      );
+    });
+
+    it("skips the rebind when the edit resolves back to the current environment", async () => {
+      environmentState.row = namedRow;
+      resolveTargetsMock.mockResolvedValue({
+        environmentIds: ["env-1"],
+        environments: [],
+        createdIds: [],
+        reusedIds: ["env-1"],
+      });
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      act(() => lastComposerProps().onChange(composeState));
+
+      await waitFor(() => expect(resolveTargetsMock).toHaveBeenCalled());
+      expect(rebindChatboxMock).not.toHaveBeenCalled();
+    });
+
+    it("an edit with no target commits nothing", () => {
+      environmentState.row = namedRow;
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      act(() =>
+        lastComposerProps().onChange({
+          ...composeState,
+          stack: { ...composeState.stack, hostIds: [] },
+        }),
+      );
+
+      expect(resolveTargetsMock).not.toHaveBeenCalled();
+      expect(rebindChatboxMock).not.toHaveBeenCalled();
+    });
+
+    it("a refused rebind rolls the strip back and shows the backend's sentence", async () => {
+      environmentState.row = namedRow;
+      resolveTargetsMock.mockResolvedValue({
+        environmentIds: ["env-2"],
+        environments: [],
+        createdIds: [],
+        reusedIds: ["env-2"],
+      });
+      rebindChatboxMock.mockRejectedValue({
+        data: {
+          code: "CONFLICT",
+          message:
+            'That setup already has a scenario — "Other". Open it instead, or change the setup.',
+        },
+      });
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      act(() => lastComposerProps().onChange(composeState));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          'That setup already has a scenario — "Other". Open it instead, or change the setup.',
+        ),
+      );
+      // Rolled back to what the scenario actually runs.
+      expect(lastComposerProps().value.environmentIds).toEqual(["env-1"]);
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/UserTestingScenarioDetail.test.tsx
@@ -23,6 +23,7 @@ const {
   resolveTargetsMock,
   composerMock,
   environmentState,
+  namedListState,
   flagState,
 } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
@@ -38,6 +39,9 @@ const {
   // What `useProjectEnvironment` answers with: `undefined` = loading,
   // `null` = not visible, a row = loaded. Mutable per test.
   environmentState: { row: undefined as unknown },
+  // The NAMED environment list (`useProjectEnvironments`): `undefined` while
+  // loading, an array once settled.
+  namedListState: { value: [] as unknown },
   flagState: { environmentsEnabled: true },
 }));
 
@@ -78,7 +82,7 @@ vi.mock("@/hooks/useChatboxes", () => ({
 vi.mock("@/hooks/useProjectEnvironments", () => ({
   useProjectEnvironment: (projectId: string | null, envId: string | null) =>
     projectId && envId ? environmentState.row : null,
-  useProjectEnvironments: () => [],
+  useProjectEnvironments: () => namedListState.value,
 }));
 
 // Same reason: the real resolver hook binds a Convex mutation.
@@ -163,6 +167,7 @@ beforeEach(() => {
   });
   locationState.search = "";
   environmentState.row = undefined;
+  namedListState.value = [];
   flagState.environmentsEnabled = true;
 });
 
@@ -498,6 +503,90 @@ describe("UserTestingScenarioDetail", () => {
 
       expect(resolveTargetsMock).not.toHaveBeenCalled();
       expect(rebindChatboxMock).not.toHaveBeenCalled();
+    });
+
+    it("stays disabled until the named-environment list settles", () => {
+      environmentState.row = namedRow;
+      namedListState.value = undefined;
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      // The resolver reuses matching NAMED rows; resolving against a list
+      // that hasn't loaded would mint an unnamed twin of one that exists.
+      expect(lastComposerProps()).toEqual(
+        expect.objectContaining({ disabled: true }),
+      );
+    });
+
+    it("ignores a second edit while a commit is in flight", async () => {
+      environmentState.row = namedRow;
+      let release!: (v: unknown) => void;
+      resolveTargetsMock.mockImplementation(
+        () => new Promise((res) => (release = res)),
+      );
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      act(() => lastComposerProps().onChange(composeState));
+      // A second edit before the first settles: its rollback would clear the
+      // in-flight guard out from under the first commit.
+      act(() => lastComposerProps().onChange(composeState));
+      expect(resolveTargetsMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        release({
+          environmentIds: ["env-2"],
+          environments: [],
+          createdIds: ["env-2"],
+          reusedIds: [],
+        });
+      });
+      await waitFor(() => expect(rebindChatboxMock).toHaveBeenCalledTimes(1));
+    });
+
+    it("compares against the last COMMITTED environment, not the lagging prop", async () => {
+      environmentState.row = namedRow;
+      resolveTargetsMock.mockResolvedValueOnce({
+        environmentIds: ["env-2"],
+        environments: [],
+        createdIds: ["env-2"],
+        reusedIds: [],
+      });
+      renderDetail({
+        environmentId: "env-1",
+        environmentName: "Checkout flow",
+      });
+
+      act(() => lastComposerProps().onChange(composeState));
+      await waitFor(() =>
+        expect(rebindChatboxMock).toHaveBeenCalledWith({
+          chatboxId: "cb-1",
+          environmentId: "env-2",
+        }),
+      );
+
+      // The reactive envelope still says env-1 (the echo lags). The user
+      // flips back to env-1 — against the PROP that reads as a no-op and the
+      // backend would silently stay on env-2.
+      resolveTargetsMock.mockResolvedValueOnce({
+        environmentIds: ["env-1"],
+        environments: [],
+        createdIds: [],
+        reusedIds: ["env-1"],
+      });
+      act(() => lastComposerProps().onChange(composeState));
+
+      await waitFor(() =>
+        expect(rebindChatboxMock).toHaveBeenCalledWith({
+          chatboxId: "cb-1",
+          environmentId: "env-1",
+        }),
+      );
+      expect(rebindChatboxMock).toHaveBeenCalledTimes(2);
     });
 
     it("a refused rebind rolls the strip back and shows the backend's sentence", async () => {

--- a/mcpjam-inspector/client/src/hooks/useChatboxes.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxes.ts
@@ -316,6 +316,13 @@ export function useChatboxMutations() {
   const setChatboxGuestExecution = useMutation(
     "chatboxes:setChatboxGuestExecution" as any,
   );
+  // Environment-backed scenarios only: re-point the chatbox at a different
+  // environment (admin-gated; refuses a target that already backs another
+  // scenario). The setup editor on the scenario detail header commits
+  // through this.
+  const rebindEnvironmentChatbox = useMutation(
+    "chatboxes:rebindEnvironmentChatbox" as any,
+  );
 
   return {
     updateChatbox,
@@ -325,5 +332,6 @@ export function useChatboxMutations() {
     upsertChatboxMember,
     removeChatboxMember,
     setChatboxGuestExecution,
+    rebindEnvironmentChatbox,
   };
 }


### PR DESCRIPTION
Follow-up to #3829, closing the gap it left: the scenario header could rename and promote, but there was still nowhere to **change the servers**. The header now renders the same shared `EnvironmentComposer` (maxTargets=1) the create flow, Swarms, and Evals use — "same setup, different server group" or "try it on Claude" is one pill edit on a live share link.

**Depends on MCPJam/mcpjam-backend#918** (`chatboxes:rebindEnvironmentChatbox`). Against an older backend the strip degrades with its own message; nothing else on the page is affected.

## How commits work

Each pill edit resolves the composition to a real environment row through the existing shared resolver (ad-hoc get-or-create by fingerprint, named-row reuse) and **rebinds the chatbox** at it. The environment itself is never mutated — a named row may back suites and other runs, and an ad-hoc row is immutable by construction. Session history stays with the chatbox either way.

- Seeded from the backing row via `composerStateFromEnvironments`, reseeded on `(environmentId, revision)` — but **not while a commit is in flight**, so the rebind's own reactive echo can't clobber the state the user is mid-editing against.
- A no-target state (cleared clients) commits nothing; the scenario keeps its current environment until the composition resolves again.
- Resolving back to the **current** environment skips the write entirely (a picker round-trip isn't an edit).
- Failures roll the strip back to what the scenario actually runs and show the backend's sentence **verbatim** — the refusals are instructions: *"That setup already has a scenario — 'X'. Open it instead, or change the setup."*, *"requires project admin"*.
- The composer renders only when `project-environments-enabled` is on **and** the environment row has loaded; loading / flag-off / host-backed scenarios keep the static identity row. "Name environment" (ad-hoc promotion, from #3829) and the cloud badge move inside the composer branch unchanged.

## Tests

Six new cases: seeding from the backing row, loading/flag-off absence, resolve→rebind payloads, same-id skip, no-target skip, refusal rollback + verbatim toast. Full client project: **8,115 passed**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Repoints live share-link scenarios to different execution environments (admin-gated backend); race-handling is thorough but wrong rebind would change what testers run.
> 
> **Overview**
> User Testing scenario detail can **change servers/setup in the header** when project environments are enabled and the backing row has loaded: the shared **`EnvironmentComposer`** (`maxTargets=1`) replaces the static environment label.
> 
> Each pill edit **resolves** the stack to an environment id (reuse ad-hoc/named rows) and **rebinds** the chatbox via **`chatboxes:rebindEnvironmentChatbox`**—environments are not mutated; session history stays on the chatbox. The UI skips writes when resolution matches the current id, does nothing on empty targets, disables until named envs load, and rolls back with backend error text on refusal (older backends get a dedicated unsupported message).
> 
> **`useChatboxMutations`** now exposes **`rebindEnvironmentChatbox`**. Tests cover seeding, flag/loading fallbacks, resolve→rebind, no-op/skip paths, in-flight guards, lagging-prop vs committed-id, and mid-commit collaborator reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31cd34ee2ec5c9b133922b24a0a39be7e05571d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Edit a scenario’s setup from the header with the shared `EnvironmentComposer` (maxTargets=1). Edits resolve to a real environment and call `chatboxes:rebindEnvironmentChatbox` without mutating environments; chat history stays intact.

- **New Features**
  - Show `EnvironmentComposer` in the header when `project-environments-enabled` is on and the env row is loaded; otherwise show the static identity row.
  - Commit edits via `chatboxes:rebindEnvironmentChatbox` (depends on `MCPJam/mcpjam-backend#918`); no-target states do nothing and same-environment resolves skip writes.
  - Safe reseed while editing; on failure, roll back to the current setup and show the backend’s message verbatim. “Name environment” and the cloud badge remain inside the composer branch.

- **Bug Fixes**
  - Disable the composer until the named-environments list settles to avoid creating unnamed twins.
  - Compare against the last committed environment id (not the lagging prop) so immediate flip-backs rebind correctly.
  - Guard against re-entry while a commit is in flight and roll back on empty resolutions to keep the strip consistent.
  - Reconcile collaborator edits: if another member rebinds mid-commit, adopt their environment after the commit to keep the strip in sync.

<sup>Written for commit 31cd34ee2ec5c9b133922b24a0a39be7e05571d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

