### PR TITLE
fix(surface): show each surface only its own activity, and share the tab strip

### DIFF
--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -85,7 +85,11 @@ import {
   SlackAgentSettingsSection,
   type SlackSettingsTabId,
 } from "./organization/slack/SlackAgentSettingsSection";
-import { DiscordAgentSettingsSection } from "./organization/discord/DiscordAgentSettingsSection";
+import {
+  DiscordAgentSettingsSection,
+  resolveDiscordSettingsTab,
+  type DiscordSettingsTabId,
+} from "./organization/discord/DiscordAgentSettingsSection";
 import { useSlackAgentSettingsEnabled } from "@/hooks/useSlackAgentSettingsEnabled";
 import { useDiscordAgentEnabled } from "@/hooks/useDiscordAgentEnabled";
 import {
@@ -606,7 +610,10 @@ function OrganizationPage({
   const billingUiEnabled = billingEntitlementsUiEnabled === true;
   const slackAgentSettingsEnabled = useSlackAgentSettingsEnabled();
   const discordAgentEnabled = useDiscordAgentEnabled();
-  const rawSlackTab = useCurrentSearchParam("tab");
+  // One `?tab=` param, read once and resolved per section — each resolver
+  // falls back to its own Connections, so a Slack tab id in a Discord URL
+  // lands somewhere real instead of on a blank panel.
+  const rawSurfaceTab = useCurrentSearchParam("tab");
   const activeSection: OrganizationRouteSection =
     section === "models"
       ? "models"
@@ -622,11 +629,13 @@ function OrganizationPage({
       section === "discord" && discordAgentEnabled
       ? "discord"
       : "overview";
-  // The sub-tab lives in `?tab=` — three views of one settings section, not
-  // three org routes. Read from the URL rather than component state so a link
-  // to a specific tab works, and through the router's location context so
-  // switching tabs actually re-renders.
-  const slackTab: SlackSettingsTabId = resolveSlackSettingsTab(rawSlackTab);
+  // The sub-tab lives in `?tab=` — views of one settings section, not separate
+  // org routes. Read from the URL rather than component state so a link to a
+  // specific tab works, and through the router's location context so switching
+  // tabs actually re-renders.
+  const slackTab: SlackSettingsTabId = resolveSlackSettingsTab(rawSurfaceTab);
+  const discordTab: DiscordSettingsTabId =
+    resolveDiscordSettingsTab(rawSurfaceTab);
   const memberInviteGate = resolveBillingGateState({
     billingUiEnabled,
     organizationId: organization._id,
@@ -958,6 +967,11 @@ function OrganizationPage({
       `${buildOrganizationPath(organization._id, "slack")}?tab=${tab}`
     );
   };
+  const navigateToDiscordTab = (tab: DiscordSettingsTabId) => {
+    appNavigate(
+      `${buildOrganizationPath(organization._id, "discord")}?tab=${tab}`
+    );
+  };
   const handleViewBilling = () => navigateToSection("billing");
 
   const openBillingUrl = useCallback(
@@ -1284,6 +1298,8 @@ function OrganizationPage({
         <DiscordAgentSettingsSection
           organizationId={organization._id}
           isAdmin={canEdit}
+          tab={discordTab}
+          onTabChange={navigateToDiscordTab}
         />
       ) : activeSection === "billing" ? (
         <>

--- a/mcpjam-inspector/client/src/components/organization/__tests__/DiscordAgentSettingsSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/DiscordAgentSettingsSection.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 /**
@@ -27,10 +28,16 @@ vi.mock("@/lib/config", () => ({
   discordInstallUrl: () => mockDiscord.installUrl,
 }));
 
-/** The connections table itself is covered by its own tests. */
+/** The panels themselves are covered by their own tests. */
 vi.mock("../surface/SurfaceConnectionsTab", () => ({
   SurfaceConnectionsTab: ({ surfaceKind }: { surfaceKind: string }) => (
     <div data-testid="surface-connections">{surfaceKind}</div>
+  ),
+}));
+
+vi.mock("../surface/SurfaceActivityTab", () => ({
+  SurfaceActivityTab: ({ surfaceKind }: { surfaceKind: string }) => (
+    <div data-testid="surface-activity">{surfaceKind}</div>
   ),
 }));
 
@@ -94,5 +101,64 @@ describe("DiscordAgentSettingsSection", () => {
       mockDiscord.installUrl =
         "https://discord.com/oauth2/authorize?client_id=1";
     }
+  });
+
+  describe("tabs", () => {
+    it("offers Connections and Activity, and no Capabilities", () => {
+      render(<DiscordAgentSettingsSection organizationId="org-1" isAdmin />);
+      const tabs = screen
+        .getAllByRole("tab")
+        .map((tab) => tab.textContent?.trim());
+      // Capabilities is org-wide in the backend, not per-surface — a Discord
+      // tab would render a second control over the same single row.
+      expect(tabs).toEqual(["Connections", "Activity"]);
+    });
+
+    it("defaults to Connections when no tab is given", () => {
+      render(<DiscordAgentSettingsSection organizationId="org-1" isAdmin />);
+      expect(screen.getByTestId("surface-connections")).toBeInTheDocument();
+      expect(screen.queryByTestId("surface-activity")).not.toBeInTheDocument();
+    });
+
+    it("renders the Activity panel for the DISCORD surface", () => {
+      render(
+        <DiscordAgentSettingsSection
+          organizationId="org-1"
+          isAdmin
+          tab="activity"
+        />,
+      );
+      // The wrong kind here would show Slack's rows on the Discord page.
+      expect(screen.getByTestId("surface-activity")).toHaveTextContent(
+        "discord",
+      );
+    });
+
+    it("falls back to Connections for a tab id it does not have", () => {
+      // `?tab=capabilities` is a real Slack URL; carried onto Discord it must
+      // land somewhere real rather than on an empty panel.
+      render(
+        <DiscordAgentSettingsSection
+          organizationId="org-1"
+          isAdmin
+          tab="capabilities"
+        />,
+      );
+      expect(screen.getByTestId("surface-connections")).toBeInTheDocument();
+    });
+
+    it("reports the selected tab to its caller", async () => {
+      const onTabChange = vi.fn();
+      render(
+        <DiscordAgentSettingsSection
+          organizationId="org-1"
+          isAdmin
+          onTabChange={onTabChange}
+        />,
+      );
+      await userEvent.click(screen.getByRole("tab", { name: "Activity" }));
+      // The section does not own the URL; OrganizationsTab writes `?tab=`.
+      expect(onTabChange).toHaveBeenCalledWith("activity");
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/organization/__tests__/SurfaceActivityTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/SurfaceActivityTab.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * The shared Activity feed.
+ *
+ * The case that matters most here is SURFACE FILTERING, because it is a fix
+ * and not only a generalization: the backing query matches on both
+ * `slack.agent.` and `discord.agent.` prefixes and always returned both, and
+ * this tab used to render whatever it got with labels looked up by the full
+ * action string. A Discord row therefore appeared in the SLACK tab as a raw
+ * `discord.agent.channel_binding_created`, attributed to "Slack <a discord
+ * user id>". These pin that each tab shows only its own rows, and that the
+ * labels are shared rather than Slack-keyed.
+ */
+
+const { activity } = vi.hoisted(() => ({
+  activity: {
+    events: [] as Array<Record<string, unknown>>,
+    isLoading: false,
+    isLoadingMore: false,
+    hasMore: false,
+    error: null as unknown,
+    refresh: vi.fn(),
+    loadMore: vi.fn(),
+  },
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useSlackAgentActivity", () => ({
+  useSlackAgentActivity: () => activity,
+}));
+
+import { SurfaceActivityTab } from "../surface/SurfaceActivityTab";
+
+function event(overrides: Record<string, unknown>) {
+  return {
+    _id: `e-${Math.abs(String(overrides.action).length)}-${String(
+      overrides._id ?? "1"
+    )}`,
+    action: "slack.agent.channel_binding_created",
+    actorType: "user",
+    actorId: null,
+    actorEmail: null,
+    organizationId: "org-1",
+    projectId: null,
+    targetType: "surfaceChannelBinding",
+    targetId: "b1",
+    metadata: {},
+    timestamp: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  activity.events = [];
+  activity.isLoading = false;
+  activity.isLoadingMore = false;
+  activity.hasMore = false;
+  activity.error = null;
+});
+
+describe("SurfaceActivityTab", () => {
+  it("shows only the requested surface's rows", () => {
+    activity.events = [
+      event({ _id: "s", action: "slack.agent.channel_binding_created" }),
+      event({ _id: "d", action: "discord.agent.channel_binding_created" }),
+    ];
+
+    render(<SurfaceActivityTab organizationId="org-1" surfaceKind="slack" />);
+    expect(
+      screen.getByTestId("activity-slack.agent.channel_binding_created")
+    ).toBeInTheDocument();
+    // The regression: this row used to render here, as a raw action string.
+    expect(
+      screen.queryByTestId("activity-discord.agent.channel_binding_created")
+    ).not.toBeInTheDocument();
+  });
+
+  it("labels a Discord action from the shared map, not as a raw string", () => {
+    activity.events = [
+      event({ _id: "d", action: "discord.agent.channel_binding_created" }),
+    ];
+
+    render(<SurfaceActivityTab organizationId="org-1" surfaceKind="discord" />);
+    expect(screen.getByText("Channel bound")).toBeInTheDocument();
+    expect(
+      screen.queryByText("discord.agent.channel_binding_created")
+    ).not.toBeInTheDocument();
+  });
+
+  it("attributes an unlinked actor to the right surface", () => {
+    activity.events = [
+      event({
+        _id: "d",
+        action: "discord.agent.proposal_created",
+        metadata: { proposerSurfaceUserId: "D_123" },
+      }),
+    ];
+
+    render(<SurfaceActivityTab organizationId="org-1" surfaceKind="discord" />);
+    // Previously "Slack D_123" — the id is a Discord one.
+    expect(screen.getByText("Discord D_123")).toBeInTheDocument();
+  });
+
+  it("keeps Load more on an empty page when more pages exist", () => {
+    // Filtering is client-side, so a page can be entirely the other surface.
+    // Without the button this reads as "no activity", which would be wrong.
+    activity.events = [
+      event({ _id: "s", action: "slack.agent.channel_binding_created" }),
+    ];
+    activity.hasMore = true;
+
+    render(<SurfaceActivityTab organizationId="org-1" surfaceKind="discord" />);
+    expect(
+      screen.getByRole("button", { name: "Load more" })
+    ).toBeInTheDocument();
+  });
+
+  it("omits Load more on an empty page when there is nothing more", () => {
+    activity.events = [];
+    activity.hasMore = false;
+
+    render(<SurfaceActivityTab organizationId="org-1" surfaceKind="discord" />);
+    expect(
+      screen.queryByRole("button", { name: "Load more" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/organization/__tests__/SurfaceSettingsTabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/SurfaceSettingsTabs.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SurfaceSettingsTabs } from "../surface/SurfaceSettingsTabs";
+
+/**
+ * The shared tab strip.
+ *
+ * Worth its own file because the reason this was extracted rather than copied
+ * is an accessibility rule that is invisible in a screenshot: only the ACTIVE
+ * tab's panel is mounted, so only the active tab may carry `aria-controls`.
+ * A second hand-written copy would very plausibly point all three at their
+ * panels and hand a screen reader two targets it cannot move to. Neither
+ * section's own tests assert this, so it is asserted here.
+ */
+
+const TABS = [
+  { id: "connections", label: "Connections", description: "Where turns land." },
+  { id: "activity", label: "Activity", description: "What the agent did." },
+] as const;
+
+function renderStrip(
+  activeTab: (typeof TABS)[number]["id"] = "connections",
+  onTabChange = vi.fn()
+) {
+  render(
+    <SurfaceSettingsTabs
+      tabs={TABS}
+      activeTab={activeTab}
+      onTabChange={onTabChange}
+      idPrefix="demo-settings"
+      ariaLabel="Demo agent settings"
+    >
+      <div data-testid="panel-body">body</div>
+    </SurfaceSettingsTabs>
+  );
+  return onTabChange;
+}
+
+describe("SurfaceSettingsTabs", () => {
+  it("points aria-controls only at the panel that is mounted", () => {
+    renderStrip("connections");
+    expect(screen.getByRole("tab", { name: "Connections" })).toHaveAttribute(
+      "aria-controls",
+      "demo-settings-panel-connections"
+    );
+    // The inactive tab's panel does not exist, so the attribute must be absent
+    // rather than dangling.
+    expect(screen.getByRole("tab", { name: "Activity" })).not.toHaveAttribute(
+      "aria-controls"
+    );
+    expect(document.getElementById("demo-settings-panel-activity")).toBeNull();
+  });
+
+  it("marks exactly one tab selected and labels the panel from it", () => {
+    renderStrip("activity");
+    expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(
+      "Activity"
+    );
+    expect(screen.getByRole("tabpanel")).toHaveAttribute(
+      "aria-labelledby",
+      "demo-settings-tab-activity"
+    );
+  });
+
+  it("names the tablist and shows the active tab's description", () => {
+    renderStrip("activity");
+    expect(
+      screen.getByRole("tablist", { name: "Demo agent settings" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("What the agent did.")).toBeInTheDocument();
+    expect(screen.queryByText("Where turns land.")).not.toBeInTheDocument();
+  });
+
+  it("reports a click to its caller", async () => {
+    const onTabChange = renderStrip("connections");
+    await userEvent.click(screen.getByRole("tab", { name: "Activity" }));
+    expect(onTabChange).toHaveBeenCalledWith("activity");
+  });
+});

--- a/mcpjam-inspector/client/src/components/organization/discord/DiscordAgentSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/discord/DiscordAgentSettingsSection.tsx
@@ -1,57 +1,89 @@
+import { useCallback, useMemo } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { useDiscordAgentEnabled } from "@/hooks/useDiscordAgentEnabled";
 import { discordInstallUrl } from "@/lib/config";
 import { SurfaceConnectionsTab } from "../surface/SurfaceConnectionsTab";
+import { SurfaceActivityTab } from "../surface/SurfaceActivityTab";
+import { SurfaceSettingsTabs } from "../surface/SurfaceSettingsTabs";
 
 /**
  * Org settings for the MCPJam agent in Discord.
  *
- * ONE VIEW, NOT THREE. Slack's section carries Connections, Capabilities and
- * Activity sub-tabs; Discord has only Connections, and the two absences are
- * deliberate rather than unfinished:
+ * TWO TABS, NOT SLACK'S THREE. Connections and Activity are shared components
+ * (`SurfaceConnectionsTab`, `SurfaceActivityTab`) rendered inside the shared
+ * strip, so the two surfaces stay the same screen rather than two screens that
+ * drift. Capabilities is the one real absence, and it is deliberate:
  *
- *   - CAPABILITIES is org-wide in the backend, not per-surface
- *     (`orgAgentCapabilityPolicies` is read with `surfaceKind: 'slack'` for
- *     every caller). A Discord tab here would render a second control over the
- *     same single row and imply the two can differ. Splitting the policy per
- *     surface is a product decision about existing Slack behavior, so it is
- *     its own change.
- *   - ACTIVITY reads `auditEvents`, which now carry `discord.agent.*` actions,
- *     but the Slack tab's copy and filters are written around Slack's
- *     vocabulary. Showing Discord rows there is a follow-up, not a blocker for
- *     binding a channel.
- *
- * A tab strip for a single tab would be chrome asserting choices that do not
- * exist, so the section renders the one view directly.
+ *   CAPABILITIES is org-wide in the backend, not per-surface
+ *   (`orgAgentCapabilityPolicies` is read with `surfaceKind: 'slack'` for
+ *   every caller). A Discord tab here would render a second control over the
+ *   same single row and imply the two can differ. Splitting the policy per
+ *   surface is a product decision about existing Slack behavior, so it is its
+ *   own change — not something to imply with a tab.
  *
  * SELF-ENFORCES THE FLAG, like Slack's section does: the nav strip already
  * hides the entry, but someone who types `/organizations/:id/discord` bypasses
  * the strip entirely.
  */
 
+export const DISCORD_SETTINGS_TABS = [
+  {
+    id: "connections",
+    label: "Connections",
+    description:
+      "Which Discord servers this organization uses, and where turns land by default.",
+  },
+  {
+    id: "activity",
+    label: "Activity",
+    description: "What the agent proposed, who approved it, and how it went.",
+  },
+] as const;
+
+export type DiscordSettingsTabId = (typeof DISCORD_SETTINGS_TABS)[number]["id"];
+
+/** An unknown or absent `?tab=` lands on Connections. */
+export function resolveDiscordSettingsTab(
+  value: unknown
+): DiscordSettingsTabId {
+  return DISCORD_SETTINGS_TABS.some((tab) => tab.id === value)
+    ? (value as DiscordSettingsTabId)
+    : "connections";
+}
+
 interface DiscordAgentSettingsSectionProps {
   organizationId: string;
   /** Org admin or owner. Members get a read-only view. */
   isAdmin: boolean;
+  /** Raw `?tab=` value; normalized here so callers do not have to. */
+  tab?: string | null;
+  onTabChange?: (tab: DiscordSettingsTabId) => void;
 }
 
 export function DiscordAgentSettingsSection({
   organizationId,
   isAdmin,
+  tab,
+  onTabChange,
 }: DiscordAgentSettingsSectionProps) {
   const enabled = useDiscordAgentEnabled();
+  const activeTab = useMemo(() => resolveDiscordSettingsTab(tab), [tab]);
+  const handleTabChange = useCallback(
+    (next: DiscordSettingsTabId) => onTabChange?.(next),
+    [onTabChange]
+  );
   // Absent when no client id is configured. An install URL built without one
   // lands on a Discord error page that reads as our bug rather than as
   // missing configuration, so the button is omitted instead of broken.
   const installUrl = discordInstallUrl();
+
   if (!enabled) return null;
 
   return (
     <div className="space-y-6" data-testid="discord-agent-settings">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <p className="max-w-prose text-sm text-muted-foreground">
-          Which Discord servers this organization uses, and where turns land by
-          default. A server appears below once someone here runs{" "}
+          A server appears here once someone in this organization runs{" "}
           <code className="font-mono text-xs">/mcpjam connect</code> in it.
         </p>
         {isAdmin && installUrl ? (
@@ -62,11 +94,27 @@ export function DiscordAgentSettingsSection({
           </Button>
         ) : null}
       </div>
-      <SurfaceConnectionsTab
-        organizationId={organizationId}
-        isAdmin={isAdmin}
-        surfaceKind="discord"
-      />
+
+      <SurfaceSettingsTabs
+        tabs={DISCORD_SETTINGS_TABS}
+        activeTab={activeTab}
+        onTabChange={handleTabChange}
+        idPrefix="discord-settings"
+        ariaLabel="Discord agent settings"
+      >
+        {activeTab === "connections" ? (
+          <SurfaceConnectionsTab
+            organizationId={organizationId}
+            isAdmin={isAdmin}
+            surfaceKind="discord"
+          />
+        ) : (
+          <SurfaceActivityTab
+            organizationId={organizationId}
+            surfaceKind="discord"
+          />
+        )}
+      </SurfaceSettingsTabs>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/organization/slack/SlackActivityTab.tsx
+++ b/mcpjam-inspector/client/src/components/organization/slack/SlackActivityTab.tsx
@@ -1,232 +1,25 @@
-import { useMemo } from "react";
-import { useConvexAuth } from "convex/react";
-import { Badge } from "@mcpjam/design-system/badge";
-import { Button } from "@mcpjam/design-system/button";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@mcpjam/design-system/table";
-import {
-  useSlackAgentActivity,
-  type SlackAgentActivityEvent,
-} from "@/hooks/useSlackAgentActivity";
+import { SurfaceActivityTab } from "../surface/SurfaceActivityTab";
 
 /**
- * Activity: what the agent proposed, who approved it, and how it went.
+ * Slack's Activity tab.
  *
- * READ-ONLY, and backed by `auditEvents` rather than the proposals table —
- * that one is swept on a 1-hour TTL and deletes terminal rows, so a feed built
- * on it would lose exactly the outcomes an admin came here to see.
+ * The implementation moved to `SurfaceActivityTab` when Discord needed the
+ * same feed — the backing query already returned both surfaces' rows. This
+ * stays as the Slack-named entry point so `SlackAgentSettingsSection` and its
+ * tests keep importing the name they always did, matching what
+ * `SlackConnectionsTab` does for the same reason.
  *
- * The rows carry surface ids (a Slack user id) and, when the person had linked
- * their account at the time, an MCPJam identity. Both are shown: the email is
- * what a reader recognises, and the Slack id is what they can search for when
- * there is no email to show.
+ * Behavior change worth knowing about: this tab now shows only `slack.agent.*`
+ * rows. It previously rendered Discord rows too, as raw action strings
+ * attributed to "Slack <a discord user id>".
  */
-
-const ACTION_LABELS: Record<string, string> = {
-  "slack.agent.proposal_created": "Proposed",
-  "slack.agent.proposal_executed": "Approved & ran",
-  "slack.agent.account_linked": "Account connected",
-  "slack.agent.account_unlinked": "Account disconnected",
-  "slack.agent.default_project_set": "Default project set",
-  "slack.agent.channel_binding_created": "Channel bound",
-  "slack.agent.channel_binding_removed": "Channel unbound",
-  "slack.agent.capabilities_updated": "Capabilities updated",
-};
-
-function readString(
-  metadata: Record<string, unknown> | null,
-  key: string
-): string | null {
-  const value = metadata?.[key];
-  return typeof value === "string" && value ? value : null;
-}
-
-function actorLabel(event: SlackAgentActivityEvent): string {
-  if (event.actorEmail) return event.actorEmail;
-  const surfaceId =
-    readString(event.metadata, "executorSurfaceUserId") ??
-    readString(event.metadata, "proposerSurfaceUserId") ??
-    readString(event.metadata, "slackUserId");
-  // A surface id with no MCPJam identity is a real state (the legacy
-  // workspace runs on a shared key), so it is shown rather than blanked.
-  return surfaceId ? `Slack ${surfaceId}` : "MCPJam";
-}
-
-function detailLabel(event: SlackAgentActivityEvent): string {
-  const operation = readString(event.metadata, "operation");
-  if (operation) return operation;
-  const channelId = readString(event.metadata, "channelId");
-  if (channelId) return channelId;
-  return event.targetId;
-}
-
-function statusFor(
-  event: SlackAgentActivityEvent
-): { label: string; variant: "default" | "secondary" | "destructive" } | null {
-  if (event.action === "slack.agent.proposal_created") {
-    return { label: "Proposed", variant: "secondary" };
-  }
-  if (event.action !== "slack.agent.proposal_executed") return null;
-  const status = readString(event.metadata, "status");
-  if (status === "failed") return { label: "Failed", variant: "destructive" };
-  return { label: "Succeeded", variant: "default" };
-}
 
 interface SlackActivityTabProps {
   organizationId: string;
 }
 
 export function SlackActivityTab({ organizationId }: SlackActivityTabProps) {
-  const { isAuthenticated } = useConvexAuth();
-  const {
-    events,
-    isLoading,
-    isLoadingMore,
-    hasMore,
-    error,
-    refresh,
-    loadMore,
-  } = useSlackAgentActivity({ organizationId, isAuthenticated });
-
-  const rows = useMemo(
-    () =>
-      events.map((event) => ({
-        event,
-        action: ACTION_LABELS[event.action] ?? event.action,
-        actor: actorLabel(event),
-        proposer: readString(event.metadata, "proposerSurfaceUserId"),
-        detail: detailLabel(event),
-        status: statusFor(event),
-        runUrl: readString(event.metadata, "resourceUrl"),
-      })),
-    [events]
-  );
-
-  // Only when there is nothing to show. A failed "Load more" keeps the rows it
-  // already has, and replacing the whole feed with an alert would take away
-  // what the admin was reading over a transient page fetch — so that case is
-  // surfaced beside the button instead, with a retry.
-  if (error && rows.length === 0) {
-    return (
-      <div className="space-y-3">
-        <p
-          className="rounded-md border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive"
-          role="alert"
-        >
-          Could not load activity. Try again in a moment.
-        </p>
-        <Button variant="outline" onClick={() => void refresh()}>
-          Try again
-        </Button>
-      </div>
-    );
-  }
-
-  if (isLoading && rows.length === 0) {
-    return (
-      <div className="px-4 py-8 text-sm text-muted-foreground">Loading…</div>
-    );
-  }
-
-  if (rows.length === 0) {
-    return (
-      <div className="space-y-2 px-4 py-8 text-sm text-muted-foreground">
-        <p>
-          Nothing yet. Activity appears here when someone uses the MCPJam agent
-          in Slack — every proposal the agent makes, and every approval that
-          runs one.
-        </p>
-      </div>
-    );
-  }
-
   return (
-    <div className="space-y-4">
-      <div className="overflow-x-auto">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>When</TableHead>
-              <TableHead>Event</TableHead>
-              <TableHead>Who</TableHead>
-              <TableHead>Detail</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Run</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {rows.map((row) => (
-              <TableRow
-                key={row.event._id}
-                data-testid={`activity-${row.event.action}`}
-              >
-                <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
-                  {new Date(row.event.timestamp).toLocaleString()}
-                </TableCell>
-                <TableCell className="text-sm">{row.action}</TableCell>
-                <TableCell className="text-sm">
-                  <div className="flex flex-col">
-                    <span>{row.actor}</span>
-                    {/* Proposing costs nothing; approving spends. When the two
-                        are different people, that difference is the whole
-                        point of the approval record. */}
-                    {row.event.action === "slack.agent.proposal_executed" &&
-                    row.proposer ? (
-                      <span className="text-xs text-muted-foreground">
-                        proposed by Slack {row.proposer}
-                      </span>
-                    ) : null}
-                  </div>
-                </TableCell>
-                <TableCell className="font-mono text-xs">
-                  {row.detail}
-                </TableCell>
-                <TableCell>
-                  {row.status ? (
-                    <Badge variant={row.status.variant}>
-                      {row.status.label}
-                    </Badge>
-                  ) : null}
-                </TableCell>
-                <TableCell>
-                  {row.runUrl ? (
-                    <a
-                      className="text-sm underline underline-offset-2 hover:text-foreground"
-                      href={row.runUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Open
-                    </a>
-                  ) : null}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-
-      {error ? (
-        <p className="text-sm text-destructive" role="alert">
-          Could not load more activity. Try again in a moment.
-        </p>
-      ) : null}
-
-      {hasMore ? (
-        <Button
-          variant="outline"
-          disabled={isLoadingMore}
-          onClick={() => void loadMore()}
-        >
-          {isLoadingMore ? "Loading…" : "Load more"}
-        </Button>
-      ) : null}
-    </div>
+    <SurfaceActivityTab organizationId={organizationId} surfaceKind="slack" />
   );
 }

--- a/mcpjam-inspector/client/src/components/organization/slack/SlackAgentSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/slack/SlackAgentSettingsSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
-import { cn } from "@/lib/utils";
 import { useSlackAgentSettingsEnabled } from "@/hooks/useSlackAgentSettingsEnabled";
+import { SurfaceSettingsTabs } from "../surface/SurfaceSettingsTabs";
 import { SlackConnectionsTab } from "./SlackConnectionsTab";
 import { SlackCapabilitiesTab } from "./SlackCapabilitiesTab";
 import { SlackActivityTab } from "./SlackActivityTab";
@@ -71,52 +71,15 @@ export function SlackAgentSettingsSection({
 
   if (!enabled) return null;
 
-  const active = SLACK_SETTINGS_TABS.find((entry) => entry.id === activeTab)!;
-
   return (
     <div className="space-y-6" data-testid="slack-agent-settings">
-      <div
-        className="flex items-end gap-1 border-b border-border/60"
-        role="tablist"
-        aria-label="Slack agent settings"
+      <SurfaceSettingsTabs
+        tabs={SLACK_SETTINGS_TABS}
+        activeTab={activeTab}
+        onTabChange={handleTabChange}
+        idPrefix="slack-settings"
+        ariaLabel="Slack agent settings"
       >
-        {SLACK_SETTINGS_TABS.map((entry) => (
-          <button
-            key={entry.id}
-            type="button"
-            role="tab"
-            id={`slack-settings-tab-${entry.id}`}
-            // Only the ACTIVE tab's panel is mounted, so only the active tab
-            // gets an `aria-controls`. Pointing the other two at ids that are
-            // not in the document gives a screen reader a target it cannot
-            // move to, which is worse than the attribute being absent.
-            aria-controls={
-              entry.id === activeTab
-                ? `slack-settings-panel-${entry.id}`
-                : undefined
-            }
-            aria-selected={entry.id === activeTab}
-            onClick={() => handleTabChange(entry.id)}
-            className={cn(
-              "-mb-px shrink-0 border-b-2 px-3 py-2.5 text-sm font-medium transition-colors sm:px-4",
-              entry.id === activeTab
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground"
-            )}
-          >
-            {entry.label}
-          </button>
-        ))}
-      </div>
-
-      <div
-        role="tabpanel"
-        id={`slack-settings-panel-${activeTab}`}
-        aria-labelledby={`slack-settings-tab-${activeTab}`}
-        className="space-y-6"
-      >
-        <p className="text-sm text-muted-foreground">{active.description}</p>
-
         {activeTab === "connections" ? (
           <SlackConnectionsTab
             organizationId={organizationId}
@@ -130,7 +93,7 @@ export function SlackAgentSettingsSection({
         ) : (
           <SlackActivityTab organizationId={organizationId} />
         )}
-      </div>
+      </SurfaceSettingsTabs>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/organization/surface/SurfaceActivityTab.tsx
+++ b/mcpjam-inspector/client/src/components/organization/surface/SurfaceActivityTab.tsx
@@ -1,0 +1,298 @@
+import { useMemo } from "react";
+import { useConvexAuth } from "convex/react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@mcpjam/design-system/table";
+import {
+  useSlackAgentActivity,
+  type SlackAgentActivityEvent,
+} from "@/hooks/useSlackAgentActivity";
+import type { SurfaceKind } from "@/hooks/useOrgSlackSettings";
+
+/**
+ * Activity: what the agent proposed, who approved it, and how it went.
+ *
+ * READ-ONLY, and backed by `auditEvents` rather than the proposals table —
+ * that one is swept on a 1-hour TTL and deletes terminal rows, so a feed built
+ * on it would lose exactly the outcomes an admin came here to see.
+ *
+ * The rows carry surface ids (a Slack user id, a Discord user id) and, when
+ * the person had linked their account at the time, an MCPJam identity. Both
+ * are shown: the email is what a reader recognises, and the surface id is what
+ * they can search for when there is no email to show.
+ *
+ * SURFACE-FILTERED, WHICH IS A FIX AND NOT ONLY A GENERALIZATION. The backing
+ * query (`slackAgentActivity:listByOrganization`) matches on
+ * `ACTION_PREFIXES = ['slack.agent.', 'discord.agent.']` and always returned
+ * both. This tab did no filtering and looked its labels up by the FULL action
+ * string, so once #916 started emitting `discord.agent.*` a Discord row landed
+ * in the Slack tab rendered as a raw `discord.agent.channel_binding_created`
+ * and attributed to "Slack <a discord user id>". Labels are now keyed by the
+ * suffix, shared across both surfaces, and each tab shows only its own rows.
+ *
+ * Filtering is client-side because the query takes no `surfaceKind` argument.
+ * Adding one is a backend change, and doing it there would make this PR wait
+ * on a backend deploy for a label bug. The cost is that one page can be all
+ * one surface, which is why the empty state keeps "Load more" — see below.
+ */
+
+/** Keyed by the part after `<surface>.agent.`, so both surfaces share it. */
+const ACTION_LABELS: Record<string, string> = {
+  proposal_created: "Proposed",
+  proposal_executed: "Approved & ran",
+  account_linked: "Account connected",
+  account_unlinked: "Account disconnected",
+  default_project_set: "Default project set",
+  channel_binding_created: "Channel bound",
+  channel_binding_removed: "Channel unbound",
+  capabilities_updated: "Capabilities updated",
+};
+
+interface SurfaceActivityCopy {
+  /** How the surface is named in prose and in actor labels. */
+  label: string;
+  /** Where the agent is used, for the empty state. */
+  emptyState: string;
+}
+
+const SURFACE_COPY: Record<SurfaceKind, SurfaceActivityCopy> = {
+  slack: {
+    label: "Slack",
+    emptyState:
+      "Nothing yet. Activity appears here when someone uses the MCPJam agent in Slack — every proposal the agent makes, and every approval that runs one.",
+  },
+  discord: {
+    label: "Discord",
+    emptyState:
+      "Nothing yet. Activity appears here when someone uses the MCPJam agent in Discord — every proposal the agent makes, and every approval that runs one.",
+  },
+};
+
+/** `slack.agent.proposal_created` → `proposal_created`. */
+function actionSuffix(action: string): string {
+  const marker = ".agent.";
+  const at = action.indexOf(marker);
+  return at === -1 ? action : action.slice(at + marker.length);
+}
+
+function readString(
+  metadata: Record<string, unknown> | null,
+  key: string
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value ? value : null;
+}
+
+function actorLabel(
+  event: SlackAgentActivityEvent,
+  surfaceLabel: string
+): string {
+  if (event.actorEmail) return event.actorEmail;
+  const surfaceId =
+    readString(event.metadata, "executorSurfaceUserId") ??
+    readString(event.metadata, "proposerSurfaceUserId") ??
+    readString(event.metadata, "slackUserId");
+  // A surface id with no MCPJam identity is a real state (the legacy
+  // workspace runs on a shared key), so it is shown rather than blanked.
+  return surfaceId ? `${surfaceLabel} ${surfaceId}` : "MCPJam";
+}
+
+function detailLabel(event: SlackAgentActivityEvent): string {
+  const operation = readString(event.metadata, "operation");
+  if (operation) return operation;
+  const channelId = readString(event.metadata, "channelId");
+  if (channelId) return channelId;
+  return event.targetId;
+}
+
+function statusFor(
+  event: SlackAgentActivityEvent
+): { label: string; variant: "default" | "secondary" | "destructive" } | null {
+  const suffix = actionSuffix(event.action);
+  if (suffix === "proposal_created") {
+    return { label: "Proposed", variant: "secondary" };
+  }
+  if (suffix !== "proposal_executed") return null;
+  const status = readString(event.metadata, "status");
+  if (status === "failed") return { label: "Failed", variant: "destructive" };
+  return { label: "Succeeded", variant: "default" };
+}
+
+interface SurfaceActivityTabProps {
+  organizationId: string;
+  surfaceKind: SurfaceKind;
+}
+
+export function SurfaceActivityTab({
+  organizationId,
+  surfaceKind,
+}: SurfaceActivityTabProps) {
+  const { isAuthenticated } = useConvexAuth();
+  const copy = SURFACE_COPY[surfaceKind];
+  const {
+    events,
+    isLoading,
+    isLoadingMore,
+    hasMore,
+    error,
+    refresh,
+    loadMore,
+  } = useSlackAgentActivity({ organizationId, isAuthenticated });
+
+  const rows = useMemo(() => {
+    const prefix = `${surfaceKind}.agent.`;
+    return events
+      .filter((event) => event.action.startsWith(prefix))
+      .map((event) => {
+        const suffix = actionSuffix(event.action);
+        return {
+          event,
+          suffix,
+          // Falls back to the raw action so an action this build has no label
+          // for is still legible rather than blank.
+          action: ACTION_LABELS[suffix] ?? event.action,
+          actor: actorLabel(event, copy.label),
+          proposer: readString(event.metadata, "proposerSurfaceUserId"),
+          detail: detailLabel(event),
+          status: statusFor(event),
+          runUrl: readString(event.metadata, "resourceUrl"),
+        };
+      });
+  }, [events, surfaceKind, copy.label]);
+
+  const loadMoreButton = hasMore ? (
+    <Button
+      variant="outline"
+      disabled={isLoadingMore}
+      onClick={() => void loadMore()}
+    >
+      {isLoadingMore ? "Loading…" : "Load more"}
+    </Button>
+  ) : null;
+
+  // Only when there is nothing to show. A failed "Load more" keeps the rows it
+  // already has, and replacing the whole feed with an alert would take away
+  // what the admin was reading over a transient page fetch — so that case is
+  // surfaced beside the button instead, with a retry.
+  if (error && rows.length === 0) {
+    return (
+      <div className="space-y-3">
+        <p
+          className="rounded-md border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+          role="alert"
+        >
+          Could not load activity. Try again in a moment.
+        </p>
+        <Button variant="outline" onClick={() => void refresh()}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  if (isLoading && rows.length === 0) {
+    return (
+      <div className="px-4 py-8 text-sm text-muted-foreground">Loading…</div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="space-y-4 px-4 py-8 text-sm text-muted-foreground">
+        {/* "Load more" survives the empty state on purpose. Because the feed
+            is filtered client-side, a page can be entirely the other surface
+            — an org that uses Slack heavily and Discord once would see
+            "Nothing yet" on Discord with its one row still a page away.
+            Without the button that reads as "no activity", which is wrong. */}
+        <p>
+          {hasMore
+            ? `${copy.emptyState} Older events may be further back.`
+            : copy.emptyState}
+        </p>
+        {loadMoreButton}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>When</TableHead>
+              <TableHead>Event</TableHead>
+              <TableHead>Who</TableHead>
+              <TableHead>Detail</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Run</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow
+                key={row.event._id}
+                data-testid={`activity-${row.event.action}`}
+              >
+                <TableCell className="whitespace-nowrap text-xs text-muted-foreground">
+                  {new Date(row.event.timestamp).toLocaleString()}
+                </TableCell>
+                <TableCell className="text-sm">{row.action}</TableCell>
+                <TableCell className="text-sm">
+                  <div className="flex flex-col">
+                    <span>{row.actor}</span>
+                    {/* Proposing costs nothing; approving spends. When the two
+                        are different people, that difference is the whole
+                        point of the approval record. */}
+                    {row.suffix === "proposal_executed" && row.proposer ? (
+                      <span className="text-xs text-muted-foreground">
+                        proposed by {copy.label} {row.proposer}
+                      </span>
+                    ) : null}
+                  </div>
+                </TableCell>
+                <TableCell className="font-mono text-xs">
+                  {row.detail}
+                </TableCell>
+                <TableCell>
+                  {row.status ? (
+                    <Badge variant={row.status.variant}>
+                      {row.status.label}
+                    </Badge>
+                  ) : null}
+                </TableCell>
+                <TableCell>
+                  {row.runUrl ? (
+                    <a
+                      className="text-sm underline underline-offset-2 hover:text-foreground"
+                      href={row.runUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Open
+                    </a>
+                  ) : null}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-destructive" role="alert">
+          Could not load more activity. Try again in a moment.
+        </p>
+      ) : null}
+
+      {loadMoreButton}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/organization/surface/SurfaceSettingsTabs.tsx
+++ b/mcpjam-inspector/client/src/components/organization/surface/SurfaceSettingsTabs.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The tab strip shared by the Slack and Discord org settings sections.
+ *
+ * Extracted rather than copied because the interesting part is the
+ * accessibility detail, not the layout: only the ACTIVE tab's panel is
+ * mounted, so only the active tab may carry `aria-controls` — pointing the
+ * others at ids that are not in the document gives a screen reader a target
+ * it cannot move to, which is worse than the attribute being absent. That is
+ * exactly the kind of rule a second hand-written copy loses.
+ *
+ * Generic over the tab id so each caller keeps its own literal union and
+ * `onTabChange` stays typed end to end.
+ */
+
+export interface SurfaceSettingsTab<Id extends string> {
+  id: Id;
+  label: string;
+  description: string;
+}
+
+interface SurfaceSettingsTabsProps<Id extends string> {
+  tabs: readonly SurfaceSettingsTab<Id>[];
+  activeTab: Id;
+  onTabChange: (tab: Id) => void;
+  /** `slack-settings` → `slack-settings-tab-connections`. */
+  idPrefix: string;
+  /** Names the tablist for screen readers, e.g. "Slack agent settings". */
+  ariaLabel: string;
+  children: ReactNode;
+}
+
+export function SurfaceSettingsTabs<Id extends string>({
+  tabs,
+  activeTab,
+  onTabChange,
+  idPrefix,
+  ariaLabel,
+  children,
+}: SurfaceSettingsTabsProps<Id>) {
+  const active = tabs.find((entry) => entry.id === activeTab);
+
+  return (
+    <>
+      <div
+        className="flex items-end gap-1 border-b border-border/60"
+        role="tablist"
+        aria-label={ariaLabel}
+      >
+        {tabs.map((entry) => (
+          <button
+            key={entry.id}
+            type="button"
+            role="tab"
+            id={`${idPrefix}-tab-${entry.id}`}
+            aria-controls={
+              entry.id === activeTab
+                ? `${idPrefix}-panel-${entry.id}`
+                : undefined
+            }
+            aria-selected={entry.id === activeTab}
+            onClick={() => onTabChange(entry.id)}
+            className={cn(
+              "-mb-px shrink-0 border-b-2 px-3 py-2.5 text-sm font-medium transition-colors sm:px-4",
+              entry.id === activeTab
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {entry.label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={`${idPrefix}-panel-${activeTab}`}
+        aria-labelledby={`${idPrefix}-tab-${activeTab}`}
+        className="space-y-6"
+      >
+        {active ? (
+          <p className="text-sm text-muted-foreground">{active.description}</p>
+        ) : null}
+        {children}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## A live mislabel, not just a missing tab

The activity feed's backing query matches on
`ACTION_PREFIXES = ['slack.agent.', 'discord.agent.']` and has **always
returned both**. `SlackActivityTab` did no surface filtering and looked its
labels up by the full action string:

```ts
action: ACTION_LABELS[event.action] ?? event.action,
```

So once MCPJam/mcpjam-backend#916 started emitting `discord.agent.*`, a Discord
row rendered **in the Slack tab** as a raw
`discord.agent.channel_binding_created`, attributed to
`Slack <a discord user id>`. Latent until that backend reaches prod — which is
the next step on the Discord rollout, so this lands ahead of it.

Fixing it properly is also the UX parity ask: filter per surface, key the
labels by suffix so both surfaces share one map, and Discord gets the tab it
was missing.

## What is now shared

- **`SurfaceActivityTab`** — the feed, parameterized by surface. Labels keyed
  by the part after `<surface>.agent.`; actor prefix and empty-state copy come
  from one `SURFACE_COPY` table, matching what `SurfaceConnectionsTab` already
  does.
- **`SurfaceSettingsTabs`** — the tab strip. Extracted rather than copied
  because the interesting part is an accessibility rule, not layout: only the
  active tab's panel is mounted, so only the active tab may carry
  `aria-controls` — pointing the others at ids that aren't in the document
  gives a screen reader a target it cannot move to. That's exactly what a
  second hand-written copy loses.
- **`SlackActivityTab`** is now a thin wrapper, matching `SlackConnectionsTab`,
  so `SlackAgentSettingsSection` and its 21 existing tests import the same name
  and pass unchanged.

Discord's section goes from one view to **Connections + Activity**, with
`?tab=` wired through `OrganizationsTab` the same way Slack's is. One `?tab=`
param, resolved per section — each resolver falls back to its own Connections,
so a Slack tab id carried onto a Discord URL lands somewhere real.

## Capabilities is still deliberately absent

Not an oversight, and documented in-file. `orgAgentCapabilityPolicies` is a
single org-wide row read with `surfaceKind: 'slack'` by every caller. A Discord
tab would render a second control over that same row and imply the two can
differ. Making the policy per-surface changes how an existing live Slack
control behaves, so it belongs in a change that is *about* capability policy.

## Client-side filtering, and the one place it shows

The query takes no `surfaceKind` argument. Adding one is a backend change, and
this PR would then wait on a backend deploy to fix a label bug — so the filter
is client-side.

The one visible consequence: a page can be entirely the other surface, so a
Discord tab could show "Nothing yet" with its one row still a page away.
**"Load more" therefore survives the empty state**, which is a real difference
from the old component and has its own test.

## Tests

**5 for the feed** — surface filtering (the regression), shared label map,
actor attribution, and both empty-state/`Load more` cases.

**5 for the Discord tab strip** — tab set with no Capabilities, default tab,
activity panel gets the right surface, unknown tab id falls back, selection
reported to the caller.

**4 for `SurfaceSettingsTabs`.** These exist because I checked what Slack's
21 existing tests actually assert, and they never touch the tablist, the ids,
or `aria-controls` — so "Slack's tests still pass" was *not* evidence that the
extraction preserved the accessibility rule it was extracted to protect. The
new file asserts it directly: the inactive tab has no `aria-controls`, and the
panel it would have pointed at is genuinely absent from the document.

**Both fixes verified non-vacuous:**

- remove the surface filter → "shows only the requested surface's rows" fails,
  with the Discord row appearing in the Slack tab. That is the shipped bug,
  reproduced.
- make `aria-controls` unconditional → the a11y test fails.

Slack's 21 section tests pass untouched. **8,162 client tests green**,
typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9304e1008a68dca5e9252da18629fe83bc7f04a4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters activity per surface and shares a single settings tab strip across Slack and Discord. Discord gains an Activity tab; Slack’s Activity now wraps a shared feed, and `?tab=` routing is unified per section.

- New Features
  - Added `SurfaceActivityTab`: shared feed with labels keyed by action suffix, per-surface copy, and correct actor attribution; used by Slack and Discord.
  - Added `SurfaceSettingsTabs`: shared, accessible tab strip (only active tab has `aria-controls`); `OrganizationsTab` resolves one `?tab=` for both surfaces; Discord section supports tab changes.
  - Capabilities intentionally excluded from Discord (policy is org-wide, not per-surface).

- Bug Fixes
  - Activity feed now filters by surface, so Slack no longer shows Discord rows.
  - Keeps “Load more” on empty filtered pages to reach older cross-surface pages.
  - Added tests for surface filtering, label/actor correctness, Discord tab defaults/fallbacks, and tabstrip a11y.

<sup>Written for commit 9304e1008a68dca5e9252da18629fe83bc7f04a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

