### PR TITLE
feat(plugins): chatbox plugin provenance, worker plugin read tools, httpVariant transport mapping (Track A)

### DIFF
--- a/cli/src/lib/op-bindings.ts
+++ b/cli/src/lib/op-bindings.ts
@@ -91,6 +91,14 @@ export const CLI_BINDINGS: Readonly<Record<string, CliBinding>> = {
   update_project_environment: { command: "environments update" },
   archive_project_environment: { command: "environments archive" },
   restore_project_environment: { command: "environments restore" },
+  list_project_plugins: {
+    excluded:
+      "No `plugins` command group yet — the read surface shipped for the MCP catalog and API first. Bind both plugin reads together when the CLI grows one.",
+  },
+  get_plugin_version: {
+    excluded:
+      "No `plugins` command group yet — the read surface shipped for the MCP catalog and API first. Bind both plugin reads together when the CLI grows one.",
+  },
   list_sandbox_images: { command: "images list" },
   get_sandbox_image: { command: "images get" },
   create_sandbox_image: { command: "images create" },

--- a/docs/reference/openapi.json
+++ b/docs/reference/openapi.json
@@ -30,6 +30,10 @@
       "description": "Project environments: named, live-editable execution bundles (one host, an optional standalone server group, optionally pinned skills and plugin versions) that eval suites and journeys run against. Distinct from Sandbox images, which are Computer base images. Reads require project membership; every write requires project admin."
     },
     {
+      "name": "Plugins",
+      "description": "Agent Plugins imported into a project — read-only inventory and version detail."
+    },
+    {
       "name": "Sandbox images",
       "description": "Custom Computer images: a digest-pinned Dockerfile built into an immutable image your project's computers boot from."
     },
