### PR TITLE
fix(oauth): require a client id before saving a pre-registered target

### DIFF
--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -144,13 +144,20 @@ export function OAuthProfileModal({
       // keeps the derived default. It never carries credentials (see the
       // OAuthProfileAgentSeed type).
       setServerName(agentSeed?.serverName ?? generateDefaultName());
-      setDraft({
+      const nextDraft = {
         ...derivedProfile,
         ...(agentSeed?.serverUrl ? { serverUrl: agentSeed.serverUrl } : {}),
         ...(agentSeed?.registrationStrategy
           ? { registrationStrategy: agentSeed.registrationStrategy }
           : {}),
-      });
+      };
+      setDraft(nextDraft);
+      // Derived from `nextDraft`, not `draft`: the setDraft above has not
+      // landed yet, so reading state here would reveal (or hide) the section
+      // based on the previously configured server.
+      setAdvancedOpen(
+        nextDraft.registrationStrategy === "preregistered" ? "advanced" : "",
+      );
       setHeaderRows(
         derivedProfile.customHeaders.length
           ? derivedProfile.customHeaders.map((header) =>
@@ -171,15 +178,15 @@ export function OAuthProfileModal({
 
   // The Client ID input lives inside "Advanced settings (optional)", which is
   // collapsed by default, while Registration is a top-level dropdown. Picking
-  // "Pre-registered" therefore hid the one field that strategy cannot run
-  // without, and the flow only failed later at the registration step. Reveal
-  // the section as soon as the strategy needs it. A manual collapse sticks:
-  // this only fires when the strategy changes (or the modal reopens).
-  useEffect(() => {
-    if (open && draft.registrationStrategy === "preregistered") {
+  // "Pre-registered" hid the one field that strategy cannot run without, and
+  // the flow only failed later at the registration step. Reveal the section
+  // whenever that strategy is chosen; a manual collapse afterwards sticks.
+  const handleRegistrationChange = (value: OAuthRegistrationStrategy) => {
+    setDraft((prev) => ({ ...prev, registrationStrategy: value }));
+    if (value === "preregistered") {
       setAdvancedOpen("advanced");
     }
-  }, [open, draft.registrationStrategy]);
+  };
 
   const normalizedHeaders = useMemo(
     () =>
@@ -460,11 +467,9 @@ export function OAuthProfileModal({
                   <Select
                     value={draft.registrationStrategy}
                     onValueChange={(value) =>
-                      setDraft((prev) => ({
-                        ...prev,
-                        registrationStrategy:
-                          value as OAuthRegistrationStrategy,
-                      }))
+                      handleRegistrationChange(
+                        value as OAuthRegistrationStrategy,
+                      )
                     }
                   >
                     <SelectTrigger

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -94,6 +94,14 @@ const createHeaderRow = (initial?: Partial<HeaderRow>): HeaderRow => {
   };
 };
 
+/**
+ * Named so the Registration dropdown can retract exactly this error and leave
+ * every other one standing — see `handleRegistrationChange`.
+ */
+const PREREGISTERED_CLIENT_ID_ERROR =
+  "Client ID is required for pre-registered registration. Add one under " +
+  "Advanced settings, or switch Registration to Dynamic (DCR).";
+
 const describeRegistrationStrategy = (strategy: string): string => {
   if (strategy === "cimd") return "CIMD (URL-based)";
   if (strategy === "dcr") return "Dynamic (DCR)";
@@ -201,10 +209,11 @@ export function OAuthProfileModal({
   // whenever that strategy is chosen; a manual collapse afterwards sticks.
   const handleRegistrationChange = (value: OAuthRegistrationStrategy) => {
     setDraft((prev) => ({ ...prev, registrationStrategy: value }));
-    // The client-id error names switching to DCR as one of its two remedies,
-    // so leaving it on screen after the user does exactly that reads as though
-    // the save is still blocked. Any strategy change re-opens the question.
-    setError(null);
+    // That error names switching to DCR as one of its two remedies, so it must
+    // not outlive the user doing exactly that. Retract only that message: no
+    // other field clears the banner on edit, and a duplicate name or a bad URL
+    // survives a strategy change untouched.
+    setError((prev) => (prev === PREREGISTERED_CLIENT_ID_ERROR ? null : prev));
     if (value === "preregistered") {
       setAdvancedOpen("advanced");
     }
@@ -250,9 +259,7 @@ export function OAuthProfileModal({
     // here would delete the very credential the flow would fall back to.
     if (draft.registrationStrategy === "preregistered" && !trimmedClientId) {
       setAdvancedOpen("advanced");
-      setError(
-        "Client ID is required for pre-registered registration. Add one under Advanced settings, or switch Registration to Dynamic (DCR).",
-      );
+      setError(PREREGISTERED_CLIENT_ID_ERROR);
       return null;
     }
 

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Switch } from "@mcpjam/design-system/switch";
@@ -138,36 +138,54 @@ export function OAuthProfileModal({
     return baseName;
   }, [server?.name, existingServerNames]);
 
+  // Seeding is an event — the modal opening, or a fresh agent prefill — not a
+  // re-render. `derivedProfile` and `generateDefaultName` change identity every
+  // time the parent's server record ticks (connection status, tokens), and
+  // reseeding on that would wipe whatever the user has typed into an open
+  // dialog. These two refs make the effect body run once per such event.
+  const seededWhileOpenRef = useRef(false);
+  const seededAgentSeedRef = useRef<OAuthProfileAgentSeed | null | undefined>(
+    undefined,
+  );
+
   useEffect(() => {
-    if (open) {
-      // The agent seed overlays the server-derived values; anything it omits
-      // keeps the derived default. It never carries credentials (see the
-      // OAuthProfileAgentSeed type).
-      setServerName(agentSeed?.serverName ?? generateDefaultName());
-      const nextDraft = {
-        ...derivedProfile,
-        ...(agentSeed?.serverUrl ? { serverUrl: agentSeed.serverUrl } : {}),
-        ...(agentSeed?.registrationStrategy
-          ? { registrationStrategy: agentSeed.registrationStrategy }
-          : {}),
-      };
-      setDraft(nextDraft);
-      // Derived from `nextDraft`, not `draft`: the setDraft above has not
-      // landed yet, so reading state here would reveal (or hide) the section
-      // based on the previously configured server.
-      setAdvancedOpen(
-        nextDraft.registrationStrategy === "preregistered" ? "advanced" : "",
-      );
-      setHeaderRows(
-        derivedProfile.customHeaders.length
-          ? derivedProfile.customHeaders.map((header) =>
-              createHeaderRow(header),
-            )
-          : [createHeaderRow()],
-      );
-      setAllowPathScopedIssuer(server?.oauthAllowPathScopedIssuer === true);
-      setError(null);
+    if (!open) {
+      seededWhileOpenRef.current = false;
+      return;
     }
+    // An agent command can re-target an already-open modal, so a new seed must
+    // still reseed; anything else while open is parent churn to ignore.
+    if (seededWhileOpenRef.current && seededAgentSeedRef.current === agentSeed) {
+      return;
+    }
+    seededWhileOpenRef.current = true;
+    seededAgentSeedRef.current = agentSeed;
+
+    // The agent seed overlays the server-derived values; anything it omits
+    // keeps the derived default. It never carries credentials (see the
+    // OAuthProfileAgentSeed type).
+    setServerName(agentSeed?.serverName ?? generateDefaultName());
+    const nextDraft = {
+      ...derivedProfile,
+      ...(agentSeed?.serverUrl ? { serverUrl: agentSeed.serverUrl } : {}),
+      ...(agentSeed?.registrationStrategy
+        ? { registrationStrategy: agentSeed.registrationStrategy }
+        : {}),
+    };
+    setDraft(nextDraft);
+    // Derived from `nextDraft`, not `draft`: the setDraft above has not landed
+    // yet, so reading state here would reveal (or hide) the section based on
+    // the previously configured server.
+    setAdvancedOpen(
+      nextDraft.registrationStrategy === "preregistered" ? "advanced" : "",
+    );
+    setHeaderRows(
+      derivedProfile.customHeaders.length
+        ? derivedProfile.customHeaders.map((header) => createHeaderRow(header))
+        : [createHeaderRow()],
+    );
+    setAllowPathScopedIssuer(server?.oauthAllowPathScopedIssuer === true);
+    setError(null);
   }, [
     open,
     derivedProfile,
@@ -183,6 +201,10 @@ export function OAuthProfileModal({
   // whenever that strategy is chosen; a manual collapse afterwards sticks.
   const handleRegistrationChange = (value: OAuthRegistrationStrategy) => {
     setDraft((prev) => ({ ...prev, registrationStrategy: value }));
+    // The client-id error names switching to DCR as one of its two remedies,
+    // so leaving it on screen after the user does exactly that reads as though
+    // the save is still blocked. Any strategy change re-opens the question.
+    setError(null);
     if (value === "preregistered") {
       setAdvancedOpen("advanced");
     }

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -125,6 +125,9 @@ export function OAuthProfileModal({
   const [allowPathScopedIssuer, setAllowPathScopedIssuer] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  // Controlled so the pre-registered guard below can reveal the section that
+  // holds the Client ID. "" is the collapsed state for a single-type Accordion.
+  const [advancedOpen, setAdvancedOpen] = useState("");
   const supportedStrategies = useMemo(
     () => getSupportedRegistrationStrategies(draft.protocolVersion),
     [draft.protocolVersion],
@@ -166,6 +169,18 @@ export function OAuthProfileModal({
     server?.oauthAllowPathScopedIssuer,
   ]);
 
+  // The Client ID input lives inside "Advanced settings (optional)", which is
+  // collapsed by default, while Registration is a top-level dropdown. Picking
+  // "Pre-registered" therefore hid the one field that strategy cannot run
+  // without, and the flow only failed later at the registration step. Reveal
+  // the section as soon as the strategy needs it. A manual collapse sticks:
+  // this only fires when the strategy changes (or the modal reopens).
+  useEffect(() => {
+    if (open && draft.registrationStrategy === "preregistered") {
+      setAdvancedOpen("advanced");
+    }
+  }, [open, draft.registrationStrategy]);
+
   const normalizedHeaders = useMemo(
     () =>
       headerRows
@@ -195,6 +210,23 @@ export function OAuthProfileModal({
     }
 
     const trimmedClientId = draft.clientId.trim();
+
+    // A pre-registered flow has no way to obtain a client id: DCR is skipped,
+    // so an empty field means the flow dies at the registration step with
+    // "Pre-registered client ID is required". Reject the save instead.
+    //
+    // There is deliberately no exemption for a client id left over in
+    // `mcp-client-<name>` from an earlier DCR run: saving with an empty field
+    // removes that record (`saveOAuthConfigToLocalStorage`), so honouring it
+    // here would delete the very credential the flow would fall back to.
+    if (draft.registrationStrategy === "preregistered" && !trimmedClientId) {
+      setAdvancedOpen("advanced");
+      setError(
+        "Client ID is required for pre-registered registration. Add one under Advanced settings, or switch Registration to Dynamic (DCR).",
+      );
+      return null;
+    }
+
     // Preserve the exact typed secret — only whether there's a real value is
     // trim-based (whitespace-only counts as none). Trimming the value itself
     // would silently corrupt a secret with legitimate surrounding whitespace.
@@ -458,7 +490,12 @@ export function OAuthProfileModal({
             </div>
 
             <div className="rounded-lg border border-border">
-              <Accordion type="single" collapsible defaultValue="">
+              <Accordion
+                type="single"
+                collapsible
+                value={advancedOpen}
+                onValueChange={setAdvancedOpen}
+              >
                 <AccordionItem value="advanced" className="border-none">
                   <AccordionTrigger className="px-4 py-3 cursor-pointer">
                     <span className="text-sm font-medium">

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -191,6 +191,67 @@ describe("OAuthProfileModal", () => {
 
     releaseSave?.();
   });
+
+  it("rejects a pre-registered target saved without a client id", async () => {
+    // Pre-registered skips DCR, so an empty client id only failed later, in the
+    // flow itself ("Pre-registered client ID is required"). No exemption for a
+    // client id stored by an earlier DCR run: the save itself deletes that
+    // record, so the flow would still have nothing to use.
+    const user = userEvent.setup();
+    const { onSave } = renderModal({
+      agentSeed: {
+        serverUrl: "https://agent.example.com/mcp",
+        registrationStrategy: "preregistered",
+      },
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Client ID is required for pre-registered/i,
+    );
+  });
+
+  it("reveals the collapsed advanced section when pre-registered is in play", async () => {
+    // The client id input lives behind "Advanced settings (optional)", so a
+    // required field was hidden by a control that calls itself optional.
+    renderModal({
+      agentSeed: {
+        serverUrl: "https://agent.example.com/mcp",
+        registrationStrategy: "preregistered",
+      },
+    });
+
+    expect(screen.getByPlaceholderText("Client ID")).toBeInTheDocument();
+  });
+
+  it("saves a pre-registered target once a client id is filled in", async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderModal({
+      agentSeed: {
+        serverUrl: "https://agent.example.com/mcp",
+        registrationStrategy: "preregistered",
+      },
+    });
+
+    await user.type(screen.getByPlaceholderText("Client ID"), "client-abc");
+    await user.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formData: expect.objectContaining({ clientId: "client-abc" }),
+        profile: expect.objectContaining({
+          clientId: "client-abc",
+          registrationStrategy: "preregistered",
+        }),
+      }),
+    );
+  });
 });
 
 describe("OAuthProfileModal — agentSeed", () => {

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -215,6 +215,28 @@ describe("OAuthProfileModal", () => {
     );
   });
 
+  it("clears the client-id error once the strategy moves off pre-registered", async () => {
+    // The error names switching to DCR as a remedy, so it must not survive the
+    // user doing exactly that.
+    const user = userEvent.setup();
+    renderModal({
+      agentSeed: {
+        serverUrl: "https://agent.example.com/mcp",
+        registrationStrategy: "preregistered",
+      },
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/Registration/));
+    await user.click(await screen.findByRole("option", { name: "Dynamic (DCR)" }));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("reveals the collapsed advanced section when pre-registered is in play", async () => {
     // The client id input lives behind "Advanced settings (optional)", so a
     // required field was hidden by a control that calls itself optional.
@@ -358,5 +380,74 @@ describe("OAuthProfileModal — agentSeed", () => {
     );
 
     expect(screen.queryByPlaceholderText("Client ID")).not.toBeInTheDocument();
+  });
+
+  it("keeps user edits when the parent refreshes its server record mid-edit", async () => {
+    // `derivedProfile`/`generateDefaultName` change identity whenever the
+    // server row ticks (connection status, tokens) or the name list is rebuilt.
+    // Reseeding on that churn wipes the open dialog's typed values.
+    const user = userEvent.setup();
+    const server = createServer("oauth-flow-target");
+    const { rerender } = render(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        server={server}
+        existingServerNames={["oauth-flow-target"]}
+        onSave={vi.fn()}
+      />,
+    );
+
+    await user.clear(screen.getByLabelText(/Server URL/));
+    await user.type(
+      screen.getByLabelText(/Server URL/),
+      "https://typed.example.com/mcp",
+    );
+
+    // A status tick replaces the server object and the name array wholesale.
+    rerender(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        server={{ ...server, connectionStatus: "connecting" } as ServerWithName}
+        existingServerNames={["oauth-flow-target"]}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/Server URL/)).toHaveValue(
+      "https://typed.example.com/mcp",
+    );
+  });
+
+  it("still reseeds when an agent re-targets an already-open modal", () => {
+    // The churn guard above must not swallow a genuine new prefill: the agent
+    // command sets a seed and opens the modal even when it is already open.
+    const { rerender } = render(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        existingServerNames={[]}
+        onSave={vi.fn()}
+        agentSeed={{ serverUrl: "https://first.example.com/mcp" }}
+      />,
+    );
+    expect(screen.getByLabelText(/Server URL/)).toHaveValue(
+      "https://first.example.com/mcp",
+    );
+
+    rerender(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        existingServerNames={[]}
+        onSave={vi.fn()}
+        agentSeed={{ serverUrl: "https://second.example.com/mcp" }}
+      />,
+    );
+
+    expect(screen.getByLabelText(/Server URL/)).toHaveValue(
+      "https://second.example.com/mcp",
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -237,6 +237,30 @@ describe("OAuthProfileModal", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
+  it("leaves an unrelated error standing when the strategy changes", async () => {
+    // Only the client-id message is retracted: the name collision is untouched
+    // by the strategy, so dismissing it would hide a problem that still blocks
+    // the save. No other field clears the banner on edit either.
+    const user = userEvent.setup();
+    renderModal({ existingServerNames: ["staging-mcp"] });
+
+    await user.clear(screen.getByLabelText(/Server Name/));
+    await user.type(screen.getByLabelText(/Server Name/), "staging-mcp");
+    await user.type(
+      screen.getByLabelText(/Server URL/),
+      "https://staging.example.com/mcp",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Save configuration" }),
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
+
+    await user.click(screen.getByLabelText(/Registration/));
+    await user.click(await screen.findByRole("option", { name: "Pre-registered" }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/already exists/i);
+  });
+
   it("reveals the collapsed advanced section when pre-registered is in play", async () => {
     // The client id input lives behind "Advanced settings (optional)", so a
     // required field was hidden by a control that calls itself optional.

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthProfileModal.test.tsx
@@ -320,4 +320,43 @@ describe("OAuthProfileModal — agentSeed", () => {
       "oauth-flow-target",
     );
   });
+
+  it("collapses the advanced section again on a reopen that does not need it", () => {
+    // The modal is never unmounted, so the accordion state outlives a close —
+    // without a reset the next (DCR) target opens with Advanced expanded.
+    const { rerender } = render(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        existingServerNames={[]}
+        onSave={vi.fn()}
+        agentSeed={{
+          serverUrl: "https://agent.example.com/mcp",
+          registrationStrategy: "preregistered",
+        }}
+      />,
+    );
+    expect(screen.getByPlaceholderText("Client ID")).toBeInTheDocument();
+
+    rerender(
+      <OAuthProfileModal
+        open={false}
+        onOpenChange={vi.fn()}
+        existingServerNames={[]}
+        onSave={vi.fn()}
+        agentSeed={null}
+      />,
+    );
+    rerender(
+      <OAuthProfileModal
+        open
+        onOpenChange={vi.fn()}
+        existingServerNames={[]}
+        onSave={vi.fn()}
+        agentSeed={null}
+      />,
+    );
+
+    expect(screen.queryByPlaceholderText("Client ID")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
The OAuth debugger's Registration dropdown is a top-level field, but the Client ID it depends on sits inside the collapsed "Advanced settings (optional)" accordion. Picking "Pre-registered" and saving therefore looked fine and only failed later, mid-flow, with "Pre-registered client ID is required" (Sentry INSPECTOR-CLIENT-21F).

Reject that save, and reveal the advanced section whenever the strategy needs it. No exemption for a client id stored by an earlier DCR run: saving with an empty field deletes that record, so the flow would still have nothing to fall back to.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent saving a pre-registered OAuth target without a Client ID and auto-reveal Advanced so users can fix it immediately. Seed the modal only on open, reset Advanced on reopen, and clear only the client-id error when Registration changes.

- **Bug Fixes**
  - Block save when `registrationStrategy` is `preregistered` and Client ID is empty; show an inline error that retracts only that message on strategy change (other errors stay).
  - Auto-expand Advanced when `preregistered` is selected or seeded; collapse on reopen if not needed.
  - Seed once per open to preserve edits during parent refresh; still reseed when an agent re-targets; tests cover validation, Advanced reveal/reset, preserving edits, and reseeding.

<sup>Written for commit 6127cb2bf9ed1fbd7713bbbde9b50b89459fee76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/MCPJam/inspector/pull/3858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

