### PR TITLE
fix(discord): register the org settings route so the page is reachable

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/app-surface-coverage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/app-surface-coverage.test.ts
@@ -18,7 +18,12 @@ import {
   isAppSurfaceId,
   listAppSurfaceNavSegments,
 } from "@/shared/app-surfaces";
-import { routePaths } from "../app-navigation";
+import {
+  buildOrganizationPath,
+  ORGANIZATION_ROUTE_SECTIONS,
+  parseOrganizationSection,
+  routePaths,
+} from "../app-navigation";
 import {
   HOSTED_HASH_ALLOWED_TABS,
   HOSTED_HASH_BLOCKED_TABS,
@@ -75,6 +80,38 @@ describe("route table ↔ surface manifests", () => {
     const ids = APP_SURFACES.map((s) => s.id);
     expect(ids.length).toBe(new Set(ids).size);
   });
+});
+
+describe("every organization section is actually reachable", () => {
+  // The failure this catches: a section can be added to the nav, given a path
+  // by `buildOrganizationPath`, and rendered by OrganizationsTab while no
+  // route ever matches it. There is no 404 to notice — the router's `"*"`
+  // falls through to Servers, so the nav item silently navigates to the wrong
+  // screen. Discord shipped exactly that way.
+  //
+  // Passing ":orgId" as the id makes the built path come out as the literal
+  // route pattern, so this is an exact comparison rather than a regex.
+  const patterns = new Set(screenRoutes.map((r) => `/${r.path}`));
+
+  it.each([...ORGANIZATION_ROUTE_SECTIONS])(
+    "%s has a registered route",
+    (section) => {
+      const built = buildOrganizationPath(":orgId", section);
+      expect(patterns.has(built), `${section} → ${built}`).toBe(true);
+    },
+  );
+
+  it.each([...ORGANIZATION_ROUTE_SECTIONS])(
+    "%s round-trips back out of its own path",
+    (section) => {
+      // The other direction: a registered route whose segment the parser does
+      // not know lands on "overview", which looks like the nav item doing
+      // nothing rather than like a bug.
+      const built = buildOrganizationPath("org-1", section);
+      const segment = built.split("/")[3];
+      expect(parseOrganizationSection(segment)).toBe(section);
+    },
+  );
 });
 
 describe("surface manifests are model-usable", () => {

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -15,12 +15,43 @@ import type { EvalRoutePrefix } from "./eval-route-url";
 import { normalizeHostedHashTab } from "./hosted-tab-policy";
 import { listAppSurfaceNavSegments } from "@/shared/app-surfaces";
 
+/**
+ * Every organization settings section.
+ *
+ * A runtime list rather than a bare union so the route-coverage test can walk
+ * it. `buildOrganizationPath` below is the only thing that decides these URLs,
+ * and nothing used to check that the paths it produced were actually
+ * registered — the Discord section shipped that way and was unreachable: the
+ * nav sent you to `/organizations/:id/discord`, no route matched, and the
+ * router's `"*"` wildcard rendered Servers instead. Adding a member here now
+ * fails the test until the route table, the element map and the surface
+ * manifest all know about it.
+ */
+export const ORGANIZATION_ROUTE_SECTIONS = [
+  "overview",
+  "billing",
+  "models",
+  "slack",
+  "discord",
+] as const;
+
 export type OrganizationRouteSection =
-  | "overview"
-  | "billing"
-  | "models"
-  | "slack"
-  | "discord";
+  (typeof ORGANIZATION_ROUTE_SECTIONS)[number];
+
+/**
+ * Third path segment → section. "overview" is the section with no segment, so
+ * an unknown segment lands there too; that is what makes an unregistered
+ * section fail quietly rather than 404, and why the coverage test exists.
+ */
+export function parseOrganizationSection(
+  segment: string | undefined
+): OrganizationRouteSection {
+  if (segment === "billing") return "billing";
+  if (segment === "models") return "models";
+  if (segment === "slack") return "slack";
+  if (segment === "discord") return "discord";
+  return "overview";
+}
 
 /** Typed canonical paths used across the app. */
 export const routePaths = {
@@ -483,17 +514,7 @@ export function useCurrentOrgRoute(): CurrentOrgRoute | null {
   if (segments[0] !== "organizations") return null;
   const orgId = segments[1];
   if (!orgId) return null;
-  const sectionSegment = segments[2];
-  const orgSection: OrganizationRouteSection =
-    sectionSegment === "billing"
-      ? "billing"
-      : sectionSegment === "models"
-      ? "models"
-      : sectionSegment === "slack"
-      ? "slack"
-      : sectionSegment === "discord"
-      ? "discord"
-      : "overview";
+  const orgSection = parseOrganizationSection(segments[2]);
   return { orgId: decodePathSegment(orgId), orgSection };
 }
 

--- a/mcpjam-inspector/client/src/lib/app-routes.ts
+++ b/mcpjam-inspector/client/src/lib/app-routes.ts
@@ -152,6 +152,19 @@ export const APP_ROUTES: readonly AppRouteEntry[] = [
     kind: "screen",
     surfaceId: "organizations",
   },
+  // Discord agent org settings, on the same terms as Slack above — an
+  // `organizations` section, not a surface. It has no `?tab=` because it is a
+  // single view (see DiscordAgentSettingsSection), which changes nothing here:
+  // sub-tabs never appeared in the path for Slack either.
+  // Discord agent org settings, on the same terms as Slack above — an
+  // `organizations` section, not a surface. It has no `?tab=` because it is a
+  // single view (see DiscordAgentSettingsSection), which changes nothing here:
+  // sub-tabs never appeared in the path for Slack either.
+  {
+    path: "organizations/:orgId/discord",
+    kind: "screen",
+    surfaceId: "organizations",
+  },
   { path: "evals", kind: "screen", surfaceId: "evals" },
   { path: "evals/create", kind: "screen", surfaceId: "evals" },
   { path: "evals/suite/:suiteId", kind: "screen", surfaceId: "evals" },

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -166,6 +166,7 @@ const ROUTE_ELEMENTS: Record<
   "organizations/:orgId/billing": { element: <OrganizationsRoute /> },
   "organizations/:orgId/models": { element: <OrganizationsRoute /> },
   "organizations/:orgId/slack": { element: <OrganizationsRoute /> },
+  "organizations/:orgId/discord": { element: <OrganizationsRoute /> },
   evals: { element: <EvalsRoute /> },
   "evals/create": { element: <EvalsRoute /> },
   "evals/suite/:suiteId": { element: <EvalsRoute /> },

--- a/mcpjam-inspector/shared/app-surfaces.ts
+++ b/mcpjam-inspector/shared/app-surfaces.ts
@@ -599,6 +599,9 @@ export const APP_SURFACES = [
       // it at a screen most orgs cannot see would waste a turn on a door that
       // is locked.
       "organizations/:orgId/slack",
+      // Discord agent settings — same reasoning as Slack directly above,
+      // including staying out of `userActivities` while `discord-agent` is off.
+      "organizations/:orgId/discord",
     ],
     navSegments: ["organizations"],
     title: "Organizations",


### PR DESCRIPTION
## The bug

`/organizations/:orgId/discord` was never registered. #3830 added the nav
entry, the section component, the path builder and the parser — everything
except the two route tables — so the URL matched nothing and the router's `"*"`
wildcard rendered **Servers** instead. The Discord settings page shipped
unreachable.

Found by Codex review on #3830, confirmed here: a repo-wide search for the
pattern returns only `app-routes.ts` and `router.tsx` entries for Slack.

## Why nothing caught it

`app-surface-coverage.test.ts` already checks route registration in both
directions, rigorously — but it checks the route table against the **surface
manifests**. Neither table had the Discord path, so they agreed with each
other and the suite stayed green.

Nothing checked either of them against `buildOrganizationPath`, which is the
function that actually decides these URLs. And the failure mode is silent by
construction: there is no 404 to notice, because the wildcard renders a real
screen and the parser treats an unknown segment as `"overview"`.

The component tests couldn't have caught it either — they render
`<OrganizationsTab section="discord" />` with the section passed as a prop, so
they prove the section renders once you're there and never that a URL gets you
there. That's the seam this PR closes.

## The guard

`OrganizationRouteSection` is now derived from a runtime
`ORGANIZATION_ROUTE_SECTIONS` list, so a test can walk it. Two new cases, one
per direction:

- every section's built path is a registered screen route — passing `":orgId"`
  as the id makes the built path come out as the literal route pattern, so
  it's an exact set membership test, not a regex;
- every section round-trips back out of its own path — the reverse gap, where
  a route exists but the parser doesn't know its segment and quietly lands on
  the overview.

The section-parsing ternary moved out of `useCurrentOrgRoute` into an exported
`parseOrganizationSection` so the second direction is testable without
rendering a hook. No behavior change.

Adding a sixth section now fails the suite until the route table, the element
map and the surface manifest all know about it.

## Verified non-vacuous

Reverted the `app-routes.ts` entry and re-ran: 2 failures, the new one naming
the exact problem — `discord → /organizations/:orgId/discord: expected false
to be true`. Restored.

Not covered, deliberately: `ROUTE_ELEMENTS` in `router.tsx` still isn't
cross-checked, because this test file reads only pure data modules on purpose.
A missing element there already throws at router construction, which is loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client routing and test-only guardrails; no auth, billing, or data-path changes.
> 
> **Overview**
> Fixes **Discord org settings** shipping unreachable: nav and `buildOrganizationPath` pointed at `/organizations/:orgId/discord`, but that path was missing from **`APP_ROUTES`**, **`ROUTE_ELEMENTS`**, and the organizations surface **`routePatterns`**, so the catch-all sent users to **Servers**.
> 
> Registers **`organizations/:orgId/discord`** in those three places (same pattern as Slack).
> 
> Adds **`ORGANIZATION_ROUTE_SECTIONS`** and exported **`parseOrganizationSection`** (used by **`useCurrentOrgRoute`**) so coverage tests can walk every org section. New tests assert each section’s built path is a registered screen route and that **`parseOrganizationSection`** round-trips the URL segment—closing the gap where surface↔route tests could pass while **`buildOrganizationPath`** URLs still didn’t match anything.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570285a502847b8d79f01e6277ba5f2b4798ca5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an unreachable Discord org settings page by registering `/organizations/:orgId/discord` so it loads correctly instead of falling back to Servers. Adds a test guard to ensure every org section has a registered route and round-trips from URL to section.

- **Bug Fixes**
  - Registered `organizations/:orgId/discord` in `APP_ROUTES`, `ROUTE_ELEMENTS`, and the `organizations` surface manifest.

- **Refactors**
  - Added `ORGANIZATION_ROUTE_SECTIONS` and derived `OrganizationRouteSection` from it.
  - Extracted `parseOrganizationSection` and updated `useCurrentOrgRoute` to use it.
  - Expanded coverage test: each section’s built path must exist, and each section must round-trip from its URL segment.

<sup>Written for commit 570285a502847b8d79f01e6277ba5f2b4798ca5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

