### PR TITLE
feat(oauth): toast what the provider actually returned on refresh failure

### DIFF
--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
@@ -29,6 +29,8 @@ import {
   validateHostedServer,
   type HostedServerValidateContext,
 } from "@/lib/apis/web/servers-api";
+import { describeHostedOAuthFailure } from "@/lib/hosted-oauth-failure";
+import { toast } from "@/lib/toast";
 import { slugify } from "@/lib/chatbox-session";
 import { captureCurrentReturnPath, routePaths } from "@/lib/app-navigation";
 import { ingestOAuthTraceLogs } from "@/stores/traffic-log-store";
@@ -291,6 +293,59 @@ export function useHostedOAuthGate({
     );
   }, [oauthServers, surface, isVaultBacked, verifyVaultCredentialOnLoad]);
 
+  // `authorizeServer` is declared below and changes identity with its deps.
+  // Reaching it through a ref keeps the Reconnect action current without
+  // adding a dependency that would re-run the processing effect.
+  const authorizeServerRef = useRef<
+    ((server: HostedOAuthServerDescriptor) => Promise<void>) | null
+  >(null);
+
+  const showHostedOAuthFailureToast = useCallback(
+    (error: unknown, server: HostedOAuthServerDescriptor) => {
+      const copy = describeHostedOAuthFailure(error, server.serverName);
+      if (!copy) {
+        return;
+      }
+
+      toast.error(copy.title, {
+        id: `hosted-oauth-failure-${server.serverId}`,
+        description: copy.detail.join("\n"),
+        descriptionClassName: "whitespace-pre-wrap break-all font-mono text-xs",
+        ...(copy.action === "reconnect"
+          ? {
+              action: {
+                label: "Reconnect",
+                onClick: () => {
+                  void authorizeServerRef.current?.(server);
+                },
+              },
+            }
+          : {}),
+        ...(copy.action === "retry"
+          ? {
+              action: {
+                label: "Retry",
+                onClick: () => {
+                  setOAuthStateByServerId((previous) => ({
+                    ...previous,
+                    [server.serverId]: {
+                      status: "verifying",
+                      errorMessage: null,
+                      serverUrl:
+                        previous[server.serverId]?.serverUrl ??
+                        server.serverUrl ??
+                        null,
+                    },
+                  }));
+                },
+              },
+            }
+          : {}),
+      });
+    },
+    []
+  );
+
   useEffect(() => {
     if (oauthServers.length === 0) {
       return;
@@ -389,6 +444,10 @@ export function useHostedOAuthGate({
           serverName: server.serverName,
           error: validation.error,
         });
+        // The inline banner carries the generic copy. A refresh that failed
+        // upstream gets a toast on top of it, because the two upstream causes
+        // need opposite actions from the user and the banner cannot say which.
+        showHostedOAuthFailureToast(validation.error, server);
         clearHostedOAuthResumeMarker();
         setStoredOAuthTokenState(
           server.serverName,
@@ -424,6 +483,7 @@ export function useHostedOAuthGate({
     chatboxId,
     accessVersion,
     projectId,
+    showHostedOAuthFailureToast,
   ]);
 
   const authorizeServer = useCallback(
@@ -563,6 +623,10 @@ export function useHostedOAuthGate({
       projectId,
     ]
   );
+
+  useEffect(() => {
+    authorizeServerRef.current = authorizeServer;
+  }, [authorizeServer]);
 
   const markOAuthRequired = useCallback(
     (details?: HostedOAuthRequiredDetails) => {

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-failure.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-oauth-failure.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { describeHostedOAuthFailure } from "@/lib/hosted-oauth-failure";
+
+// Messages below are copied from real CONVEX-PY events rather than invented,
+// so the parser is pinned to what the backend actually throws.
+const UNREACHABLE =
+  "Uncaught Error: HTTP 530 trying to load OAuth metadata from https://eliya.descope.team/.well-known/oauth-authorization-server/v1/apps/agentic/P3HPHwb4OyQsnBBe0qSh1lzd0beM/MS3HPHzvY6sFscOfZ416p9ZWLDTLa (error code: 1033)";
+
+const DECLINED = "Uncaught InvalidGrantError: Token is not active";
+
+const DECLINED_WITH_BODY =
+  'Uncaught ServerError: HTTP 400: Invalid OAuth error response: [{"expected":"string"}]. Raw body: {"code":400,"error_code":"refresh_token_not_found","msg":"Invalid Refresh Token: Refresh Token Not Found"}';
+
+describe("describeHostedOAuthFailure", () => {
+  it("names the host and shows the status the host returned", () => {
+    const copy = describeHostedOAuthFailure(UNREACHABLE, "Descope");
+
+    expect(copy).toEqual({
+      kind: "unreachable",
+      title: "Could not reach eliya.descope.team",
+      detail: [
+        "GET https://eliya.descope.team/.well-known/oauth-authorization-server/v1/apps/agentic/P3HPHwb4OyQsnBBe0qSh1lzd0beM/MS3HPHzvY6sFscOfZ416p9ZWLDTLa",
+        "HTTP 530, error code: 1033",
+      ],
+      action: "retry",
+    });
+  });
+
+  it("omits the body clause when the backend captured no body", () => {
+    const copy = describeHostedOAuthFailure(
+      "HTTP 502 trying to load OAuth metadata from https://tal.descope.team/.well-known/oauth-authorization-server",
+      "Descope"
+    );
+
+    expect(copy?.detail[1]).toBe("HTTP 502");
+  });
+
+  it("asks for a reconnect when the provider rejected the refresh token", () => {
+    const copy = describeHostedOAuthFailure(DECLINED, "Linear");
+
+    expect(copy?.kind).toBe("declined");
+    expect(copy?.title).toBe("Refresh token declined for Linear");
+    expect(copy?.action).toBe("reconnect");
+  });
+
+  it("shows the provider's own body rather than the schema noise wrapping it", () => {
+    const copy = describeHostedOAuthFailure(DECLINED_WITH_BODY, "Supabase");
+
+    expect(copy?.kind).toBe("declined");
+    expect(copy?.detail).toEqual([
+      '{"code":400,"error_code":"refresh_token_not_found","msg":"Invalid Refresh Token: Refresh Token Not Found"}',
+    ]);
+  });
+
+  it("never pairs a host with a message that host did not return", () => {
+    // An unreachable host cannot also have answered "Token is not active" —
+    // whichever branch matches must carry only its own event's values.
+    const copy = describeHostedOAuthFailure(UNREACHABLE, "Descope");
+
+    expect(copy?.kind).toBe("unreachable");
+    expect(copy?.detail.join(" ")).not.toMatch(/not active/i);
+  });
+
+  it("returns null when the error is not an OAuth refresh failure", () => {
+    expect(describeHostedOAuthFailure("Something else broke", "X")).toBeNull();
+    expect(describeHostedOAuthFailure("", "X")).toBeNull();
+    expect(describeHostedOAuthFailure(null, "X")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-failure.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-failure.ts
@@ -1,0 +1,105 @@
+/**
+ * Turns a hosted OAuth refresh failure into toast copy.
+ *
+ * Two failures reach the user through the same thrown error, and they need
+ * opposite actions:
+ *
+ * - The authorization server could not be reached at all, so discovery never
+ *   got as far as the token request. Retrying may work.
+ * - The authorization server answered and rejected the stored refresh token.
+ *   Retrying never works; the user has to authorize again.
+ *
+ * Every value below is read off the error. Nothing is filled in by hand, so a
+ * host is only ever named next to the response that host actually returned.
+ */
+
+export type HostedOAuthFailureKind = "unreachable" | "declined" | "unknown";
+
+export interface HostedOAuthFailureCopy {
+  kind: HostedOAuthFailureKind;
+  title: string;
+  /** Lines rendered under the title, in order. May be empty. */
+  detail: string[];
+  action: "retry" | "reconnect" | null;
+}
+
+/** `HTTP 530 trying to load OAuth metadata from https://host/... (body)` */
+const METADATA_FAILURE =
+  /HTTP (\d{3}) trying to load (?:OAuth|OpenID provider) metadata from (\S+?)(?:\s+\(([^)]*)\))?\s*$/i;
+
+/** The token endpoint answered, and the answer was "no". */
+const DECLINED =
+  /invalid[_\s-]?grant|InvalidGrantError|refresh[_\s-]?token[_\s-]?not[_\s-]?found|token is not active|expired (?:access\/)?refresh token/i;
+
+function toMessage(error: unknown): string {
+  const raw =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : error && typeof error === "object" && "message" in error
+          ? String((error as { message: unknown }).message)
+          : "";
+
+  return raw
+    .replace(/\s+/g, " ")
+    .replace(/^Uncaught\s+(?:\w*Error):\s*/i, "")
+    .trim();
+}
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pulls the provider's own words out of a wrapped error. The backend nests the
+ * upstream payload behind `Raw body:`, which is the part worth showing; the
+ * schema-validation noise in front of it is not.
+ */
+function upstreamDetail(message: string): string | null {
+  const rawBody = message.match(/Raw body:\s*(.+)$/i);
+  if (rawBody?.[1]) {
+    return rawBody[1].trim();
+  }
+
+  const status = message.match(/HTTP (\d{3})/i);
+  return status ? `HTTP ${status[1]}` : null;
+}
+
+export function describeHostedOAuthFailure(
+  error: unknown,
+  serverName: string
+): HostedOAuthFailureCopy | null {
+  const message = toMessage(error);
+  if (!message) {
+    return null;
+  }
+
+  const metadata = message.match(METADATA_FAILURE);
+  if (metadata) {
+    const [, status, url, body] = metadata;
+    const host = hostOf(url);
+    return {
+      kind: "unreachable",
+      title: `Could not reach ${host ?? url}`,
+      detail: [`GET ${url}`, body ? `HTTP ${status}, ${body}` : `HTTP ${status}`],
+      action: "retry",
+    };
+  }
+
+  if (DECLINED.test(message)) {
+    const detail = upstreamDetail(message);
+    return {
+      kind: "declined",
+      title: `Refresh token declined for ${serverName}`,
+      detail: detail ? [detail] : [message],
+      action: "reconnect",
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
…lure

A hosted OAuth refresh fails two ways that need opposite actions: the authorization server could not be reached, or it answered and rejected the stored refresh token. Both surfaced as the same generic banner.

Show a toast built only from values read off the error, so a host is never named next to a response it did not return.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-accurate toast for hosted OAuth refresh failures. The toast shows exactly what the provider returned and guides the user to Retry or Reconnect as appropriate.

- **New Features**
  - Classifies errors as "unreachable" or "declined" via `describeHostedOAuthFailure`.
  - Shows a toast built from the error (host, status, and raw body when present) without misattributing hosts.
  - Provides context-aware actions: Retry for unreachable, Reconnect for declined (Reconnect wired via a ref to the current authorizer).
  - Keeps the existing generic banner; the toast appears only on refresh failures to clarify next steps.
  - Adds unit tests using real backend messages to pin parsing behavior.

<sup>Written for commit 33c5feaf32d7338edebb93ff1c3e7c407e47e262. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