@@ -4019,6 +4023,102 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
+          }
+        }
+      }
+    },
+    "/projects/{projectId}/plugins": {
+      "get": {
+        "operationId": "listProjectPlugins",
+        "tags": [
+          "Plugins"
+        ],
+        "summary": "List a project's plugins",
+        "description": "The live (installed, non-uninstalled) Agent Plugins in the project, disabled ones included (marked `enabled: false`). Read-only: import, activation, enable/disable and uninstall are app flows, not API operations.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/projectId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The project's plugins.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginPage"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "502": {
+            "$ref": "#/components/responses/ServerUnreachable"
+          }
+        }
+      }
+    },
+    "/plugin-versions/{pluginVersionId}": {
+      "get": {
+        "operationId": "getPluginVersion",
+        "tags": [
+          "Plugins"
+        ],
+        "summary": "Get a plugin version",
+        "description": "One imported plugin version with its component projections: declared MCP servers (placement, auth timing, materialized server id) and declared skills (namespaced model refs). Addressed by the version id alone — access is membership of the version's own project, and historical versions of uninstalled plugins stay readable because eval snapshots and stale environment pins reference them.",
+        "parameters": [
+          {
+            "name": "pluginVersionId",
+            "in": "path",
+            "required": true,
+            "description": "A plugin's `activeVersionId` from the list endpoint, or a pinned id from an environment's `pluginVersionIds`.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The plugin version.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginVersion"
+                }
+              }
+            }
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -8499,6 +8599,216 @@
             "items": {
               "$ref": "#/components/schemas/ProjectEnvironment"
             }
+          }
+        }
+      },
+      "Plugin": {
+        "type": "object",
+        "description": "An Agent Plugin (agent-plugins.org bundle) imported into a project. Versions materialize MCP servers and skills; environments pin version ids to run them.",
+        "required": [
+          "id",
+          "projectId",
+          "name",
+          "enabled",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "projectId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "description": "Normalized plugin name — the namespace its skills load under."
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Disabled plugins keep their versions but resolve for no run."
+          },
+          "activeVersionId": {
+            "type": "string",
+            "description": "The version environment pins default to. Absent before the first activation."
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "updatedAt": {
+            "type": "number"
+          }
+        }
+      },
+      "PluginPage": {
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Plugin"
+            }
+          }
+        }
+      },
+      "PluginVersion": {
+        "type": "object",
+        "description": "One immutable imported plugin version with its component projections.",
+        "required": [
+          "id",
+          "pluginId",
+          "bundleHash",
+          "status",
+          "componentCounts",
+          "servers",
+          "skills",
+          "createdAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "pluginId": {
+            "type": "string"
+          },
+          "declaredVersion": {
+            "type": "string",
+            "description": "`manifest.version` — metadata only; `bundleHash` is the identity."
+          },
+          "bundleHash": {
+            "type": "string"
+          },
+          "manifestHash": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "staging",
+              "ready",
+              "invalid"
+            ],
+            "description": "Only `ready` versions resolve at runtime."
+          },
+          "componentCounts": {
+            "type": "object",
+            "description": "Per-component tallies. `apps` counts preserved `.app.json` metadata entries only (no runtime effect).",
+            "required": [
+              "skills",
+              "servers",
+              "apps",
+              "assets",
+              "unsupported"
+            ],
+            "properties": {
+              "skills": {
+                "type": "number"
+              },
+              "servers": {
+                "type": "number"
+              },
+              "apps": {
+                "type": "number"
+              },
+              "assets": {
+                "type": "number"
+              },
+              "unsupported": {
+                "type": "number"
+              }
+            }
+          },
+          "servers": {
+            "type": "array",
+            "description": "Declared MCP server components, with the project server row each one materialized as.",
+            "items": {
+              "type": "object",
+              "required": [
+                "componentId",
+                "componentKey",
+                "declaredName",
+                "placement",
+                "authenticationPolicy",
+                "materializedServerId"
+              ],
+              "properties": {
+                "componentId": {
+                  "type": "string"
+                },
+                "componentKey": {
+                  "type": "string"
+                },
+                "declaredName": {
+                  "type": "string"
+                },
+                "placement": {
+                  "type": "string",
+                  "enum": [
+                    "remote",
+                    "local",
+                    "computer"
+                  ],
+                  "description": "Where the component can execute; `local`/`computer` components never run on MCPJam hosted servers."
+                },
+                "authenticationPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "on_install",
+                    "on_use"
+                  ]
+                },
+                "materializedServerId": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "skills": {
+            "type": "array",
+            "description": "Declared skill components, with the project skill row each one materialized as.",
+            "items": {
+              "type": "object",
+              "required": [
+                "componentId",
+                "componentKey",
+                "declaredName",
+                "modelRef",
+                "materializedSkillId"
+              ],
+              "properties": {
+                "componentId": {
+                  "type": "string"
+                },
+                "componentKey": {
+                  "type": "string"
+                },
+                "declaredName": {
+                  "type": "string"
+                },
+                "modelRef": {
+                  "type": "string",
+                  "description": "Namespaced model-facing reference: `<plugin-name>/<skill-name>`."
+                },
+                "materializedSkillId": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "createdAt": {
+            "type": "number"
+          },
+          "readyAt": {
+            "type": "number"
           }
         }
       },

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -64,6 +64,8 @@ so results respect the caller's project access.
 | `list_project_environments` | List the project environments in an MCPJam project. | — |
 | `get_project_environment` | Show one project environment: its host, optional standalone server group, pinned skill selection, pinned plugin versions, and its current `revision` (which you pass as `expectedRevision` when updating it). | — |
 | `resolve_project_environment` | Resolve a project environment to the exact execution inputs a run would use right now: the host's current config, the closed server set (including servers contributed by pinned plugin versions), and the resolved plugin versions. | — |
+| `list_project_plugins` | List the live Agent Plugins installed in a project: name, display name, enabled state, and active version id. | — |
+| `get_plugin_version` | Show one imported plugin version: status, component counts, and per-component summaries (servers with placement and auth timing, skills with their namespaced refs). | — |
 | `list_chatboxes` | List the chatboxes published from an MCPJam project: name, access mode, attached servers, and share link. | ✅ |
 | `get_chatbox` | Get one chatbox's read-only settings: model, system prompt, temperature, tool-approval policy, and resolved servers. | ✅ |
 | `list_chat_sessions` | List chat sessions visible to the caller, most recent activity first. | — |

--- a/mcp/src/tools/platformTools.ts
+++ b/mcp/src/tools/platformTools.ts
@@ -27,6 +27,7 @@ import {
   getEvalRunStepsOperation,
   getEvalSuiteOperation,
   getEnvironmentOperation,
+  getPluginVersionOperation,
   getProjectServerOperation,
   getServerPromptOperation,
   isPlatformApiError,
@@ -37,6 +38,7 @@ import {
   listEvalSuiteRunsOperation,
   listEvalSuitesOperation,
   listEnvironmentsOperation,
+  listProjectPluginsOperation,
   listProjectsOperation,
   listProjectServersOperation,
   listServerPromptsOperation,
@@ -111,6 +113,11 @@ export const PLATFORM_CATALOG_OPERATIONS: ReadonlyArray<
   listEnvironmentsOperation,
   getEnvironmentOperation,
   resolveEnvironmentOperation,
+  // Agent Plugins: the READ half only. Every plugin write (import, activate,
+  // enable/disable, uninstall) stays off this unattended surface by policy —
+  // there is no excluded write operation to list because the SDK ships none.
+  listProjectPluginsOperation,
+  getPluginVersionOperation,
   listChatboxesOperation,
   getChatboxOperation,
   listChatSessionsOperation,

--- a/mcp/tests/platformTools.test.ts
+++ b/mcp/tests/platformTools.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ALL_OPERATIONS, listProjectsOperation } from "@mcpjam/sdk/platform";
+import {
+  ALL_OPERATIONS,
+  getPluginVersionOperation,
+  listProjectPluginsOperation,
+  listProjectsOperation,
+} from "@mcpjam/sdk/platform";
 import {
   EXCLUDED_FROM_CATALOG,
   PLATFORM_CATALOG_OPERATIONS,
@@ -122,6 +127,9 @@ const PLAIN_TOOLS = [
   "list_project_environments",
   "get_project_environment",
   "resolve_project_environment",
+  // Agent Plugins reads: agent-oriented payloads, no widget view.
+  "list_project_plugins",
+  "get_plugin_version",
   "get_eval_iteration_trace",
   "get_eval_run_steps",
   "cancel_eval_run",
@@ -237,6 +245,8 @@ describe("platform tool registration", () => {
       "list_project_environments",
       "get_project_environment",
       "resolve_project_environment",
+      "list_project_plugins",
+      "get_plugin_version",
       "list_chatboxes",
       "get_chatbox",
       "list_chat_sessions",
@@ -371,6 +381,70 @@ describe("widget payload tagging", () => {
     expect(result.isError).toBeUndefined();
     expect(result.structuredContent?.widget).toBe("servers");
     expect(result.structuredContent?.servers).toEqual([]);
+  });
+});
+
+describe("plugin read tools", () => {
+  it("list_project_plugins resolves the project and returns the live plugins", async () => {
+    const pluginsPage = {
+      items: [
+        {
+          id: "plugin-1",
+          projectId: "project-1",
+          name: "linear-tools",
+          displayName: "Linear Tools",
+          enabled: true,
+          activeVersionId: "pv-1",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    };
+    stubPlatformFetch({
+      "/projects": PROJECTS_PAGE,
+      "/projects/project-1/plugins": pluginsPage,
+    });
+
+    const result = (await runPlatformOperation(
+      fakeToolContext({ bearerToken: "user-jwt" }),
+      listProjectPluginsOperation,
+      {}
+    )) as ToolResult;
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toMatchObject({
+      project: { id: "project-1" },
+      items: pluginsPage.items,
+    });
+  });
+
+  it("get_plugin_version returns the version detail by raw id", async () => {
+    const version = {
+      id: "pv-1",
+      pluginId: "plugin-1",
+      bundleHash: "hash-abc",
+      status: "ready",
+      componentCounts: {
+        skills: 1,
+        servers: 1,
+        apps: 0,
+        assets: 0,
+        unsupported: 0,
+      },
+      servers: [],
+      skills: [],
+      createdAt: 1,
+    };
+    stubPlatformFetch({ "/plugin-versions/pv-1": version });
+
+    const result = (await runPlatformOperation(
+      fakeToolContext({ bearerToken: "user-jwt" }),
+      getPluginVersionOperation,
+      { pluginVersionId: "pv-1" }
+    )) as ToolResult;
+
+    expect(result.isError).toBeUndefined();
+    expect(result.structuredContent).toEqual(version);
   });
 });
 

--- a/mcpjam-inspector/server/routes/v1/__tests__/plugins.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/plugins.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+// Covers the v1 AGENT PLUGINS read surface (server/routes/v1/plugins.ts):
+// auth + guest gating, the public DTO mapping (clean `id`, no Convex
+// `pluginId`/`pluginVersionId` field leak), the forwarded Convex args, and
+// the structured-ConvexError translation (NOT_FOUND and FORBIDDEN both 404,
+// so the route is never an existence oracle). Convex is mocked at the
+// `convex/browser` boundary — membership enforcement itself lives in
+// mcpjam-backend/convex/plugins.ts.
+
+const {
+  validateGuestTokenMock,
+  validateApiKeyMock,
+  resolveUserByExternalIdMock,
+  lookupWorkosKeyBindingMock,
+  convexQueryMock,
+} = vi.hoisted(() => ({
+  validateGuestTokenMock: vi.fn(),
+  validateApiKeyMock: vi.fn(),
+  resolveUserByExternalIdMock: vi.fn(),
+  lookupWorkosKeyBindingMock: vi.fn(),
+  convexQueryMock: vi.fn(),
+}));
+
+vi.mock("../../../services/guest-token.js", () => ({
+  validateGuestTokenDetailedAsync: validateGuestTokenMock,
+}));
+
+// WorkOS API-key seams — only reached by `sk_` bearers (none here), but the
+// auth middleware imports them at module load, so stub them out.
+vi.mock("../../../services/workos-client.js", () => ({
+  getWorkOSClient: () => ({
+    apiKeys: { createValidation: validateApiKeyMock },
+  }),
+}));
+vi.mock("../../../services/identity.js", () => ({
+  resolveUserByExternalId: resolveUserByExternalIdMock,
+}));
+vi.mock("../../../services/workos-key-bindings.js", () => ({
+  lookupWorkosKeyBinding: lookupWorkosKeyBindingMock,
+}));
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: vi.fn(),
+    query: convexQueryMock,
+  })),
+}));
+
+import v1Routes from "../index.js";
+
+function makeApp(): Hono {
+  const app = new Hono();
+  app.route("/api/v1", v1Routes);
+  return app;
+}
+
+function request(
+  path: string,
+  opts: { token?: string | null } = {}
+): Promise<Response> {
+  const { token = "tok" } = opts;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return Promise.resolve(makeApp().request(path, { method: "GET", headers }));
+}
+
+const PLUGIN_ROW = {
+  pluginId: "pl1",
+  projectId: "p1",
+  name: "linear-tools",
+  displayName: "Linear Tools",
+  description: "Linear helpers",
+  enabled: true,
+  activeVersionId: "pv1",
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+const VERSION_ROW = {
+  pluginVersionId: "pv1",
+  pluginId: "pl1",
+  declaredVersion: "1.2.0",
+  bundleHash: "hash-abc",
+  manifestHash: "hash-manifest",
+  status: "ready" as const,
+  componentCounts: { skills: 1, servers: 1, apps: 0, assets: 0, unsupported: 0 },
+  createdAt: 1,
+  readyAt: 2,
+  servers: [
+    {
+      componentId: "psc1",
+      componentKey: "server:linear",
+      declaredName: "linear",
+      placement: "remote" as const,
+      authenticationPolicy: "on_use" as const,
+      materializedServerId: "s1",
+    },
+  ],
+  skills: [
+    {
+      componentId: "pskc1",
+      componentKey: "skill:triage",
+      declaredName: "triage",
+      modelRef: "linear-tools/triage",
+      materializedSkillId: "sk1",
+    },
+  ],
+};
+
+/**
+ * A rejection shaped like a `ConvexError`: the structured `{ code, message }`
+ * rides on `.data`, which is what the route branches on.
+ */
+function convexError(code: string, message: string): Error {
+  const error = new Error(`Uncaught ConvexError: ${message}`);
+  (error as unknown as { data: unknown }).data = { code, message };
+  return error;
+}
+
+describe("v1 plugin routes", () => {
+  const originalConvexUrl = process.env.CONVEX_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_URL = "https://convex.example.com";
+    validateGuestTokenMock.mockResolvedValue({ valid: false });
+  });
+
+  afterEach(() => {
+    if (originalConvexUrl) process.env.CONVEX_URL = originalConvexUrl;
+    else delete process.env.CONVEX_URL;
+  });
+
+  describe("auth", () => {
+    it("rejects a request with no bearer token (401)", async () => {
+      const res = await request("/api/v1/projects/p1/plugins", { token: null });
+      expect(res.status).toBe(401);
+    });
+
+    it("denies guest callers — plugins are not on the guest allowlist (401)", async () => {
+      validateGuestTokenMock.mockResolvedValue({
+        valid: true,
+        guestId: "guest_1",
+      });
+      const res = await request("/api/v1/projects/p1/plugins", {
+        token: "guest-jwt",
+      });
+      expect(res.status).toBe(401);
+      expect(convexQueryMock).not.toHaveBeenCalled();
+    });
+
+    it("denies guest reads of a plugin version (401)", async () => {
+      validateGuestTokenMock.mockResolvedValue({
+        valid: true,
+        guestId: "guest_1",
+      });
+      const res = await request("/api/v1/plugin-versions/pv1", {
+        token: "guest-jwt",
+      });
+      expect(res.status).toBe(401);
+      expect(convexQueryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /projects/:projectId/plugins", () => {
+    it("lists plugins in the public DTO shape (clean id, no pluginId leak)", async () => {
+      convexQueryMock.mockResolvedValue([PLUGIN_ROW]);
+      const res = await request("/api/v1/projects/p1/plugins");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { items: Record<string, unknown>[] };
+      expect(body.items).toEqual([
+        {
+          id: "pl1",
+          projectId: "p1",
+          name: "linear-tools",
+          displayName: "Linear Tools",
+          description: "Linear helpers",
+          enabled: true,
+          activeVersionId: "pv1",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ]);
+      expect(convexQueryMock).toHaveBeenCalledWith(
+        "plugins:listProjectPlugins",
+        { projectId: "p1" }
+      );
+    });
+
+    it("omits the optional fields a sparse row does not carry", async () => {
+      convexQueryMock.mockResolvedValue([
+        {
+          pluginId: "pl2",
+          projectId: "p1",
+          name: "bare",
+          enabled: false,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ]);
+      const res = await request("/api/v1/projects/p1/plugins");
+      const body = (await res.json()) as { items: Record<string, unknown>[] };
+      expect(body.items[0]).toEqual({
+        id: "pl2",
+        projectId: "p1",
+        name: "bare",
+        enabled: false,
+        createdAt: 1,
+        updatedAt: 1,
+      });
+    });
+
+    it("maps a non-member FORBIDDEN to 404, not 403", async () => {
+      convexQueryMock.mockRejectedValue(
+        convexError("FORBIDDEN", "Not a member of this project")
+      );
+      const res = await request("/api/v1/projects/p1/plugins");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /plugin-versions/:pluginVersionId", () => {
+    it("returns the version detail in the public DTO shape", async () => {
+      convexQueryMock.mockResolvedValue(VERSION_ROW);
+      const res = await request("/api/v1/plugin-versions/pv1");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).toEqual({
+        id: "pv1",
+        pluginId: "pl1",
+        declaredVersion: "1.2.0",
+        bundleHash: "hash-abc",
+        manifestHash: "hash-manifest",
+        status: "ready",
+        componentCounts: {
+          skills: 1,
+          servers: 1,
+          apps: 0,
+          assets: 0,
+          unsupported: 0,
+        },
+        servers: VERSION_ROW.servers,
+        skills: VERSION_ROW.skills,
+        createdAt: 1,
+        readyAt: 2,
+      });
+      expect(convexQueryMock).toHaveBeenCalledWith("plugins:getPluginVersion", {
+        pluginVersionId: "pv1",
+      });
+    });
+
+    it("maps a missing version's NOT_FOUND to 404", async () => {
+      convexQueryMock.mockRejectedValue(
+        convexError("NOT_FOUND", "Plugin version not found")
+      );
+      const res = await request("/api/v1/plugin-versions/missing");
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
+++ b/mcpjam-inspector/server/routes/v1/__tests__/sdk-coverage.test.ts
@@ -102,6 +102,10 @@ const ROUTE_TO_SDK: Readonly<Record<string, string>> = {
   "post /projects/{projectId}/environments/{environmentId}/restore":
     "restoreEnvironment",
 
+  // Agent Plugins (read-only)
+  "get /projects/{projectId}/plugins": "listProjectPlugins",
+  "get /plugin-versions/{pluginVersionId}": "getPluginVersion",
+
   // Sandbox images
   "get /projects/{projectId}/images": "listImages",
   "post /projects/{projectId}/images": "createImage",

--- a/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
+++ b/mcpjam-inspector/server/routes/v1/agent-op-registry.ts
@@ -643,6 +643,14 @@ export const EXCLUDED_FROM_AGENT: Readonly<Record<string, string>> = {
   resolve_project_environment:
     "Resolution detail the agent has no use for; get_environment suffices.",
 
+  // Agent Plugins. Read-only inventory, shipped for the MCP catalog surface
+  // first; registering them here is a deliberate widening of the public
+  // agent's brief, to be made when plugin questions become a turn concern.
+  list_project_plugins:
+    "Plugin inventory is a setup/administration read, not a turn concern yet; exposed on the MCP catalog and public API.",
+  get_plugin_version:
+    "Plugin version detail is a setup/administration read, not a turn concern yet; exposed on the MCP catalog and public API.",
+
   // Sandbox images and computers: minutes-long builds and billable compute.
   list_sandbox_images:
     "Image lifecycle is an operator surface, exposed via the CLI.",

--- a/mcpjam-inspector/server/routes/v1/index.ts
+++ b/mcpjam-inspector/server/routes/v1/index.ts
@@ -25,6 +25,7 @@ import evals from "./evals.js";
 import hosts from "./hosts.js";
 import harness from "./harness.js";
 import environments from "./environments.js";
+import plugins from "./plugins.js";
 import journeys from "./journeys.js";
 import scenarios from "./scenarios.js";
 import sandboxImages from "./images.js";
@@ -77,6 +78,10 @@ v1.route("/", harness);
 // OFF the guest allowlist — reads need project membership and every write needs
 // project admin. Distinct from the Computer sandbox images below.
 v1.route("/", environments);
+// Agent Plugins — READ-ONLY (list + version detail). Guest-DENIED by default
+// (no GUEST_ALLOWED_V1_RULES entry): the Convex reads are member-gated
+// anyway, and there is no share-link flow that needs plugin inventory.
+v1.route("/", plugins);
 // Journeys + journey runs — the public API for Swarms. Flag-gated beta
 // (`sandboxes-enabled`, enforced server-side on writes), so these are absent
 // from the OpenAPI spec and from the MCP/agent/workspace catalogs until GA.

--- a/mcpjam-inspector/server/routes/v1/plugins.ts
+++ b/mcpjam-inspector/server/routes/v1/plugins.ts
@@ -1,0 +1,200 @@
+/**
+ * Public v1 Agent Plugins surface — READ-ONLY.
+ *
+ * A plugin is an agent-plugins.org bundle imported into a project; each
+ * immutable VERSION materializes MCP servers and skills as ordinary project
+ * rows, and environments pin `pluginVersionIds` to run them. Import,
+ * activation, enable/disable and uninstall are deliberately NOT here: they
+ * are project-admin app flows, and this surface feeds unattended callers
+ * (the platform MCP worker) where no plugin write belongs.
+ *
+ * Thin proxies over the Convex `plugins:*` member-gated reads, called with
+ * the request's Convex bearer:
+ *
+ *   - `listProjectPlugins` takes the path's `projectId` and scopes inside
+ *     Convex, like the environments routes.
+ *   - `getPluginVersion` takes ONLY the version id; Convex gates on
+ *     membership of the version's own project. The route therefore does NOT
+ *     carry a `projectId` path segment it could not enforce — a decorative
+ *     scope is worse than none. Historical versions of uninstalled plugins
+ *     stay readable by backend design (eval snapshots and stale environment
+ *     pins reference them).
+ */
+import { Hono } from "hono";
+import { ConvexHttpClient } from "convex/browser";
+import { ErrorCode, WebRouteError } from "../web/errors.js";
+import { getConvexBearerForRequest } from "../../utils/v1-convex-token.js";
+import { v1PageJson, v1Resource } from "./envelope.js";
+import { translateConvexReadError } from "./convex-read-errors.js";
+
+const plugins = new Hono();
+
+// ── Convex row shapes (hand-mirrored from convex/plugins.ts) ─────────────────
+
+type PluginRow = {
+  pluginId: string;
+  projectId: string;
+  name: string;
+  displayName?: string;
+  description?: string;
+  enabled: boolean;
+  activeVersionId?: string;
+  /** Always absent here — `listProjectPlugins` filters uninstalled rows. */
+  deletedAt?: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+type PluginVersionRow = {
+  pluginVersionId: string;
+  pluginId: string;
+  declaredVersion?: string;
+  bundleHash: string;
+  manifestHash?: string;
+  status: "staging" | "ready" | "invalid";
+  componentCounts: {
+    skills: number;
+    servers: number;
+    apps: number;
+    assets: number;
+    unsupported: number;
+  };
+  createdAt: number;
+  readyAt?: number;
+  servers?: Array<{
+    componentId: string;
+    componentKey: string;
+    declaredName: string;
+    placement: "remote" | "local" | "computer";
+    authenticationPolicy: "on_install" | "on_use";
+    materializedServerId: string;
+  }>;
+  skills?: Array<{
+    componentId: string;
+    componentKey: string;
+    declaredName: string;
+    modelRef: string;
+    materializedSkillId: string;
+  }>;
+};
+
+// ── Public DTO mappers (clean `id`; no Convex `pluginId` leak) ───────────────
+
+function toPluginDto(row: PluginRow) {
+  return {
+    id: row.pluginId,
+    projectId: row.projectId,
+    name: row.name,
+    ...(row.displayName !== undefined ? { displayName: row.displayName } : {}),
+    ...(row.description !== undefined ? { description: row.description } : {}),
+    enabled: row.enabled,
+    ...(row.activeVersionId !== undefined
+      ? { activeVersionId: row.activeVersionId }
+      : {}),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function toPluginVersionDto(row: PluginVersionRow) {
+  return {
+    id: row.pluginVersionId,
+    pluginId: row.pluginId,
+    ...(row.declaredVersion !== undefined
+      ? { declaredVersion: row.declaredVersion }
+      : {}),
+    bundleHash: row.bundleHash,
+    ...(row.manifestHash !== undefined
+      ? { manifestHash: row.manifestHash }
+      : {}),
+    status: row.status,
+    componentCounts: row.componentCounts,
+    servers: row.servers ?? [],
+    skills: row.skills ?? [],
+    createdAt: row.createdAt,
+    ...(row.readyAt !== undefined ? { readyAt: row.readyAt } : {}),
+  };
+}
+
+function createConvexClient(convexAuthToken: string): ConvexHttpClient {
+  const convexUrl = process.env.CONVEX_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_URL configuration"
+    );
+  }
+  const client = new ConvexHttpClient(convexUrl);
+  client.setAuth(convexAuthToken);
+  return client;
+}
+
+/**
+ * The `plugins:*` reads throw structured `ConvexError` data (`fail()` in
+ * convex/plugins.ts): `NOT_FOUND` for a missing/invalid id, `FORBIDDEN` for
+ * a non-member. Both become 404 — confirming that a version id exists to
+ * someone outside its project would be a free existence oracle. Everything
+ * else goes through the shared read classifier (bad credential → 401,
+ * anything of ours → redacted 502).
+ */
+function translatePluginReadError(error: unknown): WebRouteError {
+  const data = (error as { data?: unknown } | null)?.data;
+  const code =
+    data && typeof data === "object" && !Array.isArray(data)
+      ? (data as { code?: unknown }).code
+      : undefined;
+  if (code === "NOT_FOUND" || code === "FORBIDDEN") {
+    return new WebRouteError(404, ErrorCode.NOT_FOUND, "Plugin not found");
+  }
+  return translateConvexReadError(error, {
+    scope: "v1/plugins",
+    notFoundMessage: "Plugin or project not found, or you do not have access.",
+  });
+}
+
+// ── Routes ───────────────────────────────────────────────────────────────────
+
+// GET /v1/projects/:projectId/plugins — the LIVE (non-uninstalled) plugins
+// installed in a project, disabled ones included (marked `enabled: false`).
+plugins.get("/projects/:projectId/plugins", async (c) => {
+  const projectId = c.req.param("projectId");
+  const readClient = createConvexClient(await getConvexBearerForRequest(c));
+  let rows: PluginRow[] | null | undefined;
+  try {
+    rows = (await readClient.query(
+      "plugins:listProjectPlugins" as any,
+      { projectId } as any
+    )) as PluginRow[] | null | undefined;
+  } catch (error) {
+    throw translatePluginReadError(error);
+  }
+  return v1PageJson(c, (rows ?? []).map(toPluginDto));
+});
+
+// GET /v1/plugin-versions/:pluginVersionId — one imported version with its
+// component projections. Membership of the version's project is enforced by
+// Convex (`loadVersionForRead`).
+plugins.get("/plugin-versions/:pluginVersionId", async (c) => {
+  const pluginVersionId = c.req.param("pluginVersionId");
+  const readClient = createConvexClient(await getConvexBearerForRequest(c));
+  let row: PluginVersionRow | null | undefined;
+  try {
+    row = (await readClient.query(
+      "plugins:getPluginVersion" as any,
+      { pluginVersionId } as any
+    )) as PluginVersionRow | null | undefined;
+  } catch (error) {
+    throw translatePluginReadError(error);
+  }
+  if (!row) {
+    throw new WebRouteError(
+      404,
+      ErrorCode.NOT_FOUND,
+      "Plugin version not found"
+    );
+  }
+  return v1Resource(c, toPluginVersionDto(row));
+});
+
+export default plugins;

--- a/mcpjam-inspector/server/routes/web/__tests__/auth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth.test.ts
@@ -189,3 +189,56 @@ describe("createManualHostedConnection — xaaPolicy survives schema stripping",
     expect(thrown?.details?.reason).toBe("xaa_policy_invalid");
   });
 });
+
+// Declared plugin transports (`httpVariant` on the authorize serverConfig,
+// once the backend serves it): `sse` skips the Streamable HTTP attempt,
+// `streamable-http` rules out the silent SSE downgrade, absence — every row
+// today — leaves the config byte-identical.
+describe("toHttpConfig — declared httpVariant mapping", () => {
+  it("maps a declared sse transport to preferSSE", async () => {
+    const { toHttpConfig } = await import("../auth.js");
+    const config = toHttpConfig(
+      {
+        serverConfig: {
+          transportType: "http",
+          url: "https://sse.example.com/mcp",
+          httpVariant: "sse",
+        },
+      },
+      1000
+    );
+    expect(config.preferSSE).toBe(true);
+    expect(config.disableSseFallback).toBeUndefined();
+  });
+
+  it("maps a declared streamable-http transport to disableSseFallback", async () => {
+    const { toHttpConfig } = await import("../auth.js");
+    const config = toHttpConfig(
+      {
+        serverConfig: {
+          transportType: "http",
+          url: "https://streamable.example.com/mcp",
+          httpVariant: "streamable-http",
+        },
+      },
+      1000
+    );
+    expect(config.disableSseFallback).toBe(true);
+    expect(config.preferSSE).toBeUndefined();
+  });
+
+  it("sets neither flag when no transport was declared", async () => {
+    const { toHttpConfig } = await import("../auth.js");
+    const config = toHttpConfig(
+      {
+        serverConfig: {
+          transportType: "http",
+          url: "https://plain.example.com/mcp",
+        },
+      },
+      1000
+    );
+    expect(config.preferSSE).toBeUndefined();
+    expect(config.disableSseFallback).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/auth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth.test.ts
@@ -224,7 +224,28 @@ describe("toHttpConfig — declared httpVariant mapping", () => {
       1000
     );
     expect(config.disableSseFallback).toBe(true);
-    expect(config.preferSSE).toBeUndefined();
+    // Explicitly false, not merely absent — see below.
+    expect(config.preferSSE).toBe(false);
+  });
+
+  it("pins preferSSE false so a /sse URL cannot override the declaration", async () => {
+    // The SDK resolves `config.preferSSE ?? url.pathname.endsWith("/sse")`,
+    // so an undefined preferSSE would let URL shape beat the declaration and
+    // route a declared streamable-http server to SSE without ever attempting
+    // Streamable HTTP.
+    const { toHttpConfig } = await import("../auth.js");
+    const config = toHttpConfig(
+      {
+        serverConfig: {
+          transportType: "http",
+          url: "https://plugin.example.com/sse",
+          httpVariant: "streamable-http",
+        },
+      },
+      1000
+    );
+    expect(config.preferSSE).toBe(false);
+    expect(config.disableSseFallback).toBe(true);
   });
 
   it("sets neither flag when no transport was declared", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.chatbox-environment.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.chatbox-environment.test.ts
@@ -371,4 +371,105 @@ describe("web chat-v2 — environment-backed chatbox", () => {
     expect(response.status).toBe(502);
     expect(prepareChatV2Mock).not.toHaveBeenCalled();
   });
+
+  // ── Phase 6.1: plugin provenance from the payload's pinned versions ──────
+
+  /** The pinned version the payload carries once mcpjam-backend serves it. */
+  const PINNED_VERSION = {
+    pluginId: "pl_1",
+    pluginVersionId: "pv_1",
+    name: "linear-tools",
+    bundleHash: "hash_1",
+  };
+
+  it("attributes plugin origin when the payload pins versions and the probe answers", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        ...CHATBOX_CONFIG,
+        environment: {
+          ...ENVIRONMENT_PAYLOAD,
+          pluginVersions: [PINNED_VERSION],
+        },
+      },
+    });
+    convexQueryMock.mockImplementation(async (ref: string) => {
+      if (ref === "plugins:resolvePluginRuntimePreview") {
+        return {
+          pluginVersions: [PINNED_VERSION],
+          effectiveServerIds: ["env-server-2"],
+          serverComponents: [
+            {
+              pluginVersionId: "pv_1",
+              componentKey: "server:asana",
+              placement: "remote",
+              authenticationPolicy: "on_use",
+              materializedServerId: "env-server-2",
+            },
+          ],
+          pluginSkills: [],
+          unavailableComponents: [],
+        };
+      }
+      throw new Error(`Unexpected convex query: ${ref}`);
+    });
+
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    expect(convexQueryMock).toHaveBeenCalledWith(
+      "plugins:resolvePluginRuntimePreview",
+      { projectId: "project-1", pluginVersionIds: ["pv_1"] }
+    );
+
+    const capabilities =
+      prepareChatV2Mock.mock.calls.at(-1)![0].skillsSource.capabilities;
+    expect(capabilities.problems).toEqual([]);
+    expect(
+      capabilities.servers.find(
+        (server: { serverId: string }) => server.serverId === "env-server-2"
+      ).plugin
+    ).toEqual(PINNED_VERSION);
+  });
+
+  it("degrades to no origin when the probe fails — the turn still runs", async () => {
+    fetchChatboxRuntimeConfigMock.mockResolvedValue({
+      ok: true,
+      config: {
+        ...CHATBOX_CONFIG,
+        environment: {
+          ...ENVIRONMENT_PAYLOAD,
+          pluginVersions: [PINNED_VERSION],
+        },
+      },
+    });
+    // The member-gated probe rejecting is exactly what a guest turn sees.
+    convexQueryMock.mockRejectedValue(new Error("Not a member of this project"));
+
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+
+    const capabilities =
+      prepareChatV2Mock.mock.calls.at(-1)![0].skillsSource.capabilities;
+    expect(
+      capabilities.problems.map((problem: { code: string }) => problem.code)
+    ).toEqual(["plugin_origin_unavailable"]);
+    // Classification survives (`source: "plugin"`); only the version label is
+    // unreported.
+    expect(capabilities.pluginServerIds).toEqual(["env-server-2"]);
+    expect(
+      capabilities.servers.find(
+        (server: { serverId: string }) => server.serverId === "env-server-2"
+      ).plugin
+    ).toBeUndefined();
+  });
+
+  it("adds no probe read when the payload pins no versions", async () => {
+    const { app, token } = createWebTestApp();
+    const response = await postJson(app, "/api/web/chat-v2", BASE_BODY, token);
+    expect(response.status).toBe(200);
+    expect(convexQueryMock).not.toHaveBeenCalled();
+  });
 });

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -352,6 +352,11 @@ export type ConvexAuthorizeResponse = {
   serverConfig: {
     transportType: "stdio" | "http";
     url?: string;
+    // Declared wire transport from a plugin manifest (parser `httpVariant`),
+    // once the backend persists + serves it. Absent on every ordinary row
+    // and on older backends — absence means "no declaration", never a
+    // default.
+    httpVariant?: "streamable-http" | "sse";
     headers?: Record<string, string>;
     hasHeaders?: boolean;
     useOAuth?: boolean;
@@ -839,6 +844,16 @@ export function toHttpConfig(
     },
     timeout: timeoutMs,
     ...(onUnauthorized ? { onUnauthorized } : {}),
+    // Plugin-declared transports are authoritative: `sse` skips the
+    // Streamable HTTP attempt, `streamable-http` rules out the silent SSE
+    // downgrade. Rows without a declaration keep the SDK's URL-heuristic +
+    // fallback behavior.
+    ...(authResponse.serverConfig.httpVariant === "sse"
+      ? { preferSSE: true }
+      : {}),
+    ...(authResponse.serverConfig.httpVariant === "streamable-http"
+      ? { disableSseFallback: true }
+      : {}),
     // mcpProfile.initialize.* pins, forwarded to the SDK's
     // `BaseServerConfig.clientInfo` / `.supportedProtocolVersions` per
     // `sdk/src/mcp-client-manager/types.ts`. Undefined → SDK defaults.

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -848,11 +848,16 @@ export function toHttpConfig(
     // Streamable HTTP attempt, `streamable-http` rules out the silent SSE
     // downgrade. Rows without a declaration keep the SDK's URL-heuristic +
     // fallback behavior.
+    //
+    // `preferSSE: false` is load-bearing on the streamable-http branch — see
+    // the same mapping in `local-server-resolver.ts::toMCPServerConfig`: the
+    // SDK falls back to a `/sse` URL-path heuristic when `preferSSE` is
+    // undefined, which would bypass the Streamable HTTP attempt entirely.
     ...(authResponse.serverConfig.httpVariant === "sse"
       ? { preferSSE: true }
       : {}),
     ...(authResponse.serverConfig.httpVariant === "streamable-http"
-      ? { disableSseFallback: true }
+      ? { preferSSE: false, disableSseFallback: true }
       : {}),
     // mcpProfile.initialize.* pins, forwarded to the SDK's
     // `BaseServerConfig.clientInfo` / `.supportedProtocolVersions` per

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -89,7 +89,10 @@ import {
   runtimeSkills as environmentRuntimeSkills,
   type ResolvedEnvironmentRuntime,
 } from "../../services/environments/runtime.js";
-import { fetchPluginRuntimeAttribution } from "../../services/environments/plugin-attribution.js";
+import {
+  fetchPluginRuntimeAttribution,
+  type PluginRuntimeAttribution,
+} from "../../services/environments/plugin-attribution.js";
 import {
   pluginOriginByServerId,
   resolveEffectiveCapabilities,
@@ -396,15 +399,65 @@ chatV2.post("/", async (c) => {
         }
         if (environmentRead.kind === "present") {
           chatboxEnvironment = environmentRead.environment;
+          // Phase 6.1: attribution for chatbox turns, from the payload's own
+          // pinned plugin versions. Guarded on their presence — a backend
+          // that predates `pluginVersions` (or an environment pinning none)
+          // costs zero extra reads — and FAIL-OPEN like the environment
+          // target's probe: this turn is guest-reachable, and the probe is
+          // member-gated backend-side, so a guest (or any probe failure)
+          // degrades to "origin unknown" rather than stopping the send.
+          let attribution: PluginRuntimeAttribution | null = null;
+          const pinnedVersionIds = (
+            chatboxEnvironment.pluginVersions ?? []
+          ).map((plugin) => plugin.pluginVersionId);
+          if (pinnedVersionIds.length > 0) {
+            try {
+              attribution = await fetchPluginRuntimeAttribution(
+                createConvexClient(await getConvexBearerForRequest(c)),
+                {
+                  projectId: hostedBody.projectId,
+                  pluginVersionIds: pinnedVersionIds,
+                }
+              );
+            } catch (error) {
+              // `fetchPluginRuntimeAttribution` already swallows probe
+              // failures; this catches client construction (missing
+              // CONVEX_URL on a deployment that never configured it).
+              logger.warn(
+                "[chat-v2] chatbox attribution unavailable; running without plugin origin",
+                {
+                  chatboxId,
+                  error:
+                    error instanceof Error ? error.message : String(error),
+                }
+              );
+            }
+          }
           // Same projection the environment target uses, so the EMULATED
           // engine advertises the environment's skills (skillsSource:
-          // "resolved") instead of silently delivering zero. Attribution is
-          // null on purpose: the payload pins no plugin versions (the backend
-          // already re-gated plugins before serving it), so there is nothing
-          // to attribute and no probe to degrade on a guest-reachable turn.
+          // "resolved") instead of silently delivering zero.
           effectiveCapabilities = resolveEffectiveCapabilities(
             chatboxEnvironment,
-            null
+            attribution
+          );
+          if (effectiveCapabilities.problems.length > 0) {
+            // Codes and ids only — same redaction rationale as the
+            // environment-target log above.
+            logger.warn("[chat-v2] effective capability problems", {
+              environmentId: chatboxEnvironment.environmentRef.environmentId,
+              codes: effectiveCapabilities.problems.map(
+                (problem) => problem.code
+              ),
+              skillIds: effectiveCapabilities.problems.flatMap((problem) =>
+                "skillId" in problem ? [problem.skillId] : []
+              ),
+            });
+          }
+          // Plugin origin on this turn's RPC frames, exactly as the
+          // environment target stamps it. Empty (no-op) until the backend
+          // serves `pluginVersions` and the probe attributes them.
+          rpcCollector?.setPluginOriginByServerId(
+            pluginOriginByServerId(effectiveCapabilities)
           );
         }
         hostRuntimeConfig = runtime.config as unknown as Record<

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
@@ -246,6 +246,35 @@ describe("toMCPServerConfig — onUnauthorized wiring", () => {
   });
 });
 
+describe("toMCPServerConfig — declared httpVariant mapping", () => {
+  it("maps a declared sse transport to preferSSE", () => {
+    const config: any = toMCPServerConfig({
+      ...httpHeaderOnlyAuth,
+      serverConfig: { ...httpHeaderOnlyAuth.serverConfig, httpVariant: "sse" },
+    });
+    expect(config.preferSSE).toBe(true);
+    expect(config.disableSseFallback).toBeUndefined();
+  });
+
+  it("maps a declared streamable-http transport to disableSseFallback", () => {
+    const config: any = toMCPServerConfig({
+      ...httpHeaderOnlyAuth,
+      serverConfig: {
+        ...httpHeaderOnlyAuth.serverConfig,
+        httpVariant: "streamable-http" as const,
+      },
+    });
+    expect(config.disableSseFallback).toBe(true);
+    expect(config.preferSSE).toBeUndefined();
+  });
+
+  it("sets neither flag when no transport was declared", () => {
+    const config: any = toMCPServerConfig(httpHeaderOnlyAuth);
+    expect(config.preferSSE).toBeUndefined();
+    expect(config.disableSseFallback).toBeUndefined();
+  });
+});
+
 describe("resolveLocalServerForConnect — refresh on missing access token", () => {
   beforeEach(() => {
     process.env.CONVEX_HTTP_URL = "https://example.convex.site";

--- a/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-server-resolver.test.ts
@@ -265,7 +265,25 @@ describe("toMCPServerConfig — declared httpVariant mapping", () => {
       },
     });
     expect(config.disableSseFallback).toBe(true);
-    expect(config.preferSSE).toBeUndefined();
+    // Explicitly false, not merely absent — see below.
+    expect(config.preferSSE).toBe(false);
+  });
+
+  it("pins preferSSE false so a /sse URL cannot override the declaration", () => {
+    // The SDK resolves `config.preferSSE ?? url.pathname.endsWith("/sse")`.
+    // Leaving preferSSE undefined here would hand a DECLARED streamable-http
+    // server straight to SSE on URL shape alone, and `disableSseFallback`
+    // could not save it — it only guards the post-attempt fallback.
+    const config: any = toMCPServerConfig({
+      ...httpHeaderOnlyAuth,
+      serverConfig: {
+        ...httpHeaderOnlyAuth.serverConfig,
+        url: "https://plugin.example.com/sse",
+        httpVariant: "streamable-http" as const,
+      },
+    });
+    expect(config.preferSSE).toBe(false);
+    expect(config.disableSseFallback).toBe(true);
   });
 
   it("sets neither flag when no transport was declared", () => {

--- a/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
+++ b/mcpjam-inspector/server/utils/built-in-tools/mcpjam.ts
@@ -171,6 +171,8 @@ export const EXCLUDED_FROM_WORKSPACE: Readonly<Record<string, string>> = {
   update_project_environment: "Environment authoring has its own editor.",
   archive_project_environment: "Environment lifecycle has its own controls.",
   restore_project_environment: "Environment lifecycle has its own controls.",
+  list_project_plugins: "Plugin inventory lives in the Plugins surface.",
+  get_plugin_version: "Plugin version detail lives in the Plugins surface.",
 
   // Sandbox images and computers: minutes-long builds and billable compute.
   list_sandbox_images:

--- a/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
@@ -65,6 +65,20 @@ export type ChatboxEnvironmentRuntime = {
     channels?: RuntimeSkillChannel[];
     files?: Array<{ path: string; size: number; url: string | null }>;
   }>;
+  /**
+   * Phase 6.1: the environment's pinned plugin versions, mirrored from the
+   * resolution the backend already performed for this payload. Same shape as
+   * `ResolvedEnvironmentRuntime.pluginVersions`, so the chatbox branch can
+   * feed the attribution probe the environment target uses. ABSENT on every
+   * backend that predates the field — absence degrades to "no plugin origin
+   * reported", never to a guess from `connectable[].source`.
+   */
+  pluginVersions?: Array<{
+    pluginId: string;
+    pluginVersionId: string;
+    name: string;
+    bundleHash?: string;
+  }>;
 };
 
 export type ChatboxRuntimeConfig = RuntimeExecutionFields & {
@@ -437,6 +451,31 @@ export function readChatboxEnvironment(
       })
     : undefined;
 
+  // Additive like `connectable`/`skills`: a malformed entry (or a torn id)
+  // drops to nothing — losing a provenance LABEL, never a capability.
+  const pluginVersions = Array.isArray(raw.pluginVersions)
+    ? raw.pluginVersions.flatMap((entry) => {
+        if (
+          !isRecord(entry) ||
+          typeof entry.pluginId !== "string" ||
+          typeof entry.pluginVersionId !== "string" ||
+          typeof entry.name !== "string"
+        ) {
+          return [];
+        }
+        return [
+          {
+            pluginId: entry.pluginId,
+            pluginVersionId: entry.pluginVersionId,
+            name: entry.name,
+            ...(typeof entry.bundleHash === "string"
+              ? { bundleHash: entry.bundleHash }
+              : {}),
+          },
+        ];
+      })
+    : undefined;
+
   return {
     kind: "present",
     environment: {
@@ -450,6 +489,7 @@ export function readChatboxEnvironment(
         ...(connectable ? { connectable } : {}),
       },
       ...(skills ? { skills } : {}),
+      ...(pluginVersions ? { pluginVersions } : {}),
     },
   };
 }

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -732,9 +732,17 @@ export function toMCPServerConfig(
   // Plugin-declared transports are authoritative: `sse` skips the Streamable
   // HTTP attempt, `streamable-http` rules out the silent SSE downgrade. Rows
   // without a declaration keep the SDK's URL-heuristic + fallback behavior.
+  //
+  // `preferSSE: false` is load-bearing on the streamable-http branch: the SDK
+  // resolves `config.preferSSE ?? url.pathname.endsWith("/sse")`, so a
+  // DECLARED streamable-http server served at a `/sse` path would otherwise
+  // be routed straight to SSE by the URL heuristic and never attempt
+  // Streamable HTTP at all — `disableSseFallback` only guards the fallback
+  // AFTER an attempt, so it cannot rescue that case.
   if (serverConfig.httpVariant === "sse") {
     http.preferSSE = true;
   } else if (serverConfig.httpVariant === "streamable-http") {
+    http.preferSSE = false;
     http.disableSseFallback = true;
   }
   if (typeof timeout === "number") http.timeout = timeout;

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -64,6 +64,11 @@ type LocalAuthorizeServerConfig =
   | {
       transportType: "http";
       url: string;
+      // Declared wire transport from a plugin manifest (parser
+      // `httpVariant`), once the backend persists + serves it. Absent on
+      // every ordinary row and on older backends — absence means "no
+      // declaration", never a default.
+      httpVariant?: "streamable-http" | "sse";
       headers: Record<string, string>;
       hasHeaders?: boolean;
       timeout?: number;
@@ -724,6 +729,14 @@ export function toMCPServerConfig(
     url,
     requestInit: { headers },
   };
+  // Plugin-declared transports are authoritative: `sse` skips the Streamable
+  // HTTP attempt, `streamable-http` rules out the silent SSE downgrade. Rows
+  // without a declaration keep the SDK's URL-heuristic + fallback behavior.
+  if (serverConfig.httpVariant === "sse") {
+    http.preferSSE = true;
+  } else if (serverConfig.httpVariant === "streamable-http") {
+    http.disableSseFallback = true;
+  }
   if (typeof timeout === "number") http.timeout = timeout;
   if (clientCapabilities) {
     http.capabilities = clientCapabilities;

--- a/sdk/src/http-server-doctor.ts
+++ b/sdk/src/http-server-doctor.ts
@@ -531,6 +531,14 @@ async function connectViaHttp(
     } catch (error) {
       streamableError = error;
       await safeCloseTransport(streamableTransport);
+      // Same opt-out the connect path honors: a server whose transport was
+      // DECLARED streamable-http must not be diagnosed "ready" over SSE.
+      // Without this the doctor contradicts MCPClientManager, which refuses
+      // the very same server — misleading diagnostics on an SSE-only
+      // endpoint that the declaration says should not be used.
+      if (config.disableSseFallback) {
+        throw error;
+      }
     }
   }
 

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -575,8 +575,14 @@ export class MCPClientManager {
       transportType = "stdio";
     } else {
       const url = new URL(config.url);
+      // Same nullish precedence the CONNECT path uses (`connectViaHttp`):
+      // an explicit `preferSSE: false` — how a plugin-declared
+      // streamable-http server pins its transport — must beat the `/sse`
+      // URL heuristic here too, or this reports "sse" for a connection that
+      // actually ran over Streamable HTTP, and that wrong value reaches
+      // snapshots, conformance output and hosted trace metadata.
       transportType =
-        config.preferSSE || url.pathname.endsWith("/sse")
+        (config.preferSSE ?? url.pathname.endsWith("/sse"))
           ? "sse"
           : "streamable-http";
     }

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -574,17 +574,25 @@ export class MCPClientManager {
     if (this.isStdioConfig(config)) {
       transportType = "stdio";
     } else {
-      const url = new URL(config.url);
-      // Same nullish precedence the CONNECT path uses (`connectViaHttp`):
-      // an explicit `preferSSE: false` — how a plugin-declared
-      // streamable-http server pins its transport — must beat the `/sse`
-      // URL heuristic here too, or this reports "sse" for a connection that
-      // actually ran over Streamable HTTP, and that wrong value reaches
-      // snapshots, conformance output and hosted trace metadata.
-      transportType =
-        (config.preferSSE ?? url.pathname.endsWith("/sse"))
+      // Report the transport that ACTUALLY connected, not the one the config
+      // asked for. Deriving this from `config` is wrong in both directions:
+      // a declared streamable-http server at a `/sse` path reads as "sse"
+      // though it ran over Streamable HTTP, and a connection that fell back
+      // to SSE reads as "streamable-http" — the transport that failed. This
+      // value feeds snapshots, conformance output and hosted trace metadata,
+      // so it has to describe the live connection. The config heuristic
+      // stays only as the pre-connect fallback.
+      const activeTransport = liveState?.transport;
+      if (activeTransport instanceof SSEClientTransport) {
+        transportType = "sse";
+      } else if (activeTransport instanceof StreamableHTTPClientTransport) {
+        transportType = "streamable-http";
+      } else {
+        const url = new URL(config.url);
+        transportType = (config.preferSSE ?? url.pathname.endsWith("/sse"))
           ? "sse"
           : "streamable-http";
+      }
     }
 
     // Public negotiated-version accessor (upstream

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -2665,6 +2665,16 @@ export class MCPClientManager {
         onInsufficientScope: "throw",
       });
 
+      // The upstream Client closes a failed transport during `connect`, and
+      // that close fires `onclose` → `clearClosedPendingConnectionState`,
+      // discarding the pending live state the SSE fallback below still
+      // needs — the fallback then completed only to be thrown away as
+      // "cancelled". A FIRST-attempt failure is a fallback trigger, not a
+      // client close, so the handler is detached for this attempt and
+      // restored on every exit (mid-handshake closes on the attempt that
+      // ends up owning the connection keep their cancel semantics).
+      const pendingOnClose = client.onclose;
+      client.onclose = undefined;
       try {
         const logger = this.resolveRpcLogger(config);
         const wrapped = this.applyFirstPageOnly(
@@ -2678,10 +2688,12 @@ export class MCPClientManager {
         await client.connect(wrapped, {
           timeout: Math.min(timeout, HTTP_CONNECT_TIMEOUT),
         });
+        client.onclose = pendingOnClose;
         return streamableTransport;
       } catch (error) {
         streamableError = error;
         await this.safeCloseTransport(streamableTransport);
+        client.onclose = pendingOnClose;
         // SEP-2350: a connect-time `403 insufficient_scope` surfaces here as a
         // clean `InsufficientScopeError` (transport built
         // `onInsufficientScope: "throw"` above). Rethrow it immediately —
@@ -2693,6 +2705,27 @@ export class MCPClientManager {
         // serialize the challenge and drive the union-scope re-authorization.
         if (isInsufficientScopeError(error)) {
           throw error;
+        }
+        // Declared-transport servers (`disableSseFallback`) never downgrade
+        // to SSE: surface the Streamable HTTP failure, keeping the auth
+        // classification the combined path below would have produced so
+        // hosts still see an MCPAuthError where OAuth escalation hooks in.
+        if (config.disableSseFallback) {
+          const authCheck = isAuthError(error);
+          if (authCheck.isAuth) {
+            throw new MCPAuthError(
+              `Authentication failed for MCP server "${serverId}": Streamable HTTP error: ${formatError(
+                error
+              )}`,
+              authCheck.statusCode,
+              { cause: error }
+            );
+          }
+          throw new Error(
+            `Failed to connect to MCP server "${serverId}" using Streamable HTTP, and this server's declared transport rules out the SSE fallback. Streamable HTTP error: ${formatError(
+              error
+            )}`
+          );
         }
       }
     }

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -362,6 +362,7 @@ export type StdioServerConfig = BaseServerConfig & {
   reconnectionOptions?: never;
   sessionId?: never;
   preferSSE?: never;
+  disableSseFallback?: never;
   refreshToken?: never;
   clientId?: never;
   clientSecret?: never;
@@ -412,6 +413,17 @@ export type HttpServerConfig = BaseServerConfig & {
   sessionId?: StreamableHTTPClientTransportOptions["sessionId"];
   /** Prefer SSE transport over Streamable HTTP */
   preferSSE?: boolean;
+  /**
+   * Opt out of the silent Streamable-HTTP → SSE downgrade. By default a
+   * failed Streamable HTTP connect falls back to SSE, which is right for
+   * ad-hoc URLs but wrong for a server whose transport was DECLARED
+   * streamable-http (e.g. an Agent Plugins manifest): connecting over SSE
+   * would misrepresent the server under test. When set, the Streamable HTTP
+   * failure surfaces instead of being retried over SSE. Meaningful only when
+   * Streamable HTTP is attempted first — inert alongside `preferSSE`, which
+   * makes SSE the declared transport rather than a fallback.
+   */
+  disableSseFallback?: boolean;
   /**
    * Pinned MCP protocol version (wire literal that lands in `_meta` +
    * `MCP-Protocol-Version` header). Absent → SDK default at request

--- a/sdk/src/platform/client.ts
+++ b/sdk/src/platform/client.ts
@@ -39,6 +39,8 @@ import type {
   PlatformMe,
   PlatformModel,
   PlatformPage,
+  PlatformPlugin,
+  PlatformPluginVersion,
   PlatformProject,
   PlatformProjectServer,
   PlatformTunnelClosed,
@@ -554,6 +556,41 @@ export class PlatformApiClient {
         params.projectId
       )}/environments/${encodeURIComponent(params.environmentId)}/restore`,
       { body: { expectedRevision: params.expectedRevision } },
+      options
+    );
+  }
+
+  // ── Agent Plugins ────────────────────────────────────────────────────
+  //
+  // Read-only: the live plugins installed in a project, and one imported
+  // version's detail. Import/enable/disable/uninstall stay in the app.
+
+  listProjectPlugins(
+    params: { projectId: string },
+    options?: RequestOptions
+  ): Promise<PlatformPage<PlatformPlugin>> {
+    return this.request(
+      "GET",
+      `/projects/${encodeURIComponent(params.projectId)}/plugins`,
+      {},
+      options
+    );
+  }
+
+  /**
+   * One imported plugin version with its component projections. Addressed by
+   * the version id alone — access is the version's own project membership,
+   * and historical versions of uninstalled plugins stay readable (eval
+   * snapshots and stale environment pins reference them).
+   */
+  getPluginVersion(
+    params: { pluginVersionId: string },
+    options?: RequestOptions
+  ): Promise<PlatformPluginVersion> {
+    return this.request(
+      "GET",
+      `/plugin-versions/${encodeURIComponent(params.pluginVersionId)}`,
+      {},
       options
     );
   }

--- a/sdk/src/platform/index.ts
+++ b/sdk/src/platform/index.ts
@@ -74,6 +74,11 @@ export type {
   PlatformMe,
   PlatformModel,
   PlatformPage,
+  PlatformPlugin,
+  PlatformPluginComponentCounts,
+  PlatformPluginServerComponent,
+  PlatformPluginSkillComponent,
+  PlatformPluginVersion,
   PlatformProject,
   PlatformProjectServer,
   PlatformTunnelClosed,
@@ -170,6 +175,8 @@ export {
   updateEnvironmentOperation,
   archiveEnvironmentOperation,
   restoreEnvironmentOperation,
+  listProjectPluginsOperation,
+  getPluginVersionOperation,
   listProjectsOperation,
   listProjectServersOperation,
   listServerPromptsOperation,
@@ -226,6 +233,9 @@ export {
   type UpdateHostInput,
   type ListEnvironmentsInput,
   type ListEnvironmentsResult,
+  type ListProjectPluginsInput,
+  type ListProjectPluginsResult,
+  type GetPluginVersionInput,
   // Journeys (Swarms) and scenarios (user testing). The operations above are
   // useless from outside without these — a caller cannot type the value an
   // operation returns, and reaching into `operations.js` for it would depend on

--- a/sdk/src/platform/operations.ts
+++ b/sdk/src/platform/operations.ts
@@ -64,6 +64,8 @@ import type {
   PlatformPage,
   PlatformMe,
   PlatformModel,
+  PlatformPlugin,
+  PlatformPluginVersion,
   PlatformProject,
   PlatformProjectServer,
   PlatformTunnelGrant,
@@ -3728,6 +3730,84 @@ export const restoreEnvironmentOperation: PlatformOperation<
   },
 };
 
+// ── Agent Plugins ────────────────────────────────────────────────────────────
+//
+// Read-only. Import, activate, enable/disable and uninstall stay in the app —
+// no plugin write belongs on an unattended surface.
+
+const listProjectPluginsInput = z.object({
+  project: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(PROJECT_SELECTOR_DESCRIPTION),
+});
+export type ListProjectPluginsInput = z.infer<typeof listProjectPluginsInput>;
+
+export type ListProjectPluginsResult = {
+  project: SelectedProjectInfo;
+  items: PlatformPlugin[];
+  otherProjects: ProjectInfo[];
+};
+
+export const listProjectPluginsOperation: PlatformOperation<
+  ListProjectPluginsInput,
+  ListProjectPluginsResult
+> = {
+  name: "list_project_plugins",
+  title: "List MCPJam project plugins",
+  description:
+    "List the live (installed, non-uninstalled) Agent Plugins in an MCPJam project. Each plugin names its active version id — pass that to get_plugin_version for the version's servers and skills. Disabled plugins are listed too, marked `enabled: false`.",
+  readOnly: true,
+  inputSchema: listProjectPluginsInput,
+  async execute(input, { client, signal }) {
+    const { project, sortedProjects } = await resolveProjectOrThrow(
+      client,
+      input.project,
+      signal
+    );
+    const page = await client.listProjectPlugins(
+      { projectId: project.id },
+      { signal }
+    );
+    return {
+      project: toSelectedProjectInfo(project),
+      items: page.items,
+      otherProjects: toOtherProjects(sortedProjects, project.id),
+    };
+  },
+};
+
+const getPluginVersionInput = z.object({
+  pluginVersionId: z
+    .string()
+    .trim()
+    .min(1)
+    .describe(
+      "Plugin version ID — a plugin's `activeVersionId` from list_project_plugins, or a pinned id from an environment's `pluginVersionIds`."
+    ),
+});
+export type GetPluginVersionInput = z.infer<typeof getPluginVersionInput>;
+
+export const getPluginVersionOperation: PlatformOperation<
+  GetPluginVersionInput,
+  PlatformPluginVersion
+> = {
+  name: "get_plugin_version",
+  title: "Show an MCPJam plugin version",
+  description:
+    "Show one imported Agent Plugin version: its status, component counts, and per-component summaries (declared MCP servers with placement and auth timing, declared skills with their namespaced model refs). Requires membership of the version's project; historical versions of uninstalled plugins stay readable.",
+  readOnly: true,
+  inputSchema: getPluginVersionInput,
+  async execute(input, { client, signal }) {
+    return client.getPluginVersion(
+      { pluginVersionId: input.pluginVersionId },
+      { signal }
+    );
+  },
+};
+
 // ── Sandbox images ───────────────────────────────────────────────────────────
 
 const IMAGE_SELECTOR_DESCRIPTION = "Sandbox image name or ID.";
@@ -4719,6 +4799,8 @@ export const ALL_OPERATIONS: readonly AnyPlatformOperation[] = [
   updateEnvironmentOperation,
   archiveEnvironmentOperation,
   restoreEnvironmentOperation,
+  listProjectPluginsOperation,
+  getPluginVersionOperation,
   listImagesOperation,
   getImageOperation,
   createImageOperation,

--- a/sdk/src/platform/types.ts
+++ b/sdk/src/platform/types.ts
@@ -475,6 +475,80 @@ export interface PlatformEnvironmentResolved {
   sandboxImageId?: string;
 }
 
+// ── Agent Plugins ────────────────────────────────────────────────────────────
+//
+// A plugin bundle (agent-plugins.org format) imported into a project. Each
+// immutable VERSION materializes MCP servers and skills as ordinary project
+// rows; environments pin `pluginVersionIds` to run them. This surface is
+// READ-ONLY — import, activate, enable/disable and uninstall stay in the app.
+
+/** One live (installed, non-uninstalled) plugin in a project. */
+export interface PlatformPlugin {
+  id: string;
+  projectId: string;
+  /** Normalized plugin name — the namespace its skills load under. */
+  name: string;
+  displayName?: string;
+  description?: string;
+  /** Disabled plugins keep their versions but resolve for no run. */
+  enabled: boolean;
+  /** The version environment pins default to; absent before first activate. */
+  activeVersionId?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Per-component tallies of one imported version. `apps` counts preserved
+ *  `.app.json` metadata entries only (no runtime effect). */
+export interface PlatformPluginComponentCounts {
+  skills: number;
+  servers: number;
+  apps: number;
+  assets: number;
+  unsupported: number;
+}
+
+/** One MCP server a plugin version declares, with its materialized row. */
+export interface PlatformPluginServerComponent {
+  componentId: string;
+  /** Stable key within the version (normalized server map key). */
+  componentKey: string;
+  declaredName: string;
+  /** Where the component can execute; `local`/`computer` never run hosted. */
+  placement: "remote" | "local" | "computer";
+  /** Declared auth timing: setup right after import, or on first use. */
+  authenticationPolicy: "on_install" | "on_use";
+  /** The project server row this component materialized as. */
+  materializedServerId: string;
+}
+
+/** One skill a plugin version declares, with its materialized row. */
+export interface PlatformPluginSkillComponent {
+  componentId: string;
+  componentKey: string;
+  declaredName: string;
+  /** Namespaced model-facing reference: `<plugin-name>/<skill-name>`. */
+  modelRef: string;
+  materializedSkillId: string;
+}
+
+/** One immutable imported version with its component projections. */
+export interface PlatformPluginVersion {
+  id: string;
+  pluginId: string;
+  /** `manifest.version` — metadata only; `bundleHash` is the identity. */
+  declaredVersion?: string;
+  bundleHash: string;
+  manifestHash?: string;
+  /** Only `ready` versions resolve at runtime or serve bundle bytes. */
+  status: "staging" | "ready" | "invalid";
+  componentCounts: PlatformPluginComponentCounts;
+  servers: PlatformPluginServerComponent[];
+  skills: PlatformPluginSkillComponent[];
+  createdAt: number;
+  readyAt?: number;
+}
+
 // ── Sandbox images ───────────────────────────────────────────────────────────
 //
 // A project's custom Computer base image: a blueprint plus its builds. Named

--- a/sdk/tests/MCPClientManager.sse-fallback.test.ts
+++ b/sdk/tests/MCPClientManager.sse-fallback.test.ts
@@ -1,0 +1,157 @@
+import http from "http";
+import type { AddressInfo } from "net";
+import { afterEach, describe, expect, it } from "vitest";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { MCPAuthError, MCPClientManager } from "../src/mcp-client-manager";
+import { createMockServer, startMockStreamableHttpServer } from "./mock-servers";
+
+/**
+ * `disableSseFallback` (Agent Plugins Phase 3): a server whose transport was
+ * DECLARED streamable-http must never silently downgrade to SSE. The flag is
+ * strictly opt-in — the first test pins today's fallback behavior unchanged.
+ *
+ * The mock speaks SSE only, on a path that does NOT end in `/sse` so the
+ * URL heuristic keeps Streamable HTTP as the first attempt: GET /mcp opens
+ * the SSE stream, POST /mcp (the Streamable HTTP initialize) is rejected.
+ */
+async function startSseOnlyServerOnPlainPath(): Promise<{
+  url: string;
+  stop: () => Promise<void>;
+}> {
+  const mcpServer = createMockServer();
+  let sseTransport: InstanceType<typeof SSEServerTransport> | null = null;
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.url === "/mcp" && req.method === "GET") {
+      sseTransport = new SSEServerTransport("/message", res);
+      await mcpServer.connect(sseTransport);
+      return;
+    }
+    if (req.url?.startsWith("/message") && req.method === "POST") {
+      const activeTransport = sseTransport;
+      if (!activeTransport) {
+        res.writeHead(400);
+        res.end("No SSE connection established");
+        return;
+      }
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", async () => {
+        try {
+          await activeTransport.handlePostMessage(req, res, body);
+        } catch (error) {
+          res.writeHead(500);
+          res.end(String(error));
+        }
+      });
+      return;
+    }
+    // Streamable HTTP's POST /mcp lands here.
+    res.writeHead(405);
+    res.end("SSE only");
+  });
+
+  return new Promise((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => {
+      const address = httpServer.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${address.port}/mcp`,
+        stop: () =>
+          new Promise<void>((resolveStop) => {
+            httpServer.close(() => resolveStop());
+          }),
+      });
+    });
+  });
+}
+
+/** Every request (both transports) answers 401 — the auth-classification case. */
+async function startAlways401Server(): Promise<{
+  url: string;
+  stop: () => Promise<void>;
+}> {
+  const httpServer = http.createServer((_req, res) => {
+    res.writeHead(401, { "WWW-Authenticate": "Bearer" });
+    res.end("Unauthorized");
+  });
+  return new Promise((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => {
+      const address = httpServer.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${address.port}/mcp`,
+        stop: () =>
+          new Promise<void>((resolveStop) => {
+            httpServer.close(() => resolveStop());
+          }),
+      });
+    });
+  });
+}
+
+describe("MCPClientManager disableSseFallback", () => {
+  const managers: MCPClientManager[] = [];
+  const stops: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(managers.map((manager) => manager.disconnectAllServers()));
+    managers.length = 0;
+    await Promise.all(stops.map((stop) => stop()));
+    stops.length = 0;
+  });
+
+  it("without the flag, an SSE-only server still connects via the fallback", async () => {
+    const server = await startSseOnlyServerOnPlainPath();
+    stops.push(server.stop);
+    const manager = new MCPClientManager();
+    managers.push(manager);
+
+    await manager.connectToServer("sse-only", { url: server.url });
+    expect(manager.getConnectionStatus("sse-only")).toBe("connected");
+  }, 15000);
+
+  it("with the flag, the Streamable HTTP failure surfaces instead of downgrading", async () => {
+    const server = await startSseOnlyServerOnPlainPath();
+    stops.push(server.stop);
+    const manager = new MCPClientManager();
+    managers.push(manager);
+
+    await expect(
+      manager.connectToServer("declared-streamable", {
+        url: server.url,
+        disableSseFallback: true,
+      })
+    ).rejects.toThrow(/Streamable HTTP.*SSE fallback/s);
+    expect(manager.getConnectionStatus("declared-streamable")).not.toBe(
+      "connected"
+    );
+  }, 15000);
+
+  it("with the flag, a working Streamable HTTP server connects unchanged", async () => {
+    const server = await startMockStreamableHttpServer();
+    stops.push(server.stop);
+    const manager = new MCPClientManager();
+    managers.push(manager);
+
+    await manager.connectToServer("streamable", {
+      url: server.url,
+      disableSseFallback: true,
+    });
+    expect(manager.getConnectionStatus("streamable")).toBe("connected");
+  }, 15000);
+
+  it("keeps the MCPAuthError classification hosts key OAuth escalation on", async () => {
+    const server = await startAlways401Server();
+    stops.push(server.stop);
+    const manager = new MCPClientManager();
+    managers.push(manager);
+
+    await expect(
+      manager.connectToServer("auth-required", {
+        url: server.url,
+        disableSseFallback: true,
+      })
+    ).rejects.toThrow(MCPAuthError);
+  }, 15000);
+});

--- a/sdk/tests/MCPClientManager.sse-fallback.test.ts
+++ b/sdk/tests/MCPClientManager.sse-fallback.test.ts
@@ -214,5 +214,20 @@ describe("MCPClientManager disableSseFallback", () => {
     const info = manager.getInitializationInfo("declared-on-sse-path");
     expect(info?.transport).toBe("streamable-http");
   }, 15000);
+
+  it("reports sse when the connection actually fell back to SSE", async () => {
+    // The mirror case: config says Streamable HTTP first, but the server is
+    // SSE-only and the fallback is allowed. Reporting the CONFIG here would
+    // record the transport that failed.
+    const server = await startSseOnlyServerOnPlainPath();
+    stops.push(server.stop);
+    const manager = new MCPClientManager();
+    managers.push(manager);
+
+    await manager.connectToServer("fell-back", { url: server.url });
+    expect(manager.getConnectionStatus("fell-back")).toBe("connected");
+    const info = manager.getInitializationInfo("fell-back");
+    expect(info?.transport).toBe("sse");
+  }, 15000);
 });
 

--- a/sdk/tests/MCPClientManager.sse-fallback.test.ts
+++ b/sdk/tests/MCPClientManager.sse-fallback.test.ts
@@ -2,6 +2,7 @@ import http from "http";
 import type { AddressInfo } from "net";
 import { afterEach, describe, expect, it } from "vitest";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { MCPAuthError, MCPClientManager } from "../src/mcp-client-manager";
 import { createMockServer, startMockStreamableHttpServer } from "./mock-servers";
 
@@ -58,6 +59,43 @@ async function startSseOnlyServerOnPlainPath(): Promise<{
       const address = httpServer.address() as AddressInfo;
       resolve({
         url: `http://127.0.0.1:${address.port}/mcp`,
+        stop: () =>
+          new Promise<void>((resolveStop) => {
+            httpServer.close(() => resolveStop());
+          }),
+      });
+    });
+  });
+}
+
+/**
+ * A genuine Streamable HTTP server served at a `/sse` PATH — the shape that
+ * makes the URL heuristic disagree with the declaration.
+ */
+async function startStreamableServerOnSsePath(): Promise<{
+  url: string;
+  stop: () => Promise<void>;
+}> {
+  const mcpServer = createMockServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => `session-${Math.random()}`,
+  });
+  await mcpServer.connect(transport);
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.url === "/sse") {
+      await transport.handleRequest(req, res);
+      return;
+    }
+    res.writeHead(404);
+    res.end("Not found");
+  });
+
+  return new Promise((resolve) => {
+    httpServer.listen(0, "127.0.0.1", () => {
+      const address = httpServer.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${address.port}/sse`,
         stop: () =>
           new Promise<void>((resolveStop) => {
             httpServer.close(() => resolveStop());
@@ -154,4 +192,27 @@ describe("MCPClientManager disableSseFallback", () => {
       })
     ).rejects.toThrow(MCPAuthError);
   }, 15000);
+
+  it("reports streamable-http when preferSSE is pinned false on a /sse URL", async () => {
+    // The declared-streamable mapping sends `preferSSE: false` precisely so
+    // the `/sse` URL heuristic cannot claim the connection. The REPORTED
+    // transport must agree with the one actually used, or snapshots and
+    // hosted trace metadata record a transport that never ran.
+    const server = await startStreamableServerOnSsePath();
+    stops.push(server.stop);
+    const manager = new MCPClientManager();
+    managers.push(manager);
+
+    await manager.connectToServer("declared-on-sse-path", {
+      url: server.url,
+      preferSSE: false,
+      disableSseFallback: true,
+    });
+    expect(manager.getConnectionStatus("declared-on-sse-path")).toBe(
+      "connected"
+    );
+    const info = manager.getInitializationInfo("declared-on-sse-path");
+    expect(info?.transport).toBe("streamable-http");
+  }, 15000);
 });
+

--- a/sdk/tests/platform/operations.test.ts
+++ b/sdk/tests/platform/operations.test.ts
@@ -11,12 +11,14 @@ import {
   getEvalIterationTraceOperation,
   getEvalRunOperation,
   getEvalRunStepsOperation,
+  getPluginVersionOperation,
   getServerPromptOperation,
   listChatboxesOperation,
   listChatSessionsOperation,
   listEvalRunIterationsOperation,
   listEvalSuiteRunsOperation,
   listEvalSuitesOperation,
+  listProjectPluginsOperation,
   listProjectServersOperation,
   listProjectsOperation,
   listServerPromptsOperation,
@@ -190,6 +192,50 @@ const ENVIRONMENTS = [
   },
 ];
 
+const PLUGINS = [
+  {
+    id: "plugin-1",
+    projectId: "project-new",
+    name: "linear-tools",
+    displayName: "Linear Tools",
+    enabled: true,
+    activeVersionId: "pv-1",
+    createdAt: 1,
+    updatedAt: 2,
+  },
+];
+
+const PLUGIN_VERSION = {
+  id: "pv-1",
+  pluginId: "plugin-1",
+  declaredVersion: "1.2.0",
+  bundleHash: "hash-abc",
+  manifestHash: "hash-manifest",
+  status: "ready",
+  componentCounts: { skills: 1, servers: 1, apps: 0, assets: 0, unsupported: 0 },
+  servers: [
+    {
+      componentId: "psc-1",
+      componentKey: "server:linear",
+      declaredName: "linear",
+      placement: "remote",
+      authenticationPolicy: "on_use",
+      materializedServerId: "server-1",
+    },
+  ],
+  skills: [
+    {
+      componentId: "pskc-1",
+      componentKey: "skill:triage",
+      declaredName: "triage",
+      modelRef: "linear-tools/triage",
+      materializedSkillId: "skill-1",
+    },
+  ],
+  createdAt: 1,
+  readyAt: 2,
+};
+
 const CHATBOXES = [
   {
     id: "box-1",
@@ -288,6 +334,12 @@ function makeClient(overrides: FixtureOverrides = {}): {
     }
     if (/^\/api\/v1\/projects\/[^/]+\/environments$/.test(path)) {
       return Response.json({ items: ENVIRONMENTS });
+    }
+    if (/^\/api\/v1\/projects\/[^/]+\/plugins$/.test(path)) {
+      return Response.json({ items: PLUGINS });
+    }
+    if (/^\/api\/v1\/plugin-versions\/[^/]+$/.test(path)) {
+      return Response.json(PLUGIN_VERSION);
     }
     if (/^\/api\/v1\/projects\/[^/]+\/eval-runs$/.test(path)) {
       expect(init?.method).toBe("POST");
@@ -1110,6 +1162,35 @@ describe("chatbox operations", () => {
   });
 });
 
+describe("plugin operations", () => {
+  it("lists the project's live plugins with the project resolved by selector", async () => {
+    const { client } = makeClient();
+
+    const result = await listProjectPluginsOperation.execute(
+      { project: "new" },
+      { client }
+    );
+
+    expect(result.project.id).toBe("project-new");
+    expect(result.items).toEqual(PLUGINS);
+  });
+
+  it("fetches a plugin version by raw id, no project resolution round-trip", async () => {
+    const { client, fetchMock } = makeClient();
+
+    const result = await getPluginVersionOperation.execute(
+      { pluginVersionId: "pv-1" },
+      { client }
+    );
+
+    expect(result).toEqual(PLUGIN_VERSION);
+    const paths = fetchMock.mock.calls.map((call) =>
+      new URL(String(call[0])).pathname
+    );
+    expect(paths).toEqual(["/api/v1/plugin-versions/pv-1"]);
+  });
+});
+
 describe("listChatSessionsOperation", () => {
   it("lists sessions unfiltered when no project is given", async () => {
     const { client, fetchMock } = makeClient();
@@ -1309,6 +1390,8 @@ describe("operation catalog consistency", () => {
     update_host: { host: "h", name: "renamed" },
     delete_host: { host: "h" },
     list_project_environments: {},
+    list_project_plugins: {},
+    get_plugin_version: { pluginVersionId: "pv" },
     get_project_environment: { environment: "e" },
     resolve_project_environment: { environment: "e" },
     create_project_environment: { name: "e", hostId: "h" },


### PR DESCRIPTION
Track A of the Agent Plugins program: three independent pieces, one consolidated PR.

## 1. Chatbox runtime payload — plugin provenance (Phase 6.1)

The env-backed chatbox branch of `web/chat-v2` used to pass `null` attribution into `resolveEffectiveCapabilities`, so chatbox traces lost plugin origin while environment-target traces carried it.

- `ChatboxEnvironmentRuntime` gains an optional `pluginVersions` field (same shape as `ResolvedEnvironmentRuntime.pluginVersions`), parsed tolerantly in `readChatboxEnvironment`: malformed entries drop to nothing — losing a provenance label, never a capability.
- When the payload pins versions, the chatbox branch fetches attribution through the same `fetchPluginRuntimeAttribution` probe the environment target uses, resolves capabilities with it, logs `problems` the same aggregated way, and stamps `setPluginOriginByServerId` onto the turn's RPC collector.
- **Guest-safe / fail-open**: the probe (`plugins:resolvePluginRuntimePreview`) is member-gated backend-side. Chatbox turns are guest-reachable, so every failure — guest bearer, deploy skew, timeout, missing `CONVEX_URL` — degrades to "origin unknown" and never stops the send. No new read happens at all when the payload pins nothing (i.e. on every turn today).

**Backend dependency (honest gap):** the deployed `mcpjam-backend` does **not** yet serve `environment.pluginVersions` on `/web/chatbox/runtime-config` — I verified `buildEnvironmentChatboxRuntimeConfig` resolves the pins for its D2 re-gate but does not serialize them into the payload. Until the backend adds that one field (mirror of `ResolvedEnvironmentRuntime.pluginVersions`: `{pluginId, pluginVersionId, name, bundleHash?}[]`), this path is wired but inert and behavior is byte-identical.

## 2. mcp/ worker — read-only plugin tools (Phase 6.2)

Two new READ-ONLY tools on the platform MCP worker, wired exactly like every sibling tool (SDK platform operation → `PlatformApiClient` → `/api/v1` → Convex string ref):

- `list_project_plugins` — live plugins in a project (name, displayName, enabled, activeVersionId), project selector like every list tool.
- `get_plugin_version` — one version's detail: status, componentCounts, per-component server summaries (placement, auth timing, materialized server id) and skill summaries (namespaced `modelRef`).

Supporting chain (all in this repo):
- New v1 routes `GET /v1/projects/:projectId/plugins` and `GET /v1/plugin-versions/:pluginVersionId`, thin proxies over the existing member-gated Convex reads `plugins:listProjectPlugins` / `plugins:getPluginVersion` (environments.ts pattern — the Convex-native read-proxy pattern the v1 README prefers needs a backend-repo half this PR cannot add). Structured `NOT_FOUND`/`FORBIDDEN` ConvexErrors both map to 404 so the route is never an existence oracle. Guest-DENIED by default (no allowlist entry).
- The version route is deliberately **not** project-scoped in the path: the backend query takes only the version id and gates on membership of the version's own project, so a `projectId` path segment would be decorative scope the gateway could not enforce.
- SDK: `PlatformPlugin`/`PlatformPluginVersion` types, `listProjectPlugins`/`getPluginVersion` client methods, two operations registered in `ALL_OPERATIONS` (new exports only).
- All five operation-partition surfaces stay total: the worker catalog **registers** both (plus README tool-table rows); the public-agent registry, in-app workspace toolset, and CLI bindings **exclude** them with written reasons — registering plugin reads on those surfaces is a deliberate widening to make separately, not to smuggle into this PR.
- OpenAPI: both routes + `Plugin`/`PluginPage`/`PluginVersion` schemas documented (drift + sdk-coverage ratchets green).

No write tools: the SDK ships no plugin write operations at all, so there is nothing to exclude — the read half is the whole surface.

## 3. httpVariant → transport mapping (Phase 3 remainder)

Agent Plugins declares per-server transport; the parser stores `httpVariant: "streamable-http" | "sse"`. Authorize payloads will carry it once the backend persists it — **today the field is absent**, and everything here is tolerant of that (absence = no declaration, config byte-identical).

- `toMCPServerConfig` (local) and `toHttpConfig` (hosted) both map: `httpVariant === "sse"` → `preferSSE: true`; `httpVariant === "streamable-http"` → `disableSseFallback: true`. The optional field is declared on both authorize serverConfig types.
- SDK: new strictly opt-in `disableSseFallback?: boolean` on `HttpServerConfig` — a server whose transport was DECLARED streamable-http must never silently downgrade to SSE. When set and the Streamable HTTP attempt fails in a way that would normally fall back, the failure surfaces instead, keeping the `MCPAuthError` classification hosts key OAuth escalation on. Inert alongside `preferSSE` (no fallback exists on that path) and on the 2026 stateless path.
- **Fallback bug fix (pre-existing, exposed by the baseline test):** the silent Streamable→SSE fallback itself was broken — the upstream Client closes the failed first transport during `connect`, firing `onclose` → `clearClosedPendingConnectionState`, so the successful SSE fallback was discarded as `"connection was cancelled"`. The close handler is now detached for the discardable first attempt only and restored on every exit; the pinned stdio handshake-cancel semantics are unchanged (its test still passes).
- **Deliberately deferred:** `disableSseFallback` is NOT added to the eval replay-config wire DTO (`MCPServerReplayConfig`). The deployed backend validates that payload with a closed `v.object` (`sdkServerReplayConfigValidator`), so an unknown field would 400 the whole replay-config store. Replayed eval connections therefore run without the flag until the backend widens the validator — noted here so that follow-up carries both halves together.

## Tests

- sdk: 202 files, 3877 passed / 1 skipped — incl. new `MCPClientManager.sse-fallback.test.ts` (4 tests: baseline fallback now connects, flag surfaces the error, flag inert on a working streamable server, MCPAuthError preserved) and 2 new platform-operation tests.
- server: 352 files, 5002 passed — incl. 3 new chatbox-attribution route tests, 8 new v1 plugins route tests, 3 + 3 new httpVariant mapping tests, and the partition/openapi/sdk-coverage ratchets.
- mcp worker: 5 files, 44 passed (catalog partition, registration order, plugin tool round-trips, README tool table).
- cli: `op-bindings` ratchet 4 passed (node:test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat turn capability resolution, MCP connect/fallback semantics, and new authenticated read routes; behavior is mostly additive and fail-open on chatbox attribution, but transport and fallback changes affect how plugin-declared servers connect and what traces record.
> 
> **Overview**
> **Track A** bundles three changes: read-only plugin inventory on the public API/MCP worker, chatbox turns that can stamp plugin origin when the runtime payload carries pins, and honoring plugin-declared `httpVariant` end-to-end in the MCP client stack.
> 
> **Plugin reads** add `GET /projects/{projectId}/plugins` and `GET /plugin-versions/{pluginVersionId}` (Convex proxies, member-gated, guests denied, `NOT_FOUND`/`FORBIDDEN` → 404), OpenAPI schemas, SDK types/client/operations, and **`list_project_plugins` / `get_plugin_version` on the platform MCP catalog only** — public agent, in-app workspace tools, and CLI document explicit exclusions until a `plugins` CLI group exists.
> 
> **Chatbox provenance (Phase 6.1)** parses optional `pluginVersions` on the chatbox environment payload, probes attribution like the environment target when pins are present, and feeds `resolveEffectiveCapabilities` plus RPC `pluginOriginByServerId`; probe failures are fail-open (guest-safe). **Inert until the backend serves `pluginVersions` on chatbox runtime config.**
> 
> **Transport (Phase 3)** maps authorize `httpVariant` in local/hosted resolvers: `sse` → `preferSSE`, `streamable-http` → `preferSSE: false` + new opt-in **`disableSseFallback`** so declared streamable servers do not silently use SSE; the HTTP doctor and reported transport metadata follow the live connection. Fixes a pre-existing bug where the first Streamable HTTP attempt’s `onclose` cancelled a successful SSE fallback. **`disableSseFallback` is not on eval replay-config wire** yet (backend validator).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1206f75f38bb39f75b0f3fdc1265aaa14caa044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds chatbox plugin provenance, read-only plugin inventory APIs/tools, and declared HTTP transport mapping with stricter, correct behavior. Also fixes Streamable→SSE fallback and makes transport metadata report the transport that actually connected.

- **New Features**
  - Chatbox provenance: reads `pluginVersions` from the chatbox environment payload, resolves attribution via the same probe as environments, and stamps per-server plugin origin on RPC frames. Fail-open for guests; no probe when nothing is pinned. Behavior is inert until the backend serves `pluginVersions`.
  - Plugin APIs/tools: adds `GET /v1/projects/{projectId}/plugins` and `GET /v1/plugin-versions/{pluginVersionId}` (member-gated; 404 for NOT_FOUND/FORBIDDEN). SDK adds `PlatformPlugin`/`PlatformPluginVersion` and client methods `listProjectPlugins`/`getPluginVersion`, plus MCP worker ops; public agent, workspace, and CLI exclude them for now. OpenAPI updated.
  - Transport mapping: maps declared `httpVariant` to SDK config in both local and hosted resolvers. `"sse"` → `preferSSE: true`. `"streamable-http"` → `disableSseFallback: true` and `preferSSE: false` so a `/sse` URL cannot override the declaration. Replay-config DTO unchanged.

- **Bug Fixes**
  - Fixed the Streamable→SSE fallback being cancelled by an early `onclose` during the first attempt; the close handler is now detached for the discardable attempt and restored afterward.
  - Reported transport now reflects the live connection (SSE vs Streamable HTTP), not config heuristics; honors `preferSSE: false` and avoids misreporting on `/sse` paths or after fallbacks. The HTTP server doctor also respects `disableSseFallback` instead of diagnosing readiness over SSE after a failed Streamable HTTP attempt.

<sup>Written for commit a1206f75f38bb39f75b0f3fdc1265aaa14caa044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

