### PR TITLE
feat(computers): local computer engine endgame — playground polish, local terminal, launch prep

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/tool-part-run-location.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/tool-part-run-location.test.tsx
@@ -115,6 +115,8 @@ describe("readToolRunLocation", () => {
   });
 
   it("ignores an absent, unknown, or non-object result", () => {
+    expect(readToolRunLocation("bash", {})).toBeNull();
+    expect(readToolRunLocation("bash", { engine: "" })).toBeNull();
     expect(readToolRunLocation("bash", { stdout: "hi" })).toBeNull();
     expect(readToolRunLocation("bash", { engine: "quantum" })).toBeNull();
     expect(readToolRunLocation("bash", null)).toBeNull();

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/tool-part-run-location.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/tool-part-run-location.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * The bash card's run-location pill. Non-hosted bash turns stamp
+ * `engine: "local" | "cloud"` onto the tool result; the card surfaces it so the
+ * transcript says WHICH machine ran the command. Everything else — old
+ * transcripts, hosted turns, the ephemeral sandbox-bash tool, non-bash tools —
+ * must render nothing rather than guess.
+ *
+ * Mock stack mirrors tool-part-approval.test.tsx, except `getToolNameFromType`
+ * returns "bash" (the pill is bash-only).
+ */
+
+vi.mock("lucide-react", () => {
+  const s = (props: any) => <div {...props} />;
+  return {
+    Box: s,
+    Check: s,
+    ChevronDown: s,
+    Database: s,
+    Loader2: s,
+    Maximize2: s,
+    MessageCircle: s,
+    Pencil: s,
+    PictureInPicture2: s,
+    Play: s,
+    RotateCcw: s,
+    Shield: s,
+    ShieldCheck: s,
+    ShieldX: s,
+    Terminal: s,
+    X: s,
+  };
+});
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (selector: any) => selector({ themeMode: "light" }),
+}));
+
+vi.mock("@/stores/widget-debug-store", () => ({
+  useWidgetDebugStore: (selector: any) => selector({ widgets: new Map() }),
+}));
+
+const toolNameState = vi.hoisted(() => ({ name: "bash" }));
+vi.mock("../../thread-helpers", () => ({
+  getToolNameFromType: () => toolNameState.name,
+  getToolStateMeta: () => ({
+    Icon: (props: any) => <div data-testid="status-icon" {...props} />,
+    className: "",
+  }),
+  safeStringify: (v: any) => JSON.stringify(v),
+  isDynamicTool: () => false,
+}));
+
+vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => ({
+  UIType: { MCP_APPS: "mcp-apps", OPENAI_SDK: "openai-apps" },
+}));
+
+vi.mock("@mcpjam/design-system/tooltip", () => ({
+  Tooltip: ({ children }: any) => <>{children}</>,
+  TooltipTrigger: ({ children }: any) => <>{children}</>,
+  TooltipContent: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock("@mcpjam/design-system/badge", () => ({
+  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}));
+
+vi.mock("../../sandbox-debug-panel", () => ({
+  SandboxDebugPanel: () => null,
+}));
+
+vi.mock("@/components/ui/json-editor", () => ({
+  JsonEditor: ({ value }: any) => (
+    <pre data-testid="json-editor">{JSON.stringify(value)}</pre>
+  ),
+}));
+
+vi.mock("../text-part", () => ({
+  TextPart: ({ text }: { text: string }) => (
+    <div data-testid="text-part">{text}</div>
+  ),
+}));
+
+import { ToolPart, readToolRunLocation } from "../tool-part";
+
+const basePart = {
+  type: "tool-invocation" as const,
+  toolName: "bash",
+  toolCallId: "call-1",
+  state: "output-available",
+  input: { command: "uname -a" },
+  output: {},
+};
+
+function renderBash(output: unknown, extra: Record<string, unknown> = {}) {
+  return render(
+    <ToolPart
+      part={{ ...basePart, output } as any}
+      uiType="mcp-apps"
+      {...(extra as any)}
+    />,
+  );
+}
+
+describe("readToolRunLocation", () => {
+  it("reads the stamped engine on a bash result", () => {
+    expect(readToolRunLocation("bash", { engine: "local" })).toBe("local");
+    expect(readToolRunLocation("bash", { engine: "cloud" })).toBe("cloud");
+  });
+
+  it("ignores non-bash tools even when the field is present", () => {
+    expect(readToolRunLocation("readFile", { engine: "local" })).toBeNull();
+  });
+
+  it("ignores an absent, unknown, or non-object result", () => {
+    expect(readToolRunLocation("bash", { stdout: "hi" })).toBeNull();
+    expect(readToolRunLocation("bash", { engine: "quantum" })).toBeNull();
+    expect(readToolRunLocation("bash", null)).toBeNull();
+    expect(readToolRunLocation("bash", "output")).toBeNull();
+    expect(readToolRunLocation(undefined, { engine: "local" })).toBeNull();
+  });
+});
+
+describe("ToolPart run-location pill", () => {
+  it("renders 'this machine' for a local bash result", () => {
+    renderBash({ stdout: "Linux", exitCode: 0, engine: "local" });
+    expect(screen.getByTestId("tool-run-location")).toHaveTextContent(
+      "this machine",
+    );
+  });
+
+  it("renders 'cloud' for a cloud bash result", () => {
+    renderBash({ stdout: "Linux", exitCode: 0, engine: "cloud" });
+    expect(screen.getByTestId("tool-run-location")).toHaveTextContent("cloud");
+  });
+
+  it("renders on an ERROR result too — a failed command still ran somewhere", () => {
+    renderBash({ error: "Command failed to run.", engine: "local" });
+    expect(screen.getByTestId("tool-run-location")).toHaveTextContent(
+      "this machine",
+    );
+  });
+
+  it("renders nothing when the result carries no engine (old transcript / hosted)", () => {
+    renderBash({ stdout: "Linux", exitCode: 0 });
+    expect(screen.queryByTestId("tool-run-location")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a non-bash tool", () => {
+    toolNameState.name = "readFile";
+    try {
+      renderBash({ engine: "local" });
+      expect(screen.queryByTestId("tool-run-location")).not.toBeInTheDocument();
+    } finally {
+      toolNameState.name = "bash";
+    }
+  });
+
+  it("reads the RAW output, not the editable display value", () => {
+    // `rawOutput` is the frozen server value; `outputValue` is what the Raw tab
+    // editor shows and a user can rewrite. Provenance must follow the former.
+    render(
+      <ToolPart
+        part={{ ...basePart, output: { engine: "cloud" } } as any}
+        uiType="mcp-apps"
+        rawOutput={{ engine: "local" }}
+        outputValue={{ engine: "cloud" }}
+      />,
+    );
+    expect(screen.getByTestId("tool-run-location")).toHaveTextContent(
+      "this machine",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/tool-part-run-location.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/tool-part-run-location.test.tsx
@@ -138,7 +138,10 @@ describe("ToolPart run-location pill", () => {
     expect(screen.getByTestId("tool-run-location")).toHaveTextContent("cloud");
   });
 
-  it("renders on an ERROR result too — a failed command still ran somewhere", () => {
+  it("renders when the result carries an `error` field — a failed command still ran somewhere", () => {
+    // The local bash tool reports soft failures as a NORMAL tool result with an
+    // `error` field (not the AI SDK's `output-error` state), which is why this
+    // is `output-available` with `error` inside the output.
     renderBash({ error: "Command failed to run.", engine: "local" });
     expect(screen.getByTestId("tool-run-location")).toHaveTextContent(
       "this machine",

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -209,6 +209,12 @@ export function ToolPart({
   const inputData = (part as any).input;
   const outputData = (part as any).output;
   const rawResultData = rawOutput ?? outputData;
+  // Where this bash call actually ran. Read from the RAW output (the frozen
+  // server value) rather than `resultDisplayData` — the latter is the editable
+  // Raw-tab value, which a user can rewrite, and provenance must not be
+  // editable. Absent on old transcripts, hosted turns, and the ephemeral
+  // sandbox-bash tool, which is why nothing renders in that case.
+  const runLocation = readToolRunLocation(label, rawResultData);
   const resultDisplayData =
     outputValue !== undefined ? outputValue : rawResultData;
   const imagePreviewData = rawResultData;
@@ -935,6 +941,19 @@ export function ToolPart({
                 from {appToolAttribution.appName}
               </span>
             )}
+            {runLocation && (
+              <span
+                data-testid="tool-run-location"
+                title={
+                  runLocation === "local"
+                    ? "This command ran on the computer running the inspector."
+                    : "This command ran in your cloud computer."
+                }
+                className="inline-flex items-center rounded-full bg-foreground/5 px-1.5 py-0.5 text-[10px] text-muted-foreground/80 shrink-0"
+              >
+                {runLocation === "local" ? "this machine" : "cloud"}
+              </span>
+            )}
           </span>
         </span>
         <span className="inline-flex items-center gap-1.5 text-muted-foreground">
@@ -1121,4 +1140,29 @@ export function ToolPart({
       )}
     </div>
   );
+}
+
+/**
+ * Run-location provenance for the computer `bash` tool.
+ *
+ * Non-hosted bash turns stamp `engine: "local" | "cloud"` onto the tool result
+ * (success AND error) so the transcript can say which machine the command
+ * actually ran on — the one thing a user cannot infer from the output. The
+ * field is absent everywhere else (old transcripts, hosted servers, the
+ * ephemeral sandbox-bash tool), and an absent/unknown value renders nothing
+ * rather than guessing.
+ *
+ * Kept local to this file on purpose: `thread-helpers` is a pure re-export of
+ * `@mcpjam/chat-ui` and is not a home for inspector-specific display logic.
+ */
+export function readToolRunLocation(
+  toolName: string | undefined,
+  rawResult: unknown,
+): "local" | "cloud" | null {
+  if (toolName !== "bash") return null;
+  if (!rawResult || typeof rawResult !== "object") return null;
+  const engine = (rawResult as { engine?: unknown }).engine;
+  if (engine === "local") return "local";
+  if (engine === "cloud") return "cloud";
+  return null;
 }

--- a/mcpjam-inspector/client/src/components/computer/ComputerTabView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTabView.tsx
@@ -1,3 +1,4 @@
+import { track } from "@/lib/analytics";
 import { HOSTED_MODE } from "@/lib/config";
 import { ViewModeSelector } from "@/components/shared/view-mode-selector";
 import { useComputerEngine } from "@/hooks/useComputerEngine";
@@ -48,7 +49,14 @@ export function ComputerTabView({
               { value: "local", label: "This machine" },
               { value: "cloud", label: "Cloud" },
             ]}
-            onChange={(next) => engine.setEngine(next)}
+            onChange={(next) => {
+              // The engine NAME only — no project id, no workspace path.
+              track("computer_engine_selected", {
+                location: "computer_tab",
+                engine: next,
+              });
+              engine.setEngine(next);
+            }}
           />
         </div>
       ) : null}

--- a/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
@@ -124,6 +124,8 @@ export function ComputerTerminal({
   className,
   baseUrl,
   cwd,
+  wsPath,
+  uploadEnabled = true,
 }: {
   mintToken: () => Promise<string>;
   themeMode: "light" | "dark";
@@ -140,6 +142,20 @@ export function ComputerTerminal({
    * To re-target an already-open terminal, remount with a new `key`.
    */
   cwd?: string;
+  /**
+   * WebSocket route. Defaults to the cloud terminal; the local ("This machine")
+   * pane passes `LOCAL_TERMINAL_WS_PATH`.
+   */
+  wsPath?: string;
+  /**
+   * Whether drag-and-drop upload is offered. The upload targets the CLOUD box's
+   * upload route, so the LOCAL pane must pass `false`: there it would burn its
+   * single-use nonce against the wrong route and toast "Upload failed". When
+   * false the drop handlers are not attached at all and the overlay copy is
+   * suppressed, so there is no affordance suggesting a capability that isn't
+   * there.
+   */
+  uploadEnabled?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -209,6 +225,7 @@ export function ComputerTerminal({
       rows: term.rows,
       ...(baseUrl ? { baseUrl } : {}),
       ...(cwd ? { cwd } : {}),
+      ...(wsPath ? { path: wsPath } : {}),
       onOutput: (bytes) => {
         if (isStale()) return;
         term.write(bytes);
@@ -239,7 +256,7 @@ export function ComputerTerminal({
       if (isStale()) return;
       conn.ping();
     }, PING_INTERVAL_MS);
-  }, [mintToken, teardownConnection, baseUrl, cwd]);
+  }, [mintToken, teardownConnection, baseUrl, cwd, wsPath]);
 
   const handleCopy = useCallback(() => {
     const sel = termRef.current?.getSelection();
@@ -462,13 +479,17 @@ export function ComputerTerminal({
         {/* Terminal canvas + overlay */}
         <div
           className="relative min-h-0 flex-1"
-          onDragEnter={handleDragEnter}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
+          {...(uploadEnabled
+            ? {
+                onDragEnter: handleDragEnter,
+                onDragOver: handleDragOver,
+                onDragLeave: handleDragLeave,
+                onDrop: handleDrop,
+              }
+            : {})}
         >
           <div ref={containerRef} className="absolute inset-0 p-1" onClick={() => termRef.current?.focus()} />
-          {dragActive || uploading ? (
+          {uploadEnabled && (dragActive || uploading) ? (
             <div className="pointer-events-none absolute inset-2 z-10 flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-primary/60 bg-background/85 text-sm">
               {uploading ? (
                 <span className="inline-flex items-center gap-2 text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
@@ -152,9 +152,12 @@ export function ComputerTerminal({
    * Whether drag-and-drop upload is offered. The upload targets the CLOUD box's
    * upload route, so the LOCAL pane must pass `false`: there it would burn its
    * single-use nonce against the wrong route and toast "Upload failed". When
-   * false the drop handlers are not attached at all and the overlay copy is
-   * suppressed, so there is no affordance suggesting a capability that isn't
-   * there.
+   * false the upload and the overlay copy are suppressed, so there is no
+   * affordance suggesting a capability that isn't there.
+   *
+   * The drop handlers STAY attached either way — they must still cancel the
+   * browser's default file-drop navigation, which would otherwise unload the
+   * inspector and lose the session. Do not condition them on this flag.
    */
   uploadEnabled?: boolean;
 }) {
@@ -508,6 +511,7 @@ export function ComputerTerminal({
         {/* Terminal canvas + overlay */}
         <div
           className="relative min-h-0 flex-1"
+          data-testid="terminal-drop-surface"
           onDragEnter={handleDragEnter}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}

--- a/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
@@ -274,29 +274,51 @@ export function ComputerTerminal({
   const hasDraggedFiles = (e: React.DragEvent) =>
     Array.from(e.dataTransfer?.types ?? []).includes("Files");
 
-  const handleDragEnter = useCallback((e: React.DragEvent) => {
-    if (!hasDraggedFiles(e)) return;
-    e.preventDefault();
-    dragDepthRef.current += 1;
-    setDragActive(true);
-  }, []);
+  const handleDragEnter = useCallback(
+    (e: React.DragEvent) => {
+      if (!hasDraggedFiles(e)) return;
+      // Cancel the browser default even when uploads are OFF (see handleDrop);
+      // only the overlay state is upload-specific.
+      e.preventDefault();
+      if (!uploadEnabled) return;
+      dragDepthRef.current += 1;
+      setDragActive(true);
+    },
+    [uploadEnabled]
+  );
 
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    if (!hasDraggedFiles(e)) return;
-    // Required for the drop event to fire.
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "copy";
-  }, []);
+  const handleDragOver = useCallback(
+    (e: React.DragEvent) => {
+      if (!hasDraggedFiles(e)) return;
+      // Required for the drop event to fire — and required on the
+      // uploads-disabled pane too, so `drop` reaches our handler instead of
+      // the browser's default navigation.
+      e.preventDefault();
+      if (!uploadEnabled) return;
+      e.dataTransfer.dropEffect = "copy";
+    },
+    [uploadEnabled]
+  );
 
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    if (!hasDraggedFiles(e)) return;
-    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) setDragActive(false);
-  }, []);
+  const handleDragLeave = useCallback(
+    (e: React.DragEvent) => {
+      if (!hasDraggedFiles(e)) return;
+      if (!uploadEnabled) return;
+      dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+      if (dragDepthRef.current === 0) setDragActive(false);
+    },
+    [uploadEnabled]
+  );
 
   const handleDrop = useCallback(
     async (e: React.DragEvent) => {
+      // ALWAYS cancel the default, uploads enabled or not. A file dropped onto
+      // an element with no drop handler makes the browser NAVIGATE to that
+      // local file, unloading the inspector and losing the session — so the
+      // uploads-disabled pane still has to swallow the event; it just does
+      // nothing with it.
       e.preventDefault();
+      if (!uploadEnabled) return;
       dragDepthRef.current = 0;
       setDragActive(false);
       const files = Array.from(e.dataTransfer?.files ?? []);
@@ -344,7 +366,7 @@ export function ComputerTerminal({
         setUploading(false);
       }
     },
-    [state, mintToken, baseUrl, cwd]
+    [state, mintToken, baseUrl, cwd, uploadEnabled]
   );
 
   // Create the xterm instance once; wire input + resize; auto-connect.
@@ -479,14 +501,10 @@ export function ComputerTerminal({
         {/* Terminal canvas + overlay */}
         <div
           className="relative min-h-0 flex-1"
-          {...(uploadEnabled
-            ? {
-                onDragEnter: handleDragEnter,
-                onDragOver: handleDragOver,
-                onDragLeave: handleDragLeave,
-                onDrop: handleDrop,
-              }
-            : {})}
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
         >
           <div ref={containerRef} className="absolute inset-0 p-1" onClick={() => termRef.current?.focus()} />
           {uploadEnabled && (dragActive || uploading) ? (

--- a/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
+++ b/mcpjam-inspector/client/src/components/computer/ComputerTerminal.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import {
+  LOCAL_TERMINAL_WS_PATH,
   openTerminalConnection,
   uploadFilesToComputer,
   type TerminalConnection,
@@ -125,7 +126,7 @@ export function ComputerTerminal({
   baseUrl,
   cwd,
   wsPath,
-  uploadEnabled = true,
+  uploadEnabled: uploadEnabledProp = true,
 }: {
   mintToken: () => Promise<string>;
   themeMode: "light" | "dark";
@@ -157,6 +158,12 @@ export function ComputerTerminal({
    */
   uploadEnabled?: boolean;
 }) {
+  // The upload posts to the CLOUD box's route, so it is structurally
+  // incompatible with the local terminal — enforced here rather than left to
+  // caller discipline, since the failure mode (burning the pane's single-use
+  // nonce against the wrong endpoint) is silent from the call site.
+  const uploadEnabled = uploadEnabledProp && wsPath !== LOCAL_TERMINAL_WS_PATH;
+
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerConsentGate.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerConsentGate.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ShieldQuestion } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
+import { track } from "@/lib/analytics";
 
 /**
  * First-run consent for the local computer engine. Allowing it grants the
@@ -21,17 +22,42 @@ export function LocalComputerConsentGate({
   const [granting, setGranting] = useState(false);
   const [error, setError] = useState(false);
 
+  // Content-free funnel: shown → granted | denied. `cloud_offered` records
+  // whether the decline affordance existed at all, since a pure-local
+  // inspector has no "Use cloud instead" button and its denials are invisible
+  // by construction.
+  const cloudOffered = !!onUseCloud;
+  useEffect(() => {
+    track("local_computer_consent_gate_shown", {
+      location: "computer_tab_local",
+      cloud_offered: cloudOffered,
+    });
+  }, [cloudOffered]);
+
   const handleAllow = async () => {
     setGranting(true);
     setError(false);
     try {
       const ok = await onAllow();
       if (!ok) setError(true);
+      track("local_computer_consent_granted", {
+        location: "computer_tab_local",
+        outcome: ok ? "stored" : "failed",
+      });
     } catch {
       setError(true);
+      track("local_computer_consent_granted", {
+        location: "computer_tab_local",
+        outcome: "failed",
+      });
     } finally {
       setGranting(false);
     }
+  };
+
+  const handleUseCloud = () => {
+    track("local_computer_consent_denied", { location: "computer_tab_local" });
+    onUseCloud?.();
   };
 
   return (
@@ -58,7 +84,7 @@ export function LocalComputerConsentGate({
           <Button
             size="sm"
             variant="outline"
-            onClick={onUseCloud}
+            onClick={handleUseCloud}
             disabled={granting}
           >
             Use cloud instead

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
@@ -66,17 +66,19 @@ export function LocalComputerView({
   );
 
   // One `computer_terminal_opened` per opened SESSION (not per reconnect), and
-  // one `local_terminal_unavailable` per degraded state — content-free either
-  // way. The key includes `projectId` because the pane is keyed by it: a project
-  // switch remounts `ComputerTerminal`, minting a fresh nonce and starting a
-  // real new shell, which must be counted even though THIS component didn't
-  // remount.
+  // one `local_terminal_unavailable` per degraded state.
+  //
+  // Only the `open` key carries `projectId`: the pane is keyed by project, so a
+  // switch remounts `ComputerTerminal` and starts a REAL new shell that must be
+  // counted even though this component didn't remount. Degradation, by contrast,
+  // is a property of the MACHINE (node-pty is missing) — re-reporting it per
+  // project would inflate the count with events that reflect no change at all.
   const showTerminal = consent.granted && localTerminalAvailable;
   const showDegraded = consent.granted && !localTerminalAvailable;
   const lastReportedRef = useRef<string | null>(null);
   useEffect(() => {
     const state = showTerminal ? "open" : showDegraded ? "degraded" : null;
-    const key = state === null ? null : `${state}:${projectId}`;
+    const key = state === "open" ? `open:${projectId}` : state;
     if (key === null || lastReportedRef.current === key) return;
     lastReportedRef.current = key;
     if (state === "open") {

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
@@ -66,7 +66,13 @@ export function LocalComputerView({
   );
 
   // One `computer_terminal_opened` per opened SESSION (not per reconnect), and
-  // one `local_terminal_unavailable` per degraded state.
+  // one `local_terminal_unavailable` per entry into the degraded state.
+  //
+  // The dedupe key is the CURRENT state, and `null` ("no pane") is tracked as a
+  // state like any other. That matters: leaving and re-entering a state is a
+  // genuinely new event, so "Forget & re-authorize" (which drops to `null` and
+  // back to `open` in the same project) reports the new shell instead of being
+  // swallowed as a repeat.
   //
   // Only the `open` key carries `projectId`: the pane is keyed by project, so a
   // switch remounts `ComputerTerminal` and starts a REAL new shell that must be
@@ -77,11 +83,17 @@ export function LocalComputerView({
   const showDegraded = consent.granted && !localTerminalAvailable;
   const lastReportedRef = useRef<string | null>(null);
   useEffect(() => {
-    const state = showTerminal ? "open" : showDegraded ? "degraded" : null;
-    const key = state === "open" ? `open:${projectId}` : state;
-    if (key === null || lastReportedRef.current === key) return;
+    const key = showTerminal
+      ? `open:${projectId}`
+      : showDegraded
+        ? "degraded"
+        : null;
+    if (lastReportedRef.current === key) return;
+    // Record every transition, including into `null`, so the next entry into a
+    // reportable state is not mistaken for a repeat of the last one.
     lastReportedRef.current = key;
-    if (state === "open") {
+    if (key === null) return;
+    if (showTerminal) {
       track("computer_terminal_opened", { location: "computer_tab_local" });
     } else {
       track("local_terminal_unavailable", { reason: "terminal_unavailable" });

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
@@ -134,6 +134,12 @@ export function LocalComputerView({
           // Writing dropped files onto the user's real filesystem is a separate
           // consent question, deliberately out of scope here.
           <ComputerTerminal
+            // Keyed by project: `ComputerTerminal` connects from a MOUNT-ONLY
+            // effect, so switching projects while staying on the Computer tab
+            // would otherwise leave the live PTY in the previous project's
+            // workspace (and journaled under it) while this view showed the new
+            // one. Remounting closes that session and opens one in the right dir.
+            key={projectId}
             mintToken={mintToken}
             themeMode={themeMode === "dark" ? "dark" : "light"}
             wsPath={LOCAL_TERMINAL_WS_PATH}

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
@@ -65,22 +65,27 @@ export function LocalComputerView({
     [projectId, consentToken],
   );
 
-  // One `computer_terminal_opened` per mounted local pane (not per reconnect),
-  // and one `local_terminal_unavailable` per degraded mount — content-free
-  // either way.
+  // One `computer_terminal_opened` per opened SESSION (not per reconnect), and
+  // one `local_terminal_unavailable` per degraded state — content-free either
+  // way. The key includes `projectId` because the pane is keyed by it: a project
+  // switch remounts `ComputerTerminal`, minting a fresh nonce and starting a
+  // real new shell, which must be counted even though THIS component didn't
+  // remount.
   const showTerminal = consent.granted && localTerminalAvailable;
   const showDegraded = consent.granted && !localTerminalAvailable;
   const lastReportedRef = useRef<string | null>(null);
   useEffect(() => {
-    const key = showTerminal ? "open" : showDegraded ? "degraded" : null;
+    const state = showTerminal ? "open" : showDegraded ? "degraded" : null;
+    const key = state === null ? null : `${state}:${projectId}`;
     if (key === null || lastReportedRef.current === key) return;
     lastReportedRef.current = key;
-    if (key === "open") {
+    if (state === "open") {
       track("computer_terminal_opened", { location: "computer_tab_local" });
     } else {
       track("local_terminal_unavailable", { reason: "terminal_unavailable" });
     }
-  }, [showTerminal, showDegraded]);
+    // `projectId` is deliberately a dependency — see the key above.
+  }, [showTerminal, showDegraded, projectId]);
 
   const onAllow = async (): Promise<boolean> => {
     const ok = await consent.grant();

--- a/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
+++ b/mcpjam-inspector/client/src/components/computer/LocalComputerView.tsx
@@ -1,7 +1,13 @@
+import { useCallback, useEffect, useRef } from "react";
 import { Laptop, FolderTree } from "lucide-react";
+import { track } from "@/lib/analytics";
 import { createInspectorCommandClientError } from "@/lib/inspector-command-handlers";
 import { useSurfaceAgentBridge } from "@/lib/webmcp/use-surface-agent-bridge";
 import type { ComputerEngineState } from "@/hooks/useComputerEngine";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+import { mintLocalTerminalNonce } from "@/lib/local-computer-consent";
+import { LOCAL_TERMINAL_WS_PATH } from "@/lib/computer-terminal-connection";
+import { ComputerTerminal } from "./ComputerTerminal";
 import { LocalComputerConsentGate } from "./LocalComputerConsentGate";
 import { PaneMessage } from "./PaneMessage";
 
@@ -11,9 +17,12 @@ import { PaneMessage } from "./PaneMessage";
  * ready — no sleep/wake/image/billing. Shown only for a signed-in member on a
  * non-hosted inspector when the local engine is SELECTED (see `ComputerTabView`).
  *
- * The interactive terminal lands in a later PR (node-pty); until
- * `engine.localTerminalAvailable` flips true this shows a terminal-unavailable
- * note — bash from chat already works.
+ * The interactive terminal is a real PTY on this machine (node-pty), reached
+ * over `/api/web/computers/local-terminal` with a single-use nonce minted
+ * against the consent capability. When node-pty isn't installable (no build
+ * toolchain, or the packaged Electron app, which carries no node_modules)
+ * `engine.localTerminalAvailable` stays false and this degrades to a note —
+ * bash from chat still works.
  */
 export function LocalComputerView({
   projectId,
@@ -45,6 +54,33 @@ export function LocalComputerView({
       workspaceDir,
     }),
   });
+
+  const themeMode = usePreferencesStore((state) => state.themeMode);
+
+  // A fresh nonce per (re)connect — it is single-use by construction, so the
+  // reconnect button in `ComputerTerminal` must mint again rather than replay.
+  const consentToken = consent.token;
+  const mintToken = useCallback(
+    () => mintLocalTerminalNonce({ projectId, consentToken }),
+    [projectId, consentToken],
+  );
+
+  // One `computer_terminal_opened` per mounted local pane (not per reconnect),
+  // and one `local_terminal_unavailable` per degraded mount — content-free
+  // either way.
+  const showTerminal = consent.granted && localTerminalAvailable;
+  const showDegraded = consent.granted && !localTerminalAvailable;
+  const lastReportedRef = useRef<string | null>(null);
+  useEffect(() => {
+    const key = showTerminal ? "open" : showDegraded ? "degraded" : null;
+    if (key === null || lastReportedRef.current === key) return;
+    lastReportedRef.current = key;
+    if (key === "open") {
+      track("computer_terminal_opened", { location: "computer_tab_local" });
+    } else {
+      track("local_terminal_unavailable", { reason: "terminal_unavailable" });
+    }
+  }, [showTerminal, showDegraded]);
 
   const onAllow = async (): Promise<boolean> => {
     const ok = await consent.grant();
@@ -92,9 +128,18 @@ export function LocalComputerView({
               : {})}
           />
         ) : localTerminalAvailable ? (
-          // The node-pty terminal PR wires the real pane here; until then this
-          // branch is unreachable (terminalAvailable is false).
-          <PaneMessage>Terminal ready.</PaneMessage>
+          // `uploadEnabled={false}`: the pane's drag-and-drop upload posts to
+          // the CLOUD box's upload route, which would burn this pane's
+          // single-use nonce against the wrong endpoint and toast a failure.
+          // Writing dropped files onto the user's real filesystem is a separate
+          // consent question, deliberately out of scope here.
+          <ComputerTerminal
+            mintToken={mintToken}
+            themeMode={themeMode === "dark" ? "dark" : "light"}
+            wsPath={LOCAL_TERMINAL_WS_PATH}
+            uploadEnabled={false}
+            className="h-full"
+          />
         ) : (
           <PaneMessage dashed>
             The terminal for this machine isn&apos;t available yet. Agents can
@@ -115,7 +160,12 @@ export function LocalComputerView({
             type="button"
             data-testid="local-computer-reauthorize"
             className="font-medium text-primary hover:underline"
-            onClick={() => void consent.revoke()}
+            onClick={() => {
+              track("local_computer_consent_reauthorized", {
+                location: "computer_tab_local",
+              });
+              void consent.revoke();
+            }}
           >
             Forget &amp; re-authorize
           </button>

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTerminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTerminal.test.tsx
@@ -142,3 +142,70 @@ describe("ComputerTerminal — stale-connection guards", () => {
     expect(h.connections).toHaveLength(0);
   });
 });
+
+describe("ComputerTerminal — wsPath + uploadEnabled", () => {
+  it("threads wsPath through to the connection", async () => {
+    const mintToken = vi.fn(async () => "nonce");
+    render(
+      <ComputerTerminal
+        mintToken={mintToken}
+        themeMode="dark"
+        wsPath="/api/web/computers/local-terminal"
+      />
+    );
+
+    await waitFor(() => expect(h.connections).toHaveLength(1));
+    expect(h.connections[0].opts.path).toBe(
+      "/api/web/computers/local-terminal"
+    );
+  });
+
+  it("omits path entirely by default (cloud terminal)", async () => {
+    const mintToken = vi.fn(async () => "tok");
+    render(<ComputerTerminal mintToken={mintToken} themeMode="dark" />);
+
+    await waitFor(() => expect(h.connections).toHaveLength(1));
+    expect(h.connections[0].opts.path).toBeUndefined();
+  });
+
+  it("uploadEnabled={false} attaches NO drop handlers and shows no overlay", async () => {
+    const mintToken = vi.fn(async () => "nonce");
+    const { container } = render(
+      <ComputerTerminal
+        mintToken={mintToken}
+        themeMode="dark"
+        uploadEnabled={false}
+      />
+    );
+    await waitFor(() => expect(h.connections).toHaveLength(1));
+
+    const surface = container.querySelector(".relative.min-h-0.flex-1");
+    expect(surface).not.toBeNull();
+    // A drag that WOULD open the overlay must do nothing: on the local pane the
+    // upload posts to the cloud box's route and would burn the single-use nonce.
+    fireEvent.dragEnter(surface!, { dataTransfer: { types: ["Files"] } });
+    expect(
+      container.textContent?.includes("Drop files to upload")
+    ).toBe(false);
+
+    // And the mint must not have been called a second time by a drop.
+    fireEvent.drop(surface!, {
+      dataTransfer: { types: ["Files"], files: [new File(["x"], "a.txt")] },
+    });
+    expect(mintToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploadEnabled defaults to true — the cloud pane keeps its drop overlay", async () => {
+    const mintToken = vi.fn(async () => "tok");
+    const { container } = render(
+      <ComputerTerminal mintToken={mintToken} themeMode="dark" />
+    );
+    await waitFor(() => expect(h.connections).toHaveLength(1));
+
+    const surface = container.querySelector(".relative.min-h-0.flex-1");
+    fireEvent.dragEnter(surface!, { dataTransfer: { types: ["Files"] } });
+    await waitFor(() =>
+      expect(container.textContent?.includes("Drop files to upload")).toBe(true)
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTerminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTerminal.test.tsx
@@ -227,6 +227,29 @@ describe("ComputerTerminal — wsPath + uploadEnabled", () => {
     }
   });
 
+  it("forces uploads OFF on the local route even if a caller leaves the default", async () => {
+    // The invariant is structural, not caller discipline: the upload posts to
+    // the CLOUD box's route, so on the local pane it would burn the single-use
+    // nonce against the wrong endpoint.
+    const mintToken = vi.fn(async () => "nonce");
+    const { container } = render(
+      <ComputerTerminal
+        mintToken={mintToken}
+        themeMode="dark"
+        wsPath={LOCAL_TERMINAL_WS_PATH}
+      />
+    );
+    await waitFor(() => expect(h.connections).toHaveLength(1));
+
+    const surface = container.querySelector(".relative.min-h-0.flex-1")!;
+    fireEvent.dragEnter(surface, { dataTransfer: { types: ["Files"] } });
+    expect(container.textContent?.includes("Drop files to upload")).toBe(false);
+    fireEvent.drop(surface, {
+      dataTransfer: { types: ["Files"], files: [new File(["x"], "a.txt")] },
+    });
+    expect(mintToken).toHaveBeenCalledTimes(1);
+  });
+
   it("uploadEnabled defaults to true — the cloud pane keeps its drop overlay", async () => {
     const mintToken = vi.fn(async () => "tok");
     const { container } = render(

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTerminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTerminal.test.tsx
@@ -185,7 +185,7 @@ describe("ComputerTerminal — wsPath + uploadEnabled", () => {
     );
     await waitFor(() => expect(h.connections).toHaveLength(1));
 
-    const surface = container.querySelector(".relative.min-h-0.flex-1");
+    const surface = container.querySelector('[data-testid="terminal-drop-surface"]');
     expect(surface).not.toBeNull();
     // A drag that WOULD open the overlay must do nothing: on the local pane the
     // upload posts to the cloud box's route and would burn the single-use nonce.
@@ -212,7 +212,7 @@ describe("ComputerTerminal — wsPath + uploadEnabled", () => {
       />
     );
     await waitFor(() => expect(h.connections).toHaveLength(1));
-    const surface = container.querySelector(".relative.min-h-0.flex-1")!;
+    const surface = container.querySelector('[data-testid="terminal-drop-surface"]')!;
 
     for (const type of ["dragEnter", "dragOver", "drop"] as const) {
       const event = new Event(type.toLowerCase(), {
@@ -241,7 +241,7 @@ describe("ComputerTerminal — wsPath + uploadEnabled", () => {
     );
     await waitFor(() => expect(h.connections).toHaveLength(1));
 
-    const surface = container.querySelector(".relative.min-h-0.flex-1")!;
+    const surface = container.querySelector('[data-testid="terminal-drop-surface"]')!;
     fireEvent.dragEnter(surface, { dataTransfer: { types: ["Files"] } });
     expect(container.textContent?.includes("Drop files to upload")).toBe(false);
     fireEvent.drop(surface, {
@@ -257,7 +257,7 @@ describe("ComputerTerminal — wsPath + uploadEnabled", () => {
     );
     await waitFor(() => expect(h.connections).toHaveLength(1));
 
-    const surface = container.querySelector(".relative.min-h-0.flex-1");
+    const surface = container.querySelector('[data-testid="terminal-drop-surface"]');
     fireEvent.dragEnter(surface!, { dataTransfer: { types: ["Files"] } });
     await waitFor(() =>
       expect(container.textContent?.includes("Drop files to upload")).toBe(true)

--- a/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTerminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/ComputerTerminal.test.tsx
@@ -1,6 +1,9 @@
 import { render, fireEvent, waitFor, act } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenTerminalOptions } from "@/lib/computer-terminal-connection";
+import {
+  LOCAL_TERMINAL_WS_PATH,
+  type OpenTerminalOptions,
+} from "@/lib/computer-terminal-connection";
 
 // xterm can't render under jsdom, and we don't need it to — stub the bits the
 // component touches and record writes so we can assert stale output is dropped.
@@ -43,7 +46,12 @@ const h = vi.hoisted(() => {
 
 vi.mock("@xterm/xterm", () => ({ Terminal: h.FakeTerminal }));
 vi.mock("@xterm/addon-fit", () => ({ FitAddon: h.FakeFit }));
-vi.mock("@/lib/computer-terminal-connection", () => ({
+vi.mock("@/lib/computer-terminal-connection", async () => ({
+  // Spread the real module so route CONSTANTS stay real — a test that
+  // hardcoded the path would keep passing if the constant ever moved.
+  ...(await vi.importActual<
+    typeof import("@/lib/computer-terminal-connection")
+  >("@/lib/computer-terminal-connection")),
   openTerminalConnection: (opts: OpenTerminalOptions) => {
     const conn = {
       opts,
@@ -150,14 +158,12 @@ describe("ComputerTerminal — wsPath + uploadEnabled", () => {
       <ComputerTerminal
         mintToken={mintToken}
         themeMode="dark"
-        wsPath="/api/web/computers/local-terminal"
+        wsPath={LOCAL_TERMINAL_WS_PATH}
       />
     );
 
     await waitFor(() => expect(h.connections).toHaveLength(1));
-    expect(h.connections[0].opts.path).toBe(
-      "/api/web/computers/local-terminal"
-    );
+    expect(h.connections[0].opts.path).toBe(LOCAL_TERMINAL_WS_PATH);
   });
 
   it("omits path entirely by default (cloud terminal)", async () => {
@@ -168,7 +174,7 @@ describe("ComputerTerminal — wsPath + uploadEnabled", () => {
     expect(h.connections[0].opts.path).toBeUndefined();
   });
 
-  it("uploadEnabled={false} attaches NO drop handlers and shows no overlay", async () => {
+  it("uploadEnabled={false} suppresses the upload and the overlay", async () => {
     const mintToken = vi.fn(async () => "nonce");
     const { container } = render(
       <ComputerTerminal
@@ -184,15 +190,41 @@ describe("ComputerTerminal — wsPath + uploadEnabled", () => {
     // A drag that WOULD open the overlay must do nothing: on the local pane the
     // upload posts to the cloud box's route and would burn the single-use nonce.
     fireEvent.dragEnter(surface!, { dataTransfer: { types: ["Files"] } });
-    expect(
-      container.textContent?.includes("Drop files to upload")
-    ).toBe(false);
+    expect(container.textContent?.includes("Drop files to upload")).toBe(false);
 
     // And the mint must not have been called a second time by a drop.
     fireEvent.drop(surface!, {
       dataTransfer: { types: ["Files"], files: [new File(["x"], "a.txt")] },
     });
     expect(mintToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploadEnabled={false} STILL cancels the browser's file-drop navigation", async () => {
+    // A file dropped on an element with no drop handler makes the browser
+    // navigate to that local file, unloading the inspector and losing the
+    // session. Disabling uploads must not disable that cancellation.
+    const mintToken = vi.fn(async () => "nonce");
+    const { container } = render(
+      <ComputerTerminal
+        mintToken={mintToken}
+        themeMode="dark"
+        uploadEnabled={false}
+      />
+    );
+    await waitFor(() => expect(h.connections).toHaveLength(1));
+    const surface = container.querySelector(".relative.min-h-0.flex-1")!;
+
+    for (const type of ["dragEnter", "dragOver", "drop"] as const) {
+      const event = new Event(type.toLowerCase(), {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, "dataTransfer", {
+        value: { types: ["Files"], files: [], dropEffect: "none" },
+      });
+      fireEvent(surface, event);
+      expect(event.defaultPrevented).toBe(true);
+    }
   });
 
   it("uploadEnabled defaults to true — the cloud pane keeps its drop overlay", async () => {

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.agent.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.agent.test.tsx
@@ -16,6 +16,11 @@ import type {
 import { LocalComputerView } from "../LocalComputerView";
 import type { ComputerEngineState } from "@/hooks/useComputerEngine";
 
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (sel: (s: { themeMode: string }) => unknown) =>
+    sel({ themeMode: "dark" }),
+}));
+
 function engineState(): ComputerEngineState {
   return {
     engine: "local",

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
@@ -150,6 +150,33 @@ describe("LocalComputerView — terminal branch", () => {
     });
   });
 
+  it("counts a project switch as a new opened session", () => {
+    const { rerender } = render(
+      <LocalComputerView projectId="proj_1" engine={engineState()} />,
+    );
+    rerender(
+      <LocalComputerView projectId="proj_2" engine={engineState()} />,
+    );
+
+    // The pane remounts and starts a real new shell on the user's machine, so
+    // the metric has to reflect it even though THIS component didn't remount.
+    expect(
+      trackSpy.mock.calls.filter((c) => c[0] === "computer_terminal_opened"),
+    ).toHaveLength(2);
+  });
+
+  it("does not re-count an unrelated re-render", () => {
+    const { rerender } = render(
+      <LocalComputerView projectId="proj_1" engine={engineState()} />,
+    );
+    rerender(
+      <LocalComputerView projectId="proj_1" engine={engineState()} />,
+    );
+    expect(
+      trackSpy.mock.calls.filter((c) => c[0] === "computer_terminal_opened"),
+    ).toHaveLength(1);
+  });
+
   it("never mounts the pane before consent, whatever the probe says", () => {
     render(
       <LocalComputerView

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
@@ -191,6 +191,44 @@ describe("LocalComputerView — terminal branch", () => {
     ).toHaveLength(1);
   });
 
+  it("re-reports after Forget & re-authorize in the same project", () => {
+    const granted = () => engineState();
+    const ungranted = () =>
+      engineState({ consent: { granted: false, token: null, status: "absent" } });
+
+    const { rerender } = render(
+      <LocalComputerView projectId="proj_1" engine={granted()} />,
+    );
+    // Revoke clears storage synchronously, so the view drops to the consent gate.
+    rerender(<LocalComputerView projectId="proj_1" engine={ungranted()} />);
+    // Re-granting opens a genuinely new session: fresh nonce, fresh PTY. Tracking
+    // only the last REPORTED state would swallow this as a repeat.
+    rerender(<LocalComputerView projectId="proj_1" engine={granted()} />);
+
+    expect(
+      trackSpy.mock.calls.filter((c) => c[0] === "computer_terminal_opened"),
+    ).toHaveLength(2);
+  });
+
+  it("re-reports degradation after leaving and re-entering that state", () => {
+    const degraded = () => engineState({ localTerminalAvailable: false });
+    const ungranted = () =>
+      engineState({
+        localTerminalAvailable: false,
+        consent: { granted: false, token: null, status: "absent" },
+      });
+
+    const { rerender } = render(
+      <LocalComputerView projectId="proj_1" engine={degraded()} />,
+    );
+    rerender(<LocalComputerView projectId="proj_1" engine={ungranted()} />);
+    rerender(<LocalComputerView projectId="proj_1" engine={degraded()} />);
+
+    expect(
+      trackSpy.mock.calls.filter((c) => c[0] === "local_terminal_unavailable"),
+    ).toHaveLength(2);
+  });
+
   it("never mounts the pane before consent, whatever the probe says", () => {
     render(
       <LocalComputerView

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The local face's TERMINAL branch. What matters here is the wiring, not
+ * xterm: the pane must dial the LOCAL route, mint a fresh nonce carrying the
+ * consent capability, and have upload switched off (the pane's drag-and-drop
+ * posts to the CLOUD upload route).
+ */
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (sel: (s: { themeMode: string }) => unknown) =>
+    sel({ themeMode: "dark" }),
+}));
+
+vi.mock("@/lib/webmcp/use-surface-agent-bridge", () => ({
+  useSurfaceAgentBridge: () => {},
+}));
+
+const mintSpy = vi.hoisted(() => vi.fn(async () => "nonce-xyz"));
+vi.mock("@/lib/local-computer-consent", () => ({
+  mintLocalTerminalNonce: mintSpy,
+}));
+
+const trackSpy = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/analytics", () => ({ track: trackSpy }));
+
+// Capture the props the pane receives instead of booting xterm under jsdom.
+const terminalProps = vi.hoisted(
+  () => [] as Array<Record<string, unknown>>,
+);
+vi.mock("../ComputerTerminal", () => ({
+  ComputerTerminal: (props: Record<string, unknown>) => {
+    terminalProps.push(props);
+    return <div data-testid="local-terminal-pane" />;
+  },
+}));
+
+import { LocalComputerView } from "../LocalComputerView";
+import { LOCAL_TERMINAL_WS_PATH } from "@/lib/computer-terminal-connection";
+import type { ComputerEngineState } from "@/hooks/useComputerEngine";
+
+function engineState(
+  overrides: Partial<ComputerEngineState> & {
+    consent?: Partial<ComputerEngineState["consent"]>;
+  } = {},
+): ComputerEngineState {
+  const { consent: consentOverrides, ...rest } = overrides;
+  return {
+    engine: "local",
+    selectedEngine: "local",
+    setEngine: vi.fn(),
+    resolved: true,
+    localAvailable: true,
+    localTerminalAvailable: true,
+    workspaceDisplayRoot: "~/.mcpjam/computer",
+    cloudAvailable: true,
+    toggleVisible: true,
+    consent: {
+      status: "granted",
+      granted: true,
+      token: "consent-token",
+      grant: vi.fn().mockResolvedValue(true),
+      revoke: vi.fn(),
+      ...consentOverrides,
+    },
+    ...rest,
+  };
+}
+
+beforeEach(() => {
+  terminalProps.length = 0;
+  mintSpy.mockClear();
+  trackSpy.mockClear();
+});
+
+describe("LocalComputerView — terminal branch", () => {
+  it("mounts the pane on the LOCAL route with upload disabled", () => {
+    render(<LocalComputerView projectId="proj_1" engine={engineState()} />);
+
+    expect(screen.getByTestId("local-terminal-pane")).toBeInTheDocument();
+    const props = terminalProps[0]!;
+    expect(props.wsPath).toBe(LOCAL_TERMINAL_WS_PATH);
+    // Not merely "not true" — the pane must be told explicitly, because its
+    // default is the cloud behavior.
+    expect(props.uploadEnabled).toBe(false);
+    expect(props.themeMode).toBe("dark");
+  });
+
+  it("mints a project-scoped nonce carrying the consent capability", async () => {
+    render(<LocalComputerView projectId="proj_1" engine={engineState()} />);
+
+    const mintToken = terminalProps[0]!.mintToken as () => Promise<string>;
+    await expect(mintToken()).resolves.toBe("nonce-xyz");
+    expect(mintSpy).toHaveBeenCalledWith({
+      projectId: "proj_1",
+      consentToken: "consent-token",
+    });
+  });
+
+  it("emits computer_terminal_opened once for the local pane", async () => {
+    render(<LocalComputerView projectId="proj_1" engine={engineState()} />);
+
+    await waitFor(() =>
+      expect(trackSpy).toHaveBeenCalledWith("computer_terminal_opened", {
+        location: "computer_tab_local",
+      }),
+    );
+    expect(
+      trackSpy.mock.calls.filter((c) => c[0] === "computer_terminal_opened"),
+    ).toHaveLength(1);
+  });
+
+  it("degrades to a note (and reports it) when node-pty isn't available", async () => {
+    render(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({ localTerminalAvailable: false })}
+      />,
+    );
+
+    expect(screen.queryByTestId("local-terminal-pane")).not.toBeInTheDocument();
+    expect(screen.getByText(/isn't available/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(trackSpy).toHaveBeenCalledWith("local_terminal_unavailable", {
+        reason: "terminal_unavailable",
+      }),
+    );
+  });
+
+  it("never mounts the pane before consent, whatever the probe says", () => {
+    render(
+      <LocalComputerView
+        projectId="proj_1"
+        engine={engineState({
+          consent: { granted: false, token: null, status: "absent" },
+        })}
+      />,
+    );
+
+    expect(screen.queryByTestId("local-terminal-pane")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("local-computer-consent-gate"),
+    ).toBeInTheDocument();
+    expect(trackSpy).not.toHaveBeenCalledWith(
+      "computer_terminal_opened",
+      expect.anything(),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
@@ -177,6 +177,20 @@ describe("LocalComputerView — terminal branch", () => {
     ).toHaveLength(1);
   });
 
+  it("does NOT re-report degradation on a project switch", () => {
+    const degraded = () => engineState({ localTerminalAvailable: false });
+    const { rerender } = render(
+      <LocalComputerView projectId="proj_1" engine={degraded()} />,
+    );
+    rerender(<LocalComputerView projectId="proj_2" engine={degraded()} />);
+
+    // node-pty availability is a property of the MACHINE, not the project — a
+    // switch is not a new degrade event and must not inflate the count.
+    expect(
+      trackSpy.mock.calls.filter((c) => c[0] === "local_terminal_unavailable"),
+    ).toHaveLength(1);
+  });
+
   it("never mounts the pane before consent, whatever the probe says", () => {
     render(
       <LocalComputerView

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.terminal.test.tsx
@@ -128,6 +128,28 @@ describe("LocalComputerView — terminal branch", () => {
     );
   });
 
+  it("remounts the pane when the project changes", () => {
+    const { rerender } = render(
+      <LocalComputerView projectId="proj_1" engine={engineState()} />,
+    );
+    expect(terminalProps).toHaveLength(1);
+
+    rerender(
+      <LocalComputerView projectId="proj_2" engine={engineState()} />,
+    );
+
+    // `ComputerTerminal` connects from a mount-only effect, so without a
+    // project key the live PTY would stay in the previous project's workspace
+    // while this view showed the new one.
+    expect(terminalProps.length).toBeGreaterThan(1);
+    const latestMint = terminalProps.at(-1)!.mintToken as () => Promise<string>;
+    void latestMint();
+    expect(mintSpy).toHaveBeenLastCalledWith({
+      projectId: "proj_2",
+      consentToken: "consent-token",
+    });
+  });
+
   it("never mounts the pane before consent, whatever the probe says", () => {
     render(
       <LocalComputerView

--- a/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/LocalComputerView.test.tsx
@@ -3,6 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 
 // The agent bridge is exercised in LocalComputerView.agent.test — here it's a
 // no-op so these render tests don't touch the global command registry.
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (sel: (s: { themeMode: string }) => unknown) =>
+    sel({ themeMode: "dark" }),
+}));
+
 vi.mock("@/lib/webmcp/use-surface-agent-bridge", () => ({
   useSurfaceAgentBridge: () => {},
 }));

--- a/mcpjam-inspector/client/src/components/computer/__tests__/local-computer-analytics.test.tsx
+++ b/mcpjam-inspector/client/src/components/computer/__tests__/local-computer-analytics.test.tsx
@@ -1,0 +1,262 @@
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The local-engine analytics funnel. Two things are being pinned:
+ *  1. each emit fires ONCE, at the right moment;
+ *  2. every payload is CONTENT-FREE — enums, booleans and locations only.
+ *     No command text, no workspace path, no project id, no consent token.
+ */
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (sel: (s: { themeMode: string }) => unknown) =>
+    sel({ themeMode: "dark" }),
+}));
+
+vi.mock("@/lib/webmcp/use-surface-agent-bridge", () => ({
+  useSurfaceAgentBridge: () => {},
+}));
+
+vi.mock("@/lib/local-computer-consent", () => ({
+  mintLocalTerminalNonce: vi.fn(async () => "nonce"),
+}));
+
+vi.mock("../ComputerTerminal", () => ({
+  ComputerTerminal: () => <div data-testid="local-terminal-pane" />,
+}));
+
+const trackSpy = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/analytics", () => ({ track: trackSpy }));
+
+vi.mock("@/lib/config", () => ({ HOSTED_MODE: false }));
+
+vi.mock("../ComputerView", () => ({
+  ComputerView: () => <div data-testid="cloud-computer-view" />,
+}));
+
+const engineHookState = vi.hoisted(() => ({
+  setEngine: vi.fn(),
+}));
+vi.mock("@/hooks/useComputerEngine", () => ({
+  useComputerEngine: () => ({
+    engine: "cloud",
+    selectedEngine: "cloud",
+    setEngine: engineHookState.setEngine,
+    resolved: true,
+    localAvailable: true,
+    localTerminalAvailable: false,
+    workspaceDisplayRoot: "~/.mcpjam/computer",
+    cloudAvailable: true,
+    toggleVisible: true,
+    consent: {
+      status: "absent",
+      granted: false,
+      token: null,
+      grant: vi.fn(),
+      revoke: vi.fn(),
+    },
+  }),
+}));
+
+import { LocalComputerConsentGate } from "../LocalComputerConsentGate";
+import { LocalComputerView } from "../LocalComputerView";
+import { ComputerTabView } from "../ComputerTabView";
+import type { ComputerEngineState } from "@/hooks/useComputerEngine";
+
+/** Every prop value we ever emit, flattened, so it can be scanned for content. */
+function allEmittedValues(): string[] {
+  return trackSpy.mock.calls.flatMap(([, props]) =>
+    Object.values((props ?? {}) as Record<string, unknown>).map(String),
+  );
+}
+
+function engineState(
+  overrides: Partial<ComputerEngineState> & {
+    consent?: Partial<ComputerEngineState["consent"]>;
+  } = {},
+): ComputerEngineState {
+  const { consent: consentOverrides, ...rest } = overrides;
+  return {
+    engine: "local",
+    selectedEngine: "local",
+    setEngine: vi.fn(),
+    resolved: true,
+    localAvailable: true,
+    localTerminalAvailable: false,
+    workspaceDisplayRoot: "~/.mcpjam/computer",
+    cloudAvailable: true,
+    toggleVisible: true,
+    consent: {
+      status: "absent",
+      granted: false,
+      token: null,
+      grant: vi.fn().mockResolvedValue(true),
+      revoke: vi.fn().mockResolvedValue(undefined),
+      ...consentOverrides,
+    },
+    ...rest,
+  };
+}
+
+beforeEach(() => {
+  trackSpy.mockClear();
+  engineHookState.setEngine.mockClear();
+});
+
+describe("consent gate analytics", () => {
+  it("reports the gate exactly once on mount", () => {
+    const { rerender } = render(
+      <LocalComputerConsentGate onAllow={() => true} onUseCloud={() => {}} />,
+    );
+    rerender(
+      <LocalComputerConsentGate onAllow={() => true} onUseCloud={() => {}} />,
+    );
+
+    const shown = trackSpy.mock.calls.filter(
+      (c) => c[0] === "local_computer_consent_gate_shown",
+    );
+    expect(shown).toHaveLength(1);
+    expect(shown[0]![1]).toEqual({
+      location: "computer_tab_local",
+      cloud_offered: true,
+    });
+  });
+
+  it("records whether a decline affordance even existed", () => {
+    render(<LocalComputerConsentGate onAllow={() => true} />);
+    expect(
+      trackSpy.mock.calls.find(
+        (c) => c[0] === "local_computer_consent_gate_shown",
+      )![1],
+    ).toEqual({ location: "computer_tab_local", cloud_offered: false });
+  });
+
+  it("reports a successful Allow", async () => {
+    render(
+      <LocalComputerConsentGate
+        onAllow={async () => true}
+        onUseCloud={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+
+    await waitFor(() =>
+      expect(trackSpy).toHaveBeenCalledWith("local_computer_consent_granted", {
+        location: "computer_tab_local",
+        outcome: "stored",
+      }),
+    );
+  });
+
+  it("reports a FAILED Allow as an outcome, not a silent drop", async () => {
+    render(
+      <LocalComputerConsentGate
+        onAllow={async () => false}
+        onUseCloud={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+
+    await waitFor(() =>
+      expect(trackSpy).toHaveBeenCalledWith("local_computer_consent_granted", {
+        location: "computer_tab_local",
+        outcome: "failed",
+      }),
+    );
+  });
+
+  it("reports a REJECTED Allow the same way", async () => {
+    render(
+      <LocalComputerConsentGate
+        onAllow={async () => {
+          throw new Error("boom");
+        }}
+        onUseCloud={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+
+    await waitFor(() =>
+      expect(trackSpy).toHaveBeenCalledWith("local_computer_consent_granted", {
+        location: "computer_tab_local",
+        outcome: "failed",
+      }),
+    );
+  });
+
+  it("reports the decline path and still switches to cloud", () => {
+    const onUseCloud = vi.fn();
+    render(
+      <LocalComputerConsentGate onAllow={() => true} onUseCloud={onUseCloud} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /use cloud instead/i }));
+
+    expect(trackSpy).toHaveBeenCalledWith("local_computer_consent_denied", {
+      location: "computer_tab_local",
+    });
+    expect(onUseCloud).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("re-authorize analytics", () => {
+  it("reports the re-authorize action once and still revokes", async () => {
+    const revoke = vi.fn().mockResolvedValue(undefined);
+    render(
+      <LocalComputerView
+        projectId="proj_secret_name"
+        engine={engineState({
+          consent: { granted: true, token: "tok", status: "granted", revoke },
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("local-computer-reauthorize"));
+
+    await waitFor(() => expect(revoke).toHaveBeenCalledTimes(1));
+    const calls = trackSpy.mock.calls.filter(
+      (c) => c[0] === "local_computer_consent_reauthorized",
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]![1]).toEqual({ location: "computer_tab_local" });
+  });
+});
+
+describe("engine toggle analytics", () => {
+  it("reports the selected engine name and applies the preference", () => {
+    render(<ComputerTabView projectId="proj_1" isSignedInMember />);
+
+    fireEvent.click(screen.getByRole("button", { name: /This machine/i }));
+
+    expect(trackSpy).toHaveBeenCalledWith("computer_engine_selected", {
+      location: "computer_tab",
+      engine: "local",
+    });
+    expect(engineHookState.setEngine).toHaveBeenCalledWith("local");
+  });
+});
+
+describe("payload hygiene", () => {
+  it("never emits a project id, workspace path, or consent token", async () => {
+    const revoke = vi.fn().mockResolvedValue(undefined);
+    render(
+      <LocalComputerView
+        projectId="proj_secret_name"
+        engine={engineState({
+          consent: {
+            granted: true,
+            token: "super-secret-consent-token",
+            status: "granted",
+            revoke,
+          },
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("local-computer-reauthorize"));
+    await waitFor(() => expect(revoke).toHaveBeenCalled());
+
+    const values = allEmittedValues();
+    expect(values.length).toBeGreaterThan(0);
+    expect(values).not.toContain("proj_secret_name");
+    expect(values).not.toContain("super-secret-consent-token");
+    expect(values.join("|")).not.toContain("~/.mcpjam/computer");
+  });
+});

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
@@ -192,7 +192,10 @@ function LocalShellBody({ engine }: { engine: ComputerEngineState }) {
   return (
     <>
       <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2">
-        <RailEngineChip engine={engine.engine} />
+        {/* Same `toggleVisible` gate as the cloud body: with only one engine
+            available there is no choice to indicate, and the body copy below
+            already names the machine. */}
+        {engine.toggleVisible ? <RailEngineChip engine={engine.engine} /> : null}
       </div>
       <div className="min-h-0 flex-1 px-3 pb-3">
         {!consent.granted ? (

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundRightRail.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useState } from "react";
 import {
+  Cloud,
   FileText,
   FolderTree,
+  Laptop,
   Loader2,
   PanelRightClose,
   TerminalSquare,
@@ -12,8 +14,13 @@ import { cn } from "@/lib/utils";
 import { LoggerView } from "@/components/logger-view";
 import { ComputerStatusChip } from "@/components/computer/ComputerStatusChip";
 import { ComputerTerminalPane } from "@/components/computer/ComputerTerminalPane";
+import { PaneMessage } from "@/components/computer/PaneMessage";
 import { useComputerTerminal } from "@/components/computer/useComputerTerminal";
 import { useComputersEnabledState } from "@/hooks/useComputersEnabled";
+import {
+  useComputerEngine,
+  type ComputerEngineState,
+} from "@/hooks/useComputerEngine";
 import { useHarnessWorkdir } from "@/stores/harness-workdir-store";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 
@@ -73,33 +80,19 @@ function RightRailTabbed({
   hostId: string | null;
 }) {
   const [activeTab, setActiveTab] = useState<RightRailTab>("logs");
-  // Bumped to remount (and thus reconnect) the terminal into the latest harness
-  // workdir on demand — cwd only applies at connect time.
-  const [reloadKey, setReloadKey] = useState(0);
-  // One controller for the rail so the terminal session survives Logs ⇄ Shell
-  // toggles (both bodies stay mounted; we only show/hide).
-  const ct = useComputerTerminal({ projectId, isAuthenticated });
-  // Open the terminal in the harness session workdir — but only for harness
-  // hosts (plain computer hosts have no such dir → home).
-  const isHarnessHost = !!hostConfig?.harness;
-  // Read with the SAME key the chat stream writes (previewedHostId), not
-  // hostConfig.id — those are different identifiers and would never match.
-  const streamedWorkdir = useHarnessWorkdir(projectId, hostId);
-  // COMP-16: open the terminal in the configured working directory. For a
-  // harness host use the streamed per-session dir; for a plain computer host
-  // fall back to the host-configured `computer.workdir` (the same dir the bash
-  // tool runs in) so the Shell opens where the model works.
-  const harnessCwd = isHarnessHost
-    ? streamedWorkdir
-    : hostConfig?.computer?.workdir;
-  // Only offer "Open terminal" once the data-plane config has resolved to a
-  // usable plane — opening while it's still loading mounts the terminal at the
-  // page origin; opening with no plane reserves a computer it can't reach.
-  const canOpenTerminal =
-    ct.dataPlaneResolved &&
-    !ct.dataPlaneUnavailable &&
-    isAuthenticated &&
-    !!projectId;
+  // Which engine serves this project's computer work. The rail is an INDICATOR
+  // only — switching lives on the Computer tab, which owns the consent gate.
+  //
+  // NOTE: `projectId` here is `sharedProjectId ?? activeProjectId`, while
+  // PlaygroundMain's engine reads `sharedProjectId` only. The divergence is
+  // harmless (the engine hooks no-op without a shared project) and deliberate.
+  const engine = useComputerEngine(projectId);
+  // The BODY follows `selectedEngine` (consent-blind), mirroring the Computer
+  // tab's face choice: someone who picked "This machine" but hasn't authorized
+  // it yet must see the local body's pointer, not a cloud terminal they didn't
+  // ask for. The CHIP follows the resolved `engine`, so it can never claim
+  // "This machine" while commands actually run in the cloud.
+  const isLocalShell = engine.selectedEngine === "local";
 
   const handleTabClick = useCallback(
     (next: RightRailTab) => {
@@ -154,50 +147,172 @@ function RightRailTabbed({
           activeTab === "shell" ? "flex" : "hidden",
         )}
       >
-        <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2">
+        {/* The local body deliberately does NOT mount the cloud terminal
+            controller: `useComputerTerminal` reserves (and wakes) a cloud box
+            on open, which would be a real machine started behind the user's
+            back while their chat bash runs on this laptop. Swapping bodies
+            mid-session drops a live cloud socket — the reserved box stays up
+            until the idle sweep, and switching back reconnects with a fresh
+            token mint. */}
+        {isLocalShell ? (
+          <LocalShellBody engine={engine} />
+        ) : (
+          <CloudShellBody
+            engine={engine}
+            projectId={projectId}
+            isAuthenticated={isAuthenticated}
+            hostConfig={hostConfig}
+            hostId={hostId}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Which machine this project's computer work runs on. Indicator only. */
+function RailEngineChip({ engine }: { engine: "local" | "cloud" }) {
+  const isLocal = engine === "local";
+  const Icon = isLocal ? Laptop : Cloud;
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[10px] font-medium text-muted-foreground"
+      data-testid="rail-engine-chip"
+      title="Switch engines from the Computer tab"
+    >
+      <Icon className="size-3" aria-hidden />
+      {isLocal ? "This machine" : "Cloud computer"}
+    </span>
+  );
+}
+
+/** The Shell body for the local engine: no cloud controller, no reserve. */
+function LocalShellBody({ engine }: { engine: ComputerEngineState }) {
+  const { consent, localTerminalAvailable } = engine;
+  return (
+    <>
+      <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2">
+        <RailEngineChip engine={engine.engine} />
+      </div>
+      <div className="min-h-0 flex-1 px-3 pb-3">
+        {!consent.granted ? (
+          // A pointer, NOT a second consent gate: the Computer tab owns the
+          // grant (and the blunt copy that goes with it).
+          <PaneMessage dashed>
+            <span data-testid="rail-local-unconsented">
+              This machine isn&apos;t authorized yet. Open the Computer tab to
+              allow agent commands here.
+            </span>
+          </PaneMessage>
+        ) : localTerminalAvailable ? (
+          <PaneMessage dashed>
+            <span data-testid="rail-local-terminal-pointer">
+              Open the terminal for this machine from the Computer tab.
+            </span>
+          </PaneMessage>
+        ) : (
+          <PaneMessage dashed>
+            <span data-testid="rail-local-terminal-unavailable">
+              The terminal for this machine isn&apos;t available. Agents can
+              still run bash commands here from chat.
+            </span>
+          </PaneMessage>
+        )}
+      </div>
+    </>
+  );
+}
+
+/** The Shell body for the cloud engine — unchanged behavior. */
+function CloudShellBody({
+  engine,
+  projectId,
+  isAuthenticated,
+  hostConfig,
+  hostId,
+}: {
+  engine: ComputerEngineState;
+  projectId: string | null;
+  isAuthenticated: boolean;
+  hostConfig: HostConfigDtoV2 | null;
+  hostId: string | null;
+}) {
+  // Bumped to remount (and thus reconnect) the terminal into the latest harness
+  // workdir on demand — cwd only applies at connect time.
+  const [reloadKey, setReloadKey] = useState(0);
+  // One controller for the rail so the terminal session survives Logs ⇄ Shell
+  // toggles (both bodies stay mounted; we only show/hide).
+  const ct = useComputerTerminal({ projectId, isAuthenticated });
+  // Open the terminal in the harness session workdir — but only for harness
+  // hosts (plain computer hosts have no such dir → home).
+  const isHarnessHost = !!hostConfig?.harness;
+  // Read with the SAME key the chat stream writes (previewedHostId), not
+  // hostConfig.id — those are different identifiers and would never match.
+  const streamedWorkdir = useHarnessWorkdir(projectId, hostId);
+  // COMP-16: open the terminal in the configured working directory. For a
+  // harness host use the streamed per-session dir; for a plain computer host
+  // fall back to the host-configured `computer.workdir` (the same dir the bash
+  // tool runs in) so the Shell opens where the model works.
+  const harnessCwd = isHarnessHost
+    ? streamedWorkdir
+    : hostConfig?.computer?.workdir;
+  // Only offer "Open terminal" once the data-plane config has resolved to a
+  // usable plane — opening while it's still loading mounts the terminal at the
+  // page origin; opening with no plane reserves a computer it can't reach.
+  const canOpenTerminal =
+    ct.dataPlaneResolved &&
+    !ct.dataPlaneUnavailable &&
+    isAuthenticated &&
+    !!projectId;
+
+  return (
+    <>
+      <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
           <ComputerStatusChip
             status={ct.liveStatus}
             hibernatedReason={ct.status?.hibernatedReason}
           />
-          {!ct.terminalOpen && canOpenTerminal ? (
-            <Button
-              size="sm"
-              onClick={() => void ct.openTerminal()}
-              disabled={ct.starting}
-            >
-              {ct.starting ? (
-                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <TerminalSquare className="mr-1.5 h-3.5 w-3.5" />
-              )}
-              Open terminal
-            </Button>
-          ) : ct.terminalOpen && harnessCwd ? (
-            // cwd is applied at connect time; remount to reconnect into the
-            // latest harness workdir (e.g. after a new turn ran).
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setReloadKey((k) => k + 1)}
-              title={`Reconnect in ${harnessCwd}`}
-            >
-              <FolderTree className="mr-1.5 h-3.5 w-3.5" />
-              Reload in harness dir
-            </Button>
-          ) : null}
+          {engine.toggleVisible ? <RailEngineChip engine="cloud" /> : null}
         </div>
-        {/* Key on reloadKey ONLY (explicit reconnect) — NOT on cwd, so a newer
-            harness workdir streaming in mid-session doesn't yank the user's open
-            terminal. Reopening the terminal already picks up the latest cwd
-            (ComputerTerminal remounts when terminalOpen flips). */}
-        <ComputerTerminalPane
-          key={reloadKey}
-          controller={ct}
-          className="px-3 pb-3"
-          {...(harnessCwd ? { cwd: harnessCwd } : {})}
-        />
+        {!ct.terminalOpen && canOpenTerminal ? (
+          <Button
+            size="sm"
+            onClick={() => void ct.openTerminal()}
+            disabled={ct.starting}
+          >
+            {ct.starting ? (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <TerminalSquare className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            Open terminal
+          </Button>
+        ) : ct.terminalOpen && harnessCwd ? (
+          // cwd is applied at connect time; remount to reconnect into the
+          // latest harness workdir (e.g. after a new turn ran).
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setReloadKey((k) => k + 1)}
+            title={`Reconnect in ${harnessCwd}`}
+          >
+            <FolderTree className="mr-1.5 h-3.5 w-3.5" />
+            Reload in harness dir
+          </Button>
+        ) : null}
       </div>
-    </div>
+      {/* Key on reloadKey ONLY (explicit reconnect) — NOT on cwd, so a newer
+          harness workdir streaming in mid-session doesn't yank the user's open
+          terminal. Reopening the terminal already picks up the latest cwd
+          (ComputerTerminal remounts when terminalOpen flips). */}
+      <ComputerTerminalPane
+        key={reloadKey}
+        controller={ct}
+        className="px-3 pb-3"
+        {...(harnessCwd ? { cwd: harnessCwd } : {})}
+      />
+    </>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
@@ -134,10 +134,26 @@ describe("PlaygroundRightRail — engine indicator", () => {
     );
   });
 
-  it("is hidden when there is no engine choice to indicate", () => {
+  it("is hidden when there is no engine choice to indicate (cloud body)", () => {
     engineState.toggleVisible = false;
     renderRail();
     expect(screen.queryByTestId("rail-engine-chip")).not.toBeInTheDocument();
+  });
+
+  it("is hidden on the LOCAL body too when there is no choice", () => {
+    // Both bodies gate on the same flag — a local-only install (no cloud
+    // computer) has nothing to indicate, and the body copy already names the
+    // machine.
+    engineState.engine = "local";
+    engineState.selectedEngine = "local";
+    engineState.granted = true;
+    engineState.toggleVisible = false;
+    renderRail();
+    expect(screen.queryByTestId("rail-engine-chip")).not.toBeInTheDocument();
+    // The body itself is still the local one.
+    expect(
+      screen.getByTestId("rail-local-terminal-unavailable"),
+    ).toBeInTheDocument();
   });
 });
 

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
@@ -253,4 +253,18 @@ describe("PlaygroundRightRail — no computer attached", () => {
     expect(screen.getByTestId("logger-view")).toBeInTheDocument();
     expect(screen.queryByTestId("rail-engine-chip")).not.toBeInTheDocument();
   });
+
+  it("falls back to the log viewer for a null hostConfig too", () => {
+    render(
+      <PlaygroundRightRail
+        onClose={() => {}}
+        hostConfig={null}
+        hostId={null}
+        projectId="proj-1"
+        isAuthenticated
+      />,
+    );
+    expect(screen.getByTestId("logger-view")).toBeInTheDocument();
+    expect(terminalSpies.useComputerTerminal).not.toHaveBeenCalled();
+  });
 });

--- a/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
+++ b/mcpjam-inspector/client/src/components/playground/__tests__/PlaygroundRightRail.test.tsx
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+/**
+ * The rail's Shell tab is engine-aware: the CLOUD controller
+ * (`useComputerTerminal`, which reserves/wakes a real cloud box on open) must
+ * never be mounted while the project's computer engine is local. These suites
+ * pin exactly that — plus the indicator chip and the local body's three states
+ * (unconsented / terminal available / terminal unavailable).
+ */
+
+const engineState = vi.hoisted(() => ({
+  engine: "cloud" as "local" | "cloud",
+  selectedEngine: "cloud" as "local" | "cloud",
+  localTerminalAvailable: false,
+  toggleVisible: true,
+  granted: false,
+}));
+
+const terminalSpies = vi.hoisted(() => ({
+  useComputerTerminal: vi.fn(),
+  openTerminal: vi.fn(),
+}));
+
+vi.mock("@/hooks/useComputerEngine", () => ({
+  useComputerEngine: () => ({
+    engine: engineState.engine,
+    selectedEngine: engineState.selectedEngine,
+    setEngine: vi.fn(),
+    resolved: true,
+    localAvailable: true,
+    localTerminalAvailable: engineState.localTerminalAvailable,
+    workspaceDisplayRoot: "~/.mcpjam/computer",
+    cloudAvailable: true,
+    toggleVisible: engineState.toggleVisible,
+    consent: {
+      status: engineState.granted ? "granted" : "absent",
+      granted: engineState.granted,
+      token: engineState.granted ? "tok" : null,
+      grant: vi.fn(),
+      revoke: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("@/components/computer/useComputerTerminal", () => ({
+  useComputerTerminal: (...args: unknown[]) => {
+    terminalSpies.useComputerTerminal(...args);
+    return {
+      liveStatus: "ready",
+      status: null,
+      terminalOpen: false,
+      starting: false,
+      dataPlaneResolved: true,
+      dataPlaneUnavailable: false,
+      openTerminal: terminalSpies.openTerminal,
+    };
+  },
+}));
+
+vi.mock("@/hooks/useComputersEnabled", () => ({
+  useComputersEnabledState: () => true,
+}));
+
+vi.mock("@/components/logger-view", () => ({
+  LoggerView: () => <div data-testid="logger-view" />,
+}));
+
+vi.mock("@/components/computer/ComputerStatusChip", () => ({
+  ComputerStatusChip: () => <div data-testid="computer-status-chip" />,
+}));
+
+vi.mock("@/components/computer/ComputerTerminalPane", () => ({
+  ComputerTerminalPane: () => <div data-testid="cloud-terminal-pane" />,
+}));
+
+vi.mock("@/stores/harness-workdir-store", () => ({
+  useHarnessWorkdir: () => undefined,
+}));
+
+vi.mock("@/lib/analytics", () => ({ track: vi.fn() }));
+
+import { PlaygroundRightRail } from "../PlaygroundRightRail";
+
+const hostConfig = { computer: { workdir: "/home/user" } } as any;
+
+function renderRail() {
+  return render(
+    <PlaygroundRightRail
+      onClose={() => {}}
+      hostConfig={hostConfig}
+      hostId="host-1"
+      projectId="proj-1"
+      isAuthenticated
+    />,
+  );
+}
+
+beforeEach(() => {
+  engineState.engine = "cloud";
+  engineState.selectedEngine = "cloud";
+  engineState.localTerminalAvailable = false;
+  engineState.toggleVisible = true;
+  engineState.granted = false;
+  terminalSpies.useComputerTerminal.mockClear();
+  terminalSpies.openTerminal.mockClear();
+});
+
+describe("PlaygroundRightRail — engine indicator", () => {
+  it("reads 'Cloud computer' on the cloud engine", () => {
+    renderRail();
+    expect(screen.getByTestId("rail-engine-chip")).toHaveTextContent(
+      "Cloud computer",
+    );
+  });
+
+  it("reads 'This machine' once local is both selected and consented", () => {
+    engineState.engine = "local";
+    engineState.selectedEngine = "local";
+    engineState.granted = true;
+    renderRail();
+    expect(screen.getByTestId("rail-engine-chip")).toHaveTextContent(
+      "This machine",
+    );
+  });
+
+  it("still reads 'Cloud computer' when local is selected but unconsented — commands really do go to the cloud", () => {
+    engineState.engine = "cloud"; // consent-gated resolution
+    engineState.selectedEngine = "local";
+    engineState.granted = false;
+    renderRail();
+    expect(screen.getByTestId("rail-engine-chip")).toHaveTextContent(
+      "Cloud computer",
+    );
+  });
+
+  it("is hidden when there is no engine choice to indicate", () => {
+    engineState.toggleVisible = false;
+    renderRail();
+    expect(screen.queryByTestId("rail-engine-chip")).not.toBeInTheDocument();
+  });
+});
+
+describe("PlaygroundRightRail — cloud engine body", () => {
+  it("mounts the cloud terminal controller and pane", () => {
+    renderRail();
+    expect(terminalSpies.useComputerTerminal).toHaveBeenCalled();
+    expect(screen.getByTestId("cloud-terminal-pane")).toBeInTheDocument();
+    expect(screen.getByTestId("computer-status-chip")).toBeInTheDocument();
+  });
+
+  it("offers Open terminal", () => {
+    renderRail();
+    expect(
+      screen.getByRole("button", { name: /open terminal/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("PlaygroundRightRail — local engine body", () => {
+  beforeEach(() => {
+    engineState.selectedEngine = "local";
+  });
+
+  it("never mounts the cloud controller (no reserve behind the user's back)", () => {
+    engineState.engine = "local";
+    engineState.granted = true;
+    renderRail();
+    expect(terminalSpies.useComputerTerminal).not.toHaveBeenCalled();
+    expect(terminalSpies.openTerminal).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("cloud-terminal-pane")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /open terminal/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("points at the Computer tab when this machine isn't authorized yet", () => {
+    renderRail();
+    expect(screen.getByTestId("rail-local-unconsented")).toBeInTheDocument();
+    expect(terminalSpies.useComputerTerminal).not.toHaveBeenCalled();
+    // The consent gate itself is the Computer tab's job — not duplicated here.
+    expect(
+      screen.queryByTestId("local-computer-consent-gate"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("points at the Computer tab's terminal when one is available", () => {
+    engineState.engine = "local";
+    engineState.granted = true;
+    engineState.localTerminalAvailable = true;
+    renderRail();
+    expect(
+      screen.getByTestId("rail-local-terminal-pointer"),
+    ).toBeInTheDocument();
+  });
+
+  it("degrades honestly when the local terminal isn't available", () => {
+    engineState.engine = "local";
+    engineState.granted = true;
+    engineState.localTerminalAvailable = false;
+    renderRail();
+    expect(
+      screen.getByTestId("rail-local-terminal-unavailable"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("PlaygroundRightRail — flipping engines mid-session", () => {
+  it("swaps the shell body (dropping the live cloud pane) and restores it on the way back", () => {
+    const { rerender } = renderRail();
+    expect(screen.getByTestId("cloud-terminal-pane")).toBeInTheDocument();
+
+    engineState.engine = "local";
+    engineState.selectedEngine = "local";
+    engineState.granted = true;
+    rerender(
+      <PlaygroundRightRail
+        onClose={() => {}}
+        hostConfig={hostConfig}
+        hostId="host-1"
+        projectId="proj-1"
+        isAuthenticated
+      />,
+    );
+    expect(screen.queryByTestId("cloud-terminal-pane")).not.toBeInTheDocument();
+
+    engineState.engine = "cloud";
+    engineState.selectedEngine = "cloud";
+    rerender(
+      <PlaygroundRightRail
+        onClose={() => {}}
+        hostConfig={hostConfig}
+        hostId="host-1"
+        projectId="proj-1"
+        isAuthenticated
+      />,
+    );
+    expect(screen.getByTestId("cloud-terminal-pane")).toBeInTheDocument();
+  });
+});
+
+describe("PlaygroundRightRail — no computer attached", () => {
+  it("falls back to the plain log viewer", () => {
+    render(
+      <PlaygroundRightRail
+        onClose={() => {}}
+        hostConfig={{} as any}
+        hostId="host-1"
+        projectId="proj-1"
+        isAuthenticated
+      />,
+    );
+    expect(screen.getByTestId("logger-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("rail-engine-chip")).not.toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -130,7 +130,10 @@ import { PlaygroundEnvironmentSection } from "@/components/playground/Playground
 import { useHarnessBuiltinTools } from "@/hooks/useHarnessBuiltinTools";
 import { useComputersEnabled } from "@/hooks/useComputersEnabled";
 import { useComputerAttachmentUpload } from "@/hooks/useComputerAttachmentUpload";
-import { buildComputerAttachmentNote } from "@/lib/computer-attachments";
+import {
+  buildComputerAttachmentNote,
+  isComputerAttachmentUploadActive,
+} from "@/lib/computer-attachments";
 import {
   getBillingErrorMessage,
   isComputerStartLimitError,
@@ -860,11 +863,15 @@ export function PlaygroundMain({
 
   // COMP-14 gate: composer attachments go into the sandbox only when the
   // previewed host actually attaches a computer (honesty rule — no computer, no
-  // sandbox upload; attachments stay inline-only exactly as before).
-  const computerAttachmentsActive =
-    computersEnabled &&
-    isConvexAuthenticated &&
-    !!previewedHost?.config?.computer;
+  // sandbox upload; attachments stay inline-only exactly as before) AND the
+  // resolved engine is cloud — the upload targets the CLOUD box, so on "This
+  // machine" it would wake a sandbox the local bash tool can't see.
+  const computerAttachmentsActive = isComputerAttachmentUploadActive({
+    computersEnabled: computersEnabled === true,
+    isAuthenticated: isConvexAuthenticated,
+    hostHasComputer: !!previewedHost?.config?.computer,
+    engine: playgroundComputerEngine.engine,
+  });
 
   // Use shared chat session hook
   const composerOnResetRef = useRef<() => void>(() => {});

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePostHogIdentify.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePostHogIdentify.test.ts
@@ -7,6 +7,7 @@ const mockState = vi.hoisted(() => ({
     identify: vi.fn(),
     register: vi.fn(),
     reset: vi.fn(),
+    setPersonPropertiesForFlags: vi.fn(),
   },
   auth: {
     user: null as {
@@ -73,6 +74,7 @@ describe("usePostHogIdentify", () => {
     renderHook(() => usePostHogIdentify());
 
     expect(mockState.posthog.identify).toHaveBeenCalledWith("user_123", {
+      deployment: "self_hosted",
       email: "user@example.com",
       name: "Taylor Smith",
       first_name: "Taylor",
@@ -91,7 +93,11 @@ describe("usePostHogIdentify", () => {
 
     renderHook(() => usePostHogIdentify());
 
-    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {});
+    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {
+      // Set for EVERY actor, guests included, so a "self_hosted" flag cohort
+      // evaluates before sign-in too.
+      deployment: "self_hosted",
+    });
     expect(mockState.posthog.register).toHaveBeenCalledWith({
       user_id: "guest_abc",
     });
@@ -139,6 +145,7 @@ describe("usePostHogIdentify", () => {
     const { rerender } = renderHook(() => usePostHogIdentify());
 
     expect(mockState.posthog.identify).toHaveBeenCalledWith("user_123", {
+      deployment: "self_hosted",
       email: "user@example.com",
       name: "Taylor Smith",
       first_name: "Taylor",
@@ -161,9 +168,20 @@ describe("usePostHogIdentify", () => {
       deployment: "self_hosted",
       source: "client",
     });
-    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {});
+    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {
+      // Set for EVERY actor, guests included, so a "self_hosted" flag cohort
+      // evaluates before sign-in too.
+      deployment: "self_hosted",
+    });
     expect(mockState.posthog.register).toHaveBeenCalledWith({
       user_id: "guest_abc",
+    });
+    // `reset()` clears flag person properties too, so they must be restored —
+    // otherwise every flag evaluated before the next page load targets an
+    // unknown deployment.
+    expect(mockState.posthog.setPersonPropertiesForFlags).toHaveBeenCalledWith({
+      deployment: "self_hosted",
+      platform: "mac",
     });
   });
 
@@ -174,7 +192,11 @@ describe("usePostHogIdentify", () => {
 
     const { rerender } = renderHook(() => usePostHogIdentify());
 
-    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {});
+    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {
+      // Set for EVERY actor, guests included, so a "self_hosted" flag cohort
+      // evaluates before sign-in too.
+      deployment: "self_hosted",
+    });
 
     vi.clearAllMocks();
 
@@ -191,6 +213,7 @@ describe("usePostHogIdentify", () => {
 
     expect(mockState.posthog.reset).not.toHaveBeenCalled();
     expect(mockState.posthog.identify).toHaveBeenCalledWith("user_123", {
+      deployment: "self_hosted",
       email: "user@example.com",
       name: "Taylor Smith",
       first_name: "Taylor",
@@ -215,6 +238,7 @@ describe("usePostHogIdentify", () => {
     renderHook(() => usePostHogIdentify());
 
     expect(mockState.posthog.identify).toHaveBeenCalledWith("user_123", {
+      deployment: "self_hosted",
       email: "user@example.com",
       name: "Taylor Smith",
       first_name: "Taylor",
@@ -237,6 +261,7 @@ describe("usePostHogIdentify", () => {
     renderHook(() => usePostHogIdentify());
 
     expect(mockState.posthog.identify).toHaveBeenCalledWith("user_123", {
+      deployment: "self_hosted",
       email: "user@example.com",
       name: "Taylor Smith",
       first_name: "Taylor",

--- a/mcpjam-inspector/client/src/hooks/usePostHogIdentify.ts
+++ b/mcpjam-inspector/client/src/hooks/usePostHogIdentify.ts
@@ -42,11 +42,25 @@ export function usePostHogIdentify() {
         deployment: HOSTED_MODE ? "hosted" : "self_hosted",
         source: "client",
       });
+      // `reset()` clears flag person properties too — restore them, or every
+      // flag evaluated between the reset and the next page load would target
+      // an unknown deployment.
+      posthog.setPersonPropertiesForFlags?.({
+        deployment: HOSTED_MODE ? "hosted" : "self_hosted",
+        platform: detectPlatform(),
+      });
     }
 
-    let personProperties: Record<string, string | null | undefined> = {};
+    // `deployment` is a PERSON property here, not just a super property: the
+    // super prop rides events, while `/flags` targeting reads person
+    // properties. Set for every actor (guest included) so a cohort rule like
+    // "self_hosted signed-in users" evaluates correctly.
+    let personProperties: Record<string, string | null | undefined> = {
+      deployment: HOSTED_MODE ? "hosted" : "self_hosted",
+    };
     if (isAuthedActor && user) {
       personProperties = {
+        ...personProperties,
         email: user.email,
         name:
           user.firstName && user.lastName

--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -288,6 +288,19 @@ export const options = {
       // previously carried no `source` at all.
       source: "client",
     });
+    // Super properties ride EVENTS; `/flags` evaluates PERSON properties, so a
+    // registered `deployment` is invisible to flag targeting. This makes the
+    // same discriminator usable in a flag rule (e.g. rolling the local computer
+    // engine out to the self-hosted signed-in cohort) from the first request of
+    // the session, before any identify has run.
+    // Guarded: `loaded` also runs against partial posthog stand-ins (tests, and
+    // any host that pins an older posthog-js without this method). Flag
+    // targeting degrading to "no person properties" is acceptable; throwing
+    // inside `loaded` would take out the whole analytics init.
+    posthog.setPersonPropertiesForFlags?.({
+      deployment: HOSTED_MODE ? "hosted" : "self_hosted",
+      platform: detectPlatform(),
+    });
   },
 };
 

--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -339,6 +339,16 @@ export const getPostHogOptions = () =>
         // not a config field, so passing it here was silently ignored and dev
         // events flowed into prod PostHog from 2026-03-12 until this fix.
         opt_out_capturing_by_default: true,
+        // This branch keeps /decide ON for flag evaluation, so it needs the flag
+        // PERSON properties too — otherwise a `deployment = self_hosted` rule
+        // targets nobody in exactly the local build someone would use to test
+        // that rollout.
+        loaded: (posthog: any) => {
+          posthog.setPersonPropertiesForFlags?.({
+            deployment: HOSTED_MODE ? "hosted" : "self_hosted",
+            platform: detectPlatform(),
+          });
+        },
       }
     : options;
 

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-attachments.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-attachments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   COMPUTER_ATTACHMENTS_DIR,
   buildComputerAttachmentNote,
+  isComputerAttachmentUploadActive,
   uploadAttachmentsToComputer,
   zipAttachmentNoteEntries,
 } from "../computer-attachments";
@@ -157,5 +158,47 @@ describe("uploadAttachmentsToComputer", () => {
         { projectId: "p1", files: [makeFile("a.txt")] },
       ),
     ).rejects.toThrow(/storage quota/i);
+  });
+});
+
+describe("isComputerAttachmentUploadActive", () => {
+  const base = {
+    computersEnabled: true,
+    isAuthenticated: true,
+    hostHasComputer: true,
+    engine: "cloud" as const,
+  };
+
+  it("is active for a signed-in user on a computer-attached host, cloud engine", () => {
+    expect(isComputerAttachmentUploadActive(base)).toBe(true);
+  });
+
+  it("is INACTIVE on the local engine — the upload targets the cloud box", () => {
+    expect(
+      isComputerAttachmentUploadActive({ ...base, engine: "local" }),
+    ).toBe(false);
+  });
+
+  it("stays inactive on the local engine even with every other gate open", () => {
+    expect(
+      isComputerAttachmentUploadActive({
+        computersEnabled: true,
+        isAuthenticated: true,
+        hostHasComputer: true,
+        engine: "local",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps the pre-existing COMP-14 gates", () => {
+    expect(
+      isComputerAttachmentUploadActive({ ...base, computersEnabled: false }),
+    ).toBe(false);
+    expect(
+      isComputerAttachmentUploadActive({ ...base, isAuthenticated: false }),
+    ).toBe(false);
+    expect(
+      isComputerAttachmentUploadActive({ ...base, hostHasComputer: false }),
+    ).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-attachments.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-attachments.test.ts
@@ -179,13 +179,12 @@ describe("isComputerAttachmentUploadActive", () => {
     ).toBe(false);
   });
 
-  it("stays inactive on the local engine even with every other gate open", () => {
+  it("stays inactive on the local engine when the host has no computer either", () => {
     expect(
       isComputerAttachmentUploadActive({
-        computersEnabled: true,
-        isAuthenticated: true,
-        hostHasComputer: true,
+        ...base,
         engine: "local",
+        hostHasComputer: false,
       }),
     ).toBe(false);
   });

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildComputerUploadUrl,
   buildTerminalWsUrl,
+  LOCAL_TERMINAL_WS_PATH,
   openTerminalConnection,
   toTerminalWsBase,
   uploadFilesToComputer,
@@ -302,5 +303,59 @@ describe("toTerminalWsBase", () => {
   it("returns undefined for invalid or non-http(s) inputs", () => {
     expect(toTerminalWsBase("not a url")).toBeUndefined();
     expect(toTerminalWsBase("ftp://dp.example.test")).toBeUndefined();
+  });
+});
+
+describe("terminal route selection", () => {
+  it("defaults to the CLOUD terminal route", () => {
+    const url = buildTerminalWsUrl({ cols: 80, rows: 24, baseUrl: "ws://h" });
+    expect(url).toBe("ws://h/api/web/computers/terminal?cols=80&rows=24");
+  });
+
+  it("targets the LOCAL terminal route when asked", () => {
+    const url = buildTerminalWsUrl({
+      cols: 80,
+      rows: 24,
+      baseUrl: "ws://h",
+      path: LOCAL_TERMINAL_WS_PATH,
+    });
+    expect(url).toBe("ws://h/api/web/computers/local-terminal?cols=80&rows=24");
+  });
+
+  it("keeps geometry and cwd query params on the local route", () => {
+    const url = buildTerminalWsUrl({
+      cols: 120,
+      rows: 40,
+      baseUrl: "ws://h",
+      cwd: "/home/me/work",
+      path: LOCAL_TERMINAL_WS_PATH,
+    });
+    expect(url).toContain("/api/web/computers/local-terminal?");
+    expect(url).toContain("cols=120");
+    expect(url).toContain("rows=40");
+    expect(url).toContain("cwd=%2Fhome%2Fme%2Fwork");
+  });
+
+  it("openTerminalConnection dials the requested path with the nonce as subprotocol", () => {
+    FakeWebSocket.instances.length = 0;
+    openTerminalConnection({
+      token: "nonce-abc",
+      cols: 80,
+      rows: 24,
+      baseUrl: "ws://h",
+      path: LOCAL_TERMINAL_WS_PATH,
+      onOutput: () => {},
+      onEvent: () => {},
+      onClose: () => {},
+      wsFactory: (url, protocols) =>
+        new FakeWebSocket(url, protocols) as unknown as WebSocket,
+    });
+
+    const socket = FakeWebSocket.instances.at(-1)!;
+    expect(socket.url).toContain("/api/web/computers/local-terminal");
+    // Same transport as the cloud terminal: the credential rides the
+    // subprotocol slot, never the query string.
+    expect(socket.protocols).toEqual(["nonce-abc"]);
+    expect(socket.url).not.toContain("nonce-abc");
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/computer-terminal-connection.test.ts
@@ -336,6 +336,18 @@ describe("terminal route selection", () => {
     expect(url).toContain("cwd=%2Fhome%2Fme%2Fwork");
   });
 
+  it("omits cwd entirely when it is empty, keeping the local route", () => {
+    const url = buildTerminalWsUrl({
+      cols: 80,
+      rows: 24,
+      baseUrl: "ws://h",
+      cwd: "",
+      path: LOCAL_TERMINAL_WS_PATH,
+    });
+    expect(url).toBe("ws://h/api/web/computers/local-terminal?cols=80&rows=24");
+    expect(url).not.toContain("cwd");
+  });
+
   it("openTerminalConnection dials the requested path with the nonce as subprotocol", () => {
     FakeWebSocket.instances.length = 0;
     openTerminalConnection({

--- a/mcpjam-inspector/client/src/lib/__tests__/posthog-utils.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/posthog-utils.test.ts
@@ -45,6 +45,29 @@ describe("PosthogUtils", () => {
     });
   });
 
+  it("sets deployment + platform as FLAG person properties, not just super properties", () => {
+    const posthog = {
+      register: vi.fn(),
+      setPersonPropertiesForFlags: vi.fn(),
+    };
+    options.loaded(posthog);
+
+    // `register` feeds EVENTS; `/flags` evaluates PERSON properties. Without
+    // this call a `deployment = self_hosted` flag rule matches nobody.
+    expect(posthog.setPersonPropertiesForFlags).toHaveBeenCalledWith({
+      deployment: "self_hosted",
+      platform: expect.any(String),
+    });
+  });
+
+  it("does not throw when posthog-js has no setPersonPropertiesForFlags", () => {
+    // A partial stand-in (or a host pinning an older posthog-js): flag
+    // targeting degrades, analytics init must still complete.
+    const posthog = { register: vi.fn() };
+    expect(() => options.loaded(posthog)).not.toThrow();
+    expect(posthog.register).toHaveBeenCalled();
+  });
+
   it("registers deployment: hosted when built for hosted mode", async () => {
     vi.stubEnv("VITE_MCPJAM_HOSTED_MODE", "true");
     vi.resetModules();

--- a/mcpjam-inspector/client/src/lib/computer-attachments.ts
+++ b/mcpjam-inspector/client/src/lib/computer-attachments.ts
@@ -29,6 +29,35 @@ import {
  *  recognizable at a glance. The server confines it under `/home/user`. */
 export const COMPUTER_ATTACHMENTS_DIR = "/home/user/attachments";
 
+/**
+ * Does a composer attachment ALSO get uploaded to the computer on send?
+ *
+ * COMP-14 gate (computers on + signed in + the previewed host actually attaches
+ * a computer) AND the resolved engine is `cloud`. The engine clause is the
+ * local-engine correction: the upload path targets the CLOUD box's upload route,
+ * so on "This machine" it would reserve/wake a cloud sandbox and drop the files
+ * somewhere the local bash tool can never read them. On the local engine
+ * attachments behave exactly as they do on a computer-less host — inline model
+ * parts only, no sandbox note.
+ *
+ * A local-engine computer upload is deliberately NOT reimplemented here: writing
+ * arbitrary composer files onto the user's real filesystem is a separate consent
+ * question from running approved commands, and is out of v1 scope.
+ */
+export function isComputerAttachmentUploadActive(args: {
+  computersEnabled: boolean;
+  isAuthenticated: boolean;
+  hostHasComputer: boolean;
+  engine: "local" | "cloud";
+}): boolean {
+  return (
+    args.computersEnabled &&
+    args.isAuthenticated &&
+    args.hostHasComputer &&
+    args.engine === "cloud"
+  );
+}
+
 export interface ComputerAttachmentNoteEntry {
   /** The user's original filename (what they'll recognize in the transcript). */
   name: string;

--- a/mcpjam-inspector/client/src/lib/computer-terminal-connection.ts
+++ b/mcpjam-inspector/client/src/lib/computer-terminal-connection.ts
@@ -43,7 +43,18 @@ export interface OpenTerminalOptions {
   cwd?: string;
   /** WebSocket factory override for tests. */
   wsFactory?: (url: string, protocols: string[]) => WebSocket;
+  /**
+   * Route to connect to. Defaults to the CLOUD terminal
+   * (`/api/web/computers/terminal`); the local ("This machine") pane passes
+   * `/api/web/computers/local-terminal`. Everything else about the protocol
+   * — subprotocol auth, framing, control messages — is identical, which is
+   * why the two panes share this client.
+   */
+  path?: string;
 }
+
+export const CLOUD_TERMINAL_WS_PATH = "/api/web/computers/terminal";
+export const LOCAL_TERMINAL_WS_PATH = "/api/web/computers/local-terminal";
 
 /**
  * Convert a data-plane HTTP(S) origin into the `ws(s)://host` base expected
@@ -136,6 +147,8 @@ export function buildTerminalWsUrl(args: {
   rows: number;
   baseUrl?: string;
   cwd?: string;
+  /** Defaults to the cloud terminal route; see `OpenTerminalOptions.path`. */
+  path?: string;
 }): string {
   const origin =
     args.baseUrl ??
@@ -147,7 +160,7 @@ export function buildTerminalWsUrl(args: {
     rows: String(args.rows),
   });
   if (args.cwd) params.set("cwd", args.cwd);
-  return `${origin}/api/web/computers/terminal?${params.toString()}`;
+  return `${origin}${args.path ?? CLOUD_TERMINAL_WS_PATH}?${params.toString()}`;
 }
 
 export function openTerminalConnection(

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -160,6 +160,50 @@ export async function grantLocalComputerConsent(): Promise<boolean> {
 }
 
 /**
+ * Mint a single-use nonce for the local terminal WebSocket.
+ *
+ * Lives here (rather than in a terminal module) because it presents the SAME
+ * consent capability, through the same `authFetch` path, to the same
+ * `/api/mcp/computers` router — and because the consent token must never leak
+ * into a URL or a persisted transcript, which the header keeps it out of.
+ *
+ * Throws with a user-presentable message on failure: `ComputerTerminal`'s
+ * connect path renders it in the pane's error overlay, so a 403 (consent gone
+ * stale) or a 503 (node-pty missing) reads as an explanation instead of a
+ * silent dead socket.
+ */
+export async function mintLocalTerminalNonce(args: {
+  projectId: string;
+  consentToken: string | null;
+}): Promise<string> {
+  const response = await authFetch(
+    "/api/mcp/computers/local-terminal-token",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(args.consentToken
+          ? { [LOCAL_CONSENT_HEADER]: args.consentToken }
+          : {}),
+      },
+      body: JSON.stringify({ projectId: args.projectId }),
+    },
+  );
+  const json = (await response.json().catch(() => null)) as {
+    nonce?: unknown;
+    error?: unknown;
+  } | null;
+  if (!response.ok || typeof json?.nonce !== "string") {
+    throw new Error(
+      typeof json?.error === "string"
+        ? json.error
+        : "Could not open a terminal on this machine.",
+    );
+  }
+  return json.nonce;
+}
+
+/**
  * SERVER-ONLY revoke: unlink the device's capability. Deliberately does NOT
  * touch local storage — the caller clears storage synchronously up front (the
  * user's explicit forget) and this best-effort network call runs after.

--- a/mcpjam-inspector/client/src/lib/local-computer-consent.ts
+++ b/mcpjam-inspector/client/src/lib/local-computer-consent.ts
@@ -193,7 +193,10 @@ export async function mintLocalTerminalNonce(args: {
     nonce?: unknown;
     error?: unknown;
   } | null;
-  if (!response.ok || typeof json?.nonce !== "string") {
+  // Length-checked like `mintLocalComputerConsent` above: this value becomes a
+  // WebSocket SUBPROTOCOL, and an empty/short one would fail as a silent dead
+  // socket instead of the presentable error this function promises.
+  if (!response.ok || typeof json?.nonce !== "string" || json.nonce.length < 16) {
     throw new Error(
       typeof json?.error === "string"
         ? json.error

--- a/mcpjam-inspector/docs/local-computer-engine.md
+++ b/mcpjam-inspector/docs/local-computer-engine.md
@@ -74,12 +74,19 @@ Every entry point into local execution, with what gates it:
 | Chat `bash` (guest / chatbox / web route) | **never local** — `isGuestChatRequest` forces cloud |
 | Comparison cards / org-model turns | same engine resolution as the playground; no separate path |
 | Terminal nonce mint (`POST /api/mcp/computers/local-terminal-token`) | inspector session + verified sign-in + non-guest + kill switch + server-verified consent + availability probe + validated project key |
-| Terminal WebSocket (`GET /api/web/computers/local-terminal`) | allowed `Origin` (**absent Origin rejected**) + availability probe + single-use, 60s, project-bound nonce |
+| Terminal WebSocket (`GET /api/web/computers/local-terminal`) | allowed `Origin` (**absent Origin rejected**) + availability probe + single-use, 60s, project-bound nonce + the nonce's consent fingerprint must still match the live capability |
 | Hosted build | `/api/mcp` unmounted, kill switch forced off, WS route not mounted, `terminalAvailable: false` |
 
 The terminal has **no per-command approval** — an interactive shell can't have
 one. That is precisely why its mint requires consent that already exists, and
 why the nonce is single-use with a short TTL.
+
+The nonce also carries a **fingerprint of the consent capability** it was minted
+against (the capability's stored hash), which the WebSocket re-checks against the
+live one. Without that, the 60s TTL would outlive a revoke: a nonce minted a
+second before the user clicked "Forget & re-authorize" would still open a shell.
+A re-grant from another browser profile rotates the capability and invalidates
+outstanding nonces the same way.
 
 ## Kill switch
 

--- a/mcpjam-inspector/docs/local-computer-engine.md
+++ b/mcpjam-inspector/docs/local-computer-engine.md
@@ -83,7 +83,7 @@ why the nonce is single-use with a short TTL.
 
 ## Kill switch
 
-```
+```dotenv
 MCPJAM_LOCAL_COMPUTER_ENABLED=false
 ```
 

--- a/mcpjam-inspector/docs/local-computer-engine.md
+++ b/mcpjam-inspector/docs/local-computer-engine.md
@@ -1,0 +1,218 @@
+# Local computer engine ("This machine")
+
+Engineering notes for the Playground's local computer engine: what it is, what
+it is *not*, and the checklist for turning it on and off in production. The
+user-facing page lives in the separate Mintlify repo behind
+`docs.mcpjam.com/inspector/*` — see the launch checklist below.
+
+## What it is
+
+A second **engine** behind the Computer surface. Where the cloud engine runs
+`bash` in an E2B sandbox reached through the Convex control plane, the local
+engine runs it as a child process of the inspector server itself, in a
+per-project workspace directory under `~/.mcpjam/computer/<projectId>`.
+
+There is no Convex row for the local machine, so there is no reserve/wake, no
+sandbox-info exchange, no `recordComputerCommand`, no billing, and no idle
+sweep. The machine is always ready.
+
+### Pieces
+
+| Concern | Where |
+| --- | --- |
+| Engine resolution + actor coercion | `server/utils/computers/engine.ts` |
+| Bash execution, env allowlist, workspace dirs, journal | `server/utils/computers/local-machine.ts` |
+| Consent capability (mint / verify / revoke) | `server/utils/computers/local-consent.ts`, `server/routes/mcp/computers.ts` |
+| Guest boundary | `server/utils/computers/local-engine-request.ts` (`isGuestChatRequest`) |
+| node-pty loader + availability probe | `server/utils/computers/local-pty.ts` |
+| PTY adapter onto the shared `createPtyWithCwd` | `server/utils/computers/local-pty-adapter.ts` |
+| Terminal handshake nonces | `server/utils/computers/local-terminal-auth.ts` |
+| Terminal WebSocket | `server/routes/web/local-computer-terminal.ts` |
+| Client engine resolution | `client/src/hooks/useComputerEngine.ts` |
+| Consent projection (storage only) | `client/src/hooks/useLocalComputerConsent.ts` |
+| Computer tab faces | `client/src/components/computer/*` |
+
+## Trust model
+
+Read this before changing anything in `local-machine.ts` or the terminal route.
+It mirrors the `TRUST MODEL` block at the top of `local-machine.ts`.
+
+- **This is not a sandbox.** Commands run as the OS user, with all of that
+  user's permissions. The boundaries are *consent*, *per-command chat approval*,
+  and the *actor gates* — never paths.
+- **The workspace dir is a convention**, a tidy default cwd, not confinement.
+  What *is* validated is the project key, because it becomes a path segment
+  under a fixed root: it must be exactly one bounded segment.
+- **The child env is an allowlist**, not a secret-name denylist. It reduces
+  accidental leakage of cloud credentials into transcripts and PTYs; it is not
+  a security boundary, since a same-user process can read credential stores
+  regardless.
+- **Consent is server-verified.** A request field alone is never proof. Grant
+  mints a random capability; the server persists only its SHA-256 hash
+  (`~/.mcpjam/computer/consent.json`, 0600); the client stores the plaintext
+  and presents it in `X-MCPJam-Local-Consent`, which the server re-verifies on
+  every use. The client deliberately does **not** pre-verify — a stale token
+  simply fails the next server check.
+- **Consent is device-scoped**, not per-project: the thing being consented to
+  is *this machine* executing commands.
+
+The consent gate's copy is the honest statement of all of the above, and should
+stay blunt:
+
+> The bash tool runs real commands on this computer, as your user account. The
+> project folder is only a starting directory, not a sandbox — commands can read
+> or change any files and credentials your user can access. Each agent command
+> still asks for approval in chat before it runs.
+
+## Actor and route enumeration
+
+Every entry point into local execution, with what gates it:
+
+| Entry point | Gates |
+| --- | --- |
+| Chat `bash` (playground) | non-hosted + kill switch + signed-in non-guest + server-verified consent + per-command approval |
+| Chat `bash` (guest / chatbox / web route) | **never local** — `isGuestChatRequest` forces cloud |
+| Comparison cards / org-model turns | same engine resolution as the playground; no separate path |
+| Terminal nonce mint (`POST /api/mcp/computers/local-terminal-token`) | inspector session + verified sign-in + non-guest + kill switch + server-verified consent + availability probe + validated project key |
+| Terminal WebSocket (`GET /api/web/computers/local-terminal`) | allowed `Origin` (**absent Origin rejected**) + availability probe + single-use, 60s, project-bound nonce |
+| Hosted build | `/api/mcp` unmounted, kill switch forced off, WS route not mounted, `terminalAvailable: false` |
+
+The terminal has **no per-command approval** — an interactive shell can't have
+one. That is precisely why its mint requires consent that already exists, and
+why the nonce is single-use with a short TTL.
+
+## Kill switch
+
+```
+MCPJAM_LOCAL_COMPUTER_ENABLED=false
+```
+
+Turns the whole engine off on a server:
+
+- `GET /api/web/computers/config` reports `engines.local.available: false` with
+  a reason, `terminalAvailable: false`, and `defaultEngine` falls through to
+  cloud (or `null` when no engine can serve).
+- The consent routes and the terminal mint 404.
+- The engine resolver never resolves `local`, so chat bash goes to the cloud
+  engine (or reports that no computer is available).
+
+It is forced off in hosted mode regardless of the env var.
+
+**Caveat that governs rollback:** the kill switch is a *server* env var. Users
+running a published `npx @mcpjam/inspector` or a packaged Electron build are on
+their own machines — flipping anything server-side does not reach them. Pulling
+the feature back from already-published clients needs a **patch release**. Plan
+rollback accordingly: the feature flag governs UI exposure in the hosted app;
+the kill switch governs a given self-hosted server; neither retroactively
+disarms a shipped binary.
+
+## Cloud-only surfaces
+
+Swarms, evals, and user testing execute their computer commands in MCPJam cloud
+sandboxes **regardless** of the engine setting, and preflight on
+`capabilities.ephemeralCloudAvailable`. They carry the `CloudRunBadge` so the
+provenance is visible. Do not wire the local engine into them without a
+separate design pass — they run unattended, and the per-command approval that
+makes local bash safe in chat does not exist there.
+
+## Terminal degrade
+
+`node-pty` is an **optional** dependency with a native addon. Three shipping
+paths legitimately lack it, and none may crash:
+
+1. `npx @mcpjam/inspector` on a machine with no build toolchain — npm skips the
+   optional dependency and the install still succeeds.
+2. The **packaged Electron app**, which carries no `node_modules` at all
+   (`@electron-forge/plugin-vite` packages only `.vite`), so the runtime require
+   always fails. **Electron is terminal-degrade by design in v1.** Real support
+   needs `extraResource` plus custom resolution and is a scoped follow-up.
+3. An ABI mismatch after a Node upgrade.
+
+In all three the loader returns `{ ok: false }`, the probe reports
+`terminalAvailable: false`, and the Computer tab shows a note explaining that
+the terminal isn't available while chat bash keeps working. `node-pty` is listed
+in `external` for both `server/tsup.config.ts` and `vite.main.config.ts` — it
+can never be bundled, and the Electron main build fails outright without the
+latter entry.
+
+## Analytics
+
+All events are registered in `shared/analytics-events.ts` and emitted through
+`track()` (the ratchet test forbids raw `posthog.capture`). Props are enums,
+booleans, and counts **only** — never command text, output, paths, workspace
+dirs, OS usernames, or consent tokens.
+
+| Event | Fires |
+| --- | --- |
+| `computer_engine_selected` | Local⇄Cloud toggle moved (`engine`) |
+| `local_computer_consent_gate_shown` | consent gate rendered (`cloud_offered`) |
+| `local_computer_consent_granted` | Allow (`outcome: stored \| failed`) |
+| `local_computer_consent_denied` | "Use cloud instead" — the only decline affordance |
+| `local_computer_consent_reauthorized` | "Forget & re-authorize" |
+| `computer_terminal_opened` | a terminal pane mounted (`location`) |
+| `local_terminal_unavailable` | terminal offered but degraded (`reason`) |
+
+**Scoped out of v1:** a per-command `local_bash_result` event. No client code
+reads a tool's `exitCode` today, a render-time emit would multi-fire across
+re-renders, and outcome data already lands in the local JSONL journal
+(`~/.mcpjam/computer/logs/commands.jsonl`). Add it as a fast-follow if a launch
+gate needs the local success rate.
+
+### Flag targeting
+
+`deployment` (`"hosted" | "self_hosted"`) is registered as a **super property**
+(rides events) *and* set as a **person property for flags**
+(`setPersonPropertiesForFlags`, plus `identify` person properties). Super
+properties alone are invisible to `/flags`, which evaluates person properties —
+that is why both exist. `platform` is set alongside it.
+
+The rollout rule itself is a **dashboard operation**, not code:
+
+> `computers-enabled` → employees ∪ (`deployment = self_hosted` AND signed in)
+
+## Launch / rollback checklist
+
+**Owner:** whoever runs the launch (currently @marcelo).
+
+Pre-launch:
+
+- [ ] Flag `computers-enabled` rule set to employees ∪ `deployment = self_hosted`
+      signed-in cohort; dry-run the targeting against a known self-hosted
+      distinct_id before widening.
+- [ ] Confirm `deployment` shows up as a **person** property (not only as an
+      event property) in PostHog for a fresh browser profile.
+- [ ] Confirm the consent funnel is intact:
+      `local_computer_consent_gate_shown` → `_granted` / `_denied`, with zero
+      command content on any event.
+- [ ] Dev-run the happy path: consent → "This machine" → `uname -a` in chat runs
+      locally and the tool card reads "this machine"; the Playground rail's
+      engine chip agrees; the composer's computer-upload path is inactive.
+- [ ] Terminal: open from the Computer tab → a real PTY in
+      `~/.mcpjam/computer/<projectId>`; `echo $E2B_API_KEY` is empty; drag-drop
+      over the local pane does nothing.
+- [ ] Degrade: rename the `node-pty` module → the tab shows the terminal-off
+      note and chat bash still works.
+- [ ] Hosted build: the mint 404s, the WS route is unmounted,
+      `terminalAvailable` is false.
+- [ ] Packaged Electron: the build succeeds and the app degrades cleanly (no
+      crash) with no terminal.
+- [ ] macOS `npx` smoke via the packed tarball.
+
+Rollback:
+
+- [ ] Turn the flag off — this is the fast lever, and it governs hosted UI
+      exposure.
+- [ ] For a specific self-hosted server: set
+      `MCPJAM_LOCAL_COMPUTER_ENABLED=false` and restart.
+- [ ] For already-published npx/Electron clients: **cut a patch release.** No
+      server-side switch reaches them.
+
+Follow-ups (explicitly not in this program):
+
+- [ ] Publish the user-facing page at `docs.mcpjam.com/inspector/*` — that
+      content lives in the **separate Mintlify repo**, not in this `docs/`
+      directory, which is engineering notes only.
+- [ ] Real Electron terminal support (`extraResource` + custom node-pty
+      resolution).
+- [ ] `local_bash_result` per-command outcome event, if the launch gate needs
+      the rate.

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -205,6 +205,9 @@
     "zod": "^4.2.0",
     "zustand": "^5.0.6"
   },
+  "optionalDependencies": {
+    "node-pty": "1.1.0"
+  },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",
     "@electron-forge/maker-deb": "^7.11.1",

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -76,6 +76,10 @@ import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url.js";
 import { initComputersStartup } from "./utils/computers/remote-data-plane.js";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { createComputerTerminalWsHandler } from "./routes/web/computer-terminal.js";
+import {
+  createLocalComputerTerminalWsHandler,
+  shutdownLocalComputerTerminals,
+} from "./routes/web/local-computer-terminal.js";
 import { createComputerUploadHandler } from "./routes/web/computer-upload.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -280,6 +284,14 @@ export async function createHonoApp() {
     "/api/web/computers/terminal",
     createComputerTerminalWsHandler(upgradeWebSocket)
   );
+  // LOCAL computer terminal WebSocket ("This machine"). Never mounted hosted.
+  // Mirror of the mount in server/index.ts.
+  if (!HOSTED_MODE) {
+    app.get(
+      "/api/web/computers/local-terminal",
+      createLocalComputerTerminalWsHandler(upgradeWebSocket)
+    );
+  }
   app.post(
     "/api/web/computers/upload",
     bodyLimit({
@@ -566,5 +578,8 @@ export async function createHonoApp() {
 
   // Return `injectWebSocket` alongside the app so the caller (src/main.ts) can
   // attach the WS upgrade handler to its node server — same as server/index.ts.
-  return { app, injectWebSocket };
+  // `shutdownLocalComputerTerminals` rides along for the same reason: the
+  // Electron entry owns this process's lifecycle and must kill live local PTYs
+  // on quit (server.close() does not close established sockets).
+  return { app, injectWebSocket, shutdownLocalComputerTerminals };
 }

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -78,6 +78,7 @@ import { createNodeWebSocket } from "@hono/node-ws";
 import { createComputerTerminalWsHandler } from "./routes/web/computer-terminal.js";
 import {
   createLocalComputerTerminalWsHandler,
+  killLocalComputerTerminals,
   shutdownLocalComputerTerminals,
 } from "./routes/web/local-computer-terminal.js";
 import { createComputerUploadHandler } from "./routes/web/computer-upload.js";
@@ -578,8 +579,15 @@ export async function createHonoApp() {
 
   // Return `injectWebSocket` alongside the app so the caller (src/main.ts) can
   // attach the WS upgrade handler to its node server — same as server/index.ts.
-  // `shutdownLocalComputerTerminals` rides along for the same reason: the
-  // Electron entry owns this process's lifecycle and must kill live local PTYs
-  // on quit (server.close() does not close established sockets).
-  return { app, injectWebSocket, shutdownLocalComputerTerminals };
+  // The two PTY-cleanup hooks ride along for the same reason: the Electron entry
+  // owns this process's lifecycle and must kill live local PTYs itself
+  // (server.close() does not close established sockets). `shutdown…` latches
+  // and belongs on a real quit; `kill…` does not and belongs on
+  // `window-all-closed`, which on macOS is followed by a server RESTART.
+  return {
+    app,
+    injectWebSocket,
+    shutdownLocalComputerTerminals,
+    killLocalComputerTerminals,
+  };
 }

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -54,6 +54,10 @@ import { getSystemLogger } from "./utils/request-logger";
 import { requestLogContextMiddleware } from "./middleware/request-log-context";
 import { getInspectorFrontendUrl } from "./utils/inspector-frontend-url";
 import { createComputerTerminalWsHandler } from "./routes/web/computer-terminal";
+import {
+  createLocalComputerTerminalWsHandler,
+  shutdownLocalComputerTerminals,
+} from "./routes/web/local-computer-terminal";
 import { createComputerUploadHandler } from "./routes/web/computer-upload";
 import { initComputersStartup } from "./utils/computers/remote-data-plane";
 import { registerSelfFetch } from "./utils/self-app";
@@ -448,6 +452,15 @@ app.get(
   "/api/web/computers/terminal",
   createComputerTerminalWsHandler(upgradeWebSocket)
 );
+// LOCAL computer terminal WebSocket ("This machine"). Never mounted hosted —
+// a hosted server must have no path at all to a local PTY. Auth is the
+// single-use nonce from POST /api/mcp/computers/local-terminal-token.
+if (!HOSTED_MODE) {
+  app.get(
+    "/api/web/computers/local-terminal",
+    createLocalComputerTerminalWsHandler(upgradeWebSocket)
+  );
+}
 // Computer file upload (drag-and-drop from the Shell panel). Same terminal-token
 // auth as the WS above; its own 30MB bodyLimit (the global /api/web/* 1MB cap
 // excludes this path). See routes/web/computer-upload.
@@ -863,6 +876,10 @@ async function shutdown() {
     // and lets in-flight sessions report a terminal attempt. Bounded internally.
     await shutdownRunningJourneyRuns();
     await tunnelManager.closeAll();
+    // Kill local PTYs BEFORE server.close(): close() stops new connections but
+    // does NOT tear down established sockets, so a live shell would otherwise
+    // outlive the inspector.
+    shutdownLocalComputerTerminals();
     server.close();
     // Flush queued server-side analytics (bounded internally; forceExitTimer
     // is the backstop). Billing/funnel events must not die in the queue.

--- a/mcpjam-inspector/server/middleware/origin-validation.ts
+++ b/mcpjam-inspector/server/middleware/origin-validation.ts
@@ -92,6 +92,21 @@ function matchesAllowedOrigin(
 }
 
 /**
+ * Is this `Origin` header value on the allowlist?
+ *
+ * Exported for handlers that must re-check the origin THEMSELVES rather than
+ * rely on the middleware — currently the local computer terminal WebSocket,
+ * which tightens the rule: an ABSENT Origin is allowed through by the
+ * middleware below (curl, same-origin non-browser clients), but a browser
+ * always sends one on a WS handshake, so the local PTY route treats "absent"
+ * as a reject. Defense-in-depth only; the single-use nonce is the real gate.
+ */
+export function isAllowedRequestOrigin(origin: string | undefined): boolean {
+  if (!origin) return false;
+  return matchesAllowedOrigin(origin, getAllowedOrigins());
+}
+
+/**
  * Origin validation middleware.
  * Blocks requests from non-localhost origins.
  */

--- a/mcpjam-inspector/server/routes/mcp/__tests__/computers-local-terminal-token.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/computers-local-terminal-token.test.ts
@@ -134,7 +134,7 @@ describe("POST /api/mcp/computers/local-terminal-token", () => {
     };
     expect(typeof json.nonce).toBe("string");
     expect(json.expiresAtMs).toBeGreaterThan(Date.now());
-    expect(consumeLocalTerminalNonce(json.nonce)).toEqual({
+    expect(consumeLocalTerminalNonce(json.nonce)).toMatchObject({
       projectId: "proj_1",
     });
   });
@@ -245,6 +245,45 @@ describe("POST /api/mcp/computers/local-terminal-token", () => {
       );
       expect(response.status).toBe(400);
     }
+  });
+
+  it("binds the nonce to the LIVE consent capability", async () => {
+    const consent = await grantConsent();
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    const { nonce } = (await response.json()) as { nonce: string };
+
+    // The WS handler re-checks this against the live capability, so a revoke or
+    // a re-grant inside the 60s TTL invalidates the nonce.
+    const claim = consumeLocalTerminalNonce(nonce);
+    expect(claim?.consentFingerprint).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("re-mints against a ROTATED capability, not the old one", async () => {
+    const first = await grantConsent();
+    const a = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: first }
+    );
+    const firstClaim = consumeLocalTerminalNonce(
+      ((await a.json()) as { nonce: string }).nonce
+    );
+
+    // A second grant rotates the capability.
+    const second = await grantConsent();
+    const b = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: second }
+    );
+    const secondClaim = consumeLocalTerminalNonce(
+      ((await b.json()) as { nonce: string }).nonce
+    );
+
+    expect(secondClaim?.consentFingerprint).not.toBe(
+      firstClaim?.consentFingerprint
+    );
   });
 
   it("mints a DISTINCT nonce per call (no reuse across reconnects)", async () => {

--- a/mcpjam-inspector/server/routes/mcp/__tests__/computers-local-terminal-token.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/computers-local-terminal-token.test.ts
@@ -1,0 +1,264 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * ACTOR ENUMERATION for the local-terminal nonce mint. This route hands out the
+ * only credential that opens an interactive shell on the user's machine — with
+ * no per-command approval, unlike the chat `bash` tool. Every gate gets a
+ * negative test here:
+ *
+ *   session          — app-level `/api/mcp` middleware (its own suites)
+ *   verified sign-in — `requireVerifiedAuth` (401)
+ *   non-guest        — explicit guest check (403)
+ *   kill switch      — MCPJAM_LOCAL_COMPUTER_ENABLED off (404)
+ *   consent          — server-verified capability (403)
+ *   availability     — node-pty / engine probe (503)
+ *   project key      — one bounded path segment (400)
+ *
+ * Hosted mode is covered structurally elsewhere: `/api/mcp` isn't mounted at
+ * all hosted, and `LOCAL_COMPUTER_ENABLED` is forced off there.
+ */
+const scratch = mkdtempSync(join(tmpdir(), "mcpjam-local-terminal-token-"));
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return { ...actual, homedir: () => scratch };
+});
+
+const authState = vi.hoisted(() => ({
+  verified: true,
+  guest: false,
+  bearerSeen: 0,
+  verifySeen: 0,
+}));
+vi.mock("../../../middleware/bearer-auth.js", () => ({
+  bearerAuthMiddleware: (c: any, next: any) => {
+    authState.bearerSeen += 1;
+    if (authState.guest) c.set("guestId", "guest-1");
+    return next();
+  },
+}));
+vi.mock("../../../middleware/require-verified-auth.js", () => ({
+  requireVerifiedAuth: () => (c: any, next: any) => {
+    authState.verifySeen += 1;
+    if (!authState.verified) {
+      return c.json({ error: "unauthorized" }, 401);
+    }
+    return next();
+  },
+}));
+
+const configState = vi.hoisted(() => ({ localEnabled: true }));
+vi.mock("../../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../config.js")>(
+    "../../../config.js"
+  );
+  return {
+    ...actual,
+    get LOCAL_COMPUTER_ENABLED() {
+      return configState.localEnabled;
+    },
+  };
+});
+
+const terminalState = vi.hoisted(() => ({
+  availability: { available: true } as
+    | { available: true }
+    | { available: false; reason: string },
+}));
+vi.mock("../../../utils/computers/local-pty.js", () => ({
+  getLocalTerminalAvailability: async () => terminalState.availability,
+}));
+
+import computers from "../computers.js";
+import { LOCAL_CONSENT_HEADER } from "../../../utils/computers/local-consent.js";
+import {
+  consumeLocalTerminalNonce,
+  resetLocalTerminalNoncesForTests,
+} from "../../../utils/computers/local-terminal-auth.js";
+
+afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+function createApp() {
+  const app = new Hono();
+  app.route("/api/mcp/computers", computers);
+  return app;
+}
+
+async function grantConsent(): Promise<string> {
+  const response = await createApp().request(
+    "/api/mcp/computers/local-consent/grant",
+    { method: "POST" }
+  );
+  const json = (await response.json()) as { token: string };
+  return json.token;
+}
+
+function mint(
+  body: unknown,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  return Promise.resolve(
+    createApp().request("/api/mcp/computers/local-terminal-token", {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+beforeEach(() => {
+  authState.verified = true;
+  authState.guest = false;
+  authState.bearerSeen = 0;
+  authState.verifySeen = 0;
+  configState.localEnabled = true;
+  terminalState.availability = { available: true };
+  resetLocalTerminalNoncesForTests();
+});
+
+describe("POST /api/mcp/computers/local-terminal-token", () => {
+  it("mints a redeemable, project-bound nonce for a consented member", async () => {
+    const consent = await grantConsent();
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as {
+      nonce: string;
+      expiresAtMs: number;
+    };
+    expect(typeof json.nonce).toBe("string");
+    expect(json.expiresAtMs).toBeGreaterThan(Date.now());
+    expect(consumeLocalTerminalNonce(json.nonce)).toEqual({
+      projectId: "proj_1",
+    });
+  });
+
+  it("returns the nonce and its deadline — and NOTHING else", async () => {
+    const consent = await grantConsent();
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    // No workspace path, no shell, no OS username may leave the server here.
+    expect(Object.keys((await response.json()) as object).sort()).toEqual([
+      "expiresAtMs",
+      "nonce",
+    ]);
+  });
+
+  it("APPLIES the auth middleware stack exactly once", async () => {
+    const consent = await grantConsent();
+    authState.bearerSeen = 0;
+    authState.verifySeen = 0;
+    await mint({ projectId: "proj_1" }, { [LOCAL_CONSENT_HEADER]: consent });
+    // The gates must actually run on this path (an unmatched registration would
+    // silently leave the mint ungated) — and exactly once, so the bearer isn't
+    // resolved twice per mint.
+    expect(authState.bearerSeen).toBe(1);
+    expect(authState.verifySeen).toBe(1);
+  });
+
+  it("401s an unverified caller", async () => {
+    const consent = await grantConsent();
+    authState.verified = false;
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("403s a guest", async () => {
+    const consent = await grantConsent();
+    authState.guest = true;
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it("404s when the kill switch is off", async () => {
+    const consent = await grantConsent();
+    configState.localEnabled = false;
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    expect(response.status).toBe(404);
+  });
+
+  it("403s with NO consent header — an unauthorized machine never mints", async () => {
+    await grantConsent();
+    const response = await mint({ projectId: "proj_1" });
+    expect(response.status).toBe(403);
+  });
+
+  it("403s a WRONG consent token", async () => {
+    await grantConsent();
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: "n".repeat(43) }
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it("403s once consent has been revoked", async () => {
+    const consent = await grantConsent();
+    await createApp().request("/api/mcp/computers/local-consent/revoke", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: consent }),
+    });
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it("503s when the local terminal isn't available (node-pty missing)", async () => {
+    const consent = await grantConsent();
+    terminalState.availability = {
+      available: false,
+      reason: "node-pty is not available on this server",
+    };
+    const response = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    expect(response.status).toBe(503);
+  });
+
+  it("400s a project key that isn't one bounded path segment", async () => {
+    const consent = await grantConsent();
+    for (const projectId of ["../../etc", "a/b", "", 42]) {
+      const response = await mint(
+        { projectId },
+        { [LOCAL_CONSENT_HEADER]: consent }
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it("mints a DISTINCT nonce per call (no reuse across reconnects)", async () => {
+    const consent = await grantConsent();
+    const a = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    const b = await mint(
+      { projectId: "proj_1" },
+      { [LOCAL_CONSENT_HEADER]: consent }
+    );
+    const first = (await a.json()) as { nonce: string };
+    const second = (await b.json()) as { nonce: string };
+    expect(first.nonce).not.toBe(second.nonce);
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/computers.ts
+++ b/mcpjam-inspector/server/routes/mcp/computers.ts
@@ -24,10 +24,13 @@ import { LOCAL_COMPUTER_ENABLED } from "../../config.js";
 import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
 import { requireVerifiedAuth } from "../../middleware/require-verified-auth.js";
 import {
+  LOCAL_CONSENT_HEADER,
   grantLocalComputerConsent,
   revokeLocalComputerConsent,
   verifyLocalComputerConsent,
 } from "../../utils/computers/local-consent.js";
+import { getLocalTerminalAvailability } from "../../utils/computers/local-pty.js";
+import { issueLocalTerminalNonce } from "../../utils/computers/local-terminal-auth.js";
 
 const computers = new Hono();
 
@@ -38,6 +41,28 @@ computers.use("/local-consent/*", async (c, next) => {
   }
   if (c.get("guestId")) {
     return c.json({ error: "Guests cannot enable the local computer" }, 403);
+  }
+  return next();
+});
+
+// The consent gates above are scoped to `/local-consent/*` ONLY — the mint
+// route needs its own identical stack, or it would inherit nothing but the
+// app-level session middleware.
+// Registered on the EXACT path, not `/local-terminal-token/*`: the mint is a
+// single bare path with no sub-routes, and an exact registration can't be
+// wrong about whether a wildcard covers its own prefix. (`bearerAuthMiddleware`
+// resolves the bearer, so matching twice would also do that work twice.)
+computers.use(
+  "/local-terminal-token",
+  bearerAuthMiddleware,
+  requireVerifiedAuth()
+);
+computers.use("/local-terminal-token", async (c, next) => {
+  if (!LOCAL_COMPUTER_ENABLED) {
+    return c.json({ error: "Not found" }, 404);
+  }
+  if (c.get("guestId")) {
+    return c.json({ error: "Guests cannot open a local terminal" }, 403);
   }
   return next();
 });
@@ -62,6 +87,41 @@ computers.post("/local-consent/revoke", async (c) => {
   const token = typeof body?.token === "string" ? body.token : null;
   await revokeLocalComputerConsent(token);
   return c.json({ ok: true });
+});
+
+/**
+ * Mint a single-use nonce for the local terminal WebSocket.
+ *
+ * On top of the middleware stack above (session + verified sign-in + non-guest
+ * + kill switch) this requires SERVER-VERIFIED consent: the same capability the
+ * chat `bash` path checks. No consent, no nonce — an interactive shell is
+ * strictly more than the per-command-approved bash tool, so it can never be the
+ * first thing that runs on a machine the user never authorized.
+ *
+ * The response carries the nonce and its deadline and NOTHING else — no
+ * workspace path, no shell, no username.
+ */
+computers.post("/local-terminal-token", async (c) => {
+  const consentToken = c.req.header(LOCAL_CONSENT_HEADER);
+  if (!(await verifyLocalComputerConsent(consentToken))) {
+    return c.json({ error: "Local computer consent is required" }, 403);
+  }
+  const availability = await getLocalTerminalAvailability();
+  if (!availability.available) {
+    return c.json({ error: availability.reason }, 503);
+  }
+  const body = (await c.req.json().catch(() => null)) as {
+    projectId?: unknown;
+  } | null;
+  const projectId = typeof body?.projectId === "string" ? body.projectId : "";
+  try {
+    // `issueLocalTerminalNonce` re-validates the project key (one bounded path
+    // segment) — an invalid key never reaches the WS handler.
+    const { nonce, expiresAtMs } = issueLocalTerminalNonce(projectId);
+    return c.json({ nonce, expiresAtMs });
+  } catch {
+    return c.json({ error: "Invalid project for the local terminal" }, 400);
+  }
 });
 
 export default computers;

--- a/mcpjam-inspector/server/routes/mcp/computers.ts
+++ b/mcpjam-inspector/server/routes/mcp/computers.ts
@@ -25,6 +25,7 @@ import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
 import { requireVerifiedAuth } from "../../middleware/require-verified-auth.js";
 import {
   LOCAL_CONSENT_HEADER,
+  getLocalConsentFingerprint,
   grantLocalComputerConsent,
   revokeLocalComputerConsent,
   verifyLocalComputerConsent,
@@ -110,6 +111,15 @@ computers.post("/local-terminal-token", async (c) => {
   if (!availability.available) {
     return c.json({ error: availability.reason }, 503);
   }
+  // Bind the nonce to the capability that authorized it. Without this the 60s
+  // TTL would outlive a revoke: a nonce minted a second before the user clicked
+  // "Forget & re-authorize" would still open a shell. The WS handler re-checks
+  // this fingerprint against the live capability, so a revoke OR a re-grant
+  // (which rotates it) kills anything already handed out.
+  const consentFingerprint = await getLocalConsentFingerprint();
+  if (!consentFingerprint) {
+    return c.json({ error: "Local computer consent is required" }, 403);
+  }
   const body = (await c.req.json().catch(() => null)) as {
     projectId?: unknown;
   } | null;
@@ -117,7 +127,10 @@ computers.post("/local-terminal-token", async (c) => {
   try {
     // `issueLocalTerminalNonce` re-validates the project key (one bounded path
     // segment) — an invalid key never reaches the WS handler.
-    const { nonce, expiresAtMs } = issueLocalTerminalNonce(projectId);
+    const { nonce, expiresAtMs } = issueLocalTerminalNonce(
+      projectId,
+      consentFingerprint
+    );
     return c.json({ nonce, expiresAtMs });
   } catch {
     return c.json({ error: "Invalid project for the local terminal" }, 400);

--- a/mcpjam-inspector/server/routes/mcp/computers.ts
+++ b/mcpjam-inspector/server/routes/mcp/computers.ts
@@ -25,9 +25,9 @@ import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
 import { requireVerifiedAuth } from "../../middleware/require-verified-auth.js";
 import {
   LOCAL_CONSENT_HEADER,
-  getLocalConsentFingerprint,
   grantLocalComputerConsent,
   revokeLocalComputerConsent,
+  verifyAndFingerprintLocalConsent,
   verifyLocalComputerConsent,
 } from "../../utils/computers/local-consent.js";
 import { getLocalTerminalAvailability } from "../../utils/computers/local-pty.js";
@@ -103,20 +103,22 @@ computers.post("/local-consent/revoke", async (c) => {
  * workspace path, no shell, no username.
  */
 computers.post("/local-terminal-token", async (c) => {
-  const consentToken = c.req.header(LOCAL_CONSENT_HEADER);
-  if (!(await verifyLocalComputerConsent(consentToken))) {
-    return c.json({ error: "Local computer consent is required" }, 403);
-  }
   const availability = await getLocalTerminalAvailability();
   if (!availability.available) {
     return c.json({ error: availability.reason }, 503);
   }
-  // Bind the nonce to the capability that authorized it. Without this the 60s
-  // TTL would outlive a revoke: a nonce minted a second before the user clicked
-  // "Forget & re-authorize" would still open a shell. The WS handler re-checks
-  // this fingerprint against the live capability, so a revoke OR a re-grant
-  // (which rotates it) kills anything already handed out.
-  const consentFingerprint = await getLocalConsentFingerprint();
+  // Verify the capability AND capture its fingerprint in ONE read — see
+  // `verifyAndFingerprintLocalConsent`. Two separate reads would let a
+  // concurrent re-grant verify the old token and then bind the nonce to the
+  // NEW capability, surviving the rotation it should have died to.
+  //
+  // Binding at all is what stops the 60s TTL outliving a revoke: a nonce minted
+  // a second before the user clicked "Forget & re-authorize" would otherwise
+  // still open a shell. The WS handler re-checks the fingerprint against the
+  // live capability, so revoke AND rotation both invalidate outstanding nonces.
+  const consentFingerprint = await verifyAndFingerprintLocalConsent(
+    c.req.header(LOCAL_CONSENT_HEADER)
+  );
   if (!consentFingerprint) {
     return c.json({ error: "Local computer consent is required" }, 403);
   }

--- a/mcpjam-inspector/server/routes/mcp/computers.ts
+++ b/mcpjam-inspector/server/routes/mcp/computers.ts
@@ -45,13 +45,13 @@ computers.use("/local-consent/*", async (c, next) => {
   return next();
 });
 
-// The consent gates above are scoped to `/local-consent/*` ONLY — the mint
-// route needs its own identical stack, or it would inherit nothing but the
-// app-level session middleware.
-// Registered on the EXACT path, not `/local-terminal-token/*`: the mint is a
-// single bare path with no sub-routes, and an exact registration can't be
-// wrong about whether a wildcard covers its own prefix. (`bearerAuthMiddleware`
-// resolves the bearer, so matching twice would also do that work twice.)
+// The gates above are scoped to `/local-consent/*` ONLY, so the terminal mint
+// needs its own identical stack — without this it would inherit nothing but the
+// app-level session middleware. Registered on the EXACT path rather than
+// `/local-terminal-token/*`: the mint is a single bare path with no sub-routes,
+// and an exact registration can't be wrong about whether a wildcard covers its
+// own prefix. (`bearerAuthMiddleware` resolves the bearer, so a double match
+// would also do that work twice.)
 computers.use(
   "/local-terminal-token",
   bearerAuthMiddleware,

--- a/mcpjam-inspector/server/routes/web/__tests__/computers-local-terminal-config.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers-local-terminal-config.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 
 /**
@@ -9,22 +9,11 @@ import { Hono } from "hono";
  * can't assert the `true` branch on a CI box that has no native addon.
  */
 
-const configState = vi.hoisted(() => ({ hosted: false, localEnabled: true }));
-vi.mock("../../../config.js", async () => {
-  const actual = await vi.importActual<typeof import("../../../config.js")>(
-    "../../../config.js"
-  );
-  return {
-    ...actual,
-    get HOSTED_MODE() {
-      return configState.hosted;
-    },
-    get LOCAL_COMPUTER_ENABLED() {
-      return configState.localEnabled;
-    },
-  };
-});
-
+// No `config.js` mock here on purpose: both consumers of HOSTED_MODE /
+// LOCAL_COMPUTER_ENABLED on this route's config path (`local-machine`,
+// `local-pty`) are mocked below, and `createComputersRoutes` never reads
+// `config.js` itself. The sibling `computers.test.ts` needs that mock precisely
+// because it exercises the REAL probes.
 const engineState = vi.hoisted(() => ({
   engine: { available: true } as
     | { available: true }
@@ -45,6 +34,20 @@ vi.mock("../../../utils/computers/local-pty.js", () => ({
 
 import { createComputersRoutes } from "../computers.js";
 
+/**
+ * Keep the control plane out of it: `/config` also resolves
+ * `resolveComputersLocalConfigured()` / `resolveComputersRemoteDataPlaneUrl()`,
+ * which would make real outbound calls (with retries) if CONVEX_HTTP_URL happens
+ * to be set in the environment — slow, and order-dependent through their
+ * memoized discovery promises.
+ */
+function installFetchStub() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response("{}", { status: 404 }))
+  );
+}
+
 function createApp() {
   const app = new Hono();
   app.route("/api/web/computers", createComputersRoutes());
@@ -60,10 +63,13 @@ async function readLocalEngineBlock(): Promise<Record<string, unknown>> {
 }
 
 beforeEach(() => {
-  configState.hosted = false;
-  configState.localEnabled = true;
+  installFetchStub();
   engineState.engine = { available: true };
   terminalState.terminal = { available: true };
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe("GET /api/web/computers/config — local terminal probe", () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/computers-local-terminal-config.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers-local-terminal-config.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+/**
+ * `GET /api/web/computers/config` is how the CLIENT learns whether to offer the
+ * local terminal at all. This suite pins the flip in both directions with the
+ * node-pty probe stubbed — the sibling `computers.test.ts` composes its
+ * expectation from the real probe (honest on any host), which by construction
+ * can't assert the `true` branch on a CI box that has no native addon.
+ */
+
+const configState = vi.hoisted(() => ({ hosted: false, localEnabled: true }));
+vi.mock("../../../config.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../config.js")>(
+    "../../../config.js"
+  );
+  return {
+    ...actual,
+    get HOSTED_MODE() {
+      return configState.hosted;
+    },
+    get LOCAL_COMPUTER_ENABLED() {
+      return configState.localEnabled;
+    },
+  };
+});
+
+const engineState = vi.hoisted(() => ({
+  engine: { available: true } as
+    | { available: true }
+    | { available: false; reason: string },
+}));
+vi.mock("../../../utils/computers/local-machine.js", () => ({
+  isLocalComputerEngineAvailable: () => engineState.engine,
+}));
+
+const terminalState = vi.hoisted(() => ({
+  terminal: { available: true } as
+    | { available: true }
+    | { available: false; reason: string },
+}));
+vi.mock("../../../utils/computers/local-pty.js", () => ({
+  getLocalTerminalAvailability: async () => terminalState.terminal,
+}));
+
+import { createComputersRoutes } from "../computers.js";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/api/web/computers", createComputersRoutes());
+  return app;
+}
+
+async function readLocalEngineBlock(): Promise<Record<string, unknown>> {
+  const response = await createApp().request("/api/web/computers/config");
+  const json = (await response.json()) as {
+    engines: { local: Record<string, unknown> };
+  };
+  return json.engines.local;
+}
+
+beforeEach(() => {
+  configState.hosted = false;
+  configState.localEnabled = true;
+  engineState.engine = { available: true };
+  terminalState.terminal = { available: true };
+});
+
+describe("GET /api/web/computers/config — local terminal probe", () => {
+  it("reports terminalAvailable:true once node-pty loads", async () => {
+    await expect(readLocalEngineBlock()).resolves.toMatchObject({
+      available: true,
+      terminalAvailable: true,
+      workspaceDisplayRoot: "~/.mcpjam/computer",
+    });
+  });
+
+  it("reports terminalAvailable:false when node-pty is missing — engine still on", async () => {
+    terminalState.terminal = {
+      available: false,
+      reason: "node-pty is not available on this server",
+    };
+    // The honest degrade: bash from chat keeps working, the client renders the
+    // terminal-off state instead of a broken pane.
+    await expect(readLocalEngineBlock()).resolves.toMatchObject({
+      available: true,
+      terminalAvailable: false,
+    });
+  });
+
+  it("never offers a terminal when the local engine itself is unavailable", async () => {
+    engineState.engine = {
+      available: false,
+      reason: "the local computer engine is disabled on this server",
+    };
+    terminalState.terminal = {
+      available: false,
+      reason: "the local computer engine is disabled on this server",
+    };
+    await expect(readLocalEngineBlock()).resolves.toMatchObject({
+      available: false,
+      terminalAvailable: false,
+      workspaceDisplayRoot: null,
+    });
+  });
+
+  it("does not leak an absolute home path or OS username", async () => {
+    const block = await readLocalEngineBlock();
+    expect(String(block.workspaceDisplayRoot)).toBe("~/.mcpjam/computer");
+    expect(JSON.stringify(block)).not.toContain("/home/");
+    expect(JSON.stringify(block)).not.toContain("/Users/");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/computers.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../../config.js", async () => {
 
 import { createComputersRoutes } from "../computers";
 import { isLocalComputerEngineAvailable } from "../../../utils/computers/local-machine";
+import { getLocalTerminalAvailability } from "../../../utils/computers/local-pty";
 import type { BashRunner } from "../../../utils/computers/run-command";
 
 // Route-level tests: GET /config (data-plane discovery) and POST /exec (the
@@ -124,16 +125,21 @@ describe("GET /api/web/computers/config", () => {
   // The local-engine block depends on the host running the tests (bash on
   // PATH); compose the expectation from the same probe the route consults so
   // the suite is honest on a bash-less machine instead of failing on it.
-  function expectedLocalEngineBlock() {
+  async function expectedLocalEngineBlock() {
     const availability = isLocalComputerEngineAvailable();
+    // node-pty is an OPTIONAL native dep, so `terminalAvailable` depends on the
+    // host running the tests just like `available` does — compose it from the
+    // same probe the route consults rather than hard-coding either answer.
+    const terminal = await getLocalTerminalAvailability();
     return availability.available
       ? {
           available: true,
-          terminalAvailable: false,
+          terminalAvailable: terminal.available,
           workspaceDisplayRoot: "~/.mcpjam/computer",
         }
       : {
           available: false,
+          // A machine whose local ENGINE is off never offers a terminal.
           terminalAvailable: false,
           workspaceDisplayRoot: null,
           reason: availability.reason,
@@ -141,7 +147,7 @@ describe("GET /api/web/computers/config", () => {
   }
 
   it("reports an unconfigured server — legacy fields intact, engines added", async () => {
-    const localBlock = expectedLocalEngineBlock();
+    const localBlock = await expectedLocalEngineBlock();
     const response = await createApp().request("/api/web/computers/config");
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({

--- a/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
@@ -81,9 +81,19 @@ interface FakePtyRecord {
 
 const spawned: FakePtyRecord[] = [];
 
+/** When set, the next spawn sweeps the live set from inside `spawn` itself. */
+let killDuringNextSpawn = false;
+
 function installFakePty(): void {
   const module: NodePtyModule = {
     spawn: (file, _args, options) => {
+      if (killDuringNextSpawn) {
+        killDuringNextSpawn = false;
+        // Runs BEFORE `createPtyWithCwd` resolves, so the handle provably is not
+        // in `livePtys` yet — the generation check is the only thing that can
+        // still kill it.
+        killLocalComputerTerminals();
+      }
       const dataListeners: Array<(d: string) => void> = [];
       const exitListeners: Array<(e: { exitCode: number }) => void> = [];
       const record: FakePtyRecord = {
@@ -225,6 +235,7 @@ let server: { port: number; close: () => Promise<void> };
 beforeEach(async () => {
   vi.stubEnv("ALLOWED_ORIGINS", ALLOWED_ORIGIN);
   spawned.length = 0;
+  killDuringNextSpawn = false;
   consentState.fingerprint = MINT_FINGERPRINT;
   resetLocalTerminalNoncesForTests();
   resetLocalPtyCachesForTests();
@@ -379,6 +390,19 @@ describe("local terminal WS — shutdown", () => {
     expect(spawned).toHaveLength(2);
     reopened.close();
     await waitForClose(reopened);
+  });
+
+  it("kills a PTY whose spawn was in flight when the set was drained", async () => {
+    killDuringNextSpawn = true;
+    const { nonce } = mintNonce();
+    const ws = connect(server.port, nonce);
+
+    await vi.waitFor(() => expect(spawned).toHaveLength(1));
+    // The sweep happened mid-spawn, so this handle was never registered — only
+    // the generation check can account for it being dead.
+    await vi.waitFor(() => expect(spawned[0]!.killed).toBe(true));
+    ws.close();
+    await waitForClose(ws);
   });
 
   it("refuses NEW handshakes once shutdown has begun", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
@@ -39,9 +39,18 @@ vi.mock("node:os", async () => {
   return { ...actual, homedir: () => scratch };
 });
 
+const consentState = vi.hoisted(() => ({
+  fingerprint: "a".repeat(64) as string | null,
+}));
+vi.mock("../../../utils/computers/local-consent.js", () => ({
+  getLocalConsentFingerprint: async () => consentState.fingerprint,
+}));
+
 import {
   createLocalComputerTerminalWsHandler,
+  resetLocalTerminalShutdownForTests,
   resolveLocalShell,
+  shutdownLocalComputerTerminals,
 } from "../local-computer-terminal.js";
 import {
   resetLocalPtyCachesForTests,
@@ -142,6 +151,13 @@ async function startServer(): Promise<{
   };
 }
 
+const MINT_FINGERPRINT = "a".repeat(64);
+
+/** Mint a nonce bound to the fingerprint the handler will see as live. */
+function mintNonce(projectId = "proj_1", fingerprint = MINT_FINGERPRINT) {
+  return issueLocalTerminalNonce(projectId, fingerprint);
+}
+
 function connect(
   port: number,
   nonce: string,
@@ -208,8 +224,10 @@ let server: { port: number; close: () => Promise<void> };
 beforeEach(async () => {
   vi.stubEnv("ALLOWED_ORIGINS", ALLOWED_ORIGIN);
   spawned.length = 0;
+  consentState.fingerprint = MINT_FINGERPRINT;
   resetLocalTerminalNoncesForTests();
   resetLocalPtyCachesForTests();
+  resetLocalTerminalShutdownForTests();
   installFakePty();
   server = await startServer();
 });
@@ -219,11 +237,12 @@ afterEach(async () => {
   vi.unstubAllEnvs();
   resetLocalPtyCachesForTests();
   resetLocalTerminalNoncesForTests();
+  resetLocalTerminalShutdownForTests();
 });
 
 describe("local terminal WS — auth", () => {
   it("opens a PTY for a valid nonce and announces ready", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     const ready = await waitForJson(ws, "ready");
 
@@ -252,7 +271,7 @@ describe("local terminal WS — auth", () => {
   });
 
   it("4401s a REUSED nonce — single use survives a replayed handshake", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const first = connect(server.port, nonce);
     await waitForJson(first, "ready");
     first.close();
@@ -265,7 +284,7 @@ describe("local terminal WS — auth", () => {
   });
 
   it("4401s a DISALLOWED Origin", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce, {
       origin: "https://evil.example.com",
     });
@@ -276,7 +295,7 @@ describe("local terminal WS — auth", () => {
   });
 
   it("4401s an ABSENT Origin — the local tightening over the HTTP middleware", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce, { origin: null });
     const { code } = await waitForClose(ws);
 
@@ -285,7 +304,7 @@ describe("local terminal WS — auth", () => {
   });
 
   it("does NOT consume the nonce when the Origin is rejected", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const rejected = connect(server.port, nonce, { origin: null });
     await waitForClose(rejected);
 
@@ -298,10 +317,66 @@ describe("local terminal WS — auth", () => {
   });
 });
 
+describe("local terminal WS — consent is re-checked at redeem", () => {
+  it("4401s a nonce whose consent has been REVOKED inside the TTL", async () => {
+    const { nonce } = mintNonce();
+    // The user clicked "Forget & re-authorize" between mint and connect. The
+    // 60s TTL must not outlive the capability that authorized it.
+    consentState.fingerprint = null;
+
+    const ws = connect(server.port, nonce);
+    const { code } = await waitForClose(ws);
+
+    expect(code).toBe(4401);
+    expect(spawned).toHaveLength(0);
+  });
+
+  it("4401s a nonce whose consent was ROTATED by a re-grant", async () => {
+    const { nonce } = mintNonce();
+    // Another browser profile re-granted, rotating the capability.
+    consentState.fingerprint = "b".repeat(64);
+
+    const ws = connect(server.port, nonce);
+    const { code } = await waitForClose(ws);
+
+    expect(code).toBe(4401);
+    expect(spawned).toHaveLength(0);
+  });
+});
+
+describe("local terminal WS — shutdown", () => {
+  it("kills a live PTY", async () => {
+    const { nonce } = mintNonce();
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+
+    shutdownLocalComputerTerminals();
+    expect(spawned[0]!.killed).toBe(true);
+
+    // The fake PTY's kill doesn't emit `exit`, so the socket is still open —
+    // close it here rather than leaving it for the server teardown.
+    ws.close();
+    await waitForClose(ws);
+  });
+
+  it("refuses NEW handshakes once shutdown has begun", async () => {
+    const { nonce } = mintNonce();
+    shutdownLocalComputerTerminals();
+
+    const ws = connect(server.port, nonce);
+    const { code } = await waitForClose(ws);
+
+    // Otherwise a handshake landing during the shutdown window spawns a shell
+    // that nothing will ever kill.
+    expect(code).toBe(4503);
+    expect(spawned).toHaveLength(0);
+  });
+});
+
 describe("local terminal WS — degrade", () => {
   it("4503s with an explanatory message when node-pty can't load", async () => {
     setLocalPtyModuleForTests(null);
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     const error = await waitForJson(ws, "error");
     const { code } = await waitForClose(ws);
@@ -314,7 +389,7 @@ describe("local terminal WS — degrade", () => {
 
 describe("local terminal WS — wire protocol", () => {
   it("spawns in the project workspace dir with the allowlisted env", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     await waitForJson(ws, "ready");
 
@@ -332,7 +407,7 @@ describe("local terminal WS — wire protocol", () => {
   });
 
   it("streams PTY output to the client as binary frames", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     await waitForJson(ws, "ready");
 
@@ -344,7 +419,7 @@ describe("local terminal WS — wire protocol", () => {
   });
 
   it("forwards binary client frames to PTY stdin", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     await waitForJson(ws, "ready");
 
@@ -354,7 +429,7 @@ describe("local terminal WS — wire protocol", () => {
   });
 
   it("answers ping with pong", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     await waitForJson(ws, "ready");
 
@@ -364,7 +439,7 @@ describe("local terminal WS — wire protocol", () => {
   });
 
   it("applies resize, CLAMPED to sane geometry", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     await waitForJson(ws, "ready");
 
@@ -381,7 +456,7 @@ describe("local terminal WS — wire protocol", () => {
   });
 
   it("ignores malformed text frames instead of dying", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     await waitForJson(ws, "ready");
 
@@ -394,7 +469,7 @@ describe("local terminal WS — wire protocol", () => {
 
 describe("local terminal WS — lifecycle", () => {
   it("KILLS the PTY when the socket closes (no orphaned shells)", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     await waitForJson(ws, "ready");
     expect(spawned[0]!.killed).toBe(false);
@@ -404,7 +479,7 @@ describe("local terminal WS — lifecycle", () => {
   });
 
   it("closes the socket cleanly when the PTY exits", async () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = mintNonce();
     const ws = connect(server.port, nonce);
     await waitForJson(ws, "ready");
 

--- a/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
@@ -39,7 +39,10 @@ vi.mock("node:os", async () => {
   return { ...actual, homedir: () => scratch };
 });
 
-import { createLocalComputerTerminalWsHandler } from "../local-computer-terminal.js";
+import {
+  createLocalComputerTerminalWsHandler,
+  resolveLocalShell,
+} from "../local-computer-terminal.js";
 import {
   resetLocalPtyCachesForTests,
   setLocalPtyModuleForTests,
@@ -411,5 +414,32 @@ describe("local terminal WS — lifecycle", () => {
 
     await exited;
     expect((await closed).code).toBe(1000);
+  });
+});
+
+describe("resolveLocalShell", () => {
+  it("prefers $SHELL when it exists", () => {
+    const bash = resolveLocalShell({ PATH: process.env.PATH });
+    // Use a shell we know is present on this host as the "preferred" value.
+    expect(resolveLocalShell({ PATH: process.env.PATH, SHELL: bash })).toBe(
+      bash
+    );
+  });
+
+  it("falls back to bash when $SHELL is STALE rather than failing the open", () => {
+    // node-pty spawns synchronously and would throw on a nonexistent shell,
+    // surfacing as "failed to open a terminal" on a machine where bash exists.
+    const resolved = resolveLocalShell({
+      PATH: process.env.PATH,
+      SHELL: "/nonexistent/shell",
+    });
+    expect(resolved).not.toBe("/nonexistent/shell");
+    expect(resolved).toMatch(/bash|^sh$/);
+  });
+
+  it("falls back to a bare sh when nothing else resolves", () => {
+    expect(resolveLocalShell({ PATH: "/nonexistent/bin" })).toMatch(
+      /bash|^sh$/
+    );
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
@@ -48,6 +48,7 @@ vi.mock("../../../utils/computers/local-consent.js", () => ({
 
 import {
   createLocalComputerTerminalWsHandler,
+  killLocalComputerTerminals,
   resetLocalTerminalShutdownForTests,
   resolveLocalShell,
   shutdownLocalComputerTerminals,
@@ -357,6 +358,27 @@ describe("local terminal WS — shutdown", () => {
     // close it here rather than leaving it for the server teardown.
     ws.close();
     await waitForClose(ws);
+  });
+
+  it("kill-only does NOT latch — the server can come back", async () => {
+    const first = mintNonce();
+    const ws = connect(server.port, first.nonce);
+    await waitForJson(ws, "ready");
+
+    // Electron's `window-all-closed` path: the server goes away but the process
+    // survives and restarts on dock activation. Latching here would 4503 every
+    // handshake for the rest of the process lifetime.
+    killLocalComputerTerminals();
+    expect(spawned[0]!.killed).toBe(true);
+    ws.close();
+    await waitForClose(ws);
+
+    const second = mintNonce();
+    const reopened = connect(server.port, second.nonce);
+    await waitForJson(reopened, "ready");
+    expect(spawned).toHaveLength(2);
+    reopened.close();
+    await waitForClose(reopened);
   });
 
   it("refuses NEW handshakes once shutdown has begun", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/local-computer-terminal.test.ts
@@ -1,0 +1,415 @@
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WebSocket } from "ws";
+import { Hono } from "hono";
+import { createNodeWebSocket } from "@hono/node-ws";
+
+/**
+ * Route-level tests for GET /api/web/computers/local-terminal — the only path
+ * from a browser to an interactive shell on the user's own machine.
+ *
+ * The transport under test is the WS handshake itself (the nonce rides
+ * `Sec-WebSocket-Protocol`), so these run a real http.Server with a real `ws`
+ * client, following computer-terminal.test.ts's recipe. node-pty is replaced by
+ * a fake module — the native addon isn't installable in CI, and a fake lets us
+ * assert the wire protocol and the kill-on-close contract deterministically.
+ *
+ * NOTE on Origin: `startServer()` builds a BARE Hono app, so the global
+ * `originValidationMiddleware` (which 403s a disallowed Origin pre-upgrade in
+ * both production entrypoints) is NOT in play here. What these exercise is the
+ * handler's own in-handler check — including the local tightening that an
+ * ABSENT Origin is rejected, which the HTTP middleware deliberately allows.
+ */
+
+const scratch = mkdtempSync(join(tmpdir(), "mcpjam-local-terminal-ws-"));
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return { ...actual, homedir: () => scratch };
+});
+
+import { createLocalComputerTerminalWsHandler } from "../local-computer-terminal.js";
+import {
+  resetLocalPtyCachesForTests,
+  setLocalPtyModuleForTests,
+  type NodePtyModule,
+  type NodePtyProcess,
+} from "../../../utils/computers/local-pty.js";
+import {
+  issueLocalTerminalNonce,
+  resetLocalTerminalNoncesForTests,
+} from "../../../utils/computers/local-terminal-auth.js";
+
+const ALLOWED_ORIGIN = "http://localhost:5173";
+
+afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+interface FakePtyRecord {
+  proc: NodePtyProcess;
+  writes: string[];
+  resizes: Array<{ cols: number; rows: number }>;
+  killed: boolean;
+  emit: (data: string) => void;
+  exit: () => void;
+  spawnOptions: Record<string, unknown>;
+  spawnFile: string;
+}
+
+const spawned: FakePtyRecord[] = [];
+
+function installFakePty(): void {
+  const module: NodePtyModule = {
+    spawn: (file, _args, options) => {
+      const dataListeners: Array<(d: string) => void> = [];
+      const exitListeners: Array<(e: { exitCode: number }) => void> = [];
+      const record: FakePtyRecord = {
+        writes: [],
+        resizes: [],
+        killed: false,
+        spawnFile: file,
+        spawnOptions: options as Record<string, unknown>,
+        emit: (data) => dataListeners.forEach((l) => l(data)),
+        exit: () => exitListeners.forEach((l) => l({ exitCode: 0 })),
+        proc: {
+          pid: 1234,
+          onData: (listener) => {
+            dataListeners.push(listener);
+            return { dispose: () => {} };
+          },
+          onExit: (listener) => {
+            exitListeners.push(listener as never);
+            return { dispose: () => {} };
+          },
+          write: (data) => {
+            record.writes.push(data);
+          },
+          resize: (cols, rows) => {
+            record.resizes.push({ cols, rows });
+          },
+          kill: () => {
+            record.killed = true;
+          },
+        },
+      };
+      spawned.push(record);
+      return record.proc;
+    },
+  };
+  setLocalPtyModuleForTests(module);
+}
+
+async function startServer(): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  const app = new Hono();
+  const { upgradeWebSocket, injectWebSocket } = createNodeWebSocket({ app });
+  app.get(
+    "/api/web/computers/local-terminal",
+    createLocalComputerTerminalWsHandler(upgradeWebSocket)
+  );
+  const server = http.createServer();
+  injectWebSocket(server);
+  server.on("request", (_req, res) => {
+    res.statusCode = 404;
+    res.end();
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        // `server.close()` alone does NOT drop established sockets — the same
+        // reason `shutdownLocalComputerTerminals()` has to exist.
+        server.closeAllConnections?.();
+        server.close(() => resolve());
+      }),
+  };
+}
+
+function connect(
+  port: number,
+  nonce: string,
+  opts: { origin?: string | null } = {}
+): WebSocket {
+  const origin = opts.origin === undefined ? ALLOWED_ORIGIN : opts.origin;
+  return new WebSocket(
+    `ws://127.0.0.1:${port}/api/web/computers/local-terminal?cols=100&rows=30`,
+    [nonce],
+    origin === null ? {} : { origin }
+  );
+}
+
+function waitForClose(
+  ws: WebSocket
+): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve) => {
+    ws.on("close", (code, reason) =>
+      resolve({ code, reason: reason.toString() })
+    );
+  });
+}
+
+function waitForJson(
+  ws: WebSocket,
+  type: string
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out waiting for ${type}`)),
+      5_000
+    );
+    ws.on("message", (data, isBinary) => {
+      if (isBinary) return;
+      try {
+        const message = JSON.parse(data.toString()) as Record<string, unknown>;
+        if (message.type === type) {
+          clearTimeout(timer);
+          resolve(message);
+        }
+      } catch {
+        // non-JSON text frame; ignore
+      }
+    });
+  });
+}
+
+function waitForBinary(ws: WebSocket): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("timed out waiting for binary")),
+      5_000
+    );
+    ws.on("message", (data, isBinary) => {
+      if (!isBinary) return;
+      clearTimeout(timer);
+      resolve(data as Buffer);
+    });
+  });
+}
+
+let server: { port: number; close: () => Promise<void> };
+
+beforeEach(async () => {
+  vi.stubEnv("ALLOWED_ORIGINS", ALLOWED_ORIGIN);
+  spawned.length = 0;
+  resetLocalTerminalNoncesForTests();
+  resetLocalPtyCachesForTests();
+  installFakePty();
+  server = await startServer();
+});
+
+afterEach(async () => {
+  await server.close();
+  vi.unstubAllEnvs();
+  resetLocalPtyCachesForTests();
+  resetLocalTerminalNoncesForTests();
+});
+
+describe("local terminal WS — auth", () => {
+  it("opens a PTY for a valid nonce and announces ready", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    const ready = await waitForJson(ws, "ready");
+
+    expect(typeof ready.sessionId).toBe("string");
+    expect(spawned).toHaveLength(1);
+    ws.close();
+  });
+
+  it("4401s an unknown nonce — and never spawns", async () => {
+    const ws = connect(server.port, "not-a-real-nonce");
+    const { code } = await waitForClose(ws);
+
+    expect(code).toBe(4401);
+    expect(spawned).toHaveLength(0);
+  });
+
+  it("4401s an EMPTY nonce", async () => {
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${server.port}/api/web/computers/local-terminal`,
+      { origin: ALLOWED_ORIGIN }
+    );
+    const { code } = await waitForClose(ws);
+
+    expect(code).toBe(4401);
+    expect(spawned).toHaveLength(0);
+  });
+
+  it("4401s a REUSED nonce — single use survives a replayed handshake", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const first = connect(server.port, nonce);
+    await waitForJson(first, "ready");
+    first.close();
+
+    const replay = connect(server.port, nonce);
+    const { code } = await waitForClose(replay);
+
+    expect(code).toBe(4401);
+    expect(spawned).toHaveLength(1);
+  });
+
+  it("4401s a DISALLOWED Origin", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce, {
+      origin: "https://evil.example.com",
+    });
+    const { code } = await waitForClose(ws);
+
+    expect(code).toBe(4401);
+    expect(spawned).toHaveLength(0);
+  });
+
+  it("4401s an ABSENT Origin — the local tightening over the HTTP middleware", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce, { origin: null });
+    const { code } = await waitForClose(ws);
+
+    expect(code).toBe(4401);
+    expect(spawned).toHaveLength(0);
+  });
+
+  it("does NOT consume the nonce when the Origin is rejected", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const rejected = connect(server.port, nonce, { origin: null });
+    await waitForClose(rejected);
+
+    // The origin check runs first, so a blocked probe can't burn a legitimate
+    // user's nonce out from under them.
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+    expect(spawned).toHaveLength(1);
+    ws.close();
+  });
+});
+
+describe("local terminal WS — degrade", () => {
+  it("4503s with an explanatory message when node-pty can't load", async () => {
+    setLocalPtyModuleForTests(null);
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    const error = await waitForJson(ws, "error");
+    const { code } = await waitForClose(ws);
+
+    expect(code).toBe(4503);
+    expect(String(error.message)).toMatch(/unavailable/i);
+    expect(spawned).toHaveLength(0);
+  });
+});
+
+describe("local terminal WS — wire protocol", () => {
+  it("spawns in the project workspace dir with the allowlisted env", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+
+    const options = spawned[0]!.spawnOptions;
+    expect(String(options.cwd)).toBe(
+      join(scratch, ".mcpjam", "computer", "proj_1")
+    );
+    const env = options.env as NodeJS.ProcessEnv;
+    // The allowlist, not process.env: cloud credentials must never reach a PTY.
+    expect(env).not.toHaveProperty("E2B_API_KEY");
+    expect(env).not.toHaveProperty("INSPECTOR_SERVICE_TOKEN");
+    expect(options.cols).toBe(100);
+    expect(options.rows).toBe(30);
+    ws.close();
+  });
+
+  it("streams PTY output to the client as binary frames", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+
+    const received = waitForBinary(ws);
+    spawned[0]!.emit("hello from the pty");
+
+    expect((await received).toString("utf8")).toBe("hello from the pty");
+    ws.close();
+  });
+
+  it("forwards binary client frames to PTY stdin", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+
+    ws.send(Buffer.from("ls -la\n", "utf8"));
+    await vi.waitFor(() => expect(spawned[0]!.writes).toContain("ls -la\n"));
+    ws.close();
+  });
+
+  it("answers ping with pong", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+
+    ws.send(JSON.stringify({ type: "ping" }));
+    await waitForJson(ws, "pong");
+    ws.close();
+  });
+
+  it("applies resize, CLAMPED to sane geometry", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+
+    ws.send(JSON.stringify({ type: "resize", cols: 120, rows: 40 }));
+    ws.send(JSON.stringify({ type: "resize", cols: 99_999, rows: 99_999 }));
+    ws.send(JSON.stringify({ type: "resize", cols: -5, rows: 0 }));
+
+    await vi.waitFor(() => expect(spawned[0]!.resizes).toHaveLength(3));
+    expect(spawned[0]!.resizes[0]).toEqual({ cols: 120, rows: 40 });
+    expect(spawned[0]!.resizes[1]).toEqual({ cols: 500, rows: 300 });
+    // Out-of-range low values fall back to the defaults rather than 0/negative.
+    expect(spawned[0]!.resizes[2]).toEqual({ cols: 80, rows: 24 });
+    ws.close();
+  });
+
+  it("ignores malformed text frames instead of dying", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+
+    ws.send("{not json");
+    ws.send(JSON.stringify({ type: "ping" }));
+    await waitForJson(ws, "pong");
+    ws.close();
+  });
+});
+
+describe("local terminal WS — lifecycle", () => {
+  it("KILLS the PTY when the socket closes (no orphaned shells)", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+    expect(spawned[0]!.killed).toBe(false);
+
+    ws.close();
+    await vi.waitFor(() => expect(spawned[0]!.killed).toBe(true));
+  });
+
+  it("closes the socket cleanly when the PTY exits", async () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const ws = connect(server.port, nonce);
+    await waitForJson(ws, "ready");
+
+    const exited = waitForJson(ws, "exit");
+    const closed = waitForClose(ws);
+    spawned[0]!.exit();
+
+    await exited;
+    expect((await closed).code).toBe(1000);
+  });
+});

--- a/mcpjam-inspector/server/routes/web/computers.ts
+++ b/mcpjam-inspector/server/routes/web/computers.ts
@@ -34,6 +34,7 @@ import { executionScopeSchema } from "../../utils/execution-scope.js";
 import { resolveComputersLocalConfigured } from "../../utils/computers/runtime-config.js";
 import { resolveComputersRemoteDataPlaneUrl } from "../../utils/computers/remote-data-plane.js";
 import { isLocalComputerEngineAvailable } from "../../utils/computers/local-machine.js";
+import { getLocalTerminalAvailability } from "../../utils/computers/local-pty.js";
 import {
   MAX_COMMAND_TIMEOUT_S,
   e2bRunner,
@@ -68,6 +69,10 @@ export function createComputersRoutes(runner: BashRunner = e2bRunner): Hono {
       resolveComputersRemoteDataPlaneUrl(),
     ]);
     const localEngine = isLocalComputerEngineAvailable();
+    // Probed once per process (node-pty is an optional native dep — see
+    // local-pty.ts). False here is a clean degrade: chat bash still works, the
+    // client just renders the terminal-off state.
+    const localTerminal = await getLocalTerminalAvailability();
     // The capability SPLIT is the point of this shape: `remoteDataPlaneUrl`
     // delegates only PERSONAL-computer exec/terminal, so a remote-only
     // inspector can drive a personal Computer yet cannot execute one
@@ -82,9 +87,7 @@ export function createComputersRoutes(runner: BashRunner = e2bRunner): Hono {
       engines: {
         local: {
           available: localEngine.available,
-          // PR 8 (node-pty) wires the real probe; until then the local
-          // engine is bash-only and the client shows the terminal-off state.
-          terminalAvailable: false,
+          terminalAvailable: localTerminal.available,
           // This endpoint is OPEN (no bearer), so only the tilde display
           // root ever leaves the server — never an absolute home path or OS
           // username. The client renders `${workspaceDisplayRoot}/<projectId>`;

--- a/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
@@ -81,6 +81,18 @@ const livePtys = new Set<NodePtyProcess>();
 let shuttingDown = false;
 
 /**
+ * Bumped by every kill. A handshake captures it and re-checks after the awaits
+ * in its open path, so a PTY whose spawn was already in flight when the set was
+ * drained gets killed instead of registered — `livePtys.clear()` alone can't
+ * see it yet, and nothing else would ever kill it.
+ *
+ * A monotonic counter rather than a flag, deliberately: it invalidates in-flight
+ * spawns without any state that has to be cleared again afterwards, so it works
+ * for the non-terminating `killLocalComputerTerminals()` path too.
+ */
+let ptyGeneration = 0;
+
+/**
  * Kill every live local PTY, WITHOUT latching shutdown.
  *
  * For paths where the server goes away but the process may keep running and
@@ -90,6 +102,7 @@ let shuttingDown = false;
  * terminal handshake after the user reopened the window.
  */
 export function killLocalComputerTerminals(): void {
+  ptyGeneration += 1;
   for (const pty of livePtys) {
     try {
       pty.kill();
@@ -115,6 +128,7 @@ export function shutdownLocalComputerTerminals(): void {
 /** Test seam: the shutdown latch is module state for the process lifetime. */
 export function resetLocalTerminalShutdownForTests(): void {
   shuttingDown = false;
+  ptyGeneration = 0;
   livePtys.clear();
 }
 
@@ -210,6 +224,9 @@ export function createLocalComputerTerminalWsHandler(
     }
 
     const sessionId = randomUUID();
+    // Captured at handshake: any kill between here and registration invalidates
+    // this spawn (see `ptyGeneration`).
+    const openGeneration = ptyGeneration;
     let pty: NodePtyProcess | null = null;
     let closed = false;
     // Only journal a `close` for a session that was journaled `open`. The open
@@ -266,10 +283,11 @@ export function createLocalComputerTerminalWsHandler(
               },
               workspaceDir
             );
-            if (closed || shuttingDown) {
-              // The socket died — or the server began shutting down — while the
-              // PTY was coming up. Either way this handle is not in `livePtys`
-              // yet, so nothing else will ever kill it.
+            if (closed || shuttingDown || openGeneration !== ptyGeneration) {
+              // The socket died, the server began shutting down, or a kill swept
+              // the live set while this PTY was still coming up. In every case
+              // the handle is not in `livePtys` yet, so nothing else would ever
+              // kill it.
               try {
                 handle.kill();
               } catch {}

--- a/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
@@ -30,6 +30,7 @@
  *                    | {type:"error", message} | {type:"pong"}
  */
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import type { UpgradeWebSocket } from "hono/ws";
 import type { MiddlewareHandler } from "hono";
 import { createPtyWithCwd } from "../../utils/computers/create-pty.js";
@@ -98,9 +99,19 @@ function toUint8Array(data: unknown): Uint8Array | null {
   return null;
 }
 
-/** `$SHELL` if the allowlisted env carries one, else bash, else a bare `sh`. */
-function resolveLocalShell(env: NodeJS.ProcessEnv): string {
-  return env.SHELL || resolveLocalBashPath() || "sh";
+/**
+ * `$SHELL` if the allowlisted env carries a shell that actually exists, else
+ * bash, else a bare `sh`.
+ *
+ * The `existsSync` check matters: a stale `SHELL` (a shell uninstalled since
+ * login, or one inherited from a different container image) would make
+ * node-pty's synchronous spawn throw, and the user would get "failed to open a
+ * terminal" on a machine where bash is sitting right there.
+ */
+export function resolveLocalShell(env: NodeJS.ProcessEnv): string {
+  const preferred = env.SHELL;
+  if (preferred && existsSync(preferred)) return preferred;
+  return resolveLocalBashPath() || "sh";
 }
 
 export function createLocalComputerTerminalWsHandler(

--- a/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
@@ -41,6 +41,7 @@ import {
 } from "../../utils/computers/local-pty.js";
 import { createLocalPtyCreator } from "../../utils/computers/local-pty-adapter.js";
 import { consumeLocalTerminalNonce } from "../../utils/computers/local-terminal-auth.js";
+import { getLocalConsentFingerprint } from "../../utils/computers/local-consent.js";
 import {
   appendLocalCommandLog,
   buildLocalCommandEnv,
@@ -68,11 +69,22 @@ const CLOSE_UNAVAILABLE = 4503;
 const livePtys = new Set<NodePtyProcess>();
 
 /**
+ * Latched by `shutdownLocalComputerTerminals()`. A handshake can be mid-spawn
+ * when shutdown runs — `createPtyWithCwd` is awaited — and that PTY would be
+ * registered AFTER the live set was drained, outliving the inspector. The
+ * open path re-checks this after every await and kills rather than registers.
+ * Also refuses new handshakes outright.
+ */
+let shuttingDown = false;
+
+/**
  * Kill every live local PTY. THE shutdown mechanism — called from
  * `server/index.ts`'s `shutdown()` (standalone) and `src/main.ts`'s
- * `before-quit` (Electron). Safe to call when none are open.
+ * `before-quit` / `window-all-closed` (Electron). Safe to call repeatedly and
+ * when none are open.
  */
 export function shutdownLocalComputerTerminals(): void {
+  shuttingDown = true;
   for (const pty of livePtys) {
     try {
       pty.kill();
@@ -80,6 +92,12 @@ export function shutdownLocalComputerTerminals(): void {
       // Already dead — nothing to clean up.
     }
   }
+  livePtys.clear();
+}
+
+/** Test seam: the shutdown latch is module state for the process lifetime. */
+export function resetLocalTerminalShutdownForTests(): void {
+  shuttingDown = false;
   livePtys.clear();
 }
 
@@ -142,7 +160,10 @@ export function createLocalComputerTerminalWsHandler(
     // headers) and 403s a disallowed Origin pre-upgrade. This in-handler check
     // additionally rejects an ABSENT Origin, and covers embeddings that mount
     // the route on a bare Hono app without the global middleware.
-    if (!isAllowedRequestOrigin(origin)) {
+    if (shuttingDown) {
+      rejectCode = CLOSE_UNAVAILABLE;
+      rejectMessage = "The inspector is shutting down.";
+    } else if (!isAllowedRequestOrigin(origin)) {
       rejectCode = CLOSE_UNAUTHORIZED;
       rejectMessage = "Terminal requests must come from the inspector UI.";
     } else {
@@ -157,6 +178,14 @@ export function createLocalComputerTerminalWsHandler(
         if (!claim) {
           rejectCode = CLOSE_UNAUTHORIZED;
           rejectMessage = "Invalid or expired terminal token.";
+        } else if (
+          claim.consentFingerprint !== (await getLocalConsentFingerprint())
+        ) {
+          // The capability that authorized this nonce is no longer the live one:
+          // consent was revoked, or a re-grant from another browser profile
+          // rotated it. The 60s TTL must not outlive either.
+          rejectCode = CLOSE_UNAUTHORIZED;
+          rejectMessage = "Local computer consent is no longer valid.";
         } else {
           projectId = claim.projectId;
         }
@@ -166,6 +195,10 @@ export function createLocalComputerTerminalWsHandler(
     const sessionId = randomUUID();
     let pty: NodePtyProcess | null = null;
     let closed = false;
+    // Only journal a `close` for a session that was journaled `open`. The open
+    // write happens after the PTY spawns, so a degrade (4503) or a socket that
+    // dies mid-spawn would otherwise leave a dangling close with no match.
+    let journaledOpen = false;
 
     return {
       onOpen: (_evt, ws) => {
@@ -216,8 +249,10 @@ export function createLocalComputerTerminalWsHandler(
               },
               workspaceDir
             );
-            if (closed) {
-              // The socket died while the PTY was coming up — don't leak it.
+            if (closed || shuttingDown) {
+              // The socket died — or the server began shutting down — while the
+              // PTY was coming up. Either way this handle is not in `livePtys`
+              // yet, so nothing else will ever kill it.
               try {
                 handle.kill();
               } catch {}
@@ -234,6 +269,7 @@ export function createLocalComputerTerminalWsHandler(
             });
             // Journal the SESSION only — never the keystrokes (see
             // appendLocalCommandLog's contract).
+            journaledOpen = true;
             void appendLocalCommandLog({
               ts: new Date().toISOString(),
               projectId: boundProjectId,
@@ -315,7 +351,7 @@ export function createLocalComputerTerminalWsHandler(
             // Already exited.
           }
         }
-        if (projectId) {
+        if (projectId && journaledOpen) {
           void appendLocalCommandLog({
             ts: new Date().toISOString(),
             projectId,

--- a/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
@@ -1,0 +1,325 @@
+/**
+ * LOCAL computer terminal WebSocket bridge
+ * (`GET /api/web/computers/local-terminal`).
+ *
+ * The "This machine" twin of `computer-terminal.ts`: same wire protocol, same
+ * xterm client, but the PTY is a child process of THIS server rather than an
+ * E2B sandbox. There is no control plane, no Convex row, no billing, and no
+ * activity touch — the machine is always ready.
+ *
+ * TRUST MODEL — read before editing. This opens an INTERACTIVE shell on the
+ * user's own machine, as their OS user, with no per-command approval (unlike
+ * the chat `bash` tool). The gates, in order:
+ *   1. `getLocalTerminalAvailability()` — hosted servers, the
+ *      `MCPJAM_LOCAL_COMPUTER_ENABLED` kill switch, a bash-less machine, and a
+ *      missing node-pty all degrade to a clean 4503, never a PTY.
+ *   2. A single-use, 60s, project-bound nonce minted by
+ *      `POST /api/mcp/computers/local-terminal-token`, which itself sits behind
+ *      the inspector session token + a verified sign-in + a non-guest check +
+ *      server-verified local consent. The nonce IS the auth here.
+ *   3. The `Origin` header must be on the allowlist — and unlike the HTTP
+ *      middleware, an ABSENT Origin is REJECTED (browsers always send one on a
+ *      handshake; a non-browser client has no business opening this).
+ * Nothing else reaches a PTY. This route is mounted only when `!HOSTED_MODE`.
+ *
+ * Wire protocol (identical to the cloud terminal, so the client is shared):
+ *   client → server  binary frame            raw stdin bytes
+ *   client → server  text JSON {type:"resize", cols, rows} | {type:"ping"}
+ *   server → client  binary frame            raw PTY output
+ *   server → client  text JSON {type:"ready", sessionId} | {type:"exit"}
+ *                    | {type:"error", message} | {type:"pong"}
+ */
+import { randomUUID } from "node:crypto";
+import type { UpgradeWebSocket } from "hono/ws";
+import type { MiddlewareHandler } from "hono";
+import { createPtyWithCwd } from "../../utils/computers/create-pty.js";
+import {
+  getLocalTerminalAvailability,
+  loadLocalPtyModule,
+  type NodePtyProcess,
+} from "../../utils/computers/local-pty.js";
+import { createLocalPtyCreator } from "../../utils/computers/local-pty-adapter.js";
+import { consumeLocalTerminalNonce } from "../../utils/computers/local-terminal-auth.js";
+import {
+  appendLocalCommandLog,
+  buildLocalCommandEnv,
+  getLocalComputerWorkspaceDir,
+  resolveLocalBashPath,
+} from "../../utils/computers/local-machine.js";
+import { isAllowedRequestOrigin } from "../../middleware/origin-validation.js";
+import { logger } from "../../utils/logger.js";
+
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const MAX_COLS = 500;
+const MAX_ROWS = 300;
+
+// Close codes (4xxx = application-defined) — same meanings as the cloud
+// terminal, so the client's `closeMessage` mapping is shared.
+const CLOSE_UNAUTHORIZED = 4401;
+const CLOSE_UNAVAILABLE = 4503;
+
+/**
+ * Every live local PTY, so shutdown can kill them. `server.close()` does NOT
+ * close established sockets, so without this a `Ctrl-C` on the inspector
+ * leaves orphaned shells attached to the terminal's process group.
+ */
+const livePtys = new Set<NodePtyProcess>();
+
+/**
+ * Kill every live local PTY. THE shutdown mechanism — called from
+ * `server/index.ts`'s `shutdown()` (standalone) and `src/main.ts`'s
+ * `before-quit` (Electron). Safe to call when none are open.
+ */
+export function shutdownLocalComputerTerminals(): void {
+  for (const pty of livePtys) {
+    try {
+      pty.kill();
+    } catch {
+      // Already dead — nothing to clean up.
+    }
+  }
+  livePtys.clear();
+}
+
+function clampDimension(
+  raw: string | number | undefined,
+  fallback: number,
+  max: number
+): number {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 1) return fallback;
+  return Math.min(Math.floor(value), max);
+}
+
+function toUint8Array(data: unknown): Uint8Array | null {
+  if (data instanceof Uint8Array) return data;
+  if (data instanceof ArrayBuffer) return new Uint8Array(data);
+  return null;
+}
+
+/** `$SHELL` if the allowlisted env carries one, else bash, else a bare `sh`. */
+function resolveLocalShell(env: NodeJS.ProcessEnv): string {
+  return env.SHELL || resolveLocalBashPath() || "sh";
+}
+
+export function createLocalComputerTerminalWsHandler(
+  upgradeWebSocket: UpgradeWebSocket<
+    unknown,
+    { onError: (err: unknown) => void }
+  >
+): MiddlewareHandler {
+  return upgradeWebSocket(async (c) => {
+    // The nonce rides the Sec-WebSocket-Protocol handshake header for the same
+    // reason the cloud token does: no custom headers on a browser WS handshake,
+    // and a query string would land in access logs. No fallback.
+    const protocolHeader = c.req.header("sec-websocket-protocol") ?? "";
+    const nonce = protocolHeader.split(",")[0]?.trim() ?? "";
+    const cols = clampDimension(c.req.query("cols"), DEFAULT_COLS, MAX_COLS);
+    const rows = clampDimension(c.req.query("rows"), DEFAULT_ROWS, MAX_ROWS);
+    const origin = c.req.header("Origin");
+
+    // Resolve everything we can before the socket opens; failures become an
+    // immediate close-with-code in onOpen (createEvents cannot return an HTTP
+    // rejection once the client has requested an upgrade).
+    let rejectCode: number | null = null;
+    let rejectMessage = "";
+    let projectId: string | null = null;
+
+    // Defense-in-depth: the global `originValidationMiddleware` already runs on
+    // this upgrade (@hono/node-ws dispatches through app.request() with the raw
+    // headers) and 403s a disallowed Origin pre-upgrade. This in-handler check
+    // additionally rejects an ABSENT Origin, and covers embeddings that mount
+    // the route on a bare Hono app without the global middleware.
+    if (!isAllowedRequestOrigin(origin)) {
+      rejectCode = CLOSE_UNAUTHORIZED;
+      rejectMessage = "Terminal requests must come from the inspector UI.";
+    } else {
+      const availability = await getLocalTerminalAvailability();
+      if (!availability.available) {
+        rejectCode = CLOSE_UNAVAILABLE;
+        rejectMessage = `Local terminal unavailable: ${availability.reason}`;
+      } else {
+        // Single use: redeeming removes it, so a replayed handshake fails even
+        // within the TTL.
+        const claim = consumeLocalTerminalNonce(nonce);
+        if (!claim) {
+          rejectCode = CLOSE_UNAUTHORIZED;
+          rejectMessage = "Invalid or expired terminal token.";
+        } else {
+          projectId = claim.projectId;
+        }
+      }
+    }
+
+    const sessionId = randomUUID();
+    let pty: NodePtyProcess | null = null;
+    let closed = false;
+
+    return {
+      onOpen: (_evt, ws) => {
+        if (rejectCode !== null || !projectId) {
+          ws.send(
+            JSON.stringify({
+              type: "error",
+              message: rejectMessage || "Terminal unavailable.",
+            })
+          );
+          ws.close(rejectCode ?? CLOSE_UNAVAILABLE, rejectMessage.slice(0, 120));
+          return;
+        }
+        const boundProjectId = projectId;
+        void (async () => {
+          try {
+            const loaded = await loadLocalPtyModule();
+            if (!loaded.ok) {
+              throw new Error(loaded.reason);
+            }
+            const env = buildLocalCommandEnv();
+            const workspaceDir =
+              await getLocalComputerWorkspaceDir(boundProjectId);
+            const creator = createLocalPtyCreator({
+              ptyModule: loaded.pty,
+              shell: resolveLocalShell(env),
+              env,
+            });
+            const handle = await createPtyWithCwd(
+              creator,
+              {
+                cols,
+                rows,
+                // Not applicable to a local child process — the adapter ignores
+                // it; the socket's lifetime is the PTY's.
+                timeoutMs: 0,
+                onData: (data) => {
+                  if (closed) return;
+                  // Copy into a standalone ArrayBuffer: WSContext.send is typed
+                  // for Uint8Array<ArrayBuffer>.
+                  ws.send(
+                    data.buffer.slice(
+                      data.byteOffset,
+                      data.byteOffset + data.byteLength
+                    ) as ArrayBuffer
+                  );
+                },
+              },
+              workspaceDir
+            );
+            if (closed) {
+              // The socket died while the PTY was coming up — don't leak it.
+              try {
+                handle.kill();
+              } catch {}
+              return;
+            }
+            pty = handle;
+            livePtys.add(handle);
+            handle.onExit(() => {
+              livePtys.delete(handle);
+              if (!closed) {
+                ws.send(JSON.stringify({ type: "exit" }));
+                ws.close(1000, "PTY exited");
+              }
+            });
+            // Journal the SESSION only — never the keystrokes (see
+            // appendLocalCommandLog's contract).
+            void appendLocalCommandLog({
+              ts: new Date().toISOString(),
+              projectId: boundProjectId,
+              commandId: sessionId,
+              source: "terminal",
+              action: "open",
+            });
+            ws.send(JSON.stringify({ type: "ready", sessionId }));
+          } catch (error) {
+            logger.warn("[local-computer-terminal] PTY open failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            if (!closed) {
+              ws.send(
+                JSON.stringify({
+                  type: "error",
+                  message: "Failed to open a terminal on this machine.",
+                })
+              );
+              ws.close(CLOSE_UNAVAILABLE, "PTY open failed");
+            }
+          }
+        })();
+      },
+
+      onMessage: (evt, ws) => {
+        const data = evt.data;
+        // Text frames are JSON control messages.
+        if (typeof data === "string") {
+          let message: { type?: string; cols?: number; rows?: number };
+          try {
+            message = JSON.parse(data);
+          } catch {
+            return;
+          }
+          if (message.type === "ping") {
+            ws.send(JSON.stringify({ type: "pong" }));
+            return;
+          }
+          if (
+            message.type === "resize" &&
+            pty &&
+            typeof message.cols === "number" &&
+            typeof message.rows === "number"
+          ) {
+            try {
+              pty.resize(
+                clampDimension(message.cols, DEFAULT_COLS, MAX_COLS),
+                clampDimension(message.rows, DEFAULT_ROWS, MAX_ROWS)
+              );
+            } catch {
+              // Racing a PTY that just exited; the exit handler owns the close.
+            }
+          }
+          return;
+        }
+        // Binary frames are stdin. node-pty's `write` takes a string, so decode
+        // as UTF-8 — non-streaming is fine because a keystroke frame is never
+        // split mid-codepoint by the client (xterm sends whole `onData` chunks).
+        const bytes = toUint8Array(data);
+        if (bytes && pty) {
+          try {
+            pty.write(Buffer.from(bytes).toString("utf8"));
+          } catch {
+            // Same race as resize.
+          }
+        }
+      },
+
+      onClose: () => {
+        closed = true;
+        const handle = pty;
+        pty = null;
+        if (handle) {
+          livePtys.delete(handle);
+          try {
+            handle.kill();
+          } catch {
+            // Already exited.
+          }
+        }
+        if (projectId) {
+          void appendLocalCommandLog({
+            ts: new Date().toISOString(),
+            projectId,
+            commandId: sessionId,
+            source: "terminal",
+            action: "close",
+          });
+        }
+      },
+
+      onError: (evt) => {
+        logger.debug("[local-computer-terminal] websocket error", {
+          event: String((evt as { type?: unknown })?.type ?? "error"),
+        });
+      },
+    };
+  });
+}

--- a/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
+++ b/mcpjam-inspector/server/routes/web/local-computer-terminal.ts
@@ -69,22 +69,27 @@ const CLOSE_UNAVAILABLE = 4503;
 const livePtys = new Set<NodePtyProcess>();
 
 /**
- * Latched by `shutdownLocalComputerTerminals()`. A handshake can be mid-spawn
- * when shutdown runs — `createPtyWithCwd` is awaited — and that PTY would be
- * registered AFTER the live set was drained, outliving the inspector. The
- * open path re-checks this after every await and kills rather than registers.
- * Also refuses new handshakes outright.
+ * Latched by `shutdownLocalComputerTerminals()` only. A handshake can be
+ * mid-spawn when shutdown runs — `createPtyWithCwd` is awaited — and that PTY
+ * would be registered AFTER the live set was drained, outliving the process.
+ * The open path re-checks this after every await and kills rather than
+ * registers; new handshakes are refused outright.
+ *
+ * This is deliberately a ONE-WAY latch for a terminating process, which is why
+ * it is NOT set by `killLocalComputerTerminals()`.
  */
 let shuttingDown = false;
 
 /**
- * Kill every live local PTY. THE shutdown mechanism — called from
- * `server/index.ts`'s `shutdown()` (standalone) and `src/main.ts`'s
- * `before-quit` / `window-all-closed` (Electron). Safe to call repeatedly and
- * when none are open.
+ * Kill every live local PTY, WITHOUT latching shutdown.
+ *
+ * For paths where the server goes away but the process may keep running and
+ * come back — Electron's `window-all-closed` on macOS, which closes the server
+ * and then restarts it on dock activation. Latching there would leave
+ * `shuttingDown` true for the rest of the process lifetime and 4503 every
+ * terminal handshake after the user reopened the window.
  */
-export function shutdownLocalComputerTerminals(): void {
-  shuttingDown = true;
+export function killLocalComputerTerminals(): void {
   for (const pty of livePtys) {
     try {
       pty.kill();
@@ -93,6 +98,18 @@ export function shutdownLocalComputerTerminals(): void {
     }
   }
   livePtys.clear();
+}
+
+/**
+ * Kill every live local PTY and refuse further ones. THE shutdown mechanism for
+ * a TERMINATING process — `server/index.ts`'s `shutdown()` (standalone) and
+ * `src/main.ts`'s `before-quit` (Electron). Safe to call repeatedly.
+ *
+ * Use `killLocalComputerTerminals()` instead when the process will survive.
+ */
+export function shutdownLocalComputerTerminals(): void {
+  shuttingDown = true;
+  killLocalComputerTerminals();
 }
 
 /** Test seam: the shutdown latch is module state for the process lifetime. */

--- a/mcpjam-inspector/server/tsup.config.ts
+++ b/mcpjam-inspector/server/tsup.config.ts
@@ -52,6 +52,12 @@ export default defineConfig({
     "execa",
     // Sentry packages with native modules must remain external
     "@sentry/node",
+    // node-pty (local computer terminal) is an OPTIONAL dependency with a
+    // native addon: it may be absent entirely (no build toolchain on an npx
+    // install) and can never be bundled. Keep it external so the runtime
+    // `import("node-pty")` resolves from node_modules — and cleanly fails to,
+    // degrading the terminal off, when it isn't there. See utils/computers/local-pty.ts.
+    "node-pty",
     // evals-cli dependencies
     "posthog-node",
     "@openrouter/ai-sdk-provider",

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-consent.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-consent.test.ts
@@ -35,8 +35,10 @@ vi.mock("node:fs/promises", async () => {
 });
 
 import {
+  getLocalConsentFingerprint,
   grantLocalComputerConsent,
   revokeLocalComputerConsent,
+  verifyAndFingerprintLocalConsent,
   verifyLocalComputerConsent,
 } from "../local-consent.js";
 
@@ -118,5 +120,51 @@ describe("local computer consent capability", () => {
     expect(
       await verifyLocalComputerConsent("definitely-not-the-token-but-long")
     ).toBe(false);
+  });
+});
+
+
+describe("verifyAndFingerprintLocalConsent", () => {
+  it("returns the matched fingerprint for the live token", async () => {
+    const { token } = await grantLocalComputerConsent();
+    const fingerprint = await verifyAndFingerprintLocalConsent(token);
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    // It IS the stored hash, not some other derivation.
+    expect(fingerprint).toBe(await getLocalConsentFingerprint());
+  });
+
+  it("rejects a wrong, empty, or absent token", async () => {
+    await grantLocalComputerConsent();
+    expect(await verifyAndFingerprintLocalConsent("n".repeat(43))).toBeNull();
+    expect(await verifyAndFingerprintLocalConsent("")).toBeNull();
+    expect(await verifyAndFingerprintLocalConsent(null)).toBeNull();
+    expect(await verifyAndFingerprintLocalConsent(undefined)).toBeNull();
+  });
+
+  it("rejects once consent is revoked", async () => {
+    const { token } = await grantLocalComputerConsent();
+    await revokeLocalComputerConsent(token);
+    expect(await verifyAndFingerprintLocalConsent(token)).toBeNull();
+  });
+
+  it("rejects the OLD token after a re-grant rotates the capability", async () => {
+    const first = await grantLocalComputerConsent();
+    const second = await grantLocalComputerConsent();
+
+    // The whole point of pairing verify+fingerprint in one read: the old token
+    // must never come back with the NEW capability's fingerprint.
+    expect(await verifyAndFingerprintLocalConsent(first.token)).toBeNull();
+    const live = await verifyAndFingerprintLocalConsent(second.token);
+    expect(live).toBe(await getLocalConsentFingerprint());
+  });
+
+  it("returns the fingerprint the token was CHECKED against, never a newer one", async () => {
+    const { token } = await grantLocalComputerConsent();
+    const fingerprint = await verifyAndFingerprintLocalConsent(token);
+
+    // After a rotation the old fingerprint is stale — which is exactly what the
+    // WS handler's re-check detects.
+    await grantLocalComputerConsent();
+    expect(await getLocalConsentFingerprint()).not.toBe(fingerprint);
   });
 });

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-pty-adapter.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-pty-adapter.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createPtyWithCwd } from "../create-pty.js";
+import { createLocalPtyCreator } from "../local-pty-adapter.js";
+import type { NodePtyModule, NodePtyProcess } from "../local-pty.js";
+
+/**
+ * The adapter exists so the local terminal can reuse `createPtyWithCwd`. Each
+ * assertion below pins one place where node-pty's contract differs from E2B's
+ * — the differences are the whole reason this is not a pass-through.
+ */
+
+const realDir = mkdtempSync(join(tmpdir(), "mcpjam-pty-adapter-"));
+afterAll(() => rmSync(realDir, { recursive: true, force: true }));
+
+function fakePty(overrides: Partial<NodePtyProcess> = {}) {
+  const dataListeners: Array<(d: string) => void> = [];
+  const proc: NodePtyProcess = {
+    pid: 4242,
+    onData: (listener) => {
+      dataListeners.push(listener);
+      return { dispose: () => {} };
+    },
+    onExit: () => ({ dispose: () => {} }),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    ...overrides,
+  };
+  return { proc, emit: (s: string) => dataListeners.forEach((l) => l(s)) };
+}
+
+function moduleWith(spawn: NodePtyModule["spawn"]): NodePtyModule {
+  return { spawn };
+}
+
+type SpawnArgs = Parameters<NodePtyModule["spawn"]>;
+
+/** A spawn mock whose `mock.calls` keeps node-pty's argument tuple. */
+function spawnMock(proc: NodePtyProcess) {
+  return vi.fn((..._args: SpawnArgs) => proc);
+}
+
+const baseOpts = {
+  cols: 80,
+  rows: 24,
+  timeoutMs: 3_600_000,
+  onData: () => {},
+};
+
+describe("createLocalPtyCreator", () => {
+  it("spawns the configured shell with the allowlisted env and geometry", async () => {
+    const { proc } = fakePty();
+    const spawn = spawnMock(proc);
+    const creator = createLocalPtyCreator({
+      ptyModule: moduleWith(spawn),
+      shell: "/bin/zsh",
+      env: { PATH: "/usr/bin", HOME: "/home/me" },
+    });
+
+    await creator.pty.create({ ...baseOpts, cwd: realDir });
+
+    expect(spawn).toHaveBeenCalledWith("/bin/zsh", [], {
+      name: "xterm-color",
+      cols: 80,
+      rows: 24,
+      cwd: realDir,
+      env: { PATH: "/usr/bin", HOME: "/home/me" },
+    });
+  });
+
+  it("IGNORES timeoutMs — an E2B sandbox TTL has no local analogue", async () => {
+    const { proc } = fakePty();
+    const spawn = spawnMock(proc);
+    const creator = createLocalPtyCreator({
+      ptyModule: moduleWith(spawn),
+      shell: "/bin/bash",
+      env: {},
+    });
+
+    await creator.pty.create({ ...baseOpts, cwd: realDir });
+
+    const options = spawn.mock.calls[0]![2] as Record<string, unknown>;
+    expect(options).not.toHaveProperty("timeoutMs");
+  });
+
+  it("converts node-pty's string output into bytes", async () => {
+    const { proc, emit } = fakePty();
+    const chunks: Uint8Array[] = [];
+    const creator = createLocalPtyCreator({
+      ptyModule: moduleWith(() => proc),
+      shell: "/bin/bash",
+      env: {},
+    });
+
+    await creator.pty.create({
+      ...baseOpts,
+      cwd: realDir,
+      onData: (bytes) => chunks.push(bytes),
+    });
+    emit("héllo");
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBeInstanceOf(Uint8Array);
+    expect(Buffer.from(chunks[0]!).toString("utf8")).toBe("héllo");
+  });
+
+  it("REJECTS on a missing cwd — node-pty would hand back an instantly-dead shell", async () => {
+    const spawn = spawnMock(fakePty().proc);
+    const creator = createLocalPtyCreator({
+      ptyModule: moduleWith(spawn),
+      shell: "/bin/bash",
+      env: {},
+    });
+
+    await expect(
+      creator.pty.create({ ...baseOpts, cwd: join(realDir, "gone") })
+    ).rejects.toThrow(/working directory/i);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("turns a SYNCHRONOUS spawn throw into a rejection", async () => {
+    const creator = createLocalPtyCreator({
+      ptyModule: moduleWith(() => {
+        throw new Error("posix_spawnp failed");
+      }),
+      shell: "/nope/bash",
+      env: {},
+    });
+
+    await expect(
+      creator.pty.create({ ...baseOpts, cwd: realDir })
+    ).rejects.toThrow("posix_spawnp failed");
+  });
+});
+
+describe("createPtyWithCwd over the adapter", () => {
+  it("falls back to a cwd-less spawn when the workspace dir is gone", async () => {
+    const { proc } = fakePty();
+    const spawn = spawnMock(proc);
+    const creator = createLocalPtyCreator({
+      ptyModule: moduleWith(spawn),
+      shell: "/bin/bash",
+      env: {},
+    });
+
+    // This is the behavior the pre-check buys: without a rejection,
+    // createPtyWithCwd's retry never fires and the user gets a dead terminal.
+    const handle = await createPtyWithCwd(
+      creator,
+      baseOpts,
+      join(realDir, "vanished")
+    );
+
+    expect(handle).toBe(proc);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0]![2]).not.toHaveProperty("cwd");
+  });
+
+  it("keeps the cwd when it exists", async () => {
+    const { proc } = fakePty();
+    const spawn = spawnMock(proc);
+    const creator = createLocalPtyCreator({
+      ptyModule: moduleWith(spawn),
+      shell: "/bin/bash",
+      env: {},
+    });
+
+    await createPtyWithCwd(creator, baseOpts, realDir);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0]![2]).toMatchObject({ cwd: realDir });
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-pty.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-pty.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * node-pty is an OPTIONAL native dependency: an npx install with no build
+ * toolchain, the packaged Electron app (no node_modules at all), and an ABI
+ * mismatch all leave it absent. None of those may throw — they must degrade to
+ * "terminal unavailable", with chat bash still working. That degrade IS the
+ * contract these tests pin.
+ */
+
+const engineState = vi.hoisted(() => ({
+  availability: { available: true } as
+    | { available: true }
+    | { available: false; reason: string },
+}));
+
+vi.mock("../local-machine.js", () => ({
+  isLocalComputerEngineAvailable: () => engineState.availability,
+}));
+
+import {
+  getLocalTerminalAvailability,
+  loadLocalPtyModule,
+  resetLocalPtyCachesForTests,
+  setLocalPtyModuleForTests,
+} from "../local-pty.js";
+
+beforeEach(() => {
+  engineState.availability = { available: true };
+  resetLocalPtyCachesForTests();
+});
+
+afterEach(() => {
+  resetLocalPtyCachesForTests();
+});
+
+describe("loadLocalPtyModule", () => {
+  it("reports a clean failure when node-pty cannot be required (never throws)", async () => {
+    // node-pty is not installed in CI, so this exercises the REAL import path.
+    const loaded = await loadLocalPtyModule();
+    if (loaded.ok) {
+      expect(typeof loaded.pty.spawn).toBe("function");
+    } else {
+      expect(loaded.reason).toBe("node-pty is not available on this server");
+    }
+  });
+
+  it("memoizes the answer — resolution is not re-attempted per connection", async () => {
+    const first = await loadLocalPtyModule();
+    const second = await loadLocalPtyModule();
+    expect(second).toBe(first);
+  });
+});
+
+describe("getLocalTerminalAvailability", () => {
+  it("is unavailable — with the ENGINE's reason — whenever the engine is off", async () => {
+    engineState.availability = {
+      available: false,
+      reason: "hosted servers never execute locally",
+    };
+    // Even with a perfectly good node-pty: a terminal on a machine that may not
+    // execute bash would be a second, ungated execution path.
+    setLocalPtyModuleForTests({ spawn: (() => {}) as never });
+    resetLocalPtyCachesForTests();
+    setLocalPtyModuleForTests({ spawn: (() => {}) as never });
+
+    await expect(getLocalTerminalAvailability()).resolves.toEqual({
+      available: false,
+      reason: "hosted servers never execute locally",
+    });
+  });
+
+  it("is available when the engine is on and node-pty loads", async () => {
+    setLocalPtyModuleForTests({ spawn: (() => {}) as never });
+    await expect(getLocalTerminalAvailability()).resolves.toEqual({
+      available: true,
+    });
+  });
+
+  it("degrades with node-pty's reason when the module is missing", async () => {
+    setLocalPtyModuleForTests(null);
+    await expect(getLocalTerminalAvailability()).resolves.toEqual({
+      available: false,
+      reason: "node-pty is not available on this server",
+    });
+  });
+
+  it("caches the probe for the process lifetime", async () => {
+    setLocalPtyModuleForTests(null);
+    const first = await getLocalTerminalAvailability();
+    // Flipping the engine after the probe must NOT change the cached answer —
+    // the config route calls this on every SPA boot and it cannot change
+    // without a restart.
+    engineState.availability = { available: true };
+    expect(await getLocalTerminalAvailability()).toEqual(first);
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-pty.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-pty.test.ts
@@ -61,8 +61,6 @@ describe("getLocalTerminalAvailability", () => {
     // Even with a perfectly good node-pty: a terminal on a machine that may not
     // execute bash would be a second, ungated execution path.
     setLocalPtyModuleForTests({ spawn: (() => {}) as never });
-    resetLocalPtyCachesForTests();
-    setLocalPtyModuleForTests({ spawn: (() => {}) as never });
 
     await expect(getLocalTerminalAvailability()).resolves.toEqual({
       available: false,

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-terminal-auth.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-terminal-auth.test.ts
@@ -1,11 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   LOCAL_TERMINAL_NONCE_TTL_MS,
+  MAX_OUTSTANDING_NONCES,
   consumeLocalTerminalNonce,
   issueLocalTerminalNonce,
   outstandingLocalTerminalNonceCount,
   resetLocalTerminalNoncesForTests,
 } from "../local-terminal-auth.js";
+
+const FINGERPRINT = "a".repeat(64);
+
+/** Every nonce is bound to a consent fingerprint; default to a stable one. */
+function issue(projectId: string, fingerprint: string = FINGERPRINT) {
+  return issueLocalTerminalNonce(projectId, fingerprint);
+}
 
 /**
  * The nonce IS the auth on the local terminal WebSocket — a browser can't send
@@ -24,7 +32,7 @@ afterEach(() => {
 
 describe("issueLocalTerminalNonce", () => {
   it("mints a base64url nonce — a valid Sec-WebSocket-Protocol token", () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = issue("proj_1");
     // RFC 6455 restricts the subprotocol header to HTTP tokens: no `+`, `/`
     // or `=` may appear, which is exactly what base64url guarantees.
     expect(nonce).toMatch(/^[A-Za-z0-9_-]+$/);
@@ -32,14 +40,14 @@ describe("issueLocalTerminalNonce", () => {
   });
 
   it("mints a distinct nonce every time", () => {
-    const a = issueLocalTerminalNonce("proj_1").nonce;
-    const b = issueLocalTerminalNonce("proj_1").nonce;
+    const a = issue("proj_1").nonce;
+    const b = issue("proj_1").nonce;
     expect(a).not.toBe(b);
   });
 
   it("reports a deadline one TTL out", () => {
     const before = Date.now();
-    const { expiresAtMs } = issueLocalTerminalNonce("proj_1");
+    const { expiresAtMs } = issue("proj_1");
     expect(expiresAtMs).toBeGreaterThanOrEqual(
       before + LOCAL_TERMINAL_NONCE_TTL_MS - 50
     );
@@ -48,35 +56,40 @@ describe("issueLocalTerminalNonce", () => {
     );
   });
 
+  it("refuses to mint without a consent fingerprint", () => {
+    // A nonce with nothing to re-verify against would be a 60s bypass of revoke.
+    expect(() => issueLocalTerminalNonce("proj_1", "")).toThrow(/consent/i);
+  });
+
   it("rejects a project key that isn't one bounded path segment", () => {
-    expect(() => issueLocalTerminalNonce("../../etc")).toThrow();
-    expect(() => issueLocalTerminalNonce("a/b")).toThrow();
-    expect(() => issueLocalTerminalNonce("")).toThrow();
-    expect(() => issueLocalTerminalNonce("x".repeat(129))).toThrow();
+    expect(() => issue("../../etc")).toThrow();
+    expect(() => issue("a/b")).toThrow();
+    expect(() => issue("")).toThrow();
+    expect(() => issue("x".repeat(129))).toThrow();
   });
 });
 
 describe("consumeLocalTerminalNonce", () => {
   it("redeems a fresh nonce and returns the bound project", () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
-    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1" });
+    const { nonce } = issue("proj_1");
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1", consentFingerprint: FINGERPRINT });
   });
 
   it("is SINGLE USE — a replayed handshake gets nothing", () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
-    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1" });
+    const { nonce } = issue("proj_1");
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1", consentFingerprint: FINGERPRINT });
     expect(consumeLocalTerminalNonce(nonce)).toBeNull();
   });
 
   it("binds to the project it was minted for", () => {
-    const a = issueLocalTerminalNonce("proj_a").nonce;
-    const b = issueLocalTerminalNonce("proj_b").nonce;
-    expect(consumeLocalTerminalNonce(a)).toEqual({ projectId: "proj_a" });
-    expect(consumeLocalTerminalNonce(b)).toEqual({ projectId: "proj_b" });
+    const a = issue("proj_a").nonce;
+    const b = issue("proj_b").nonce;
+    expect(consumeLocalTerminalNonce(a)).toEqual({ projectId: "proj_a", consentFingerprint: FINGERPRINT });
+    expect(consumeLocalTerminalNonce(b)).toEqual({ projectId: "proj_b", consentFingerprint: FINGERPRINT });
   });
 
   it("rejects an unknown, empty, or non-string presentation", () => {
-    issueLocalTerminalNonce("proj_1");
+    issue("proj_1");
     expect(consumeLocalTerminalNonce("not-a-real-nonce")).toBeNull();
     expect(consumeLocalTerminalNonce("")).toBeNull();
     expect(consumeLocalTerminalNonce(null)).toBeNull();
@@ -86,43 +99,58 @@ describe("consumeLocalTerminalNonce", () => {
   });
 
   it("rejects a nonce that is a PREFIX of the real one (length is compared)", () => {
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = issue("proj_1");
     expect(consumeLocalTerminalNonce(nonce.slice(0, 8))).toBeNull();
     expect(consumeLocalTerminalNonce(`${nonce}x`)).toBeNull();
-    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1" });
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1", consentFingerprint: FINGERPRINT });
   });
 
   it("expires after the TTL", () => {
     vi.useFakeTimers();
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = issue("proj_1");
     vi.advanceTimersByTime(LOCAL_TERMINAL_NONCE_TTL_MS + 1);
     expect(consumeLocalTerminalNonce(nonce)).toBeNull();
   });
 
   it("is still redeemable just inside the TTL", () => {
     vi.useFakeTimers();
-    const { nonce } = issueLocalTerminalNonce("proj_1");
+    const { nonce } = issue("proj_1");
     vi.advanceTimersByTime(LOCAL_TERMINAL_NONCE_TTL_MS - 1_000);
-    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1" });
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1", consentFingerprint: FINGERPRINT });
   });
 
   it("prunes expired nonces so the store can't grow without bound", () => {
     vi.useFakeTimers();
-    issueLocalTerminalNonce("proj_1");
-    issueLocalTerminalNonce("proj_2");
+    issue("proj_1");
+    issue("proj_2");
     expect(outstandingLocalTerminalNonceCount()).toBe(2);
     vi.advanceTimersByTime(LOCAL_TERMINAL_NONCE_TTL_MS + 1);
     expect(outstandingLocalTerminalNonceCount()).toBe(0);
   });
 
+  it("carries the consent fingerprint it was minted against", () => {
+    const other = "b".repeat(64);
+    const { nonce } = issue("proj_1", other);
+    // The WS handler compares this against the LIVE capability, so a revoke or
+    // a re-grant (which rotates the hash) invalidates the nonce.
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({
+      projectId: "proj_1",
+      consentFingerprint: other,
+    });
+  });
+
   it("caps outstanding nonces, evicting the oldest rather than locking a user out", () => {
-    const first = issueLocalTerminalNonce("proj_1").nonce;
-    for (let i = 0; i < 80; i += 1) issueLocalTerminalNonce("proj_1");
-    const newest = issueLocalTerminalNonce("proj_1").nonce;
-    expect(outstandingLocalTerminalNonceCount()).toBeLessThanOrEqual(64);
+    const first = issue("proj_1").nonce;
+    // Derived from the exported cap, so raising it can't silently invalidate
+    // this test's premise.
+    for (let i = 0; i < MAX_OUTSTANDING_NONCES + 16; i += 1) issue("proj_1");
+    const newest = issue("proj_1").nonce;
+    expect(outstandingLocalTerminalNonceCount()).toBeLessThanOrEqual(
+      MAX_OUTSTANDING_NONCES
+    );
     // The oldest was evicted; the newest — the one the user is about to
     // present — still works.
     expect(consumeLocalTerminalNonce(first)).toBeNull();
-    expect(consumeLocalTerminalNonce(newest)).toEqual({ projectId: "proj_1" });
+    expect(consumeLocalTerminalNonce(newest)).toEqual({ projectId: "proj_1", consentFingerprint: FINGERPRINT });
   });
 });

--- a/mcpjam-inspector/server/utils/computers/__tests__/local-terminal-auth.test.ts
+++ b/mcpjam-inspector/server/utils/computers/__tests__/local-terminal-auth.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LOCAL_TERMINAL_NONCE_TTL_MS,
+  consumeLocalTerminalNonce,
+  issueLocalTerminalNonce,
+  outstandingLocalTerminalNonceCount,
+  resetLocalTerminalNoncesForTests,
+} from "../local-terminal-auth.js";
+
+/**
+ * The nonce IS the auth on the local terminal WebSocket — a browser can't send
+ * an Authorization header on a handshake. These pin the four properties the WS
+ * route depends on: single use, TTL, project binding, and shape.
+ */
+
+beforeEach(() => {
+  resetLocalTerminalNoncesForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetLocalTerminalNoncesForTests();
+});
+
+describe("issueLocalTerminalNonce", () => {
+  it("mints a base64url nonce — a valid Sec-WebSocket-Protocol token", () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    // RFC 6455 restricts the subprotocol header to HTTP tokens: no `+`, `/`
+    // or `=` may appear, which is exactly what base64url guarantees.
+    expect(nonce).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(nonce.length).toBeGreaterThanOrEqual(43);
+  });
+
+  it("mints a distinct nonce every time", () => {
+    const a = issueLocalTerminalNonce("proj_1").nonce;
+    const b = issueLocalTerminalNonce("proj_1").nonce;
+    expect(a).not.toBe(b);
+  });
+
+  it("reports a deadline one TTL out", () => {
+    const before = Date.now();
+    const { expiresAtMs } = issueLocalTerminalNonce("proj_1");
+    expect(expiresAtMs).toBeGreaterThanOrEqual(
+      before + LOCAL_TERMINAL_NONCE_TTL_MS - 50
+    );
+    expect(expiresAtMs).toBeLessThanOrEqual(
+      Date.now() + LOCAL_TERMINAL_NONCE_TTL_MS
+    );
+  });
+
+  it("rejects a project key that isn't one bounded path segment", () => {
+    expect(() => issueLocalTerminalNonce("../../etc")).toThrow();
+    expect(() => issueLocalTerminalNonce("a/b")).toThrow();
+    expect(() => issueLocalTerminalNonce("")).toThrow();
+    expect(() => issueLocalTerminalNonce("x".repeat(129))).toThrow();
+  });
+});
+
+describe("consumeLocalTerminalNonce", () => {
+  it("redeems a fresh nonce and returns the bound project", () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1" });
+  });
+
+  it("is SINGLE USE — a replayed handshake gets nothing", () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1" });
+    expect(consumeLocalTerminalNonce(nonce)).toBeNull();
+  });
+
+  it("binds to the project it was minted for", () => {
+    const a = issueLocalTerminalNonce("proj_a").nonce;
+    const b = issueLocalTerminalNonce("proj_b").nonce;
+    expect(consumeLocalTerminalNonce(a)).toEqual({ projectId: "proj_a" });
+    expect(consumeLocalTerminalNonce(b)).toEqual({ projectId: "proj_b" });
+  });
+
+  it("rejects an unknown, empty, or non-string presentation", () => {
+    issueLocalTerminalNonce("proj_1");
+    expect(consumeLocalTerminalNonce("not-a-real-nonce")).toBeNull();
+    expect(consumeLocalTerminalNonce("")).toBeNull();
+    expect(consumeLocalTerminalNonce(null)).toBeNull();
+    expect(consumeLocalTerminalNonce(undefined)).toBeNull();
+    // A rejected presentation must not consume the legitimate outstanding one.
+    expect(outstandingLocalTerminalNonceCount()).toBe(1);
+  });
+
+  it("rejects a nonce that is a PREFIX of the real one (length is compared)", () => {
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    expect(consumeLocalTerminalNonce(nonce.slice(0, 8))).toBeNull();
+    expect(consumeLocalTerminalNonce(`${nonce}x`)).toBeNull();
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1" });
+  });
+
+  it("expires after the TTL", () => {
+    vi.useFakeTimers();
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    vi.advanceTimersByTime(LOCAL_TERMINAL_NONCE_TTL_MS + 1);
+    expect(consumeLocalTerminalNonce(nonce)).toBeNull();
+  });
+
+  it("is still redeemable just inside the TTL", () => {
+    vi.useFakeTimers();
+    const { nonce } = issueLocalTerminalNonce("proj_1");
+    vi.advanceTimersByTime(LOCAL_TERMINAL_NONCE_TTL_MS - 1_000);
+    expect(consumeLocalTerminalNonce(nonce)).toEqual({ projectId: "proj_1" });
+  });
+
+  it("prunes expired nonces so the store can't grow without bound", () => {
+    vi.useFakeTimers();
+    issueLocalTerminalNonce("proj_1");
+    issueLocalTerminalNonce("proj_2");
+    expect(outstandingLocalTerminalNonceCount()).toBe(2);
+    vi.advanceTimersByTime(LOCAL_TERMINAL_NONCE_TTL_MS + 1);
+    expect(outstandingLocalTerminalNonceCount()).toBe(0);
+  });
+
+  it("caps outstanding nonces, evicting the oldest rather than locking a user out", () => {
+    const first = issueLocalTerminalNonce("proj_1").nonce;
+    for (let i = 0; i < 80; i += 1) issueLocalTerminalNonce("proj_1");
+    const newest = issueLocalTerminalNonce("proj_1").nonce;
+    expect(outstandingLocalTerminalNonceCount()).toBeLessThanOrEqual(64);
+    // The oldest was evicted; the newest — the one the user is about to
+    // present — still works.
+    expect(consumeLocalTerminalNonce(first)).toBeNull();
+    expect(consumeLocalTerminalNonce(newest)).toEqual({ projectId: "proj_1" });
+  });
+});

--- a/mcpjam-inspector/server/utils/computers/local-consent.ts
+++ b/mcpjam-inspector/server/utils/computers/local-consent.ts
@@ -121,6 +121,20 @@ export async function verifyLocalComputerConsent(
 }
 
 /**
+ * Fingerprint of the CURRENTLY persisted capability (its stored SHA-256), or
+ * null when no consent exists.
+ *
+ * Lets a holder of a derived credential — the local terminal's handshake nonce —
+ * verify that the capability it was minted against is still the live one,
+ * WITHOUT holding the plaintext token. A revoke (no consent) or a re-grant from
+ * another browser profile (rotated hash) both change the answer, so a nonce
+ * minted before either becomes unredeemable.
+ */
+export async function getLocalConsentFingerprint(): Promise<string | null> {
+  return (await readPersistedConsent())?.tokenHash ?? null;
+}
+
+/**
  * Revoke the persisted capability. When `token` is supplied the revoke is
  * SCOPED: it unlinks only if that token still matches the stored hash, so a
  * slow revoke request that lost a race to a newer grant cannot sever the

--- a/mcpjam-inspector/server/utils/computers/local-consent.ts
+++ b/mcpjam-inspector/server/utils/computers/local-consent.ts
@@ -135,6 +135,35 @@ export async function getLocalConsentFingerprint(): Promise<string | null> {
 }
 
 /**
+ * Verify a presented capability AND return the fingerprint it matched, from a
+ * SINGLE read of the consent file.
+ *
+ * Minting a terminal nonce needs both facts, and taking them from two separate
+ * reads is a real race: a re-grant landing between them would verify the OLD
+ * token and then hand back the NEW capability's fingerprint, so the old browser
+ * profile would get a nonce that survives the rotation it should have died to.
+ * One read makes the pair internally consistent — the returned fingerprint is
+ * always the very hash the token was checked against.
+ *
+ * Deliberately still lock-free, like `verifyLocalComputerConsent`: this is on
+ * the enforcement path and must never queue behind a mutation. A rotation that
+ * happens *after* this read is caught later, when the WebSocket re-checks the
+ * fingerprint against the live capability.
+ */
+export async function verifyAndFingerprintLocalConsent(
+  token: string | null | undefined
+): Promise<string | null> {
+  if (!token || token.length < 16 || token.length > 256) return null;
+  const persisted = await readPersistedConsent();
+  if (!persisted) return null;
+  const presented = Buffer.from(hashToken(token), "hex");
+  const stored = Buffer.from(persisted.tokenHash, "hex");
+  const matches =
+    presented.length === stored.length && timingSafeEqual(presented, stored);
+  return matches ? persisted.tokenHash : null;
+}
+
+/**
  * Revoke the persisted capability. When `token` is supplied the revoke is
  * SCOPED: it unlinks only if that token still matches the stored hash, so a
  * slow revoke request that lost a race to a newer grant cannot sever the

--- a/mcpjam-inspector/server/utils/computers/local-consent.ts
+++ b/mcpjam-inspector/server/utils/computers/local-consent.ts
@@ -106,18 +106,17 @@ export function grantLocalComputerConsent(): Promise<{
   });
 }
 
-/** Constant-time verify of a presented capability against the stored hash. */
+/**
+ * Constant-time verify of a presented capability against the stored hash.
+ *
+ * Delegates to `verifyAndFingerprintLocalConsent` so the length bounds and the
+ * `timingSafeEqual` compare live in exactly ONE place and cannot drift apart.
+ * Same single-read property, same lock-free behavior.
+ */
 export async function verifyLocalComputerConsent(
   token: string | null | undefined
 ): Promise<boolean> {
-  if (!token || token.length < 16 || token.length > 256) return false;
-  const persisted = await readPersistedConsent();
-  if (!persisted) return false;
-  const presented = Buffer.from(hashToken(token), "hex");
-  const stored = Buffer.from(persisted.tokenHash, "hex");
-  return (
-    presented.length === stored.length && timingSafeEqual(presented, stored)
-  );
+  return (await verifyAndFingerprintLocalConsent(token)) !== null;
 }
 
 /**

--- a/mcpjam-inspector/server/utils/computers/local-machine.ts
+++ b/mcpjam-inspector/server/utils/computers/local-machine.ts
@@ -182,10 +182,16 @@ export async function getLocalComputerWorkspaceDir(
  * Never fails the command; rotates at ~10MB by renaming to `.1` (one
  * generation — this is an audit convenience, not a log pipeline). Lines may
  * contain sensitive command text; the directory is 0700 for that reason.
+ *
+ * Exported so the local terminal WS route can journal its own open/close
+ * (`source:"terminal"`, `action:"open"|"close"`) through the SAME writer —
+ * a second journal file would split the audit trail. PTY keystrokes are
+ * deliberately never journaled: unlike a discrete approved `bash` command,
+ * an interactive session's bytes include passwords typed at prompts.
  */
 const LOG_ROTATE_BYTES = 10 * 1024 * 1024;
 
-async function appendLocalCommandLog(entry: {
+export async function appendLocalCommandLog(entry: {
   ts: string;
   projectId: string;
   commandId: string;

--- a/mcpjam-inspector/server/utils/computers/local-pty-adapter.ts
+++ b/mcpjam-inspector/server/utils/computers/local-pty-adapter.ts
@@ -1,0 +1,54 @@
+/**
+ * node-pty → `PtyCreator` adapter, so the local terminal reuses the cloud
+ * terminal's `createPtyWithCwd` (and its "stale cwd must not brick the open"
+ * retry) instead of growing a second spawn path.
+ *
+ * This is NOT a pass-through — every difference below is load-bearing:
+ *
+ *  - E2B's `pty.create` REJECTS on a bad cwd, which is what triggers the retry
+ *    in `createPtyWithCwd`. `node-pty.spawn` is synchronous and does not: a
+ *    missing cwd gives you a shell that dies milliseconds later, so the retry
+ *    never fires and the user gets an empty terminal that immediately exits.
+ *    We pre-check `existsSync(cwd)` and throw, restoring the rejection the
+ *    retry is written against.
+ *  - `spawn` throws SYNCHRONOUSLY (bad shell path, fork failure). `create` is
+ *    declared async so those become rejections, which is what callers expect.
+ *  - node-pty streams `string`; the WS wire protocol and `PtyBaseOpts.onData`
+ *    are bytes. We encode to UTF-8.
+ *  - `timeoutMs` is an E2B sandbox-side PTY TTL. There is no such concept for a
+ *    local child process (its lifetime is the socket's), so it is ignored.
+ */
+import { existsSync } from "node:fs";
+import type { PtyCreator } from "./create-pty.js";
+import type { NodePtyModule, NodePtyProcess } from "./local-pty.js";
+
+export function createLocalPtyCreator(args: {
+  ptyModule: NodePtyModule;
+  /** Absolute path to the shell to spawn ($SHELL → bash → sh). */
+  shell: string;
+  /** The local-command env ALLOWLIST (see local-machine.ts) — never process.env. */
+  env: NodeJS.ProcessEnv;
+}): PtyCreator<NodePtyProcess> {
+  const encoder = new TextEncoder();
+  return {
+    pty: {
+      create: async (opts) => {
+        if (opts.cwd !== undefined && !existsSync(opts.cwd)) {
+          // Restores the rejection `createPtyWithCwd`'s fallback is written
+          // against; without it a stale workspace dir yields an instantly-dead
+          // shell instead of a retry into home.
+          throw new Error(`Terminal working directory does not exist.`);
+        }
+        const proc = args.ptyModule.spawn(args.shell, [], {
+          name: "xterm-color",
+          cols: opts.cols,
+          rows: opts.rows,
+          ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+          env: args.env,
+        });
+        proc.onData((chunk) => opts.onData(encoder.encode(chunk)));
+        return proc;
+      },
+    },
+  };
+}

--- a/mcpjam-inspector/server/utils/computers/local-pty.ts
+++ b/mcpjam-inspector/server/utils/computers/local-pty.ts
@@ -1,0 +1,126 @@
+/**
+ * node-pty loader + availability probe for the local computer terminal.
+ *
+ * `node-pty` is an OPTIONAL dependency with a native addon. Every way this
+ * inspector ships can legitimately fail to provide it, and none of them may
+ * crash:
+ *  - `npx @mcpjam/inspector` on a machine with no build toolchain — npm skips
+ *    the optional dep and the install still succeeds.
+ *  - The packaged Electron app — `@electron-forge/plugin-vite` packages only
+ *    `.vite`, so there is no `node_modules` in the asar at all and the runtime
+ *    require always fails. Electron is terminal-degrade by design in v1; real
+ *    support needs `extraResource` + custom resolution and is a follow-up.
+ *  - An ABI mismatch after a Node upgrade.
+ *
+ * So the contract is: probe once, cache the answer, and degrade to bash-only.
+ * `getLocalTerminalAvailability()` is what the config route and the WS handler
+ * both consult — it also reports unavailable whenever the local ENGINE itself
+ * is unavailable (hosted, kill switch off, no bash), because a terminal on a
+ * machine that may not execute bash would be a second, ungated execution path.
+ */
+import { logger } from "../logger.js";
+import { isLocalComputerEngineAvailable } from "./local-machine.js";
+
+/** The slice of node-pty's surface this server uses. */
+export interface NodePtyProcess {
+  pid: number;
+  onData(listener: (data: string) => void): { dispose(): void };
+  onExit(listener: (event: { exitCode: number; signal?: number }) => void): {
+    dispose(): void;
+  };
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(signal?: string): void;
+}
+
+export interface NodePtyModule {
+  spawn(
+    file: string,
+    args: string[] | string,
+    options: {
+      name?: string;
+      cols?: number;
+      rows?: number;
+      cwd?: string;
+      env?: NodeJS.ProcessEnv;
+    }
+  ): NodePtyProcess;
+}
+
+export type LocalPtyModuleLoad =
+  | { ok: true; pty: NodePtyModule }
+  | { ok: false; reason: string };
+
+let loadPromise: Promise<LocalPtyModuleLoad> | null = null;
+
+/**
+ * Lazily `import("node-pty")`, memoized (including the failure — a missing
+ * native addon will not appear mid-process, and retrying per connection would
+ * pay the resolution cost on every socket).
+ */
+export function loadLocalPtyModule(): Promise<LocalPtyModuleLoad> {
+  if (!loadPromise) {
+    // `as string` widens the specifier for TYPE resolution only — node-pty is
+    // optional, so `tsc` must not fail when it isn't installed (and must not
+    // fight the package's own types when it is). The cast is erased before
+    // esbuild/Rollup see the AST, so both still read a string literal and honor
+    // the `node-pty` entry in their `external` lists.
+    loadPromise = import("node-pty" as string)
+      .then((mod): LocalPtyModuleLoad => {
+        // ESM/CJS interop: the native addon is CommonJS, so `spawn` may live on
+        // the namespace or on `default` depending on the loader.
+        const candidate = (mod as { default?: unknown }).default ?? mod;
+        const spawn = (candidate as Partial<NodePtyModule>).spawn;
+        if (typeof spawn !== "function") {
+          return { ok: false, reason: "node-pty did not export spawn()" };
+        }
+        return { ok: true, pty: candidate as NodePtyModule };
+      })
+      .catch((error): LocalPtyModuleLoad => {
+        const reason =
+          error instanceof Error ? error.message : "node-pty is not installed";
+        logger.debug("[local-pty] node-pty unavailable", { reason });
+        return { ok: false, reason: "node-pty is not available on this server" };
+      });
+  }
+  return loadPromise;
+}
+
+export type LocalTerminalAvailability =
+  | { available: true }
+  | { available: false; reason: string };
+
+let cachedAvailability: LocalTerminalAvailability | undefined;
+
+/**
+ * Can this server open a local PTY? Cached for the process lifetime — the
+ * config route calls this on every SPA boot and the answer cannot change
+ * without a restart.
+ */
+export async function getLocalTerminalAvailability(): Promise<LocalTerminalAvailability> {
+  if (cachedAvailability !== undefined) return cachedAvailability;
+  const engine = isLocalComputerEngineAvailable();
+  if (!engine.available) {
+    cachedAvailability = { available: false, reason: engine.reason };
+    return cachedAvailability;
+  }
+  const loaded = await loadLocalPtyModule();
+  cachedAvailability = loaded.ok
+    ? { available: true }
+    : { available: false, reason: loaded.reason };
+  return cachedAvailability;
+}
+
+/** Test seam: both the module load and the probe are process-lifetime caches. */
+export function resetLocalPtyCachesForTests(): void {
+  loadPromise = null;
+  cachedAvailability = undefined;
+}
+
+/** Test seam: inject a fake node-pty module (the native addon isn't installable in CI). */
+export function setLocalPtyModuleForTests(module: NodePtyModule | null): void {
+  loadPromise = module
+    ? Promise.resolve({ ok: true, pty: module })
+    : Promise.resolve({ ok: false, reason: "node-pty is not available on this server" });
+  cachedAvailability = undefined;
+}

--- a/mcpjam-inspector/server/utils/computers/local-terminal-auth.ts
+++ b/mcpjam-inspector/server/utils/computers/local-terminal-auth.ts
@@ -1,0 +1,115 @@
+/**
+ * Single-use handshake nonces for the LOCAL computer terminal WebSocket.
+ *
+ * Why a nonce at all: a browser cannot attach an `Authorization` header to a
+ * WebSocket handshake, and a `?token=` query string lands in proxy/CDN access
+ * logs — so the cloud terminal already puts its token in the
+ * `Sec-WebSocket-Protocol` slot. The local terminal reuses that transport, but
+ * there is no Convex-minted JWT to put there: this PTY is on the user's own
+ * machine and no control plane knows about it.
+ *
+ * So the mint route (`POST /api/mcp/computers/local-terminal-token`, which sits
+ * behind the inspector session token + a VERIFIED sign-in + a non-guest check +
+ * server-verified local consent) issues one of these, and the WS handler
+ * consumes it. Properties that matter:
+ *
+ *  - In-memory only. It never outlives the process that minted it, and a
+ *    second inspector cannot redeem another's nonce.
+ *  - SINGLE USE. Consuming removes it, so a nonce leaked into a log or a
+ *    replayed handshake buys nothing after the legitimate connect.
+ *  - Short TTL (60s) — a handshake follows its mint immediately.
+ *  - Bound to the validated project key, so a nonce minted for one project's
+ *    workspace can't open a PTY in another's.
+ *  - Constant-time compare on the lookup key, so redemption cannot be turned
+ *    into a timing oracle for guessing 32 random bytes.
+ *
+ * The nonce is base64url so it is a valid `Sec-WebSocket-Protocol` token
+ * (RFC 6455 restricts that header to HTTP tokens — base64 padding/`+`/`/`
+ * would not survive).
+ */
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { validateLocalProjectKey } from "./local-machine.js";
+
+export const LOCAL_TERMINAL_NONCE_TTL_MS = 60_000;
+
+/** Backstop against unbounded growth if something mints in a loop. */
+const MAX_OUTSTANDING_NONCES = 64;
+
+interface IssuedNonce {
+  nonce: string;
+  projectId: string;
+  expiresAtMs: number;
+}
+
+const outstanding: IssuedNonce[] = [];
+
+function pruneExpired(now: number): void {
+  for (let i = outstanding.length - 1; i >= 0; i -= 1) {
+    const entry = outstanding[i];
+    if (entry && entry.expiresAtMs <= now) outstanding.splice(i, 1);
+  }
+}
+
+/**
+ * Mint a single-use nonce for `projectId`. Throws if the project key isn't one
+ * bounded path segment — the same validation the workspace resolver applies,
+ * done HERE so an invalid key never reaches the WS handler at all.
+ */
+export function issueLocalTerminalNonce(projectId: string): {
+  nonce: string;
+  expiresAtMs: number;
+} {
+  const validated = validateLocalProjectKey(projectId);
+  const now = Date.now();
+  pruneExpired(now);
+  // Drop the oldest rather than refuse: a legitimate user reconnecting in a
+  // tight loop must never be locked out by their own stale nonces.
+  while (outstanding.length >= MAX_OUTSTANDING_NONCES) outstanding.shift();
+  const nonce = randomBytes(32).toString("base64url");
+  const expiresAtMs = now + LOCAL_TERMINAL_NONCE_TTL_MS;
+  outstanding.push({ nonce, projectId: validated, expiresAtMs });
+  return { nonce, expiresAtMs };
+}
+
+/**
+ * Redeem a nonce. Returns the bound projectId on success and `null` otherwise;
+ * either way the nonce is gone afterwards. The scan is unconditional (no early
+ * exit) and compares with `timingSafeEqual`, so a caller learns nothing from
+ * how long a rejection took.
+ */
+export function consumeLocalTerminalNonce(
+  presented: string | null | undefined
+): { projectId: string } | null {
+  const now = Date.now();
+  pruneExpired(now);
+  if (typeof presented !== "string" || presented.length === 0) return null;
+  const presentedBuf = Buffer.from(presented, "utf8");
+  let matchIndex = -1;
+  for (let i = 0; i < outstanding.length; i += 1) {
+    const entry = outstanding[i];
+    if (!entry) continue;
+    const storedBuf = Buffer.from(entry.nonce, "utf8");
+    const equal =
+      storedBuf.length === presentedBuf.length &&
+      timingSafeEqual(storedBuf, presentedBuf);
+    if (equal && matchIndex === -1) matchIndex = i;
+  }
+  if (matchIndex === -1) return null;
+  const [claimed] = outstanding.splice(matchIndex, 1);
+  if (!claimed) return null;
+  // Re-check the deadline on the CLAIMED entry: pruning ran before the compare,
+  // and an entry that expires in between must not be honored.
+  if (claimed.expiresAtMs <= Date.now()) return null;
+  return { projectId: claimed.projectId };
+}
+
+/** Test seam: the store is process-global. */
+export function resetLocalTerminalNoncesForTests(): void {
+  outstanding.length = 0;
+}
+
+/** Test/diagnostic helper: how many un-redeemed nonces are outstanding. */
+export function outstandingLocalTerminalNonceCount(): number {
+  pruneExpired(Date.now());
+  return outstanding.length;
+}

--- a/mcpjam-inspector/server/utils/computers/local-terminal-auth.ts
+++ b/mcpjam-inspector/server/utils/computers/local-terminal-auth.ts
@@ -32,13 +32,22 @@ import { validateLocalProjectKey } from "./local-machine.js";
 
 export const LOCAL_TERMINAL_NONCE_TTL_MS = 60_000;
 
-/** Backstop against unbounded growth if something mints in a loop. */
-const MAX_OUTSTANDING_NONCES = 64;
+/** Backstop against unbounded growth if something mints in a loop. Exported so
+ *  the eviction test derives its bounds from the source of truth. */
+export const MAX_OUTSTANDING_NONCES = 64;
 
 interface IssuedNonce {
   nonce: string;
   projectId: string;
   expiresAtMs: number;
+  /**
+   * Fingerprint of the consent capability this nonce was minted against. The
+   * TTL alone would let a nonce outlive the consent that authorized it: revoke
+   * (or a re-grant from another profile, which ROTATES the capability) must
+   * invalidate anything already handed out, so redemption re-checks this
+   * against the live capability rather than trusting the 60s window.
+   */
+  consentFingerprint: string;
 }
 
 const outstanding: IssuedNonce[] = [];
@@ -55,11 +64,17 @@ function pruneExpired(now: number): void {
  * bounded path segment — the same validation the workspace resolver applies,
  * done HERE so an invalid key never reaches the WS handler at all.
  */
-export function issueLocalTerminalNonce(projectId: string): {
+export function issueLocalTerminalNonce(
+  projectId: string,
+  consentFingerprint: string
+): {
   nonce: string;
   expiresAtMs: number;
 } {
   const validated = validateLocalProjectKey(projectId);
+  if (!consentFingerprint) {
+    throw new Error("A consent capability is required to mint a terminal nonce.");
+  }
   const now = Date.now();
   pruneExpired(now);
   // Drop the oldest rather than refuse: a legitimate user reconnecting in a
@@ -67,19 +82,27 @@ export function issueLocalTerminalNonce(projectId: string): {
   while (outstanding.length >= MAX_OUTSTANDING_NONCES) outstanding.shift();
   const nonce = randomBytes(32).toString("base64url");
   const expiresAtMs = now + LOCAL_TERMINAL_NONCE_TTL_MS;
-  outstanding.push({ nonce, projectId: validated, expiresAtMs });
+  outstanding.push({
+    nonce,
+    projectId: validated,
+    expiresAtMs,
+    consentFingerprint,
+  });
   return { nonce, expiresAtMs };
 }
 
 /**
- * Redeem a nonce. Returns the bound projectId on success and `null` otherwise;
- * either way the nonce is gone afterwards. The scan is unconditional (no early
- * exit) and compares with `timingSafeEqual`, so a caller learns nothing from
- * how long a rejection took.
+ * Redeem a nonce. Returns the bound projectId and the consent fingerprint it was
+ * minted against on success, `null` otherwise; either way the nonce is gone
+ * afterwards. The CALLER must still check that fingerprint against the live
+ * capability — see `IssuedNonce.consentFingerprint`.
+ *
+ * The scan is unconditional (no early exit) and compares with `timingSafeEqual`,
+ * so a caller learns nothing from how long a rejection took.
  */
 export function consumeLocalTerminalNonce(
   presented: string | null | undefined
-): { projectId: string } | null {
+): { projectId: string; consentFingerprint: string } | null {
   const now = Date.now();
   pruneExpired(now);
   if (typeof presented !== "string" || presented.length === 0) return null;
@@ -100,7 +123,10 @@ export function consumeLocalTerminalNonce(
   // Re-check the deadline on the CLAIMED entry: pruning ran before the compare,
   // and an entry that expires in between must not be honored.
   if (claimed.expiresAtMs <= Date.now()) return null;
-  return { projectId: claimed.projectId };
+  return {
+    projectId: claimed.projectId,
+    consentFingerprint: claimed.consentFingerprint,
+  };
 }
 
 /** Test seam: the store is process-global. */

--- a/mcpjam-inspector/shared/analytics-events.ts
+++ b/mcpjam-inspector/shared/analytics-events.ts
@@ -101,6 +101,23 @@ export const ANALYTICS_EVENTS = {
   computer_chat_attachment_uploaded: { source: "client" },
   computer_start_limit_hit: { source: "client" },
   computer_terminal_opened: { source: "client" },
+  // --- Local computer engine ("This machine") ---
+  // Content-free by construction: props are enums/booleans only. NEVER a
+  // command, a path, a workspace dir, an OS username, or a consent token.
+  // computer_engine_selected: the user moved the Local⇄Cloud toggle {engine}.
+  // local_computer_consent_gate_shown: the consent gate rendered.
+  // local_computer_consent_granted / _denied: Allow / "Use cloud instead" —
+  //   the only two affordances on the gate.
+  // local_computer_consent_reauthorized: "Forget & re-authorize" (the stale-
+  //   capability recovery path).
+  // local_terminal_unavailable: the local terminal could not be offered
+  //   {reason} — an enum, never a node-pty error string.
+  computer_engine_selected: { source: "client" },
+  local_computer_consent_denied: { source: "client" },
+  local_computer_consent_gate_shown: { source: "client" },
+  local_computer_consent_granted: { source: "client" },
+  local_computer_consent_reauthorized: { source: "client" },
+  local_terminal_unavailable: { source: "client" },
   connect_host_overlay_add_clicked: { source: "client" },
   connect_host_overlay_opened: { source: "client" },
   connect_host_overlay_quick_added: { source: "client" },

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -81,6 +81,7 @@ if (!app.isDefaultProtocolClient("mcpjam")) {
 let mainWindow: BrowserWindow | null = null;
 let server: any = null;
 let serverPort: number = 0;
+let shutdownLocalTerminals: (() => void) | null = null;
 let pendingProtocolUrl: string | null = null;
 let appBootstrapped = false;
 
@@ -334,7 +335,14 @@ async function startHonoServer(): Promise<number> {
     // Node's cache; subsequent calls just return the cached exports, which
     // is exactly what we want now that we're reusing the same port.
     const { createHonoApp } = await import("../server/app.js");
-    const { app: honoApp, injectWebSocket } = await createHonoApp();
+    const {
+      app: honoApp,
+      injectWebSocket,
+      shutdownLocalComputerTerminals,
+    } = await createHonoApp();
+    // Held for `before-quit`: killing live local PTYs is the ONLY thing that
+    // stops them — `server.close()` does not tear down established sockets.
+    shutdownLocalTerminals = shutdownLocalComputerTerminals;
 
     server = serve({
       fetch: honoApp.fetch,
@@ -884,6 +892,7 @@ app.on("before-quit", (event) => {
     event.preventDefault();
     return;
   }
+  shutdownLocalTerminals?.();
   if (server) {
     server.close?.();
   }

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -82,6 +82,7 @@ let mainWindow: BrowserWindow | null = null;
 let server: any = null;
 let serverPort: number = 0;
 let shutdownLocalTerminals: (() => void) | null = null;
+let killLocalTerminals: (() => void) | null = null;
 let pendingProtocolUrl: string | null = null;
 let appBootstrapped = false;
 
@@ -339,10 +340,14 @@ async function startHonoServer(): Promise<number> {
       app: honoApp,
       injectWebSocket,
       shutdownLocalComputerTerminals,
+      killLocalComputerTerminals,
     } = await createHonoApp();
-    // Held for `before-quit`: killing live local PTYs is the ONLY thing that
-    // stops them — `server.close()` does not tear down established sockets.
+    // Held for teardown: killing live local PTYs is the ONLY thing that stops
+    // them — `server.close()` does not tear down established sockets. The
+    // latching variant is for a real quit; the plain kill is for
+    // `window-all-closed`, after which macOS may restart this same server.
     shutdownLocalTerminals = shutdownLocalComputerTerminals;
+    killLocalTerminals = killLocalComputerTerminals;
 
     server = serve({
       fetch: honoApp.fetch,
@@ -809,10 +814,11 @@ app.whenReady().then(async () => {
 
 app.on("window-all-closed", () => {
   // Close the server when all windows are closed. On macOS the app stays alive
-  // here, so this is not a quit — but the server is going away, and a local PTY
-  // must not outlive it. (A destroyed renderer's socket usually closes and the
-  // WS teardown kills the PTY anyway; this makes it unconditional.)
-  shutdownLocalTerminals?.();
+  // here, so this is NOT a quit — the server restarts on dock activation. Kill
+  // live PTYs (a destroyed renderer's socket usually closes and the WS teardown
+  // does it anyway; this makes it unconditional) but do NOT latch shutdown, or
+  // every terminal handshake after reopening would be refused.
+  killLocalTerminals?.();
   if (server) {
     server.close?.();
     serverPort = 0;

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -808,7 +808,11 @@ app.whenReady().then(async () => {
 });
 
 app.on("window-all-closed", () => {
-  // Close the server when all windows are closed
+  // Close the server when all windows are closed. On macOS the app stays alive
+  // here, so this is not a quit — but the server is going away, and a local PTY
+  // must not outlive it. (A destroyed renderer's socket usually closes and the
+  // WS teardown kills the PTY anyway; this makes it unconditional.)
+  shutdownLocalTerminals?.();
   if (server) {
     server.close?.();
     serverPort = 0;

--- a/mcpjam-inspector/vite.main.config.ts
+++ b/mcpjam-inspector/vite.main.config.ts
@@ -45,6 +45,14 @@ export default defineConfig({
     rollupOptions: {
       external: [
         "electron",
+        // `src/main.ts` dynamically imports the WHOLE server, so the server's
+        // optional native dep is in this bundle's graph. node-pty must stay
+        // external or the main-process build fails outright; at runtime the
+        // packaged app has no node_modules (electron-forge's vite plugin packs
+        // only `.vite`), so the require fails and the local terminal degrades
+        // off by design. Real Electron terminal support (extraResource +
+        // custom resolution) is a scoped follow-up.
+        "node-pty",
         ...builtinModules,
         ...builtinModules.map((m) => `node:${m}`),
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -549,6 +549,9 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "node-pty": "1.1.0"
       }
     },
     "mcpjam-inspector/node_modules/@ai-sdk/amazon-bedrock": {
@@ -29727,6 +29730,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-api-version": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
@@ -29814,6 +29824,17 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.37",


### PR DESCRIPTION
Closes out the local-computer-engine program: the remaining five planned PRs, consolidated into the three workstreams (A / B / C) and landed together on one branch. PRs 1–6 shipped the working end-to-end path (#3799, #3805, #3812, #3815, #3818, #3827); this is the endgame.

Commits map 1:1 to the workstreams and are the recommended review order. Two files (`LocalComputerView.tsx`, `shared/analytics-events.ts`) carry changes from both B and C, so they ride in B to keep that commit self-consistent.

## A — playground polish (client only)

Two corrections to what shipped, plus the run-location badge.

- **The rail's Shell tab was always driving the CLOUD terminal controller.** `useComputerTerminal` reserves (and wakes) a real cloud box on open, so with the engine set to local, "Open terminal" would start a machine behind the user's back while their chat bash ran on their laptop. The Shell body is now engine-aware and simply does not mount that controller on the local engine.
  - The **body** follows `selectedEngine` (consent-blind), mirroring the Computer tab's face choice — someone who picked "This machine" but hasn't authorized it yet gets a pointer to the Computer tab, not a cloud terminal they didn't ask for. The **chip** follows the resolved `engine`, so it can never read "This machine" while commands really go to the cloud.
  - Local body branches on consent, then on `localTerminalAvailable`, so it is correct whether or not B is present.
  - Mid-session flips are covered: swapping bodies drops a live cloud pane (the reserved box stays up until the idle sweep) and switching back reconnects with a fresh mint.
- **Composer attachments**: the computer-upload PATH is gated to the cloud engine. It targets the cloud box's upload route, so on the local engine it would wake a sandbox and drop files where local bash can never read them. Attachments fall back to exactly the computer-less behavior. The attach button itself serves generic model attachments and is untouched.
- **Run-location badge**: bash results already carry `engine` on non-hosted turns, so the tool card now shows a `this machine` / `cloud` pill next to the app-attribution pill it's styled after. Read from the **raw** output, not the editable Raw-tab value — provenance must not be user-rewritable. Absent field (old transcripts, hosted, ephemeral sandbox-bash, non-bash) renders nothing.

## B — local terminal (server + client pane)

An interactive shell on the machine the inspector runs on, from the Computer tab's "This machine" face. Same wire protocol and the same xterm client as the cloud terminal; the PTY is a child of this server instead of an E2B sandbox.

**Auth.** This is the one path to a shell with *no per-command approval*, so the gates are the review-critical part:

| Gate | Where |
| --- | --- |
| inspector session | app-level `/api/mcp` middleware |
| verified sign-in | `requireVerifiedAuth` → 401 |
| non-guest | explicit check → 403 |
| kill switch | `MCPJAM_LOCAL_COMPUTER_ENABLED` → 404 |
| server-verified consent | `verifyLocalComputerConsent` → 403 |
| availability probe | node-pty / engine → 503 |
| project key | one bounded path segment → 400 |
| single-use nonce | 60s, project-bound, constant-time compare → WS 4401 |
| allowed Origin | **absent Origin rejected** → WS 4401 |
| hosted | `/api/mcp` unmounted, flag forced off, WS route not mounted, `terminalAvailable: false` |

Two notes worth a reviewer's eye:

- The existing consent middleware is scoped to `/local-consent/*`, so the mint needed **its own** stack — without it the route would inherit nothing but the session middleware. Registered on the exact path (not a wildcard) and there's a test asserting the gates run exactly once.
- Consent is required to mint: an interactive shell is strictly more than the per-command-approved bash tool, so it can never be the first thing that runs on a machine the user never authorized.

**Packaging — node-pty's absence is a supported state, not a failure.** `npx` with no build toolchain, an ABI mismatch, and the packaged Electron app (electron-forge's vite plugin packs only `.vite`, so there is no `node_modules` to require from) all land on `{ok:false}` → `terminalAvailable:false` → the existing degrade note, with chat bash still working. **Electron is terminal-degrade by design in v1**; real support needs `extraResource` + custom resolution and is a scoped follow-up. It's `external` in **both** `server/tsup.config.ts` and `vite.main.config.ts` — `src/main.ts` dynamically imports the whole server, so the latter is load-bearing (verified: removing it fails the main build with `Rollup failed to resolve import "node-pty"`).

**Reuse over a second spawn path.** A node-pty adapter satisfies the structural `PtyCreator`, so `createPtyWithCwd` and its stale-cwd retry are shared. The adapter is deliberately **not** a pass-through — node-pty spawns synchronously and hands back an instantly-dead shell on a bad cwd instead of rejecting, so the retry would never fire. It pre-checks the dir, wraps sync throws, encodes string output to bytes, and ignores the E2B TTL. Each divergence has its own test.

**Shutdown.** `server.close()` does not drop established sockets, so `shutdownLocalComputerTerminals()` is the mechanism — wired into the standalone `shutdown()` and Electron's `before-quit`.

**Client.** The connection helper gains a `path` option (cloud stays the default); `ComputerTerminal` gains `wsPath` and an `uploadEnabled` gate. The local pane passes `uploadEnabled={false}` — the pane's drag-and-drop posts to the *cloud* upload route and would burn the single-use nonce against the wrong endpoint. No reserve/status polling: the machine is always ready, and the existing generation guard already handles reconnect races.

**Journaling** reuses the existing local command log with `source:"terminal"` and open/close actions. PTY keystrokes are deliberately never journaled — unlike an approved bash command, an interactive session's bytes include passwords typed at prompts.

## C — launch prep (analytics + docs)

- **Flag targeting.** `deployment` existed only as a *super* property, which rides events and is invisible to `/flags` — flag rules evaluate *person* properties, and no `setPersonProperties*` call existed anywhere in the client. It's now also set via `setPersonPropertiesForFlags` at init (applying from the first request, before any identify) and carried on identify for every actor, guests included, and restored after `reset()`. Reuses the existing naming rather than inventing a parallel `inspector_runtime`. The call is optional-chained so a partial posthog stand-in or an older posthog-js degrades flag targeting instead of taking out analytics init — with tests on both sides of that guard, so it can't silently defeat the feature.
- **Analytics.** Five registry entries for the consent funnel and the engine toggle, emitted through `track()`. Props are enums/booleans/locations only. `cloud_offered` is recorded on the gate because a pure-local inspector has no decline affordance and its refusals are otherwise invisible; a failed or rejected Allow reports as an `outcome` rather than a silent drop.
- **Docs.** `docs/local-computer-engine.md` — architecture, trust model, the full actor/route enumeration, kill-switch semantics, cloud-only surfaces, the terminal degrade paths, and the launch/rollback checklist with the exact flag rule.

The rollback caveat is the important line in there: **the kill switch is a server env var and does not reach already-published npx/Electron clients**, which need a patch release. The flag governs hosted UI exposure; the kill switch governs a given self-hosted server; neither retroactively disarms a shipped binary.

**Scoped out of v1** (recorded in the doc): a per-command `local_bash_result` event — no client code reads a tool's `exitCode` today, a render-time emit would multi-fire, and outcome data already lands in the local JSONL journal. Fast-follow if the launch gate needs the rate. The user-facing `docs.mcpjam.com` page lives in the separate Mintlify repo and is a checklist item, not code here.

## Verification

- `npm test` — **1177 files passed, 3 skipped, 13781 tests passed, 0 failures.**
- `npx tsc --noEmit -p client/tsconfig.typecheck.json` — **exit 0.**
- `tsc -p server/tsconfig.json` — 105 errors, all in pre-existing files this branch does not touch (baseline ~104; the new files are clean).
- `npm run build` — passes. `dist/server/index.js` keeps `import("node-pty")` as a runtime import with nothing inlined (no `node-addon-api`, no `pty.node`).
- Electron vite main build — passes with node-pty external; **fails without it**, confirming the config entry is load-bearing rather than dead.
- `git show --stat` across all four commits — no file flipped to `Bin`.

### Not verified here (needs a real machine)

The cloud runner has no node-pty and no display, so these are for local follow-up: the dev happy path end to end; a real PTY in `~/.mcpjam/computer/<projectId>` with `echo $E2B_API_KEY` empty; drag-drop over the local pane doing nothing; the degrade path via renaming the node-pty module; a hosted-mode run; the macOS npx smoke via the packed tarball; and the packaged Electron smoke (build succeeds, app degrades cleanly). The checklist in `docs/local-computer-engine.md` carries all of them.

### One unrelated observation

`server/utils/computers/__tests__/local-machine.test.ts` on `main` contains NUL bytes and git treats it as binary. It predates this branch and is untouched here — flagging it since the program's own commit hygiene rule is what surfaced it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYtNZF2QkELMfb4x2GBfRC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Opens an interactive shell on the user’s machine with a large auth/consent surface; mistakes in nonce, consent fingerprint, or PTY lifecycle could allow unauthorized local execution or leave orphaned processes.
> 
> **Overview**
> Closes the local computer engine program: **local interactive terminal**, **playground corrections**, and **launch prep** in one pass.
> 
> **Local terminal (server + Computer tab)** wires a real node-pty shell over `GET /api/web/computers/local-terminal`, sharing the cloud terminal’s xterm client and wire protocol. Access is minted via `POST /api/mcp/computers/local-terminal-token` behind session, verified sign-in, non-guest, kill switch, and **server-verified consent**; nonces are single-use, short-lived, project-bound, and tied to the live consent fingerprint so revoke/re-grant invalidates outstanding tokens. The WS path rejects disallowed or **absent** `Origin`, spawns in the per-project workspace with an allowlisted env, journals open/close only (no keystrokes), and **kills PTYs on shutdown** (with generation guards for in-flight spawns). Optional `node-pty` degrades cleanly when missing (npx without toolchain, Electron v1). `LocalComputerView` mounts `ComputerTerminal` on the local WS with uploads forced off and remounts per project.
> 
> **Playground polish** makes the right-rail Shell tab **engine-aware** so the local engine never mounts `useComputerTerminal` (no silent cloud reserve). The shell body follows `selectedEngine`; the chip follows resolved `engine`. Composer **computer attachment uploads** are gated to the **cloud** engine only. Bash tool cards gain a **this machine / cloud** pill from raw result `engine` via `readToolRunLocation`.
> 
> **Launch prep** sets `deployment` (and platform) as PostHog **person properties for flags** at init and on identify/reset; tracks the consent funnel and engine toggle with content-free payloads; adds `docs/local-computer-engine.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eefc159061e9138f58781eb34ef4f9aeae4a51e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships a local “This machine” terminal with single‑use nonce auth tied to user consent, engine‑aware playground UI, and launch analytics. Tightens shutdown/auth flows, polishes terminal/upload UX, and finalizes docs and packaging; analytics now re‑report after re‑authorize.

- New Features
  - Local terminal WebSocket at `/api/web/computers/local-terminal`; nonce minted via `POST /api/mcp/computers/local-terminal-token` (single‑use, 60s, project‑bound, consent‑bound). Origin is re‑checked; absent or disallowed Origin is rejected. Never mounted in hosted mode.
  - Reuses xterm client and wire protocol; `ComputerTerminal` accepts `wsPath` and forces uploads off on the local route. Journaling adds `source:"terminal"` open/close entries; PTY keystrokes are never recorded.
  - Playground Shell tab is engine‑aware (never mounts the cloud controller on local), shows a “this machine/cloud” run‑location pill from raw bash output, and gates composer uploads to the cloud engine only.
  - Launch prep: sets `deployment` and platform as PostHog person properties for flags (at init, on identify/reset); tracks the consent funnel and engine toggle with content‑free payloads; adds `docs/local-computer-engine.md`. `node-pty` is optional, external in server/Electron builds, and cleanly degrades to “terminal unavailable.”

- Bug Fixes
  - Security: terminal nonces are bound to the live consent fingerprint; mint now atomically verifies and fingerprints to prevent a rotation race. Length‑checks nonce values; rejected Origin does not burn a nonce.
  - Shutdown/teardown: split kill vs shutdown paths for Electron; add a monotonic generation guard to kill in‑flight spawns during sweep/shutdown; refuse new handshakes during shutdown; fix macOS reopen.
  - Correctness/UX: remount terminal on project change; always cancel browser navigation on file drag/drop when uploads are off; hide the rail’s engine chip when `toggleVisible` is false; fall back to `bash` when a stale `$SHELL` is detected.
  - Analytics: `computer_terminal_opened` now counts per project and re‑reports after “Forget & re‑authorize” (transitions into “no pane” are tracked); `local_terminal_unavailable` is de‑duplicated per machine.

<sup>Written for commit 5eefc159061e9138f58781eb34ef4f9aeae4a51e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

