### PR TITLE
fix(surface): retry the failed page, and stop reading Slack's actor key elsewhere

### DIFF
--- a/mcpjam-inspector/client/src/components/organization/__tests__/SurfaceActivityTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/SurfaceActivityTab.test.tsx
@@ -129,4 +129,60 @@ describe("SurfaceActivityTab", () => {
       screen.queryByRole("button", { name: "Load more" })
     ).not.toBeInTheDocument();
   });
+
+  it("ignores the Slack-only legacy actor key on another surface", () => {
+    // Not reachable today — `slackUserId` is written only by
+    // `slackAccountLinks`, which emits `slack.agent.*`. Pinned anyway because
+    // reading a surface-specific key on every surface is the shape of the bug
+    // this component exists to remove.
+    activity.events = [
+      event({
+        _id: "d",
+        action: "discord.agent.account_linked",
+        metadata: { slackUserId: "U_SLACK" },
+      }),
+    ];
+
+    render(<SurfaceActivityTab organizationId="org-1" surfaceKind="discord" />);
+    expect(screen.queryByText("Discord U_SLACK")).not.toBeInTheDocument();
+    expect(screen.getByText("MCPJam")).toBeInTheDocument();
+  });
+
+  describe("retrying a failed page", () => {
+    // `error` is one shared state for the first fetch and for `loadMore`, and
+    // `refresh` resets the cursor. Once this tab began filtering, "no rows"
+    // stopped meaning "nothing loaded" — so the two failures need telling
+    // apart or a failed page hands the user a button that restarts paging.
+    it("offers loadMore, not refresh, when a page failed but events exist", () => {
+      activity.events = [
+        event({ _id: "s", action: "slack.agent.channel_binding_created" }),
+      ];
+      activity.hasMore = true;
+      activity.error = new Error("network");
+
+      render(
+        <SurfaceActivityTab organizationId="org-1" surfaceKind="discord" />
+      );
+      expect(
+        screen.getByRole("button", { name: "Load more" })
+      ).toBeInTheDocument();
+      // "Try again" is the cursor-resetting refresh; it must not be the offer
+      // here, or the user loops over the same page forever.
+      expect(
+        screen.queryByRole("button", { name: "Try again" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("still offers refresh when nothing loaded at all", () => {
+      activity.events = [];
+      activity.error = new Error("network");
+
+      render(
+        <SurfaceActivityTab organizationId="org-1" surfaceKind="discord" />
+      );
+      expect(
+        screen.getByRole("button", { name: "Try again" })
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/organization/surface/SurfaceActivityTab.tsx
+++ b/mcpjam-inspector/client/src/components/organization/surface/SurfaceActivityTab.tsx
@@ -92,13 +92,22 @@ function readString(
 
 function actorLabel(
   event: SlackAgentActivityEvent,
+  surfaceKind: SurfaceKind,
   surfaceLabel: string
 ): string {
   if (event.actorEmail) return event.actorEmail;
   const surfaceId =
     readString(event.metadata, "executorSurfaceUserId") ??
     readString(event.metadata, "proposerSurfaceUserId") ??
-    readString(event.metadata, "slackUserId");
+    // `slackUserId` is the pre-generic spelling and is Slack's alone, so it is
+    // only consulted for Slack. Unreachable today — the only writers are
+    // `slackAccountLinks`, which emits `slack.agent.*` — but reading a
+    // surface-specific key on every surface is the exact shape of the
+    // mislabel this component was written to remove, and the generic keys
+    // above already cover Discord.
+    (surfaceKind === "slack"
+      ? readString(event.metadata, "slackUserId")
+      : null);
   // A surface id with no MCPJam identity is a real state (the legacy
   // workspace runs on a shared key), so it is shown rather than blanked.
   return surfaceId ? `${surfaceLabel} ${surfaceId}` : "MCPJam";
@@ -158,7 +167,7 @@ export function SurfaceActivityTab({
           // Falls back to the raw action so an action this build has no label
           // for is still legible rather than blank.
           action: ACTION_LABELS[suffix] ?? event.action,
-          actor: actorLabel(event, copy.label),
+          actor: actorLabel(event, surfaceKind, copy.label),
           proposer: readString(event.metadata, "proposerSurfaceUserId"),
           detail: detailLabel(event),
           status: statusFor(event),
@@ -177,11 +186,17 @@ export function SurfaceActivityTab({
     </Button>
   ) : null;
 
-  // Only when there is nothing to show. A failed "Load more" keeps the rows it
-  // already has, and replacing the whole feed with an alert would take away
-  // what the admin was reading over a transient page fetch — so that case is
-  // surfaced beside the button instead, with a retry.
-  if (error && rows.length === 0) {
+  // NOTHING LOADED AT ALL, measured on the unfiltered `events` rather than on
+  // the filtered `rows`. The two used to be the same thing; once this tab
+  // started filtering by surface they diverged, and the difference decides
+  // which retry the user gets. `error` is one shared state set by both the
+  // first fetch and `loadMore`, and `refresh` calls `setCursor(null)` — so
+  // keying this branch on `rows` would answer a failed `loadMore` (on a page
+  // that happened to hold none of this surface's rows) by throwing the cursor
+  // away and refetching page one, stranding the user on a page they cannot
+  // get past. Empty-but-loaded is handled below, where the retry is
+  // `loadMore`.
+  if (error && events.length === 0) {
     return (
       <div className="space-y-3">
         <p
@@ -197,7 +212,9 @@ export function SurfaceActivityTab({
     );
   }
 
-  if (isLoading && rows.length === 0) {
+  // Same reasoning: `isLoading` is the first fetch (paging sets
+  // `isLoadingMore`), so it pairs with the unfiltered count.
+  if (isLoading && events.length === 0) {
     return (
       <div className="px-4 py-8 text-sm text-muted-foreground">Loading…</div>
     );
@@ -216,6 +233,13 @@ export function SurfaceActivityTab({
             ? `${copy.emptyState} Older events may be further back.`
             : copy.emptyState}
         </p>
+        {/* A page fetch that failed here is reported in place, keeping
+            `loadMore` as the retry so the cursor survives. */}
+        {error ? (
+          <p className="text-sm text-destructive" role="alert">
+            Could not load more activity. Try again in a moment.
+          </p>
+        ) : null}
         {loadMoreButton}
       </div>
     );


### PR DESCRIPTION
Both findings from review on #3840. One is a real regression that PR
introduced; the other is not reachable today. Saying which is which, because
they deserve different confidence.

## 1. A failed page offered the wrong retry — real, and mine

`error` is **one shared state** in `useSlackAgentActivity`, set by both the
first fetch and by `loadMore`. `refresh` calls `setCursor(null)`.

Before #3840 the "nothing to show" branch was safe, because `rows` was every
loaded event — empty rows genuinely meant nothing had loaded. Client-side
surface filtering broke that equivalence: `rows` can now be empty while
`events` is full.

So a `loadMore` failure on a page holding none of this surface's rows landed in
the initial-load branch and offered **"Try again" → `refresh()`**, which throws
the cursor away and refetches page one. The user cannot retry the page that
failed, and paging forward re-runs the same failure.

Both "nothing loaded" branches now key on the unfiltered `events.length`, which
is what they were always asking about. The empty-but-loaded state reports a
page error in place and keeps `loadMore` as the retry, so the cursor survives.

## 2. Slack's legacy actor key was read on every surface — hardening

`actorLabel` fell back to `metadata.slackUserId` regardless of surface, so a
`discord.agent.*` event carrying that key would render `Discord <a Slack id>` —
the same mislabel #3840 removed.

**Not reachable today**, and I checked rather than assuming: the only writer of
`slackUserId` metadata is `slackAccountLinks.ts`, which emits exclusively
`slack.agent.account_linked` / `_unlinked`. `surfaceLinkSessions.ts` — the path
every Discord link takes — never writes it.

Gated to Slack anyway. The generic `executorSurfaceUserId` /
`proposerSurfaceUserId` already cover Discord, so the legacy key has nothing to
contribute elsewhere, and leaving a surface-specific key in a surface-neutral
read is how this becomes a real bug the first time someone adds a Discord
writer. The test says in its own comment that it is pinning an unreachable
case.

## Tests

3 new: the two retry branches (page failed with events present → `loadMore`,
never `Try again`; nothing loaded → `Try again` still offered) and the legacy
key being ignored off-Slack.

**Verified non-vacuous**: reverting both fixes fails exactly those two new
cases and nothing else.

Full file green (8). Client suite green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Org admin UI only—activity list retry behavior and display labels—with no auth, API, or data-model changes.
> 
> **Overview**
> Fixes **Surface activity** paging and actor display after client-side surface filtering.
> 
> **Failed-page retry:** Initial error and loading states now use unfiltered `events.length` instead of filtered `rows.length`. A `loadMore` failure on a page with no rows for the current surface no longer shows **Try again** (`refresh`, cursor reset); the empty state shows an inline error and keeps **Load more** so the cursor survives.
> 
> **Actor labels:** `actorLabel` only falls back to `metadata.slackUserId` when `surfaceKind === "slack"`, avoiding mislabeled Discord rows if that legacy key appears on non-Slack events.
> 
> Adds three tests covering off-Slack `slackUserId` ignore and the two retry branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d54b886036937203d94fa6ec6c17e7eb045761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes activity feed retry behavior so a failed page can be retried without resetting the cursor, and stops using Slack’s legacy actor id on non-Slack surfaces to prevent mislabels.

- **Bug Fixes**
  - Retry: Base “nothing loaded” on unfiltered events, not filtered rows. A failed page now shows “Load more” and keeps the cursor. Initial-load errors still show “Try again,” and empty-but-loaded shows an inline page error.
  - Actor labeling: Only read `metadata.slackUserId` when `surfaceKind` is `slack`. Use generic `executorSurfaceUserId`/`proposerSurfaceUserId` elsewhere to avoid “Discord <Slack id>”.

<sup>Written for commit 22d54b886036937203d94fa6ec6c17e7eb045761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

