### PR TITLE
feat(computers): dark-launch the local engine behind a local-computer-enabled flag

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/tool-part-run-location.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/__tests__/tool-part-run-location.test.tsx
@@ -43,6 +43,12 @@ vi.mock("@/stores/widget-debug-store", () => ({
 }));
 
 const toolNameState = vi.hoisted(() => ({ name: "bash" }));
+// Dark-launch flag: the pill is part of the local-engine rollout. ON by
+// default so the pill rows test the pill; the flag-off row flips it.
+const flagState = vi.hoisted(() => ({ localComputerEnabled: true }));
+vi.mock("@/hooks/useComputersEnabled", () => ({
+  useLocalComputerEnabled: () => flagState.localComputerEnabled,
+}));
 vi.mock("../../thread-helpers", () => ({
   getToolNameFromType: () => toolNameState.name,
   getToolStateMeta: () => ({
@@ -151,6 +157,18 @@ describe("ToolPart run-location pill", () => {
   it("renders nothing when the result carries no engine (old transcript / hosted)", () => {
     renderBash({ stdout: "Linux", exitCode: 0 });
     expect(screen.queryByTestId("tool-run-location")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing while the `local-computer-enabled` flag is off — even on a stamped result", () => {
+    // Dark launch: users outside the rollout must see no run-location UI,
+    // including "cloud" pills and old dogfooding transcripts stamped "local".
+    flagState.localComputerEnabled = false;
+    try {
+      renderBash({ stdout: "Linux", exitCode: 0, engine: "local" });
+      expect(screen.queryByTestId("tool-run-location")).not.toBeInTheDocument();
+    } finally {
+      flagState.localComputerEnabled = true;
+    }
   });
 
   it("renders nothing for a non-bash tool", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -26,6 +26,7 @@ import {
 import { UITools, ToolUIPart, DynamicToolUIPart } from "ai";
 
 import { track } from "@/lib/analytics";
+import { useLocalComputerEnabled } from "@/hooks/useComputersEnabled";
 import { type DisplayMode } from "@/stores/ui-playground-store";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { useWidgetDebugStore } from "@/stores/widget-debug-store";
@@ -213,8 +214,13 @@ export function ToolPart({
   // server value) rather than `resultDisplayData` — the latter is the editable
   // Raw-tab value, which a user can rewrite, and provenance must not be
   // editable. Absent on old transcripts, hosted turns, and the ephemeral
-  // sandbox-bash tool, which is why nothing renders in that case.
-  const runLocation = readToolRunLocation(label, rawResultData);
+  // sandbox-bash tool, which is why nothing renders in that case. The pill is
+  // part of the local-engine dark launch: users outside the
+  // `local-computer-enabled` rollout see no run-location UI at all.
+  const localComputerEnabled = useLocalComputerEnabled();
+  const runLocation = localComputerEnabled
+    ? readToolRunLocation(label, rawResultData)
+    : null;
   const resultDisplayData =
     outputValue !== undefined ? outputValue : rawResultData;
   const imagePreviewData = rawResultData;

--- a/mcpjam-inspector/client/src/hooks/__tests__/useComputerEngine.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useComputerEngine.test.tsx
@@ -11,12 +11,18 @@ const state = vi.hoisted(() => ({
   hosted: false,
   config: undefined as unknown,
   consentGranted: false,
+  // Dark-launch flag. Defaults ON here so the resolution-rule rows stay
+  // about the rule; the flag-off rows flip it explicitly.
+  localFlagEnabled: true,
 }));
 
 vi.mock("@/lib/config", () => ({
   get HOSTED_MODE() {
     return state.hosted;
   },
+}));
+vi.mock("@/hooks/useComputersEnabled", () => ({
+  useLocalComputerEnabled: () => state.localFlagEnabled,
 }));
 vi.mock("@/hooks/useProjectComputer", () => ({
   useComputersDataPlaneConfig: () => state.config,
@@ -62,6 +68,7 @@ describe("useComputerEngine", () => {
     state.hosted = false;
     state.config = config({});
     state.consentGranted = false;
+    state.localFlagEnabled = true;
   });
 
   it("hosted: always cloud, toggle hidden, storage untouched", () => {
@@ -176,5 +183,27 @@ describe("useComputerEngine", () => {
     state.config = config({});
     const { result } = renderHook(() => useComputerEngine("p1"));
     expect(result.current.toggleVisible).toBe(true);
+  });
+
+  it("flag off: local never qualifies — even with consent + a stored 'local' pref", () => {
+    // Dark launch: the server advertises the engine, the user granted consent,
+    // and a preference is stored — the UI must still look pre-feature.
+    state.localFlagEnabled = false;
+    state.consentGranted = true;
+    saveComputerEngine("p1", "local");
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.engine).toBe("cloud");
+    expect(result.current.selectedEngine).toBe("cloud");
+    expect(result.current.localAvailable).toBe(false);
+    expect(result.current.localTerminalAvailable).toBe(false);
+    expect(result.current.toggleVisible).toBe(false);
+  });
+
+  it("flag off + server default 'local': resolution falls through to cloud", () => {
+    state.localFlagEnabled = false;
+    state.config = config({ defaultEngine: "local", terminalAvailable: true });
+    const { result } = renderHook(() => useComputerEngine("p1"));
+    expect(result.current.selectedEngine).toBe("cloud");
+    expect(result.current.localTerminalAvailable).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useComputerEngine.ts
+++ b/mcpjam-inspector/client/src/hooks/useComputerEngine.ts
@@ -6,10 +6,15 @@
  * elsewhere:
  *
  *   1. HOSTED_MODE ⇒ cloud. Toggle hidden, storage never read.
- *   2. Candidates in order: stored preference → server defaultEngine →
+ *   2. The `local-computer-enabled` PostHog flag gates local CANDIDACY: while
+ *      a user isn't flagged in, `local` is never available/selectable, so the
+ *      toggle, faces, rail body, and transmission all stay dark even though
+ *      the server advertises the engine (dark launch — see
+ *      `useComputersEnabled.ts`).
+ *   3. Candidates in order: stored preference → server defaultEngine →
  *      local → cloud. The first candidate that is AVAILABLE — and, for
  *      `local`, whose consent capability is SERVER-VERIFIED — wins.
- *   3. Nothing qualifies ⇒ `cloud` with `cloudAvailable:false`; consumers
+ *   4. Nothing qualifies ⇒ `cloud` with `cloudAvailable:false`; consumers
  *      render the existing unavailable state.
  *
  * Consent GATES the engine: an unconsented machine never resolves local —
@@ -30,6 +35,7 @@ import {
   useLocalComputerConsent,
   type LocalComputerConsent,
 } from "@/hooks/useLocalComputerConsent";
+import { useLocalComputerEnabled } from "@/hooks/useComputersEnabled";
 import { useComputersDataPlaneConfig } from "@/hooks/useProjectComputer";
 
 export interface ComputerEngineState {
@@ -67,6 +73,9 @@ export function useComputerEngine(
 ): ComputerEngineState {
   const config = useComputersDataPlaneConfig();
   const consent = useLocalComputerConsent();
+  // Dark-launch flag: false (including still-loading) kills local candidacy
+  // outright — the one choke point every local-engine surface derives from.
+  const localFlagEnabled = useLocalComputerEnabled();
   // Read the stored preference SYNCHRONOUSLY, keyed to the CURRENT projectId —
   // via useSyncExternalStore rather than a passive effect, so a project switch
   // never renders once with the previous project's preference (and switching
@@ -91,7 +100,10 @@ export function useComputerEngine(
     [projectId],
   );
 
-  const localAvailable = !HOSTED_MODE && (config?.engines.local.available ?? false);
+  const localAvailable =
+    !HOSTED_MODE &&
+    localFlagEnabled &&
+    (config?.engines.local.available ?? false);
   const cloudAvailable = config?.engines.cloud.available ?? false;
 
   let engine: ComputerEngineChoice = "cloud";
@@ -129,7 +141,9 @@ export function useComputerEngine(
     resolved: config !== undefined,
     localAvailable,
     localTerminalAvailable:
-      !HOSTED_MODE && (config?.engines.local.terminalAvailable ?? false),
+      !HOSTED_MODE &&
+      localFlagEnabled &&
+      (config?.engines.local.terminalAvailable ?? false),
     workspaceDisplayRoot: HOSTED_MODE
       ? null
       : (config?.engines.local.workspaceDisplayRoot ?? null),

--- a/mcpjam-inspector/client/src/hooks/useComputersEnabled.ts
+++ b/mcpjam-inspector/client/src/hooks/useComputersEnabled.ts
@@ -28,3 +28,24 @@ export function useComputersEnabledState(): boolean | undefined {
 export function useComputersEnabled(): boolean {
   return useComputersEnabledState() === true;
 }
+
+/**
+ * Dark-launch gate for the LOCAL computer engine ("This machine")
+ * specifically — a second, narrower flag inside the `computers-enabled`
+ * surface. It gates local-engine CANDIDACY in `useComputerEngine` (which
+ * hides the Computer tab's Local⇄Cloud toggle and local face, the playground
+ * rail's local shell body, the consent gate, and the local chat
+ * transmission in one place) plus the bash run-location pill. Flag off ⇒ a
+ * local inspector looks and behaves exactly as before the local engine
+ * shipped. The server keeps the capability (`MCPJAM_LOCAL_COMPUTER_ENABLED`
+ * remains the emergency stop), so flagging a user in needs no env var and
+ * launching needs no release — just the PostHog rollout.
+ *
+ * `undefined` while flags load ⇒ off (`=== true`): fail-closed, same as
+ * `useComputersEnabled`.
+ */
+export const LOCAL_COMPUTER_FEATURE_FLAG = "local-computer-enabled";
+
+export function useLocalComputerEnabled(): boolean {
+  return useFeatureFlagEnabled(LOCAL_COMPUTER_FEATURE_FLAG) === true;
+}

--- a/mcpjam-inspector/docs/local-computer-engine.md
+++ b/mcpjam-inspector/docs/local-computer-engine.md
@@ -107,11 +107,19 @@ It is forced off in hosted mode regardless of the env var.
 
 **Caveat that governs rollback:** the kill switch is a *server* env var. Users
 running a published `npx @mcpjam/inspector` or a packaged Electron build are on
-their own machines — flipping anything server-side does not reach them. Pulling
-the feature back from already-published clients needs a **patch release**. Plan
-rollback accordingly: the feature flag governs UI exposure in the hosted app;
-the kill switch governs a given self-hosted server; neither retroactively
-disarms a shipped binary.
+their own machines — flipping anything server-side does not reach them.
+
+That is why UI exposure has its own, client-evaluated gate: the
+`local-computer-enabled` PostHog flag (`useLocalComputerEnabled`,
+`client/src/hooks/useComputersEnabled.ts`). It gates local-engine *candidacy*
+in `useComputerEngine` — flag off ⇒ the Local⇄Cloud toggle, the "This machine"
+face, the consent gate, the rail's local body, the run-location pill, and the
+local chat transmission are all invisible, and the inspector behaves exactly
+as before the local engine shipped. Published clients fetch flags at runtime,
+so flipping this flag **does** reach shipped binaries (fail-closed: no PostHog
+⇒ off). The env kill switch remains the server-side stop for the execution
+capability itself; a **patch release** is only needed to disarm the server
+code paths in already-published clients, not to hide the feature.
 
 ## Cloud-only surfaces
 
@@ -173,9 +181,15 @@ gate needs the local success rate.
 properties alone are invisible to `/flags`, which evaluates person properties —
 that is why both exist. `platform` is set alongside it.
 
-The rollout rule itself is a **dashboard operation**, not code:
+The rollout rules themselves are **dashboard operations**, not code. Two flags:
 
 > `computers-enabled` → employees ∪ (`deployment = self_hosted` AND signed in)
+> — the whole Project Computers surface, unchanged.
+>
+> `local-computer-enabled` → **off for everyone at ship time** (dark launch);
+> then employees for dogfooding; then widen to the
+> `deployment = self_hosted` cohort at launch. Gates only the LOCAL engine UI
+> inside the computers surface.
 
 ## Launch / rollback checklist
 
@@ -183,9 +197,13 @@ The rollout rule itself is a **dashboard operation**, not code:
 
 Pre-launch:
 
+- [ ] `local-computer-enabled` exists in PostHog and is **off for everyone**
+      before any deploy/release that carries this code; enable for employees to
+      dogfood.
 - [ ] Flag `computers-enabled` rule set to employees ∪ `deployment = self_hosted`
       signed-in cohort; dry-run the targeting against a known self-hosted
-      distinct_id before widening.
+      distinct_id before widening. Launch = widening `local-computer-enabled`
+      to the same cohort.
 - [ ] Confirm `deployment` shows up as a **person** property (not only as an
       event property) in PostHog for a fresh browser profile.
 - [ ] Confirm the consent funnel is intact:
@@ -207,12 +225,15 @@ Pre-launch:
 
 Rollback:
 
-- [ ] Turn the flag off — this is the fast lever, and it governs hosted UI
-      exposure.
+- [ ] Turn `local-computer-enabled` off — this is the fast lever, and it hides
+      the local-engine UI in ALL clients (hosted and published binaries alike;
+      flags are fetched at runtime, fail-closed).
 - [ ] For a specific self-hosted server: set
       `MCPJAM_LOCAL_COMPUTER_ENABLED=false` and restart.
-- [ ] For already-published npx/Electron clients: **cut a patch release.** No
-      server-side switch reaches them.
+- [ ] For already-published npx/Electron clients: the flag hides the UI at
+      runtime; **cut a patch release** only if the server-side execution paths
+      themselves must be disarmed (no server-side switch reaches a shipped
+      binary).
 
 Follow-ups (explicitly not in this program):
 


### PR DESCRIPTION
Dark-launches the local computer engine before the next deploy/release. The endgame (#3845) merged with the local engine visible by default on every non-hosted inspector — this PR puts ALL of its UI behind a new client-evaluated PostHog flag, **`local-computer-enabled`**, which is already created and at **0% rollout** ([flag 810300](https://us.posthog.com/project/212744/feature_flags/810300)). Ship this and users see nothing until the flag is widened from the dashboard.

## How it gates

- **`useComputerEngine`** — the flag kills local *candidacy* at the one choke point every surface derives from. Flag off ⇒ the Computer tab's Local⇄Cloud toggle and "This machine" face, the consent gate, the Playground rail's engine chip + local shell body, and the local chat transmission (playground + comparison cards) are all invisible, and the inspector behaves exactly as before the local engine shipped — **even with a stored "local" preference and granted consent** (covered by tests).
- **Run-location pill** (`tool-part.tsx`) — part of the same rollout: users outside it see no run-location UI at all, including "cloud" pills and dogfooding transcripts already stamped `engine: "local"`.

## Why a client flag (not the env default)

- Published npx/Electron clients fetch PostHog flags at runtime, so flipping the flag **reaches shipped binaries** — hiding the UI needs no patch release, and dogfooding needs no env var (just flag someone in).
- Fail-closed: `undefined` while flags load, or no PostHog at all, both read as off — same convention as `computers-enabled`.
- The server keeps the capability: `MCPJAM_LOCAL_COMPUTER_ENABLED` remains the server-side emergency stop, and hosted mode remains forced off. Server routes stay consent + member-auth gated as before; this flag is a visibility gate, per the existing `useComputersEnabled` pattern.

## Actor sweep (flag off)

Computer tab → cloud `ComputerView`, byte-identical. Rail → cloud body, no chip. Chat → `personalComputerEngine.engine` is `"cloud"`, so `sendLocalEngine` is false and no engine/consent header leaves the client (playground, both comparison-card sites). Uploads → `computerAttachmentsActive` behaves pre-feature (engine is cloud). Consent gate, terminal pane, and all local analytics emits are only reachable inside the gated faces.

## Rollout

0% now (ship dark) → employees for dogfooding → widen to the `deployment = self_hosted` cohort at launch. `docs/local-computer-engine.md` launch/rollback checklist updated accordingly.

Tests: flag-off rows in the engine-hook matrix and the pill suite; all computer/rail/playground/thread-parts suites green; client typecheck exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eded59651b295e3fc69e2f49c4bc42ab42b2966a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dark-launches the local computer engine behind a client PostHog flag so it stays hidden until we roll it out. With `local-computer-enabled` at 0%, users see no local engine UI and the app behaves as before.

- **New Features**
  - Added `useLocalComputerEnabled` for the `local-computer-enabled` flag (fail-closed; fetched at runtime by published `npx`/Electron clients).
  - Gated local candidacy in `useComputerEngine`: flag off forces cloud, hides the Local⇄Cloud toggle, "This machine" face, consent gate, rail local body, and local chat transmission; local terminal is unavailable.
  - Hid the run-location pill in the bash tool when the flag is off.
  - Tests cover flag-off behavior; docs updated with rollout/rollback. Server kill switch `MCPJAM_LOCAL_COMPUTER_ENABLED` remains; hosted mode stays forced cloud.

<sup>Written for commit eded59651b295e3fc69e2f49c4bc42ab42b2966a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

