### PR TITLE
fix(client-picker): logo rows and a primary dot on the right (PUR-15)

### DIFF
--- a/design-system/src/components/dropdown-menu.tsx
+++ b/design-system/src/components/dropdown-menu.tsx
@@ -120,22 +120,34 @@ function DropdownMenuRadioGroup({
 function DropdownMenuRadioItem({
   className,
   children,
+  hideIndicator = false,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  /**
+   * Drop the built-in left-gutter dot (and the padding reserved for it) so the
+   * caller can own the selected-state marker — e.g. a client picker that puts
+   * logos on the left edge and its own accent dot on the right. Radio
+   * semantics are unaffected; only the indicator is suppressed.
+   */
+  hideIndicator?: boolean;
+}) {
   return (
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        hideIndicator ? "pl-2" : "pl-8",
         className,
       )}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
-        </DropdownMenuPrimitive.ItemIndicator>
-      </span>
+      {hideIndicator ? null : (
+        <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+          <DropdownMenuPrimitive.ItemIndicator>
+            <CircleIcon className="size-2 fill-current" />
+          </DropdownMenuPrimitive.ItemIndicator>
+        </span>
+      )}
       {children}
     </DropdownMenuPrimitive.RadioItem>
   );

--- a/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
@@ -20,7 +20,7 @@ import { CreateHostDialog } from "./CreateHostDialog";
 import { getCatalogHost, getCatalogTemplate } from "@mcpjam/sdk/host-compat";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { getHostLogoSrc } from "@/lib/host-ui-metadata";
-import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
+import { resolveHostLogoByName } from "@/lib/host-logo";
 
 const QUICK_ADD_TEMPLATES = ["claude", "chatgpt", "copilot"] as const;
 
@@ -290,10 +290,7 @@ export function HostOverlayBar({
                 onValueChange={handleChange}
               >
                 {sortedHosts.map((host) => {
-                  const rowLogo = resolveHostLogoByDisplayName(
-                    host.name,
-                    themeMode
-                  );
+                  const rowLogo = resolveHostLogoByName(host.name, themeMode);
                   return (
                     <DropdownMenuRadioItem
                       key={host.hostId}
@@ -301,20 +298,12 @@ export function HostOverlayBar({
                       hideIndicator
                       className="group pr-1.5"
                     >
-                      {rowLogo ? (
-                        <img
-                          src={rowLogo}
-                          alt=""
-                          data-testid={`host-overlay-logo-${host.hostId}`}
-                          className="size-3.5 shrink-0 object-contain"
-                        />
-                      ) : (
-                        <span
-                          aria-hidden
-                          data-testid={`host-overlay-logo-${host.hostId}`}
-                          className="size-3.5 shrink-0 rounded-full bg-muted"
-                        />
-                      )}
+                      <img
+                        src={rowLogo}
+                        alt=""
+                        data-testid={`host-overlay-logo-${host.hostId}`}
+                        className="size-3.5 shrink-0 object-contain"
+                      />
                       <span
                         className="flex-1 truncate"
                         data-testid={`host-overlay-label-${host.hostId}`}

--- a/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
@@ -20,6 +20,7 @@ import { CreateHostDialog } from "./CreateHostDialog";
 import { getCatalogHost, getCatalogTemplate } from "@mcpjam/sdk/host-compat";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { getHostLogoSrc } from "@/lib/host-ui-metadata";
+import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
 
 const QUICK_ADD_TEMPLATES = ["claude", "chatgpt", "copilot"] as const;
 
@@ -288,48 +289,83 @@ export function HostOverlayBar({
                 value={effectiveHostId ?? undefined}
                 onValueChange={handleChange}
               >
-                {sortedHosts.map((host) => (
-                  <DropdownMenuRadioItem
-                    key={host.hostId}
-                    value={host.hostId}
-                    className="group pr-1.5"
-                  >
-                    <span className="flex-1 truncate">{host.name}</span>
-                    <span className="ml-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-data-[highlighted]:opacity-100">
-                      <button
-                        type="button"
-                        aria-label={`Edit ${host.name}`}
-                        data-testid={`host-overlay-edit-${host.hostId}`}
-                        className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
-                        onPointerDown={(e) => e.stopPropagation()}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          setMenuOpen(false);
-                          onEditHost(host.hostId);
-                        }}
+                {sortedHosts.map((host) => {
+                  const rowLogo = resolveHostLogoByDisplayName(
+                    host.name,
+                    themeMode
+                  );
+                  return (
+                    <DropdownMenuRadioItem
+                      key={host.hostId}
+                      value={host.hostId}
+                      hideIndicator
+                      className="group pr-1.5"
+                    >
+                      {rowLogo ? (
+                        <img
+                          src={rowLogo}
+                          alt=""
+                          data-testid={`host-overlay-logo-${host.hostId}`}
+                          className="size-3.5 shrink-0 object-contain"
+                        />
+                      ) : (
+                        <span
+                          aria-hidden
+                          data-testid={`host-overlay-logo-${host.hostId}`}
+                          className="size-3.5 shrink-0 rounded-full bg-muted"
+                        />
+                      )}
+                      <span
+                        className="flex-1 truncate"
+                        data-testid={`host-overlay-label-${host.hostId}`}
                       >
-                        <Pencil className="size-3.5" />
-                      </button>
-                      <button
-                        type="button"
-                        aria-label={`Delete ${host.name}`}
-                        data-testid={`host-overlay-delete-${host.hostId}`}
-                        disabled={isDeleting || !canDelete}
-                        title={!canDelete ? LAST_HOST_DELETE_REASON : undefined}
-                        className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
-                        onPointerDown={(e) => e.stopPropagation()}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          void handleDelete(host.hostId);
-                        }}
-                      >
-                        <Trash2 className="size-3.5" />
-                      </button>
-                    </span>
-                  </DropdownMenuRadioItem>
-                ))}
+                        {host.name}
+                      </span>
+                      <span className="ml-2 flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-data-[highlighted]:opacity-100">
+                        <button
+                          type="button"
+                          aria-label={`Edit ${host.name}`}
+                          data-testid={`host-overlay-edit-${host.hostId}`}
+                          className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+                          onPointerDown={(e) => e.stopPropagation()}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setMenuOpen(false);
+                            onEditHost(host.hostId);
+                          }}
+                        >
+                          <Pencil className="size-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Delete ${host.name}`}
+                          data-testid={`host-overlay-delete-${host.hostId}`}
+                          disabled={isDeleting || !canDelete}
+                          title={
+                            !canDelete ? LAST_HOST_DELETE_REASON : undefined
+                          }
+                          className="inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+                          onPointerDown={(e) => e.stopPropagation()}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            void handleDelete(host.hostId);
+                          }}
+                        >
+                          <Trash2 className="size-3.5" />
+                        </button>
+                      </span>
+                      {host.hostId === effectiveHostId ? (
+                        <span
+                          aria-hidden
+                          data-testid={`host-overlay-selected-dot-${host.hostId}`}
+                          className="size-1.5 shrink-0 rounded-full bg-primary"
+                        />
+                      ) : null}
+                    </DropdownMenuRadioItem>
+                  );
+                })}
               </DropdownMenuRadioGroup>
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/HostOverlayBar.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/HostOverlayBar.test.tsx
@@ -134,6 +134,85 @@ describe("HostOverlayBar", () => {
     expect(screen.getByTestId("host-overlay-save-as-new")).toBeVisible();
   });
 
+  it("renders a client logo on every dropdown row", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
+
+    render(
+      <HostOverlayBar
+        projectId="proj-1"
+        previewedHostId="host-a"
+        onChangePreviewedHostId={vi.fn()}
+        onEditHost={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Client used for preview" })
+    );
+
+    const logoA = await screen.findByTestId("host-overlay-logo-host-a");
+    expect(logoA).toHaveAttribute("src", expect.stringContaining("mcp_jam"));
+    expect(screen.getByTestId("host-overlay-logo-host-b")).toHaveAttribute(
+      "src",
+      expect.stringContaining("claude")
+    );
+  });
+
+  it("marks the selected row with a single primary-colored dot", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
+
+    render(
+      <HostOverlayBar
+        projectId="proj-1"
+        previewedHostId="host-a"
+        onChangePreviewedHostId={vi.fn()}
+        onEditHost={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Client used for preview" })
+    );
+
+    // Only the previewed host gets a dot, so the design-system's built-in
+    // left-gutter indicator must be gone — two dots would read as two
+    // selections.
+    const dots = await screen.findAllByTestId(/^host-overlay-selected-dot-/);
+    expect(dots).toHaveLength(1);
+    expect(dots[0]).toHaveAttribute(
+      "data-testid",
+      "host-overlay-selected-dot-host-a"
+    );
+    expect(dots[0]).toHaveClass("bg-primary");
+
+    const row = screen.getByRole("menuitemradio", { name: /MCPJam/ });
+    expect(row.querySelector("span.absolute")).toBeNull();
+  });
+
+  it("places the selected dot after the client name so logos own the left edge", async () => {
+    const user = userEvent.setup();
+    render(
+      <HostOverlayBar
+        projectId="proj-1"
+        previewedHostId="host-a"
+        onChangePreviewedHostId={vi.fn()}
+        onEditHost={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Client used for preview" })
+    );
+
+    const label = await screen.findByTestId("host-overlay-label-host-a");
+    const dot = screen.getByTestId("host-overlay-selected-dot-host-a");
+    expect(
+      label.compareDocumentPosition(dot) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("cycles to the next host when the right arrow is clicked", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/mcpjam-inspector/client/src/components/hosts/__tests__/HostOverlayBar.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/__tests__/HostOverlayBar.test.tsx
@@ -159,6 +159,59 @@ describe("HostOverlayBar", () => {
     );
   });
 
+  it("falls back to the generic MCP mark for a client it cannot place", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({
+      hosts: [{ ...oneHost[0], name: "Acme Internal Bot" }],
+      isLoading: false,
+    });
+
+    render(
+      <HostOverlayBar
+        projectId="proj-1"
+        previewedHostId="host-a"
+        onChangePreviewedHostId={vi.fn()}
+        onEditHost={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Client used for preview" })
+    );
+
+    // Not an empty circle — HostCanvasSelector shows /mcp.svg for the same
+    // unknown-name case, and the two pickers must agree.
+    const logo = await screen.findByTestId("host-overlay-logo-host-a");
+    expect(logo.tagName).toBe("IMG");
+    expect(logo).toHaveAttribute("src", "/mcp.svg");
+  });
+
+  it("places a decorated client name the exact-match resolver would miss", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({
+      hosts: [{ ...oneHost[0], name: "Cursor (staging)" }],
+      isLoading: false,
+    });
+
+    render(
+      <HostOverlayBar
+        projectId="proj-1"
+        previewedHostId="host-a"
+        onChangePreviewedHostId={vi.fn()}
+        onEditHost={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Client used for preview" })
+    );
+
+    expect(await screen.findByTestId("host-overlay-logo-host-a")).toHaveAttribute(
+      "src",
+      expect.stringContaining("cursor")
+    );
+  });
+
   it("marks the selected row with a single primary-colored dot", async () => {
     const user = userEvent.setup();
     mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
@@ -16,6 +16,7 @@ import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { useHostCatalog } from "@/lib/host-compat/use-host-catalog";
 import { buildHostsPath } from "@/lib/app-navigation";
 import { getHostLogoSrc } from "@/lib/host-ui-metadata";
+import { resolveHostLogoByName } from "@/lib/host-logo";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { track } from "@/lib/analytics";
 import { CreateHostDialog } from "@/components/hosts/CreateHostDialog";
@@ -50,36 +51,6 @@ const PILL_CLASS =
 
 /** Height of the interactive controls inside each pill. */
 const CONTROL_HEIGHT = "h-8";
-
-/**
- * Hosts don't persist which catalog template they came from, so the logo is
- * inferred from the display name. Unknown names fall back to the generic MCP
- * mark — never wrong, just anonymous.
- */
-const LOGO_NAME_HINTS: Array<[RegExp, string]> = [
-  [/mcpjam/i, "mcpjam"],
-  [/claude[ -]?code/i, "claude-code"],
-  [/claude/i, "claude"],
-  [/chatgpt|openai/i, "chatgpt"],
-  [/copilot/i, "copilot"],
-  [/cursor/i, "cursor"],
-  [/vs ?code/i, "vscode"],
-  [/goose/i, "goose"],
-  [/cline/i, "cline"],
-  [/perplexity/i, "perplexity"],
-  [/notion/i, "notion"],
-  [/slack/i, "slack"],
-  [/mistral/i, "mistral"],
-];
-
-const FALLBACK_LOGO = "/mcp.svg";
-
-function inferLogoId(name: string): string | null {
-  for (const [re, id] of LOGO_NAME_HINTS) {
-    if (re.test(name)) return id;
-  }
-  return null;
-}
 
 interface HostCanvasSelectorProps {
   projectId: string;
@@ -191,10 +162,7 @@ export function HostCanvasSelector({
     }
   };
 
-  const logoFor = (name: string) => {
-    const id = inferLogoId(name);
-    return id ? getHostLogoSrc(id, themeMode) : FALLBACK_LOGO;
-  };
+  const logoFor = (name: string) => resolveHostLogoByName(name, themeMode);
 
   if (isLoading || !active) {
     return (

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostCanvasSelector.tsx
@@ -313,6 +313,7 @@ export function HostCanvasSelector({
                 <DropdownMenuRadioItem
                   key={host.hostId}
                   value={host.hostId}
+                  hideIndicator
                   className="group gap-2.5 py-2 pr-1.5"
                 >
                   <img
@@ -320,7 +321,12 @@ export function HostCanvasSelector({
                     alt=""
                     className="size-4 shrink-0 object-contain"
                   />
-                  <span className="flex-1 truncate">{host.name}</span>
+                  <span
+                    className="flex-1 truncate"
+                    data-testid={`host-canvas-label-${host.hostId}`}
+                  >
+                    {host.name}
+                  </span>
                   <span className="ml-2 flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 group-data-[highlighted]:opacity-100">
                     <button
                       type="button"
@@ -339,6 +345,13 @@ export function HostCanvasSelector({
                       <Trash2 className="size-3.5" />
                     </button>
                   </span>
+                  {host.hostId === activeHostId ? (
+                    <span
+                      aria-hidden
+                      data-testid={`host-canvas-selected-dot-${host.hostId}`}
+                      className="size-1.5 shrink-0 rounded-full bg-primary"
+                    />
+                  ) : null}
                 </DropdownMenuRadioItem>
               ))}
             </DropdownMenuRadioGroup>

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
@@ -141,6 +141,26 @@ describe("HostCanvasSelector", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("falls back to the same generic MCP mark as the header picker", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({
+      hosts: [{ ...oneHost[0], name: "Acme Internal Bot" }],
+      isLoading: false,
+    });
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    await user.click(screen.getByTestId("host-canvas-current"));
+
+    // Deliberately asserts the same concrete value as the matching case in
+    // HostOverlayBar.test.tsx. The two pickers used to disagree here — one drew
+    // an empty circle — so pinning it from both sides is what catches a picker
+    // going back to its own resolver.
+    const row = await screen.findByRole("menuitemradio", {
+      name: /Acme Internal Bot/,
+    });
+    expect(row.querySelector("img")).toHaveAttribute("src", "/mcp.svg");
+  });
+
   it("marks the active client with a single primary-colored dot", async () => {
     const user = userEvent.setup();
     mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/__tests__/HostCanvasSelector.test.tsx
@@ -141,6 +141,41 @@ describe("HostCanvasSelector", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("marks the active client with a single primary-colored dot", async () => {
+    const user = userEvent.setup();
+    mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    await user.click(screen.getByTestId("host-canvas-current"));
+
+    // Only the active host gets a dot, so the design-system's built-in
+    // left-gutter indicator must be gone — two dots would read as two
+    // selections, and it would also collide with the row logo.
+    const dots = await screen.findAllByTestId(/^host-canvas-selected-dot-/);
+    expect(dots).toHaveLength(1);
+    expect(dots[0]).toHaveAttribute(
+      "data-testid",
+      "host-canvas-selected-dot-host-a"
+    );
+    expect(dots[0]).toHaveClass("bg-primary");
+
+    const row = screen.getByRole("menuitemradio", { name: /MCPJam/ });
+    expect(row.querySelector("span.absolute")).toBeNull();
+  });
+
+  it("places the active dot after the client name so the logo owns the left edge", async () => {
+    const user = userEvent.setup();
+    render(<HostCanvasSelector projectId="proj-1" activeHostId="host-a" />);
+
+    await user.click(screen.getByTestId("host-canvas-current"));
+
+    const label = await screen.findByTestId("host-canvas-label-host-a");
+    const dot = screen.getByTestId("host-canvas-selected-dot-host-a");
+    expect(
+      label.compareDocumentPosition(dot) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("navigates to the picked host and updates the preview pointer", async () => {
     const user = userEvent.setup();
     mockUseHostList.mockReturnValue({ hosts: twoHosts, isLoading: false });

--- a/mcpjam-inspector/client/src/lib/__tests__/host-logo.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-logo.test.ts
@@ -9,6 +9,11 @@ import { resolveHostLogoByName, UNKNOWN_HOST_LOGO } from "@/lib/host-logo";
 describe("resolveHostLogoByName", () => {
   it("falls back to the generic MCP mark for a name it cannot place", () => {
     expect(resolveHostLogoByName("Acme Internal Bot")).toBe(UNKNOWN_HOST_LOGO);
+    // The return type is a plain string, so the blank cases have to resolve to
+    // the mark too rather than falling through to undefined. `trim()` is what
+    // the exact-match pass guards on, hence the whitespace-only case.
+    expect(resolveHostLogoByName("")).toBe(UNKNOWN_HOST_LOGO);
+    expect(resolveHostLogoByName("   ")).toBe(UNKNOWN_HOST_LOGO);
   });
 
   it("still places a decorated name via the hint table", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/host-logo.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-logo.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveHostLogoByName, UNKNOWN_HOST_LOGO } from "@/lib/host-logo";
+
+// Hosts don't persist the catalog template they came from, so both single-select
+// client pickers infer the logo from the display name. They used to do it two
+// different ways — an exact style-name match (HostOverlayBar) and a regex hint
+// table (HostCanvasSelector) — which made the same custom client render a
+// different mark in each. This helper is the one resolver both now share.
+describe("resolveHostLogoByName", () => {
+  it("falls back to the generic MCP mark for a name it cannot place", () => {
+    expect(resolveHostLogoByName("Acme Internal Bot")).toBe(UNKNOWN_HOST_LOGO);
+  });
+
+  it("still places a decorated name via the hint table", () => {
+    // The exact-match resolver alone returns null here.
+    expect(resolveHostLogoByName("Cursor (staging)")).toContain("cursor");
+  });
+
+  it("places a style id the hint table does not list", () => {
+    // `codex` is a real style id but absent from the regex hints, so this only
+    // resolves through the exact-name pass.
+    expect(resolveHostLogoByName("Codex")).toContain("codex");
+  });
+
+  it("places a plain known name", () => {
+    expect(resolveHostLogoByName("Claude")).toContain("claude");
+  });
+
+  it("resolves the same mark for the same name regardless of caller", () => {
+    // The property the two pickers depend on: one name, one answer.
+    for (const name of ["MCPJam", "Cursor (staging)", "Acme Internal Bot"]) {
+      expect(resolveHostLogoByName(name, "light")).toBe(
+        resolveHostLogoByName(name, "light")
+      );
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/__tests__/host-logo.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-logo.test.ts
@@ -31,12 +31,4 @@ describe("resolveHostLogoByName", () => {
     expect(resolveHostLogoByName("Claude")).toContain("claude");
   });
 
-  it("resolves the same mark for the same name regardless of caller", () => {
-    // The property the two pickers depend on: one name, one answer.
-    for (const name of ["MCPJam", "Cursor (staging)", "Acme Internal Bot"]) {
-      expect(resolveHostLogoByName(name, "light")).toBe(
-        resolveHostLogoByName(name, "light")
-      );
-    }
-  });
 });

--- a/mcpjam-inspector/client/src/lib/host-logo.ts
+++ b/mcpjam-inspector/client/src/lib/host-logo.ts
@@ -1,0 +1,48 @@
+import type { HostThemeMode } from "@/lib/client-styles";
+import { resolveHostLogoByDisplayName } from "@/lib/chatbox-client-style";
+import { getHostLogoSrc, UNKNOWN_HOST_LOGO } from "@/lib/host-ui-metadata";
+
+export { UNKNOWN_HOST_LOGO };
+
+/**
+ * Hosts don't persist which catalog template they came from, so a client's logo
+ * has to be inferred from its display name.
+ *
+ * There were two inference strategies in the tree and they disagreed, which is
+ * how the same custom client ended up with a different mark in each
+ * single-select picker. Neither was a superset of the other:
+ *
+ * - The hint table places DECORATED names (`Cursor (staging)`), which an exact
+ *   match cannot.
+ * - The exact style-name pass places ids the hint table never listed (`codex`,
+ *   `agentcore`, `n8n`).
+ *
+ * So this runs hints first — preserving what the canvas selector already
+ * rendered for every name it covered — then the exact pass, then the generic MCP
+ * mark. That mark is never wrong, just anonymous, which beats an empty circle.
+ */
+const LOGO_NAME_HINTS: Array<[RegExp, string]> = [
+  [/mcpjam/i, "mcpjam"],
+  [/claude[ -]?code/i, "claude-code"],
+  [/claude/i, "claude"],
+  [/chatgpt|openai/i, "chatgpt"],
+  [/copilot/i, "copilot"],
+  [/cursor/i, "cursor"],
+  [/vs ?code/i, "vscode"],
+  [/goose/i, "goose"],
+  [/cline/i, "cline"],
+  [/perplexity/i, "perplexity"],
+  [/notion/i, "notion"],
+  [/slack/i, "slack"],
+  [/mistral/i, "mistral"],
+];
+
+export function resolveHostLogoByName(
+  name: string,
+  themeMode?: HostThemeMode | null
+): string {
+  for (const [pattern, hostId] of LOGO_NAME_HINTS) {
+    if (pattern.test(name)) return getHostLogoSrc(hostId, themeMode);
+  }
+  return resolveHostLogoByDisplayName(name, themeMode) ?? UNKNOWN_HOST_LOGO;
+}

--- a/mcpjam-inspector/client/src/lib/host-ui-metadata.ts
+++ b/mcpjam-inspector/client/src/lib/host-ui-metadata.ts
@@ -20,7 +20,7 @@ import slackLogo from "/slack_logo.png";
 
 export const DEFAULT_CATALOG_HOST_ID = "mcpjam";
 
-const UNKNOWN_HOST_LOGO = "/mcp.svg";
+export const UNKNOWN_HOST_LOGO = "/mcp.svg";
 
 const LOGO_BY_HOST_ID: Record<string, string> = {
   mcpjam: mcpjamLogo,


### PR DESCRIPTION
## What

Both single-select client pickers marked the active row with the design system's
built-in left-gutter dot. That dot renders `fill-current`, so it inherited the
menu's plain foreground colour instead of the accent the multi-select picker
already uses (`bg-primary` on its checkbox). `HostOverlayBar` also rendered no
client logos at all — just names.

Both now put the client logo on the left edge and a `bg-primary` dot on the
right, so the two single-select pickers read as one component.

| Picker | Before | After |
| --- | --- | --- |
| `HostOverlayBar` (app header) | `• Cursor` — no logo, black dot left | `[logo] Cursor ●` |
| `HostCanvasSelector` (Connect canvas) | `• [logo] Cursor` — black dot left | `[logo] Cursor ●` |

## How

`DropdownMenuRadioItem` gains an opt-in `hideIndicator` prop that drops the
built-in indicator and the `pl-8` gutter reserved for it, letting the caller own
the marker. Radio semantics are untouched and the prop defaults to `false`, so
the other nine call sites render exactly as before.

Before:
<img width="556" height="610" alt="image" src="https://github.com/user-attachments/assets/21a883c8-f525-4e34-a67a-3ef10b2f7a12" />
<img width="838" height="656" alt="image" src="https://github.com/user-attachments/assets/c9cd2af1-6133-45a2-b246-eeb4ab81549e" />

After:
<img width="412" height="382" alt="image" src="https://github.com/user-attachments/assets/d3133c22-e27e-4d2f-bb88-627259f9bc52" />
<img width="420" height="368" alt="image" src="https://github.com/user-attachments/assets/aa8c8369-0dcd-4eeb-b624-00200a22e224" />
<img width="237" height="253" alt="image" src="https://github.com/user-attachments/assets/a97fc7cc-3043-43d4-af61-6b4446916c69" />
<img width="434" height="552" alt="image" src="https://github.com/user-attachments/assets/a4f6f0b6-3442-46f0-af1d-6c515d6cccda" />


## Testing

- 5 new tests across the two pickers: every row renders a logo, **exactly one**
  dot exists and carries `bg-primary`, and it follows the label in DOM order.
  The "exactly one" assertion is what catches a leftover built-in indicator.
- `client/src/components/hosts`: 378 pass. Root `typecheck` and
  `typecheck:client`: clean.

## Notes

- The `HostOverlayBar` diff looks big because resolving a per-row logo means
  wrapping the `.map()` in a block, which reindents the body. ~30 lines are
  substantive.
- This closes the visual asks on PUR-15. Consolidating all ~8 client pickers
  into a single component is deliberately left out of scope; `hideIndicator` is
  the groundwork for it.
