### PR TITLE
Fix review findings on #3844: picker footer keyboard activation, copy reporting, tester-link label

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
@@ -207,15 +207,17 @@ export function ChatboxShareSection({
           Tester link
         </label>
         <div className="flex gap-2">
-          <div
+          {/* `output` rather than a div: the label above needs a LABELABLE
+              control to point at, and this is a read-only value, not an input. */}
+          <output
             id="chatbox-tester-link"
             className="flex min-w-0 flex-1 items-center rounded-md border border-input bg-muted/30 px-3 py-2"
             title={shareLink ?? undefined}
           >
-            <p className="truncate text-sm text-muted-foreground">
+            <span className="truncate text-sm text-muted-foreground">
               {displayLink ?? "No share link yet."}
-            </p>
-          </div>
+            </span>
+          </output>
           <Button
             type="button"
             variant="outline"

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxShareSection.test.tsx
@@ -65,7 +65,12 @@ describe("ChatboxShareSection", () => {
       <ChatboxShareSection chatbox={createChatbox()} projectName="Acme" />,
     );
 
-    expect(screen.getByText("Tester link")).toBeInTheDocument();
+    // getByLabelText, not getByText: the "Tester link" label has to resolve to
+    // a real labelable control, so the link reads as that label's value to
+    // assistive tech instead of as unassociated text.
+    expect(screen.getByLabelText("Tester link")).toHaveTextContent(
+      "/chatbox/my-chatbox/t",
+    );
     expect(screen.getByTestId("chatbox-copy-tester-link")).toBeInTheDocument();
     expect(screen.getByText("Invite with email")).toBeInTheDocument();
     expect(screen.getByText("Access settings")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/project-environments/NameEnvironmentDialog.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/NameEnvironmentDialog.tsx
@@ -92,12 +92,12 @@ export function NameEnvironmentDialog({
         ...(description.trim() ? { description: description.trim() } : {}),
       });
       toast.success(
-        `Environment named "${trimmedName}" — it is now editable from Environments.`,
+        `Saved as "${trimmedName}" — it is now editable from Environments.`,
       );
       onOpenChange(false);
       onNamed?.(named);
     } catch (err) {
-      setError(convexErrMessage(err, "Failed to name the environment."));
+      setError(convexErrMessage(err, "Failed to save the environment."));
     } finally {
       setIsSaving(false);
     }
@@ -122,9 +122,9 @@ export function NameEnvironmentDialog({
           </DialogTitle>
           <DialogDescription>
             This environment was created automatically from a setup, so it
-            can&apos;t be edited. Naming it turns it into an ordinary
-            environment you can manage from the Environments page — everything
-            already running on it follows along.
+            can&apos;t be edited. Saving it turns it into an ordinary environment
+            you can manage from the Environments page — everything already
+            running on it follows along.
           </DialogDescription>
         </DialogHeader>
 

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-picker.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-picker.test.tsx
@@ -6,7 +6,7 @@
  * extraction ADDED: the controlled contract (the component never persists) and
  * single-select mode, which the Playground will use in Phase 2.
  */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -294,5 +294,12 @@ describe("EnvironmentPicker — ad-hoc rows", () => {
     await userEvent.keyboard(key);
 
     expect(onFooterAction).toHaveBeenCalledTimes(1);
+    // …and the close still happens, just AFTER the action: keyboard activation
+    // has to dismiss the popover exactly like a pointer click does.
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("picker-footer-action")
+      ).not.toBeInTheDocument()
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-picker.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/environment-picker.test.tsx
@@ -7,6 +7,7 @@
  * single-select mode, which the Playground will use in Phase 2.
  */
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { mockEnvironments } = vi.hoisted(() => ({
@@ -257,5 +258,41 @@ describe("EnvironmentPicker — ad-hoc rows", () => {
     fireEvent.click(screen.getByRole("button"));
     expect(screen.getByTestId("picker-footer-action")).toBeInTheDocument();
     expect(screen.getByText("Manage environments →")).toBeInTheDocument();
+  });
+
+  // The wrapper that closes the popover once a footer action fires must listen
+  // for the CLICK only. Closing on keydown unmounts the button before the
+  // browser dispatches its activation click, so Enter/Space would silently do
+  // nothing — the reason this pair of cases exists.
+  it.each([
+    ["Enter", "{Enter}"],
+    ["Space", " "],
+  ])("runs a footer action activated with %s", async (_label, key) => {
+    const onFooterAction = vi.fn();
+    render(
+      <EnvironmentPicker
+        projectId="p_1"
+        value={[]}
+        onChange={vi.fn()}
+        multi
+        triggerTestId="picker"
+        footerSlot={
+          <button
+            type="button"
+            data-testid="picker-footer-action"
+            onClick={onFooterAction}
+          >
+            Save as environment
+          </button>
+        }
+      />
+    );
+    fireEvent.click(screen.getByTestId("picker"));
+
+    const action = screen.getByTestId("picker-footer-action");
+    action.focus();
+    await userEvent.keyboard(key);
+
+    expect(onFooterAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcpjam-inspector/client/src/components/project-environments/__tests__/name-environment-dialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/__tests__/name-environment-dialog.test.tsx
@@ -159,7 +159,7 @@ describe("NameEnvironmentDialog", () => {
 
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
     expect(toastMock.success).toHaveBeenCalledWith(
-      expect.stringContaining('named "Checkout flow"'),
+      expect.stringContaining('Saved as "Checkout flow"'),
     );
   });
 });

--- a/mcpjam-inspector/client/src/components/project-environments/environment-picker.tsx
+++ b/mcpjam-inspector/client/src/components/project-environments/environment-picker.tsx
@@ -339,13 +339,11 @@ export function EnvironmentPicker({
         ) : null}
         <div className="mt-0.5 border-t pt-0.5">
           {footerSlot ? (
-            <div
-              className="contents"
-              onClick={() => setOpen(false)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") setOpen(false);
-              }}
-            >
+            // Close on the bubbled CLICK only. A keydown handler here would fire
+            // before the browser dispatches a button's synthetic click for Enter
+            // and Space, unmounting the footer action before it ever ran; the
+            // click covers pointer and keyboard activation alike.
+            <div className="contents" onClick={() => setOpen(false)}>
               {footerSlot}
             </div>
           ) : null}

--- a/mcpjam-inspector/client/src/lib/__tests__/clipboard.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/clipboard.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `copyToClipboard`'s return value is a PROMISE the callers act on — every
+ * caller branches straight into a success or failure toast — so the boolean has
+ * to describe what actually reached the clipboard, including in the deprecated
+ * `execCommand` fallback, which reports failure by returning false rather than
+ * by throwing.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { copyToClipboard } from "../clipboard";
+
+const originalClipboard = navigator.clipboard;
+
+function stubClipboard(writeText: (text: string) => Promise<void>) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: originalClipboard,
+  });
+  vi.restoreAllMocks();
+});
+
+describe("copyToClipboard", () => {
+  it("uses the Clipboard API when it resolves", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+
+    await expect(copyToClipboard("https://example.test/x")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("https://example.test/x");
+  });
+
+  it("reports success when the execCommand fallback copies", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await expect(copyToClipboard("text")).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    // The scratch textarea must not outlive the attempt.
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("reports FAILURE when the execCommand fallback returns false", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn().mockReturnValue(false),
+    });
+
+    // Regression: this used to resolve `true`, so callers showed "Link copied"
+    // for a copy the browser had refused.
+    await expect(copyToClipboard("text")).resolves.toBe(false);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("reports failure when the fallback throws", async () => {
+    stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn(() => {
+        throw new Error("no execCommand");
+      }),
+    });
+
+    await expect(copyToClipboard("text")).resolves.toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/clipboard.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/clipboard.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { copyToClipboard } from "../clipboard";
 
 const originalClipboard = navigator.clipboard;
+const originalExecCommand = document.execCommand;
 
 function stubClipboard(writeText: (text: string) => Promise<void>) {
   Object.defineProperty(navigator, "clipboard", {
@@ -18,14 +19,30 @@ function stubClipboard(writeText: (text: string) => Promise<void>) {
   });
 }
 
+function stubExecCommand(impl: () => boolean) {
+  const execCommand = vi.fn(impl);
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: execCommand,
+  });
+  return execCommand;
+}
+
 beforeEach(() => {
   vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
+// Both stubs are installed with defineProperty rather than vi.spyOn (jsdom
+// leaves `execCommand` undefined), so restoreAllMocks does not undo them —
+// they have to be put back by hand or they leak into later tests.
 afterEach(() => {
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
     value: originalClipboard,
+  });
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: originalExecCommand,
   });
   vi.restoreAllMocks();
 });
@@ -41,11 +58,7 @@ describe("copyToClipboard", () => {
 
   it("reports success when the execCommand fallback copies", async () => {
     stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
-    const execCommand = vi.fn().mockReturnValue(true);
-    Object.defineProperty(document, "execCommand", {
-      configurable: true,
-      value: execCommand,
-    });
+    const execCommand = stubExecCommand(() => true);
 
     await expect(copyToClipboard("text")).resolves.toBe(true);
     expect(execCommand).toHaveBeenCalledWith("copy");
@@ -55,10 +68,7 @@ describe("copyToClipboard", () => {
 
   it("reports FAILURE when the execCommand fallback returns false", async () => {
     stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
-    Object.defineProperty(document, "execCommand", {
-      configurable: true,
-      value: vi.fn().mockReturnValue(false),
-    });
+    stubExecCommand(() => false);
 
     // Regression: this used to resolve `true`, so callers showed "Link copied"
     // for a copy the browser had refused.
@@ -68,13 +78,12 @@ describe("copyToClipboard", () => {
 
   it("reports failure when the fallback throws", async () => {
     stubClipboard(vi.fn().mockRejectedValue(new Error("denied")));
-    Object.defineProperty(document, "execCommand", {
-      configurable: true,
-      value: vi.fn(() => {
-        throw new Error("no execCommand");
-      }),
+    stubExecCommand(() => {
+      throw new Error("no execCommand");
     });
 
     await expect(copyToClipboard("text")).resolves.toBe(false);
+    // A throw must not strand the scratch textarea in the document either.
+    expect(document.querySelector("textarea")).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/lib/clipboard.ts
+++ b/mcpjam-inspector/client/src/lib/clipboard.ts
@@ -8,8 +8,8 @@ export async function copyToClipboard(text: string): Promise<boolean> {
     return true;
   } catch {
     // Fallback for older browsers or permission denied
+    const textarea = document.createElement("textarea");
     try {
-      const textarea = document.createElement("textarea");
       textarea.value = text;
       textarea.style.position = "fixed";
       textarea.style.opacity = "0";
@@ -19,7 +19,6 @@ export async function copyToClipboard(text: string): Promise<boolean> {
       // the result has to be forwarded — swallowing it makes every caller show a
       // success toast for a copy that never happened.
       const copied = document.execCommand("copy");
-      document.body.removeChild(textarea);
       if (!copied) {
         console.warn(
           "Clipboard copy failed: execCommand fallback reported failure",
@@ -35,6 +34,11 @@ export async function copyToClipboard(text: string): Promise<boolean> {
         "Clipboard copy failed: both modern and fallback methods failed",
       );
       return false;
+    } finally {
+      // In `finally`, not on the success path: the scratch textarea must not
+      // outlive the attempt even when execCommand THROWS, or a fixed-position
+      // invisible node is left in the document.
+      textarea.remove();
     }
   }
 }

--- a/mcpjam-inspector/client/src/lib/clipboard.ts
+++ b/mcpjam-inspector/client/src/lib/clipboard.ts
@@ -15,8 +15,17 @@ export async function copyToClipboard(text: string): Promise<boolean> {
       textarea.style.opacity = "0";
       document.body.appendChild(textarea);
       textarea.select();
-      document.execCommand("copy");
+      // execCommand REPORTS failure by returning false rather than throwing, so
+      // the result has to be forwarded — swallowing it makes every caller show a
+      // success toast for a copy that never happened.
+      const copied = document.execCommand("copy");
       document.body.removeChild(textarea);
+      if (!copied) {
+        console.warn(
+          "Clipboard copy failed: execCommand fallback reported failure",
+        );
+        return false;
+      }
       console.warn(
         "Clipboard API unavailable, used deprecated execCommand fallback",
       );


### PR DESCRIPTION
Triage of the automated review on #3844. Targets that PR's branch so the fixes land inside it rather than as a separate change against `main`.

Four findings were raised across CodeRabbit and the Codex connector; all four were reproduced against the current code and fixed. Nothing was skipped.

### `EnvironmentPicker` footer — keyboard activation was dead (raised twice: Major + P2)

The wrapper that closes the popover once a footer action fires listened for `keydown` as well as `click`. On Enter or Space the keydown bubbled first, `setOpen(false)` unmounted the footer button, and the browser's activation click never landed — so "Save as environment" did nothing for keyboard users. Closing on the bubbled `click` alone covers pointer and keyboard activation, since both produce a click after the action runs.

Locked in with a case per key. Verified they fail against the old code (`expected "spy" to be called 1 times, but got 0 times` for both Enter and Space) and pass after.

### `copyToClipboard` reported success for refused copies

`document.execCommand("copy")` reports failure by returning `false` rather than throwing, and the fallback discarded that boolean and returned `true` regardless — so `ChatboxShareSection.handleCopyLink` showed "Link copied" for a copy that never happened. The result is now forwarded. Fixed in `clipboard.ts` rather than at the call site, so every caller benefits. New unit test covers all four paths (Clipboard API, fallback succeeds, fallback returns false, fallback throws).

### "Tester link" label pointed at a `div`

`htmlFor="chatbox-tester-link"` targeted a `div`, which cannot be a label's control, so assistive tech got no label/value association. The read-only link is now an `output` — labelable, and semantically a computed read-only value rather than an input. The inner `<p>` became a `<span>` (`output` is phrasing content). Visuals are unchanged. The existing test now asserts through `getByLabelText`, which only resolves for genuinely labelable elements.

### `NameEnvironmentDialog` mixed vocabulary

Title and submit button say "Save as environment" while the description, success toast, and failure message still said "Naming"/"named"/"Failed to name". Now one vocabulary throughout; the affected toast assertion was updated.

## Testing

- `vitest run --project client` over `project-environments`, `chatboxes`, and `environment-composer`: 308 passed. The one failing suite (`ChatboxUsagePanel.flow-selection`) fails to resolve `@mcpjam/sdk/predicates` because the SDK dist isn't built in this checkout — unrelated to these changes and reproducible without them.
- `tsc --noEmit -p client/tsconfig.json`: no new errors. The two reported in `ChatboxShareSection.test.tsx` pre-exist on the base branch (confirmed by stashing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZ75URpkRN8JXEHFtrZpcS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ab59a1c866ea2f3e2d9a4b162c78561550a6d27c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes review findings from #3844: restores keyboard activation in the environment picker footer, corrects clipboard copy success reporting and cleans up the fallback node, improves tester-link accessibility, and unifies “Save as environment” wording. These changes land on #3844’s branch.

- **Bug Fixes**
  - EnvironmentPicker footer: close popover on bubbled click only so Enter/Space activate the action; tests cover both keys and assert the popover dismisses after activation.
  - Clipboard: forward `execCommand("copy")`’s boolean; return false when the browser refuses the copy; always remove the scratch textarea in `finally`; tests cover Clipboard API, fallback success, false return, and throw.
  - Tester link: switch target from `div` to `output` so the label association works; test now asserts via `getByLabelText`.
  - NameEnvironmentDialog: standardize wording to “Save as environment” across description, success toast, and error.

<sup>Written for commit 2b36e84cd0f0e1f3522fc3717a5af7b8c378be55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

