### PR TITLE
test(computers): complete the useComputersEnabled mock on the route guard

### DIFF
--- a/mcpjam-inspector/client/src/__tests__/ComputerRoute.flag-hydration.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/ComputerRoute.flag-hydration.test.tsx
@@ -19,6 +19,15 @@ vi.mock("../hooks/useComputersEnabled", () => ({
   COMPUTERS_FEATURE_FLAG: "computers-enabled",
   useComputersEnabledState: () => flagState,
   useComputersEnabled: () => flagState === true,
+  // The local-engine dark-launch flag lives in the same module and is read by
+  // `useComputerEngine`, which this route reaches through `ComputerTabView`.
+  // This mock replaces the module wholesale, so omitting the export throws
+  // rather than falling through to the real hook. Mocked `false` to match the
+  // flag's own default-off semantics: this test is about the tri-state
+  // `computers-enabled` hydration guard and says nothing about the local
+  // engine.
+  LOCAL_COMPUTER_FEATURE_FLAG: "local-computer-enabled",
+  useLocalComputerEnabled: () => false,
 }));
 
 vi.mock("react-router", async (importOriginal) => {


### PR DESCRIPTION
## Why

**`main` is red, and with it every open inspector PR.**

#3851 made `useComputerEngine` read `useLocalComputerEnabled` from `hooks/useComputersEnabled`. `ComputerRoute.flag-hydration.test.tsx` replaces that module wholesale with a factory `vi.mock`, so the missing export **throws** rather than falling through to the real hook — and `ComputerRoute` reaches `useComputerEngine` through `ComputerTabView`:

```
Error: [vitest] No "useLocalComputerEnabled" export is defined on the
"../hooks/useComputersEnabled" mock.
  ❯ useComputerEngine src/hooks/useComputerEngine.ts:78:28
  ❯ ComputerTabView src/components/computer/ComputerTabView.tsx:30:18
```

Surfaced on PR #3852's CI (1 failed / 13,951 passed), but it is a base-branch break, not that PR's doing — it reproduces on `origin/main`.

## The fix

Add the two missing exports to the factory mock. `useLocalComputerEnabled` is mocked **`false`**, matching the flag's own default-off semantics: this test is about the tri-state `computers-enabled` hydration guard and says nothing about the local engine.

## Blast radius

Thirteen other suites mock the same module without the new export and still pass — none of them render a component that reaches `useComputerEngine`, so they are latent rather than broken and are deliberately left alone. Verified by running every suite that mocks the module: **52 files / 461 tests green**, plus the target file's 3 tests.

Note: an identical fix already rides on the #3839 branch (carried there by a parallel session for the same reason). Landing it on `main` is what unblocks the rest of the open PRs; whichever merges second is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 874d4220a46c764224a97c4ff64e718b91d312c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing route-guard test by completing the `../hooks/useComputersEnabled` factory mock with `LOCAL_COMPUTER_FEATURE_FLAG` and `useLocalComputerEnabled` (mocked false). This resolves the missing-export error in `useComputerEngine` and unblocks CI.

<sup>Written for commit 874d4220a46c764224a97c4ff64e718b91d312c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

