### PR TITLE
fix(mcp): add the DO delete-class migration to the production env

### DIFF
--- a/mcp/wrangler.jsonc
+++ b/mcp/wrangler.jsonc
@@ -80,10 +80,14 @@
       // binding are gone. Migrations are append-only and must carry the full
       // applied history: the deployed staging worker's last-applied tag is
       // `v1`, so `v1` stays and `v2` deletes the class. A lone `v2` entry is
-      // rejected by wrangler. The other envs list no migrations at all — `dev`
-      // is local-only with no persisted state, `preview` workers are created
-      // fresh per PR (so they never create the DO in the first place), and
-      // `production` has never been deployed.
+      // rejected by wrangler. `production` carries the identical block for the
+      // same reason (see below). `dev` and `preview` list no migrations at all:
+      // `dev` is local-only with no persisted state, and preview workers are
+      // recreated per PR and never serve enough traffic to instantiate the DO,
+      // so Cloudflare lets the class disappear without a delete-class
+      // migration. Do NOT add these migrations to `preview` — a freshly
+      // created worker would apply `v1`, which asks for a `new_sqlite_classes`
+      // class the stateless script no longer exports.
       "migrations": [
         {
           "tag": "v1",
@@ -95,9 +99,8 @@
         }
       ]
     },
-    // Production config is ready but no workflow deploys it yet — prod
-    // rollout is a deliberate future step. No migrations block: nothing has
-    // ever been deployed here, so there is no applied DO history to unwind.
+    // Promoted manually via deploy-mcp-prod.yml (workflow_dispatch only) —
+    // prod rollout is a deliberate step, never a side effect of merging.
     "production": {
       "workers_dev": false,
       "routes": [
@@ -112,7 +115,25 @@
         "PLATFORM_API_URL": "https://app.mcpjam.com/api/v1",
         "MCPJAM_GUEST_JWKS_URL": "https://app.mcpjam.com/api/web/guest-jwks",
         "MCPJAM_GUEST_MINT_URL": "https://app.mcpjam.com/api/web/guest-token"
-      }
+      },
+      // Same DO teardown as staging, and for the same reason: `production`
+      // HAS been deployed (repeatedly, most recently 2026-08-06) with the
+      // `v1` DO migration, so the live worker holds `McpJamMcpServer`
+      // instances and Cloudflare rejects any version that stops exporting the
+      // class (error 10064). `v1` is the applied history and must stay; `v2`
+      // deletes the class. The deleted state is per-session MCP scratch (a
+      // tool registrar and a cached guest token) that the stateless worker
+      // recreates per request, so there is nothing durable to preserve.
+      "migrations": [
+        {
+          "tag": "v1",
+          "new_sqlite_classes": ["McpJamMcpServer"]
+        },
+        {
+          "tag": "v2",
+          "deleted_classes": ["McpJamMcpServer"]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Problem

The [production MCP worker deploy](https://github.com/MCPJam/inspector/actions/runs/31409352644) fails at the `Deploy production worker` step with Cloudflare API error 10064:

> New version of script does not export class `McpJamMcpServer` which is depended on by existing Durable Objects. Did you forget to include it? If you renamed it, try a rename-class migration.

## Cause

#3760 made the `mcp/` worker stateless and removed the `McpJamMcpServer` Durable Object class. It added the required `v2` `deleted_classes` migration to the `staging` env but not to `production`, on the stated assumption that production "has never been deployed".

That assumption was wrong. `deploy-mcp-prod.yml` has run successfully many times — most recently **2026-08-06**, the run before #3760 merged on 08-07 — and each of those deploys applied the `v1` DO migration. The live `mcpjam-mcp-production` worker therefore holds `McpJamMcpServer` instances, and Cloudflare refuses any version that stops exporting the class without an explicit delete-class migration.

Staging hit the same wall, which is why it got the migration and went green on 08-07. Production just wasn't covered.

## Fix

Give `production` the identical migration block staging already carries:

- `v1` stays — migrations are append-only and must carry the full applied history; wrangler rejects a lone `v2`.
- `v2` deletes the class.

**On the data being deleted:** the DO held only per-session MCP scratch — a session tool registrar and a cached guest token (see the pre-#3760 `mcp/src/server.ts`). The stateless worker recreates both per request, so nothing durable is lost. Any in-flight MCP session breaks on this deploy regardless of the migration, since the request handler itself is being replaced.

## Why `dev` and `preview` still carry no migrations

Left as-is, with the reasoning now written down — adding the block there would actively break them. A freshly created preview worker would apply `v1`, which asks for a `new_sqlite_classes` class the stateless script no longer exports.

Preview deploys have stayed green throughout because those workers never serve enough traffic to instantiate the DO, so Cloudflare lets the class disappear without a delete-class migration. Verified: every `PR MCP Preview` run since 08-07 succeeded.

## Verification

- `wrangler deploy --env production --dry-run` succeeds: config resolves, the migration block is accepted, and the resolved bindings are identical to those printed by the failing run (so this changes migration history only, not runtime behavior).
- `prettier --check mcp/wrangler.jsonc` clean.
- Config-only change; no source touched.

## After merge

`deploy-mcp-prod.yml` is `workflow_dispatch`-only and enforces `main`, so production needs a fresh dispatch once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production deploy will delete existing `McpJamMcpServer` Durable Objects and can break in-flight MCP sessions, though the removed state was ephemeral per-session scratch only.
> 
> **Overview**
> Unblocks **production MCP worker deploys** after the worker went stateless by adding the same Durable Object migration history **staging** already has.
> 
> **`production`** in `mcp/wrangler.jsonc` now declares append-only migrations **`v1`** (`new_sqlite_classes: McpJamMcpServer`) and **`v2`** (`deleted_classes: McpJamMcpServer`). Without **`v2`**, Cloudflare error **10064** blocks deploy because live production still has **`McpJamMcpServer`** instances from prior deploys.
> 
> Comments are expanded to document why **`production`** needs this block, that **`dev`** / **`preview`** must **not** get it (fresh workers would fail on **`v1`** against a script that no longer exports the class), and that prod promotion is manual via **`deploy-mcp-prod.yml`**.
> 
> Config-only; no runtime binding or source changes beyond migration metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaa73d375651433f20392dcb640a88a12d011764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing production MCP worker deploys by adding the missing Durable Object delete-class migration to the `production` env in `mcp/wrangler.jsonc`. This matches staging and unblocks the stateless worker deploy (resolves Cloudflare error 10064).

- **Bug Fixes**
  - Added `migrations` to `production`: keep `v1` (`new_sqlite_classes: ["McpJamMcpServer"]`), add `v2` (`deleted_classes: ["McpJamMcpServer"]`).
  - Left `dev` and `preview` without migrations to avoid introducing the dropped class; previews work since the DO never instantiates.
  - Verified with `wrangler deploy --env production --dry-run`; config-only change.
  - After merge: manually dispatch `deploy-mcp-prod.yml` to deploy.

<sup>Written for commit eaa73d375651433f20392dcb640a88a12d011764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

